### PR TITLE
[Rx] Smooth scroll to top of History content when changing pages.

### DIFF
--- a/src/js/rx/containers/Active.jsx
+++ b/src/js/rx/containers/Active.jsx
@@ -69,7 +69,8 @@ class Active extends React.Component {
         <p className="rx-tab-explainer rx-loading-error">
           We couldn't retrieve your prescriptions.
           Please refresh this page or try again later.
-        </p>);
+        </p>
+      );
     }
 
     return (

--- a/src/js/rx/containers/History.jsx
+++ b/src/js/rx/containers/History.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
+import Scroll from 'react-scroll';
 import _ from 'lodash';
 
 import SortableTable from '../../common/components/SortableTable';
@@ -11,6 +12,9 @@ import SortMenu from '../components/SortMenu';
 import { rxStatuses } from '../config';
 import { formatDate, getModalTerm } from '../utils/helpers';
 
+const ScrollElement = Scroll.Element;
+const scroller = Scroll.scroller;
+
 class History extends React.Component {
   constructor(props) {
     super(props);
@@ -18,6 +22,7 @@ class History extends React.Component {
     this.handleSort = this.handleSort.bind(this);
     this.handlePageSelect = this.handlePageSelect.bind(this);
     this.openGlossaryModal = this.openGlossaryModal.bind(this);
+    this.scrollToTop = this.scrollToTop.bind(this);
   }
 
   componentDidMount() {
@@ -25,7 +30,11 @@ class History extends React.Component {
     this.props.loadPrescriptions(query);
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
+    if (prevProps.page !== this.props.page) {
+      this.scrollToTop();
+    }
+
     const oldPage = this.props.page;
     const oldSort = this.formattedSortParam(
       this.props.sort.value,
@@ -39,6 +48,14 @@ class History extends React.Component {
     if (newPage !== oldPage || newSort !== oldSort) {
       this.props.loadPrescriptions(query);
     }
+  }
+
+  scrollToTop() {
+    scroller.scrollTo('history', {
+      duration: 500,
+      delay: 0,
+      smooth: true
+    });
   }
 
   formattedSortParam(value, order) {
@@ -137,9 +154,12 @@ class History extends React.Component {
     }
 
     return (
-      <div id="rx-history" className="va-tab-content">
+      <ScrollElement
+          id="rx-history"
+          name="history"
+          className="va-tab-content">
         {content}
-      </div>
+      </ScrollElement>
     );
   }
 }

--- a/src/js/rx/containers/History.jsx
+++ b/src/js/rx/containers/History.jsx
@@ -110,6 +110,7 @@ class History extends React.Component {
 
       content = (
         <div>
+          <p className="rx-tab-explainer">Your VA prescription refill history.</p>
           <SortMenu
               onChange={this.handleSort}
               options={fields}
@@ -126,11 +127,17 @@ class History extends React.Component {
               pages={this.props.pages}/>
         </div>
       );
+    } else {
+      content = (
+        <p className="rx-tab-explainer rx-loading-error">
+          We couldn't retrieve your prescriptions.
+          Please refresh this page or try again later.
+        </p>
+      );
     }
 
     return (
       <div id="rx-history" className="va-tab-content">
-        <p className="rx-tab-explainer">Your VA prescription refill history.</p>
         {content}
       </div>
     );

--- a/src/js/rx/containers/History.jsx
+++ b/src/js/rx/containers/History.jsx
@@ -31,22 +31,27 @@ class History extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.page !== this.props.page) {
-      this.scrollToTop();
-    }
-
-    const oldPage = this.props.page;
-    const oldSort = this.formattedSortParam(
+    const currentPage = this.props.page;
+    const currentSort = this.formattedSortParam(
       this.props.sort.value,
       this.props.sort.order
     );
 
     const query = _.pick(this.props.location.query, ['page', 'sort']);
-    const newPage = +query.page || oldPage;
-    const newSort = query.sort || oldSort;
+    const requestedPage = +query.page || currentPage;
+    const requestedSort = query.sort || currentSort;
 
-    if (newPage !== oldPage || newSort !== oldSort) {
+    const pageChanged = requestedPage !== currentPage;
+    const sortChanged = requestedSort !== currentSort;
+
+    if (pageChanged || sortChanged) {
       this.props.loadPrescriptions(query);
+    }
+
+    const pageUpdated = prevProps.page !== currentPage;
+
+    if (pageUpdated) {
+      this.scrollToTop();
     }
   }
 


### PR DESCRIPTION
Closes #3680.

### Changes
* Smooth scrolling to top of History content after page update.
* Renamed variables in `componentDidUpdate` in History.
* Added error message in History when there are no prescriptions.
    * Although, I don't think these really work right now... Might have to handle the error more explicitly in the action creator and will revisit when implementing the loading screen).