### PR TITLE
Add login entry code to disability benefits

### DIFF
--- a/src/js/disability-benefits/disability-benefits-entry.jsx
+++ b/src/js/disability-benefits/disability-benefits-entry.jsx
@@ -12,6 +12,7 @@ import reducer from './reducers';
 import routes from './routes.jsx';
 
 require('../../sass/disability-benefits.scss');
+require('../login/login-entry.jsx');
 
 let store;
 if (__BUILDTYPE__ === 'development' && window.devToolsExtension) {


### PR DESCRIPTION
We should be including login-entry.jsx, since we'll need it in the future and because it includes polyfills that we need for the app to work in our supported browsers.
