### PR TITLE
Make date of birth field disallow anyone under 17.

### DIFF
--- a/src/js/common/utils/validations.js
+++ b/src/js/common/utils/validations.js
@@ -93,6 +93,15 @@ function isValidAnyDate(day, month, year) {
   }).isValid();
 }
 
+function isValidDateOver17(day, month, year) {
+  const momentDate = moment({
+    day,
+    month: parseInt(month, 10) - 1,
+    year
+  });
+  return momentDate.isBefore(moment().endOf('day').subtract(17, 'years'));
+}
+
 function isValidName(value) {
   return /^[a-zA-Z][a-zA-Z '\-]*$/.test(value);
 }
@@ -520,5 +529,6 @@ export {
   isValidMedicareMedicaid,
   isValidServiceInformation,
   isValidSection,
-  isValidAnyDate
+  isValidAnyDate,
+  isValidDateOver17
 };

--- a/src/js/edu-benefits/components/veteran-information/VeteranInformationFields.jsx
+++ b/src/js/edu-benefits/components/veteran-information/VeteranInformationFields.jsx
@@ -6,6 +6,16 @@ import SocialSecurityNumber from '../../../common/components/questions/SocialSec
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
 
 import { binaryGenders } from '../../utils/options-for-select';
+import { isValidDateOver17, isValidAnyDate, validateIfDirtyDate } from '../../../common/utils/validations';
+
+function getDateMessage({ month, day, year }) {
+  if (isValidAnyDate(day.value, month.value, year.value)
+      && !isValidDateOver17(day.value, month.value, year.value)) {
+    return 'You must be at least 17 to apply';
+  }
+
+  return 'Please provide a valid date of birth';
+}
 
 export default class PersonalInformationFields extends React.Component {
   render() {
@@ -22,7 +32,8 @@ export default class PersonalInformationFields extends React.Component {
               ssn={this.props.data.veteranSocialSecurityNumber}
               onValueChange={(update) => {this.props.onStateChange('veteranSocialSecurityNumber', update);}}/>
           <DateInput required
-              errorMessage="Please provide a valid date of birth"
+              errorMessage={getDateMessage(this.props.data.veteranDateOfBirth)}
+              validation={validateIfDirtyDate(this.props.data.veteranDateOfBirth.day, this.props.data.veteranDateOfBirth.month, this.props.data.veteranDateOfBirth.year, isValidDateOver17)}
               name="veteranBirth"
               day={this.props.data.veteranDateOfBirth.day}
               month={this.props.data.veteranDateOfBirth.month}

--- a/test/common/utils/validations.unit.spec.js
+++ b/test/common/utils/validations.unit.spec.js
@@ -1,6 +1,15 @@
 import { expect } from 'chai';
+import moment from 'moment';
 
-import { isValidDate, isValidSSN, isValidName, isNotBlank, isBlank, isValidMonetaryValue } from '../../../src/js/common/utils/validations.js';
+import {
+  isValidDate,
+  isValidSSN,
+  isValidName,
+  isNotBlank,
+  isBlank,
+  isValidMonetaryValue,
+  isValidDateOver17
+} from '../../../src/js/common/utils/validations.js';
 
 describe('Validations unit tests', () => {
   describe('isValidSSN', () => {
@@ -125,6 +134,18 @@ describe('Validations unit tests', () => {
       expect(isValidMonetaryValue('1,000')).to.be.false;
       expect(isValidMonetaryValue('abc')).to.be.false;
       expect(isValidMonetaryValue('$100')).to.be.false;
+    });
+  });
+
+  describe('isValidDateOver17', () => {
+    it('validates turning 17 today', () => {
+      const date = moment().startOf('day').subtract(17, 'years');
+      expect(isValidDateOver17(date.date(), date.month() + 1, date.year())).to.be.true;
+    });
+
+    it('does not validate turning 17 tomorrow', () => {
+      const date = moment().startOf('day').subtract(17, 'years').add(1, 'days');
+      expect(isValidDateOver17(date.date(), date.month() + 1, date.year())).to.be.false;
     });
   });
 });


### PR DESCRIPTION
Closes #3413.

Based on discussion in the above issue, we're setting the minimum age to be 17 to make sure we don't exclude anyone.

(Note that today is 10/24):

![screen shot 2016-10-24 at 4 40 36 pm](https://cloud.githubusercontent.com/assets/634932/19663549/74dd4a9a-9a0a-11e6-89ca-bf78903930e4.png)
![screen shot 2016-10-24 at 4 40 33 pm](https://cloud.githubusercontent.com/assets/634932/19663548/74da736a-9a0a-11e6-98e0-b49cbd0acb28.png)
