### PR TITLE
TrackPackageLink Component

### DIFF
--- a/src/js/rx/components/AlertBox.jsx
+++ b/src/js/rx/components/AlertBox.jsx
@@ -8,11 +8,11 @@ class AlertBox extends React.Component {
       return <div/>;
     }
 
-    let alertClass = classNames({
-      'rx-alert': true,
-      'usa-alert': true,
-      [`usa-alert-${this.props.status}`]: true
-    });
+    const alertClass = classNames(
+      'rx-alert',
+      'usa-alert',
+      `usa-alert-${this.props.status}`
+    );
 
     let closeButton;
     if (this.props.onCloseAlert) {

--- a/src/js/rx/components/Prescription.jsx
+++ b/src/js/rx/components/Prescription.jsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router';
 
 import MessageProviderLink from './MessageProviderLink';
 import RefillsRemainingCounter from './RefillsRemainingCounter';
+import TrackPackageLink from './TrackPackageLink';
 import SubmitButton from './SubmitButton';
 
 class Prescription extends React.Component {
@@ -31,8 +32,11 @@ class Prescription extends React.Component {
     }
 
     if (trackable) {
-      // TODO: Replace this with a component.
-      action = <a className="usa-button">Track package</a>;
+      action = (
+        <TrackPackageLink
+            className="usa-button"
+            text="Track package"/>
+      );
     } else {
       action = <div className="rx-prescription-refill-requested">Refill requested</div>;
     }

--- a/src/js/rx/components/TrackPackageLink.jsx
+++ b/src/js/rx/components/TrackPackageLink.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import classNames from 'classnames';
+
+class TrackPackageLink extends React.Component {
+  render() {
+    const linkClass = classNames(
+      'rx-track-package-link',
+      this.props.className
+    );
+
+    return (
+      <a
+          className={linkClass}
+          rel="noopener noreferrer"
+          target="_blank">
+        {this.props.text}
+      </a>
+    );
+  }
+}
+
+TrackPackageLink.propTypes = {
+  text: React.PropTypes.string.isRequired
+}
+
+export default TrackPackageLink;

--- a/src/js/rx/components/TrackPackageLink.jsx
+++ b/src/js/rx/components/TrackPackageLink.jsx
@@ -22,6 +22,6 @@ class TrackPackageLink extends React.Component {
 
 TrackPackageLink.propTypes = {
   text: React.PropTypes.string.isRequired
-}
+};
 
 export default TrackPackageLink;

--- a/src/sass/rx/_partials/_rx-prescription-card.scss
+++ b/src/sass/rx/_partials/_rx-prescription-card.scss
@@ -33,13 +33,8 @@
 
   .rx-track-package-link {
     background: $color-primary;
-    border-radius: 3px;
-    color: #ffffff;
     display: block;
-    font-weight: bold;
     margin: 0;
-    text-align: center;
-    text-decoration: none;
   }
 }
 

--- a/src/sass/rx/_partials/_rx-prescription-card.scss
+++ b/src/sass/rx/_partials/_rx-prescription-card.scss
@@ -29,7 +29,18 @@
   // of .rx-prescription-count, .rx-prescription-action below
   padding: 2rem;
   position: relative;
-  height: 21.2rem;
+  height: 24.5rem;
+
+  .rx-track-package-link {
+    background: $color-primary;
+    border-radius: 3px;
+    color: #ffffff;
+    display: block;
+    font-weight: bold;
+    margin: 0;
+    text-align: center;
+    text-decoration: none;
+  }
 }
 
 .rx-prescription-title {


### PR DESCRIPTION
Closes #2599.

Also going to be used as a regular link under 'Tracking status' in OrderHistory and History page tables, so only styled it as a button in Rx card.

TBD: Link to actual tracking info.

Mock: https://marvelapp.com/1h10heg#14227006
## Preview

![screenshot from 2016-08-23 20 54 41](https://cloud.githubusercontent.com/assets/1067024/17914903/1ad4d7f0-6974-11e6-9e1c-084a974427d9.png)
