### PR TITLE
Adding .va-button-primary to work-learn pages. closes #1572

### DIFF
--- a/_education/work-learn.md
+++ b/_education/work-learn.md
@@ -9,7 +9,7 @@ template: 1-topic-landing
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/work-learn/co-op-training.md
+++ b/_education/work-learn/co-op-training.md
@@ -9,7 +9,7 @@ template: 4-action-page
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/work-learn/job-and-apprenticeship.md
+++ b/_education/work-learn/job-and-apprenticeship.md
@@ -9,7 +9,7 @@ template: 4-action-page
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/work-learn/non-college-degree-program.md
+++ b/_education/work-learn/non-college-degree-program.md
@@ -9,7 +9,7 @@ template: 6-info-page
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/work-learn/non-traditional.md
+++ b/_education/work-learn/non-traditional.md
@@ -9,7 +9,7 @@ template: 6-info-page
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/work-learn/non-traditional/accelerated-payments.md
+++ b/_education/work-learn/non-traditional/accelerated-payments.md
@@ -9,7 +9,7 @@ concurrence: incomplete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/work-learn/non-traditional/correspondence-training.md
+++ b/_education/work-learn/non-traditional/correspondence-training.md
@@ -9,7 +9,7 @@ concurrence: incomplete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/work-learn/non-traditional/independent-distance-learning.md
+++ b/_education/work-learn/non-traditional/independent-distance-learning.md
@@ -9,7 +9,7 @@ concurrence: incomplete
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>

--- a/_education/work-learn/workstudy.md
+++ b/_education/work-learn/workstudy.md
@@ -9,7 +9,7 @@ template: 4-action-page
 <div class="action-bar">
   <div class="row">
     <div class="small-12 columns">
-      <a class="usa-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
+      <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Groundwork for issue #1449. Changes to the following:
- _education/work-learn.md
- _education/work-learn/co-op-training.md
- _education/work-learn/job-and-apprenticeship.md
- _education/work-learn/non-college-degree-program.md
- _education/work-learn/non-traditional.md
- _education/work-learn/non-traditional/accelerated-payments.md
- _education/work-learn/non-traditional/correspondence-training.md
- _education/work-learn/non-traditional/independent-distance-learning.md
- _education/work-learn/workstudy.md
