### PR TITLE
Add aria-live to watch for content changes

### DIFF
--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -114,7 +114,7 @@ export class Main extends React.Component {
               onCreateNewFolder={this.props.openCreateFolderModal}
               onFolderChange={this.handleFolderChange}/>
         </div>
-        <div id="messaging-content">
+        <div id="messaging-content" aria-live="assertive">
           {this.props.children}
         </div>
         <ModalAttachments


### PR DESCRIPTION
- Resolves https://github.com/department-of-veterans-affairs/vets-website/issues/4592

I think that the accessibility issues are caused by a content change on the page triggered by Javascript. The compose view and all of the folder view are loaded on the page in the absence of a full page refresh.

I tried a few different things but settled on this very minor change which is the cleanest way. It is supported by the latest versions of JAWS and NVDA on IE. Adding various focus events on `componentDidMount` was messy because of load events that occur in rapid succession after the mount, e.g. fetching recipients.

After this is merged, we should retest with a windows PC/IE 11 screen reader to confirm that `aria-live` is sufficient to alert the screen reader that content has changed, which should make all of the content accessible.

FYI references for more info:
- https://msdn.microsoft.com/en-us/library/dd433065(v=vs.85).aspx
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
- screen reader/browser usage % http://webaim.org/projects/screenreadersurvey6/