### PR TITLE
add federal employment page

### DIFF
--- a/_employment/job-seekers/federal-employment.md
+++ b/_employment/job-seekers/federal-employment.md
@@ -1,0 +1,69 @@
+---
+title: Federal Employment
+concurrence: incomplete
+template: 1-topic-landing
+---
+
+<div class="main" role="main" markdown="0">
+
+<div class="section one" markdown="0">
+<div class="primary" markdown="0">
+<div class="row" markdown="0">
+<div class="small-12 columns" markdown="1">
+
+  Federal jobs, including those at VA, offer outstanding opportunities to Veterans and their spouses. Skills learned in the military are easily transferrable to many positions, and by working for a federal agency, you can continue to serve your country. In addition, your military service counts toward a civilian pension.   
+
+The federal job-application process is very detailed compared with most civilian organizations. Federal positions are listed, with very few exceptions, on [USAJobs](http://www.usajobs.gov).   
+
+One-on-one assistance in applying for federal jobs is available at local [Employment Centers](https://www.doleta.gov/usworkforce/onestop/onestopmap.cfm). You can also go to [Feds Hire Vets](http://www.fedshirevets.gov) for tips on applying for federal positions.   
+
+### Veterans’ Preference
+The Veterans’ Preference program awards points to you during the application process, giving you an advantage in job placement. This program assists you only when you are applying to competitive positions—those announced publicly to a pool of job seekers.
+ 
+<div class="call-out" markdown="1">
+
+### Are you eligible for federal Veterans’ Preference?
+
+  Yes, if:  
+
+- You are applying to a position listed as an Excepted Career. 
+- You were discharged under conditions other than dishonorable.. 
+- You were not retired from service. (You may be medically retired and qualify for disabled preference eligibility.) 
+
+You are 0-point preference eligible if you are a Veteran who is the only surviving child in a family in which the father or mother or one or more siblings:
+
+- Served in the Armed Forces, and
+- Was killed, died as a result of wounds, accident, or disease; is in a captured or missing-in-action status; or is permanently 100% disabled or hospitalized and is not gainfully employed because of the disability.
+
+You are 5-point preference eligible if you served:
+
+- For more than 180 consecutive days, other than for training, any part of which occurred during the period beginning September 11, 2001, and ending August 31, 2010, the last day of Operation Iraqi Freedom, or
+- Between August 2, 1990, and January 2, 1992, or
+- For more than 180 consecutive days, other than for training, any part of which occurred after January 31, 1955, and before October 15, 1976.
+- In a war, campaign, or expedition for which a campaign badge has been authorized or between April 28, 1952, and July 1, 1955.
+
+You are a 10-point preference eligible if you:
+
+- Have a service-connected disability, or
+- Received a Purple Heart.
+
+
+You may be eligible for a federal position without having to compete with the public. This is called Noncompetitive Hiring. If you have a 30% or more service-connected disability or a severe physical, intellectual, or psychological disability, you may be placed on a fast track to a position. 
+In order to apply for one of these jobs, you must provide the following documents:
+
+- SF-15, Application for 10-Point Veteran Preference
+- DD214, Certificate of Release or Discharge from Active Duty
+- Other medical documentation as requested 
+
+</div>
+</div>
+</div>
+</div>
+
+<div class="action-bar">
+  <div class="row">
+    <div class="small-12 columns">
+      <a class="usa-button-primary" href="https://www.vets.gov/veterans-employment-center/">Veteran Employment Center</a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Added the Federal Employment Page

Needs to check how to use the blue box template- unclear on how it relates to the content for this page.

Also not sure where to link to this page from (pivotal says the "search page" but 
- we can't change the search page right now since it's in production until we have some sort of staging branch for VEC
- The search page doesn't have links on it, just search and results: https://www.vets.gov/veterans-employment-center/search_jobs
