### PR TITLE
Call local api from claims list page

### DIFF
--- a/src/js/common/components/Pagination.jsx
+++ b/src/js/common/components/Pagination.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import classNames from 'classnames';
+
+class Pagination extends React.Component {
+  constructor(props) {
+    super(props);
+    this.selectNext = this.selectNext.bind(this);
+    this.selectPrev = this.selectPrev.bind(this);
+  }
+
+  selectNext() {
+    if (this.props.page < this.props.pages) {
+      this.props.onPageSelect(this.props.page + 1);
+    }
+  }
+
+  selectPrev() {
+    if (this.props.page > 1) {
+      this.props.onPageSelect(this.props.page - 1);
+    }
+  }
+
+  render() {
+    const pageList = Array(this.props.pages).fill().map((e, i) => {
+      const pageNumber = i + 1;
+      const pageClass = classNames({
+        'va-pagination-active': this.props.page === pageNumber
+      });
+
+      return (
+        <a
+            key={pageNumber}
+            className={pageClass}
+            onClick={() => this.props.onPageSelect(pageNumber)}>
+          {pageNumber}
+        </a>
+      );
+    });
+
+    const prevPage = (
+      <a className="va-pagination-prev" onClick={this.selectPrev}>
+        <abbr title="Previous">Prev</abbr>
+      </a>
+    );
+
+    const nextPage = (
+      <a className="va-pagination-next" onClick={this.selectNext}>
+        Next
+      </a>
+    );
+
+    return (
+      <div className="va-pagination">
+        <div className="va-pagination-inner">
+          {prevPage}
+          {pageList}
+          {nextPage}
+        </div>
+      </div>
+    );
+  }
+}
+
+Pagination.propTypes = {
+  onPageSelect: React.PropTypes.func.isRequired,
+  page: React.PropTypes.number.isRequired,
+  pages: React.PropTypes.number.isRequired
+};
+
+export default Pagination;

--- a/src/js/disability-benefits/actions/index.js
+++ b/src/js/disability-benefits/actions/index.js
@@ -1,27 +1,18 @@
 export const SET_CLAIMS = 'SET_CLAIMS';
 
+// localhost needs to be replaced to make this api calls work in dev or staging
+// http://localhost:3000/v0 -> /api/v0
+
 export function getClaims() {
   return (dispatch) => {
-    // fetch('/api/v0/disability_claims', {
-    //   method: 'GET',
-    //   headers: {
-    //     'Content-Type': 'application/json',
-    //     'X-Key-Inflection': 'camel'
-    //   }
-    // })
-    //   .then(res => res.json())
-    //   .then(
-    //     claims => dispatch({ type: 'SET_CLAIMS', claims })
-    //   );
-    dispatch({
-      type: SET_CLAIMS,
-      claims: [{
-        id: '1234',
-        type: 'disability_claims',
-        attributes: {
-          dateFiled: '2016-06-01'
-        }
-      }]
-    });
+    fetch('//localhost:3000/v0/disability_claims', {
+      method: 'GET',
+      mode: 'cors',
+      headers: {
+        'X-Key-Inflection': 'camel',
+      }
+    })
+      .then(res => res.json())
+      .then(claims => dispatch({ type: 'SET_CLAIMS', claims: claims.data }));
   };
 }

--- a/src/js/disability-benefits/actions/index.js
+++ b/src/js/disability-benefits/actions/index.js
@@ -1,4 +1,5 @@
 export const SET_CLAIMS = 'SET_CLAIMS';
+export const CHANGE_CLAIMS_PAGE = 'CHANGE_CLAIMS_PAGE';
 
 // localhost needs to be replaced to make this api calls work in dev or staging
 // http://localhost:3000/v0 -> /api/v0
@@ -14,5 +15,12 @@ export function getClaims() {
     })
       .then(res => res.json())
       .then(claims => dispatch({ type: 'SET_CLAIMS', claims: claims.data }));
+  };
+}
+
+export function changePage(page) {
+  return {
+    type: CHANGE_CLAIMS_PAGE,
+    page
   };
 }

--- a/src/js/disability-benefits/actions/index.js
+++ b/src/js/disability-benefits/actions/index.js
@@ -1,19 +1,24 @@
+import environment from '../../common/helpers/environment';
+
 export const SET_CLAIMS = 'SET_CLAIMS';
 export const CHANGE_CLAIMS_PAGE = 'CHANGE_CLAIMS_PAGE';
 
-// localhost needs to be replaced to make this api calls work in dev or staging
-// http://localhost:3000/v0 -> /api/v0
-
 export function getClaims() {
   return (dispatch) => {
-    fetch('//localhost:3000/v0/disability_claims', {
+    fetch(`${environment.API_URL}/v0/disability_claims`, {
       method: 'GET',
       mode: 'cors',
       headers: {
         'X-Key-Inflection': 'camel',
       }
     })
-      .then(res => res.json())
+      .then(res => {
+        if (res.ok) {
+          return res.json();
+        }
+
+        return Promise.reject(res.statusText);
+      })
       .then(claims => dispatch({ type: 'SET_CLAIMS', claims: claims.data }));
   };
 }

--- a/src/js/disability-benefits/components/ClaimsListItem.jsx
+++ b/src/js/disability-benefits/components/ClaimsListItem.jsx
@@ -5,7 +5,7 @@ export default function ClaimsListItem({ claim }) {
   const filesNeeded = claim.attributes.trackedItems.stillNeedFromYouList ? claim.attributes.trackedItems.stillNeedFromYouList.length : null;
   return (
     <Link className="claim-list-item" to={`/your-claims/${claim.attributes.evssId}/status`}>
-      <h4>Compensation Claim</h4>
+      <h4 className="claim-list-item-header">Compensation Claim</h4>
       <p className="status">Status: {claim.attributes.phaseDates.latestPhaseType}</p>
       {filesNeeded !== null
         ? <p><i className="fa fa-exclamation-triangle"></i>We need {filesNeeded} {filesNeeded > 1 ? 'files' : 'file'} from you</p>

--- a/src/js/disability-benefits/components/ClaimsListItem.jsx
+++ b/src/js/disability-benefits/components/ClaimsListItem.jsx
@@ -10,7 +10,7 @@ export default function ClaimsListItem({ claim }) {
       {filesNeeded !== null
         ? <p><i className="fa fa-exclamation-triangle"></i>We need {filesNeeded} {filesNeeded > 1 ? 'files' : 'file'} from you</p>
         : null}
-      <p><i className="fa fa-envelope"></i>We sent you a development letter</p>
+      <p><i className="fa fa-envelope"></i>We sent you a development letter (TODO)</p>
       <p>Last Update: TODO</p>
     </Link>
   );

--- a/src/js/disability-benefits/components/ClaimsListItem.jsx
+++ b/src/js/disability-benefits/components/ClaimsListItem.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+export default function ClaimsListItem({ claim }) {
+  const filesNeeded = claim.attributes.trackedItems.stillNeedFromYouList ? claim.attributes.trackedItems.stillNeedFromYouList.length : null;
+  return (
+    <Link className="claim-list-item" to={`/your-claims/${claim.attributes.evssId}/status`}>
+      <h4>Compensation Claim</h4>
+      <p className="status">Status: {claim.attributes.phaseDates.latestPhaseType}</p>
+      {filesNeeded !== null
+        ? <p><i className="fa fa-exclamation-triangle"></i>We need {filesNeeded} {filesNeeded > 1 ? 'files' : 'file'} from you</p>
+        : null}
+      <p><i className="fa fa-envelope"></i>We sent you a development letter</p>
+      <p>Last Update: TODO</p>
+    </Link>
+  );
+}
+
+ClaimsListItem.propTypes = {
+  claim: React.PropTypes.object
+};

--- a/src/js/disability-benefits/components/ClaimsListItem.jsx
+++ b/src/js/disability-benefits/components/ClaimsListItem.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 export default function ClaimsListItem({ claim }) {
   const filesNeeded = claim.attributes.trackedItems.stillNeedFromYouList ? claim.attributes.trackedItems.stillNeedFromYouList.length : null;
   return (
-    <Link className="claim-list-item" to={`/your-claims/${claim.attributes.evssId}/status`}>
+    <Link className="claim-list-item" to={`/your-claims/${claim.id}/status`}>
       <h4 className="claim-list-item-header">Compensation Claim</h4>
       <p className="status">Status: {claim.attributes.phaseDates.latestPhaseType}</p>
       {filesNeeded !== null

--- a/src/js/disability-benefits/components/NoClaims.jsx
+++ b/src/js/disability-benefits/components/NoClaims.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function NoClaims() {
+  return (
+    <div className="you-have-no-claims">
+      <h4>You do not have any submitted claims</h4>
+      <p>Claims that you have submitted will appear here. If you have an open application for a claim but have not yet submitted it, you can continue your application on <a href="https://www.ebenefits.va.gov/">ebenefits</a></p>
+    </div>
+  );
+}

--- a/src/js/disability-benefits/containers/YourClaimsPage.jsx
+++ b/src/js/disability-benefits/containers/YourClaimsPage.jsx
@@ -3,6 +3,8 @@ import { connect } from 'react-redux';
 
 import { getClaims } from '../actions';
 import AskVAQuestions from '../components/AskVAQuestions';
+import ClaimsListItem from '../components/ClaimsListItem';
+import NoClaims from '../components/NoClaims';
 
 class YourClaimsPage extends React.Component {
   componentDidMount() {
@@ -11,24 +13,16 @@ class YourClaimsPage extends React.Component {
   render() {
     const { claims } = this.props;
 
-    let claimsList;
-    if (claims.length > 0) {
-      claimsList = (<div className="claim-list">
-        {claims.map(claim =>
-          <div key={claim.id} className="claim-list-item">
-            <h4>Compensation Claim</h4>
-            <p className="status">Status: Complete</p>
-            <p><i className="fa fa-exclamation-triangle"></i>We need 2 files from you</p>
-            <p><i className="fa fa-envelope"></i>We sent you a development letter</p>
-            <p>Last Update: {claim.attributes.dateField}</p>
-          </div>
-        )}
+    let content;
+
+    if (claims === null) {
+      content = <div>Loading...</div>;
+    } else if (claims.length > 0) {
+      content = (<div className="claim-list">
+        {claims.map(claim => <ClaimsListItem claim={claim} key={claim.id}/>)}
       </div>);
     } else {
-      claimsList = (<div className="you-have-no-claims">
-        <h4>You do not have any submitted claims</h4>
-        <p>Claims that you have submitted will appear here. If you have an open application for a claim but have not yet submitted it, you can continue your application on <a href="https://www.ebenefits.va.gov/">ebenefits</a></p>
-      </div>);
+      content = <NoClaims/>;
     }
 
     return (
@@ -38,7 +32,7 @@ class YourClaimsPage extends React.Component {
             <div>
               <h1>Your Claims</h1>
             </div>
-            {claimsList}
+            {content}
           </div>
           <AskVAQuestions/>
         </div>
@@ -49,7 +43,7 @@ class YourClaimsPage extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    claims: state.claimsList
+    claims: state.claims.list
   };
 }
 

--- a/src/js/disability-benefits/containers/YourClaimsPage.jsx
+++ b/src/js/disability-benefits/containers/YourClaimsPage.jsx
@@ -1,25 +1,47 @@
 import React from 'react';
+import Scroll from 'react-scroll';
 import { connect } from 'react-redux';
 
-import { getClaims } from '../actions';
+import { getClaims, changePage } from '../actions';
 import AskVAQuestions from '../components/AskVAQuestions';
 import ClaimsListItem from '../components/ClaimsListItem';
 import NoClaims from '../components/NoClaims';
+import Pagination from '../../common/components/Pagination';
+
+const Element = Scroll.Element;
+const scroller = Scroll.scroller;
+
+const scrollToTop = () => {
+  scroller.scrollTo('topScrollElement', {
+    duration: 500,
+    delay: 0,
+    smooth: true,
+  });
+};
 
 class YourClaimsPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.changePage = this.changePage.bind(this);
+  }
   componentDidMount() {
     this.props.getClaims();
   }
+  changePage(page) {
+    this.props.changePage(page);
+    scrollToTop();
+  }
   render() {
-    const { claims } = this.props;
+    const { claims, pages, page, loading } = this.props;
 
     let content;
 
-    if (claims === null) {
+    if (loading) {
       content = <div>Loading...</div>;
     } else if (claims.length > 0) {
       content = (<div className="claim-list">
         {claims.map(claim => <ClaimsListItem claim={claim} key={claim.id}/>)}
+        <Pagination page={page} pages={pages} onPageSelect={this.props.changePage}/>
       </div>);
     } else {
       content = <NoClaims/>;
@@ -27,6 +49,7 @@ class YourClaimsPage extends React.Component {
 
     return (
       <div>
+        <Element name="topScrollElement"/>
         <div className="row">
           <div className="large-8 columns your-claims">
             <div>
@@ -43,13 +66,18 @@ class YourClaimsPage extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    claims: state.claims.list
+    loading: state.claims.list === null,
+    claims: state.claims.visibleRows,
+    pages: state.claims.pages,
+    page: state.claims.page
   };
 }
 
 const mapDispatchToProps = {
-  getClaims
+  getClaims,
+  changePage
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(YourClaimsPage);
 
+export { YourClaimsPage };

--- a/src/js/disability-benefits/reducers/claims-list.js
+++ b/src/js/disability-benefits/reducers/claims-list.js
@@ -2,12 +2,16 @@
 
 import { SET_CLAIMS } from '../actions';
 
-const initialState = [];
+const initialState = {
+  list: null
+};
 
 export default function claimsReducer(state = initialState, action) {
   switch (action.type) {
     case SET_CLAIMS: {
-      return action.claims;
+      return {
+        list: action.claims
+      };
     }
     default:
       return state;

--- a/src/js/disability-benefits/reducers/claims-list.js
+++ b/src/js/disability-benefits/reducers/claims-list.js
@@ -1,17 +1,32 @@
-// import _ from 'lodash/fp';
+import _ from 'lodash/fp';
 
-import { SET_CLAIMS } from '../actions';
+import { SET_CLAIMS, CHANGE_CLAIMS_PAGE } from '../actions';
+
+const ROWS_PER_PAGE = 10;
 
 const initialState = {
-  list: null
+  list: null,
+  visibleRows: [],
+  page: 1,
+  pages: 1
 };
 
 export default function claimsReducer(state = initialState, action) {
   switch (action.type) {
     case SET_CLAIMS: {
-      return {
-        list: action.claims
-      };
+      const current = (state.page - 1) * ROWS_PER_PAGE;
+      return _.merge(state, {
+        list: action.claims,
+        visibleRows: action.claims.slice(current, current + ROWS_PER_PAGE),
+        pages: Math.ceil(action.claims.length / ROWS_PER_PAGE)
+      });
+    }
+    case CHANGE_CLAIMS_PAGE: {
+      const current = (action.page - 1) * ROWS_PER_PAGE;
+      return _.assign(state, {
+        page: action.page,
+        visibleRows: state.list.slice(current, current + ROWS_PER_PAGE)
+      });
     }
     default:
       return state;

--- a/src/js/disability-benefits/reducers/index.js
+++ b/src/js/disability-benefits/reducers/index.js
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
-import claimsList from './claims-list';
+import claims from './claims-list';
 
 export default combineReducers({
-  claimsList
+  claims
 });

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -185,6 +185,16 @@
   }
 }
 
+a.claim-list-item {
+  text-decoration: none;
+  display: block;
+  color: inherit;
+  &:visited, &:hover, &:active {
+    color: inherit;
+    text-decoration: none;
+  }
+}
+
 .your-claims {
   h1, h3 {
     margin-top: 1em;

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -1,4 +1,5 @@
 @import 'style';
+@import 'modules/va-pagination';
 
 .claim-list {
   margin-bottom: 2em;
@@ -193,6 +194,14 @@ a.claim-list-item {
     color: inherit;
     text-decoration: none;
   }
+}
+
+.claim-list-item-header {
+  color: $color-primary;
+}
+
+.claim-list-item:hover .claim-list-item-header {
+  color: $color-primary-darker;
 }
 
 .your-claims {

--- a/src/sass/modules/_va-pagination.scss
+++ b/src/sass/modules/_va-pagination.scss
@@ -1,0 +1,94 @@
+// CSS for pagination navigation
+// TODO: Move these to vets-website
+
+.va-pagination {
+  border-top: 1px solid $color-gray-lightest;
+  font-size: .9em;
+  overflow: hidden;
+  padding: 1rem;
+  position: relative;
+  text-align: center;
+  width: 100%;
+
+  a {
+    line-height: 2;
+    text-decoration: none;
+  }
+
+  &-prev,
+  &-next {
+    padding: 0 1rem;
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+
+  &-prev,
+  &-next,
+  &-inner {
+    display: inline-block;
+  }
+
+  &-inner {
+    line-height: 1.5;
+    max-width: 66%;
+    white-space: nowrap;
+
+    @media (max-width: $small-screen) {
+      @supports (display: flex) {
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: nowrap;
+        align-items: center;
+      }
+    }
+
+    @media (min-width: $large-screen) {
+      margin: 0 1rem;
+      max-width: 85%;
+    }
+  }
+
+  &-prev {
+    &::before {
+      content: '\003c\a0\a0';
+    }
+  }
+
+  &-next {
+    &::after {
+      content: '\a0\a0\003e';
+    }
+  }
+
+  @media (max-width: $small-screen) {
+    @supports (display: flex) {
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: nowrap;
+      align-items: center;
+    }
+  }
+}
+
+.va-pagination-inner a {
+  border-radius: 1000px;
+  display: inline-block;
+  height: 3rem;
+  margin: 0 .25rem;
+  min-width: 3rem;
+  text-decoration: none;
+
+  @media (max-width: $small-screen) {
+    flex: 0 0 3rem;
+  }
+}
+
+.va-pagination-inner a:hover,
+.va-pagination-inner a:focus,
+.va-pagination-active,
+.va-pagination-active:visited {
+  background: $color-primary;
+  color: $color-white;
+}

--- a/test/disability-benefits/components/YourClaimsPage.unit.spec.jsx
+++ b/test/disability-benefits/components/YourClaimsPage.unit.spec.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { YourClaimsPage } from '../../../src/js/disability-benefits/containers/YourClaimsPage';
+
+describe('<YourClaimsPage>', () => {
+  it('should render loading div', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+          loading
+          claims={claims}
+          page={page}
+          pages={pages}
+          getClaims={getClaims}
+          changePage={changePage}/>
+    );
+    expect(tree.everySubTree('div').some(el => el.text() === 'Loading...')).to.be.true;
+  });
+
+  it('should render no claims message', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+          claims={claims}
+          page={page}
+          pages={pages}
+          getClaims={getClaims}
+          changePage={changePage}/>
+    );
+    expect(tree.everySubTree('NoClaims').length).to.equal(1);
+  });
+
+  it('should render claims list and pagination', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [{}, {}];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+          claims={claims}
+          page={page}
+          pages={pages}
+          getClaims={getClaims}
+          changePage={changePage}/>
+    );
+    expect(tree.everySubTree('ClaimsListItem').length).to.equal(2);
+    expect(tree.subTree('Pagination').props.page).to.equal(page);
+    expect(tree.subTree('Pagination').props.pages).to.equal(pages);
+  });
+});

--- a/test/disability-benefits/reducers/claims-list.unit.spec.jsx
+++ b/test/disability-benefits/reducers/claims-list.unit.spec.jsx
@@ -1,0 +1,35 @@
+
+import { expect } from 'chai';
+
+import claimsList from '../../../src/js/disability-benefits/reducers/claims-list';
+import { SET_CLAIMS, CHANGE_CLAIMS_PAGE } from '../../../src/js/disability-benefits/actions';
+
+describe('Claims list reducer', () => {
+  it('should populate the claims list', () => {
+    const claims = Array(12).fill(4);
+    const state = claimsList(undefined, {
+      type: SET_CLAIMS,
+      claims
+    });
+
+    expect(state.list).to.deep.equal(claims);
+    expect(state.visibleRows).to.deep.equal(claims.slice(0, 10));
+  });
+
+  it('should change the claims list page', () => {
+    const claims = Array(12).fill(4);
+    const previousState = {
+      list: claims,
+      page: 1,
+      pages: 2,
+      visibleRows: claims.slice(0, 10)
+    };
+    const state = claimsList(previousState, {
+      type: CHANGE_CLAIMS_PAGE,
+      page: 2
+    });
+
+    expect(state.visibleRows).to.deep.equal(claims.slice(10, 12));
+    expect(state.page).to.equal(2);
+  });
+});


### PR DESCRIPTION
Related to [this item](https://github.com/department-of-veterans-affairs/sunsets-team/issues/25), but I'm not closing it because it's not fully done.

This calls the local api to get claims records. It uses as much data as we can from the api, but a couple things are missing or not in the test records we have.

I've also moved over Rx's pagination component and written some unit tests for the code I added.

This is the only changed part of the UI:

![screen shot 2016-10-05 at 12 40 20 pm](https://cloud.githubusercontent.com/assets/634932/19122555/f6c2e536-8af8-11e6-9723-b17af70a6d4e.png)
