### PR TITLE
Don't capitalize particular words in breadcrumbs. closes #1328

### DIFF
--- a/_plugins/breadcrumbs.rb
+++ b/_plugins/breadcrumbs.rb
@@ -1,17 +1,17 @@
 module Jekyll
   class BreadcrumbsTag < Liquid::Tag
   
-	def humanize(s)
+    def humanize(s)
       # Words that shouldn't get capitalized
       filterwords = ['for','a']
       s.split("-").collect do |s|
-      	# if s is not in filterwords array, capitalize it
-      	# otherwise just return s.
-	    if !filterwords.include? s
-	      s.capitalize
-	    else
-	      s
-	    end
+        # if s is not in filterwords array, capitalize it
+        # otherwise just return s.
+        if !filterwords.include? s
+          s.capitalize
+        else
+          s
+        end
       end.join(" ")
     end
 

--- a/_plugins/breadcrumbs.rb
+++ b/_plugins/breadcrumbs.rb
@@ -1,9 +1,17 @@
 module Jekyll
   class BreadcrumbsTag < Liquid::Tag
-
-    def humanize(s)
+  
+	def humanize(s)
+      # Words that shouldn't get capitalized
+      filterwords = ['for','a']
       s.split("-").collect do |s|
-        s.capitalize
+      	# if s is not in filterwords array, capitalize it
+      	# otherwise just return s.
+	    if !filterwords.include? s
+	      s.capitalize
+	    else
+	      s
+	    end
       end.join(" ")
     end
 


### PR DESCRIPTION
Adds list of words, and a check for whether words in an array should
be capitalized.

modified:   _plugins/breadcrumbs.rb
