### PR TITLE
[Messaging] Compose page mobile layout fixes.

### DIFF
--- a/src/sass/messaging/partials/_message-compose.scss
+++ b/src/sass/messaging/partials/_message-compose.scss
@@ -1,6 +1,6 @@
 .messaging-subject-group {
   position: relative;
-
+ 
   @media (min-width: $medium-screen) {
     > div {
       display: flex;
@@ -20,9 +20,13 @@
   
   legend {
     font-size: inherit;
-    padding-top: 1.25rem;
-    margin-bottom: -1rem;
-  }   
+    margin-top: 1rem;
+    position: absolute;
+    top: 50%;
+    -webkit-transform: translateY(-50%);  
+    -ms-transform: translateY(-50%);
+    transform: translateY(-50%);
+  }
 } 
 
 @media (min-width: $medium-screen) {
@@ -49,8 +53,7 @@
 
 .messaging-recipient > div,
 .messaging-from,
-.messaging-subject-group,
-.messaging-write {
+.messaging-subject-group {
   padding: 1.5rem;
 }
 
@@ -136,10 +139,8 @@
 }
 
 .messaging-write {
-  @media (min-width: $medium-screen) {
-    padding: 1.5rem 0 0 0;
-  }
-    
+  margin-top: 3rem;
+     
   textarea {
     margin: 1rem 0 0 0;
     max-width: 100%;

--- a/src/sass/messaging/partials/_message-compose.scss
+++ b/src/sass/messaging/partials/_message-compose.scss
@@ -1,6 +1,18 @@
 .messaging-subject-group {
   position: relative;
 
+  > div {
+    width: 100%;
+  }
+
+  legend {
+    font-size: inherit;
+    margin: 0;
+    padding-top: 1.5rem;
+    position: relative;
+    transform: none;
+  }
+
   @media (min-width: $medium-screen) {
     > div {
       display: flex;
@@ -10,22 +22,22 @@
       width: 70%;
     }
 
+    legend {
+      margin-top: 1rem;
+      padding: 0;
+      position: absolute;
+      top: 50%;
+      -webkit-transform: translateY(-50%);
+      -ms-transform: translateY(-50%);
+      transform: translateY(-50%);
+    }
+
     margin: 0 -1.5rem;
   }
 
   label {
     position: absolute;
     left: -999em;
-  }
-
-  legend {
-    font-size: inherit;
-    margin-top: 1rem;
-    position: absolute;
-    top: 50%;
-    -webkit-transform: translateY(-50%);
-    -ms-transform: translateY(-50%);
-    transform: translateY(-50%);
   }
 }
 

--- a/src/sass/messaging/partials/_message-compose.scss
+++ b/src/sass/messaging/partials/_message-compose.scss
@@ -1,6 +1,6 @@
 .messaging-subject-group {
   position: relative;
- 
+
   @media (min-width: $medium-screen) {
     > div {
       display: flex;
@@ -12,28 +12,28 @@
 
     margin: 0 -1.5rem;
   }
-     
+
   label {
     position: absolute;
     left: -999em;
   }
-  
+
   legend {
     font-size: inherit;
     margin-top: 1rem;
     position: absolute;
     top: 50%;
-    -webkit-transform: translateY(-50%);  
+    -webkit-transform: translateY(-50%);
     -ms-transform: translateY(-50%);
     transform: translateY(-50%);
   }
-} 
+}
 
 @media (min-width: $medium-screen) {
   .messaging-category {
     margin-right: 1rem;
     -webkit-flex: 0 1 40%;
-    flex: 0 1 40%; 
+    flex: 0 1 40%;
   }
   .messaging-subject {
     -webkit-flex: 1 1 60%;
@@ -45,7 +45,7 @@
 .messaging-from,
 .messaging-subject-group {
   -webkit-align-items: center;
-  align-items: center; 
+  align-items: center;
   display: -webkit-flex;
   display: flex;
   margin-bottom: 0;
@@ -75,12 +75,12 @@
 .messaging-recipient label,
 .messaging-from-label {
   padding-right: 1rem;
-  
+
   @media (min-width: $medium-screen) {
     -webkit-flex: 0 0 8rem;
     flex:  0 0 8rem;
     text-align: right;
-	}
+  }
 }
 
 .messaging-btn-delete {
@@ -89,14 +89,14 @@
     float: right;
   }
 }
-  
+
 .messaging-send-group {
   background: $color-gray-lightest;
   border: 1px solid $color-gray;
   border-top-width: 0;
   padding: 1rem;
   position: relative;
-  
+
   @media (max-width: $medium-screen) {
     display: -webkit-flex;
     display: flex;
@@ -105,21 +105,21 @@
     -webkit-flex-wrap: wrap;
     flex-wrap: wrap;
   }
-  
+
   [type="button"] {
     margin: 0 1rem 0 0;
-    
+
     @media (max-width: $medium-screen) {
       -webkit-flex: 0 0 48%;
       flex: 0 0 48%;
-      margin: 1.5rem 0rem .5rem; 
+      margin: 1.5rem 0rem .5rem;
     }
 
     &[disabled] {
       background: $color-gray;
     }
   }
-     
+
   .messaging-btn-delete {
     @media (max-width: $medium-screen) {
       display: none;
@@ -135,12 +135,12 @@
   &[disabled] {
     color: $color-gray !important;
     box-shadow: inset 0 0 0 2px $color-gray !important;
-  }  
+  }
 }
 
 .messaging-write {
   margin-top: 3rem;
-     
+
   textarea {
     margin: 1rem 0 0 0;
     max-width: 100%;
@@ -150,7 +150,7 @@
       border: none;
       padding: 0;
     }
-    
+
     @media (min-width: $medium-screen) {
       resize: vertical;
     }
@@ -165,12 +165,12 @@
     order: -1;
     text-align: right;
   }
-  
+
   @media (min-width: $medium-screen) {
     float: right;
     margin-top: .7rem;
   }
-    
+
   &.isnegative {
     color: $color-secondary;
   }
@@ -179,7 +179,7 @@
 .messaging-attach {
   display: inline-block;
   position: relative;
-  
+
   @media (max-width: $medium-screen) {
     display: inherit;
     -webkit-flex: 1 1 50%;
@@ -187,8 +187,8 @@
     -webkit-order: -2;
     order: -2;
   }
- 
-  label{
+
+  label {
     background-color: inherit;
     cursor: pointer;
     font-weight: inherit;
@@ -199,23 +199,23 @@
     white-space: nowrap;
     width: auto;
     z-index: 1;
-    
+
     &:focus span,
     &:hover span {
       color: $color-primary-darker;
     }
   }
-  
+
   .fa {
     padding-right: .5ex;
   }
-  
+
   span {
     color: $color-primary;
     text-decoration: underline;
   }
-  
-  input{
+
+  input {
     border: 0;
     height: auto;
     left: -9999px;
@@ -224,6 +224,5 @@
     position: absolute;
     top: 0;
     width: auto;
-  } 
+  }
 }
-

--- a/src/sass/messaging/partials/_message-compose.scss
+++ b/src/sass/messaging/partials/_message-compose.scss
@@ -47,6 +47,7 @@
     -webkit-flex: 0 1 40%;
     flex: 0 1 40%;
   }
+
   .messaging-subject {
     -webkit-flex: 1 1 60%;
     flex: 1 1 60%;
@@ -156,15 +157,17 @@
   textarea {
     margin: 1rem 0 0 0;
     max-width: 100%;
-    resize: none;
+    resize: vertical;
+  }
 
-    @media (max-width: $medium-screen) {
+  @media (max-width: $medium-screen) {
+    margin: 0;
+    padding: 1.5rem;
+
+    textarea {
       border: none;
       padding: 0;
-    }
-
-    @media (min-width: $medium-screen) {
-      resize: vertical;
+      resize: none;
     }
   }
 }

--- a/src/sass/messaging/partials/_message-compose.scss
+++ b/src/sass/messaging/partials/_message-compose.scss
@@ -82,13 +82,6 @@
   }
 }
 
-.messaging-btn-delete {
-  margin: 0;
-  @media (min-width: $medium-screen) {
-    float: right;
-  }
-}
-
 .messaging-send-group {
   background: $color-gray-lightest;
   border: 1px solid $color-gray;
@@ -125,8 +118,10 @@
     @media (max-width: $medium-screen) {
       display: none;
     }
+
     float: right;
-    margin-right: 0;
+    margin: 0 0 0 1rem;
+    padding: 1rem;
   }
 }
 

--- a/src/sass/messaging/partials/_message-compose.scss
+++ b/src/sass/messaging/partials/_message-compose.scss
@@ -58,7 +58,6 @@
 }
 
 .messaging-from,
-.messaging-write,
 .messaging-recipient,
 .messaging-subject-group {
   @media (max-width: $medium-screen) {
@@ -98,12 +97,14 @@
   position: relative;
 
   @media (max-width: $medium-screen) {
+    border-width: 0;
     display: -webkit-flex;
     display: flex;
     -webkit-justify-content: space-between;
     justify-content: space-between;
     -webkit-flex-wrap: wrap;
     flex-wrap: wrap;
+    padding: 1.5rem;
   }
 
   [type="button"] {

--- a/src/sass/messaging/partials/_message-compose.scss
+++ b/src/sass/messaging/partials/_message-compose.scss
@@ -1,6 +1,8 @@
 .messaging-subject-group {
   position: relative;
 
+  // Needed to make the element expand to 100% width
+  // on small screen in Firefox.
   > div {
     width: 100%;
   }

--- a/src/sass/messaging/partials/_message-compose.scss
+++ b/src/sass/messaging/partials/_message-compose.scss
@@ -41,19 +41,6 @@
   }
 }
 
-@media (min-width: $medium-screen) {
-  .messaging-category {
-    margin-right: 1rem;
-    -webkit-flex: 0 1 40%;
-    flex: 0 1 40%;
-  }
-
-  .messaging-subject {
-    -webkit-flex: 1 1 60%;
-    flex: 1 1 60%;
-  }
-}
-
 .messaging-recipient > div,
 .messaging-from,
 .messaging-subject-group {
@@ -152,7 +139,7 @@
 }
 
 .messaging-write {
-  margin-top: 3rem;
+  margin-top: 4rem;
 
   textarea {
     margin: 1rem 0 0 0;
@@ -239,5 +226,23 @@
     position: absolute;
     top: 0;
     width: auto;
+  }
+}
+
+@media (min-width: $medium-screen) {
+  .messaging-from {
+    padding: 0 1.5rem;
+    margin-top: 1.5rem;
+  }
+
+  .messaging-category {
+    margin-right: 1rem;
+    -webkit-flex: 0 1 40%;
+    flex: 0 1 40%;
+  }
+
+  .messaging-subject {
+    -webkit-flex: 1 1 60%;
+    flex: 1 1 60%;
   }
 }

--- a/src/sass/messaging/partials/_message-compose.scss
+++ b/src/sass/messaging/partials/_message-compose.scss
@@ -7,10 +7,7 @@
 
   legend {
     font-size: inherit;
-    margin: 0;
     padding-top: 1.5rem;
-    position: relative;
-    transform: none;
   }
 
   @media (min-width: $medium-screen) {
@@ -23,8 +20,6 @@
     }
 
     legend {
-      margin-top: 1rem;
-      padding: 0;
       position: absolute;
       top: 50%;
       -webkit-transform: translateY(-50%);

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -138,7 +138,8 @@
   }
 
   .messaging-write {
-    padding-top: 0;
+    margin: 0;
+    padding: 0;
 
     label {
       display: none;


### PR DESCRIPTION
Changes:
- Subject line label un-squished from the subject line text input (incorporated from #3188).
- Width of subject line inputs stretched to fill width in smaller screen (on Firefox).
- Padding in message write section.
- Border lines removed from bottom form sections.
- [Desktop] Spacing between compose form sections.
- [Desktop] Spacing between delete button and edge of box.
- Removed trailing whitespace in stylesheet.
