### PR TITLE
Claims status text updates

### DIFF
--- a/src/js/disability-benefits/components/ClaimPhase.jsx
+++ b/src/js/disability-benefits/components/ClaimPhase.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import moment from 'moment';
 import _ from 'lodash/fp';
-import { getHistoryPhaseDescription, getUserPhaseDescription } from '../utils/helpers';
+import { getUserPhaseDescription } from '../utils/helpers';
 
 const stepClasses = {
   1: 'one',
@@ -44,7 +44,7 @@ export default class ClaimPhase extends React.Component {
       case 'phase_entered':
         return (
           <div className="claims-evidence-item columns medium-9">
-            Your claim moved to {getHistoryPhaseDescription(this.props.phase)}
+            Your claim moved to {getUserPhaseDescription(this.props.phase)}
           </div>
         );
 

--- a/src/js/disability-benefits/components/SubmittedTrackedItem.jsx
+++ b/src/js/disability-benefits/components/SubmittedTrackedItem.jsx
@@ -21,7 +21,7 @@ export default function SubmittedTrackedItem({ item }) {
         : null}
       {closed &&
         <div>
-          <h6>No longer requested or needed</h6>
+          <h6>No longer needed</h6>
         </div>}
       {!closed && reviewed &&
         <div>

--- a/src/js/disability-benefits/utils/helpers.js
+++ b/src/js/disability-benefits/utils/helpers.js
@@ -15,13 +15,6 @@ const phaseMap = {
   8: 'Complete'
 };
 
-const microPhaseMap = {
-  3: 'Gathering of evidence',
-  4: 'Review of evidence',
-  5: 'Preparation for decision',
-  6: 'Pending Decision approval'
-};
-
 export function getPhaseDescription(phase) {
   return phaseMap[phase];
 }
@@ -34,18 +27,6 @@ export function getUserPhaseDescription(phase) {
   }
 
   return phaseMap[phase + 3];
-}
-
-export function getHistoryPhaseDescription(phase) {
-  if (phase === 3) {
-    return microPhaseMap[phase];
-  }
-
-  return getUserPhaseDescription(phase);
-}
-
-export function getMicroPhaseDescription(phase) {
-  return microPhaseMap[phase] || phaseMap[phase];
 }
 
 export function getPhaseDescriptionFromEvent(event) {

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -66,7 +66,7 @@
     h6 {
       display: inline-block;
       padding: 0;
-      text-transform: capitalize;
+      text-transform: none;
       i {
         margin-right: 6px;
       }

--- a/test/disability-benefits/components/SubmittedTrackedItem.unit.spec.jsx
+++ b/test/disability-benefits/components/SubmittedTrackedItem.unit.spec.jsx
@@ -118,7 +118,7 @@ describe('<SubmittedTrackedItem>', () => {
           item={item}/>
     );
 
-    expect(tree.subTree('.submitted-file-list-item').text()).to.contain('No longer requested or needed');
+    expect(tree.subTree('.submitted-file-list-item').text()).to.contain('No longer needed');
   });
   it('should render no longer needed item by status', () => {
     const item = {
@@ -137,6 +137,6 @@ describe('<SubmittedTrackedItem>', () => {
           item={item}/>
     );
 
-    expect(tree.subTree('.submitted-file-list-item').text()).to.contain('No longer requested or needed');
+    expect(tree.subTree('.submitted-file-list-item').text()).to.contain('No longer needed');
   });
 });

--- a/test/disability-benefits/e2e/02.claim-files.e2e.spec.js
+++ b/test/disability-benefits/e2e/02.claim-files.e2e.spec.js
@@ -47,7 +47,7 @@ if (!process.env.BUILDTYPE || process.env.BUILDTYPE === 'development') {
         .expect.element('.submitted-file-list-item:last-child h6').text.to.equal('Submitted');
       // should show a reviewed date message
       client
-        .expect.element('.submitted-file-list-item h6').text.to.equal('Reviewed By VA');
+        .expect.element('.submitted-file-list-item h6').text.to.equal('Reviewed by VA');
 
       client.end();
     }

--- a/test/disability-benefits/utils/helpers.unit.spec.js
+++ b/test/disability-benefits/utils/helpers.unit.spec.js
@@ -9,7 +9,6 @@ import {
   displayFileSize,
   getUserPhase,
   getUserPhaseDescription,
-  getHistoryPhaseDescription,
   getPhaseDescription,
   truncateDescription,
   getItemDate,
@@ -277,13 +276,6 @@ describe('Disability benefits helpers: ', () => {
       const desc = getUserPhaseDescription(3);
 
       expect(desc).to.equal('Evidence gathering, review, and decision');
-    });
-  });
-  describe('getHistoryPhaseDescription', () => {
-    it('should use micro phases for phase 3', () => {
-      const desc = getHistoryPhaseDescription(3);
-
-      expect(desc).to.equal('Gathering of evidence');
     });
   });
   describe('getPhaseDescription', () => {


### PR DESCRIPTION
Related to [249](https://github.com/department-of-veterans-affairs/sunsets-team/issues/249) and [248](https://github.com/department-of-veterans-affairs/sunsets-team/issues/248)

Updates the text for the phase 3 name in the mictrotransations list and the no longer needed text in the files list.

![screen shot 2016-11-30 at 1 27 03 pm](https://cloud.githubusercontent.com/assets/634932/20765933/5ef0f5d2-b702-11e6-9ee4-066921749b76.png)
---
![screen shot 2016-11-30 at 1 26 16 pm](https://cloud.githubusercontent.com/assets/634932/20765934/5ef11bac-b702-11e6-8bed-a6f117ea3aab.png)
