### PR TITLE
Adds folders to MoveTo component

### DIFF
--- a/src/js/messaging/components/MoveTo.jsx
+++ b/src/js/messaging/components/MoveTo.jsx
@@ -2,27 +2,36 @@ import React from 'react';
 
 import ButtonCreateFolder from './buttons/ButtonCreateFolder';
 import ButtonMove from './buttons/ButtonMove';
-import { folderIds } from '../config';
+import MoveToOption from './MoveToOption';
 
 class MoveTo extends React.Component {
   render() {
+    const folderOptions = this.props.folders.map((folder) => {
+      return (
+        <li key={folder.folderId}>
+          <MoveToOption
+              folderName={folder.name}
+              folderId={folder.folderId}/>
+        </li>
+      );
+    });
+
     return (
       <div className="msg-move-to">
         <ButtonMove onClick={this.props.onToggleMoveTo}/>
-        <form hidden={this.props.isOpen}>
-          <fieldset onChange={this.props.onChooseFolder}>
+        <form
+            hidden={this.props.isOpen}
+            onChange={this.props.onChooseFolder}>
+          <input
+              name="threadId"
+              type="hidden"
+              value={this.props.threadId}/>
+          <fieldset>
             <legend className="usa-sr-only">
               Move this message to
             </legend>
             <ul className="msg-move-to-options">
-              <li>
-                <input
-                    className="msg-hidden-radio"
-                    type="radio"
-                    id="msg-moveto-deleted"
-                    value={folderIds.DELETED}/>
-                <label htmlFor="msg-moveto-deleted">Deleted</label>
-              </li>
+              {folderOptions}
               <li><ButtonCreateFolder onClick={this.props.onCreateFolder}/></li>
             </ul>
           </fieldset>
@@ -33,7 +42,16 @@ class MoveTo extends React.Component {
 }
 
 MoveTo.propTypes = {
+  folders: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      folderId: React.PropTypes.number.isRequired,
+      name: React.PropTypes.string.isRequired,
+      count: React.PropTypes.number.isRequired,
+      unreadCount: React.PropTypes.number.isRequired
+    })
+  ).isRequired,
   isOpen: React.PropTypes.bool,
+  threadId: React.PropTypes.string.isRequired,
   onChooseFolder: React.PropTypes.func.isRequired,
   onCreateFolder: React.PropTypes.func.isRequired,
   onToggleMoveTo: React.PropTypes.func.isRequired,

--- a/src/js/messaging/components/MoveToOption.jsx
+++ b/src/js/messaging/components/MoveToOption.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+class MoveToOption extends React.Component {
+  render() {
+    const folderHtmlId = `msg-move-to-${this.props.folderName}`;
+    return (
+      <div>
+        <input
+            className="msg-hidden-radio"
+            name="messagingMoveToFolder"
+            type="radio"
+            id={folderHtmlId}
+            value={this.props.folderId}/>
+        <label
+            className="msg-move-to-label"
+            htmlFor={folderHtmlId}>{this.props.folderName}</label>
+      </div>
+    );
+  }
+}
+
+MoveToOption.propTypes = {
+  folderName: React.PropTypes.string,
+  folderId: React.PropTypes.number
+};
+
+export default MoveToOption;

--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -34,10 +34,12 @@ class ThreadHeader extends React.Component {
           <div>
             <Link to={paths.INBOX_URL}>&lt; Back to Inbox</Link>
             <MoveTo
+                folders={this.props.folders}
                 isOpen={!this.props.moveToIsOpen}
                 onChooseFolder={this.props.onChooseFolder}
                 onCreateFolder={this.props.onCreateFolder}
-                onToggleMoveTo={this.props.onToggleMoveTo}/>
+                onToggleMoveTo={this.props.onToggleMoveTo}
+                threadId={this.props.threadId}/>
           </div>
           <MessageNav
               currentRange={this.props.currentMessageNumber}
@@ -61,10 +63,19 @@ class ThreadHeader extends React.Component {
 
 ThreadHeader.propTypes = {
   currentMessageNumber: React.PropTypes.number.isRequired,
+  folders: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      folderId: React.PropTypes.number.isRequired,
+      name: React.PropTypes.string.isRequired,
+      count: React.PropTypes.number.isRequired,
+      unreadCount: React.PropTypes.number.isRequired
+    })
+  ).isRequired,
   folderMessageCount: React.PropTypes.number.isRequired,
   handlePrev: React.PropTypes.func,
   handleNext: React.PropTypes.func,
   subject: React.PropTypes.string.isRequired,
+  threadId: React.PropTypes.string.isRequired,
   threadMessageCount: React.PropTypes.number.isRequired,
   messagesCollapsed: React.PropTypes.bool,
   moveToIsOpen: React.PropTypes.bool,

--- a/src/js/messaging/config.js
+++ b/src/js/messaging/config.js
@@ -12,12 +12,7 @@ module.exports = {
   paths: {
     INBOX_URL: '/messaging',
     COMPOSE_URL: '/messaging/compose',
-    DRAFTS_URL: '/messaging/folder/-2',
-    DELETED_URL: '/messaging/folder/-3'
-  },
-
-  folderIds: {
-    DELETED: -3
+    DRAFTS_URL: '/messaging/folder/-2'
   },
 
   // An array of objects containing the category name (label) and a

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -28,6 +28,7 @@ class Thread extends React.Component {
     this.handleReplySave = this.handleReplySave.bind(this);
     this.handleReplySend = this.handleReplySend.bind(this);
     this.handleReplyDelete = this.handleReplyDelete.bind(this);
+    this.handleMoveTo = this.handleMoveTo.bind(this);
   }
 
   componentDidMount() {
@@ -46,6 +47,15 @@ class Thread extends React.Component {
   }
 
   handleReplyDelete() {
+  }
+
+  handleMoveTo() {
+    // TODO: Make this call a function that dispatches an action
+    // domEvent will bubble up from the radio button
+    // to the form, which is why we're using currentTarget.
+    // instead of target.
+    // const folderId = domEvent.currentTarget.messagingMoveToFolder.value;
+    // const threadId = domEvent.currentTarget.threadId.value;
   }
 
   render() {
@@ -95,14 +105,16 @@ class Thread extends React.Component {
       header = (
         <ThreadHeader
             currentMessageNumber={currentIndex + 1}
+            folders={this.props.folders.data.items}
             folderMessageCount={folderMessageCount}
             handlePrev={fetchPrevMessage}
             handleNext={fetchNextMessage}
             subject={thread[0].subject}
             threadMessageCount={thread.length}
+            threadId={this.props.params.id}
             messagesCollapsed={(this.props.messagesCollapsed.size > 0)}
             moveToIsOpen={this.props.moveToOpened}
-            onChooseFolder={(e) => {e.preventDefault();}}
+            onChooseFolder={this.handleMoveTo}
             onCreateFolder={(e) => {e.preventDefault();}}
             onToggleThread={this.props.toggleMessagesCollapsed}
             onToggleMoveTo={this.props.toggleMoveTo}/>
@@ -160,6 +172,7 @@ class Thread extends React.Component {
 const mapStateToProps = (state) => {
   return {
     charsRemaining: state.messages.ui.charsRemaining,
+    folders: state.folders,
     folderMessages: state.folders.data.currentItem.messages,
     messagesCollapsed: state.messages.ui.messagesCollapsed,
     moveToOpened: state.messages.ui.moveToOpened,

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -105,7 +105,7 @@ class Thread extends React.Component {
       header = (
         <ThreadHeader
             currentMessageNumber={currentIndex + 1}
-            folders={this.props.folders.data.items}
+            folders={this.props.folders}
             folderMessageCount={folderMessageCount}
             handlePrev={fetchPrevMessage}
             handleNext={fetchNextMessage}
@@ -172,7 +172,7 @@ class Thread extends React.Component {
 const mapStateToProps = (state) => {
   return {
     charsRemaining: state.messages.ui.charsRemaining,
-    folders: state.folders,
+    folders: state.folders.data.items,
     folderMessages: state.folders.data.currentItem.messages,
     messagesCollapsed: state.messages.ui.messagesCollapsed,
     moveToOpened: state.messages.ui.moveToOpened,

--- a/src/js/messaging/reducers/messages.js
+++ b/src/js/messaging/reducers/messages.js
@@ -20,7 +20,7 @@ const initialState = {
     charsRemaining: composeMessageMaxChars,
     messagesCollapsed: new Set(),
     visibleDetailsId: null,
-    moveToOpened: true
+    moveToOpened: false
   }
 };
 

--- a/src/sass/messaging/partials/_messaging-moveto.scss
+++ b/src/sass/messaging/partials/_messaging-moveto.scss
@@ -1,4 +1,5 @@
 .msg-move-to {
+  display: inline-block;
   position: relative;
 }
 
@@ -11,10 +12,6 @@
   width: auto;
   
   & + label {
-    display: block;
-    padding: .5rem;
-    margin: 0;
-    
     &:hover {
       background: $color-gray-lightest;
     }
@@ -37,13 +34,22 @@
   margin: -1px 0 0 0;
   padding-left: 0;
   position: absolute;
-  width: 20rem;
-  z-index: 1;
+  z-index: 3;
   
   .msg-btn-newfolder[type="button"] {
     display: block;
     padding: .5rem;
+    white-space: nowrap;
     width: 100%;
   }
 }
 
+.msg-move-to-label {
+  display: block;
+  margin: 0;
+  overflow: hidden;
+  padding: 1rem;
+  text-overflow: ellipsis;
+  width: 25rem;
+  white-space: nowrap;
+}


### PR DESCRIPTION
WIP on department-of-veterans-affairs/messaging-fe#44
- Adds folders as a prop of ThreadHeader, MoveTo.
- Passes threadId down to MoveTo.
- Set moveToIsOpened to false
- Changes positioning of MoveTo component to sit next to 'Back to Inbox' link
- Adds MoveToOption component to list each destination folder.
- Removes unnecessary folderIds config option.

Still to do:
- Make the MoveTo component actually move a message
- Exclude the current folder from the MoveTo folder list.
- Make Create New Folder button trigger the Create New Folder modal.

Blocked by department-of-veterans-affairs/messaging-fe#47
