### PR TITLE
[SM] Thread page and Message component

### DIFF
--- a/src/js/messaging/actions/messages.js
+++ b/src/js/messaging/actions/messages.js
@@ -1,0 +1,15 @@
+export const FETCH_THREAD_SUCCESS = 'FETCH_THREAD_SUCCESS';
+export const FETCH_THREAD_FAILURE = 'FETCH_THREAD_FAILURE';
+
+const baseUri = 'http://mock-prescriptions-api.herokuapp.com/v0/messaging/health/messages';
+
+export function fetchThread(id = 12345) {
+  return dispatch => {
+    fetch(`${baseUri}/${id}/thread`)
+    .then(res => res.json())
+    .then(
+      data => dispatch({ type: FETCH_THREAD_SUCCESS, data }),
+      err => dispatch({ type: FETCH_THREAD_FAILURE, err })
+    );
+  };
+}

--- a/src/js/messaging/components/Message.jsx
+++ b/src/js/messaging/components/Message.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import moment from 'moment';
+
+class Message extends React.Component {
+  render() {
+    return (
+      <div className="messaging-thread-message">
+        <div className="messaging-message-sender">
+          {this.props.attrs.sender_name}
+        </div>
+        <div className="messaging-message-sent-date">
+          {
+            moment(
+              this.props.attrs.sent_date
+            ).format('DD MMM YYYY [@] HH[:]mm')
+          }
+        </div>
+        <div className="messaging-message-recipient">
+          to {this.props.attrs.recipient_name}
+        </div>
+        <p className="messaging-message-body">
+          {this.props.attrs.body}
+        </p>
+      </div>
+    );
+  }
+}
+
+Message.propTypes = {
+  attrs: React.PropTypes.shape({
+    // TODO: Remove when we switch to camel case.
+    // Lack of camel case makes eslint complain.
+    /* eslint-disable */
+    message_id: React.PropTypes.number.isRequired,
+    category: React.PropTypes.string.isRequired,
+    subject: React.PropTypes.string.isRequired,
+    body: React.PropTypes.string.isRequired,
+    attachment: React.PropTypes.bool.isRequired,
+    sent_date: React.PropTypes.string.isRequired,
+    sender_id: React.PropTypes.number.isRequired,
+    sender_name: React.PropTypes.string.isRequired,
+    recipient_id: React.PropTypes.number.isRequired,
+    recipient_name: React.PropTypes.string.isRequired,
+    read_receipt: React.PropTypes.oneOf(['READ', 'UNREAD']).isRequired
+    /* eslint-enable */
+  }).isRequired
+};
+
+export default Message;

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -8,7 +8,6 @@ class Folder extends React.Component {
     // TODO: When the API supports getting messages for any folder,
     // fetch the folder with the id from the URL.
     // const id = this.props.param.id
-    // this.props.dispatch(setCurrentFolder(id));
     this.props.dispatch(fetchFolder());
   }
 

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -13,7 +13,7 @@ class Folder extends React.Component {
   }
 
   render() {
-    const folder = this.props.folders.currentItem;
+    const folder = this.props.folder;
     let folderName;
     let folderMessages;
 
@@ -58,12 +58,10 @@ class Folder extends React.Component {
   }
 }
 
-Folder.propTypes = {
-};
-
-// TODO: fill this out
 const mapStateToProps = (state) => {
-  return state;
+  return {
+    folder: state.folders.currentItem
+  };
 };
 
 export default connect(mapStateToProps)(Folder);

--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -8,11 +8,11 @@ class Main extends React.Component {
   render() {
     return (
       <div>
-        <div id="main-nav">
+        <div id="messaging-nav">
           <ComposeButton/>
           <FolderNav folders={this.props.folders}/>
         </div>
-        <div id="main-content">
+        <div id="messaging-content">
           {this.props.children}
         </div>
       </div>

--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -6,13 +6,11 @@ import FolderNav from '../components/FolderNav';
 
 class Main extends React.Component {
   render() {
-    const folders = this.props.folders.items;
-
     return (
       <div>
         <div id="main-nav">
           <ComposeButton/>
-          <FolderNav folders={folders}/>
+          <FolderNav folders={this.props.folders}/>
         </div>
         <div id="main-content">
           {this.props.children}
@@ -26,9 +24,10 @@ Main.propTypes = {
   children: React.PropTypes.node
 };
 
-// TODO: fill this out
 const mapStateToProps = (state) => {
-  return state;
+  return {
+    folders: state.folders.items
+  };
 };
 
 export default connect(mapStateToProps)(Main);

--- a/src/js/messaging/containers/MessagingApp.jsx
+++ b/src/js/messaging/containers/MessagingApp.jsx
@@ -27,9 +27,4 @@ MessagingApp.propTypes = {
   children: React.PropTypes.node
 };
 
-// TODO: fill this out
-const mapStateToProps = (state) => {
-  return state;
-};
-
-export default connect(mapStateToProps)(MessagingApp);
+export default connect()(MessagingApp);

--- a/src/js/messaging/containers/Modal.jsx
+++ b/src/js/messaging/containers/Modal.jsx
@@ -8,11 +8,11 @@ class Modal extends React.Component {
   render() {
     return (
       <div>
-        <div id="main-nav">
+        <div id="messaging-nav">
           <ComposeButton/>
           <FolderNav folders={this.props.folders}/>
         </div>
-        <div id="main-content">
+        <div id="messaging-content">
           {this.props.children}
         </div>
       </div>

--- a/src/js/messaging/containers/Modal.jsx
+++ b/src/js/messaging/containers/Modal.jsx
@@ -6,13 +6,11 @@ import FolderNav from '../components/FolderNav';
 
 class Modal extends React.Component {
   render() {
-    const folders = this.props.folders.items;
-
     return (
       <div>
         <div id="main-nav">
           <ComposeButton/>
-          <FolderNav folders={folders}/>
+          <FolderNav folders={this.props.folders}/>
         </div>
         <div id="main-content">
           {this.props.children}
@@ -26,9 +24,10 @@ Modal.propTypes = {
   children: React.PropTypes.node
 };
 
-// TODO: fill this out
 const mapStateToProps = (state) => {
-  return state;
+  return {
+    folders: state.folders.items
+  };
 };
 
 export default connect(mapStateToProps)(Modal);

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -15,11 +15,16 @@ class Thread extends React.Component {
   render() {
     const thread = this.props.thread;
     let subject;
+    let messageCount;
     let messages;
 
     if (thread.length > 0) {
       subject = thread[0].subject;
       messages = thread.map((message, i) => <Message key={i} attrs={message}/>);
+
+      if (thread.length > 1) {
+        messageCount = <span> ({thread.length})</span>;
+      }
     }
 
     return (
@@ -29,7 +34,7 @@ class Thread extends React.Component {
           originally messaged. It may have been reassigned in an effort to
           address your question as effectively and efficiently as possible.
         </p>
-        <h2 className="messaging-thread-name">{subject}</h2>
+        <h2 className="messaging-thread-name">{subject}{messageCount}</h2>
         <div>
           {messages}
         </div>

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { fetchThread } from '../actions/messages';
+
+class Thread extends React.Component {
+  componentWillMount() {
+    // TODO: When the API supports getting any thread,
+    // fetch the thread with the id from the URL.
+    // const id = this.props.param.id
+    this.props.dispatch(fetchThread());
+  }
+
+  render() {
+    const thread = this.props.thread;
+    let subject;
+
+    if (thread.length > 0) {
+      subject = thread[0].subject;
+    }
+
+    return (
+      <div>
+        <p>
+          <strong>Note:</strong> This message may not be from the person you
+          originally messaged. It may have been reassigned in an effort to
+          address your question as effectively and efficiently as possible.
+        </p>
+        <h2>{subject}</h2>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    thread: state.messages.thread
+  };
+};
+
+export default connect(mapStateToProps)(Thread);

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -33,6 +33,9 @@ class Thread extends React.Component {
         <div>
           {messages}
         </div>
+        <div className="messaging-thread-reply">
+          <textarea placeholder="Click here to reply"/>
+        </div>
       </div>
     );
   }

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { fetchThread } from '../actions/messages';
+import Message from '../components/Message';
 
 class Thread extends React.Component {
   componentWillMount() {
@@ -14,19 +15,24 @@ class Thread extends React.Component {
   render() {
     const thread = this.props.thread;
     let subject;
+    let messages;
 
     if (thread.length > 0) {
       subject = thread[0].subject;
+      messages = thread.map((message, i) => <Message key={i} attrs={message}/>);
     }
 
     return (
       <div>
-        <p>
+        <p className="messaging-thread-note">
           <strong>Note:</strong> This message may not be from the person you
           originally messaged. It may have been reassigned in an effort to
           address your question as effectively and efficiently as possible.
         </p>
-        <h2>{subject}</h2>
+        <h2 className="messaging-thread-name">{subject}</h2>
+        <div>
+          {messages}
+        </div>
       </div>
     );
   }

--- a/src/js/messaging/reducers/index.js
+++ b/src/js/messaging/reducers/index.js
@@ -1,7 +1,9 @@
 import { combineReducers } from 'redux';
 
 import folders from './folders';
+import messages from './messages';
 
 export default combineReducers({
-  folders
+  folders,
+  messages
 });

--- a/src/js/messaging/reducers/messages.js
+++ b/src/js/messaging/reducers/messages.js
@@ -1,0 +1,22 @@
+import set from 'lodash/fp/set';
+
+import {
+  FETCH_THREAD_SUCCESS,
+  FETCH_THREAD_FAILURE,
+} from '../actions/messages';
+
+const initialState = {
+  thread: []
+};
+
+export default function folders(state = initialState, action) {
+  switch (action.type) {
+    case FETCH_THREAD_SUCCESS: {
+      const messages = action.data.data.map(message => message.attributes);
+      return set('thread', messages, state);
+    }
+    case FETCH_THREAD_FAILURE:
+    default:
+      return state;
+  }
+}

--- a/src/js/messaging/routes.jsx
+++ b/src/js/messaging/routes.jsx
@@ -3,6 +3,7 @@ import Compose from './components/Compose';
 import Folder from './containers/Folder';
 import Main from './containers/Main';
 import Modal from './containers/Modal';
+import Thread from './containers/Thread';
 
 const routes = {
   path: '/messaging',
@@ -22,8 +23,8 @@ const routes = {
       path: '',
       component: Modal,
       childRoutes: [
-        { path: 'compose', component: Compose }
-        // { path: 'thread/:id', component: Thread }
+        { path: 'compose', component: Compose },
+        { path: 'thread/:id', component: Thread }
       ]
     }
   ]

--- a/src/sass/messaging/_partials/_messaging-thread.scss
+++ b/src/sass/messaging/_partials/_messaging-thread.scss
@@ -36,3 +36,14 @@
 .messaging-message-recipient {
   color: $color-gray-medium;
 }
+
+.messaging-thread-reply {
+  padding: 3rem 2rem;
+
+  textarea {
+    height: 10rem;
+    max-width: 100%;
+    width: 100%;
+  }
+
+}

--- a/src/sass/messaging/_partials/_messaging-thread.scss
+++ b/src/sass/messaging/_partials/_messaging-thread.scss
@@ -1,0 +1,38 @@
+.messaging-thread-note {
+  border-bottom: 1px solid $color-black;
+  border-top: 1px solid $color-black;
+  font-size: 1.5rem;
+  margin: 0;
+  padding: 1.5rem 2rem;
+}
+
+.messaging-thread-name {
+  // Overriding `#content .section h*`.
+  padding: 2.25rem 2rem !important;
+  border-bottom: 2px solid $color-black;
+}
+
+.messaging-thread-message {
+  padding: 1.5rem 2rem;
+  border-bottom: 1px solid $color-black;
+}
+
+.messaging-message-sender {
+  width: 75%;
+}
+
+.messaging-message-sent-date {
+  text-align: right;
+  width: 25%;
+}
+
+.messaging-message-sender,
+.messaging-message-sent-date {
+  display: inline-block;
+  font-weight: bold;
+  vertical-align: top;
+}
+
+.messaging-message-recipient {
+  color: $color-gray-medium;
+}

--- a/src/sass/messaging/messaging.scss
+++ b/src/sass/messaging/messaging.scss
@@ -4,6 +4,8 @@
 
 @import "../style";
 
+@import "_partials/messaging-thread";
+
 #messaging-app {
   margin: auto;
   max-width: $site-max-width;

--- a/src/sass/messaging/messaging.scss
+++ b/src/sass/messaging/messaging.scss
@@ -5,17 +5,25 @@
 @import "../style";
 
 #messaging-app {
-  padding: 3rem 1.5rem;
   margin: auto;
   max-width: $site-max-width;
+  padding: 3rem 1.5rem;
 }
 
-#main-nav {
+#messaging-nav {
+  box-sizing: border-box;
   display: inline-block;
+  width: 20%;
+
+  .rx-compose-button {
+    width: 100%;
+  }
 }
 
-#main-content {
+#messaging-content {
+  box-sizing: border-box;
   display: inline-block;
-  margin-left: 3rem;
+  padding-left: 3rem;
   vertical-align: top;
+  width: 80%;
 }


### PR DESCRIPTION
Closes:
- department-of-veterans-affairs/messaging-fe#18
- department-of-veterans-affairs/messaging-fe#25
- department-of-veterans-affairs/messaging-fe#26

This adds the basic structure for the pages where users can view messages in their folders.
For now, it loads a thread from the mock API.
Also started limiting access of containers to the store to only what they need.
## Mocks

Desktop: https://marvelapp.com/159dfd8/screen/14605162
## Preview

![screenshot from 2016-09-09 20 04 56](https://cloud.githubusercontent.com/assets/1067024/18406254/b633bb38-76c8-11e6-8e4d-eb8e4e3c2e81.png)
