### PR TITLE
Refactor styles

### DIFF
--- a/_health-care/_js/components/Nav.jsx
+++ b/_health-care/_js/components/Nav.jsx
@@ -22,19 +22,19 @@ class Nav extends React.Component {
             <h5 className={this.props.currentUrl.startsWith('/personal-information') ? ' section-current' : ''}>Personal Information</h5>
             <ul className="usa-unstyled-list">
               <li className={this.props.currentUrl === '/personal-information/name-and-general-information' ? ' section-current' : ''}>
-                  Name and General Information
+                Name and General
               </li>
               <li className={this.props.currentUrl === '/personal-information/va-information' ? ' section-current' : ''}>
-                  VA-Specific Information
+                VA-Specific
               </li>
               <li className={this.props.currentUrl === '/personal-information/additional-information' ? ' section-current' : ''}>
-                  Additional Information
+                Additional
               </li>
               <li className={this.props.currentUrl === '/personal-information/demographic-information' ? ' section-current' : ''}>
-                  Demographic Information
+                Demographic
               </li>
               <li className={this.props.currentUrl === '/personal-information/veteran-address' ? ' section-current' : ''}>
-                  Veteran Address
+                Veteran Address
               </li>
             </ul>
           </div>
@@ -44,10 +44,10 @@ class Nav extends React.Component {
             <h5 className={this.props.currentUrl.startsWith('/insurance-information') ? ' section-current' : ''}>Insurance Information</h5>
             <ul className="usa-unstyled-list">
               <li className={this.props.currentUrl === '/insurance-information/general' ? ' section-current' : ''}>
-                  General Insurance Information
+                General Insurance
               </li>
               <li className={this.props.currentUrl === '/insurance-information/medicare-medicaid' ? ' section-current' : ''}>
-                  Medicare/Medicaid Information
+                Medicare/Medicaid
               </li>
             </ul>
           </div>
@@ -57,10 +57,10 @@ class Nav extends React.Component {
             <h5 className={this.props.currentUrl.startsWith('/military-service') ? ' section-current' : ''}>Military Service</h5>
             <ul className="usa-unstyled-list">
               <li className={this.props.currentUrl === '/military-service/service-information' ? ' section-current' : ''}>
-                  Service Information
+                Service
               </li>
               <li className={this.props.currentUrl === '/military-service/additional-information' ? ' section-current' : ''}>
-                  Additional Military Information
+                Additional Military
               </li>
             </ul>
           </div>
@@ -73,21 +73,21 @@ class Nav extends React.Component {
                 Financial Disclosure
               </li>
               <li className={this.props.currentUrl === '/financial-assessment/spouse-information' ? ' section-current' : ''}>
-                  Spouse Information
+                Spouse
               </li>
               <li className={this.props.currentUrl === '/financial-assessment/child-information' ? ' section-current' : ''}>
-                  Child Information
+                Child
               </li>
               <li className={this.props.currentUrl === '/financial-assessment/annual-income' ? ' section-current' : ''}>
-                  Annual Income
+                Annual Income
               </li>
               <li className={this.props.currentUrl === '/financial-assessment/deductible-expenses' ? ' section-current' : ''}>
-                  Deductible Expenses
+                Deductible Expenses
               </li>
             </ul>
           </div>
         </li>
-        <li role="presentation" className="step six wow fadeIn animated">
+        <li role="presentation" className="step six last wow fadeIn animated">
           <div>
             <h5 className={this.props.currentUrl.startsWith('/review-and-submit') ? ' section-current' : ''}>Review and Submit</h5>
           </div>

--- a/_health-care/_js/components/financial-assessment/Child.jsx
+++ b/_health-care/_js/components/financial-assessment/Child.jsx
@@ -49,7 +49,7 @@ class Child extends React.Component {
 
         <div className="row">
           <div className="small-12 columns">
-            <h5>Date Child Became Dependent</h5>
+            <label>Date Child Became Dependent</label>
             <DateInput required
                 day={this.props.data.childBecameDependent.day}
                 month={this.props.data.childBecameDependent.month}
@@ -60,7 +60,7 @@ class Child extends React.Component {
 
         <div className="row">
           <div className="small-12 columns">
-            <h5>Child’s Date of Birth</h5>
+            <label>Child’s Date of Birth</label>
             <DateInput required
                 day={this.props.data.childDateOfBirth.day}
                 month={this.props.data.childDateOfBirth.month}

--- a/_health-care/_js/components/financial-assessment/SpouseInformationSection.jsx
+++ b/_health-care/_js/components/financial-assessment/SpouseInformationSection.jsx
@@ -77,8 +77,7 @@ class SpouseInformationSection extends React.Component {
 
               <div className="row">
                 <div className="small-9 columns">
-                  <h5>Spouse’s Date of Birth</h5>
-                  <span className="usa-form-hint usa-datefield-hint" id="dobHint">For example: 04 28 1986</span>
+                  <label>Spouse’s Date of Birth</label>
                   <DateInput
                       day={this.props.data.spouseDateOfBirth.day}
                       month={this.props.data.spouseDateOfBirth.month}
@@ -89,8 +88,7 @@ class SpouseInformationSection extends React.Component {
 
               <div className="row">
                 <div className="small-9 columns">
-                  <h5>Date of Marriage</h5>
-                  <span className="usa-form-hint usa-datefield-hint" id="dobHint">For example: 04 28 1986</span>
+                  <label>Date of Marriage</label>
                   <DateInput
                       day={this.props.data.dateOfMarriage.day}
                       month={this.props.data.dateOfMarriage.month}

--- a/_health-care/_js/components/form-elements/DateInput.jsx
+++ b/_health-care/_js/components/form-elements/DateInput.jsx
@@ -43,54 +43,57 @@ class DateInput extends React.Component {
     }
 
     return (
-      <div className={isValid ? undefined : 'usa-input-error'}>
-        <div className="usa-date-of-birth">
-          <div className="usa-datefield usa-form-group usa-form-group-month">
-            <label
-                className={isValid ? undefined : 'usa-input-error-label'}
-                htmlFor={`${this.id}-month`}>
-              Month
-            </label>
-            <input
-                className="usa-form-control"
-                id={`${this.id}-month`}
-                max="12"
-                min="1"
-                pattern="0?[1-9]|1[012]"
-                ref={(c) => { this._month = c; }}
-                type="number"
-                value={this.props.month}
-                onChange={this.handleChange}/>
-          </div>
-          <div className="usa-datefield usa-form-group usa-form-group-day">
-            <label
-                className={isValid ? undefined : 'usa-input-error-label'}
-                htmlFor={`${this.id}-day`}>Day</label>
-            <input
-                className="usa-form-control"
-                id={`${this.id}-day`}
-                max="31"
-                min="1"
-                pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]"
-                ref={(c) => { this._day = c; }}
-                type="number"
-                value={this.props.day}
-                onChange={this.handleChange}/>
-          </div>
-          <div className="usa-datefield usa-form-group usa-form-group-year">
-            <label
-                className={isValid ? undefined : 'usa-input-error-label'}
-                htmlFor={`${this.id}-year`}>Year</label>
-            <input
-                className="usa-form-control"
-                id={`${this.id}-year`}
-                max={new Date().getFullYear()}
-                min="1900"
-                pattern="[0-9]{4}"
-                ref={(c) => { this._year = c; }}
-                type="number"
-                value={this.props.year}
-                onChange={this.handleChange}/>
+      <div>
+        <span className="usa-form-hint usa-datefield-hint" id="dobHint">For example: 04 28 1986</span>
+        <div className={isValid ? undefined : 'usa-input-error'}>
+          <div className="usa-date-of-birth">
+            <div className="usa-datefield usa-form-group usa-form-group-month">
+              <label
+                  className={isValid ? undefined : 'usa-input-error-label'}
+                  htmlFor={`${this.id}-month`}>
+                Month
+              </label>
+              <input
+                  className="usa-form-control"
+                  id={`${this.id}-month`}
+                  max="12"
+                  min="1"
+                  pattern="0?[1-9]|1[012]"
+                  ref={(c) => { this._month = c; }}
+                  type="number"
+                  value={this.props.month}
+                  onChange={this.handleChange}/>
+            </div>
+            <div className="usa-datefield usa-form-group usa-form-group-day">
+              <label
+                  className={isValid ? undefined : 'usa-input-error-label'}
+                  htmlFor={`${this.id}-day`}>Day</label>
+              <input
+                  className="usa-form-control"
+                  id={`${this.id}-day`}
+                  max="31"
+                  min="1"
+                  pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]"
+                  ref={(c) => { this._day = c; }}
+                  type="number"
+                  value={this.props.day}
+                  onChange={this.handleChange}/>
+            </div>
+            <div className="usa-datefield usa-form-group usa-form-group-year">
+              <label
+                  className={isValid ? undefined : 'usa-input-error-label'}
+                  htmlFor={`${this.id}-year`}>Year</label>
+              <input
+                  className="usa-form-control"
+                  id={`${this.id}-year`}
+                  max={new Date().getFullYear()}
+                  min="1900"
+                  pattern="[0-9]{4}"
+                  ref={(c) => { this._year = c; }}
+                  type="number"
+                  value={this.props.year}
+                  onChange={this.handleChange}/>
+            </div>
           </div>
         </div>
       </div>

--- a/_health-care/_js/components/insurance-information/InsuranceInformationSection.jsx
+++ b/_health-care/_js/components/insurance-information/InsuranceInformationSection.jsx
@@ -23,7 +23,7 @@ class InsuranceInformationSection extends React.Component {
 
   render() {
     return (
-      <div>
+      <fieldset>
         <div className="row">
           <div className="small-12 columns">
             <h4>Coverage Information </h4>
@@ -39,7 +39,7 @@ class InsuranceInformationSection extends React.Component {
                 rows={this.props.data.providers}/>
           </div>
         </div>
-      </div>
+      </fieldset>
     );
   }
 }

--- a/_health-care/_js/components/insurance-information/MedicareMedicaidSection.jsx
+++ b/_health-care/_js/components/insurance-information/MedicareMedicaidSection.jsx
@@ -44,6 +44,7 @@ class MedicareMedicaidSection extends React.Component {
         </div>
         <div className="row">
           <div className="small-12 columns">
+            <label>If so, what is your Medicare Part A effective date?</label>
             <DateInput
                 day={this.props.data.medicarePartAEffectiveDate.day}
                 month={this.props.data.medicarePartAEffectiveDate.month}

--- a/_health-care/_js/components/insurance-information/Provider.jsx
+++ b/_health-care/_js/components/insurance-information/Provider.jsx
@@ -16,42 +16,51 @@ class Provider extends React.Component {
             label="Name"
             value={this.props.data.insuranceName}
             onValueChange={(update) => {this.props.onValueChange('insuranceName', update);}}/>
+
         <ErrorableTextInput
             label="Address"
             value={this.props.data.insuranceAddress}
             onValueChange={(update) => {this.props.onValueChange('insuranceAddress', update);}}/>
+
         <ErrorableTextInput
             label="City"
             value={this.props.data.insuranceCity}
             onValueChange={(update) => {this.props.onValueChange('insuranceCity', update);}}/>
+
         <ErrorableSelect
             label="Country"
             options={countries}
             value={this.props.data.insuranceCountry}
             onValueChange={(update) => {this.props.onValueChange('insuranceCountry', update);}}/>
+
         <ErrorableSelect
             label="State"
             options={states}
             value={this.props.data.insuranceState}
             onValueChange={(update) => {this.props.onValueChange('insuranceState', update);}}/>
+
         <ErrorableTextInput
             label="Zipcode"
             value={this.props.data.insuranceZipcode}
             onValueChange={(update) => {this.props.onValueChange('insuranceZipcode', update);}}/>
+
         <Phone required
             label="Phone"
             value={this.props.data.insurancePhone}
             onValueChange={(update) => {this.props.onValueChange('insurancePhone', update);}}/>
+
         <ErrorableTextInput required
             errorMessage={isNotBlank(this.props.data.insurancePolicyHolderName) ? undefined : 'Please enter the name of the policy holder'}
             label="Name of Policy Holder"
             value={this.props.data.insurancePolicyHolderName}
             onValueChange={(update) => {this.props.onValueChange('insurancePolicyHolderName', update);}}/>
+
         <ErrorableTextInput required
             errorMessage={isNotBlank(this.props.data.insurancePolicyNumber) ? undefined : 'Please enter the policy number'}
             label="Policy Number"
             value={this.props.data.insurancePolicyNumber}
             onValueChange={(update) => {this.props.onValueChange('insurancePolicyNumber', update);}}/>
+
         <ErrorableTextInput
             label="Group Code"
             value={this.props.data.insuranceGroupCode}

--- a/_health-care/_js/components/military-service/ServiceInformationSection.jsx
+++ b/_health-care/_js/components/military-service/ServiceInformationSection.jsx
@@ -22,9 +22,7 @@ class ServiceInformationSection extends React.Component {
                 onUserInput={(update) => {this.props.onStateChange('lastServiceBranch', update);}}/>
           </div>
           <div className="small-12 columns">
-            <p>
-              Last entry date
-            </p>
+            <label>Last entry date</label>
             <DateInput
                 day={this.props.data.lastEntryDate.day}
                 month={this.props.data.lastEntryDate.month}
@@ -32,9 +30,7 @@ class ServiceInformationSection extends React.Component {
                 onValueChange={(update) => {this.props.onStateChange('lastEntryDate', update);}}/>
           </div>
           <div className="small-12 columns">
-            <p>
-              Last discharge date
-            </p>
+            <label>Last discharge date</label>
             <DateInput
                 day={this.props.data.lastDischargeDate.day}
                 month={this.props.data.lastDischargeDate.month}

--- a/_health-care/_js/components/personal-information/AdditionalInformationSection.jsx
+++ b/_health-care/_js/components/personal-information/AdditionalInformationSection.jsx
@@ -7,15 +7,10 @@ import VaMedicalFacility from './VaMedicalFacility';
 class AdditionalInformationSection extends React.Component {
   render() {
     return (
-      <div>
+      <fieldset>
         <div className="row">
           <div className="small-12 columns">
             <h4>Additional Information</h4>
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="small-12 columns">
             <ErrorableCheckbox
                 label="I am enrolling to obtain minimal essential coverage under the affordable care act"
                 checked={this.props.data.isEssentialAcaCoverage}
@@ -42,7 +37,7 @@ class AdditionalInformationSection extends React.Component {
                 onValueChange={(update) => {this.props.onStateChange('wantsInitialVaContact', update);}}/>
           </div>
         </div>
-      </div>
+      </fieldset>
     );
   }
 }

--- a/_health-care/_js/components/personal-information/MothersMaidenName.jsx
+++ b/_health-care/_js/components/personal-information/MothersMaidenName.jsx
@@ -28,7 +28,7 @@ class MothersMaidenName extends React.Component {
 
   render() {
     return (
-      <div className="usa-input-grid usa-input-grid-large">
+      <div>
         <ErrorableTextInput
             errorMessage={this.validateRequiredFields(this.props.value) ? undefined : 'Please enter a valid name'}
             label="Mother’s Maiden Name"

--- a/_health-care/_js/components/personal-information/NameAndGeneralInfoSection.jsx
+++ b/_health-care/_js/components/personal-information/NameAndGeneralInfoSection.jsx
@@ -13,55 +13,41 @@ import { maritalStatuses } from '../../utils/options-for-select.js';
 class NameAndGeneralInfoSection extends React.Component {
   render() {
     return (
-      <div className="tabs-content">
+      <fieldset>
         <div className="row">
           <div className="small-12 columns">
-            <h3>Name and General Information</h3>
+            <h4>Veteran's Name</h4>
+            <FullName required
+                value={this.props.data.fullName}
+                onUserInput={(update) => {this.props.onStateChange('fullName', update);}}/>
+            <MothersMaidenName value={this.props.data.mothersMaidenName}
+                onUserInput={(update) => {this.props.onStateChange('mothersMaidenName', update);}}/>
+            <SocialSecurityNumber required
+                ssn={this.props.data.socialSecurityNumber}
+                onValueChange={(update) => {this.props.onStateChange('socialSecurityNumber', update);}}/>
+            <Gender value={this.props.data.gender} onUserInput={(update) => {this.props.onStateChange('gender', update);}}/>
+          </div>
+          <div className="small-12 columns">
+            <label>Date of Birth</label>
+            <DateInput required
+                day={this.props.data.dateOfBirth.day}
+                month={this.props.data.dateOfBirth.month}
+                year={this.props.data.dateOfBirth.year}
+                onValueChange={(update) => {this.props.onStateChange('dateOfBirth', update);}}/>
           </div>
         </div>
-        <fieldset className="usa-fieldset-inputs usa-sans">
-          <div className="row">
-            <div className="small-12 columns">
-              <h4>Veteran's Name</h4>
-              <FullName required
-                  value={this.props.data.fullName}
-                  onUserInput={(update) => {this.props.onStateChange('fullName', update);}}/>
-              <MothersMaidenName value={this.props.data.mothersMaidenName}
-                  onUserInput={(update) => {this.props.onStateChange('mothersMaidenName', update);}}/>
-              <SocialSecurityNumber required
-                  ssn={this.props.data.socialSecurityNumber}
-                  onValueChange={(update) => {this.props.onStateChange('socialSecurityNumber', update);}}/>
-              <Gender value={this.props.data.gender} onUserInput={(update) => {this.props.onStateChange('gender', update);}}/>
-            </div>
-            <div className="small-12 columns">
-              <h4>Date of Birth</h4>
-              <span className="usa-form-hint usa-datefield-hint" id="dobHint">For example: 04 28 1986</span>
-              <DateInput required
-                  day={this.props.data.dateOfBirth.day}
-                  month={this.props.data.dateOfBirth.month}
-                  year={this.props.data.dateOfBirth.year}
-                  onValueChange={(update) => {this.props.onStateChange('dateOfBirth', update);}}/>
-            </div>
-          </div>
 
-          <div className="usa-input-grid usa-input-grid-large">
-            <h4>Place of Birth</h4>
-            <div>
-              <div className="usa-input-grid usa-input-grid-medium">
-                <label htmlFor="veteran_city_of_birth">City</label>
-                <input type="text" name="veteran[city_of_birth]"/>
-              </div>
-              <State value={this.props.data.state} onUserInput={(update) => {this.props.onStateChange('state', update);}}/>
-            </div>
-          </div>
-          <div className="sa-input-grid usa-input-grid-large">
-            <ErrorableSelect label="Current Marital Status"
-                options={maritalStatuses}
-                value={this.props.data.maritalStatus}
-                onValueChange={(update) => {this.props.onStateChange('maritalStatus', update);}}/>
-          </div>
-        </fieldset>
-      </div>
+        <div>
+          <h4>Place of Birth</h4>
+          <label htmlFor="veteran_city_of_birth">City</label>
+          <input type="text" name="veteran[city_of_birth]"/>
+          <State value={this.props.data.state} onUserInput={(update) => {this.props.onStateChange('state', update);}}/>
+        </div>
+        <ErrorableSelect label="Current Marital Status"
+            options={maritalStatuses}
+            value={this.props.data.maritalStatus}
+            onValueChange={(update) => {this.props.onStateChange('maritalStatus', update);}}/>
+      </fieldset>
     );
   }
 }

--- a/_health-care/_js/components/personal-information/VAInformationSection.jsx
+++ b/_health-care/_js/components/personal-information/VAInformationSection.jsx
@@ -24,9 +24,9 @@ class VaInformationSection extends React.Component {
                   label="Are you compensable VA Service Connected 0% - 40%?"
                   checked={this.props.data.compensableVaServiceConnected}
                   onValueChange={(update) => {this.props.onStateChange('compensableVaServiceConnected', update);}}/>
-              <p>
+              <span>
                 A VA determination that a Service-connected disability is severe enough to warrant monetary compensation.
-              </p>
+              </span>
             </div>
           }
           {this.props.data.isVaServiceConnected === true && this.props.data.compensableVaServiceConnected === true &&

--- a/_health-care/_js/components/personal-information/VeteranAddressSection.jsx
+++ b/_health-care/_js/components/personal-information/VeteranAddressSection.jsx
@@ -21,7 +21,7 @@ class VeteranAddressSection extends React.Component {
 
   render() {
     return (
-      <div>
+      <fieldset>
         <div className="row">
           <div className="small-12 columns">
             <h4>Permanent Address</h4>
@@ -57,7 +57,7 @@ class VeteranAddressSection extends React.Component {
                 onValueChange={(update) => {this.props.onStateChange('mobilePhone', update);}}/>
           </div>
         </div>
-      </div>
+      </fieldset>
     );
   }
 }

--- a/_health-care/_js/components/questions/Email.jsx
+++ b/_health-care/_js/components/questions/Email.jsx
@@ -25,7 +25,7 @@ class Email extends React.Component {
       errorMessage = isValidEmail(this.props.value) ? undefined : 'Please put your email in this format x@x.xxx';
     }
     return (
-      <div className="usa-input-grid usa-input-grid-large">
+      <div>
         <ErrorableTextInput
             errorMessage={errorMessage}
             label={this.props.label}

--- a/_health-care/_js/components/questions/FullName.jsx
+++ b/_health-care/_js/components/questions/FullName.jsx
@@ -76,7 +76,7 @@ class FullName extends React.Component {
               onValueChange={(update) => {this.handleChange('last', update);}}/>
         </div>
 
-        <div className="usa-input-grid usa-input-grid-small">
+        <div>
           <ErrorableSelect
               label="Suffix"
               options={suffixes}

--- a/_health-care/_js/components/questions/Gender.jsx
+++ b/_health-care/_js/components/questions/Gender.jsx
@@ -23,7 +23,7 @@ class Gender extends React.Component {
 
   render() {
     return (
-      <div className="usa-input-grid usa-input-grid-large">
+      <div>
         <label htmlFor={this.selectId}>
           Gender
         </label>

--- a/_health-care/_js/components/questions/Phone.jsx
+++ b/_health-care/_js/components/questions/Phone.jsx
@@ -27,7 +27,7 @@ class Phone extends React.Component {
     }
 
     return (
-      <div className="usa-input-grid usa-input-grid-large">
+      <div>
         <ErrorableTextInput
             errorMessage={errorMessage}
             label={this.props.label}

--- a/_health-care/_js/components/questions/SocialSecurityNumber.jsx
+++ b/_health-care/_js/components/questions/SocialSecurityNumber.jsx
@@ -32,7 +32,7 @@ class SocialSecurityNumber extends React.Component {
   render() {
     const errorMessage = this.validate(this.props.ssn) ? undefined : 'Please put your number in this format xxx-xx-xxxx';
     return (
-      <div className="usa-input-grid usa-input-grid-medium">
+      <div>
         <ErrorableTextInput
             errorMessage={errorMessage}
             label={this.props.label || 'Social Security Number'}

--- a/_health-care/_js/components/questions/State.jsx
+++ b/_health-care/_js/components/questions/State.jsx
@@ -95,7 +95,7 @@ class State extends React.Component {
     });
 
     return (
-      <div className="usa-input-grid usa-input-grid-large">
+      <div>
         <label htmlFor={this.selectId}>
           State
         </label>

--- a/_sass/_hca.scss
+++ b/_sass/_hca.scss
@@ -1,0 +1,35 @@
+// TODO: properly incorporate usds web standards for this
+body .row {
+  max-width: 62.5em;
+}
+
+.form-panel {
+  @include media($medium-screen) {
+    max-width: $usa-form-width;
+  }
+}
+
+.main-form,
+.progress-box {
+  button {
+    width: 100%;
+  }
+}
+
+.progress-box {
+  padding: 1rem 2rem;
+  margin: 1.5rem 0  ;
+  border: 1px solid #eee;
+}
+
+.form-section {
+  display: none;
+}
+
+#content .section {
+  fieldset {
+    h4 {
+      padding: 0;
+    }
+  }
+}

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -22,60 +22,6 @@ body {
   margin-top: 0;
 }
 
-// TODO: properly incorporate usds web standards for this
-body .row {
-  max-width: 62.5em;
-}
-
-.usa-sidenav-list {
-  li {
-    list-style: none;
-    line-height: 2em;
-
-    a {
-      text-decoration: none;
-      background: none;
-
-      &.usa-current {
-        color: $color-base;
-        font-weight: normal;
-      }
-    }
-  }
-
-  .usa-sidenav-sub_list {
-    padding-left: 0.5em;
-
-    a.usa-current {
-      color: $color-primary;
-      font-weight: $font-bold;
-    }
-  }
-}
-
-.form-panel {
-  @include media($medium-screen) {
-    max-width: $usa-form-width;
-  }
-}
-
-.main-form,
-.progress-box {
-  button {
-    width: 100%;
-  }
-}
-
-.progress-box {
-  padding: 1rem 2rem;
-  margin: 1.5rem 0  ;
-  border: 1px solid #eee;
-}
-
-.form-section {
-  display: none;
-}
-
 // Skip link
 
 .show-on-focus {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -42,3 +42,4 @@
 
 
 @import "va";
+@import "hca";


### PR DESCRIPTION
Still in progress, but wanted to create a PR for what I have so far so that we can merge this and build off of it. Main changes:
- Created a separate scss file for HCA-specific styles. Some of the styles are overwriting general vets.gov styles and I wanted it to be clear that these were for HCA only. Also, eventually if we're pulling HCA out of vets.gov it'll make it easier to pull out the styles.
- I don't think we were using the web standards classes correctly. We were using `usa-input-grid` classes when I think those should only be used if you need your inputs to align to a grid, which we don't need to. So I mostly removed those. I think there are other classes we should be using for grid layout.
- Remove "Information" from all of the section titles. 
- Changed some html tags to be consistent and styled correctly.

Still to do:
- Figure out spacing between elements on the page. U.S. web design standards adds margin top to the labels of inputs instead of margin bottom to the inputs themselves to create spacing between questions. This leads to some strange behavior where there is no space between the last input in a set of inputs and the header or continue button that follows it. Need to figure out a good solution for this.

<img width="613" alt="screen shot 2016-03-21 at 5 47 15 pm" src="https://cloud.githubusercontent.com/assets/3886085/13935296/068d9bd0-ef8d-11e5-8d69-69278b9d38aa.png">
