### PR TITLE
Fixed style of delete buttons in SM settings page.

### DIFF
--- a/src/js/messaging/containers/Settings.jsx
+++ b/src/js/messaging/containers/Settings.jsx
@@ -27,6 +27,7 @@ export class Settings extends React.Component {
           </td>
           <td>
             <ButtonDelete
+                className="va-icon-link"
                 onClickHandler={() => this.props.deleteFolder(folder)}/>
           </td>
         </tr>

--- a/src/sass/messaging/partials/_messaging-settings.scss
+++ b/src/sass/messaging/partials/_messaging-settings.scss
@@ -10,6 +10,7 @@
 
     button {
       float: right;
+      font-size: 1.6rem;
       font-weight: normal;
       margin: 0;
       padding: 0;


### PR DESCRIPTION
### Before
> <img width="795" alt="screen shot 2016-12-28 at 6 56 51 pm" src="https://cloud.githubusercontent.com/assets/1067024/21536842/28d24fc2-cd56-11e6-9727-1b151197dc8f.png">

### After
> <img width="737" alt="screen shot 2016-12-28 at 11 32 06 pm" src="https://cloud.githubusercontent.com/assets/1067024/21536843/2d272df4-cd56-11e6-9d48-860247a1ab3c.png">
