### PR TITLE
Adding a va-nav-category selector for piano keys. Closes #1787

### DIFF
--- a/_disability-benefits/conditions.md
+++ b/_disability-benefits/conditions.md
@@ -68,7 +68,7 @@ Access the [complete schedule of disabilities](http://www.benefits.va.gov/warms/
 <div class="row">
 <div class="small-12 columns">
 
-<ul class="small-block-grid-1 medium-block-grid-3 cards small">
+<ul class="va-nav-category">
 
 
 <li>

--- a/_sass/components/_va-nav-category.scss
+++ b/_sass/components/_va-nav-category.scss
@@ -1,0 +1,58 @@
+// Category navigation AKA "piano keys"
+// pattern. These are the links at the bottom
+// of secondary-level pages.
+
+.va-nav-category {
+  color: $color-gray-dark;
+  list-style: none;
+  margin: 0 !important;
+  padding: 0;
+  
+  @media #{$small} {
+    margin: 0 -0.625rem !important;
+  }
+  
+  &::before, &::after {
+    clear: both;
+    content: " ";
+    display: table; 
+  }
+  
+  li {
+    border-bottom: 1px solid rgba(0,0,0,0.2);
+    display: block;
+    height: auto;
+    margin: 0;
+    width: 100%;
+  }
+  
+  a {
+    color: $color-gray-dark !important;
+    border-radius: 0;
+    border-left: 4px solid rgba(0,0,0,0);
+    border-bottom: none;
+    box-shadow: none;
+    display: block;
+    text-decoration: none;
+    padding: 1em .5em;
+    height: auto;
+    margin: 0;
+    
+    &:hover {
+      background: rgba(0,0,0,0.1);
+      border-left-color: $color-primary;
+      text-decoration: none;
+    }
+  }
+}  
+
+.va-nav-category-title, 
+.va-nav-category h5 {
+  color: #112e51;
+  font-weight: 700;
+  font-family: "Source Sans Pro","Helvetica","Arial",sans-serif;
+  font-size: 1.35em;
+  padding: 0 0 .25em 0;
+  margin: 0;
+  width: 100%;
+}

--- a/_sass/components/_va-nav-category.scss
+++ b/_sass/components/_va-nav-category.scss
@@ -48,7 +48,7 @@
 
 .va-nav-category-title, 
 .va-nav-category h5 {
-  color: #112e51;
+  color: $color-primary-darkest;
   font-weight: 700;
   font-family: "Source Sans Pro","Helvetica","Arial",sans-serif;
   font-size: 1.35em;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -40,6 +40,7 @@
 @import "components/accordions";
 @import "components/forms";
 @import "components/sidenav";
+@import "components/va-nav-category";
 
 @import "va-variables";
 @import "va";


### PR DESCRIPTION
Blocks #1813, #1814, #1816, #1817, #1819, #1820, #1821.  

It's the same change, but to almost every file on the site, which is why I split them into several pull requests.
