### PR TITLE
Update 6-agentorange-registry-health-exam.md

### DIFF
--- a/_disability/6-agentorange-registry-health-exam.md
+++ b/_disability/6-agentorange-registry-health-exam.md
@@ -37,12 +37,6 @@ template: action-page
 <div class="row" markdown="0">
 <div class="small-12 medium-8 columns" markdown="0">
 
-<dl class="panel-list plain" markdown="0">
-<dt>{{ page.title }}</dt>
-<dd>Dates: 1962-1986</dd>
-<dd>Sites: Vietnam and areas exposed to herbicides</dd>
-</dl>
-
 <div markdown="1">
 
 If you suspect you were exposed to Agent Orange or other herbicides during your military service, you can request a VA Agent Orange Registry health exam. Even if you don’t have a known illness, the exam could alert you to health problems that may be related to herbicide exposure. Your participation also helps VA better understand and serve those affected by Agent Orange–related health problems.


### PR DESCRIPTION
Removed redundant headline and dates list from top of page -- dates and location not helpful on this page, though they are on most of the other Agent Orange. Offering prayers to the Git Gods that this doesn't break the page. Pulled this code:

<div class="section one" markdown="0">
<div class="primary" markdown="0">
<div class="row" markdown="0">
<div class="small-12 medium-8 columns" markdown="0">

<dl class="panel-list plain" markdown="0">
<dt>{{ page.title }}</dt>
<dd>Dates: 1962-1986</dd>
<dd>Sites: Vietnam and areas exposed to herbicides</dd>
</dl>
