### PR TITLE
Make heroku bind all IPs.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -104,7 +104,7 @@ desc "Run the development jekyll server on a given port with webpack bootstrappe
 task :"heroku-serve", :port do |t, args|
   raise "heroku-serve needs port argument" if args[:port].empty?
   Rake::Task[:"webpack-dev"].invoke
-  sh "bundle exec jekyll serve --no-watch -P #{args[:port]}"
+  sh "bundle exec jekyll serve --no-watch --host 0.0.0.0 -P #{args[:port]}"
 end
 
 desc "Serve the website"


### PR DESCRIPTION
When bound only to localhost, heroku doesn't notice the server is
running and hangs.
