### PR TITLE
Remove aria-hidden=true & display:none equivalence

### DIFF
--- a/_sass/core/_base.scss
+++ b/_sass/core/_base.scss
@@ -19,7 +19,3 @@ body {
     filter: none !important;
   }
 }
-
-[aria-hidden=true] {
-  display: none !important;
-}


### PR DESCRIPTION
Per ARIA spec, https://www.w3.org/TR/wai-aria/states_and_properties#aria-hidden
aria-hidden MAY be used for DOM elements that should be visibly
rendered, but the removal of which will improve the experience of users
of assistive technology.

Classic example of this seems to be Google Maps divs with the map tiles
which must be displayed for non-assistive browsers but which are not
useful for screen readers since it is picture information. Equiating
area-hidden and display:none in CSS incorrectly breaks the non-ARIA
experience.
