### PR TITLE
Adds MessageSubject component

### DIFF
--- a/src/js/messaging/actions/compose.js
+++ b/src/js/messaging/actions/compose.js
@@ -1,8 +1,17 @@
 export const SET_CATEGORY = 'SET_CATEGORY';
+export const SET_SUBJECT = 'SET_SUBJECT';
+
 
 export function setCategory(value) {
   return {
     type: SET_CATEGORY,
+    value
+  };
+}
+
+export function setSubject(value) {
+  return {
+    type: SET_SUBJECT,
     value
   };
 }

--- a/src/js/messaging/components/compose/MessageSubject.jsx
+++ b/src/js/messaging/components/compose/MessageSubject.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import ErrorableTextInput from '../../../common/components/form-elements/ErrorableTextInput';
+import { makeField } from '../../../common/model/fields.js';
+
+class MessageSubject extends React.Component {
+  render() {
+    const subjectValue = makeField(this.props.value);
+
+    return (
+      <div className="messaging-subject">
+        <ErrorableTextInput
+            errorMessage={this.props.errorMessage}
+            label="Subject Line:"
+            onValueChange={this.props.onValueChange}
+            placeholder={this.props.placeholder}
+            name="messageSubject"
+            required
+            field={subjectValue}/>
+      </div>
+    );
+  }
+}
+
+MessageSubject.propTypes = {
+  errorMessage: React.PropTypes.string,
+  subjectClass: React.PropTypes.string,
+  name: React.PropTypes.string,
+  onValueChange: React.PropTypes.func,
+  value: React.PropTypes.string
+};
+
+export default MessageSubject;

--- a/src/js/messaging/config.js
+++ b/src/js/messaging/config.js
@@ -23,5 +23,8 @@ module.exports = {
       value: 'Other'
     }
   ],
-  messageCategoryError: 'Please select a category'
+  composeMessageErrors: {
+    category: 'Please select a category.',
+    subject: 'Please add subject description.'
+  }
 };

--- a/src/js/messaging/containers/Compose.jsx
+++ b/src/js/messaging/containers/Compose.jsx
@@ -1,29 +1,44 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { messageCategories, messageCategoryError } from '../config.js';
+import { messageCategories, composeMessageErrors } from '../config.js';
 import MessageCategory from '../components/compose/MessageCategory';
-import { setCategory } from '../actions/compose.js';
+import MessageSubject from '../components/compose/MessageSubject';
+import { setCategory, setSubject } from '../actions/compose.js';
 
 class Compose extends React.Component {
   constructor() {
     super();
     this.dispatchCategoryChange = this.dispatchCategoryChange.bind(this);
+    this.dispatchSubjectChange = this.dispatchSubjectChange.bind(this);
   }
 
-  dispatchCategoryChange(event) {
-    this.props.dispatch(setCategory(event));
+  dispatchCategoryChange(valueObj) {
+    this.props.setCategory(valueObj);
+    this.props.setSubject(valueObj);
+  }
+
+  dispatchSubjectChange(valueObj) {
+    this.props.setSubject(valueObj);
   }
 
   render() {
     return (
       <div>
         <h2>New message</h2>
+        <p>
+          <strong>Note:</strong> Messages may be saved to your health record at
+          your team's discretion.
+        </p>
         <MessageCategory
             categories={messageCategories}
-            errorMessage={messageCategoryError}
+            errorMessage={composeMessageErrors.category}
             onValueChange={this.dispatchCategoryChange}
             value={this.props.compose.category}/>
+        <MessageSubject
+            errorMessage={composeMessageErrors.subjet}
+            onValueChange={this.dispatchSubjectChange}
+            value={this.props.compose.subject}/>
       </div>
     );
   }
@@ -34,6 +49,9 @@ const mapStateToProps = (state) => {
   return state;
 };
 
-export default connect(mapStateToProps)(Compose);
+const mapDispatchToProps = {
+  setCategory,
+  setSubject
+};
 
-// export default Compose;
+export default connect(mapStateToProps, mapDispatchToProps)(Compose);

--- a/src/js/messaging/reducers/compose.js
+++ b/src/js/messaging/reducers/compose.js
@@ -1,14 +1,17 @@
 import set from 'lodash/fp/set';
-import { SET_CATEGORY } from '../actions/compose.js';
+import { SET_CATEGORY, SET_SUBJECT } from '../actions/compose.js';
 
 const initialState = {
-  category: undefined
+  category: undefined,
+  subject: ''
 };
 
 export default function compose(state = initialState, action) {
   switch (action.type) {
     case SET_CATEGORY:
       return set('category', action.value.value, state);
+    case SET_SUBJECT:
+      return set('subject', action.value.value, state);
     default:
       return state;
   }


### PR DESCRIPTION
- Passes action creators with a mapDispatchAsProps object instead of this.props.dispatch.
- Refactored Compose-related error messages to be a single object
- closes department-of-veterans-affairs/messaging-fe#39
