### PR TITLE
Fix path for health care form in karma.conf.js

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       'spec/javascripts/**/*.spec.js',
-      { pattern: '_site/health-care/form.html', watched: true, included: false, served: true, nocache: true },
+      { pattern: '_site/health-care/form/index.html', watched: true, included: false, served: true, nocache: true },
       { pattern: '_site/**/*', watched: false, included: false, served: true, nocache: true },
       { pattern: 'spec/fixtures/javascripts/**/*', watched: true, included: false, served: true, nocache: true }
     ],


### PR DESCRIPTION
Issue noticed during code review this afternoon. Removes a warning when running `rake test:ci`.
