### PR TITLE
[SM] Filter by 'To' instead of 'From' in Drafts and Sent folders.

### DIFF
--- a/src/js/messaging/components/MessageSearch.jsx
+++ b/src/js/messaging/components/MessageSearch.jsx
@@ -58,6 +58,7 @@ class MessageSearch extends React.Component {
         {basicSearch}
         <MessageSearchAdvanced
             params={this.props.params}
+            hasRecipientField={this.props.hasRecipientField}
             isVisible={this.props.isAdvancedVisible}
             onAdvancedSearch={this.props.onAdvancedSearch}
             onFieldChange={this.props.onFieldChange}
@@ -68,6 +69,7 @@ class MessageSearch extends React.Component {
 
 MessageSearch.propTypes = {
   cssClass: React.PropTypes.string,
+  hasRecipientField: React.PropTypes.bool,
   isAdvancedVisible: React.PropTypes.bool.isRequired,
   onAdvancedSearch: React.PropTypes.func.isRequired,
   onError: React.PropTypes.func.isRequired,

--- a/src/js/messaging/components/MessageSearchAdvanced.jsx
+++ b/src/js/messaging/components/MessageSearchAdvanced.jsx
@@ -13,6 +13,8 @@ class MessageSearchAdvanced extends React.Component {
     this.handleEndDateChange = this.handleEndDateChange.bind(this);
     this.handleFromChange = this.handleFromChange.bind(this);
     this.handleFromExactChange = this.handleFromExactChange.bind(this);
+    this.handleToChange = this.handleToChange.bind(this);
+    this.handleToExactChange = this.handleToExactChange.bind(this);
     this.handleSubjectChange = this.handleSubjectChange.bind(this);
     this.handleSubjectExactChange = this.handleSubjectExactChange.bind(this);
   }
@@ -27,6 +29,14 @@ class MessageSearchAdvanced extends React.Component {
 
   handleFromExactChange(field) {
     this.props.onFieldChange('from.exact', field);
+  }
+
+  handleToChange(field) {
+    this.props.onFieldChange('to.field', field);
+  }
+
+  handleToExactChange(field) {
+    this.props.onFieldChange('to.exact', field);
   }
 
   handleSubjectChange(field) {
@@ -55,21 +65,41 @@ class MessageSearchAdvanced extends React.Component {
       'fa-chevron-down': !this.props.isVisible
     });
 
+    let senderOrRecipientField;
+
+    if (this.props.hasRecipientField) {
+      senderOrRecipientField = (
+        <div className="msg-search-advanced-group">
+          <ErrorableTextInput
+              field={this.props.params.to.field}
+              label="To"
+              onValueChange={this.handleToChange}/>
+          <ErrorableCheckbox
+              checked={this.props.params.to.exact}
+              label="Exact match"
+              onValueChange={this.handleToExactChange}/>
+        </div>
+      );
+    } else {
+      senderOrRecipientField = (
+        <div className="msg-search-advanced-group">
+          <ErrorableTextInput
+              field={this.props.params.from.field}
+              label="From"
+              onValueChange={this.handleFromChange}/>
+          <ErrorableCheckbox
+              checked={this.props.params.from.exact}
+              label="Exact match"
+              onValueChange={this.handleFromExactChange}/>
+        </div>
+      );
+    }
+
     if (this.props.isVisible) {
       advancedSearchForm = (
         <fieldset className="msg-search-advanced-controls">
           <legend className="usa-sr-only">Search using additional criteria</legend>
-          <div className="msg-search-advanced-group">
-            <ErrorableTextInput
-                field={this.props.params.from.field}
-                label="From"
-                onValueChange={this.handleFromChange}/>
-
-            <ErrorableCheckbox
-                checked={this.props.params.from.exact}
-                label="Exact match"
-                onValueChange={this.handleFromExactChange}/>
-          </div>
+          {senderOrRecipientField}
 
           <div className="msg-search-advanced-group">
             <ErrorableTextInput
@@ -125,7 +155,7 @@ class MessageSearchAdvanced extends React.Component {
 }
 
 MessageSearchAdvanced.propTypes = {
-  endDateRange: React.PropTypes.object,
+  hasRecipientField: React.PropTypes.bool,
   isVisible: React.PropTypes.bool.isRequired,
   onAdvancedSearch: React.PropTypes.func.isRequired,
   onDateChange: React.PropTypes.func.isRequired,
@@ -136,6 +166,13 @@ MessageSearchAdvanced.propTypes = {
       end: React.PropTypes.object
     }),
     from: React.PropTypes.shape({
+      field: React.PropTypes.shape({
+        value: React.PropTypes.string,
+        dirty: React.PropTypes.bool
+      }),
+      exact: React.PropTypes.bool
+    }),
+    to: React.PropTypes.shape({
       field: React.PropTypes.shape({
         value: React.PropTypes.string,
         dirty: React.PropTypes.bool

--- a/src/js/messaging/containers/Folder.jsx
+++ b/src/js/messaging/containers/Folder.jsx
@@ -92,6 +92,8 @@ export class Folder extends React.Component {
     const queryParams = [
       'page',
       'sort',
+      'filter[[recipient_name][eq]]',
+      'filter[[recipient_name][match]]',
       'filter[[sent_date][gteq]]',
       'filter[[sent_date][lteq]]',
       'filter[[sender_name][eq]]',
@@ -112,23 +114,33 @@ export class Folder extends React.Component {
 
   buildSearchQuery(object) {
     const filters = {};
+    const fromValue = _.get(object, 'from.field.value');
+    const toValue = _.get(object, 'to.field.value');
+    const subjectValue = _.get(object, 'subject.field.value');
+    const startDate = _.get(object, 'dateRange.start');
+    const endDate = _.get(object, 'dateRange.end');
 
-    if (_.get(object, 'from.field.value')) {
+    if (fromValue) {
       const fromExact = object.from.exact ? 'eq' : 'match';
-      filters[`filter[[sender_name][${fromExact}]]`] = object.from.field.value;
+      filters[`filter[[sender_name][${fromExact}]]`] = fromValue;
     }
 
-    if (_.get(object, 'subject.field.value')) {
+    if (toValue) {
+      const fromExact = object.from.exact ? 'eq' : 'match';
+      filters[`filter[[recipient_name][${fromExact}]]`] = toValue;
+    }
+
+    if (subjectValue) {
       const subjectExact = object.subject.exact ? 'eq' : 'match';
-      filters[`filter[[subject][${subjectExact}]]`] = object.subject.field.value;
+      filters[`filter[[subject][${subjectExact}]]`] = subjectValue;
     }
 
-    if (_.get(object, 'dateRange.start')) {
-      filters['filter[[sent_date][gteq]]'] = object.dateRange.start.format();
+    if (startDate) {
+      filters['filter[[sent_date][gteq]]'] = startDate.format();
     }
 
-    if (_.get(object, 'dateRange.end')) {
-      filters['filter[[sent_date][lteq]]'] = object.dateRange.end.format();
+    if (endDate) {
+      filters['filter[[sent_date][lteq]]'] = endDate.format();
     }
 
     return filters;
@@ -326,10 +338,10 @@ export class Folder extends React.Component {
       return <LoadingIndicator message="Loading the folder..."/>;
     }
 
-    const folderId = _.get(this.props.attributes, 'folderId', null);
+    const { folderId, name: folderName } = this.props.attributes;
     let componentContent;
 
-    if (folderId === null) {
+    if (folderId === undefined) {
       const lastRequest = this.props.lastRequestedFolder;
 
       if (lastRequest && lastRequest.id !== null) {
@@ -364,6 +376,7 @@ export class Folder extends React.Component {
       let messageSearch;
       if (this.props.messages && this.props.messages.length || this.props.filter) {
         messageSearch = (<MessageSearch
+            hasRecipientField={folderName === 'Sent' || folderName === 'Drafts'}
             isAdvancedVisible={this.props.isAdvancedVisible}
             onAdvancedSearch={this.props.toggleAdvancedSearch}
             onDateChange={this.props.setDateRange}
@@ -385,8 +398,6 @@ export class Folder extends React.Component {
         </div>
       );
     }
-
-    const folderName = _.get(this.props.attributes, 'name');
 
     return (
       <div>

--- a/src/js/messaging/reducers/search.js
+++ b/src/js/messaging/reducers/search.js
@@ -23,6 +23,10 @@ const initialState = {
       field: makeField(''),
       exact: false
     },
+    to: {
+      field: makeField(''),
+      exact: false
+    },
     subject: {
       field: makeField(''),
       exact: false
@@ -42,10 +46,18 @@ export default function modals(state = initialState, action) {
       const params = {
         dateRange: { ...initialState.params.dateRange },
         from: { ...initialState.params.from },
+        to: { ...initialState.params.to },
         subject: { ...initialState.params.subject }
       };
 
-      const { senderName, sentDate, subject } = filter;
+      const { recipientName, senderName, sentDate, subject } = filter;
+
+      if (recipientName) {
+        params.to.field = !!recipientName.eq
+                          ? makeField(recipientName.eq, true)
+                          : makeField(recipientName.match, true);
+        params.to.exact = !!recipientName.eq;
+      }
 
       if (senderName) {
         params.from.field = !!senderName.eq

--- a/src/js/messaging/reducers/search.js
+++ b/src/js/messaging/reducers/search.js
@@ -41,7 +41,7 @@ export default function modals(state = initialState, action) {
   switch (action.type) {
     case FETCH_FOLDER_SUCCESS: {
       const { filter } = action.messages.meta;
-      if (!filter) { return state; }
+      if (!filter) { return initialState; }
 
       const params = {
         dateRange: { ...initialState.params.dateRange },

--- a/test/messaging/components/MessageSearch.unit.spec.jsx
+++ b/test/messaging/components/MessageSearch.unit.spec.jsx
@@ -110,4 +110,3 @@ describe('MessageSearch', () => {
     expect(onSubmit.calledWith(params)).to.be.true;
   });
 });
-

--- a/test/messaging/components/MessageSearchAdvanced.unit.spec.jsx
+++ b/test/messaging/components/MessageSearchAdvanced.unit.spec.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { makeField } from '../../../src/js/common/model/fields';
+import MessageSearchAdvanced from '../../../src/js/messaging/components/MessageSearchAdvanced';
+
+const props = {
+  isVisible: false,
+  params: {
+    dateRange: {
+      start: null,
+      end: null
+    },
+    from: {
+      field: makeField(''),
+      exact: false
+    },
+    to: {
+      field: makeField(''),
+      exact: false
+    },
+    subject: {
+      field: makeField(''),
+      exact: false
+    }
+  },
+  onAdvancedSearch: () => {},
+  onFieldChange: () => {},
+  onDateChange: () => {},
+};
+
+describe('MessageSearchAdvanced', () => {
+  it('should render', () => {
+    const tree = SkinDeep.shallowRender(<MessageSearchAdvanced {...props}/>);
+    const vdom = tree.getRenderOutput();
+    expect(vdom).to.not.be.undefined;
+    expect(tree.subTree('.msg-search-advanced-toggle')).to.not.be.false;
+  });
+
+  it('should display a form when expanded', () => {
+    const tree = SkinDeep.shallowRender(
+      <MessageSearchAdvanced {...props} isVisible/>
+    );
+    expect(tree.subTree('.msg-search-advanced-controls')).to.not.be.false;
+    expect(tree.subTree('.msg-search-advanced-toggle')).to.not.be.false;
+  });
+
+  it('should search by recipient instead of sender', () => {
+    const tree = SkinDeep.shallowRender(
+      <MessageSearchAdvanced {...props} hasRecipientField isVisible/>
+    );
+    const fields = tree.everySubTree('.msg-search-advanced-group');
+    expect(fields[0].subTree('ErrorableTextInput').props.label).to.equal('To');
+  });
+});
+
+

--- a/test/messaging/components/MessageSearchAdvanced.unit.spec.jsx
+++ b/test/messaging/components/MessageSearchAdvanced.unit.spec.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import ReactTestUtils from 'react-addons-test-utils';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
-import sinon from 'sinon';
 
 import { makeField } from '../../../src/js/common/model/fields';
 import MessageSearchAdvanced from '../../../src/js/messaging/components/MessageSearchAdvanced';
@@ -56,5 +54,3 @@ describe('MessageSearchAdvanced', () => {
     expect(fields[0].subTree('ErrorableTextInput').props.label).to.equal('To');
   });
 });
-
-

--- a/test/messaging/reducers/search.unit.spec.js
+++ b/test/messaging/reducers/search.unit.spec.js
@@ -149,6 +149,8 @@ describe('search reducer', () => {
     expect(newState.params.dateRange.end).to.eql(moment(endDate));
     expect(newState.params.from.field).to.eql(makeField(senderName, true));
     expect(newState.params.from.exact).to.be.true;
+    expect(newState.params.to.field).to.eql(makeField(recipientName, true));
+    expect(newState.params.to.exact).to.be.true;
     expect(newState.params.subject.field).to.eql(makeField(subject, true));
     expect(newState.params.subject.exact).to.be.false;
   });

--- a/test/messaging/reducers/search.unit.spec.js
+++ b/test/messaging/reducers/search.unit.spec.js
@@ -24,6 +24,10 @@ const initialState = {
       field: makeField(''),
       exact: false
     },
+    to: {
+      field: makeField(''),
+      exact: false
+    },
     subject: {
       field: makeField(''),
       exact: false
@@ -153,5 +157,32 @@ describe('search reducer', () => {
     expect(newState.params.to.exact).to.be.true;
     expect(newState.params.subject.field).to.eql(makeField(subject, true));
     expect(newState.params.subject.exact).to.be.false;
+  });
+
+  it('should clear search params when folder loads without filters', () => {
+    const newState = searchReducer({
+      params: {
+        dateRange: {
+          start: '2017-01-01T00:00:00-05:00',
+          end: '2017-01-14T23:59:59-05:00'
+        },
+        from: {
+          field: makeField('Veteran', true),
+          exact: true
+        },
+        to: {
+          field: makeField('Clinician', true),
+          exact: false
+        },
+        subject: {
+          field: makeField('Testing 123', true),
+          exact: false
+        }
+      }
+    }, {
+      type: FETCH_FOLDER_SUCCESS,
+      messages: { meta: {} }
+    });
+    expect(newState.params).to.eql(initialState.params);
   });
 });


### PR DESCRIPTION
Closes department-of-veterans-affairs/messaging-fe#208.

### Changes
* Show 'To' field in advanced search for Drafts and Sent folders instead of 'From'.
* Clear search fields when changing folders.
* Added unit tests for MessageSearchAdvanced component and more tests for existing search modules.

#### Advanced search in Sent folder.
> <img width="742" alt="screen shot 2017-01-06 at 7 23 18 pm" src="https://cloud.githubusercontent.com/assets/1067024/21737575/296dd688-d448-11e6-95d5-8644c4640aa9.png">
