### PR TITLE
Make dependents page dependent on service dates

### DIFF
--- a/src/js/common/components/Nav.jsx
+++ b/src/js/common/components/Nav.jsx
@@ -1,15 +1,10 @@
 import React from 'react';
-import _ from 'lodash';
 import classnames from 'classnames';
+
+import { isActivePage } from '../utils/helpers';
 
 function lastPage(chapter) {
   return chapter.pages.slice(-1)[0].path;
-}
-
-// Checks to see if a page's data dependencies are met
-// i.e., has the user filled out the required information?
-function isHidden(page, data) {
-  return page.depends !== undefined && _.matches(page.depends)(data) === false;
 }
 
 function determineChapterStyles(pageState, formChapter, currentUrl) {
@@ -22,7 +17,7 @@ function determineChapterStyles(pageState, formChapter, currentUrl) {
 function determinePageStyles(page, currentUrl, data) {
   return classnames(
     { 'sub-section-current': currentUrl === page.path },
-    { 'sub-section-hidden': isHidden(page, data) }
+    { 'sub-section-hidden': !isActivePage(page, data) }
   );
 }
 

--- a/src/js/common/components/NavButtons.jsx
+++ b/src/js/common/components/NavButtons.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import _ from 'lodash';
+
+import { getActivePages } from '../utils/helpers';
 
 import ProgressButton from '../../common/components/form-elements/ProgressButton';
 
@@ -33,9 +34,7 @@ export default class NavButtons extends React.Component {
   }
   findNeighbor(increment) {
     const { pages, path, data } = this.props;
-    const filtered = pages.filter(page => {
-      return page.depends === undefined || _.matches(page.depends)(data);
-    });
+    const filtered = getActivePages(pages, data);
     const currentIndex = filtered.map(page => page.name).indexOf(path);
     const index = currentIndex + increment;
     return filtered[index].name;

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -1,0 +1,13 @@
+import _ from 'lodash';
+
+export function isActivePage(page, data) {
+  if (typeof page.depends === 'function') {
+    return page.depends(data);
+  }
+
+  return page.depends === undefined || _.matches(page.depends)(data);
+}
+
+export function getActivePages(pages, data) {
+  return pages.filter(page => isActivePage(page, data));
+}

--- a/src/js/edu-benefits/components/ReviewCollapsiblePanel.jsx
+++ b/src/js/edu-benefits/components/ReviewCollapsiblePanel.jsx
@@ -3,7 +3,7 @@ import Scroll from 'react-scroll';
 import _ from 'lodash';
 
 import * as validations from '../utils/validations';
-import { getActivePages } from '../utils/helpers';
+import { getActivePages } from '../../common/utils/helpers';
 import { pages } from '../routes';
 
 const Element = Scroll.Element;

--- a/src/js/edu-benefits/routes.jsx
+++ b/src/js/edu-benefits/routes.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Route } from 'react-router';
 
-import { chapterNames, groupPagesIntoChapters, getPageList } from './utils/helpers';
+import { chapterNames, groupPagesIntoChapters, getPageList, hasServiceBefore1978 } from './utils/helpers';
 
 import IntroductionPage from './containers/IntroductionPage.jsx';
 import VeteranInformationReview from './components/veteran-information/VeteranInformationReview';
@@ -137,6 +137,7 @@ const routes = [
       key="/personal-information/dependents"
       path="/personal-information/dependents"
       chapter={chapterNames.personalInformation}
+      depends={hasServiceBefore1978}
       name="Dependents"/>,
   <Route
       component={FormPage}

--- a/src/js/edu-benefits/utils/helpers.js
+++ b/src/js/edu-benefits/utils/helpers.js
@@ -59,12 +59,6 @@ export function getLabel(options, value) {
   return matched ? matched.label : null;
 }
 
-export function getActivePages(pages, data) {
-  return pages.filter(page => {
-    return page.depends === undefined || _.matches(page.depends)(data);
-  });
-}
-
 export function showSchoolAddress(educationType) {
   return educationType === 'college'
     || educationType === 'flightTraining'
@@ -93,4 +87,11 @@ export function displayDateIfValid(dateObject) {
 export function showSomeoneElseServiceQuestion(claimType) {
   return claimType !== ''
     && claimType !== 'vocationalRehab';
+}
+
+export function hasServiceBefore1978(data) {
+  return data.toursOfDuty.some(tour => {
+    const fromDate = dateToMoment(tour.dateRange.from);
+    return fromDate.isValid() && fromDate.isBefore('1978-01-02');
+  });
 }

--- a/test/common/utils/helpers.unit.spec.js
+++ b/test/common/utils/helpers.unit.spec.js
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { isActivePage } from '../../../src/js/common/utils/helpers.js';
+
+describe('Helpers unit tests', () => {
+  describe('isActivePage', () => {
+    it('matches against data', () => {
+      const page = {
+        depends: { testData: 'Y' }
+      };
+      const data = {
+        testData: 'Y'
+      };
+
+      const result = isActivePage(page, data);
+
+      expect(result).to.be.true;
+    });
+    it('false with mismatched data', () => {
+      const page = {
+        depends: { testData: 'Y' }
+      };
+      const data = {
+        testData: 'N'
+      };
+
+      const result = isActivePage(page, data);
+
+      expect(result).to.be.false;
+    });
+    it('matches using function', () => {
+      const matcher = sinon.stub().returns(true);
+      const page = {
+        depends: matcher
+      };
+      const data = {
+        testData: 'Y'
+      };
+
+      const result = isActivePage(page, data);
+
+      expect(result).to.be.true;
+      expect(matcher.calledWith(data)).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
Closes #3055.

I move some of the active page logic to common, since I needed to make changes to it for the nav components. It now accepts a function, so you can do more complicated checks like any service start dates before 1978.
