### PR TITLE
Adding an action-bar include. closes #2090

### DIFF
--- a/_includes/action-bar.html
+++ b/_includes/action-bar.html
@@ -1,0 +1,7 @@
+<div class="action-bar {{ action_class }}">
+  <div class="row">
+    <div class="small-12 columns">
+      <a class="usa-button-primary va-button-primary" href="{{ action_url }}">{{ action_text }}</a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Making it into a configurable include that we can repurpose in multiple places.

new file:   _includes/action-bar.html
