### PR TITLE
Try to force webpack to build on the production branch.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,7 +84,7 @@ end
 
 desc "Run webpack with production settings"
 task :webpack_production do
-  sh "npm run-script webpack -- -p --config webpack_production.config.js"
+  sh "npm run-script webpack-production"
 end
 
 desc "Run the development webpack in watch mode"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "watch": "npm start & npm run watch-js & npm run watch-lint",
     "watch-js": "karma start",
     "watch-lint": "nodemon --watch _health-care/_js --watch _webpack --watch assets/js/entry.js --ignore _webpack/public/assets/js/generated --watch spec --ext js,jsx --exec 'npm run lint'",
-    "webpack": "webpack"
+    "webpack": "webpack",
+    "webpack-production": "webpack -p --config webpack_production.config.js"
   },
   "private": true
 }


### PR DESCRIPTION
Something changed in the way npm passes parameters such that the rake command invoking the production build of webpack was silently failing. This meant that the deploy did not have a bundle.js breaking all JS on the site.
