### PR TITLE
[Messaging] Converted Back link into button. Fixed layout of thread controls in mobile.

### DIFF
--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router';
 
+import ButtonBack from './buttons/ButtonBack';
 import ButtonDelete from './buttons/ButtonDelete';
 import MoveTo from './MoveTo';
 import MessageNav from './MessageNav';
@@ -67,12 +67,10 @@ class ThreadHeader extends React.Component {
       }
     }
 
-    const backUrl = folderUrl(folderName);
-
     return (
       <div className="messaging-thread-header">
         <div className="messaging-thread-nav">
-          <Link to={backUrl}>&lt; Back to {folderName}</Link>
+          <ButtonBack url={folderUrl(folderName)}/>
           {messageNav}
           {moveTo}
           {deleteButton}

--- a/src/js/messaging/components/buttons/ButtonBack.jsx
+++ b/src/js/messaging/components/buttons/ButtonBack.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+class ButtonBack extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onClick = this.onClick.bind(this);
+  }
+
+  onClick() {
+    this.context.router.push(this.props.url);
+  }
+
+  render() {
+    return (
+      <button
+          className="msg-btn-back"
+          onClick={this.onClick}>
+        <i className="fa fa-chevron-left"></i>
+        <span>Back</span>
+      </button>
+    );
+  }
+}
+
+ButtonBack.contextTypes = {
+  router: React.PropTypes.object.isRequired
+};
+
+ButtonBack.propTypes = {
+  url: React.PropTypes.string.isRequired
+};
+
+export default ButtonBack;

--- a/src/js/messaging/components/buttons/ButtonDelete.jsx
+++ b/src/js/messaging/components/buttons/ButtonDelete.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 
 class ButtonDelete extends React.Component {
   constructor(props) {
@@ -11,10 +12,12 @@ class ButtonDelete extends React.Component {
   }
 
   render() {
+    const buttonClass = classNames(this.props.className, 'msg-btn-delete');
+
     return (
       <button
           onClick={this.handleClick}
-          className="va-icon-link msg-btn-delete"
+          className={buttonClass}
           type="button">
         <i className="fa fa-trash"></i>
         <span>Delete</span>
@@ -24,6 +27,7 @@ class ButtonDelete extends React.Component {
 }
 
 ButtonDelete.propTypes = {
+  className: React.PropTypes.string,
   onClickHandler: React.PropTypes.func.isRequired
 };
 

--- a/src/js/messaging/components/compose/MessageSend.jsx
+++ b/src/js/messaging/components/compose/MessageSend.jsx
@@ -63,7 +63,7 @@ class MessageSend extends React.Component {
             name="messageAttachments"
             onChange={this.handleAttachmentsChange}/>
         <ButtonDelete
-            compact
+            className="va-icon-link"
             onClickHandler={this.props.onDelete}/>
       </div>
     );

--- a/src/sass/messaging/messaging.scss
+++ b/src/sass/messaging/messaging.scss
@@ -4,6 +4,34 @@
 
 $messaging-label-width: 10rem;
 
+%messaging-rectangular-button {
+  background: $color-white;
+  border-radius: 0;
+  border: 1px solid $color-black;
+  color: $color-black;
+  font-size: 1.5rem;
+  margin: 0;
+  padding: 1rem;
+  width: auto;
+
+  &:focus,
+  &:hover,
+  &:active {
+    background: $color-white;
+    color: $color-black;
+    border-bottom: 1px solid $color-black;
+  }
+
+  &[disabled] {
+    &,
+    &:hover,
+    &:active {
+      color: $color-gray;
+      border-color: $color-gray;
+    }
+  }
+}
+
 @import "partials/message-category";
 @import "partials/message-compose";
 @import "partials/messaging-app";

--- a/src/sass/messaging/partials/_messaging-app.scss
+++ b/src/sass/messaging/partials/_messaging-app.scss
@@ -185,6 +185,29 @@
   }
 }
 
+.msg-btn-back {
+  background: $color-white;
+  border-radius: 0;
+  border: 1px solid $color-black;
+  color: $color-black;
+  font-size: 1.5rem;
+  margin: 0;
+  padding: 1rem;
+  width: auto;
+
+  &:focus,
+  &:hover,
+  &:active {
+    background: $color-white;
+    color: $color-black;
+    border-bottom: 1px solid $color-black;
+  }
+
+  i {
+    margin-right: .5rem;
+  }
+}
+
 .messaging-modal {
   .va-modal-inner {
     @media(min-width: $medium-screen) {

--- a/src/sass/messaging/partials/_messaging-app.scss
+++ b/src/sass/messaging/partials/_messaging-app.scss
@@ -186,22 +186,7 @@
 }
 
 .msg-btn-back {
-  background: $color-white;
-  border-radius: 0;
-  border: 1px solid $color-black;
-  color: $color-black;
-  font-size: 1.5rem;
-  margin: 0;
-  padding: 1rem;
-  width: auto;
-
-  &:focus,
-  &:hover,
-  &:active {
-    background: $color-white;
-    color: $color-black;
-    border-bottom: 1px solid $color-black;
-  }
+  @extend %messaging-rectangular-button;
 
   i {
     margin-right: .5rem;

--- a/src/sass/messaging/partials/_messaging-count-nav.scss
+++ b/src/sass/messaging/partials/_messaging-count-nav.scss
@@ -8,31 +8,7 @@
 }
 
 .messaging-message-nav button {
-  background: $color-white;
-  border-radius: 0;
-  border: 1px solid $color-black;
-  color: $color-black;
-  font-size: 1.5rem;
-  margin: 0;
-  padding: 1rem;
-  width: auto;
-
-  &:focus,
-  &:hover,
-  &:active {
-    background: $color-white;
-    color: $color-black;
-    border-bottom: 1px solid $color-black;
-  }
-
-  &[disabled] {
-    &,
-    &:hover,
-    &:active {
-      color: $color-gray;
-      border-color: $color-gray;
-    }
-  }
+  @extend %messaging-rectangular-button;
 
   &:first-of-type {
     border-right: none;

--- a/src/sass/messaging/partials/_messaging-count-nav.scss
+++ b/src/sass/messaging/partials/_messaging-count-nav.scss
@@ -5,10 +5,6 @@
 
 .messaging-message-nav {
   float: right;
-
-  @media (max-width: $medium-screen) {
-    margin-bottom: 1em;
-  }
 }
 
 .messaging-message-nav button {

--- a/src/sass/messaging/partials/_messaging-folder.scss
+++ b/src/sass/messaging/partials/_messaging-folder.scss
@@ -9,6 +9,10 @@
 
   @media (max-width: $medium-screen) {
     padding: 0 2rem;
+
+    .messaging-message-nav {
+      margin: 2rem 0;
+    }
   }
 
   @media (min-width: $medium-screen) {
@@ -32,7 +36,7 @@
 }
 
 .msg-folder-sort-select {
-  padding: 1rem 2rem 2rem;
+  margin: 2rem;
 
   @media (min-width: $medium-screen) {
     display: none;

--- a/src/sass/messaging/partials/_messaging-moveto.scss
+++ b/src/sass/messaging/partials/_messaging-moveto.scss
@@ -6,20 +6,7 @@
 }
 
 .messaging-move {
-  background: $color-white;
-  border-radius: 0;
-  border: 1px solid $color-black;
-  color: $color-black;
-  font-size: 1.5rem;
-  margin: 0;
-  padding: 1rem;
-
-  &:hover,
-  &:active {
-    background: $color-white;
-    color: inherit;
-    border-bottom: 1px solid $color-black;
-  }
+  @extend %messaging-rectangular-button;
 
   > i {
     margin-left: .5rem;

--- a/src/sass/messaging/partials/_messaging-moveto.scss
+++ b/src/sass/messaging/partials/_messaging-moveto.scss
@@ -6,7 +6,7 @@
 }
 
 .messaging-move {
-  background: inherit;
+  background: $color-white;
   border-radius: 0;
   border: 1px solid $color-black;
   color: $color-black;
@@ -16,7 +16,7 @@
 
   &:hover,
   &:active {
-    background: inherit;
+    background: $color-white;
     color: inherit;
     border-bottom: 1px solid $color-black;
   }

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -36,11 +36,11 @@
   padding: 0 0 2.25rem 0;
 
   .messaging-toggle-thread,
+  .msg-btn-delete,
   .msg-btn-print {
     background: transparent;
     color: $color-black;
     float: none;
-    font-size: 1.5rem;
     font-weight: normal;
     margin: 0 1rem;
     padding: 0;
@@ -96,7 +96,6 @@
   .msg-btn-delete,
   .msg-btn-print {
     display: none;
-    padding: 1rem;
   }
 
   @media (max-width: $medium-screen) {
@@ -129,7 +128,7 @@
 
 .messaging-thread-controls {
   float: right;
-  margin: .25rem 1rem;
+  margin: 0 1rem;
 
   @media (max-width: $medium-screen) {
     .msg-btn-delete,

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -35,6 +35,11 @@
   border-bottom: 2px solid $color-black;
   padding: 0 0 2.25rem 0;
 
+  button {
+    vertical-align: middle;
+    width: auto;
+  }
+
   .messaging-toggle-thread,
   .msg-btn-delete,
   .msg-btn-print {
@@ -44,8 +49,6 @@
     font-weight: normal;
     margin: 0 1rem;
     padding: 0;
-    vertical-align: middle;
-    width: auto;
 
     &:hover,
     &:focus {
@@ -73,11 +76,6 @@
   margin-bottom: 2rem;
   padding-bottom: 2rem;
   position: relative;
-
-  button {
-    vertical-align: middle;
-    width: auto;
-  }
 
   i {
     font-size: inherit !important;

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -75,6 +75,7 @@
   position: relative;
 
   button {
+    vertical-align: middle;
     width: auto;
   }
 
@@ -95,6 +96,7 @@
   .msg-btn-delete,
   .msg-btn-print {
     display: none;
+    padding: 1rem;
   }
 
   @media (max-width: $medium-screen) {

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -79,18 +79,13 @@
     width: auto;
   }
 
-  a {
-    margin-right: 1rem;
-    max-width: 50%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    vertical-align: middle;
-    white-space: nowrap;
+  i {
+    font-size: inherit !important;
   }
 
-  i {
-    margin-left: .5rem;
-    font-size: inherit !important;
+  .msg-btn-back,
+  .msg-move-to {
+    margin-right: 1rem;
   }
 
   .msg-btn-delete,
@@ -109,9 +104,9 @@
       display: inline-block;
     }
 
-    a {
+    .msg-btn-back {
       float: left;
-      margin: .5rem 1rem;
+      margin: 0 1rem;
     }
 
     .messaging-message-nav {

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -112,6 +112,10 @@
       float: left;
       margin: .5rem 1rem;
     }
+
+    .messaging-message-nav {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
Closes department-of-veterans-affairs/messaging-fe#200.

## Before:
#### Narrow spacing between search expand and pagination.
> <img width="359" alt="screen shot 2016-12-22 at 7 52 39 pm" src="https://cloud.githubusercontent.com/assets/1067024/21461160/1b549d7e-c91d-11e6-95f0-7dc0588d1cdd.png">
#### Thread controls layout was messed up.
> <img width="362" alt="screen shot 2016-12-22 at 7 50 33 pm" src="https://cloud.githubusercontent.com/assets/1067024/21461157/18be4cd6-c91d-11e6-8a4f-1c0bb70df6d0.png">

## After
#### Increased spacing between search expand and pagination.
> <img width="361" alt="screen shot 2016-12-22 at 7 47 57 pm" src="https://cloud.githubusercontent.com/assets/1067024/21461180/360c996e-c91d-11e6-89d4-123478311ea1.png">
#### New Back button to replace link. Consistent styles for buttons in title line (font size, color, no text underline).
> <img width="741" alt="screen shot 2016-12-23 at 2 21 38 pm" src="https://cloud.githubusercontent.com/assets/1067024/21461181/3a3f3726-c91d-11e6-8308-cb1260a90411.png">
#### Fixed layout issues in thread controls.
> <img width="360" alt="screen shot 2016-12-23 at 2 21 53 pm" src="https://cloud.githubusercontent.com/assets/1067024/21461184/3ea2b860-c91d-11e6-8815-11929dd596d3.png">






