### PR TITLE
Config.yml: Remove excess whitespace

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,10 +27,10 @@ exclude:
   - "npm-shrinkwrap.json"
   - "package.json"
   - "webpack.config.js"
-  - "webpack_dev.config.js"        
+  - "webpack_dev.config.js"
   - "webpack_prod.config.js"
   - "docs"
- 
+
 # Specifically include files left out in dev.
 include:
   - "_dummy-placeholder.html"
@@ -178,4 +178,4 @@ defaults:
     values:
       breadcrumb_1: "Careers and Employment"
       layout: "page-breadcrumbs"
-      body_class: "page-employment"    
+      body_class: "page-employment"


### PR DESCRIPTION
Please set your editors to trim excess whitespace on save. In Sublime Text, the setting is `"trim_trailing_white_space_on_save": true`.
