### PR TITLE
Hca improve UI for adding children providers

### DIFF
--- a/_health-care/_js/components/financial-assessment/Child.jsx
+++ b/_health-care/_js/components/financial-assessment/Child.jsx
@@ -8,120 +8,131 @@ import FullName from '../questions/FullName';
 import SocialSecurityNumber from '../questions/SocialSecurityNumber';
 
 import { childRelationships } from '../../utils/options-for-select.js';
-import { isBlank, isNotBlank, isValidMonetaryValue } from '../../utils/validations';
+import * as validations from '../../utils/validations';
 
 // TODO: create unique nodes for each child in applicationData
 
 class Child extends React.Component {
   render() {
     const message = 'Please enter only numbers and a decimal point if necessary (no commas or currency signs)';
+    let content;
+
+    if (this.props.view === 'collapsed') {
+      content = `${this.props.data.childFullName.first} ${this.props.data.childFullName.last}`;
+    } else {
+      content = (
+        <fieldset>
+          <div className="row">
+            <div className="small-12 columns">
+              <p>Child's Name</p>
+              <FullName required
+                  value={this.props.data.childFullName}
+                  onUserInput={(update) => {this.props.onValueChange('childFullName', update);}}/>
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="small-12 columns">
+              <ErrorableSelect required
+                  errorMessage={validations.isNotBlank(this.props.data.childRelation) ? undefined : 'Please select an option'}
+                  label="Child’s relationship to you"
+                  options={childRelationships}
+                  value={this.props.data.childRelation}
+                  onValueChange={(update) => {this.props.onValueChange('childRelation', update);}}/>
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="small-12 columns">
+              <SocialSecurityNumber label="Child’s Social Security Number"
+                  required
+                  ssn={this.props.data.childSocialSecurityNumber}
+                  onValueChange={(update) => {this.props.onValueChange('childSocialSecurityNumber', update);}}/>
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="small-12 columns">
+              <DateInput required
+                  label="Date Child Became Dependent"
+                  day={this.props.data.childBecameDependent.day}
+                  month={this.props.data.childBecameDependent.month}
+                  year={this.props.data.childBecameDependent.year}
+                  onValueChange={(update) => {this.props.onValueChange('childBecameDependent', update);}}/>
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="small-12 columns">
+              <DateInput required
+                  label="Child’s Date of Birth"
+                  day={this.props.data.childDateOfBirth.day}
+                  month={this.props.data.childDateOfBirth.month}
+                  year={this.props.data.childDateOfBirth.year}
+                  onValueChange={(update) => {this.props.onValueChange('childDateOfBirth', update);}}/>
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="small-12 columns">
+              <ErrorableCheckbox
+                  label="Was child permanently and totally disabled before the age of 18?"
+                  checked={this.props.data.childDisabledBefore18}
+                  onValueChange={(update) => {this.props.onValueChange('childDisabledBefore18', update);}}/>
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="small-12 columns">
+              <ErrorableCheckbox
+                  label="If child is between 18 and 23 years of age, did child attend school last calendar year?"
+                  checked={this.props.data.childAttendedSchoolLastYear}
+                  onValueChange={(update) => {this.props.onValueChange('childAttendedSchoolLastYear', update);}}/>
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="small-12 columns">
+              <ErrorableTextInput
+                  errorMessage={validations.isBlank(this.props.data.childEducationExpenses) || validations.isValidMonetaryValue(this.props.data.childEducationExpenses) ? undefined : message}
+                  label="Expenses paid by your dependent child for college, vocational rehabilitation or training
+                      (e.g., tuition, books, materials)?"
+                  value={this.props.data.childEducationExpenses}
+                  onValueChange={(update) => {this.props.onValueChange('childEducationExpenses', update);}}/>
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="small-12 columns">
+              <ErrorableCheckbox
+                  label="Did your child live with you last year?"
+                  checked={this.props.data.childCohabitedLastYear}
+                  onValueChange={(update) => {this.props.onValueChange('childCohabitedLastYear', update);}}/>
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="small-12 columns">
+              <p>Count child support contributions even if not paid in regular set amounts. Contributions
+              can include tuition payments or payments of medical bills.</p>
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="small-12 columns">
+              <ErrorableCheckbox
+                  label="If your dependent child did not live with you last year, did you provide support?"
+                  checked={this.props.data.childReceivedSupportLastYear}
+                  onValueChange={(update) => {this.props.onValueChange('childReceivedSupportLastYear', update);}}/>
+            </div>
+          </div>
+        </fieldset>
+      );
+    }
 
     return (
       <div>
-        <div className="row">
-          <div className="small-12 columns">
-            <p>Child's Name</p>
-            <FullName required
-                value={this.props.data.childFullName}
-                onUserInput={(update) => {this.props.onValueChange('childFullName', update);}}/>
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="small-12 columns">
-            <ErrorableSelect required
-                errorMessage={isNotBlank(this.props.data.childRelation) ? undefined : 'Please select an option'}
-                label="Child’s relationship to you"
-                options={childRelationships}
-                value={this.props.data.childRelation}
-                onValueChange={(update) => {this.props.onValueChange('childRelation', update);}}/>
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="small-12 columns">
-            <SocialSecurityNumber label="Child’s Social Security Number"
-                required
-                ssn={this.props.data.childSocialSecurityNumber}
-                onValueChange={(update) => {this.props.onValueChange('childSocialSecurityNumber', update);}}/>
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="small-12 columns">
-            <DateInput required
-                label="Date Child Became Dependent"
-                day={this.props.data.childBecameDependent.day}
-                month={this.props.data.childBecameDependent.month}
-                year={this.props.data.childBecameDependent.year}
-                onValueChange={(update) => {this.props.onValueChange('childBecameDependent', update);}}/>
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="small-12 columns">
-            <DateInput required
-                label="Child’s Date of Birth"
-                day={this.props.data.childDateOfBirth.day}
-                month={this.props.data.childDateOfBirth.month}
-                year={this.props.data.childDateOfBirth.year}
-                onValueChange={(update) => {this.props.onValueChange('childDateOfBirth', update);}}/>
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="small-12 columns">
-            <ErrorableCheckbox
-                label="Was child permanently and totally disabled before the age of 18?"
-                checked={this.props.data.childDisabledBefore18}
-                onValueChange={(update) => {this.props.onValueChange('childDisabledBefore18', update);}}/>
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="small-12 columns">
-            <ErrorableCheckbox
-                label="If child is between 18 and 23 years of age, did child attend school last calendar year?"
-                checked={this.props.data.childAttendedSchoolLastYear}
-                onValueChange={(update) => {this.props.onValueChange('childAttendedSchoolLastYear', update);}}/>
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="small-12 columns">
-            <ErrorableTextInput
-                errorMessage={isBlank(this.props.data.childEducationExpenses) || isValidMonetaryValue(this.props.data.childEducationExpenses) ? undefined : message}
-                label="Expenses paid by your dependent child for college, vocational rehabilitation or training
-                    (e.g., tuition, books, materials)?"
-                value={this.props.data.childEducationExpenses}
-                onValueChange={(update) => {this.props.onValueChange('childEducationExpenses', update);}}/>
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="small-12 columns">
-            <ErrorableCheckbox
-                label="Did your child live with you last year?"
-                checked={this.props.data.childCohabitedLastYear}
-                onValueChange={(update) => {this.props.onValueChange('childCohabitedLastYear', update);}}/>
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="small-12 columns">
-            <p>Count child support contributions even if not paid in regular set amounts. Contributions
-            can include tuition payments or payments of medical bills.</p>
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="small-12 columns">
-            <ErrorableCheckbox
-                label="If your dependent child did not live with you last year, did you provide support?"
-                checked={this.props.data.childReceivedSupportLastYear}
-                onValueChange={(update) => {this.props.onValueChange('childReceivedSupportLastYear', update);}}/>
-          </div>
-        </div>
+        {content}
       </div>
     );
   }
@@ -129,6 +140,7 @@ class Child extends React.Component {
 
 Child.propTypes = {
   data: React.PropTypes.object.isRequired,
+  view: React.PropTypes.string,
   onValueChange: React.PropTypes.func.isRequired
 };
 

--- a/_health-care/_js/components/financial-assessment/ChildInformationSection.jsx
+++ b/_health-care/_js/components/financial-assessment/ChildInformationSection.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import Child from './Child';
 import ErrorableCheckbox from '../form-elements/ErrorableCheckbox';
 import GrowableTable from '../form-elements/GrowableTable.jsx';
-import { veteranUpdateField } from '../../actions';
+import { veteranUpdateField, ensureFieldsInitialized } from '../../actions';
 
 /**
  * Props:
@@ -43,7 +43,7 @@ class ChildInformationSection extends React.Component {
 
   render() {
     let notRequiredMessage;
-    let hasChildrenContent;
+    let childrenContent;
 
     if (this.props.receivesVaPension === true) {
       notRequiredMessage = (
@@ -57,12 +57,18 @@ class ChildInformationSection extends React.Component {
     }
 
     if (this.props.data.hasChildrenToReport === true) {
-      hasChildrenContent = (
-        <GrowableTable
-            component={Child}
-            createRow={this.createBlankChild}
-            onRowsUpdate={(update) => {this.props.onStateChange('children', update);}}
-            rows={this.props.data.children}/>
+      childrenContent = (
+        <div className="input-section">
+          <hr/>
+          <GrowableTable
+              component={Child}
+              createRow={this.createBlankChild}
+              data={this.props.data}
+              initializeCurrentElement={() => {this.props.initializeFields();}}
+              onRowsUpdate={(update) => {this.props.onStateChange('children', update);}}
+              path="/financial-assessment/child-information"
+              rows={this.props.data.children}/>
+        </div>
       );
     }
 
@@ -82,10 +88,8 @@ class ChildInformationSection extends React.Component {
               label="Do you have any children to report?"
               checked={this.props.data.hasChildrenToReport}
               onValueChange={(update) => {this.props.onStateChange('hasChildrenToReport', update);}}/>
-
-          {hasChildrenContent}
-
         </div>
+        {childrenContent}
       </div>
     );
   }
@@ -102,6 +106,9 @@ function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
       dispatch(veteranUpdateField(['childInformation', field], update));
+    },
+    initializeFields: () => {
+      dispatch(ensureFieldsInitialized('/financial-assessment/child-information'));
     }
   };
 }

--- a/_health-care/_js/components/form-elements/DateInput.jsx
+++ b/_health-care/_js/components/form-elements/DateInput.jsx
@@ -29,10 +29,12 @@ class DateInput extends React.Component {
   }
 
   handleChange(path, update) {
+    const isYearNumber = this.props.year === null || this.props.year === '';
+
     const date = {
       month: Number(this.props.month),
       day: Number(this.props.day),
-      year: Number(this.props.year)
+      year: isYearNumber ? this.props.year : Number(this.props.year)
     };
 
     date[path] = Number(update);

--- a/_health-care/_js/components/form-elements/GrowableTable.jsx
+++ b/_health-care/_js/components/form-elements/GrowableTable.jsx
@@ -1,19 +1,65 @@
 import React from 'react';
 import _ from 'lodash';
 
+import * as validations from '../../utils/validations';
+
 class GrowableTable extends React.Component {
   constructor(props) {
     super(props);
+    this.createNewElement = this.createNewElement.bind(this);
     this.handleAdd = this.handleAdd.bind(this);
+    this.handleEdit = this.handleEdit.bind(this);
+    this.handleSave = this.handleSave.bind(this);
     this.handleRemove = this.handleRemove.bind(this);
+    this.state = {};
   }
 
-  handleAdd() {
+  componentWillMount() {
+    if (this.props.rows.length > 0) {
+      this.props.rows.map((obj) => {
+        this.setState({ [obj.key]: 'complete' });
+        return true;
+      });
+    }
+  }
+
+  componentDidMount() {
+    if (this.props.rows.length === 0) {
+      this.createNewElement();
+    }
+  }
+
+  createNewElement() {
     const blankRowData = this.props.createRow();
     blankRowData.key = _.uniqueId('key-');
     const rows = this.props.rows.slice();
     rows.push(blankRowData);
     this.props.onRowsUpdate(rows);
+
+    this.setState({ [blankRowData.key]: 'incomplete' });
+  }
+
+  handleAdd() {
+    if (validations.isValidSection(this.props.path, this.props.data)) {
+      this.createNewElement();
+    }
+  }
+
+  handleEdit(event) {
+    this.setState({ [event.target.dataset.key]: 'incomplete' });
+  }
+
+  handleSave(event) {
+    this.props.initializeCurrentElement();
+
+    if (validations.isValidSection(this.props.path, this.props.data)) {
+      this.setState({ [event.target.dataset.key]: 'complete' });
+      document.getElementsByClassName('input-section')[1].scrollIntoView();
+    } else {
+      // TODO: figure out how to deal with the fact that this runs before the
+      // child component renders, so there will be no error classes yet
+      document.getElementsByClassName('usa-input-error')[0].scrollIntoView();
+    }
   }
 
   handleRemove(event) {
@@ -28,37 +74,84 @@ class GrowableTable extends React.Component {
     this.props.onRowsUpdate(rows);
   }
 
+  // TODO: change this to not use reaactKey, and instead perhaps add
+  // `this.rows = []` in the constructor and update on changes
   render() {
+    let reactKey = 0;
+    let rowContent;
+    const state = this.state;
     const rowElements = this.props.rows.map((obj, index) => {
-      return (
-        <div className="row" key={obj.key}>
-          <hr/>
-          <div className="small-3 columns">
-            <button onClick={this.handleRemove} data-index={index}>Remove</button>
+      if (state[obj.key] && state[obj.key] === 'complete') {
+        rowContent = (
+          <div key={reactKey++}>
+            <div className="row" key={obj.key}>
+              <div className="small-6 columns">
+                {React.createElement(this.props.component,
+                  { data: obj,
+                    view: 'collapsed',
+                    onValueChange: (subfield, update) => {
+                      const rows = this.props.rows.slice();
+                      const newRow = Object.assign({}, rows[index]);
+                      newRow[subfield] = update;
+                      rows[index] = newRow;
+                      this.props.onRowsUpdate(rows);
+                    }
+                  })}
+              </div>
+              <div className="small-3 columns">
+                <button onClick={(event) => this.handleEdit(event)} data-key={obj.key}>Edit</button>
+              </div>
+              <div className="small-3 columns">
+                <button onClick={this.handleRemove} data-index={index}>Remove</button>
+              </div>
+            </div>
+            <hr/>
           </div>
-          <div className="small-9 columns">
-            {React.createElement(this.props.component,
-              { data: obj,
-                onValueChange: (subfield, update) => {
-                  const rows = this.props.rows.slice();
-                  const newRow = Object.assign({}, rows[index]);
-                  newRow[subfield] = update;
-                  rows[index] = newRow;
-                  this.props.onRowsUpdate(rows);
-                }
-              })}
+        );
+      } else {
+        rowContent = (
+          <div key={reactKey++}>
+            <div className="row">
+              <div className="small-3 right columns">
+                <button onClick={this.handleRemove} data-index={index}>Remove</button>
+              </div>
+            </div>
+            <div className="row" key={obj.key}>
+              <div className="small-12 columns">
+                {React.createElement(this.props.component,
+                  { data: obj,
+                    view: 'expanded',
+                    onValueChange: (subfield, update) => {
+                      const rows = this.props.rows.slice();
+                      const newRow = Object.assign({}, rows[index]);
+                      newRow[subfield] = update;
+                      rows[index] = newRow;
+                      this.props.onRowsUpdate(rows);
+                    }
+                  })}
+              </div>
+            </div>
+            <div className="row">
+              <div className="small-3 right columns">
+                <button onClick={(event) => this.handleSave(event)} data-key={obj.key}>Save</button>
+              </div>
+            </div>
+            <hr/>
           </div>
-        </div>
-      );
+        );
+      }
+
+      return rowContent;
     });
+
     return (
       <div>
+        {rowElements}
         <div className="row">
-          <div className="small-12 columns">
+          <div className="small-3 small-centered columns">
             <button onClick={this.handleAdd}>Add</button>
           </div>
         </div>
-        {rowElements}
       </div>
     );
   }
@@ -67,7 +160,10 @@ class GrowableTable extends React.Component {
 GrowableTable.propTypes = {
   component: React.PropTypes.func.isRequired,
   createRow: React.PropTypes.func.isRequired,
+  data: React.PropTypes.object.isRequired,
+  initializeCurrentElement: React.PropTypes.func.isRequired,
   onRowsUpdate: React.PropTypes.func.isRequired,
+  path: React.PropTypes.string.isRequired,
   rows: React.PropTypes.array.isRequired
 };
 

--- a/_health-care/_js/components/insurance-information/InsuranceInformationSection.jsx
+++ b/_health-care/_js/components/insurance-information/InsuranceInformationSection.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import ErrorableCheckbox from '../form-elements/ErrorableCheckbox';
 import GrowableTable from '../form-elements/GrowableTable.jsx';
 import Provider from './Provider.jsx';
-import { veteranUpdateField } from '../../actions';
+import { veteranUpdateField, ensureFieldsInitialized } from '../../actions';
 
 /**
  * Props:
@@ -29,9 +29,24 @@ class InsuranceInformationSection extends React.Component {
   }
 
   render() {
+    let providersTable;
+
+    if (this.props.data.isCoveredByHealthInsurance) {
+      providersTable = (
+        <GrowableTable
+            component={Provider}
+            createRow={this.createBlankProvider}
+            data={this.props.data}
+            initializeCurrentElement={() => {this.props.initializeFields();}}
+            onRowsUpdate={(update) => {this.props.onStateChange('providers', update);}}
+            path="/insurance-information/general"
+            rows={this.props.data.providers}/>
+      );
+    }
+
     return (
       <fieldset>
-        <div className={`input-section ${this.props.data.sectionComplete ? 'review-view' : 'edit-view'}`}>
+        <div className={`input-section${this.props.data.sectionComplete ? ' review-view' : ' edit-view'}`}>
           <h4>Coverage Information</h4>
           <ErrorableCheckbox
               label={`${this.props.data.sectionComplete ? 'Edit' : 'Update'}`}
@@ -43,11 +58,7 @@ class InsuranceInformationSection extends React.Component {
               checked={this.props.data.isCoveredByHealthInsurance}
               onValueChange={(update) => {this.props.onStateChange('isCoveredByHealthInsurance', update);}}/>
           <hr/>
-          <GrowableTable
-              component={Provider}
-              createRow={this.createBlankProvider}
-              onRowsUpdate={(update) => {this.props.onStateChange('providers', update);}}
-              rows={this.props.data.providers}/>
+          {providersTable}
         </div>
       </fieldset>
     );
@@ -64,6 +75,9 @@ function mapDispatchToProps(dispatch) {
   return {
     onStateChange: (field, update) => {
       dispatch(veteranUpdateField(['insuranceInformation', field], update));
+    },
+    initializeFields: () => {
+      dispatch(ensureFieldsInitialized('/insurance-information/general'));
     }
   };
 }

--- a/_health-care/_js/components/insurance-information/Provider.jsx
+++ b/_health-care/_js/components/insurance-information/Provider.jsx
@@ -9,62 +9,74 @@ import Phone from '../questions/Phone';
 
 class Provider extends React.Component {
   render() {
+    let content;
+
+    if (this.props.view === 'collapsed') {
+      content = this.props.data.insuranceName;
+    } else {
+      content = (
+        <div className="input-section">
+          <ErrorableTextInput required
+              errorMessage={isNotBlank(this.props.data.insuranceName) ? undefined : 'Please enter the insurer’s name'}
+              label="Name"
+              value={this.props.data.insuranceName}
+              onValueChange={(update) => {this.props.onValueChange('insuranceName', update);}}/>
+
+          <ErrorableTextInput
+              label="Address"
+              value={this.props.data.insuranceAddress}
+              onValueChange={(update) => {this.props.onValueChange('insuranceAddress', update);}}/>
+
+          <ErrorableTextInput
+              label="City"
+              value={this.props.data.insuranceCity}
+              onValueChange={(update) => {this.props.onValueChange('insuranceCity', update);}}/>
+
+          <ErrorableSelect
+              label="Country"
+              options={countries}
+              value={this.props.data.insuranceCountry}
+              onValueChange={(update) => {this.props.onValueChange('insuranceCountry', update);}}/>
+
+          <ErrorableSelect
+              label="State"
+              options={states}
+              value={this.props.data.insuranceState}
+              onValueChange={(update) => {this.props.onValueChange('insuranceState', update);}}/>
+
+          <ErrorableTextInput
+              label="Zipcode"
+              value={this.props.data.insuranceZipcode}
+              onValueChange={(update) => {this.props.onValueChange('insuranceZipcode', update);}}/>
+
+          <Phone required
+              label="Phone"
+              value={this.props.data.insurancePhone}
+              onValueChange={(update) => {this.props.onValueChange('insurancePhone', update);}}/>
+
+          <ErrorableTextInput required
+              errorMessage={isNotBlank(this.props.data.insurancePolicyHolderName) ? undefined : 'Please enter the name of the policy holder'}
+              label="Name of Policy Holder"
+              value={this.props.data.insurancePolicyHolderName}
+              onValueChange={(update) => {this.props.onValueChange('insurancePolicyHolderName', update);}}/>
+
+          <ErrorableTextInput required
+              errorMessage={isNotBlank(this.props.data.insurancePolicyNumber) ? undefined : 'Please enter the policy number'}
+              label="Policy Number"
+              value={this.props.data.insurancePolicyNumber}
+              onValueChange={(update) => {this.props.onValueChange('insurancePolicyNumber', update);}}/>
+
+          <ErrorableTextInput
+              label="Group Code"
+              value={this.props.data.insuranceGroupCode}
+              onValueChange={(update) => {this.props.onValueChange('insuranceGroupCode', update);}}/>
+        </div>
+      );
+    }
+
     return (
       <div>
-        <ErrorableTextInput required
-            errorMessage={isNotBlank(this.props.data.insuranceName) ? undefined : 'Please enter the insurer’s name'}
-            label="Name"
-            value={this.props.data.insuranceName}
-            onValueChange={(update) => {this.props.onValueChange('insuranceName', update);}}/>
-
-        <ErrorableTextInput
-            label="Address"
-            value={this.props.data.insuranceAddress}
-            onValueChange={(update) => {this.props.onValueChange('insuranceAddress', update);}}/>
-
-        <ErrorableTextInput
-            label="City"
-            value={this.props.data.insuranceCity}
-            onValueChange={(update) => {this.props.onValueChange('insuranceCity', update);}}/>
-
-        <ErrorableSelect
-            label="Country"
-            options={countries}
-            value={this.props.data.insuranceCountry}
-            onValueChange={(update) => {this.props.onValueChange('insuranceCountry', update);}}/>
-
-        <ErrorableSelect
-            label="State"
-            options={states}
-            value={this.props.data.insuranceState}
-            onValueChange={(update) => {this.props.onValueChange('insuranceState', update);}}/>
-
-        <ErrorableTextInput
-            label="Zipcode"
-            value={this.props.data.insuranceZipcode}
-            onValueChange={(update) => {this.props.onValueChange('insuranceZipcode', update);}}/>
-
-        <Phone required
-            label="Phone"
-            value={this.props.data.insurancePhone}
-            onValueChange={(update) => {this.props.onValueChange('insurancePhone', update);}}/>
-
-        <ErrorableTextInput required
-            errorMessage={isNotBlank(this.props.data.insurancePolicyHolderName) ? undefined : 'Please enter the name of the policy holder'}
-            label="Name of Policy Holder"
-            value={this.props.data.insurancePolicyHolderName}
-            onValueChange={(update) => {this.props.onValueChange('insurancePolicyHolderName', update);}}/>
-
-        <ErrorableTextInput required
-            errorMessage={isNotBlank(this.props.data.insurancePolicyNumber) ? undefined : 'Please enter the policy number'}
-            label="Policy Number"
-            value={this.props.data.insurancePolicyNumber}
-            onValueChange={(update) => {this.props.onValueChange('insurancePolicyNumber', update);}}/>
-
-        <ErrorableTextInput
-            label="Group Code"
-            value={this.props.data.insuranceGroupCode}
-            onValueChange={(update) => {this.props.onValueChange('insuranceGroupCode', update);}}/>
+        {content}
       </div>
     );
   }
@@ -72,6 +84,7 @@ class Provider extends React.Component {
 
 Provider.propTypes = {
   data: React.PropTypes.object.isRequired,
+  view: React.PropTypes.string,
   onValueChange: React.PropTypes.func.isRequired
 };
 

--- a/_health-care/_js/reducers/veteran/index.js
+++ b/_health-care/_js/reducers/veteran/index.js
@@ -10,6 +10,8 @@ _.mixin(lodashDeep);
 
 // TODO(awong): This structure should reflect a logical data model for a veteran. Currently it
 // mirrors the UI stricture too much.
+
+// TODO: Remove providers and children if checkbox within section is unchecked
 const blankVeteran = {
   nameAndGeneralInformation: {
     fullName: {

--- a/_health-care/_js/utils/validations.js
+++ b/_health-care/_js/utils/validations.js
@@ -105,18 +105,24 @@ function isValidSpouseInformation(data) {
       (isBlank(data.spousePhone) || isValidPhone(data.spousePhone));
 }
 
-function isValidChildInformation(data) {
+function isValidChildInformation(child) {
+  return (isValidName(child.childFullName.first) &&
+      (isBlank(child.childFullName.middle) || isValidName(child.childFullName.middle)) &&
+      isValidName(child.childFullName.last) &&
+      isNotBlank(child.childRelation) &&
+      isValidSSN(child.childSocialSecurityNumber) &&
+      isValidDate(child.childBecameDependent.day, child.childBecameDependent.month, child.childBecameDependent.year) &&
+      isValidDate(child.childDateOfBirth.day, child.childDateOfBirth.month, child.childDateOfBirth.year) &&
+      (isBlank(child.childEducationExpenses) || isValidMonetaryValue(child.childEducationExpenses)));
+}
+
+function isValidChildren(data) {
   const children = data.children;
+  if (!data.hasChildrenToReport) {
+    return true;
+  }
   for (let i = 0; i < children.length; i++) {
-    if (!(isValidName(children[i].childFullName.first) &&
-        (isBlank(children[i].childFullName.middle) || isValidName(children[i].childFullName.middle)) &&
-        isValidName(children[i].childFullName.last) &&
-        isNotBlank(children[i].childRelation) &&
-        isValidSSN(children[i].childSocialSecurityNumber) &&
-        isValidDate(children[i].childBecameDependent.day, children[i].childBecameDependent.month, children[i].childBecameDependent.year) &&
-        isValidDate(children[i].childDateOfBirth.day, children[i].childDateOfBirth.month, children[i].childDateOfBirth.year) &&
-        (isBlank(children[i].childEducationExpenses) || isValidMonetaryValue(children[i].childEducationExpenses)))
-    ) {
+    if (!isValidChildInformation(children[i])) {
       return false;
     }
   }
@@ -143,6 +149,9 @@ function isValidDeductibleExpenses(data) {
 
 function isValidGeneralInsurance(data) {
   const providers = data.providers;
+  if (!data.isCoveredByHealthInsurance) {
+    return true;
+  }
   for (let i = 0; i < providers.length; i++) {
     if (!(isNotBlank(providers[i].insuranceName) &&
         isNotBlank(providers[i].insurancePolicyHolderName) &&
@@ -176,7 +185,7 @@ function isValidSection(completePath, sectionData) {
     case '/financial-assessment/spouse-information':
       return isValidSpouseInformation(sectionData);
     case '/financial-assessment/child-information':
-      return isValidChildInformation(sectionData);
+      return isValidChildren(sectionData);
     case '/financial-assessment/annual-income':
       return isValidAnnualIncome(sectionData);
     case '/financial-assessment/deductible-expenses':
@@ -219,6 +228,7 @@ export {
   isValidVeteranAddress,
   isValidSpouseInformation,
   isValidChildInformation,
+  isValidChildren,
   isValidAnnualIncome,
   isValidDeductibleExpenses,
   isValidGeneralInsurance,

--- a/spec/javascripts/health-care/components/form-elements/GrowableTable.spec.jsx
+++ b/spec/javascripts/health-care/components/form-elements/GrowableTable.spec.jsx
@@ -28,50 +28,86 @@ describe('<GrowableTable>', () => {
 
     it('component is required', () => {
       SkinDeep.shallowRender(
-        <GrowableTable rows={[]} createRow={func} onRowsUpdate={func}/>);
+        <GrowableTable createRow={func} data={{}} initializeCurrentElement={func} onRowsUpdate={func} path="" rows={[]}/>);
       sinon.assert.calledWithMatch(consoleStub, /Required prop `component` was not specified in `GrowableTable`/);
     });
 
     it('component must be a func', () => {
       SkinDeep.shallowRender(
-        <GrowableTable rows={[]} component createRow={func} onRowsUpdate={func}/>);
+        <GrowableTable component createRow={func} data={{}} initializeCurrentElement={func} onRowsUpdate={func} path="" rows={[]}/>);
       sinon.assert.calledWithMatch(consoleStub, /Invalid prop `component` of type `boolean` supplied to `GrowableTable`, expected `function`/);
     });
 
     it('createRow is required', () => {
       SkinDeep.shallowRender(
-        <GrowableTable rows={[]} component={func} onRowsUpdate={func}/>);
+        <GrowableTable component={func} data={{}} initializeCurrentElement={func} onRowsUpdate={func} path="" rows={[]}/>);
       sinon.assert.calledWithMatch(consoleStub, /Required prop `createRow` was not specified in `GrowableTable`/);
     });
 
     it('createRow must be a func', () => {
       SkinDeep.shallowRender(
-        <GrowableTable rows={[]} component={func} createRow onRowsUpdate={func}/>);
+        <GrowableTable component={func} createRow data={{}} initializeCurrentElement={func} onRowsUpdate={func} path="" rows={[]}/>);
       sinon.assert.calledWithMatch(consoleStub, /Invalid prop `createRow` of type `boolean` supplied to `GrowableTable`, expected `function`/);
+    });
+
+    it('data is required', () => {
+      SkinDeep.shallowRender(
+        <GrowableTable component={func} createRow={func} initializeCurrentElement={func} onRowsUpdate={func} path="" rows={[]}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Required prop `data` was not specified in `GrowableTable`/);
+    });
+
+    it('data must be an object', () => {
+      SkinDeep.shallowRender(
+        <GrowableTable component={func} createRow={func} data initializeCurrentElement={func} onRowsUpdate={func} path="" rows={[]}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `data` of type `boolean` supplied to `GrowableTable`, expected `object`/);
+    });
+
+    it('initializeCurrentElement is required', () => {
+      SkinDeep.shallowRender(
+        <GrowableTable component={func} createRow={func} data={{}} onRowsUpdate={func} path="" rows={[]}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Required prop `initializeCurrentElement` was not specified in `GrowableTable`/);
+    });
+
+    it('initializeCurrentElement must be a func', () => {
+      SkinDeep.shallowRender(
+        <GrowableTable component={func} createRow={func} data={{}} initializeCurrentElement onRowsUpdate={func} path="" rows={[]}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `initializeCurrentElement` of type `boolean` supplied to `GrowableTable`, expected `function`/);
     });
 
     it('onRowsUpdate is required', () => {
       SkinDeep.shallowRender(
-        <GrowableTable rows={[]} component={func} createRow={func}/>);
+        <GrowableTable component={func} createRow={func} data={{}} initializeCurrentElement={func} path="" rows={[]}/>);
       sinon.assert.calledWithMatch(consoleStub, /Required prop `onRowsUpdate` was not specified in `GrowableTable`/);
     });
 
     it('onRowsUpdate must be a func', () => {
       SkinDeep.shallowRender(
-        <GrowableTable rows={[]} component={func} createRow={func} onRowsUpdate/>);
+        <GrowableTable component={func} createRow={func} data={{}} initializeCurrentElement={func} onRowsUpdate path="" rows={[]}/>);
       sinon.assert.calledWithMatch(consoleStub, /Invalid prop `onRowsUpdate` of type `boolean` supplied to `GrowableTable`, expected `function`/);
+    });
+
+    it('path is required', () => {
+      SkinDeep.shallowRender(
+        <GrowableTable component={func} createRow={func} data={{}} initializeCurrentElement={func} onRowsUpdate={func} rows={[]}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Required prop `path` was not specified in `GrowableTable`/);
+    });
+
+    it('path must be an object', () => {
+      SkinDeep.shallowRender(
+        <GrowableTable component={func} createRow={func} data={{}} initializeCurrentElement={func} onRowsUpdate={func} path rows={[]}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `path` of type `boolean` supplied to `GrowableTable`, expected `string`/);
     });
 
     xit('rows is required', () => {
       SkinDeep.shallowRender(
-        <GrowableTable component={func} createRow={func} onRowsUpdate={func}/>);
+        <GrowableTable component={func} createRow={func} data={{}} initializeCurrentElement={func} onRowsUpdate={func} path=""/>);
       sinon.assert.calledWithMatch(consoleStub, /Required prop `rows` was not specified in `GrowableTable`/);
     });
 
     xit('rows must be an array', () => {
       SkinDeep.shallowRender(
-        <GrowableTable rows component={func} createRow={func} onRowsUpdate={func}/>);
-      sinon.assert.calledWithMatch(consoleStub, /Required prop `rows` was not specified in `GrowableTable`/);
+        <GrowableTable component={func} createRow={func} data={{}} initializeCurrentElement={func} onRowsUpdate={func} path="" rows/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `rows` of type `boolean` supplied to `GrowableTable`, expected `array`/);
     });
   });
 
@@ -82,6 +118,7 @@ describe('<GrowableTable>', () => {
       { key: 'k2', value: 'b' }
     ];
     const onRowsUpdate = sinon.spy();
+    const initializeCurrentElement = sinon.spy();
 
     // Function that generates a new model for a row. Use numbers instead of letters to ensure
     // it never collides with the initial static row model objects in `rows`.
@@ -95,8 +132,10 @@ describe('<GrowableTable>', () => {
         <GrowableTable
             component={Row}
             createRow={createRow}
+            initializeCurrentElement={initializeCurrentElement}
             rows={rows}
-            onRowsUpdate={onRowsUpdate}/>
+            onRowsUpdate={onRowsUpdate}
+            path=""/>
       );
     });
 


### PR DESCRIPTION
Feedback we received from user testing was that users expected that checking the checkbox to indicate they have insurance/children should expand the first field for adding a provider/child. In order to do this, I had to change both the UI and the functionality of `GrowableTable`. 

<img width="1066" alt="screenshot 2016-03-31 22 36 25" src="https://cloud.githubusercontent.com/assets/3886085/14196400/00686b92-f792-11e5-9fc0-ad0b19e18a4c.png">
<img width="1109" alt="screenshot 2016-03-31 22 36 15" src="https://cloud.githubusercontent.com/assets/3886085/14196401/02087d3e-f792-11e5-89d4-36d55b5abe5d.png">

I also changed the validations for that section in the event a user checks the checkbox, the provider/child fields are expanded, they try to continue, they get validation errors, and then uncheck the checkbox. While this will hide the fields, it does not delete the entry in state and therefore will still be invalid, preventing the user from continuing onto the next page. It could be confusing to be unable to continue without seeing any actual validation errors, so I changed the validation to be valid if the checkbox is unchecked. I also added a TODO to remove providers/children if the checkbox value is `false` when the form is finally submitted. 

I would like input on the design, specifically on the "Remove" and "Add" buttons placement.
<img width="820" alt="screenshot 2016-03-31 22 35 58" src="https://cloud.githubusercontent.com/assets/3886085/14196397/f8f48f12-f791-11e5-9bdc-6ce317d478c8.png">
