### PR TITLE
[Messaging] Update message counts after moving messages and saving drafts.

### DIFF
--- a/src/js/messaging/actions/messages.js
+++ b/src/js/messaging/actions/messages.js
@@ -105,9 +105,8 @@ export function fetchThreadMessage(messageId) {
   };
 }
 
-export function moveMessageToFolder(messageId, folder) {
-  const folderId = folder.folderId;
-  const url = `${baseUrl}/${messageId}/move?folder_id=${folderId}`;
+export function moveMessageToFolder(messageId, toFolder, fromFolder) {
+  const url = `${baseUrl}/${messageId}/move?folder_id=${toFolder.folderId}`;
 
   window.dataLayer.push({
     event: 'sm-move-message',
@@ -119,13 +118,13 @@ export function moveMessageToFolder(messageId, folder) {
     apiRequest(
       url,
       { method: 'PATCH' },
-      () => dispatch({ type: MOVE_MESSAGE_SUCCESS, folder }),
+      () => dispatch({ type: MOVE_MESSAGE_SUCCESS, toFolder, fromFolder }),
       () => dispatch({ type: MOVE_MESSAGE_FAILURE })
     );
   };
 }
 
-export function createFolderAndMoveMessage(folderName, messageId) {
+export function createFolderAndMoveMessage(folderName, messageId, fromFolder) {
   const foldersUrl = '/folders';
   const folderData = { folder: { name: folderName } };
 
@@ -146,9 +145,13 @@ export function createFolderAndMoveMessage(folderName, messageId) {
       foldersUrl,
       settings,
       (data) => {
-        const folder = data.data.attributes;
-        dispatch({ type: CREATE_FOLDER_SUCCESS, folder, noAlert: true });
-        return dispatch(moveMessageToFolder(messageId, folder));
+        const toFolder = data.data.attributes;
+        dispatch({
+          type: CREATE_FOLDER_SUCCESS,
+          folder: toFolder,
+          noAlert: true
+        });
+        return dispatch(moveMessageToFolder(messageId, toFolder, fromFolder));
       },
       () => dispatch({ type: CREATE_FOLDER_FAILURE })
     );

--- a/src/js/messaging/actions/messages.js
+++ b/src/js/messaging/actions/messages.js
@@ -203,12 +203,17 @@ export function saveDraft(message) {
       settings,
       (response) => {
         if (isSavedDraft) {
-          return dispatch({ type: SAVE_DRAFT_SUCCESS, message });
+          return dispatch({
+            type: SAVE_DRAFT_SUCCESS,
+            message,
+            isSavedDraft
+          });
         }
 
         return dispatch({
           type: SAVE_DRAFT_SUCCESS,
-          message: response.data.attributes
+          message: response.data.attributes,
+          isSavedDraft
         });
       },
       () => dispatch({ type: SAVE_DRAFT_FAILURE })

--- a/src/js/messaging/components/MoveTo.jsx
+++ b/src/js/messaging/components/MoveTo.jsx
@@ -23,13 +23,23 @@ class MoveTo extends React.Component {
     const moveToFolder = this.props.folders.find((folder) => {
       return folder.folderId === folderId;
     });
-    this.props.onChooseFolder(this.props.messageId, moveToFolder);
+
+    this.props.onChooseFolder(
+      this.props.messageId,
+      moveToFolder,
+      this.props.currentFolder
+    );
   }
 
   render() {
-    // Return only Inbox, and veteran-defined folders
+    // Only list Inbox, and veteran-defined folders
+    // and exclude the current folder.
     const folders = this.props.folders.filter((folder) => {
-      return folder.folderId >= 0;
+      const folderId = folder.folderId;
+      const isEligibleFolder =
+        folderId >= 0 &&
+        folderId !== this.props.currentFolder.folderId;
+      return isEligibleFolder;
     });
 
     const folderOptions = folders.map((folder) => {
@@ -67,6 +77,12 @@ class MoveTo extends React.Component {
 }
 
 MoveTo.propTypes = {
+  currentFolder: React.PropTypes.shape({
+    folderId: React.PropTypes.number.isRequired,
+    name: React.PropTypes.string.isRequired,
+    count: React.PropTypes.number.isRequired,
+    unreadCount: React.PropTypes.number.isRequired
+  }),
   folders: React.PropTypes.arrayOf(
     React.PropTypes.shape({
       folderId: React.PropTypes.number.isRequired,

--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -9,7 +9,8 @@ import { folderUrl } from '../utils/helpers';
 
 class ThreadHeader extends React.Component {
   render() {
-    const folderName = this.props.folderName;
+    const currentFolder = this.props.currentFolder;
+    const folderName = currentFolder.name;
     let toggleThread;
     let moveTo;
     let deleteButton;
@@ -33,7 +34,8 @@ class ThreadHeader extends React.Component {
       if (folderName !== 'Drafts') {
         moveTo = (
           <MoveTo
-              folders={this.props.moveToFolders}
+              currentFolder={currentFolder}
+              folders={this.props.folders}
               isOpen={this.props.moveToIsOpen}
               messageId={this.props.message.messageId}
               onChooseFolder={this.props.onChooseFolder}
@@ -71,8 +73,11 @@ class ThreadHeader extends React.Component {
 }
 
 ThreadHeader.propTypes = {
+  currentFolder: React.PropTypes.shape({
+    name: React.PropTypes.string.isRequired
+  }),
   currentMessageNumber: React.PropTypes.number.isRequired,
-  moveToFolders: React.PropTypes.arrayOf(
+  folders: React.PropTypes.arrayOf(
     React.PropTypes.shape({
       folderId: React.PropTypes.number.isRequired,
       name: React.PropTypes.string.isRequired,
@@ -81,7 +86,6 @@ ThreadHeader.propTypes = {
     })
   ).isRequired,
   folderMessageCount: React.PropTypes.number.isRequired,
-  folderName: React.PropTypes.string.isRequired,
   message: React.PropTypes.shape({
     messageId: React.PropTypes.number,
     subject: React.PropTypes.string

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -234,7 +234,8 @@ export class Folder extends React.Component {
   }
 
   makeMessagesTable() {
-    const messages = this.props.messages;
+    const { attributes, messages } = this.props;
+
     if (!messages || messages.length === 0) {
       return <p className="msg-nomessages">You have no messages in this folder.</p>;
     }
@@ -249,11 +250,9 @@ export class Folder extends React.Component {
       { label: 'Date', value: 'sentDate' }
     ];
 
-    const folderId = this.props.attributes.folderId;
-    const folderName = this.props.attributes.name;
+    const { folderId, name: folderName } = attributes;
     const isDraftsFolder = folderName === 'Drafts';
     const isSentFolder = folderName === 'Sent';
-    const moveToFolders = [];
     const markUnread = folderId >= 0;
 
     if (isDraftsFolder || isSentFolder) {
@@ -266,17 +265,11 @@ export class Folder extends React.Component {
       }
     } else {
       fields.push({ label: '', value: 'moveToButton' });
-
-      // Exclude the current folder from the list of folders
-      // that are passed down to the MoveTo component.
-      this.props.folders.forEach((folder) => {
-        if (folderId !== folder.folderId) {
-          moveToFolders.push(folder);
-        }
-      });
     }
 
-    const data = this.props.messages.map(message => {
+    const folders = Array.from(this.props.folders.values());
+
+    const data = messages.map(message => {
       const id = message.messageId;
       const rowClass = classNames({
         'messaging-message-row': true,
@@ -286,7 +279,8 @@ export class Folder extends React.Component {
 
       const moveToButton = (
         <MoveTo
-            folders={moveToFolders}
+            currentFolder={attributes}
+            folders={folders}
             isOpen={id === this.props.moveToId}
             messageId={id}
             onChooseFolder={this.props.moveMessageToFolder}

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -149,17 +149,6 @@ export class Thread extends React.Component {
       return null;
     }
 
-    const currentFolder = this.getCurrentFolder();
-
-    // Exclude the current folder from the list of folders
-    // that are passed down to the MoveTo component.
-    const moveToFolders = [];
-    folders.forEach((folder) => {
-      if (folder.folderId !== currentFolder.folderId) {
-        moveToFolders.push(folder);
-      }
-    });
-
     // Find the current message's position
     // among the messages in the current folder.
     const currentIndex = folderMessages.findIndex((folderMessage) => {
@@ -181,10 +170,10 @@ export class Thread extends React.Component {
 
     return (
       <ThreadHeader
+          currentFolder={this.getCurrentFolder()}
           currentMessageNumber={currentIndex + 1}
-          moveToFolders={moveToFolders}
           folderMessageCount={folderMessages.length}
-          folderName={currentFolder.name}
+          folders={Array.from(folders.values())}
           message={message}
           onMessageSelect={handleMessageSelect}
           threadMessageCount={thread.length + 1}

--- a/src/js/messaging/reducers/alert.js
+++ b/src/js/messaging/reducers/alert.js
@@ -91,7 +91,7 @@ export default function alert(state = initialState, action) {
       );
 
     case MOVE_MESSAGE_SUCCESS: {
-      const folderName = action.folder.name;
+      const folderName = action.toFolder.name;
       const link = <Link to={folderUrl(folderName)}>{folderName}</Link>;
       return createAlert(
         <b>Your message has been moved to {link}.</b>,

--- a/src/js/messaging/reducers/folders.js
+++ b/src/js/messaging/reducers/folders.js
@@ -161,18 +161,17 @@ export default function folders(state = initialState, action) {
 
     case MOVE_MESSAGE_SUCCESS: {
       // Update the counts on the affected folders after moving a message.
-      const items = state.data.items;
       const newItems = new Map(state.data.items);
 
       const fromFolderKey = folderKey(action.fromFolder.name);
-      const fromFolder = items.get(fromFolderKey);
+      const fromFolder = newItems.get(fromFolderKey);
       newItems.set(fromFolderKey, {
         ...fromFolder,
         count: fromFolder.count - 1
       });
 
       const toFolderKey = folderKey(action.toFolder.name);
-      const toFolder = items.get(toFolderKey);
+      const toFolder = newItems.get(toFolderKey);
       newItems.set(toFolderKey, {
         ...toFolder,
         count: toFolder.count + 1
@@ -184,9 +183,28 @@ export default function folders(state = initialState, action) {
       return setRedirect(newState);
     }
 
+    case SAVE_DRAFT_SUCCESS: {
+      let newState = state;
+
+      // After saving a new draft, increment the count on Drafts.
+      if (!action.isSavedDraft) {
+        const newItems = new Map(state.data.items);
+        const draftsKey = folderKey('Drafts');
+        const draftsFolder = newItems.get(draftsKey);
+
+        newItems.set(draftsKey, {
+          ...draftsFolder,
+          count: draftsFolder.count + 1
+        });
+
+        newState = set('data.items', newItems, newState);
+      }
+
+      return setRedirect(newState);
+    }
+
     case DELETE_COMPOSE_MESSAGE:
     case DELETE_MESSAGE_SUCCESS:
-    case SAVE_DRAFT_SUCCESS:
     case SEND_MESSAGE_SUCCESS: {
       return setRedirect(state);
     }

--- a/src/js/messaging/reducers/folders.js
+++ b/src/js/messaging/reducers/folders.js
@@ -83,6 +83,11 @@ export default function folders(state = initialState, action) {
       const sortValue = Object.keys(sort)[0];
       const sortOrder = sort[sortValue];
 
+      // Update corresponding folder data in map.
+      const newItems = new Map(state.data.items);
+      newItems.set(folderKey(attributes.name), attributes);
+      const newState = set('data.items', newItems, state);
+
       return set('data.currentItem', {
         attributes,
         filter,
@@ -93,7 +98,7 @@ export default function folders(state = initialState, action) {
           value: sortValue,
           order: sortOrder
         },
-      }, state);
+      }, newState);
     }
 
     case FETCH_FOLDERS_SUCCESS: {

--- a/src/js/messaging/reducers/folders.js
+++ b/src/js/messaging/reducers/folders.js
@@ -54,6 +54,20 @@ const initialState = {
 
 const folderKey = (folderName) => _.kebabCase(folderName);
 
+const setRedirect = (state) => {
+  // Set the redirect to the most recent folder.
+  // Default to 'Inbox' if no folder has been visited.
+
+  const folderName = _.get(
+    state,
+    'data.currentItem.attributes.name',
+    'Inbox'
+  );
+
+  const url = folderUrl(folderName);
+  return set('ui.redirect', url, state);
+};
+
 export default function folders(state = initialState, action) {
   switch (action.type) {
     // TODO: Handle the response in an appropriate way
@@ -145,21 +159,36 @@ export default function folders(state = initialState, action) {
       // The + forces +action.folderId to be a number
       return set('data.currentItem.persistFolder', +action.folderId, state);
 
+    case MOVE_MESSAGE_SUCCESS: {
+      // Update the counts on the affected folders after moving a message.
+      const items = state.data.items;
+      const newItems = new Map(state.data.items);
+
+      const fromFolderKey = folderKey(action.fromFolder.name);
+      const fromFolder = items.get(fromFolderKey);
+      newItems.set(fromFolderKey, {
+        ...fromFolder,
+        count: fromFolder.count - 1
+      });
+
+      const toFolderKey = folderKey(action.toFolder.name);
+      const toFolder = items.get(toFolderKey);
+      newItems.set(toFolderKey, {
+        ...toFolder,
+        count: toFolder.count + 1
+      });
+
+      const newState = set('data.items', newItems, state);
+
+      // Redirect after the move.
+      return setRedirect(newState);
+    }
+
     case DELETE_COMPOSE_MESSAGE:
     case DELETE_MESSAGE_SUCCESS:
-    case MOVE_MESSAGE_SUCCESS:
     case SAVE_DRAFT_SUCCESS:
     case SEND_MESSAGE_SUCCESS: {
-      // Upon completing any of these actions, set the redirect to the most
-      // recent folder. Default to 'Inbox' if no folder has been visited.
-      const folderName = _.get(
-        state,
-        'data.currentItem.attributes.name',
-        'Inbox'
-      );
-
-      const url = folderUrl(folderName);
-      return set('ui.redirect', url, state);
+      return setRedirect(state);
     }
 
     case UPDATE_ROUTE:

--- a/test/messaging/reducers/alert.unit.spec.js
+++ b/test/messaging/reducers/alert.unit.spec.js
@@ -138,7 +138,7 @@ describe('alert reducer', () => {
     const folder = testData.folders.data[0].attributes;
     const newState = alertReducer(initialState, {
       type: MOVE_MESSAGE_SUCCESS,
-      folder
+      toFolder: folder
     });
     expect(newState.visible).to.be.true;
     expect(newState.status).to.eql('success');

--- a/test/messaging/reducers/folders.unit.spec.jsx
+++ b/test/messaging/reducers/folders.unit.spec.jsx
@@ -92,6 +92,8 @@ describe('folders reducer', () => {
       .to.eql(messages.data.map(message => message.attributes));
     expect(newState.data.currentItem.pagination)
       .to.eql(messages.meta.pagination);
+    expect(newState.data.items.get('test-folder-123'))
+      .to.eql(folder.data.attributes);
   });
 
   it('should set folders fetched from the server', () => {

--- a/test/messaging/reducers/folders.unit.spec.jsx
+++ b/test/messaging/reducers/folders.unit.spec.jsx
@@ -122,7 +122,6 @@ describe('folders reducer', () => {
 
   it('should increment the count of Drafts after saving a new draft', () => {
     const newState = foldersReducer({
-      ...initialState,
       data: { items: new Map([['drafts', { count: 1 }]]) }
     }, {
       type: SAVE_DRAFT_SUCCESS,
@@ -134,7 +133,6 @@ describe('folders reducer', () => {
 
   it('should not increment the count of Drafts after re-saving a draft', () => {
     const newState = foldersReducer({
-      ...initialState,
       data: { items: new Map([['drafts', { count: 1 }]]) }
     }, {
       type: SAVE_DRAFT_SUCCESS,
@@ -146,7 +144,6 @@ describe('folders reducer', () => {
 
   it('should update folder counts after moving a message', () => {
     const newState = foldersReducer({
-      ...initialState,
       data: {
         items: new Map([
           ['folder-1', { count: 1 }],

--- a/test/messaging/reducers/folders.unit.spec.jsx
+++ b/test/messaging/reducers/folders.unit.spec.jsx
@@ -7,6 +7,7 @@ import {
   DELETE_FOLDER_SUCCESS,
   FETCH_FOLDER_SUCCESS,
   FETCH_FOLDERS_SUCCESS,
+  MOVE_MESSAGE_SUCCESS,
   SAVE_DRAFT_SUCCESS,
   TOGGLE_FOLDER_NAV,
   TOGGLE_MANAGED_FOLDERS
@@ -141,5 +142,24 @@ describe('folders reducer', () => {
       isSavedDraft: true
     });
     expect(newState.data.items.get('drafts').count).to.equal(1);
+  });
+
+  it('should update folder counts after moving a message', () => {
+    const newState = foldersReducer({
+      ...initialState,
+      data: {
+        items: new Map([
+          ['folder-1', { count: 1 }],
+          ['folder-2', { count: 2 }]
+        ])
+      }
+    }, {
+      type: MOVE_MESSAGE_SUCCESS,
+      message: { body: 'testing 123' },
+      fromFolder: { name: 'Folder1' },
+      toFolder: { name: 'Folder2' }
+    });
+    expect(newState.data.items.get('folder-1').count).to.equal(0);
+    expect(newState.data.items.get('folder-2').count).to.equal(3);
   });
 });

--- a/test/messaging/reducers/folders.unit.spec.jsx
+++ b/test/messaging/reducers/folders.unit.spec.jsx
@@ -7,6 +7,7 @@ import {
   DELETE_FOLDER_SUCCESS,
   FETCH_FOLDER_SUCCESS,
   FETCH_FOLDERS_SUCCESS,
+  SAVE_DRAFT_SUCCESS,
   TOGGLE_FOLDER_NAV,
   TOGGLE_MANAGED_FOLDERS
 } from '../../../src/js/messaging/utils/constants';
@@ -116,5 +117,29 @@ describe('folders reducer', () => {
     expect(newState.ui.nav.foldersExpanded).to.be.true;
     newState = foldersReducer(newState, { type: TOGGLE_MANAGED_FOLDERS });
     expect(newState.ui.nav.foldersExpanded).to.be.false;
+  });
+
+  it('should increment the count of Drafts after saving a new draft', () => {
+    const newState = foldersReducer({
+      ...initialState,
+      data: { items: new Map([['drafts', { count: 1 }]]) }
+    }, {
+      type: SAVE_DRAFT_SUCCESS,
+      message: { body: 'testing 123' },
+      isSavedDraft: false
+    });
+    expect(newState.data.items.get('drafts').count).to.equal(2);
+  });
+
+  it('should not increment the count of Drafts after re-saving a draft', () => {
+    const newState = foldersReducer({
+      ...initialState,
+      data: { items: new Map([['drafts', { count: 1 }]]) }
+    }, {
+      type: SAVE_DRAFT_SUCCESS,
+      message: { body: 'testing 123' },
+      isSavedDraft: true
+    });
+    expect(newState.data.items.get('drafts').count).to.equal(1);
   });
 });


### PR DESCRIPTION
## Changes
* When moving a message, decrement the count of the original folder and increment the count of the destination folder.
    * Closes department-of-veterans-affairs/messaging-fe#189.
    * Moved the responsibility of filtering the folders to display to the MoveTo component itself. It was previously filtering in two stages; one within a parent component to remove the current folder, and the other within itself to only keep 'Inbox' and personal folders. Now that it's also receiving the data of the current folder, it might as well process that folders list in one place.
* When saving a new draft (not saving an existing one), increment the Draft count.
    * Closes department-of-veterans-affairs/messaging-fe#195.
* When fetching a folder, update its entry in the map of all folders in state. So if, for example, a draft was saved in a separate session, fetching the Drafts folder will update with the correct count.