### PR TITLE
Fix doc title on status page and Adding Details logic

### DIFF
--- a/src/js/disability-benefits/containers/ClaimPage.jsx
+++ b/src/js/disability-benefits/containers/ClaimPage.jsx
@@ -7,7 +7,6 @@ import { getClaimDetail } from '../actions';
 class ClaimPage extends React.Component {
   componentDidMount() {
     this.props.getClaimDetail(this.props.params.id, this.props.router);
-    document.title = 'Your Disability Compensation Claim';
   }
   render() {
     return this.props.children;

--- a/src/js/disability-benefits/utils/helpers.js
+++ b/src/js/disability-benefits/utils/helpers.js
@@ -167,8 +167,7 @@ export function getDocTypeDescription(docType) {
 export function isPopulatedClaim({ attributes }) {
   return !!attributes.claimType
     && (attributes.contentionList && !!attributes.contentionList.length)
-    && !!attributes.dateFiled
-    && !!attributes.vaRepresentative;
+    && !!attributes.dateFiled;
 }
 
 export function hasBeenReviewed(trackedItem) {

--- a/test/disability-benefits/utils/helpers.unit.spec.js
+++ b/test/disability-benefits/utils/helpers.unit.spec.js
@@ -178,8 +178,7 @@ describe('Disability benefits helpers: ', () => {
           contentionList: [
             'thing'
           ],
-          dateFiled: 'asdf',
-          vaRepresentative: null
+          dateFiled: '',
         }
       };
 
@@ -194,7 +193,7 @@ describe('Disability benefits helpers: ', () => {
             'thing'
           ],
           dateFiled: 'asdf',
-          vaRepresentative: 'asdf'
+          vaRepresentative: null
         }
       };
 


### PR DESCRIPTION
Related to [246](https://github.com/department-of-veterans-affairs/sunsets-team/issues/246) and [247](https://github.com/department-of-veterans-affairs/sunsets-team/issues/247)

Removes an errant document title call and removes the VA rep field from `isPopulatedClaim` logic.

Details change:
![screen shot 2016-11-29 at 3 42 57 pm](https://cloud.githubusercontent.com/assets/634932/20728396/89e73c36-b64b-11e6-9369-8e108ec350e5.png)

