### PR TITLE
Update 4-get-filing-fullydeveloped-dbq.md

### DIFF
--- a/_disability/4-get-filing-fullydeveloped-dbq.md
+++ b/_disability/4-get-filing-fullydeveloped-dbq.md
@@ -12,7 +12,7 @@ template: 6-info-page
 <div class="small-12 columns" markdown="0">
 
 <ul class="breadcrumbs" role="menubar" aria-label="Primary">
-<li class="parent"><a href="{{ site.url }}/disability-benefits/">Disability benefits</a></li>
+<li class="parent"><a href="{{ site.url }}/disability-benefits/">Disability Benefits</a></li>
 <li class="parent"><a href="{{ site.url }}/disability-benefits/get/">Apply for Benefits</a></li>
 <li class="parent"><a href="{{ site.url }}/disability-benefits/get/filing">Filing</a></li>
 <li class="active">{{ page.title }}</li>
@@ -38,13 +38,16 @@ template: 6-info-page
 
 <div class="call-out" markdown="1">
 
-### Yes.
-
-If you’re an active-duty Servicemember, you can initiate a [predischarge claim](/disability-benefits/get/filing/active-duty/).
-
-If you’re filing after separation, you can use the Disability Benefits Questionnaires (DBQs) to create a fully developed claim.
 
 </div>  
+
+<div class="call-out" markdown="1">
+
+### Fully Developed Claim
+
+The Fully Developed Claims (FDC) program is an optional way for Veterans and survivors to get faster decisions by submitting all relevant records in their possession, and those records which are easily obtainable, such as private medical records, when they make their claim and certify that they have no further evidence to submit. VA can process these claims more quickly.
+
+</div>
 
 <div class="call-out" markdown="1">
 
@@ -54,7 +57,7 @@ To speed up the processing of compensation and pension claims, you now have the 
 
 If you choose to go to your own healthcare provider, you will need to bring the appropriate Disability Benefits Questionnaires, or DBQs. These downloadable forms that are specific to your [condition](http://www.benefits.va.gov/COMPENSATION/dbq_ListByDBQFormName.asp) or [symptom](http://www.benefits.va.gov/COMPENSATION/dbq_ListBySymptom.asp) enable private healthcare providers to capture important information needed by VA to accurately evaluate and promptly decide on your claims for benefits.
 
-Visit our [DBQ List by Form Name](http://www.benefits.va.gov/COMPENSATION/dbq_ListByDBQFormName.asp) or [DBQ List by Symptom](http://www.benefits.va.gov/COMPENSATION/dbq_ListBySymptom.asp) pages to access the 70 forms available. See detailed instructions:
+Visit our [DBQ List by Form Name](http://www.benefits.va.gov/COMPENSATION/dbq_ListByDBQFormName.asp) or [DBQ List by Symptom](http://www.benefits.va.gov/COMPENSATION/dbq_ListBySymptom.asp) to access the 70 forms available. See detailed instructions:
 
 -	[Veteran](http://www.benefits.va.gov/compensation/dbq_veteraninstruct.asp)
 -	[VSO](http://www.benefits.va.gov/compensation/dbq_vsoinstruct.asp)
@@ -68,17 +71,13 @@ Visit our [DBQ List by Form Name](http://www.benefits.va.gov/COMPENSATION/dbq_Li
 
 See our [DBQ Frequently Asked Questions](http://www.benefits.va.gov/COMPENSATION/dbq_FAQS.asp) for more information. You can also call us at 1-800-827-1000 or [ask us a question online](https://iris.custhelp.com/app/ask/session/L3RpbWUvMTMyMzEwMDk5My9zaWQvM0htaElRS2s%3D).
 
-DBQs also help support VA's Fully Developed Claims (FDC) program. DBQs are valuable for claims processing because they provide medical information that is relevant to determining a disability rating. When submitted with a [fully developed claim](http://benefits.va.gov/transformation/fastclaims/), DBQs ensure VA's rating specialists have precisely the information they need to start processing the claim.
+DBQs help support VA's Fully Developed Claims (FDC) program. DBQs are valuable for claims processing because they provide medical information that is relevant to determining a disability rating. When submitted with a [Fully Developed Claim](http://benefits.va.gov/transformation/fastclaims/), DBQs ensure VA's rating specialists have precisely the information they need to start processing the claim.
+
+If you’re an active-duty Servicemember, you can initiate a [predischarge claim](/disability-benefits/get/filing/active-duty/).
 
 </div>
 
-<div class="call-out" markdown="1">
 
-### Fully Developed Claim
-
-The Fully Developed Claims (FDC) program is an optional way for Veterans and survivors to get faster decisions by submitting all relevant records in their possession, and those records which are easily obtainable, such as private medical records, when they make their claim and certify that they have no further evidence to submit. VA can process these claims more quickly.
-
-</div>
 
 </div>
 </div>


### PR DESCRIPTION
Brought Fully Developed Claim section to the top of the page. Deleted the blue box that was at the top with "Yes" as a header. Moved predischarge claim sentence with link to the Where can I get more info? section. And a couple small proof changes.
