### PR TITLE
Hca allow ssn without dashes

### DIFF
--- a/_health-care/_js/components/Nav.jsx
+++ b/_health-care/_js/components/Nav.jsx
@@ -12,7 +12,7 @@ class Nav extends React.Component {
     const subnavStyles = 'step one wow fadeIn animated';
     // TODO(akainic): change this check once the alias for introduction has been changed
     return (
-      <ol className="hca-process">
+      <ol className="process hca-process">
         <li className={`one ${subnavStyles} ${this.props.currentUrl.startsWith('/introduction') ? ' section-current' : ''}`}>
           <div>
             <h5>Introduction</h5>

--- a/_health-care/_js/utils/validations.js
+++ b/_health-care/_js/utils/validations.js
@@ -16,7 +16,7 @@ function isNotBlank(value) {
 
 function isValidSSN(value) {
   if (value !== null) {
-    return /^\d{3}-\d{2}-\d{4}$/.test(value);
+    return /^\d{3}-?\d{2}-?\d{4}$/.test(value);
   }
   return true;
 }

--- a/spec/javascripts/health-care/utils/validations.spec.js
+++ b/spec/javascripts/health-care/utils/validations.spec.js
@@ -15,6 +15,7 @@ describe('Validations unit tests', () => {
       expect(isValidSSN('900-22-1234')).to.be.true;
       expect(isValidSSN('111-00-1234')).to.be.true;
       expect(isValidSSN('111-22-0000')).to.be.true;
+      expect(isValidSSN('111221234')).to.be.true;
     });
 
     it('rejects invalid ssn format', () => {
@@ -29,9 +30,6 @@ describe('Validations unit tests', () => {
       // No leading or trailing spaces.
       expect(isValidSSN('111-22-1A34 ')).to.be.false;
       expect(isValidSSN(' 111-22-1234')).to.be.false;
-
-      // Dashes are required.
-      expect(isValidSSN('111221234')).to.be.false;
 
       // Too few numbers is invalid.
       expect(isValidSSN('111-22-123')).to.be.false;


### PR DESCRIPTION
During user testing, veterans were confused by not being allowed to enter their SSN without dashes. We decided to change the validation to allow both dashes or no dashes. If we need to submit a particular format in the xml, we can alter their response on the back end. 

This PR also adds the `process` class back to the Nav. This was changed last week to `hca-process` for hca-specific styles in the effort not to conflict with other subway map styling elsewhere on vets.gov, but we still need the basic subway map styling here.
