### PR TITLE
Moved messaging modal to common components.

### DIFF
--- a/src/js/common/components/Modal.jsx
+++ b/src/js/common/components/Modal.jsx
@@ -12,25 +12,27 @@ class Modal extends React.Component {
   }
 
   render() {
-    const modalCss = classNames('rx-modal', this.props.cssClass);
+    const modalCss = classNames('va-modal', this.props.cssClass);
 
     if (!this.props.visible) {
       return <div/>;
     }
 
+    const closeButton = this.props.hideCloseButton ? '' : (
+      <button
+          className="va-modal-close"
+          type="button"
+          onClick={this.props.onClose}>
+        <i className="fa fa-close"></i>
+        <span className="usa-sr-only">Close this modal</span>
+      </button>
+    );
+
     return (
-      <div
-          className={modalCss}
-          id={this.props.id}>
-        <div className="rx-modal-inner">
-          <button
-              className="rx-modal-close"
-              onClick={this.handleClose}
-              type="button">
-            <i className="fa fa-close"></i>
-            <span className="usa-sr-only">Close</span>
-          </button>
-          <div className="rx-modal-body">
+      <div className={modalCss} id={this.props.id}>
+        <div className="va-modal-inner">
+          {closeButton}
+          <div className="va-modal-body">
             {this.props.contents}
           </div>
         </div>
@@ -44,7 +46,8 @@ Modal.propTypes = {
   cssClass: React.PropTypes.string,
   id: React.PropTypes.string,
   onClose: React.PropTypes.func.isRequired,
-  visible: React.PropTypes.bool.isRequired
+  visible: React.PropTypes.bool.isRequired,
+  hideCloseButton: React.PropTypes.bool
 };
 
 export default Modal;

--- a/src/js/messaging/components/compose/ModalConfirmDelete.jsx
+++ b/src/js/messaging/components/compose/ModalConfirmDelete.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Modal from '../Modal';
+import Modal from '../../../common/components/Modal';
 
 class ModalConfirmDelete extends React.Component {
   render() {
@@ -10,7 +10,7 @@ class ModalConfirmDelete extends React.Component {
             Are you sure you want to delete this draft?
         </h3>
         <p>This draft will not be recoverable after deletion.</p>
-        <div>
+        <div className="va-modal-button-group">
           <button type="submit">Yes, delete forever</button>
           <button
               className="usa-button-outline"

--- a/src/js/rx/components/ConfirmRefillModal.jsx
+++ b/src/js/rx/components/ConfirmRefillModal.jsx
@@ -32,11 +32,11 @@ class ConfirmRefillModal extends React.Component {
     let element;
     if (this.props.isVisible) {
       element = (
-        <section className="rx-modal" id="rx-confirm-refill">
-          <form className="rx-modal-inner" onSubmit={this.handlerConfirmRefill}>
+        <section className="va-modal rx-modal" id="rx-confirm-refill">
+          <form className="va-modal-inner" onSubmit={this.handlerConfirmRefill}>
             <div>
               <h3 className="rx-modal-title">Confirm refill</h3>
-              <div className="rx-modal-refillinfo rx-modal-body">
+              <div className="rx-modal-refillinfo va-modal-body">
                 <div>
                   <span className="rx-modal-drug">{this.props['prescription-name']}</span>
                 </div>
@@ -49,7 +49,7 @@ class ConfirmRefillModal extends React.Component {
                 <div className="rx-modal-lastrefilled">
                   Last requested: {moment(this.props['refill-date']).format('MMM D, YYYY')}
                 </div>
-                <div className="rx-button-group cf">
+                <div className="va-modal-button-group cf">
                   <button type="submit" value={this.props['prescription-id']}>Order refill</button>
                   <button type="button" className="usa-button-outline"
                       onClick={this.handlerCloseModal}>Cancel</button>

--- a/src/sass/messaging/messaging.scss
+++ b/src/sass/messaging/messaging.scss
@@ -1,4 +1,5 @@
 @import "../style";
+@import "../modules/m-modal";
 
 $messaging-label-width: 10rem;
 
@@ -8,7 +9,5 @@ $messaging-label-width: 10rem;
 @import "partials/messaging-btn-delete";
 @import "partials/messaging-folder";
 @import "partials/messaging-thread";
+@import "partials/messaging-modal";
 
-// TODO: Swap with common modal styles once
-// they exist.
-@import "../rx/_partials/rx-modal";

--- a/src/sass/messaging/partials/_messaging-modal.scss
+++ b/src/sass/messaging/partials/_messaging-modal.scss
@@ -1,0 +1,5 @@
+.messaging-modal {
+  &-title {
+    color: $color-primary; 
+  }
+}

--- a/src/sass/modules/_m-modal.scss
+++ b/src/sass/modules/_m-modal.scss
@@ -1,0 +1,67 @@
+// Styles for application modals
+// Used in prescriptions, messaging.
+
+.va-modal {
+  background: rgba($color-primary-darkest, .8);
+  content: ' ';
+  display: block;
+  height: 100%;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 3;
+
+  &-inner {
+    background: $color-white;
+    margin: auto;
+    max-width: 40rem;
+    min-width: 320px;
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 100%;
+  }
+
+  &-body {
+    padding: 2rem;
+  }
+  
+  &-button-group {
+    bottom: 0;
+    display: -webkit-flex;
+    display: flex;
+    -webkit-align-items: flex-start;
+    align-items: flex-start;
+    position: relative;
+    margin-top: 5rem;
+  
+    button {
+      margin: 0 1rem 0 0;
+    }
+  
+    .usa-button-outline:hover {
+      background: transparent !important;
+    }
+  }
+}
+
+.va-modal button {
+  white-space: nowrap;
+} 
+
+.va-modal-close {
+  background-color: inherit;
+  color: rgba($color-base, .8);
+  font-size: 2.5rem;
+  padding: .5rem 1rem;
+  position: absolute;
+  margin: .25rem;
+  right: 0;
+  top: 0;
+  
+  &:hover {
+    background-color: inherit;
+    color: $color-base;
+  }
+} 

--- a/src/sass/rx/_partials/_rx-modal.scss
+++ b/src/sass/rx/_partials/_rx-modal.scss
@@ -1,29 +1,13 @@
-// Styles for confirm refill modal
-// Also affects messaging modals.
-// TODO: Make into a common partial
+// Styles for application modals
+// Used in prescriptions, messaging.
 
 .rx-modal {
-  background: rgba($color-primary-darkest, .8);
-  content: ' ';
-  display: block;
-  height: 100%;
-  left: 0;
-  position: fixed;
-  top: 0;
-  width: 100%;
-  z-index: 3;
-
-  &-inner {
-    background: $color-white;
-    margin: auto;
-    max-width: 30rem;
-    min-width: 320px;
-    position: relative;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 100%;
+  &-drug, &-dosage {
+    color: $color-primary;
+    font-size: 2.4rem;
+    font-weight: bold;
   }
-
+  
   &-title {
     background: $color-primary-darkest;
     color: $color-white;
@@ -32,60 +16,13 @@
     // Abusing important until #content .section h3 is cleared up.
     padding: .5rem 2rem !important;
   }
-
-  &-body {
-    padding: 2rem;
-  }
-
-  &-drug, &-dosage {
-    color: $color-primary;
-    font-size: 2.4rem;
-    font-weight: bold;
-  }
-
+  
   &-rxnumber {
     font-weight: bold;
   }
-  // TODO: Somewhere in the code is an actual close button style
-  // Refactor to make that work.
-  &-close {
-    color: $color-base;
-    background-color: inherit;
-    font-size: 2.5rem;
-    margin: 0;
-    padding: 0 1rem;
-    position: absolute;
-    right: .5rem;
-    top: .5rem;
-    width: auto;
     
-    &:focus,
-    &:hover {
-      background-color: inherit;
-      color: rgba($color-base, .8);
-    }
-  }
-  
-  .rx-button-group {
-    bottom: 0;
-    display: flex;
-    align-items: flex-start;
-    position: relative;
-    margin-top: 5rem;
-    
-    button {
-      margin: 0 1rem 0 0;
-    }
-    
-    .usa-button-outline:hover {
-      background: transparent !important;
-    }
-  }
-  
   .rx-glossary {
     margin: 0 auto;
   }
 }
-.rx-button-group button {
-  white-space: nowrap;
-}
+

--- a/src/sass/rx/rx.scss
+++ b/src/sass/rx/rx.scss
@@ -3,6 +3,7 @@
 // elements version of these files.
 
 @import "../style";
+@import "../modules/m-modal";
 
 // TODO: Contributed these back to core / Vanguard.
 @import "_partials/va-tabs";


### PR DESCRIPTION
- Moved rx/rx-modal partial to modules/m-modal and updated paths.
- Updated modal class names to use va-modal prefix
- Pared rx-modal partials styles down to Rx-specific CSS.
- Added messaging-specific SCSS partials.
- Refactoring modal CSS.
- Adding messaging-modal specific CSS.
- Added modal close button, made it hide-able.

Unblocks department-of-veterans-affairs/vets-website#3091.
