### PR TITLE
Fix mobile scrolling bug on edu benefits

### DIFF
--- a/src/js/edu-benefits/containers/EduBenefitsApp.jsx
+++ b/src/js/edu-benefits/containers/EduBenefitsApp.jsx
@@ -62,8 +62,8 @@ class EduBenefitsApp extends React.Component {
     return (
       <div className="row">
         {devPanel}
+        <Element name="topScrollElement"/>
         <div className="medium-4 columns show-for-medium-up">
-          <Element name="topScrollElement"/>
           <Nav
               data={data}
               pages={pageState}


### PR DESCRIPTION
Closes #3765.

The scroll to element was inside the div for the subway nav that's hidden on mobile. Now it's not!