### PR TITLE
Create Nav component

### DIFF
--- a/content/pages/education/apply-for-education-benefits/apply.md
+++ b/content/pages/education/apply-for-education-benefits/apply.md
@@ -1,8 +1,7 @@
 ---
 title: Apply for education benefits
 entryname: edu-benefits
-template: 6-info-page
-concurrence: incomplete
+layout: page-react.html
 ---
 <div id="main">
   <div class="section">
@@ -32,4 +31,3 @@ concurrence: incomplete
   </div>-->
   <!-- Maintenance Page End -->
 </div>
-

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "node script/build.js",
     "heroku-serve": "http-server",
     "lint": "npm run lint:js && npm run lint:sass",
-    "lint:js": "eslint --quiet --ignore-pattern src/js/legacy --ext .js --ext .jsx src/js test/js",
+    "lint:js": "eslint --quiet --ext .js --ext .jsx .",
     "lint:sass": "sass-lint -c config/sass-lint.yml",
     "nightwatch": "nightwatch -c config/nightwatch.js",
     "selenium:bootstrap": "selenium-standalone install",

--- a/script/build.js
+++ b/script/build.js
@@ -162,22 +162,22 @@ if (options.watch) {
   // TODO(awong): Enable live reload of metalsmith pages per instructions at
   //   https://www.npmjs.com/package/metalsmith-watch
   smith.use(watch());
-  
+
   // If in watch mode, assume hot reloading for JS and use webpack devserver.
   const devServerConfig = {
     contentBase: `build/${options.buildtype}`,
     historyApiFallback: {
       rewrites: [
-        { from: '^\/rx(.*)', to: '/rx/' },
-        { from: '^\/healthcare\/apply\/application(.*)', to: '/healthcare/apply/application/' },
-        { from: '^\/education\/apply-for-education-benefits\/apply(.*)', to: '/education/apply-for-education-benefits/apply/' },
-        { from: '^\/(.*)', to: function(context){ return context.parsedUrl.pathname; }}
+        { from: '^/rx(.*)', to: '/rx/' },
+        { from: '^/healthcare/apply/application(.*)', to: '/healthcare/apply/application/' },
+        { from: '^/education/apply-for-education-benefits/apply(.*)', to: '/education/apply-for-education-benefits/apply/' },
+        { from: '^/(.*)', to(context) { return context.parsedUrl.pathname; } }
       ],
     },
     hot: true,
     port: options.port,
     publicPath: '/generated/',
-    stats: { 
+    stats: {
       colors: true,
       assets: false,
       version: false,
@@ -198,15 +198,18 @@ if (options.watch) {
       '/api/*': {
         target: `https://${api.host}${api.path}`,
         auth: api.auth,
-        rewrite: function (req) {
+        rewrite(req) {
+          /* eslint-disable no-param-reassign */
           req.url = req.url.replace(/^\/api/, '');
           req.headers.host = api.host;
+          /* eslint-enable no-param-reassign */
         }
       }
-    }
+    };
+    // eslint-disable-next-line no-console
     console.log('API proxy enabled');
-  } catch(e){
-    // No proxy config file found.  
+  } catch (e) {
+    // No proxy config file found.
   }
 
   smith.use(webpackDevServer(webpackConfig, devServerConfig));

--- a/script/build.js
+++ b/script/build.js
@@ -162,15 +162,19 @@ if (options.watch) {
   // TODO(awong): Enable live reload of metalsmith pages per instructions at
   //   https://www.npmjs.com/package/metalsmith-watch
   smith.use(watch());
-
+  
   // If in watch mode, assume hot reloading for JS and use webpack devserver.
   const devServerConfig = {
     contentBase: `build/${options.buildtype}`,
-    historyApiFallback: false,
+    historyApiFallback: {
+      rewrites: [
+        { from: '^\/rx(.*)', to: '/rx/' }
+      ],
+    },
     hot: true,
     port: options.port,
     publicPath: '/generated/',
-    stats: {
+    stats: { 
       colors: true,
       assets: false,
       version: false,
@@ -199,7 +203,7 @@ if (options.watch) {
     }
     console.log('API proxy enabled');
   } catch(e){
-    // No proxy config file found.
+    // No proxy config file found.  
   }
 
   smith.use(webpackDevServer(webpackConfig, devServerConfig));

--- a/script/build.js
+++ b/script/build.js
@@ -162,19 +162,15 @@ if (options.watch) {
   // TODO(awong): Enable live reload of metalsmith pages per instructions at
   //   https://www.npmjs.com/package/metalsmith-watch
   smith.use(watch());
-  
+
   // If in watch mode, assume hot reloading for JS and use webpack devserver.
   const devServerConfig = {
     contentBase: `build/${options.buildtype}`,
-    historyApiFallback: {
-      rewrites: [
-        { from: '^\/rx(.*)', to: '/rx/' }
-      ],
-    },
+    historyApiFallback: false,
     hot: true,
     port: options.port,
     publicPath: '/generated/',
-    stats: { 
+    stats: {
       colors: true,
       assets: false,
       version: false,
@@ -203,7 +199,7 @@ if (options.watch) {
     }
     console.log('API proxy enabled');
   } catch(e){
-    // No proxy config file found.  
+    // No proxy config file found.
   }
 
   smith.use(webpackDevServer(webpackConfig, devServerConfig));

--- a/src/js/edu-benefits/actions/index.js
+++ b/src/js/edu-benefits/actions/index.js
@@ -1,5 +1,58 @@
-export function placeholderAction() {
+export const UPDATE_COMPLETED_STATUS = 'UPDATE_COMPLETED_STATUS';
+export const UPDATE_INCOMPLETE_STATUS = 'UPDATE_INCOMPLETE_STATUS';
+export const UPDATE_REVIEW_STATUS = 'UPDATE_REVIEW_STATUS';
+export const UPDATE_VERIFIED_STATUS = 'UPDATE_VERIFIED_STATUS';
+export const UPDATE_SUBMISSION_STATUS = 'UPDATE_SUBMISSION_STATUS';
+export const UPDATE_SUBMISSION_ID = 'UPDATE_SUBMISSION_ID';
+export const UPDATE_SUBMISSION_TIMESTAMP = 'UPDATE_SUBMISSION_TIMESTAMP';
+
+export function updateCompletedStatus(path) {
   return {
-    type: 'ACTION'
+    type: UPDATE_COMPLETED_STATUS,
+    path
+  };
+}
+
+export function updateIncompleteStatus(path) {
+  return {
+    type: UPDATE_INCOMPLETE_STATUS,
+    path
+  };
+}
+
+export function updateReviewStatus(path, value) {
+  return {
+    type: UPDATE_REVIEW_STATUS,
+    path,
+    value
+  };
+}
+
+export function updateVerifiedStatus(path, value) {
+  return {
+    type: UPDATE_VERIFIED_STATUS,
+    path,
+    value
+  };
+}
+
+export function updateSubmissionStatus(value) {
+  return {
+    type: UPDATE_SUBMISSION_STATUS,
+    value
+  };
+}
+
+export function updateSubmissionId(value) {
+  return {
+    type: UPDATE_SUBMISSION_ID,
+    value
+  };
+}
+
+export function updateSubmissionTimestamp(value) {
+  return {
+    type: UPDATE_SUBMISSION_TIMESTAMP,
+    value
   };
 }

--- a/src/js/edu-benefits/components/Nav.jsx
+++ b/src/js/edu-benefits/components/Nav.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+const formPanels = [
+  {
+    path: '/benefits-eligibility',
+    name: 'Benefits Eligibility',
+    classes: 'one',
+    sections: []
+  },
+  {
+    path: '/military-history',
+    name: 'Military History',
+    classes: 'two',
+    sections: [
+      { path: '/military-history/service', name: 'Military Service' },
+      { path: '/military-history/rotc-history', name: 'ROTC History' },
+      { path: '/military-history/benefits-history', name: 'Benefits History' }
+    ]
+  },
+  {
+    path: '/education-history',
+    name: 'Education History',
+    classes: 'three',
+    sections: []
+  },
+  {
+    path: '/employment-history',
+    name: 'Employment History',
+    classes: 'four',
+    sections: []
+  },
+  {
+    path: '/school-selection',
+    name: 'School Selection',
+    classes: 'five',
+    sections: []
+  },
+  {
+    path: '/veteran-information',
+    name: 'Veteran Information',
+    classes: 'six',
+    sections: [
+      { path: '/veteran-information/personal-information', name: 'Personal Information' },
+      { path: '/veteran-information/address', name: 'Address' },
+      { path: '/veteran-information/contact', name: 'Contact Information' },
+      { path: '/veteran-information/secondary-contact', name: 'Secondary Contact' },
+      { path: '/veteran-information/dependent-information', name: 'Dependent Information' },
+      { path: '/veteran-information/direct-deposit', name: 'Direct Deposit' },
+    ]
+  },
+  {
+    path: '/review-and-submit',
+    name: 'Review',
+    classes: 'seven last',
+    sections: []
+  }];
+
+function determinePanelStyles(path, sectionState, formPanel, currentUrl) {
+  let classes = '';
+  if (currentUrl.startsWith(path)) {
+    classes += ' section-current';
+  }
+  if (sectionState[path] && sectionState[path].complete) {
+    classes += ' section-complete';
+  } else if (formPanel.sections.length > 0 && sectionState[formPanel.sections.slice(-1)[0].path].complete) {
+    classes += ' section-complete';
+  }
+  return classes;
+}
+
+function determineSectionStyles(name, currentUrl) {
+  return currentUrl === name ? ' sub-section-current' : '';
+}
+
+/**
+ * Component for navigation, with links to each section of the form.
+ * Parent links redirect to first section link within topic.
+ *
+ * Props:
+ * `currentUrl` - String. Specifies the current url.
+ */
+class Nav extends React.Component {
+  render() {
+    const subnavStyles = 'step one wow fadeIn animated';
+    const { sections, currentUrl } = this.props;
+
+    return (
+      <ol className="process form-process">
+        {formPanels.map(panel => {
+          return (<li role="presentation" className={`${panel.classes} ${subnavStyles}
+           ${determinePanelStyles(panel.path, sections, panel, currentUrl)}`} key={panel.path}>
+            <div>
+              <h5>{panel.name}</h5>
+              <ul className="usa-unstyled-list">
+                {panel.sections.map(subSection => {
+                  return (<li className={`${determineSectionStyles(subSection.path, currentUrl)}`} key={subSection.path}>
+                    {subSection.name}
+                  </li>);
+                })}
+              </ul>
+            </div>
+          </li>);
+        })}
+      </ol>
+    );
+  }
+}
+
+Nav.propTypes = {
+  currentUrl: React.PropTypes.string.isRequired,
+  sections: React.PropTypes.object.isRequired
+};
+
+export default Nav;

--- a/src/js/edu-benefits/components/Nav.jsx
+++ b/src/js/edu-benefits/components/Nav.jsx
@@ -1,59 +1,8 @@
 import React from 'react';
 
-const formPanels = [
-  {
-    path: '/benefits-eligibility',
-    name: 'Benefits Eligibility',
-    classes: 'one',
-    sections: []
-  },
-  {
-    path: '/military-history',
-    name: 'Military History',
-    classes: 'two',
-    sections: [
-      { path: '/military-history/service', name: 'Military Service' },
-      { path: '/military-history/rotc-history', name: 'ROTC History' },
-      { path: '/military-history/benefits-history', name: 'Benefits History' }
-    ]
-  },
-  {
-    path: '/education-history',
-    name: 'Education History',
-    classes: 'three',
-    sections: []
-  },
-  {
-    path: '/employment-history',
-    name: 'Employment History',
-    classes: 'four',
-    sections: []
-  },
-  {
-    path: '/school-selection',
-    name: 'School Selection',
-    classes: 'five',
-    sections: []
-  },
-  {
-    path: '/veteran-information',
-    name: 'Veteran Information',
-    classes: 'six',
-    sections: [
-      { path: '/veteran-information/personal-information', name: 'Personal Information' },
-      { path: '/veteran-information/address', name: 'Address' },
-      { path: '/veteran-information/contact', name: 'Contact Information' },
-      { path: '/veteran-information/secondary-contact', name: 'Secondary Contact' },
-      { path: '/veteran-information/dependent-information', name: 'Dependent Information' },
-      { path: '/veteran-information/direct-deposit', name: 'Direct Deposit' },
-    ]
-  },
-  {
-    path: '/review-and-submit',
-    name: 'Review',
-    classes: 'seven last',
-    sections: []
-  }];
+function lastSection(panel) {
+  return panel.sections.slice(-1)[0].path;
+}
 
 function determinePanelStyles(path, sectionState, formPanel, currentUrl) {
   let classes = '';
@@ -62,7 +11,7 @@ function determinePanelStyles(path, sectionState, formPanel, currentUrl) {
   }
   if (sectionState[path] && sectionState[path].complete) {
     classes += ' section-complete';
-  } else if (formPanel.sections.length > 0 && sectionState[formPanel.sections.slice(-1)[0].path].complete) {
+  } else if (formPanel.sections.length > 0 && sectionState[lastSection(formPanel)].complete) {
     classes += ' section-complete';
   }
   return classes;
@@ -78,28 +27,34 @@ function determineSectionStyles(name, currentUrl) {
  *
  * Props:
  * `currentUrl` - String. Specifies the current url.
+ * `sections` - A hash of section names and the current validation state and fields
+ * `panels` - A list of the panels in the nav and their sub-sections
  */
 class Nav extends React.Component {
   render() {
     const subnavStyles = 'step one wow fadeIn animated';
-    const { sections, currentUrl } = this.props;
+    const { sections, currentUrl, panels } = this.props;
 
     return (
       <ol className="process form-process">
-        {formPanels.map(panel => {
-          return (<li role="presentation" className={`${panel.classes} ${subnavStyles}
-           ${determinePanelStyles(panel.path, sections, panel, currentUrl)}`} key={panel.path}>
-            <div>
-              <h5>{panel.name}</h5>
-              <ul className="usa-unstyled-list">
-                {panel.sections.map(subSection => {
-                  return (<li className={`${determineSectionStyles(subSection.path, currentUrl)}`} key={subSection.path}>
-                    {subSection.name}
-                  </li>);
-                })}
-              </ul>
-            </div>
-          </li>);
+        {panels.map(panel => {
+          return (
+            <li role="presentation" className={`${panel.classes} ${subnavStyles}
+              ${determinePanelStyles(panel.path, sections, panel, currentUrl)}`} key={panel.path}>
+              <div>
+                <h5>{panel.name}</h5>
+                <ul className="usa-unstyled-list">
+                  {panel.sections.map(section => {
+                    return (
+                      <li className={`${determineSectionStyles(section.path, currentUrl)}`} key={section.path}>
+                        {section.name}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            </li>
+          );
         })}
       </ol>
     );
@@ -108,7 +63,8 @@ class Nav extends React.Component {
 
 Nav.propTypes = {
   currentUrl: React.PropTypes.string.isRequired,
-  sections: React.PropTypes.object.isRequired
+  sections: React.PropTypes.object.isRequired,
+  panels: React.PropTypes.array.isRequired
 };
 
 export default Nav;

--- a/src/js/edu-benefits/components/Nav.jsx
+++ b/src/js/edu-benefits/components/Nav.jsx
@@ -21,6 +21,13 @@ function determineSectionStyles(name, currentUrl) {
   return currentUrl === name ? ' sub-section-current' : '';
 }
 
+function getStepClassFromIndex(index, length) {
+  const numbers = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+  const lastClass = (index + 1) === length ? 'last' : '';
+
+  return (index + 1) < numbers.length ? `${numbers[index]} ${lastClass}` : lastClass;
+}
+
 /**
  * Component for navigation, with links to each section of the form.
  * Parent links redirect to first section link within topic.
@@ -37,9 +44,9 @@ class Nav extends React.Component {
 
     return (
       <ol className="process form-process">
-        {panels.map(panel => {
+        {panels.map((panel, i) => {
           return (
-            <li role="presentation" className={`${panel.classes} ${subnavStyles}
+            <li role="presentation" className={`${getStepClassFromIndex(i, panels.length)} ${subnavStyles}
               ${determinePanelStyles(panel.path, sections, panel, currentUrl)}`} key={panel.path}>
               <div>
                 <h5>{panel.name}</h5>

--- a/src/js/edu-benefits/containers/EduBenefitsApp.jsx
+++ b/src/js/edu-benefits/containers/EduBenefitsApp.jsx
@@ -25,13 +25,13 @@ class EduBenefitsApp extends React.Component {
       }
     }
 
-    const sections = this.props.uiState.sections;
+    const { panels, sections } = this.props.uiState;
     const currentLocation = this.props.currentLocation;
 
     return (
       <div className="row">
         {devPanel}
-        <Nav sections={sections} currentUrl={currentLocation.pathname}/>
+        <Nav sections={sections} panels={panels} currentUrl={currentLocation.pathname}/>
         <span className="js-test-location hidden" data-location={currentLocation.pathname} hidden></span>
       </div>
     );

--- a/src/js/edu-benefits/containers/EduBenefitsApp.jsx
+++ b/src/js/edu-benefits/containers/EduBenefitsApp.jsx
@@ -3,9 +3,7 @@ import _ from 'lodash';
 
 import { connect } from 'react-redux';
 
-import { bindActionCreators } from 'redux';
-
-import { placeholderAction } from '../actions';
+import Nav from '../components/Nav';
 
 class EduBenefitsApp extends React.Component {
   render() {
@@ -27,30 +25,30 @@ class EduBenefitsApp extends React.Component {
       }
     }
 
+    const sections = this.props.uiState.sections;
+    const currentLocation = this.props.currentLocation;
+
     return (
       <div>
         {devPanel}
-        Get your education benefits here!
-        <span className="js-test-location hidden" data-location={this.props.location.pathname} hidden></span>
+        <Nav sections={sections} currentUrl={currentLocation.pathname}/>
+        <span className="js-test-location hidden" data-location={currentLocation.pathname} hidden></span>
       </div>
     );
   }
 }
 
-EduBenefitsApp.contextTypes = {
-  router: React.PropTypes.object.isRequired
-};
-
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
   return {
-    placeholder: state.placeholder,
+    uiState: state.uiState,
+    currentLocation: ownProps.location
   };
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ placeholderAction }, dispatch);
+// Fill this in when we start using actions
+function mapDispatchToProps() {
+  return {};
 }
 
-// TODO(awong): Remove the pure: false once we start using ImmutableJS.
-export default connect(mapStateToProps, mapDispatchToProps, undefined, { pure: false })(EduBenefitsApp);
+export default connect(mapStateToProps, mapDispatchToProps)(EduBenefitsApp);
 export { EduBenefitsApp };

--- a/src/js/edu-benefits/containers/EduBenefitsApp.jsx
+++ b/src/js/edu-benefits/containers/EduBenefitsApp.jsx
@@ -29,7 +29,7 @@ class EduBenefitsApp extends React.Component {
     const currentLocation = this.props.currentLocation;
 
     return (
-      <div>
+      <div className="row">
         {devPanel}
         <Nav sections={sections} currentUrl={currentLocation.pathname}/>
         <span className="js-test-location hidden" data-location={currentLocation.pathname} hidden></span>

--- a/src/js/edu-benefits/reducers/index.js
+++ b/src/js/edu-benefits/reducers/index.js
@@ -1,8 +1,6 @@
 import { combineReducers } from 'redux';
-
-const initState = {};
-const placeholder = (state = initState) => state;
+import uiState from './uiState/index';
 
 export default combineReducers({
-  placeholder
+  uiState
 });

--- a/src/js/edu-benefits/reducers/uiState/index.js
+++ b/src/js/edu-benefits/reducers/uiState/index.js
@@ -93,7 +93,62 @@ const ui = {
       verified: false,
       fields: []
     }
-  }
+  },
+  panels: [
+    {
+      path: '/benefits-eligibility',
+      name: 'Benefits Eligibility',
+      classes: 'one',
+      sections: []
+    },
+    {
+      path: '/military-history',
+      name: 'Military History',
+      classes: 'two',
+      sections: [
+        { path: '/military-history/service', name: 'Military Service' },
+        { path: '/military-history/rotc-history', name: 'ROTC History' },
+        { path: '/military-history/benefits-history', name: 'Benefits History' }
+      ]
+    },
+    {
+      path: '/education-history',
+      name: 'Education History',
+      classes: 'three',
+      sections: []
+    },
+    {
+      path: '/employment-history',
+      name: 'Employment History',
+      classes: 'four',
+      sections: []
+    },
+    {
+      path: '/school-selection',
+      name: 'School Selection',
+      classes: 'five',
+      sections: []
+    },
+    {
+      path: '/veteran-information',
+      name: 'Veteran Information',
+      classes: 'six',
+      sections: [
+        { path: '/veteran-information/personal-information', name: 'Personal Information' },
+        { path: '/veteran-information/address', name: 'Address' },
+        { path: '/veteran-information/contact', name: 'Contact Information' },
+        { path: '/veteran-information/secondary-contact', name: 'Secondary Contact' },
+        { path: '/veteran-information/dependent-information', name: 'Dependent Information' },
+        { path: '/veteran-information/direct-deposit', name: 'Direct Deposit' },
+      ]
+    },
+    {
+      path: '/review-and-submit',
+      name: 'Review',
+      classes: 'seven last',
+      sections: []
+    }
+  ]
 };
 
 function uiState(state = ui, action) {

--- a/src/js/edu-benefits/reducers/uiState/index.js
+++ b/src/js/edu-benefits/reducers/uiState/index.js
@@ -1,0 +1,127 @@
+import _ from 'lodash/fp';
+
+import {
+  UPDATE_COMPLETED_STATUS,
+  UPDATE_INCOMPLETE_STATUS,
+  UPDATE_REVIEW_STATUS,
+  UPDATE_VERIFIED_STATUS,
+  UPDATE_SUBMISSION_STATUS,
+  UPDATE_SUBMISSION_ID,
+  UPDATE_SUBMISSION_TIMESTAMP
+} from '../../actions';
+
+const ui = {
+  submission: {
+    status: false,
+    errorMessage: false,
+    id: false,
+    timestamp: false
+  },
+  sections: {
+    '/introduction': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/benefits-eligibility': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/military-history/service': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/military-history/rotc-history': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/military-history/benefits-history': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/education-history': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/employment-history': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/school-selection': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/veteran-information/personal-information': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/veteran-information/address': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/veteran-information/contact': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/veteran-information/secondary-contact': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/veteran-information/dependent-information': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/veteran-information/direct-deposit': {
+      complete: false,
+      verified: false,
+      fields: []
+    },
+    '/review-and-submit': {
+      complete: false,
+      verified: false,
+      fields: []
+    }
+  }
+};
+
+function uiState(state = ui, action) {
+  switch (action.type) {
+    case UPDATE_COMPLETED_STATUS:
+      return _.set(['sections', action.path, 'complete'], true, state);
+
+    case UPDATE_INCOMPLETE_STATUS:
+      return _.set(['sections', action.path, 'complete'], false, state);
+
+    case UPDATE_REVIEW_STATUS:
+      return _.set(['sections', action.path, 'complete'], action.value, state);
+
+    case UPDATE_VERIFIED_STATUS:
+      return _.set(['sections', action.path, 'verified'], action.value, state);
+
+    case UPDATE_SUBMISSION_STATUS:
+      return _.set(['submission', action.path, 'status'], action.value, state);
+
+    case UPDATE_SUBMISSION_ID:
+      return _.set(['submission', action.path, 'id'], action.value, state);
+
+    case UPDATE_SUBMISSION_TIMESTAMP:
+      return _.set(['submission', action.path, 'timestamp'], action.value, state);
+
+    default:
+      return state;
+  }
+}
+
+export default uiState;

--- a/src/js/edu-benefits/reducers/uiState/index.js
+++ b/src/js/edu-benefits/reducers/uiState/index.js
@@ -98,13 +98,11 @@ const ui = {
     {
       path: '/benefits-eligibility',
       name: 'Benefits Eligibility',
-      classes: 'one',
       sections: []
     },
     {
       path: '/military-history',
       name: 'Military History',
-      classes: 'two',
       sections: [
         { path: '/military-history/service', name: 'Military Service' },
         { path: '/military-history/rotc-history', name: 'ROTC History' },
@@ -114,25 +112,21 @@ const ui = {
     {
       path: '/education-history',
       name: 'Education History',
-      classes: 'three',
       sections: []
     },
     {
       path: '/employment-history',
       name: 'Employment History',
-      classes: 'four',
       sections: []
     },
     {
       path: '/school-selection',
       name: 'School Selection',
-      classes: 'five',
       sections: []
     },
     {
       path: '/veteran-information',
       name: 'Veteran Information',
-      classes: 'six',
       sections: [
         { path: '/veteran-information/personal-information', name: 'Personal Information' },
         { path: '/veteran-information/address', name: 'Address' },
@@ -145,7 +139,6 @@ const ui = {
     {
       path: '/review-and-submit',
       name: 'Review',
-      classes: 'seven last',
       sections: []
     }
   ]
@@ -166,13 +159,13 @@ function uiState(state = ui, action) {
       return _.set(['sections', action.path, 'verified'], action.value, state);
 
     case UPDATE_SUBMISSION_STATUS:
-      return _.set(['submission', action.path, 'status'], action.value, state);
+      return _.set('submission.status', action.value, state);
 
     case UPDATE_SUBMISSION_ID:
-      return _.set(['submission', action.path, 'id'], action.value, state);
+      return _.set('submission.id', action.value, state);
 
     case UPDATE_SUBMISSION_TIMESTAMP:
-      return _.set(['submission', action.path, 'timestamp'], action.value, state);
+      return _.set('submission.timestamp', action.value, state);
 
     default:
       return state;

--- a/src/sass/edu-benefits.scss
+++ b/src/sass/edu-benefits.scss
@@ -1,6 +1,7 @@
 // Variables
 
 @import 'style';
+@import 'modules/m-form-process';
 
 $button-stroke: inset 0 0 0 1px;
 

--- a/src/sass/modules/_m-form-process.scss
+++ b/src/sass/modules/_m-form-process.scss
@@ -1,0 +1,35 @@
+.form-process {
+  li {
+    h5 {
+      color: $color-gray;
+    }
+    li {
+      display: none;
+    }
+    &:before {
+      background: $color-gray;
+    }
+    &.section-complete {
+      &:before {
+        background: $color-green;
+        content: "\2714";
+      }
+    }
+    &.section-current {
+      h5 {
+        font-weight: bold;
+        color: $color-primary;
+      }
+      li {
+        display: list-item;
+        &.sub-section-current {
+          font-weight: bold;
+          color: $color-primary;
+        }
+      }
+      &:before {
+        background: $color-primary;
+      }
+    }
+  }
+}

--- a/test/edu-benefits/components/Nav.unit.spec.jsx
+++ b/test/edu-benefits/components/Nav.unit.spec.jsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 
 import Nav from '../../../src/js/edu-benefits/components/Nav';
 
-describe.only('<Nav>', () => {
+describe('<Nav>', () => {
   it('should render all panels', () => {
     const currentUrl = '/some-url';
     const panels = [
@@ -29,6 +29,7 @@ describe.only('<Nav>', () => {
     };
     const tree = SkinDeep.shallowRender(<Nav sections={sections} panels={panels} currentUrl={currentUrl}/>);
     expect(tree.everySubTree('.step').length).to.equal(panels.length);
+    expect(tree.everySubTree('.two').length).to.equal(1);
     expect(tree.everySubTree('.step')[0].subTree('h5').text()).to.equal(panels[0].name);
   });
   it('should render all sections in panels', () => {

--- a/test/edu-benefits/components/Nav.unit.spec.jsx
+++ b/test/edu-benefits/components/Nav.unit.spec.jsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+
+import Nav from '../../../src/js/edu-benefits/components/Nav';
+
+describe.only('<Nav>', () => {
+  it('should render all panels', () => {
+    const currentUrl = '/some-url';
+    const panels = [
+      {
+        path: '/some-url',
+        name: 'Some url',
+        sections: []
+      },
+      {
+        path: '/some-url2',
+        name: 'Some url2',
+        sections: []
+      }
+    ];
+    const sections = {
+      '/some-url': {
+        complete: false
+      },
+      '/some-url2': {
+        complete: false
+      }
+    };
+    const tree = SkinDeep.shallowRender(<Nav sections={sections} panels={panels} currentUrl={currentUrl}/>);
+    expect(tree.everySubTree('.step').length).to.equal(panels.length);
+    expect(tree.everySubTree('.step')[0].subTree('h5').text()).to.equal(panels[0].name);
+  });
+  it('should render all sections in panels', () => {
+    const currentUrl = '/some-url';
+    const panels = [
+      {
+        path: '/some-url',
+        name: 'Some url',
+        sections: [
+          {
+            path: '/some-url/2',
+            name: 'Some url 2',
+          },
+          {
+            path: '/some-url/3',
+            name: 'Some url 3',
+          }
+        ]
+      }
+    ];
+    const sections = {
+      '/some-url': {
+        complete: false
+      },
+      '/some-url/2': {
+        complete: false
+      },
+      '/some-url/3': {
+        complete: false
+      }
+    };
+    const tree = SkinDeep.shallowRender(<Nav sections={sections} panels={panels} currentUrl={currentUrl}/>);
+    expect(tree.subTree('.usa-unstyled-list').everySubTree('li').length).to.equal(panels[0].sections.length);
+    expect(tree.subTree('.usa-unstyled-list').everySubTree('li')[0].text()).to.equal(panels[0].sections[0].name);
+  });
+  it('active panels have section-current', () => {
+    const currentUrl = '/some-url';
+    const panels = [
+      {
+        path: '/some-url',
+        name: 'Some url',
+        sections: []
+      }
+    ];
+    const sections = {
+      '/some-url': {
+        complete: false
+      }
+    };
+    const tree = SkinDeep.shallowRender(<Nav sections={sections} panels={panels} currentUrl={currentUrl}/>);
+    expect(tree.everySubTree('.section-current').length).to.equal(1);
+  });
+  it('active sections have sub-section-current', () => {
+    const currentUrl = '/some-url/thing';
+    const panels = [
+      {
+        path: '/some-url',
+        name: 'Some url',
+        sections: [{ path: '/some-url/thing', name: 'Test' }]
+      }
+    ];
+    const sections = {
+      '/some-url/thing': {
+        complete: false
+      }
+    };
+    const tree = SkinDeep.shallowRender(<Nav sections={sections} panels={panels} currentUrl={currentUrl}/>);
+    expect(tree.everySubTree('.sub-section-current').length).to.equal(1);
+  });
+  it('complete panels have section-complete', () => {
+    const currentUrl = '/some-url';
+    const panels = [
+      {
+        path: '/some-url',
+        name: 'Some url',
+        sections: []
+      }
+    ];
+    const sections = {
+      '/some-url': {
+        complete: true
+      }
+    };
+    const tree = SkinDeep.shallowRender(<Nav sections={sections} panels={panels} currentUrl={currentUrl}/>);
+    expect(tree.everySubTree('.section-complete').length).to.equal(1);
+  });
+  it('complete panels with sections have section-complete', () => {
+    const currentUrl = '/some-url/thing';
+    const panels = [
+      {
+        path: '/some-url',
+        name: 'Some url',
+        sections: [{ path: '/some-url/thing', name: 'Test' }]
+      }
+    ];
+    const sections = {
+      '/some-url/thing': {
+        complete: true
+      }
+    };
+    const tree = SkinDeep.shallowRender(<Nav sections={sections} panels={panels} currentUrl={currentUrl}/>);
+    expect(tree.everySubTree('.section-complete').length).to.equal(1);
+  });
+});

--- a/test/edu-benefits/reducers/uiState.unit.spec.js
+++ b/test/edu-benefits/reducers/uiState.unit.spec.js
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+
+import uiStateReducer from '../../../src/js/edu-benefits/reducers/uiState/index';
+import {
+  UPDATE_COMPLETED_STATUS,
+  UPDATE_INCOMPLETE_STATUS,
+  UPDATE_REVIEW_STATUS,
+  UPDATE_VERIFIED_STATUS,
+  UPDATE_SUBMISSION_STATUS,
+  UPDATE_SUBMISSION_ID,
+  UPDATE_SUBMISSION_TIMESTAMP
+} from '../../../src/js/edu-benefits/actions/index';
+
+describe('uiState reducer', () => {
+  it('should set the complete status', () => {
+    const uiState = {
+      sections: {
+        '/path': {
+          complete: false
+        }
+      }
+    };
+    const newState = uiStateReducer(uiState, { type: UPDATE_COMPLETED_STATUS, path: '/path' });
+    expect(newState.sections['/path'].complete).to.be.true;
+  });
+  it('should set the incomplete status', () => {
+    const uiState = {
+      sections: {
+        '/path': {
+          complete: true
+        }
+      }
+    };
+    const newState = uiStateReducer(uiState, { type: UPDATE_INCOMPLETE_STATUS, path: '/path' });
+    expect(newState.sections['/path'].complete).to.be.false;
+  });
+  it('should set the review status', () => {
+    const uiState = {
+      sections: {
+        '/path': {
+          complete: true
+        }
+      }
+    };
+    const newState = uiStateReducer(uiState, { type: UPDATE_REVIEW_STATUS, path: '/path', value: false });
+    expect(newState.sections['/path'].complete).to.be.false;
+  });
+  it('should set the verified status', () => {
+    const uiState = {
+      sections: {
+        '/path': {
+          verified: true
+        }
+      }
+    };
+    const newState = uiStateReducer(uiState, { type: UPDATE_VERIFIED_STATUS, path: '/path', value: false });
+    expect(newState.sections['/path'].verified).to.be.false;
+  });
+  it('should set the submission status', () => {
+    const uiState = {
+      submission: {
+        status: false
+      }
+    };
+    const newState = uiStateReducer(uiState, { type: UPDATE_SUBMISSION_STATUS, value: true });
+    expect(newState.submission.status).to.be.true;
+  });
+  it('should set the submission id', () => {
+    const uiState = {
+      submission: {
+        id: false
+      }
+    };
+    const newState = uiStateReducer(uiState, { type: UPDATE_SUBMISSION_ID, value: 'idnumber' });
+    expect(newState.submission.id).to.equal('idnumber');
+  });
+  it('should set the submission timestamp', () => {
+    const uiState = {
+      submission: {
+        timestamp: false
+      }
+    };
+    const newState = uiStateReducer(uiState, { type: UPDATE_SUBMISSION_TIMESTAMP, value: '2016-05-24T00:00:00' });
+    expect(newState.submission.timestamp).to.equal('2016-05-24T00:00:00');
+  });
+});


### PR DESCRIPTION
Closes #2821

This has the Nav component, based on the navigation for hca. Should look exactly the same, but with different panels/sections.

I refactored how it was working in hca in a few ways:
1. It's not directly connected to the Redux store and gets all of the data for the sections from props. This makes the unit tests much easier and less brittle.
2. I pulled the actual form configuration (the panel names, grouping, etc) out of the component and put in the Redux store. This might be overkill, but it also simplifies testing. It also makes it easier to respond to changes in the form layout (which I expect we'll have), since those are not mixed up in JSX and most of that config is in the uiState reducer now. It also means we could use the same Nav component for hca and edu-benefits. I should note that this isn't something that Redux encourages or discourages, I just thought it was cleaner overall.
3. I copied the `hca-process` styles to a `form-process` class and put in the sass modules folder. 

I also fixed something with the eslint config that was merged incorrectly and cleaned up some linting errors.
