### PR TITLE
Always show track package / Refill requested. Closes #3383

### DIFF
--- a/src/js/rx/components/Prescription.jsx
+++ b/src/js/rx/components/Prescription.jsx
@@ -13,6 +13,9 @@ class Prescription extends React.Component {
   constructor() {
     super();
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.showTracking = this.showTracking.bind(this);
+    this.showMessageProvider = this.showMessageProvider.bind(this);
+    this.showRefillStatus = this.showRefillStatus.bind(this);
   }
 
   handleSubmit(domEvent) {
@@ -24,59 +27,95 @@ class Prescription extends React.Component {
     this.props.openRefillModal(content.attributes);
   }
 
+  showTracking() {
+    let trackMessage;
+
+    const trackable = this.props.attributes.isTrackable;
+    const id = this.props.id;
+
+    if (trackable) {
+      trackMessage = (
+        <TrackPackageLink
+            key={`rx-${id}-track`}
+            className="usa-button"
+            text="Track package"
+            url={`/rx/prescription/${id}#rx-order-history`}/>
+      );
+    } else {
+      trackMessage = (
+        <div
+            key={`rx-${id}-requested`}
+            className="rx-prescription-refill-requested">
+          Refill requested
+        </div>
+      );
+    }
+
+    return trackMessage;
+  }
+
+  showMessageProvider() {
+    let msgProvider;
+    const id = this.props.id;
+    const remaining = this.props.attributes.refillRemaining;
+
+    if (remaining === 0) {
+      msgProvider = (
+        <div className="rx-call-provider">
+          <Link
+              key={`rx-${id}-call`}
+              to="/messaging">Message Provider</Link>
+        </div>
+      );
+    }
+    return msgProvider;
+  }
+
+  showRefillStatus() {
+    const refillable = this.props.attributes.isRefillable;
+    const id = this.props.id;
+    const status = this.props.attributes.refillStatus;
+
+    let refillStatus;
+
+    if (refillable === true) {
+      refillStatus = (
+        <SubmitRefill
+            key={`rx-${id}-refill`}
+            cssClass="rx-prescription-button"
+            onSubmit={this.handleSubmit}
+            refillId={id}
+            text="Refill Prescription"/>
+      );
+    } else {
+      refillStatus = (
+        <div
+            key={`rx-${id}-status`}
+            className="rx-prescription-status">
+            Refill status:
+          <span> {rxStatuses[status]}</span>
+        </div>
+      );
+    }
+
+    return refillStatus;
+  }
+
   render() {
     const attrs = this.props.attributes;
     const id = this.props.id;
     const name = attrs.prescriptionName;
-    const status = attrs.refillStatus;
 
     let action = [];
 
-    if (attrs.isRefillable === true) {
-      action.push(<SubmitRefill
-          key={`rx-${id}-refill`}
-          cssClass="rx-prescription-button"
-          onSubmit={this.handleSubmit}
-          refillId={id}
-          text="Refill Prescription"/>);
-    } else {
-      const callProvider = <div key={`rx-${id}-call`}>Call Provider</div>;
+    // Show tracking if applicable
+    action.push(this.showTracking());
 
-      if (status !== 'active') {
-        action.push((
-          <div
-              key={`rx-${id}-status`}
-              className="rx-prescription-status">
-            Refill status:
-            <span> {rxStatuses[status]}</span>
-          </div>
-        ));
+    // Show Refill prescription button or refill status
+    action.push(this.showRefillStatus());
 
-        if (status !== 'submitted') {
-          action.push(callProvider);
-        }
-      } else {
-        if (attrs.isTrackable === true) {
-          action.push(<TrackPackageLink
-              key={`rx-${id}-track`}
-              className="usa-button"
-              text="Track package"
-              url={`/rx/prescription/${id}#rx-order-history`}/>);
-        } else {
-          action.push((
-            <div
-                key={`rx-${id}-requested`}
-                className="rx-prescription-refill-requested">
-              Refill requested
-            </div>
-          ));
-        }
-
-        if (attrs.refillRemaining === 0) {
-          action.push(callProvider);
-        }
-      }
-    }
+    // Show 'Message Provider' link when refillsRemaining === 0
+    action.push(this.showMessageProvider());
 
     return (
       <div className="rx-prescription">

--- a/src/sass/rx/partials/_rx-prescriptions.scss
+++ b/src/sass/rx/partials/_rx-prescriptions.scss
@@ -104,8 +104,20 @@ button.rx-prescription-button,
   font-weight: bold;
 }
 
+.rx-prescription-status,
+.rx-call-provider {
+  margin-top: .75rem;
+  text-align: right;
+}
+
+.rx-prescription-refill-requested {
+  margin-bottom: .75rem;
+  text-align: right;
+} 
+
 .rx-track-package-link {
-  margin: 0;  
+  display: block;
+  margin: 0 0 1rem;  
 }
 
 //====== Prescription group


### PR DESCRIPTION
Also refactors logic for prescription card states.
- Adds showTracking method to always show package status.
- Adds showMessageProvider to show Message Provider link when refills = 0.
- Adds showRefillStatus to show 'Refill prescription' button or Refill status as appropriate.
