### PR TITLE
Fix file upload error check

### DIFF
--- a/src/js/disability-benefits/actions/index.js
+++ b/src/js/disability-benefits/actions/index.js
@@ -191,7 +191,8 @@ export function submitFiles(claimId, trackedItem, files) {
           });
         },
         onError: (id, name, reason) => {
-          if (!reason.endsWith('204')) {
+          // this is a little hackish, but uploader expects a json response
+          if (!reason.substr(-3).startsWith('2')) {
             hasError = true;
           }
         }


### PR DESCRIPTION
Closes [190](https://github.com/department-of-veterans-affairs/sunsets-team/issues/190)

I was checking too specific of a response code in a hack I had to do to get the uploader to work correctly. This should work, but I haven't been able to test it locally.

No unit tests for this because we don't have a way to mock libraries right now.