### PR TITLE
Playbook: Remove liquid tag that doesn't work

### DIFF
--- a/content/pages/playbook/index.html
+++ b/content/pages/playbook/index.html
@@ -6,13 +6,6 @@ body_class: page-playbook
 layout: page-playbook.html
 ---
 
-<!-- Add a comment showing production vs staging for easy verification of deploy sanity. -->
-{% if site.production %}
-<!-- Production -->
-{% else %}
-<!-- Staging -->
-{% endif %}
-
 <div class="main" role="main">
   <div class="section primary">
     <div class="tagline-content">


### PR DESCRIPTION
Not sure if this tag is still wanted for some reason or not, but it definitely does not work ATM. Does anyone know the history here?

Fixes #2896 
