### PR TITLE
Add max char limit to policy holder name

### DIFF
--- a/src/js/hca/components/insurance-information/Provider.jsx
+++ b/src/js/hca/components/insurance-information/Provider.jsx
@@ -15,6 +15,7 @@ class Provider extends React.Component {
         <div className="input-section">
           <ErrorableTextInput required
               errorMessage={validateIfDirty(this.props.data.insuranceName, isNotBlank) ? undefined : 'Please enter the insurer’s name'}
+              charMax={100}
               label="Name of provider"
               name="insuranceName"
               field={this.props.data.insuranceName}
@@ -30,6 +31,7 @@ class Provider extends React.Component {
 
           <ErrorableTextInput required
               errorMessage={validateIfDirtyProvider(this.props.data.insurancePolicyNumber, this.props.data.insuranceGroupCode, isValidInsurancePolicy) ? undefined : 'Please enter the policy number or group code'}
+              charMax={30}
               label="Policy number (either this or group code is required)"
               name="insurancePolicyNumber"
               field={this.props.data.insurancePolicyNumber}
@@ -37,6 +39,7 @@ class Provider extends React.Component {
 
           <ErrorableTextInput required
               errorMessage={validateIfDirtyProvider(this.props.data.insurancePolicyNumber, this.props.data.insuranceGroupCode, isValidInsurancePolicy) ? undefined : 'Please enter the policy number or group code'}
+              charMax={30}              
               label="Group code (either this or policy number is required)"
               name="insuranceGroupCode"
               field={this.props.data.insuranceGroupCode}

--- a/src/js/hca/components/insurance-information/Provider.jsx
+++ b/src/js/hca/components/insurance-information/Provider.jsx
@@ -39,7 +39,7 @@ class Provider extends React.Component {
 
           <ErrorableTextInput required
               errorMessage={validateIfDirtyProvider(this.props.data.insurancePolicyNumber, this.props.data.insuranceGroupCode, isValidInsurancePolicy) ? undefined : 'Please enter the policy number or group code'}
-              charMax={30}              
+              charMax={30}
               label="Group code (either this or policy number is required)"
               name="insuranceGroupCode"
               field={this.props.data.insuranceGroupCode}

--- a/src/js/hca/components/insurance-information/Provider.jsx
+++ b/src/js/hca/components/insurance-information/Provider.jsx
@@ -22,6 +22,7 @@ class Provider extends React.Component {
 
           <ErrorableTextInput required
               errorMessage={validateIfDirty(this.props.data.insurancePolicyHolderName, isNotBlank) ? undefined : 'Please enter the name of the policy holder'}
+              charMax={50}
               label="Name of policy holder"
               name="insurancePolicyHolderName"
               field={this.props.data.insurancePolicyHolderName}


### PR DESCRIPTION
Got additional from Josh about other character limits.

Corresponding schema change: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/42