### PR TITLE
Refactor build for local, staging, and prod builds

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require "tmpdir"
 # TODO(awong): Add method for overriding these if building on the local
 # machine. Currently it keys off of Travis configs only which makes it
 # less natural as an "API" for local development.
-enable_dev_features = (ENV['TRAVIS_BRANCH'] == "production")
+enable_dev_features = (ENV['TRAVIS_BRANCH'] != "production")
 enable_optimizations = (ENV['CI'])
 
 # Clones the current git repository into a temp directory that shares the
@@ -39,16 +39,16 @@ task :bootstrap do
   Rake::Task[:install].invoke
 end
 
-desc "Build the website with development features"
+desc "Build the website. This target chooses a dev or prod config based on environment variables"
 task :build do
   if enable_dev_features then
-    Rake::Task[:build_prod].invoke
-  else
     Rake::Task[:build_dev].invoke
+  else
+    Rake::Task[:build_prod].invoke
   end
 end
 
-desc "Build the website with development features"
+desc "Build the website with development configs"
 task :build_dev do
   Rake::Task[:webpack_dev].invoke
   sh "bundle exec jekyll build"
@@ -88,7 +88,7 @@ task :lint do
   sh "npm run-script lint"
 end
 
-desc "Run webpack with development features turned on. Build is optimized."
+desc "Run webpack with development features turned on."
 task :webpack_dev do
   sh "rm -rf assets/js/generated"
   if enable_optimizations then

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,10 @@
 require "tmpdir"
 
+# TODO(awong): Add method for overriding these if building on the local
+# machine. Currently it keys off of Travis configs only which makes it
+# less natural as an "API" for local development.
+enable_dev_features = (ENV['TRAVIS_BRANCH'] == "production")
+enable_optimizations = (ENV['CI'])
 
 # Clones the current git repository into a temp directory that shares the
 # object store. Also sets up a github remote.
@@ -31,23 +36,29 @@ task :bootstrap do
   sh "brew install npm"
 
   # Continue with install.
-  Rake::Task["install"].invoke
+  Rake::Task[:install].invoke
 end
 
-desc "Build the website"
+desc "Build the website with development features"
 task :build do
-  Rake::Task["webpack"].invoke
+  if enable_dev_features then
+    Rake::Task[:build_prod].invoke
+  else
+    Rake::Task[:build_dev].invoke
+  end
+end
+
+desc "Build the website with development features"
+task :build_dev do
+  Rake::Task[:webpack_dev].invoke
   sh "bundle exec jekyll build"
 end
 
 desc "Build the website with production configs"
-task :build_production do
-  Rake::Task["webpack_production"].invoke
+task :build_prod do
+  Rake::Task[:webpack_prod].invoke
   sh "bundle exec jekyll build --config _config.yml,_config_production.yml"
 end
-
-desc "Build every configuration"
-multitask :build_all_configurations =>  [ :build, :build_production ]
 
 desc "Push the *remote* master branch to *remote* production. Does NOT merge."
 task :deploy do
@@ -77,19 +88,29 @@ task :lint do
   sh "npm run-script lint"
 end
 
-desc "Run webpack with development settings"
-task :webpack do
-  sh "BUILD_TYPE=dev npm run-script webpack"
+desc "Run webpack with development features turned on. Build is optimized."
+task :webpack_dev do
+  sh "rm -rf assets/js/generated"
+  if enable_optimizations then
+    sh "BUILD_TYPE=dev npm run-script webpack"
+  else
+    sh "BUILD_TYPE=dev npm run-script webpack-noopt"
+  end
 end
 
-desc "Run webpack with production settings"
-task :webpack_production do
-  sh "npm run-script webpack-production"
+desc "Run webpack with production features only "
+task :webpack_prod do
+  sh "rm -rf assets/js/generated"
+  if enable_optimizations then
+    sh "npm run-script webpack-production"
+  else
+    sh "npm run-script webpack-production-noopt"
+  end
 end
 
 desc "Run the development webpack in watch mode"
 task :webpack_watch do
-  sh "BUILD_TYPE=dev npm run-script webpack -- -w"
+  sh "BUILD_TYPE=dev npm run-script webpack-noopt -- -w"
 end
 
 desc "Run the development jekyll server in watch mode"
@@ -97,10 +118,13 @@ task :jekyll_watch do
   sh "bundle exec jekyll serve"
 end
 
+# TODO(awong): This does not respect the branch so heroku will always deploy
+# no-opt with development features turned on even on the production branch
+# build. Need to find a way to pipe the config into Heroku.
 desc "Run the development jekyll server on a given port with webpack bootstrapped. Used by Heroku."
 task :heroku_serve, :port do |t, args|
   raise "heroku_serve needs port argument" if args[:port].empty?
-  Rake::Task["webpack"].invoke
+  Rake::Task[:webpack_dev].invoke
   sh "bundle exec jekyll serve -P #{args[:port]}"
 end
 
@@ -108,15 +132,19 @@ desc "Serve the website"
 multitask :serve => [ :webpack_watch, :jekyll_watch ]
 
 namespace :tests do
-  task :all => [ :build_all_configurations, :all_nobuild ]
+  task :all => [ :build, :all_nobuild ]
 
   desc "NO JEKYLL REBUILD: Run all tests including slow/flaky ones (eg external link checks)."
   task :all_nobuild => [ :ci_nobuild, :htmlproof_external_only ]
 
-  # TODO(awong): The production build does not get tested. This need to be fixed. Either
-  # it should always tests both configurations, or it should only test one and the configuration
-  # should change based on environment variable. #1177
-  task :ci=> [ :build_all_configurations, :ci_nobuild ]
+  desc "Run by the continuous build system. Looks at the environment to decide between prod/dev configs."
+  task :ci => [:build, :ci_nobuild]
+
+  desc "Builds and tests the site in development configuration"
+  task :ci_dev => [ :build_dev, :ci_nobuild ]
+
+  desc "Builds and tests the site in production configuration"
+  task :ci_prod => [ :build_prod, :ci_nobuild ]
 
   desc "NO JEKYLL REBUILD: Run standard continuous integration tests."
   task :ci_nobuild => [ :lint, :htmlproof, :javascript ]

--- a/_config.yml
+++ b/_config.yml
@@ -31,13 +31,13 @@ paginate_path: "/experience/:num/"
 
 excerpt_separator: <!--more-->
 
-#number of items in RSS feed
+# number of items in RSS feed
 rss_limit: 20
 
-#whether production or dev, minifies JS, bool
-production: true
+# whether production or dev. Allows `site.production` to enable/disable features in the Jekyll Templates.
+production: false
 
-#build config
+# build config
 
 timezone: America/New_York
 encoding: UTF-8

--- a/_config_production.yml
+++ b/_config_production.yml
@@ -1,2 +1,3 @@
 domain: www.vets.gov
 destination:  ./_site_production
+production: true

--- a/_health-care/form-react.html
+++ b/_health-care/form-react.html
@@ -3,7 +3,7 @@ title: React! Health Care! Cheerios!
 template: 1-topic-landing
 ---
 
-{% if site.domain != "staging.vets.gov" %}
+{% if site.production %}
 <div class="main" role="main">
   <div class="section primary">
     <div class="row">

--- a/_health-care/form.html
+++ b/_health-care/form.html
@@ -3,7 +3,7 @@ title: Apply for Health Care
 template: 1-topic-landing
 ---
 
-{% if site.domain != "staging.vets.gov" %}
+{% if site.production %}
 <div class="main" role="main">
   <div class="section primary">
     <div class="row">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -76,7 +76,11 @@
 
 <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
 <script src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA" id="_fed_an_ua_tag"></script>
-<script src="/assets/js/generated/bundle.js"></script>
+{% if site.production %}
+<script src="/assets/js/generated/prod/bundle.js"></script>
+{% else %}
+<script src="/assets/js/generated/dev/bundle.js"></script>
+{% endif %}
 
 <!--[if lt IE 9]>
 <script src="/assets/js/vendor/html5shiv.js"></script>

--- a/package.json
+++ b/package.json
@@ -73,8 +73,10 @@
     "watch": "npm start & npm run watch-js & npm run watch-lint",
     "watch-js": "karma start",
     "watch-lint": "nodemon --watch _health-care/_js --watch _webpack --watch assets/js/entry.js --ignore _webpack/public/assets/js/generated --watch spec --ext js,jsx --exec 'npm run lint'",
-    "webpack": "webpack",
-    "webpack-production": "webpack -p --config webpack_production.config.js"
+    "webpack": "webpack -p",
+    "webpack-noopt": "webpack",
+    "webpack-production": "webpack -p --config webpack_production.config.js",
+    "webpack-production-noopt": "webpack --config webpack_production.config.js"
   },
   "private": true
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,11 +4,11 @@ var webpack = require('webpack');
 var config = {
   entry: "./assets/js/entry.js",
   output: {
-    path: path.join(__dirname, "assets/js/generated"),
-    publicPath: "/assets/js/generated/",
+    path: path.join(__dirname, "assets/js/generated/dev"),
+    publicPath: "/assets/js/generated/dev/",
     filename: "bundle.js"
   },
-  devtool: "#source-map",
+  devtool: '#cheap-module-eval-source-map',
   module: {
     loaders: [
       {

--- a/webpack_dev.config.js
+++ b/webpack_dev.config.js
@@ -6,7 +6,6 @@ var path = require('path');
 var config = require('./webpack.config');
 
 config.output.path = path.join(__dirname, "_webpack/public/assets/js/generated");
-config.devtool = '#cheap-module-eval-source-map';
 config.entry = "./_webpack/public/fake-entry.js",
 
 module.exports = config;

--- a/webpack_production.config.js
+++ b/webpack_production.config.js
@@ -5,6 +5,8 @@ var path = require('path');
 
 var config = require('./webpack.config');
 
-config.output.path = path.join(__dirname, "_site_production/assets/js/generated");
+config.output.path = path.join(__dirname, "assets/js/generated/prod");
+config.output.publicPath = "/assets/js/generated/prod/";
+config.devtool = '#source-map';
 
 module.exports = config;


### PR DESCRIPTION
== Background ==
There are 4 effective environments.
 (a) Local desktop for iterative development.
 (b) Production (must NOT have unlreleased dev features)
 (c) Staging (must HAVE unreleased dev features)
 (d) CI PR builds which must match the environment they are merging to.

There are 3 dimensions in the above:
 (1) JS Optimization flags. On for b, c, and d but off for a.
 (2) Unreleased "dev" features. On for a, c and off for b.
     Conditionally off for d.
 (3) Output directory. _site for all but b. _site_production for b.

3 is a defensive safeguard against a dev build accidentally getting
pushed to prod (has happened before). These can be collapsed into 2
flags "enable_dev_features" and "enable_optimizations".

== Change summary ==
This CL adds rake targets that support builds varying in the reduced two
dimensions. Summary of changes to targets are as follows:
- Removed: build_all_configurations
  This was a hack used previously to make Travis always build _site and
  _site_production. However, it caused a race condition on production
  push due to the use of `multitask`. Is is no longer needed so removing.
- Changed: build
  This target now inspects the environment and either builds with
  development features on or off based on whether or not it sees a
  production branch Travis build.
- Changed: build_production -> build_prod
  Renamed to be consistent with "prod" naming used elsewhere.
  This target builds into _site_production with development features
  disabled. It has optimizations enabled if building in CI.
- Changed: build_dev
  This target builds into _site with development features enabled.
  It has optimizations enabled if building in CI.
- No change: webpack_watch
  Always builds without optimizations with dev features on.
- Added: ci_dev
  Convenience target for simulating a ci dev BUILD locally.
- Added: ci_prod
  Convenience target for simulating a ci prod BUILD locally.

Other changes:
- jekyll `site.production` variable configured correctly. Previously
  it was set but unused.
- Development sourcemaps changed to cheap version for faster
  builds.
- Javascript bundle now has environment name mangled into the path.
  Again, defensive coding to avoid crossing wires on deployment.
