### PR TITLE
Veteran information page

### DIFF
--- a/src/js/common/components/form-elements/DateInput.jsx
+++ b/src/js/common/components/form-elements/DateInput.jsx
@@ -85,7 +85,7 @@ class DateInput extends React.Component {
     // Calculate required.
     let requiredSpan = undefined;
     if (this.props.required) {
-      requiredSpan = <span className="hca-required-span">*</span>;
+      requiredSpan = <span className="form-required-span">*</span>;
     }
 
     return (
@@ -97,7 +97,7 @@ class DateInput extends React.Component {
         {errorSpan}
         <div className={isValid ? undefined : 'usa-input-error'}>
           <div className="usa-date-of-birth row">
-            <div className="hca-datefield-month">
+            <div className="form-datefield-month">
               <ErrorableSelect errorMessage={isValid ? undefined : ''}
                   label="Month"
                   name={`${this.props.name}Month`}
@@ -105,7 +105,7 @@ class DateInput extends React.Component {
                   value={this.props.month}
                   onValueChange={(update) => {this.handleChange('month', update);}}/>
             </div>
-            <div className="hca-datefield-day">
+            <div className="form-datefield-day">
               <ErrorableSelect errorMessage={isValid ? undefined : ''}
                   label="Day"
                   name={`${this.props.name}Day`}

--- a/src/js/common/components/form-elements/ErrorableTextInput.jsx
+++ b/src/js/common/components/form-elements/ErrorableTextInput.jsx
@@ -71,7 +71,7 @@ class ErrorableTextInput extends React.Component {
     // Calculate required.
     let requiredSpan = undefined;
     if (this.props.required) {
-      requiredSpan = <span className="hca-required-span">*</span>;
+      requiredSpan = <span className="form-required-span">*</span>;
     }
 
     return (

--- a/src/js/common/components/questions/Gender.jsx
+++ b/src/js/common/components/questions/Gender.jsx
@@ -12,10 +12,18 @@ import { validateIfDirty, isNotBlank } from '../../utils/validations';
  */
 class Gender extends React.Component {
   render() {
+    let isValid;
+
+    if (this.props.required) {
+      isValid = validateIfDirty(this.props.value, isNotBlank);
+    } else {
+      isValid = true;
+    }
+
     return (
       <div>
         <ErrorableSelect required={this.props.required}
-            errorMessage={validateIfDirty(this.props.value, isNotBlank) ? undefined : 'Please select a gender'}
+            errorMessage={isValid ? undefined : 'Please select a gender'}
             label="Gender"
             name="gender"
             options={genders}

--- a/src/js/edu-benefits/components/NavButtons.jsx
+++ b/src/js/edu-benefits/components/NavButtons.jsx
@@ -91,7 +91,7 @@ export default class NavButtons extends React.Component {
       }
 
       buttons = (<div>
-        <div className="row progress-buttons">
+        <div className="row form-progress-buttons">
           <div className="small-6 medium-5 columns">
             {backButton}
           </div>
@@ -110,7 +110,7 @@ export default class NavButtons extends React.Component {
       </div>);
     } else if (path === '/submit-message') {
       buttons = (
-        <div className="row progress-buttons">
+        <div className="row form-progress-buttons">
           <div className="small-6 medium-5 columns">
             <a href="/">
               <button className="usa-button-primary">Back to Main Page</button>
@@ -120,7 +120,7 @@ export default class NavButtons extends React.Component {
       );
     } else if (path === '/introduction') {
       buttons = (
-        <div className="row progress-buttons">
+        <div className="row form-progress-buttons">
           <div className="small-6 medium-5 columns">
             <ProgressButton
                 onButtonClick={goForward}
@@ -132,7 +132,7 @@ export default class NavButtons extends React.Component {
       );
     } else {
       buttons = (
-        <div className="row progress-buttons">
+        <div className="row form-progress-buttons">
           <div className="small-6 medium-5 columns">
             {backButton}
           </div>

--- a/src/js/edu-benefits/components/veteran-information/PersonalInformationFields.jsx
+++ b/src/js/edu-benefits/components/veteran-information/PersonalInformationFields.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import DateInput from '../../../common/components/form-elements/DateInput';
+import FullName from '../../../common/components/questions/FullName';
+import SocialSecurityNumber from '../../../common/components/questions/SocialSecurityNumber';
+import Gender from '../../../common/components/questions/Gender';
+
+export default class PersonalInformationFields extends React.Component {
+  render() {
+    return (
+      <fieldset>
+        <p>(<span className="form-required-span">*</span>) Indicates a required field</p>
+        <p>Personal Information</p>
+        <div className="input-section">
+          <FullName required
+              name={this.props.data.veteranFullName}
+              onUserInput={(update) => {this.props.onStateChange('veteranFullName', update);}}/>
+          <SocialSecurityNumber required
+              ssn={this.props.data.veteranSocialSecurityNumber}
+              onValueChange={(update) => {this.props.onStateChange('veteranSocialSecurityNumber', update);}}/>
+          <DateInput required
+              name="veteranBirth"
+              day={this.props.data.veteranDateOfBirth.day}
+              month={this.props.data.veteranDateOfBirth.month}
+              year={this.props.data.veteranDateOfBirth.year}
+              onValueChange={(update) => {this.props.onStateChange('veteranDateOfBirth', update);}}/>
+          <Gender
+              value={this.props.data.gender}
+              onUserInput={(update) => {this.props.onStateChange('gender', update);}}/>
+        </div>
+      </fieldset>
+    );
+  }
+}
+
+PersonalInformationFields.propTypes = {
+  onStateChange: React.PropTypes.func.isRequired,
+  data: React.PropTypes.object.isRequired
+};

--- a/src/js/edu-benefits/containers/veteran-information/PersonalInformationPage.jsx
+++ b/src/js/edu-benefits/containers/veteran-information/PersonalInformationPage.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { connect } from 'react-redux';
+
+import PersonalInformationFields from '../../components/veteran-information/PersonalInformationFields';
+
+import { veteranUpdateField } from '../../actions/index';
+
+class PersonalInformationPage extends React.Component {
+  render() {
+    const { section, data, onStateChange } = this.props;
+
+    return (
+      <div className="form-panel">
+        <PersonalInformationFields data={data} section={section} onStateChange={onStateChange}/>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  return {
+    data: state.veteran,
+    section: state.uiState.sections[ownProps.location.pathname],
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onStateChange(field, update) {
+      dispatch(veteranUpdateField(field, update));
+    }
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(PersonalInformationPage);
+export { PersonalInformationPage };

--- a/src/js/edu-benefits/reducers/uiState/index.js
+++ b/src/js/edu-benefits/reducers/uiState/index.js
@@ -71,7 +71,7 @@ const ui = {
     '/veteran-information/personal-information': {
       complete: false,
       verified: false,
-      fields: []
+      fields: ['veteranFullName', 'veteranSocialSecurityNumber', 'veteranDateOfBirth', 'gender']
     },
     '/veteran-information/address': {
       complete: false,

--- a/src/js/edu-benefits/reducers/veteran/index.js
+++ b/src/js/edu-benefits/reducers/veteran/index.js
@@ -1,14 +1,27 @@
 import _ from 'lodash/fp';
 
 import { VETERAN_FIELD_UPDATE, ENSURE_FIELDS_INITIALIZED } from '../../actions';
-import { makeField } from '../../../common/model/fields';
+import { makeField, dirtyAllFields } from '../../../common/model/fields';
 
 const blankVeteran = {
   benefitsRelinquished: makeField(''),
   chapter30: false,
   chapter1606: false,
   chapter32: false,
-  chapter33: false
+  chapter33: false,
+  veteranFullName: {
+    first: makeField(''),
+    middle: makeField(''),
+    last: makeField(''),
+    suffix: makeField(''),
+  },
+  veteranSocialSecurityNumber: makeField(''),
+  veteranDateOfBirth: {
+    month: makeField(''),
+    day: makeField(''),
+    year: makeField(''),
+  },
+  gender: makeField(''),
 };
 
 export default function veteran(state = blankVeteran, action) {
@@ -17,11 +30,21 @@ export default function veteran(state = blankVeteran, action) {
       return _.set(action.propertyPath, action.value, state);
     }
     case ENSURE_FIELDS_INITIALIZED: {
-      return action.fields.reduce((vet, field) => {
-        return _.isObject(vet[field]) ?
-          _.set([field, 'dirty'], true, vet) :
-          vet;
-      }, state);
+      const newState = Object.assign({}, state);
+
+      if (action.parentNode) {
+        action.fields.map((field) => {
+          Object.assign(newState[action.parentNode][0][field], dirtyAllFields(newState[action.parentNode][0][field]));
+          return newState;
+        });
+      } else {
+        action.fields.map((field) => {
+          Object.assign(newState[field], dirtyAllFields(newState[field]));
+          return newState;
+        });
+      }
+
+      return newState;
     }
     default:
       return state;

--- a/src/js/edu-benefits/routes.jsx
+++ b/src/js/edu-benefits/routes.jsx
@@ -5,6 +5,7 @@ import { chapterNames, groupPagesIntoChapters, getPageList } from './utils/helpe
 
 import IntroductionSection from './containers/IntroductionSection.jsx';
 import BenefitsSelection from './containers/BenefitsSelection';
+import PersonalInformationPage from './containers/veteran-information/PersonalInformationPage';
 import PlaceholderSection from './containers/PlaceholderSection';
 
 const routes = [
@@ -14,7 +15,7 @@ const routes = [
       key="/introduction"
       path="/introduction"/>,
   <Route
-      component={PlaceholderSection}
+      component={PersonalInformationPage}
       key="/veteran-information/personal-information"
       path="/veteran-information/personal-information"
       chapter={chapterNames.veteranInformation}

--- a/src/js/edu-benefits/utils/validations.js
+++ b/src/js/edu-benefits/utils/validations.js
@@ -223,7 +223,9 @@ function isValidMarriageDate(date, dateOfBirth, spouseDateOfBirth) {
 }
 
 function isValidPersonalInfoSection(data) {
-  return isValidFullNameField(data.veteranFullName);
+  return isValidFullNameField(data.veteranFullName) &&
+      isValidRequiredField(isValidSSN, data.veteranSocialSecurityNumber) &&
+      isValidDateField(data.veteranDateOfBirth);
 }
 
 function isValidBirthInformationSection(data) {
@@ -387,18 +389,20 @@ function isValidServiceInformation(data) {
       isNotBlank(data.dischargeType.value);
 }
 
-function isBenefitsInformationSectionValid(data) {
+function isValidBenefitsInformationSection(data) {
   return !data.chapter33 || isNotBlank(data.benefitsRelinquished.value);
 }
 
 function isValidForm(data) {
-  return isBenefitsInformationSectionValid(data);
+  return isValidBenefitsInformationSection(data);
 }
 
 function isValidSection(completePath, sectionData) {
   switch (completePath) {
+    case '/veteran-information/personal-information':
+      return isValidPersonalInfoSection(sectionData);
     case '/benefits-eligibility/benefits-selection':
-      return isBenefitsInformationSectionValid(sectionData);
+      return isValidBenefitsInformationSection(sectionData);
     default:
       return true;
   }

--- a/src/js/hca/components/HealthCareApp.jsx
+++ b/src/js/hca/components/HealthCareApp.jsx
@@ -232,7 +232,7 @@ class HealthCareApp extends React.Component {
 
     if (this.props.location.pathname === '/review-and-submit') {
       buttons = (<div>
-        <div className="row progress-buttons">
+        <div className="row form-progress-buttons">
           <div className="small-6 medium-5 columns">
             {backButton}
           </div>
@@ -251,7 +251,7 @@ class HealthCareApp extends React.Component {
       </div>);
     } else if (this.props.location.pathname === '/introduction') {
       buttons = (
-        <div className="row progress-buttons">
+        <div className="row form-progress-buttons">
           <div className="small-6 medium-5 columns">
             <ProgressButton
                 onButtonClick={this.handleContinue}
@@ -263,7 +263,7 @@ class HealthCareApp extends React.Component {
       );
     } else if (this.props.location.pathname === '/submit-message') {
       buttons = (
-        <div className="row progress-buttons">
+        <div className="row form-progress-buttons">
           <div className="small-6 medium-5 columns">
             {/* TODO: Figure out where this button should take the user. */}
             <a href="/">
@@ -274,7 +274,7 @@ class HealthCareApp extends React.Component {
       );
     } else {
       buttons = (
-        <div className="row progress-buttons">
+        <div className="row form-progress-buttons">
           <div className="small-6 medium-5 columns">
             {backButton}
           </div>

--- a/src/sass/hca.scss
+++ b/src/sass/hca.scss
@@ -44,10 +44,6 @@ legend {
   text-align: center;
 }
 
-.row.progress-buttons {
-  max-width: 47rem;
-}
-
 button.short {
   font-weight: 500;
   padding: 1rem;

--- a/src/sass/modules/_m-button.scss
+++ b/src/sass/modules/_m-button.scss
@@ -13,3 +13,7 @@ button,
     background-color: $color-primary-darkest;
   }
 }
+
+.row.form-progress-buttons {
+  max-width: 47rem;
+}


### PR DESCRIPTION
The first page in the veteran information chapter. Built from wireframes here: https://app.moqups.com/greg@adhocteam.us/l32hJ36b/view/page/a3c1b5b8f

Need feedback on a couple of things in particular:
1. @jbalboni I changed the `ensureFieldsInitialized` reducer back to what we had for HCA because I was having trouble getting the education version working (due to nested veteran object). But happy to optimize it once we can make sure it works.
2. @cweber are there too many questions on this page? You need to scroll before you see the Continue button, and something we tried to do on HCA is keep each section as short as possible. We can always figure this out later, just something to keep in mind.

![personalinformationpage](https://cloud.githubusercontent.com/assets/3886085/18175364/0c92a650-703f-11e6-8627-484602c7e2e6.png)
