### PR TITLE
Remove double blue bar from HCA footer

### DIFF
--- a/content/includes/1-topic-landing.html
+++ b/content/includes/1-topic-landing.html
@@ -3,18 +3,17 @@
     <div class="primary">
       <div class="row">
         <div class="small-12 columns usa-content">
-       
 
         <h1>{{ title }}</h1>
         <!-- Page content begins -->
-  
-        {{ contents }} 
+
+        {{ contents }}
         <!-- Page content ends -->
         </div>
       </div>
     </div>
-    {% include "content/includes/main-navigation.html" %}
+    {% if relatedlinks %}
+      {% include "content/includes/main-navigation.html" %}
+    {% endif %}
   </div>
 </div>
-
-

--- a/content/pages/healthcare/apply.md
+++ b/content/pages/healthcare/apply.md
@@ -3,6 +3,7 @@ layout: page-breadcrumbs.html
 title: Apply for VA Health Care
 template: 1-topic-landing
 showtempbar: true
+relatedlinks: false
 ---
 
 VA health care includes regular checkups with your primary care doctor and access to specialists, such as cardiologists, gynecologists, and mental health providers. You can also get home health care and geriatric care, as well as medical equipment, prosthetics, and prescriptions.

--- a/content/pages/healthcare/apply.md
+++ b/content/pages/healthcare/apply.md
@@ -3,7 +3,6 @@ layout: page-breadcrumbs.html
 title: Apply for VA Health Care
 template: 1-topic-landing
 showtempbar: true
-relatedlinks: false
 ---
 
 VA health care includes regular checkups with your primary care doctor and access to specialists, such as cardiologists, gynecologists, and mental health providers. You can also get home health care and geriatric care, as well as medical equipment, prosthetics, and prescriptions.


### PR DESCRIPTION
Closes: [#3970](https://github.com/department-of-veterans-affairs/vets-website/issues/3970)

Add if statement to check if .md files contain `relatedlinks` for `1-topic-landing.html` to prevent `content/includes/main-navigation.html` from loading an empty blue bar on the page.

## Before
![screen shot 2017-01-05 at 2 17 25 pm](https://cloud.githubusercontent.com/assets/6254227/21694503/ab1a8ed8-d353-11e6-81ec-a34369c86c07.png)

## After
![screen shot 2017-01-05 at 2 14 41 pm](https://cloud.githubusercontent.com/assets/6254227/21694514/b55350ba-d353-11e6-89e7-de5931306078.png)


