### PR TITLE
Changed #trigger-overlay to .overlay-trigger. closes #2029

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -113,12 +113,12 @@
     {% if include.search != 'false' %}
       <!-- Mobile search button -->
       <div class="hide-for-medium-up search-button">
-        <button id="trigger-overlay" type="button" class="usa-button usa-button-outline-inverse" aria-controls="mobile-menu" aria-flowto="mobile-menu">Search</button>
+        <button data-show="#mobile-menu" class="va-overlay-trigger va-mobile-searchtrigger usa-button usa-button-outline-inverse" aria-controls="mobile-menu" aria-flowto="mobile-menu">Search</button>
       </div>
 
-      <div id="mobile-menu" class="overlay" role="dialog">
+      <div id="mobile-menu" class="va-overlay" role="dialog">
         <div class="medium-5 medium-offset-3 text-right columns">
-          <button type="button" class="overlay-close" aria-label="close search form - mobile only">Close</button>
+          <button type="button" class="va-mobile-searchclose va-overlay-close" aria-label="close search form - mobile only">Close</button>
           <div class="menu">
             <form accept-charset="UTF-8" action="https://search.vets.gov/search" id="search_form" method="get">
               <div style="margin:0;padding:0;display:inline">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -118,7 +118,7 @@
 
 
 
-      <div id="mobile-menu" class="overlay overlay-fullscreen" role="dialog">
+      <div id="mobile-menu" class="overlay" role="dialog">
         <div class="medium-5 medium-offset-3 text-right columns">
           <button type="button" class="overlay-close" aria-label="close search form - mobile only">Close</button>
           <div class="menu">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -116,8 +116,6 @@
         <button id="trigger-overlay" type="button" class="usa-button usa-button-outline-inverse" aria-controls="mobile-menu" aria-flowto="mobile-menu">Search</button>
       </div>
 
-
-
       <div id="mobile-menu" class="overlay" role="dialog">
         <div class="medium-5 medium-offset-3 text-right columns">
           <button type="button" class="overlay-close" aria-label="close search form - mobile only">Close</button>

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -1275,8 +1275,8 @@ li {
   .footer-seal {
     background:url(../images/design/sprites/sprite.png)  no-repeat 0 -23px;
     background-size: 215px 72px;
-	  width: 215px;
-	  height: 49px;
+    width: 215px;
+    height: 49px;
     text-indent: -999em;
     overflow: hidden;
     margin: 0 auto;
@@ -1400,7 +1400,7 @@ li {
 
 
 a.facebook {
-	background: url('../images/design/sprites/sprite.png') no-repeat -22px 0;
+  background: url('../images/design/sprites/sprite.png') no-repeat -22px 0;
   background-size: 215px 72px;
   width: 17px;
   height: 17px;
@@ -1409,10 +1409,10 @@ a.facebook {
 }
 
 a.twitter {
-	background: url('../images/design/sprites/sprite.png') no-repeat 0 0;
+  background: url('../images/design/sprites/sprite.png') no-repeat 0 0;
   background-size: 215px 72px;
-	width: 20px;
-	height: 16px;
+  width: 20px;
+  height: 16px;
   text-indent: -999em;
   overflow: hidden;
 }
@@ -2228,10 +2228,16 @@ button[class*="usa-button-"] {
 // Mobile menu
 
 /* Overlay style */
+@media #{$medium} {
+.va-overlay-close {
+    display: none;
+  }
+}
+  
 
 @media #{$small-only} {
 
-  .overlay {
+  .va-overlay {
     background: rgba($color-primary-darkest, .95);
     height: 100%;
     left: 0;
@@ -2244,36 +2250,28 @@ button[class*="usa-button-"] {
     width: 100%;
     z-index: 800;
   
-    button {
-      border-radius: 0;
-      display: block;
-      width: 100% !important;
-      margin: 0;
-      width: auto;
-      background: $color-primary;
-    }
-
     input[type="text"] {
       -webkit-appearance: none;
       border-radius: 3px 0 0 3px;
     }
   }
 
-  /* Overlay closing cross */
-  .overlay .overlay-close {
-    display: block;
-    border: none;
-    outline: none;
-    z-index: 100;
+  .va-mobile-searchclose  {
+    border-radius: 0;
+    display: block !important;
+    width: 100% !important;
+    margin: 0;
+    width: auto;
+    background: $color-primary;
   }
-
-  button#trigger-overlay {
+    
+  .va-mobile-searchtrigger {
     padding: .5em;
     margin-top: 0;
     border-radius: .15em;
   }
 
-  .overlay.open {
+  .va-overlay--open {
     opacity: 1;
     visibility: visible;
     -webkit-transition: opacity 0.5s;
@@ -2284,13 +2282,13 @@ button[class*="usa-button-"] {
     }
   }
 
-  .overlay .menu {
+  .va-overlay .menu {
     -webkit-perspective: 1200px;
     perspective: 1200px;
     padding: 1em 1em;
   }
 
-  .overlay form {
+  .va-overlay form {
     opacity: 0.4;
     -webkit-transform: translateY(-25%) rotateX(35deg);
     transform: translateY(-25%) rotateX(35deg);
@@ -2298,15 +2296,21 @@ button[class*="usa-button-"] {
     transition: transform 0.5s, opacity 0.5s;
   }
 
-  .overlay.open form {
+  .va-overlay--open form {
     opacity: 1;
     -webkit-transform: rotateX(0deg);
     transform: rotateX(0deg);
   }
 
-  .overlay.close form {
+  .va-overlay--closed form {
     -webkit-transform: translateY(25%) rotateX(-35deg);
     transform: translateY(25%) rotateX(-35deg);
+  }
+  .va-overlay--closed {
+    display: block;
+    border: none;
+    outline: none;
+    z-index: 100;
   }
 
   @media screen and (max-height: 30.5em) {
@@ -2316,9 +2320,6 @@ button[class*="usa-button-"] {
   }
 }
 
-.overlay-close {
-  display: none;
-}
 
 
 // List overrides

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -2232,13 +2232,32 @@ button[class*="usa-button-"] {
 @media #{$small-only} {
 
   .overlay {
-  	position: fixed;
-  	width: 100%;
-  	height: 100%;
-  	top: 0;
-  	left: 0;
-    z-index: 800;
   	background: rgba($color-primary-darkest, .95);
+  	height: 100%;
+  	left: 0;
+  	-webkit-transition: opacity 0.5s, visibility 0s 0.5s;
+  	opacity: 0;
+  	position: fixed;
+  	top: 0;
+  	transition: opacity 0.5s, visibility 0s 0.5s;
+    visibility: hidden;
+    width: 100%;
+  	z-index: 800;
+  	
+  	button {
+      border-radius: 0;
+      display: block;
+      width: 100% !important;
+      margin: 0;
+      width: auto;
+      background: $color-primary;
+
+    }
+
+    input[type="text"] {
+      -webkit-appearance: none;
+      border-radius: 3px 0 0 3px;
+    }
   }
 
   /* Overlay closing cross */
@@ -2256,31 +2275,7 @@ button[class*="usa-button-"] {
     border-radius: .15em;
   }
 
-  /* Effects */
-  .overlay-fullscreen {
-  	opacity: 0;
-  	visibility: hidden;
-  	-webkit-transition: opacity 0.5s, visibility 0s 0.5s;
-  	transition: opacity 0.5s, visibility 0s 0.5s;
-
-    button {
-      border-radius: 0;
-      display: block;
-      width: 100% !important;
-      margin: 0;
-      width: auto;
-      background: $color-primary;
-
-    }
-
-    input[type="text"] {
-      -webkit-appearance: none;
-      border-radius: 3px 0 0 3px;
-    }
-
-  }
-
-  .overlay-fullscreen.open {
+  .overlay.open {
   	opacity: 1;
   	visibility: visible;
   	-webkit-transition: opacity 0.5s;
@@ -2290,13 +2285,13 @@ button[class*="usa-button-"] {
     }
   }
 
-  .overlay-fullscreen .menu {
+  .overlay .menu {
   	-webkit-perspective: 1200px;
   	perspective: 1200px;
     padding: 1em 1em;
   }
 
-  .overlay-fullscreen form {
+  .overlay form {
   	opacity: 0.4;
   	-webkit-transform: translateY(-25%) rotateX(35deg);
   	transform: translateY(-25%) rotateX(35deg);
@@ -2304,13 +2299,13 @@ button[class*="usa-button-"] {
   	transition: transform 0.5s, opacity 0.5s;
   }
 
-  .overlay-fullscreen.open form {
+  .overlay.open form {
   	opacity: 1;
   	-webkit-transform: rotateX(0deg);
   	transform: rotateX(0deg);
   }
 
-  .overlay-fullscreen.close form {
+  .overlay.close form {
   	-webkit-transform: translateY(25%) rotateX(-35deg);
   	transform: translateY(25%) rotateX(-35deg);
   }
@@ -2327,6 +2322,7 @@ button[class*="usa-button-"] {
 .overlay-close {
   display: none;
 }
+
 
 // List overrides
 

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -2232,21 +2232,39 @@ button[class*="usa-button-"] {
 @media #{$small-only} {
 
   .overlay {
-  	position: fixed;
-  	width: 100%;
-  	height: 100%;
-  	top: 0;
-  	left: 0;
+    background: rgba($color-primary-darkest, .95);
+    height: 100%;
+    left: 0;
+    -webkit-transition: opacity 0.5s, visibility 0s 0.5s;
+    opacity: 0;
+    position: fixed;
+    top: 0;
+    transition: opacity 0.5s, visibility 0s 0.5s;
+    visibility: hidden;
+    width: 100%;
     z-index: 800;
-  	background: rgba($color-primary-darkest, .95);
+  
+    button {
+      border-radius: 0;
+      display: block;
+      width: 100% !important;
+      margin: 0;
+      width: auto;
+      background: $color-primary;
+    }
+
+    input[type="text"] {
+      -webkit-appearance: none;
+      border-radius: 3px 0 0 3px;
+    }
   }
 
   /* Overlay closing cross */
   .overlay .overlay-close {
     display: block;
     border: none;
-  	outline: none;
-  	z-index: 100;
+    outline: none;
+    z-index: 100;
   }
 
 
@@ -2256,77 +2274,52 @@ button[class*="usa-button-"] {
     border-radius: .15em;
   }
 
-  /* Effects */
-  .overlay-fullscreen {
-  	opacity: 0;
-  	visibility: hidden;
-  	-webkit-transition: opacity 0.5s, visibility 0s 0.5s;
-  	transition: opacity 0.5s, visibility 0s 0.5s;
-
-    button {
-      border-radius: 0;
-      display: block;
-      width: 100% !important;
-      margin: 0;
-      width: auto;
-      background: $color-primary;
-
-    }
-
-    input[type="text"] {
-      -webkit-appearance: none;
-      border-radius: 3px 0 0 3px;
-    }
-
-  }
-
-  .overlay-fullscreen.open {
-  	opacity: 1;
-  	visibility: visible;
-  	-webkit-transition: opacity 0.5s;
-  	transition: opacity 0.5s;
+  .overlay.open {
+    opacity: 1;
+    visibility: visible;
+    -webkit-transition: opacity 0.5s;
+    transition: opacity 0.5s;
     .columns {
       padding: 0;
     }
   }
 
-  .overlay-fullscreen .menu {
-  	-webkit-perspective: 1200px;
-  	perspective: 1200px;
+  .overlay .menu {
+    -webkit-perspective: 1200px;
+    perspective: 1200px;
     padding: 1em 1em;
   }
 
-  .overlay-fullscreen form {
-  	opacity: 0.4;
-  	-webkit-transform: translateY(-25%) rotateX(35deg);
-  	transform: translateY(-25%) rotateX(35deg);
-  	-webkit-transition: -webkit-transform 0.5s, opacity 0.5s;
-  	transition: transform 0.5s, opacity 0.5s;
+  .overlay form {
+    opacity: 0.4;
+    -webkit-transform: translateY(-25%) rotateX(35deg);
+    transform: translateY(-25%) rotateX(35deg);
+    -webkit-transition: -webkit-transform 0.5s, opacity 0.5s;
+    transition: transform 0.5s, opacity 0.5s;
   }
 
-  .overlay-fullscreen.open form {
-  	opacity: 1;
-  	-webkit-transform: rotateX(0deg);
-  	transform: rotateX(0deg);
+  .overlay.open form {
+    opacity: 1;
+    -webkit-transform: rotateX(0deg);
+    transform: rotateX(0deg);
   }
 
-  .overlay-fullscreen.close form {
-  	-webkit-transform: translateY(25%) rotateX(-35deg);
-  	transform: translateY(25%) rotateX(-35deg);
+  .overlay.close form {
+    -webkit-transform: translateY(25%) rotateX(-35deg);
+    transform: translateY(25%) rotateX(-35deg);
   }
 
   @media screen and (max-height: 30.5em) {
-  	.overlay form {
-  		height: 70%;
-  	}
-
+    .overlay form {
+      height: 70%;
+    }
   }
-
 }
 
 .overlay-close {
   display: none;
 }
+
 
 // List overrides
 

--- a/_sass/_va.scss
+++ b/_sass/_va.scss
@@ -2232,7 +2232,6 @@ button[class*="usa-button-"] {
 @media #{$small-only} {
 
   .overlay {
-<<<<<<< HEAD
     background: rgba($color-primary-darkest, .95);
     height: 100%;
     left: 0;
@@ -2259,7 +2258,6 @@ button[class*="usa-button-"] {
       border-radius: 3px 0 0 3px;
     }
   }
-<<<<<<< HEAD
 
   /* Overlay closing cross */
   .overlay .overlay-close {
@@ -2269,19 +2267,6 @@ button[class*="usa-button-"] {
     z-index: 100;
   }
 
-
-=======
-
-  /* Overlay closing cross */
-  .overlay .overlay-close {
-    display: block;
-    border: none;
-  	outline: none;
-  	z-index: 100;
-  }
-
-
->>>>>>> a068a3bd30689f773a76c2d0bb98eced2269f300
   button#trigger-overlay {
     padding: .5em;
     margin-top: 0;
@@ -2289,35 +2274,23 @@ button[class*="usa-button-"] {
   }
 
   .overlay.open {
-<<<<<<< HEAD
     opacity: 1;
     visibility: visible;
     -webkit-transition: opacity 0.5s;
     transition: opacity 0.5s;
-=======
-  	opacity: 1;
-  	visibility: visible;
-  	-webkit-transition: opacity 0.5s;
-  	transition: opacity 0.5s;
->>>>>>> a068a3bd30689f773a76c2d0bb98eced2269f300
+
     .columns {
       padding: 0;
     }
   }
 
   .overlay .menu {
-<<<<<<< HEAD
     -webkit-perspective: 1200px;
     perspective: 1200px;
-=======
-  	-webkit-perspective: 1200px;
-  	perspective: 1200px;
->>>>>>> a068a3bd30689f773a76c2d0bb98eced2269f300
     padding: 1em 1em;
   }
 
   .overlay form {
-<<<<<<< HEAD
     opacity: 0.4;
     -webkit-transform: translateY(-25%) rotateX(35deg);
     transform: translateY(-25%) rotateX(35deg);
@@ -2334,24 +2307,6 @@ button[class*="usa-button-"] {
   .overlay.close form {
     -webkit-transform: translateY(25%) rotateX(-35deg);
     transform: translateY(25%) rotateX(-35deg);
-=======
-  	opacity: 0.4;
-  	-webkit-transform: translateY(-25%) rotateX(35deg);
-  	transform: translateY(-25%) rotateX(35deg);
-  	-webkit-transition: -webkit-transform 0.5s, opacity 0.5s;
-  	transition: transform 0.5s, opacity 0.5s;
-  }
-
-  .overlay.open form {
-  	opacity: 1;
-  	-webkit-transform: rotateX(0deg);
-  	transform: rotateX(0deg);
-  }
-
-  .overlay.close form {
-  	-webkit-transform: translateY(25%) rotateX(-35deg);
-  	transform: translateY(25%) rotateX(-35deg);
->>>>>>> a068a3bd30689f773a76c2d0bb98eced2269f300
   }
 
   @media screen and (max-height: 30.5em) {

--- a/assets/js/vendor/menu.js
+++ b/assets/js/vendor/menu.js
@@ -1,6 +1,7 @@
 $(document).ready(function() {
 	var triggerBttn = document.getElementById( 'trigger-overlay' );
-	var overlay = document.querySelector( 'div.overlay' );
+
+	var overlay = document.querySelector( '.overlay' );
      if (overlay === null) {
        // More intentionally handle pages with the wrong page structure.
        console.error('No overlay. This function should not be loaded.');

--- a/assets/js/vendor/menu.js
+++ b/assets/js/vendor/menu.js
@@ -1,46 +1,28 @@
 $(document).ready(function() {
-	var triggerBttn = document.getElementById( 'trigger-overlay' );
 
-	var overlay = document.querySelector( '.overlay' );
-     if (overlay === null) {
-       // More intentionally handle pages with the wrong page structure.
-       console.error('No overlay. This function should not be loaded.');
-       return;
-     }
-	var closeBttn = overlay.querySelector( 'button.overlay-close' );
-	var transEndEventNames = {
-			'WebkitTransition': 'webkitTransitionEnd',
-			'MozTransition': 'transitionend',
-			'OTransition': 'oTransitionEnd',
-			'msTransition': 'MSTransitionEnd',
-			'transition': 'transitionend'
-		},
-		transEndEventName = transEndEventNames[ Modernizr.prefixed( 'transition' ) ],
-		support = { transitions : Modernizr.csstransitions };
-
-	function toggleOverlay() {
-		if( overlay.classList.contains( 'open' ) ) {
-			overlay.classList.remove( 'open' );
-			overlay.classList.add( 'close' );
-			var onEndTransitionFn = function( ev ) {
-				if( support.transitions ) {
-					if( ev.propertyName !== 'visibility' ) return;
-					this.removeEventListener( transEndEventName, onEndTransitionFn );
-				}
-				overlay.classList.remove( 'close' );
-			};
-			if( support.transitions ) {
-				overlay.addEventListener( transEndEventName, onEndTransitionFn );
-			}
-			else {
-				onEndTransitionFn();
-			}
-		}
-		else if( !overlay.classList.contains( 'close' ) ) {
-			overlay.classList.add( 'open' );
+	function toggleOverlay(event) {
+	  event.preventDefault();
+	  
+	  // Let overlay be _either_ the value of 
+	  // - href attribute
+	  // - data-show attribute
+	  // - The button's ancestor element, .va-overlay
+	  // Only one of these should ever be defined per button.
+	  
+	  var overlay = $(this).attr('href') || $(this).data('show') || $(this).parents('.va-overlay');
+	  
+	  if( $(overlay).hasClass('va-overlay--open')) {
+	  
+	    $(overlay).toggleClass('va-overlay--open', false);
+	    $(overlay).toggleClass('va-overlay--closed', true);
+		
+		} else {
+		
+		  $(overlay).toggleClass('va-overlay--closed', false);
+	    $(overlay).toggleClass('va-overlay--open', true);
+		
 		}
 	}
 
-	triggerBttn.addEventListener( 'click', toggleOverlay );
-	closeBttn.addEventListener( 'click', toggleOverlay );
+  $('.va-overlay-trigger, .va-overlay-close').on('click', toggleOverlay);
 });


### PR DESCRIPTION
- Made overlay into a reusable pattern.
- Renamed .overlay-\* elements to use a .va-overlay-\* prefix.
- Rewrote menu.js to take full advantage of jQuery, eliminated Modernizr dependency for this feature.
- closes #2030 as well.

Blocks #2467.
