### PR TITLE
Updates to match mocks

### DIFF
--- a/src/js/rx/components/OrderHistory.jsx
+++ b/src/js/rx/components/OrderHistory.jsx
@@ -11,7 +11,7 @@ class OrderHistory extends React.Component {
         <td>
           Shipped on {moment(
             attrs['shipped-date']
-          ).format('MMM D, YYYY')}
+          ).format('MMM DD, YYYY')}
         </td>
         <td>
           <TrackPackageLink

--- a/src/js/rx/components/Prescription.jsx
+++ b/src/js/rx/components/Prescription.jsx
@@ -38,8 +38,7 @@ class Prescription extends React.Component {
         if (attrs['is-trackable'] === true) {
           action.push(<TrackPackageLink
               className="usa-button"
-              text="Track package"/>
-          );
+              text="Track package"/>);
         } else {
           action.push((
             <div className="rx-prescription-refill-requested">

--- a/src/js/rx/components/Prescription.jsx
+++ b/src/js/rx/components/Prescription.jsx
@@ -18,15 +18,18 @@ class Prescription extends React.Component {
 
     if (attrs['is-refillable'] === true) {
       action.push(<SubmitButton
+          key={`rx-${id}-refill`}
           cssClass="usa-button-outline rx-prescription-button"
           value={id}
           text="Refill Prescription"/>);
     } else {
-      const callProvider = <div>Call Provider</div>;
+      const callProvider = <div key={`rx-${id}-call`}>Call Provider</div>;
 
       if (status !== 'active') {
         action.push((
-          <div className="rx-prescription-status">
+          <div
+              key={`rx-${id}-status`}
+              className="rx-prescription-status">
             {rxStatuses[status]}
           </div>
         ));
@@ -37,11 +40,14 @@ class Prescription extends React.Component {
       } else {
         if (attrs['is-trackable'] === true) {
           action.push(<TrackPackageLink
+              key={`rx-${id}-track`}
               className="usa-button"
               text="Track package"/>);
         } else {
           action.push((
-            <div className="rx-prescription-refill-requested">
+            <div
+                key={`rx-${id}-requested`}
+                className="rx-prescription-refill-requested">
               Refill requested
             </div>
           ));
@@ -54,9 +60,7 @@ class Prescription extends React.Component {
     }
 
     return (
-      <div className="rx-prescription"
-          key={id}
-          id={`rx-${id}`}>
+      <div className="rx-prescription" id={`rx-${id}`}>
         <div className="rx-prescription-inner cf">
           <h3 className="rx-prescription-title" title={name}>
             <Link to={`/rx/prescription/${id}`}>

--- a/src/js/rx/components/Prescription.jsx
+++ b/src/js/rx/components/Prescription.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import moment from 'moment';
-
 import { Link } from 'react-router';
+import moment from 'moment';
 
 import { rxStatuses } from '../config.js';
 import RefillsRemainingCounter from './RefillsRemainingCounter';
@@ -13,7 +12,7 @@ class Prescription extends React.Component {
     const attrs = this.props.attributes;
     const id = this.props.id;
     const name = attrs['prescription-name'];
-    const remaining = attrs['refill-remaining'];
+    const status = attrs['refill-status'];
 
     let action = [];
 
@@ -24,24 +23,31 @@ class Prescription extends React.Component {
     } else {
       const callProvider = <div>Call Provider</div>;
 
-      if (attrs['refill-status'] !== 'active') {
-        action.push(<div className="rx-prescription-status">{rxStatuses[attrs['refill-status']]}</div>);
+      if (status !== 'active') {
+        action.push((
+          <div className="rx-prescription-status">
+            {rxStatuses[status]}
+          </div>
+        ));
 
-        if (attrs['refill-status'] !== 'submitted') {
+        if (status !== 'submitted') {
           action.push(callProvider);
         }
       } else {
         if (attrs['is-trackable'] === true) {
           action.push(<TrackPackageLink
               className="usa-button"
-              text="Track package"/>);
+              text="Track package"/>
+          );
         } else {
-          action.push(<div
-              className="rx-prescription-refill-requested">Refill
-          requested</div>);
+          action.push((
+            <div className="rx-prescription-refill-requested">
+              Refill requested
+            </div>
+          ));
         }
 
-        if (remaining === 0) {
+        if (attrs['refill-remaining'] === 0) {
           action.push(callProvider);
         }
       }
@@ -70,7 +76,7 @@ class Prescription extends React.Component {
             Facility name: {attrs['facility-name']}
           </div>
           <div className="rx-prescription-refilled">
-            Last filled date: {moment(attrs['refill-date']).format('ll')}
+            Last fill date: {moment(attrs['dispensed-date']).format('ll')}
           </div>
           <div className="rx-prescription-countaction">
             <RefillsRemainingCounter

--- a/src/js/rx/components/Prescription.jsx
+++ b/src/js/rx/components/Prescription.jsx
@@ -64,13 +64,13 @@ class Prescription extends React.Component {
             </Link>
           </h3>
           <div className="rx-prescription-number">
-            Prescription <abbr title="number">#</abbr>: {attrs['prescription-id']}
+            Prescription <abbr title="number">#</abbr>: {id}
           </div>
           <div className="rx-prescription-facility">
             Facility name: {attrs['facility-name']}
           </div>
           <div className="rx-prescription-refilled">
-            Last fill date: {moment(attrs['dispensed-date']).format('ll')}
+            Last fill date: {moment(attrs['dispensed-date']).format('L')}
           </div>
           <div className="rx-prescription-countaction">
             <RefillsRemainingCounter

--- a/src/js/rx/containers/Detail.jsx
+++ b/src/js/rx/containers/Detail.jsx
@@ -48,8 +48,12 @@ class Detail extends React.Component {
               {status}
             </a>
           ),
-          'Last fill date': moment(attrs['dispensed-date']).format('ll'),
-          'Expiration date': moment(attrs['expiration-date']).format('ll'),
+          'Last fill date': moment(
+              attrs['dispensed-date']
+            ).format('MMM DD, YYYY'),
+          'Expiration date': moment(
+              attrs['expiration-date']
+            ).format('MMM DD, YYYY'),
           'Prescription #': attrs['prescription-number'],
           Refills: (
             <span>

--- a/src/js/rx/containers/Detail.jsx
+++ b/src/js/rx/containers/Detail.jsx
@@ -2,14 +2,13 @@ import React from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
 
-import { glossary } from '../config.js';
 import { loadData } from '../actions/prescriptions.js';
 import { openGlossaryModal } from '../actions/modal.js';
-
 import BackLink from '../components/BackLink';
 import ContactCard from '../components/ContactCard';
 import OrderHistory from '../components/OrderHistory';
 import TableVerticalHeader from '../components/tables/TableVerticalHeader';
+import { glossary, rxStatuses } from '../config.js';
 
 class Detail extends React.Component {
   componentWillMount() {
@@ -41,17 +40,13 @@ class Detail extends React.Component {
         const attrs = item.rx.attributes;
         const data = {
           Quantity: attrs.quantity,
-          // 'Prescription status': attrs[''],
-          'Prescription date': moment(
-              attrs['refill-submit-date']
-            ).format('D MMM YYYY'),
-          'Expiration date': moment(
-              attrs['expiration-date']
-            ).format('D MMM YYYY'),
+          'Prescription status': rxStatuses[attrs['refill-status']],
+          'Last fill date': moment(attrs['dispensed-date']).format('ll'),
+          'Expiration date': moment(attrs['expiration-date']).format('ll'),
           'Prescription #': attrs['prescription-number'],
           Refills: (
             <span>
-              {attrs['refill-remaining']} left
+              {attrs['refill-remaining']} remaining
               <a className="rx-refill-link">Refill prescription</a>
             </span>
           )

--- a/src/js/rx/containers/Detail.jsx
+++ b/src/js/rx/containers/Detail.jsx
@@ -11,16 +11,21 @@ import TableVerticalHeader from '../components/tables/TableVerticalHeader';
 import { glossary, rxStatuses } from '../config.js';
 
 class Detail extends React.Component {
-  componentWillMount() {
-    this.props.dispatch(loadData(this.props.params.id));
-    this.getGlossaryTerm = this.getGlossaryTerm.bind(this);
+  constructor(props) {
+    super(props);
+    this.openGlossaryModal = this.openGlossaryModal.bind(this);
   }
 
-  // Returns an object containing the glossary term we're seeking.
-  getGlossaryTerm(list, term) {
-    return list.filter((object) => {
-      return object.term === term;
+  componentWillMount() {
+    this.props.dispatch(loadData(this.props.params.id));
+  }
+
+  openGlossaryModal(term) {
+    const content = glossary.filter((obj) => {
+      return obj.term === term;
     });
+
+    this.props.dispatch(openGlossaryModal(content));
   }
 
   render() {
@@ -30,17 +35,19 @@ class Detail extends React.Component {
     let orderHistory;
 
     const item = this.props.prescriptions.currentItem;
-    // TODO: Replace this with the refill status
-    // const glossaryTerm = this.getGlossaryTerm(glossary, item.attributes.status);
-    const glossaryTerm = this.getGlossaryTerm(glossary, 'Discontinued');
 
     if (item) {
       // Compose components from Rx data.
       if (item.rx) {
         const attrs = item.rx.attributes;
+        const status = rxStatuses[attrs['refill-status']];
         const data = {
           Quantity: attrs.quantity,
-          'Prescription status': rxStatuses[attrs['refill-status']],
+          'Prescription status': (
+            <a onClick={() => this.openGlossaryModal(status)}>
+              {status}
+            </a>
+          ),
           'Last fill date': moment(attrs['dispensed-date']).format('ll'),
           'Expiration date': moment(attrs['expiration-date']).format('ll'),
           'Prescription #': attrs['prescription-number'],
@@ -96,11 +103,6 @@ class Detail extends React.Component {
         {rxInfo}
         {contactCard}
         {orderHistory}
-        <p>
-          <button
-              onClick={() => {this.props.dispatch(openGlossaryModal(glossaryTerm));}}
-              type="button"
-              value="Discontinued">Discontinued</button></p>
       </div>
     );
   }


### PR DESCRIPTION
Closes #2878, #2929.
- Detail page includes status (which pops up the glossary modal) and last fill date.
- Rx card displays last fill date using `dispensedDate`.
- Date formats are same as mocks.
## Mocks

Desktop: https://marvelapp.com/1h10heg#14227011
Mobile: https://marvelapp.com/iaa9b9#14368789
