### PR TITLE
Fixed auto-scroll to unclosed alert box when its parent component updates

### DIFF
--- a/src/js/common/components/AlertBox.jsx
+++ b/src/js/common/components/AlertBox.jsx
@@ -7,6 +7,13 @@ class AlertBox extends React.Component {
     this.scrollToAlert = this.scrollToAlert.bind(this);
   }
 
+  shouldComponentUpdate(nextProps) {
+    const visibilityChanged = this.props.isVisible !== nextProps.isVisible;
+    const contentChanged = this.props.content !== nextProps.content;
+    const statusChanged = this.props.status !== nextProps.status;
+    return visibilityChanged || contentChanged || statusChanged;
+  }
+
   componentDidUpdate() {
     if (this.props.isVisible && this.props.scrollOnShow) {
       this.scrollToAlert();
@@ -14,10 +21,9 @@ class AlertBox extends React.Component {
   }
 
   scrollToAlert() {
-    const isInView =
-      this._ref && window.scrollY <= this._ref.offsetTop;
+    const isInView = window.scrollY <= this._ref.offsetTop;
 
-    if (!isInView) {
+    if (this._ref && !isInView) {
       this._ref.scrollIntoView({
         block: 'end',
         behavior: 'smooth'


### PR DESCRIPTION
The issue could be reproduced when keeping an alert open (not closing it) and switching between different views (changing tabs in Rx, going to settings or compose pages in Messaging, etc.).

Defined AlertBox's `shouldComponentUpdate` lifecycle method to determine whether or not it needs to update. For some reason, switching between views under the parent container was triggering the update for AlertBox as well.