### PR TITLE
[Rx] Fixes for prescription status in history view.

### DIFF
--- a/src/js/rx/config.js
+++ b/src/js/rx/config.js
@@ -39,7 +39,7 @@ module.exports = {
     active: 'Active',
     discontinued: 'Discontinued',
     expired: 'Expired',
-    onHold: 'On hold',
+    hold: 'On hold',
     submitted: 'Pending',
     suspended: 'Suspended',
     refillinprocess: 'Refill in process',

--- a/src/js/rx/containers/History.jsx
+++ b/src/js/rx/containers/History.jsx
@@ -9,7 +9,7 @@ import { openGlossaryModal } from '../actions/modal.js';
 import Pagination from '../components/Pagination';
 import SortableTable from '../components/tables/SortableTable';
 import SortMenu from '../components/SortMenu';
-import { glossary } from '../config.js';
+import { glossary, rxStatuses } from '../config.js';
 
 class History extends React.Component {
   constructor(props) {
@@ -67,7 +67,7 @@ class History extends React.Component {
 
       const data = items.map(item => {
         const attrs = item.attributes;
-        const status = _.capitalize(attrs['refill-status']);
+        const status = _.capitalize(rxStatuses[attrs['refill-status']]);
 
         return {
           'ordered-date': moment(


### PR DESCRIPTION
Fixes:
- Mapping 'on hold' status from the proper key.
- Statuses in history view are translated from API form to readable form.
