### PR TITLE
Hca leading zero fix dateinput

### DIFF
--- a/_health-care/_js/components/form-elements/DateInput.jsx
+++ b/_health-care/_js/components/form-elements/DateInput.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import _ from 'lodash';
 
+import ErrorableSelect from '../form-elements/ErrorableSelect';
+import ErrorableNumberInput from '../form-elements/ErrorableNumberInput';
+
+import { months, days } from '../../utils/options-for-select.js';
 import { isBlank, isValidDate } from '../../utils/validations';
 
 /**
@@ -24,18 +28,27 @@ class DateInput extends React.Component {
     this.id = _.uniqueId('date-input-');
   }
 
-  handleChange() {
+  handleChange(path, update) {
     const date = {
-      month: Number(this._month.value),
-      day: Number(this._day.value),
-      year: Number(this._year.value)
+      month: Number(this.props.month),
+      day: Number(this.props.day),
+      year: Number(this.props.year)
     };
+
+    date[path] = Number(update);
 
     this.props.onValueChange(date);
   }
 
   render() {
     let isValid;
+    let daysForSelectedMonth = [];
+    const selectedMonth = this.props.month;
+
+    if (selectedMonth) {
+      daysForSelectedMonth = days[selectedMonth];
+    }
+
     if (this.props.required) {
       isValid = isValidDate(this.props.day, this.props.month, this.props.year);
     } else {
@@ -46,55 +59,31 @@ class DateInput extends React.Component {
     return (
       <div>
         <label>{this.props.label ? this.props.label : 'Date of Birth'}</label>
-        <span className="usa-form-hint usa-datefield-hint" id="dobHint">For example: 04 28 1986</span>
+        <span className="usa-form-hint usa-datefield-hint" id="dobHint">For example: Apr 28 1986</span>
         <div className={isValid ? undefined : 'usa-input-error'}>
           <div className="usa-date-of-birth row">
-            <div className="usa-datefield usa-form-group usa-form-group-month">
-              <label
-                  className={isValid ? undefined : 'usa-input-error-label'}
-                  htmlFor={`${this.id}-month`}>
-                Month
-              </label>
-              <input
-                  className="usa-form-control"
-                  id={`${this.id}-month`}
-                  max="12"
-                  min="1"
-                  pattern="0?[1-9]|1[012]"
-                  ref={(c) => { this._month = c; }}
-                  type="number"
+            <div className="hca-datefield-month">
+              <ErrorableSelect errorMessage={isValid ? undefined : ''}
+                  label="Month"
+                  options={months}
                   value={this.props.month}
-                  onChange={this.handleChange}/>
+                  onValueChange={(update) => {this.handleChange('month', update);}}/>
             </div>
-            <div className="usa-datefield usa-form-group usa-form-group-day">
-              <label
-                  className={isValid ? undefined : 'usa-input-error-label'}
-                  htmlFor={`${this.id}-day`}>Day</label>
-              <input
-                  className="usa-form-control"
-                  id={`${this.id}-day`}
-                  max="31"
-                  min="1"
-                  pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]"
-                  ref={(c) => { this._day = c; }}
-                  type="number"
+            <div className="hca-datefield-day">
+              <ErrorableSelect errorMessage={isValid ? undefined : ''}
+                  label="Day"
+                  options={daysForSelectedMonth}
                   value={this.props.day}
-                  onChange={this.handleChange}/>
+                  onValueChange={(update) => {this.handleChange('day', update);}}/>
             </div>
             <div className="usa-datefield usa-form-group usa-form-group-year">
-              <label
-                  className={isValid ? undefined : 'usa-input-error-label'}
-                  htmlFor={`${this.id}-year`}>Year</label>
-              <input
-                  className="usa-form-control"
-                  id={`${this.id}-year`}
+              <ErrorableNumberInput errorMessage={isValid ? undefined : ''}
+                  label="Year"
                   max={new Date().getFullYear()}
                   min="1900"
                   pattern="[0-9]{4}"
-                  ref={(c) => { this._year = c; }}
-                  type="number"
                   value={this.props.year}
-                  onChange={this.handleChange}/>
+                  onValueChange={(update) => {this.handleChange('year', update);}}/>
             </div>
           </div>
         </div>

--- a/_health-care/_js/components/form-elements/ErrorableNumberInput.jsx
+++ b/_health-care/_js/components/form-elements/ErrorableNumberInput.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import _ from 'lodash';
+
+/**
+ * A form input with a label that can display error messages.
+ *
+ * Props:
+ * `errorMessage` - Error string to display in the component.
+ *                  When defined, indicates input has a validation error.
+ * `label` - String for the input field label.
+ * `max` - String or function.
+ * `min` - String or function.
+ * `pattern` - String specifying the pattern for the input.
+ * `placeholder` - placeholder string for input field.
+ * `required` - boolean. Render marker indicating field is required.
+ * `value` - string. Value of the input field.
+ * `onValueChange` - a function with this prototype: (newValue)
+ */
+class ErrorableNumberInput extends React.Component {
+  constructor() {
+    super();
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  componentWillMount() {
+    this.inputId = _.uniqueId('errorable-number-input-');
+  }
+
+  handleChange(domEvent) {
+    this.props.onValueChange(domEvent.target.value);
+  }
+
+  render() {
+    // Calculate error state.
+    let errorSpan = '';
+    let errorSpanId = undefined;
+
+    // TODO: Look into an alternate way of adding error styling not based on presence of errorMessage:
+    // There could be cases where there is an error but we don't want a message to appear, and this
+    // is not clear right now
+    if (this.props.errorMessage) {
+      errorSpanId = `${this.inputId}-error-message`;
+      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
+    }
+
+    // Calculate required.
+    let requiredSpan = '';
+    if (this.props.required) {
+      requiredSpan = <span className="usa-additional_text">Required</span>;
+    }
+
+    return (
+      <div className={this.props.errorMessage ? 'usa-input-error' : undefined}>
+        <label
+            className={this.props.errorMessage !== undefined ? 'usa-input-error-label' : undefined}
+            htmlFor={this.inputId}>
+              {this.props.label}
+              {requiredSpan}
+        </label>
+        {errorSpan}
+        <input
+            aria-describedby={errorSpanId}
+            id={this.inputId}
+            max={this.props.max}
+            min={this.props.min}
+            pattern={this.props.pattern}
+            placeholder={this.props.placeholder}
+            type="number"
+            value={this.props.value}
+            onChange={this.handleChange}/>
+      </div>
+    );
+  }
+}
+
+ErrorableNumberInput.propTypes = {
+  errorMessage: React.PropTypes.string,
+  label: React.PropTypes.string.isRequired,
+  min: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.func
+  ]),
+  max: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.func
+  ]),
+  pattern: React.PropTypes.string,
+  placeholder: React.PropTypes.string,
+  required: React.PropTypes.bool,
+  value: React.PropTypes.string,
+  onValueChange: React.PropTypes.func.isRequired,
+};
+
+export default ErrorableNumberInput;

--- a/_health-care/_js/components/form-elements/ErrorableSelect.jsx
+++ b/_health-care/_js/components/form-elements/ErrorableSelect.jsx
@@ -63,7 +63,7 @@ class ErrorableSelect extends React.Component {
     return (
       <div className={this.props.errorMessage ? 'usa-input-error' : undefined}>
         <label
-            className={this.props.errorMessage ? 'usa-input-error-label' : undefined}
+            className={this.props.errorMessage !== undefined ? 'usa-input-error-label' : undefined}
             htmlFor={this.selectId}>
               {this.props.label}
               {requiredSpan}

--- a/_health-care/_js/components/personal-information/DemographicInformationSection.jsx
+++ b/_health-care/_js/components/personal-information/DemographicInformationSection.jsx
@@ -10,7 +10,7 @@ class DemographicInformationSection extends React.Component {
 
         <div className="input-section">
           <ErrorableCheckbox
-              label="Are you Spanish, Hispanic, or Lantino?"
+              label="Are you Spanish, Hispanic, or Latino?"
               checked={this.props.data.isSpanishHispanicLatino}
               onValueChange={(update) => {this.props.onStateChange('isSpanishHispanicLatino', update);}}/>
         </div>

--- a/_health-care/_js/utils/options-for-select.js
+++ b/_health-care/_js/utils/options-for-select.js
@@ -213,8 +213,8 @@ const countries = [
   { value: 'TUV', label: 'Tuvalu' },
   { value: 'UGA', label: 'Uganda' },
   { value: 'UKR', label: 'Ukraine' },
-  { value: 'ARE', label: 'United' },
-  { value: 'GBR', label: 'United' },
+  { value: 'ARE', label: 'United Arab Emirates' },
+  { value: 'GBR', label: 'United Kingdom' },
   { value: 'URY', label: 'Uruguay' },
   { value: 'UZB', label: 'Uzbekistan' },
   { value: 'VUT', label: 'Vanuatu' },
@@ -328,6 +328,40 @@ const suffixes = [
   'Jr.',
   'Sr.'
 ];
+
+const months = [
+  { label: 'Jan', value: 1 },
+  { label: 'Feb', value: 2 },
+  { label: 'Mar', value: 3 },
+  { label: 'Apr', value: 4 },
+  { label: 'May', value: 5 },
+  { label: 'Jun', value: 6 },
+  { label: 'Jul', value: 7 },
+  { label: 'Aug', value: 8 },
+  { label: 'Sep', value: 9 },
+  { label: 'Oct', value: 10 },
+  { label: 'Nov', value: 11 },
+  { label: 'Dec', value: 12 }
+];
+
+const twentyNineDays = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29'];
+const thirtyDays = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30'];
+const thirtyOneDays = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31'];
+
+const days = {
+  1: thirtyOneDays,
+  2: twentyNineDays,
+  3: thirtyOneDays,
+  4: thirtyDays,
+  5: thirtyOneDays,
+  6: thirtyDays,
+  7: thirtyOneDays,
+  8: thirtyOneDays,
+  9: thirtyDays,
+  10: thirtyOneDays,
+  11: thirtyDays,
+  12: thirtyOneDays
+};
 
 const vaMedicalFacilities = {
   AK: [
@@ -1374,6 +1408,8 @@ export {
   dischargeTypes,
   states,
   suffixes,
+  months,
+  days,
   vaMedicalFacilities,
   childRelationships
 };

--- a/_sass/_hca.scss
+++ b/_sass/_hca.scss
@@ -46,6 +46,28 @@ body .row {
   }
 }
 
+.hca-datefield-month,
+.hca-datefield-day {
+  clear: none;
+  float: left;
+  margin-right: 1.5rem;
+  width: 10rem;
+
+  & select {
+    padding-top: 0.85rem;
+    padding-bottom: 0.85rem;
+  }
+}
+
+.usa-input-error {
+  .hca-datefield-month,
+  .hca-datefield-day {
+    select {
+      border: 3px solid $color-secondary-dark;
+    }
+  }
+}
+
 .hca-process {
   li {
     h5 {

--- a/spec/javascripts/health-care/components/form-elements/DateInput.spec.jsx
+++ b/spec/javascripts/health-care/components/form-elements/DateInput.spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactTestUtils from 'react-addons-test-utils';
 import SkinDeep from 'skin-deep';
 
 import DateInput from '../../../../../_health-care/_js/components/form-elements/DateInput';
@@ -70,85 +69,10 @@ describe('<DateInput>', () => {
     });
   });
 
-  describe('error css', () => {
-    it('no error styles when date is valid', () => {
-      // Smarch is not a real month.
-      const tree = SkinDeep.shallowRender(
-        <DateInput day="1" month="12" year="2010" onValueChange={(_update) => {}}/>);
-      expect(tree.everySubTree('.usa-input-error')).to.have.lengthOf(0);
-      expect(tree.everySubTree('.usa-input-error-label')).to.have.lengthOf(0);
-    });
-
-    it('has error styles when date is invalid', () => {
-      const tree = SkinDeep.shallowRender(
-        <DateInput day="1" month="13" year="2010" onValueChange={(_update) => {}}/>);
-      expect(tree.everySubTree('.usa-input-error')).to.have.lengthOf(1);
-      expect(tree.everySubTree('.usa-input-error-label')).to.have.lengthOf(3);
-    });
-  });
-
-  describe('ensure value changes propagate', () => {
-    it('day changes', () => {
-      let dateInput;
-
-      const updatePromise = new Promise((resolve, _reject) => {
-        dateInput = ReactTestUtils.renderIntoDocument(
-          <DateInput
-              day={1}
-              month={2}
-              year={2010}
-              onValueChange={(update) => { resolve(update); }}/>
-        );
-      });
-
-      dateInput._day.value = 3;
-      ReactTestUtils.Simulate.change(dateInput._day);
-
-      return expect(updatePromise).to.eventually.eql({ day: 3, month: 2, year: 2010 });
-    });
-
-    it('month changes', () => {
-      let dateInput;
-
-      const updatePromise = new Promise((resolve, _reject) => {
-        dateInput = ReactTestUtils.renderIntoDocument(
-          <DateInput
-              day={1}
-              month={2}
-              year={2010}
-              onValueChange={(update) => { resolve(update); }}/>
-        );
-      });
-
-      dateInput._month.value = 3;
-      ReactTestUtils.Simulate.change(dateInput._month);
-
-      return expect(updatePromise).to.eventually.eql({ day: 1, month: 3, year: 2010 });
-    });
-
-    it('year changes', () => {
-      let dateInput;
-
-      const updatePromise = new Promise((resolve, _reject) => {
-        dateInput = ReactTestUtils.renderIntoDocument(
-          <DateInput
-              day={1}
-              month={2}
-              year={2010}
-              onValueChange={(update) => { resolve(update); }}/>
-        );
-      });
-
-      dateInput._year.value = 1900;
-      ReactTestUtils.Simulate.change(dateInput._year);
-
-      return expect(updatePromise).to.eventually.eql({ day: 1, month: 2, year: 1900 });
-    });
-  });
-
   it('has sane looking features', () => {
     const tree = SkinDeep.shallowRender(
       <DateInput day={1} month={12} year={2010} onValueChange={(_update) => {}}/>);
-    expect(tree.everySubTree('input')).to.have.lengthOf(3);
+    expect(tree.everySubTree('ErrorableNumberInput')).to.have.lengthOf(1);
+    expect(tree.everySubTree('ErrorableSelect')).to.have.lengthOf(2);
   });
 });

--- a/spec/javascripts/health-care/components/form-elements/ErrorableNumberInput.spec.jsx
+++ b/spec/javascripts/health-care/components/form-elements/ErrorableNumberInput.spec.jsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
+import SkinDeep from 'skin-deep';
+
+import ErrorableNumberInput from '../../../../../_health-care/_js/components/form-elements/ErrorableNumberInput';
+
+describe('<ErrorableNumberInput>', () => {
+  describe('propTypes', () => {
+    let consoleStub;
+    beforeEach(() => {
+      consoleStub = sinon.stub(console, 'error');
+    });
+
+    afterEach(() => {
+      consoleStub.restore();
+    });
+
+    it('label is required', () => {
+      SkinDeep.shallowRender(
+        <ErrorableNumberInput onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Required prop `label` was not specified in `ErrorableNumberInput`/);
+    });
+
+    it('label must be a string', () => {
+      SkinDeep.shallowRender(
+        <ErrorableNumberInput label onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `label` of type `boolean` supplied to `ErrorableNumberInput`, expected `string`./);
+    });
+
+    it('min must be a string or a function', () => {
+      SkinDeep.shallowRender(
+        <ErrorableNumberInput label="test" min onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `min` supplied to `ErrorableNumberInput`./);
+    });
+
+    it('max must be a string or a function', () => {
+      SkinDeep.shallowRender(
+        <ErrorableNumberInput label="test" max onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `max` supplied to `ErrorableNumberInput`./);
+    });
+
+    it('pattern must be a string', () => {
+      SkinDeep.shallowRender(
+        <ErrorableNumberInput label="test" pattern onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `pattern` of type `boolean` supplied to `ErrorableNumberInput`, expected `string`./);
+    });
+
+    it('onValueChange is required', () => {
+      SkinDeep.shallowRender(<ErrorableNumberInput label="test"/>);
+      sinon.assert.calledWithMatch(consoleStub, /Required prop `onValueChange` was not specified in `ErrorableNumberInput`/);
+    });
+
+    it('onValueChange must be a function', () => {
+      SkinDeep.shallowRender(<ErrorableNumberInput label="test" onValueChange/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `onValueChange` of type `boolean` supplied to `ErrorableNumberInput`, expected `function`/);
+    });
+
+    it('errorMessage must be a string', () => {
+      SkinDeep.shallowRender(
+        <ErrorableNumberInput label="test" errorMessage onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `errorMessage` of type `boolean` supplied to `ErrorableNumberInput`, expected `string`/);
+    });
+
+    it('placeholder must be a string', () => {
+      SkinDeep.shallowRender(
+        <ErrorableNumberInput label="test" placeholder onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `placeholder` of type `boolean` supplied to `ErrorableNumberInput`, expected `string`/);
+    });
+
+    it('value must be a string', () => {
+      SkinDeep.shallowRender(
+        <ErrorableNumberInput label="test" value onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `value` of type `boolean` supplied to `ErrorableNumberInput`, expected `string`/);
+    });
+
+    it('required must be a boolean', () => {
+      SkinDeep.shallowRender(
+        <ErrorableNumberInput label="test" required="hi" onValueChange={(_update) => {}}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `required` of type `string` supplied to `ErrorableNumberInput`, expected `boolean`/);
+    });
+  });
+
+  it('ensure value changes propagate', () => {
+    let errorableInput;
+
+    const updatePromise = new Promise((resolve, _reject) => {
+      errorableInput = ReactTestUtils.renderIntoDocument(
+        <ErrorableNumberInput label="test" onValueChange={(update) => { resolve(update); }}/>
+      );
+    });
+
+    const input = ReactTestUtils.findRenderedDOMComponentWithTag(errorableInput, 'input');
+    input.value = '1';
+    ReactTestUtils.Simulate.change(input);
+
+    return expect(updatePromise).to.eventually.eql('1');
+  });
+
+  it('no error styles when errorMessage undefined', () => {
+    const tree = SkinDeep.shallowRender(
+      <ErrorableNumberInput label="my label" onValueChange={(_update) => {}}/>);
+
+    // No error classes.
+    expect(tree.everySubTree('.usa-input-error')).to.have.lengthOf(0);
+    expect(tree.everySubTree('.usa-input-error-label')).to.have.lengthOf(0);
+    expect(tree.everySubTree('.usa-input-error-message')).to.have.lengthOf(0);
+
+    // Ensure no unnecessary class names on label w/o error..
+    const labels = tree.everySubTree('label');
+    expect(labels).to.have.lengthOf(1);
+    expect(labels[0].props.className).to.be.undefined;
+
+    // No error means no aria-describedby to not confuse screen readers.
+    const inputs = tree.everySubTree('input');
+    expect(inputs).to.have.lengthOf(1);
+    expect(inputs[0].props['aria-describedby']).to.be.undefined;
+  });
+
+  it('has error styles when errorMessage is set', () => {
+    const tree = SkinDeep.shallowRender(
+      <ErrorableNumberInput label="my label" errorMessage="error message" onValueChange={(_update) => {}}/>);
+
+    // Ensure all error classes set.
+    expect(tree.everySubTree('.usa-input-error')).to.have.lengthOf(1);
+
+    const labels = tree.everySubTree('.usa-input-error-label');
+    expect(labels).to.have.lengthOf(1);
+    expect(labels[0].text()).to.equal('my label');
+
+    const errorMessages = tree.everySubTree('.usa-input-error-message');
+    expect(errorMessages).to.have.lengthOf(1);
+    expect(errorMessages[0].text()).to.equal('error message');
+
+    // No error means no aria-describedby to not confuse screen readers.
+    const inputs = tree.everySubTree('input');
+    expect(inputs).to.have.lengthOf(1);
+    expect(inputs[0].props['aria-describedby']).to.not.be.undefined;
+    expect(inputs[0].props['aria-describedby']).to.equal(errorMessages[0].props.id);
+  });
+
+  it('required=false does not have required span', () => {
+    const tree = SkinDeep.shallowRender(
+      <ErrorableNumberInput label="my label" onValueChange={(_update) => {}}/>);
+
+    expect(tree.everySubTree('.usa-additional_text')).to.have.lengthOf(0);
+  });
+
+  it('required=true has required span', () => {
+    const tree = SkinDeep.shallowRender(
+      <ErrorableNumberInput label="my label" required onValueChange={(_update) => {}}/>);
+
+    const requiredSpan = tree.everySubTree('.usa-additional_text');
+    expect(requiredSpan).to.have.lengthOf(1);
+    expect(requiredSpan[0].text()).to.equal('Required');
+  });
+
+  it('label attribute propagates', () => {
+    const tree = SkinDeep.shallowRender(
+      <ErrorableNumberInput label="my label" onValueChange={(_update) => {}}/>);
+
+    // Ensure label text is correct.
+    const labels = tree.everySubTree('label');
+    expect(labels).to.have.lengthOf(1);
+    expect(labels[0].text()).to.equal('my label');
+
+    // Ensure label htmlFor is attached to input id.
+    const inputs = tree.everySubTree('input');
+    expect(inputs).to.have.lengthOf(1);
+    expect(inputs[0].props.id).to.not.be.undefined;
+    expect(inputs[0].props.id).to.equal(labels[0].props.htmlFor);
+  });
+});


### PR DESCRIPTION
During usability testing users were confused by the input fields for month and day not accepting leading zeros. The options were either to change the input type to a text field or to use dropdowns. As the original form uses dropdowns for both month and day, I decided to follow that format. I also created an `ErrorableNumberInput` component for the year. 

I removed tests in `DateInput` because those tests are now under the purview of `ErrorableNumberInput` and `ErrorableSelect`. Also had to add some specific styles for a date field with 2 dropdowns, and made 2 other minor typo fixes as well.
