### PR TITLE
Fix text when no contention list in claims status

### DIFF
--- a/src/js/disability-benefits/components/ClaimDetailLayout.jsx
+++ b/src/js/disability-benefits/components/ClaimDetailLayout.jsx
@@ -26,9 +26,9 @@ export default class ClaimDetailLayout extends React.Component {
           <div className="claim-conditions">
             <h6>Your Claimed Conditions:</h6>
             <p className="list">
-              {claim.attributes.contentionList
+              {claim.attributes.contentionList && claim.attributes.contentionList.length
                 ? claim.attributes.contentionList.join(', ')
-                : null}
+                : 'Not available'}
             </p>
           </div>
           <TabNav id={this.props.claim.id}/>

--- a/test/disability-benefits/components/ClaimDetailLayout.unit.spec.jsx
+++ b/test/disability-benefits/components/ClaimDetailLayout.unit.spec.jsx
@@ -30,6 +30,21 @@ describe('<ClaimDetailLayout>', () => {
 
     expect(tree.subTree('.list').text()).to.contain('Condition 1, Condition 2');
   });
+  it('should render not available if no contention list', () => {
+    const claim = {
+      attributes: {
+        contentionList: [
+        ]
+      }
+    };
+
+    const tree = SkinDeep.shallowRender(
+      <ClaimDetailLayout
+          claim={claim}/>
+    );
+
+    expect(tree.subTree('.list').text()).to.contain('Not available');
+  });
   it('should render adding details info', () => {
     const claim = {
       attributes: {


### PR DESCRIPTION
Closes [179](https://github.com/department-of-veterans-affairs/sunsets-team/issues/179)

Sets contention list to 'Not available' if the list is empty or missing.

![screen shot 2016-11-03 at 12 03 09 pm](https://cloud.githubusercontent.com/assets/634932/19974052/8dbcb9f0-a1bd-11e6-9c3e-fe0c7cd09c0d.png)
