### PR TITLE
Reduce nightwatch parallelization

### DIFF
--- a/config/nightwatch.js
+++ b/config/nightwatch.js
@@ -46,7 +46,7 @@ module.exports = {
       },
       test_workers: {
         enabled: true,
-        workers: 10,
+        workers: 3,
       },
     },
 


### PR DESCRIPTION
Working with Travis to determine memory constraint issues that may be
killing processes mid-test when a larger number of processes are used
to run the E2E tests.

This has potentially caused itermittent failures in the form of timeouts
waiting for elements to appear and disconnections from the browser client.