### PR TITLE
Add build_production rake task.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ task :build do
   sh "bundle exec jekyll build"
 end
 
-desc "Build the website with produciton configs"
+desc "Build the website with production configs"
 task :build_production do
   sh "webpack"
   sh "bundle exec jekyll build --config _config.yml,_config_production.yml"

--- a/Rakefile
+++ b/Rakefile
@@ -39,6 +39,12 @@ task :build do
   sh "bundle exec jekyll build"
 end
 
+desc "Build the website with produciton configs"
+task :build_production do
+  sh "webpack"
+  sh "bundle exec jekyll build --config _config.yml,_config_production.yml"
+end
+
 desc "Push the *remote* master branch to *remote* production. Does NOT merge."
 task :deploy do
   run_in_cloned_git do

--- a/_config.yml
+++ b/_config.yml
@@ -2,19 +2,26 @@ name: Vets.gov
 
 domain: staging.vets.gov
 
+destination:  ./_site
+
 #files to exclude, array
 exclude:
   - "/node_modules"
   - "/spec"
   - "/vendor/bundle"
-  - Gemfile
-  - Gemfile.lock
-  - README.md
-  - Procfile
-  - Rakefile
-  - app.json
-  - karma.conf.js
-  - npm-debug.log
+  - "Gemfile"
+  - "Gemfile.lock"
+  - "Procfile"
+  - "README.md"
+  - "Rakefile"
+  - "_site"
+  - "_site_production"
+  - "app.json"
+  - "karma.conf.js"
+  - "npm-debug.log"
+  - "package.json"
+  - "npm-shrinkwrap.json"
+  - "webpack.config.js"
 
 #posts per page
 paginate: 4

--- a/_config_production.yml
+++ b/_config_production.yml
@@ -1,1 +1,2 @@
 domain: www.vets.gov
+destination:  ./_site_production


### PR DESCRIPTION
Currently, deploys are done off the exact same build settings in staging
and production which is allowing for code leakage to the production
website. This adds a `build_production` rake task that produces a
_site_production directory.  Having a different output target makes
it harder to cross wires during deploy.

This isn't a complete solution as the CI set up does NOT run against
the production directory. Checking this is first to fix the current
production fire. Will fix CI next.
