### PR TITLE
Removing color from va-header-logo closes issue#2045

### DIFF
--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -139,7 +139,6 @@ figcaption {
 }
 
 .va-header-logo {
-  color: $color-white;
   line-height: 1em; 
   margin: 0; 
   


### PR DESCRIPTION
.va-header-logo color of white matched that of the body element, which triggered an error in automated tests.
