### PR TITLE
Changing 'Back to' link behavior

### DIFF
--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -93,7 +93,8 @@ ThreadHeader.propTypes = {
   onChooseFolder: React.PropTypes.func,
   onCreateFolder: React.PropTypes.func,
   onToggleThread: React.PropTypes.func,
-  onToggleMoveTo: React.PropTypes.func
+  onToggleMoveTo: React.PropTypes.func,
+  persistedFolder: React.PropTypes.number
 };
 
 export default ThreadHeader;

--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
 
-import { paths } from '../config';
+import { paths, systemFolders } from '../config';
 import ButtonDelete from './buttons/ButtonDelete';
 import MoveTo from './MoveTo';
 import ButtonPrint from './buttons/ButtonPrint';
@@ -19,6 +19,8 @@ class ThreadHeader extends React.Component {
 
   render() {
     let toggleThread;
+    let returnUrlText;
+    let returnUrlPath;
 
     if (this.props.threadMessageCount > 1) {
       toggleThread = (
@@ -28,10 +30,18 @@ class ThreadHeader extends React.Component {
       );
     }
 
+    if (this.props.persistedFolder === undefined) {
+      returnUrlText = 'Inbox';
+      returnUrlPath = `${paths.FOLDERS_URL}/0`;
+    } else {
+      returnUrlText = systemFolders[Math.abs(this.props.persistedFolder)];
+      returnUrlPath = `${paths.FOLDERS_URL}/${this.props.persistedFolder}`;
+    }
+
     return (
       <div className="messaging-thread-header">
         <div className="messaging-thread-nav">
-          <Link to={paths.INBOX_URL}>&lt; Back to Inbox</Link>
+          <Link to={returnUrlPath}>&lt; Back to {returnUrlText}</Link>
           <MoveTo
               folders={this.props.moveToFolders}
               isOpen={!this.props.moveToIsOpen}

--- a/src/js/messaging/components/compose/ModalConfirmDelete.jsx
+++ b/src/js/messaging/components/compose/ModalConfirmDelete.jsx
@@ -25,7 +25,7 @@ class ModalConfirmDelete extends React.Component {
           cssClass={this.props.cssClass}
           contents={modalContents}
           id={this.props.id}
-          onClose={this.props.onDelete}
+          onClose={this.props.onClose}
           visible={this.props.visible}/>
     );
   }

--- a/src/js/messaging/components/compose/ModalConfirmDelete.jsx
+++ b/src/js/messaging/components/compose/ModalConfirmDelete.jsx
@@ -25,7 +25,7 @@ class ModalConfirmDelete extends React.Component {
           cssClass={this.props.cssClass}
           contents={modalContents}
           id={this.props.id}
-          onClose={this.props.onClose}
+          onClose={this.props.onDelete}
           visible={this.props.visible}/>
     );
   }

--- a/src/js/messaging/config.js
+++ b/src/js/messaging/config.js
@@ -22,8 +22,13 @@ module.exports = {
   paths: {
     INBOX_URL: '/messaging',
     COMPOSE_URL: '/messaging/compose',
-    DRAFTS_URL: '/messaging/folder/-2'
+    FOLDERS_URL: '/messaging/folder'
   },
+
+  // The indices of systemFolders are positive. The
+  // actual folder IDs are negative. Remember to invert
+  // when needed.
+  systemFolders: ['Inbox', 'Sent', 'Drafts', 'Deleted'],
 
   // An array of objects containing the category name (label) and a
   // value for use with select, radio button inputs.

--- a/src/js/messaging/containers/Compose.jsx
+++ b/src/js/messaging/containers/Compose.jsx
@@ -75,7 +75,10 @@ class Compose extends React.Component {
   handleConfirmDelete(domEvent) {
     // TODO: Dispatch an action that makes this API call
     domEvent.preventDefault();
-    browserHistory.push(paths.DRAFTS_URL);
+    // Send back to Inbox
+    const returnUrl = `${paths.FOLDERS_URL}/0`;
+
+    browserHistory.push(returnUrl);
     this.props.toggleConfirmDelete();
     this.props.deleteComposeMessage();
   }
@@ -163,6 +166,7 @@ class Compose extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
+    persistFolder: state.folders.data.currentItem.persistFolder,
     message: state.compose.message,
     recipients: state.compose.recipients,
     modals: {

--- a/src/js/messaging/containers/Compose.jsx
+++ b/src/js/messaging/containers/Compose.jsx
@@ -54,7 +54,6 @@ class Compose extends React.Component {
     this.props.sendMessage(this.props.message);
   }
 
-
   handleCategoryChange(valueObj) {
     this.props.setMessageField('message.category', valueObj);
   }
@@ -166,7 +165,6 @@ class Compose extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
-    persistFolder: state.folders.data.currentItem.persistFolder,
     message: state.compose.message,
     recipients: state.compose.recipients,
     modals: {

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -120,6 +120,7 @@ class Thread extends React.Component {
             currentMessageNumber={currentIndex + 1}
             moveToFolders={folders}
             folderMessageCount={folderMessageCount}
+            persistedFolder={this.props.persistFolder}
             onClickPrev={fetchPrevMessage}
             onClickNext={fetchNextMessage}
             subject={thread[0].subject}


### PR DESCRIPTION
Making 'Back to' link return the veteran to the folder of the current message thread.
- Closes department-of-veterans-affairs/messaging-fe#74
- Removing paths.DRAFTS_URL in favor of a systemFolders config option.
- Updating reference to paths.DRAFTS_URL in Compose.
