### PR TITLE
Updates link color for 508 compliance

### DIFF
--- a/src/sass/base/_b-variables.scss
+++ b/src/sass/base/_b-variables.scss
@@ -28,7 +28,7 @@ $font-serif:          'Roboto Slab',serif;  // This is not a serif.
 // $color-primary:              #0071bc;
 $color-primary-darker:       #003E73;
 // $color-primary-darkest:      #112e51;
-$color-link-default:         #0058A6;
+$color-link-default:         #004795;
 
 // $color-primary-alt:          #02bfe7;
 // $color-primary-alt-dark:     #00a6d2;

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -964,7 +964,7 @@ ul, ol {
 // Breadcrumbs
 .va-nav-breadcrumbs {
   background: $color-white;
-  color: $color-primary;
+  color: $color-link-default;
   font-size: inherit;
   padding: 1em 0;
 
@@ -992,7 +992,7 @@ ul, ol {
     }
   }
   a {
-    color: $color-primary;
+    color: $color-link-default;
     display: inline-block;
     padding: 2px;
 


### PR DESCRIPTION
Closes #2681

- Updates global link color to pass compliance when on blue callout background
- Updates breadcrumbs to use global link color