### PR TITLE
Validate inputs on blur

### DIFF
--- a/src/js/common/components/form-elements/ErrorableNumberInput.jsx
+++ b/src/js/common/components/form-elements/ErrorableNumberInput.jsx
@@ -23,6 +23,7 @@ class ErrorableNumberInput extends React.Component {
   constructor() {
     super();
     this.handleChange = this.handleChange.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
   }
 
   componentWillMount() {
@@ -30,7 +31,11 @@ class ErrorableNumberInput extends React.Component {
   }
 
   handleChange(domEvent) {
-    this.props.onValueChange(makeField(domEvent.target.value, true));
+    this.props.onValueChange(makeField(domEvent.target.value, this.props.field.dirty));
+  }
+
+  handleBlur() {
+    this.props.onValueChange(makeField(this.props.field.value, true));
   }
 
   render() {
@@ -71,7 +76,8 @@ class ErrorableNumberInput extends React.Component {
             placeholder={this.props.placeholder}
             type="number"
             value={this.props.field.value}
-            onChange={this.handleChange}/>
+            onChange={this.handleChange}
+            onBlur={this.handleBlur}/>
       </div>
     );
   }

--- a/src/js/common/components/form-elements/ErrorableTextInput.jsx
+++ b/src/js/common/components/form-elements/ErrorableTextInput.jsx
@@ -27,6 +27,7 @@ class ErrorableTextInput extends React.Component {
   constructor() {
     super();
     this.handleChange = this.handleChange.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
   }
 
   componentWillMount() {
@@ -34,7 +35,11 @@ class ErrorableTextInput extends React.Component {
   }
 
   handleChange(domEvent) {
-    this.props.onValueChange(makeField(domEvent.target.value, true));
+    this.props.onValueChange(makeField(domEvent.target.value, this.props.field.dirty));
+  }
+
+  handleBlur() {
+    this.props.onValueChange(makeField(this.props.field.value, true));
   }
 
   render() {
@@ -94,7 +99,8 @@ class ErrorableTextInput extends React.Component {
             type="text"
             maxLength={this.props.charMax}
             value={this.props.field.value}
-            onChange={this.handleChange}/>
+            onChange={this.handleChange}
+            onBlur={this.handleBlur}/>
             {maxCharacters}
             {toolTip}
       </div>

--- a/src/js/common/components/form-elements/ErrorableTextarea.jsx
+++ b/src/js/common/components/form-elements/ErrorableTextarea.jsx
@@ -36,8 +36,12 @@ class ErrorableTextarea extends React.Component {
     const val = domEvent.target.value;
     // IE9 doesn't support max length on textareas
     if (!this.props.charMax || val.length <= this.props.charMax) {
-      this.props.onValueChange(makeField(val, true));
+      this.props.onValueChange(makeField(val, this.props.field.dirty));
     }
+  }
+
+  handleBlur() {
+    this.props.onValueChange(makeField(this.props.field.value, true));
   }
 
   render() {

--- a/src/js/common/components/form-elements/ErrorableTextarea.jsx
+++ b/src/js/common/components/form-elements/ErrorableTextarea.jsx
@@ -26,6 +26,7 @@ class ErrorableTextarea extends React.Component {
   constructor() {
     super();
     this.handleChange = this.handleChange.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
   }
 
   componentWillMount() {
@@ -99,7 +100,8 @@ class ErrorableTextarea extends React.Component {
             tabIndex={this.props.tabIndex}
             maxLength={this.props.charMax}
             value={this.props.field.value}
-            onChange={this.handleChange}/>
+            onChange={this.handleChange}
+            onBlur={this.handleBlur}/>
             {maxCharacters}
             {toolTip}
       </div>

--- a/src/js/common/utils/validations.js
+++ b/src/js/common/utils/validations.js
@@ -10,7 +10,7 @@ function validateIfDirty(field, validator) {
 }
 
 function validateIfDirtyDate(dayField, monthField, yearField, validator) {
-  if (dayField.dirty || monthField.dirty || yearField.dirty) {
+  if (dayField.dirty && monthField.dirty && yearField.dirty) {
     return validator(dayField.value, monthField.value, yearField.value);
   }
 

--- a/src/js/edu-benefits/components/military-history/MilitaryServiceFields.jsx
+++ b/src/js/edu-benefits/components/military-history/MilitaryServiceFields.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
-import ErrorableTextInput from '../../../common/components/form-elements/ErrorableTextInput';
+import ErrorableNumberInput from '../../../common/components/form-elements/ErrorableNumberInput';
 import GrowableTable from '../../../common/components/form-elements/GrowableTable';
 
 import MilitaryServiceTour from './MilitaryServiceTour';
 import { createTour } from '../../utils/veteran';
 
-import { validateIfDirty, isNotBlank, isValidYear, isValidPage } from '../../utils/validations';
+import { validateIfDirty, isNotBlank, isValidYear, isValidPage, isValidField } from '../../utils/validations';
 import { yesNo } from '../../utils/options-for-select';
 
 export default class MilitaryServiceFields extends React.Component {
@@ -46,11 +46,12 @@ export default class MilitaryServiceFields extends React.Component {
       <p>(<span className="form-required-span">*</span>) Indicates a required field</p>
       <div className="input-section">
         <p>If you graduated from a military service academy, what year did you graduate?</p>
-        <ErrorableTextInput
-            errorMessage={validateIfDirty(this.props.data.serviceAcademyGraduationYear, isValidYear) ? undefined : 'Please enter a valid year'}
+        <ErrorableNumberInput
+            errorMessage={validateIfDirty(this.props.data.serviceAcademyGraduationYear, (value) => isValidField(isValidYear, { value })) ? undefined : 'Please enter a valid year'}
             label="Year"
             placeholder="yyyy"
             name="serviceAcademyGraduationYear"
+            min="1900"
             field={this.props.data.serviceAcademyGraduationYear}
             onValueChange={(update) => {this.props.onStateChange('serviceAcademyGraduationYear', update);}}/>
         <ErrorableRadioButtons

--- a/src/js/edu-benefits/components/military-history/MilitaryServiceTour.jsx
+++ b/src/js/edu-benefits/components/military-history/MilitaryServiceTour.jsx
@@ -52,7 +52,7 @@ export default class MilitaryServiceTour extends React.Component {
             value={tour.serviceBranch}
             onValueChange={(update) => {onValueChange('serviceBranch', update);}}/>
         <DateInput required
-            errorMessage="Please provide a response"
+            errorMessage="Please provide a valid date"
             validation={validateIfDirtyDateObj(tour.dateRange.from, isValidDateField)}
             label="Date entered"
             name="fromDate"
@@ -61,7 +61,7 @@ export default class MilitaryServiceTour extends React.Component {
             year={tour.dateRange.from.year}
             onValueChange={(update) => {onValueChange('dateRange.from', update);}}/>
         <DateInput required
-            errorMessage={isValidDateRange(tour.dateRange.from, tour.dateRange.to) ? 'Please provide a response' : 'Date separated must be after date entered'}
+            errorMessage={isValidDateRange(tour.dateRange.from, tour.dateRange.to) ? 'Please provide a valid date' : 'Date separated must be after date entered'}
             validation={validateIfDirtyDateObj(tour.dateRange.to, date => isValidDateRange(tour.dateRange.from, date))}
             label="Date separated"
             name="toDate"

--- a/src/js/edu-benefits/components/veteran-information/VeteranInformationFields.jsx
+++ b/src/js/edu-benefits/components/veteran-information/VeteranInformationFields.jsx
@@ -19,6 +19,7 @@ export default class PersonalInformationFields extends React.Component {
               ssn={this.props.data.veteranSocialSecurityNumber}
               onValueChange={(update) => {this.props.onStateChange('veteranSocialSecurityNumber', update);}}/>
           <DateInput required
+              errorMessage="Please provide a valid date of birth"
               name="veteranBirth"
               day={this.props.data.veteranDateOfBirth.day}
               month={this.props.data.veteranDateOfBirth.month}

--- a/src/js/edu-benefits/utils/validations.js
+++ b/src/js/edu-benefits/utils/validations.js
@@ -328,7 +328,7 @@ function isValidForm(data) {
 
 function isValidPage(completePath, pageData) {
   switch (completePath) {
-    case '/veteran-information/personal-information':
+    case '/veteran-information':
       return isValidPersonalInfoPage(pageData);
     case '/veteran-information/contact-information':
       return isValidContactInformationPage(pageData);

--- a/test/common/components/form-elements/ErrorableNumberInput.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableNumberInput.unit.spec.jsx
@@ -25,7 +25,22 @@ describe('<ErrorableNumberInput>', () => {
     input.value = '1';
     ReactTestUtils.Simulate.change(input);
 
-    return expect(updatePromise).to.eventually.eql(makeField('1', true));
+    return expect(updatePromise).to.eventually.eql(makeField('1', false));
+  });
+
+  it('ensure blur makes field dirty', () => {
+    let errorableInput;
+
+    const updatePromise = new Promise((resolve, _reject) => {
+      errorableInput = ReactTestUtils.renderIntoDocument(
+        <ErrorableNumberInput field={testValue} label="test" onValueChange={(update) => { resolve(update); }}/>
+      );
+    });
+
+    const input = ReactTestUtils.findRenderedDOMComponentWithTag(errorableInput, 'input');
+    ReactTestUtils.Simulate.blur(input);
+
+    return expect(updatePromise).to.eventually.eql(makeField('', true));
   });
 
   it('no error styles when errorMessage undefined', () => {

--- a/test/common/components/form-elements/ErrorableTextInput.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableTextInput.unit.spec.jsx
@@ -23,7 +23,22 @@ describe('<ErrorableTextInput>', () => {
     input.value = 'newValue';
     ReactTestUtils.Simulate.change(input);
 
-    return expect(updatePromise).to.eventually.eql(makeField('newValue', true));
+    return expect(updatePromise).to.eventually.eql(makeField('newValue', false));
+  });
+
+  it('ensure blur makes field dirty', () => {
+    let errorableInput;
+
+    const updatePromise = new Promise((resolve, _reject) => {
+      errorableInput = ReactTestUtils.renderIntoDocument(
+        <ErrorableTextInput field={makeField(1)} label="test" onValueChange={(update) => { resolve(update); }}/>
+      );
+    });
+
+    const input = ReactTestUtils.findRenderedDOMComponentWithTag(errorableInput, 'input');
+    ReactTestUtils.Simulate.blur(input);
+
+    return expect(updatePromise).to.eventually.eql(makeField(1, true));
   });
 
   it('no error styles when errorMessage undefined', () => {

--- a/test/common/components/form-elements/ErrorableTextarea.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableTextarea.unit.spec.jsx
@@ -24,7 +24,22 @@ describe('<ErrorableTextarea>', () => {
     textarea.value = 'newValue';
     ReactTestUtils.Simulate.change(textarea);
 
-    return expect(updatePromise).to.eventually.eql(makeField('newValue', true));
+    return expect(updatePromise).to.eventually.eql(makeField('newValue', false));
+  });
+
+  it('ensure blur makes field dirty', () => {
+    let errorableInput;
+
+    const updatePromise = new Promise((resolve, _reject) => {
+      errorableInput = ReactTestUtils.renderIntoDocument(
+        <ErrorableTextarea field={makeField(1)} label="test" onValueChange={(update) => { resolve(update); }}/>
+      );
+    });
+
+    const textarea = ReactTestUtils.findRenderedDOMComponentWithTag(errorableInput, 'textarea');
+    ReactTestUtils.Simulate.blur(textarea);
+
+    return expect(updatePromise).to.eventually.eql(makeField(1, true));
   });
 
   it('ensure value doesn\'t propagate when using more than charMax', () => {


### PR DESCRIPTION
Closes #3025.

This changes forms to set `dirty` when you lose focus on inputs, instead of when the value changes.

This was simpler than I thought it would be, so I may be missing something.
