### PR TITLE
Updating prescription card hover styles. closes #2815

### DIFF
--- a/src/sass/rx/_partials/_rx-prescription-card.scss
+++ b/src/sass/rx/_partials/_rx-prescription-card.scss
@@ -8,7 +8,7 @@
   border-color: $color-white;
   border-style: solid;
   border-width: 1rem 0;
-
+  
   @media (min-width: $medium-screen) {
     float: left;
     width: 50%;
@@ -25,20 +25,29 @@
 
 .rx-prescription-inner {
   background: $color-gray-lightest;
+  // As this changes, adjust the position 
+  // of .rx-prescription-count, .rx-prescription-action below
   padding: 2rem;
   position: relative;
+  height: 21.2rem;
 }
 
 .rx-prescription-title {
   color: $color-primary;
   margin: 0;
-  text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
   padding-bottom: 0;
 
   a {
+    display: block;
+    overflow: hidden;
     text-decoration: none;
+    text-overflow: ellipsis;
+
+    &:hover {
+      background: none; 
+      text-decoration: underline;
+    }
   }
 }
 
@@ -50,12 +59,15 @@
   padding-bottom: 3rem;
 }
 
+.rx-prescription-refill-requested {
+  font-weight: bold;
+}
+
 button.rx-prescription-button,
 [type=submit].rx-prescription-button {
   background: transparent;
   display: inline-block;
   font-weight: bold;
-  float: right;
   margin: 0;
 
   @media (max-width: $small-screen) {
@@ -66,12 +78,22 @@ button.rx-prescription-button,
 
 .rx-prescription-count {
   display: inline-block;
-  position: absolute;
   bottom: 1.5rem;
   
   &-zero {
     color: $color-secondary;
   }
+}
+
+.rx-prescription-count,
+.rx-prescription-action {
+  position: absolute;
+}
+
+.rx-prescription-action {
+  text-align: right;
+  right: 2rem;
+  bottom: 2rem;
 }
 
 .rx-prescription-count-number {
@@ -111,9 +133,5 @@ button.rx-prescription-button,
   }
   .rx-prescription-count-number {
     display: inline;
-
-    &::after {
-      content: '\a0';
-    }
   }
 }


### PR DESCRIPTION
- Also refactors text-overflow behavior for rx-prescription-title so that the ellipsis matches the style of the link.
- Also pulls in changes from master to rx.
