### PR TITLE
Children income fields

### DIFF
--- a/_health-care/_js/actions/index.js
+++ b/_health-care/_js/actions/index.js
@@ -4,7 +4,7 @@ export const UPDATE_COMPLETION_STATUS = 'UPDATE_COMPLETION_STATUS';
 export const UPDATE_REVIEW_STATUS = 'UPDATE_REVIEW_STATUS';
 export const UPDATE_SPOUSE_ADDRESS = 'UPDATE_SPOUSE_ADDRESS';
 export const UPDATE_SUBMISSION_STATUS = 'UPDATE_SUBMISSION_STATUS';
-export const ENSURE_CHILD_FIELDS_INITIALIZED = 'ENSURE_CHILD_FIELDS_INITIALIZED';
+export const CREATE_CHILD_INCOME_FIELDS = 'CREATE_CHILD_INCOME_FIELDS';
 
 export function ensureFieldsInitialized(path) {
   return {
@@ -51,9 +51,9 @@ export function updateSubmissionStatus(field) {
   };
 }
 
-export function ensureChildFieldsInitialized(path) {
+export function createChildIncomeFields(path) {
   return {
-    type: ENSURE_CHILD_FIELDS_INITIALIZED,
+    type: CREATE_CHILD_INCOME_FIELDS,
     path
   };
 }

--- a/_health-care/_js/actions/index.js
+++ b/_health-care/_js/actions/index.js
@@ -4,6 +4,7 @@ export const UPDATE_COMPLETION_STATUS = 'UPDATE_COMPLETION_STATUS';
 export const UPDATE_REVIEW_STATUS = 'UPDATE_REVIEW_STATUS';
 export const UPDATE_SPOUSE_ADDRESS = 'UPDATE_SPOUSE_ADDRESS';
 export const UPDATE_SUBMISSION_STATUS = 'UPDATE_SUBMISSION_STATUS';
+export const ENSURE_CHILD_FIELDS_INITIALIZED = 'ENSURE_CHILD_FIELDS_INITIALIZED';
 
 export function ensureFieldsInitialized(path) {
   return {
@@ -47,5 +48,12 @@ export function updateSubmissionStatus(field) {
   return {
     type: UPDATE_SUBMISSION_STATUS,
     field
+  };
+}
+
+export function ensureChildFieldsInitialized(path) {
+  return {
+    type: ENSURE_CHILD_FIELDS_INITIALIZED,
+    path
   };
 }

--- a/_health-care/_js/components/financial-assessment/AnnualIncomeSection.jsx
+++ b/_health-care/_js/components/financial-assessment/AnnualIncomeSection.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import ChildIncome from './ChildIncome';
 import ErrorableCheckbox from '../form-elements/ErrorableCheckbox';
 import ErrorableTextInput from '../form-elements/ErrorableTextInput';
+import FixedTable from '../form-elements/FixedTable.jsx';
 import { isBlank, isValidMonetaryValue } from '../../utils/validations';
-import { updateReviewStatus, veteranUpdateField } from '../../actions';
+import { ensureChildFieldsInitialized, updateReviewStatus, veteranUpdateField } from '../../actions';
 
 /**
  * Props:
@@ -36,6 +38,21 @@ class AnnualIncomeSection extends React.Component {
             indicated you are receiving a VA pension.
           </strong>
         </p>
+      );
+    }
+
+    let childrenIncomeInput;
+
+    if (this.props.hasChildrenToReport === true) {
+      childrenIncomeInput = (
+        <div className="input-section">
+          <h6>Children</h6>
+          <FixedTable
+              component={ChildIncome}
+              initializeCurrentElement={() => {this.props.initializeFields();}}
+              onRowsUpdate={(update) => {this.props.onStateChange('children', update);}}
+              rows={this.props.data.children}/>
+        </div>
       );
     }
 
@@ -185,26 +202,8 @@ class AnnualIncomeSection extends React.Component {
               onValueChange={(update) => {this.props.onStateChange('spouseOtherIncome', update);}}/>
         </div>
 
-        <div className="input-section">
-          <h6>Children</h6>
-          <ErrorableTextInput
-              errorMessage={this.isValidMonetaryValue(this.props.data.childrenGrossIncome, message)}
-              label="Children Gross Income"
-              value={this.props.data.childrenGrossIncome}
-              onValueChange={(update) => {this.props.onStateChange('childrenGrossIncome', update);}}/>
+        {childrenIncomeInput}
 
-          <ErrorableTextInput
-              errorMessage={this.isValidMonetaryValue(this.props.data.childrenNetIncome, message)}
-              label="Children Net Income"
-              value={this.props.data.childrenNetIncome}
-              onValueChange={(update) => {this.props.onStateChange('childrenNetIncome', update);}}/>
-
-          <ErrorableTextInput
-              errorMessage={this.isValidMonetaryValue(this.props.data.childrenOtherIncome, message)}
-              label="Children Other Income"
-              value={this.props.data.childrenOtherIncome}
-              onValueChange={(update) => {this.props.onStateChange('childrenOtherIncome', update);}}/>
-        </div>
       </div>);
     }
 
@@ -230,6 +229,7 @@ class AnnualIncomeSection extends React.Component {
 function mapStateToProps(state) {
   return {
     data: state.veteran.annualIncome,
+    hasChildrenToReport: state.childInformation.hasChildrenToReport,
     receivesVaPension: state.veteran.vaInformation.receivesVaPension,
     isSectionComplete: state.uiState.completedSections['/financial-assessment/annual-income']
   };
@@ -242,6 +242,9 @@ function mapDispatchToProps(dispatch) {
     },
     onUIStateChange: (update) => {
       dispatch(updateReviewStatus(['/financial-assessment/annual-income'], update));
+    },
+    initializeFields: () => {
+      dispatch(ensureChildFieldsInitialized('/financial-assessment/annual-income'));
     }
   };
 }

--- a/_health-care/_js/components/financial-assessment/AnnualIncomeSection.jsx
+++ b/_health-care/_js/components/financial-assessment/AnnualIncomeSection.jsx
@@ -6,7 +6,7 @@ import ErrorableCheckbox from '../form-elements/ErrorableCheckbox';
 import ErrorableTextInput from '../form-elements/ErrorableTextInput';
 import FixedTable from '../form-elements/FixedTable.jsx';
 import { isBlank, isValidMonetaryValue } from '../../utils/validations';
-import { ensureChildFieldsInitialized, updateReviewStatus, veteranUpdateField } from '../../actions';
+import { createChildIncomeFields, updateReviewStatus, veteranUpdateField } from '../../actions';
 
 /**
  * Props:
@@ -19,6 +19,10 @@ class AnnualIncomeSection extends React.Component {
     this.isValidMonetaryValue = this.isValidMonetaryValue.bind(this);
   }
 
+  componentWillMount() {
+    this.props.initializeChildIncomeFields();
+  }
+
   isValidMonetaryValue(value, message) {
     return isBlank(value) || isValidMonetaryValue(value) ? undefined : message;
   }
@@ -27,6 +31,8 @@ class AnnualIncomeSection extends React.Component {
   render() {
     const message = 'Please enter only numbers and a decimal point if necessary (no commas or currency signs)';
     let notRequiredMessage;
+    let childrenIncomeInput;
+    let childrenIncomeReview;
     let content;
     let editButton;
 
@@ -41,75 +47,86 @@ class AnnualIncomeSection extends React.Component {
       );
     }
 
-    let childrenIncomeInput;
-
-    if (this.props.hasChildrenToReport === true) {
+    if (this.props.childrenData.hasChildrenToReport === true) {
       childrenIncomeInput = (
         <div className="input-section">
-          <h6>Children</h6>
           <FixedTable
               component={ChildIncome}
-              initializeCurrentElement={() => {this.props.initializeFields();}}
               onRowsUpdate={(update) => {this.props.onStateChange('children', update);}}
+              relatedData={this.props.childrenData.children}
               rows={this.props.data.children}/>
         </div>
       );
     }
 
     if (this.props.isSectionComplete && this.props.reviewSection) {
-      content = (<div>
-        <h6>Veteran</h6>
-        <table className="review usa-table-borderless">
-          <tbody>
-            <tr>
-              <td>Veteran Gross Income:</td>
-              <td>{this.props.data.veteranGrossIncome}</td>
-            </tr>
-            <tr>
-              <td>Veteran Net Income:</td>
-              <td>{this.props.data.veteranNetIncome}</td>
-            </tr>
-            <tr>
-              <td>Veteran Other Income:</td>
-              <td>{this.props.data.veteranOtherIncome}</td>
-            </tr>
-          </tbody>
-        </table>
-        <h6>Spouse</h6>
-        <table className="review usa-table-borderless">
-          <tbody>
-            <tr>
-              <td>Spouse Gross Income:</td>
-              <td>{this.props.data.spouseGrossIncome}</td>
-            </tr>
-            <tr>
-              <td>Spouse Net Income:</td>
-              <td>{this.props.data.spouseNetIncome}</td>
-            </tr>
-            <tr>
-              <td>Spouse Other Income:</td>
-              <td>{this.props.data.spouseOtherIncome}</td>
-            </tr>
-          </tbody>
-        </table>
-        <h6>Children</h6>
-        <table className="review usa-table-borderless">
-          <tbody>
-            <tr>
-              <td>Children Gross Income:</td>
-              <td>{this.props.data.childrenGrossIncome}</td>
-            </tr>
-            <tr>
-              <td>Children Net Income:</td>
-              <td>{this.props.data.childrenNetIncome}</td>
-            </tr>
-            <tr>
-              <td>Children Other Income:</td>
-              <td>{this.props.data.childrenOtherIncome}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>);
+      const childrenData = this.props.childrenData.children;
+      let reactKey = 0;
+      childrenIncomeReview = this.props.data.children.map((obj, index) => {
+        return (
+          <div key={reactKey++}>
+            <h6>Child: {`${childrenData[index].childFullName.first} ${childrenData[index].childFullName.last}`}</h6>
+            <table className="review usa-table-borderless">
+              <tbody>
+                <tr>
+                  <td>Children Gross Income:</td>
+                  <td>{obj.childGrossIncome}</td>
+                </tr>
+                <tr>
+                  <td>Children Net Income:</td>
+                  <td>{obj.childNetIncome}</td>
+                </tr>
+                <tr>
+                  <td>Children Other Income:</td>
+                  <td>{obj.childOtherIncome}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        );
+      });
+
+      content = (
+        <div>
+          <h6>Veteran</h6>
+          <table className="review usa-table-borderless">
+            <tbody>
+              <tr>
+                <td>Veteran Gross Income:</td>
+                <td>{this.props.data.veteranGrossIncome}</td>
+              </tr>
+              <tr>
+                <td>Veteran Net Income:</td>
+                <td>{this.props.data.veteranNetIncome}</td>
+              </tr>
+              <tr>
+                <td>Veteran Other Income:</td>
+                <td>{this.props.data.veteranOtherIncome}</td>
+              </tr>
+            </tbody>
+          </table>
+          <h6>Spouse</h6>
+          <table className="review usa-table-borderless">
+            <tbody>
+              <tr>
+                <td>Spouse Gross Income:</td>
+                <td>{this.props.data.spouseGrossIncome}</td>
+              </tr>
+              <tr>
+                <td>Spouse Net Income:</td>
+                <td>{this.props.data.spouseNetIncome}</td>
+              </tr>
+              <tr>
+                <td>Spouse Other Income:</td>
+                <td>{this.props.data.spouseOtherIncome}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          {childrenIncomeReview}
+
+        </div>
+      );
     } else {
       content = (<div>
                 {notRequiredMessage}
@@ -229,7 +246,7 @@ class AnnualIncomeSection extends React.Component {
 function mapStateToProps(state) {
   return {
     data: state.veteran.annualIncome,
-    hasChildrenToReport: state.childInformation.hasChildrenToReport,
+    childrenData: state.veteran.childInformation,
     receivesVaPension: state.veteran.vaInformation.receivesVaPension,
     isSectionComplete: state.uiState.completedSections['/financial-assessment/annual-income']
   };
@@ -243,8 +260,8 @@ function mapDispatchToProps(dispatch) {
     onUIStateChange: (update) => {
       dispatch(updateReviewStatus(['/financial-assessment/annual-income'], update));
     },
-    initializeFields: () => {
-      dispatch(ensureChildFieldsInitialized('/financial-assessment/annual-income'));
+    initializeChildIncomeFields: () => {
+      dispatch(createChildIncomeFields('/financial-assessment/annual-income'));
     }
   };
 }

--- a/_health-care/_js/components/financial-assessment/ChildIncome.jsx
+++ b/_health-care/_js/components/financial-assessment/ChildIncome.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import ErrorableTextInput from '../form-elements/ErrorableTextInput';
+
+import { isBlank, isValidMonetaryValue } from '../../utils/validations';
+
+/**
+ * Sub-component for children income portion AnnualIncomeSection.
+ *
+ * Props:
+ * `data` - Collection of numbers for each field.
+ * `onValueChange` - a function with this prototype: (newValue)
+ */
+class ChildIncome extends React.Component {
+  render() {
+    const message = 'Please enter only numbers and a decimal point if necessary (no commas or currency signs)';
+
+    return (
+      <div>
+        <h6>{this.props.data.childShortName}</h6>
+        <ErrorableTextInput
+            errorMessage={isBlank(this.props.data.childGrossIncome) || isValidMonetaryValue(this.props.data.childGrossIncome) ? undefined : message}
+            label="Gross Income"
+            value={this.props.data.childGrossIncome}
+            onValueChange={(update) => {this.props.onValueChange('childGrossIncome', update);}}/>
+        <ErrorableTextInput
+            errorMessage={isBlank(this.props.data.childNetIncome) || isValidMonetaryValue(this.props.data.childNetIncome) ? undefined : message}
+            label="Net Income"
+            value={this.props.data.childNetIncome}
+            onValueChange={(update) => {this.props.onValueChange('childNetIncome', update);}}/>
+        <ErrorableTextInput
+            errorMessage={isBlank(this.props.data.childOtherIncome) || isValidMonetaryValue(this.props.data.childOtherIncome) ? undefined : message}
+            label="Other Income"
+            value={this.props.data.childOtherIncome}
+            onValueChange={(update) => {this.props.onValueChange('childOtherIncome', update);}}/>
+      </div>
+    );
+  }
+}
+
+ChildIncome.propTypes = {
+  data: React.PropTypes.object.isRequired,
+  onValueChange: React.PropTypes.func.isRequired
+};
+
+export default ChildIncome;

--- a/_health-care/_js/components/financial-assessment/ChildIncome.jsx
+++ b/_health-care/_js/components/financial-assessment/ChildIncome.jsx
@@ -9,6 +9,7 @@ import { isBlank, isValidMonetaryValue } from '../../utils/validations';
  *
  * Props:
  * `data` - Collection of numbers for each field.
+ * `relatedData` - Used to pass down child information data.
  * `onValueChange` - a function with this prototype: (newValue)
  */
 class ChildIncome extends React.Component {
@@ -17,7 +18,7 @@ class ChildIncome extends React.Component {
 
     return (
       <div>
-        <h6>{this.props.data.childShortName}</h6>
+        <h6>Child: {`${this.props.relatedData.childFullName.first} ${this.props.relatedData.childFullName.last}`}</h6>
         <ErrorableTextInput
             errorMessage={isBlank(this.props.data.childGrossIncome) || isValidMonetaryValue(this.props.data.childGrossIncome) ? undefined : message}
             label="Gross Income"
@@ -40,6 +41,7 @@ class ChildIncome extends React.Component {
 
 ChildIncome.propTypes = {
   data: React.PropTypes.object.isRequired,
+  relatedData: React.PropTypes.object.isRequired,
   onValueChange: React.PropTypes.func.isRequired
 };
 

--- a/_health-care/_js/components/form-elements/FixedTable.jsx
+++ b/_health-care/_js/components/form-elements/FixedTable.jsx
@@ -5,23 +5,19 @@ import React from 'react';
  *
  * This component has the following props.
  * `component` - The UI element that is repeated.
- * `initializeCurrentElement` - a chance to update something before rendering
+ * `relatedData` - used to pass down relevant data to the component this renders
  * `rows` - Data for each UI element.
  * `onRowsUpdate` - Function that updates the source rows.
  */
 class FixedTable extends React.Component {
-  componentWillMount() {
-    if (this.props.initializeCurrentElement !== undefined) {
-      this.props.initializeCurrentElement();
-    }
-  }
-
   render() {
+    const relatedData = this.props.relatedData;
     const rowElements = this.props.rows.map((obj, index) => {
       return (
         <div className="input-section" key={index}>
           {React.createElement(this.props.component,
             { data: obj,
+              relatedData: relatedData[index],
               onValueChange: (subfield, update) => {
                 const rows = this.props.rows.slice();
                 const newRow = Object.assign({}, rows[index]);
@@ -43,8 +39,8 @@ class FixedTable extends React.Component {
 
 FixedTable.propTypes = {
   component: React.PropTypes.func.isRequired,
-  initializeCurrentElement: React.PropTypes.func,
   onRowsUpdate: React.PropTypes.func.isRequired,
+  relatedData: React.PropTypes.array,
   rows: React.PropTypes.array.isRequired
 };
 

--- a/_health-care/_js/components/form-elements/FixedTable.jsx
+++ b/_health-care/_js/components/form-elements/FixedTable.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+/**
+ * A container for a fixed number of repeating elements.
+ *
+ * This component has the following props.
+ * `component` - The UI element that is repeated.
+ * `initializeCurrentElement` - a chance to update something before rendering
+ * `rows` - Data for each UI element.
+ * `onRowsUpdate` - Function that updates the source rows.
+ */
+class FixedTable extends React.Component {
+  componentWillMount() {
+    if (this.props.initializeCurrentElement !== undefined) {
+      this.props.initializeCurrentElement();
+    }
+  }
+
+  render() {
+    const rowElements = this.props.rows.map((obj, index) => {
+      return (
+        <div className="input-section" key={index}>
+          {React.createElement(this.props.component,
+            { data: obj,
+              onValueChange: (subfield, update) => {
+                const rows = this.props.rows.slice();
+                const newRow = Object.assign({}, rows[index]);
+                newRow[subfield] = update;
+                rows[index] = newRow;
+                this.props.onRowsUpdate(rows);
+              }
+            })}
+        </div>
+      );
+    });
+    return (
+      <div>
+        {rowElements}
+      </div>
+    );
+  }
+}
+
+FixedTable.propTypes = {
+  component: React.PropTypes.func.isRequired,
+  initializeCurrentElement: React.PropTypes.func,
+  onRowsUpdate: React.PropTypes.func.isRequired,
+  rows: React.PropTypes.array.isRequired
+};
+
+export default FixedTable;

--- a/_health-care/_js/reducers/veteran/index.js
+++ b/_health-care/_js/reducers/veteran/index.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import lodashDeep from 'lodash-deep';
 
-import { ENSURE_FIELDS_INITIALIZED, VETERAN_FIELD_UPDATE, UPDATE_SPOUSE_ADDRESS, ENSURE_CHILD_FIELDS_INITIALIZED } from '../../actions';
+import { ENSURE_FIELDS_INITIALIZED, VETERAN_FIELD_UPDATE, UPDATE_SPOUSE_ADDRESS, CREATE_CHILD_INCOME_FIELDS } from '../../actions';
 import { initializeNullValues } from '../../utils/validations';
 import { pathToData } from '../../store';
 
@@ -170,7 +170,6 @@ const blankVeteran = {
 
 function createBlankChild() {
   return {
-    childShortName: null,
     childGrossIncome: null,
     childNetIncome: null,
     childOtherIncome: null
@@ -213,16 +212,14 @@ function veteran(state = blankVeteran, action) {
       return newState;
     }
 
-    case ENSURE_CHILD_FIELDS_INITIALIZED:
+    case CREATE_CHILD_INCOME_FIELDS:
       newState = Object.assign({}, state);
       // update children income from children info
       newState.annualIncome.children.splice(newState.childInformation.children.length);
       for (let i = 0; i < newState.childInformation.children.length; i++) {
-        const shortName = `${newState.childInformation.children[i].childFullName.first} ${newState.childInformation.children[i].childFullName.last}`;
         if (newState.annualIncome.children[i] === undefined) {
           newState.annualIncome.children[i] = createBlankChild();
         }
-        newState.annualIncome.children[i].childShortName = shortName;
       }
       Object.assign(pathToData(newState, action.path), initializeNullValues(pathToData(newState, action.path)));
       return newState;

--- a/_health-care/_js/reducers/veteran/index.js
+++ b/_health-care/_js/reducers/veteran/index.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import lodashDeep from 'lodash-deep';
 
-import { ENSURE_FIELDS_INITIALIZED, VETERAN_FIELD_UPDATE, UPDATE_SPOUSE_ADDRESS } from '../../actions';
+import { ENSURE_FIELDS_INITIALIZED, VETERAN_FIELD_UPDATE, UPDATE_SPOUSE_ADDRESS, ENSURE_CHILD_FIELDS_INITIALIZED } from '../../actions';
 import { initializeNullValues } from '../../utils/validations';
 import { pathToData } from '../../store';
 
@@ -116,9 +116,7 @@ const blankVeteran = {
     spouseGrossIncome: null,
     spouseNetIncome: null,
     spouseOtherIncome: null,
-    childrenGrossIncome: null,
-    childrenNetIncome: null,
-    childrenOtherIncome: null
+    children: []
   },
 
   deductibleExpenses: {
@@ -170,6 +168,15 @@ const blankVeteran = {
   }
 };
 
+function createBlankChild() {
+  return {
+    childShortName: null,
+    childGrossIncome: null,
+    childNetIncome: null,
+    childOtherIncome: null
+  };
+}
+
 function veteran(state = blankVeteran, action) {
   let newState = undefined;
   switch (action.type) {
@@ -205,6 +212,20 @@ function veteran(state = blankVeteran, action) {
       }
       return newState;
     }
+
+    case ENSURE_CHILD_FIELDS_INITIALIZED:
+      newState = Object.assign({}, state);
+      // update children income from children info
+      newState.annualIncome.children.splice(newState.childInformation.children.length);
+      for (let i = 0; i < newState.childInformation.children.length; i++) {
+        const shortName = `${newState.childInformation.children[i].childFullName.first} ${newState.childInformation.children[i].childFullName.last}`;
+        if (newState.annualIncome.children[i] === undefined) {
+          newState.annualIncome.children[i] = createBlankChild();
+        }
+        newState.annualIncome.children[i].childShortName = shortName;
+      }
+      Object.assign(pathToData(newState, action.path), initializeNullValues(pathToData(newState, action.path)));
+      return newState;
 
     default:
       return state;

--- a/_health-care/_js/utils/validations.js
+++ b/_health-care/_js/utils/validations.js
@@ -179,6 +179,22 @@ function isValidChildren(data) {
   return true;
 }
 
+function isValidChildIncome(child) {
+  return (isBlank(child.childGrossIncome) || isValidMonetaryValue(child.childGrossIncome)) &&
+    (isBlank(child.childNetIncome) || isValidMonetaryValue(child.childNetIncome)) &&
+    (isBlank(child.childOtherIncome) || isValidMonetaryValue(child.childOtherIncome));
+}
+
+function isValidChildrenIncome(data) {
+  const children = data.children;
+  for (let i = 0; i < children.length; i++) {
+    if (!isValidChildIncome(children[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function isValidAnnualIncome(data) {
   return (isBlank(data.veteranGrossIncome) || isValidMonetaryValue(data.veteranGrossIncome)) &&
     (isBlank(data.veteranNetIncome) || isValidMonetaryValue(data.veteranNetIncome)) &&
@@ -186,9 +202,7 @@ function isValidAnnualIncome(data) {
     (isBlank(data.spouseGrossIncome) || isValidMonetaryValue(data.spouseGrossIncome)) &&
     (isBlank(data.spouseNetIncome) || isValidMonetaryValue(data.spouseNetIncome)) &&
     (isBlank(data.spouseOtherIncome) || isValidMonetaryValue(data.spouseOtherIncome)) &&
-    (isBlank(data.childrenGrossIncome) || isValidMonetaryValue(data.childrenGrossIncome)) &&
-    (isBlank(data.childrenNetIncome) || isValidMonetaryValue(data.childrenNetIncome)) &&
-    (isBlank(data.childrenOtherIncome) || isValidMonetaryValue(data.childrenOtherIncome));
+    isValidChildrenIncome(data);
 }
 
 function isValidDeductibleExpenses(data) {

--- a/spec/javascripts/health-care/components/form-elements/FixedTable.spec.jsx
+++ b/spec/javascripts/health-care/components/form-elements/FixedTable.spec.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+
+import FixedTable from '../../../../../_health-care/_js/components/form-elements/FixedTable';
+
+describe('<FixedTable>', () => {
+  describe('propTypes', () => {
+    let consoleStub;
+    beforeEach(() => {
+      consoleStub = sinon.stub(console, 'error');
+    });
+
+    afterEach(() => {
+      consoleStub.restore();
+    });
+
+    /** Mock function used to verify propType checks for functions. */
+    const func = () => {};
+
+    it('component is required', () => {
+      SkinDeep.shallowRender(
+        <FixedTable rows={[]} onRowsUpdate={func}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Required prop `component` was not specified in `FixedTable`/);
+    });
+
+    it('component must be a func', () => {
+      SkinDeep.shallowRender(
+        <FixedTable rows={[]} component onRowsUpdate={func}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `component` of type `boolean` supplied to `FixedTable`, expected `function`/);
+    });
+
+    it('onRowsUpdate is required', () => {
+      SkinDeep.shallowRender(
+        <FixedTable rows={[]} component={func}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Required prop `onRowsUpdate` was not specified in `FixedTable`/);
+    });
+
+    it('onRowsUpdate must be a func', () => {
+      SkinDeep.shallowRender(
+        <FixedTable rows={[]} component={func} onRowsUpdate/>);
+      sinon.assert.calledWithMatch(consoleStub, /Invalid prop `onRowsUpdate` of type `boolean` supplied to `FixedTable`, expected `function`/);
+    });
+
+    xit('rows is required', () => {
+      SkinDeep.shallowRender(
+        <FixedTable component={func} onRowsUpdate={func}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Required prop `rows` was not specified in `FixedTable`/);
+    });
+
+    xit('rows must be an array', () => {
+      SkinDeep.shallowRender(
+        <FixedTable rows component={func} onRowsUpdate={func}/>);
+      sinon.assert.calledWithMatch(consoleStub, /Required prop `rows` was not specified in `FixedTable`/);
+    });
+  });
+});
+


### PR DESCRIPTION
We need to add fields for each child on the `AnnualIncome` section based on how many children were added earlier in the financial assessment topic. We created a new action to create the child income fields that is called before the `AnnualIncome` section is rendered. 
