### PR TITLE
E2E and accessibility tests use prod build type properly

### DIFF
--- a/script/travis-build.sh
+++ b/script/travis-build.sh
@@ -36,10 +36,12 @@ npm run lint
 
 if [[ $TRAVIS_BRANCH == 'staging' || $TRAVIS_BRANCH == 'production' ]]
 then
-  npm run build -- --buildtype production;
+  export BUILDTYPE=production;
 else
-  npm run build;
+  export BUILDTYPE=development;
 fi
+
+npm run build -- --buildtype $BUILDTYPE;
 
 # And run the selected test suite
 


### PR DESCRIPTION
The BUILDTYPE env is used to determine which content the test
server serves during e2e and accessibility tests. While the production
build type was used for the build command, the BUILDTYPE defaulted
to development, causing the test server to serve content that didn't
exist, which in turn caused these tests to fail.

This change sets BUILDTYPE appropriately.
