### PR TITLE
[SM] Message Navigation + Message Count

### DIFF
--- a/src/js/messaging/actions/messages.js
+++ b/src/js/messaging/actions/messages.js
@@ -8,11 +8,18 @@ export const TOGGLE_MESSAGES_COLLAPSED = 'TOGGLE_MESSAGES_COLLAPSED';
 const baseUrl = `${apiUrl}/messages`;
 
 export function fetchThread(id) {
+  const messageUrl = `${baseUrl}/${id}`;
+  const threadUrl = `${messageUrl}/thread`;
+
   return dispatch => {
-    fetch(`${baseUrl}/${id}/thread`)
-    .then(res => res.json())
-    .then(
-      data => dispatch({ type: FETCH_THREAD_SUCCESS, data }),
+    Promise.all([messageUrl, threadUrl].map(url =>
+      fetch(url).then(res => res.json())
+    )).then(
+      data => dispatch({
+        type: FETCH_THREAD_SUCCESS,
+        message: data[0].data,
+        thread: data[1].data
+      }),
       err => dispatch({ type: FETCH_THREAD_FAILURE, err })
     );
   };

--- a/src/js/messaging/components/FolderNav.jsx
+++ b/src/js/messaging/components/FolderNav.jsx
@@ -100,11 +100,11 @@ class FolderNav extends React.Component {
       <li className="messaging-folder-nav-actions">
         <button>
           <i className="fa fa-folder"></i>
-          &nbsp;&nbsp;Manage folders
+          &nbsp;Manage folders
         </button>
         <button>
           <i className="fa fa-plus"></i>
-          &nbsp;&nbsp;Create new folder
+          &nbsp;Create new folder
         </button>
       </li>
     );

--- a/src/js/messaging/components/MessageNav.jsx
+++ b/src/js/messaging/components/MessageNav.jsx
@@ -1,25 +1,21 @@
 import React from 'react';
 
 class MessageNav extends React.Component {
-  goToPrevious() {
-  }
-
-  goToNext() {
-  }
-
   render() {
     return (
-      <div className="messaging-nav">
+      <div className="messaging-message-nav">
         <span className="messaging-count">
-          {this.props.current} of {this.props.total}
+          <b>{this.props.currentMessageNumber}</b>
+          &nbsp;of&nbsp;
+          <b>{this.props.messageCount}</b>
         </span>
-        <button type="button">
+        <button type="button" onClick={this.props.handlePrev}>
           <i className="fa fa-chevron-left"></i>
-          Previous
+          <span>Previous</span>
         </button>
-        <button type="button">
+        <button type="button" onClick={this.props.handleNext}>
+          <span>Next</span>
           <i className="fa fa-chevron-right"></i>
-          Next
         </button>
       </div>
     );
@@ -27,8 +23,10 @@ class MessageNav extends React.Component {
 }
 
 MessageNav.propTypes = {
-  currentMessage: React.PropTypes.number.isRequired,
-  messageCount: React.PropTypes.number.isRequired
+  currentMessageNumber: React.PropTypes.number.isRequired,
+  messageCount: React.PropTypes.number.isRequired,
+  handlePrev: React.PropTypes.func,
+  handleNext: React.PropTypes.func
 };
 
 export default MessageNav;

--- a/src/js/messaging/components/MessageNav.jsx
+++ b/src/js/messaging/components/MessageNav.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+class MessageNav extends React.Component {
+  goToPrevious() {
+  }
+
+  goToNext() {
+  }
+
+  render() {
+    return (
+      <div className="messaging-nav">
+        <span className="messaging-count">
+          {this.props.current} of {this.props.total}
+        </span>
+        <button type="button">
+          <i className="fa fa-chevron-left"></i>
+          Previous
+        </button>
+        <button type="button">
+          <i className="fa fa-chevron-right"></i>
+          Next
+        </button>
+      </div>
+    );
+  }
+}
+
+MessageNav.propTypes = {
+  currentMessage: React.PropTypes.number.isRequired,
+  messageCount: React.PropTypes.number.isRequired
+};
+
+export default MessageNav;

--- a/src/js/messaging/components/MessageNav.jsx
+++ b/src/js/messaging/components/MessageNav.jsx
@@ -5,7 +5,7 @@ class MessageNav extends React.Component {
     return (
       <div className="messaging-message-nav">
         <span className="messaging-count">
-          <b>{this.props.currentMessageNumber}</b>
+          <b>{this.props.currentRange}</b>
           &nbsp;of&nbsp;
           <b>{this.props.messageCount}</b>
         </span>
@@ -23,7 +23,7 @@ class MessageNav extends React.Component {
 }
 
 MessageNav.propTypes = {
-  currentMessageNumber: React.PropTypes.number.isRequired,
+  currentRange: React.PropTypes.string.isRequired,
   messageCount: React.PropTypes.number.isRequired,
   handlePrev: React.PropTypes.func,
   handleNext: React.PropTypes.func

--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -34,7 +34,7 @@ class ThreadHeader extends React.Component {
           <MessageNav/>
         </div>
         <div className="messaging-thread-title-line">
-          <h2 className="messaging-thread-subject">{this.props.title}</h2>
+          <h2 className="messaging-thread-subject">{this.props.subject}</h2>
           <div className="messaging-thread-controls">
             {toggleThread}
             <ButtonDelete
@@ -48,7 +48,7 @@ class ThreadHeader extends React.Component {
 }
 
 ThreadHeader.propTypes = {
-  title: React.PropTypes.string.isRequired,
+  subject: React.PropTypes.string.isRequired,
   messagesCount: React.PropTypes.number.isRequired,
   messagesCollapsed: React.PropTypes.bool,
   onToggleThread: React.PropTypes.func

--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
 import ButtonDelete from './buttons/ButtonDelete';
+import ButtonMove from './buttons/ButtonMove';
 import ButtonPrint from './buttons/ButtonPrint';
+import MessageNav from './MessageNav';
 import ToggleThread from './ToggleThread';
 
 class ThreadHeader extends React.Component {
@@ -26,12 +28,19 @@ class ThreadHeader extends React.Component {
 
     return (
       <div className="messaging-thread-header">
-        <h2 className="messaging-thread-subject">{this.props.title}</h2>
-        <div className="messaging-thread-controls">
-          {toggleThread}
-          <ButtonDelete
-              onClickHandler={this.handleDelete}/>
-          <ButtonPrint/>
+        <div className="messaging-thread-nav-line">
+          <a>Back to Inbox</a>
+          <ButtonMove/>
+          <MessageNav/>
+        </div>
+        <div className="messaging-thread-title-line">
+          <h2 className="messaging-thread-subject">{this.props.title}</h2>
+          <div className="messaging-thread-controls">
+            {toggleThread}
+            <ButtonDelete
+                onClickHandler={this.handleDelete}/>
+            <ButtonPrint/>
+          </div>
         </div>
       </div>
     );

--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { Link } from 'react-router';
 
+import { paths } from '../config';
 import ButtonDelete from './buttons/ButtonDelete';
 import ButtonMove from './buttons/ButtonMove';
 import ButtonPrint from './buttons/ButtonPrint';
@@ -18,7 +20,7 @@ class ThreadHeader extends React.Component {
   render() {
     let toggleThread;
 
-    if (this.props.messagesCount > 1) {
+    if (this.props.threadMessageCount > 1) {
       toggleThread = (
         <ToggleThread
             messagesCollapsed={this.props.messagesCollapsed}
@@ -28,12 +30,18 @@ class ThreadHeader extends React.Component {
 
     return (
       <div className="messaging-thread-header">
-        <div className="messaging-thread-nav-line">
-          <a>Back to Inbox</a>
-          <ButtonMove/>
-          <MessageNav/>
+        <div className="messaging-thread-nav">
+          <div>
+            <Link to={paths.INBOX_URL}>&lt; Back to Inbox</Link>
+            <ButtonMove/>
+          </div>
+          <MessageNav
+              currentMessageNumber={this.props.currentMessageNumber}
+              messageCount={this.props.folderMessageCount}
+              handlePrev={this.props.handlePrev}
+              handleNext={this.props.handleNext}/>
         </div>
-        <div className="messaging-thread-title-line">
+        <div className="messaging-thread-title">
           <h2 className="messaging-thread-subject">{this.props.subject}</h2>
           <div className="messaging-thread-controls">
             {toggleThread}
@@ -48,8 +56,12 @@ class ThreadHeader extends React.Component {
 }
 
 ThreadHeader.propTypes = {
+  currentMessageNumber: React.PropTypes.number.isRequired,
+  folderMessageCount: React.PropTypes.number.isRequired,
+  handlePrev: React.PropTypes.func,
+  handleNext: React.PropTypes.func,
   subject: React.PropTypes.string.isRequired,
-  messagesCount: React.PropTypes.number.isRequired,
+  threadMessageCount: React.PropTypes.number.isRequired,
   messagesCollapsed: React.PropTypes.bool,
   onToggleThread: React.PropTypes.func
 };

--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -36,7 +36,7 @@ class ThreadHeader extends React.Component {
             <ButtonMove/>
           </div>
           <MessageNav
-              currentMessageNumber={this.props.currentMessageNumber}
+              currentRange={this.props.currentMessageNumber}
               messageCount={this.props.folderMessageCount}
               handlePrev={this.props.handlePrev}
               handleNext={this.props.handleNext}/>

--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -14,13 +14,21 @@ class ThreadHeader extends React.Component {
   }
 
   render() {
+    let toggleThread;
+
+    if (this.props.messagesCount > 1) {
+      toggleThread = (
+        <ToggleThread
+            messagesCollapsed={this.props.messagesCollapsed}
+            onClick={this.props.onToggleThread}/>
+      );
+    }
+
     return (
       <div className="messaging-thread-header">
         <h2 className="messaging-thread-subject">{this.props.title}</h2>
         <div className="messaging-thread-controls">
-          <ToggleThread
-              messagesCollapsed={this.props.messagesCollapsed}
-              onClick={this.props.onToggleThread}/>
+          {toggleThread}
           <ButtonDelete
               onClickHandler={this.handleDelete}/>
           <ButtonPrint/>
@@ -32,6 +40,7 @@ class ThreadHeader extends React.Component {
 
 ThreadHeader.propTypes = {
   title: React.PropTypes.string.isRequired,
+  messagesCount: React.PropTypes.number.isRequired,
   messagesCollapsed: React.PropTypes.bool,
   onToggleThread: React.PropTypes.func
 };

--- a/src/js/messaging/components/buttons/ButtonMove.jsx
+++ b/src/js/messaging/components/buttons/ButtonMove.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+class ButtonMove extends React.Component {
+  render() {
+    return (
+      <button className="messaging-move">
+        <span>Move</span>
+        <i className="fa fa-caret-down"></i>
+      </button>
+    );
+  }
+}
+
+export default ButtonMove;
+

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import classNames from 'classnames';
 
 import { fetchFolder } from '../actions/folders';
+import MessageNav from '../components/MessageNav';
 
 class Folder extends React.Component {
   componentDidMount() {
@@ -76,6 +77,11 @@ class Folder extends React.Component {
     return (
       <div>
         <h2>{folderName}</h2>
+        <div className="messaging-folder-controls">
+          <MessageNav
+              currentRange={this.props.currentRange}
+              messageCount={this.props.messageCount}/>
+        </div>
         {folderMessages}
       </div>
     );
@@ -88,9 +94,13 @@ const mapStateToProps = (state) => {
     return folder.folder_id === currentFolder.id;
   });
   const messages = currentFolder.messages;
+  const startCount = currentFolder.startCount;
+  const endCount = currentFolder.endCount;
 
   return {
-    folder: { attributes, messages }
+    folder: { attributes, messages },
+    currentRange: `${startCount}-${endCount}`,
+    messageCount: currentFolder.totalCount
   };
 };
 

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -51,7 +51,7 @@ class Thread extends React.Component {
 
       header = (
         <ThreadHeader
-            title={thread[0].subject}
+            subject={thread[0].subject}
             messagesCount={thread.length}
             messagesCollapsed={this.props.messagesCollapsed}
             onToggleThread={this.props.toggleMessagesCollapsed}/>

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -69,16 +69,16 @@ class Thread extends React.Component {
          Then pass these functions to the navigation components. */
 
       let fetchPrevMessage;
-      if (currentIndex + 1 < folderMessageCount) {
-        const prevId = folderMessages[currentIndex + 1].message_id;
+      if (currentIndex - 1 >= 0) {
+        const prevId = folderMessages[currentIndex - 1].message_id;
         fetchPrevMessage = () => {
           this.props.fetchThread(prevId);
         };
       }
 
       let fetchNextMessage;
-      if (currentIndex - 1 >= 0) {
-        const nextId = folderMessages[currentIndex - 1].message_id;
+      if (currentIndex + 1 < folderMessageCount) {
+        const nextId = folderMessages[currentIndex + 1].message_id;
         fetchNextMessage = () => {
           this.props.fetchThread(nextId);
         };

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -52,6 +52,7 @@ class Thread extends React.Component {
       header = (
         <ThreadHeader
             title={thread[0].subject}
+            messagesCount={thread.length}
             messagesCollapsed={this.props.messagesCollapsed}
             onToggleThread={this.props.toggleMessagesCollapsed}/>
       );

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -42,22 +42,63 @@ class Thread extends React.Component {
 
   render() {
     const thread = this.props.thread;
+    const folderMessages = this.props.folderMessages;
+    const folderMessageCount = folderMessages.length;
     let lastSender;
     let header;
-    let messages;
+    let threadMessages;
 
     if (thread.length > 0) {
-      lastSender = thread[thread.length - 1].sender_name;
+      const currentMessage = thread[thread.length - 1];
+
+      // TODO: Presumably, when the API provides pagination,
+      // we will be able to directly pull information about
+      // the next and previous messages. Until then, we rely
+      // on logic around the array of folder messages we get.
+
+      // Find the current message's position
+      // among the messages in the current folder.
+      const currentIndex = folderMessages.findIndex((message) => {
+        return message.message_id === currentMessage.message_id;
+      });
+
+      /* Once the position of current position has been determined,
+         create functions to navigate to the previous and next
+         messages within the folder.
+
+         Then pass these functions to the navigation components. */
+
+      let fetchPrevMessage;
+      if (currentIndex + 1 < folderMessageCount) {
+        const prevId = folderMessages[currentIndex + 1].message_id;
+        fetchPrevMessage = () => {
+          this.props.fetchThread(prevId);
+        };
+      }
+
+      let fetchNextMessage;
+      if (currentIndex - 1 >= 0) {
+        const nextId = folderMessages[currentIndex - 1].message_id;
+        fetchNextMessage = () => {
+          this.props.fetchThread(nextId);
+        };
+      }
 
       header = (
         <ThreadHeader
+            currentMessageNumber={currentIndex + 1}
+            folderMessageCount={folderMessageCount}
+            handlePrev={fetchPrevMessage}
+            handleNext={fetchNextMessage}
             subject={thread[0].subject}
-            messagesCount={thread.length}
+            threadMessageCount={thread.length}
             messagesCollapsed={this.props.messagesCollapsed}
             onToggleThread={this.props.toggleMessagesCollapsed}/>
       );
 
-      messages = thread.map((message, i) => {
+      lastSender = currentMessage.sender_name;
+
+      threadMessages = thread.map((message, i) => {
         const isCollapsed = this.props.messagesCollapsed &&
                             (i !== thread.length - 1);
         const detailsVisible =
@@ -78,7 +119,7 @@ class Thread extends React.Component {
       <div>
         {header}
         <div className="messaging-thread-messages">
-          {messages}
+          {threadMessages}
         </div>
         <div className="messaging-thread-reply">
           <div className="messaging-thread-reply-recipient">
@@ -103,6 +144,7 @@ class Thread extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
+    folderMessages: state.folders.data.currentItem.messages,
     thread: state.messages.data.thread,
     messagesCollapsed: state.messages.ui.messagesCollapsed,
     visibleDetailsId: state.messages.ui.visibleDetailsId

--- a/src/js/messaging/reducers/folders.js
+++ b/src/js/messaging/reducers/folders.js
@@ -12,7 +12,10 @@ const initialState = {
   data: {
     currentItem: {
       id: null,
-      messages: []
+      messages: [],
+      startCount: 0,
+      endCount: 0,
+      totalCount: 0
     },
     items: []
   },
@@ -30,11 +33,26 @@ export default function folders(state = initialState, action) {
       return set('data.items', items, state);
     }
     case FETCH_FOLDER_SUCCESS: {
-      const id = action.data.meta.folder_id;
+      const meta = action.data.meta;
+
+      // Set the messages of the currently viewed folder.
+      const id = meta.folder_id;
       const messages = action.data.data.map(
         message => message.attributes
       );
-      const newItem = { id, messages };
+
+      // Set the pagination data for the folder.
+      const totalCount = meta.count;
+      const startCount = 1 + (meta.current_page - 1) * meta.per_page;
+      const endCount = Math.min(totalCount, meta.current_page * meta.per_page);
+
+      const newItem = {
+        id,
+        messages,
+        startCount,
+        endCount,
+        totalCount
+      };
 
       return set('data.currentItem', newItem, state);
     }

--- a/src/js/messaging/reducers/messages.js
+++ b/src/js/messaging/reducers/messages.js
@@ -20,8 +20,10 @@ const initialState = {
 export default function folders(state = initialState, action) {
   switch (action.type) {
     case FETCH_THREAD_SUCCESS: {
-      const messages = action.data.data.map(message => message.attributes);
-      return set('data.thread', messages, state);
+      const currentMessage = action.message.attributes;
+      const thread = action.thread.map(message => message.attributes);
+      thread.reverse().push(currentMessage);
+      return set('data.thread', thread, state);
     }
     case SET_VISIBLE_DETAILS:
       return set('ui.visibleDetailsId', action.messageId, state);

--- a/src/sass/messaging/messaging.scss
+++ b/src/sass/messaging/messaging.scss
@@ -7,7 +7,7 @@ $messaging-label-width: 10rem;
 @import "partials/message-compose";
 @import "partials/messaging-app";
 @import "partials/messaging-btn-delete";
+@import "partials/messaging-count-nav";
 @import "partials/messaging-folder";
 @import "partials/messaging-thread";
 @import "partials/messaging-modal";
-

--- a/src/sass/messaging/partials/_messaging-app.scss
+++ b/src/sass/messaging/partials/_messaging-app.scss
@@ -94,10 +94,11 @@
     &:hover {
       background: $color-gray-lightest;
     }
-  }
 
-  i {
-    text-decoration: inherit;
+    i {
+      display: inline;
+      font-size: 1.8rem;
+    }
   }
 }
 

--- a/src/sass/messaging/partials/_messaging-count-nav.scss
+++ b/src/sass/messaging/partials/_messaging-count-nav.scss
@@ -8,6 +8,10 @@
   right: 0;
   top: 0;
 
+  i {
+    margin-left: .5rem;
+  }
+
   button:first-of-type {
     border-right: none;
 

--- a/src/sass/messaging/partials/_messaging-count-nav.scss
+++ b/src/sass/messaging/partials/_messaging-count-nav.scss
@@ -1,0 +1,46 @@
+.messaging-count {
+  margin-right: 1rem;
+  vertical-align: middle;
+}
+
+.messaging-message-nav {
+  position: absolute;
+  right: 0;
+  top: 0;
+
+  button:first-of-type {
+    border-right: none;
+
+    i {
+      margin-left: 0;
+      margin-right: .5rem;
+    }
+  }
+}
+
+.messaging-message-nav button,
+.messaging-move {
+  background: $color-white;
+  border-radius: 0;
+  border: 1px solid $color-black;
+  color: $color-black;
+  font-size: 1.3rem;
+  padding: .5rem;
+  margin: 0;
+
+  &:hover,
+  &:active {
+    background: $color-white;
+    color: $color-black;
+    border-bottom: 1px solid $color-black;
+  }
+
+  i {
+    font-size: 1.5rem !important;
+    vertical-align: middle;
+  }
+
+  span {
+    vertical-align: middle;
+  }
+}

--- a/src/sass/messaging/partials/_messaging-folder.scss
+++ b/src/sass/messaging/partials/_messaging-folder.scss
@@ -1,3 +1,8 @@
+.messaging-folder-controls {
+  position: relative;
+  margin-bottom: 4.5rem;
+}
+
 .messaging-message-row {
   &--unread {
     font-weight: bold;

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -2,6 +2,69 @@
  * Thread Header *
  *****************/
 
+.messaging-thread-nav {
+  border-bottom: 1px solid $color-black;
+  margin-bottom: 2rem;
+  padding-bottom: 2rem;
+  position: relative;
+
+  a {
+    margin-right: 1rem;
+    vertical-align: middle;
+  }
+
+  i {
+    margin-left: .5rem;
+  }
+}
+
+.messaging-count {
+  margin-right: 1rem;
+  vertical-align: middle;
+}
+
+.messaging-message-nav {
+  position: absolute;
+  right: 0;
+  top: 0;
+
+  button:first-of-type {
+    border-right: none;
+
+    i {
+      margin-left: 0;
+      margin-right: .5rem;
+    }
+  }
+}
+
+.messaging-message-nav button,
+.messaging-move {
+  background: $color-white;
+  border-radius: 0;
+  border: 1px solid $color-black;
+  color: $color-black;
+  font-size: 1.3rem;
+  padding: .5rem;
+  margin: 0;
+
+  &:hover,
+  &:active {
+    background: $color-white;
+    color: $color-black;
+    border-bottom: 1px solid $color-black;
+  }
+
+  i {
+    font-size: 1.5rem !important;
+    vertical-align: middle;
+  }
+
+  span {
+    vertical-align: middle;
+  }
+}
+
 .messaging-thread-header {
   border-bottom: 2px solid $color-black;
   padding: 2.25rem 0;

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -1,13 +1,18 @@
+/*****************
+ * Thread Header *
+ *****************/
+
 .messaging-thread-header {
   border-bottom: 2px solid $color-black;
+  padding: 2.25rem 0;
 }
 
 .messaging-thread-subject {
   display: inline-block;
   font-weight: normal;
   // Overriding `#content .section h*`.
-  padding: 2.25rem 2rem !important;
-  vertical-align: middle;
+  padding: 0 2rem !important;
+  vertical-align: top;
   width: 60%;
 }
 
@@ -15,7 +20,7 @@
   display: inline-block;
   padding-right: 1rem;
   text-align: right;
-  vertical-align: middle;
+  vertical-align: top;
   width: 40%;
 
   button {
@@ -46,6 +51,10 @@
     margin-left: 0.5rem;
   }
 }
+
+/******************
+ * Thread Message *
+ ******************/
 
 .messaging-thread-message {
   padding: 1.5rem 2rem;
@@ -131,6 +140,10 @@
 .messaging-message-recipient {
   color: $color-gray-medium;
 }
+
+/****************
+ * Thread Reply *
+ ****************/
 
 .messaging-thread-reply {
   font-size: 1.8rem;

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -48,7 +48,7 @@
   }
 
   span {
-    margin-left: 0.5rem;
+    padding-left: 0.5rem;
   }
 }
 

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -18,53 +18,6 @@
   }
 }
 
-.messaging-count {
-  margin-right: 1rem;
-  vertical-align: middle;
-}
-
-.messaging-message-nav {
-  position: absolute;
-  right: 0;
-  top: 0;
-
-  button:first-of-type {
-    border-right: none;
-
-    i {
-      margin-left: 0;
-      margin-right: .5rem;
-    }
-  }
-}
-
-.messaging-message-nav button,
-.messaging-move {
-  background: $color-white;
-  border-radius: 0;
-  border: 1px solid $color-black;
-  color: $color-black;
-  font-size: 1.3rem;
-  padding: .5rem;
-  margin: 0;
-
-  &:hover,
-  &:active {
-    background: $color-white;
-    color: $color-black;
-    border-bottom: 1px solid $color-black;
-  }
-
-  i {
-    font-size: 1.5rem !important;
-    vertical-align: middle;
-  }
-
-  span {
-    vertical-align: middle;
-  }
-}
-
 .messaging-thread-header {
   border-bottom: 2px solid $color-black;
   padding: 2.25rem 0;
@@ -229,6 +182,7 @@
   }
 
   textarea {
+    margin: 0;
     padding: 1rem 1.5rem;
   }
 }


### PR DESCRIPTION
Closes:
- department-of-veterans-affairs/messaging-fe#9
- department-of-veterans-affairs/messaging-fe#10
- department-of-veterans-affairs/messaging-fe#15
- department-of-veterans-affairs/messaging-fe#19
## Changes
- Added message count ("x of y") on folder and thread view.
- Added previous and next buttons for navigation on folder and thread view.
- Temporary handling of message navigation from thread view.
- Link back to inbox from thread view.
- Placeholder "Move" button.
- Combine queries (`GET /messages/:id` and `GET /messages/:id/thread`) to get a full thread.
## Mocks

https://marvelapp.com/1bdd199/screen/15044691
https://marvelapp.com/1bdd199/screen/15044682
## Previews
### Thread

<img width="791" alt="screen shot 2016-09-19 at 9 52 27 pm" src="https://cloud.githubusercontent.com/assets/1067024/18655013/6442f288-7eb3-11e6-9e53-dc7ffb77e769.png">
### Folder

<img width="800" alt="screen shot 2016-09-19 at 9 52 40 pm" src="https://cloud.githubusercontent.com/assets/1067024/18655014/662c6ab6-7eb3-11e6-9445-3eb7eaa8e5ed.png">
