### PR TITLE
Merging h1 a, .header h1 into .va-header-logo block. closes #1668

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -105,7 +105,7 @@
   <!-- /header alert box -->
   <div class="row full">
     <div class="small-6 medium-4 columns">
-      <h1 role="banner"><a href="/">Vets.gov</a></h1>
+      <h1 role="banner" class="va-header-logo"><a href="/">Vets.gov</a></h1>
     </div>
 
 

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -23,7 +23,6 @@ body {
 }
 
 // Skip link
-
 .show-on-focus {
   position: absolute;
   top: -10em;
@@ -130,18 +129,21 @@ figcaption {
 }
 
 // Logo and Header
-
 .header {
   clear: both;
   padding: 0 0 .5em 0;
   margin: 0;
-
-  h1 {margin: 0; line-height: 1em; @media #{$small} {margin: .25em 0 0 0;} }
-  color: #fff;
 }
 
-h1 {
+.va-header-logo {
   color: #fff;
+  line-height: 1em; 
+  margin: 0; 
+  
+  @media #{$small} {
+    margin: .25em 0 0 0;
+  } 
+
   a {
     text-indent: 180%;
     white-space: nowrap;
@@ -154,18 +156,24 @@ h1 {
     background-size: contain;
     border-bottom: none;
     text-decoration: none;
-    &:hover, &:active, &:focus {background: $color-primary-darkest url(../images/design/logo/logo-hover.png) top left no-repeat; background-size: contain;}
-  @media #{$small} {
-    background: $color-primary-darkest url(../images/design/logo/logo.png) top left no-repeat;
-    width: 263px;
-    height: 50px;
-    background-size: contain;
-    &:hover {
-      background: $color-primary-darkest url(../images/design/logo/logo-hover.png) top left no-repeat;
+    
+    &:hover, &:active, &:focus {
+      background: $color-primary-darkest url(../images/design/logo/logo-hover.png) top left no-repeat; 
       background-size: contain;
     }
+  
+    @media #{$small} {
+      background: $color-primary-darkest url(../images/design/logo/logo.png) top left no-repeat;
+      width: 263px;
+      height: 50px;
+      background-size: contain;
+      
+      &:hover {
+        background: $color-primary-darkest url(../images/design/logo/logo-hover.png) top left no-repeat;
+        background-size: contain;
+      }
+    }
   }
-}
 }
 
 // Type
@@ -175,7 +183,7 @@ h1, h2 {
   font-weight: 600;
 }
 h3, h4, h5, h6 {
-  color:$color-primary-darkest;
+  color: $color-primary-darkest;
   font-weight: 600;
 }
 


### PR DESCRIPTION
- Combined h1 a and .header h1 blocks since they target the same element.
- Changed `h1 a` selector to .va-header-logo so that we can reduce the
  specificity of other h1 selectors, reduce likelihood of side effects.
- Reformatted code blocks for easier readability.
