### PR TITLE
Simplifying abbr selectors. closes #1664

### DIFF
--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -82,8 +82,8 @@ body .row.full {
 
 // Abbr
 
-abbr, a abbr, abbr[title] {
-  border-bottom: none;
+abbr {
+  border-bottom: 0px !important;
   text-decoration: none;
   font-weight: inherit;
   font-style: inherit;


### PR DESCRIPTION
Changed abbr, a abbr, abbr[title] to use just abbr, with an !important for the border style.
