### PR TITLE
[Messaging] Fixes for Thread view and draft forms. ThreadHeader unit tests.

### DIFF
--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -12,6 +12,7 @@ class ThreadHeader extends React.Component {
     const {
       currentFolder,
       folderMessageCount,
+      isNewMessage,
       message,
       threadMessageCount
     } = this.props;
@@ -43,29 +44,38 @@ class ThreadHeader extends React.Component {
       );
     }
 
-    // Hide the 'Delete' button for sent messages,
-    // since they can't be deleted.
-    if (folderName !== 'Sent') {
+    // Hide the 'Delete' button for drafts and sent messages,
+    // since drafts should only be deletable from the form,
+    // and sent messages can't be deleted.
+    // Also hide the 'Move' button for drafts and sent messages,
+    // since they can't be moved to other folders.
+    if (folderName !== 'Sent' && folderName !== 'Drafts') {
       deleteButton =
         <ButtonDelete onClickHandler={this.props.onDeleteMessage}/>;
 
-      // Hide the 'Move' button for drafts and sent messages,
-      // since they can't be moved to other folders.
-      if (folderName !== 'Drafts') {
-        const { folders, moveToIsOpen } = this.props;
+      const { folders, moveToIsOpen } = this.props;
 
-        moveTo = (
-          <MoveTo
-              currentFolder={currentFolder}
-              folders={folders}
-              isOpen={moveToIsOpen}
-              messageId={message.messageId}
-              onChooseFolder={this.props.onChooseFolder}
-              onCreateFolder={this.props.onCreateFolder}
-              onToggleMoveTo={this.props.onToggleMoveTo}/>
-        );
-      }
+      moveTo = (
+        <MoveTo
+            currentFolder={currentFolder}
+            folders={folders}
+            isOpen={moveToIsOpen}
+            messageId={message.messageId}
+            onChooseFolder={this.props.onChooseFolder}
+            onCreateFolder={this.props.onCreateFolder}
+            onToggleMoveTo={this.props.onToggleMoveTo}/>
+      );
     }
+
+    const titleSection = !isNewMessage && (
+      <div className="messaging-thread-title">
+        <div className="messaging-thread-controls">
+          {toggleThread}
+          {deleteButton}
+        </div>
+        <h2 className="messaging-thread-subject">{message.subject}</h2>
+      </div>
+    );
 
     return (
       <div className="messaging-thread-header">
@@ -75,13 +85,7 @@ class ThreadHeader extends React.Component {
           {moveTo}
           {deleteButton}
         </div>
-        <div className="messaging-thread-title">
-          <div className="messaging-thread-controls">
-            {toggleThread}
-            {deleteButton}
-          </div>
-          <h2 className="messaging-thread-subject">{message.subject}</h2>
-        </div>
+        {titleSection}
       </div>
     );
   }
@@ -92,6 +96,7 @@ ThreadHeader.propTypes = {
     name: React.PropTypes.string.isRequired
   }),
   currentMessageNumber: React.PropTypes.number.isRequired,
+  folderMessageCount: React.PropTypes.number.isRequired,
   folders: React.PropTypes.arrayOf(
     React.PropTypes.shape({
       folderId: React.PropTypes.number.isRequired,
@@ -100,12 +105,11 @@ ThreadHeader.propTypes = {
       unreadCount: React.PropTypes.number.isRequired
     })
   ).isRequired,
-  folderMessageCount: React.PropTypes.number.isRequired,
+  isNewMessage: React.PropTypes.bool,
   message: React.PropTypes.shape({
     messageId: React.PropTypes.number,
     subject: React.PropTypes.string
   }).isRequired,
-  threadMessageCount: React.PropTypes.number.isRequired,
   messagesCollapsed: React.PropTypes.bool,
   moveToIsOpen: React.PropTypes.bool,
   onChooseFolder: React.PropTypes.func,
@@ -113,7 +117,8 @@ ThreadHeader.propTypes = {
   onDeleteMessage: React.PropTypes.func,
   onMessageSelect: React.PropTypes.func,
   onToggleThread: React.PropTypes.func,
-  onToggleMoveTo: React.PropTypes.func
+  onToggleMoveTo: React.PropTypes.func,
+  threadMessageCount: React.PropTypes.number
 };
 
 export default ThreadHeader;

--- a/src/js/messaging/components/compose/ModalConfirmDelete.jsx
+++ b/src/js/messaging/components/compose/ModalConfirmDelete.jsx
@@ -3,9 +3,13 @@ import React from 'react';
 import Modal from '../../../common/components/Modal';
 
 class ModalConfirmDelete extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleDelete = this.handleDelete.bind(this);
+  }
 
-  handleDelete = (e) => {
-    e.preventDefault();
+  handleDelete(event) {
+    event.preventDefault();
     this.props.onDelete();
   }
 

--- a/src/js/messaging/containers/Compose.jsx
+++ b/src/js/messaging/containers/Compose.jsx
@@ -116,8 +116,7 @@ export class Compose extends React.Component {
     }
   }
 
-  handleConfirmDelete(domEvent) {
-    domEvent.preventDefault();
+  handleConfirmDelete() {
     this.props.toggleConfirmDelete();
     this.props.deleteComposeMessage();
   }

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -163,6 +163,7 @@ export class Thread extends React.Component {
   makeHeader() {
     const {
       folder,
+      isNewMessage,
       isSavedDraft,
       message,
       messagesCollapsed,
@@ -206,16 +207,17 @@ export class Thread extends React.Component {
           currentMessageNumber={currentIndex + 1}
           folderMessageCount={folderMessages.length}
           folders={folders}
+          isNewMessage={isNewMessage}
           message={message}
-          onMessageSelect={handleMessageSelect}
-          threadMessageCount={thread.length + 1}
           messagesCollapsed={(messagesCollapsed.size > 0)}
           moveToIsOpen={moveToOpened}
           onChooseFolder={this.props.moveMessageToFolder}
           onCreateFolder={this.props.openMoveToNewFolderModal}
           onDeleteMessage={deleteMessageHandler}
+          onMessageSelect={handleMessageSelect}
           onToggleThread={this.props.toggleMessagesCollapsed}
-          onToggleMoveTo={this.props.toggleThreadMoveTo}/>
+          onToggleMoveTo={this.props.toggleThreadMoveTo}
+          threadMessageCount={thread.length + 1}/>
     );
   }
 

--- a/src/js/messaging/reducers/messages.js
+++ b/src/js/messaging/reducers/messages.js
@@ -1,4 +1,3 @@
-import assign from 'lodash/fp/assign';
 import set from 'lodash/fp/set';
 
 import { makeField } from '../../common/model/fields';
@@ -58,10 +57,10 @@ export default function messages(state = initialState, action) {
       return set('data.draft.attachments', state.data.draft.attachments, state);
 
     case FETCH_THREAD_MESSAGE_SUCCESS: {
-      const updatedMessage = assign(
-        action.message.data.attributes,
-        { attachments: action.message.included }
-      );
+      const updatedMessage = {
+        ...action.message.data.attributes,
+        attachments: action.message.included
+      };
 
       const messageIndex = state.data.thread.findIndex(message =>
         message.messageId === updatedMessage.messageId
@@ -72,10 +71,10 @@ export default function messages(state = initialState, action) {
 
     case FETCH_THREAD_SUCCESS: {
       // Consolidate message attributes and attachments
-      const currentMessage = assign(
-        action.message.data.attributes,
-        { attachments: action.message.included }
-      );
+      const currentMessage = {
+        ...action.message.data.attributes,
+        attachments: action.message.included
+      };
 
       // Thread is received in most recent order.
       // Reverse to display most recent message at the bottom.
@@ -88,9 +87,11 @@ export default function messages(state = initialState, action) {
         return message.messageId;
       }));
 
-      const draft = assign({}, initialState.data.draft);
-      draft.category = makeField(currentMessage.category);
-      draft.subject = makeField(currentMessage.subject);
+      const draft = {
+        ...initialState.data.draft,
+        category: makeField(currentMessage.category),
+        subject: makeField(currentMessage.subject)
+      };
 
       // The message is the draft if it hasn't been sent yet.
       // Otherwise, the draft is an new, unsaved reply to the message.

--- a/src/js/messaging/reducers/messages.js
+++ b/src/js/messaging/reducers/messages.js
@@ -39,10 +39,6 @@ const initialState = {
   }
 };
 
-const resetDraft = (state) => {
-  return set('data.draft', initialState.data.draft, state);
-};
-
 export default function messages(state = initialState, action) {
   switch (action.type) {
     case ADD_DRAFT_ATTACHMENTS:
@@ -52,7 +48,10 @@ export default function messages(state = initialState, action) {
       ], state);
 
     case CLEAR_DRAFT:
-      return resetDraft(state);
+      return set('data.draft', {
+        ...state.data.draft,
+        body: makeField('')
+      }, state);
 
     case DELETE_DRAFT_ATTACHMENT:
       state.data.draft.attachments.splice(action.index, 1);
@@ -118,11 +117,13 @@ export default function messages(state = initialState, action) {
       return set('data.message', currentMessage, newState);
     }
 
-    case LOADING_THREAD:
+    case LOADING_THREAD: {
+      const newState = set('data', initialState.data, state);
       return set('ui', {
         ...initialState.ui,
         lastRequestedId: action.messageId
-      }, state);
+      }, newState);
+    }
 
     case TOGGLE_MESSAGE_COLLAPSED: {
       const newMessagesCollapsed = new Set(state.ui.messagesCollapsed);

--- a/src/sass/messaging/partials/_message-compose.scss
+++ b/src/sass/messaging/partials/_message-compose.scss
@@ -119,6 +119,7 @@
     }
 
     float: right;
+    font-size: 1.6rem;
     line-height: 3.5rem;
     margin: 0 0 0 1rem;
     padding: 0 1rem;

--- a/src/sass/messaging/partials/_message-compose.scss
+++ b/src/sass/messaging/partials/_message-compose.scss
@@ -400,11 +400,11 @@ button.msg-btn-save {
 
     label {
       display: inline-block;
+      font-weight: bold;
     }
   }
 
   label {
-    font-weight: bold;
     margin: 0;
   }
 

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -40,12 +40,17 @@
     width: auto;
   }
 
+  i {
+    font-size: inherit !important;
+  }
+
   .messaging-toggle-thread,
   .msg-btn-delete,
   .msg-btn-print {
     background: transparent;
     color: $color-black;
     float: none;
+    font-size: 1.6rem;
     font-weight: normal;
     margin: 0 1rem;
     padding: 0;
@@ -61,10 +66,6 @@
       outline: 0;
     }
 
-    i {
-      font-size: 1.8rem;
-    }
-
     span {
       padding-left: 0.5rem;
     }
@@ -76,10 +77,6 @@
   margin-bottom: 2rem;
   padding-bottom: 2rem;
   position: relative;
-
-  i {
-    font-size: inherit !important;
-  }
 
   .msg-btn-back,
   .msg-move-to {

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -32,9 +32,6 @@
  *****************/
 
 .messaging-thread-header {
-  border-bottom: 2px solid $color-black;
-  padding: 0 0 2.25rem 0;
-
   button {
     vertical-align: middle;
     width: auto;
@@ -74,9 +71,14 @@
 
 .messaging-thread-nav {
   border-bottom: 1px solid $color-black;
-  margin-bottom: 2rem;
   padding-bottom: 2rem;
   position: relative;
+
+  &:after {
+    clear: both;
+    content: '';
+    display: 'block';
+  }
 
   .msg-btn-back,
   .msg-move-to {
@@ -108,6 +110,11 @@
       display: none;
     }
   }
+}
+
+.messaging-thread-title {
+  border-bottom: 2px solid $color-black;
+  padding: 2.25rem 0;
 }
 
 .messaging-thread-subject {

--- a/test/messaging/components/ThreadHeader.unit.spec.jsx
+++ b/test/messaging/components/ThreadHeader.unit.spec.jsx
@@ -67,8 +67,8 @@ describe('ThreadHeader', () => {
 
     tree = SkinDeep.shallowRender(
       <ThreadHeader
-        {...props }
-        currentFolder={{ name: 'Sent' }}/>
+          {...props }
+          currentFolder={{ name: 'Sent' }}/>
     );
 
     expect(tree.subTree('ButtonDelete')).to.be.false;
@@ -84,9 +84,8 @@ describe('ThreadHeader', () => {
     const tree = SkinDeep.shallowRender(
       <ThreadHeader
           {...props }
-          isNewMessage={true}/>
+          isNewMessage/>
     );
     expect(tree.subTree('.messaging-thread-title')).to.be.false;
   });
-
 });

--- a/test/messaging/components/ThreadHeader.unit.spec.jsx
+++ b/test/messaging/components/ThreadHeader.unit.spec.jsx
@@ -7,7 +7,7 @@ import ThreadHeader from '../../../src/js/messaging/components/ThreadHeader';
 const props = {
   currentFolder: { name: 'Inbox' },
   currentMessageNumber: 1,
-  folderMessageCount: 2,
+  folderMessageCount: 1,
   folders: [{ folderId: 0, name: 'Inbox' }],
   isNewMessage: false,
   message: { messageId: 123, subject: 'Subject' },
@@ -28,6 +28,18 @@ describe('ThreadHeader', () => {
     expect(tree.subTree('MessageNav')).to.not.be.false;
   });
 
+  it('should hide message nav in case of folder message count errors', () => {
+    const tree = SkinDeep.shallowRender(
+      <ThreadHeader {...props } folderMessageCount={0}/>
+    );
+    expect(tree.subTree('MessageNav')).to.be.false;
+  });
+
+  it('should show a move button', () => {
+    const tree = SkinDeep.shallowRender(<ThreadHeader {...props }/>);
+    expect(tree.subTree('MoveTo')).to.not.be.false;
+  });
+
   it('should show a button to expand or collapse a thread with multiple messages', () => {
     const tree = SkinDeep.shallowRender(<ThreadHeader {...props }/>);
     expect(tree.subTree('ToggleThread')).to.not.be.false;
@@ -43,7 +55,7 @@ describe('ThreadHeader', () => {
     expect(tree.subTree('ButtonDelete')).to.not.be.false;
   });
 
-  it('should not show a delete button for drafts or sent messages', () => {
+  it('should not show delete or move buttons for drafts or sent messages', () => {
     let tree = SkinDeep.shallowRender(
       <ThreadHeader
           {...props }
@@ -51,6 +63,7 @@ describe('ThreadHeader', () => {
     );
 
     expect(tree.subTree('ButtonDelete')).to.be.false;
+    expect(tree.subTree('MoveTo')).to.be.false;
 
     tree = SkinDeep.shallowRender(
       <ThreadHeader
@@ -59,28 +72,21 @@ describe('ThreadHeader', () => {
     );
 
     expect(tree.subTree('ButtonDelete')).to.be.false;
+    expect(tree.subTree('MoveTo')).to.be.false;
   });
 
-  it('should show a move button', () => {
+  it('should show the subject line in the title', () => {
     const tree = SkinDeep.shallowRender(<ThreadHeader {...props }/>);
-    expect(tree.subTree('MoveTo')).to.not.be.false;
+    expect(tree.dive(['h2']).text()).to.equal('Subject');
   });
 
-  it('should not show a move button for drafts or sent messages', () => {
-    let tree = SkinDeep.shallowRender(
+  it('should not show the subject line for a draft of a new message', () => {
+    const tree = SkinDeep.shallowRender(
       <ThreadHeader
           {...props }
-          currentFolder={{ name: 'Drafts' }}/>
+          isNewMessage={true}/>
     );
-
-    expect(tree.subTree('MoveTo')).to.be.false;
-
-    tree = SkinDeep.shallowRender(
-      <ThreadHeader
-          {...props }
-          currentFolder={{ name: 'Sent' }}/>
-    );
-
-    expect(tree.subTree('MoveTo')).to.be.false;
+    expect(tree.subTree('.messaging-thread-title')).to.be.false;
   });
+
 });

--- a/test/messaging/components/ThreadHeader.unit.spec.jsx
+++ b/test/messaging/components/ThreadHeader.unit.spec.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+
+import ThreadHeader from '../../../src/js/messaging/components/ThreadHeader';
+
+const props = {
+  currentFolder: { name: 'Inbox' },
+  currentMessageNumber: 1,
+  folderMessageCount: 2,
+  folders: [{ folderId: 0, name: 'Inbox' }],
+  isNewMessage: false,
+  message: { messageId: 123, subject: 'Subject' },
+  messagesCollapsed: true,
+  moveToIsOpen: false,
+  threadMessageCount: 2
+};
+
+describe('ThreadHeader', () => {
+  it('should render', () => {
+    const tree = SkinDeep.shallowRender(<ThreadHeader {...props}/>);
+    const vdom = tree.getRenderOutput();
+    expect(vdom).to.not.be.undefined;
+  });
+
+  it('should show a message nav', () => {
+    const tree = SkinDeep.shallowRender(<ThreadHeader {...props }/>);
+    expect(tree.subTree('MessageNav')).to.not.be.false;
+  });
+
+  it('should show a button to expand or collapse a thread with multiple messages', () => {
+    const tree = SkinDeep.shallowRender(<ThreadHeader {...props }/>);
+    expect(tree.subTree('ToggleThread')).to.not.be.false;
+  });
+
+  it('should not show a button to expand or collapse a thread with only one message', () => {
+    const tree = SkinDeep.shallowRender(<ThreadHeader {...props } threadMessageCount={1}/>);
+    expect(tree.subTree('ToggleThread')).to.be.false;
+  });
+
+  it('should show a delete button', () => {
+    const tree = SkinDeep.shallowRender(<ThreadHeader {...props }/>);
+    expect(tree.subTree('ButtonDelete')).to.not.be.false;
+  });
+
+  it('should not show a delete button for drafts or sent messages', () => {
+    let tree = SkinDeep.shallowRender(
+      <ThreadHeader
+          {...props }
+          currentFolder={{ name: 'Drafts' }}/>
+    );
+
+    expect(tree.subTree('ButtonDelete')).to.be.false;
+
+    tree = SkinDeep.shallowRender(
+      <ThreadHeader
+        {...props }
+        currentFolder={{ name: 'Sent' }}/>
+    );
+
+    expect(tree.subTree('ButtonDelete')).to.be.false;
+  });
+
+  it('should show a move button', () => {
+    const tree = SkinDeep.shallowRender(<ThreadHeader {...props }/>);
+    expect(tree.subTree('MoveTo')).to.not.be.false;
+  });
+
+  it('should not show a move button for drafts or sent messages', () => {
+    let tree = SkinDeep.shallowRender(
+      <ThreadHeader
+          {...props }
+          currentFolder={{ name: 'Drafts' }}/>
+    );
+
+    expect(tree.subTree('MoveTo')).to.be.false;
+
+    tree = SkinDeep.shallowRender(
+      <ThreadHeader
+          {...props }
+          currentFolder={{ name: 'Sent' }}/>
+    );
+
+    expect(tree.subTree('MoveTo')).to.be.false;
+  });
+});


### PR DESCRIPTION
## Changes:
* Various style fixes.
    * Un-bolded "Attach" link in reply form.
    * Consistent font-size on buttons in Thread.
* Fixed delete draft behaviors.
    * Thread was replacing reply form with new message form after clearing draft.
    * Compose was handling undefined event argument.
* Hide title section for drafts of new messages. Hide delete button in title section on all drafts.
    * Closes department-of-veterans-affairs/messaging-fe#199.
* Unit tests for ThreadHeader.

#### No title section when editing saved draft of new message.
> <img width="744" alt="screen shot 2016-12-23 at 6 35 54 pm" src="https://cloud.githubusercontent.com/assets/1067024/21463908/da6a8a36-c93e-11e6-8f73-ee3d08353aa9.png">

#### No 'Delete' button in title section of saved draft (but still available in reply form).
> <img width="738" alt="screen shot 2016-12-23 at 6 38 44 pm" src="https://cloud.githubusercontent.com/assets/1067024/21463915/15dfcf86-c93f-11e6-8a1a-44a5b0ba6a61.png">
