### PR TITLE
Make notification close button transparent

### DIFF
--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -669,6 +669,7 @@ h6.claims-turnedin-file-header {
 }
 
 .notification-close {
+  background-color: transparent;
   @media (max-width: $small-screen) {
     margin: -5px 5px 0 0;
     width: 0;


### PR DESCRIPTION
Related to [259](https://github.com/department-of-veterans-affairs/sunsets-team/issues/259)

Make the close icon background not blue.

![screen shot 2016-12-09 at 3 33 39 pm](https://cloud.githubusercontent.com/assets/634932/21063700/0eb12de2-be25-11e6-84ae-84f02a3e3f1d.png)
