### PR TITLE
Show AddingDetails on claims status

### DIFF
--- a/src/js/disability-benefits/components/AddingDetails.jsx
+++ b/src/js/disability-benefits/components/AddingDetails.jsx
@@ -4,8 +4,8 @@ class AddingDetails extends React.Component {
   render() {
     return (
       <div className="usa-alert usa-alert-info claims-no-icon">
-        <h4>We have your claim information</h4>
-        <p>Thank you for filing your claim information. Don’t worry if you see “not available” here. We have all your information in the system and are preparing to send it to a Veterans Service Representative for review. Check back soon for an update.</p>
+        <h4>We're adding your details</h4>
+        We've received your claim and are still adding some of your information. Check back soon to see the complete details of your claim.
       </div>
     );
   }

--- a/src/js/disability-benefits/components/ClaimDetailLayout.jsx
+++ b/src/js/disability-benefits/components/ClaimDetailLayout.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import TabNav from '../components/TabNav';
 import AskVAQuestions from '../components/AskVAQuestions';
 import Loading from '../components/Loading';
+import AddingDetails from '../components/AddingDetails';
+
+import { isCompleteClaim } from '../utils/helpers';
 
 export default class ClaimDetailLayout extends React.Component {
   render() {
@@ -23,6 +26,7 @@ export default class ClaimDetailLayout extends React.Component {
           </div>
           <TabNav id={this.props.claim.id}/>
           <div className="va-tab-content">
+            {isCompleteClaim(claim) ? null : <AddingDetails/>}
             {this.props.children}
           </div>
         </div>

--- a/src/js/disability-benefits/components/NeedFilesFromYou.jsx
+++ b/src/js/disability-benefits/components/NeedFilesFromYou.jsx
@@ -4,13 +4,12 @@ class NeedFilesFromYou extends React.Component {
   render() {
     const filesNeeded = this.props.events.filter(event => event.type === 'still_need_from_you_list').length;
     return (
-      <div className="need-files-from-you usa-alert usa-alert-warning claims-no-icon">
-        <h4 className="warning-title">
-          <i className="fa fa-exclamation-triangle"></i>
-          {filesNeeded} {filesNeeded === 1 ? 'item needs' : 'items need'} your attention
-        </h4>
-        <button className="va-button-secondary">View Details</button>
-        <div className="clearfix"></div>
+      <div className="usa-alert usa-alert-warning claims-alert">
+        <div className="usa-alert-body">
+          <h4 className="usa-alert-heading">{filesNeeded} {filesNeeded === 1 ? 'item needs' : 'items need'} your attention</h4>
+          <button className="va-button-secondary">View Details</button>
+          <div className="clearfix"></div>
+        </div>
       </div>
     );
   }

--- a/src/js/disability-benefits/containers/StatusPage.jsx
+++ b/src/js/disability-benefits/containers/StatusPage.jsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import NeedFilesFromYou from '../components/NeedFilesFromYou';
 import ClaimsDecision from '../components/ClaimsDecision';
 import AskVAToDecide from '../components/AskVAToDecide';
-import AddingDetails from '../components/AddingDetails';
 import ClaimsTimeline from '../components/ClaimsTimeline';
 import ClaimDetailLayout from '../components/ClaimDetailLayout';
 
@@ -21,7 +20,6 @@ class StatusPage extends React.Component {
 
       content = (
         <div >
-          {phase === null ? <AddingDetails/> : null}
           {claim.attributes.documentsNeeded && !claim.attributes.decisionLetterSent
             ? <NeedFilesFromYou events={claim.attributes.eventsTimeline}/>
             : null}

--- a/src/js/disability-benefits/utils/helpers.js
+++ b/src/js/disability-benefits/utils/helpers.js
@@ -112,3 +112,10 @@ export const DOC_TYPES = [
 export function getDocTypeDescription(docType) {
   return DOC_TYPES.filter(type => type.value === docType)[0].label;
 }
+
+export function isCompleteClaim({ attributes }) {
+  return !!attributes.claimType
+    && !!attributes.contentionList.length
+    && !!attributes.dateFiled
+    && !!attributes.vaRepresentative;
+}

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -162,6 +162,9 @@
 .claims-no-icon,
 .usa-alert-info.claims-no-icon {
   background-image: none;
+  h4 {
+    padding-bottom: 0 !important;
+  }
 }
 
 .form-process li.section-complete:before {
@@ -528,7 +531,7 @@ p.first-of-type {
   > .usa-alert-body {
     padding-left: 4.2rem;
   }
-  > button {
+  button {
     position: absolute;
     top: 0.5em;
     right: 0;

--- a/test/disability-benefits/utils/helpers.unit.spec.js
+++ b/test/disability-benefits/utils/helpers.unit.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { groupTimelineActivity } from '../../../src/js/disability-benefits/utils/helpers';
+import { groupTimelineActivity, isCompleteClaim } from '../../../src/js/disability-benefits/utils/helpers';
 
 describe('Disability benefits helpers:', () => {
   describe('groupTimelineActivity', () => {
@@ -40,6 +40,51 @@ describe('Disability benefits helpers:', () => {
 
       expect(phaseActivity[1][0].type).to.equal('filed');
       expect(phaseActivity[2].length).to.equal(2);
+    });
+  });
+  describe('isCompleteClaim', () => {
+    it('should return false if any field is empty', () => {
+      const claim = {
+        attributes: {
+          claimType: 'something',
+          contentionList: [
+            'thing'
+          ],
+          dateFiled: 'asdf',
+          vaRepresentative: null
+        }
+      };
+
+      expect(isCompleteClaim(claim)).to.be.false;
+    });
+
+    it('should return true if no field is empty', () => {
+      const claim = {
+        attributes: {
+          claimType: 'something',
+          contentionList: [
+            'thing'
+          ],
+          dateFiled: 'asdf',
+          vaRepresentative: 'asdf'
+        }
+      };
+
+      expect(isCompleteClaim(claim)).to.be.true;
+    });
+
+    it('should return false if contention list is empty', () => {
+      const claim = {
+        attributes: {
+          claimType: 'something',
+          contentionList: [
+          ],
+          dateFiled: 'asdf',
+          vaRepresentative: 'test'
+        }
+      };
+
+      expect(isCompleteClaim(claim)).to.be.false;
     });
   });
 });


### PR DESCRIPTION
Closes [91](https://github.com/department-of-veterans-affairs/sunsets-team/issues/91)

This shows the AddingDetails component when the claim is not completely entered. I also updated the copy and adjusted the need files alert.

![screen shot 2016-10-20 at 12 01 18 pm](https://cloud.githubusercontent.com/assets/634932/19567768/02c9b7d6-96bd-11e6-81e9-e541b1b8cda2.png)
![screen shot 2016-10-20 at 12 01 14 pm](https://cloud.githubusercontent.com/assets/634932/19567770/055c1d86-96bd-11e6-9fcf-ab3e2840e508.png)
