### PR TITLE
Fix icon issues on edu benefits

### DIFF
--- a/src/js/common/components/NavHeader.jsx
+++ b/src/js/common/components/NavHeader.jsx
@@ -15,9 +15,9 @@ export default class NavHeader extends React.Component {
         }
       });
 
-    return (
-      <h4 className={className}><span className="form-process-step current">{step}</span> of {total} {name}</h4>
-    );
+    return step
+      ? <h4 className={className}><span className="form-process-step current">{step}</span> of {total} {name}</h4>
+      : null;
   }
 }
 

--- a/src/js/edu-benefits/components/personal-information/ContactInformationFields.jsx
+++ b/src/js/edu-benefits/components/personal-information/ContactInformationFields.jsx
@@ -27,12 +27,6 @@ export default class ContactInformationFields extends React.Component {
       <fieldset>
         <p>(<span className="form-required-span">*</span>) Indicates a required field</p>
         <legend>Contact information</legend>
-        <div className="input-section">
-          <div className="usa-alert usa-alert-info">
-            <p className="usa-alert-text">Providing as much contact information as possible will help the VA
-            get in touch more efficiently, should we need more information.</p>
-          </div>
-        </div>
         <h4>Address</h4>
         <div className="input-section">
           <Address required

--- a/src/js/edu-benefits/containers/IntroductionPage.jsx
+++ b/src/js/edu-benefits/containers/IntroductionPage.jsx
@@ -12,18 +12,14 @@ class IntroductionPage extends React.Component {
 
         <div className="row">
           <div className="small-12 columns">
-            <p>
-              Fill out this application with the most accurate information you have. The more accurate it is, the more likely you are to get a rapid response.
-            </p>
-            <p>
-              VA uses the information you submit to determine your eligibility and to provide you with the best service.
-            </p>
-            <p>
-              Federal law provides criminal penalties, including a fine and/or imprisonment for up to 5 years, for concealing a material fact or making a materially false statement. (See <a href="https://www.justice.gov/usam/criminal-resource-manual-903-false-statements-concealment-18-usc-1001" target="_blank">18 U.S.C. 1001</a>)
-            </p>
+            <p>Complete this application to receive your official certificate of eligibility for the benefit you wish to receive.</p>
             <div className="usa-alert usa-alert-info">
-              <strong>Note:</strong> You will not be able to save your progress once you have started the form.
+              <div className="usa-alert-body">
+                <span><b>You will not be able to save your work or come back later to finish.</b> So it's helpful to have paperwork related to your military history, and information about the school you want to attend, if you have it.</span>
+              </div>
             </div>
+            <p>This application is based on VA Form 22-1990.</p>
+            <strong>Note:</strong> According to federal law, there are criminal penalties, including a fine and/or imprisonment for up to 5 years, for withholding information or for providing incorrect information. (See 18 U.S.C. 1001)
           </div>
         </div>
       </div>

--- a/src/sass/modules/_m-form-process.scss
+++ b/src/sass/modules/_m-form-process.scss
@@ -57,6 +57,7 @@
 .form-review-panel {
   button {
       background-color: $color-primary;
+      background-image: none;
       color: $white;
       &:hover {
         background-color: $color-primary-darker;


### PR DESCRIPTION
Since SVGs are working correctly now, they've shown up in a few places we weren't expecting. This fixes those and a related issue:
- Fixed overlapping icon on introduction page (and updated copy)
- Removed callout box from contact information page (at designers' request)
- Hide mobile navigation header when not on a page with a step (i.e. the intro page)
- Hide the `-` icon that started showing up on buttons on the review page

![screen shot 2016-09-22 at 5 34 42 pm](https://cloud.githubusercontent.com/assets/634932/18767002/dd2cc69a-80ea-11e6-8422-656a22db462e.png)
![screen shot 2016-09-22 at 5 35 17 pm](https://cloud.githubusercontent.com/assets/634932/18767028/f73c11b2-80ea-11e6-8ff5-1a79f0fb520d.png)
