### PR TITLE
Fix email confirmation validation on edu benefits form

### DIFF
--- a/src/js/edu-benefits/components/personal-information/ContactInformationFields.jsx
+++ b/src/js/edu-benefits/components/personal-information/ContactInformationFields.jsx
@@ -15,7 +15,8 @@ export default class ContactInformationFields extends React.Component {
   }
 
   confirmEmail() {
-    if (this.props.data.email.value.toLowerCase() !== this.props.data.emailConfirmation.value.toLowerCase()) {
+    if (this.props.data.emailConfirmation.dirty
+      && this.props.data.email.value.toLowerCase() !== this.props.data.emailConfirmation.value.toLowerCase()) {
       return 'Please ensure your entries match';
     }
 


### PR DESCRIPTION
If you enter a value in the email field on the contact information page, the email confirmation field immediately displays a validation error. This adds a dirty check to avoid that.
