### PR TITLE
Hides disclaimer using Liquid instead of CSS. closes #1940

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,15 +1,17 @@
 <a class="sr-only" href="#feedback-tool">Give feedback on this page</a>
 
+
+
+{% unless page.body_class == 'page-playbook' or page.body_class == 'home' %}
 <div class="disclaimer">
   <div class="row">
     <div class="small-12 columns">
-
+      
       <p>Please note: Content on this Web page is for informational purposes only. It is not intended to provide legal advice or to be a comprehensive statement or analysis of applicable statutes, regulations, and case law governing this topic. Rather, it’s a plain-language summary. If you are seeking claims assistance, your local VA regional office, a VA-recognized Veterans Service Organization, or a VA-accredited attorney or agent can help. <a target="_blank" href="http://www.va.gov/ogc/apps/accreditation/index.asp">Search Accredited Attorneys, Claims Agents, or Veterans Service Organizations (VSO) Representatives</a>.</p>
-
     </div>
   </div>
 </div>
-
+{% endunless %}
 
 <div class="footer" role="contentinfo">
   <div class="row wow fadeIn animated">

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -2367,12 +2367,6 @@ button[class*="usa-button-"] {
   }
 }
 
-/* body.home .disclaimer, 
-body.page-playbook .disclaimer {
-  display: none;
-} */
-
-
 // Mobile menu
 
 /* Overlay style */

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -999,8 +999,8 @@ li {
 // Blog / Playbook
 
 body.page-playbook {
-background:$color-white url(../images/design/background/thread.png) top left no-repeat;
-background-size: contain;
+  background:$color-white url(../images/design/background/thread.png) top left no-repeat;
+  background-size: contain;
 
   h1 a {
     text-indent: 180%;
@@ -1013,6 +1013,7 @@ background-size: contain;
     height: 30px;
     background: $color-white url(../images/design/logo/logo-alt.png) top left no-repeat;
     background-size: contain;
+    
     &:hover, &:active, &:focus {
       background: $color-white url(../images/design/logo/logo-alt-hover.png) top left no-repeat;
       border-bottom: none;
@@ -1092,34 +1093,29 @@ span.next {
     margin: 1.35em 0 0 0 !important; 
     z-index: 100 !important;
   }  
-    
-    padding: 0; 
-    margin: 0 0 2em 0; 
-    background: none; 
-    color: $color-primary-darkest;
-    
-    a {
-      text-decoration: none; 
-      margin: 0; 
-      color: $color-primary-darkest; 
-      background: $color-gold; 
-      border-bottom: none; 
-      padding: .5em .25em; 
-      // Transition only these properties.
-      -webkit-transition-property: padding;
-      transition-property: padding;
-          
-      &:hover {
-        padding: .5em .65em;
-      }
-    }
-    
-    @media #{$medium} {
-      position: absolute; 
-      margin: 1.35em 0 0 0; 
-      z-index: 100;
+
+  a {
+    text-decoration: none; 
+    margin: 0; 
+    color: $color-primary-darkest; 
+    background: $color-gold; 
+    border-bottom: none; 
+    padding: .5em .25em; 
+    // Transition only these properties.
+    -webkit-transition-property: padding;
+    transition-property: padding;
+        
+    &:hover {
+      padding: .5em .65em;
     }
   }
+  
+  @media #{$medium} {
+    position: absolute; 
+    margin: 1.35em 0 0 0; 
+    z-index: 100;
+  }
+}
 
 .va-headingflag--tagline {
   padding: 0;
@@ -1152,8 +1148,8 @@ figure {
   }
 
   @media #{$large} {
-      margin-left: -16.66667%;
-      margin-right: -16.66667%;
+    margin-left: -16.66667%;
+    margin-right: -16.66667%;
   }
 }
 
@@ -1199,9 +1195,7 @@ figure {
     line-height: 1.65em;
     font-size: inherit;
   }
-  
-
-  
+ 
   a {
     text-decoration: underline;
     color: $color-primary-darker;
@@ -2373,9 +2367,10 @@ button[class*="usa-button-"] {
   }
 }
 
-body.home .disclaimer, body.page-playbook .disclaimer {
+/* body.home .disclaimer, 
+body.page-playbook .disclaimer {
   display: none;
-}
+} */
 
 
 // Mobile menu


### PR DESCRIPTION
- Adds a check for the page.body_class value set in the  Markdown file or _config.yml and shows the disclaimer unless the value of page.body_class is home or page-playbook
- Removes the body.home .disclaimer, body.page-playbook .disclaimer blocks from the CSS.

modified:   _includes/footer.html
modified:   _sass/_va.scss
