### PR TITLE
ErrorableCheckbox

### DIFF
--- a/_health-care/_js/components/HealthCareApp.jsx
+++ b/_health-care/_js/components/HealthCareApp.jsx
@@ -41,11 +41,25 @@ class HealthCareApp extends React.Component {
             }
           },
 
-          vaInformation: {},
+          vaInformation: {
+            isVaServiceConnected: false,
+            compensableVaServiceConnected: false,
+            receivesVaPension: false
+          },
 
-          additionalInformation: {},
+          additionalInformation: {
+            isEssentialAcaCoverage: false,
+            wantsInitialVaContact: false
+          },
 
-          demographicInformation: {},
+          demographicInformation: {
+            isSpanishHispanicLatino: false,
+            isAmericanIndianOrAlaskanNative: false,
+            isBlackOrAfricanAmerican: false,
+            isNativeHawaiianOrOtherPacificIslander: false,
+            isAsian: false,
+            isWhite: false
+          },
 
           veteranAddress: {}
         }

--- a/_health-care/_js/components/PersonalInformationPanel.jsx
+++ b/_health-care/_js/components/PersonalInformationPanel.jsx
@@ -14,17 +14,37 @@ class PersonalInformationPanel extends React.Component {
             data={this.props.applicationData.personalInformation.nameAndGeneralInfo}
             onStateChange={
               (subfield, update) => {
-                this.props.publishStateChange(['personalInformation', subfield], update);
+                this.props.publishStateChange(['personalInformation', 'nameAndGeneralInfo', subfield], update);
               }
             }/>
         <VAInformationSection
-            data={this.props.applicationData.personalInformation.vaInformation}/>
+            data={this.props.applicationData.personalInformation.vaInformation}
+            onStateChange={
+              (subfield, update) => {
+                this.props.publishStateChange(['personalInformation', 'vaInformation', subfield], update);
+              }
+            }/>
         <AdditionalInformationSection
-            data={this.props.applicationData.personalInformation.additionalInformation}/>
+            data={this.props.applicationData.personalInformation.additionalInformation}
+            onStateChange={
+              (subfield, update) => {
+                this.props.publishStateChange(['personalInformation', 'additionalInformation', subfield], update);
+              }
+            }/>
         <DemographicInformationSection
-            data={this.props.applicationData.personalInformation.demographicInformation}/>
+            data={this.props.applicationData.personalInformation.demographicInformation}
+            onStateChange={
+              (subfield, update) => {
+                this.props.publishStateChange(['personalInformation', 'demographicInformation', subfield], update);
+              }
+            }/>
         <VeteranAddressSection
-            data={this.props.applicationData.personalInformation.veteranAddress}/>
+            data={this.props.applicationData.personalInformation.veteranAddress}
+            onStateChange={
+              (subfield, update) => {
+                this.props.publishStateChange(['personalInformation', 'veteranAddress', subfield], update);
+              }
+            }/>
       </div>
     );
   }

--- a/_health-care/_js/components/form-elements/ErrorableCheckbox.jsx
+++ b/_health-care/_js/components/form-elements/ErrorableCheckbox.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import _ from 'lodash';
+
+/**
+ * A form checkbox with a label that can display error messages.
+ *
+ * Validation has the following props.
+ * `checked` - Boolean. Whether or not the checkbox is checked.
+ * `errorMessage` - Error string to display in the component.
+ *                  When defined, indicates checkbox has a validation error.
+ * `label` - String for the checkbox label.
+ * `onValueChange` - a function with this prototype: (newValue)
+ * `required` - boolean. Render marker indicating field is required.
+ */
+class ErrorableCheckbox extends React.Component {
+  constructor() {
+    super();
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  componentWillMount() {
+    this.inputId = _.uniqueId('errorable-checkbox-');
+  }
+
+  handleChange(domEvent) {
+    this.props.onValueChange(domEvent.target.checked);
+  }
+
+  render() {
+    // TODO: extract error logic into a utility function
+    // Calculate error state.
+    let errorSpan = '';
+    let errorSpanId = undefined;
+    if (this.props.errorMessage) {
+      errorSpanId = `${this.inputId}-error-message`;
+      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
+    }
+
+    // Calculate required.
+    let requiredSpan = '';
+    if (this.props.required) {
+      requiredSpan = <span className="usa-additional_text">Required</span>;
+    }
+
+    return (
+      <div className={`usa-input-grid usa-input-grid-large ${this.props.errorMessage ? 'usa-input-error' : ''}`}>
+        <input
+            aria-describedby={errorSpanId}
+            checked={this.props.checked}
+            id={this.inputId}
+            type="checkbox"
+            onChange={this.handleChange}/>
+        <label
+            className={this.props.errorMessage ? 'usa-input-error-label' : undefined}
+            htmlFor={this.inputId}>
+              {this.props.label}
+              {requiredSpan}
+        </label>
+        {errorSpan}
+      </div>
+    );
+  }
+}
+
+ErrorableCheckbox.propTypes = {
+  checked: React.PropTypes.bool,
+  errorMessage: React.PropTypes.string,
+  label: React.PropTypes.string.isRequired,
+  onValueChange: React.PropTypes.func.isRequired,
+  required: React.PropTypes.bool,
+};
+
+export default ErrorableCheckbox;

--- a/_health-care/_js/components/personal-information/AdditionalInformationSection.jsx
+++ b/_health-care/_js/components/personal-information/AdditionalInformationSection.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import ErrorableCheckbox from '../form-elements/ErrorableCheckbox';
+
 class AdditionalInformationSection extends React.Component {
   render() {
     return (
@@ -12,11 +14,10 @@ class AdditionalInformationSection extends React.Component {
 
         <div className="row">
           <div className="small-12 columns">
-            <input
-                type="checkbox"
-                id="veteran_is_essential_aca_coverage"
-                name="veteran_is_essential_aca_coverage"/>
-            <label htmlFor="veteran_is_essential_aca_coverage">I am enrolling to obtain minimal essential coverage under the affordable care act</label>
+            <ErrorableCheckbox
+                label="I am enrolling to obtain minimal essential coverage under the affordable care act"
+                checked={this.props.data.isEssentialAcaCoverage}
+                onValueChange={(update) => {this.props.onStateChange('isEssentialAcaCoverage', update);}}/>
           </div>
         </div>
 
@@ -36,11 +37,10 @@ class AdditionalInformationSection extends React.Component {
 
         <div className="row">
           <div className="small-12 columns">
-            <input
-                type="checkbox"
-                name="veteran_wants_initial_va_contact"
-                id="veteran_wants_initial_va_contact"/>
-            <label htmlFor="veteran_wants_initial_va_contact">Do you want VA to contact you to schedule your first appointment?</label>
+            <ErrorableCheckbox
+                label="Do you want VA to contact you to schedule your first appointment?"
+                checked={this.props.data.wantsInitialVaContact}
+                onValueChange={(update) => {this.props.onStateChange('wantsInitialVaContact', update);}}/>
           </div>
         </div>
       </div>

--- a/_health-care/_js/components/personal-information/DemographicInformationSection.jsx
+++ b/_health-care/_js/components/personal-information/DemographicInformationSection.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import ErrorableCheckbox from '../form-elements/ErrorableCheckbox';
+
 class DemographicInformationSection extends React.Component {
   render() {
     return (
@@ -12,11 +14,10 @@ class DemographicInformationSection extends React.Component {
 
         <div className="row">
           <div className="small-12 columns">
-            <input
-                type="checkbox"
-                id="veteran_is_spanish_hispanic_latino"
-                name="veteran_is_spanish_hispanic_latino"/>
-            <label htmlFor="veteran_is_spanish_hispanic_latino">Are you Spanish, Hispanic, or Lantino?</label>
+            <ErrorableCheckbox
+                label="Are you Spanish, Hispanic, or Lantino?"
+                checked={this.props.data.isSpanishHispanicLatino}
+                onValueChange={(update) => {this.props.onStateChange('isSpanishHispanicLatino', update);}}/>
           </div>
         </div>
 
@@ -24,35 +25,30 @@ class DemographicInformationSection extends React.Component {
           <div className="small-12 columns">
             <h4>What is your race?</h4>
             <span className="usa-form-hint">You may check more than one.</span>
-            <input
-                type="checkbox"
-                id="veteran_is_american_indian_or_alaksa_native"
-                name="veteran_is_american_indian_or_alaksa_native"/>
-            <label htmlFor="veteran_is_american_indian_or_alaksa_native">American Indian or Alaksan Native</label>
+            <ErrorableCheckbox
+                label="American Indian or Alaksan Native"
+                checked={this.props.data.isAmericanIndianOrAlaskanNative}
+                onValueChange={(update) => {this.props.onStateChange('isAmericanIndianOrAlaskanNative', update);}}/>
 
-            <input
-                type="checkbox"
-                id="veteran_is_black_or_african_american"
-                name="veteran_is_black_or_african_american"/>
-            <label htmlFor="veteran_is_black_or_african_american">Black or African American</label>
+            <ErrorableCheckbox
+                label="Black or African American"
+                checked={this.props.data.isBlackOrAfricanAmerican}
+                onValueChange={(update) => {this.props.onStateChange('isBlackOrAfricanAmerican', update);}}/>
 
-            <input
-                type="checkbox"
-                id="veteran_is_native_hawaiian_or_other_pacific_islander"
-                name="veteran_is_native_hawaiian_or_other_pacific_islander"/>
-            <label htmlFor="veteran_is_native_hawaiian_or_other_pacific_islander">Native Hawaiian or Other Pacific Islander</label>
+            <ErrorableCheckbox
+                label="Native Hawaiian or Other Pacific Islander"
+                checked={this.props.data.isNativeHawaiianOrOtherPacificIslander}
+                onValueChange={(update) => {this.props.onStateChange('isNativeHawaiianOrOtherPacificIslander', update);}}/>
 
-            <input
-                type="checkbox"
-                id="veteran_is_asian"
-                name="veteran[is_asian]"/>
-            <label htmlFor="veteran_is_asian">Asian</label>
+            <ErrorableCheckbox
+                label="Asian"
+                checked={this.props.data.isAsian}
+                onValueChange={(update) => {this.props.onStateChange('isAsian', update);}}/>
 
-            <input
-                type="checkbox"
-                id="veteran_is_white"
-                name="veteran_is_white"/>
-            <label htmlFor="veteran_is_white">White</label>
+            <ErrorableCheckbox
+                label="White"
+                checked={this.props.data.isWhite}
+                onValueChange={(update) => {this.props.onStateChange('isWhite', update);}}/>
           </div>
         </div>
       </div>

--- a/_health-care/_js/components/personal-information/VAInformationSection.jsx
+++ b/_health-care/_js/components/personal-information/VAInformationSection.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import ErrorableCheckbox from '../form-elements/ErrorableCheckbox';
+
 class VaInformationSection extends React.Component {
   render() {
     return (
@@ -12,26 +14,20 @@ class VaInformationSection extends React.Component {
             Health Benefits you should complete.
           </p>
 
-          <input
-              id="veteran_is_service_connected_50_100"
-              name="veteran_is_service_connected_50_100"
-              type="checkbox"
-              value="veteran_is_service_connected_50_100"/>
-          <label htmlFor="veteran_is_service_connected_50_100">Are you VA Service Connected 50% to 100% Disabled?</label>
+          <ErrorableCheckbox
+              label="Are you VA Service Connected 50% to 100% Disabled?"
+              checked={this.props.data.isVaServiceConnected}
+              onValueChange={(update) => {this.props.onStateChange('isVaServiceConnected', update);}}/>
 
-          <input
-              id="veteran_is_compensable_va_service_connected_0_40"
-              name="veteran_is_compensable_va_service_connected_0_40"
-              type="checkbox"
-              value="veteran_is_compensable_va_service_connected_0_40"/>
-          <label htmlFor="veteran_is_compensable_va_service_connected_0_40">Are you compensable VA Service Connected 0% - 40%?</label>
+          <ErrorableCheckbox
+              label="Are you compensable VA Service Connected 0% - 40%?"
+              checked={this.props.data.compensableVaServiceConnected}
+              onValueChange={(update) => {this.props.onStateChange('compensableVaServiceConnected', update);}}/>
 
-          <input
-              id="veteran_receives_va_pension"
-              name="veteran_receives_va_pension"
-              type="checkbox"
-              value="veteran_receives_va_pension"/>
-          <label htmlFor="veteran_receives_va_pension">Do you receive a VA pension?</label>
+          <ErrorableCheckbox
+              label="Do you receive a VA pension?"
+              checked={this.props.data.receivesVaPension}
+              onValueChange={(update) => {this.props.onStateChange('receivesVaPension', update);}}/>
         </div>
       </div>
     );

--- a/spec/javascripts/health-care/components/form-elements/ErrorableCheckbox.spec.jsx
+++ b/spec/javascripts/health-care/components/form-elements/ErrorableCheckbox.spec.jsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
+import SkinDeep from 'skin-deep';
+
+import ErrorableCheckbox from '../../../../../_health-care/_js/components/form-elements/ErrorableCheckbox';
+
+describe('<ErrorableCheckbox>', () => {
+  describe('propTypes', () => {
+    let consoleStub;
+    beforeEach(() => {
+      consoleStub = sinon.stub(console, 'error');
+    });
+
+    afterEach(() => {
+      consoleStub.restore();
+    });
+
+    it('label is required', () => {
+      SkinDeep.shallowRender(
+        <ErrorableCheckbox onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Required prop `label` was not specified in `ErrorableCheckbox`/);
+    });
+
+    it('label must be a string', () => {
+      SkinDeep.shallowRender(
+        <ErrorableCheckbox label onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `label` of type `boolean` supplied to `ErrorableCheckbox`, expected `string`/);
+    });
+
+    it('onValueChange is required', () => {
+      SkinDeep.shallowRender(<ErrorableCheckbox label="test"/>);
+      sinon.assert.calledWithMatch(consoleStub, /Required prop `onValueChange` was not specified in `ErrorableCheckbox`/);
+    });
+
+    it('onValueChange must be a function', () => {
+      SkinDeep.shallowRender(<ErrorableCheckbox label="test" onValueChange/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `onValueChange` of type `boolean` supplied to `ErrorableCheckbox`, expected `function`/);
+    });
+
+    it('errorMessage must be a string', () => {
+      SkinDeep.shallowRender(
+        <ErrorableCheckbox label="test" errorMessage onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `errorMessage` of type `boolean` supplied to `ErrorableCheckbox`, expected `string`/);
+    });
+
+    it('checked must be a boolean', () => {
+      SkinDeep.shallowRender(
+        <ErrorableCheckbox label="test" checked="test" onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `checked` of type `string` supplied to `ErrorableCheckbox`, expected `boolean`/);
+    });
+
+    it('required must be a boolean', () => {
+      SkinDeep.shallowRender(
+        <ErrorableCheckbox label="test" required="hi" onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `required` of type `string` supplied to `ErrorableCheckbox`, expected `boolean`/);
+    });
+  });
+
+  it('ensure checked changes propagate', () => {
+    let errorableInput;
+
+    const updatePromise = new Promise((resolve, _reject) => {
+      errorableInput = ReactTestUtils.renderIntoDocument(
+        <ErrorableCheckbox label="test" onValueChange={(update) => { resolve(update); }}/>
+      );
+    });
+
+    const input = ReactTestUtils.findRenderedDOMComponentWithTag(errorableInput, 'input');
+    input.checked = false;
+    ReactTestUtils.Simulate.change(input);
+
+    return expect(updatePromise).to.eventually.eql(false);
+  });
+
+  it('no error styles when errorMessage undefined', () => {
+    const tree = SkinDeep.shallowRender(
+      <ErrorableCheckbox label="my label" onValueChange={(_update) => {}}/>);
+
+    // No error classes.
+    expect(tree.everySubTree('.usa-input-error')).to.have.lengthOf(0);
+    expect(tree.everySubTree('.usa-input-error-label')).to.have.lengthOf(0);
+    expect(tree.everySubTree('.usa-input-error-message')).to.have.lengthOf(0);
+
+    // Ensure no unnecessary class names on label w/o error..
+    const labels = tree.everySubTree('label');
+    expect(labels).to.have.lengthOf(1);
+    expect(labels[0].props.className).to.be.undefined;
+
+    // No error means no aria-describedby to not confuse screen readers.
+    const inputs = tree.everySubTree('input');
+    expect(inputs).to.have.lengthOf(1);
+    expect(inputs[0].props['aria-describedby']).to.be.undefined;
+  });
+
+  it('has error styles when errorMessage is set', () => {
+    const tree = SkinDeep.shallowRender(
+      <ErrorableCheckbox label="my label" errorMessage="error message" onValueChange={(_update) => {}}/>);
+
+    // Ensure all error classes set.
+    expect(tree.everySubTree('.usa-input-error')).to.have.lengthOf(1);
+
+    const labels = tree.everySubTree('.usa-input-error-label');
+    expect(labels).to.have.lengthOf(1);
+    expect(labels[0].text()).to.equal('my label');
+
+    const errorMessages = tree.everySubTree('.usa-input-error-message');
+    expect(errorMessages).to.have.lengthOf(1);
+    expect(errorMessages[0].text()).to.equal('error message');
+
+    // No error means no aria-describedby to not confuse screen readers.
+    const inputs = tree.everySubTree('input');
+    expect(inputs).to.have.lengthOf(1);
+    expect(inputs[0].props['aria-describedby']).to.not.be.undefined;
+    expect(inputs[0].props['aria-describedby']).to.equal(errorMessages[0].props.id);
+  });
+
+  it('required=false does not have required span', () => {
+    const tree = SkinDeep.shallowRender(
+      <ErrorableCheckbox label="my label" onValueChange={(_update) => {}}/>);
+
+    expect(tree.everySubTree('.usa-additional_text')).to.have.lengthOf(0);
+  });
+
+  it('required=true has required span', () => {
+    const tree = SkinDeep.shallowRender(
+      <ErrorableCheckbox label="my label" required onValueChange={(_update) => {}}/>);
+
+    const requiredSpan = tree.everySubTree('.usa-additional_text');
+    expect(requiredSpan).to.have.lengthOf(1);
+    expect(requiredSpan[0].text()).to.equal('Required');
+  });
+
+  it('label attribute propagates', () => {
+    const tree = SkinDeep.shallowRender(
+      <ErrorableCheckbox label="my label" onValueChange={(_update) => {}}/>);
+
+    // Ensure label text is correct.
+    const labels = tree.everySubTree('label');
+    expect(labels).to.have.lengthOf(1);
+    expect(labels[0].text()).to.equal('my label');
+
+    // Ensure label htmlFor is attached to input id.
+    const inputs = tree.everySubTree('input');
+    expect(inputs).to.have.lengthOf(1);
+    expect(inputs[0].props.id).to.not.be.undefined;
+    expect(inputs[0].props.id).to.equal(labels[0].props.htmlFor);
+  });
+});


### PR DESCRIPTION
Created a component for checkboxes called `ErrorableCheckbox` and replaced all the markup in `PersonalInformation` with the new component. I kept in all the error logic for validations in the component, even though it doesn't look like any of the checkboxes are currently required, and therefore won't need to be validated. Also mainly copied the spec for `ErrorableTextInput` over for `ErrorableCheckbox.spec.jsx`. 
