### PR TITLE
Simplified #content .primary p:nth-child selector. closes #1450

### DIFF
--- a/_sass/_va-variables.scss
+++ b/_sass/_va-variables.scss
@@ -6,10 +6,14 @@ $color-green-darker: #195c27;
 $base-font-size: rem(16px);
 
 // Other Colors
-$polar:#E8F5FA;
-$wild-sand:#f6f6f6;
-$green-white:#eff0e6;
-$olso-gray:#849097;
+$polar: #E8F5FA;
+$wild-sand: #f6f6f6;
+$green-white: #eff0e6;
+$olso-gray: #849097;
+
+// TODO: This color is close enough to $color-gray-warm-dark  
+// that maybe we should replace it.
+$color-gray-cool-dark: #444; 
 
 // VA Fonts
 $roboto-slab: 'Roboto Slab', serif;

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -1,5 +1,3 @@
-
-
 html {
   font-family: $font-sans;
   font-size: $em-base;
@@ -102,8 +100,8 @@ a {
 }
 
 a:visited {
-  color: #4c2c92
-  }
+  color: #4c2c92;
+}
 
 
 // Figure / Caption
@@ -280,6 +278,14 @@ h3, h4, h5, h6 {
 
   p {padding-top: 0; margin-top: 0; padding-bottom: 1em;}
 
+  p:nth-child(1) {
+    font-size: 1.25em;
+    color: $color-primary-darker;
+    letter-spacing: normal;
+    font-weight: normal;
+    padding-bottom: 1em;
+  }
+  
   h3 {
     padding: 0 0 .5em 0; font-size: 1.25em;
     @media #{$small} {font-size: 1.8em;}
@@ -386,13 +392,6 @@ h6 {font-size: 1.15em; font-weight: bold;}
     color: #333;
     font-size: 1em;
     padding-bottom: 0;
-  }
-  p:nth-child(1) {
-    font-size: 1.25em;
-    color: $color-primary-darker;
-    letter-spacing: normal;
-    font-weight: normal;
-    padding-bottom: 1em;
   }
 }
 
@@ -1154,7 +1153,15 @@ figure {
 }
 
 .post {
-  a, p, li, h1, h2, h3, h4, h5, h6, dl, dd, dt, caption, figure, blockquote {color: #444; line-height: 1.65em;}
+  a, p, p:nth-child(1), li, h1, h2, h3, h4, h5, h6, dl, dd, dt, caption, figure,   
+  blockquote {
+    color: #444; 
+    line-height: 1.65em;
+    font-size: inherit;
+  }
+  
+
+  
   a {
     text-decoration: underline;
     color: $color-primary-darker;

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -100,7 +100,7 @@ a {
 }
 
 a:visited {
-  color: #4c2c92;
+  color: $color-visited;
 }
 
 
@@ -197,7 +197,7 @@ h3, h4, h5, h6 {
     margin: .5em 0 0 0;
       white-space: pre-wrap;
     color: #333;
-    a {background: $color-gold; color: #444;}
+    a {background: $color-gold; color: $color-gray-cool-dark;}
   }
 
   h2 span {clear: both; padding: .04em; display: inline-block; background: $color-gold; font-weight: normal;}
@@ -490,7 +490,7 @@ h6 {font-size: 1.15em; font-weight: bold;}
   .section.three {
     background: #fff;
     padding: 5em 0;
-    h2, h3, h4, h5, h6, p, li {color: #444;}
+    h2, h3, h4, h5, h6, p, li {color: $color-gray-cool-dark;}
     h4 {font-size: 1em; margin: 0; padding: 0; line-height: 1.2em;}
     a {color: $color-primary-darkest;}
   }
@@ -550,7 +550,7 @@ background: rgba(255,255,255,.85);
 #content .section.do {
   background: #efefef;
   padding: 2em 0;
-  h2, h3, h4, h5, h6, p, li {color: #444;}
+  h2, h3, h4, h5, h6, p, li {color: $color-gray-cool-dark;}
   h4 {font-size: 1em; margin: 0; padding: 0; line-height: 1.2em;}
   a {color: #fff;}
 }
@@ -1023,7 +1023,7 @@ background-size: contain;
   }
 }
 
-.post-date, .post-author {color: #444;}
+.post-date, .post-author {color: $color-gray-cool-dark;}
 
 .post-date {
   margin-bottom: 2.5em;
@@ -1146,7 +1146,7 @@ figure {
           padding-left: .5em;
         }
         .post-title {color: $color-primary-darker; font-size: 1em; font-weight: bold; margin: 0; padding: 0;}
-        .post-date {color: #444; margin: 0; padding: 0 0 1em 0;}
+        .post-date {color: $color-gray-cool-dark; margin: 0; padding: 0 0 1em 0;}
       }
     }
   }
@@ -1155,7 +1155,7 @@ figure {
 .post {
   a, p, p:nth-child(1), li, h1, h2, h3, h4, h5, h6, dl, dd, dt, caption, figure,   
   blockquote {
-    color: #444; 
+    color: $color-gray-cool-dark; 
     line-height: 1.65em;
     font-size: inherit;
   }
@@ -1168,7 +1168,7 @@ figure {
   }
 
   .page-number {
-    color: #444;
+    color: $color-gray-cool-dark;
   }
 
   span.previous {
@@ -2311,7 +2311,7 @@ button[class*="usa-button-"] {
   border-top: 1px solid #ddd;
 
   z-index:500;
-  color: #444;
+  color: $color-gray-cool-dark;
   background: #fff;
 
   &.minimal {


### PR DESCRIPTION
- Replacing #content .primary p:nth-child(1) with .primary p:nth-child(q)
- Adds .post p:nth-child(1) to avoid visual regression on blog.
- Reformats some blocks for easier readability.

modified:   _sass/_va.scss
