### PR TITLE
Fix placement of buttons on Files tab

### DIFF
--- a/src/js/disability-benefits/components/NeedFilesFromYou.jsx
+++ b/src/js/disability-benefits/components/NeedFilesFromYou.jsx
@@ -5,7 +5,7 @@ class NeedFilesFromYou extends React.Component {
   render() {
     const filesNeeded = this.props.events.filter(event => event.status === 'NEEDED' && event.type === 'still_need_from_you_list').length;
     return (
-      <div className="usa-alert usa-alert-warning claims-alert claims-alert-status">
+      <div className="usa-alert usa-alert-warning claims-alert claims-alert-status need-files-alert">
         <div className="usa-alert-body item-title-container">
           <h4 className="usa-alert-heading">{filesNeeded} {filesNeeded === 1 ? 'item needs' : 'items need'} your attention</h4>
         </div>

--- a/src/js/disability-benefits/containers/FilesPage.jsx
+++ b/src/js/disability-benefits/containers/FilesPage.jsx
@@ -51,9 +51,7 @@ class FilesPage extends React.Component {
                   <p>{truncateDescription(item.description)}</p>
                   <DueDate date={item.suspenseDate}/>
                 </div>
-                <div className="button-container">
-                  <Link className="usa-button usa-button-outline" to={`your-claims/${claim.id}/document-request/${item.trackedItemId}`}>View Details</Link>
-                </div>
+                <Link className="usa-button usa-button-outline view-details-button" to={`your-claims/${claim.id}/document-request/${item.trackedItemId}`}>View Details</Link>
                 <div className="clearfix"></div>
               </div>
             ))}
@@ -65,9 +63,7 @@ class FilesPage extends React.Component {
                   <p>{truncateDescription(item.description)}</p>
                   <div className="claims-optional-desc"><h6>Optional</h6> - we requested this from others, but you may upload it if you have it.</div>
                 </div>
-                <div className="button-container">
-                  <Link className="usa-button usa-button-outline" to={`your-claims/${claim.id}/document-request/${item.trackedItemId}`}>View Details</Link>
-                </div>
+                <Link className="usa-button usa-button-outline view-details-button" to={`your-claims/${claim.id}/document-request/${item.trackedItemId}`}>View Details</Link>
                 <div className="clearfix"></div>
               </div>
             ))}
@@ -82,11 +78,11 @@ class FilesPage extends React.Component {
                   <p>You asked VA to make a decision on your claims based on the evidence you filed. You don't have to do anything else.</p>
                 </div>
                 :
-                <div className="usa-alert">
-                  <p>Do you have additional evidence to submit in order to support your claim? Upload it here now.</p>
-                  <div className="button-container">
-                    <Link className="usa-button usa-button-outline" to={`your-claims/${claim.id}/turn-in-evidence`}>View Details</Link>
+                <div className="usa-alert additional-evidence-alert">
+                  <div className="item-container">
+                    <p>Do you have additional evidence to submit in order to support your claim? Upload it here now.</p>
                   </div>
+                  <Link className="usa-button usa-button-outline view-details-button" to={`your-claims/${claim.id}/turn-in-evidence`}>View Details</Link>
                   <div className="clearfix"></div>
                 </div>
               }

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -95,35 +95,27 @@
 
 .file-request-list-item {
   margin-top: 1.5em;
-  .item-container {
-    margin: 0.5em 0;
-    float: left;
-    h6 {
-      display: inline-block;
-      text-transform: none;
-    }
-    p {
-      display: inline-block;
-      margin: 0;
-    }
-    button {
-      float: right;
-    }
-  }
-  .button-container {
-    float: right;
-    a {
-      margin: 0;
-    }
-    @media (max-width: $small-screen) {
-      float: none;
-    }
-  }
   &:last-child {
     border: none;
   }
   .file-request-title {
     padding-bottom: 0 !important;
+  }
+}
+
+.item-container {
+  margin: 0 0 0.5em 0;
+  float: left;
+  h6 {
+    display: inline-block;
+    text-transform: none;
+  }
+  p {
+    display: inline-block;
+    margin: 0;
+  }
+  @media (min-width: $medium-screen) {
+    width: 66%;
   }
 }
 
@@ -589,18 +581,22 @@ p.first-of-type {
     width: 100%;
   }
 }
-.ask-va-alert {
+.ask-va-alert, .file-request-list-item, .additional-evidence-alert, .need-files-alert {
   position: relative;
   padding-bottom: 3.5em;
-  @media (min-width: $small-screen) {
+  @media (min-width: $medium-screen) {
     padding-bottom: 1em;
   }
+}
+
+.need-files-alert {
+  padding-bottom: 4em;
 }
 
 .view-details-button {
   float: right;
   margin: 0;
-  @media (max-width: $small-screen) {
+  @media (max-width: $medium-screen) {
     float: none;
     position: absolute;
     bottom: 1em;


### PR DESCRIPTION
Related to [138](https://github.com/department-of-veterans-affairs/sunsets-team/issues/138)

Need to make the same change we did on the status tab for the View Details buttons on the Files tab.

![screen shot 2016-11-06 at 10 45 45 am](https://cloud.githubusercontent.com/assets/634932/20039238/9655ac18-a40e-11e6-8595-1db3e76173bc.png)
![screen shot 2016-11-06 at 10 45 38 am](https://cloud.githubusercontent.com/assets/634932/20039236/96553dc8-a40e-11e6-8ecc-a6f76abaf178.png)
![screen shot 2016-11-06 at 10 45 35 am](https://cloud.githubusercontent.com/assets/634932/20039237/96555470-a40e-11e6-9284-8d4b7485e7e6.png)
