### PR TITLE
Allow future dates in date component and effective date on edu benefits

### DIFF
--- a/src/js/common/components/form-elements/DateInput.jsx
+++ b/src/js/common/components/form-elements/DateInput.jsx
@@ -6,7 +6,7 @@ import ErrorableNumberInput from './ErrorableNumberInput';
 
 import ToolTip from './ToolTip';
 
-import { validateIfDirtyDate, isBlank, isValidDate } from '../../utils/validations';
+import { validateIfDirtyDate, isBlank, isValidDate, isValidAnyDate } from '../../utils/validations';
 import { months, days } from '../../utils/options-for-select.js';
 
 /**
@@ -55,16 +55,17 @@ class DateInput extends React.Component {
     const day = this.props.day;
     const month = this.props.month;
     const year = this.props.year;
+    const dateValidator = this.props.allowFutureDates ? isValidAnyDate : isValidDate;
 
     if (month.value) {
       daysForSelectedMonth = days[month.value];
     }
 
     if (this.props.required) {
-      isValid = validateIfDirtyDate(day, month, year, isValidDate) && (this.props.validation !== undefined ? this.props.validation : true);
+      isValid = validateIfDirtyDate(day, month, year, dateValidator) && (this.props.validation !== undefined ? this.props.validation : true);
     } else {
       isValid = (isBlank(day.value) && isBlank(month.value) && isBlank(year.value)) ||
-        (validateIfDirtyDate(day, month, year, isValidDate) && (this.props.validation !== undefined ? this.props.validation : true));
+        (validateIfDirtyDate(day, month, year, dateValidator) && (this.props.validation !== undefined ? this.props.validation : true));
     }
 
     if (!isValid && this.props.errorMessage) {
@@ -136,6 +137,7 @@ DateInput.propTypes = {
   required: React.PropTypes.bool,
   errorMessage: React.PropTypes.string,
   validation: React.PropTypes.bool,
+  allowFutureDates: React.PropTypes.bool,
   label: React.PropTypes.string,
   name: React.PropTypes.string.isRequired,
   day: React.PropTypes.shape({

--- a/src/js/common/utils/validations.js
+++ b/src/js/common/utils/validations.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import moment from 'moment';
 import { states } from './options-for-select';
 
 function validateIfDirty(field, validator) {
@@ -81,6 +82,14 @@ function isValidDate(day, month, year) {
   return date.getDate() === Number(day) &&
     date.getMonth() === adjustedMonth &&
     date.getFullYear() === Number(year);
+}
+
+function isValidAnyDate(day, month, year) {
+  return moment({
+    day,
+    month: parseInt(month, 10) - 1,
+    year
+  }).isValid();
 }
 
 function isValidName(value) {
@@ -496,5 +505,6 @@ export {
   isValidGeneralInsurance,
   isValidMedicareMedicaid,
   isValidServiceInformation,
-  isValidSection
+  isValidSection,
+  isValidAnyDate
 };

--- a/src/js/edu-benefits/components/benefits-eligibility/BenefitsSelectionFields.jsx
+++ b/src/js/edu-benefits/components/benefits-eligibility/BenefitsSelectionFields.jsx
@@ -4,7 +4,7 @@ import ErrorableRadioButtons from '../../../common/components/form-elements/Erro
 import ErrorableCheckbox from '../../../common/components/form-elements/ErrorableCheckbox';
 import RadioButtonsSubSection from '../../../common/components/form-elements/RadioButtonsSubSection';
 import DateInput from '../../../common/components/form-elements/DateInput';
-import { validateIfDirty, isNotBlank, validateIfDirtyDateObj, isValidDateField } from '../../utils/validations';
+import { validateIfDirty, isNotBlank, validateIfDirtyDateObj, isValidFutureDateField } from '../../utils/validations';
 import { relinquishableBenefits, yesNo, ownBenefitsOptions } from '../../utils/options-for-select';
 import { showRelinquishedEffectiveDate } from '../../utils/helpers';
 
@@ -35,8 +35,9 @@ export default class BenefitsSelectionFields extends React.Component {
           </div>
           {showRelinquishedEffectiveDate(this.props.data.benefitsRelinquished.value)
             ? <DateInput required={showRelinquishedEffectiveDate(this.props.data.benefitsRelinquished.value)}
-                errorMessage="Please provide a response"
-                validation={validateIfDirtyDateObj(this.props.data.benefitsRelinquishedDate, isValidDateField)}
+                allowFutureDates
+                errorMessage="Please provide a date that's the same as or later than today"
+                validation={validateIfDirtyDateObj(this.props.data.benefitsRelinquishedDate, isValidFutureDateField)}
                 label="Effective date"
                 name="benefitsRelinquishedDate"
                 day={this.props.data.benefitsRelinquishedDate.day}

--- a/src/js/edu-benefits/utils/validations.js
+++ b/src/js/edu-benefits/utils/validations.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import moment from 'moment';
 import { states } from './options-for-select';
 import { dateToMoment, showRelinquishedEffectiveDate } from './helpers';
 
@@ -151,6 +152,21 @@ function isBlankDateField(field) {
 
 function isValidDateField(field) {
   return isValidDate(field.day.value, field.month.value, field.year.value);
+}
+
+function isValidFutureDate(day, month, year) {
+  const today = moment().startOf('day');
+  const date = moment({
+    day,
+    month: parseInt(month, 10) - 1,
+    year
+  });
+
+  return date.isValid() && date.isSameOrAfter(today);
+}
+
+function isValidFutureDateField(field) {
+  return isValidFutureDate(field.day.value, field.month.value, field.year.value);
 }
 
 function isValidFutureOrPastDateField(field) {
@@ -377,5 +393,6 @@ export {
   isValidContactInformationPage,
   isValidMilitaryServicePage,
   isValidPage,
-  isValidValue
+  isValidValue,
+  isValidFutureDateField
 };


### PR DESCRIPTION
Closes #3109.

This allows future dates on the date component and uses that on effective date in the benefits selection page.
