### PR TITLE
Limiting link transition properties. closes #1663

### DIFF
--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -50,7 +50,6 @@ $olso-gray:#849097;
 $roboto-slab: 'Roboto Slab', serif;
 
 
-
 // General
 html, body {
   padding: 0;
@@ -100,16 +99,25 @@ abbr, a abbr, abbr[title] {
 
 a {
   background: rgba(0,0,0,0.05);
-  text-decoration: none;
-  &:hover {text-decoration: none;}
-  -webkit-transition: all 0.3s ease-in-out;
-  -moz-transition: all 0.3s ease-in-out;
-  -o-transition: all 0.3s ease-in-out;
-  -ms-transition: all 0.3s ease-in-out;
-  transition: all 0.3s ease-in-out;
   color: $color-gray-dark;
+  text-decoration: none;
+ 
+  -webkit-transition-duration: 0.3s;
+     -moz-transition-duration: 0.3s;
+          transition-duration: 0.3s;
+  
+  -webkit-transition-timing-function: ease-in-out;
+     -moz-transition-timing-function: ease-in-out;
+          transition-timing-function: ease-in-out;
+          
+  // Transition only these properties.
+  -webkit-transition-property: color, background-color, border-color;
+     -moz-transition-property: color, background-color, border-color;
+          transition-property: color, background-color, border-color;
+
   &:hover {
-    color: $color-gray-dark;
+    color: inherit;
+    text-decoration: none;
   }
 }
 
@@ -130,9 +138,6 @@ figcaption {
 #content.interior a[href^="https://"] {
   position: relative;
 }
-
-
-
 
 // Logo and Header
 


### PR DESCRIPTION
- Removed -o- and -ms- prefixed properties because they're no longer necessary.
- Limiting transition of properties to color, background-color, and  border-color
