### PR TITLE
Menu now closes when veteran changes the folder.

### DIFF
--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -36,6 +36,7 @@ export class Main extends React.Component {
   handleFolderChange(domEvent) {
     const folderId = domEvent.target.dataset.folderid;
     this.props.setCurrentFolder(folderId);
+    this.props.toggleFolderNav();
   }
 
   handleFolderNameChange(field) {


### PR DESCRIPTION
- Closes department-of-veterans-affairs/messaging-fe#177
- Updated handleFolderChange in Main to add this.props.toggleFolderNav()