### PR TITLE
Add auth token to xhr requests for disability benefits

### DIFF
--- a/src/js/disability-benefits/actions/index.js
+++ b/src/js/disability-benefits/actions/index.js
@@ -12,6 +12,7 @@ export function getClaims() {
       mode: 'cors',
       headers: {
         'X-Key-Inflection': 'camel',
+        'Authorization': `Token token=${localStorage.userToken}`
       }
     })
       .then(res => {
@@ -42,6 +43,7 @@ export function getClaimDetail(id) {
       mode: 'cors',
       headers: {
         'X-Key-Inflection': 'camel',
+        'Authorization': `Token token=${localStorage.userToken}`
       }
     })
       .then(res => {

--- a/src/js/disability-benefits/actions/index.js
+++ b/src/js/disability-benefits/actions/index.js
@@ -12,7 +12,7 @@ export function getClaims() {
       mode: 'cors',
       headers: {
         'X-Key-Inflection': 'camel',
-        'Authorization': `Token token=${localStorage.userToken}`
+        Authorization: `Token token=${localStorage.userToken}`
       }
     })
       .then(res => {
@@ -43,7 +43,7 @@ export function getClaimDetail(id) {
       mode: 'cors',
       headers: {
         'X-Key-Inflection': 'camel',
-        'Authorization': `Token token=${localStorage.userToken}`
+        Authorization: `Token token=${localStorage.userToken}`
       }
     })
       .then(res => {


### PR DESCRIPTION
The backend for disability benefits is still skipping authentication but we can start sending the token now
