### PR TITLE
Added spacing above navigation buttons on Introduction and Review pages

### DIFF
--- a/src/js/edu-benefits/containers/IntroductionPage.jsx
+++ b/src/js/edu-benefits/containers/IntroductionPage.jsx
@@ -12,14 +12,16 @@ class IntroductionPage extends React.Component {
 
         <div className="row">
           <div className="small-12 columns">
-            <p>Complete this application to receive your official certificate of eligibility for the benefit you wish to receive.</p>
-            <div className="usa-alert usa-alert-info">
-              <div className="usa-alert-body">
-                <span><b>You will not be able to save your work or come back later to finish.</b> So it's helpful to have paperwork related to your military history, and information about the school you want to attend, if you have it.</span>
+            <div className="input-section">
+              <p>Complete this application to receive your official certificate of eligibility for the benefit you wish to receive.</p>
+              <div className="usa-alert usa-alert-info">
+                <div className="usa-alert-body">
+                  <span><b>You will not be able to save your work or come back later to finish.</b> So it's helpful to have paperwork related to your military history, and information about the school you want to attend, if you have it.</span>
+                </div>
               </div>
+              <p>This application is based on VA Form 22-1990.</p>
+              <strong>Note:</strong> According to federal law, there are criminal penalties, including a fine and/or imprisonment for up to 5 years, for withholding information or for providing incorrect information. (See 18 U.S.C. 1001)
             </div>
-            <p>This application is based on VA Form 22-1990.</p>
-            <strong>Note:</strong> According to federal law, there are criminal penalties, including a fine and/or imprisonment for up to 5 years, for withholding information or for providing incorrect information. (See 18 U.S.C. 1001)
           </div>
         </div>
       </div>

--- a/src/js/edu-benefits/containers/ReviewPage.jsx
+++ b/src/js/edu-benefits/containers/ReviewPage.jsx
@@ -61,7 +61,9 @@ class ReviewPage extends React.Component {
     return (
       <div>
         <h4>Review Application</h4>
-        {content}
+        <div className="input-section">
+          {content}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Noticed that the Introduction and Review pages were missing spacing above the navigation buttons. Wrapped the main content on each of those pages in a `div` with the class `input-section`, which the other pages use for adding that spacing.

Closes #3157 
