### PR TITLE
Removes uppercase transform on H6

### DIFF
--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -354,7 +354,6 @@ h6 {
   font-size: 0.9em;
   line-height: 1.5;
   font-weight: bold;
-  text-transform: uppercase;
 }
 
 // Banner


### PR DESCRIPTION
Closes #4253 

Improves readability by making H6 sentence case instead of uppercase - all caps are hard for users to read and comprehend (mixed case is better).