### PR TITLE
[SM] Individual messages in a thread can be expanded and collapsed.

### DIFF
--- a/src/js/messaging/actions/messages.js
+++ b/src/js/messaging/actions/messages.js
@@ -3,6 +3,7 @@ import { apiUrl } from '../config';
 export const FETCH_THREAD_SUCCESS = 'FETCH_THREAD_SUCCESS';
 export const FETCH_THREAD_FAILURE = 'FETCH_THREAD_FAILURE';
 export const SET_VISIBLE_DETAILS = 'SET_VISIBLE_DETAILS';
+export const TOGGLE_MESSAGE_COLLAPSED = 'TOGGLE_MESSAGE_COLLAPSED';
 export const TOGGLE_MESSAGES_COLLAPSED = 'TOGGLE_MESSAGES_COLLAPSED';
 export const UPDATE_REPLY_CHARACTER_COUNT = 'UPDATE_REPLY_CHARACTER_COUNT';
 
@@ -28,6 +29,10 @@ export function fetchThread(id) {
 
 export function setVisibleDetails(messageId) {
   return { type: SET_VISIBLE_DETAILS, messageId };
+}
+
+export function toggleMessageCollapsed(messageId) {
+  return { type: TOGGLE_MESSAGE_COLLAPSED, messageId };
 }
 
 export function toggleMessagesCollapsed() {

--- a/src/js/messaging/components/Message.jsx
+++ b/src/js/messaging/components/Message.jsx
@@ -29,9 +29,7 @@ class Message extends React.Component {
     } else {
       details = (
         <div className="messaging-message-recipient">
-          <span onClick={this.handleToggleCollapsed}>
-            to {this.props.attrs.recipient_name}
-          </span>
+          to {this.props.attrs.recipient_name}
           <MessageDetails { ...this.props }/>
         </div>
       );
@@ -54,8 +52,8 @@ class Message extends React.Component {
               ).format('DD MMM YYYY [@] HH[:]mm')
             }
           </div>
+          {details}
         </div>
-        {details}
         <p className="messaging-message-body">
           {this.props.attrs.body}
         </p>

--- a/src/js/messaging/components/Message.jsx
+++ b/src/js/messaging/components/Message.jsx
@@ -5,6 +5,15 @@ import moment from 'moment';
 import MessageDetails from './MessageDetails';
 
 class Message extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleToggleCollapsed = this.handleToggleCollapsed.bind(this);
+  }
+
+  handleToggleCollapsed() {
+    this.props.onToggleCollapsed(this.props.attrs.message_id);
+  }
+
   render() {
     const messageClass = classNames({
       'messaging-thread-message': true,
@@ -12,27 +21,39 @@ class Message extends React.Component {
     });
 
     let details;
+    let headerOnClick;
+    let messageOnClick;
 
-    if (!this.props.isCollapsed) {
+    if (this.props.isCollapsed) {
+      messageOnClick = this.handleToggleCollapsed;
+    } else {
       details = (
         <div className="messaging-message-recipient">
-          to {this.props.attrs.recipient_name}
+          <span onClick={this.handleToggleCollapsed}>
+            to {this.props.attrs.recipient_name}
+          </span>
           <MessageDetails { ...this.props }/>
         </div>
       );
+
+      headerOnClick = this.handleToggleCollapsed;
     }
 
     return (
-      <div className={messageClass}>
-        <div className="messaging-message-sender">
-          {this.props.attrs.sender_name}
-        </div>
-        <div className="messaging-message-sent-date">
-          {
-            moment(
-              this.props.attrs.sent_date
-            ).format('DD MMM YYYY [@] HH[:]mm')
-          }
+      <div className={messageClass} onClick={messageOnClick}>
+        <div
+            className="messaging-message-header"
+            onClick={headerOnClick}>
+          <div className="messaging-message-sender">
+            {this.props.attrs.sender_name}
+          </div>
+          <div className="messaging-message-sent-date">
+            {
+              moment(
+                this.props.attrs.sent_date
+              ).format('DD MMM YYYY [@] HH[:]mm')
+            }
+          </div>
         </div>
         {details}
         <p className="messaging-message-body">
@@ -63,6 +84,7 @@ Message.propTypes = {
   }).isRequired,
   isCollapsed: React.PropTypes.bool,
   detailsVisible: React.PropTypes.bool,
+  onToggleCollapsed: React.PropTypes.func,
   setVisibleDetails: React.PropTypes.func
 };
 

--- a/src/js/messaging/components/Message.jsx
+++ b/src/js/messaging/components/Message.jsx
@@ -81,8 +81,8 @@ Message.propTypes = {
     /* eslint-enable */
   }).isRequired,
   isCollapsed: React.PropTypes.bool,
-  detailsVisible: React.PropTypes.bool,
   onToggleCollapsed: React.PropTypes.func,
+  hasVisibleDetails: React.PropTypes.bool,
   setVisibleDetails: React.PropTypes.func
 };
 

--- a/src/js/messaging/components/MessageDetails.jsx
+++ b/src/js/messaging/components/MessageDetails.jsx
@@ -26,7 +26,7 @@ class MessageDetails extends React.Component {
 
   render() {
     let messageDetails;
-    if (this.props.detailsVisible) {
+    if (this.props.hasVisibleDetails) {
       messageDetails = (
         <div
             className="messaging-message-details"
@@ -90,7 +90,7 @@ MessageDetails.propTypes = {
     recipient_name: React.PropTypes.string.isRequired,
     /* eslint-enable */
   }).isRequired,
-  detailsVisible: React.PropTypes.bool,
+  hasVisibleDetails: React.PropTypes.bool,
   setVisibleDetails: React.PropTypes.func
 };
 

--- a/src/js/messaging/components/MessageDetails.jsx
+++ b/src/js/messaging/components/MessageDetails.jsx
@@ -32,7 +32,8 @@ class MessageDetails extends React.Component {
             className="messaging-message-details"
             ref="messageDetails"
             tabIndex="-1"
-            onBlur={this.hideDetails}>
+            onBlur={this.hideDetails}
+            onClick={(domEvent) => domEvent.stopPropagation()}>
           <table>
             <tbody>
               <tr>

--- a/src/js/messaging/components/MessageDetails.jsx
+++ b/src/js/messaging/components/MessageDetails.jsx
@@ -19,7 +19,8 @@ class MessageDetails extends React.Component {
     this.props.setVisibleDetails(null);
   }
 
-  showDetails() {
+  showDetails(domEvent) {
+    domEvent.stopPropagation();
     this.props.setVisibleDetails(this.props.attrs.message_id);
   }
 

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -109,7 +109,7 @@ class Thread extends React.Component {
         const isCollapsed =
           this.props.messagesCollapsed.has(message.message_id);
 
-        const detailsVisible =
+        const hasVisibleDetails =
           this.props.visibleDetailsId === message.message_id;
 
         return (
@@ -117,9 +117,9 @@ class Thread extends React.Component {
               key={message.message_id}
               attrs={message}
               isCollapsed={isCollapsed}
-              detailsVisible={detailsVisible}
-              setVisibleDetails={this.props.setVisibleDetails}
-              onToggleCollapsed={this.props.toggleMessageCollapsed}/>
+              onToggleCollapsed={this.props.toggleMessageCollapsed}
+              hasVisibleDetails={hasVisibleDetails}
+              setVisibleDetails={this.props.setVisibleDetails}/>
         );
       });
     }

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import {
   fetchThread,
   setVisibleDetails,
+  toggleMessageCollapsed,
   toggleMessagesCollapsed,
   updateReplyCharacterCount
 } from '../actions/messages';
@@ -98,15 +99,16 @@ class Thread extends React.Component {
             handleNext={fetchNextMessage}
             subject={thread[0].subject}
             threadMessageCount={thread.length}
-            messagesCollapsed={this.props.messagesCollapsed}
+            messagesCollapsed={(this.props.messagesCollapsed.size > 0)}
             onToggleThread={this.props.toggleMessagesCollapsed}/>
       );
 
       lastSender = currentMessage.sender_name;
 
-      threadMessages = thread.map((message, i) => {
-        const isCollapsed = this.props.messagesCollapsed &&
-                            (i !== thread.length - 1);
+      threadMessages = thread.map((message) => {
+        const isCollapsed =
+          this.props.messagesCollapsed.has(message.message_id);
+
         const detailsVisible =
           this.props.visibleDetailsId === message.message_id;
 
@@ -116,7 +118,8 @@ class Thread extends React.Component {
               attrs={message}
               isCollapsed={isCollapsed}
               detailsVisible={detailsVisible}
-              setVisibleDetails={this.props.setVisibleDetails}/>
+              setVisibleDetails={this.props.setVisibleDetails}
+              onToggleCollapsed={this.props.toggleMessageCollapsed}/>
         );
       });
     }
@@ -161,6 +164,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = {
   fetchThread,
+  toggleMessageCollapsed,
   toggleMessagesCollapsed,
   setVisibleDetails,
   updateReplyCharacterCount

--- a/src/js/messaging/reducers/messages.js
+++ b/src/js/messaging/reducers/messages.js
@@ -41,7 +41,6 @@ export default function folders(state = initialState, action) {
       return set('ui.visibleDetailsId', action.messageId, state);
 
     case TOGGLE_MESSAGE_COLLAPSED: {
-      console.log('TOGGLE_MESSAGE_COLLAPSED');
       // Don't allow the currently viewed message (last in thread)
       // to be collapsed.
       const thread = state.data.thread;

--- a/src/js/messaging/reducers/messages.js
+++ b/src/js/messaging/reducers/messages.js
@@ -4,6 +4,7 @@ import {
   FETCH_THREAD_SUCCESS,
   FETCH_THREAD_FAILURE,
   SET_VISIBLE_DETAILS,
+  TOGGLE_MESSAGE_COLLAPSED,
   TOGGLE_MESSAGES_COLLAPSED,
   UPDATE_REPLY_CHARACTER_COUNT
 } from '../actions/messages';
@@ -16,7 +17,7 @@ const initialState = {
   },
   ui: {
     charsRemaining: composeMessageMaxChars,
-    messagesCollapsed: true,
+    messagesCollapsed: new Set(),
     visibleDetailsId: null
   }
 };
@@ -26,15 +27,61 @@ export default function folders(state = initialState, action) {
     case FETCH_THREAD_SUCCESS: {
       const currentMessage = action.message.attributes;
       const thread = action.thread.map(message => message.attributes);
-      thread.reverse().push(currentMessage);
-      return set('data.thread', thread, state);
+      const messagesCollapsed = new Set(thread.map((message) => {
+        return message.message_id;
+      }));
+      thread.reverse();
+
+      const newState = set('ui.messagesCollapsed', messagesCollapsed, state);
+      thread.push(currentMessage);
+      return set('data.thread', thread, newState);
     }
+
     case SET_VISIBLE_DETAILS:
       return set('ui.visibleDetailsId', action.messageId, state);
-    case TOGGLE_MESSAGES_COLLAPSED:
-      return set('ui.messagesCollapsed', !state.ui.messagesCollapsed, state);
+
+    case TOGGLE_MESSAGE_COLLAPSED: {
+      console.log('TOGGLE_MESSAGE_COLLAPSED');
+      // Don't allow the currently viewed message (last in thread)
+      // to be collapsed.
+      const thread = state.data.thread;
+      const currentMessageId = thread[thread.length - 1].message_id;
+      if (action.messageId === currentMessageId) {
+        return state;
+      }
+
+      const newMessagesCollapsed = new Set(state.ui.messagesCollapsed);
+      if (newMessagesCollapsed.has(action.messageId)) {
+        newMessagesCollapsed.delete(action.messageId);
+      } else {
+        newMessagesCollapsed.add(action.messageId);
+      }
+
+      return set('ui.messagesCollapsed', newMessagesCollapsed, state);
+    }
+
+    case TOGGLE_MESSAGES_COLLAPSED: {
+      // If any messages are collapsed at all, toggling
+      // this option should expand all messages.
+      // Only collapse all if everything has been expanded.
+      const currentCollapsed = state.ui.messagesCollapsed;
+      let newMessagesCollapsed = new Set();
+
+      if (currentCollapsed.size === 0) {
+        // The current message should never be collapsed.
+        const messagesExceptCurrent = state.data.thread.slice(0, -1);
+        newMessagesCollapsed =
+          new Set(messagesExceptCurrent.map((message) => {
+            return message.message_id;
+          }));
+      }
+
+      return set('ui.messagesCollapsed', newMessagesCollapsed, state);
+    }
+
     case UPDATE_REPLY_CHARACTER_COUNT:
       return set('ui.charsRemaining', action.chars, state);
+
     case FETCH_THREAD_FAILURE:
     default:
       return state;

--- a/src/js/messaging/reducers/messages.js
+++ b/src/js/messaging/reducers/messages.js
@@ -41,7 +41,6 @@ export default function folders(state = initialState, action) {
 
     case SET_VISIBLE_DETAILS:
       return set('ui.visibleDetailsId', action.messageId, state);
-<<<<<<< HEAD
 
     case TOGGLE_MESSAGE_COLLAPSED: {
       // Don't allow the currently viewed message (last in thread)

--- a/src/sass/messaging/partials/_messaging-count-nav.scss
+++ b/src/sass/messaging/partials/_messaging-count-nav.scss
@@ -27,7 +27,7 @@
 }
 
 .messaging-move {
-  padding: .5rem, .75rem;
+  padding: .5rem .75rem;
 }
 
 .messaging-message-nav button,

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -160,16 +160,11 @@
 
 .messaging-message-recipient {
   color: $color-gray-medium;
-
-  span {
-    cursor: pointer;
-  }
 }
 
 // The last message in a thread should not be collapsible.
 .messaging-thread-message:last-child {
-  .messaging-message-header,
-  .messaging-message-recipient span {
+  .messaging-message-header {
     cursor: auto;
   }
 }

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -78,6 +78,7 @@
 
   &--collapsed {
     background: $color-gray-lightest;
+    cursor: pointer;
 
     p {
       margin: 0;
@@ -86,6 +87,10 @@
       white-space: nowrap;
     }
   }
+}
+
+.messaging-message-header {
+  cursor: pointer;
 }
 
 .messaging-message-details-control {
@@ -155,6 +160,18 @@
 
 .messaging-message-recipient {
   color: $color-gray-medium;
+
+  span {
+    cursor: pointer;
+  }
+}
+
+// The last message in a thread should not be collapsible.
+.messaging-thread-message:last-child {
+  .messaging-message-header,
+  .messaging-message-recipient span {
+    cursor: auto;
+  }
 }
 
 /****************

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -178,8 +178,12 @@
   font-size: 1.8rem;
   padding: 3rem 2rem;
 
-  .messaging-write label {
-    display: none;
+  .messaging-write {
+    padding-top: 0;
+
+    label {
+      display: none;
+    }
   }
 
   &-recipient {

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -136,6 +136,7 @@
 .messaging-message-details {
   background: $color-white;
   border: 1px solid $color-black;
+  cursor: auto;
   font-size: 1.5rem;
   padding: 1rem;
   position: absolute;


### PR DESCRIPTION
Closes department-of-veterans-affairs/messaging-fe#65.

Changes the binary state of whether a thread's messages are collapsed to a set of messages (tracked by ids) that are currently collapsed.
