### PR TITLE
Display 'No messages' when message list is empty.

### DIFF
--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -99,7 +99,9 @@ export class Folder extends React.Component {
 
   makeMessagesTable() {
     const messages = this.props.messages;
-    if (!messages || messages.length === 0) { return null; }
+    if (!messages || messages.length === 0) {
+      return <h1 className="msg-nomessages">No messages</h1>;
+    }
 
     const makeMessageLink = (content, id) => {
       return <Link to={`/thread/${id}`}>{content}</Link>;

--- a/src/sass/messaging/partials/_messaging-folder.scss
+++ b/src/sass/messaging/partials/_messaging-folder.scss
@@ -1,21 +1,34 @@
 #messaging-folder-controls {
+  margin: 0;  
   position: relative;
-  margin-bottom: 4.5rem;
+  width: 100%;
 
   .messaging-compose-button {
-    display: none;
-    margin: 0;
-    width: 100%;
+    margin: 2rem 0;
   }
 
   @media (max-width: $medium-screen) {
-    margin: 0;
-    padding: 2rem;
+    padding: 0 2rem;
+  }
+
+  @media (min-width: $medium-screen) {
+    &::after {
+      content: '\A0';
+      display: block;
+      clear: both;
+    }
+
+    padding: 0;
 
     .messaging-compose-button {
-      display: block;
+      display: none;
+      margin-bottom: 4.5rem;
     }
   }
+}
+
+.msg-nomessages {
+  margin: 0;
 }
 
 .messaging-message-row {


### PR DESCRIPTION
Affects folder view and search results view.

Closes department-of-veterans-affairs/messaging-fe#127
