### PR TITLE
[Messaging] Folder container unit tests.

### DIFF
--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -9,13 +9,33 @@ import { folderUrl } from '../utils/helpers';
 
 class ThreadHeader extends React.Component {
   render() {
-    const currentFolder = this.props.currentFolder;
+    const {
+      currentFolder,
+      folderMessageCount,
+      message,
+      threadMessageCount
+    } = this.props;
+
     const folderName = currentFolder.name;
-    let toggleThread;
+    let messageNav;
     let moveTo;
     let deleteButton;
+    let toggleThread;
 
-    if (this.props.threadMessageCount > 1) {
+    if (folderMessageCount) {
+      const { currentMessageNumber } = this.props;
+
+      messageNav = (
+        <MessageNav
+            currentRange={currentMessageNumber}
+            messageCount={folderMessageCount}
+            onItemSelect={this.props.onMessageSelect}
+            itemNumber={currentMessageNumber}
+            totalItems={folderMessageCount}/>
+      );
+    }
+
+    if (threadMessageCount > 1) {
       toggleThread = (
         <ToggleThread
             messagesCollapsed={this.props.messagesCollapsed}
@@ -32,12 +52,14 @@ class ThreadHeader extends React.Component {
       // Hide the 'Move' button for drafts and sent messages,
       // since they can't be moved to other folders.
       if (folderName !== 'Drafts') {
+        const { folders, moveToIsOpen } = this.props;
+
         moveTo = (
           <MoveTo
               currentFolder={currentFolder}
-              folders={this.props.folders}
-              isOpen={this.props.moveToIsOpen}
-              messageId={this.props.message.messageId}
+              folders={folders}
+              isOpen={moveToIsOpen}
+              messageId={message.messageId}
               onChooseFolder={this.props.onChooseFolder}
               onCreateFolder={this.props.onCreateFolder}
               onToggleMoveTo={this.props.onToggleMoveTo}/>
@@ -51,12 +73,7 @@ class ThreadHeader extends React.Component {
       <div className="messaging-thread-header">
         <div className="messaging-thread-nav">
           <Link to={backUrl}>&lt; Back to {folderName}</Link>
-          <MessageNav
-              currentRange={this.props.currentMessageNumber}
-              messageCount={this.props.folderMessageCount}
-              onItemSelect={this.props.onMessageSelect}
-              itemNumber={this.props.currentMessageNumber}
-              totalItems={this.props.folderMessageCount}/>
+          {messageNav}
           {moveTo}
           {deleteButton}
         </div>
@@ -65,7 +82,7 @@ class ThreadHeader extends React.Component {
             {toggleThread}
             {deleteButton}
           </div>
-          <h2 className="messaging-thread-subject">{this.props.message.subject}</h2>
+          <h2 className="messaging-thread-subject">{message.subject}</h2>
         </div>
       </div>
     );

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -54,8 +54,11 @@ export class Folder extends React.Component {
     // In the typical case of redirects, we go to the most recent folder
     // and proceed with fetching its data. If that's not the case,
     // go ahead to the URL specified in the redirect.
-    if (redirect && redirect !== this.props.location.pathname) {
-      this.context.router.replace(redirect);
+    if (redirect && redirect.url !== this.props.location.pathname) {
+      this.context.router.push({
+        pathname: redirect.url,
+        state: { preserveAlert: true }
+      });
       return;
     }
 

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -160,16 +160,19 @@ export class Folder extends React.Component {
   }
 
   makeMessageNav() {
-    const { currentRange, messageCount, currentPage, totalPages } = this.props;
+    const { pagination } = this.props;
+    const { currentPage, perPage, totalEntries, totalPages } = pagination;
 
-    if (messageCount === 0) {
-      return null;
-    }
+    if (_.isEmpty(pagination) || !totalEntries) return null;
+
+    const startCount = 1 + (currentPage - 1) * perPage;
+    const endCount = Math.min(totalEntries, currentPage * perPage);
+    const currentRange = `${startCount} - ${endCount}`;
 
     return (
       <MessageNav
           currentRange={currentRange}
-          messageCount={messageCount}
+          messageCount={totalEntries}
           onItemSelect={this.handlePageSelect}
           itemNumber={currentPage}
           totalItems={totalPages}/>
@@ -400,24 +403,17 @@ Folder.contextTypes = {
 const mapStateToProps = (state) => {
   const folder = state.folders.data.currentItem;
   const { attributes, filter, messages, pagination, sort } = folder;
-  const { currentPage, perPage, totalEntries, totalPages } = pagination;
-
-  const startCount = 1 + (currentPage - 1) * perPage;
-  const endCount = Math.min(totalEntries, currentPage * perPage);
 
   return {
     attributes,
-    currentRange: `${startCount} - ${endCount}`,
     filter,
     folders: state.folders.data.items,
     lastRequestedFolder: state.folders.ui.lastRequestedFolder,
     loading: state.loading,
-    messageCount: totalEntries,
     messages,
     moveToId: state.folders.ui.moveToId,
-    currentPage,
+    pagination,
     redirect: state.folders.ui.redirect,
-    totalPages,
     isAdvancedVisible: state.search.advanced.visible,
     searchParams: state.search.params,
     sort

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -237,7 +237,7 @@ export class Folder extends React.Component {
   }
 
   makeMessagesTable() {
-    const { messages, filter, attributes } = this.props;
+    const { attributes, filter, messages } = this.props;
 
     if (!messages || messages.length === 0) {
       if (filter) {
@@ -246,9 +246,7 @@ export class Folder extends React.Component {
       return <p className="msg-nomessages">You have no messages in this folder.</p>;
     }
 
-    const makeMessageLink = (content, id) => {
-      return <Link to={`/${this.props.params.folderName}/${id}`}>{content}</Link>;
-    };
+    // Create sortable table headers.
 
     const fields = [
       { label: 'From', value: 'senderName' },
@@ -273,10 +271,16 @@ export class Folder extends React.Component {
       fields.push({ label: '', value: 'moveToButton' });
     }
 
+    // Create sortable table rows.
+
     const folders = [];
     this.props.folders.forEach(v => {
       folders.push(v);
     });
+
+    const makeMessageLink = (content, id) => {
+      return <Link to={`/${this.props.params.folderName}/${id}`}>{content}</Link>;
+    };
 
     const data = messages.map(message => {
       const id = message.messageId;
@@ -403,18 +407,19 @@ Folder.contextTypes = {
 const mapStateToProps = (state) => {
   const folder = state.folders.data.currentItem;
   const { attributes, filter, messages, pagination, sort } = folder;
+  const { lastRequestedFolder, moveToId, redirect } = state.folders.ui;
 
   return {
     attributes,
     filter,
     folders: state.folders.data.items,
-    lastRequestedFolder: state.folders.ui.lastRequestedFolder,
+    isAdvancedVisible: state.search.advanced.visible,
+    lastRequestedFolder,
     loading: state.loading,
     messages,
-    moveToId: state.folders.ui.moveToId,
+    moveToId,
     pagination,
-    redirect: state.folders.ui.redirect,
-    isAdvancedVisible: state.search.advanced.visible,
+    redirect,
     searchParams: state.search.params,
     sort
   };

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -343,14 +343,22 @@ export class Folder extends React.Component {
 
         componentContent = (
           <div className="columns">
-            <p>
+            <p className="msg-loading-error">
               Could not retrieve the folder.&nbsp;
-              <a onClick={reloadFolder}>Click here to try again.</a>
+              <a className="msg-reload" onClick={reloadFolder}>
+                Click here to try again.
+              </a>
             </p>
           </div>
         );
       } else {
-        componentContent = <div className="columns"><p>Sorry, this folder does not exist.</p></div>;
+        componentContent = (
+          <div className="columns">
+            <p className="msg-loading-error">
+              Sorry, this folder does not exist.
+            </p>
+          </div>
+        );
       }
     } else {
       const messageNav = this.makeMessageNav();

--- a/src/js/messaging/reducers/folders.js
+++ b/src/js/messaging/reducers/folders.js
@@ -111,6 +111,9 @@ export default function folders(state = initialState, action) {
     }
 
     case LOADING_FOLDER: {
+      const newState =
+        set('data.currentItem', initialState.data.currentItem, state);
+
       return set('ui', {
         ...initialState.ui,
         nav: {
@@ -118,7 +121,7 @@ export default function folders(state = initialState, action) {
           visible: false
         },
         lastRequestedFolder: action.request
-      }, state);
+      }, newState);
     }
 
     case TOGGLE_FOLDER_MOVE_TO: {

--- a/src/js/messaging/reducers/folders.js
+++ b/src/js/messaging/reducers/folders.js
@@ -26,12 +26,7 @@ const initialState = {
       attributes: {},
       filter: {},
       messages: [],
-      pagination: {
-        currentPage: 0,
-        perPage: 0,
-        totalEntries: 0,
-        totalPages: 0
-      },
+      pagination: {},
       sort: {
         value: 'sentDate',
         order: 'DESC'

--- a/src/sass/messaging/partials/_messaging-count-nav.scss
+++ b/src/sass/messaging/partials/_messaging-count-nav.scss
@@ -30,6 +30,7 @@
   }
 
   &[disabled] {
+    &,
     &:hover,
     &:active {
       color: $color-gray;

--- a/test/messaging/containers/Folder.unit.spec.jsx
+++ b/test/messaging/containers/Folder.unit.spec.jsx
@@ -60,8 +60,8 @@ describe('Folder', () => {
       <Folder {...props } loading={{ folder: true }}/>
     );
     expect(tree.subTree('LoadingIndicator')).to.not.be.false;
-    expect(tree.subTree('MessageNav')).to.be.false;
     expect(tree.subTree('MessageSearch')).to.be.false;
+    expect(tree.subTree('MessageNav')).to.be.false;
     expect(tree.subTree('SortableTable')).to.be.false;
   });
 
@@ -71,8 +71,8 @@ describe('Folder', () => {
     );
     expect(tree.subTree('.msg-loading-error')).to.not.be.false;
     expect(tree.subTree('.msg-reload')).to.be.false;
-    expect(tree.subTree('MessageNav')).to.be.false;
     expect(tree.subTree('MessageSearch')).to.be.false;
+    expect(tree.subTree('MessageNav')).to.be.false;
     expect(tree.subTree('SortableTable')).to.be.false;
   });
 
@@ -85,8 +85,17 @@ describe('Folder', () => {
     );
     expect(tree.subTree('.msg-loading-error')).to.not.be.false;
     expect(tree.subTree('.msg-reload')).to.be.not.be.false;
-    expect(tree.subTree('MessageNav')).to.be.false;
     expect(tree.subTree('MessageSearch')).to.be.false;
+    expect(tree.subTree('MessageNav')).to.be.false;
     expect(tree.subTree('SortableTable')).to.be.false;
+  });
+
+  it('should display message controls', () => {
+    const tree = SkinDeep.shallowRender(
+      <Folder {...props }/>
+    );
+    expect(tree.subTree('ComposeButton')).to.not.be.false;
+    expect(tree.subTree('MessageSearch')).to.not.be.false;
+    expect(tree.subTree('MessageNav')).to.not.be.false;
   });
 });

--- a/test/messaging/containers/Folder.unit.spec.jsx
+++ b/test/messaging/containers/Folder.unit.spec.jsx
@@ -55,7 +55,7 @@ describe('Folder', () => {
     expect(vdom).to.not.be.undefined;
   });
 
-  it('should display a loading screen', () => {
+  it('should show a loading screen', () => {
     const tree = SkinDeep.shallowRender(
       <Folder {...props } loading={{ folder: true }}/>
     );
@@ -65,7 +65,7 @@ describe('Folder', () => {
     expect(tree.subTree('SortableTable')).to.be.false;
   });
 
-  it('should display an error message without a reload', () => {
+  it('should show an error message without a reload', () => {
     const tree = SkinDeep.shallowRender(
       <Folder {...props } attributes={{}}/>
     );
@@ -76,7 +76,7 @@ describe('Folder', () => {
     expect(tree.subTree('SortableTable')).to.be.false;
   });
 
-  it('should display an error message with a reload', () => {
+  it('should show an error message with a reload', () => {
     const tree = SkinDeep.shallowRender(
       <Folder
           {...props }
@@ -90,7 +90,7 @@ describe('Folder', () => {
     expect(tree.subTree('SortableTable')).to.be.false;
   });
 
-  it('should display message controls', () => {
+  it('should show folder controls', () => {
     const tree = SkinDeep.shallowRender(
       <Folder {...props }/>
     );

--- a/test/messaging/containers/Folder.unit.spec.jsx
+++ b/test/messaging/containers/Folder.unit.spec.jsx
@@ -138,6 +138,7 @@ describe('Folder', () => {
     expect(tree.subTree('ComposeButton')).to.not.be.false;
     expect(tree.subTree('MessageSearch')).to.not.be.false;
     expect(tree.subTree('MessageNav')).to.not.be.false;
+    expect(tree.subTree('.msg-folder-sort-select')).to.not.be.false;
     expect(tree.subTree('SortableTable')).to.not.be.false;
   });
 
@@ -157,6 +158,7 @@ describe('Folder', () => {
     expect(tree.dive(['h2']).text()).to.equal('Inbox');
     expect(tree.subTree('MessageSearch')).to.not.be.false;
     expect(tree.subTree('MessageNav')).to.not.be.false;
+    expect(tree.subTree('.msg-folder-sort-select')).to.not.be.false;
     expect(tree.subTree('SortableTable')).to.not.be.false;
   });
 });

--- a/test/messaging/containers/Folder.unit.spec.jsx
+++ b/test/messaging/containers/Folder.unit.spec.jsx
@@ -90,6 +90,44 @@ describe('Folder', () => {
     expect(tree.subTree('SortableTable')).to.be.false;
   });
 
+  it('should say that there are no messages in the folder', () => {
+    const tree = SkinDeep.shallowRender(
+      <Folder
+          {...props }
+          filter={undefined}
+          messages={[]}
+          pagination={{
+            currentPage: 1,
+            perPage: 10,
+            totalPages: 1,
+            totalEntries: 0
+          }}/>
+    );
+    expect(tree.subTree('.msg-nomessages')).to.not.be.false;
+    expect(tree.subTree('MessageSearch')).to.be.false;
+    expect(tree.subTree('MessageNav')).to.be.false;
+    expect(tree.subTree('SortableTable')).to.be.false;
+  });
+
+  it('should say that no messages were found through search', () => {
+    const tree = SkinDeep.shallowRender(
+      <Folder
+          {...props }
+          filter={{ subject: { match: 'no match' } }}
+          messages={[]}
+          pagination={{
+            currentPage: 1,
+            perPage: 10,
+            totalPages: 1,
+            totalEntries: 0
+          }}/>
+    );
+    expect(tree.subTree('.msg-nomessages')).to.not.be.false;
+    expect(tree.subTree('MessageSearch')).to.not.be.false;
+    expect(tree.subTree('MessageNav')).to.be.false;
+    expect(tree.subTree('SortableTable')).to.be.false;
+  });
+
   it('should show folder controls', () => {
     const tree = SkinDeep.shallowRender(
       <Folder {...props }/>

--- a/test/messaging/containers/Folder.unit.spec.jsx
+++ b/test/messaging/containers/Folder.unit.spec.jsx
@@ -23,11 +23,11 @@ const props = {
     folder: false
   },
   messages: [
-    { body: 'test1' },
-    { body: 'test2' },
-    { body: 'test3' },
-    { body: 'test4' },
-    { body: 'test5' }
+    { subject: 'foo', body: 'test1' },
+    { subject: 'bar', body: 'test2' },
+    { subject: 'baz', body: 'test3' },
+    { subject: 'quux', body: 'test4' },
+    { subject: 'untitled', body: 'test5' }
   ],
   moveToId: null,
   pagination: {
@@ -113,7 +113,7 @@ describe('Folder', () => {
     const tree = SkinDeep.shallowRender(
       <Folder
           {...props }
-          filter={{ subject: { match: 'no match' } }}
+          filter={{ subject: { match: 'error' } }}
           messages={[]}
           pagination={{
             currentPage: 1,
@@ -133,6 +133,24 @@ describe('Folder', () => {
       <Folder {...props }/>
     );
     expect(tree.subTree('ComposeButton')).to.not.be.false;
+    expect(tree.subTree('MessageSearch')).to.not.be.false;
+    expect(tree.subTree('MessageNav')).to.not.be.false;
+    expect(tree.subTree('SortableTable')).to.not.be.false;
+  });
+
+  it('should show messages found through search', () => {
+    const tree = SkinDeep.shallowRender(
+      <Folder
+          {...props }
+          filter={{ subject: { match: 'ba' } }}
+          messages={[props.messages[1], props.messages[2]]}
+          pagination={{
+            currentPage: 1,
+            perPage: 10,
+            totalPages: 1,
+            totalEntries: 2
+          }}/>
+    );
     expect(tree.subTree('MessageSearch')).to.not.be.false;
     expect(tree.subTree('MessageNav')).to.not.be.false;
     expect(tree.subTree('SortableTable')).to.not.be.false;

--- a/test/messaging/containers/Folder.unit.spec.jsx
+++ b/test/messaging/containers/Folder.unit.spec.jsx
@@ -59,7 +59,32 @@ describe('Folder', () => {
     const tree = SkinDeep.shallowRender(
       <Folder {...props } loading={{ folder: true }}/>
     );
-    expect(tree.dive(['LoadingIndicator'])).to.not.be.undefined;
+    expect(tree.subTree('LoadingIndicator')).to.not.be.false;
+    expect(tree.subTree('MessageNav')).to.be.false;
+    expect(tree.subTree('MessageSearch')).to.be.false;
+    expect(tree.subTree('SortableTable')).to.be.false;
+  });
+
+  it('should display an error message without a reload', () => {
+    const tree = SkinDeep.shallowRender(
+      <Folder {...props } attributes={{}}/>
+    );
+    expect(tree.subTree('.msg-loading-error')).to.not.be.false;
+    expect(tree.subTree('.msg-reload')).to.be.false;
+    expect(tree.subTree('MessageNav')).to.be.false;
+    expect(tree.subTree('MessageSearch')).to.be.false;
+    expect(tree.subTree('SortableTable')).to.be.false;
+  });
+
+  it('should display an error message with a reload', () => {
+    const tree = SkinDeep.shallowRender(
+      <Folder
+          {...props }
+          attributes={{}}
+          lastRequestedFolder={{ id: 0, query: {} }}/>
+    );
+    expect(tree.subTree('.msg-loading-error')).to.not.be.false;
+    expect(tree.subTree('.msg-reload')).to.be.not.be.false;
     expect(tree.subTree('MessageNav')).to.be.false;
     expect(tree.subTree('MessageSearch')).to.be.false;
     expect(tree.subTree('SortableTable')).to.be.false;

--- a/test/messaging/containers/Folder.unit.spec.jsx
+++ b/test/messaging/containers/Folder.unit.spec.jsx
@@ -103,6 +103,7 @@ describe('Folder', () => {
             totalEntries: 0
           }}/>
     );
+    expect(tree.dive(['h2']).text()).to.equal('Inbox');
     expect(tree.subTree('.msg-nomessages')).to.not.be.false;
     expect(tree.subTree('MessageSearch')).to.be.false;
     expect(tree.subTree('MessageNav')).to.be.false;
@@ -122,6 +123,7 @@ describe('Folder', () => {
             totalEntries: 0
           }}/>
     );
+    expect(tree.dive(['h2']).text()).to.equal('Inbox');
     expect(tree.subTree('.msg-nomessages')).to.not.be.false;
     expect(tree.subTree('MessageSearch')).to.not.be.false;
     expect(tree.subTree('MessageNav')).to.be.false;
@@ -132,6 +134,7 @@ describe('Folder', () => {
     const tree = SkinDeep.shallowRender(
       <Folder {...props }/>
     );
+    expect(tree.dive(['h2']).text()).to.equal('Inbox');
     expect(tree.subTree('ComposeButton')).to.not.be.false;
     expect(tree.subTree('MessageSearch')).to.not.be.false;
     expect(tree.subTree('MessageNav')).to.not.be.false;
@@ -151,6 +154,7 @@ describe('Folder', () => {
             totalEntries: 2
           }}/>
     );
+    expect(tree.dive(['h2']).text()).to.equal('Inbox');
     expect(tree.subTree('MessageSearch')).to.not.be.false;
     expect(tree.subTree('MessageNav')).to.not.be.false;
     expect(tree.subTree('SortableTable')).to.not.be.false;

--- a/test/messaging/containers/Folder.unit.spec.jsx
+++ b/test/messaging/containers/Folder.unit.spec.jsx
@@ -17,6 +17,8 @@ const props = {
     ['deleted', {}],
     ['personal-folder', {}],
   ]),
+  isAdvancedVisible: false,
+  lastRequestedFolder: null,
   loading: {
     folder: false
   },
@@ -47,10 +49,19 @@ const props = {
 };
 
 describe('Folder', () => {
-  const tree = SkinDeep.shallowRender(<Folder {...props}/>);
-
   it('should render', () => {
+    const tree = SkinDeep.shallowRender(<Folder {...props}/>);
     const vdom = tree.getRenderOutput();
     expect(vdom).to.not.be.undefined;
+  });
+
+  it('should display a loading screen', () => {
+    const tree = SkinDeep.shallowRender(
+      <Folder {...props } loading={{ folder: true }}/>
+    );
+    expect(tree.dive(['LoadingIndicator'])).to.not.be.undefined;
+    expect(tree.subTree('MessageNav')).to.be.false;
+    expect(tree.subTree('MessageSearch')).to.be.false;
+    expect(tree.subTree('SortableTable')).to.be.false;
   });
 });

--- a/test/messaging/containers/Folder.unit.spec.jsx
+++ b/test/messaging/containers/Folder.unit.spec.jsx
@@ -156,6 +156,7 @@ describe('Folder', () => {
           }}/>
     );
     expect(tree.dive(['h2']).text()).to.equal('Inbox');
+    expect(tree.subTree('ComposeButton')).to.not.be.false;
     expect(tree.subTree('MessageSearch')).to.not.be.false;
     expect(tree.subTree('MessageNav')).to.not.be.false;
     expect(tree.subTree('.msg-folder-sort-select')).to.not.be.false;

--- a/test/messaging/containers/Folder.unit.spec.jsx
+++ b/test/messaging/containers/Folder.unit.spec.jsx
@@ -9,7 +9,7 @@ const props = {
     folderId: 0,
     name: 'Inbox'
   },
-  currentRange: '1 - 5',
+  filter: {},
   folders: new Map([
     ['inbox', {}],
     ['drafts', {}],
@@ -17,7 +17,6 @@ const props = {
     ['deleted', {}],
     ['personal-folder', {}],
   ]),
-  filter: undefined,
   loading: {
     folder: false
   },
@@ -28,15 +27,20 @@ const props = {
     { body: 'test4' },
     { body: 'test5' }
   ],
-  messageCount: 5,
-  page: 1,
+  moveToId: null,
+  pagination: {
+    currentPage: 1,
+    perPage: 10,
+    totalEntries: 5,
+    totalPages: 1
+  },
   params: { folderName: 'inbox' },
-  recipients: [],
+  redirect: null,
+  searchParams: {},
   sort: {
     value: 'sentDate',
     order: 'DESC'
   },
-  totalPages: 1,
 
   // No-op function to override dispatch
   dispatch: () => {}

--- a/test/messaging/containers/Folder.unit.spec.jsx
+++ b/test/messaging/containers/Folder.unit.spec.jsx
@@ -128,12 +128,13 @@ describe('Folder', () => {
     expect(tree.subTree('SortableTable')).to.be.false;
   });
 
-  it('should show folder controls', () => {
+  it('should show folder controls and messages', () => {
     const tree = SkinDeep.shallowRender(
       <Folder {...props }/>
     );
     expect(tree.subTree('ComposeButton')).to.not.be.false;
     expect(tree.subTree('MessageSearch')).to.not.be.false;
     expect(tree.subTree('MessageNav')).to.not.be.false;
+    expect(tree.subTree('SortableTable')).to.not.be.false;
   });
 });


### PR DESCRIPTION
### Changes
* Fleshed out the unit tests for Folder.
* Refactored pagination state and how it's used in Folder.
* Fixed redirect usage in Folder.
* Hide MessageNav in Thread until the messages list is populated and enables navigation.
* Reset current item in folder state when loading so no residual data remains and prevents error messages from displaying.