### PR TITLE
Resolves sm#148 message date queries

### DIFF
--- a/src/js/messaging/reducers/search.js
+++ b/src/js/messaging/reducers/search.js
@@ -1,4 +1,5 @@
 import set from 'lodash/fp/set';
+import moment from 'moment';
 
 import { makeField } from '../../common/model/fields';
 
@@ -35,6 +36,9 @@ const initialState = {
 export default function modals(state = initialState, action) {
   switch (action.type) {
     case SET_ADVSEARCH_END_DATE:
+      if (moment(action.date).isSame(state.params.dateRange.start)) {
+        return set('params.dateRange.end', moment(action.date).add(1, 'days'), state);
+      }
       return set('params.dateRange.end', action.date, state);
     case SET_ADVSEARCH_START_DATE:
       return set('params.dateRange.start', action.date, state);

--- a/src/js/messaging/reducers/search.js
+++ b/src/js/messaging/reducers/search.js
@@ -36,10 +36,7 @@ const initialState = {
 export default function modals(state = initialState, action) {
   switch (action.type) {
     case SET_ADVSEARCH_END_DATE:
-      if (moment(action.date).isSame(state.params.dateRange.start)) {
-        return set('params.dateRange.end', moment(action.date).add(1, 'days'), state);
-      }
-      return set('params.dateRange.end', action.date, state);
+      return set('params.dateRange.end', moment(action.date).endOf('day'), state);
     case SET_ADVSEARCH_START_DATE:
       return set('params.dateRange.start', action.date, state);
     case SET_SEARCH_PARAM:

--- a/test/messaging/reducers/search.unit.spec.js
+++ b/test/messaging/reducers/search.unit.spec.js
@@ -40,7 +40,7 @@ describe('search reducer', () => {
     });
 
     expect(newState.params.dateRange.end.toString())
-      .to.eql(today.toString());
+      .to.eql(today.endOf('day').toString());
 
     const weekAgo = today.clone().subtract(1, 'weeks');
     newState = searchReducer(newState, {
@@ -49,7 +49,7 @@ describe('search reducer', () => {
     });
 
     expect(newState.params.dateRange.end.toString())
-      .to.eql(weekAgo.toString());
+      .to.eql(weekAgo.endOf('day').toString());
   });
 
   it('should set start date for advanced search', () => {


### PR DESCRIPTION
- Resolves https://github.com/department-of-veterans-affairs/messaging-fe/issues/148

This PR makes it so that a user selecting the same date for start and end will have the end date incremented by 1 day. If this is confusing, we can also hide this from the user and do it in the action itself.

It seems like we need to always increment the end date by 1 day to have inclusive behavior? i.e. 12-14 to 12-15 returns messages sent on 12-14 AND 12-15