### PR TITLE
Reverting Rx/Messaging workaround that used the proxy instead of local API.

### DIFF
--- a/src/js/messaging/config.js
+++ b/src/js/messaging/config.js
@@ -13,9 +13,9 @@ function getHeaders(optionalHeaders = {}) {
 }
 
 function getApiUrl() {
-  let url = '/api';
+  let url;
 
-  if (environment && environment.BASE_URL !== 'http://localhost:3001') {
+  if (environment) {
     url = environment.API_URL;
   }
 

--- a/src/js/rx/config.js
+++ b/src/js/rx/config.js
@@ -13,9 +13,9 @@ function getHeaders() {
 }
 
 function getApiUrl() {
-  let url = '/api';
+  let url;
 
-  if (environment && environment.BASE_URL !== 'http://localhost:3001') {
+  if (environment) {
     url = environment.API_URL;
   }
 


### PR DESCRIPTION
You'll need this change to point API requests to the local vets-api running at localhost:3000. It appears the proxy doesn't work with logins, and you'd need the token from the login to authorize the API requests.