### PR TITLE
Set height of prescription cards. Closes #3382.

### DIFF
--- a/src/sass/rx/partials/_rx-prescriptions.scss
+++ b/src/sass/rx/partials/_rx-prescriptions.scss
@@ -71,7 +71,6 @@ button.rx-prescription-button,
 }
 
 .rx-prescription-count {
-  // position: absolute;
   bottom: 0;
   display: inline-block;
   &-zero {

--- a/src/sass/rx/partials/_rx-prescriptions.scss
+++ b/src/sass/rx/partials/_rx-prescriptions.scss
@@ -25,6 +25,7 @@
 
 .rx-prescription-inner {
   background: $color-gray-lightest;
+  height: 25.7rem;
   padding: 2rem;
   position: relative;
 }
@@ -70,7 +71,7 @@ button.rx-prescription-button,
 }
 
 .rx-prescription-count {
-  position: absolute;
+  // position: absolute;
   bottom: 0;
   display: inline-block;
   &-zero {
@@ -93,7 +94,7 @@ button.rx-prescription-button,
 }
 
 .rx-prescription-countaction {
-  bottom: 0;
+  bottom: -2rem;
   line-height: 2rem;
   padding-top: 2rem;
   position: relative;


### PR DESCRIPTION
- Adjusted position of .rx-prescription-countaction so that it remains anchored to the bottom.
- Part of #3306
