### PR TITLE
Prevent default event on draft deletion

### DIFF
--- a/src/js/messaging/components/compose/ModalConfirmDelete.jsx
+++ b/src/js/messaging/components/compose/ModalConfirmDelete.jsx
@@ -3,15 +3,21 @@ import React from 'react';
 import Modal from '../../../common/components/Modal';
 
 class ModalConfirmDelete extends React.Component {
+
+  handleDelete = (e) => {
+    e.preventDefault();
+    this.props.onDelete();
+  }
+
   render() {
     const modalContents = (
-      <form onSubmit={this.props.onDelete}>
+      <form>
         <h3>
             Are you sure you want to delete this draft?
         </h3>
         <p>This draft will not be recoverable after deletion.</p>
         <div className="va-modal-button-group">
-          <button type="submit">Yes, delete forever</button>
+          <button type="submit" onClick={this.handleDelete}>Yes, delete forever</button>
           <button
               className="usa-button-outline"
               onClick={this.props.onClose}

--- a/src/js/messaging/reducers/folders.js
+++ b/src/js/messaging/reducers/folders.js
@@ -57,7 +57,6 @@ const folderKey = (folderName) => _.kebabCase(folderName);
 const setRedirect = (state) => {
   // Set the redirect to the most recent folder.
   // Default to 'Inbox' if no folder has been visited.
-
   const folderName = _.get(
     state,
     'data.currentItem.attributes.name',


### PR DESCRIPTION
- potentially resolves https://github.com/department-of-veterans-affairs/messaging-fe/issues/206

This is difficult for me to debug because I still have some trouble with using SSH to hit the real server, but could it be that clicking the submit button triggers a full page reload? This is what seems to happen for me when I click it.

With this change, the full page refresh goes away, and I can see the "Failed to delete message" alert on top. (Expected since the Heroku mock endpoint has a 500 error