### PR TITLE
Add in broken link checking. Fix pension pages.

### DIFF
--- a/content/pages/pension/family.html
+++ b/content/pages/pension/family.html
@@ -1,69 +1,59 @@
 ---
 title: Family
+layout: page-breadcrumbs.html
 ---
-<!-- <div class="main" role="main">
- --><!--   <div class="splash">
+<div class="main" role="main">
+  <div class="section primary">
     <div class="row">
-      <div class="small-12 medium-push-1 medium-6 columns">
-        <div class="pitch">
-          <h2 class="tagline">{{ title }}</h2>
-          <p>A VA pension can provide some level of income security for economically disadvantaged wartime Veterans and their survivors.</p>
-        </div>
+      <div class="small-12 columns">
+        <h4>{{ title }}</h4>
+        <p>A VA pension can provide some level of income security for economically disadvantaged wartime Veterans and their survivors.</p>
       </div>
     </div>
-  </div> -->
-
-<div class="row">
-  <div class="small-12 columns services">
-    <ul class="breadcrumbs" role="menubar" aria-label="Primary">
-      <li><a href="#">Home</a></li>
-      <li class="current"><a href="../">Pension Benefits</a></li>
-      <li class="current"><a href="{{ page.url }}">{{ title }}</a></li>
-    </ul>
   </div>
-</div>
 
-<div class="primary">
-  <div class="row">
-    <div class="small-8 columns services">
-      <h3>Veterans’ Survivors Pension Eligibility Overview</h3>
+  <div class="section secondary">
+    <div class="row">
+      <div class="small-8 columns services">
+        <h3>Veterans’ Survivors Pension Eligibility Overview</h3>
 
-      <p>Veterans’ Survivors Pension Eligibility Overview
-      VA offers pension benefits to the survivors of wartime Veterans who meet certain criteria. Among other requirements, yearly family income must be less than the amount set by Congress. Those eligible may receive tax-free supplemental income. VA offers the following types of pension support for Veterans’ survivors:</p>
+        <p>Veterans’ Survivors Pension Eligibility Overview
+        VA offers pension benefits to the survivors of wartime Veterans who meet certain criteria. Among other requirements, yearly family income must be less than the amount set by Congress. Those eligible may receive tax-free supplemental income. VA offers the following types of pension support for Veterans’ survivors:</p>
 
-      <ul>
-        <li><a target="_blank" href="http://benefits.va.gov/pension/spousepen.asp">Survivors Pension</a> – Surviving spouses and dependent children of deceased wartime Veterans are eligible for monthly pension benefits if they meet the net worth and income requirements.</li>
-        <li><a target="_blank" href="http://benefits.va.gov/pension/aid_attendance_housebound.asp">Additional Pension Allowance</a> – Surviving spouses and dependent children of deceased wartime Veterans may receive a larger pension if they are housebound or cannot perform activities of daily living without the aid of another person.</li>
-      </ul>
-    </div>
+        <ul>
+          <li><a target="_blank" href="http://benefits.va.gov/pension/spousepen.asp">Survivors Pension</a> – Surviving spouses and dependent children of deceased wartime Veterans are eligible for monthly pension benefits if they meet the net worth and income requirements.</li>
+          <li><a target="_blank" href="http://benefits.va.gov/pension/aid_attendance_housebound.asp">Additional Pension Allowance</a> – Surviving spouses and dependent children of deceased wartime Veterans may receive a larger pension if they are housebound or cannot perform activities of daily living without the aid of another person.</li>
+        </ul>
+      </div>
 
-    <div class="small-4 columns">
-      <h3>Veterans’ Resources and Claims Assistance</h3>
+      <div class="small-4 columns">
+        <h3>Veterans’ Resources and Claims Assistance</h3>
 
-      <h4>Application Assistance</h4>
-      <ul>
-        <li><a target="_blank" href="http://www.benefits.va.gov/benefits/offices.asp">Find VA Regional Offices</a></li>
-        <li><a target="_blank" href="http://www.va.gov/statedva.htm">State Veterans Affairs Directors</a></li>
-        <li><a target="_blank" href="http://nacvso.org/find-a-service-officer/">County Veteran Service Officers</a></li>
-        <li><a target="_blank" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=request-vso-representative">Accredited Veterans Service Organizations</a></li>
-      </ul>
+        <h4>Application Assistance</h4>
+        <ul>
+          <li><a target="_blank" href="http://www.benefits.va.gov/benefits/offices.asp">Find VA Regional Offices</a></li>
+          <li><a target="_blank" href="http://www.va.gov/statedva.htm">State Veterans Affairs Directors</a></li>
+          <li><a target="_blank" href="http://nacvso.org/find-a-service-officer/">County Veteran Service Officers</a></li>
+          <li><a target="_blank" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=request-vso-representative">Accredited Veterans Service Organizations</a></li>
+        </ul>
 
-      <hr>
+        <hr>
 
-      <h4>Documents</h4>
-      <ul>
-        <li><a target="_blank" href="http://www.benefits.va.gov/benefits/offices.asp">VA Form 21-527EZ</a>  – Veterans Pension</li>
-        <li><a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-534EZ-ARE.pdf">VA Form 21-534EZ</a> – Survivors Pension</li>
-        <li><a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-2680-ARE.pdf">VA Form 21-2680</a> – Special Monthly Pension for Veterans and Surviving Spouses</li>
-      </ul>
+        <h4>Documents</h4>
+        <ul>
+          <li><a target="_blank" href="http://www.benefits.va.gov/benefits/offices.asp">VA Form 21-527EZ</a>  – Veterans Pension</li>
+          <li><a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-534EZ-ARE.pdf">VA Form 21-534EZ</a> – Survivors Pension</li>
+          <li><a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-2680-ARE.pdf">VA Form 21-2680</a> – Special Monthly Pension for Veterans and Surviving Spouses</li>
+        </ul>
 
-      <hr>
+        <hr>
 
-      <h4>How Tos</h4>
-      <ul>
-        <li><a target="_blank" href="http://benefits.va.gov/pension/rates.asp">How to Read Pension Benefits Rate Tables</a> – Learn how VA calculates Pension benefits</li>
-      </ul>
+        <h4>How Tos</h4>
+        <ul>
+          <li><a target="_blank" href="http://benefits.va.gov/pension/rates.asp">How to Read Pension Benefits Rate Tables</a> – Learn how VA calculates Pension benefits</li>
+        </ul>
 
+      </div>
     </div>
   </div>
 </div>

--- a/content/pages/pension/index.html
+++ b/content/pages/pension/index.html
@@ -1,128 +1,120 @@
 ---
 title: Pension
 permalink: /pension/index.html
+layout: page-breadcrumbs.html
 ---
-<!-- <div class="main" role="main">
- --><!--   <div class="splash">
+<div class="main" role="main">
+  <div class="section primary">
     <div class="row">
-      <div class="small-12 medium-push-1 medium-6 columns">
-        <div class="pitch">
-          <h2 class="tagline">{{ title }}</h2>
-          <p>A VA pension can provide some level of income security for economically disadvantaged wartime Veterans and their survivors.</p>
-        </div>
+      <div class="small-12 columns">
+        <h2 class="tagline">{{ title }}</h2>
+        <p>A VA pension can provide some level of income security for economically disadvantaged wartime Veterans and their survivors.</p>
       </div>
-    </div>
-  </div> -->
-
-<div class="row">
-  <div class="small-12 columns services">
-    <ul class="breadcrumbs" role="menubar" aria-label="Primary">
-      <li><a href="#">Home</a></li>
-      <li class="current"><a href="#">Pensions</a></li>
-    </ul>
-  </div>
-</div>
-<div class="primary">
-  <div class="row">
-    <div class="small-12 columns services">
-
-      <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3 cards">
-
-        <li>
-        <a href="../family/">
-          <div>
-            <h4>Spouses, Dependents, and Survivors Eligibility</h4>
-          </div>
-        </a>
-        </li>
-      </ul>
-
     </div>
   </div>
 
-  <div class="row">
-    <div class="small-8 columns services">
+  <div class="section secondary">
+    <div class="row">
+      <div class="small-12 columns services">
 
-      <h3>How to Apply</h3>
+        <ul class="small-block-grid-1 medium-block-grid-2 large-block-grid-3 cards">
 
-      <p><b>The fastest way</b> to obtain a pension benefit decision is to file a Fully Developed Claim (FDC) using the following forms, as applicable:</p>
-
-      <div class="row">
-        <div class="small-4 columns text-center"><h4>Veterans Pension</h4></div>
-        <div class="small-4 columns text-center"><h4>Survivors Pension</h4></div>
-        <div class="small-4 columns text-center"><h4>Special Monthly Pension for Veterans</h4></div>
-      </div>
-
-      <h3>VA Pension</h3>
-
-      <p>A VA pension may provide income to make life more secure for Veterans and their loved ones.</p>
-
-      <p>Pension is a needs-based benefit for wartime Veterans with limited or no income who are age 65 or older or who have a permanent and total non-service-connected disability.</p>
-
-      <p>Veterans who establish eligibility for a basic pension but are housebound or who require the aid and attendance of another person in order to perform activities of daily living, may qualify for pension at an increased rate (this is called “Special Monthly Pension”).</p>
-
-      <h3>VA Requirements</h3>
-
-      <ul>
-        <li>Proof of income and net worth information (e.g., bank statements, paystubs)</li>
-
-        <li>Private medical treatment records and where to find any relevant treatment records that might be held by a federal facility, such as a VA medical center</li>
-
-        <li>Completed pension program applications:
-
-        <ul>
-          <li>Veterans Pension – <a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-527EZ-ARE.pdf">VA Form 21-527EZ</a></li>
-          <li>Survivors Pension – <a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-534EZ-ARE.pdf">VA Form 21-534EZ</a></li>
-          <li>Special Monthly Pension for Veterans and Surviving Spouses (if applicable) – <a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-2680-ARE.pdf">VA Form 21-2680</a></li>
+          <li>
+          <a href="family/">
+            <div>
+              <h4>Spouses, Dependents, and Survivors Eligibility</h4>
+            </div>
+          </a>
+          </li>
         </ul>
 
-        </li>
-      </ul>
-
-      <p>Eligible Veterans may receive headstones, markers, or medallions to place in private cemeteries worldwide. Some Veterans may also be eligible for burial allowances or use benefits for private cemetery burials that also include a headstone or marker, a burial flag, and a Presidential Memorial Certificate.</p>
-
-      <p>Please note that grave sites cannot be reserved in advance.</p>
-
-      <a target="_blank" href="http://www.benefits.va.gov/pension/" class="button">Explore VA Pension Benefits Today</a>
-
-      <h3>VA Application Process</h3>
-
-      <p>Pension claim decision times vary depending on the complexity of the case and evidence. The fastest way to obtain a pension benefit decision is to file a Fully Developed Claim (FDC). Here are some typical steps in the process:</p>
-
-      <ul>
-        <li>Select the type of pension claim and gather the evidence it requires.</li>
-        <li>Collect military medical and other records.</li>
-        <li>Gather any private medical records.</li>
-        <li>Submit your application.</li>
-      </ul>
+      </div>
     </div>
 
-    <div class="small-4 columns">
-      <h3>Veterans’ Resources and Claims Assistance</h3>
+    <div class="row">
+      <div class="small-8 columns services">
 
-      <h4>Application Assistance</h4>
-      <ul>
-        <li><a target="_blank" href="http://www.benefits.va.gov/benefits/offices.asp">Find VA Regional Offices</a></li>
-        <li><a target="_blank" href="http://www.va.gov/statedva.htm">State Veterans Affairs Directors</a></li>
-        <li><a target="_blank" href="http://nacvso.org/find-a-service-officer/">County Veteran Service Officers</a></li>
-        <li><a target="_blank" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=request-vso-representative">Accredited Veterans Service Organizations</a></li>
-      </ul>
+        <h3>How to Apply</h3>
 
-      <hr>
+        <p><b>The fastest way</b> to obtain a pension benefit decision is to file a Fully Developed Claim (FDC) using the following forms, as applicable:</p>
 
-      <h4>Documents</h4>
-      <ul>
-        <li><a target="_blank" href="http://www.benefits.va.gov/benefits/offices.asp">VA Form 21-527EZ</a> 	– Veterans Pension</li>
-        <li><a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-534EZ-ARE.pdf">VA Form 21-534EZ</a> – Survivors Pension</li>
-        <li><a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-2680-ARE.pdf">VA Form 21-2680</a> – Special Monthly Pension for Veterans and Surviving Spouses</li>
-      </ul>
+        <div class="row">
+          <div class="small-4 columns text-center"><h4>Veterans Pension</h4></div>
+          <div class="small-4 columns text-center"><h4>Survivors Pension</h4></div>
+          <div class="small-4 columns text-center"><h4>Special Monthly Pension for Veterans</h4></div>
+        </div>
 
-      <hr>
+        <h3>VA Pension</h3>
 
-      <h4>How Tos</h4>
-      <ul>
-        <li><a target="_blank" href="http://benefits.va.gov/pension/rates.asp">How to Read Pension Benefits Rate Tables</a> – Learn how VA calculates Pension benefits</li>
-      </ul>
+        <p>A VA pension may provide income to make life more secure for Veterans and their loved ones.</p>
+
+        <p>Pension is a needs-based benefit for wartime Veterans with limited or no income who are age 65 or older or who have a permanent and total non-service-connected disability.</p>
+
+        <p>Veterans who establish eligibility for a basic pension but are housebound or who require the aid and attendance of another person in order to perform activities of daily living, may qualify for pension at an increased rate (this is called “Special Monthly Pension”).</p>
+
+        <h3>VA Requirements</h3>
+
+        <ul>
+          <li>Proof of income and net worth information (e.g., bank statements, paystubs)</li>
+
+          <li>Private medical treatment records and where to find any relevant treatment records that might be held by a federal facility, such as a VA medical center</li>
+
+          <li>Completed pension program applications:
+
+          <ul>
+            <li>Veterans Pension – <a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-527EZ-ARE.pdf">VA Form 21-527EZ</a></li>
+            <li>Survivors Pension – <a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-534EZ-ARE.pdf">VA Form 21-534EZ</a></li>
+            <li>Special Monthly Pension for Veterans and Surviving Spouses (if applicable) – <a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-2680-ARE.pdf">VA Form 21-2680</a></li>
+          </ul>
+
+          </li>
+        </ul>
+
+        <p>Eligible Veterans may receive headstones, markers, or medallions to place in private cemeteries worldwide. Some Veterans may also be eligible for burial allowances or use benefits for private cemetery burials that also include a headstone or marker, a burial flag, and a Presidential Memorial Certificate.</p>
+
+        <p>Please note that grave sites cannot be reserved in advance.</p>
+
+        <a target="_blank" href="http://www.benefits.va.gov/pension/" class="button">Explore VA Pension Benefits Today</a>
+
+        <h3>VA Application Process</h3>
+
+        <p>Pension claim decision times vary depending on the complexity of the case and evidence. The fastest way to obtain a pension benefit decision is to file a Fully Developed Claim (FDC). Here are some typical steps in the process:</p>
+
+        <ul>
+          <li>Select the type of pension claim and gather the evidence it requires.</li>
+          <li>Collect military medical and other records.</li>
+          <li>Gather any private medical records.</li>
+          <li>Submit your application.</li>
+        </ul>
+      </div>
+
+      <div class="small-4 columns">
+        <h3>Veterans’ Resources and Claims Assistance</h3>
+
+        <h4>Application Assistance</h4>
+        <ul>
+          <li><a target="_blank" href="http://www.benefits.va.gov/benefits/offices.asp">Find VA Regional Offices</a></li>
+          <li><a target="_blank" href="http://www.va.gov/statedva.htm">State Veterans Affairs Directors</a></li>
+          <li><a target="_blank" href="http://nacvso.org/find-a-service-officer/">County Veteran Service Officers</a></li>
+          <li><a target="_blank" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=request-vso-representative">Accredited Veterans Service Organizations</a></li>
+        </ul>
+
+        <hr>
+
+        <h4>Documents</h4>
+        <ul>
+          <li><a target="_blank" href="http://www.benefits.va.gov/benefits/offices.asp">VA Form 21-527EZ</a> 	– Veterans Pension</li>
+          <li><a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-534EZ-ARE.pdf">VA Form 21-534EZ</a> – Survivors Pension</li>
+          <li><a target="_blank" href="http://www.vba.va.gov/pubs/forms/VBA-21-2680-ARE.pdf">VA Form 21-2680</a> – Special Monthly Pension for Veterans and Surviving Spouses</li>
+        </ul>
+
+        <hr>
+
+        <h4>How Tos</h4>
+        <ul>
+          <li><a target="_blank" href="http://benefits.va.gov/pension/rates.asp">How to Read Pension Benefits Rate Tables</a> – Learn how VA calculates Pension benefits</li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -59,6 +59,11 @@
       "from": "amdefine@>=0.0.4",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
+    "animate.css": {
+      "version": "3.5.1",
+      "from": "animate.css@latest",
+      "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-3.5.1.tgz"
+    },
     "ansi-escapes": {
       "version": "1.4.0",
       "from": "ansi-escapes@>=1.1.0 <2.0.0",
@@ -4293,6 +4298,11 @@
         }
       }
     },
+    "metalsmith-broken-link-checker": {
+      "version": "0.1.10",
+      "from": "metalsmith-broken-link-checker@latest",
+      "resolved": "https://registry.npmjs.org/metalsmith-broken-link-checker/-/metalsmith-broken-link-checker-0.1.10.tgz"
+    },
     "metalsmith-collections": {
       "version": "0.7.0",
       "from": "metalsmith-collections@>=0.7.0 <0.8.0",
@@ -7387,6 +7397,11 @@
       "from": "unzip-response@>=1.0.0 <2.0.0",
       "resolved": "http://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz"
     },
+    "urijs": {
+      "version": "1.18.1",
+      "from": "urijs@>=1.17.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.18.1.tgz"
+    },
     "urix": {
       "version": "0.1.0",
       "from": "urix@>=0.1.0 <0.2.0",
@@ -7714,14 +7729,7 @@
     "wowjs": {
       "version": "1.1.3",
       "from": "wowjs@latest",
-      "resolved": "https://registry.npmjs.org/wowjs/-/wowjs-1.1.3.tgz",
-      "dependencies": {
-        "animate.css": {
-          "version": "3.5.1",
-          "from": "animate.css@latest",
-          "resolved": "https://registry.npmjs.org/animate.css/-/animate.css-3.5.1.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/wowjs/-/wowjs-1.1.3.tgz"
     },
     "wrap-ansi": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "metalsmith-archive": "^0.1.1",
     "metalsmith-assets": "^0.1.0",
     "metalsmith-better-excerpts": "^0.1.7",
+    "metalsmith-broken-link-checker": "^0.1.10",
     "metalsmith-collections": "^0.7.0",
     "metalsmith-date-in-filename": "^0.0.14",
     "metalsmith-define": "^2.0.1",

--- a/script/build.js
+++ b/script/build.js
@@ -3,6 +3,7 @@
 const Metalsmith = require('metalsmith');
 const archive = require('metalsmith-archive');
 const assets = require('metalsmith-assets');
+const blc = require('metalsmith-broken-link-checker');
 const collections = require('metalsmith-collections');
 const commandLineArgs = require('command-line-args')
 const dateInFilename = require('metalsmith-date-in-filename');
@@ -177,6 +178,30 @@ if (options.watch) {
     }
   ));
 } else {
+  // Broken link checking does not work well with watch. It continually shows broken links
+  // for permalink processed files. Only run outside of watch mode.
+  smith.use(blc({
+    allowRedirects: true,  // Don't require trailing slash for index.html links.
+    warn: process.env.NODE_ENV !== 'production',
+    allowRegex: new RegExp(
+        [ '/disability-benefits/',
+          '/disability-benefits/apply-for-benefits/',
+          '/disability-benefits/learn/',
+          '/disability-benefits/learn/eligibility/.*',
+          '/employment/commitments',
+          '/employment/employers',
+          '/employment/employers/',
+          '/employment/job-seekers/create-resume',
+          '/employment/job-seekers/search-jobs',
+          '/employment/job-seekers/skills-translator',
+          '/employment/users/sign_in',
+          '/gi-bill-comparison-tool/',
+          '/gibill/',
+          '/healthcare/apply/application',
+          '/veterans-employment-center/',
+          'Employment-Resources/', ].join('|'))
+  }));
+
   smith.use(webpack(webpackConfig));
 }
 


### PR DESCRIPTION
Broken link checking is super important for CI.

The pension pages on the otherhand look like they have been broken for a
while. The fixes here at least make the text visible and allow the
broken link checker to pass but #2732 has been filed to figure out what
to do with these pages.
