### PR TITLE
Fix grouping bug in claims timeline

### DIFF
--- a/src/js/disability-benefits/components/ClaimPhase.jsx
+++ b/src/js/disability-benefits/components/ClaimPhase.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import moment from 'moment';
 import _ from 'lodash/fp';
-import { getHistoryPhaseDescription, getUserPhaseDescription, getMicroPhaseDescription } from '../utils/helpers';
+import { getHistoryPhaseDescription, getUserPhaseDescription } from '../utils/helpers';
 
 const stepClasses = {
   1: 'one',
@@ -46,13 +46,6 @@ export default class ClaimPhase extends React.Component {
         return (
           <div className="claims-evidence-item columns medium-9">
             Your claim moved to {getHistoryPhaseDescription(this.props.phase)}
-          </div>
-        );
-
-      case 'micro_phase':
-        return (
-          <div className="claims-evidence-item columns medium-9">
-            Your claim moved to {getMicroPhaseDescription(event.phaseNumber)}
           </div>
         );
 

--- a/src/js/disability-benefits/utils/helpers.js
+++ b/src/js/disability-benefits/utils/helpers.js
@@ -59,40 +59,60 @@ export function getUserPhase(phase) {
   return phase - 3;
 }
 
+export function getSubmittedItemDate(item) {
+  if (item.receivedDate) {
+    return item.receivedDate;
+  } else if (item.documents && item.documents.length) {
+    return item.documents[item.documents.length - 1].uploadDate;
+  } else if (item.type === 'other_documents_list') {
+    return item.uploadDate;
+  }
+
+  return item.date;
+}
+
+function getPhaseNumber(phase) {
+  return parseInt(phase.replace('phase', ''), 10);
+}
+
+function isEventOrPrimaryPhase(event) {
+  if (event.type === 'phase_entered') {
+    return event.phase <= 3 || event.phase >= 7;
+  }
+
+  return !!getSubmittedItemDate(event);
+}
+
 export function groupTimelineActivity(events) {
   const phases = {};
-  const phaseEvents = events;
   let activity = [];
-  let lastPhaseNumber = 1;
-  let firstPhase = true;
+
+  const phaseEvents = events
+    .map(event => {
+      if (event.type.startsWith('phase')) {
+        return {
+          type: 'phase_entered',
+          phase: getPhaseNumber(event.type) + 1,
+          date: event.date
+        };
+      }
+
+      return event;
+    })
+    .filter(isEventOrPrimaryPhase);
 
   phaseEvents.forEach(event => {
     if (event.type.startsWith('phase')) {
-      const phaseNumber = parseInt(event.type.replace('phase', ''), 10);
-      const userPhaseNumber = getUserPhase(phaseNumber);
-      if (userPhaseNumber !== lastPhaseNumber || firstPhase) {
-        activity.push({
-          type: 'phase_entered',
-          date: event.date
-        });
-        phases[userPhaseNumber + 1] = (phases[userPhaseNumber + 1] || []).concat(activity);
-        activity = [];
-        lastPhaseNumber = userPhaseNumber;
-        firstPhase = false;
-      } else {
-        activity.push({
-          type: 'micro_phase',
-          phaseNumber: phaseNumber + 1,
-          date: event.date
-        });
-      }
+      activity.push(event);
+      phases[getUserPhase(event.phase)] = activity;
+      activity = [];
     } else {
       activity.push(event);
     }
   });
 
   if (activity.length > 0) {
-    phases[lastPhaseNumber] = (phases[lastPhaseNumber] || []).concat(activity);
+    phases[1] = activity;
   }
 
   return phases;
@@ -170,18 +190,6 @@ export function truncateDescription(text) {
   }
 
   return text;
-}
-
-export function getSubmittedItemDate(item) {
-  if (item.receivedDate) {
-    return item.receivedDate;
-  } else if (item.documents && item.documents.length) {
-    return item.documents[item.documents.length - 1].uploadDate;
-  } else if (item.type === 'other_documents_list') {
-    return item.uploadDate;
-  }
-
-  return item.date;
 }
 
 export function isClaimComplete(claim) {

--- a/test/disability-benefits/components/ClaimPhase.unit.spec.jsx
+++ b/test/disability-benefits/components/ClaimPhase.unit.spec.jsx
@@ -157,17 +157,6 @@ describe('<ClaimPhase>', () => {
 
       expect(descTree.text()).to.equal('Your claim moved to Claim received');
     });
-    it('should show micro entered description', () => {
-      const output = instance.getEventDescription({
-        type: 'micro_phase',
-        phaseNumber: 4,
-        date: '2010-01-04'
-      });
-
-      const descTree = SkinDeep.shallowRender(output);
-
-      expect(descTree.text()).to.equal('Your claim moved to Review of evidence');
-    });
     it('should show file description', () => {
       const output = instance.getEventDescription({
         type: 'filed',

--- a/test/disability-benefits/utils/helpers.unit.spec.js
+++ b/test/disability-benefits/utils/helpers.unit.spec.js
@@ -16,7 +16,7 @@ import {
   itemsNeedingAttentionFromVet
 } from '../../../src/js/disability-benefits/utils/helpers';
 
-describe('Disability benefits helpers:', () => {
+describe('Disability benefits helpers: ', () => {
   describe('groupTimelineActivity', () => {
     it('should group events before a phase into phase 1', () => {
       const events = [
@@ -55,7 +55,7 @@ describe('Disability benefits helpers:', () => {
       expect(phaseActivity[1][0].type).to.equal('filed');
       expect(phaseActivity[2].length).to.equal(3);
     });
-    it('should group micro phases into phase 3', () => {
+    it('should discard micro phases', () => {
       const events = [
         {
           type: 'phase5',
@@ -85,10 +85,75 @@ describe('Disability benefits helpers:', () => {
 
       const phaseActivity = groupTimelineActivity(events);
 
-      expect(phaseActivity[3].length).to.equal(3);
-      expect(phaseActivity[3][0].type).to.equal('micro_phase');
-      expect(phaseActivity[3][1].type).to.equal('micro_phase');
-      expect(phaseActivity[3][2].type).to.equal('phase_entered');
+      expect(phaseActivity[3].length).to.equal(1);
+      expect(phaseActivity[3][0].type).to.equal('phase_entered');
+    });
+    it('should group events into correct bucket', () => {
+      const events = [
+        {
+          type: 'received_from_you_list',
+          date: '2016-11-02'
+        },
+        {
+          type: 'received_from_you_list',
+          date: '2016-11-02'
+        },
+        {
+          type: 'received_from_you_list',
+          date: '2016-11-02'
+        },
+        {
+          type: 'received_from_you_list',
+          date: '2016-11-02'
+        },
+        {
+          type: 'phase5',
+          date: '2016-11-02'
+        },
+        {
+          type: 'phase4',
+          date: '2016-11-02'
+        },
+        {
+          type: 'phase3',
+          date: '2016-11-02'
+        },
+        {
+          type: 'phase2',
+          date: '2016-11-02'
+        },
+        {
+          type: 'other_documents_list',
+          uploadDate: '2016-03-24'
+        },
+        {
+          type: 'other_documents_list',
+          uploadDate: '2015-08-28'
+        },
+        {
+          type: 'other_documents_list',
+          uploadDate: '2015-08-28'
+        },
+        {
+          type: 'phase1',
+          date: '2015-04-20'
+        },
+        {
+          type: 'filed',
+          date: '2015-04-20'
+        },
+        {
+          type: 'other_documents_list',
+          uploadDate: null
+        }
+      ];
+
+      const phaseActivity = groupTimelineActivity(events);
+
+      expect(phaseActivity[3].length).to.equal(5);
+      expect(phaseActivity[3][4].type).to.equal('phase_entered');
+      expect(phaseActivity[2].length).to.equal(4);
+      expect(phaseActivity[1].length).to.equal(1);
     });
   });
   describe('isPopulatedClaim', () => {


### PR DESCRIPTION
Related to [182](https://github.com/department-of-veterans-affairs/sunsets-team/issues/182)

Fixes the grouping issue by simplifying the partitioning logic (and looping through more times).

Looks like this with claim data from staging:
![screen shot 2016-11-08 at 5 19 27 pm](https://cloud.githubusercontent.com/assets/634932/20119688/8b3c39b2-a5d7-11e6-99d2-2699b5888ea6.png)
