### PR TITLE
Enable tests for pushes to master and production

### DIFF
--- a/script/travis-build.sh
+++ b/script/travis-build.sh
@@ -58,16 +58,6 @@ echo "TRAVIS_COMMIT=$TRAVIS_COMMIT" >> $BUILD_DETAILS_FILE
 echo "TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE" >> $BUILD_DETAILS_FILE
 echo "TRAVIS_BRANCH=$TRAVIS_BRANCH" >> $BUILD_DETAILS_FILE
 
-# Don't run tests for pushes to production or master. Tests were already run
-# with the PR build that was merged and caused this to run.
-
-if [[ ( $TRAVIS_BRANCH == "production" ||
-        $TRAVIS_BRANCH == "master" ) &&
-      $TRAVIS_PULL_REQUEST == "false" ]]
-then
-  exit 0;
-fi
-
 # Run unit tests
 time npm run test:unit;
 

--- a/script/travis-build.sh
+++ b/script/travis-build.sh
@@ -58,6 +58,14 @@ echo "TRAVIS_COMMIT=$TRAVIS_COMMIT" >> $BUILD_DETAILS_FILE
 echo "TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE" >> $BUILD_DETAILS_FILE
 echo "TRAVIS_BRANCH=$TRAVIS_BRANCH" >> $BUILD_DETAILS_FILE
 
+# Don't run tests for pushes to production. Tests were already run with the
+# PR build that was merged and caused this to run.
+
+if [[ $TRAVIS_BRANCH == "production" ]]
+then
+  exit 0;
+fi
+
 # Run unit tests
 time npm run test:unit;
 


### PR DESCRIPTION
For merge after "Require branches to be up to date before merging" is unchecked.

For performance purposes we'd disabled the requirement to run tests on pushes to
master and production branches, since the PR containing the merge was fully tested
prior to merge. With this option disabled, we re-enable these tests.