### PR TITLE
Hca update navigation styling

### DIFF
--- a/_health-care/_js/components/HealthCareApp.jsx
+++ b/_health-care/_js/components/HealthCareApp.jsx
@@ -272,10 +272,10 @@ class HealthCareApp extends React.Component {
 
     return (
       <div className="row">
-        <div className="small-4 columns">
+        <div className="medium-4 columns show-for-medium-up">
           <Nav currentUrl={this.props.location.pathname}/>
         </div>
-        <div className="small-8 columns">
+        <div className="medium-8 columns">
           <div className="progress-box">
             <div className="form-panel">
               {children}

--- a/_health-care/_js/components/Nav.jsx
+++ b/_health-care/_js/components/Nav.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { Link } from 'react-router';
 
+/**
+ * Component for navigation, with links to each section of the form.
+ * Parent links redirect to first section link within topic.
+ *
+ * Props:
+ * `currentUrl` - String. Specifies the current url.
+ */
 class Nav extends React.Component {
   render() {
-    // TODO(akainic): DRY this up
     // TODO(akainic): change this check once the alias for introduction has been changed
     return (
       <ul className="usa-sidenav-list">
@@ -13,7 +19,9 @@ class Nav extends React.Component {
           </Link>
         </li>
         <li role="presentation">
-          Personal Information
+          <Link to="/personal-information" className={this.props.currentUrl.startsWith('/personal-information/') ? ' usa-current' : ''}>
+            Personal Information
+          </Link>
           <ul className="usa-sidenav-sub_list">
             <li>
               <Link to="/personal-information/name-and-general-information" activeClassName="usa-current">
@@ -43,7 +51,9 @@ class Nav extends React.Component {
           </ul>
         </li>
         <li role="presentation">
-          Insurance Information
+          <Link to="/insurance-information" className={this.props.currentUrl.startsWith('/insurance-information/') ? ' usa-current' : ''}>
+            Insurance Information
+          </Link>
           <ul className="usa-sidenav-sub_list">
             <li>
               <Link to="/insurance-information/general" activeClassName="usa-current">
@@ -58,7 +68,9 @@ class Nav extends React.Component {
           </ul>
         </li>
         <li role="presentation">
-          Military Service
+          <Link to="/military-service" className={this.props.currentUrl.startsWith('/military-service/') ? ' usa-current' : ''}>
+            Military Service
+          </Link>
           <ul className="usa-sidenav-sub_list">
             <li>
               <Link to="/military-service/service-information" activeClassName="usa-current">
@@ -73,7 +85,9 @@ class Nav extends React.Component {
           </ul>
         </li>
         <li role="presentation">
-          Financial Assessment
+          <Link to="/financial-assessment" className={this.props.currentUrl.startsWith('/financial-assessment/') ? ' usa-current' : ''}>
+            Financial Assessment
+          </Link>
           <ul className="usa-sidenav-sub_list">
             <li>
               <Link to="/financial-assessment/financial-disclosure" activeClassName="usa-current">
@@ -111,5 +125,9 @@ class Nav extends React.Component {
     );
   }
 }
+
+Nav.propTypes = {
+  currentUrl: React.PropTypes.string.isRequired
+};
 
 export default Nav;

--- a/_health-care/_js/components/insurance-information/InsuranceInformationSection.jsx
+++ b/_health-care/_js/components/insurance-information/InsuranceInformationSection.jsx
@@ -34,12 +34,12 @@ class InsuranceInformationSection extends React.Component {
                 label="Country"
                 options={countries}
                 value={this.props.data.insuranceCountry}
-                onUserInput={(update) => {this.props.onStateChange('insuranceCountry', update);}}/>
+                onValueChange={(update) => {this.props.onStateChange('insuranceCountry', update);}}/>
             <ErrorableSelect
                 label="State"
                 options={states}
                 value={this.props.data.insuranceState}
-                onUserInput={(update) => {this.props.onStateChange('insuranceState', update);}}/>
+                onValueChange={(update) => {this.props.onStateChange('insuranceState', update);}}/>
             <ErrorableTextInput
                 label="Zipcode"
                 value={this.props.data.insuranceZipcode}

--- a/_health-care/_js/routes.jsx
+++ b/_health-care/_js/routes.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route } from 'react-router';
+import { Route, Redirect } from 'react-router';
 
 import AdditionalInformationSection from './components/personal-information/AdditionalInformationSection';
 import AdditionalMilitaryInformationSection from './components/military-service/AdditionalMilitaryInformationSection';
@@ -19,15 +19,17 @@ import VAInformationSection from './components/personal-information/VAInformatio
 import VeteranAddressSection from './components/personal-information/VeteranAddressSection';
 
 const routes = [
+  // Introduction route.
+  <Route
+      component={IntroductionSection}
+      key="/introduction"
+      path="/introduction"/>,
+
   // Personal Information routes.
-  <Route
-      component={AdditionalInformationSection}
-      key="/personal-information/additional-information"
-      path="/personal-information/additional-information"/>,
-  <Route
-      component={DemographicInformationSection}
-      key="/personal-information/demographic-information"
-      path="/personal-information/demographic-information"/>,
+  <Redirect
+      key="/personal-information"
+      from="/personal-information"
+      to="/personal-information/name-and-general-information"/>,
   <Route
       component={NameAndGeneralInfoSection}
       key="/personal-information/name-and-general-information"
@@ -37,11 +39,23 @@ const routes = [
       key="/personal-information/va-information"
       path="/personal-information/va-information"/>,
   <Route
+      component={AdditionalInformationSection}
+      key="/personal-information/additional-information"
+      path="/personal-information/additional-information"/>,
+  <Route
+      component={DemographicInformationSection}
+      key="/personal-information/demographic-information"
+      path="/personal-information/demographic-information"/>,
+  <Route
       component={VeteranAddressSection}
       key="/personal-information/veteran-address"
       path="/personal-information/veteran-address"/>,
 
   // Insurance Information routes.
+  <Redirect
+      key="/insurance-information"
+      from="/insurance-information"
+      to="/insurance-information/general"/>,
   <Route
       component={InsuranceInformationSection}
       key="/insurance-information/general"
@@ -51,19 +65,25 @@ const routes = [
       key="/insurance-information/medicare-medicaid"
       path="/insurance-information/medicare-medicaid"/>,
 
+  // Military Service routes.
+  <Redirect
+      key="/military-service"
+      from="/military-service"
+      to="/military-service/service-information"/>,
+  <Route
+      component={ServiceInformationSection}
+      key="/military-service/service-information"
+      path="/military-service/service-information"/>,
+  <Route
+      component={AdditionalMilitaryInformationSection}
+      key="/military-service/additional-information"
+      path="/military-service/additional-information"/>,
+
   // Financial Assessment routes.
-  <Route
-      component={AnnualIncomeSection}
-      key="/financial-assessment/annual-income"
-      path="/financial-assessment/annual-income"/>,
-  <Route
-      component={ChildInformationSection}
-      key="/financial-assessment/child-information"
-      path="/financial-assessment/child-information"/>,
-  <Route
-      component={DeductibleExpensesSection}
-      key="/financial-assessment/deductible-expenses"
-      path="/financial-assessment/deductible-expenses"/>,
+  <Redirect
+      key="/financial-assessment"
+      from="/financial-assessment"
+      to="/financial-assessment/financial-disclosure"/>,
   <Route
       component={FinancialDisclosureSection}
       key="/financial-assessment/financial-disclosure"
@@ -72,22 +92,20 @@ const routes = [
       component={SpouseInformationSection}
       key="/financial-assessment/spouse-information"
       path="/financial-assessment/spouse-information"/>,
-
-  // Military Service routes.
   <Route
-      component={AdditionalMilitaryInformationSection}
-      key="/military-service/additional-information"
-      path="/military-service/additional-information"/>,
+      component={ChildInformationSection}
+      key="/financial-assessment/child-information"
+      path="/financial-assessment/child-information"/>,
   <Route
-      component={ServiceInformationSection}
-      key="/military-service/service-information"
-      path="/military-service/service-information"/>,
-
+      component={AnnualIncomeSection}
+      key="/financial-assessment/annual-income"
+      path="/financial-assessment/annual-income"/>,
   <Route
-      component={IntroductionSection}
-      key="/introduction"
-      path="/introduction"/>,
+      component={DeductibleExpensesSection}
+      key="/financial-assessment/deductible-expenses"
+      path="/financial-assessment/deductible-expenses"/>,
 
+  // Review and Submit route.
   <Route
       component={ReviewAndSubmitSection}
       key="/review-and-submit"

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -34,6 +34,20 @@ body .row {
     a {
       text-decoration: none;
       background: none;
+
+      &.usa-current {
+        color: $color-base;
+        font-weight: normal;
+      }
+    }
+  }
+
+  .usa-sidenav-sub_list {
+    padding-left: 0.5em;
+
+    a.usa-current {
+      color: $color-primary;
+      font-weight: $font-bold;
     }
   }
 }

--- a/spec/javascripts/health-care/components/Nav.spec.jsx
+++ b/spec/javascripts/health-care/components/Nav.spec.jsx
@@ -1,11 +1,39 @@
 import React from 'react';
 import ReactTestUtils from 'react-addons-test-utils';
 import { Router, Route, createMemoryHistory } from 'react-router';
+import SkinDeep from 'skin-deep';
 
 import Nav from '../../../../_health-care/_js/components/Nav';
 import routes from '../../../../_health-care/_js/routes';
 
+class Container extends React.Component {
+  render() {
+    return (<Nav currentUrl={this.props.location.pathname}/>);
+  }
+}
+
 describe('<Nav>', () => {
+  describe('propTypes', () => {
+    let consoleStub;
+    beforeEach(() => {
+      consoleStub = sinon.stub(console, 'error');
+    });
+
+    afterEach(() => {
+      consoleStub.restore();
+    });
+
+    xit('currentUrl is required', () => {
+      SkinDeep.shallowRender(<Nav/>);
+      sinon.assert.calledWithMatch(consoleStub, /Required prop `currentUrl` was not specified in `Nav`/);
+    });
+
+    xit('currentUrl must be a string', () => {
+      SkinDeep.shallowRender(<Nav currentUrl/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `currentUrl` of type `boolean` supplied to `Nav`, expected `string`/);
+    });
+  });
+
   describe('active links have usa-current class', () => {
     const history = createMemoryHistory('/');
     let nav;
@@ -17,12 +45,20 @@ describe('<Nav>', () => {
       expect(activeLinks[0].getAttribute('href')).to.equal(path);
     };
 
+    const expectActiveLinksForNavAndSubNav = (component, path) => {
+      history.replace(path);
+      const activeLinks = ReactTestUtils.scryRenderedDOMComponentsWithClass(component, 'usa-current');
+      expect(activeLinks).to.have.lengthOf(2);
+      expect(activeLinks[0].getAttribute('href').startsWith(activeLinks[1].getAttribute('href')));
+      expect(activeLinks[1].getAttribute('href')).to.equal(path);
+    };
+
     before(() => {
       // It's perfectly fine in this test to reuse the rendered component. Do that
       // cause it cuts the test time from 1s down to ~0.1s.
       nav = ReactTestUtils.renderIntoDocument(
         <Router history={history}>
-          <Route path="/" component={Nav}>
+          <Route path="/" component={Container}>
             {routes}
           </Route>
         </Router>
@@ -39,59 +75,59 @@ describe('<Nav>', () => {
     });
 
     it('/personal-information/name-and-general-information', () => {
-      expectOneActiveLink(nav, '/personal-information/name-and-general-information');
+      expectActiveLinksForNavAndSubNav(nav, '/personal-information/name-and-general-information');
     });
 
     it('/personal-information/va-information', () => {
-      expectOneActiveLink(nav, '/personal-information/va-information');
+      expectActiveLinksForNavAndSubNav(nav, '/personal-information/va-information');
     });
 
     it('/personal-information/additional-information', () => {
-      expectOneActiveLink(nav, '/personal-information/additional-information');
+      expectActiveLinksForNavAndSubNav(nav, '/personal-information/additional-information');
     });
 
     it('/personal-information/demographic-information', () => {
-      expectOneActiveLink(nav, '/personal-information/demographic-information');
+      expectActiveLinksForNavAndSubNav(nav, '/personal-information/demographic-information');
     });
 
     it('/personal-information/veteran-address', () => {
-      expectOneActiveLink(nav, '/personal-information/veteran-address');
+      expectActiveLinksForNavAndSubNav(nav, '/personal-information/veteran-address');
     });
 
     it('/insurance-information/general', () => {
-      expectOneActiveLink(nav, '/insurance-information/general');
+      expectActiveLinksForNavAndSubNav(nav, '/insurance-information/general');
     });
 
     it('/insurance-information/medicare-medicaid', () => {
-      expectOneActiveLink(nav, '/insurance-information/medicare-medicaid');
+      expectActiveLinksForNavAndSubNav(nav, '/insurance-information/medicare-medicaid');
     });
 
     it('/military-service/service-information', () => {
-      expectOneActiveLink(nav, '/military-service/service-information');
+      expectActiveLinksForNavAndSubNav(nav, '/military-service/service-information');
     });
 
     it('/military-service/additional-information', () => {
-      expectOneActiveLink(nav, '/military-service/additional-information');
+      expectActiveLinksForNavAndSubNav(nav, '/military-service/additional-information');
     });
 
     it('/financial-assessment/financial-disclosure', () => {
-      expectOneActiveLink(nav, '/financial-assessment/financial-disclosure');
+      expectActiveLinksForNavAndSubNav(nav, '/financial-assessment/financial-disclosure');
     });
 
     it('/financial-assessment/spouse-information', () => {
-      expectOneActiveLink(nav, '/financial-assessment/spouse-information');
+      expectActiveLinksForNavAndSubNav(nav, '/financial-assessment/spouse-information');
     });
 
     it('/financial-assessment/child-information', () => {
-      expectOneActiveLink(nav, '/financial-assessment/child-information');
+      expectActiveLinksForNavAndSubNav(nav, '/financial-assessment/child-information');
     });
 
     it('/financial-assessment/annual-income', () => {
-      expectOneActiveLink(nav, '/financial-assessment/annual-income');
+      expectActiveLinksForNavAndSubNav(nav, '/financial-assessment/annual-income');
     });
 
     it('/financial-assessment/deductible-expenses', () => {
-      expectOneActiveLink(nav, '/financial-assessment/deductible-expenses');
+      expectActiveLinksForNavAndSubNav(nav, '/financial-assessment/deductible-expenses');
     });
 
     it('/review-and-submit', () => {


### PR DESCRIPTION
The way that we currently handle routes is making it difficult to style the navigation the way that we want to, as well as potentially making a confusing UX. When a link is active, we want to indicate that with styling for both it and its parent link. 
<img width="377" alt="screen shot 2016-03-10 at 9 18 08 pm" src="https://cloud.githubusercontent.com/assets/3886085/13691437/d3fab29a-e706-11e5-8933-1f35710d21a2.png">

Currently, the "parent link" is not a link at all, but just a span. Not clickable and not easily styled:
<img width="374" alt="screen shot 2016-03-10 at 9 18 57 pm" src="https://cloud.githubusercontent.com/assets/3886085/13691478/25799244-e707-11e5-86dd-f290358060a3.png">

The fix in this PR is to create actual links for the parent links by using `<Redirect>` as the route to redirect to the first sub link in the list when it is clicked. Styles tweaked and the side nav hidden on small screens.
