### PR TITLE
Removing a rogue .process li li selector. closes #1515

### DIFF
--- a/_health-care/_js/components/Nav.jsx
+++ b/_health-care/_js/components/Nav.jsx
@@ -12,7 +12,7 @@ class Nav extends React.Component {
     const subnavStyles = 'step one wow fadeIn animated';
     // TODO(akainic): change this check once the alias for introduction has been changed
     return (
-      <ol className="process">
+      <ol className="hca-process">
         <li className={`one ${subnavStyles} ${this.props.currentUrl.startsWith('/introduction') ? ' section-current' : ''}`}>
           <div>
             <h5>Introduction</h5>

--- a/_sass/_hca.scss
+++ b/_sass/_hca.scss
@@ -46,7 +46,7 @@ body .row {
   }
 }
 
-.process {
+.hca-process {
   li {
     h5 {
       color: $color-gray;


### PR DESCRIPTION
Changed .process to .hca-process in _sass/_hca.scss to limit the effects of its styles.
