### PR TITLE
Fix condition alignment in claim tab header

### DIFF
--- a/src/js/disability-benefits/components/ClaimDetailLayout.jsx
+++ b/src/js/disability-benefits/components/ClaimDetailLayout.jsx
@@ -29,12 +29,12 @@ export default class ClaimDetailLayout extends React.Component {
             <h6>Your Claimed Conditions:</h6>
             <p className="list">
               {claim.attributes.contentionList && claim.attributes.contentionList.length
-                ? claim.attributes.contentionList.slice(0, MAX_CONDITIONS).join(', ')
+                  ? claim.attributes.contentionList.slice(0, MAX_CONDITIONS).map(cond => cond.trim()).join(', ')
                 : 'Not available'}
-              {claim.attributes.contentionList && claim.attributes.contentionList.length > MAX_CONDITIONS
-                  ? <span><br/><Link to={`your-claims/${claim.id}/details`}>See all</Link></span>
-                : null}
             </p>
+            {claim.attributes.contentionList && claim.attributes.contentionList.length > MAX_CONDITIONS
+                ? <span><br/><Link to={`your-claims/${claim.id}/details`}>See all</Link></span>
+              : null}
           </div>
           <TabNav id={this.props.claim.id}/>
           <div className="va-tab-content">

--- a/test/disability-benefits/components/ClaimDetailLayout.unit.spec.jsx
+++ b/test/disability-benefits/components/ClaimDetailLayout.unit.spec.jsx
@@ -50,7 +50,7 @@ describe('<ClaimDetailLayout>', () => {
     );
 
     expect(tree.subTree('.list').text()).to.contain('Condition 1, Condition 2, Condition 3');
-    expect(tree.subTree('.list').subTree('Link').props.to).to.equal('your-claims/5/details');
+    expect(tree.subTree('.claim-conditions').subTree('Link').props.to).to.equal('your-claims/5/details');
   });
   it('should render not available if no contention list', () => {
     const claim = {


### PR DESCRIPTION
Related to [209](https://github.com/department-of-veterans-affairs/sunsets-team/issues/209)

Fixes an alignment issue in the conditions list. I also add some code to trim spaces, since the conditions often have extra.

![screen shot 2016-11-08 at 10 04 20 am](https://cloud.githubusercontent.com/assets/634932/20104154/de54b936-a59a-11e6-9446-d63cdcd3a57b.png)
