### PR TITLE
Claim status page style fixes

### DIFF
--- a/src/js/disability-benefits/components/AskVAToDecide.jsx
+++ b/src/js/disability-benefits/components/AskVAToDecide.jsx
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router';
 class AskVAToDecide extends React.Component {
   render() {
     return (
-      <div className="usa-alert usa-alert-info claims-no-icon">
+      <div className="usa-alert usa-alert-info claims-no-icon claims-alert-status">
         <h4>Ask VA to decide your claims</h4>
         <p>
           You can ask VA to start evaluating your claim if you don't have anymore documents or evidence to file.

--- a/src/js/disability-benefits/components/ClaimDetailLayout.jsx
+++ b/src/js/disability-benefits/components/ClaimDetailLayout.jsx
@@ -22,8 +22,8 @@ export default class ClaimDetailLayout extends React.Component {
             </ul>
           </nav>
           {message}
+          <h1 className="claim-title">Your {"Compensation"} Claim</h1>
           <div className="claim-conditions">
-            <h1>Your {"Compensation"} Claim</h1>
             <h6>Your Claimed Conditions:</h6>
             <p className="list">
               {claim.attributes.contentionList

--- a/src/js/disability-benefits/components/ClaimPhase.jsx
+++ b/src/js/disability-benefits/components/ClaimPhase.jsx
@@ -139,8 +139,13 @@ export default class ClaimPhase extends React.Component {
   }
   render() {
     const { phase, current, children } = this.props;
+    const expandCollapseIcon = phase < current && phase !== COMPLETE_PHASE
+      ? <i className={this.state.open ? 'fa fa-minus claim-timeline-icon' : 'fa fa-plus claim-timeline-icon'}></i>
+      : null;
+
     return (
       <li onClick={() => this.expandCollapse()} role="presentation" className={`${getClasses(phase, current)}`}>
+        {expandCollapseIcon}
         <h5>{getUserPhaseDescription(phase)}</h5>
         {this.state.open || phase === COMPLETE_PHASE
           ? <div>

--- a/src/js/disability-benefits/components/ClaimsDecision.jsx
+++ b/src/js/disability-benefits/components/ClaimsDecision.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 class ClaimsDecision extends React.Component {
   render() {
     return (
-      <div className="claim-decision-is-ready usa-alert usa-alert-info claims-no-icon">
+      <div className="claim-decision-is-ready usa-alert usa-alert-info claims-no-icon claims-alert-status">
         <h4>Your claim decision is ready</h4>
         <p>We sent you a packet by U.S. mail that includes details of the decision or award. Please allow 7 business days for your packet to arrive before contacting a VA call center.</p>
         <p>Do you disagree with your claim decision? <a href="/disability-benefits/claims-appeal">File an appeal</a></p>

--- a/src/js/disability-benefits/components/NeedFilesFromYou.jsx
+++ b/src/js/disability-benefits/components/NeedFilesFromYou.jsx
@@ -5,7 +5,7 @@ class NeedFilesFromYou extends React.Component {
   render() {
     const filesNeeded = this.props.events.filter(event => event.type === 'still_need_from_you_list').length;
     return (
-      <div className="usa-alert usa-alert-warning claims-alert">
+      <div className="usa-alert usa-alert-warning claims-alert claims-alert-status">
         <div className="usa-alert-body">
           <h4 className="usa-alert-heading">{filesNeeded} {filesNeeded === 1 ? 'item needs' : 'items need'} your attention</h4>
           <Link to={`your-claims/${this.props.claimId}/files`} className="usa-button">View Details</Link>

--- a/src/js/disability-benefits/containers/DetailsPage.jsx
+++ b/src/js/disability-benefits/containers/DetailsPage.jsx
@@ -10,10 +10,9 @@ class DetailsPage extends React.Component {
   render() {
     const { claim, loading } = this.props;
 
-    return (
-      <ClaimDetailLayout
-          claim={claim}
-          loading={loading}>
+    let content = null;
+    if (!loading) {
+      content = (
         <div className="claim-details">
           <div className="claim-types">
             <h6>Claim Type</h6>
@@ -37,6 +36,14 @@ class DetailsPage extends React.Component {
             <p>{claim.attributes.vaRepresentative || 'Not Available'}</p>
           </div>
         </div>
+      );
+    }
+
+    return (
+      <ClaimDetailLayout
+          claim={claim}
+          loading={loading}>
+        {content}
       </ClaimDetailLayout>
     );
   }

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -3,6 +3,11 @@
 @import 'modules/m-modal';
 @import 'modules/m-progress-bar';
 
+.claim-alert-status {
+  margin-top: 0;
+  margin-bottom: 2em;
+}
+
 .claim-list {
   margin-bottom: 2em;
 }
@@ -85,11 +90,8 @@
   }
 }
 
-.file-request-list {
-  margin-top: 1.5em;
-}
-
 .file-request-list-item {
+  margin-top: 1.5em;
   .item-container {
     margin: 0.5em 0;
     float: left;
@@ -152,7 +154,6 @@
 
 .claim-decision-is-ready,
 .you-have-no-claims {
-  margin-bottom: 1em;
   h4, p {
     margin: 0.5em 0;
     padding: 0;
@@ -254,27 +255,27 @@ a.claim-list-item {
   }
 }
 
+.claim-title {
+  margin: 0;
+  display: inline-block;
+}
+
 .claim-conditions {
-  h1, p {
+  margin-top: 0.5em;
+  margin-bottom: 2em;
+  p {
     margin: 0;
   }
   h6, p {
     display: inline-block;
   }
-  p {
-    margin-top: 10px;
-  }
-  .request-decision-button {
-    margin-bottom: 1
-  }
-  .list {
-    margin-left: 6px;
+  h6 {
+    margin-right: 6px !important;
+    padding-bottom: 0 !important;
   }
 }
 
 .claim-details {
-  margin-top: 1.5em;
-
   .claim-conditions-list,
   .claim-date-recieved,
   .claim-va-representative {
@@ -357,6 +358,7 @@ a.claim-list-item {
 }
 
 .va-tab-content {
+  padding-top: 2.5em;
   border-top: 1px solid $color-gray;
 }
 
@@ -398,18 +400,24 @@ a.claim-list-item {
 }
 
 .disability-benefits-timeline {
+  padding-top: 0;
   > li.step:not(.section-current) {
     cursor: pointer;
   }
+  > li > h5 {
+    padding-right: 23px !important;
+  }
+}
+
+.claim-timeline-icon {
+  float: right;
+  margin-top: 6px;
+  font-size: 17px;
 }
 
 button.older-updates {
   margin-top: 1em;
   margin-bottom: 0;
-}
-
-.claims-alert {
-  margin-bottom: 1.5em;
 }
 
 .claims-alert-checkbox {
@@ -520,7 +528,6 @@ p.first-of-type {
 
 .claims-alert {
   position: relative;
-  margin-bottom: 0.5em;
   &.usa-alert {
     background-size: 4.1rem;
     background-position: 1rem 1.9rem;
@@ -540,6 +547,12 @@ p.first-of-type {
   }
 }
 
+.claims-alert-status {
+  margin-top: 0;
+  margin-bottom: 2em;
+}
+
 .claims-header {
   margin: 0;
 }
+


### PR DESCRIPTION
Closes [122](https://github.com/department-of-veterans-affairs/sunsets-team/issues/122)

Various styles fixes for the status page. Also fixes the details page so that it doesn't error if you refresh the page.

Spacing on top of details tab:
![screen shot 2016-10-25 at 3 46 27 pm](https://cloud.githubusercontent.com/assets/634932/19701643/385ce826-9aca-11e6-9861-06f8bfed5e7f.png)
Spacing on top of files tab:
![screen shot 2016-10-25 at 3 46 24 pm](https://cloud.githubusercontent.com/assets/634932/19701639/38595300-9aca-11e6-9188-0cf75dbc96dc.png)
Spacing on top of status tab and claim conditions alignment:
![screen shot 2016-10-25 at 3 46 12 pm](https://cloud.githubusercontent.com/assets/634932/19701642/385c28d2-9aca-11e6-9687-c9a195826eff.png)
Spacing below alert:
![screen shot 2016-10-25 at 3 45 52 pm](https://cloud.githubusercontent.com/assets/634932/19701640/3859fe4a-9aca-11e6-8bf3-e61b54a9fc51.png)
Icons and alignment:
![screen shot 2016-10-25 at 3 45 48 pm](https://cloud.githubusercontent.com/assets/634932/19701644/385dad60-9aca-11e6-9357-152036935e54.png)
