### PR TITLE
Fix various sticky action box issues

### DIFF
--- a/src/js/common/utils/sticky-action-box.js
+++ b/src/js/common/utils/sticky-action-box.js
@@ -31,17 +31,25 @@ function resetSmallActionBox(smallActionBox) {
 }
 
 function moveActionBoxOnScroll(actionBox, offset, positionFunction, resetFunction) {
-  const initialPosition = offset.top + document.body.scrollTop;
+  let initialPosition = offset.height > 0 ? offset.top + document.body.scrollTop : null;
   window.addEventListener('scroll', _.throttle(() => {
     if (offset.top < 0) {
       positionFunction(actionBox);
       offset = actionBox.getBoundingClientRect();
     }
 
-    if (document.body.scrollTop > initialPosition) {
+    if (initialPosition && document.body.scrollTop > initialPosition) {
       positionFunction(actionBox);
     } else {
       resetFunction(actionBox);
+    }
+  }, 100));
+  window.addEventListener('resize', _.throttle(() => {
+    if (!initialPosition) {
+      const newOffset = actionBox.getBoundingClientRect();
+      if (newOffset.height) {
+        initialPosition = newOffset.top + document.body.scrollTop;
+      }
     }
   }, 100));
 }
@@ -67,4 +75,3 @@ if (window.addEventListener) {
 } else {
   window.attachEvent('onload', stickyActionBox);
 }
-

--- a/src/js/common/utils/sticky-action-box.js
+++ b/src/js/common/utils/sticky-action-box.js
@@ -13,6 +13,7 @@ function setSmallActionBoxAtTop(smallActionBox) {
   smallActionBox.style.top = '0px';
   smallActionBox.style.left = '0px';
   smallActionBox.style.width = '100%';
+  smallActionBox.style.marginLeft = '0';
 }
 
 function resetLargeActionBox(largeActionBox) {
@@ -25,17 +26,19 @@ function resetSmallActionBox(smallActionBox) {
   smallActionBox.style.position = 'initial';
   smallActionBox.style.top = 'initial';
   smallActionBox.style.left = 'initial';
-  smallActionBox.style.width = '35rem';
+  smallActionBox.style.width = '';
+  smallActionBox.style.marginLeft = '';
 }
 
 function moveActionBoxOnScroll(actionBox, offset, positionFunction, resetFunction) {
+  const initialPosition = offset.top + document.body.scrollTop;
   window.addEventListener('scroll', _.throttle(() => {
     if (offset.top < 0) {
       positionFunction(actionBox);
       offset = actionBox.getBoundingClientRect();
     }
 
-    if (document.body.scrollTop > offset.top) {
+    if (document.body.scrollTop > initialPosition) {
       positionFunction(actionBox);
     } else {
       resetFunction(actionBox);

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -2262,7 +2262,8 @@ pre[class*='language-']  {
   }
 
   .hide-for-large-up & {
-    width: 35rem;
+    width: calc(100% + 0.9375rem + 0.9375rem);
+    margin-left: -0.9375rem;
   }
 
   #content & p,


### PR DESCRIPTION
Closes #3827, #3828, #3935 

Fixes some positioning issues by grabbing the initial position of the box and using that for comparisons when scrolling. Also sets the box to full width on mobile and adds a resize handler so that it works properly when resizing between mobile and desktop.

![screen shot 2016-11-29 at 12 25 30 pm](https://cloud.githubusercontent.com/assets/634932/20720988/45adb05c-b62f-11e6-9e35-a634a5a3c9e7.png)
![screen shot 2016-11-29 at 12 25 16 pm](https://cloud.githubusercontent.com/assets/634932/20720987/45ada076-b62f-11e6-845b-13dc9db60c31.png)
![screen shot 2016-11-29 at 12 25 12 pm](https://cloud.githubusercontent.com/assets/634932/20720989/45b223ee-b62f-11e6-80b5-6602cd502fc1.png)
