### PR TITLE
Adding .va-button-primary class to GI bill pages. closes #1570

### DIFF
--- a/_education/gi-bill/buy-up-program.md
+++ b/_education/gi-bill/buy-up-program.md
@@ -9,7 +9,7 @@ concurrence: incomplete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/foreign-programs.md
+++ b/_education/gi-bill/foreign-programs.md
@@ -9,7 +9,7 @@ concurrence: incomplete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/higher-learning.md
+++ b/_education/gi-bill/higher-learning.md
@@ -9,7 +9,7 @@ concurrence: incomplete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/montgomery-active-duty.md
+++ b/_education/gi-bill/montgomery-active-duty.md
@@ -9,7 +9,7 @@ concurrence: incomplete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/montgomery-selected-reserve.md
+++ b/_education/gi-bill/montgomery-selected-reserve.md
@@ -9,7 +9,7 @@ template: 4-action-page
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/post-9-11.md
+++ b/_education/gi-bill/post-9-11.md
@@ -9,7 +9,7 @@ concurrence: complete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/post-9-11/bill-transfer.md
+++ b/_education/gi-bill/post-9-11/bill-transfer.md
@@ -8,7 +8,7 @@ template: 6-info-page
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/post-9-11/fry-scholarship.md
+++ b/_education/gi-bill/post-9-11/fry-scholarship.md
@@ -8,7 +8,7 @@ template: 4-action-page
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/post-9-11/yellow-ribbon-program.md
+++ b/_education/gi-bill/post-9-11/yellow-ribbon-program.md
@@ -9,7 +9,7 @@ concurrence: incomplete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/survivors-dependent-assistance.md
+++ b/_education/gi-bill/survivors-dependent-assistance.md
@@ -9,7 +9,7 @@ Template: 6-info-page
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/survivors-dependent-assistance/dependents-education.md
+++ b/_education/gi-bill/survivors-dependent-assistance/dependents-education.md
@@ -9,7 +9,7 @@ concurrence: incomplete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/survivors-dependent-assistance/fry-scholarship.md
+++ b/_education/gi-bill/survivors-dependent-assistance/fry-scholarship.md
@@ -8,7 +8,7 @@ concurrence: incomplete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/transfer.md
+++ b/_education/gi-bill/transfer.md
@@ -9,7 +9,7 @@ concurrence: complete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/tuition-assistance.md
+++ b/_education/gi-bill/tuition-assistance.md
@@ -9,7 +9,7 @@ Template: 4-action-page
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/tutorial-assistance.md
+++ b/_education/gi-bill/tutorial-assistance.md
@@ -9,7 +9,7 @@ concurrence: incomplete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/gi-bill/yellow-ribbon.md
+++ b/_education/gi-bill/yellow-ribbon.md
@@ -9,7 +9,7 @@ concurrence: incomplete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Groundwork for issue #1449. Changes to:
- _education/gi-bill/buy-up-program.md
- _education/gi-bill/foreign-programs.md
- _education/gi-bill/higher-learning.md
- _education/gi-bill/montgomery-active-duty.md
- _education/gi-bill/montgomery-selected-reserve.md
- _education/gi-bill/post-9-11.md
- _education/gi-bill/post-9-11/bill-transfer.md
- _education/gi-bill/post-9-11/fry-scholarship.md
- _education/gi-bill/post-9-11/yellow-ribbon-program.md
- _education/gi-bill/survivors-dependent-assistance.md
- _education/gi-bill/survivors-dependent-assistance/dependents-education.md
- _education/gi-bill/survivors-dependent-assistance/fry-scholarship.md
- _education/gi-bill/transfer.md
- _education/gi-bill/tuition-assistance.md
- _education/gi-bill/tutorial-assistance.md
- _education/gi-bill/yellow-ribbon.md
