### PR TITLE
Update footer.html

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,7 +24,7 @@
     <div class="small-12 medium-3 columns">
       <dl class="va-list--linkgroup">
         <dt class="va-list--linkgroup-title">Resources</dt>
-        <dd><a href="/veterans-employment-center/">Veterans Employment Center&trade;</a></dd>
+        <dd><a href="/veterans-employment-center/">Veterans Employment Center</a></dd>
         <dd><a href="/facility-locator">Facility Locator</a></dd>
         <dd><a href="/gi-bill-comparison-tool/">GI Bill Comparison Tool</a></dd>
       </dl>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,7 +24,7 @@
     <div class="small-12 medium-3 columns">
       <dl class="va-list--linkgroup">
         <dt class="va-list--linkgroup-title">Resources</dt>
-        <dd><a href="/veterans-employment-center/">Veterans Employment Center</a></dd>
+        <dd><a href="/employment/">Veterans Employment Center</a></dd>
         <dd><a href="/facility-locator">Facility Locator</a></dd>
         <dd><a href="/gi-bill-comparison-tool/">GI Bill Comparison Tool</a></dd>
       </dl>


### PR DESCRIPTION
Removing TM from vets.gov footer, as we only need the trademark symbol in one place on the site and it is already located at https://www.vets.gov/employment/
