### PR TITLE
Left align tabs with header on mobile. closes #3380.

### DIFF
--- a/src/sass/rx/partials/_va-tabs.scss
+++ b/src/sass/rx/partials/_va-tabs.scss
@@ -19,11 +19,6 @@
     border-style: solid;
     display: inline-block;
   }
-     
-  // Center navigation in viewports < 600px;
-  @media (max-width: $medium-screen) {
-    text-align: center;
-  } 
 }
 
 .va-tab-trigger { 


### PR DESCRIPTION
Related to #3306.
