### PR TITLE
Resolves #4278 external link icon

### DIFF
--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -209,7 +209,7 @@ hr {
 
 // Adds external icon to all links that begin
 // with http (including https)
-[href^="http://"]:not([href*="vets.gov"]), [href^="https://"]:not([href*="vets.gov"]) {
+a[href^=http] {
   // Using longhand properties instead of the shorthand to limit
   // risk and impact of side effects
   background-image: url(/img/icons/exit-icon.png);


### PR DESCRIPTION
Previous selector was too specific and overrode `background-image: none` on certain elements