### PR TITLE
[Messaging] Fixed unauthorized downloads of attachments.

### DIFF
--- a/src/js/messaging/components/MessageAttachmentsViewItem.jsx
+++ b/src/js/messaging/components/MessageAttachmentsViewItem.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 
 import { authFetch } from '../utils/helpers';
 
@@ -6,22 +7,46 @@ class MessageAttachmentsViewItem extends React.Component {
   constructor(props) {
     super(props);
     this.downloadAttachment = this.downloadAttachment.bind(this);
+    this.downloadUrl = null;
+    this.state = { downloading: false };
   }
 
   downloadAttachment(event) {
     event.preventDefault();
-    authFetch(this.props.url)
+
+    if (this.state.downloading) return;
+
+    if (this.downloadUrl) {
+      window.open(this.downloadUrl, '_blank');
+      return;
+    }
+
+    this.setState({ downloading: true });
+    const requestUrl = this.props.url;
+    authFetch(requestUrl)
     .then(response => response.blob())
     .then(blob => {
-      window.open(URL.createObjectURL(blob), '_blank');
+      const downloadUrl = URL.createObjectURL(blob);
+      this.downloadUrl = downloadUrl;
+      this.setState({ downloading: false });
+      window.open(this.downloadUrl, '_blank');
     });
   }
 
   render() {
+    const iconClass = classNames({
+      fa: true,
+      'fa-paperclip': !this.state.downloading,
+      'fa-spinner': this.state.downloading,
+      'fa-pulse': this.state.downloading,
+      'msg-attachment-icon': true
+    });
+
     return (
       <li>
-        <a onClick={this.downloadAttachment} href={this.props.url} className="msg-attachment-item" download>
-          <i className="fa fa-paperclip msg-attachment-icon"></i>
+        <a onClick={this.downloadAttachment} href={this.props.url} className="msg-attachment-item">
+          <i className={iconClass}></i>
+          <span className="usa-sr-only">Loading...</span>
           {this.props.name}
         </a>
       </li>

--- a/src/js/messaging/components/MessageAttachmentsViewItem.jsx
+++ b/src/js/messaging/components/MessageAttachmentsViewItem.jsx
@@ -1,10 +1,26 @@
 import React from 'react';
 
+import { authFetch } from '../utils/helpers';
+
 class MessageAttachmentsViewItem extends React.Component {
+  constructor(props) {
+    super(props);
+    this.downloadAttachment = this.downloadAttachment.bind(this);
+  }
+
+  downloadAttachment(event) {
+    event.preventDefault();
+    authFetch(this.props.url)
+    .then(response => response.blob())
+    .then(blob => {
+      window.open(URL.createObjectURL(blob), '_blank');
+    });
+  }
+
   render() {
     return (
       <li>
-        <a href={this.props.url} className="msg-attachment-item" download>
+        <a onClick={this.downloadAttachment} href={this.props.url} className="msg-attachment-item" download>
           <i className="fa fa-paperclip msg-attachment-icon"></i>
           {this.props.name}
         </a>

--- a/src/js/messaging/utils/helpers.js
+++ b/src/js/messaging/utils/helpers.js
@@ -29,21 +29,29 @@ export function createUrlWithQuery(url, query) {
   return fullUrl;
 }
 
+export function authFetch(url, optionalSettings) {
+  const defaultSettings = {
+    method: 'GET',
+    headers: {
+      Authorization: `Token token=${sessionStorage.userToken}`
+    }
+  };
+
+  return fetch(url, merge(defaultSettings, optionalSettings));
+}
+
 export function apiRequest(resource, optionalSettings = {}, success, error) {
   const baseUrl = `${environment.API_URL}/v0/messaging/health`;
   const url = [baseUrl, resource].join('');
 
   const defaultSettings = {
     method: 'GET',
-    headers: {
-      Authorization: `Token token=${sessionStorage.userToken}`,
-      'X-Key-Inflection': 'camel'
-    }
+    headers: { 'X-Key-Inflection': 'camel' }
   };
 
   const settings = merge(defaultSettings, optionalSettings);
 
-  return fetch(url, settings)
+  return authFetch(url, settings)
     .then((response) => {
       if (!response.ok) {
         return Promise.reject(response);

--- a/src/sass/messaging/partials/_messaging-attachments.scss
+++ b/src/sass/messaging/partials/_messaging-attachments.scss
@@ -21,7 +21,7 @@
 
 .msg-attachment-icon {
   color: $color-base;
-  padding-right: .75rem;
+  margin-right: .75rem;
 }
 
 .msg-attachment-item {


### PR DESCRIPTION
Closes department-of-veterans-affairs/messaging-fe#159.

We were previously trying to access the attached files through the API without an auth header. Even with that header, we still need to convert the retrieved data into a blob and use the URL for it. In this case, I just have it open in a new tab.

I also added a small spinner to indicate that the file is being downloaded.

#### Display spinner while attachment is downloading.
> <img width="739" alt="screen shot 2016-12-21 at 2 41 58 pm" src="https://cloud.githubusercontent.com/assets/1067024/21403801/5fc20bc8-c78c-11e6-918a-690efb36a80d.png">

