### PR TITLE
Update one-on-one.md

### DIFF
--- a/_employment/job-seekers/one-on-one.md
+++ b/_employment/job-seekers/one-on-one.md
@@ -39,7 +39,7 @@ Yes, if:
 There are many government and private resources available to you as you make this transition.
 
 #### All Veterans
-- [Veteran Employment Specialists](http://vaforvets.va.gov/hr/RVECS/Pages/default.asp) from the Veteran Employment Services Office (VESO) can help you find jobs in your area. 
+- [Veteran Employment Specialists](http://vaforvets.va.gov/hr/RVECS/Pages/rvecs-map.asp) from the Veteran Employment Services Office (VESO) can help you find jobs in your area. 
 
 - [VA for Vets](http://vaforvets.va.gov/) can help you find VA or other federal jobs.
 


### PR DESCRIPTION
Changed the link for Veteran Employment Specialists to a map page.  This change now makes sense because the stakeholder webmaster Dominique Martinez was willing to add a sentence on his side to make the transition from Vets.gov to va.gov a little smoother.  He responded by adding sentence on the top of the VES page:  "Veteran Employment Specialist are available by region to provide one-on-one assistance to Veterans looking for work and employers looking to hire."

@mariana-almeida @koconnor719 @maryannbrody 
