### PR TITLE
Make background of usa-button-outline transparent. Closes #4332.

### DIFF
--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -164,9 +164,24 @@ input:focus:-ms-input-placeholder {
   color: transparent;
 }
 
-// TODO(crew): Remove this at some point. Fix this by using JS for title casing or passing nav labels as an object.
-.text-capitalize {
-  text-transform: capitalize;
+.usa-button,
+.usa-button-primary,
+.usa-button:visited,
+.usa-button-primary:visited,
+button,
+[type='button'],
+[type='submit'],
+[type='reset'],
+[type='image'] {
+  // TODO(crew): Remove this at some point. Fix this by using JS for title casing or passing nav labels as an object.
+  &.text-capitalize {
+    text-transform: capitalize;
+  }
+}
+
+.usa-button-outline.transparent,
+.usa-button-outline.transparent:hover {
+  background-color: rgba(0,0,0,0);
 }
 
 input.va-input-medium-large {
@@ -208,6 +223,41 @@ a[href^=http] {
   background-image: none;
   // TODO: clean up #content .main.interior a then remove !important
   text-decoration: none !important;
+}
+// Option for adding exit-icon to ghost buttons
+.usa-button-outline-exit.usa-button-primary[href^=http]{
+  &::after {
+    background-image: url(/img/icons/exit-icon-primary.png);
+    background-size: 1em auto;
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    // Content must have a decender in it
+    content: "leave vets.gov";
+    background-repeat: no-repeat;
+    background-position: top center;
+    margin-left: .3em;
+    text-indent: -9999em;
+    padding-right: 1.1em;
+  }
+  &.warn-exit{
+    color: $color-secondary-darkest;
+    box-shadow: inset 0 0 0 2px $color-secondary-darkest;
+    &::after {
+      background-image: url(/img/icons/exit-icon-warn.png);
+    }
+    &:hover{
+      color: darken($color-secondary-darkest, 5%);
+      box-shadow: inset 0 0 0 2px darken($color-secondary-darkest, 5%);
+      &::after {
+        background-image: url(/img/icons/exit-icon-warn.png);
+      }
+    }
+  }
+}
+
+.usa-button-outline-exit.usa-button-primary[href^=http]:hover::after {
+  background-image: url(/img/icons/exit-icon-primary-darker.png);
 }
 
 // Logo and Header
@@ -1905,7 +1955,6 @@ li.twenty:before {content: '20';}
 .usa-accordion-content[aria-hidden=true] {
     display: none !important;
 }
-
 button[class*='usa-button-'] {
   font-weight:500;
   span {
@@ -1914,6 +1963,7 @@ button[class*='usa-button-'] {
 }
 
 // Disclaimer
+
 .disclaimer {
   padding: 1em 0;
   border-top: 1px solid #ddd;

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -1903,13 +1903,6 @@ li.twenty:before {content: '20';}
     display: none !important;
 }
 
-button[class*='usa-button-'] {
-  font-weight:500;
-  span {
-    font-weight:700
-  }
-}
-
 // Disclaimer
 .disclaimer {
   padding: 1em 0;

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -164,21 +164,6 @@ input:focus:-ms-input-placeholder {
   color: transparent;
 }
 
-.usa-button,
-.usa-button-primary,
-.usa-button:visited,
-.usa-button-primary:visited,
-button,
-[type='button'],
-[type='submit'],
-[type='reset'],
-[type='image'] {
-  // TODO(crew): Remove this at some point. Fix this by using JS for title casing or passing nav labels as an object.
-  &.text-capitalize {
-    text-transform: capitalize;
-  }
-}
-
 input.va-input-medium-large {
   max-width: 18rem;
 }

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -164,24 +164,9 @@ input:focus:-ms-input-placeholder {
   color: transparent;
 }
 
-.usa-button,
-.usa-button-primary,
-.usa-button:visited,
-.usa-button-primary:visited,
-button,
-[type='button'],
-[type='submit'],
-[type='reset'],
-[type='image'] {
-  // TODO(crew): Remove this at some point. Fix this by using JS for title casing or passing nav labels as an object.
-  &.text-capitalize {
-    text-transform: capitalize;
-  }
-}
-
-.usa-button-outline.transparent,
-.usa-button-outline.transparent:hover {
-  background-color: rgba(0,0,0,0);
+// TODO(crew): Remove this at some point. Fix this by using JS for title casing or passing nav labels as an object.
+.text-capitalize {
+  text-transform: capitalize;
 }
 
 input.va-input-medium-large {
@@ -223,41 +208,6 @@ a[href^=http] {
   background-image: none;
   // TODO: clean up #content .main.interior a then remove !important
   text-decoration: none !important;
-}
-// Option for adding exit-icon to ghost buttons
-.usa-button-outline-exit.usa-button-primary[href^=http]{
-  &::after {
-    background-image: url(/img/icons/exit-icon-primary.png);
-    background-size: 1em auto;
-    display: inline-block;
-    width: 1em;
-    height: 1em;
-    // Content must have a decender in it
-    content: "leave vets.gov";
-    background-repeat: no-repeat;
-    background-position: top center;
-    margin-left: .3em;
-    text-indent: -9999em;
-    padding-right: 1.1em;
-  }
-  &.warn-exit{
-    color: $color-secondary-darkest;
-    box-shadow: inset 0 0 0 2px $color-secondary-darkest;
-    &::after {
-      background-image: url(/img/icons/exit-icon-warn.png);
-    }
-    &:hover{
-      color: darken($color-secondary-darkest, 5%);
-      box-shadow: inset 0 0 0 2px darken($color-secondary-darkest, 5%);
-      &::after {
-        background-image: url(/img/icons/exit-icon-warn.png);
-      }
-    }
-  }
-}
-
-.usa-button-outline-exit.usa-button-primary[href^=http]:hover::after {
-  background-image: url(/img/icons/exit-icon-primary-darker.png);
 }
 
 // Logo and Header
@@ -1955,6 +1905,7 @@ li.twenty:before {content: '20';}
 .usa-accordion-content[aria-hidden=true] {
     display: none !important;
 }
+
 button[class*='usa-button-'] {
   font-weight:500;
   span {
@@ -1963,7 +1914,6 @@ button[class*='usa-button-'] {
 }
 
 // Disclaimer
-
 .disclaimer {
   padding: 1em 0;
   border-top: 1px solid #ddd;

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -189,7 +189,10 @@ hr {
 
 // Adds external icon to all links that begin
 // with http (including https)
-a[href^=http] {
+// Using this selector makes it easier for the content team to write content
+// TODO: Refine this so that any links that do begin with https://vets.gov
+// or https://www.vets.gov are excluded.
+[href^=http] {
   // Using longhand properties instead of the shorthand to limit
   // risk and impact of side effects
   background-image: url(/img/icons/exit-icon.png);
@@ -197,47 +200,6 @@ a[href^=http] {
   background-repeat: no-repeat;
   background-size: 1em auto;
   padding-right: 1.2em;
-}
-
-.usa-button-primary[href^=http] {
-  background-image: none;
-  // TODO: clean up #content .main.interior a then remove !important
-  text-decoration: none !important;
-}
-// Option for adding exit-icon to ghost buttons
-.usa-button-outline-exit.usa-button-primary[href^=http]{
-  &::after {
-    background-image: url(/img/icons/exit-icon-primary.png);
-    background-size: 1em auto;
-    display: inline-block;
-    width: 1em;
-    height: 1em;
-    // Content must have a decender in it
-    content: "leave vets.gov";
-    background-repeat: no-repeat;
-    background-position: top center;
-    margin-left: .3em;
-    text-indent: -9999em;
-    padding-right: 1.1em;
-  }
-  &.warn-exit{
-    color: $color-secondary-darkest;
-    box-shadow: inset 0 0 0 2px $color-secondary-darkest;
-    &::after {
-      background-image: url(/img/icons/exit-icon-warn.png);
-    }
-    &:hover{
-      color: darken($color-secondary-darkest, 5%);
-      box-shadow: inset 0 0 0 2px darken($color-secondary-darkest, 5%);
-      &::after {
-        background-image: url(/img/icons/exit-icon-warn.png);
-      }
-    }
-  }
-}
-
-.usa-button-outline-exit.usa-button-primary[href^=http]:hover::after {
-  background-image: url(/img/icons/exit-icon-primary-darker.png);
 }
 
 // Logo and Header

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -179,11 +179,6 @@ button,
   }
 }
 
-.usa-button-outline.transparent,
-.usa-button-outline.transparent:hover {
-  background-color: rgba(0,0,0,0);
-}
-
 input.va-input-medium-large {
   max-width: 18rem;
 }

--- a/src/sass/hca.scss
+++ b/src/sass/hca.scss
@@ -132,6 +132,10 @@ button.hca-button-disabled {
   }
 }
 
+.text-capitalize {
+  text-transform: capitalize;
+}
+
 .hca-tooltip {
   max-width: 46rem;
   width: 100%;
@@ -145,6 +149,3 @@ button.hca-button-disabled {
   }
 }
 
-.progress-box button.usa-button-outline {
-  font-weight: 500;
-}

--- a/src/sass/hca.scss
+++ b/src/sass/hca.scss
@@ -50,27 +50,6 @@ button.short {
   padding: 1rem;
 }
 
-button.usa-button-outline {
-  box-shadow: $button-stroke $color-primary;
-
-  &:hover,
-  &.usa-button-hover {
-    box-shadow: $button-stroke $color-primary-darker;
-    color: $color-primary-darker;
-  }
-
-  &:active,
-  &.usa-button-active {
-    box-shadow: $button-stroke $color-primary-darkest;
-    color: $color-primary-darkest;
-  }
-
-  &:focus,
-  &.usa-button-focus {
-    box-shadow: $button-stroke $color-primary-darkest, $focus-shadow;
-  }
-}
-
 button.hca-button-green {
   background: $color-green;
 }

--- a/src/sass/hca.scss
+++ b/src/sass/hca.scss
@@ -132,10 +132,6 @@ button.hca-button-disabled {
   }
 }
 
-.text-capitalize {
-  text-transform: capitalize;
-}
-
 .hca-tooltip {
   max-width: 46rem;
   width: 100%;

--- a/src/sass/hca.scss
+++ b/src/sass/hca.scss
@@ -144,7 +144,3 @@ button.hca-button-disabled {
     text-align: left;
   }
 }
-
-.progress-box button.usa-button-outline {
-  font-weight: 500;
-}

--- a/src/sass/hca.scss
+++ b/src/sass/hca.scss
@@ -132,10 +132,6 @@ button.hca-button-disabled {
   }
 }
 
-.text-capitalize {
-  text-transform: capitalize;
-}
-
 .hca-tooltip {
   max-width: 46rem;
   width: 100%;
@@ -149,3 +145,6 @@ button.hca-button-disabled {
   }
 }
 
+.progress-box button.usa-button-outline {
+  font-weight: 500;
+}

--- a/src/sass/modules/_m-button.scss
+++ b/src/sass/modules/_m-button.scss
@@ -17,7 +17,16 @@ button,
 }
 
 .usa-button-disabled {
-    background-color: $color-gray-lighter;
+  background-color: $color-gray-lighter;
+}
+
+// Overrides USWDS selector
+button.usa-button-outline,
+[type=button].usa-button-outline,
+[type=submit].usa-button-outline,
+[type=reset].usa-button-outline {
+  background-color: transparent;
+  font-weight: bold;
 }
 
 .row.form-progress-buttons {
@@ -37,32 +46,6 @@ button i.fa {
 button.short {
   font-weight: 500;
   padding: 1rem;
-}
-
-button.usa-button-outline {
-  box-shadow: $button-stroke $color-primary;
-
-  &:hover,
-  &.usa-button-hover {
-    box-shadow: $button-stroke $color-primary-darker;
-    color: $color-primary-darker;
-  }
-
-  &:active,
-  &.usa-button-active {
-    box-shadow: $button-stroke $color-primary-darkest;
-    color: $color-primary-darkest;
-  }
-
-  &:focus,
-  &.usa-button-focus {
-    box-shadow: $button-stroke $color-primary-darkest, $focus-shadow;
-  }
-
-  &.va-button-warn {
-    box-shadow: $button-stroke $color-secondary-darkest;
-    color: $color-secondary-darkest;
-  }
 }
 
 // For links and buttons that look like links and have an icon.

--- a/src/sass/modules/_m-button.scss
+++ b/src/sass/modules/_m-button.scss
@@ -39,32 +39,6 @@ button.short {
   padding: 1rem;
 }
 
-button.usa-button-outline {
-  box-shadow: $button-stroke $color-primary;
-
-  &:hover,
-  &.usa-button-hover {
-    box-shadow: $button-stroke $color-primary-darker;
-    color: $color-primary-darker;
-  }
-
-  &:active,
-  &.usa-button-active {
-    box-shadow: $button-stroke $color-primary-darkest;
-    color: $color-primary-darkest;
-  }
-
-  &:focus,
-  &.usa-button-focus {
-    box-shadow: $button-stroke $color-primary-darkest, $focus-shadow;
-  }
-
-  &.va-button-warn {
-    box-shadow: $button-stroke $color-secondary-darkest;
-    color: $color-secondary-darkest;
-  }
-}
-
 // For links and buttons that look like links and have an icon.
 .va-icon-link,
 .va-icon-link[type="button"] {

--- a/src/sass/modules/_m-button.scss
+++ b/src/sass/modules/_m-button.scss
@@ -17,16 +17,7 @@ button,
 }
 
 .usa-button-disabled {
-  background-color: $color-gray-lighter;
-}
-
-// Overrides USWDS selector
-button.usa-button-outline,
-[type=button].usa-button-outline,
-[type=submit].usa-button-outline,
-[type=reset].usa-button-outline {
-  background-color: transparent;
-  font-weight: bold;
+    background-color: $color-gray-lighter;
 }
 
 .row.form-progress-buttons {
@@ -46,6 +37,32 @@ button i.fa {
 button.short {
   font-weight: 500;
   padding: 1rem;
+}
+
+button.usa-button-outline {
+  box-shadow: $button-stroke $color-primary;
+
+  &:hover,
+  &.usa-button-hover {
+    box-shadow: $button-stroke $color-primary-darker;
+    color: $color-primary-darker;
+  }
+
+  &:active,
+  &.usa-button-active {
+    box-shadow: $button-stroke $color-primary-darkest;
+    color: $color-primary-darkest;
+  }
+
+  &:focus,
+  &.usa-button-focus {
+    box-shadow: $button-stroke $color-primary-darkest, $focus-shadow;
+  }
+
+  &.va-button-warn {
+    box-shadow: $button-stroke $color-secondary-darkest;
+    color: $color-secondary-darkest;
+  }
 }
 
 // For links and buttons that look like links and have an icon.

--- a/src/sass/modules/_m-button.scss
+++ b/src/sass/modules/_m-button.scss
@@ -8,16 +8,45 @@ button,
 [type="reset"],
 [type="image"] {
   background-color: $color-primary;
+
+  &.usa-button-outline {
+    background: transparent;
+  }
 }
 
 .usa-button-primary {
   &:hover {
-    background-color: $color-primary-darker;
+    // background-color: $color-primary-darker;
+  } 
+  &[href^=http] {
+    background-image: none;
+    // TODO: clean up #content .main.interior a then remove !important
+    text-decoration: none !important;
+  }
+}
+
+.usa-button-outline-exit {
+  &::after {
+    background-image: url(/img/icons/exit-icon-primary.png);
+    background-size: 1em auto;
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    // Content must have a decender in it
+    content: "leave vets.gov";
+    background-repeat: no-repeat;
+    background-position: top center;
+    margin-left: .3em;
+    text-indent: -9999em;
+    padding-right: 1.1em;
+  }
+  &:hover::after {
+    background-image: url(/img/icons/exit-icon-primary-darker.png);
   }
 }
 
 .usa-button-disabled {
-    background-color: $color-gray-lighter;
+  background-color: $color-gray-lighter;
 }
 
 .row.form-progress-buttons {

--- a/src/sass/modules/_m-modal.scss
+++ b/src/sass/modules/_m-modal.scss
@@ -117,10 +117,6 @@
     background-size: 1em auto;
     padding-right: 1.2em;
   }
-
-  .usa-button-outline:hover {
-    background: transparent !important;
-  }
 }
 
 .va-modal button {

--- a/src/sass/modules/_m-modal.scss
+++ b/src/sass/modules/_m-modal.scss
@@ -117,6 +117,10 @@
     background-size: 1em auto;
     padding-right: 1.2em;
   }
+
+  .usa-button-outline:hover {
+    background: transparent !important;
+  }
 }
 
 .va-modal button {

--- a/src/sass/rx/partials/_rx-prescriptions.scss
+++ b/src/sass/rx/partials/_rx-prescriptions.scss
@@ -58,9 +58,9 @@
   }
 }
 
+// Because USWDS has high specificity
 button.rx-prescription-button,
 [type=submit].rx-prescription-button {
-  background: transparent;
   display: inline-block;
   font-weight: bold;
   margin: 0;

--- a/src/sass/rx/partials/_rx-prescriptions.scss
+++ b/src/sass/rx/partials/_rx-prescriptions.scss
@@ -60,6 +60,7 @@
 
 button.rx-prescription-button,
 [type=submit].rx-prescription-button {
+  background: transparent;
   display: inline-block;
   font-weight: bold;
   margin: 0;

--- a/src/sass/rx/partials/_rx-prescriptions.scss
+++ b/src/sass/rx/partials/_rx-prescriptions.scss
@@ -60,7 +60,6 @@
 
 button.rx-prescription-button,
 [type=submit].rx-prescription-button {
-  background: transparent;
   display: inline-block;
   font-weight: bold;
   margin: 0;

--- a/src/sass/rx/rx.scss
+++ b/src/sass/rx/rx.scss
@@ -45,12 +45,6 @@ button.usa-button-outline {
   font-weight: bold;
 }
 
-// Enhances a USWDS style that has higher specificity.
-// Do not refactor.
-button.usa-button-outline {
-  font-weight: bold;
-}
-
 .rx-header {
   margin-bottom: 3rem;
 }

--- a/src/sass/rx/rx.scss
+++ b/src/sass/rx/rx.scss
@@ -45,6 +45,12 @@ button.usa-button-outline {
   font-weight: bold;
 }
 
+// Enhances a USWDS style that has higher specificity.
+// Do not refactor.
+button.usa-button-outline {
+  font-weight: bold;
+}
+
 .rx-header {
   margin-bottom: 3rem;
 }


### PR DESCRIPTION
- Removed .text-capitalize from hca.scss.
- Simplified .text-capitalize selector in va.scss
- Removed transparent background from .rx-prescription-button
- Removed .usa-button-outline.transparent styles.
- Removed (unused) .usa-button-outline-exit block.
- Moved button.usa-button-outline from rx to button partial.
- Removed style from modal partial.
- Restoring font-weight: 500 to HCA buttons for now.
