### PR TITLE
Change va.gov link to www.va.gov

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -57,7 +57,7 @@
 
     <div class="large-8 columns">
       <ul class="final-list">
-        <li><a target="_blank" href="http://va.gov/">VA.gov</a></li>
+        <li><a target="_blank" href="http://www.va.gov/">VA.gov</a></li>
         <li><a target="_blank" href="http://www.va.gov/oig/">Inspector General</a></li>
         <li><a target="_blank" href="http://www.section508.va.gov/">Accessibility</a></li>
         <li><a target="_blank" href="http://www.va.gov/privacy/">Privacy</a></li>


### PR DESCRIPTION
Seems like people on the internal VA network get an error when the link goes straight to va.gov (without www)
