### PR TITLE
Use -p for production webpack; fix invocation.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,13 +35,13 @@ end
 
 desc "Build the website"
 task :build do
-  sh "webpack"
+  sh "npm run-script webpack"
   sh "bundle exec jekyll build"
 end
 
 desc "Build the website with production configs"
 task :build_production do
-  sh "webpack"
+  sh "npm run-script webpack -- -p --config webpack_production.config.js"
   sh "bundle exec jekyll build --config _config.yml,_config_production.yml"
 end
 
@@ -96,11 +96,11 @@ namespace :tests do
 
   desc "Run Javascript tests in a single-shot."
   task :javascript do
-    sh "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+    sh "npm run-script karma -- start --single-run --browsers PhantomJS"
   end
 
   desc "Run Javascript tests continuously."
   task :javascript_watch do
-    sh "./node_modules/.bin/karma start --browsers PhantomJS"
+    sh "npm run-script karma -- start --browsers PhantomJS"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,4 +1,13 @@
 {
+  "//": "Javascript libraries actually deployed to production.",
+  "dependencies": {
+    "classlist-polyfill": "^1.0.2",
+    "dataset": "^0.3.1",
+    "foundation": "^4.2.1-1",
+    "jquery": "^2.2.0",
+    "sizzle": "^2.3.0",
+    "wow.js": "^1.1.2"
+  },
   "//": "Used by Karma the test runner and Webpack, for managing JS libraries.",
   "devDependencies": {
     "chai": "^3.5.0",
@@ -22,13 +31,9 @@
     "phantomjs": "^1.9.19",
     "webpack": "^1.12.13"
   },
-  "private": true,
-  "dependencies": {
-    "classlist-polyfill": "^1.0.2",
-    "dataset": "^0.3.1",
-    "foundation": "^4.2.1-1",
-    "jquery": "^2.2.0",
-    "sizzle": "^2.3.0",
-    "wow.js": "^1.1.2"
-  }
+  "scripts": {
+    "webpack": "webpack",
+    "karma": "karma"
+  },
+  "private": true
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,3 @@
-// webpack.config.js
 var path = require('path');
 var webpack = require('webpack');
 

--- a/webpack_production.config.js
+++ b/webpack_production.config.js
@@ -1,0 +1,7 @@
+var path = require('path');
+
+var config = require ('./webpack.config');
+
+config.output.path = path.join(__dirname, "_site_production/assets/js/generated");
+
+module.exports = config;


### PR DESCRIPTION
- Use -p to minify and optimize JS code in webpack.
- Use npm scripts so neither `npm install -g` nor reaching into
  node_mules is needed for webpack and karma.

fixes #1158.
