### PR TITLE
Remove education application from ignoreList for staging

### DIFF
--- a/script/build.js
+++ b/script/build.js
@@ -118,7 +118,6 @@ if (options.buildtype === 'production') {
   ignoreList.push('auth/*');
   ignoreList.push('education/apply-for-education-benefits-new');
 } else if (options.buildtype === 'staging') {
-  ignoreList.push('education/apply-for-education-benefits/application.md');
   ignoreList.push('facilities/*');
   ignoreList.push('profile/*');
   ignoreList.push('education/apply-for-education-benefits-new');


### PR DESCRIPTION
Now that education is password protected on staging (https://github.com/department-of-veterans-affairs/devops/pull/885), we can expose the application on staging for testing!
