### PR TITLE
Removed properties with prefixes that are now obsolete

### DIFF
--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -2032,7 +2032,6 @@ li.twenty:before {content: "20";}
     padding: 1.5em 1.5em .2em;
   }
   .graphic {
-    -webkit-background-size: 138px 138px;
     background-size: 165px 165px;
     padding: 0;
     height: 209px;

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -98,16 +98,13 @@ a {
   text-decoration: none;
  
   -webkit-transition-duration: 0.3s;
-     -moz-transition-duration: 0.3s;
           transition-duration: 0.3s;
   
   -webkit-transition-timing-function: ease-in-out;
-     -moz-transition-timing-function: ease-in-out;
           transition-timing-function: ease-in-out;
           
   // Transition only these properties.
   -webkit-transition-property: color, background-color, border-color;
-     -moz-transition-property: color, background-color, border-color;
           transition-property: color, background-color, border-color;
 
   &:hover {

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -776,7 +776,6 @@ li {
     &:last-of-type { border-bottom: none;}
     a {
     color: $color-primary-darkest;
-    -webkit-box-shadow: none;
     border-bottom: none;
     box-shadow: none;
     text-decoration: none;
@@ -833,8 +832,8 @@ body.home .main-navigation {
 }
 
 #content  .cards {
--webkit-backface-visibility: hidden;
-backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
 
   a, .coming-soon {
     padding: 1em 1.15em;
@@ -845,7 +844,7 @@ backface-visibility: hidden;
     font-weight: normal;
     text-decoration: none;
     background: $color-primary-darker;
-    -webkit-box-shadow: 0 0 5px rgba(0,0,0,.1);
+    box-shadow: 0 0 5px rgba(0,0,0,.1);
     @media #{$small} {padding: .45em .75em; border-bottom: none; text-align: left; border-radius: .2em; margin: 0 0 .25em 0}
     @media #{$medium} {height: 10em;}
 
@@ -869,8 +868,6 @@ backface-visibility: hidden;
 
     &:hover, &:active, &:focus {
       background: $color-primary;
-      -webkit-box-shadow: 0 0 5px rgba(0,0,0,.35);
-      -moz-box-shadow: 0 0 5px rgba(0,0,0,.35);
       box-shadow: 0 0 5px rgba(0,0,0,.35);
     }
 
@@ -893,7 +890,6 @@ backface-visibility: hidden;
     color: #fff;
     p {color: #fff;}
     border-bottom: 2px solid rgba(0,0,0,0);
-    -webkit-box-shadow: none;
     box-shadow: none;
   }
 }
@@ -1504,10 +1500,6 @@ a.twitter {
     background: $color-primary-darker;
     bottom: .85em;
     right: 0;
-    -webkit-border-top-left-radius: .3em;
-    -webkit-border-bottom-left-radius: .3em;
-    -moz-border-radius-topleft: .3em;
-    -moz-border-radius-bottomleft: .3em;
     border-top-left-radius: .3em;
     border-bottom-left-radius: .3em;
     span.icon {
@@ -1586,8 +1578,6 @@ a.twitter {
     width: 100%;
     padding: 0;
     border-radius: 0px 3px 3px 0px;
-    -moz-border-radius: 0px 3px 3px 0px;
-    -webkit-border-radius: 0px 3px 3px 0px;
   }
 
 }
@@ -2375,10 +2365,8 @@ body.home .disclaimer, body.page-playbook .disclaimer {
     }
 
     input[type="text"] {
-      border-radius: 3px 0 0 3px;
-      -moz-border-radius: 3px 0 0 3px;
-      -webkit-border-radius: 3px 0 0 3px;
       -webkit-appearance: none;
+      border-radius: 3px 0 0 3px;
     }
 
   }

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -609,7 +609,6 @@ text-align: left;
   @media #{$small} {margin: 0 0 1em 0;}
   border-radius: 0;
   border-radius: none;
-  -webkit-border-radius: 0;
 
   li {
   text-transform: none;

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -1567,7 +1567,6 @@ a.twitter {
     width: 100%;
     color: $color-gray-dark;
     padding: .2em;
-    -webkit-box-sizing: border-box;
     box-sizing: border-box;
   }
 


### PR DESCRIPTION
- Removes -webkit-border-radius
- Removes prefixed border-radius, box shadow properties.
- Removes -webkit-box-sizing property.
- Removes -webkit-background-size property.
- Removes -moz-transition\* properties.
