### PR TITLE
[SM] Split character count state between compose and reply.

### DIFF
--- a/src/js/messaging/actions/compose.js
+++ b/src/js/messaging/actions/compose.js
@@ -14,7 +14,7 @@ export const SEND_MESSAGE = 'SEND_MESSAGE';
 
 export const DELETE_DRAFT = 'DELETE_DRAFT';
 export const SET_MESSAGE_FIELD = 'SET_MESSAGE_FIELD';
-export const UPDATE_CHARACTER_COUNT = 'UPDATE_CHARACTER_COUNT';
+export const UPDATE_COMPOSE_CHARACTER_COUNT = 'UPDATE_COMPOSE_CHARACTER_COUNT';
 
 const baseUrl = `${apiUrl}/recipients`;
 
@@ -74,10 +74,10 @@ export function fetchRecipients() {
   };
 }
 
-export function updateCharacterCount(field, maxLength) {
+export function updateComposeCharacterCount(field, maxLength) {
   const chars = maxLength - field.value.length;
   return {
-    type: UPDATE_CHARACTER_COUNT,
+    type: UPDATE_COMPOSE_CHARACTER_COUNT,
     chars
   };
 }

--- a/src/js/messaging/actions/messages.js
+++ b/src/js/messaging/actions/messages.js
@@ -4,6 +4,7 @@ export const FETCH_THREAD_SUCCESS = 'FETCH_THREAD_SUCCESS';
 export const FETCH_THREAD_FAILURE = 'FETCH_THREAD_FAILURE';
 export const SET_VISIBLE_DETAILS = 'SET_VISIBLE_DETAILS';
 export const TOGGLE_MESSAGES_COLLAPSED = 'TOGGLE_MESSAGES_COLLAPSED';
+export const UPDATE_REPLY_CHARACTER_COUNT = 'UPDATE_REPLY_CHARACTER_COUNT';
 
 const baseUrl = `${apiUrl}/messages`;
 
@@ -24,4 +25,12 @@ export function setVisibleDetails(messageId) {
 
 export function toggleMessagesCollapsed() {
   return { type: TOGGLE_MESSAGES_COLLAPSED };
+}
+
+export function updateReplyCharacterCount(field, maxLength) {
+  const chars = maxLength - field.value.length;
+  return {
+    type: UPDATE_REPLY_CHARACTER_COUNT,
+    chars
+  };
 }

--- a/src/js/messaging/containers/Compose.jsx
+++ b/src/js/messaging/containers/Compose.jsx
@@ -26,7 +26,7 @@ import {
   setSubjectRequired,
   fetchRecipients,
   fetchSenderName,
-  updateCharacterCount
+  updateComposeCharacterCount
 } from '../actions/compose';
 
 import {
@@ -59,7 +59,7 @@ class Compose extends React.Component {
 
   handleMessageChange(valueObj) {
     this.props.setMessageField('message.text', valueObj);
-    this.props.updateCharacterCount(valueObj, composeMessageMaxChars);
+    this.props.updateComposeCharacterCount(valueObj, composeMessageMaxChars);
   }
 
   handleRecipientChange(valueObj) {
@@ -160,7 +160,7 @@ const mapDispatchToProps = {
   fetchRecipients,
   fetchSenderName,
   toggleConfirmDelete,
-  updateCharacterCount
+  updateComposeCharacterCount
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Compose);

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -4,7 +4,8 @@ import { connect } from 'react-redux';
 import {
   fetchThread,
   setVisibleDetails,
-  toggleMessagesCollapsed
+  toggleMessagesCollapsed,
+  updateReplyCharacterCount
 } from '../actions/messages';
 
 import Message from '../components/Message';
@@ -12,7 +13,11 @@ import MessageSend from '../components/compose/MessageSend';
 import MessageWrite from '../components/compose/MessageWrite';
 import NoticeBox from '../components/NoticeBox';
 import ThreadHeader from '../components/ThreadHeader';
-import { composeMessagePlaceholders } from '../config';
+
+import {
+  composeMessageMaxChars,
+  composeMessagePlaceholders
+} from '../config';
 
 class Thread extends React.Component {
   constructor(props) {
@@ -28,7 +33,8 @@ class Thread extends React.Component {
     this.props.fetchThread(id);
   }
 
-  handleReplyChange() {
+  handleReplyChange(valueObj) {
+    this.props.updateReplyCharacterCount(valueObj, composeMessageMaxChars);
   }
 
   handleReplySave() {
@@ -79,7 +85,7 @@ class Thread extends React.Component {
         <div className="messaging-thread-messages">
           {messages}
         </div>
-        <div className="messaging-thread-reply">
+        <form className="messaging-thread-reply">
           <div className="messaging-thread-reply-recipient">
             <label>To:</label>
             {lastSender}
@@ -89,11 +95,12 @@ class Thread extends React.Component {
               onValueChange={this.handleReplyChange}
               placeholder={composeMessagePlaceholders.message}/>
           <MessageSend
+              charCount={this.props.charsRemaining}
               cssClass="messaging-send-group"
               onSave={this.handleReplySave}
               onSend={this.handleReplySend}
               onDelete={this.handleReplyDelete}/>
-        </div>
+        </form>
         <NoticeBox/>
       </div>
     );
@@ -102,8 +109,10 @@ class Thread extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
-    thread: state.messages.data.thread,
+    charsRemaining: state.messages.ui.charsRemaining,
+    folderMessages: state.folders.data.currentItem.messages,
     messagesCollapsed: state.messages.ui.messagesCollapsed,
+    thread: state.messages.data.thread,
     visibleDetailsId: state.messages.ui.visibleDetailsId
   };
 };
@@ -111,7 +120,8 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = {
   fetchThread,
   toggleMessagesCollapsed,
-  setVisibleDetails
+  setVisibleDetails,
+  updateReplyCharacterCount
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Thread);

--- a/src/js/messaging/reducers/compose.js
+++ b/src/js/messaging/reducers/compose.js
@@ -11,7 +11,7 @@ import {
   FETCH_SENDER_SUCCESS,
   FETCH_RECIPIENTS_FAILURE,
   TOGGLE_CONFIRM_DELETE,
-  UPDATE_CHARACTER_COUNT
+  UPDATE_COMPOSE_CHARACTER_COUNT
 } from '../actions/compose';
 
 const initialState = {
@@ -62,7 +62,7 @@ export default function compose(state = initialState, action) {
       return set('message.sender', action.sender, state);
     case TOGGLE_CONFIRM_DELETE:
       return set('modals.deleteConfirm.visible', !state.modals.deleteConfirm.visible, state);
-    case UPDATE_CHARACTER_COUNT:
+    case UPDATE_COMPOSE_CHARACTER_COUNT:
       return set('message.charsRemaining', action.chars, state);
     case FETCH_RECIPIENTS_FAILURE:
     case SEND_MESSAGE:

--- a/src/js/messaging/reducers/messages.js
+++ b/src/js/messaging/reducers/messages.js
@@ -4,14 +4,18 @@ import {
   FETCH_THREAD_SUCCESS,
   FETCH_THREAD_FAILURE,
   SET_VISIBLE_DETAILS,
-  TOGGLE_MESSAGES_COLLAPSED
+  TOGGLE_MESSAGES_COLLAPSED,
+  UPDATE_REPLY_CHARACTER_COUNT
 } from '../actions/messages';
+
+import { composeMessageMaxChars } from '../config';
 
 const initialState = {
   data: {
     thread: []
   },
   ui: {
+    charsRemaining: composeMessageMaxChars,
     messagesCollapsed: true,
     visibleDetailsId: null
   }
@@ -27,6 +31,8 @@ export default function folders(state = initialState, action) {
       return set('ui.visibleDetailsId', action.messageId, state);
     case TOGGLE_MESSAGES_COLLAPSED:
       return set('ui.messagesCollapsed', !state.ui.messagesCollapsed, state);
+    case UPDATE_REPLY_CHARACTER_COUNT:
+      return set('ui.charsRemaining', action.chars, state);
     case FETCH_THREAD_FAILURE:
     default:
       return state;


### PR DESCRIPTION
These changes ensure that the character counts between the `MessageWrite` components in compose view and in thread view don't get mixed up.
