### PR TITLE
Allow html to be displayed for tracked item description

### DIFF
--- a/src/js/disability-benefits/containers/DocumentRequestPage.jsx
+++ b/src/js/disability-benefits/containers/DocumentRequestPage.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 import React from 'react';
 import Scroll from 'react-scroll';
 import { withRouter, Link } from 'react-router';
@@ -78,7 +79,7 @@ class DocumentRequestPage extends React.Component {
               <p><strong>Optional</strong> - we've asked others to send this to us, but you may upload it if you have it.</p>
             </div>
             : null}
-          <p>{trackedItem.description}</p>
+          <p dangerouslySetInnerHTML={{ __html: trackedItem.description }}/>
           <AddFilesForm
               field={this.props.uploadField}
               progress={this.props.progress}


### PR DESCRIPTION
Closes [144](https://github.com/department-of-veterans-affairs/sunsets-team/issues/144)

(There's a `<br/>` in the text):
![screen shot 2016-10-27 at 4 19 16 pm](https://cloud.githubusercontent.com/assets/634932/19784095/6ac95cc4-9c62-11e6-880f-91374259e974.png)
