### PR TITLE
[Messaging] Folder page navigation is reflected in URL query string.

### DIFF
--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -23,13 +23,13 @@ export class Folder extends React.Component {
     this.props.fetchFolder(id, query);
   }
 
-  componentDidUpdate(prevProps) {
-    const newId = this.props.params.id;
-    const oldId = prevProps.params.id;
+  componentDidUpdate() {
+    const newId = +this.props.params.id;
+    const oldId = this.props.folder.attributes.folderId;
 
     const query = _.pick(this.props.location.query, ['page']);
-    const newPage = query.page;
-    const oldPage = prevProps.location.query.page;
+    const newPage = +query.page;
+    const oldPage = this.props.page;
 
     if (newId !== oldId || newPage !== oldPage) {
       this.props.fetchFolder(newId, query);

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -37,7 +37,7 @@ export class Folder extends React.Component {
   }
 
   makeMessageNav() {
-    const { folder, currentRange, messageCount, page, totalPages } = this.props;
+    const { currentRange, messageCount, page, totalPages } = this.props;
 
     if (messageCount === 0) {
       return null;

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -43,7 +43,6 @@ export class Folder extends React.Component {
       return null;
     }
 
-    const folderId = folder.attributes.folderId;
     let handleClickPrev;
     let handleClickNext;
 

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router';
+import { Link, browserHistory } from 'react-router';
 import _ from 'lodash';
 import classNames from 'classnames';
 
@@ -14,18 +14,25 @@ import {
 import ComposeButton from '../components/ComposeButton';
 import MessageNav from '../components/MessageNav';
 import MessageSearch from '../components/MessageSearch';
+import { paths } from '../config';
 
 export class Folder extends React.Component {
   componentDidMount() {
     const id = this.props.params.id;
-    this.props.fetchFolder(id);
+    const query = _.pick(this.props.location.query, ['page']);
+    this.props.fetchFolder(id, query);
   }
 
   componentDidUpdate(prevProps) {
-    const oldId = prevProps.params.id;
     const newId = this.props.params.id;
-    if (oldId !== newId) {
-      this.props.fetchFolder(newId);
+    const oldId = prevProps.params.id;
+
+    const query = _.pick(this.props.location.query, ['page']);
+    const newPage = query.page;
+    const oldPage = prevProps.location.query.page;
+
+    if (newId !== oldId || newPage !== oldPage) {
+      this.props.fetchFolder(newId, query);
     }
   }
 
@@ -42,13 +49,19 @@ export class Folder extends React.Component {
 
     if (page > 1) {
       handleClickPrev = () => {
-        this.props.fetchFolder(folderId, { page: page - 1 });
+        browserHistory.push({
+          pathname: `${paths.FOLDERS_URL}/${this.props.params.id}`,
+          query: { page: page - 1 }
+        });
       };
     }
 
     if (page < totalPages) {
       handleClickNext = () => {
-        this.props.fetchFolder(folderId, { page: page + 1 });
+        browserHistory.push({
+          pathname: `${paths.FOLDERS_URL}/${this.props.params.id}`,
+          query: { page: page + 1 }
+        });
       };
     }
 


### PR DESCRIPTION
Clicking 'Previous' and 'Next' within a folder will add a query string corresponding to the page that is being queried. Accessing the folder directly with the query string will also go to the proper page. If the query fails, clicking 'Previous' or 'Next' again will go to the proper page as well.
