### PR TITLE
Update prescriptions API url

### DIFF
--- a/script/build.js
+++ b/script/build.js
@@ -211,14 +211,13 @@ if (options.watch) {
     // Check to see if we have a proxy config file
     const api = require('../config/config.proxy.js').api;
     devServerConfig.proxy = {
-      '/rx-api/*': {
+      '/api/v0/prescriptions*': {
         target: `https://${api.host}/`,
         auth: api.auth,
         secure: true,
         changeOrigin: true,
         rewrite: function rewrite(req) {
           /* eslint-disable no-param-reassign */
-          req.url = req.url.replace(/rx-api/, api.path);
           req.headers.host = api.host;
           /* eslint-enable no-param-reassign */
           return;

--- a/src/js/rx/actions/prescriptions.js
+++ b/src/js/rx/actions/prescriptions.js
@@ -1,8 +1,11 @@
 import _ from 'lodash';
 
+// TODO: move this into a separate config file
+const apiUrl = '/api/v0/prescriptions';
+
 export function loadPrescription(id) {
   if (id) {
-    const rxUrl = `/rx-api/prescriptions/${id}`;
+    const rxUrl = `${apiUrl}/${id}`;
     const rxUrls = [rxUrl, `${rxUrl}/trackings`];
 
     // Fetch both the prescription and its tracking history and
@@ -28,7 +31,7 @@ export function loadPrescription(id) {
 }
 
 export function loadPrescriptions(options) {
-  let uri = '/rx-api/prescriptions';
+  let uri = apiUrl;
   const queries = [];
 
   // Construct segments of the final URI based on options passed in.
@@ -73,7 +76,7 @@ export function loadPrescriptions(options) {
 
 export function refillPrescription(id) {
   if (id) {
-    const uri = `/rx-api/prescriptions/${id}/refill`;
+    const uri = `${apiUrl}/${id}/refill`;
 
     return dispatch => fetch(uri, {
       method: 'PATCH'


### PR DESCRIPTION
This updates the prescriptions API to look more like it does on production.  This will mean that it will work regardless of where it is deployed.
