### PR TITLE
Fix address and date schema validation issues

### DIFF
--- a/src/js/common/components/form-elements/DateInput.jsx
+++ b/src/js/common/components/form-elements/DateInput.jsx
@@ -71,7 +71,7 @@ class DateInput extends React.Component {
     if (this.props.required) {
       isValid = validateIfDirtyDate(day, month, year, dateValidator) && (this.props.validation !== undefined ? this.props.validation : true);
     } else {
-      isValid = (isBlank(day.value) && isBlank(month.value) && isBlank(year.value)) ||
+      isValid = ((isBlank(day.value) || this.props.hideDayField) && isBlank(month.value) && isBlank(year.value)) ||
         (validateIfDirtyDate(day, month, year, dateValidator) && (this.props.validation !== undefined ? this.props.validation : true));
     }
 

--- a/src/js/edu-benefits/utils/validations.js
+++ b/src/js/edu-benefits/utils/validations.js
@@ -170,6 +170,10 @@ function isBlankDateField(field) {
   return isBlank(field.day.value) && isBlank(field.month.value) && isBlank(field.year.value);
 }
 
+function isNotBlankDateField(field) {
+  return isNotBlank(field.day.value) && isNotBlank(field.month.value) && isNotBlank(field.year.value);
+}
+
 function isValidDateField(field) {
   return isValidDate(field.day.value, field.month.value, field.year.value);
 }
@@ -190,7 +194,7 @@ function isValidFutureDateField(field) {
 }
 
 function isValidFutureOrPastDateField(field) {
-  if (!isBlankDateField(field)) {
+  if (isNotBlankDateField(field)) {
     const momentDate = dateToMoment(field);
     return momentDate.isValid() && momentDate.year() > 1900;
   }
@@ -199,14 +203,14 @@ function isValidFutureOrPastDateField(field) {
 }
 
 function isValidDateRange(fromDate, toDate) {
-  if (!isBlankDateField(fromDate) && !isBlankDateField(toDate)) {
+  if (isNotBlankDateField(fromDate) && isNotBlankDateField(toDate)) {
     const momentStart = dateToMoment(fromDate);
     const momentEnd = dateToMoment(toDate);
 
     return momentStart.isBefore(momentEnd);
   }
 
-  return true;
+  return isBlankDateField(fromDate) && isBlankDateField(toDate);
 }
 
 function isValidFullNameField(field) {
@@ -250,7 +254,7 @@ function isValidRelinquishedDate(field) {
   const pastDate = moment().subtract(2, 'years');
   const date = dateToMoment(field);
 
-  return !isBlankDateField(field) && date.isValid() && date.isAfter(pastDate);
+  return isNotBlankDateField(field) && date.isValid() && date.isAfter(pastDate);
 }
 
 function isValidBenefitsRelinquishmentPage(data) {
@@ -331,8 +335,8 @@ function isValidDirectDepositPage(data) {
 
 function isValidContributionsPage(data) {
   return !data.activeDutyRepaying ||
-    (!isBlankDateField(data.activeDutyRepayingPeriod.from)
-    && !isBlankDateField(data.activeDutyRepayingPeriod.to)
+    (isNotBlankDateField(data.activeDutyRepayingPeriod.from)
+    && isNotBlankDateField(data.activeDutyRepayingPeriod.to)
     && isValidDateRange(data.activeDutyRepayingPeriod.from, data.activeDutyRepayingPeriod.to));
 }
 

--- a/src/js/edu-benefits/utils/veteran.js
+++ b/src/js/edu-benefits/utils/veteran.js
@@ -1,5 +1,6 @@
 import _ from 'lodash/fp';
 import { makeField } from '../../common/model/fields';
+import { isValidAddressField } from '../utils/validations';
 import { dateToMoment } from './helpers';
 import moment from 'moment';
 
@@ -247,8 +248,9 @@ export function veteranToApplication(veteran) {
 
         return false;
 
+      case 'veteranAddress':
       case 'address':
-        if (value.city.value === '' && value.street.value === '') {
+        if (!isValidAddressField(value)) {
           return undefined;
         }
 

--- a/test/edu-benefits/utils/validations.unit.spec.js
+++ b/test/edu-benefits/utils/validations.unit.spec.js
@@ -67,6 +67,37 @@ describe('Validations unit tests', () => {
       };
       expect(isValidDateRange(fromDate, toDate)).to.be.false;
     });
+    it('does not validate with partial dates', () => {
+      const fromDate = {
+        day: {
+          value: '',
+          dirty: true
+        },
+        month: {
+          value: 3,
+          dirty: true
+        },
+        year: {
+          value: 2006,
+          dirty: true
+        }
+      };
+      const toDate = {
+        day: {
+          value: 3,
+          dirty: true
+        },
+        month: {
+          value: 4,
+          dirty: true
+        },
+        year: {
+          value: 2008,
+          dirty: true
+        }
+      };
+      expect(isValidDateRange(fromDate, toDate)).to.be.false;
+    });
   });
   describe('isValidPage:', () => {
     describe('EmploymentHistory', () => {

--- a/test/edu-benefits/utils/veteran.unit.spec.js
+++ b/test/edu-benefits/utils/veteran.unit.spec.js
@@ -81,4 +81,17 @@ describe('veteranToApplication', () => {
 
     expect(applicationData.serviceAcademyGraduationYear).to.be.undefined;
   });
+  it('removes addresses with missing info', () => {
+    const formData = createVeteran();
+    formData.school.address = {
+      city: makeField('Test'),
+      street: makeField(''),
+      state: makeField('MA'),
+      country: makeField('USA'),
+      postalCode: makeField('01060')
+    };
+    const applicationData = JSON.parse(veteranToApplication(formData));
+
+    expect(applicationData.school.address).to.be.undefined;
+  });
 });


### PR DESCRIPTION
This contains fixes for the two schema validation issues Lihan brought up in Slack:

```Form The property '#/school/address' did not contain a required property of 'street' in schema 6d3ac55d-0966-5868-be2d-0f1191776ce9#```

```Form The property '#/postHighSchoolTrainings/0/dateRange' did not contain a required property of 'from' in schema 6d3ac55d-0966-5868-be2d-0f1191776ce9#, Form The property '#/postHighSchoolTrainings/1/dateRange' did not contain a required property of 'from' in schema 6d3ac55d-0966-5868-be2d-0f1191776ce9#, Form The property '#/postHighSchoolTrainings/1/dateRange' did not contain a required property of 'to' in schema 6d3ac55d-0966-5868-be2d-0f1191776ce9#```

The changes are to filter out partial addresses more thoroughly, until we get real partial address checking in the Address component, and to check for partial dates in the date range validator function. We were previously letting moment handle invalid date checking, but it treats dates without a day as valid, which causes problems we we convert them to the json application format.