### PR TITLE
Header: Remove extra slash and .html in OG:url

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,7 +25,7 @@
 {% endif %}
 
 {% if page.url %}
-<meta content="https://www.vets.gov/{{ page.url }}" property="og:url">
+<meta content="https://www.vets.gov{{ page.url | replace:'/index.html','/' }}" property="og:url">
 {% endif %}
 {% if page.date %}
 <meta content="{{ page.date | date_to_xmlschema }}" property="article:published_time">


### PR DESCRIPTION
The URL was rendering out as e.g. `<meta content="https://www.vets.gov//employment/index.html" property="og:url">`.
