### PR TITLE
Remove fake data from History List

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "express": "^4.14.0",
     "express-history-api-fallback": "^2.0.0",
     "extract-text-webpack-plugin": "^1.0.1",
-    "faker": "^3.1.0",
     "file-loader": "^0.9.0",
     "font-awesome": "^4.6.3",
     "foundation-sites": "^5.5.3",

--- a/src/js/rx/containers/Active.jsx
+++ b/src/js/rx/containers/Active.jsx
@@ -6,11 +6,8 @@ import PrescriptionList from '../components/PrescriptionList';
 import PrintList from '../components/PrintList';
 import SortMenu from '../components/SortMenu';
 
-import { loadData } from '../actions/prescriptions.js';
-
 class Active extends React.Component {
   componentWillMount() {
-    this.props.dispatch(loadData());
     this.handleSortOnChange = this.handleSortOnChange.bind(this);
     this.handleSortOnClick = this.handleSortOnClick.bind(this);
     this.dispatchSortAction = this.dispatchSortAction.bind(this);

--- a/src/js/rx/containers/History.jsx
+++ b/src/js/rx/containers/History.jsx
@@ -1,35 +1,23 @@
 import React from 'react';
-import faker from 'faker';
-import moment from 'moment';
+import { connect } from 'react-redux';
+
 import { Table } from 'reactable';
 
 import PrintList from '../components/PrintList';
 import Pagination from '../components/Pagination';
 
-// Generate fake data.  TODO: Retrieve this from the actual API
-function createFakeData() {
-  return {
-    'Date prescribed': moment(faker.date.past()).format('ll'),
-    Medicine: faker.commerce.productName(),
-    'Last filled': moment(faker.date.past()).format('ll'),
-    Dosage: faker.random.number(),
-    Prescriber: `Dr. ${faker.name.findName()}`,
-    Status: 'Active'
-  };
-}
-
-const data = Array.from({ length: 400 }, createFakeData);
-
-
 class History extends React.Component {
   render() {
+    const items = this.props.prescriptions.items;
+
+    // TODO: replace reactable
     return (
       <div className="va-tab-content">
         <PrintList
             type="history"/>
         <Table
             className="usa-table-borderless rx-table"
-            data={data}
+            data={items}
             itemsPerPage={10}
             pageButtonLimit={20}/>
         <Pagination/>
@@ -38,4 +26,8 @@ class History extends React.Component {
   }
 }
 
-export default History;
+const mapStateToProps = (state) => {
+  return state;
+};
+
+export default connect(mapStateToProps)(History);

--- a/src/js/rx/containers/Main.jsx
+++ b/src/js/rx/containers/Main.jsx
@@ -3,12 +3,16 @@ import { connect } from 'react-redux';
 
 import { closeAlert } from '../actions/alert.js';
 import { closeDisclaimer } from '../actions/disclaimer.js';
+import { loadData } from '../actions/prescriptions.js';
 
 import AlertBox from '../components/AlertBox';
 import TabNav from '../components/TabNav';
 import Disclaimer from '../components/Disclaimer';
 
 class Main extends React.Component {
+  componentWillMount() {
+    this.props.loadData();
+  }
   render() {
     let alertBox;
 
@@ -44,5 +48,6 @@ const mapStateToProps = (state) => {
 
 export default connect(mapStateToProps, {
   closeAlert,
-  closeDisclaimer
+  closeDisclaimer,
+  loadData
 })(Main);


### PR DESCRIPTION
This PR does three things:
- Move the `loadData()` action into Main.jsx.  This way, it will load regardless if you're looking at Active or History.
- Replaces the fake data from faker with actual data from the API.
- Removes faker from package.json
