### PR TITLE
Replacing too-specific .usa-button-primary selectors. closes #1573

### DIFF
--- a/_disability-benefits/apply-for-benefits.md
+++ b/_disability-benefits/apply-for-benefits.md
@@ -21,7 +21,7 @@ template: 7-get-page
 </div>
 
 <div class="small-12 medium-4 columns actions">
-<a class="usa-button-primary start" href="https://www.ebenefits.va.gov/ebenefits/homepage">Go to eBenefits to apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/homepage">Go to eBenefits to apply</a>
 </div>
 
 </div>
@@ -196,7 +196,7 @@ If you disagree with the decision, you may appeal it. The decision letter contai
 <div class="row" markdown="0">
 <div class="small-12 columns" markdown="0">
 
-<a class="usa-button-primary start" href="https://www.ebenefits.va.gov/ebenefits/homepage">Go to eBenefits to apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/homepage">Go to eBenefits to apply</a>
 
 </div>
 </div>

--- a/_disability-benefits/index.md
+++ b/_disability-benefits/index.md
@@ -49,7 +49,7 @@ template: 1-topic-landing
   <div class="row">
     <div class="small-12 columns">
       <div class="actions">
-        <a href="/disability-benefits/apply-for-benefits/" class="usa-button-primary usa-button-big">Apply for Benefits</a>
+        <a href="/disability-benefits/apply-for-benefits/" class="usa-button-primary va-button-primary usa-button-big">Apply for Benefits</a>
       </div>
     </div>
   </div>

--- a/_education/index.html
+++ b/_education/index.html
@@ -75,7 +75,7 @@ template: 1-topic-landing
   <div class="row">
     <div class="small-12 columns">
       <div class="actions">
-        <a href="/education/apply-for-education-benefits/" class="usa-button-primary">Apply for Education Benefits</a>
+        <a href="/education/apply-for-education-benefits/" class="usa-button-primary va-button-primary">Apply for Education Benefits</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Replacing start class applied to buttons in markup, CSS with .va-button-primary
- Adding .va-button-primary class to instances of usa-button-primary in div class="section do"
