### PR TITLE
Revert "Only build master"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,4 @@
 language: ruby
-
-branches:
-  only:
-    - master
-
 install:
   - rake install
 


### PR DESCRIPTION
This reverts commit e4fc2b6d613a25d017c8ad73d837739beed27383.

This condition breaks deploys to production because Travis will disable itself. It's possible we should just add production to the array, but for now reverting is safer.
