### PR TITLE
Tweaks to expand collapse and alerts on claims status

### DIFF
--- a/src/js/disability-benefits/components/AddingDetails.jsx
+++ b/src/js/disability-benefits/components/AddingDetails.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 class AddingDetails extends React.Component {
   render() {
     return (
-      <div className="usa-alert usa-alert-info claims-no-icon">
+      <div className="usa-alert usa-alert-info claims-no-icon claims-alert-status">
         <h4>We're adding your details</h4>
         We've received your claim and are still adding some of your information. Check back soon to see the complete details of your claim.
       </div>

--- a/src/js/disability-benefits/components/ClaimPhase.jsx
+++ b/src/js/disability-benefits/components/ClaimPhase.jsx
@@ -139,7 +139,7 @@ export default class ClaimPhase extends React.Component {
   }
   render() {
     const { phase, current, children } = this.props;
-    const expandCollapseIcon = phase < current && phase !== COMPLETE_PHASE
+    const expandCollapseIcon = phase <= current && phase !== COMPLETE_PHASE
       ? <i className={this.state.open ? 'fa fa-minus claim-timeline-icon' : 'fa fa-plus claim-timeline-icon'}></i>
       : null;
 

--- a/src/js/disability-benefits/components/NoClaims.jsx
+++ b/src/js/disability-benefits/components/NoClaims.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function NoClaims() {
   return (
-    <div className="usa-alert usa-alert-info claims-alert claims-no-icon">
+    <div className="usa-alert usa-alert-info claims-alert claims-no-icon claims-alert-status">
       <h4>You do not have any submitted claims</h4>
       <p>Claims that you have submitted will appear here. If you have an open application for a claim but have not yet submitted it, you can continue your application on <a href="https://www.ebenefits.va.gov/">eBenefits</a></p>
     </div>

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -358,10 +358,9 @@ a.claim-list-item {
 }
 
 .va-tab-content {
-  padding-top: 2.5em;
+  padding-top: 2em;
   border-top: 1px solid $color-gray;
 }
-
 
 .clearfix:after {
   content: " ";
@@ -401,7 +400,7 @@ a.claim-list-item {
 
 .disability-benefits-timeline {
   padding-top: 0;
-  > li.step:not(.section-current) {
+  > li.step:not(.last) {
     cursor: pointer;
   }
   > li > h5 {

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -400,7 +400,7 @@ a.claim-list-item {
 
 .disability-benefits-timeline {
   padding-top: 0;
-  > li.step:not(.last) {
+  > li.step.section-current:not(.last), > li.step.section-complete:not(.last) {
     cursor: pointer;
   }
   > li > h5 {


### PR DESCRIPTION
Closes [142](https://github.com/department-of-veterans-affairs/sunsets-team/issues/142) and [151](https://github.com/department-of-veterans-affairs/sunsets-team/issues/151).

Updates the cursor type logic and shows expand/collapse icons for the current phase.
