### PR TITLE
Removing foreground color from .va-header-logo a. closes #2045

### DIFF
--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -147,8 +147,7 @@ figcaption {
     white-space: nowrap;
     overflow: hidden;
     display: block;
-    color: $color-white;
-    background: $color-primary-darkest url(../images/design/logo/logo.png) top left no-repeat;
+    background: url(../images/design/logo/logo.png) top left no-repeat;
     width: 180px;
     height: 30px;
     background-size: contain;


### PR DESCRIPTION
Section 508 accessibility fix.
