### PR TITLE
Empty state for search results

### DIFF
--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -234,8 +234,11 @@ export class Folder extends React.Component {
   }
 
   makeMessagesTable() {
-    const messages = this.props.messages;
+    const { messages, filter } = this.props;
     if (!messages || messages.length === 0) {
+      if (filter) {
+        return <p className="msg-nomessages">No messages found for your search.</p>;
+      }
       return <p className="msg-nomessages">You have no messages in this folder.</p>;
     }
 
@@ -348,7 +351,7 @@ export class Folder extends React.Component {
       const folderMessages = this.makeMessagesTable();
 
       let messageSearch;
-      if (this.props.messages && this.props.messages.length) {
+      if (this.props.messages && this.props.messages.length || this.props.filter) {
         messageSearch = (<MessageSearch
             isAdvancedVisible={this.props.isAdvancedVisible}
             onAdvancedSearch={this.props.toggleAdvancedSearch}

--- a/src/js/messaging/reducers/search.js
+++ b/src/js/messaging/reducers/search.js
@@ -36,7 +36,10 @@ const initialState = {
 export default function modals(state = initialState, action) {
   switch (action.type) {
     case SET_ADVSEARCH_END_DATE:
-      return set('params.dateRange.end', moment(action.date).endOf('day'), state);
+      if (action.date) {
+        return set('params.dateRange.end', moment(action.date).endOf('day'), state);
+      }
+      return set('params.dateRange.end', null, state);
     case SET_ADVSEARCH_START_DATE:
       return set('params.dateRange.start', action.date, state);
     case SET_SEARCH_PARAM:


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/messaging-fe/issues/175

- Shows a more clear error message when search results are empty
- leaves search control visible so that users can more easily perform another search
- fixes a bug when end date parameter is set to null