### PR TITLE
Handle requests that fail from expired userToken in Rx and SM.

### DIFF
--- a/src/js/messaging/components/MessageAttachmentsViewItem.jsx
+++ b/src/js/messaging/components/MessageAttachmentsViewItem.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { authFetch } from '../utils/helpers';
+import { apiRequest } from '../utils/helpers';
 
 class MessageAttachmentsViewItem extends React.Component {
   constructor(props) {
@@ -23,14 +23,19 @@ class MessageAttachmentsViewItem extends React.Component {
 
     this.setState({ downloading: true });
     const requestUrl = this.props.url;
-    authFetch(requestUrl)
-    .then(response => response.blob())
-    .then(blob => {
-      const downloadUrl = URL.createObjectURL(blob);
-      this.downloadUrl = downloadUrl;
-      this.setState({ downloading: false });
-      window.open(this.downloadUrl, '_blank');
-    });
+    apiRequest(
+      requestUrl,
+      null,
+      response => {
+        response.blob().then(blob => {
+          const downloadUrl = URL.createObjectURL(blob);
+          this.downloadUrl = downloadUrl;
+          this.setState({ downloading: false });
+          window.open(this.downloadUrl, '_blank');
+        });
+      },
+      () => { this.setState({ downloading: false }); }
+    );
   }
 
   render() {

--- a/src/js/messaging/utils/helpers.js
+++ b/src/js/messaging/utils/helpers.js
@@ -48,6 +48,8 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
   return fetch(url, settings)
     .then((response) => {
       if (!response.ok) {
+        // Refresh to show login view when requests are unauthorized.
+        if (response.status === 401) { return window.location.reload(); }
         return Promise.reject(response);
       } else if (isJson(response)) {
         return response.json();

--- a/src/js/messaging/utils/helpers.js
+++ b/src/js/messaging/utils/helpers.js
@@ -29,29 +29,23 @@ export function createUrlWithQuery(url, query) {
   return fullUrl;
 }
 
-export function authFetch(url, optionalSettings) {
+export function apiRequest(resource, optionalSettings = {}, success, error) {
+  const baseUrl = `${environment.API_URL}/v0/messaging/health`;
+  const url = resource[0] === '/'
+            ? [baseUrl, resource].join('')
+            : resource;
+
   const defaultSettings = {
     method: 'GET',
     headers: {
-      Authorization: `Token token=${sessionStorage.userToken}`
+      Authorization: `Token token=${sessionStorage.userToken}`,
+      'X-Key-Inflection': 'camel'
     }
-  };
-
-  return fetch(url, merge(defaultSettings, optionalSettings));
-}
-
-export function apiRequest(resource, optionalSettings = {}, success, error) {
-  const baseUrl = `${environment.API_URL}/v0/messaging/health`;
-  const url = [baseUrl, resource].join('');
-
-  const defaultSettings = {
-    method: 'GET',
-    headers: { 'X-Key-Inflection': 'camel' }
   };
 
   const settings = merge(defaultSettings, optionalSettings);
 
-  return authFetch(url, settings)
+  return fetch(url, settings)
     .then((response) => {
       if (!response.ok) {
         return Promise.reject(response);

--- a/test/util/rx-helpers.js
+++ b/test/util/rx-helpers.js
@@ -166,7 +166,7 @@ function initApplicationSubmitMock() {
     uri: `${E2eHelpers.apiUrl}/mock`,
     method: 'POST',
     json: {
-      path: '/v0/prescriptions',
+      path: '/v0/prescriptions/',
       verb: 'get',
       value: prescriptions
     }


### PR DESCRIPTION
Closes #3843.

### Changes
* Merged `authFetch `and `apiRequest` in SM back together.
    * Updated usage in `MessageAttachmentsViewItem` to also revert to base state when request fails.
* Refactored `apiRequest` in Rx to be same as SM.
* Rx and SM do a page refresh upon getting 401 in order to go back to the login view.