### PR TITLE
Allow partial dates where applicable on edu benefits form

### DIFF
--- a/src/js/common/components/form-elements/DateInput.jsx
+++ b/src/js/common/components/form-elements/DateInput.jsx
@@ -1,3 +1,6 @@
+/**
+ * Please use one of the ErrorableDate components instead of this
+ */
 import React from 'react';
 import _ from 'lodash';
 

--- a/src/js/common/components/form-elements/ErrorableDate.jsx
+++ b/src/js/common/components/form-elements/ErrorableDate.jsx
@@ -12,11 +12,11 @@ import { isDirtyDate, isValidPartialDate, isNotBlankDateField, validateCustomFor
 import { months, days } from '../../utils/options-for-select.js';
 
 /**
- * A form input with a label that can display error messages.
+ * A date input field that accepts values for month and year
  *
  * Props:
  * `required` - boolean. Render marker indicating field is required.
- * `validation` - object. Result of custom validation. Should include a valid prop and a message prop
+ * `validation` - object or array. Result of custom validation. Should include a valid prop and a message prop
  * `label` - string. Label for entire question.
  * `name` - string. Used to create unique name attributes for each input.
  * `toolTipText` - String with help text for user.

--- a/src/js/common/components/form-elements/ErrorableMonthYear.jsx
+++ b/src/js/common/components/form-elements/ErrorableMonthYear.jsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import _ from 'lodash';
+import { set } from 'lodash/fp';
+import moment from 'moment';
+
+import ErrorableSelect from './ErrorableSelect';
+import ErrorableNumberInput from './ErrorableNumberInput';
+
+import ToolTip from './ToolTip';
+
+import { isDirtyDate, isValidPartialDate, isNotBlankDateField, validateCustomFormComponent } from '../../utils/validations';
+import { months, days } from '../../utils/options-for-select.js';
+
+/**
+ * A form input with a label that can display error messages.
+ *
+ * Props:
+ * `required` - boolean. Render marker indicating field is required.
+ * `validation` - object. Result of custom validation. Should include a valid prop and a message prop
+ * `label` - string. Label for entire question.
+ * `name` - string. Used to create unique name attributes for each input.
+ * `toolTipText` - String with help text for user.
+ * `tabIndex` - Number for keyboard tab order.
+ * `date` - object. Date value. Should have month, day, and year props
+ * `onValueChange` - a function with this prototype: (newValue)
+ */
+class ErrorableDate extends React.Component {
+  constructor() {
+    super();
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  componentWillMount() {
+    this.id = _.uniqueId('date-input-');
+  }
+
+  handleChange(path, update) {
+    let date = set(path, update, this.props.date);
+    if (!date.month.value) {
+      date = set('day.value', '', date);
+    }
+
+    this.props.onValueChange(date);
+  }
+
+  render() {
+    const { day, month, year } = this.props.date;
+
+    let daysForSelectedMonth = [];
+    if (month.value) {
+      daysForSelectedMonth = days[month.value];
+    }
+
+    // we want to do validations in a specific order, so we show the message
+    // that makes the most sense to the user
+    let isValid = true;
+    let errorMessage;
+    if (isDirtyDate(this.props.date)) {
+      // make sure the user enters a full date first, if required
+      if (this.props.required && !isNotBlankDateField(this.props.date)) {
+        isValid = false;
+        errorMessage = this.props.requiredMessage;
+      // make sure the user has entered a minimally valid date
+      } else if (!isValidPartialDate(day.value, month.value, year.value)) {
+        isValid = false;
+        errorMessage = this.props.invalidMessage;
+      } else {
+        const validationResult = validateCustomFormComponent(this.props.validation);
+        isValid = validationResult.valid;
+        errorMessage = validationResult.message;
+      }
+    }
+
+    let errorSpanId;
+    let errorSpan = '';
+    if (!isValid) {
+      errorSpanId = `${this.inputId}-error-message`;
+      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{errorMessage}</span>;
+    }
+
+    // Adds ToolTip if text is provided.
+    let toolTip;
+    if (this.props.toolTipText) {
+      toolTip = (
+        <ToolTip
+            tabIndex={this.props.tabIndex}
+            toolTipText={this.props.toolTipText}/>
+      );
+    }
+
+    return (
+      <div>
+        <label>
+          {this.props.label ? this.props.label : 'Date of birth'}
+          {this.props.required && <span className="form-required-span">*</span>}
+        </label>
+        {errorSpan}
+        <div className={isValid ? undefined : 'usa-input-error form-error-date'}>
+          <div className="usa-date-of-birth row">
+            <div className="form-datefield-month">
+              <ErrorableSelect errorMessage={isValid ? undefined : ''}
+                  autocomplete="false"
+                  label="Month"
+                  name={`${this.props.name}Month`}
+                  options={months}
+                  value={month}
+                  onValueChange={(update) => {this.handleChange('month', update);}}/>
+            </div>
+            <div className="form-datefield-day">
+              <ErrorableSelect errorMessage={isValid ? undefined : ''}
+                  autocomplete="false"
+                  label="Day"
+                  name={`${this.props.name}Day`}
+                  options={daysForSelectedMonth}
+                  value={day}
+                  onValueChange={(update) => {this.handleChange('day', update);}}/>
+            </div>
+            <div className="usa-datefield usa-form-group usa-form-group-year">
+              <ErrorableNumberInput errorMessage={isValid ? undefined : ''}
+                  autocomplete="false"
+                  label="Year"
+                  name={`${this.props.name}Year`}
+                  max={moment().add(100, 'year').year()}
+                  min="1900"
+                  pattern="[0-9]{4}"
+                  field={year}
+                  onValueChange={(update) => {this.handleChange('year', update);}}/>
+            </div>
+          </div>
+          {toolTip}
+        </div>
+      </div>
+    );
+  }
+}
+
+ErrorableDate.propTypes = {
+  required: React.PropTypes.bool,
+  validation: React.PropTypes.shape({
+    valid: React.PropTypes.bool,
+    message: React.PropTypes.string
+  }),
+  label: React.PropTypes.string,
+  name: React.PropTypes.string.isRequired,
+  date: React.PropTypes.shape({
+    day: React.PropTypes.shape({
+      value: React.PropTypes.string,
+      dirty: React.PropTypes.bool,
+    }),
+    month: React.PropTypes.shape({
+      value: React.PropTypes.string,
+      dirty: React.PropTypes.bool,
+    }),
+    year: React.PropTypes.shape({
+      value: React.PropTypes.string,
+      dirty: React.PropTypes.bool,
+    })
+  }).isRequired,
+  onValueChange: React.PropTypes.func.isRequired,
+  toolTipText: React.PropTypes.string,
+  requiredMessage: React.PropTypes.string,
+  invalidMessage: React.PropTypes.string
+};
+
+ErrorableDate.defaultProps = {
+  requiredMessage: 'Please provide a response',
+  invalidMessage: 'Please provide a valid date'
+};
+
+export default ErrorableDate;

--- a/src/js/common/components/form-elements/ErrorableMonthYear.jsx
+++ b/src/js/common/components/form-elements/ErrorableMonthYear.jsx
@@ -8,15 +8,15 @@ import ErrorableNumberInput from './ErrorableNumberInput';
 
 import ToolTip from './ToolTip';
 
-import { isValidMonthYear, validateCustomFormComponent } from '../../utils/validations';
+import { isValidPartialMonthYear, validateCustomFormComponent } from '../../utils/validations';
 import { months } from '../../utils/options-for-select.js';
 
 /**
- * A form input with a label that can display error messages.
+ * A date input field that accepts values for month and year
  *
  * Props:
  * `required` - boolean. Render marker indicating field is required.
- * `validation` - object. Result of custom validation. Should include a valid prop and a message prop
+ * `validation` - object or array. Result of custom validation. Should include a valid prop and a message prop
  * `label` - string. Label for entire question.
  * `name` - string. Used to create unique name attributes for each input.
  * `toolTipText` - String with help text for user.
@@ -53,7 +53,7 @@ class ErrorableMonthYear extends React.Component {
         isValid = false;
         errorMessage = this.props.requiredMessage;
       // make sure the user has entered a minimally valid date
-      } else if (!isValidMonthYear(month.value, year.value)) {
+      } else if (!isValidPartialMonthYear(month.value, year.value)) {
         isValid = false;
         errorMessage = this.props.invalidMessage;
       } else {
@@ -81,7 +81,7 @@ class ErrorableMonthYear extends React.Component {
     }
 
     return (
-      <div>
+      <div className={!isValid && 'input-error-date'}>
         <label>
           {this.props.label}
           {this.props.required && <span className="form-required-span">*</span>}

--- a/src/js/common/components/form-elements/ErrorableMonthYear.jsx
+++ b/src/js/common/components/form-elements/ErrorableMonthYear.jsx
@@ -8,8 +8,8 @@ import ErrorableNumberInput from './ErrorableNumberInput';
 
 import ToolTip from './ToolTip';
 
-import { isDirtyDate, isValidPartialDate, isNotBlankDateField, validateCustomFormComponent } from '../../utils/validations';
-import { months, days } from '../../utils/options-for-select.js';
+import { isValidMonthYear, validateCustomFormComponent } from '../../utils/validations';
+import { months } from '../../utils/options-for-select.js';
 
 /**
  * A form input with a label that can display error messages.
@@ -24,7 +24,7 @@ import { months, days } from '../../utils/options-for-select.js';
  * `date` - object. Date value. Should have month, day, and year props
  * `onValueChange` - a function with this prototype: (newValue)
  */
-class ErrorableDate extends React.Component {
+class ErrorableMonthYear extends React.Component {
   constructor() {
     super();
     this.handleChange = this.handleChange.bind(this);
@@ -35,33 +35,25 @@ class ErrorableDate extends React.Component {
   }
 
   handleChange(path, update) {
-    let date = set(path, update, this.props.date);
-    if (!date.month.value) {
-      date = set('day.value', '', date);
-    }
+    const date = set(path, update, this.props.date);
 
     this.props.onValueChange(date);
   }
 
   render() {
-    const { day, month, year } = this.props.date;
-
-    let daysForSelectedMonth = [];
-    if (month.value) {
-      daysForSelectedMonth = days[month.value];
-    }
+    const { month, year } = this.props.date;
 
     // we want to do validations in a specific order, so we show the message
     // that makes the most sense to the user
     let isValid = true;
     let errorMessage;
-    if (isDirtyDate(this.props.date)) {
+    if (month.dirty && year.dirty) {
       // make sure the user enters a full date first, if required
-      if (this.props.required && !isNotBlankDateField(this.props.date)) {
+      if (this.props.required && (!month.value || !year.value)) {
         isValid = false;
         errorMessage = this.props.requiredMessage;
       // make sure the user has entered a minimally valid date
-      } else if (!isValidPartialDate(day.value, month.value, year.value)) {
+      } else if (!isValidMonthYear(month.value, year.value)) {
         isValid = false;
         errorMessage = this.props.invalidMessage;
       } else {
@@ -91,7 +83,7 @@ class ErrorableDate extends React.Component {
     return (
       <div>
         <label>
-          {this.props.label ? this.props.label : 'Date of birth'}
+          {this.props.label}
           {this.props.required && <span className="form-required-span">*</span>}
         </label>
         {errorSpan}
@@ -105,15 +97,6 @@ class ErrorableDate extends React.Component {
                   options={months}
                   value={month}
                   onValueChange={(update) => {this.handleChange('month', update);}}/>
-            </div>
-            <div className="form-datefield-day">
-              <ErrorableSelect errorMessage={isValid ? undefined : ''}
-                  autocomplete="false"
-                  label="Day"
-                  name={`${this.props.name}Day`}
-                  options={daysForSelectedMonth}
-                  value={day}
-                  onValueChange={(update) => {this.handleChange('day', update);}}/>
             </div>
             <div className="usa-datefield usa-form-group usa-form-group-year">
               <ErrorableNumberInput errorMessage={isValid ? undefined : ''}
@@ -134,19 +117,12 @@ class ErrorableDate extends React.Component {
   }
 }
 
-ErrorableDate.propTypes = {
+ErrorableMonthYear.propTypes = {
   required: React.PropTypes.bool,
-  validation: React.PropTypes.shape({
-    valid: React.PropTypes.bool,
-    message: React.PropTypes.string
-  }),
+  validation: React.PropTypes.any,
   label: React.PropTypes.string,
   name: React.PropTypes.string.isRequired,
   date: React.PropTypes.shape({
-    day: React.PropTypes.shape({
-      value: React.PropTypes.string,
-      dirty: React.PropTypes.bool,
-    }),
     month: React.PropTypes.shape({
       value: React.PropTypes.string,
       dirty: React.PropTypes.bool,
@@ -162,9 +138,9 @@ ErrorableDate.propTypes = {
   invalidMessage: React.PropTypes.string
 };
 
-ErrorableDate.defaultProps = {
+ErrorableMonthYear.defaultProps = {
   requiredMessage: 'Please provide a response',
-  invalidMessage: 'Please provide a valid date'
+  invalidMessage: 'Please provide a valid month and/or year'
 };
 
-export default ErrorableDate;
+export default ErrorableMonthYear;

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -60,7 +60,7 @@ export function dateToMoment(dateField) {
   return moment({
     year: dateField.year.value,
     month: dateField.month.value ? parseInt(dateField.month.value, 10) - 1 : '',
-    day: dateField.day.value
+    day: dateField.day ? dateField.day.value : null
   });
 }
 

--- a/src/js/common/utils/validations.js
+++ b/src/js/common/utils/validations.js
@@ -32,8 +32,10 @@ function validateIfDirtyProvider(field1, field2, validator) {
 
 function validateCustomFormComponent(customValidation) {
   // Allow devs to pass in an array of validations with messages and display the first failed one
-  if (Array.isArray(customValidation) && customValidation.some(validator => !validator.valid)) {
-    return customValidation.filter(validator => !validator.valid)[0];
+  if (Array.isArray(customValidation)) {
+    if (customValidation.some(validator => !validator.valid)) {
+      return customValidation.filter(validator => !validator.valid)[0];
+    }
   // Also allow objects for custom validation
   } else if (typeof customValidation === 'object' && !customValidation.valid) {
     return customValidation;
@@ -119,6 +121,20 @@ function isValidPartialDate(day, month, year) {
   }
 
   return true;
+}
+
+function isValidMonthYear(month, year) {
+  if (month && Number(month) > 12 && Number(month) < 1) {
+    return false;
+  }
+
+  return isValidPartialDate(null, null, year);
+}
+
+function isValidMonthYearInPast(month, year) {
+  const momentDate = moment({ year, month: month ? parseInt(month, 10) - 1 : null });
+
+  return !year || isValidMonthYear(month, year) && momentDate.isValid() && momentDate.isSameOrBefore(moment().startOf('month'));
 }
 
 function isValidDateOver17(day, month, year) {
@@ -576,5 +592,7 @@ export {
   isValidPartialDate,
   isValidDateField,
   isValidPartialDateField,
+  isValidMonthYear,
+  isValidMonthYearInPast,
   validateCustomFormComponent
 };

--- a/src/js/common/utils/validations.js
+++ b/src/js/common/utils/validations.js
@@ -131,7 +131,7 @@ function isValidPartialDate(day, month, year) {
   return true;
 }
 
-function isValidMonthYear(month, year) {
+function isValidPartialMonthYear(month, year) {
   if (typeof month === 'object') {
     throw new Error('Pass a month and a year to function');
   }
@@ -142,13 +142,13 @@ function isValidMonthYear(month, year) {
   return isValidPartialDate(null, null, year);
 }
 
-function isValidMonthYearInPast(month, year) {
+function isValidPartialMonthYearInPast(month, year) {
   if (typeof month === 'object') {
     throw new Error('Pass a month and a year to function');
   }
   const momentDate = moment({ year, month: month ? parseInt(month, 10) - 1 : null });
 
-  return !year || isValidMonthYear(month, year) && momentDate.isValid() && momentDate.isSameOrBefore(moment().startOf('month'));
+  return !year || isValidPartialMonthYear(month, year) && momentDate.isValid() && momentDate.isSameOrBefore(moment().startOf('month'));
 }
 
 function isValidDateOver17(day, month, year) {
@@ -610,8 +610,8 @@ export {
   isValidPartialDate,
   isValidDateField,
   isValidPartialDateField,
-  isValidMonthYear,
+  isValidPartialMonthYear,
   isValidYear,
-  isValidMonthYearInPast,
+  isValidPartialMonthYearInPast,
   validateCustomFormComponent
 };

--- a/src/js/common/utils/validations.js
+++ b/src/js/common/utils/validations.js
@@ -124,7 +124,10 @@ function isValidPartialDate(day, month, year) {
 }
 
 function isValidMonthYear(month, year) {
-  if (month && Number(month) > 12 && Number(month) < 1) {
+  if (typeof month === 'object') {
+    throw new Error('Pass a month and a year to function');
+  }
+  if (month && (Number(month) > 12 || Number(month) < 1)) {
     return false;
   }
 
@@ -132,6 +135,9 @@ function isValidMonthYear(month, year) {
 }
 
 function isValidMonthYearInPast(month, year) {
+  if (typeof month === 'object') {
+    throw new Error('Pass a month and a year to function');
+  }
   const momentDate = moment({ year, month: month ? parseInt(month, 10) - 1 : null });
 
   return !year || isValidMonthYear(month, year) && momentDate.isValid() && momentDate.isSameOrBefore(moment().startOf('month'));

--- a/src/js/edu-benefits/components/education-history/EducationHistoryFields.jsx
+++ b/src/js/edu-benefits/components/education-history/EducationHistoryFields.jsx
@@ -9,7 +9,7 @@ import EducationHistoryReview from './EducationHistoryReview';
 import { createEducationPeriod } from '../../utils/veteran';
 
 import { isValidPage, isValidEducationPeriod } from '../../utils/validations';
-import { isValidMonthYearInPast } from '../../../common/utils/validations';
+import { isValidPartialMonthYearInPast } from '../../../common/utils/validations';
 
 export default class EducationHistoryFields extends React.Component {
   constructor() {
@@ -58,7 +58,7 @@ export default class EducationHistoryFields extends React.Component {
       <div className="input-section">
         <ErrorableMonthYear
             validation={{
-              valid: isValidMonthYearInPast(completionDate.month.value, completionDate.year.value),
+              valid: isValidPartialMonthYearInPast(completionDate.month.value, completionDate.year.value),
               message: 'Please provide a valid date in the past'
             }}
             label="When did you earn your high school diploma or equivalency certificate?"

--- a/src/js/edu-benefits/components/education-history/EducationHistoryFields.jsx
+++ b/src/js/edu-benefits/components/education-history/EducationHistoryFields.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import DateInput from '../../../common/components/form-elements/DateInput';
+import ErrorableMonthYear from '../../../common/components/form-elements/ErrorableMonthYear';
 import GrowableTable from '../../../common/components/form-elements/GrowableTable';
 import ErrorableTextarea from '../../../common/components/form-elements/ErrorableTextarea';
 
@@ -9,6 +9,7 @@ import EducationHistoryReview from './EducationHistoryReview';
 import { createEducationPeriod } from '../../utils/veteran';
 
 import { isValidPage, isValidEducationPeriod } from '../../utils/validations';
+import { isValidMonthYearInPast } from '../../../common/utils/validations';
 
 export default class EducationHistoryFields extends React.Component {
   constructor() {
@@ -32,7 +33,6 @@ export default class EducationHistoryFields extends React.Component {
     ];
 
     const completionDate = this.props.data.highSchoolOrGedCompletionDate;
-    const { day, month, year } = completionDate;
 
     const periodsTable = (
       <GrowableTable
@@ -56,13 +56,14 @@ export default class EducationHistoryFields extends React.Component {
       <legend className="hide-for-small-only">Education history</legend>
       <p><span className="form-required-span">*</span>Indicates a required field</p>
       <div className="input-section">
-        <DateInput
+        <ErrorableMonthYear
+            validation={{
+              valid: isValidMonthYearInPast(completionDate.month.value, completionDate.year.value),
+              message: 'Please provide a valid date in the past'
+            }}
             label="When did you earn your high school diploma or equivalency certificate?"
             name="highSchoolOrGedCompletionDate"
-            hideDayField
-            day={day}
-            month={month}
-            year={year}
+            date={completionDate}
             onValueChange={(update) => {this.props.onStateChange('highSchoolOrGedCompletionDate', update);}}/>
       </div>
       {!this.props.inReview && <div className="input-section">

--- a/src/js/edu-benefits/components/education-history/EducationPeriod.jsx
+++ b/src/js/edu-benefits/components/education-history/EducationPeriod.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
-import DateInput from '../../../common/components/form-elements/DateInput';
+import ErrorableMonthYear from '../../../common/components/form-elements/ErrorableMonthYear';
 import ErrorableTextInput from '../../../common/components/form-elements/ErrorableTextInput';
 import ErrorableNumberInput from '../../../common/components/form-elements/ErrorableNumberInput';
 import ErrorableSelect from '../../../common/components/form-elements/ErrorableSelect';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
 
-import { isValidDateRange, isValidDateField, validateIfDirtyDateObj } from '../../utils/validations';
+import { isValidMonthYearRange } from '../../utils/validations';
+import { isValidMonthYearInPast } from '../../../common/utils/validations';
 import { states, hoursTypes } from '../../utils/options-for-select';
 import EducationPeriodReview from './EducationPeriodReview';
 
@@ -33,23 +34,29 @@ export default class EducationPeriod extends React.Component {
             value={period.state}
             options={states.USA}
             onValueChange={(update) => {onValueChange('state', update);}}/>
-        <DateInput
-            errorMessage="Please provide a valid date in the past"
-            validation={validateIfDirtyDateObj(period.dateRange.from, isValidDateField)}
+        <ErrorableMonthYear
+            validation={{
+              valid: isValidMonthYearInPast(period.dateRange.from.month.value, period.dateRange.from.year.value),
+              message: 'Please provide a valid date in the past'
+            }}
             label="From"
             name="fromDate"
-            day={period.dateRange.from.day}
-            month={period.dateRange.from.month}
-            year={period.dateRange.from.year}
+            date={period.dateRange.from}
             onValueChange={(update) => {onValueChange('dateRange.from', update);}}/>
-        <DateInput
-            errorMessage={isValidDateRange(period.dateRange.from, period.dateRange.to) ? 'Please provide a response' : 'Date separated must be after date entered'}
-            validation={validateIfDirtyDateObj(period.dateRange.to, date => isValidDateRange(period.dateRange.from, date))}
+        <ErrorableMonthYear
+            validation={[
+              {
+                valid: isValidMonthYearInPast(period.dateRange.to.month.value, period.dateRange.to.year.value),
+                message: 'Please provide a valid date in the past'
+              },
+              {
+                valid: isValidMonthYearRange(period.dateRange.from, period.dateRange.to),
+                message: 'To date must be after From date'
+              },
+            ]}
             label="To"
             name="toDate"
-            day={period.dateRange.to.day}
-            month={period.dateRange.to.month}
-            year={period.dateRange.to.year}
+            date={period.dateRange.to}
             onValueChange={(update) => {onValueChange('dateRange.to', update);}}/>
         <ErrorableNumberInput
             min={0}

--- a/src/js/edu-benefits/components/education-history/EducationPeriod.jsx
+++ b/src/js/edu-benefits/components/education-history/EducationPeriod.jsx
@@ -6,8 +6,8 @@ import ErrorableNumberInput from '../../../common/components/form-elements/Error
 import ErrorableSelect from '../../../common/components/form-elements/ErrorableSelect';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
 
-import { isValidMonthYearRange } from '../../utils/validations';
-import { isValidMonthYearInPast } from '../../../common/utils/validations';
+import { isValidPartialMonthYearRange } from '../../utils/validations';
+import { isValidPartialMonthYearInPast } from '../../../common/utils/validations';
 import { states, hoursTypes } from '../../utils/options-for-select';
 import EducationPeriodReview from './EducationPeriodReview';
 
@@ -36,7 +36,7 @@ export default class EducationPeriod extends React.Component {
             onValueChange={(update) => {onValueChange('state', update);}}/>
         <ErrorableMonthYear
             validation={{
-              valid: isValidMonthYearInPast(period.dateRange.from.month.value, period.dateRange.from.year.value),
+              valid: isValidPartialMonthYearInPast(period.dateRange.from.month.value, period.dateRange.from.year.value),
               message: 'Please provide a valid date in the past'
             }}
             label="From"
@@ -46,11 +46,11 @@ export default class EducationPeriod extends React.Component {
         <ErrorableMonthYear
             validation={[
               {
-                valid: isValidMonthYearInPast(period.dateRange.to.month.value, period.dateRange.to.year.value),
+                valid: isValidPartialMonthYearInPast(period.dateRange.to.month.value, period.dateRange.to.year.value),
                 message: 'Please provide a valid date in the past'
               },
               {
-                valid: isValidMonthYearRange(period.dateRange.from, period.dateRange.to),
+                valid: isValidPartialMonthYearRange(period.dateRange.from, period.dateRange.to),
                 message: 'To date must be after From date'
               },
             ]}

--- a/src/js/edu-benefits/components/education-history/EducationPeriodReview.jsx
+++ b/src/js/edu-benefits/components/education-history/EducationPeriodReview.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { displayDateIfValid } from '../../utils/helpers.js';
+import { displayMonthYearIfValid } from '../../utils/helpers.js';
 
 export default class EducationPeriodReview extends React.Component {
   render() {
@@ -11,7 +11,7 @@ export default class EducationPeriodReview extends React.Component {
           <tbody className="edu-growable-review-desc">
             <tr>
               <td>{period.name.value}<br/>
-              {displayDateIfValid(period.dateRange.from)} &mdash; {displayDateIfValid(period.dateRange.to)}</td>
+              {displayMonthYearIfValid(period.dateRange.from)} &mdash; {displayMonthYearIfValid(period.dateRange.to)}</td>
               <td>
                 <button className="usa-button-outline float-right" onClick={this.props.onEdit}>Edit</button>
               </td>

--- a/src/js/edu-benefits/components/military-history/ContributionsFields.jsx
+++ b/src/js/edu-benefits/components/military-history/ContributionsFields.jsx
@@ -69,7 +69,7 @@ export default class ContributionsFields extends React.Component {
             <ErrorableCurrentOrPastDate required
                 validation={{
                   valid: isValidDateRange(this.props.data.activeDutyRepayingPeriod.from, this.props.data.activeDutyRepayingPeriod.to),
-                  message: 'End date must be after Start date'
+                  message: 'End date must be after start date'
                 }}
                 label="End date"
                 name="to"

--- a/src/js/edu-benefits/components/military-history/ContributionsFields.jsx
+++ b/src/js/edu-benefits/components/military-history/ContributionsFields.jsx
@@ -2,16 +2,12 @@ import React from 'react';
 
 import ErrorableCheckbox from '../../../common/components/form-elements/ErrorableCheckbox';
 import ExpandingGroup from '../../../common/components/form-elements/ExpandingGroup';
-import DateInput from '../../../common/components/form-elements/DateInput';
+import ErrorableCurrentOrPastDate from '../../../common/components/form-elements/ErrorableCurrentOrPastDate';
 
-import { validateIfDirtyDateObj, isValidDateField, isValidDateRange } from '../../utils/validations';
+import { isValidDateRange } from '../../utils/validations';
 
 export default class ContributionsFields extends React.Component {
   render() {
-    const isToDateValid = isValidDateRange(
-      this.props.data.activeDutyRepayingPeriod.to,
-      this.props.data.activeDutyRepayingPeriod.from
-    );
     const relinquished = this.props.data.benefitsRelinquished.value;
     return (<fieldset>
       <legend>Contributions</legend>
@@ -65,23 +61,19 @@ export default class ContributionsFields extends React.Component {
               checked={this.props.data.activeDutyRepaying}
               onValueChange={(update) => {this.props.onStateChange('activeDutyRepaying', update);}}/>
           <div>
-            <DateInput required
-                errorMessage="Please provide a response"
-                validation={validateIfDirtyDateObj(this.props.data.activeDutyRepayingPeriod.from, isValidDateField)}
+            <ErrorableCurrentOrPastDate required
                 label="Start date"
                 name="from"
-                day={this.props.data.activeDutyRepayingPeriod.from.day}
-                month={this.props.data.activeDutyRepayingPeriod.from.month}
-                year={this.props.data.activeDutyRepayingPeriod.from.year}
+                date={this.props.data.activeDutyRepayingPeriod.from}
                 onValueChange={(update) => {this.props.onStateChange('activeDutyRepayingPeriod.from', update);}}/>
-            <DateInput required
-                errorMessage={isToDateValid ? 'End Date must be after Start Date' : 'Please provide a response'}
-                validation={validateIfDirtyDateObj(this.props.data.activeDutyRepayingPeriod.to, (date) => isValidDateRange(this.props.data.activeDutyRepayingPeriod.from, date))}
+            <ErrorableCurrentOrPastDate required
+                validation={{
+                  valid: isValidDateRange(this.props.data.activeDutyRepayingPeriod.from, this.props.data.activeDutyRepayingPeriod.to),
+                  message: 'End date must be after Start date'
+                }}
                 label="End date"
                 name="to"
-                day={this.props.data.activeDutyRepayingPeriod.to.day}
-                month={this.props.data.activeDutyRepayingPeriod.to.month}
-                year={this.props.data.activeDutyRepayingPeriod.to.year}
+                date={this.props.data.activeDutyRepayingPeriod.to}
                 onValueChange={(update) => {this.props.onStateChange('activeDutyRepayingPeriod.to', update);}}/>
           </div>
         </ExpandingGroup>

--- a/src/js/edu-benefits/components/school-selection/SchoolSelectionFields.jsx
+++ b/src/js/edu-benefits/components/school-selection/SchoolSelectionFields.jsx
@@ -4,10 +4,9 @@ import ErrorableTextInput from '../../../common/components/form-elements/Errorab
 import ErrorableSelect from '../../../common/components/form-elements/ErrorableSelect';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
 import ExpandingGroup from '../../../common/components/form-elements/ExpandingGroup';
-import DateInput from '../../../common/components/form-elements/DateInput';
+import ErrorableDate from '../../../common/components/form-elements/ErrorableDate';
 import Address from '../Address';
 
-import { validateIfDirtyDateObj, isValidFutureOrPastDateField } from '../../utils/validations';
 import { schoolTypes, yesNo } from '../../utils/options-for-select';
 import { showSchoolAddress } from '../../utils/helpers';
 
@@ -51,15 +50,10 @@ export default class SchoolSelectionFields extends React.Component {
             name="educationObjective"
             field={this.props.data.educationObjective}
             onValueChange={(update) => {this.props.onStateChange('educationObjective', update);}}/>
-        <DateInput
-            errorMessage={isValidFutureOrPastDateField(this.props.data.educationStartDate) ? undefined : 'Please enter a valid date'}
-            validation={validateIfDirtyDateObj(this.props.data.educationStartDate, isValidFutureOrPastDateField)}
-            allowFutureDates
+        <ErrorableDate
             label="The date your training began or will begin:"
             name="educationStartDate"
-            day={this.props.data.educationStartDate.day}
-            month={this.props.data.educationStartDate.month}
-            year={this.props.data.educationStartDate.year}
+            date={this.props.data.educationStartDate}
             onValueChange={(update) => {this.props.onStateChange('educationStartDate', update);}}/>
         {this.props.data.currentlyActiveDuty.yes.value === 'Y'
           ? <ErrorableRadioButtons

--- a/src/js/edu-benefits/components/veteran-information/VeteranInformationFields.jsx
+++ b/src/js/edu-benefits/components/veteran-information/VeteranInformationFields.jsx
@@ -1,24 +1,16 @@
 import React from 'react';
 
-import DateInput from '../../../common/components/form-elements/DateInput';
+import ErrorableCurrentOrPastDate from '../../../common/components/form-elements/ErrorableCurrentOrPastDate';
 import FullName from '../../../common/components/questions/FullName';
 import SocialSecurityNumber from '../../../common/components/questions/SocialSecurityNumber';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
 
 import { binaryGenders } from '../../utils/options-for-select';
-import { isValidDateOver17, isValidAnyDate, validateIfDirtyDate } from '../../../common/utils/validations';
-
-function getDateMessage({ month, day, year }) {
-  if (isValidAnyDate(day.value, month.value, year.value)
-      && !isValidDateOver17(day.value, month.value, year.value)) {
-    return 'You must be at least 17 to apply';
-  }
-
-  return 'Please provide a valid date of birth';
-}
+import { isValidDateOver17 } from '../../../common/utils/validations';
 
 export default class PersonalInformationFields extends React.Component {
   render() {
+    const { day, month, year } = this.props.veteranDateOfBirth;
     return (
       <fieldset>
         <p>You aren’t required to fill in <strong>all</strong> fields, but VA can evaluate your claim faster if you provide more information.</p>
@@ -31,13 +23,14 @@ export default class PersonalInformationFields extends React.Component {
           <SocialSecurityNumber required
               ssn={this.props.data.veteranSocialSecurityNumber}
               onValueChange={(update) => {this.props.onStateChange('veteranSocialSecurityNumber', update);}}/>
-          <DateInput required
-              errorMessage={getDateMessage(this.props.data.veteranDateOfBirth)}
-              validation={validateIfDirtyDate(this.props.data.veteranDateOfBirth.day, this.props.data.veteranDateOfBirth.month, this.props.data.veteranDateOfBirth.year, isValidDateOver17)}
+          <ErrorableCurrentOrPastDate required
+              validation={{
+                valid: isValidDateOver17(day.value, month.value, year.value),
+                message: 'You must be at least 17 to apply'
+              }}
+              invalidMessage="Please provide a valid date of birth"
               name="veteranBirth"
-              day={this.props.data.veteranDateOfBirth.day}
-              month={this.props.data.veteranDateOfBirth.month}
-              year={this.props.data.veteranDateOfBirth.year}
+              date={this.props.data.veteranDateOfBirth}
               onValueChange={(update) => {this.props.onStateChange('veteranDateOfBirth', update);}}/>
           <ErrorableRadioButtons
               label="Gender"

--- a/src/js/edu-benefits/components/veteran-information/VeteranInformationFields.jsx
+++ b/src/js/edu-benefits/components/veteran-information/VeteranInformationFields.jsx
@@ -10,7 +10,7 @@ import { isValidDateOver17 } from '../../../common/utils/validations';
 
 export default class PersonalInformationFields extends React.Component {
   render() {
-    const { day, month, year } = this.props.veteranDateOfBirth;
+    const { day, month, year } = this.props.data.veteranDateOfBirth;
     return (
       <fieldset>
         <p>You aren’t required to fill in <strong>all</strong> fields, but VA can evaluate your claim faster if you provide more information.</p>

--- a/src/js/edu-benefits/utils/helpers.js
+++ b/src/js/edu-benefits/utils/helpers.js
@@ -55,8 +55,8 @@ export function displayDateIfValid(field) {
 }
 
 export function displayMonthYearIfValid(dateObject) {
-  if (dateObject.year.value && dateObject.month.value) {
-    return `${dateObject.month.value}/${dateObject.year.value}`;
+  if (dateObject.year.value || dateObject.month.value) {
+    return `${dateObject.month.value || 'XX'}/${dateObject.year.value || 'XXXX'}`;
   }
 
   return null;

--- a/src/js/edu-benefits/utils/helpers.js
+++ b/src/js/edu-benefits/utils/helpers.js
@@ -57,7 +57,7 @@ export function formatPartialDate(field) {
 
   const day = field.day ? field.day.value : null;
 
-  return `${formatYear(field.year.value)}-${formatDayMonth(field.month.value)}${day ? '-' : ''}${formatDayMonth(day)}`;
+  return `${formatYear(field.year.value)}-${formatDayMonth(field.month.value)}-${formatDayMonth(day)}`;
 }
 
 export function displayDateIfValid(field) {

--- a/src/js/edu-benefits/utils/helpers.js
+++ b/src/js/edu-benefits/utils/helpers.js
@@ -37,11 +37,13 @@ function formatDayMonth(val) {
 }
 
 export function formatPartialDate(field) {
-  if (!field.day.value && !field.month.value && !field.year.value) {
+  if (!field.month.value && !field.year.value) {
     return undefined;
   }
 
-  return `${field.year.value || 'XXXX'}-${formatDayMonth(field.month.value)}-${formatDayMonth(field.day.value)}`;
+  const day = field.day ? field.day.value : null;
+
+  return `${field.year.value || 'XXXX'}-${formatDayMonth(field.month.value)}-${formatDayMonth(day)}`;
 }
 
 export function displayDateIfValid(dateObject) {

--- a/src/js/edu-benefits/utils/helpers.js
+++ b/src/js/edu-benefits/utils/helpers.js
@@ -57,7 +57,7 @@ export function formatPartialDate(field) {
 
   const day = field.day ? field.day.value : null;
 
-  return `${formatYear(field.year.value)}-${formatDayMonth(field.month.value)}-${formatDayMonth(day)}`;
+  return `${formatYear(field.year.value)}-${formatDayMonth(field.month.value)}${day ? '-' : ''}${formatDayMonth(day)}`;
 }
 
 export function displayDateIfValid(field) {

--- a/src/js/edu-benefits/utils/helpers.js
+++ b/src/js/edu-benefits/utils/helpers.js
@@ -55,7 +55,7 @@ export function formatPartialDate(field) {
   }
 
   const day = field.day ? field.day.value : null;
-  
+
   return `${formatYear(field.year.value)}-${formatDayMonth(field.month.value)}-${formatDayMonth(day)}`;
 }
 

--- a/src/js/edu-benefits/utils/validations.js
+++ b/src/js/edu-benefits/utils/validations.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import { states } from './options-for-select';
 import { showRelinquishedEffectiveDate } from './helpers';
-import { isValidDateOver17, isBlankAddress, isValidPartialDateField } from '../../common/utils/validations';
+import { isValidDateOver17, isBlankAddress, isValidPartialDateField, isValidMonthYearInPast } from '../../common/utils/validations';
 import { dateToMoment } from '../../common/utils/helpers';
 
 function validateIfDirty(field, validator) {
@@ -210,6 +210,16 @@ function isValidDateRange(fromDate, toDate) {
   return momentStart.isBefore(momentEnd);
 }
 
+function isValidMonthYearRange(fromDate, toDate) {
+  if (!fromDate.year.value || !toDate.year.value) {
+    return true;
+  }
+  const momentStart = dateToMoment(fromDate);
+  const momentEnd = dateToMoment(toDate);
+
+  return momentStart.isSameOrBefore(momentEnd);
+}
+
 function isValidFullNameField(field) {
   return isValidName(field.first.value) &&
     (isBlank(field.middle.value) || isValidName(field.middle.value)) &&
@@ -289,7 +299,9 @@ function isValidEmploymentHistoryPage(data) {
 }
 
 function isValidEducationPeriod(data) {
-  return isValidDateRange(data.dateRange.from, data.dateRange.to);
+  return isValidMonthYearInPast(data.dateRange.from)
+    && isValidMonthYearInPast(data.dateRange.to)
+    && isValidMonthYearRange(data.dateRange.from, data.dateRange.to);
 }
 
 function isValidEducationHistoryPage(data) {
@@ -443,5 +455,6 @@ export {
   isValidRelinquishedDate,
   isValidTourOfDuty,
   isValidEmploymentPeriod,
-  isValidRotcScholarshipAmount
+  isValidRotcScholarshipAmount,
+  isValidMonthYearRange
 };

--- a/src/js/edu-benefits/utils/validations.js
+++ b/src/js/edu-benefits/utils/validations.js
@@ -305,7 +305,7 @@ function isValidEducationPeriod(data) {
 }
 
 function isValidEducationHistoryPage(data) {
-  return (isBlankMonthYear(data.highSchoolOrGedCompletionDate) || isValidDateField(data.highSchoolOrGedCompletionDate))
+  return (isBlankMonthYear(data.highSchoolOrGedCompletionDate) || isValidMonthYearInPast(data.highSchoolOrGedCompletionDate))
     && data.postHighSchoolTrainings.every(isValidEducationPeriod);
 }
 

--- a/src/js/edu-benefits/utils/validations.js
+++ b/src/js/edu-benefits/utils/validations.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import { states } from './options-for-select';
 import { showRelinquishedEffectiveDate } from './helpers';
-import { isValidDateOver17, isBlankAddress, isValidPartialDateField, isValidYear, isValidMonthYearInPast } from '../../common/utils/validations';
+import { isValidDateOver17, isBlankAddress, isValidPartialDateField, isValidYear, isValidPartialMonthYearInPast } from '../../common/utils/validations';
 import { dateToMoment } from '../../common/utils/helpers';
 
 function validateIfDirty(field, validator) {
@@ -209,7 +209,7 @@ function isValidDateRange(fromDate, toDate) {
   return momentStart.isBefore(momentEnd);
 }
 
-function isValidMonthYearRange(fromDate, toDate) {
+function isValidPartialMonthYearRange(fromDate, toDate) {
   if (!fromDate.year.value || !toDate.year.value) {
     return true;
   }
@@ -301,14 +301,14 @@ function isValidEmploymentHistoryPage(data) {
 }
 
 function isValidEducationPeriod(data) {
-  return isValidMonthYearInPast(data.dateRange.from.month.value, data.dateRange.from.year.value)
-    && isValidMonthYearInPast(data.dateRange.to.month.value, data.dateRange.to.year.value)
-    && isValidMonthYearRange(data.dateRange.from, data.dateRange.to);
+  return isValidPartialMonthYearInPast(data.dateRange.from.month.value, data.dateRange.from.year.value)
+    && isValidPartialMonthYearInPast(data.dateRange.to.month.value, data.dateRange.to.year.value)
+    && isValidPartialMonthYearRange(data.dateRange.from, data.dateRange.to);
 }
 
 function isValidEducationHistoryPage(data) {
   return (isBlankMonthYear(data.highSchoolOrGedCompletionDate)
-    || isValidMonthYearInPast(data.highSchoolOrGedCompletionDate.month.value, data.highSchoolOrGedCompletionDate.year.value))
+    || isValidPartialMonthYearInPast(data.highSchoolOrGedCompletionDate.month.value, data.highSchoolOrGedCompletionDate.year.value))
     && data.postHighSchoolTrainings.every(isValidEducationPeriod);
 }
 
@@ -460,6 +460,6 @@ export {
   isValidTourOfDuty,
   isValidEmploymentPeriod,
   isValidRotcScholarshipAmount,
-  isValidMonthYearRange,
+  isValidPartialMonthYearRange,
   isValidEducationPeriod
 };

--- a/src/js/edu-benefits/utils/validations.js
+++ b/src/js/edu-benefits/utils/validations.js
@@ -299,13 +299,14 @@ function isValidEmploymentHistoryPage(data) {
 }
 
 function isValidEducationPeriod(data) {
-  return isValidMonthYearInPast(data.dateRange.from)
-    && isValidMonthYearInPast(data.dateRange.to)
+  return isValidMonthYearInPast(data.dateRange.from.month.value, data.dateRange.from.year.value)
+    && isValidMonthYearInPast(data.dateRange.to.month.value, data.dateRange.to.year.value)
     && isValidMonthYearRange(data.dateRange.from, data.dateRange.to);
 }
 
 function isValidEducationHistoryPage(data) {
-  return (isBlankMonthYear(data.highSchoolOrGedCompletionDate) || isValidMonthYearInPast(data.highSchoolOrGedCompletionDate))
+  return (isBlankMonthYear(data.highSchoolOrGedCompletionDate)
+    || isValidMonthYearInPast(data.highSchoolOrGedCompletionDate.month.value, data.highSchoolOrGedCompletionDate.year.value))
     && data.postHighSchoolTrainings.every(isValidEducationPeriod);
 }
 
@@ -447,6 +448,7 @@ export {
   isValidPersonalInfoPage,
   isValidAddressField,
   isValidContactInformationPage,
+  isValidEducationHistoryPage,
   isValidMilitaryServicePage,
   isValidServicePeriodsPage,
   isValidPage,

--- a/src/js/edu-benefits/utils/veteran.js
+++ b/src/js/edu-benefits/utils/veteran.js
@@ -52,12 +52,10 @@ export function createEducationPeriod() {
     dateRange: {
       to: {
         month: makeField(''),
-        day: makeField(''),
         year: makeField(''),
       },
       from: {
         month: makeField(''),
-        day: makeField(''),
         year: makeField(''),
       }
     },
@@ -101,7 +99,6 @@ export function createVeteran() {
     faaFlightCertificatesInformation: makeField(''),
     highSchoolOrGedCompletionDate: {
       month: makeField(''),
-      day: makeField(''),
       year: makeField(''),
     },
     seniorRotcCommissioned: makeField(''),
@@ -282,7 +279,7 @@ export function veteranToApplication(veteran) {
         // fall through.
     }
 
-    if (value.month !== undefined && value.year !== undefined && value.day !== undefined) {
+    if (value.month !== undefined && value.year !== undefined) {
       return formatPartialDate(value);
     }
 

--- a/test/common/components/form-elements/ErrorableMonthYear.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableMonthYear.unit.spec.jsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+
+import ErrorableMonthYear from '../../../../src/js/common/components/form-elements/ErrorableMonthYear';
+import { makeField } from '../../../../src/js/common/model/fields';
+
+describe('<ErrorableMonthYear>', () => {
+  it('renders input elements', () => {
+    const date = {
+      month: makeField(12),
+      year: makeField(2010)
+    };
+    const tree = SkinDeep.shallowRender(
+      <ErrorableMonthYear date={date} onValueChange={(_update) => {}}/>);
+    expect(tree.everySubTree('ErrorableNumberInput')).to.have.lengthOf(1);
+    expect(tree.everySubTree('ErrorableSelect')).to.have.lengthOf(2);
+  });
+  it('displays required message', () => {
+    const date = {
+      month: makeField(''),
+      year: makeField('')
+    };
+    date.year.dirty = true;
+    date.month.dirty = true;
+
+    const tree = SkinDeep.shallowRender(
+      <ErrorableMonthYear required date={date} onValueChange={(_update) => {}}/>);
+
+    expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Please provide a response');
+  });
+  it('displays invalid message', () => {
+    const date = {
+      month: makeField(''),
+      year: makeField('1890')
+    };
+    date.year.dirty = true;
+    date.month.dirty = true;
+
+    const tree = SkinDeep.shallowRender(
+      <ErrorableMonthYear date={date} onValueChange={(_update) => {}}/>);
+
+    expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Please provide a valid date');
+  });
+  it('does not show invalid message for partial date', () => {
+    const date = {
+      month: makeField('12'),
+      year: makeField('')
+    };
+    date.year.dirty = true;
+    date.month.dirty = true;
+
+    const tree = SkinDeep.shallowRender(
+      <ErrorableMonthYear date={date} onValueChange={(_update) => {}}/>);
+
+    expect(tree.everySubTree('.usa-input-error')).to.be.empty;
+  });
+  it('displays custom message', () => {
+    const date = {
+      month: makeField(''),
+      year: makeField('2010')
+    };
+    date.year.dirty = true;
+    date.month.dirty = true;
+
+    const tree = SkinDeep.shallowRender(
+      <ErrorableMonthYear date={date} validation={{ valid: false, message: 'Test' }} onValueChange={(_update) => {}}/>);
+
+    expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Test');
+  });
+  it('displays custom message from array', () => {
+    const date = {
+      month: makeField(''),
+      year: makeField('2010')
+    };
+    date.year.dirty = true;
+    date.month.dirty = true;
+
+    const tree = SkinDeep.shallowRender(
+      <ErrorableMonthYear
+          date={date}
+          validation={[
+            { valid: true, message: 'NotShownMessage' },
+            { valid: false, message: 'Test' }
+          ]}
+          onValueChange={(_update) => {}}/>
+    );
+
+    expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Test');
+  });
+});
+

--- a/test/common/components/form-elements/ErrorableMonthYear.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableMonthYear.unit.spec.jsx
@@ -14,7 +14,7 @@ describe('<ErrorableMonthYear>', () => {
     const tree = SkinDeep.shallowRender(
       <ErrorableMonthYear date={date} onValueChange={(_update) => {}}/>);
     expect(tree.everySubTree('ErrorableNumberInput')).to.have.lengthOf(1);
-    expect(tree.everySubTree('ErrorableSelect')).to.have.lengthOf(2);
+    expect(tree.everySubTree('ErrorableSelect')).to.have.lengthOf(1);
   });
   it('displays required message', () => {
     const date = {
@@ -42,7 +42,7 @@ describe('<ErrorableMonthYear>', () => {
       <ErrorableMonthYear date={date} onValueChange={(_update) => {}}/>);
 
     expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
-    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Please provide a valid date');
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Please provide a valid month and/or year');
   });
   it('does not show invalid message for partial date', () => {
     const date = {

--- a/test/common/utils/helpers.unit.spec.js
+++ b/test/common/utils/helpers.unit.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { isActivePage } from '../../../src/js/common/utils/helpers.js';
+import { isActivePage, dateToMoment } from '../../../src/js/common/utils/helpers.js';
 
 describe('Helpers unit tests', () => {
   describe('isActivePage', () => {
@@ -57,6 +57,41 @@ describe('Helpers unit tests', () => {
       const result = isActivePage(page, data);
 
       expect(result).to.be.true;
+    });
+  });
+  describe('dateToMoment', () => {
+    it('should convert date to moment', () => {
+      const date = dateToMoment({
+        month: {
+          value: 2
+        },
+        day: {
+          value: 3
+        },
+        year: {
+          value: '1901'
+        }
+      });
+
+      expect(date.isValid()).to.be.true;
+      expect(date.year()).to.equal(1901);
+      expect(date.month()).to.equal(1);
+      expect(date.date()).to.equal(3);
+    });
+    it('should convert partial date to moment', () => {
+      const date = dateToMoment({
+        month: {
+          value: 2
+        },
+        year: {
+          value: '1901'
+        }
+      });
+
+      expect(date.isValid()).to.be.true;
+      expect(date.year()).to.equal(1901);
+      expect(date.month()).to.equal(1);
+      expect(date.date()).to.equal(1);
     });
   });
 });

--- a/test/common/utils/validations.unit.spec.js
+++ b/test/common/utils/validations.unit.spec.js
@@ -10,7 +10,9 @@ import {
   isValidMonetaryValue,
   isValidDateOver17,
   isValidPartialDate,
-  validateCustomFormComponent
+  validateCustomFormComponent,
+  isValidMonthYear,
+  isValidMonthYearInPast
 } from '../../../src/js/common/utils/validations.js';
 
 describe('Validations unit tests', () => {
@@ -210,6 +212,28 @@ describe('Validations unit tests', () => {
       ];
 
       expect(validateCustomFormComponent(validation)).to.equal(validation[1]);
+    });
+  });
+  describe('isValidMonthYear', () => {
+    it('should validate month and year', () => {
+      expect(isValidMonthYear('2', moment().add(5, 'year').year())).to.be.true;
+    });
+    it('should not validate bad year', () => {
+      expect(isValidMonthYear('2', '2500')).to.be.false;
+    });
+    it('should not validate bad month', () => {
+      expect(isValidMonthYear(20, 2001)).to.be.false;
+    });
+  });
+  describe('isValidMonthYearInPast', () => {
+    it('should validate month and year in past', () => {
+      expect(isValidMonthYearInPast('2', '2001')).to.be.true;
+    });
+    it('should validate month and year that is current', () => {
+      expect(isValidMonthYearInPast(moment().month(), moment().year())).to.be.true;
+    });
+    it('should not validate month and year that is in the future', () => {
+      expect(isValidMonthYearInPast('2', moment().add(2, 'year').year())).to.be.false;
     });
   });
 });

--- a/test/common/utils/validations.unit.spec.js
+++ b/test/common/utils/validations.unit.spec.js
@@ -11,8 +11,8 @@ import {
   isValidDateOver17,
   isValidPartialDate,
   validateCustomFormComponent,
-  isValidMonthYear,
-  isValidMonthYearInPast
+  isValidPartialMonthYear,
+  isValidPartialMonthYearInPast
 } from '../../../src/js/common/utils/validations.js';
 
 describe('Validations unit tests', () => {
@@ -214,26 +214,26 @@ describe('Validations unit tests', () => {
       expect(validateCustomFormComponent(validation)).to.equal(validation[1]);
     });
   });
-  describe('isValidMonthYear', () => {
+  describe('isValidPartialMonthYear', () => {
     it('should validate month and year', () => {
-      expect(isValidMonthYear('2', moment().add(5, 'year').year())).to.be.true;
+      expect(isValidPartialMonthYear('2', moment().add(5, 'year').year())).to.be.true;
     });
     it('should not validate bad year', () => {
-      expect(isValidMonthYear('2', '2500')).to.be.false;
+      expect(isValidPartialMonthYear('2', '2500')).to.be.false;
     });
     it('should not validate bad month', () => {
-      expect(isValidMonthYear(20, 2001)).to.be.false;
+      expect(isValidPartialMonthYear(20, 2001)).to.be.false;
     });
   });
-  describe('isValidMonthYearInPast', () => {
+  describe('isValidPartialMonthYearInPast', () => {
     it('should validate month and year in past', () => {
-      expect(isValidMonthYearInPast('2', '2001')).to.be.true;
+      expect(isValidPartialMonthYearInPast('2', '2001')).to.be.true;
     });
     it('should validate month and year that is current', () => {
-      expect(isValidMonthYearInPast(moment().month(), moment().year())).to.be.true;
+      expect(isValidPartialMonthYearInPast(moment().month(), moment().year())).to.be.true;
     });
     it('should not validate month and year that is in the future', () => {
-      expect(isValidMonthYearInPast('2', moment().add(2, 'year').year())).to.be.false;
+      expect(isValidPartialMonthYearInPast('2', moment().add(2, 'year').year())).to.be.false;
     });
   });
 });

--- a/test/edu-benefits/components/EducationHistoryFields.unit.spec.jsx
+++ b/test/edu-benefits/components/EducationHistoryFields.unit.spec.jsx
@@ -22,6 +22,6 @@ const makeTree = (_veteran) => {
 describe('<EducationHistoryFields>', () => {
   it('should render question', () => {
     const tree = makeTree();
-    expect(tree.everySubTree('DateInput').length).to.equal(1);
+    expect(tree.everySubTree('ErrorableMonthYear').length).to.equal(1);
   });
 });

--- a/test/edu-benefits/utils/validations.unit.spec.js
+++ b/test/edu-benefits/utils/validations.unit.spec.js
@@ -1,16 +1,20 @@
 import { expect } from 'chai';
+import moment from 'moment';
 
 import {
   isValidContactInformationPage,
   isValidDateRange,
   isValidFutureOrPastDateField,
   isValidPage,
-  isValidRoutingNumber
+  isValidRoutingNumber,
+  isValidMonthYearRange,
+  isValidEducationHistoryPage
 } from '../../../src/js/edu-benefits/utils/validations.js';
 
 import { createVeteran } from '../../../src/js/edu-benefits/utils/veteran.js';
+import { makeField } from '../../../src/js/common/model/fields.js';
 
-describe('Validations unit tests', () => {
+describe('Validation:', () => {
   describe('isValidDateRange', () => {
     it('validates if to date is after from date', () => {
       const fromDate = {
@@ -259,6 +263,190 @@ describe('Validations unit tests', () => {
       };
 
       expect(isValidContactInformationPage(data)).to.be.false;
+    });
+  });
+  describe('isValidMonthYearRange', () => {
+    it('should validate partial range', () => {
+      const fromDate = {
+        month: {
+          value: '2'
+        },
+        year: {
+          value: '2001'
+        }
+      };
+
+      const toDate = {
+        month: {
+          value: '3'
+        },
+        year: {
+          value: ''
+        }
+      };
+
+      expect(isValidMonthYearRange(fromDate, toDate)).to.be.true;
+    });
+    it('should not validate invalid range', () => {
+      const fromDate = {
+        month: {
+          value: '2'
+        },
+        year: {
+          value: '2002'
+        }
+      };
+
+      const toDate = {
+        month: {
+          value: '3'
+        },
+        year: {
+          value: '2001'
+        }
+      };
+
+      expect(isValidMonthYearRange(fromDate, toDate)).to.be.false;
+    });
+    it('should validate same date range', () => {
+      const fromDate = {
+        month: {
+          value: '2'
+        },
+        year: {
+          value: '2001'
+        }
+      };
+
+      const toDate = {
+        month: {
+          value: '2'
+        },
+        year: {
+          value: '2001'
+        }
+      };
+
+      expect(isValidMonthYearRange(fromDate, toDate)).to.be.true;
+    });
+    it('should validate year only range', () => {
+      const fromDate = {
+        month: {
+          value: ''
+        },
+        year: {
+          value: '2001'
+        }
+      };
+
+      const toDate = {
+        month: {
+          value: ''
+        },
+        year: {
+          value: '2002'
+        }
+      };
+
+      expect(isValidMonthYearRange(fromDate, toDate)).to.be.true;
+    });
+  });
+  describe('isValidEducationHistoryPage', () => {
+    it('should validate empty history page fields', () => {
+      const data = {
+        highSchoolOrGedCompletionDate: {
+          month: makeField(''),
+          year: makeField('')
+        },
+        postHighSchoolTrainings: [
+          {
+            dateRange: {
+              from: {
+                month: makeField(''),
+                year: makeField('')
+              },
+              to: {
+                month: makeField(''),
+                year: makeField('')
+              }
+            }
+          }
+        ]
+      };
+
+      expect(isValidEducationHistoryPage(data)).to.be.true;
+    });
+    it('should not validate future completion date', () => {
+      const data = {
+        highSchoolOrGedCompletionDate: {
+          month: makeField(''),
+          year: makeField(moment().add(1, 'year').year())
+        },
+        postHighSchoolTrainings: [
+          {
+            dateRange: {
+              from: {
+                month: makeField(''),
+                year: makeField('')
+              },
+              to: {
+                month: makeField(''),
+                year: makeField('')
+              }
+            }
+          }
+        ]
+      };
+
+      expect(isValidEducationHistoryPage(data)).to.be.false;
+    });
+    it('should not validate bad range', () => {
+      const data = {
+        highSchoolOrGedCompletionDate: {
+          month: makeField(''),
+          year: makeField('')
+        },
+        postHighSchoolTrainings: [
+          {
+            dateRange: {
+              from: {
+                month: makeField(''),
+                year: makeField('2001')
+              },
+              to: {
+                month: makeField(''),
+                year: makeField('2000')
+              }
+            }
+          }
+        ]
+      };
+
+      expect(isValidEducationHistoryPage(data)).to.be.false;
+    });
+    it('should not validate future range', () => {
+      const data = {
+        highSchoolOrGedCompletionDate: {
+          month: makeField(''),
+          year: makeField('')
+        },
+        postHighSchoolTrainings: [
+          {
+            dateRange: {
+              from: {
+                month: makeField(''),
+                year: makeField('2001')
+              },
+              to: {
+                month: makeField(''),
+                year: makeField(moment().add(1, 'year').year())
+              }
+            }
+          }
+        ]
+      };
+
+      expect(isValidEducationHistoryPage(data)).to.be.false;
     });
   });
 });

--- a/test/edu-benefits/utils/validations.unit.spec.js
+++ b/test/edu-benefits/utils/validations.unit.spec.js
@@ -9,7 +9,7 @@ import {
   isValidPage,
   isValidRoutingNumber,
   isValidRelinquishedDate,
-  isValidMonthYearRange,
+  isValidPartialMonthYearRange,
   isValidEducationPeriod,
   isValidEducationHistoryPage
 } from '../../../src/js/edu-benefits/utils/validations.js';
@@ -328,7 +328,7 @@ describe('Validation:', () => {
       expect(isValidMilitaryServicePage(data)).to.be.true;
     });
   });
-  describe('isValidMonthYearRange', () => {
+  describe('isValidPartialMonthYearRange', () => {
     it('should validate partial range', () => {
       const fromDate = {
         month: {
@@ -348,7 +348,7 @@ describe('Validation:', () => {
         }
       };
 
-      expect(isValidMonthYearRange(fromDate, toDate)).to.be.true;
+      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.true;
     });
     it('should not validate invalid range', () => {
       const fromDate = {
@@ -369,7 +369,7 @@ describe('Validation:', () => {
         }
       };
 
-      expect(isValidMonthYearRange(fromDate, toDate)).to.be.false;
+      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.false;
     });
     it('should validate same date range', () => {
       const fromDate = {
@@ -390,7 +390,7 @@ describe('Validation:', () => {
         }
       };
 
-      expect(isValidMonthYearRange(fromDate, toDate)).to.be.true;
+      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.true;
     });
     it('should validate year only range', () => {
       const fromDate = {
@@ -411,7 +411,7 @@ describe('Validation:', () => {
         }
       };
 
-      expect(isValidMonthYearRange(fromDate, toDate)).to.be.true;
+      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.true;
     });
   });
   describe('isValidEducationPeriod', () => {

--- a/test/edu-benefits/utils/veteran.unit.spec.js
+++ b/test/edu-benefits/utils/veteran.unit.spec.js
@@ -46,14 +46,24 @@ describe('veteranToApplication', () => {
     formData.toursOfDuty.push({
       serviceBranch: makeField('army'),
       fromDate: {
-        month: makeField('9'),
-        day: makeField(''),
+        month: makeField(''),
+        day: makeField('6'),
         year: makeField('1996')
       }
     });
     const applicationData = JSON.parse(veteranToApplication(formData));
 
-    expect(applicationData.toursOfDuty[0].fromDate).to.equal('1996-09-XX');
+    expect(applicationData.toursOfDuty[0].fromDate).to.equal('1996-XX-06');
+  });
+  it('converts month year dates to iso', () => {
+    const formData = createVeteran();
+    formData.highSchoolOrGedCompletionDate = {
+      month: makeField('4'),
+      year: makeField('1996')
+    };
+    const applicationData = JSON.parse(veteranToApplication(formData));
+
+    expect(applicationData.highSchoolOrGedCompletionDate).to.equal('1996-04-XX');
   });
   it('converts date ranges to iso', () => {
     const formData = createVeteran();

--- a/test/util/edu-helpers.js
+++ b/test/util/edu-helpers.js
@@ -82,12 +82,10 @@ const testValues = {
       state: 'NY',
       fromDate: {
         month: 'May',
-        day: '2',
         year: '1996'
       },
       toDate: {
         month: 'May',
-        day: '2',
         year: '1999'
       },
       hours: '9',
@@ -283,14 +281,10 @@ function completeEducationHistory(client, data, onlyRequiredFields) {
       .setValue('select[name="state"]', data.educationPeriods[0].state)
       .clearValue('select[name="fromDateMonth"]')
       .setValue('select[name="fromDateMonth"]', data.educationPeriods[0].fromDate.month)
-      .clearValue('select[name="fromDateDay"]')
-      .setValue('select[name="fromDateDay"]', data.educationPeriods[0].fromDate.day)
       .clearValue('input[name="fromDateYear"]')
       .setValue('input[name="fromDateYear"]', data.educationPeriods[0].fromDate.year)
       .clearValue('select[name="toDateMonth"]')
       .setValue('select[name="toDateMonth"]', data.educationPeriods[0].toDate.month)
-      .clearValue('select[name="toDateDay"]')
-      .setValue('select[name="toDateDay"]', data.educationPeriods[0].toDate.day)
       .clearValue('input[name="toDateYear"]')
       .setValue('input[name="toDateYear"]', data.educationPeriods[0].toDate.year)
       .clearValue('input[name="hours"]')


### PR DESCRIPTION
Closes #4085

This updates the fields listed in the above issue to be allow partial dates as required. It also converts some dates to a new month/year component. Most of the work here is updating validation; the other changes are largely the copy and pasted month year component and tests.

![screen shot 2016-12-09 at 12 28 38 pm](https://cloud.githubusercontent.com/assets/634932/21058239/15aa20c8-be0b-11e6-9ddd-c6075bf91d24.png)
![screen shot 2016-12-09 at 12 28 52 pm](https://cloud.githubusercontent.com/assets/634932/21058238/15a52b04-be0b-11e6-91fb-15481480919f.png)
![screen shot 2016-12-09 at 12 24 17 pm](https://cloud.githubusercontent.com/assets/634932/21058102/724c4460-be0a-11e6-8926-5ff14df7dfb4.png)
![screen shot 2016-12-09 at 12 25 26 pm](https://cloud.githubusercontent.com/assets/634932/21058131/9b530506-be0a-11e6-83c0-aa85f7065890.png)
