### PR TITLE
Map file names on documents page

### DIFF
--- a/src/js/disability-benefits/containers/FilesPage.jsx
+++ b/src/js/disability-benefits/containers/FilesPage.jsx
@@ -96,7 +96,10 @@ class FilesPage extends React.Component {
               {documentsTurnedIn.map(item => (
                 <div className="submitted-file-list-item" key={item.trackedItemId}>
                   <p className="submission-file-type">{item.displayName}</p>
-                  <p className="submission-item">{'file-name.pdf'}</p>
+                  {item.documents
+                    ? item.documents.map((doc, index) =>
+                      <p key={index} className="submission-item">{doc.filename}</p>)
+                    : null}
                   {hasBeenReviewed(item)
                     ?
                     <div>


### PR DESCRIPTION
This will show file names on the files page once [this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/318) is merged.
