### PR TITLE
Fix two digit year validation on education range

### DIFF
--- a/src/js/edu-benefits/utils/helpers.js
+++ b/src/js/edu-benefits/utils/helpers.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import moment from 'moment';
 
 import { dateToMoment } from '../../common/utils/helpers';
 
@@ -41,12 +42,12 @@ function formatYear(val) {
     return 'XXXX';
   }
 
-  const year = Number(val.replace(/[^\d]/g, ''));
-  if (isNaN(year)) {
+  const yearDate = moment(val, 'YYYY');
+  if (!yearDate.isValid()) {
     return 'XXXX';
   }
 
-  return year.toString();
+  return yearDate.format('YYYY');
 }
 
 export function formatPartialDate(field) {

--- a/src/js/edu-benefits/utils/validations.js
+++ b/src/js/edu-benefits/utils/validations.js
@@ -291,7 +291,7 @@ function isValidEmploymentHistoryPage(data) {
 }
 
 function isValidEducationPeriod(data) {
-  return isValidDateRange(data.dateRange.from, data.dateRange.to);
+  return isValidDateField(data.dateRange.from) && isValidDateField(data.dateRange.to) && isValidDateRange(data.dateRange.from, data.dateRange.to);
 }
 
 function isValidEducationHistoryPage(data) {
@@ -445,5 +445,6 @@ export {
   isValidRelinquishedDate,
   isValidTourOfDuty,
   isValidEmploymentPeriod,
-  isValidRotcScholarshipAmount
+  isValidRotcScholarshipAmount,
+  isValidEducationPeriod
 };

--- a/src/js/edu-benefits/utils/validations.js
+++ b/src/js/edu-benefits/utils/validations.js
@@ -291,7 +291,9 @@ function isValidEmploymentHistoryPage(data) {
 }
 
 function isValidEducationPeriod(data) {
-  return isValidDateField(data.dateRange.from) && isValidDateField(data.dateRange.to) && isValidDateRange(data.dateRange.from, data.dateRange.to);
+  return (isBlankDateField(data.dateRange.from) || isValidDateField(data.dateRange.from))
+    && (isBlankDateField(data.dateRange.to) || isValidDateField(data.dateRange.to))
+    && isValidDateRange(data.dateRange.from, data.dateRange.to);
 }
 
 function isValidEducationHistoryPage(data) {

--- a/test/edu-benefits/utils/helpers.unit.spec.js
+++ b/test/edu-benefits/utils/helpers.unit.spec.js
@@ -79,5 +79,14 @@ describe('edu helpers:', () => {
 
       expect(formatPartialDate(date)).to.be.undefined;
     });
+    it('should format a partial year', () => {
+      const date = {
+        month: makeField('12'),
+        day: makeField('31'),
+        year: makeField('96')
+      };
+
+      expect(formatPartialDate(date)).to.equal('1996-12-31');
+    });
   });
 });

--- a/test/edu-benefits/utils/validations.unit.spec.js
+++ b/test/edu-benefits/utils/validations.unit.spec.js
@@ -8,7 +8,8 @@ import {
   isValidFutureOrPastDateField,
   isValidPage,
   isValidRoutingNumber,
-  isValidRelinquishedDate
+  isValidRelinquishedDate,
+  isValidEducationPeriod
 } from '../../../src/js/edu-benefits/utils/validations.js';
 
 import { createVeteran } from '../../../src/js/edu-benefits/utils/veteran.js';
@@ -322,6 +323,38 @@ describe('Validations unit tests', () => {
       };
 
       expect(isValidMilitaryServicePage(data)).to.be.true;
+    });
+  });
+  describe('isValidEducationPeriod', () => {
+    it('should not validate bad date range', () => {
+      const data = {
+        dateRange: {
+          from: {
+            month: {
+              value: '6'
+            },
+            year: {
+              value: '96'
+            },
+            day: {
+              value: ''
+            }
+          },
+          to: {
+            month: {
+              value: '5'
+            },
+            year: {
+              value: '97'
+            },
+            day: {
+              value: ''
+            }
+          }
+        }
+      };
+
+      expect(isValidEducationPeriod(data)).to.be.false;
     });
   });
 });


### PR DESCRIPTION
Closes #4334.

There were two failures for the above validation issue. 1) We were not properly validating the education period and 2) the date formatting was passing two digit years through. This fixes both.