### PR TITLE
Update webpack-dev-server proxy settings for new API URLs.

### DIFF
--- a/script/build.js
+++ b/script/build.js
@@ -229,6 +229,7 @@ if (options.watch) {
         auth: api.auth,
         secure: true,
         changeOrigin: true,
+        pathRewrite: { '^/api': '' },
         rewrite: function rewrite(req) {
           /* eslint-disable no-param-reassign */
           req.headers.host = api.host;


### PR DESCRIPTION
New API URLs are going to be dev-api.vets.gov/v0/\* and staging-api.vets.gov/v0/*. And it sounds like *.vets.gov/api will be decommissioned after next week. Be sure to update your local config.proxy.js accordingly.

@jbalboni I noticed edu-benefits has one instance of a fetch against an API endpoint and thought you guys might be using the proxy too, so just giving a heads up.
