### PR TITLE
Hide tuition top-up option

### DIFF
--- a/src/js/edu-benefits/components/school-selection/SchoolSelectionFields.jsx
+++ b/src/js/edu-benefits/components/school-selection/SchoolSelectionFields.jsx
@@ -12,8 +12,9 @@ import { showSchoolAddress } from '../../utils/helpers';
 
 export default class SchoolSelectionFields extends React.Component {
   render() {
-    let schoolTypesList;
-    (this.props.data.chapter33 || this.props.data.chapter30) ? schoolTypesList = schoolTypesWithTuitionTopUp : schoolTypesList = schoolTypes;
+    const schoolTypesList = (this.props.data.chapter33 || this.props.data.chapter30)
+      ? schoolTypesWithTuitionTopUp 
+      : schoolTypes
 
     return (<fieldset>
       <legend className="hide-for-small-only">School selection</legend>

--- a/src/js/edu-benefits/components/school-selection/SchoolSelectionFields.jsx
+++ b/src/js/edu-benefits/components/school-selection/SchoolSelectionFields.jsx
@@ -7,11 +7,14 @@ import ExpandingGroup from '../../../common/components/form-elements/ExpandingGr
 import ErrorableDate from '../../../common/components/form-elements/ErrorableDate';
 import Address from '../Address';
 
-import { schoolTypes, yesNo } from '../../utils/options-for-select';
+import { schoolTypes, schoolTypesWithTuitionTopUp, yesNo } from '../../utils/options-for-select';
 import { showSchoolAddress } from '../../utils/helpers';
 
 export default class SchoolSelectionFields extends React.Component {
   render() {
+    let schoolTypesList;
+    (this.props.data.chapter33 || this.props.data.chapter30) ? schoolTypesList = schoolTypesWithTuitionTopUp : schoolTypesList = schoolTypes;
+
     return (<fieldset>
       <legend className="hide-for-small-only">School selection</legend>
       <p><span className="form-required-span">*</span>Indicates a required field</p>
@@ -23,7 +26,7 @@ export default class SchoolSelectionFields extends React.Component {
           <ErrorableSelect
               label="Type of education or training:"
               name="educationType"
-              options={schoolTypes}
+              options={schoolTypesList}
               value={this.props.data.educationType}
               onValueChange={(update) => {this.props.onStateChange('educationType', update);}}/>
         </div>

--- a/src/js/edu-benefits/components/school-selection/SchoolSelectionFields.jsx
+++ b/src/js/edu-benefits/components/school-selection/SchoolSelectionFields.jsx
@@ -13,8 +13,8 @@ import { showSchoolAddress } from '../../utils/helpers';
 export default class SchoolSelectionFields extends React.Component {
   render() {
     const schoolTypesList = (this.props.data.chapter33 || this.props.data.chapter30)
-      ? schoolTypesWithTuitionTopUp 
-      : schoolTypes
+      ? schoolTypesWithTuitionTopUp
+      : schoolTypes;
 
     return (<fieldset>
       <legend className="hide-for-small-only">School selection</legend>

--- a/src/js/edu-benefits/components/school-selection/SchoolSelectionReview.jsx
+++ b/src/js/edu-benefits/components/school-selection/SchoolSelectionReview.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { getLabel, showSchoolAddress, showYesNo } from '../../utils/helpers';
-import { schoolTypes } from '../../utils/options-for-select';
+import { schoolTypesWithTuitionTopUp } from '../../utils/options-for-select';
 
 export default class SchoolSelectionReview extends React.Component {
   render() {
@@ -10,7 +10,7 @@ export default class SchoolSelectionReview extends React.Component {
         <tbody>
           <tr>
             <td>Type of education or training:</td>
-            <td>{getLabel(schoolTypes, this.props.data.educationType.value)}</td>
+            <td>{getLabel(schoolTypesWithTuitionTopUp, this.props.data.educationType.value)}</td>
           </tr>
           {showSchoolAddress(this.props.data.educationType.value)
             ? <tbody>

--- a/src/js/edu-benefits/utils/options-for-select.js
+++ b/src/js/edu-benefits/utils/options-for-select.js
@@ -456,15 +456,7 @@ const schoolTypes = [
   { label: 'Correspondence', value: 'correspondence' }
 ];
 
-const schoolTypesWithTuitionTopUp = [
-  { label: 'College, university, or other educational program, including online courses', value: 'college' },
-  { label: 'Vocational flight training', value: 'flightTraining' },
-  { label: 'National test reimbursement (for example, SAT or CLEP)', value: 'testReimbursement' },
-  { label: 'Licensing or certification test reimbursement (for example, MCSE, CCNA, EMT, or NCLEX)', value: 'licensingReimbursement' },
-  { label: 'Apprenticeship or on-the-job training', value: 'apprenticeship' },
-  { label: 'Correspondence', value: 'correspondence' },
-  { label: 'Tuition assistance top-up (Post 9/11 GI Bill and MGIB-AD only)', value: 'tuitionTopUp' }
-];
+const schoolTypesWithTuitionTopUp = schoolTypes.concat({ label: 'Tuition assistance top-up (Post 9/11 GI Bill and MGIB-AD only)', value: 'tuitionTopUp' });
 
 const contactOptions = [
   { label: 'Email', value: 'email' },

--- a/src/js/edu-benefits/utils/options-for-select.js
+++ b/src/js/edu-benefits/utils/options-for-select.js
@@ -453,6 +453,15 @@ const schoolTypes = [
   { label: 'National test reimbursement (for example, SAT or CLEP)', value: 'testReimbursement' },
   { label: 'Licensing or certification test reimbursement (for example, MCSE, CCNA, EMT, or NCLEX)', value: 'licensingReimbursement' },
   { label: 'Apprenticeship or on-the-job training', value: 'apprenticeship' },
+  { label: 'Correspondence', value: 'correspondence' }
+];
+
+const schoolTypesWithTuitionTopUp = [
+  { label: 'College, university, or other educational program, including online courses', value: 'college' },
+  { label: 'Vocational flight training', value: 'flightTraining' },
+  { label: 'National test reimbursement (for example, SAT or CLEP)', value: 'testReimbursement' },
+  { label: 'Licensing or certification test reimbursement (for example, MCSE, CCNA, EMT, or NCLEX)', value: 'licensingReimbursement' },
+  { label: 'Apprenticeship or on-the-job training', value: 'apprenticeship' },
   { label: 'Correspondence', value: 'correspondence' },
   { label: 'Tuition assistance top-up (Post 9/11 GI Bill and MGIB-AD only)', value: 'tuitionTopUp' }
 ];
@@ -523,6 +532,7 @@ module.exports = {
   yesNoNA,
   serviceBranches,
   schoolTypes,
+  schoolTypesWithTuitionTopUp,
   employmentPeriodTiming,
   contactOptions,
   accountTypes,


### PR DESCRIPTION
Closes: [#3602](https://github.com/department-of-veterans-affairs/vets-website/issues/3602)

• Only displays the `tuitionTopUp` option if user selected chapter 33 (Post-9/11 GI Bill) or chapter 30 (Montgomery GI Bill Education Assistance Program).

### With chapter 30 or 33 selected
![screen shot 2016-12-20 at 1 47 07 pm](https://cloud.githubusercontent.com/assets/6254227/21363604/4e40a99e-c6bb-11e6-81a8-18c8c98a3941.png)

### Without chapter 30 or 33 selected
![screen shot 2016-12-20 at 1 46 46 pm](https://cloud.githubusercontent.com/assets/6254227/21363603/4e2f890c-c6bb-11e6-84d9-7c5561e69444.png)