### PR TITLE
Add date to claim list header text

### DIFF
--- a/src/js/disability-benefits/components/ClaimsListItem.jsx
+++ b/src/js/disability-benefits/components/ClaimsListItem.jsx
@@ -8,7 +8,7 @@ export default function ClaimsListItem({ claim }) {
   const inProgress = !isClaimComplete(claim);
   return (
     <Link className="claim-list-item" to={`your-claims/${claim.id}/status`}>
-      <h4 className="claim-list-item-header">Disability Compensation Claim</h4>
+      <h4 className="claim-list-item-header">Disability Compensation Claim – Received {moment(claim.attributes.dateFiled).format('MMMM D, YYYY')}</h4>
       <p className="status">Status: {getPhaseDescription(claim.attributes.phase)}</p>
       <div className="communications">
         {inProgress && claim.attributes.developmentLetterSent
@@ -23,8 +23,6 @@ export default function ClaimsListItem({ claim }) {
       </div>
       {claim.attributes.phaseChangeDate &&
         <p>Last update: {moment(claim.attributes.phaseChangeDate).format('MMM D, YYYY')}</p>}
-      {claim.attributes.dateFiled &&
-        <p>Date received: {moment(claim.attributes.dateFiled).format('MMM D, YYYY')}</p>}
     </Link>
   );
 }

--- a/test/disability-benefits/e2e/00.claims-list.e2e.spec.js
+++ b/test/disability-benefits/e2e/00.claims-list.e2e.spec.js
@@ -37,7 +37,7 @@ if (!process.env.BUILDTYPE || process.env.BUILDTYPE === 'development') {
       client
         .expect
         .element('.claim-list-item-header')
-        .text.to.equal('Disability Compensation Claim');
+        .text.to.equal('Disability Compensation Claim – Received September 23, 2008');
 
       // Click to detail view
       client


### PR DESCRIPTION
Related to [203](https://github.com/department-of-veterans-affairs/sunsets-team/issues/203)

Adds date to h4, removes line with received date at bottom of card.

![screen shot 2016-11-08 at 12 49 08 pm](https://cloud.githubusercontent.com/assets/634932/20110275/c3cf1ff4-a5b1-11e6-85e5-83f1267882f4.png)
