### PR TITLE
[Messaging] Show loader when fetching list of folders.

### DIFF
--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -41,7 +41,7 @@ export class Folder extends React.Component {
   }
 
   componentDidMount() {
-    if (!this.props.loading.folder && this.props.folders.size) {
+    if (!this.props.loading.folder) {
       const id = this.getRequestedFolderId();
       const query = this.getQueryParams();
       this.props.fetchFolder(id, query);
@@ -59,7 +59,7 @@ export class Folder extends React.Component {
       return;
     }
 
-    if (!this.props.loading.folder && this.props.folders.size) {
+    if (!this.props.loading.folder) {
       const lastRequest = this.props.lastRequestedFolder;
       const requestedId = this.getRequestedFolderId();
       const query = this.getQueryParams();

--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -135,13 +135,10 @@ Main.propTypes = {
 };
 
 const mapStateToProps = (state) => {
-  const folders = [];
-  state.folders.data.items.forEach(folder => folders.push(folder));
-
   return {
     attachmentsModal: state.modals.attachments,
     createFolderModal: state.modals.createFolder,
-    folders,
+    folders: Array.from(state.folders.data.items.values()),
     isVisibleAdvancedSearch: state.search.advanced.visible,
     loading: state.loading,
     nav: state.folders.ui.nav,

--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -70,7 +70,10 @@ export class Main extends React.Component {
       return (
         <p>
           The application failed to load.
-          Click <a onClick={this.props.fetchFolders}>here</a> to try again.
+          Click <a href="/healthcare/messaging" onClick={(e) => {
+              e.preventDefault();
+              this.props.fetchFolders(); }}>
+          here</a> to try again.
         </p>
       );
     }

--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -71,9 +71,9 @@ export class Main extends React.Component {
         <p>
           The application failed to load.
           Click <a href="/healthcare/messaging" onClick={(e) => {
-              e.preventDefault();
-              this.props.fetchFolders(); }}>
-          here</a> to try again.
+            e.preventDefault();
+            this.props.fetchFolders();
+          }}> here</a> to try again.
         </p>
       );
     }

--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -66,6 +66,15 @@ export class Main extends React.Component {
       return <LoadingIndicator message="Loading your application..."/>;
     }
 
+    if (!this.props.folders || !this.props.folders.length) {
+      return (
+        <p>
+          The application failed to load.
+          Click <a onClick={this.props.fetchFolders}>here</a> to try again.
+        </p>
+      );
+    }
+
     if (loading.deletingFolder) {
       return <LoadingIndicator message="Deleting your folder..."/>;
     }

--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -62,6 +62,10 @@ export class Main extends React.Component {
   render() {
     const loading = this.props.loading;
 
+    if (loading.folders) {
+      return <LoadingIndicator message="Loading your application..."/>;
+    }
+
     if (loading.deletingFolder) {
       return <LoadingIndicator message="Deleting your folder..."/>;
     }

--- a/src/js/messaging/reducers/loading.js
+++ b/src/js/messaging/reducers/loading.js
@@ -12,11 +12,14 @@ import {
   DELETING_MESSAGE,
   FETCH_FOLDER_FAILURE,
   FETCH_FOLDER_SUCCESS,
+  FETCH_FOLDERS_FAILURE,
+  FETCH_FOLDERS_SUCCESS,
   FETCH_RECIPIENTS_FAILURE,
   FETCH_RECIPIENTS_SUCCESS,
   FETCH_THREAD_FAILURE,
   FETCH_THREAD_SUCCESS,
   LOADING_FOLDER,
+  LOADING_FOLDERS,
   LOADING_RECIPIENTS,
   LOADING_THREAD,
   MOVE_MESSAGE_FAILURE,
@@ -32,6 +35,7 @@ import {
 
 const initialState = {
   folder: false,
+  folders: false,
   recipients: false,
   thread: false,
   creatingFolder: false,
@@ -67,6 +71,12 @@ export default function loading(state = initialState, action) {
       return set('folder', false, state);
     case LOADING_FOLDER:
       return set('folder', true, state);
+
+    case FETCH_FOLDERS_FAILURE:
+    case FETCH_FOLDERS_SUCCESS:
+      return set('folders', false, state);
+    case LOADING_FOLDERS:
+      return set('folders', true, state);
 
     case FETCH_RECIPIENTS_FAILURE:
     case FETCH_RECIPIENTS_SUCCESS:


### PR DESCRIPTION
Before these changes, we were briefly displaying "Sorry, this folder doesn't exist." or something to that effect before we received all of the folders. This should resolve that and prevent race conditions where children components that rely on the folders list could have failed.

#### Loading folders.
> <img width="964" alt="screen shot 2016-12-20 at 2 11 03 am" src="https://cloud.githubusercontent.com/assets/1067024/21342080/f8e4b83a-c65d-11e6-8a67-edcb1ec86504.png">

#### Failed to load folders.
> <img width="471" alt="screen shot 2016-12-20 at 2 40 34 am" src="https://cloud.githubusercontent.com/assets/1067024/21342088/06d044d2-c65e-11e6-87bf-336c93dd1121.png">