### PR TITLE
[Rx] Corrected 'Last fill date' to show date for past dates and 'Not available' for future dates.

### DIFF
--- a/src/js/rx/components/Prescription.jsx
+++ b/src/js/rx/components/Prescription.jsx
@@ -136,7 +136,7 @@ class Prescription extends React.Component {
             Last fill date: {
               formatDate(attrs.refillDate, {
                 format: 'L',
-                validateInFuture: true
+                validateInPast: true
               })
             }
           </div>

--- a/src/js/rx/containers/Detail.jsx
+++ b/src/js/rx/containers/Detail.jsx
@@ -109,7 +109,7 @@ export class Detail extends React.Component {
 
       'Last fill date': formatDate(
         attrs.refillDate,
-        { validateInFuture: true }
+        { validateInPast: true }
       ),
 
       'Expiration date': formatDate(attrs.expirationDate),

--- a/src/js/rx/containers/History.jsx
+++ b/src/js/rx/containers/History.jsx
@@ -94,7 +94,7 @@ class History extends React.Component {
 
           refillSubmitDate: formatDate(attrs.refillSubmitDate),
 
-          refillDate: formatDate(attrs.refillDate, { validateInFuture: true }),
+          refillDate: formatDate(attrs.refillDate, { validateInPast: true }),
 
           prescriptionName: (
             <Link to={`/${attrs.prescriptionId}`}>

--- a/src/js/rx/utils/helpers.js
+++ b/src/js/rx/utils/helpers.js
@@ -5,8 +5,8 @@ export function formatDate(date, options = {}) {
 
   const isValidDate =
     momentDate.isValid() &&
-    (!options.validateInFuture ||
-    momentDate.isSameOrAfter(moment()));
+    (!options.validateInPast ||
+    momentDate.isSameOrBefore(moment().endOf('day')));
 
   return isValidDate
          ? momentDate.format(options.format || 'MMM DD, YYYY')


### PR DESCRIPTION
Closes #3515.

As per discussion from the issue, we'll now show the last fill date if the date is today or before and 'Not available' if it's in the future.