### PR TITLE
Add specificity to no icon styling

### DIFF
--- a/src/sass/edu-benefits.scss
+++ b/src/sass/edu-benefits.scss
@@ -48,7 +48,8 @@ legend {
   }
 }
 
-.edu-benefits-info-no-icon {
+.edu-benefits-info-no-icon,
+.usa-alert-info.edu-benefits-info-no-icon {
   background-image: none;
 }
 


### PR DESCRIPTION
Icons were appearing in some alerts when they weren't supposed to be:

<img width="548" alt="screen shot 2016-09-29 at 3 41 47 pm" src="https://cloud.githubusercontent.com/assets/3886085/18969510/7e166528-865b-11e6-9649-5cab7b28d9f7.png">

Added another class to increase specificity so that the styles to remove the icon take precedence:

<img width="543" alt="screen shot 2016-09-29 at 3 41 13 pm" src="https://cloud.githubusercontent.com/assets/3886085/18969516/82b96a12-865b-11e6-92b7-2f68cfb98068.png">
