### PR TITLE
Display attachments received as part of a message.

### DIFF
--- a/src/js/messaging/actions/messages.js
+++ b/src/js/messaging/actions/messages.js
@@ -63,7 +63,7 @@ export function fetchThread(id) {
     )).then(
       data => dispatch({
         type: FETCH_THREAD_SUCCESS,
-        message: data[0].data,
+        message: data[0],
         thread: data[1].data
       }),
       err => dispatch({ type: FETCH_THREAD_FAILURE, err })

--- a/src/js/messaging/components/Message.jsx
+++ b/src/js/messaging/components/Message.jsx
@@ -43,13 +43,7 @@ class Message extends React.Component {
 
     let attachments;
     if (this.props.attrs.attachment) {
-      // TODO: Replace with actual attachments data
-      attachments = (<MessageAttachmentsView attachments={[
-        { name: 'file1.jpg', url: 'path/to/file1.jpg' },
-        { name: 'file2.jpg', url: 'path/to/file2.jpg' },
-        { name: 'file3.jpg', url: 'path/to/file3.jpg' },
-        { name: 'file4.jpg', url: 'path/to/file4.jpg' }
-      ]}/>);
+      attachments = (<MessageAttachmentsView attachments={this.props.attrs.attachments}/>);
     }
 
     return (

--- a/src/js/messaging/components/MessageAttachmentsView.jsx
+++ b/src/js/messaging/components/MessageAttachmentsView.jsx
@@ -10,8 +10,8 @@ class MessageAttachmentsView extends React.Component {
       return (
         <MessageAttachmentsViewItem
             key={key}
-            name={attachment.name}
-            url={attachment.url}/>
+            name={attachment.attributes.name}
+            url={attachment.links.download}/>
       );
     });
 

--- a/src/js/messaging/reducers/messages.js
+++ b/src/js/messaging/reducers/messages.js
@@ -14,16 +14,13 @@ import {
   UPDATE_DRAFT
 } from '../utils/constants';
 
-import { composeMessage } from '../config';
-
 const initialState = {
   data: {
     message: null,
     thread: [],
     draft: {
       attachments: [],
-      body: makeField(''),
-      charsRemaining: composeMessage.maxChars.message
+      body: makeField('')
     }
   },
   ui: {
@@ -74,8 +71,6 @@ export default function messages(state = initialState, action) {
           // TODO: Get attachments from the draft.
           attachments: [],
           body: makeField(currentMessage.body),
-          charsRemaining: composeMessage.maxChars.message -
-                          currentMessage.body.length,
           replyMessageId: thread.length === 0 ?
                           undefined :
                           thread[thread.length - 1].messageId
@@ -132,9 +127,7 @@ export default function messages(state = initialState, action) {
 
     case UPDATE_DRAFT:
       return set('data.draft', {
-        body: action.field,
-        charsRemaining: composeMessage.maxChars.message -
-                        action.field.value.length
+        body: action.field
       }, state);
 
     default:

--- a/src/sass/messaging/partials/_messaging-attachments.scss
+++ b/src/sass/messaging/partials/_messaging-attachments.scss
@@ -23,3 +23,8 @@
   color: $color-base;
   padding-right: .75rem;
 }
+
+.msg-attachment-item {
+  background-image: none;
+  padding-right: 0;
+}


### PR DESCRIPTION
Closes department-of-veterans-affairs/messaging-fe#112
- Sends entire message response to reducer, instead of just data[0].data
- Updates Message, MessageAttachmentsView to use actual data
