### PR TITLE
Disable the menu JS when overlay div is missing.

### DIFF
--- a/assets/js/vendor/menu.js
+++ b/assets/js/vendor/menu.js
@@ -1,7 +1,12 @@
 $(document).ready(function() {
-	var triggerBttn = document.getElementById( 'trigger-overlay' ),
-		overlay = document.querySelector( 'div.overlay' ),
-		closeBttn = overlay.querySelector( 'button.overlay-close' );
+	var triggerBttn = document.getElementById( 'trigger-overlay' );
+	var overlay = document.querySelector( 'div.overlay' );
+     if (overlay === null) {
+       // More intentionally handle pages with the wrong page structure.
+       console.error('No overlay. This function should not be loaded.');
+       return;
+     }
+	var closeBttn = overlay.querySelector( 'button.overlay-close' );
 	var transEndEventNames = {
 			'WebkitTransition': 'webkitTransitionEnd',
 			'MozTransition': 'transitionend',


### PR DESCRIPTION
Some of the legacy page structure such as facility locator doesn't
follow the same DOM structure template as the other pages. Fix this JS
to log an error rather than just throw an execption in this situation.
Not significantly better, but at least it looks semi-intentional.
