### PR TITLE
Removing body.home .main-navigation rule. closes #1674

### DIFF
--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -881,11 +881,6 @@ body.fourohfour #content {
   h3 {margin-top: 1em; font-size: 1.4em;}
 }
 
-body.home .main-navigation {
-  padding: 2em 0;
-  background: rgba(0,0,0,.2);
-}
-
 .draft {
   position: absolute;
   top: -3.5em;


### PR DESCRIPTION
- Rule isn't being used anywhere on the site and can be safely removed.
