### PR TITLE
Replace GA Code snippet with GTM code snippet

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -121,17 +121,15 @@ UserVoice.push(['identify', {
 UserVoice.push(['autoprompt', {}]);
 </script>
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-50123418-3', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-WFJWBD"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-WFJWBD');</script>
+<!-- End Google Tag Manager -->
 
 <!--
 "To care for him who shall have borne the battle and for his widow, and his orphan."


### PR DESCRIPTION
This PR replaces the Google Analytics code in the footer include with a Google Tag Manager code snippet. the GTM container has been established and will take over tracking from the old code as soon as this is pushed into production so the interruption to metric continuity will be extremely minimal, if any. The code in the VA Common GEM needs to be replaced to complete the transition to GTM. That will be done in a separate PR. 

cc; @staceylanger @ayaleloehr 
