### PR TITLE
Fix mark over search box on iPhone 5 sized screens

### DIFF
--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -249,7 +249,7 @@ hr {
     }
 
     @media #{$small} {
-      width: 263px;
+      width: 225px;
       height: 50px;
     }
   }


### PR DESCRIPTION
Closes [126](https://github.com/department-of-veterans-affairs/sunsets-team/issues/126).

The header on vets.gov is overlapping the search box and showing some of the link text that's normally pushed off the screen by `text-indent: 180%`. This changes resizes the logo so that it doesn't overlap the search box, which hides the sliver of text being shown.

Before:
![screen shot 2016-10-26 at 10 25 49 am](https://cloud.githubusercontent.com/assets/634932/19730014/e02bd87c-9b66-11e6-9765-bfbc7dbcbd54.png)
After:
![screen shot 2016-10-26 at 10 26 08 am](https://cloud.githubusercontent.com/assets/634932/19730015/e02c1576-9b66-11e6-9951-578c98b71e8f.png)
