### PR TITLE
[Messaging] Sort folder messages

### DIFF
--- a/src/js/common/components/SortableTable.jsx
+++ b/src/js/common/components/SortableTable.jsx
@@ -68,16 +68,30 @@ class SortableTable extends React.Component {
 
 SortableTable.propTypes = {
   className: React.PropTypes.string,
+
+  // Field value to sort by in either ascending or descending order.
+  // The `value` must be one of the values in the `fields` prop.
   currentSort: React.PropTypes.shape({
     value: React.PropTypes.string.isRequired,
     order: React.PropTypes.oneOf(['ASC', 'DESC'])
   }).isRequired,
-  // Mappings of each header label to the property on each data object.
+
+  // Mappings of header labels to properties on the objects in `data`.
   fields: React.PropTypes.arrayOf(React.PropTypes.shape({
     label: React.PropTypes.string.isRequired,
     value: React.PropTypes.string.isRequired
   })).isRequired,
-  data: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+
+  // Each object represents data for a row.
+  // An optional class may be provided to style specific rows.
+  data: React.PropTypes.arrayOf(React.PropTypes.shape({
+    id: React.PropTypes.oneOfType([
+      React.PropTypes.number,
+      React.PropTypes.string
+    ]).isRequired,
+    rowClass: React.PropTypes.string
+  })).isRequired,
+
   onSort: React.PropTypes.func
 };
 

--- a/src/js/common/components/SortableTable.jsx
+++ b/src/js/common/components/SortableTable.jsx
@@ -11,7 +11,7 @@ class SortableTable extends React.Component {
     return () => this.props.onSort(value, order);
   }
 
-  makeHeader(field, index) {
+  makeHeader(field) {
     // Determine what sort order the header will yield on the next click.
     // By default, it will be ascending. Only make it descending if
     // the current field is already sorted on in ascending order.
@@ -40,8 +40,7 @@ class SortableTable extends React.Component {
     );
   }
 
-  makeRow(item, index) {
-    let cellIndex = 0;
+  makeRow(item) {
     const cells = this.props.fields.map(field => {
       return <td key={`${item.id}-${field.value}`}>{item[field.value]}</td>;
     });

--- a/src/js/common/components/SortableTable.jsx
+++ b/src/js/common/components/SortableTable.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+class SortableTable extends React.Component {
+  constructor(props) {
+    super(props);
+    this.makeHeader = this.makeHeader.bind(this);
+    this.makeRow = this.makeRow.bind(this);
+  }
+
+  handleSort(value, order) {
+    return () => this.props.onSort(value, order);
+  }
+
+  makeHeader(field, index) {
+    // Determine what sort order the header will yield on the next click.
+    // By default, it will be ascending. Only make it descending if
+    // the current field is already sorted on in ascending order.
+    let nextSortOrder = 'ASC';
+    let sortIcon;
+
+    if (this.props.currentSort.value === field.value) {
+      if (this.props.currentSort.order === 'DESC') {
+        // Current icon will be descending.
+        // Next click will be ascending.
+        sortIcon = <i className="fa fa-caret-down"></i>;
+      } else {
+        // Current icon will be ascending.
+        // Next click will be descending.
+        sortIcon = <i className="fa fa-caret-up"></i>;
+        nextSortOrder = 'DESC';
+      }
+    }
+
+    return (
+      <th key={field.value}>
+        <a onClick={this.handleSort(field.value, nextSortOrder)}>
+          {field.label}&nbsp;&nbsp;&nbsp;{sortIcon}
+        </a>
+      </th>
+    );
+  }
+
+  makeRow(item, index) {
+    let cellIndex = 0;
+    const cells = this.props.fields.map(field => {
+      return <td key={`${item.id}-${field.value}`}>{item[field.value]}</td>;
+    });
+    return <tr key={item.id} className={item.rowClass}>{cells}</tr>;
+  }
+
+  render() {
+    const headers = this.props.fields.map(this.makeHeader);
+    const rows = this.props.data.map(this.makeRow);
+
+    return (
+      <table className={this.props.className}>
+        <thead>
+          <tr>
+            {headers}
+          </tr>
+        </thead>
+        <tbody>
+          {rows}
+        </tbody>
+      </table>
+    );
+  }
+}
+
+SortableTable.propTypes = {
+  className: React.PropTypes.string,
+  currentSort: React.PropTypes.shape({
+    value: React.PropTypes.string.isRequired,
+    order: React.PropTypes.oneOf(['ASC', 'DESC'])
+  }).isRequired,
+  // Mappings of each header label to the property on each data object.
+  fields: React.PropTypes.arrayOf(React.PropTypes.shape({
+    label: React.PropTypes.string.isRequired,
+    value: React.PropTypes.string.isRequired
+  })).isRequired,
+  data: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+  onSort: React.PropTypes.func
+};
+
+export default SortableTable;

--- a/src/js/messaging/components/MessageNav.jsx
+++ b/src/js/messaging/components/MessageNav.jsx
@@ -1,6 +1,24 @@
 import React from 'react';
 
 class MessageNav extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleClickNext = this.handleClickNext.bind(this);
+    this.handleClickPrev = this.handleClickPrev.bind(this);
+  }
+
+  handleClickNext() {
+    if (this.props.page < this.props.totalPages) {
+      this.props.onPageSelect(this.props.page + 1);
+    }
+  }
+
+  handleClickPrev() {
+    if (this.props.page > 1) {
+      this.props.onPageSelect(this.props.page - 1);
+    }
+  }
+
   render() {
     return (
       <div className="messaging-message-nav">
@@ -11,15 +29,15 @@ class MessageNav extends React.Component {
         </span>
         <button
             type="button"
-            disabled={!this.props.onClickPrev}
-            onClick={this.props.onClickPrev}>
+            disabled={this.props.page <= 1}
+            onClick={this.handleClickPrev}>
           <i className="fa fa-chevron-left"></i>
           <span>Previous</span>
         </button>
         <button
             type="button"
-            disabled={!this.props.onClickNext}
-            onClick={this.props.onClickNext}>
+            disabled={this.props.page >= this.props.totalPages}
+            onClick={this.handleClickNext}>
           <span>Next</span>
           <i className="fa fa-chevron-right"></i>
         </button>
@@ -34,8 +52,9 @@ MessageNav.propTypes = {
     React.PropTypes.string
   ]).isRequired,
   messageCount: React.PropTypes.number.isRequired,
-  onClickPrev: React.PropTypes.func,
-  onClickNext: React.PropTypes.func
+  onPageSelect: React.PropTypes.func,
+  page: React.PropTypes.number.isRequired,
+  totalPages: React.PropTypes.number.isRequired
 };
 
 export default MessageNav;

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -21,6 +21,7 @@ import { paths } from '../config';
 export class Folder extends React.Component {
   constructor(props) {
     super(props);
+    this.formattedSortParam = this.formattedSortParam.bind(this);
     this.handleSort = this.handleSort.bind(this);
     this.makeMessageNav = this.makeMessageNav.bind(this);
     this.makeMessagesTable = this.makeMessagesTable.bind(this);
@@ -36,16 +37,36 @@ export class Folder extends React.Component {
     const oldId = this.props.attributes.folderId;
     const newId = +this.props.params.id;
 
-    const query = _.pick(this.props.location.query, ['page']);
+    const query = _.pick(this.props.location.query, ['page', 'sort']);
+
     const oldPage = this.props.page;
     const newPage = +query.page || oldPage;
 
-    if (newId !== oldId || newPage !== oldPage) {
+    const oldSort = this.formattedSortParam(
+      this.props.sort.value,
+      this.props.sort.order
+    );
+    const newSort = query.sort || oldSort;
+
+    if (newId !== oldId || newPage !== oldPage || newSort !== oldSort) {
       this.props.fetchFolder(newId, query);
     }
   }
 
-  handleSort() {
+  formattedSortParam(value, order) {
+    const formattedValue = _.snakeCase(value);
+    const sort = order === 'DESC'
+                    ? `-${formattedValue}`
+                    : formattedValue;
+    return sort;
+  }
+
+  handleSort(value, order) {
+    const sort = this.formattedSortParam(value, order);
+    browserHistory.push({
+      pathname: `${paths.FOLDERS_URL}/${this.props.params.id}`,
+      query: { ...this.props.location.query, sort }
+    });
   }
 
   makeMessageNav() {
@@ -62,7 +83,7 @@ export class Folder extends React.Component {
       handleClickPrev = () => {
         browserHistory.push({
           pathname: `${paths.FOLDERS_URL}/${this.props.params.id}`,
-          query: { page: page - 1 }
+          query: { ...this.props.location.query, page: page - 1 }
         });
       };
     }
@@ -71,7 +92,7 @@ export class Folder extends React.Component {
       handleClickNext = () => {
         browserHistory.push({
           pathname: `${paths.FOLDERS_URL}/${this.props.params.id}`,
-          query: { page: page + 1 }
+          query: { ...this.props.location.query, page: page + 1 }
         });
       };
     }

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -97,7 +97,7 @@ export class Folder extends React.Component {
 
   makeMessagesTable() {
     const messages = this.props.messages;
-    if (messages && messages.length === 0) { return null; }
+    if (!messages || messages.length === 0) { return null; }
 
     const makeMessageLink = (content, id) => {
       return <Link to={`/messaging/thread/${id}`}>{content}</Link>;

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { Link, browserHistory } from 'react-router';
 import _ from 'lodash';
 import classNames from 'classnames';
+import moment from 'moment';
 
 import SortableTable from '../../common/components/SortableTable';
 
@@ -62,18 +63,18 @@ export class Folder extends React.Component {
     return sort;
   }
 
+  handlePageSelect(page) {
+    browserHistory.push({
+      pathname: `${paths.FOLDERS_URL}/${this.props.params.id}`,
+      query: { ...this.props.location.query, page }
+    });
+  }
+
   handleSort(value, order) {
     const sort = this.formattedSortParam(value, order);
     browserHistory.push({
       pathname: `${paths.FOLDERS_URL}/${this.props.params.id}`,
       query: { ...this.props.location.query, sort }
-    });
-  }
-
-  handlePageSelect(page) {
-    browserHistory.push({
-      pathname: `${paths.FOLDERS_URL}/${this.props.params.id}`,
-      query: { ...this.props.location.query, page }
     });
   }
 
@@ -112,6 +113,7 @@ export class Folder extends React.Component {
 
     const data = this.props.messages.map(message => {
       const id = message.messageId;
+      const sentDate = moment().calendar(message.sentDate);
       const rowClass = classNames({
         'messaging-message-row': true,
         'messaging-message-row--unread': message.readReceipt === 'UNREAD'
@@ -122,7 +124,7 @@ export class Folder extends React.Component {
         rowClass,
         senderName: makeMessageLink(message.senderName, id),
         subject: makeMessageLink(message.subject, id),
-        sentDate: makeMessageLink(message.sentDate, id)
+        sentDate: makeMessageLink(sentDate, id)
       };
     });
 

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -22,6 +22,7 @@ export class Folder extends React.Component {
   constructor(props) {
     super(props);
     this.formattedSortParam = this.formattedSortParam.bind(this);
+    this.handlePageSelect = this.handlePageSelect.bind(this);
     this.handleSort = this.handleSort.bind(this);
     this.makeMessageNav = this.makeMessageNav.bind(this);
     this.makeMessagesTable = this.makeMessagesTable.bind(this);
@@ -69,6 +70,13 @@ export class Folder extends React.Component {
     });
   }
 
+  handlePageSelect(page) {
+    browserHistory.push({
+      pathname: `${paths.FOLDERS_URL}/${this.props.params.id}`,
+      query: { ...this.props.location.query, page }
+    });
+  }
+
   makeMessageNav() {
     const { currentRange, messageCount, page, totalPages } = this.props;
 
@@ -76,33 +84,13 @@ export class Folder extends React.Component {
       return null;
     }
 
-    let handleClickPrev;
-    let handleClickNext;
-
-    if (page > 1) {
-      handleClickPrev = () => {
-        browserHistory.push({
-          pathname: `${paths.FOLDERS_URL}/${this.props.params.id}`,
-          query: { ...this.props.location.query, page: page - 1 }
-        });
-      };
-    }
-
-    if (page < totalPages) {
-      handleClickNext = () => {
-        browserHistory.push({
-          pathname: `${paths.FOLDERS_URL}/${this.props.params.id}`,
-          query: { ...this.props.location.query, page: page + 1 }
-        });
-      };
-    }
-
     return (
       <MessageNav
           currentRange={currentRange}
           messageCount={messageCount}
-          onClickPrev={handleClickPrev}
-          onClickNext={handleClickNext}/>
+          onPageSelect={this.handlePageSelect}
+          page={page}
+          totalPages={totalPages}/>
     );
   }
 

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -24,12 +24,12 @@ export class Folder extends React.Component {
   }
 
   componentDidUpdate() {
-    const newId = +this.props.params.id;
     const oldId = this.props.folder.attributes.folderId;
+    const newId = +this.props.params.id;
 
     const query = _.pick(this.props.location.query, ['page']);
-    const newPage = +query.page;
     const oldPage = this.props.page;
+    const newPage = +query.page || oldPage;
 
     if (newId !== oldId || newPage !== oldPage) {
       this.props.fetchFolder(newId, query);

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -24,7 +24,7 @@ export class Folder extends React.Component {
   }
 
   componentDidUpdate() {
-    const oldId = this.props.folder.attributes.folderId;
+    const oldId = this.props.attributes.folderId;
     const newId = +this.props.params.id;
 
     const query = _.pick(this.props.location.query, ['page']);
@@ -73,10 +73,9 @@ export class Folder extends React.Component {
     );
   }
 
-  makeMessagesTable(messages) {
-    if (messages.length === 0) {
-      return null;
-    }
+  makeMessagesTable() {
+    const messages = this.props.messages;
+    if (messages && messages.length === 0) { return null; }
 
     const makeMessageLink = (content, id) => {
       return <Link to={`/messaging/thread/${id}`}>{content}</Link>;
@@ -122,15 +121,9 @@ export class Folder extends React.Component {
   }
 
   render() {
-    const { attributes, messages } = this.props.folder;
-    let folderName;
-
-    if (!_.isEmpty(attributes)) {
-      folderName = attributes.name;
-    }
-
+    const folderName = _.get(this.props.attributes, 'name');
     const messageNav = this.makeMessageNav();
-    const folderMessages = this.makeMessagesTable(messages);
+    const folderMessages = this.makeMessagesTable();
 
     return (
       <div>
@@ -162,6 +155,7 @@ export class Folder extends React.Component {
 
 const mapStateToProps = (state) => {
   const folder = state.folders.data.currentItem;
+  const { attributes, messages } = folder;
   const pagination = folder.pagination;
   const page = pagination.currentPage;
   const perPage = pagination.perPage;
@@ -172,9 +166,10 @@ const mapStateToProps = (state) => {
   const endCount = Math.min(totalCount, page * perPage);
 
   return {
-    folder,
+    attributes,
     currentRange: `${startCount} - ${endCount}`,
     messageCount: totalCount,
+    messages,
     page,
     totalPages,
     isAdvancedVisible: state.search.advanced.visible,

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -30,7 +30,7 @@ export class Folder extends React.Component {
 
   componentDidMount() {
     const id = this.props.params.id;
-    const query = _.pick(this.props.location.query, ['page']);
+    const query = _.pick(this.props.location.query, ['page', 'sort']);
     this.props.fetchFolder(id, query);
   }
 

--- a/src/js/messaging/reducers/folders.js
+++ b/src/js/messaging/reducers/folders.js
@@ -30,7 +30,11 @@ const initialState = {
         totalEntries: 0,
         totalPages: 0
       },
-      persistFolder: 0
+      persistFolder: 0,
+      sort: {
+        value: 'sentDate',
+        order: 'DESC'
+      }
     },
     items: []
   },
@@ -63,12 +67,16 @@ export default function folders(state = initialState, action) {
       const messages = action.messages.data.map(message => message.attributes);
       const pagination = action.messages.meta.pagination;
       const persistFolder = action.folder.data.attributes.folderId;
+      const sort = action.messages.meta.sort;
+      const sortValue = Object.keys(sort)[0];
+      const sortOrder = sort[sortValue];
 
       const newItem = {
         attributes,
         messages,
         pagination,
-        persistFolder
+        persistFolder,
+        sort: { value: sortValue, order: sortOrder },
       };
 
       return set('data.currentItem', newItem, state);

--- a/test/util/messaging-helpers.js
+++ b/test/util/messaging-helpers.js
@@ -44,6 +44,9 @@ export const testData = {
       }
     ],
     meta: {
+      sort: {
+        'sentDate': 'DESC'
+      },
       pagination: {
         currentPage: 1,
         perPage: 25,

--- a/test/util/messaging-helpers.js
+++ b/test/util/messaging-helpers.js
@@ -45,7 +45,7 @@ export const testData = {
     ],
     meta: {
       sort: {
-        'sentDate': 'DESC'
+        sentDate: 'DESC'
       },
       pagination: {
         currentPage: 1,


### PR DESCRIPTION
### Changes
- Fixed bug that was causing infinite fetching for the first page of a folder when no page query param was defined.
- Pulled SortableTable component into common (leaving original in Rx to remove in later PR).
- Implemented sorting for folder messages.
  - Works along with pagination as query parameters in URL.
  - Can directly access a page with a sort order.
- Pulled logic for disabling next and prev into MessageNav.
  - Resulted in a single function for changing pages in Folder.
- First pass at date formatting in folder messages table. Will fine-tune the behavior in separate PR.
### TODO
- Remove SortableTable from Rx and update its usage there.
- Pull out common table styling.
- Customize date formatting to our needs.
