### PR TITLE
[Messaging] Replies and reply drafts.

### DIFF
--- a/src/js/messaging/actions/messages.js
+++ b/src/js/messaging/actions/messages.js
@@ -129,7 +129,7 @@ export function saveDraft(message) {
   let defaultSettings = api.settings.postJson;
 
   if (isReply) {
-    url = `${url}/${message.replyMessageId}/replydraft`
+    url = `${url}/${message.replyMessageId}/replydraft`;
   }
 
   // Update the draft if it already has an id.

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -61,12 +61,17 @@ export class Thread extends React.Component {
   }
 
   apiFormattedDraft() {
-    const draft = Object.assign({}, this.props.draft);
-    draft.body = draft.body.value;
-    draft.category = draft.category.value;
-    draft.recipient = draft.recipient.value;
-    draft.subject = draft.subject.value;
-    return draft;
+    const draft = this.props.draft;
+
+    return {
+      attachments: draft.attachments,
+      body: draft.body.value,
+      category: draft.category.value,
+      messageId: draft.messageId,
+      recipientId: +draft.recipient.value,
+      replyMessageId: draft.replyMessageId,
+      subject: draft.subject.value
+    }
   }
 
   handleMessageDelete() {

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -13,7 +13,6 @@ import {
   openMoveToNewFolderModal,
   saveDraft,
   sendMessage,
-  sendReply,
   toggleConfirmDelete,
   toggleMessageCollapsed,
   toggleMessagesCollapsed,
@@ -83,11 +82,7 @@ export class Thread extends React.Component {
   }
 
   handleReplySend() {
-    if (this.props.isNewMessage) {
-      this.props.sendMessage(this.apiFormattedDraft());
-    } else {
-      this.props.sendReply(this.apiFormattedDraft());
-    }
+    this.props.sendMessage(this.apiFormattedDraft());
   }
 
   handleReplyDelete() {
@@ -288,7 +283,6 @@ const mapDispatchToProps = {
   openMoveToNewFolderModal,
   saveDraft,
   sendMessage,
-  sendReply,
   toggleConfirmDelete,
   toggleMessageCollapsed,
   toggleMessagesCollapsed,

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -70,7 +70,7 @@ export class Thread extends React.Component {
       recipientId: +draft.recipient.value,
       replyMessageId: draft.replyMessageId,
       subject: draft.subject.value
-    }
+    };
   }
 
   handleMessageDelete() {

--- a/src/js/messaging/reducers/messages.js
+++ b/src/js/messaging/reducers/messages.js
@@ -75,6 +75,7 @@ export default function messages(state = initialState, action) {
       if (!currentMessage.sentDate) {
         draft.attachments = currentMessage.attachments || [];
         draft.body = makeField(currentMessage.body);
+        draft.messageId = currentMessage.messageId;
         draft.recipient = makeField(currentMessage.recipientId.toString());
         draft.replyMessageId = thread.length === 0
                              ? undefined

--- a/src/js/messaging/reducers/messages.js
+++ b/src/js/messaging/reducers/messages.js
@@ -66,7 +66,7 @@ export default function messages(state = initialState, action) {
       // Reverse to display most recent message at the bottom.
       thread.reverse();
 
-      const draft = initialState.data.draft;
+      const draft = Object.assign({}, initialState.data.draft);
       draft.category = makeField(currentMessage.category);
       draft.subject = makeField(currentMessage.subject);
 


### PR DESCRIPTION
Closes department-of-veterans-affairs/messaging-fe#95 and department-of-veterans-affairs/messaging-fe#113.
### Changes
- Saves drafts of replies such that they're associated with the thread they are supposed to reply to and that thread can be viewed in the draft.
- Merged `sendReply` into `sendMessage` since they share a lot of logic. Requests to send reply will now use form data as well.
- Fixed bug where draft body was persisting across threads.
### TODO
- Resolve issues from department-of-veterans-affairs/vets-api#375.
- Attachments in general are having problems, so will fix that when the cause is determined.
