### PR TITLE
Remove styles that misalign input errors

### DIFF
--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -18,14 +18,6 @@ body, .home {
   color: $color-white;
 }
 
-// TODO: look into alert / error spacing issues
-.usa-input-error {
-  right: 1rem;
-  padding-bottom: 0;
-  padding-top: 0;
-  margin-top: 0;
-}
-
 // Skip link
 .show-on-focus {
   position: absolute;


### PR DESCRIPTION
Closes #3162.

The way vets.gov input field errors align at the spacing around them does not match the USWDS standards.

After changes:
![screen shot 2016-09-27 at 12 00 46 pm](https://cloud.githubusercontent.com/assets/634932/18881645/16a81d30-84aa-11e6-834f-e8ee85186fd1.png)

Before changes:
![screen shot 2016-09-27 at 12 02 50 pm](https://cloud.githubusercontent.com/assets/634932/18881694/56723d60-84aa-11e6-9ec5-1fb48db29d20.png)
