### PR TITLE
Remove sectionComplete from veteran store and rename description

### DIFF
--- a/_health-care/_js/components/financial-assessment/AnnualIncomeSection.jsx
+++ b/_health-care/_js/components/financial-assessment/AnnualIncomeSection.jsx
@@ -8,7 +8,7 @@ import { updateReviewStatus, veteranUpdateField } from '../../actions';
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class AnnualIncomeSection extends React.Component {

--- a/_health-care/_js/components/financial-assessment/ChildInformationSection.jsx
+++ b/_health-care/_js/components/financial-assessment/ChildInformationSection.jsx
@@ -8,7 +8,7 @@ import { veteranUpdateField, ensureFieldsInitialized, updateReviewStatus } from 
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class ChildInformationSection extends React.Component {

--- a/_health-care/_js/components/financial-assessment/DeductibleExpensesSection.jsx
+++ b/_health-care/_js/components/financial-assessment/DeductibleExpensesSection.jsx
@@ -8,7 +8,7 @@ import { updateReviewStatus, veteranUpdateField } from '../../actions';
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class DeductibleExpensesSection extends React.Component {

--- a/_health-care/_js/components/financial-assessment/FinancialDisclosureSection.jsx
+++ b/_health-care/_js/components/financial-assessment/FinancialDisclosureSection.jsx
@@ -6,7 +6,7 @@ import { updateReviewStatus, veteranUpdateField } from '../../actions';
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class FinancialDisclosureSection extends React.Component {

--- a/_health-care/_js/components/financial-assessment/SpouseInformationSection.jsx
+++ b/_health-care/_js/components/financial-assessment/SpouseInformationSection.jsx
@@ -16,7 +16,7 @@ import { updateReviewStatus, veteranUpdateField, updateSpouseAddress } from '../
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class SpouseInformationSection extends React.Component {

--- a/_health-care/_js/components/insurance-information/InsuranceInformationSection.jsx
+++ b/_health-care/_js/components/insurance-information/InsuranceInformationSection.jsx
@@ -8,7 +8,7 @@ import { veteranUpdateField, ensureFieldsInitialized, updateReviewStatus } from 
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class InsuranceInformationSection extends React.Component {

--- a/_health-care/_js/components/insurance-information/MedicareMedicaidSection.jsx
+++ b/_health-care/_js/components/insurance-information/MedicareMedicaidSection.jsx
@@ -7,7 +7,7 @@ import { updateReviewStatus, veteranUpdateField } from '../../actions';
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class MedicareMedicaidSection extends React.Component {

--- a/_health-care/_js/components/military-service/AdditionalMilitaryInformationSection.jsx
+++ b/_health-care/_js/components/military-service/AdditionalMilitaryInformationSection.jsx
@@ -6,7 +6,7 @@ import { updateReviewStatus, veteranUpdateField } from '../../actions';
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class AdditionalMilitaryInformationSection extends React.Component {

--- a/_health-care/_js/components/military-service/ServiceInformationSection.jsx
+++ b/_health-care/_js/components/military-service/ServiceInformationSection.jsx
@@ -9,7 +9,7 @@ import { updateReviewStatus, veteranUpdateField } from '../../actions';
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class ServiceInformationSection extends React.Component {

--- a/_health-care/_js/components/personal-information/AdditionalInformationSection.jsx
+++ b/_health-care/_js/components/personal-information/AdditionalInformationSection.jsx
@@ -10,7 +10,7 @@ import { isNotBlank } from '../../utils/validations';
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class AdditionalInformationSection extends React.Component {

--- a/_health-care/_js/components/personal-information/DemographicInformationSection.jsx
+++ b/_health-care/_js/components/personal-information/DemographicInformationSection.jsx
@@ -6,7 +6,7 @@ import { updateReviewStatus, veteranUpdateField } from '../../actions';
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class DemographicInformationSection extends React.Component {

--- a/_health-care/_js/components/personal-information/NameAndGeneralInfoSection.jsx
+++ b/_health-care/_js/components/personal-information/NameAndGeneralInfoSection.jsx
@@ -15,7 +15,7 @@ import { updateReviewStatus, veteranUpdateField } from '../../actions';
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class NameAndGeneralInfoSection extends React.Component {

--- a/_health-care/_js/components/personal-information/VAInformationSection.jsx
+++ b/_health-care/_js/components/personal-information/VAInformationSection.jsx
@@ -9,7 +9,7 @@ import { updateReviewStatus, veteranUpdateField } from '../../actions';
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class VaInformationSection extends React.Component {

--- a/_health-care/_js/components/personal-information/VeteranAddressSection.jsx
+++ b/_health-care/_js/components/personal-information/VeteranAddressSection.jsx
@@ -10,7 +10,7 @@ import { updateReviewStatus, veteranUpdateField } from '../../actions';
 
 /**
  * Props:
- * `sectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
+ * `isSectionComplete` - Boolean. Marks the section as completed. Provides styles for completed sections.
  * `reviewSection` - Boolean. Hides components that are only needed for ReviewAndSubmitSection.
  */
 class VeteranAddressSection extends React.Component {

--- a/_health-care/_js/reducers/veteran/index.js
+++ b/_health-care/_js/reducers/veteran/index.js
@@ -28,23 +28,20 @@ const blankVeteran = {
       day: null,
       year: null,
     },
-    maritalStatus: null,
-    sectionComplete: false
+    maritalStatus: null
   },
 
   vaInformation: {
     isVaServiceConnected: null,
     compensableVaServiceConnected: null,
-    receivesVaPension: null,
-    sectionComplete: false
+    receivesVaPension: null
   },
 
   additionalInformation: {
     isEssentialAcaCoverage: false,
     facilityState: null,
     vaMedicalFacility: null,
-    wantsInitialVaContact: false,
-    sectionComplete: false
+    wantsInitialVaContact: false
   },
 
   demographicInformation: {
@@ -53,8 +50,7 @@ const blankVeteran = {
     isBlackOrAfricanAmerican: false,
     isNativeHawaiianOrOtherPacificIslander: false,
     isAsian: false,
-    isWhite: false,
-    sectionComplete: false
+    isWhite: false
   },
 
   veteranAddress: {
@@ -69,14 +65,12 @@ const blankVeteran = {
     email: null,
     emailConfirmation: null,
     homePhone: null,
-    mobilePhone: null,
-    sectionComplete: false
+    mobilePhone: null
   },
 
   financialDisclosure: {
     provideFinancialInfo: false,
-    understandsFinancialDisclosure: false,
-    sectionComplete: false
+    understandsFinancialDisclosure: false
   },
 
   spouseInformation: {
@@ -107,14 +101,12 @@ const blankVeteran = {
       state: null,
       zipcode: null,
     },
-    spousePhone: null,
-    sectionComplete: false
+    spousePhone: null
   },
 
   childInformation: {
     hasChildrenToReport: false,
-    children: [],
-    sectionComplete: false
+    children: []
   },
 
   annualIncome: {
@@ -126,21 +118,18 @@ const blankVeteran = {
     spouseOtherIncome: null,
     childrenGrossIncome: null,
     childrenNetIncome: null,
-    childrenOtherIncome: null,
-    sectionComplete: false
+    childrenOtherIncome: null
   },
 
   deductibleExpenses: {
     deductibleMedicalExpenses: null,
     deductibleFuneralExpenses: null,
-    deductibleEducationExpenses: null,
-    sectionComplete: false
+    deductibleEducationExpenses: null
   },
 
   insuranceInformation: {
     isCoveredByHealthInsurance: false,
-    providers: [],
-    sectionComplete: false
+    providers: []
   },
 
   medicareMedicaid: {
@@ -150,8 +139,7 @@ const blankVeteran = {
       month: null,
       day: null,
       year: null
-    },
-    sectionComplete: false
+    }
   },
 
   serviceInformation: {
@@ -166,8 +154,7 @@ const blankVeteran = {
       day: null,
       year: null
     },
-    dischargeType: null,
-    sectionComplete: false
+    dischargeType: null
   },
 
   militaryAdditionalInfo: {
@@ -179,8 +166,7 @@ const blankVeteran = {
     vietnamService: false,
     exposedToRadiation: false,
     radiumTreatments: false,
-    campLejeune: false,
-    sectionComplete: false
+    campLejeune: false
   }
 };
 


### PR DESCRIPTION
`sectionComplete` in veteran store is no longer being used as we now have a store for UI state. The description of the propTypes in the sections also needed to be updated from `sectionComplete` to `isSectionComplete`.
