### PR TITLE
remove routes for healthcare and healthcare-apply

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,6 @@ collections:
   - disability
   - education
   - loans
-  - health-care
   - pension
   - insurance
   - memorial
@@ -73,9 +72,6 @@ collections:
   loans:
     output: true
     permalink: /loans/:path/
-  health-care:
-    output: true
-    permalink: /health-care/:path/
   pension:
     output: true
     permalink: /pension/:path/


### PR DESCRIPTION
Since we'll need this one day, leaving the files, but removing the routes... because there's not a lot to do in the healthcare section
