### PR TITLE
Changing this.props.refill.content to this.props.refill.prescription

### DIFF
--- a/src/js/rx/containers/RxRefillsApp.jsx
+++ b/src/js/rx/containers/RxRefillsApp.jsx
@@ -13,7 +13,7 @@ class RxRefillsApp extends React.Component {
       <div>
         {this.props.children}
         <ConfirmRefillModal
-            {...this.props.modal.refill.content}
+            {...this.props.modal.refill.prescription}
             isVisible={this.props.modal.refill.visible}
             openAlert={this.props.openAlert}
             onCloseModal={this.props.closeRefillModal}/>


### PR DESCRIPTION
For confirmation modal. Fixes the last issue from #2977.

Work on #2630 
