### PR TITLE
Fix edu form error with missing to date

### DIFF
--- a/src/js/edu-benefits/utils/helpers.js
+++ b/src/js/edu-benefits/utils/helpers.js
@@ -51,7 +51,7 @@ function formatYear(val) {
 }
 
 export function formatPartialDate(field) {
-  if (!field.month.value && !field.year.value) {
+  if (!field || (!field.month.value && !field.year.value)) {
     return undefined;
   }
 

--- a/src/js/edu-benefits/utils/veteran.js
+++ b/src/js/edu-benefits/utils/veteran.js
@@ -280,6 +280,10 @@ export function veteranToApplication(veteran) {
         // fall through.
     }
 
+    if (typeof value === 'undefined') {
+      return undefined;
+    }
+
     if (value.month !== undefined && value.year !== undefined) {
       return formatPartialDate(value);
     }

--- a/test/edu-benefits/utils/helpers.unit.spec.js
+++ b/test/edu-benefits/utils/helpers.unit.spec.js
@@ -79,6 +79,9 @@ describe('edu helpers:', () => {
 
       expect(formatPartialDate(date)).to.be.undefined;
     });
+    it('should return undefined for undefined date', () => {
+      expect(formatPartialDate()).to.be.undefined;
+    });
     it('should format a partial year', () => {
       const date = {
         month: makeField('12'),

--- a/test/edu-benefits/utils/veteran.unit.spec.js
+++ b/test/edu-benefits/utils/veteran.unit.spec.js
@@ -108,6 +108,28 @@ describe('veteranToApplication', () => {
 
     expect(applicationData.toursOfDuty[0].dateRange).to.be.undefined;
   });
+  it('removes partially empty date ranges', () => {
+    const formData = createVeteran();
+    formData.toursOfDuty.push({
+      serviceBranch: makeField('army'),
+      dateRange: {
+        to: {
+          month: makeField(''),
+          day: makeField(''),
+          year: makeField('')
+        },
+        from: {
+          month: makeField('5'),
+          day: makeField('5'),
+          year: makeField('2001')
+        }
+      }
+    });
+    const applicationData = JSON.parse(veteranToApplication(formData));
+
+    expect(applicationData.toursOfDuty[0].dateRange.to).to.be.undefined;
+    expect(applicationData.toursOfDuty[0].dateRange.from).not.to.be.undefined;
+  });
   it('converts yes/no fields to booleans', () => {
     const formData = createVeteran();
     formData.serviceBefore1977.married.value = 'Y';


### PR DESCRIPTION
If you leave the to field empty on a date range, we're passing an undefined value into the json stringify function in veteranToApplication, which causes an error. This adds a check to avoid that.