### PR TITLE
Use tel and email types in form fields

### DIFF
--- a/src/js/common/components/form-elements/ErrorableTextInput.jsx
+++ b/src/js/common/components/form-elements/ErrorableTextInput.jsx
@@ -96,7 +96,7 @@ class ErrorableTextInput extends React.Component {
             name={this.props.name}
             tabIndex={this.props.tabIndex}
             autoComplete={this.props.autocomplete}
-            type="text"
+            type={this.props.type}
             maxLength={this.props.charMax}
             value={this.props.field.value}
             onChange={this.handleChange}
@@ -122,6 +122,11 @@ ErrorableTextInput.propTypes = {
   additionalClass: React.PropTypes.string,
   charMax: React.PropTypes.number,
   onValueChange: React.PropTypes.func.isRequired,
+  type: React.PropTypes.string
+};
+
+ErrorableTextInput.defaultProps = {
+  type: 'text'
 };
 
 export default ErrorableTextInput;

--- a/src/js/common/components/questions/Email.jsx
+++ b/src/js/common/components/questions/Email.jsx
@@ -32,6 +32,7 @@ class Email extends React.Component {
     return (
       <div>
         <ErrorableTextInput
+            type="email"
             required={this.props.required}
             errorMessage={errorMessage}
             label={this.props.label}

--- a/src/js/common/components/questions/Phone.jsx
+++ b/src/js/common/components/questions/Phone.jsx
@@ -35,6 +35,7 @@ class Phone extends React.Component {
     return (
       <div>
         <ErrorableTextInput
+            type="tel"
             errorMessage={errorMessage}
             label={this.props.label}
             name={this.props.name}


### PR DESCRIPTION
Closes #4110.

Uses `tel` and `email` input types for phone and email fields.

![screenshot_20161129-143507](https://cloud.githubusercontent.com/assets/634932/20725901/6e70eaf6-b641-11e6-89f2-bc196e0f4512.png)
![screenshot_20161129-143408](https://cloud.githubusercontent.com/assets/634932/20725900/6e7005e6-b641-11e6-8ce6-43684d40e1eb.png)
