### PR TITLE
Breadcrumbs layout fix for disability claims

### DIFF
--- a/src/js/disability-benefits/components/ClaimDetailLayout.jsx
+++ b/src/js/disability-benefits/components/ClaimDetailLayout.jsx
@@ -16,30 +16,43 @@ export default class ClaimDetailLayout extends React.Component {
     let content;
     if (!loading) {
       content = (
-        <div className="claim-container">
-          <nav className="va-nav-breadcrumbs">
-            <ul className="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
-              <li><Link to="your-claims">Your claims</Link></li>
-              <li className="active">Your Disability Compensation Claim</li>
-            </ul>
-          </nav>
-          {message && <Notification title={message.title} body={message.body} type={message.type} onClose={clearNotification}/>}
-          <h1 className="claim-title">Your Disability Compensation Claim</h1>
-          <div className="claim-conditions">
-            <h6>Your Claimed Conditions:</h6>
-            <p className="list">
-              {claim.attributes.contentionList && claim.attributes.contentionList.length
-                  ? claim.attributes.contentionList.slice(0, MAX_CONDITIONS).map(cond => cond.trim()).join(', ')
-                : 'Not available'}
-            </p>
-            {claim.attributes.contentionList && claim.attributes.contentionList.length > MAX_CONDITIONS
-                ? <span><br/><Link to={`your-claims/${claim.id}/details`}>See all</Link></span>
-              : null}
+        <div>
+          <div className="row">
+            <div className="medium-12 columns">
+              <nav className="va-nav-breadcrumbs">
+                <ul className="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
+                  <li><Link to="your-claims">Your claims</Link></li>
+                  <li className="active">Your Disability Compensation Claim</li>
+                </ul>
+              </nav>
+            </div>
           </div>
-          <TabNav id={this.props.claim.id}/>
-          <div className="va-tab-content" role="tabpanel" id={`tabPanel${currentTab}`} aria-labelledby={`tab${currentTab}`}>
-            {isPopulatedClaim(claim) ? null : <AddingDetails/>}
-            {this.props.children}
+          <div className="row">
+            <div className="medium-8 columns">
+              <div className="claim-container">
+                {message && <Notification title={message.title} body={message.body} type={message.type} onClose={clearNotification}/>}
+                <h1 className="claim-title">Your Disability Compensation Claim</h1>
+                <div className="claim-conditions">
+                  <h6>Your Claimed Conditions:</h6>
+                  <p className="list">
+                    {claim.attributes.contentionList && claim.attributes.contentionList.length
+                        ? claim.attributes.contentionList.slice(0, MAX_CONDITIONS).map(cond => cond.trim()).join(', ')
+                      : 'Not available'}
+                  </p>
+                  {claim.attributes.contentionList && claim.attributes.contentionList.length > MAX_CONDITIONS
+                      ? <span><br/><Link to={`your-claims/${claim.id}/details`}>See all</Link></span>
+                    : null}
+                </div>
+                <TabNav id={this.props.claim.id}/>
+                  <div className="va-tab-content" role="tabpanel" id={`tabPanel${currentTab}`} aria-labelledby={`tab${currentTab}`}>
+                  {isPopulatedClaim(claim) ? null : <AddingDetails/>}
+                  {this.props.children}
+                </div>
+              </div>
+            </div>
+            <div className="small-12 medium-4 columns">
+              <AskVAQuestions/>
+            </div>
           </div>
         </div>
       );
@@ -48,14 +61,9 @@ export default class ClaimDetailLayout extends React.Component {
     }
 
     return (
-      <div className="row">
-        <div className="small-12 medium-8 columns usa-content">
-          <div name="topScrollElement"></div>
+      <div>
+        <div name="topScrollElement"></div>
           {content}
-        </div>
-        <div className="small-12 medium-4 columns">
-          <AskVAQuestions/>
-        </div>
       </div>
     );
   }
@@ -67,4 +75,3 @@ ClaimDetailLayout.propTypes = {
   message: React.PropTypes.object,
   clearNotification: React.PropTypes.func
 };
-

--- a/src/js/disability-benefits/components/ClaimDetailLayout.jsx
+++ b/src/js/disability-benefits/components/ClaimDetailLayout.jsx
@@ -44,7 +44,7 @@ export default class ClaimDetailLayout extends React.Component {
                     : null}
                 </div>
                 <TabNav id={this.props.claim.id}/>
-                  <div className="va-tab-content" role="tabpanel" id={`tabPanel${currentTab}`} aria-labelledby={`tab${currentTab}`}>
+                <div className="va-tab-content" role="tabpanel" id={`tabPanel${currentTab}`} aria-labelledby={`tab${currentTab}`}>
                   {isPopulatedClaim(claim) ? null : <AddingDetails/>}
                   {this.props.children}
                 </div>

--- a/src/js/disability-benefits/containers/AskVAPage.jsx
+++ b/src/js/disability-benefits/containers/AskVAPage.jsx
@@ -43,7 +43,7 @@ class AskVAPage extends React.Component {
     return (
       <div>
         <div className="row">
-          <div className="medium-8 columns">
+          <div className="medium-12 columns">
             <nav className="va-nav-breadcrumbs">
               <ul className="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
                 <li><Link to="your-claims">Your claims</Link></li>
@@ -51,6 +51,10 @@ class AskVAPage extends React.Component {
                 <li className="active">Ask VA for a Claim Decision</li>
               </ul>
             </nav>
+          </div>
+        </div>
+        <div className="row">
+          <div className="medium-8 columns">
             <div>
               <h1>Ask VA for a Claim Decision</h1>
               <p className="first-of-type">You should have received a letter in the mail requesting additional evidence VA needs to support your claim.</p>

--- a/src/js/disability-benefits/containers/DocumentRequestPage.jsx
+++ b/src/js/disability-benefits/containers/DocumentRequestPage.jsx
@@ -133,8 +133,6 @@ class DocumentRequestPage extends React.Component {
             </div>
           </div>
         </div>
-
-
       );
     }
 

--- a/src/js/disability-benefits/containers/DocumentRequestPage.jsx
+++ b/src/js/disability-benefits/containers/DocumentRequestPage.jsx
@@ -80,58 +80,68 @@ class DocumentRequestPage extends React.Component {
       const message = this.props.message;
 
       content = (
-        <div className="claim-container">
-          <nav className="va-nav-breadcrumbs">
-            <ul className="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
-              <li><Link to="your-claims">Your claims</Link></li>
-              <li><Link to={filesPath}>Your Disability Compensation Claim</Link></li>
-              <li className="active">{trackedItem.displayName}</li>
-            </ul>
-          </nav>
-          {message &&
-            <div>
-              <Element name="uploadError"/>
-              <Notification title={message.title} body={message.body} type={message.type}/>
-            </div>}
-          <h1 className="claims-header">{trackedItem.displayName}</h1>
-          {trackedItem.type.endsWith('you_list') ? <DueDate date={trackedItem.suspenseDate}/> : null}
-          {trackedItem.type.endsWith('others_list')
-            ? <div className="optional-upload">
-              <p><strong>Optional</strong> - we've asked others to send this to us, but you may upload it if you have it.</p>
+        <div>
+          <div className="row">
+            <div className="medium-12 columns">
+              <nav className="va-nav-breadcrumbs">
+                <ul className="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
+                  <li><Link to="your-claims">Your claims</Link></li>
+                  <li><Link to={filesPath}>Your Disability Compensation Claim</Link></li>
+                  <li className="active">{trackedItem.displayName}</li>
+                </ul>
+              </nav>
             </div>
-            : null}
-          <p>{trackedItem.description}</p>
-          <AddFilesForm
-              field={this.props.uploadField}
-              progress={this.props.progress}
-              uploading={this.props.uploading}
-              files={this.props.files}
-              showMailOrFax={this.props.showMailOrFax}
-              backUrl={this.props.lastPage || filesPath}
-              onSubmit={() => this.props.submitFiles(
-                this.props.claim.id,
-                this.props.trackedItem,
-                this.props.files
-              )}
-              onAddFile={this.props.addFile}
-              onRemoveFile={this.props.removeFile}
-              onFieldChange={this.props.updateField}
-              onShowMailOrFax={this.props.showMailOrFaxModal}
-              onCancel={this.props.cancelUpload}
-              onDirtyFields={this.props.setFieldsDirty}/>
+          </div>
+          <div className="row">
+            <div className="medium-8 columns">
+              <div className="claim-container">
+                {message &&
+                  <div>
+                    <Element name="uploadError"/>
+                    <Notification title={message.title} body={message.body} type={message.type}/>
+                  </div>}
+                <h1 className="claims-header">{trackedItem.displayName}</h1>
+                {trackedItem.type.endsWith('you_list') ? <DueDate date={trackedItem.suspenseDate}/> : null}
+                {trackedItem.type.endsWith('others_list')
+                  ? <div className="optional-upload">
+                    <p><strong>Optional</strong> - we've asked others to send this to us, but you may upload it if you have it.</p>
+                  </div>
+                  : null}
+                <p>{trackedItem.description}</p>
+                <AddFilesForm
+                    field={this.props.uploadField}
+                    progress={this.props.progress}
+                    uploading={this.props.uploading}
+                    files={this.props.files}
+                    showMailOrFax={this.props.showMailOrFax}
+                    backUrl={this.props.lastPage || filesPath}
+                    onSubmit={() => this.props.submitFiles(
+                      this.props.claim.id,
+                      this.props.trackedItem,
+                      this.props.files
+                    )}
+                    onAddFile={this.props.addFile}
+                    onRemoveFile={this.props.removeFile}
+                    onFieldChange={this.props.updateField}
+                    onShowMailOrFax={this.props.showMailOrFaxModal}
+                    onCancel={this.props.cancelUpload}
+                    onDirtyFields={this.props.setFieldsDirty}/>
+              </div>
+            </div>
+            <div className="small-12 medium-4 columns">
+              <AskVAQuestions/>
+            </div>
+          </div>
         </div>
+
+
       );
     }
 
     return (
-      <div className="row">
-        <div className="small-12 medium-8 columns usa-content">
-          <div name="topScrollElement"></div>
+      <div>
+        <div name="topScrollElement"></div>
           {content}
-        </div>
-        <div className="small-12 medium-4 columns">
-          <AskVAQuestions/>
-        </div>
       </div>
     );
   }

--- a/src/js/disability-benefits/containers/TurnInEvidencePage.jsx
+++ b/src/js/disability-benefits/containers/TurnInEvidencePage.jsx
@@ -121,7 +121,6 @@ class TurnInEvidencePage extends React.Component {
             </div>
           </div>
         </div>
-
       );
     }
 

--- a/src/js/disability-benefits/containers/TurnInEvidencePage.jsx
+++ b/src/js/disability-benefits/containers/TurnInEvidencePage.jsx
@@ -74,52 +74,61 @@ class TurnInEvidencePage extends React.Component {
       const message = this.props.message;
 
       content = (
-        <div className="claim-container">
-          <nav className="va-nav-breadcrumbs">
-            <ul className="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
-              <li><Link to="your-claims">Your claims</Link></li>
-              <li><Link to={filesPath}>Your Disability Compensation Claim</Link></li>
-              <li className="active">Turn in More Evidence</li>
-            </ul>
-          </nav>
-          {message &&
-            <div>
-              <Element name="uploadError"/>
-              <Notification title={message.title} body={message.body} type={message.type}/>
-            </div>}
-          <h1 className="claims-header">Turn in More Evidence</h1>
-          <EvidenceWarning/>
-          <AddFilesForm
-              field={this.props.uploadField}
-              progress={this.props.progress}
-              uploading={this.props.uploading}
-              files={this.props.files}
-              showMailOrFax={this.props.showMailOrFax}
-              backUrl={this.props.lastPage || filesPath}
-              onSubmit={() => this.props.submitFiles(
-                this.props.claim.id,
-                null,
-                this.props.files
-              )}
-              onAddFile={this.props.addFile}
-              onRemoveFile={this.props.removeFile}
-              onFieldChange={this.props.updateField}
-              onShowMailOrFax={this.props.showMailOrFaxModal}
-              onCancel={this.props.cancelUpload}
-              onDirtyFields={this.props.setFieldsDirty}/>
+        <div>
+          <div className="row">
+            <div className="medium-12 columns">
+              <nav className="va-nav-breadcrumbs">
+                <ul className="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
+                  <li><Link to="your-claims">Your claims</Link></li>
+                  <li><Link to={filesPath}>Your Disability Compensation Claim</Link></li>
+                  <li className="active">Turn in More Evidence</li>
+                </ul>
+              </nav>
+            </div>
+          </div>
+          <div className="row">
+            <div className="medium-8 columns">
+              <div className="claim-container">
+                {message &&
+                  <div>
+                    <Element name="uploadError"/>
+                    <Notification title={message.title} body={message.body} type={message.type}/>
+                  </div>}
+                <h1 className="claims-header">Turn in More Evidence</h1>
+                <EvidenceWarning/>
+                <AddFilesForm
+                    field={this.props.uploadField}
+                    progress={this.props.progress}
+                    uploading={this.props.uploading}
+                    files={this.props.files}
+                    showMailOrFax={this.props.showMailOrFax}
+                    backUrl={this.props.lastPage || filesPath}
+                    onSubmit={() => this.props.submitFiles(
+                      this.props.claim.id,
+                      null,
+                      this.props.files
+                    )}
+                    onAddFile={this.props.addFile}
+                    onRemoveFile={this.props.removeFile}
+                    onFieldChange={this.props.updateField}
+                    onShowMailOrFax={this.props.showMailOrFaxModal}
+                    onCancel={this.props.cancelUpload}
+                    onDirtyFields={this.props.setFieldsDirty}/>
+              </div>
+            </div>
+            <div className="small-12 medium-4 columns">
+              <AskVAQuestions/>
+            </div>
+          </div>
         </div>
+
       );
     }
 
     return (
-      <div className="row">
-        <div className="small-12 medium-8 columns usa-content">
-          <div name="topScrollElement"></div>
+      <div>
+        <div name="topScrollElement"></div>
           {content}
-        </div>
-        <div className="small-12 medium-4 columns">
-          <AskVAQuestions/>
-        </div>
       </div>
     );
   }

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -251,9 +251,9 @@ a.claim-list-item {
 }
 
 .ask-va-questions {
-  margin-top: 1.5em;
+  // margin-top: 1.5em;
   .talk {
-    margin: .5em 0;
+    margin: 0.5em 0;
     padding: 0;
   }
   .phone-number {
@@ -263,6 +263,13 @@ a.claim-list-item {
       text-decoration: none;
       margin: 0.5em 0;
     }
+  }
+}
+
+.ask-va-questions.claims-sidebar-box {
+  padding-top: 0.6em;
+  @media (max-width: $small-screen) {
+    padding: 2em 0;
   }
 }
 

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -251,7 +251,6 @@ a.claim-list-item {
 }
 
 .ask-va-questions {
-  // margin-top: 1.5em;
   .talk {
     margin: 0.5em 0;
     padding: 0;


### PR DESCRIPTION
Closes: [Sunsets #130](https://github.com/department-of-veterans-affairs/sunsets-team/issues/130)

We decided to move the breadcrumbs into it's own separate row to fix alignment issues for the questions column. 

![screen shot 2016-11-10 at 4 26 14 pm](https://cloud.githubusercontent.com/assets/6254227/20194930/6186b62e-a762-11e6-8f35-f7d14d4f4538.png)

![screen shot 2016-11-10 at 4 05 15 pm](https://cloud.githubusercontent.com/assets/6254227/20194847/10fde682-a762-11e6-894d-781f562e8f0d.png)

![screen shot 2016-11-10 at 4 05 36 pm](https://cloud.githubusercontent.com/assets/6254227/20194846/10fd067c-a762-11e6-9df8-2fd793304ebd.png)

![screen shot 2016-11-10 at 4 05 51 pm](https://cloud.githubusercontent.com/assets/6254227/20194845/10fb9468-a762-11e6-9ecf-c26df05a4a90.png)
