### PR TITLE
Add more retry logic for the install step.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ install:
 
 script:
   - rake tests:ci
-cache:
-  directories:
-    - node_modules
-    - vendor/bundle
 notifications:
   email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 install:
-  - rake install
+  - travis_retry rake install
 
 script:
   - rake tests:ci

--- a/Rakefile
+++ b/Rakefile
@@ -67,7 +67,7 @@ end
 
 desc "Install dependencies for serving and development"
 task :install do
-  sh "bundle install --jobs 3 --retry=3 --deployment"
+  sh "bundle install --jobs 3 --deployment"
   sh "npm install"
 end
 


### PR DESCRIPTION
NPM was seeing spurious failures trying to install packages. It looked like
network errors. This article from 2013:

  https://blog.travis-ci.com/2013-05-20-network-timeouts-build-retries/

makes it look like large installs sometimes stresses out the network
enough that they fail.

Using the `travis_retry` runner to handle invoking the install scripts N
times. Also removing the bundler retry flag so as to not retry 9 times
accidentally.

This will slow things down, but at least it'll likely be more robust.

Fingers crossed it will mask the issue well enough.
