### PR TITLE
Use darker red for past due text on claim status

### DIFF
--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -39,7 +39,7 @@
   }
 
   > .past-due {
-    color: $color-secondary-dark;
+    color: $color-secondary-darkest;
     font-size: 0.9em;
   }
 


### PR DESCRIPTION
Related to [260](https://github.com/department-of-veterans-affairs/sunsets-team/issues/260)

![screen shot 2016-12-12 at 1 04 49 pm](https://cloud.githubusercontent.com/assets/634932/21110557/a354cad8-c06b-11e6-9238-9d6d18faefd8.png)
![screen shot 2016-12-12 at 12 49 47 pm](https://cloud.githubusercontent.com/assets/634932/21110558/a35b35c6-c06b-11e6-934e-daf384acae40.png)
