### PR TITLE
Adjusting position of MoveTo buttons in a table.

### DIFF
--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -1932,7 +1932,6 @@ button[class*='usa-button-'] {
 .disclaimer {
   padding: 1em 0;
   border-top: 1px solid #ddd;
-  z-index:500;
   color: $color-va-gray-cool-dark;
   background: $color-white;
 

--- a/src/sass/messaging/partials/_messaging-folder.scss
+++ b/src/sass/messaging/partials/_messaging-folder.scss
@@ -49,6 +49,8 @@
   }
 }
 
+// Also see messaging-moveto.scss for styles related
+// to the MoveTo component contained by the message table.
 .messaging-message-row {
   &--unread {
     font-weight: bold;

--- a/src/sass/messaging/partials/_messaging-moveto.scss
+++ b/src/sass/messaging/partials/_messaging-moveto.scss
@@ -2,6 +2,7 @@
   display: inline-block;
   position: relative;
   vertical-align: middle;
+  z-index: 1;
 }
 
 .messaging-move {
@@ -65,7 +66,7 @@
   }
 
   @media (min-width: $medium-screen) {
-    min-width: 25rem;
+    width: 25rem;
   }
 
   .msg-btn-newfolder[type="button"] {
@@ -83,4 +84,14 @@
   padding: 1rem;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+// Exception for button in message table. 
+.messaging-message-row {
+  .msg-move-to {
+    position: static;
+  }
+  .msg-move-to-options {
+    margin-left: -18.15rem;
+  }
 }


### PR DESCRIPTION
Solves bug in which options within the MoveTo menu are cut off. Closes department-of-veterans-affairs/messaging-fe#181.

- Removed z-index property for .disclaimer. Superfluous.
- Added comment to _messaging-folder.scss.