### PR TITLE
Create social security component and error message component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 #Compiled files.
 .sass-cache
 _site/
+_site_production/
 node_modules/
 vendor/bundle
 .ruby-gemset

--- a/_health-care/_js/_components/error-message.jsx
+++ b/_health-care/_js/_components/error-message.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+/**
+ * An error message to be included conditionally by question components in an error state.
+ *
+ * @constructor
+ */
+class ErrorMessage extends React.Component {
+  render() {
+    return (
+      <span className="usa-input-error-message"
+          id={`input-error-message-${this.props.idPrefix}`}
+          role="alert">{this.props.message}</span>
+    );
+  }
+}
+
+export default ErrorMessage;

--- a/_health-care/_js/_components/health-care-app.jsx
+++ b/_health-care/_js/_components/health-care-app.jsx
@@ -26,6 +26,8 @@ class HealthCareApp extends React.Component {
 
           mothersMaidenName: 'Arden',
 
+          socialSecurityNumber: '999-99-9999',
+
           dateOfBirth: {
             month: '1',
             day: '15',

--- a/_health-care/_js/_components/name-and-general-info-section.jsx
+++ b/_health-care/_js/_components/name-and-general-info-section.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import DateInput from './date-input';
 import FullName from './full-name';
 import MothersMaidenName from './mothers-maiden-name';
+import SocialSecurityNumber from './social-security-number';
 
 class NameAndGeneralInfoSection extends React.Component {
   render() {
@@ -21,19 +22,14 @@ class NameAndGeneralInfoSection extends React.Component {
                   onUserInput={(update) => {this.props.onStateChange('fullName', update);}}/>
               <MothersMaidenName name={this.props.data.mothersMaidenName}
                   onUserInput={(update) => {this.props.onStateChange('mothersMaidenName', update);}}/>
+              <SocialSecurityNumber ssn={this.props.data.socialSecurityNumber}
+                  onUserInput={(update) => {this.props.onStateChange('socialSecurityNumber', update);}}/>
             </div>
             <div className="small-12 columns">
               <h4>Date of Birth</h4>
               <span className="usa-form-hint usa-datefield-hint" id="dobHint">For example: 04 28 1986</span>
               <DateInput date={this.props.data.dateOfBirth}
                   onUserInput={(update) => {this.props.onStateChange('dateOfBirth', update);}}/>
-            </div>
-            <div className="usa-input-grid usa-input-grid-medium usa-input-error">
-              <label className="usa-input-error-label" htmlFor="veteran_ssn">Social Security Number
-                <span className="usa-additional_text">Required</span>
-              </label>
-              <span className="usa-input-error-message" id="input-error-message" role="alert">Please put you number in this format xxx-xx-xxxx</span>
-              <input type="text" name="veteran[ssn]" aria-describedby="input-error-message"/>
             </div>
           </div>
 

--- a/_health-care/_js/_components/social-security-number.jsx
+++ b/_health-care/_js/_components/social-security-number.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import _ from 'lodash';
+
+import TextInputRequired from './text-input-required';
+
+/**
+ * A component for social security number. Includes component for required text input.
+ * Adds error markup if in an error state: error class, error id for aria, and
+ * ErrorMessage component.
+ *
+ * @constructor
+ */
+class SocialSecurityNumber extends React.Component {
+  constructor() {
+    super();
+    // In general, I think we need to store the error state at the top level component,
+    // like we are with form data, and create the one-way data flow with that as well.
+    // This may solve the problems we're having with fields not registering errors
+    // on page refresh.
+    this.state = { hasError: false };
+    this.handleErrorChange = this.handleErrorChange.bind(this);
+  }
+
+  componentWillMount() {
+    this.id = _.uniqueId();
+  }
+
+  // TODO: What this really needs to do is loop through the inputs and if any have
+  // a state of true it needs to set the error state to true
+  // TODO: Issue #1238: figure out why this isn't getting called the first time
+  handleErrorChange(state) {
+    this.setState({ hasError: state });
+  }
+
+  render() {
+    const errorClass = this.state.hasError ? 'usa-input-error' : '';
+    return (
+      <div>
+        <div className={`usa-input-grid usa-input-grid-medium ${errorClass}`}>
+          <label className={`${errorClass}-label`} htmlFor={`${this.id}_snn`}>Social Security Number
+            <span className="usa-additional_text">Required</span>
+          </label>
+          <TextInputRequired
+              errorMessage="Please put your number in this format xxx-xx-xxxx"
+              // I don't think these "passUp" functions are a good idea, but it's just something
+              // I mocked up to see if the concept would even work.
+              passErrorUp={(state) => {this.handleErrorChange(state);}}
+              passValueUp={(update) => {this.props.onUserInput(update);}}
+              placeholder="xxx-xx-xxxx"
+              question="ssn"
+              questionValue={this.props.ssn}/>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default SocialSecurityNumber;

--- a/_health-care/_js/_components/text-input-required.jsx
+++ b/_health-care/_js/_components/text-input-required.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import _ from 'lodash';
+
+import ErrorMessage from './error-message';
+
+/**
+ * An text input to be included by any question component for a field that is not required.
+ *
+ * @constructor
+ */
+class TextInputRequired extends React.Component {
+  constructor() {
+    super();
+    this.state = { hasError: false };
+    this.handleInputChange = this.handleInputChange.bind(this);
+  }
+
+  componentWillMount() {
+    this.id = _.uniqueId();
+  }
+
+  handleInputChange() {
+    const fieldValue = this.refs.textInput.value;
+
+    if (!this.validate(fieldValue)) {
+      this.setState({ hasError: true });
+    } else {
+      this.setState({ hasError: false });
+    }
+
+    this.props.passValueUp(fieldValue);
+    this.props.passErrorUp(this.state.hasError);
+  }
+
+  validate(fieldValue) {
+    // TODO: create basic validation for presence and include specific SSN
+    // validation in the SSN component and pass down to TextInputRequired
+    return fieldValue !== '' && /^\d{3}-\d{2}-\d{4}$/.test(fieldValue);
+  }
+
+  render() {
+    let errorMessage = '';
+    if (this.state.hasError) {
+      errorMessage = <ErrorMessage message={this.props.errorMessage} idPrefix={this.id}/>;
+    }
+    return (
+      <div>
+        {errorMessage}
+        <input id={`${this.id}_${this.props.question}`}
+            onChange={this.handleInputChange}
+            placeholder={this.props.placeholder}
+            ref="textInput"
+            type="text"
+            value={this.props.questionValue}/>
+      </div>
+    );
+  }
+}
+
+export default TextInputRequired;

--- a/spec/javascripts/health-care/components/error-message.spec.jsx
+++ b/spec/javascripts/health-care/components/error-message.spec.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
+import ErrorMessage from '../../../../_health-care/_js/_components/error-message';
+
+describe('<ErrorMessage>', () => {
+  let component = null;
+
+  beforeEach(() => {
+    component = ReactTestUtils.renderIntoDocument(
+      <ErrorMessage message="There is an error here"/>
+    );
+    assert.ok(component, 'Cannot even render component');
+  });
+
+  it('has sane looking features', () => {
+    const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(component, 'span');
+    expect(inputs).to.have.length(1);
+  });
+
+  it('has the appropriate className', () => {
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(
+        component, 'usa-input-error-message')).to.have.length(1);
+  });
+
+  // This test is going to fail because it requires knowledge of the id set in the parent component,
+  // which isn't rendered here.
+  xit('has the correct content', () => {
+    const renderer = ReactTestUtils.createRenderer();
+    renderer.render(<ErrorMessage message="There is an error here"/>);
+    const renderedResult = renderer.getRenderOutput();
+    expect(renderedResult).to.eql(
+      <span className="usa-input-error-message" id="input-error-message" role="alert">There is an error here</span>
+    );
+  });
+});

--- a/spec/javascripts/health-care/components/social-security-number.spec.jsx
+++ b/spec/javascripts/health-care/components/social-security-number.spec.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
+import SocialSecurityNumber from '../../../../_health-care/_js/_components/social-security-number';
+
+describe('<SocialSecurityNumber>', () => {
+  let component = null;
+
+  beforeEach(() => {
+    component = ReactTestUtils.renderIntoDocument(
+      <SocialSecurityNumber ssn={{ ssn: '999-99-9999' }} onUserInput={(_update) => {}}/>
+    );
+    assert.ok(component, 'Cannot even render component');
+  });
+
+  it('has sane looking features', () => {
+    const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(component, 'input');
+    expect(inputs).to.have.length(1);
+  });
+
+  xit('sets and removes error css on invalid SSN', () => {
+    // Initial state should be valid.
+    expect(component.state.hasError).to.be.false;
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(
+        component, 'usa-input-error')).to.have.length(0);
+
+    // Valid SSN has no error.
+    component.refs.ssn.value = '123-45-6789';
+    ReactTestUtils.Simulate.change(component.refs.ssn);
+    expect(component.state.hasError).to.be.false;
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(
+        component, 'usa-input-error')).to.have.length(0);
+
+    // SSN with alphabetical characters is invalid.
+    component.refs.ssn.value = '123-45-678a';
+    ReactTestUtils.Simulate.change(component.refs.ssn);
+    expect(component.state.hasError).to.be.true;
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(
+        component, 'usa-input-error')).to.have.length(1);
+
+    // SSN without dashes is invalid.
+    component.refs.ssn.value = '123456789';
+    ReactTestUtils.Simulate.change(component.refs.ssn);
+    expect(component.state.hasError).to.be.true;
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(
+        component, 'usa-input-error')).to.have.length(1);
+
+    // SSN with too few numbers is invalid.
+    component.refs.ssn.value = '123-45-678';
+    ReactTestUtils.Simulate.change(component.refs.ssn);
+    expect(component.state.hasError).to.be.true;
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(
+        component, 'usa-input-error')).to.have.length(1);
+
+    // SSN with non-numberic characters is invalid.
+    component.refs.ssn.value = '#12-34-5678';
+    ReactTestUtils.Simulate.change(component.refs.ssn);
+    expect(component.state.hasError).to.be.true;
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(
+        component, 'usa-input-error')).to.have.length(1);
+  });
+
+  xit('includes ErrorMessage component when invalid SSN', () => {
+    // ErrorMessage component should not be present when valid.
+    component.refs.ssn.value = '123-45-6789';
+    ReactTestUtils.Simulate.change(component.refs.ssn);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(
+        component, 'usa-input-error-message')).to.have.length(0);
+
+    // ErrorMessage component should be present when invalid.
+    component.refs.ssn.value = '123-45-678';
+    ReactTestUtils.Simulate.change(component.refs.ssn);
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithClass(
+        component, 'usa-input-error-message')).to.have.length(1);
+  });
+});


### PR DESCRIPTION
Created a component for SSN and another one for error message that is included conditionally within SSN if there is an error. We might want to include this `ErrorMessage` component in other question components as well. Also created specs for both of these new components.

I included validation for SSN, but I did not including data masking. I was not sure if this is the right UX choice to make, so I left it out for now, but we can always include it. I did some research and it looks like all of the data masking plugins require jQuery, so if we want to include something we may have to create something of our own (which shouldn't be difficult, I already tried a few things).
