### PR TITLE
Consolidate all education validations

### DIFF
--- a/src/js/common/utils/validations.js
+++ b/src/js/common/utils/validations.js
@@ -175,6 +175,10 @@ function isValidPartialMonthYearInPast(month, year) {
   return !year || isValidPartialMonthYear(month, year) && momentDate.isValid() && momentDate.isSameOrBefore(moment().startOf('month'));
 }
 
+function isBlankMonthYear(field) {
+  return isBlank(field.month.value) && isBlank(field.year.value);
+}
+
 function isValidDateOver17(day, month, year) {
   if (!isValidYear(year)) {
     return false;
@@ -186,42 +190,6 @@ function isValidDateOver17(day, month, year) {
     year
   });
   return momentDate.isBefore(moment().endOf('day').subtract(17, 'years'));
-}
-
-function isValidEntryDateField(date, dateOfBirth) {
-  let adjustedDate;
-  let adjustedDateOfBirth;
-
-  if (!isBlankDateField(date) && !isBlankDateField(dateOfBirth)) {
-    const adjustedBirthYear = Number(dateOfBirth.year.value) + 15;
-    adjustedDate = new Date(`${date.month.value}/${date.day.value}/${date.year.value}`);
-    adjustedDateOfBirth = new Date(`${dateOfBirth.month.value}/${dateOfBirth.day.value}/${adjustedBirthYear}`);
-
-    if (adjustedDate < adjustedDateOfBirth) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-function isValidDischargeDateField(date, entryDate) {
-  let adjustedDate;
-  let adjustedEntryDate;
-  const d = new Date();
-  const today = new Date(d.setHours(0, 0, 0, 0));
-
-  if (!isBlankDateField(date) && !isBlankDateField(entryDate)) {
-    adjustedDate = new Date(`${date.month.value}/${date.day.value}/${date.year.value}`);
-    adjustedEntryDate = new Date(`${entryDate.month.value}/${entryDate.day.value}/${entryDate.year.value}`);
-
-    // Validation Rule: Discharge date must be after entry date and before today
-    if (adjustedDate < adjustedEntryDate || adjustedDate >= today) {
-      return false;
-    }
-  }
-
-  return true;
 }
 
 /**
@@ -324,6 +292,7 @@ export {
   isBlank,
   isBlankDateField,
   isBlankAddress,
+  isBlankMonthYear,
   isDirtyDate,
   isNotBlank,
   isNotBlankDateField,
@@ -335,9 +304,7 @@ export {
   isValidDateField,
   isValidDateOver17,
   isValidDateRange,
-  isValidDischargeDateField,
   isValidEmail,
-  isValidEntryDateField,
   isValidFullNameField,
   isValidField,
   isValidMonths,

--- a/src/js/common/utils/validations.js
+++ b/src/js/common/utils/validations.js
@@ -1,22 +1,14 @@
 import _ from 'lodash';
 import moment from 'moment';
 import { states } from './options-for-select';
+import { dateToMoment } from './helpers';
 
+/**
+ * General Validations *
+*/
 function validateIfDirty(field, validator) {
   if (field.dirty) {
     return validator(field.value);
-  }
-
-  return true;
-}
-
-function isDirtyDate(date) {
-  return date.day.dirty && date.year.dirty && date.month.dirty;
-}
-
-function validateIfDirtyDate(dayField, monthField, yearField, validator) {
-  if (isDirtyDate({ day: dayField, month: monthField, year: yearField })) {
-    return validator(dayField.value, monthField.value, yearField.value);
   }
 
   return true;
@@ -44,43 +36,39 @@ function isNotBlank(value) {
   return value !== '';
 }
 
-function isNotBlankDateField(field) {
-  return isNotBlank(field.day.value) && isNotBlank(field.month.value) && isNotBlank(field.year.value);
+function isValidValue(validator, value) {
+  return isBlank(value) || validator(value);
 }
 
-// Conditions for valid SSN from the original 1010ez pdf form:
-// '123456789' is not a valid SSN
-// A value where the first 3 digits are 0 is not a valid SSN
-// A value where the 4th and 5th digits are 0 is not a valid SSN
-// A value where the last 4 digits are 0 is not a valid SSN
-// A value with 3 digits, an optional -, 2 digits, an optional -, and 4 digits is a valid SSN
-// 9 of the same digits (e.g., '111111111') is not a valid SSN
-function isValidSSN(value) {
-  if (value === '123456789' || value === '123-45-6789') {
-    return false;
-  } else if (/^0{3}-?\d{2}-?\d{4}$/.test(value)) {
-    return false;
-  } else if (/^\d{3}-?0{2}-?\d{4}$/.test(value)) {
-    return false;
-  } else if (/^\d{3}-?\d{2}-?0{4}$/.test(value)) {
-    return false;
-  }
-
-  const noBadSameDigitNumber = _.without(_.range(0, 10), 2, 4, 5)
-    .every(i => {
-      const sameDigitRegex = new RegExp(`${i}{3}-?${i}{2}-?${i}{4}`);
-      return !sameDigitRegex.test(value);
-    });
-
-  if (!noBadSameDigitNumber) {
-    return false;
-  }
-
-  return /^\d{3}-?\d{2}-?\d{4}$/.test(value);
+function isValidField(validator, field) {
+  return isBlank(field.value) || validator(field.value);
 }
 
+function isValidRequiredField(validator, field) {
+  return isNotBlank(field.value) && validator(field.value);
+}
+
+/**
+ * Date Validations *
+*/
 function isValidYear(value) {
   return Number(value) >= 1900 && Number(value) <= moment().add(100, 'year').year();
+}
+
+function isValidYearOrBlank(value) {
+  return isValidYear(value) || value === '';
+}
+
+function isValidCurrentOrPastYear(value) {
+  return Number(value) >= 1900 && Number(value) < moment().year() + 1;
+}
+
+function isValidMonths(value) {
+  return Number(value) >= 0;
+}
+
+function isBlankDateField(field) {
+  return isBlank(field.day.value) && isBlank(field.month.value) && isBlank(field.year.value);
 }
 
 function isValidDate(day, month, year) {
@@ -103,6 +91,22 @@ function isValidDate(day, month, year) {
     date.getFullYear() === Number(year);
 }
 
+function isNotBlankDateField(field) {
+  return isNotBlank(field.day.value) && isNotBlank(field.month.value) && isNotBlank(field.year.value);
+}
+
+function isDirtyDate(date) {
+  return date.day.dirty && date.year.dirty && date.month.dirty;
+}
+
+function validateIfDirtyDate(dayField, monthField, yearField, validator) {
+  if (isDirtyDate({ day: dayField, month: monthField, year: yearField })) {
+    return validator(dayField.value, monthField.value, yearField.value);
+  }
+
+  return true;
+}
+
 function isValidAnyDate(day, month, year) {
   if (!isValidYear(year)) {
     return false;
@@ -123,6 +127,24 @@ function isValidPartialDate(day, month, year) {
   return true;
 }
 
+function isValidDateField(field) {
+  return isValidDate(field.day.value, field.month.value, field.year.value);
+}
+
+function isValidPartialDateField(field) {
+  return isValidPartialDate(field.day.value, field.month.value, field.year.value);
+}
+
+function isValidDateRange(fromDate, toDate) {
+  if (isBlankDateField(toDate) || isBlankDateField(fromDate)) {
+    return true;
+  }
+  const momentStart = dateToMoment(fromDate);
+  const momentEnd = dateToMoment(toDate);
+
+  return momentStart.isBefore(momentEnd);
+}
+
 function isValidPartialMonthYear(month, year) {
   if (typeof month === 'object') {
     throw new Error('Pass a month and a year to function');
@@ -132,6 +154,16 @@ function isValidPartialMonthYear(month, year) {
   }
 
   return isValidPartialDate(null, null, year);
+}
+
+function isValidPartialMonthYearRange(fromDate, toDate) {
+  if (!fromDate.year.value || !toDate.year.value) {
+    return true;
+  }
+  const momentStart = dateToMoment(fromDate);
+  const momentEnd = dateToMoment(toDate);
+
+  return momentStart.isSameOrBefore(momentEnd);
 }
 
 function isValidPartialMonthYearInPast(month, year) {
@@ -154,88 +186,6 @@ function isValidDateOver17(day, month, year) {
     year
   });
   return momentDate.isBefore(moment().endOf('day').subtract(17, 'years'));
-}
-
-function isValidName(value) {
-  return /^[a-zA-Z][a-zA-Z '\-]*$/.test(value);
-}
-
-function isValidMonetaryValue(value) {
-  if (value !== null) {
-    return /^\d+\.?\d*$/.test(value);
-  }
-  return true;
-}
-
-function isValidUSZipCode(value) {
-  return /(^\d{5}$)|(^\d{5}[ -]{0,1}\d{4}$)/.test(value);
-}
-
-function isValidCanPostalCode(value) {
-  return /^[a-zA-Z]\d[a-zA-Z][ -]{0,1}\d[a-zA-Z]\d$/.test(value);
-}
-
-// TODO: look into validation libraries (npm "validator")
-function isValidPhone(value) {
-  // Strip spaces, dashes, and parens
-  const stripped = value.replace(/[^\d]/g, '');
-  // Count number of digits
-  return /^\d{10}$/.test(stripped);
-}
-
-function isValidEmail(value) {
-  // Comes from StackOverflow: http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
-  return /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(value);
-}
-
-function isValidField(validator, field) {
-  return isBlank(field.value) || validator(field.value);
-}
-
-function isValidRequiredField(validator, field) {
-  return isNotBlank(field.value) && validator(field.value);
-}
-
-function isBlankDateField(field) {
-  return isBlank(field.day.value) && isBlank(field.month.value) && isBlank(field.year.value);
-}
-
-function isValidDateField(field) {
-  return isValidDate(field.day.value, field.month.value, field.year.value);
-}
-
-function isValidPartialDateField(field) {
-  return isValidPartialDate(field.day.value, field.month.value, field.year.value);
-}
-
-function isValidFullNameField(field) {
-  return isValidName(field.first.value) &&
-    (isBlank(field.middle.value) || isValidName(field.middle.value)) &&
-    isValidName(field.last.value);
-}
-
-function isValidAddressField(field) {
-  const initialOk = isNotBlank(field.street.value) &&
-    isNotBlank(field.city.value) &&
-    isNotBlank(field.country.value);
-
-  // if we have a defined list of values, they will
-  // be set as the state and zipcode keys
-  if (_.hasIn(states, field.country.value)) {
-    return initialOk &&
-      isNotBlank(field.state.value) &&
-      isNotBlank(field.zipcode.value);
-  }
-  // if the entry was non-USA/CAN/MEX, only postal is
-  // required, not provinceCode
-  return initialOk && isNotBlank(field.postalCode.value);
-}
-
-function isBlankAddress(address) {
-  return isBlank(address.city.value)
-    && isBlank(address.state.value)
-    && isBlank(address.street.value)
-    && isBlank(address.postalCode.value);
 }
 
 function isValidEntryDateField(date, dateOfBirth) {
@@ -274,37 +224,138 @@ function isValidDischargeDateField(date, entryDate) {
   return true;
 }
 
+/**
+ * Field Validations *
+*/
+function isValidName(value) {
+  return /^[a-zA-Z][a-zA-Z '\-]*$/.test(value);
+}
+
+function isValidFullNameField(field) {
+  return isValidName(field.first.value) &&
+    (isBlank(field.middle.value) || isValidName(field.middle.value)) &&
+    isValidName(field.last.value);
+}
+
+// Conditions for valid SSN from the original 1010ez pdf form:
+// '123456789' is not a valid SSN
+// A value where the first 3 digits are 0 is not a valid SSN
+// A value where the 4th and 5th digits are 0 is not a valid SSN
+// A value where the last 4 digits are 0 is not a valid SSN
+// A value with 3 digits, an optional -, 2 digits, an optional -, and 4 digits is a valid SSN
+// 9 of the same digits (e.g., '111111111') is not a valid SSN
+function isValidSSN(value) {
+  if (value === '123456789' || value === '123-45-6789') {
+    return false;
+  } else if (/^0{3}-?\d{2}-?\d{4}$/.test(value)) {
+    return false;
+  } else if (/^\d{3}-?0{2}-?\d{4}$/.test(value)) {
+    return false;
+  } else if (/^\d{3}-?\d{2}-?0{4}$/.test(value)) {
+    return false;
+  }
+
+  const noBadSameDigitNumber = _.without(_.range(0, 10), 2, 4, 5)
+    .every(i => {
+      const sameDigitRegex = new RegExp(`${i}{3}-?${i}{2}-?${i}{4}`);
+      return !sameDigitRegex.test(value);
+    });
+
+  if (!noBadSameDigitNumber) {
+    return false;
+  }
+
+  return /^\d{3}-?\d{2}-?\d{4}$/.test(value);
+}
+
+function isValidMonetaryValue(value) {
+  if (value !== null) {
+    return /^\d+\.?\d*$/.test(value);
+  }
+  return true;
+}
+
+function isValidUSZipCode(value) {
+  return /(^\d{5}$)|(^\d{5}[ -]{0,1}\d{4}$)/.test(value);
+}
+
+function isValidCanPostalCode(value) {
+  return /^[a-zA-Z]\d[a-zA-Z][ -]{0,1}\d[a-zA-Z]\d$/.test(value);
+}
+
+// TODO: look into validation libraries (npm "validator")
+function isValidPhone(value) {
+  // Strip spaces, dashes, and parens
+  const stripped = value.replace(/[^\d]/g, '');
+  // Count number of digits
+  return /^\d{10}$/.test(stripped);
+}
+
+function isValidEmail(value) {
+  // Comes from StackOverflow: http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
+  return /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(value);
+}
+
+function isValidAddressField(field) {
+  const initialOk = isNotBlank(field.street.value) &&
+    isNotBlank(field.city.value) &&
+    isNotBlank(field.country.value);
+
+  // if we have a defined list of values, they will
+  // be set as the state and zipcode keys
+  if (_.hasIn(states, field.country.value)) {
+    return initialOk &&
+      isNotBlank(field.state.value) &&
+      isNotBlank(field.zipcode.value);
+  }
+  // if the entry was non-USA/CAN/MEX, only postal is
+  // required, not provinceCode
+  return initialOk && isNotBlank(field.postalCode.value);
+}
+
+function isBlankAddress(address) {
+  return isBlank(address.city.value)
+    && isBlank(address.state.value)
+    && isBlank(address.street.value)
+    && isBlank(address.postalCode.value);
+}
+
 export {
-  validateIfDirty,
-  validateIfDirtyDate,
   isBlank,
   isBlankDateField,
+  isBlankAddress,
+  isDirtyDate,
   isNotBlank,
+  isNotBlankDateField,
   isValidAddressField,
-  isValidRequiredField,
+  isValidAnyDate,
+  isValidCanPostalCode,
+  isValidCurrentOrPastYear,
   isValidDate,
   isValidDateField,
-  isValidName,
-  isValidSSN,
-  isValidMonetaryValue,
-  isValidUSZipCode,
-  isValidCanPostalCode,
-  isValidPhone,
+  isValidDateOver17,
+  isValidDateRange,
+  isValidDischargeDateField,
   isValidEmail,
   isValidEntryDateField,
-  isValidDischargeDateField,
   isValidFullNameField,
   isValidField,
-  isBlankAddress,
-  isValidAnyDate,
-  isValidDateOver17,
-  isDirtyDate,
-  isNotBlankDateField,
+  isValidMonths,
+  isValidName,
+  isValidMonetaryValue,
+  isValidPhone,
   isValidPartialDate,
-  isValidDateField,
   isValidPartialDateField,
   isValidPartialMonthYear,
-  isValidYear,
   isValidPartialMonthYearInPast,
-  validateCustomFormComponent
+  isValidPartialMonthYearRange,
+  isValidRequiredField,
+  isValidSSN,
+  isValidUSZipCode,
+  isValidValue,
+  isValidYear,
+  isValidYearOrBlank,
+  validateCustomFormComponent,
+  validateIfDirty,
+  validateIfDirtyDate,
 };

--- a/src/js/edu-benefits/components/benefits-eligibility/BenefitsRelinquishmentFields.jsx
+++ b/src/js/edu-benefits/components/benefits-eligibility/BenefitsRelinquishmentFields.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
 import ErrorableDate from '../../../common/components/form-elements/ErrorableDate';
-import { validateIfDirty, isNotBlank, isValidRelinquishedDate } from '../../utils/validations';
+import { validateIfDirty, isNotBlank } from '../../../common/utils/validations';
+import { isValidRelinquishedDate } from '../../utils/validations';
 import { relinquishableBenefits } from '../../utils/options-for-select';
 import { showRelinquishedEffectiveDate } from '../../utils/helpers';
 

--- a/src/js/edu-benefits/components/education-history/EducationPeriod.jsx
+++ b/src/js/edu-benefits/components/education-history/EducationPeriod.jsx
@@ -5,9 +5,8 @@ import ErrorableTextInput from '../../../common/components/form-elements/Errorab
 import ErrorableNumberInput from '../../../common/components/form-elements/ErrorableNumberInput';
 import ErrorableSelect from '../../../common/components/form-elements/ErrorableSelect';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
+import { isValidPartialMonthYearInPast, isValidPartialMonthYearRange } from '../../../common/utils/validations';
 
-import { isValidPartialMonthYearRange } from '../../utils/validations';
-import { isValidPartialMonthYearInPast } from '../../../common/utils/validations';
 import { states, hoursTypes } from '../../utils/options-for-select';
 import EducationPeriodReview from './EducationPeriodReview';
 

--- a/src/js/edu-benefits/components/employment-history/EmploymentPeriod.jsx
+++ b/src/js/edu-benefits/components/employment-history/EmploymentPeriod.jsx
@@ -2,10 +2,9 @@ import React from 'react';
 
 import ErrorableTextInput from '../../../common/components/form-elements/ErrorableTextInput';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
-import { validateIfDirty } from '../../../common/utils/validations';
+import { validateIfDirty, isValidMonths } from '../../../common/utils/validations';
 
 import EmploymentPeriodReview from './EmploymentPeriodReview';
-import { isValidMonths } from '../../utils/validations';
 import { employmentPeriodTiming } from '../../utils/options-for-select';
 
 export default class EmploymentPeriod extends React.Component {

--- a/src/js/edu-benefits/components/employment-history/EmploymentPeriod.jsx
+++ b/src/js/edu-benefits/components/employment-history/EmploymentPeriod.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 
 import ErrorableTextInput from '../../../common/components/form-elements/ErrorableTextInput';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
+import { validateIfDirty } from '../../../common/utils/validations';
 
 import EmploymentPeriodReview from './EmploymentPeriodReview';
-import { isValidMonths, validateIfDirty } from '../../utils/validations';
+import { isValidMonths } from '../../utils/validations';
 import { employmentPeriodTiming } from '../../utils/options-for-select';
 
 export default class EmploymentPeriod extends React.Component {

--- a/src/js/edu-benefits/components/military-history/ContributionsFields.jsx
+++ b/src/js/edu-benefits/components/military-history/ContributionsFields.jsx
@@ -3,8 +3,7 @@ import React from 'react';
 import ErrorableCheckbox from '../../../common/components/form-elements/ErrorableCheckbox';
 import ExpandingGroup from '../../../common/components/form-elements/ExpandingGroup';
 import ErrorableCurrentOrPastDate from '../../../common/components/form-elements/ErrorableCurrentOrPastDate';
-
-import { isValidDateRange } from '../../utils/validations';
+import { isValidDateRange } from '../../../common/utils/validations';
 
 export default class ContributionsFields extends React.Component {
   render() {

--- a/src/js/edu-benefits/components/military-history/MilitaryServiceFields.jsx
+++ b/src/js/edu-benefits/components/military-history/MilitaryServiceFields.jsx
@@ -3,8 +3,9 @@ import React from 'react';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
 import ErrorableNumberInput from '../../../common/components/form-elements/ErrorableNumberInput';
 import ExpandingGroup from '../../../common/components/form-elements/ExpandingGroup';
+import { validateIfDirty } from '../../../common/utils/validations';
 
-import { validateIfDirty, isValidCurrentOrPastYear, isValidField } from '../../utils/validations';
+import { isValidCurrentOrPastYear, isValidField } from '../../utils/validations';
 import { yesNo } from '../../utils/options-for-select';
 
 export default class MilitaryServiceFields extends React.Component {

--- a/src/js/edu-benefits/components/military-history/MilitaryServiceFields.jsx
+++ b/src/js/edu-benefits/components/military-history/MilitaryServiceFields.jsx
@@ -3,9 +3,8 @@ import React from 'react';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
 import ErrorableNumberInput from '../../../common/components/form-elements/ErrorableNumberInput';
 import ExpandingGroup from '../../../common/components/form-elements/ExpandingGroup';
-import { validateIfDirty } from '../../../common/utils/validations';
+import { validateIfDirty, isValidCurrentOrPastYear, isValidField } from '../../../common/utils/validations';
 
-import { isValidCurrentOrPastYear, isValidField } from '../../utils/validations';
 import { yesNo } from '../../utils/options-for-select';
 
 export default class MilitaryServiceFields extends React.Component {

--- a/src/js/edu-benefits/components/military-history/MilitaryServiceTour.jsx
+++ b/src/js/edu-benefits/components/military-history/MilitaryServiceTour.jsx
@@ -6,8 +6,9 @@ import ErrorableTextarea from '../../../common/components/form-elements/Errorabl
 import ErrorableDate from '../../../common/components/form-elements/ErrorableDate';
 import ErrorableCurrentOrPastDate from '../../../common/components/form-elements/ErrorableCurrentOrPastDate';
 import ExpandingGroup from '../../../common/components/form-elements/ExpandingGroup';
+import { validateIfDirty, isNotBlank } from '../../../common/utils/validations';
 
-import { validateIfDirty, isNotBlank, isValidDateRange } from '../../utils/validations';
+import { isValidDateRange } from '../../utils/validations';
 import ServicePeriodsReview from './ServicePeriodsReview';
 
 export default class MilitaryServiceTour extends React.Component {

--- a/src/js/edu-benefits/components/military-history/MilitaryServiceTour.jsx
+++ b/src/js/edu-benefits/components/military-history/MilitaryServiceTour.jsx
@@ -6,9 +6,8 @@ import ErrorableTextarea from '../../../common/components/form-elements/Errorabl
 import ErrorableDate from '../../../common/components/form-elements/ErrorableDate';
 import ErrorableCurrentOrPastDate from '../../../common/components/form-elements/ErrorableCurrentOrPastDate';
 import ExpandingGroup from '../../../common/components/form-elements/ExpandingGroup';
-import { validateIfDirty, isNotBlank } from '../../../common/utils/validations';
+import { validateIfDirty, isNotBlank, isValidDateRange } from '../../../common/utils/validations';
 
-import { isValidDateRange } from '../../utils/validations';
 import ServicePeriodsReview from './ServicePeriodsReview';
 
 export default class MilitaryServiceTour extends React.Component {

--- a/src/js/edu-benefits/components/military-history/RotcHistoryFields.jsx
+++ b/src/js/edu-benefits/components/military-history/RotcHistoryFields.jsx
@@ -3,11 +3,11 @@ import ErrorableRadioButtons from '../../../common/components/form-elements/Erro
 import ErrorableNumberInput from '../../../common/components/form-elements/ErrorableNumberInput';
 import ExpandingGroup from '../../../common/components/form-elements/ExpandingGroup';
 import GrowableTable from '../../../common/components/form-elements/GrowableTable';
-import { validateIfDirty } from '../../../common/utils/validations';
+import { validateIfDirty, isValidYearOrBlank } from '../../../common/utils/validations';
 
 import RotcScholarship from './RotcScholarship';
 import { createRotcScholarship } from '../../utils/veteran';
-import { isValidPage, isValidYearOrBlank, isValidRotcScholarshipAmount } from '../../utils/validations';
+import { isValidPage, isValidRotcScholarshipAmount } from '../../utils/validations';
 import { yesNo } from '../../utils/options-for-select';
 
 export default class RotcHistoryFields extends React.Component {

--- a/src/js/edu-benefits/components/military-history/RotcHistoryFields.jsx
+++ b/src/js/edu-benefits/components/military-history/RotcHistoryFields.jsx
@@ -3,9 +3,11 @@ import ErrorableRadioButtons from '../../../common/components/form-elements/Erro
 import ErrorableNumberInput from '../../../common/components/form-elements/ErrorableNumberInput';
 import ExpandingGroup from '../../../common/components/form-elements/ExpandingGroup';
 import GrowableTable from '../../../common/components/form-elements/GrowableTable';
+import { validateIfDirty } from '../../../common/utils/validations';
+
 import RotcScholarship from './RotcScholarship';
 import { createRotcScholarship } from '../../utils/veteran';
-import { isValidPage, validateIfDirty, isValidYearOrBlank, isValidRotcScholarshipAmount } from '../../utils/validations';
+import { isValidPage, isValidYearOrBlank, isValidRotcScholarshipAmount } from '../../utils/validations';
 import { yesNo } from '../../utils/options-for-select';
 
 export default class RotcHistoryFields extends React.Component {

--- a/src/js/edu-benefits/components/military-history/RotcScholarship.jsx
+++ b/src/js/edu-benefits/components/military-history/RotcScholarship.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import ErrorableTextInput from '../../../common/components/form-elements/ErrorableTextInput';
 import ErrorableNumberInput from '../../../common/components/form-elements/ErrorableNumberInput';
-import { validateIfDirty, isValidYear } from '../../../common/utils/validations';
+import { validateIfDirty, isValidYear, isValidValue } from '../../../common/utils/validations';
 
-import { isValidMonetaryValue, isValidValue } from '../../utils/validations';
+import { isValidMonetaryValue } from '../../utils/validations';
 
 export default class RotcScholarship extends React.Component {
   render() {

--- a/src/js/edu-benefits/components/military-history/RotcScholarship.jsx
+++ b/src/js/edu-benefits/components/military-history/RotcScholarship.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 
 import ErrorableTextInput from '../../../common/components/form-elements/ErrorableTextInput';
 import ErrorableNumberInput from '../../../common/components/form-elements/ErrorableNumberInput';
+import { validateIfDirty, isValidYear } from '../../../common/utils/validations';
 
-import { isValidYear, validateIfDirty, isValidMonetaryValue, isValidValue } from '../../utils/validations';
+import { isValidMonetaryValue, isValidValue } from '../../utils/validations';
 
 export default class RotcScholarship extends React.Component {
   render() {

--- a/src/js/edu-benefits/components/personal-information/ContactInformationFields.jsx
+++ b/src/js/edu-benefits/components/personal-information/ContactInformationFields.jsx
@@ -4,9 +4,9 @@ import Address from '../Address';
 import Email from '../../../common/components/questions/Email';
 import Phone from '../../../common/components/questions/Phone';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
+import { validateIfDirty, isNotBlank } from '../../../common/utils/validations';
 
 import { contactOptions } from '../../utils/options-for-select';
-import { validateIfDirty, isNotBlank } from '../../utils/validations';
 
 export default class ContactInformationFields extends React.Component {
   constructor() {

--- a/src/js/edu-benefits/components/personal-information/DirectDepositFields.jsx
+++ b/src/js/edu-benefits/components/personal-information/DirectDepositFields.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 
 import ErrorableTextInput from '../../../common/components/form-elements/ErrorableTextInput';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
+import { validateIfDirty, isBlank } from '../../../common/utils/validations';
 
 import { accountTypes } from '../../utils/options-for-select';
-import { validateIfDirty, isValidRoutingNumber, isBlank } from '../../utils/validations';
+import { isValidRoutingNumber } from '../../utils/validations';
 
 export default class DirectDepositFields extends React.Component {
   render() {

--- a/src/js/edu-benefits/utils/validations.js
+++ b/src/js/edu-benefits/utils/validations.js
@@ -2,38 +2,21 @@ import _ from 'lodash';
 import moment from 'moment';
 import { states } from './options-for-select';
 import { showRelinquishedEffectiveDate } from './helpers';
-import { isValidDateOver17, isBlankAddress, isValidPartialDateField, isValidYear, isValidPartialMonthYearInPast } from '../../common/utils/validations';
 import { dateToMoment } from '../../common/utils/helpers';
-
-function validateIfDirty(field, validator) {
-  if (field.dirty) {
-    return validator(field.value);
-  }
-
-  return true;
-}
-
-function validateIfDirtyDate(dayField, monthField, yearField, validator) {
-  if (dayField.dirty && monthField.dirty && yearField.dirty) {
-    return validator(dayField.value, monthField.value, yearField.value);
-  }
-
-  return true;
-}
-
-function validateIfDirtyDateObj(date, validator) {
-  return validateIfDirtyDate(date.day, date.month, date.year, () => {
-    return validator(date);
-  });
-}
-
-function isBlank(value) {
-  return value === '';
-}
-
-function isNotBlank(value) {
-  return value !== '';
-}
+import {
+  isBlank,
+  isBlankAddress,
+  isNotBlank,
+  isValidDateField,
+  isValidDateOver17,
+  isValidEmail,
+  isValidName,
+  isValidPartialDateField,
+  isValidPartialMonthYearInPast,
+  isValidPhone,
+  isValidSSN,
+  isValidYear
+} from '../../common/utils/validations';
 
 function isValidYearOrBlank(value) {
   return isValidYear(value) || value === '';
@@ -47,79 +30,11 @@ function isValidMonths(value) {
   return Number(value) >= 0;
 }
 
-// Conditions for valid SSN from the original 1010ez pdf form:
-// '123456789' is not a valid SSN
-// A value where the first 3 digits are 0 is not a valid SSN
-// A value where the 4th and 5th digits are 0 is not a valid SSN
-// A value where the last 4 digits are 0 is not a valid SSN
-// A value with 3 digits, an optional -, 2 digits, an optional -, and 4 digits is a valid SSN
-// 9 of the same digits (e.g., '111111111') is not a valid SSN
-function isValidSSN(value) {
-  if (value === '123456789' || value === '123-45-6789') {
-    return false;
-  } else if (/^0{3}-?\d{2}-?\d{4}$/.test(value)) {
-    return false;
-  } else if (/^\d{3}-?0{2}-?\d{4}$/.test(value)) {
-    return false;
-  } else if (/^\d{3}-?\d{2}-?0{4}$/.test(value)) {
-    return false;
-  }
-
-  const noBadSameDigitNumber = _.without(_.range(0, 10), 2, 4, 5)
-    .every(i => {
-      const sameDigitRegex = new RegExp(`${i}{3}-?${i}{2}-?${i}{4}`);
-      return !sameDigitRegex.test(value);
-    });
-
-  if (!noBadSameDigitNumber) {
-    return false;
-  }
-
-  return /^\d{3}-?\d{2}-?\d{4}$/.test(value);
-}
-
-function isValidDate(day, month, year) {
-  // Use the date class to see if the date parses back sanely as a
-  // validation check. Not sure is a great idea...
-  const adjustedMonth = Number(month) - 1;  // JS Date object 0-indexes months. WTF.
-  const date = new Date(year, adjustedMonth, day);
-  const today = new Date();
-
-  if (today < date) {
-    return false;
-  }
-
-  if (Number(year) < 1900) {
-    return false;
-  }
-
-  return date.getDate() === Number(day) &&
-    date.getMonth() === adjustedMonth &&
-    date.getFullYear() === Number(year);
-}
-
-function isValidName(value) {
-  return /^[a-zA-Z][a-zA-Z '\-]*$/.test(value);
-}
-
 function isValidMonetaryValue(value) {
   if (value !== null) {
     return /^[$]{0,1}\d+\.?\d*$/.test(value);
   }
   return true;
-}
-
-// TODO: look into validation libraries (npm "validator")
-function isValidPhone(value) {
-  // Strip spaces, dashes, and parens
-  const stripped = value.replace(/[^\d]/g, '');
-  // Count number of digits
-  return /^\d{10}$/.test(stripped);
-}
-
-function isValidEmail(value) {
-  // Comes from StackOverflow: http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
-  return /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(value);
 }
 
 // Pulled from https://en.wikipedia.org/wiki/Routing_transit_number#Check_digit
@@ -158,10 +73,6 @@ function isBlankMonthYear(field) {
 
 function isNotBlankDateField(field) {
   return isNotBlank(field.day.value) && isNotBlank(field.month.value) && isNotBlank(field.year.value);
-}
-
-function isValidDateField(field) {
-  return isValidDate(field.day.value, field.month.value, field.year.value);
 }
 
 function isValidFutureDate(day, month, year) {
@@ -404,25 +315,13 @@ function isValidPage(completePath, pageData) {
 }
 
 export {
-  validateIfDirty,
-  validateIfDirtyDate,
-  validateIfDirtyDateObj,
-  isBlank,
-  isNotBlank,
   isNotBlankDateField,
-  isValidDate,
-  isValidName,
-  isValidSSN,
   isValidMonetaryValue,
-  isValidPhone,
-  isValidEmail,
-  isValidYear,
   isValidYearOrBlank,
   isValidCurrentOrPastYear,
   isValidMonths,
   isValidRoutingNumber,
   isValidField,
-  isValidDateField,
   isValidFutureOrPastDateField,
   isValidDateRange,
   isValidForm,

--- a/src/js/edu-benefits/utils/validations.js
+++ b/src/js/edu-benefits/utils/validations.js
@@ -7,28 +7,23 @@ import {
   isBlank,
   isBlankAddress,
   isNotBlank,
+  isNotBlankDateField,
+  isValidCurrentOrPastYear,
   isValidDateField,
   isValidDateOver17,
+  isValidDateRange,
   isValidEmail,
-  isValidName,
+  isValidField,
+  isValidFullNameField,
+  isValidMonths,
   isValidPartialDateField,
   isValidPartialMonthYearInPast,
+  isValidPartialMonthYearRange,
   isValidPhone,
+  isValidRequiredField,
   isValidSSN,
   isValidYear
 } from '../../common/utils/validations';
-
-function isValidYearOrBlank(value) {
-  return isValidYear(value) || value === '';
-}
-
-function isValidCurrentOrPastYear(value) {
-  return Number(value) >= 1900 && Number(value) < moment().year() + 1;
-}
-
-function isValidMonths(value) {
-  return Number(value) >= 0;
-}
 
 function isValidMonetaryValue(value) {
   if (value !== null) {
@@ -51,46 +46,8 @@ function isValidRoutingNumber(value) {
   return false;
 }
 
-function isValidValue(validator, value) {
-  return isBlank(value) || validator(value);
-}
-
-function isValidField(validator, field) {
-  return isValidValue(validator, field.value);
-}
-
-function isValidRequiredField(validator, field) {
-  return isNotBlank(field.value) && validator(field.value);
-}
-
-function isBlankDateField(field) {
-  return isBlank(field.day.value) && isBlank(field.month.value) && isBlank(field.year.value);
-}
-
 function isBlankMonthYear(field) {
   return isBlank(field.month.value) && isBlank(field.year.value);
-}
-
-function isNotBlankDateField(field) {
-  return isNotBlank(field.day.value) && isNotBlank(field.month.value) && isNotBlank(field.year.value);
-}
-
-function isValidFutureDate(day, month, year) {
-  if (!isValidYear(year)) {
-    return false;
-  }
-  const today = moment().startOf('day');
-  const date = moment({
-    day,
-    month: parseInt(month, 10) - 1,
-    year
-  });
-
-  return date.isValid() && date.isSameOrAfter(today);
-}
-
-function isValidFutureDateField(field) {
-  return isValidFutureDate(field.day.value, field.month.value, field.year.value);
 }
 
 function isValidFutureOrPastDateField(field) {
@@ -100,32 +57,6 @@ function isValidFutureOrPastDateField(field) {
   }
 
   return true;
-}
-
-function isValidDateRange(fromDate, toDate) {
-  if (isBlankDateField(toDate) || isBlankDateField(fromDate)) {
-    return true;
-  }
-  const momentStart = dateToMoment(fromDate);
-  const momentEnd = dateToMoment(toDate);
-
-  return momentStart.isBefore(momentEnd);
-}
-
-function isValidPartialMonthYearRange(fromDate, toDate) {
-  if (!fromDate.year.value || !toDate.year.value) {
-    return true;
-  }
-  const momentStart = dateToMoment(fromDate);
-  const momentEnd = dateToMoment(toDate);
-
-  return momentStart.isSameOrBefore(momentEnd);
-}
-
-function isValidFullNameField(field) {
-  return isValidName(field.first.value) &&
-    (isBlank(field.middle.value) || isValidName(field.middle.value)) &&
-    isValidName(field.last.value);
 }
 
 function isValidAddressField(field) {
@@ -175,6 +106,7 @@ function isValidBenefitsRelinquishmentPage(data) {
       (!showRelinquishedEffectiveDate(data.benefitsRelinquished.value) ||
         isValidRelinquishedDate(data.benefitsRelinquishedDate)));
 }
+
 function isValidTourOfDuty(tour) {
   return isNotBlank(tour.serviceBranch.value)
     && isValidDateField(tour.dateRange.from)
@@ -315,15 +247,9 @@ function isValidPage(completePath, pageData) {
 }
 
 export {
-  isNotBlankDateField,
   isValidMonetaryValue,
-  isValidYearOrBlank,
-  isValidCurrentOrPastYear,
-  isValidMonths,
   isValidRoutingNumber,
-  isValidField,
   isValidFutureOrPastDateField,
-  isValidDateRange,
   isValidForm,
   isValidPersonalInfoPage,
   isValidAddressField,
@@ -332,12 +258,9 @@ export {
   isValidMilitaryServicePage,
   isValidServicePeriodsPage,
   isValidPage,
-  isValidValue,
-  isValidFutureDateField,
   isValidRelinquishedDate,
   isValidTourOfDuty,
   isValidEmploymentPeriod,
   isValidRotcScholarshipAmount,
-  isValidPartialMonthYearRange,
   isValidEducationPeriod
 };

--- a/src/js/edu-benefits/utils/validations.js
+++ b/src/js/edu-benefits/utils/validations.js
@@ -6,6 +6,7 @@ import { dateToMoment } from '../../common/utils/helpers';
 import {
   isBlank,
   isBlankAddress,
+  isBlankMonthYear,
   isNotBlank,
   isNotBlankDateField,
   isValidCurrentOrPastYear,
@@ -44,10 +45,6 @@ function isValidRoutingNumber(value) {
     return (weighted % 10) === 0;
   }
   return false;
-}
-
-function isBlankMonthYear(field) {
-  return isBlank(field.month.value) && isBlank(field.year.value);
 }
 
 function isValidFutureOrPastDateField(field) {

--- a/src/js/edu-benefits/utils/veteran.js
+++ b/src/js/edu-benefits/utils/veteran.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 import { makeField } from '../../common/model/fields';
-import { isValidAddressField } from '../utils/validations';
+import { isValidAddressField } from './validations';
 import { formatPartialDate } from './helpers';
 import moment from 'moment';
 

--- a/src/js/hca/components/military-service/ServiceInformationSection.jsx
+++ b/src/js/hca/components/military-service/ServiceInformationSection.jsx
@@ -4,7 +4,8 @@ import { connect } from 'react-redux';
 import DateInput from '../../../common/components/form-elements/DateInput';
 import ErrorableSelect from '../../../common/components/form-elements/ErrorableSelect';
 import { branchesServed, dischargeTypes } from '../../../common/utils/options-for-select.js';
-import { validateIfDirty, isNotBlank, isValidDischargeDateField, isValidEntryDateField } from '../../../common/utils/validations';
+import { validateIfDirty, isNotBlank } from '../../../common/utils/validations';
+import { isValidDischargeDateField, isValidEntryDateField } from '../../utils/validations';
 import { veteranUpdateField } from '../../actions';
 import { displayLabel } from '../../store/calculated';
 

--- a/src/js/hca/utils/validations.js
+++ b/src/js/hca/utils/validations.js
@@ -6,9 +6,7 @@ import {
   isNotBlank,
   isValidCanPostalCode,
   isValidDateField,
-  isValidDischargeDateField,
   isValidEmail,
-  isValidEntryDateField,
   isValidField,
   isValidFullNameField,
   isValidMonetaryValue,
@@ -29,6 +27,42 @@ function validateIfDirtyProvider(field1, field2, validator) {
 
 function isValidLastName(value) {
   return /^[a-zA-Z '\-]{2,}$/.test(value);
+}
+
+function isValidEntryDateField(date, dateOfBirth) {
+  let adjustedDate;
+  let adjustedDateOfBirth;
+
+  if (!isBlankDateField(date) && !isBlankDateField(dateOfBirth)) {
+    const adjustedBirthYear = Number(dateOfBirth.year.value) + 15;
+    adjustedDate = new Date(`${date.month.value}/${date.day.value}/${date.year.value}`);
+    adjustedDateOfBirth = new Date(`${dateOfBirth.month.value}/${dateOfBirth.day.value}/${adjustedBirthYear}`);
+
+    if (adjustedDate < adjustedDateOfBirth) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isValidDischargeDateField(date, entryDate) {
+  let adjustedDate;
+  let adjustedEntryDate;
+  const d = new Date();
+  const today = new Date(d.setHours(0, 0, 0, 0));
+
+  if (!isBlankDateField(date) && !isBlankDateField(entryDate)) {
+    adjustedDate = new Date(`${date.month.value}/${date.day.value}/${date.year.value}`);
+    adjustedEntryDate = new Date(`${entryDate.month.value}/${entryDate.day.value}/${entryDate.year.value}`);
+
+    // Validation Rule: Discharge date must be after entry date and before today
+    if (adjustedDate < adjustedEntryDate || adjustedDate >= today) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function isValidAddressField(field) {
@@ -339,6 +373,8 @@ function isValidSection(completePath, sectionData) {
 export {
   validateIfDirtyProvider,
   isValidLastName,
+  isValidEntryDateField,
+  isValidDischargeDateField,
   isValidInsurancePolicy,
   isValidDependentDateField,
   isValidMarriageDate,

--- a/test/common/utils/validations.unit.spec.js
+++ b/test/common/utils/validations.unit.spec.js
@@ -3,6 +3,7 @@ import moment from 'moment';
 
 import {
   isValidDate,
+  isValidDateRange,
   isValidSSN,
   isValidName,
   isNotBlank,
@@ -12,6 +13,7 @@ import {
   isValidPartialDate,
   validateCustomFormComponent,
   isValidPartialMonthYear,
+  isValidPartialMonthYearRange,
   isValidPartialMonthYearInPast
 } from '../../../src/js/common/utils/validations.js';
 
@@ -90,6 +92,189 @@ describe('Validations unit tests', () => {
     it('validate future dates', () => {
       // future dates are bad.
       expect(isValidDate(1, 1, 2050)).to.be.false;
+    });
+  });
+
+  describe('isValidDateRange', () => {
+    it('validates if to date is after from date', () => {
+      const fromDate = {
+        day: {
+          value: 3,
+          dirty: true
+        },
+        month: {
+          value: 3,
+          dirty: true
+        },
+        year: {
+          value: 2006,
+          dirty: true
+        }
+      };
+      const toDate = {
+        day: {
+          value: 3,
+          dirty: true
+        },
+        month: {
+          value: 4,
+          dirty: true
+        },
+        year: {
+          value: 2006,
+          dirty: true
+        }
+      };
+      expect(isValidDateRange(fromDate, toDate)).to.be.true;
+    });
+    it('does not validate to date is before from date', () => {
+      const fromDate = {
+        day: {
+          value: 3,
+          dirty: true
+        },
+        month: {
+          value: 3,
+          dirty: true
+        },
+        year: {
+          value: 2006,
+          dirty: true
+        }
+      };
+      const toDate = {
+        day: {
+          value: 3,
+          dirty: true
+        },
+        month: {
+          value: 4,
+          dirty: true
+        },
+        year: {
+          value: 2005,
+          dirty: true
+        }
+      };
+      expect(isValidDateRange(fromDate, toDate)).to.be.false;
+    });
+    it('does validate with partial dates', () => {
+      const fromDate = {
+        day: {
+          value: '3',
+          dirty: true
+        },
+        month: {
+          value: 3,
+          dirty: true
+        },
+        year: {
+          value: 2006,
+          dirty: true
+        }
+      };
+      const toDate = {
+        day: {
+          value: '',
+          dirty: true
+        },
+        month: {
+          value: '',
+          dirty: true
+        },
+        year: {
+          value: 2008,
+          dirty: true
+        }
+      };
+      expect(isValidDateRange(fromDate, toDate)).to.be.true;
+    });
+  });
+
+  describe('isValidPartialMonthYearRange', () => {
+    it('should validate partial range', () => {
+      const fromDate = {
+        month: {
+          value: '2'
+        },
+        year: {
+          value: '2001'
+        }
+      };
+
+      const toDate = {
+        month: {
+          value: '3'
+        },
+        year: {
+          value: ''
+        }
+      };
+
+      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.true;
+    });
+    it('should not validate invalid range', () => {
+      const fromDate = {
+        month: {
+          value: '2'
+        },
+        year: {
+          value: '2002'
+        }
+      };
+
+      const toDate = {
+        month: {
+          value: '3'
+        },
+        year: {
+          value: '2001'
+        }
+      };
+
+      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.false;
+    });
+    it('should validate same date range', () => {
+      const fromDate = {
+        month: {
+          value: '2'
+        },
+        year: {
+          value: '2001'
+        }
+      };
+
+      const toDate = {
+        month: {
+          value: '2'
+        },
+        year: {
+          value: '2001'
+        }
+      };
+
+      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.true;
+    });
+    it('should validate year only range', () => {
+      const fromDate = {
+        month: {
+          value: ''
+        },
+        year: {
+          value: '2001'
+        }
+      };
+
+      const toDate = {
+        month: {
+          value: ''
+        },
+        year: {
+          value: '2002'
+        }
+      };
+
+      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.true;
     });
   });
 

--- a/test/edu-benefits/utils/validations.unit.spec.js
+++ b/test/edu-benefits/utils/validations.unit.spec.js
@@ -4,12 +4,10 @@ import moment from 'moment';
 import {
   isValidContactInformationPage,
   isValidMilitaryServicePage,
-  isValidDateRange,
   isValidFutureOrPastDateField,
   isValidPage,
   isValidRoutingNumber,
   isValidRelinquishedDate,
-  isValidPartialMonthYearRange,
   isValidEducationPeriod,
   isValidEducationHistoryPage
 } from '../../../src/js/edu-benefits/utils/validations.js';
@@ -18,101 +16,6 @@ import { createVeteran } from '../../../src/js/edu-benefits/utils/veteran.js';
 import { makeField } from '../../../src/js/common/model/fields.js';
 
 describe('Validation:', () => {
-  describe('isValidDateRange', () => {
-    it('validates if to date is after from date', () => {
-      const fromDate = {
-        day: {
-          value: 3,
-          dirty: true
-        },
-        month: {
-          value: 3,
-          dirty: true
-        },
-        year: {
-          value: 2006,
-          dirty: true
-        }
-      };
-      const toDate = {
-        day: {
-          value: 3,
-          dirty: true
-        },
-        month: {
-          value: 4,
-          dirty: true
-        },
-        year: {
-          value: 2006,
-          dirty: true
-        }
-      };
-      expect(isValidDateRange(fromDate, toDate)).to.be.true;
-    });
-    it('does not validate to date is before from date', () => {
-      const fromDate = {
-        day: {
-          value: 3,
-          dirty: true
-        },
-        month: {
-          value: 3,
-          dirty: true
-        },
-        year: {
-          value: 2006,
-          dirty: true
-        }
-      };
-      const toDate = {
-        day: {
-          value: 3,
-          dirty: true
-        },
-        month: {
-          value: 4,
-          dirty: true
-        },
-        year: {
-          value: 2005,
-          dirty: true
-        }
-      };
-      expect(isValidDateRange(fromDate, toDate)).to.be.false;
-    });
-    it('does validate with partial dates', () => {
-      const fromDate = {
-        day: {
-          value: '3',
-          dirty: true
-        },
-        month: {
-          value: 3,
-          dirty: true
-        },
-        year: {
-          value: 2006,
-          dirty: true
-        }
-      };
-      const toDate = {
-        day: {
-          value: '',
-          dirty: true
-        },
-        month: {
-          value: '',
-          dirty: true
-        },
-        year: {
-          value: 2008,
-          dirty: true
-        }
-      };
-      expect(isValidDateRange(fromDate, toDate)).to.be.true;
-    });
-  });
   describe('isValidPage:', () => {
     describe('EmploymentHistory', () => {
       it('validates page without license is valid', () => {
@@ -326,92 +229,6 @@ describe('Validation:', () => {
       };
 
       expect(isValidMilitaryServicePage(data)).to.be.true;
-    });
-  });
-  describe('isValidPartialMonthYearRange', () => {
-    it('should validate partial range', () => {
-      const fromDate = {
-        month: {
-          value: '2'
-        },
-        year: {
-          value: '2001'
-        }
-      };
-
-      const toDate = {
-        month: {
-          value: '3'
-        },
-        year: {
-          value: ''
-        }
-      };
-
-      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.true;
-    });
-    it('should not validate invalid range', () => {
-      const fromDate = {
-        month: {
-          value: '2'
-        },
-        year: {
-          value: '2002'
-        }
-      };
-
-      const toDate = {
-        month: {
-          value: '3'
-        },
-        year: {
-          value: '2001'
-        }
-      };
-
-      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.false;
-    });
-    it('should validate same date range', () => {
-      const fromDate = {
-        month: {
-          value: '2'
-        },
-        year: {
-          value: '2001'
-        }
-      };
-
-      const toDate = {
-        month: {
-          value: '2'
-        },
-        year: {
-          value: '2001'
-        }
-      };
-
-      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.true;
-    });
-    it('should validate year only range', () => {
-      const fromDate = {
-        month: {
-          value: ''
-        },
-        year: {
-          value: '2001'
-        }
-      };
-
-      const toDate = {
-        month: {
-          value: ''
-        },
-        year: {
-          value: '2002'
-        }
-      };
-
-      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.true;
     });
   });
   describe('isValidEducationPeriod', () => {


### PR DESCRIPTION
Consolidation of all education validations, both general and field. This is going to be hard to review because I moved around the order of a lot of validation functions, so the git comparison is hard to read. Mostly what I did was:
- Remove common validations from edu-benefits/utils/validations
- Move validations that could be shared from edu-benefits/utils/validations into common/utils/validations
- Reorder validations in common/utils/validations with some comments to group them