### PR TITLE
[Messaging] Thread header fixes for messages in Drafts and Sent.

### DIFF
--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -9,7 +9,9 @@ import { folderUrl } from '../utils/helpers';
 
 class ThreadHeader extends React.Component {
   render() {
+    const folderName = this.props.folderName;
     let toggleThread;
+    let moveTo;
     let deleteButton;
 
     if (this.props.threadMessageCount > 1) {
@@ -20,17 +22,16 @@ class ThreadHeader extends React.Component {
       );
     }
 
-    if (this.props.folderName !== 'Sent') {
+    // Hide the 'Delete' button for sent messages,
+    // since they can't be deleted.
+    if (folderName !== 'Sent') {
       deleteButton =
         <ButtonDelete onClickHandler={this.props.onDeleteMessage}/>;
-    }
 
-    const backUrl = folderUrl(this.props.folderName);
-
-    return (
-      <div className="messaging-thread-header">
-        <div className="messaging-thread-nav">
-          <Link to={backUrl}>&lt; Back to {this.props.folderName}</Link>
+      // Hide the 'Move' button for drafts and sent messages,
+      // since they can't be moved to other folders.
+      if (folderName !== 'Drafts') {
+        moveTo = (
           <MoveTo
               folders={this.props.moveToFolders}
               isOpen={this.props.moveToIsOpen}
@@ -38,12 +39,23 @@ class ThreadHeader extends React.Component {
               onChooseFolder={this.props.onChooseFolder}
               onCreateFolder={this.props.onCreateFolder}
               onToggleMoveTo={this.props.onToggleMoveTo}/>
+        );
+      }
+    }
+
+    const backUrl = folderUrl(folderName);
+
+    return (
+      <div className="messaging-thread-header">
+        <div className="messaging-thread-nav">
+          <Link to={backUrl}>&lt; Back to {folderName}</Link>
           <MessageNav
               currentRange={this.props.currentMessageNumber}
               messageCount={this.props.folderMessageCount}
               onItemSelect={this.props.onMessageSelect}
               itemNumber={this.props.currentMessageNumber}
               totalItems={this.props.folderMessageCount}/>
+          {moveTo}
           {deleteButton}
         </div>
         <div className="messaging-thread-title">

--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -10,6 +10,7 @@ import { folderUrl } from '../utils/helpers';
 class ThreadHeader extends React.Component {
   render() {
     let toggleThread;
+    let deleteButton;
 
     if (this.props.threadMessageCount > 1) {
       toggleThread = (
@@ -17,6 +18,11 @@ class ThreadHeader extends React.Component {
             messagesCollapsed={this.props.messagesCollapsed}
             onClick={this.props.onToggleThread}/>
       );
+    }
+
+    if (this.props.folderName !== 'Sent') {
+      deleteButton =
+        <ButtonDelete onClickHandler={this.props.onDeleteMessage}/>;
     }
 
     const backUrl = folderUrl(this.props.folderName);
@@ -38,14 +44,12 @@ class ThreadHeader extends React.Component {
               onItemSelect={this.props.onMessageSelect}
               itemNumber={this.props.currentMessageNumber}
               totalItems={this.props.folderMessageCount}/>
-          <ButtonDelete
-              onClickHandler={this.props.onDeleteMessage}/>
+          {deleteButton}
         </div>
         <div className="messaging-thread-title">
           <div className="messaging-thread-controls">
             {toggleThread}
-            <ButtonDelete
-                onClickHandler={this.props.onDeleteMessage}/>
+            {deleteButton}
           </div>
           <h2 className="messaging-thread-subject">{this.props.message.subject}</h2>
         </div>

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -163,6 +163,12 @@ export class Thread extends React.Component {
       this.context.router.push(`/${this.props.params.folderName}/${selectedId}`);
     };
 
+    // If the message is a draft, the delete button should prompt, since the
+    // draft would get deleted entirely instead of being moved to a folder.
+    const deleteMessageHandler = this.props.isSavedDraft
+                               ? this.props.toggleConfirmDelete
+                               : this.handleMessageDelete;
+
     return (
       <ThreadHeader
           currentMessageNumber={currentIndex + 1}
@@ -176,7 +182,7 @@ export class Thread extends React.Component {
           moveToIsOpen={this.props.moveToOpened}
           onChooseFolder={this.props.moveMessageToFolder}
           onCreateFolder={this.props.openMoveToNewFolderModal}
-          onDeleteMessage={this.handleMessageDelete}
+          onDeleteMessage={deleteMessageHandler}
           onToggleThread={this.props.toggleMessagesCollapsed}
           onToggleMoveTo={this.props.toggleThreadMoveTo}/>
     );


### PR DESCRIPTION
## Changes
* Removed 'Delete' from messages in Sent folder. Pop up delete confirmation modal for messages in Drafts. Closes department-of-veterans-affairs/messaging-fe#176.
* Removed 'Move' button from messages in Drafts and Sent. Closes department-of-veterans-affairs/messaging-fe#182.