### PR TITLE
Add feature warning banner for claims status

### DIFF
--- a/src/js/disability-benefits/components/FeaturesWarning.jsx
+++ b/src/js/disability-benefits/components/FeaturesWarning.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function FeaturesWarning() {
+  return (
+    <div className="va-action-bar--header disability-claims-warning">
+      <div className="row">
+        <div className="columns small-12">
+          Check your appeal status, update your personal information, and get help filing claims on <a target="_blank" href="https://www.ebenefits.va.gov/">eBenefits.</a>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/js/disability-benefits/containers/DisabilityBenefitsApp.jsx
+++ b/src/js/disability-benefits/containers/DisabilityBenefitsApp.jsx
@@ -3,15 +3,20 @@ import { connect } from 'react-redux';
 
 import ClaimsUnavailable from '../components/ClaimsUnavailable';
 import ClaimSyncWarning from '../components/ClaimSyncWarning';
+import FeaturesWarning from '../components/FeaturesWarning';
 
 class DisabilityBenefitsApp extends React.Component {
 
   render() {
     const { available, synced, syncedDate } = this.props;
+    const isListPage = this.props.location.pathname === '/your-claims';
     return (
       <div>
         {available && !synced
           ? <ClaimSyncWarning syncedDate={syncedDate}/>
+          : null}
+        {available && synced && isListPage
+          ? <FeaturesWarning/>
           : null}
         {available
           ? <div>


### PR DESCRIPTION
Closes [75](https://github.com/department-of-veterans-affairs/sunsets-team/issues/75)

Only displays on list page and is hidden if data is out of sync (per Mel).

![screen shot 2016-10-20 at 11 33 21 am](https://cloud.githubusercontent.com/assets/634932/19566637/0bed5a7e-96b9-11e6-9b3a-a44bb14633ea.png)
