### PR TITLE
Adding GA events to actions for secure messaging

### DIFF
--- a/src/js/messaging/actions/compose.js
+++ b/src/js/messaging/actions/compose.js
@@ -12,6 +12,9 @@ import {
 import { apiRequest } from '../utils/helpers';
 
 export function deleteComposeMessage() {
+  window.dataLayer.push({
+    event: 'sm-delete-compose',
+  });
   return { type: DELETE_COMPOSE_MESSAGE };
 }
 
@@ -24,6 +27,9 @@ export function setMessageField(path, field) {
 }
 
 export function addComposeAttachments(files) {
+  window.dataLayer.push({
+    event: 'sm-add-attachment',
+  });
   return {
     type: ADD_COMPOSE_ATTACHMENTS,
     files

--- a/src/js/messaging/actions/folders.js
+++ b/src/js/messaging/actions/folders.js
@@ -93,6 +93,10 @@ export function createNewFolder(folderName) {
     body: JSON.stringify(folderData)
   };
 
+  window.dataLayer.push({
+    event: 'sm-create-folder',
+  });
+
   return dispatch => {
     dispatch({ type: CREATING_FOLDER });
 

--- a/src/js/messaging/actions/messages.js
+++ b/src/js/messaging/actions/messages.js
@@ -34,6 +34,9 @@ import {
 const baseUrl = '/messages';
 
 export function addDraftAttachments(files) {
+  window.dataLayer.push({
+    event: 'sm-add-attachment',
+  });
   return { type: ADD_DRAFT_ATTACHMENTS, files };
 }
 
@@ -47,6 +50,10 @@ export function deleteDraftAttachment(index) {
 
 export function deleteMessage(id) {
   const url = `${baseUrl}/${id}`;
+
+  window.dataLayer.push({
+    event: 'sm-delete-message',
+  });
 
   return dispatch => {
     dispatch({ type: DELETING_MESSAGE });
@@ -105,6 +112,10 @@ export function moveMessageToFolder(messageId, folder) {
   const folderId = folder.folderId;
   const url = `${baseUrl}/${messageId}/move?folder_id=${folderId}`;
 
+  window.dataLayer.push({
+    event: 'sm-move-message',
+  });
+
   return dispatch => {
     dispatch({ type: MOVING_MESSAGE });
 
@@ -126,6 +137,10 @@ export function createFolderAndMoveMessage(folderName, messageId) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(folderData)
   };
+
+  window.dataLayer.push({
+    event: 'sm-move-message',
+  });
 
   return dispatch => {
     dispatch({ type: MOVING_MESSAGE });
@@ -169,6 +184,10 @@ export function saveDraft(message) {
     url = `${url}/${message.messageId}`;
     method = 'PUT';
   }
+
+  window.dataLayer.push({
+    event: 'sm-save-draft',
+  });
 
   const settings = {
     method,
@@ -221,6 +240,11 @@ export function sendMessage(message) {
   // Add each attachment as a separate item
   message.attachments.forEach((file) => {
     payload.append('uploads[]', file);
+  });
+
+  window.dataLayer.push({
+    event: 'sm-send-message',
+    has_additional_subject: message.subject.length > 0,
   });
 
   const settings = {

--- a/src/js/messaging/actions/messages.js
+++ b/src/js/messaging/actions/messages.js
@@ -244,7 +244,7 @@ export function sendMessage(message) {
 
   window.dataLayer.push({
     event: 'sm-send-message',
-    has_additional_subject: message.subject.length > 0,
+    hasAdditionalSubject: message.subject.length > 0,
   });
 
   const settings = {


### PR DESCRIPTION
Per analytics conversation. These are the ones in the spreadsheet that need to be done via custom events (from what I could see). Actions seemed most natural spot for them but welcome your thoughts.

@U-DON definitely take a look at the send message one. Alex wanted to track if there was an additional subject entered so i think the extra field added there would capture it, but definitely welcome your thoughts on that one.