### PR TITLE
Amend rendering of section components in top level app

### DIFF
--- a/_health-care/_js/components/HealthCareApp.jsx
+++ b/_health-care/_js/components/HealthCareApp.jsx
@@ -237,7 +237,7 @@ class HealthCareApp extends React.Component {
         return React.cloneElement(child, {
           data: _.get(this.state.applicationData, statePath),
           onStateChange: (subfield, update) => {
-            this.props.publishStateChange(statePath.concat(subfield), update);
+            this.publishStateChange(statePath.concat(subfield), update);
           }
         });
       });

--- a/_health-care/_js/components/personal-information/NameAndGeneralInfoSection.jsx
+++ b/_health-care/_js/components/personal-information/NameAndGeneralInfoSection.jsx
@@ -28,7 +28,8 @@ class NameAndGeneralInfoSection extends React.Component {
                   onUserInput={(update) => {this.props.onStateChange('fullName', update);}}/>
               <MothersMaidenName name={this.props.data.mothersMaidenName}
                   onUserInput={(update) => {this.props.onStateChange('mothersMaidenName', update);}}/>
-              <SocialSecurityNumber ssn={this.props.data.socialSecurityNumber}
+              <SocialSecurityNumber required
+                  ssn={this.props.data.socialSecurityNumber}
                   onValueChange={(update) => {this.props.onStateChange('socialSecurityNumber', update);}}/>
               <Gender value={this.props.data.gender} onUserInput={(update) => {this.props.onStateChange('gender', update);}}/>
             </div>


### PR DESCRIPTION
In creating the section components, this checked for a prop of `publishStateChange` on the component one layer up. Before, this would have been the panel, where indeed there was a prop of `publishStateChange`, passed from `HealthCareApp`. But now that panels no longer exist, instead of checking for the prop, we just want to pass directly from `HealthCareApp`. Also added the `required` boolean to veteran's SSN because I noticed that was missing.
