### PR TITLE
Check whether page.relatedlinks is defined before printing markup.

### DIFF
--- a/_includes/related-links.html
+++ b/_includes/related-links.html
@@ -1,3 +1,4 @@
+{% if page.relatedlinks %}
   <div class="navigation">
     <div class="row">
       <div class="small-12 columns">
@@ -17,4 +18,4 @@
       </div>
     </div>
   </div>
- 
+{% endif %}


### PR DESCRIPTION
Gets rid of extra gray bar at the bottom of the page. closes #2072
