### PR TITLE
Reduced padding for .messaging-notice-box.

### DIFF
--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -160,11 +160,7 @@
 
 .messaging-notice-box {
   background: $color-primary-alt-lightest;
-  padding: 1.5rem 2rem;
-
-  @media (max-width: $medium-screen) {
-    padding: 1.5rem 5rem;
-  }
+  padding: 1.5rem;
 
   i {
     width: 3rem;


### PR DESCRIPTION
- Removed @media query in favor of same amount of padding for every breakpoint
- Closes department-of-veterans-affairs/messaging-fe#188