### PR TITLE
Add watch task for unit tests

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1605,6 +1605,11 @@
       "from": "ejs@>=0.8.3 <0.9.0",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-0.8.8.tgz"
     },
+    "element-dataset": {
+      "version": "1.3.0",
+      "from": "element-dataset@latest",
+      "resolved": "https://registry.npmjs.org/element-dataset/-/element-dataset-1.3.0.tgz"
+    },
     "emojis-list": {
       "version": "2.0.1",
       "from": "emojis-list@>=2.0.0 <3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "npm run test:unit && npm run test:e2e",
     "test:e2e": "./script/run-nightwatch.sh",
     "test:unit": "mocha --recursive 'test/**/*.unit.spec.js?(x)' ",
+    "test:watch": "mocha --watch --recursive 'test/**/*.unit.spec.js?(x)' ",
     "watch": "node script/build.js --watch"
   },
   "repository": {
@@ -45,6 +46,7 @@
     "css-loader": "^0.23.1",
     "dataset": "^0.3.1",
     "dirty-chai": "^1.2.2",
+    "element-dataset": "^1.3.0",
     "eslint": "^2.2.0",
     "eslint-config-airbnb": "^7.0.0",
     "eslint-plugin-jsx-a11y": "^0.6.2",

--- a/test/util/unit-helpers.js
+++ b/test/util/unit-helpers.js
@@ -1,6 +1,8 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import jsdom from 'jsdom';
+import polyfillDataset from 'element-dataset';
+
 chai.use(chaiAsPromised);
 
 const expect = chai.expect;
@@ -15,72 +17,8 @@ function setupJSDom() {
   global.document = doc;
   global.window = win;
   global.navigator = win.navigator;
+
+  polyfillDataset();
 }
-
-/**
- * Convert data-attr into key
- * data-foo-bar -> fooBar
- * @param {String} val
- * @returns {String}
- */
-const _attrToDataKey = function attrToDataKeyFn(val) {
-  const out = val.substr(5);
-  return out.split('-').map((part, inx) => {
-    if (!inx) {
-      return part;
-    }
-    return part.charAt(0).toUpperCase() + part.substr(1);
-  }).join('');
-};
-
-let _datasetProxy = null;
-
- /**
- * Produce dataset object emulating behavior of el.dataset
- * @param {Element} el
- * @returns {Object}
- */
-const _getNodeDataAttrs = function getNodeDataAttrsFn(el) {
-  let i = 0;
-  const atts = el.attributes;
-  const len = atts.length;
-  let attr;
-  const _datasetMap = [];
-  // represents el.dataset
-  const proxy = {};
-  let datakey;
-
-  for (i = 0; i < len; i++) {
-    attr = atts[i].nodeName;
-    if (attr.indexOf('data-') === 0) {
-      datakey = _attrToDataKey(attr);
-      if (typeof _datasetMap[datakey] !== 'undefined') {
-        break;
-      }
-      _datasetMap[datakey] = atts[i].nodeValue;
-      /* eslint-disable no-loop-func */
-      Object.defineProperty(proxy, datakey, {
-        enumerable: true,
-        configurable: true,
-        get() {
-          return _datasetMap[datakey];
-        },
-        set(val) {
-          _datasetMap[datakey] = val;
-          el.setAttribute(attr, val);
-        }
-      });
-      /* eslint-enable no-loop-func */
-    }
-  }
-  return proxy;
-};
-
-Object.defineProperty(global.window.Element.prototype, 'dataset', {
-  get() {
-    _datasetProxy = _datasetProxy || _getNodeDataAttrs(this);
-    return _datasetProxy;
-  }
-});
 
 export { chai, expect, setupJSDom };


### PR DESCRIPTION
This adds an npm run script for Mocha's watch option, so you can have unit tests automatically re-run after making a change.

To get this to work, I had to replace the dataset polyfill in unit-helpers.js with a polyfill from npm. It's not used in any production code.
