### PR TITLE
Adding splash_image template variable to post-single. Closes #1720

### DIFF
--- a/_layouts/post-single.html
+++ b/_layouts/post-single.html
@@ -1,7 +1,7 @@
 {% include header.html %}
 <div id="content">
   <div id="experience" class="{{ page.title }}" role="main">
-    <div class="splash">
+    <div class="splash{% if page.splash_image %} splash--hasimg" style="background-image: url(/assets/images/content/posts/{{page.splash_image}});{% endif %}">
       <h2><a href="/experience/">Experience</a></h2>
     </div>
     <div class="primary">

--- a/_posts/2016-03-2-designing-for-veterans.md
+++ b/_posts/2016-03-2-designing-for-veterans.md
@@ -8,6 +8,7 @@ tags:
  - standards
  - design
 published: true
+splash_image: utah.jpg
 ---
 
 <div markdown="1">


### PR DESCRIPTION
- Adds splash_image to YAML file for Designing for Veterans post
- Adds check for splash_image to post-single.html that sets the
  background image using inline CSS.
- Affects #1680: refactoring of #experience .splash and its variants
