### PR TITLE
Fix Rx error

### DIFF
--- a/src/js/rx/containers/Active.jsx
+++ b/src/js/rx/containers/Active.jsx
@@ -70,12 +70,12 @@ class Active extends React.Component {
       );
     } else {
       content = (
-          <p className="rx-tab-explainer rx-loading-error">
-            We couldn't retrieve your prescriptions.
-            Please refresh this page or try again later.
-            If this problem persists, please call the Vets.gov Help Desk 
-            at 1-855-574-7286, Monday ‒ Friday, 8:00 a.m. ‒ 8:00 p.m. (ET).
-          </p>
+        <p className="rx-tab-explainer rx-loading-error">
+          We couldn't retrieve your prescriptions.
+          Please refresh this page or try again later.
+          If this problem persists, please call the Vets.gov Help Desk 
+          at 1-855-574-7286, Monday ‒ Friday, 8:00 a.m. ‒ 8:00 p.m. (ET).
+        </p>
       );
     }
 

--- a/src/js/rx/containers/Active.jsx
+++ b/src/js/rx/containers/Active.jsx
@@ -70,12 +70,12 @@ class Active extends React.Component {
       );
     } else {
       content = (
-        <p className="rx-tab-explainer rx-loading-error">
-          We couldn't retrieve your prescriptions.
-          Please refresh this page or try again later. <br/>
-          If this problem persists, please call the Vets.gov Help Desk at 
-          1-855-574-7286, Monday‒Friday, 8:00 a.m.‒8:00 p.m. (ET).
-        </p>
+          <p className="rx-tab-explainer rx-loading-error">
+            We couldn't retrieve your prescriptions.
+            Please refresh this page or try again later.
+            If this problem persists, please call the Vets.gov Help Desk 
+            at 1-855-574-7286, Monday ‒ Friday, 8:00 a.m. ‒ 8:00 p.m. (ET).
+          </p>
       );
     }
 

--- a/src/js/rx/containers/Active.jsx
+++ b/src/js/rx/containers/Active.jsx
@@ -72,7 +72,9 @@ class Active extends React.Component {
       content = (
         <p className="rx-tab-explainer rx-loading-error">
           We couldn't retrieve your prescriptions.
-          Please refresh this page or try again later.
+          Please refresh this page or try again later. <br/>
+          If this problem persists, please call the Vets.gov Help Desk at 
+          1-855-574-7286, Monday‒Friday, 8:00 a.m.‒8:00 p.m. (ET).
         </p>
       );
     }

--- a/src/js/rx/containers/Active.jsx
+++ b/src/js/rx/containers/Active.jsx
@@ -73,7 +73,7 @@ class Active extends React.Component {
         <p className="rx-tab-explainer rx-loading-error">
           We couldn't retrieve your prescriptions.
           Please refresh this page or try again later.
-          If this problem persists, please call the Vets.gov Help Desk 
+          If this problem persists, please call the Vets.gov Help Desk
           at 1-855-574-7286, Monday ‒ Friday, 8:00 a.m. ‒ 8:00 p.m. (ET).
         </p>
       );

--- a/src/js/rx/containers/Detail.jsx
+++ b/src/js/rx/containers/Detail.jsx
@@ -190,7 +190,7 @@ export class Detail extends React.Component {
         <p className="rx-tab-explainer rx-loading-error">
           We couldn't retrieve your prescription.
           Please refresh this page or try again later.
-          If this problem persists, please call the Vets.gov Help Desk 
+          If this problem persists, please call the Vets.gov Help Desk
           at 1-855-574-7286, Monday ‒ Friday, 8:00 a.m. ‒ 8:00 p.m. (ET).
         </p>
       );

--- a/src/js/rx/containers/Detail.jsx
+++ b/src/js/rx/containers/Detail.jsx
@@ -190,6 +190,8 @@ export class Detail extends React.Component {
         <p className="rx-tab-explainer rx-loading-error">
           We couldn't retrieve your prescription.
           Please refresh this page or try again later.
+          If this problem persists, please call the Vets.gov Help Desk 
+          at 1-855-574-7286, Monday ‒ Friday, 8:00 a.m. ‒ 8:00 p.m. (ET).
         </p>
       );
     }

--- a/src/js/rx/containers/History.jsx
+++ b/src/js/rx/containers/History.jsx
@@ -166,7 +166,9 @@ class History extends React.Component {
       content = (
         <p className="rx-tab-explainer rx-loading-error">
           We couldn't retrieve your prescriptions.
-          Please refresh this page or try again later.
+          Please refresh this page or try again later. <br/>
+          If this problem persists, please call the Vets.gov Help Desk at 
+          1-855-574-7286, Monday‒Friday, 8:00 a.m.‒8:00 p.m. (ET).
         </p>
       );
     }

--- a/src/js/rx/containers/History.jsx
+++ b/src/js/rx/containers/History.jsx
@@ -167,9 +167,9 @@ class History extends React.Component {
         <p className="rx-tab-explainer rx-loading-error">
           We couldn't retrieve your prescriptions.
           Please refresh this page or try again later.
-          If this problem persists, please call the Vets.gov Help Desk 
+          If this problem persists, please call the Vets.gov Help Desk
           at 1-855-574-7286, Monday ‒ Friday, 8:00 a.m. ‒ 8:00 p.m. (ET).
-        </p> 
+        </p>
       );
     }
 

--- a/src/js/rx/containers/History.jsx
+++ b/src/js/rx/containers/History.jsx
@@ -166,10 +166,10 @@ class History extends React.Component {
       content = (
         <p className="rx-tab-explainer rx-loading-error">
           We couldn't retrieve your prescriptions.
-          Please refresh this page or try again later. <br/>
-          If this problem persists, please call the Vets.gov Help Desk at 
-          1-855-574-7286, Monday‒Friday, 8:00 a.m.‒8:00 p.m. (ET).
-        </p>
+          Please refresh this page or try again later.
+          If this problem persists, please call the Vets.gov Help Desk 
+          at 1-855-574-7286, Monday ‒ Friday, 8:00 a.m. ‒ 8:00 p.m. (ET).
+        </p> 
       );
     }
 

--- a/src/sass/rx/rx.scss
+++ b/src/sass/rx/rx.scss
@@ -90,6 +90,7 @@ button.usa-button-outline {
 
 .rx-loading-error {
   font-weight: bold;
+  width: 66%;
 }
 
 #rx-active, #rx-history, #rx-detail {


### PR DESCRIPTION
Second attempt to close #4204 

These are the only 3 places to use the rx-loading-error class, so this style change shouldn't impact anything else. Also putting screenshots this time:

Desktop:
<img width="1069" alt="screen shot 2016-12-02 at 10 41 56 am" src="https://cloud.githubusercontent.com/assets/4719765/20839969/a5e30702-b87c-11e6-8d99-d14f49cdcf67.png">


Mobile:
<img width="395" alt="screen shot 2016-12-02 at 10 43 40 am" src="https://cloud.githubusercontent.com/assets/4719765/20839974/a9f6fe7a-b87c-11e6-8192-b894cfb4ae93.png">

@akainic you had helpful comments the first attempt, can you review this as well?