### PR TITLE
Hca refactor fullname

### DIFF
--- a/_health-care/_js/components/financial-assessment/SpouseInformationSection.jsx
+++ b/_health-care/_js/components/financial-assessment/SpouseInformationSection.jsx
@@ -44,7 +44,7 @@ class SpouseInformationSection extends React.Component {
                   label="Suffix"
                   options={suffixes}
                   value={this.props.data.spouseSuffix}
-                  onUserInput={(update) => {this.props.onStateChange('spouseSuffix', update);}}/>
+                  onValueChange={(update) => {this.props.onStateChange('spouseSuffix', update);}}/>
             </div>
           </div>
 

--- a/_health-care/_js/components/form-elements/ErrorableSelect.jsx
+++ b/_health-care/_js/components/form-elements/ErrorableSelect.jsx
@@ -11,7 +11,7 @@ import _ from 'lodash';
  * `options` - Array of options to populate select.
  * `required` - boolean. Render marker indicating field is required.
  * `value` - string. Value of the select field.
- * `onUserInput` - a function with this prototype: (newValue)
+ * `onValueChange` - a function with this prototype: (newValue)
  */
 class ErrorableSelect extends React.Component {
   constructor() {
@@ -24,7 +24,7 @@ class ErrorableSelect extends React.Component {
   }
 
   handleChange(domEvent) {
-    this.props.onUserInput(domEvent.target.value);
+    this.props.onValueChange(domEvent.target.value);
   }
 
   render() {
@@ -93,7 +93,7 @@ ErrorableSelect.propTypes = {
     ])).isRequired,
   required: React.PropTypes.bool,
   value: React.PropTypes.string,
-  onUserInput: React.PropTypes.func.isRequired,
+  onValueChange: React.PropTypes.func.isRequired,
 };
 
 export default ErrorableSelect;

--- a/_health-care/_js/components/form-elements/ErrorableTextInput.jsx
+++ b/_health-care/_js/components/form-elements/ErrorableTextInput.jsx
@@ -4,7 +4,7 @@ import _ from 'lodash';
 /**
  * A form input with a label that can display error messages.
  *
- * Validation has the following props.
+ * Props:
  * `errorMessage` - Error string to display in the component.
  *                  When defined, indicates input has a validation error.
  * `label` - String for the input field label.

--- a/_health-care/_js/components/personal-information/NameAndGeneralInfoSection.jsx
+++ b/_health-care/_js/components/personal-information/NameAndGeneralInfoSection.jsx
@@ -23,7 +23,8 @@ class NameAndGeneralInfoSection extends React.Component {
           <div className="row">
             <div className="small-12 columns">
               <h4>Veteran's Name</h4>
-              <FullName name={this.props.data.fullName}
+              <FullName required
+                  value={this.props.data.fullName}
                   onUserInput={(update) => {this.props.onStateChange('fullName', update);}}/>
               <MothersMaidenName name={this.props.data.mothersMaidenName}
                   onUserInput={(update) => {this.props.onStateChange('mothersMaidenName', update);}}/>
@@ -56,7 +57,7 @@ class NameAndGeneralInfoSection extends React.Component {
             <ErrorableSelect label="Current Marital Status"
                 options={maritalStatuses}
                 value={this.props.data.maritalStatus}
-                onUserInput={(update) => {this.props.onStateChange('maritalStatus', update);}}/>
+                onValueChange={(update) => {this.props.onStateChange('maritalStatus', update);}}/>
           </div>
         </fieldset>
       </div>

--- a/_health-care/_js/components/questions/Address.jsx
+++ b/_health-care/_js/components/questions/Address.jsx
@@ -62,13 +62,13 @@ class Address extends React.Component {
             label="Country"
             options={countries}
             value={this.props.value.country}
-            onUserInput={(update) => {this.handleChange('country', update);}}/>
+            onValueChange={(update) => {this.handleChange('country', update);}}/>
 
         <ErrorableSelect errorMesssage={isValid ? undefined : 'Please enter a valid state'}
             label="State"
             options={states}
             value={this.props.value.state}
-            onUserInput={(update) => {this.handleChange('state', update);}}/>
+            onValueChange={(update) => {this.handleChange('state', update);}}/>
 
         <ErrorableTextInput errorMessage={isValid ? undefined : 'Please enter a valid ZIP code'}
             label="ZIP Code"

--- a/_health-care/_js/components/questions/FullName.jsx
+++ b/_health-care/_js/components/questions/FullName.jsx
@@ -1,86 +1,103 @@
 import React from 'react';
 import _ from 'lodash';
 
-// TODO: Refactor to use latest conventions
+import ErrorableTextInput from '../form-elements/ErrorableTextInput';
+import ErrorableSelect from '../form-elements/ErrorableSelect';
+import { isValidName, isNotBlank } from '../../utils/validations';
+import { suffixes } from '../../utils/options-for-select';
+
+/**
+ * A form input with a label that can display error messages.
+ *
+ * Props:
+ * `required` - boolean. Render marker indicating field is required.
+ * `value` - object. Value of the full name.
+ * `onUserInput` - a function with this prototype: (newValue)
+ */
 
 class FullName extends React.Component {
   constructor() {
     super();
     this.state = { hasError: false };
     this.handleChange = this.handleChange.bind(this);
+    this.validateRequiredFields = this.validateRequiredFields.bind(this);
   }
 
   componentWillMount() {
     this.id = _.uniqueId();
   }
 
-  handleChange() {
+  // TODO: look into why this is updating so slowly
+  handleChange(path, update) {
     const name = {
-      first: this.refs.first.value,
-      middle: this.refs.middle.value,
-      last: this.refs.last.value,
-      suffix: this.refs.suffix.value
+      first: this.props.value.first,
+      middle: this.props.value.middle,
+      last: this.props.value.last,
+      suffix: this.props.value.suffix
     };
 
-    const requiredFields = [this.refs.first, this.refs.last];
-
-    for (let i = 0; i < requiredFields.length; i++) {
-      const errorDiv = requiredFields[i].parentElement;
-
-      errorDiv.classList.remove('usa-input-error');
-
-      if (!this.validate(requiredFields[i])) {
-        this.setState({ hasError: true });
-        errorDiv.classList.add('usa-input-error');
-      } else {
-        this.setState({ hasError: false });
-      }
-    }
+    name[path] = update;
 
     this.props.onUserInput(name);
   }
 
-  validate(field) {
-    return field !== '' && /^[a-zA-Z '\-]+$/.test(field.value);
+  validateRequiredFields(value) {
+    if (this.props.required) {
+      return isNotBlank(value) && isValidName(value);
+    }
+    return isValidName(value);
   }
 
   render() {
     return (
       <div>
         <div>
-          <label htmlFor={`${this.id}-first-name`}>First Name
-            <span className="usa-additional_text">Required</span>
-          </label>
-          <input type="text" value={this.props.name.first} id={`${this.id}-first-name`}
-              ref="first" onChange={this.handleChange}/>
+          <ErrorableTextInput
+              errorMessage={this.validateRequiredFields(this.props.value.first) ? undefined : 'Please enter a valid name'}
+              label="First Name"
+              required={this.props.required}
+              value={this.props.value.first}
+              onValueChange={(update) => {this.handleChange('first', update);}}/>
         </div>
 
         <div>
-          <label htmlFor={`${this.id}-middle-name`}>Middle Name</label>
-          <input type="text" value={this.props.name.middle} id={`${this.id}-middle-name`}
-              ref="middle" onChange={this.handleChange}/>
+          <ErrorableTextInput
+              errorMessage={isValidName(this.props.value.middle) ? undefined : 'Please enter a valid name'}
+              label="Middle Name"
+              value={this.props.value.middle}
+              onValueChange={(update) => {this.handleChange('middle', update);}}/>
         </div>
 
         <div>
-          <label htmlFor={`${this.id}-last-name`}>Last Name
-            <span className="usa-additional_text">Required</span>
-          </label>
-          <input type="text" value={this.props.name.last} id={`${this.id}-last-name`}
-              ref="last" onChange={this.handleChange}/>
+          <ErrorableTextInput
+              errorMessage={this.validateRequiredFields(this.props.value.last) ? undefined : 'Please enter a valid name'}
+              label="Last Name"
+              required={this.props.required}
+              value={this.props.value.last}
+              onValueChange={(update) => {this.handleChange('last', update);}}/>
         </div>
 
         <div className="usa-input-grid usa-input-grid-small">
-          <label htmlFor={`${this.id}-suffix-name`}>Suffix</label>
-          <select value={this.props.name.suffix} id={`${this.id}-suffix-name`}
-              ref="suffix" onChange={this.handleChange}>
-            <option value=""></option>
-            <option value="JR">Jr.</option>
-            <option value="SR">Sr.</option>
-          </select>
+          <ErrorableSelect
+              label="Suffix"
+              options={suffixes}
+              value={this.props.value.suffix}
+              onValueChange={(update) => {this.handleChange('suffix', update);}}/>
         </div>
       </div>
     );
   }
 }
+
+FullName.propTypes = {
+  required: React.PropTypes.bool,
+  value: React.PropTypes.shape({
+    first: React.PropTypes.string,
+    middle: React.PropTypes.string,
+    last: React.PropTypes.string,
+    suffix: React.PropTypes.string,
+  }).isRequired,
+  onUserInput: React.PropTypes.func.isRequired,
+};
 
 export default FullName;

--- a/_health-care/_js/utils/validations.js
+++ b/_health-care/_js/utils/validations.js
@@ -1,3 +1,7 @@
+function isNotBlank(value) {
+  return value !== '';
+}
+
 function isValidSSN(value) {
   return /^\d{3}-\d{2}-\d{4}$/.test(value);
 }
@@ -10,6 +14,10 @@ function isValidDate(day, month, year) {
   return date.getDate() === Number(day) &&
     date.getMonth() === adjustedMonth &&
     date.getFullYear() === Number(year);
+}
+
+function isValidName(value) {
+  return value === '' || /^[a-zA-Z '\-]+$/.test(value);
 }
 
 // TODO: look into validation libraries (npm "validator")
@@ -37,7 +45,9 @@ function isValidAddress(street, city, country, state, zipcode) {
 }
 
 export {
+  isNotBlank,
   isValidDate,
+  isValidName,
   isValidSSN,
   isValidPhone,
   isValidEmail,

--- a/spec/javascripts/health-care/components/form-elements/ErrorableSelect.spec.jsx
+++ b/spec/javascripts/health-care/components/form-elements/ErrorableSelect.spec.jsx
@@ -19,53 +19,53 @@ describe('<ErrorableSelect>', () => {
 
     it('label is required', () => {
       SkinDeep.shallowRender(
-        <ErrorableSelect options={options} onUserInput={(_update) => {}}/>);
+        <ErrorableSelect options={options} onValueChange={(_update) => {}}/>);
       sinon.assert.calledWithMatch(consoleStub, /Required prop `label` was not specified in `ErrorableSelect`/);
     });
 
     it('label must be a string', () => {
       SkinDeep.shallowRender(
-        <ErrorableSelect label options={options} onUserInput={(_update) => {}}/>);
+        <ErrorableSelect label options={options} onValueChange={(_update) => {}}/>);
       sinon.assert.calledWithMatch(consoleStub, /Invalid prop `label` of type `boolean` supplied to `ErrorableSelect`, expected `string`./);
     });
 
-    it('onUserInput is required', () => {
+    it('onValueChange is required', () => {
       SkinDeep.shallowRender(<ErrorableSelect label="test" options={options}/>);
-      sinon.assert.calledWithMatch(consoleStub, /Required prop `onUserInput` was not specified in `ErrorableSelect`/);
+      sinon.assert.calledWithMatch(consoleStub, /Required prop `onValueChange` was not specified in `ErrorableSelect`/);
     });
 
-    it('onUserInput must be a function', () => {
-      SkinDeep.shallowRender(<ErrorableSelect label="test" options={options} onUserInput/>);
-      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `onUserInput` of type `boolean` supplied to `ErrorableSelect`, expected `function`/);
+    it('onValueChange must be a function', () => {
+      SkinDeep.shallowRender(<ErrorableSelect label="test" options={options} onValueChange/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `onValueChange` of type `boolean` supplied to `ErrorableSelect`, expected `function`/);
     });
 
     it('errorMessage must be a string', () => {
       SkinDeep.shallowRender(
-        <ErrorableSelect label="test" errorMessage options={options} onUserInput={(_update) => {}}/>);
+        <ErrorableSelect label="test" errorMessage options={options} onValueChange={(_update) => {}}/>);
       sinon.assert.calledWithMatch(consoleStub, /Invalid prop `errorMessage` of type `boolean` supplied to `ErrorableSelect`, expected `string`/);
     });
 
     it('options is required', () => {
       SkinDeep.shallowRender(
-        <ErrorableSelect label="test" onUserInput={(_update) => {}}/>);
+        <ErrorableSelect label="test" onValueChange={(_update) => {}}/>);
       sinon.assert.calledWithMatch(consoleStub, /Required prop `options` was not specified in `ErrorableSelect`/);
     });
 
     it('options must be an object', () => {
       SkinDeep.shallowRender(
-        <ErrorableSelect label="test" options onUserInput={(_update) => {}}/>);
+        <ErrorableSelect label="test" options onValueChange={(_update) => {}}/>);
       sinon.assert.calledWithMatch(consoleStub, /Invalid prop `options` of type `boolean` supplied to `ErrorableSelect`, expected an array/);
     });
 
     it('value must be a string', () => {
       SkinDeep.shallowRender(
-        <ErrorableSelect label="test" options={options} value onUserInput={(_update) => {}}/>);
+        <ErrorableSelect label="test" options={options} value onValueChange={(_update) => {}}/>);
       sinon.assert.calledWithMatch(consoleStub, /Invalid prop `value` of type `boolean` supplied to `ErrorableSelect`, expected `string`/);
     });
 
     it('required must be a boolean', () => {
       SkinDeep.shallowRender(
-        <ErrorableSelect label="test" options={options} required="hi" onUserInput={(_update) => {}}/>);
+        <ErrorableSelect label="test" options={options} required="hi" onValueChange={(_update) => {}}/>);
       sinon.assert.calledWithMatch(consoleStub, /Invalid prop `required` of type `string` supplied to `ErrorableSelect`, expected `boolean`/);
     });
   });
@@ -75,7 +75,7 @@ describe('<ErrorableSelect>', () => {
 
     const updatePromise = new Promise((resolve, _reject) => {
       errorableSelect = ReactTestUtils.renderIntoDocument(
-        <ErrorableSelect label="test" options={options} onUserInput={(update) => { resolve(update); }}/>
+        <ErrorableSelect label="test" options={options} onValueChange={(update) => { resolve(update); }}/>
       );
     });
 
@@ -88,7 +88,7 @@ describe('<ErrorableSelect>', () => {
 
   it('no error styles when errorMessage undefined', () => {
     const tree = SkinDeep.shallowRender(
-      <ErrorableSelect label="my label" options={options} onUserInput={(_update) => {}}/>);
+      <ErrorableSelect label="my label" options={options} onValueChange={(_update) => {}}/>);
 
     // No error classes.
     expect(tree.everySubTree('.usa-input-error')).to.have.lengthOf(0);
@@ -108,7 +108,7 @@ describe('<ErrorableSelect>', () => {
 
   it('has error styles when errorMessage is set', () => {
     const tree = SkinDeep.shallowRender(
-      <ErrorableSelect label="my label" options={options} errorMessage="error message" onUserInput={(_update) => {}}/>);
+      <ErrorableSelect label="my label" options={options} errorMessage="error message" onValueChange={(_update) => {}}/>);
 
     // Ensure all error classes set.
     expect(tree.everySubTree('.usa-input-error')).to.have.lengthOf(1);
@@ -130,14 +130,14 @@ describe('<ErrorableSelect>', () => {
 
   it('required=false does not have required span', () => {
     const tree = SkinDeep.shallowRender(
-      <ErrorableSelect label="my label" options={options} onUserInput={(_update) => {}}/>);
+      <ErrorableSelect label="my label" options={options} onValueChange={(_update) => {}}/>);
 
     expect(tree.everySubTree('.usa-additional_text')).to.have.lengthOf(0);
   });
 
   it('required=true has required span', () => {
     const tree = SkinDeep.shallowRender(
-      <ErrorableSelect label="my label" options={options} required onUserInput={(_update) => {}}/>);
+      <ErrorableSelect label="my label" options={options} required onValueChange={(_update) => {}}/>);
 
     const requiredSpan = tree.everySubTree('.usa-additional_text');
     expect(requiredSpan).to.have.lengthOf(1);
@@ -146,7 +146,7 @@ describe('<ErrorableSelect>', () => {
 
   it('label attribute propagates', () => {
     const tree = SkinDeep.shallowRender(
-      <ErrorableSelect label="my label" options={options} onUserInput={(_update) => {}}/>);
+      <ErrorableSelect label="my label" options={options} onValueChange={(_update) => {}}/>);
 
     // Ensure label text is correct.
     const labels = tree.everySubTree('label');

--- a/spec/javascripts/health-care/utils/validations.spec.js
+++ b/spec/javascripts/health-care/utils/validations.spec.js
@@ -1,4 +1,4 @@
-import { isValidDate, isValidSSN } from '../../../../_health-care/_js/utils/validations.js';
+import { isValidDate, isValidSSN, isValidName, isNotBlank } from '../../../../_health-care/_js/utils/validations.js';
 
 describe('Validations unit tests', () => {
   describe('isValidSSN', () => {
@@ -57,6 +57,31 @@ describe('Validations unit tests', () => {
 
       // 0 is always bad.
       expect(isValidDate(0, 2, 2016)).to.be.false;
+    });
+  });
+
+  describe('isValidName', () => {
+    it('correctly validates name', () => {
+      expect(isValidName('Test')).to.be.true;
+      expect(isValidName('abc')).to.be.true;
+      expect(isValidName('Jean-Pierre')).to.be.true;
+      expect(isValidName('Vigee Le Brun')).to.be.true;
+      expect(isValidName('')).to.be.true;
+
+      expect(isValidName('123')).to.be.false;
+      expect(isValidName('#$%')).to.be.false;
+      expect(isValidName('Test1')).to.be.false;
+    });
+  });
+
+  describe('isNotBlank', () => {
+    it('correctly validates blank values', () => {
+      expect(isNotBlank('Test')).to.be.true;
+      expect(isNotBlank('abc')).to.be.true;
+      expect(isNotBlank('123')).to.be.true;
+      expect(isNotBlank('#$%')).to.be.true;
+
+      expect(isNotBlank('')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
Refactor `FullName` to use latest conventions. This will also enable us to use `FullName` in multiple panels. Main changes:
1. Add `required` prop so we can specify whether or not fields are required
2. Extracted validation logic
3. No more refs!

Some specs are failing, so temporarily commented those out while we investigate other solutions. 

Also changed prop on `ErrorableSelect` of `onUserInput` to `onValueChange` to be consistent with other form-element components.
