### PR TITLE
Small bits of refactoring for smaller file size.

### DIFF
--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -11,6 +11,13 @@ body {
   font-size: $base-font-size;
 }
 
+// General
+body, .home {
+  background: $color-primary-darkest url(../images/design/background/thread.png) top left no-repeat;
+  background-size: contain;
+  color: $color-white;
+}
+
 // TODO: look into alert / error spacing issues
 .usa-input-error {
   right: 1rem;
@@ -36,15 +43,6 @@ body {
   }
 }
 
-
-// General
-body, body.home {
-  background: $color-primary-darkest url(../images/design/background/thread.png) top left no-repeat;
-  background-size: contain;
-  color: $color-white;
-}
-
-
 // row
 body .row.full {
   width: 100%;
@@ -69,7 +67,6 @@ abbr {
   color: inherit;
   cursor: pointer;
 }
-
 
 a {
   color: $color-primary;
@@ -115,6 +112,21 @@ ul, ol {
 }
 
 // Figure / Caption
+figure {
+  font-size: .85em;
+  margin-left: -$column-gutter/2;
+  margin-right: -$column-gutter/2;
+ 
+  @media #{$small} {
+    margin-left: inherit;
+    margin-right: inherit;
+  }
+
+  @media #{$large} {
+    margin-left: -16.66667%;
+    margin-right: -16.66667%;
+  }
+}
 
 figcaption {
   color: $color-primary-darker;
@@ -188,8 +200,6 @@ hr {
   }
 }
 
-
-
 .usa-button-primary[href^=http] {
   background-image: none;
   // TODO: clean up #content .main.interior a then remove !important
@@ -245,26 +255,49 @@ hr {
   }
 }
 
-// Type
-
+// Headings
 h1, h2 {
   font-family: $font-sans;
   font-weight: 600;
 }
+
 h3, h4, h5, h6 {
   color: $color-primary-darkest;
-  font-weight: 600;
+}
+
+h3 {
+  font-size: 1.8em; 
+  padding: 0 0 1em 0;
+}
+h4 {
+  font-size: 1.5em; 
+  font-weight: normal;
+}
+h5 {
+  font-size: 1.25em;
+  font-weight: normal;
+}
+h6 {
+  font-size: 1.15em; 
+  font-weight: bold;
 }
 
 // Banner
 
-#content {margin: 0; padding: 0; color: $color-gray-dark;}
+#content {
+  margin: 0; 
+  padding: 0; 
+  color: $color-gray-dark;
+}
 
 #content .splash {
   padding: 0 0 .5em 0;
   margin: 0;
  
-  p {color: $color-white; font-family: $font-sans;}
+  p {
+    color: $color-white; 
+    font-family: $font-sans;
+  }
 
   @media #{$small} {padding: 1em 0;}
   @media #{$medium} {padding: 2em 0;}
@@ -339,24 +372,38 @@ h3, h4, h5, h6 {
   }
 }
 
-.feature-list ul {
-  margin: 0; padding: 0;
-  li {
-    a {font-weight: bold;}
-    list-style-position: outside;
-    list-style-type: none;
+// TODO: Remove .feature-list ul once it's
+// refactored from the Markdown
+.feature-list ul,
+.va-list--feature {
+  margin: 0; 
+  padding: 0;
+  list-style: none outside;
+      
+  li {   
     border-bottom: 1px solid #ccc;
     padding: 1em 0;
-    &:last-of-type {border-bottom: none;}
+    
+    &:last-of-type {
+      border-bottom: none;
+    }
+  }
+  
+  a {
+    font-weight: bold;
   }
 }
 
 .primary {
-  @media #{$small} {padding: 1em 0;}
-  @media #{$small} {padding: 2em 0;}
-  @media #{$medium} {padding: 2em 0;}
+  @media #{$small} {
+    padding: 2em 0;
+  }
 
-  p {padding-top: 0; margin-top: 0; padding-bottom: 1em;}
+  p {
+    padding-top: 0; 
+    margin-top: 0; 
+    padding-bottom: 1em; // TODO: Consider deleting.
+  }
 
   p:nth-child(1) {
     font-size: 1.25em;
@@ -367,8 +414,11 @@ h3, h4, h5, h6 {
   }
   
   h3 {
-    padding: 0 0 .5em 0; font-size: 1.25em;
-    @media #{$small} {font-size: 1.8em;}
+    padding: 0 0 .5em 0; 
+    font-size: 1.25em;
+    @media #{$small} {
+      font-size: 1.8em;
+    }
   }
 }
 
@@ -383,22 +433,12 @@ html.no-touch .banner {
   background-size: cover;
 }
 
-// Headings
-
-h3 {color: $color-primary-darkest; font-weight: bold; font-size: 1.8em; padding: 0 0 1em 0;}
-h4 {font-size: 1.5em; font-weight: normal;}
-h5 {font-size: 1.25em; font-weight: normal;}
-h6 {font-size: 1.15em; font-weight: bold;}
-
 // Use to add a horizontal rule under the heading
 .va-h-ruled {
   border-bottom: 6px solid $color-primary-darkest;
 }
 
-
-
 // tagline
-
 #content .tagline-content {
   p {
     font-size: 2.15em;
@@ -437,16 +477,24 @@ h6 {font-size: 1.15em; font-weight: bold;}
   padding: 1em;
   clear: both;
   margin: 0 0 1.5em 0;
-  p {margin-bottom: 0; padding-bottom: .5em}
+  p {
+    margin-bottom: 0; 
+    padding-bottom: .5em
+  }
   p:nth-child(1) {
-  // TODO: refactor #content.interior .primary li p:first-of-type and remove !important
+    // TODO: refactor #content.interior .primary li p:first-of-type and remove !important
     font-size: 1.25em !important;
     color: $color-gray-dark;
     padding-bottom: inherit;
   }
-  h3 {@media #{$small} {font-size: 1.65em;}}
+  h3 {
+    @media #{$small} {
+      font-size: 1.65em;
+    }
+  }
   ul {
-    margin: 0 0 .5em 1.5em; padding: 0;
+    margin: 0 0 .5em 1.5em; 
+    padding: 0;
     li {
       list-style: square;
       margin: 0;
@@ -474,6 +522,16 @@ h6 {font-size: 1.15em; font-weight: bold;}
   ul {
     margin: 0 0 .5rem 1.5rem;
     padding: 0;
+  }
+}
+
+// Usually call out boxes will be definition lists, but
+// sometimes they're unordered lists.
+ul, ol {
+  &.va-callout {
+    li {
+      margin-left: 3rem !important;
+    }
   }
 }
 
@@ -569,8 +627,10 @@ h6 {font-size: 1.15em; font-weight: bold;}
   .section.main-menu {
     padding: .5em .5em 2.35em .5em;
     overflow: hidden;
-    @media #{$small} {padding: 1em 0 1.5em 0;}
     
+    @media #{$small} {
+      padding: 1em 0 1.5em 0;
+    }
   }
 
   
@@ -655,7 +715,9 @@ h6 {font-size: 1.15em; font-weight: bold;}
 #content .section.quaternary,
 #content .section.coda {
   padding: 3em 0;
-  h3 {font-size: 2.2em;}
+  h3 {
+    font-size: 2.2em;
+  }
 }
 
 // Sections
@@ -767,9 +829,7 @@ h6 {font-size: 1.15em; font-weight: bold;}
 }
 
 // General List Styles
-
-
-  
+ 
 li {
   span.meta {
     display: inline-block;
@@ -790,53 +850,14 @@ li {
   }
 }
 
-
-// Definition lists
-
-dl.simple {
-  margin: 0;
-  padding: 0 0 1em 0;
-  
-  &.feature {padding: .25em .5em;}
-  
-  dd {
-    padding: 0; 
-    margin: 0; 
-    border-bottom: 1px solid $color-gray-lightest; 
-
-    &:last-of-type {
-      border-bottom: none;
-    }
-  }
-}
-
-// Informational Content
-.informational-content, .introductory-content {
-  padding: 2em 0 2em 0;
-  background: rgba(0,0,0,.05);
-}
-
-.introductory-content {
-  padding: 1em  0;
-  
-  @media #{$small} {
-    padding: 3em 0;
-  }
-  background: $color-gray-lightest;
-  margin: 0 auto;
-  
-  p {
-    font-size: 1em;
-  }
-  @media #{$small} {
-    font-size: 1.35em;
-  }
-}
-
 // Navigation
 .navigation {
-  padding: 1em  0;
-  @media #{$small} {padding: 1em 0 3em 0;}
+ padding: 1em  0;
+  
+  @media #{$small} {
+    padding: 1em 0 3em 0;
+  }
+  
   background: $color-gray-lightest;
   color: $color-primary-darkest;
   border-bottom: 2px solid $color-white;
@@ -865,11 +886,13 @@ dl.simple {
 
 [class*="block-grid-"]>li {
   padding: 0;
-  @media #{$small} {padding: 0 0.625rem 1.25rem 0.625rem;}
+  @media #{$small} {
+    padding: 0 0.625rem 1.25rem 0.625rem;
+  }
 }
 
 // Telephone numbers
-span.tel {
+.tel {
   background: rgba(0,0,0,.05);
   padding: .2em;
   display: inline-block;
@@ -877,41 +900,44 @@ span.tel {
 
 // Information Grid
 
-ul.information-grid {
+.information-grid {
+  strong {
+    font-size: 1.3em;
+    color: $color-primary-darkest;
+  }
 
-  li {
+  p {
+    font-size: .9em;
+  }
 
-    strong {
-      font-size: 1.3em;
-      color: $color-primary-darkest;
+  div {
+    @media #{$small} {
+      min-height: 12em;
     }
-
-    p {
-      font-size: .9em;
+    
+    background: $color-gray-lightest;
+    background: rgba(0,0,0,.05);
+    margin: 0 0 .5em 0;
+    padding: .75em;
+    
+    &:hover, &:focus, &:active {
+      background: rgba(0,0,0,.1);
     }
-
-    div {
-      padding: .75em;
-      margin: 0 0 .5em 0;
-      @media #{$small} {min-height: 12em;}
-      background: $color-gray-lightest;
-      background: rgba(0,0,0,.05);
-      &:hover, &:focus, &:active {background: rgba(0,0,0,.1);}
-    }
-    a {
-      text-decoration: none;
-      border-bottom: 2px solid $color-primary-darkest;
-    }
+  }
+  a {
+    text-decoration: none;
+    border-bottom: 2px solid $color-primary-darkest;
   }
 }
 
 
 // Blog / Playbook
 
-body.page-playbook {
+.page-playbook {
   background-color: $color-white;
-
-  .main {background: white;}
+  .main {
+    background: white;
+  }
 }
 
 
@@ -953,7 +979,7 @@ body.page-playbook {
 
 .blog-navigation {padding: 2em 0;}
 
-span.next {
+.next {
   float: right;
   display: inline-block;
 }
@@ -1018,21 +1044,6 @@ span.next {
   }
 }
 
-figure {
-  font-size: .85em;
-  margin-left: -$column-gutter/2;
-  margin-right: -$column-gutter/2;
-  @media #{$small} {
-    margin-left: inherit;
-    margin-right: inherit;
-  }
-
-  @media #{$large} {
-    margin-left: -16.66667%;
-    margin-right: -16.66667%;
-  }
-}
-
 .post-preview {
   border-bottom: 1px solid rgba(0,0,0,.2);
   padding: 0 0 3em 0;
@@ -1086,7 +1097,13 @@ figure {
 }
 
 .post {
-  a, p, p:nth-child(1), li, h1, h2, h3, h4, h5, h6, dl, dd, dt, caption, figure,   
+  a, 
+  p, p:nth-child(1), 
+  li, 
+  h1, h2, h3, h4, h5, h6, 
+  dl, dd, dt, 
+  caption, 
+  figure,   
   blockquote {
     color: $color-va-gray-cool-dark; 
     line-height: 1.65em;
@@ -1279,9 +1296,14 @@ figure {
     }
   }
 }
+
 ul.final-list {
   text-align: center;
-  @media #{$large} {text-align: left;}
+  
+  @media #{$large} {
+    text-align: left;
+  }
+  
   padding: 1.5em 0 0 0;
   width: 100%;
   border-bottom: none !important;
@@ -1295,28 +1317,30 @@ ul.final-list {
      content: " ";
      clear: both;
      height: 0;
-     }
+  }
 
 
   li {
-      padding: 0;
-      display: inline-block;
-      text-align: center;
-      &:last-child {
-        margin-right: 0;
-      }
-      &:after {
-        content:"|";
-        padding: 0 .15em;
-      }
-      &:last-of-type:after {
-        padding:0;
-        content: "";
-      }
-    a {
-        display:inline-block;
-        padding: .35em;
+    padding: 0;
+    display: inline-block;
+    text-align: center;
+    
+    &:last-child {
+      margin-right: 0;
     }
+    &:after {
+      content:"|";
+      padding: 0 .15em;
+    }
+    &:last-of-type:after {
+      padding:0;
+      content: "";
+    }
+  }
+ 
+  a {
+    display: inline-block;
+    padding: .35em;
   }
 }
 
@@ -1324,8 +1348,12 @@ li {
   list-style: none;
   padding: .5em 0;
   font-weight: 300;
-  @media #{$small}
-  {} margin: 0 auto; text-align: left; display: block;}
+   
+  margin: 0 auto; 
+  text-align: left; 
+  display: block;
+  
+  }
   padding: 2em 0 0 0;
 
   .post-script {
@@ -1351,7 +1379,6 @@ li {
     margin: 0 auto;
     display: block;
   }
-
 
 }
 
@@ -1548,96 +1575,85 @@ a.twitter {
 
 // byline
 
-p.byline {font-size: .8em; color: $color-white; color: rgba(255,255,255,.9);}
-
-
-
-// Simple List
-
-ul.simple-list, ol.simple-list {
-margin: 0 0 1em 1.25em;
-padding: 0;
-display: block;
-li {
-  padding: .35em 0;
-  list-style: square;
-
-}
+p.byline {
+  font-size: .8em; 
+  color: $color-white; 
+  color: rgba(255,255,255,.9);
 }
 
 // Info cards
 
-.card {
-position: relative;
-margin: 0 0 1.5em 0;
-padding: 1em;
-border: 1px solid $color-gray-lightest;
-dt {font-weight: 700;}
-dd {
-  padding: 0;
-  margin: 0;
-}
-&.templates {
-  height: 338px;
-}
-&:after {
-  visibility: hidden;
-  display: block;
-  font-size: 0;
-  content: " ";
-  clear: both;
-  height: 0;
-}
-
-span {
-  display: block;
-}
-
-.number {
-  font-size: 3.25em;
-  font-weight: 700;
-  float: left;
-  margin: 0;
-  color: #003E73;
-  line-height: .65em;
-  display: inline-block;
-  padding: 0 .125em 0 0;
-}
-
-.heading, .description {
-  display: block;
-}
-
-.heading {
-  color: $color-va-primary-alt-darkest;
-  font-size: .8em;
-  padding: 0;
-}
-
-.description {
-  font-size: 1.25em;
-  font-weight: 400;
-  padding: .2em 0;
-  text-align: left;
-  display: inline-block;
-  width: 100%;
-  text-transform:uppercase;
-}
-
-&.information {
-  background: rgba(0,0,0,.05);
-}
-
-&.info-graphic {
-  border: 1px solid $color-white;
-  background: none;
-  padding: 1em 1em 0;
-  line-height: 2.5;
-  span.number {
-    color: $color-white;
-    display: inline-block;
+  .card {
+  position: relative;
+  margin: 0 0 1.5em 0;
+  padding: 1em;
+  border: 1px solid $color-gray-lightest;
+  dt {font-weight: 700;}
+  dd {
+    padding: 0;
+    margin: 0;
   }
-}
+  &.templates {
+    height: 338px;
+  }
+  &:after {
+    visibility: hidden;
+    display: block;
+    font-size: 0;
+    content: " ";
+    clear: both;
+    height: 0;
+  }
+
+  span {
+    display: block;
+  }
+
+  .number {
+    font-size: 3.25em;
+    font-weight: 700;
+    float: left;
+    margin: 0;
+    color: #003E73;
+    line-height: .65em;
+    display: inline-block;
+    padding: 0 .125em 0 0;
+  }
+
+  .heading, .description {
+    display: block;
+  }
+
+  .heading {
+    color: $color-va-primary-alt-darkest;
+    font-size: .8em;
+    padding: 0;
+  }
+
+  .description {
+    font-size: 1.25em;
+    font-weight: 400;
+    padding: .2em 0;
+    text-align: left;
+    display: inline-block;
+    width: 100%;
+    text-transform:uppercase;
+  }
+
+  &.information {
+    background: rgba(0,0,0,.05);
+  }
+
+  &.info-graphic {
+    border: 1px solid $color-white;
+    background: none;
+    padding: 1em 1em 0;
+    line-height: 2.5;
+    span.number {
+      color: $color-white;
+      display: inline-block;
+    }
+  }
 
 
 
@@ -1688,41 +1704,47 @@ margin: 0;
 
 // Process line
 
+.va-process,
 .process {
+  list-style: none;
   padding: 1em 0;
   position: relative;
+  
   h2, h3, h4, h5, h6 {padding: .2em 0 0 0;}
   h5 {
     font-size: 1.3em; 
-    margin: 0; padding: 0;
+    margin: 0; 
+    padding: 0 0 .5em 0;
   }
-  h6 {font-size: 1.1em; margin: 0; padding: 0;}
+  h6, &-subtitle {
+    font-size: 1.1em; 
+    margin: 0; 
+    padding: 0;
+  }
+ 
   p:nth-child(1) {
     font-size: 1em;
     color: $color-gray-dark;
     padding-bottom: 0;
   }
-  list-style: none;
+  
   li {
-
+    list-style: none;
+    
     p:nth-child(1) {
-      font-size: 1em;
-      color: $color-gray-dark;
       padding-bottom: inherit;
     }
-
-      list-style-type: none;
-      list-style: none;
-      ol {
-        margin: 0 0 1em 1.5em;
-        padding: 0;
-        li {list-style: decimal; padding: .25em 0;}
-      }
-      ul {
-        margin: 0 0 1em 1.25em !important;
-        padding: 0;
-        li {list-style: square;}
-      }
+    
+    ol {
+      margin: 0 0 1em 1.5em;
+      padding: 0;
+      li {list-style: decimal; padding: .25em 0;}
+    }
+    ul {
+      margin: 0 0 1em 1.25em !important;
+      padding: 0;
+      li {list-style: square;}
+    }
   &.step {
     border-left: 8px solid #ccc;
     padding: 0 0 2em 2em;
@@ -2061,18 +2083,9 @@ span.color-chip {
 .icon-embed2 {width: 1.25em;}
 .icon-youtube4 {width: 2.5087890625em;}
 
-// Citation
-
-.citation {
-border-top: 1px solid $color-gray-lightest;
-padding: 1em 0 0 0;
-h5, h6 {font-size: .85em; font-family: $font-sans; color: $color-gray-dark;}
-p, ul, li {font-size: .7em;}
-font-style: italic;
-}
-
 // Panel list
-
+// TODO: Refactor to panel-list and panel-list--plain
+// or similar
 .panel-list {
   background: rgba(0,0,0,.05);
   padding: 1em;
@@ -2109,19 +2122,10 @@ font-style: italic;
 }
 
 // Highlight headings
-h4.highlight {
+.highlight {
   border-bottom: 3px solid $primary-color;
-  display: block;
   padding-bottom: .25em;
   font-weight: 700;
-  line-heighgt: 1.2em;
-  margin-bottom: .75em;
-  font-famiy: $font-sans;
-}
-
-// bumps text down to align with panel or highlighted text
-#content .section h4.bump {
-  margin-top: 0.7rem;
 }
 
 // Action bars
@@ -2319,15 +2323,14 @@ ul li p {
 
 
 // vets.gov branded apps
-
-a.vets-app {
+.vets-app {
   border-left: 3px solid $color-gold;
   display: inline-block;
   padding: 0 0 0 .5em !important;
 }
 
 // Tooltip
-button.js-simple-tooltip {
+.js-simple-tooltip {
   font-family: 'Courier New', 'Courier', serif;
   font-weight:bold;
   cursor: pointer;


### PR DESCRIPTION
- Changing h4.highlight to .highlight, removing redundant declarations
- Removing #content .section h4.bump block
- Change a.vets-app to .vets-app
- Changing button.js-simple-tooltip to .js-simple-tooltip
- Adding .va-process class + improving formatting
- Simplifying span.next to .next
- Grouping figure, figcaption blocks
- Adding .va-list--feature selector, simplifying .feature-list ul block
- Removing unused .citation block
- Removing unused .informational-content, .introductory-content blocks
- Simplifying .information-grid block selectors.
- Simplifying body.page-playbook selector to .page-playbook
- Simplifying span.tel to just .tel

Removing .simple-list block since it isn't being used.

Removing extraneous .primary @media blocks.

Combining, grouping, refactoring h1-h6 selectors, blocks.

Removing dl.simple block. Currently unused.
