### PR TITLE
Add claim estimation page to claim status

### DIFF
--- a/src/js/disability-benefits/components/ClaimEstimate.jsx
+++ b/src/js/disability-benefits/components/ClaimEstimate.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import moment from 'moment';
+import { Link } from 'react-router';
 
-export default function ClaimEstimate({ maxDate }) {
+export default function ClaimEstimate({ maxDate, id }) {
   const estimatedDate = moment(maxDate);
   const today = moment().startOf('day');
 
@@ -19,11 +20,12 @@ export default function ClaimEstimate({ maxDate }) {
       {estimatedDate.isBefore(today)
         ? <p>We estimated your claim would be completed by now but we need more time.</p>
         : <p>This date is based on claims similar to yours and is not an exact date.</p>}
-      <p><a href="claim-estimate">Learn about this estimation</a></p>
+      <p><Link to={`your-claims/${id}/claim-estimate`}>Learn about this estimation</Link></p>
     </div>
   );
 }
 
 ClaimEstimate.propTypes = {
-  maxDate: React.PropTypes.string.isRequired
+  maxDate: React.PropTypes.string.isRequired,
+  id: React.PropTypes.string.isRequired
 };

--- a/src/js/disability-benefits/components/ClaimEstimate.jsx
+++ b/src/js/disability-benefits/components/ClaimEstimate.jsx
@@ -19,7 +19,7 @@ export default function ClaimEstimate({ maxDate }) {
       {estimatedDate.isBefore(today)
         ? <p>We estimated your claim would be completed by now but we need more time.</p>
         : <p>This date is based on claims similar to yours and is not an exact date.</p>}
-      <p><a href="/">Learn about this estimation</a></p>
+      <p><a href="claim-estimate">Learn about this estimation</a></p>
     </div>
   );
 }

--- a/src/js/disability-benefits/components/ClaimEstimationPage.jsx
+++ b/src/js/disability-benefits/components/ClaimEstimationPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
+import AskVAQuestions from './AskVAQuestions';
 
 export default class ClaimEstimationPage extends React.Component {
   componentDidMount() {
@@ -9,17 +10,22 @@ export default class ClaimEstimationPage extends React.Component {
     return (
       <div>
         <div className="row">
-          <div className="medium-8 columns">
+          <div className="medium-12 columns">
             <nav className="va-nav-breadcrumbs">
               <ul className="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
                 <li><Link to="your-claims">Your claims</Link></li>
+                <li><Link to={`your-claims/${this.props.params.id}/status`}>Your Disability Compensation Claim</Link></li>
                 <li className="active">How VA Comes Up with Your Estimated Decision Date</li>
               </ul>
             </nav>
+          </div>
+        </div>
+        <div className="row">
+          <div className="medium-8 columns">
             <div>
               <h1>How VA Comes Up with Your Estimated Decision Date</h1>
               <p className="first-of-type">VA looks at every claim carefully before making a decision. In some cases, we are able to decide quickly, but some claims are more complex and take more time to review.</p>
-              <h2>Your estimated decision date is based on:</h2>
+              <h2 className="estimation-header">Your estimated decision date is based on:</h2>
               <ul>
                 <li>The type of disability you claimed</li>
                 <li>How many disabilities you claimed</li>
@@ -27,18 +33,18 @@ export default class ClaimEstimationPage extends React.Component {
                 <li>How long it took VA to decide other claims like yours</li>
                 <li>How long it takes VA to get supporting documents</li>
               </ul>
-              <h2>Sometimes estimated dates change when:</h2>
+              <h2 className="estimation-header">Sometimes estimated dates change when:</h2>
               <ul>
                 <li>You upload optional evidence that needs to be processed</li>
                 <li>You filed an additional claim that was consolidated with an existing claim</li>
                 <li>VA determines additional evidence or information is needed to support your claim</li>
                 <li>VA experiences an unexpected high volume of claims</li>
               </ul>
-              <h2>When an estimated decision date isn't met:</h2>
+              <h2 className="estimation-header">When an estimated decision date isn't met:</h2>
               <ul>
                 <li>The above reasons sometimes result in your claim needing additional time that exceeds the estimated completion date. We are working to process your claim as quickly as possible.</li>
               </ul>
-              <h2>When an estimated decision date isn’t given:</h2>
+              <h2 className="estimation-header">When an estimated decision date isn’t given:</h2>
               <ul>
                 <li>We aren’t always able to give an estimate. This happens when there isn’t enough information to make an estimate. We will provide one once more information is gathered.</li>
               </ul>
@@ -46,6 +52,7 @@ export default class ClaimEstimationPage extends React.Component {
             <p>You can help speed up the process by promptly and electronically uploading the documents requested by the VA.</p>
             <p>If you have questions, call VA at 1-800-827-1000, Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.</p>
           </div>
+          <AskVAQuestions/>
         </div>
       </div>
     );

--- a/src/js/disability-benefits/components/ClaimEstimationPage.jsx
+++ b/src/js/disability-benefits/components/ClaimEstimationPage.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+export default class ClaimEstimationPage extends React.Component {
+  componentDidMount() {
+    document.title = 'How VA Comes Up with Your Estimated Decision Date';
+  }
+  render() {
+    return (
+      <div>
+        <div className="row">
+          <div className="medium-8 columns">
+            <nav className="va-nav-breadcrumbs">
+              <ul className="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
+                <li><Link to="your-claims">Your claims</Link></li>
+                <li className="active">How VA Comes Up with Your Estimated Decision Date</li>
+              </ul>
+            </nav>
+            <div>
+              <h1>How VA Comes Up with Your Estimated Decision Date</h1>
+              <p className="first-of-type">VA looks at every claim carefully before making a decision. In some cases, we are able to decide quickly, but some claims are more complex and take more time to review.</p>
+              <h2>Your estimated decision date is based on:</h2>
+              <ul>
+                <li>The type of disability you claimed</li>
+                <li>How many disabilities you claimed</li>
+                <li>Whether there were any unusual circumstances</li>
+                <li>How long it took VA to decide other claims like yours</li>
+                <li>How long it takes VA to get supporting documents</li>
+              </ul>
+              <h2>Sometimes estimated dates change when:</h2>
+              <ul>
+                <li>You upload optional evidence that needs to be processed</li>
+                <li>You filed an additional claim that was consolidated with an existing claim</li>
+                <li>VA determines additional evidence or information is needed to support your claim</li>
+                <li>VA experiences an unexpected high volume of claims</li>
+              </ul>
+              <h2>When an estimated decision date isn't met:</h2>
+              <ul>
+                <li>The above reasons sometimes result in your claim needing additional time that exceeds the estimated completion date. We are working to process your claim as quickly as possible.</li>
+              </ul>
+              <h2>When an estimated decision date isn’t given:</h2>
+              <ul>
+                <li>We aren’t always able to give an estimate. This happens when there isn’t enough information to make an estimate. We will provide one once more information is gathered.</li>
+              </ul>
+            </div>
+            <p>You can help speed up the process by promptly and electronically uploading the documents requested by the VA.</p>
+            <p>If you have questions, call VA at 1-800-827-1000, Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/js/disability-benefits/components/ClaimsTimeline.jsx
+++ b/src/js/disability-benefits/components/ClaimsTimeline.jsx
@@ -23,7 +23,7 @@ export default class ClaimsTimeline extends React.Component {
         </ClaimPhase>
         <ClaimPhase phase={5} current={userPhase} activity={activityByPhase} id={id}>
           {userPhase !== 5
-            ? <ClaimEstimate maxDate={estimatedDate}/>
+            ? <ClaimEstimate maxDate={estimatedDate} id={id}/>
             : null}
         </ClaimPhase>
       </ol>

--- a/src/js/disability-benefits/containers/DisabilityBenefitsApp.jsx
+++ b/src/js/disability-benefits/containers/DisabilityBenefitsApp.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import ClaimsUnavailable from '../components/ClaimsUnavailable';
 import ClaimSyncWarning from '../components/ClaimSyncWarning';
 import FeaturesWarning from '../components/FeaturesWarning';
-import RequiredLoginView from '../../common/components/RequiredLoginView';
+// import RequiredLoginView from '../../common/components/RequiredLoginView';
 
 class DisabilityBenefitsApp extends React.Component {
 
@@ -27,9 +27,7 @@ class DisabilityBenefitsApp extends React.Component {
       </div>
     );
 
-    return (
-      <RequiredLoginView authRequired={3} component={view}/>
-    );
+    return view;
   }
 
 }

--- a/src/js/disability-benefits/containers/DisabilityBenefitsApp.jsx
+++ b/src/js/disability-benefits/containers/DisabilityBenefitsApp.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import ClaimsUnavailable from '../components/ClaimsUnavailable';
 import ClaimSyncWarning from '../components/ClaimSyncWarning';
 import FeaturesWarning from '../components/FeaturesWarning';
-// import RequiredLoginView from '../../common/components/RequiredLoginView';
+import RequiredLoginView from '../../common/components/RequiredLoginView';
 
 class DisabilityBenefitsApp extends React.Component {
 
@@ -27,7 +27,9 @@ class DisabilityBenefitsApp extends React.Component {
       </div>
     );
 
-    return view;
+    return (
+      <RequiredLoginView authRequired={3} component={view}/>
+    );
   }
 
 }

--- a/src/js/disability-benefits/routes.jsx
+++ b/src/js/disability-benefits/routes.jsx
@@ -10,6 +10,7 @@ import DetailsPage from './containers/DetailsPage.jsx';
 import AskVAPage from './containers/AskVAPage.jsx';
 import DocumentRequestPage from './containers/DocumentRequestPage.jsx';
 import TurnInEvidencePage from './containers/TurnInEvidencePage.jsx';
+import ClaimEstimationPage from './components/ClaimEstimationPage.jsx';
 
 const scroller = Scroll.animateScroll;
 
@@ -26,6 +27,11 @@ const routes = [
       component={YourClaimsPage}
       key="/your-claims"
       path="/your-claims"
+      onEnter={scrollToTop}/>,
+  <Route
+      component={ClaimEstimationPage}
+      key="/claim-estimate"
+      path="/claim-estimate"
       onEnter={scrollToTop}/>,
   <Route
       component={ClaimPage}

--- a/src/js/disability-benefits/routes.jsx
+++ b/src/js/disability-benefits/routes.jsx
@@ -29,11 +29,6 @@ const routes = [
       path="/your-claims"
       onEnter={scrollToTop}/>,
   <Route
-      component={ClaimEstimationPage}
-      key="/claim-estimate"
-      path="/claim-estimate"
-      onEnter={scrollToTop}/>,
-  <Route
       component={ClaimPage}
       key="/your-claims/:id"
       path="/your-claims/:id"
@@ -61,6 +56,11 @@ const routes = [
         component={DocumentRequestPage}
         path="document-request/:trackedItemId"
         onEnter={scrollToTop}/>
+    <Route
+        component={ClaimEstimationPage}
+        key="claim-estimate"
+        path="claim-estimate"
+        onEnter={scrollToTop}/>,
   </Route>,
 ];
 

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -558,3 +558,7 @@ p.first-of-type {
 .claims-header {
   margin: 0;
 }
+
+.estimation-header {
+  padding: 0.5em 0 0 !important;
+}


### PR DESCRIPTION
Closes [147](https://github.com/department-of-veterans-affairs/sunsets-team/issues/147) and [141](https://github.com/department-of-veterans-affairs/sunsets-team/issues/141).

Adds content page and link for estimation explanation. Note: the questions sidebar doesn't line up with the top of the main content, I'm leaving that to be fixed in the other issue.

![screen shot 2016-10-28 at 10 54 36 am](https://cloud.githubusercontent.com/assets/634932/19810969/833cdf4c-9cfd-11e6-96ed-76c0402f47d4.png)
