### PR TITLE
Collapsed inactive subsections in progress

### DIFF
--- a/_health-care/_js/components/Nav.jsx
+++ b/_health-care/_js/components/Nav.jsx
@@ -9,87 +9,88 @@ import React from 'react';
  */
 class Nav extends React.Component {
   render() {
+    const subnavStyles = 'step one wow fadeIn animated';
     // TODO(akainic): change this check once the alias for introduction has been changed
     return (
       <ol className="process">
-        <li className="step one wow fadeIn animated">
+        <li className={`one ${subnavStyles} ${this.props.currentUrl.startsWith('/introduction') ? ' section-current' : ''}`}>
           <div>
-            <h5 className={this.props.currentUrl.startsWith('/introduction') ? ' section-current' : ''}>Introduction</h5>
+            <h5>Introduction</h5>
           </div>
         </li>
-        <li role="presentation" className="step two wow fadeIn animated">
+        <li role="presentation" className={`two ${subnavStyles} ${this.props.currentUrl.startsWith('/personal-information') ? ' section-current' : ''}`}>
           <div>
-            <h5 className={this.props.currentUrl.startsWith('/personal-information') ? ' section-current' : ''}>Personal Information</h5>
+            <h5>Personal Information</h5>
             <ul className="usa-unstyled-list">
-              <li className={this.props.currentUrl === '/personal-information/name-and-general-information' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/personal-information/name-and-general-information' ? ' sub-section-current' : ''}>
                 Name and General
               </li>
-              <li className={this.props.currentUrl === '/personal-information/va-information' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/personal-information/va-information' ? ' sub-section-current' : ''}>
                 VA-Specific
               </li>
-              <li className={this.props.currentUrl === '/personal-information/additional-information' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/personal-information/additional-information' ? ' sub-section-current' : ''}>
                 Additional
               </li>
-              <li className={this.props.currentUrl === '/personal-information/demographic-information' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/personal-information/demographic-information' ? ' sub-section-current' : ''}>
                 Demographic
               </li>
-              <li className={this.props.currentUrl === '/personal-information/veteran-address' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/personal-information/veteran-address' ? ' sub-section-current' : ''}>
                 Veteran Address
               </li>
             </ul>
           </div>
         </li>
-        <li role="presentation" className="step three wow fadeIn animated">
+        <li role="presentation" className={`three ${subnavStyles} ${this.props.currentUrl.startsWith('/insurance-information') ? ' section-current' : ''}`}>
           <div>
-            <h5 className={this.props.currentUrl.startsWith('/insurance-information') ? ' section-current' : ''}>Insurance Information</h5>
+            <h5>Insurance Information</h5>
             <ul className="usa-unstyled-list">
-              <li className={this.props.currentUrl === '/insurance-information/general' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/insurance-information/general' ? ' sub-section-current' : ''}>
                 General Insurance
               </li>
-              <li className={this.props.currentUrl === '/insurance-information/medicare-medicaid' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/insurance-information/medicare-medicaid' ? ' sub-section-current' : ''}>
                 Medicare/Medicaid
               </li>
             </ul>
           </div>
         </li>
-        <li role="presentation" className="step four wow fadeIn animated">
+        <li role="presentation" className={`four ${subnavStyles} ${this.props.currentUrl.startsWith('/military-service') ? ' section-current' : ''}`}>
           <div>
-            <h5 className={this.props.currentUrl.startsWith('/military-service') ? ' section-current' : ''}>Military Service</h5>
+            <h5>Military Service</h5>
             <ul className="usa-unstyled-list">
-              <li className={this.props.currentUrl === '/military-service/service-information' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/military-service/service-information' ? ' sub-section-current' : ''}>
                 Service
               </li>
-              <li className={this.props.currentUrl === '/military-service/additional-information' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/military-service/additional-information' ? ' sub-section-current' : ''}>
                 Additional Military
               </li>
             </ul>
           </div>
         </li>
-        <li role="presentation" className="step five wow fadeIn animated">
+        <li role="presentation" className={`five ${subnavStyles} ${this.props.currentUrl.startsWith('/financial-assessment') ? ' section-current' : ''}`}>
           <div>
-            <h5 className={this.props.currentUrl.startsWith('/financial-assessment') ? ' section-current' : ''}>Financial Assessment</h5>
+            <h5>Financial Assessment</h5>
             <ul className="usa-unstyled-list">
-              <li className={this.props.currentUrl === '/financial-assessment/financial-disclosure' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/financial-assessment/financial-disclosure' ? ' sub-section-current' : ''}>
                 Financial Disclosure
               </li>
-              <li className={this.props.currentUrl === '/financial-assessment/spouse-information' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/financial-assessment/spouse-information' ? ' sub-section-current' : ''}>
                 Spouse
               </li>
-              <li className={this.props.currentUrl === '/financial-assessment/child-information' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/financial-assessment/child-information' ? ' sub-section-current' : ''}>
                 Child
               </li>
-              <li className={this.props.currentUrl === '/financial-assessment/annual-income' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/financial-assessment/annual-income' ? ' sub-section-current' : ''}>
                 Annual Income
               </li>
-              <li className={this.props.currentUrl === '/financial-assessment/deductible-expenses' ? ' section-current' : ''}>
+              <li className={this.props.currentUrl === '/financial-assessment/deductible-expenses' ? ' sub-section-current' : ''}>
                 Deductible Expenses
               </li>
             </ul>
           </div>
         </li>
-        <li role="presentation" className="step six last wow fadeIn animated">
+        <li role="presentation" className={`six last ${subnavStyles} ${this.props.currentUrl.startsWith('/review-and-submit') ? ' section-current' : ''}`}>
           <div>
-            <h5 className={this.props.currentUrl.startsWith('/review-and-submit') ? ' section-current' : ''}>Review and Submit</h5>
+            <h5>Review and Submit</h5>
           </div>
         </li>
       </ol>

--- a/_sass/_hca.scss
+++ b/_sass/_hca.scss
@@ -41,3 +41,33 @@ body .row {
 .input-section {
   margin-bottom: 2em; 
 }
+
+.process {
+  li {
+    h5 {
+      color: $color-gray;
+    }
+    li {
+      display: none;
+    }
+    &:before {
+      background: $color-gray;
+    }
+    &.section-current {
+      h5 {
+        font-weight: bold;
+        color: $color-primary;
+      }
+      li {
+        display: list-item;
+        &.sub-section-current {
+          font-weight: bold;
+          color: $color-primary;
+        }
+      }
+      &:before {
+        background: $color-primary;
+      }
+    }
+  }
+}

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -1817,9 +1817,6 @@ margin: 0;
   h5 {
     font-size: 1.3em; 
     margin: 0; padding: 0;
-    &.section-current {
-      font-weight: bold;
-    }
   }
   h6 {font-size: 1.1em; margin: 0; padding: 0;}
   p:nth-child(1) {
@@ -1830,10 +1827,6 @@ margin: 0;
   list-style: none;
   li {
 
-    &.section-current {
-      font-weight: bold;
-      color: $color-primary;
-    }
     p:nth-child(1) {
       font-size: 1em;
       color: #333;

--- a/spec/javascripts/health-care/components/Nav.spec.jsx
+++ b/spec/javascripts/health-care/components/Nav.spec.jsx
@@ -34,7 +34,7 @@ describe('<Nav>', () => {
     });
   });
 
-  describe('active sections have section-current class', () => {
+  describe('active sections have section-current or sub-section-current class', () => {
     const history = createMemoryHistory('/');
     let nav;
 
@@ -63,8 +63,8 @@ describe('<Nav>', () => {
 
     const expectActiveSectionForNavAndSubNav = (component, path) => {
       history.replace(path);
-      const activeSection = ReactTestUtils.scryRenderedDOMComponentsWithClass(component, 'section-current');
-      expect(activeSection).to.have.lengthOf(2);
+      const activeSubSection = ReactTestUtils.scryRenderedDOMComponentsWithClass(component, 'sub-section-current');
+      expect(activeSubSection).to.have.lengthOf(1);
     };
 
     it('/introduction', () => {


### PR DESCRIPTION
This PR:
- collapses sections that are not currently active and removes them from the users view.

What's not in this PR:
- Next I would like to add some confirmation that the user has successfully completed a previous section like a green check mark or something.

Still planning to check in with @emilyville and @gnakm to make sure the styling is how they want it.

![screen shot 2016-03-22 at 1 48 14 pm](https://cloud.githubusercontent.com/assets/3453669/13961859/c721ae0c-f034-11e5-860a-988613fb8f31.png)
