### PR TITLE
[SM] Show message before 'Edit draft'/'Reply' button on mobile.

### DIFF
--- a/src/js/messaging/components/Message.jsx
+++ b/src/js/messaging/components/Message.jsx
@@ -12,13 +12,15 @@ class Message extends React.Component {
   }
 
   componentDidUpdate() {
+    const { attrs, isCollapsed } = this.props;
+
     const shouldFetchMessage =
-      !this.props.isCollapsed &&
-      this.props.attrs.attachment &&
-      !this.props.attrs.attachments;
+      !isCollapsed &&
+      attrs.attachment &&
+      !attrs.attachments;
 
     if (shouldFetchMessage) {
-      this.props.fetchMessage(this.props.attrs.messageId);
+      this.props.fetchMessage(attrs.messageId);
     }
   }
 
@@ -29,35 +31,38 @@ class Message extends React.Component {
   }
 
   render() {
+    const { attrs, isCollapsed } = this.props;
+    const { body, senderName, sentDate } = attrs;
+
     const messageClass = classNames({
       'messaging-thread-message': true,
-      'messaging-thread-message--collapsed': this.props.isCollapsed,
-      'messaging-thread-message--expanded': !this.props.isCollapsed
+      'messaging-thread-message--draft': !sentDate,
+      'messaging-thread-message--collapsed': isCollapsed,
+      'messaging-thread-message--expanded': !isCollapsed
     });
 
     let details;
     let headerOnClick;
     let messageOnClick;
-    let attachments;
+    let attachmentsView;
 
-    if (this.props.isCollapsed) {
+    if (isCollapsed) {
       messageOnClick = this.handleToggleCollapsed;
     } else {
+      const { attachment, attachments, recipientName } = attrs;
+
       details = (
         <div className="messaging-message-recipient">
-          to {this.props.attrs.recipientName}
-          <MessageDetails { ...this.props }/>
+          to {recipientName}
+          <MessageDetails attrs={attrs}/>
         </div>
       );
 
       headerOnClick = this.handleToggleCollapsed;
 
-      if (this.props.attrs.attachment) {
-        attachments = (
-          <MessageAttachmentsView
-              attachments={this.props.attrs.attachments}/>
-        );
-      }
+      attachmentsView = attachment && (
+        <MessageAttachmentsView attachments={attachments}/>
+      );
     }
 
     return (
@@ -66,17 +71,17 @@ class Message extends React.Component {
             className="messaging-message-header"
             onClick={headerOnClick}>
           <div className="messaging-message-sent-date">
-            {formattedDate(this.props.attrs.sentDate, { fromNow: true })}
+            {sentDate && formattedDate(sentDate, { fromNow: true })}
           </div>
           <div className="messaging-message-sender">
-            {this.props.attrs.senderName}
+            {senderName}
           </div>
           {details}
         </div>
         <div className="messaging-message-body">
-          {this.props.attrs.body}
+          {body}
         </div>
-        {attachments}
+        {attachmentsView}
       </div>
     );
   }
@@ -96,9 +101,9 @@ Message.propTypes = {
     recipientName: React.PropTypes.string.isRequired,
     readReceipt: React.PropTypes.oneOf(['READ', 'UNREAD'])
   }).isRequired,
+  fetchMessage: React.PropTypes.func,
   isCollapsed: React.PropTypes.bool,
-  onToggleCollapsed: React.PropTypes.func,
-  fetchMessage: React.PropTypes.func
+  onToggleCollapsed: React.PropTypes.func
 };
 
 export default Message;

--- a/src/js/messaging/components/Message.jsx
+++ b/src/js/messaging/components/Message.jsx
@@ -94,7 +94,7 @@ Message.propTypes = {
     subject: React.PropTypes.string.isRequired,
     body: React.PropTypes.string.isRequired,
     attachment: React.PropTypes.bool.isRequired,
-    sentDate: React.PropTypes.string.isRequired,
+    sentDate: React.PropTypes.string,
     senderId: React.PropTypes.number.isRequired,
     senderName: React.PropTypes.string.isRequired,
     recipientId: React.PropTypes.number.isRequired,

--- a/src/js/messaging/components/MessageDetails.jsx
+++ b/src/js/messaging/components/MessageDetails.jsx
@@ -27,47 +27,61 @@ class MessageDetails extends React.Component {
   }
 
   render() {
+    const {
+      category,
+      messageId,
+      recipientName,
+      senderName,
+      sentDate,
+      subject
+    } = this.props.attrs;
+
+    const sentDateRow = sentDate && (
+      <tr>
+        <th>Date:</th>
+        <td>
+          {moment(sentDate).format('ddd, MMM D, YYYY [at] HH:mm')}&nbsp;
+          <abbr title="Eastern Standard Time">EST</abbr>
+        </td>
+      </tr>
+    );
+
     const messageDetails = (
       <div className="messaging-message-details">
         <table>
           <tbody>
             <tr>
               <th>From:</th>
-              <td>{this.props.attrs.senderName}</td>
+              <td>{senderName}</td>
             </tr>
             <tr>
               <th>To:</th>
-              <td>{this.props.attrs.recipientName}</td>
+              <td>{recipientName}</td>
             </tr>
-            <tr>
-              <th>Date:</th>
-              <td>
-                {
-                  moment(
-                    this.props.attrs.sentDate
-                  ).format('ddd, MMM D, YYYY [at] HH:mm')
-                } <abbr title="Eastern Standard Time">EST</abbr>
-              </td>
-            </tr>
+            {sentDateRow}
             <tr>
               <th>Message ID:</th>
-              <td>{this.props.attrs.messageId}</td>
+              <td>{messageId}</td>
             </tr>
             <tr>
               <th>Category:</th>
-              <td>{this.props.attrs.category}</td>
+              <td>{category}</td>
             </tr>
             <tr>
               <th>Subject Line:</th>
-              <td>{this.props.attrs.subject}</td>
+              <td>{subject}</td>
             </tr>
           </tbody>
         </table>
       </div>
     );
 
-    const inputId = `message-details-${this.props.attrs.messageId}`;
+    const inputId = `message-details-${messageId}`;
     const compactInputId = `compact-${inputId}`;
+
+    const compactSentDate = sentDate && (
+      <span>{formattedDate(sentDate, { fromNow: true })}</span>
+    );
 
     return (
       <div
@@ -89,9 +103,7 @@ class MessageDetails extends React.Component {
             id={compactInputId}
             className="messaging-compact-details-trigger"
             type="checkbox"/>
-        <span>
-          {formattedDate(this.props.attrs.sentDate, { fromNow: true })}
-        </span>
+        {compactSentDate}
         <label htmlFor={compactInputId}></label>
         {messageDetails}
       </div>
@@ -104,7 +116,7 @@ MessageDetails.propTypes = {
     messageId: React.PropTypes.number.isRequired,
     category: React.PropTypes.string.isRequired,
     subject: React.PropTypes.string.isRequired,
-    sentDate: React.PropTypes.string.isRequired,
+    sentDate: React.PropTypes.string,
     senderName: React.PropTypes.string.isRequired,
     recipientName: React.PropTypes.string.isRequired,
   }).isRequired,

--- a/src/js/messaging/components/ThreadHeader.jsx
+++ b/src/js/messaging/components/ThreadHeader.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 
 import ButtonBack from './buttons/ButtonBack';
 import ButtonDelete from './buttons/ButtonDelete';
@@ -67,8 +68,13 @@ class ThreadHeader extends React.Component {
       );
     }
 
-    const titleSection = !isNewMessage && (
-      <div className="messaging-thread-title">
+    const titleClass = classNames({
+      'messaging-thread-title': true,
+      'show-for-small-only': isNewMessage
+    });
+
+    const titleSection = (
+      <div className={titleClass}>
         <div className="messaging-thread-controls">
           {toggleThread}
           {deleteButton}

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -244,7 +244,7 @@ export class Thread extends React.Component {
     }
 
 
-    if (!isSavedDraft && message) {
+    if (message) {
       currentMessage = <Message attrs={message}/>;
     }
 

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -222,7 +222,7 @@ export class Thread extends React.Component {
   }
 
   makeThread() {
-    const { isSavedDraft, message, messagesCollapsed, thread } = this.props;
+    const { message, messagesCollapsed, thread } = this.props;
 
     let threadMessages;
     let currentMessage;

--- a/src/sass/messaging/partials/_messaging-message.scss
+++ b/src/sass/messaging/partials/_messaging-message.scss
@@ -163,6 +163,7 @@
     }
 
     tr:first-child,
+    tr:nth-child(2),
     tr:last-child {
       display: none;
     }
@@ -191,6 +192,7 @@
 
   & ~ span {
     display: none;
+    margin-right: .5rem;
 
     @media (max-width: $medium-screen) {
       display: inline-block;

--- a/src/sass/messaging/partials/_messaging-message.scss
+++ b/src/sass/messaging/partials/_messaging-message.scss
@@ -25,6 +25,12 @@
       }
     }
   }
+
+  &--draft {
+    @media (min-width: $medium-screen) {
+      display: none;
+    }
+  }
 }
 
 .messaging-message-header {

--- a/src/sass/messaging/partials/_messaging-message.scss
+++ b/src/sass/messaging/partials/_messaging-message.scss
@@ -175,6 +175,11 @@
     display: none;
     text-decoration: underline;
 
+    // Overwrite USWDS checkbox.
+    &:before {
+      display: none !important;
+    }
+
     &:after {
       content: 'Details';
     }
@@ -186,7 +191,6 @@
 
   & ~ span {
     display: none;
-    margin-right: 0.5rem;
 
     @media (max-width: $medium-screen) {
       display: inline-block;

--- a/src/sass/messaging/partials/_messaging-thread.scss
+++ b/src/sass/messaging/partials/_messaging-thread.scss
@@ -77,7 +77,7 @@
   &:after {
     clear: both;
     content: '';
-    display: 'block';
+    display: block;
   }
 
   .msg-btn-back,

--- a/test/messaging/components/Message.unit.spec.jsx
+++ b/test/messaging/components/Message.unit.spec.jsx
@@ -13,7 +13,7 @@ const props = {
     subject: 'Scheduling An Appointment',
     body: 'Testing 123.',
     attachment: false,
-    sentDate: "2016-12-21T05:54:26.000Z",
+    sentDate: '2016-12-21T05:54:26.000Z',
     senderId: 456,
     senderName: 'Clinician',
     recipientId: 789,
@@ -29,7 +29,7 @@ describe('Message', () => {
   it('should render', () => {
     const tree = SkinDeep.shallowRender(<Message {...props}/>);
     const vdom = tree.getRenderOutput();
-    expect(vdom).to.not.be.undefined;
+    expect(vdom).to.exist;
   });
 
   it('should show details when expanded', () => {

--- a/test/messaging/components/Message.unit.spec.jsx
+++ b/test/messaging/components/Message.unit.spec.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+
+import Message from '../../../src/js/messaging/components/Message';
+
+const props = {
+  attrs: {
+    messageId: 123,
+    category: 'APPOINTMENTS',
+    subject: 'Scheduling An Appointment',
+    body: 'Testing 123.',
+    attachment: false,
+    sentDate: "2016-12-21T05:54:26.000Z",
+    senderId: 456,
+    senderName: 'Clinician',
+    recipientId: 789,
+    recipientName: 'Veteran',
+    readReceipt: 'READ'
+  },
+  fetchMessage: () => {},
+  isCollapsed: false,
+  onToggleCollapsed: () => {}
+};
+
+describe('Message', () => {
+  it('should render', () => {
+    const tree = SkinDeep.shallowRender(<Message {...props}/>);
+    const vdom = tree.getRenderOutput();
+    expect(vdom).to.not.be.undefined;
+  });
+
+  it('should show details and attachments when expanded', () => {
+    const tree = SkinDeep.shallowRender(<Message {...props}/>);
+    expect(tree.props.className).to.contain('messaging-thread-message--expanded');
+    expect(tree.subTree('MessageDetails')).to.exist;
+    expect(tree.subTree('MessageAttachmentsView')).to.exist;
+  });
+
+  it('should hide details and attachments when collapsed', () => {
+    const tree = SkinDeep.shallowRender(<Message {...props} isCollapsed/>);
+    expect(tree.props.className).to.contain('messaging-thread-message--collapsed');
+    expect(tree.subTree('MessageDetails')).to.be.false;
+    expect(tree.subTree('MessageAttachmentsView')).to.be.false;
+  });
+});

--- a/test/messaging/components/Message.unit.spec.jsx
+++ b/test/messaging/components/Message.unit.spec.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import Message from '../../../src/js/messaging/components/Message';
 
@@ -67,5 +69,40 @@ describe('Message', () => {
     );
     expect(tree.props.className).to.contain('messaging-thread-message--draft');
     expect(tree.subTree('.messaging-message-sent-date').text()).to.be.empty;
+  });
+
+  it('should fetch attachments when they have not been loaded', () => {
+    const fetchMessage = sinon.spy();
+
+    const message = ReactTestUtils.renderIntoDocument(
+      <Message
+          {...props}
+          attrs={{ ...props.attrs, attachment: true }}
+          fetchMessage={fetchMessage}/>
+    );
+
+    message.componentDidUpdate();
+    expect(fetchMessage.calledWith(props.attrs.messageId)).to.be.true;
+  });
+
+  it('should not fetch attachments after they have already been loaded', () => {
+    const fetchMessage = sinon.spy();
+
+    const message = ReactTestUtils.renderIntoDocument(
+      <Message
+          {...props}
+          attrs={{
+            ...props.attrs,
+            attachment: true,
+            attachments: [{
+              attributes: { name: 'test_file.png' },
+              links: { download: 'http://example.com' }
+            }]
+          }}
+          fetchMessage={fetchMessage}/>
+    );
+
+    message.componentDidUpdate();
+    expect(fetchMessage.calledWith(props.attrs.messageId)).to.be.false;
   });
 });

--- a/test/messaging/components/Message.unit.spec.jsx
+++ b/test/messaging/components/Message.unit.spec.jsx
@@ -30,17 +30,42 @@ describe('Message', () => {
     expect(vdom).to.not.be.undefined;
   });
 
-  it('should show details and attachments when expanded', () => {
+  it('should show details when expanded', () => {
     const tree = SkinDeep.shallowRender(<Message {...props}/>);
     expect(tree.props.className).to.contain('messaging-thread-message--expanded');
-    expect(tree.subTree('MessageDetails')).to.exist;
-    expect(tree.subTree('MessageAttachmentsView')).to.exist;
+    expect(tree.subTree('MessageDetails')).to.be.ok;
   });
 
-  it('should hide details and attachments when collapsed', () => {
+  it('should show attachments when expanded', () => {
+    const tree = SkinDeep.shallowRender(
+      <Message {...props} attrs={{ ...props.attrs, attachment: true }}/>
+    );
+    expect(tree.props.className).to.contain('messaging-thread-message--expanded');
+    expect(tree.subTree('MessageAttachmentsView')).to.be.ok;
+  });
+
+  it('should hide details when collapsed', () => {
     const tree = SkinDeep.shallowRender(<Message {...props} isCollapsed/>);
     expect(tree.props.className).to.contain('messaging-thread-message--collapsed');
     expect(tree.subTree('MessageDetails')).to.be.false;
+  });
+
+  it('should hide attachments when collapsed', () => {
+    const tree = SkinDeep.shallowRender(
+      <Message
+          {...props}
+          attrs={{ ...props.attrs, attachment: true }}
+          isCollapsed/>
+    );
+    expect(tree.props.className).to.contain('messaging-thread-message--collapsed');
     expect(tree.subTree('MessageAttachmentsView')).to.be.false;
+  });
+
+  it('should display as a draft when there is no sent date', () => {
+    const tree = SkinDeep.shallowRender(
+      <Message {...props} attrs={{ ...props.attrs, sentDate: null }}/>
+    );
+    expect(tree.props.className).to.contain('messaging-thread-message--draft');
+    expect(tree.subTree('.messaging-message-sent-date').text()).to.be.empty;
   });
 });

--- a/test/messaging/components/MessageDetails.unit.spec.jsx
+++ b/test/messaging/components/MessageDetails.unit.spec.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+import moment from 'moment';
+
+import MessageDetails from '../../../src/js/messaging/components/MessageDetails';
+
+const props = {
+  attrs: {
+    messageId: 123,
+    category: 'APPOINTMENTS',
+    subject: 'Scheduling An Appointment',
+    sentDate: '2016-12-21T05:54:26.000Z',
+    senderName: 'Clinician',
+    recipientName: 'Veteran'
+  },
+};
+
+describe('MessageDetails', () => {
+  it('should render', () => {
+    const tree = SkinDeep.shallowRender(<MessageDetails {...props}/>);
+    const vdom = tree.getRenderOutput();
+    expect(vdom).to.exist;
+  });
+
+  it('should display the correct data', () => {
+    const tree = SkinDeep.shallowRender(<MessageDetails {...props}/>);
+
+    const rows = tree.dive(['.messaging-message-details', 'table', 'tbody']).everySubTree('tr');
+
+    expect(rows[0].dive(['td']).text()).to.equal(props.attrs.senderName);
+    expect(rows[1].dive(['td']).text()).to.equal(props.attrs.recipientName);
+
+    const expectedDate = `${moment(props.attrs.sentDate).format('ddd, MMM D, YYYY [at] HH:mm')} EST`;
+    expect(rows[2].dive(['td']).text()).to.equal(expectedDate);
+
+    expect(rows[3].dive(['td']).text()).to.equal(`${props.attrs.messageId}`);
+    expect(rows[4].dive(['td']).text()).to.equal(props.attrs.category);
+    expect(rows[5].dive(['td']).text()).to.equal(props.attrs.subject);
+  });
+});

--- a/test/messaging/components/MessageDetails.unit.spec.jsx
+++ b/test/messaging/components/MessageDetails.unit.spec.jsx
@@ -38,4 +38,20 @@ describe('MessageDetails', () => {
     expect(rows[4].dive(['td']).text()).to.equal(props.attrs.category);
     expect(rows[5].dive(['td']).text()).to.equal(props.attrs.subject);
   });
+
+  it('should not show anything with sent date when not available', () => {
+    const tree = SkinDeep.shallowRender(
+      <MessageDetails {...props} attrs={{ ...props.attrs, sentDate: null }}/>
+    );
+
+    const rows = tree.dive(['.messaging-message-details', 'table', 'tbody']).everySubTree('tr');
+
+    expect(rows).to.have.length(5);
+
+    expect(rows[0].dive(['th']).text()).to.equal('From:');
+    expect(rows[1].dive(['th']).text()).to.equal('To:');
+    expect(rows[2].dive(['th']).text()).to.equal('Message ID:');
+    expect(rows[3].dive(['th']).text()).to.equal('Category:');
+    expect(rows[4].dive(['th']).text()).to.equal('Subject Line:');
+  });
 });

--- a/test/messaging/components/ThreadHeader.unit.spec.jsx
+++ b/test/messaging/components/ThreadHeader.unit.spec.jsx
@@ -20,12 +20,12 @@ describe('ThreadHeader', () => {
   it('should render', () => {
     const tree = SkinDeep.shallowRender(<ThreadHeader {...props}/>);
     const vdom = tree.getRenderOutput();
-    expect(vdom).to.not.be.undefined;
+    expect(vdom).to.exist;
   });
 
   it('should show a message nav', () => {
     const tree = SkinDeep.shallowRender(<ThreadHeader {...props }/>);
-    expect(tree.subTree('MessageNav')).to.not.be.false;
+    expect(tree.subTree('MessageNav')).to.be.ok;
   });
 
   it('should hide message nav in case of folder message count errors', () => {
@@ -37,12 +37,12 @@ describe('ThreadHeader', () => {
 
   it('should show a move button', () => {
     const tree = SkinDeep.shallowRender(<ThreadHeader {...props }/>);
-    expect(tree.subTree('MoveTo')).to.not.be.false;
+    expect(tree.subTree('MoveTo')).to.be.ok;
   });
 
   it('should show a button to expand or collapse a thread with multiple messages', () => {
     const tree = SkinDeep.shallowRender(<ThreadHeader {...props }/>);
-    expect(tree.subTree('ToggleThread')).to.not.be.false;
+    expect(tree.subTree('ToggleThread')).to.be.ok;
   });
 
   it('should not show a button to expand or collapse a thread with only one message', () => {
@@ -52,7 +52,7 @@ describe('ThreadHeader', () => {
 
   it('should show a delete button', () => {
     const tree = SkinDeep.shallowRender(<ThreadHeader {...props }/>);
-    expect(tree.subTree('ButtonDelete')).to.not.be.false;
+    expect(tree.subTree('ButtonDelete')).to.be.ok;
   });
 
   it('should not show delete or move buttons for drafts or sent messages', () => {
@@ -80,12 +80,12 @@ describe('ThreadHeader', () => {
     expect(tree.dive(['h2']).text()).to.equal('Subject');
   });
 
-  it('should not show the subject line for a draft of a new message', () => {
+  it('should show only on mobile the subject line for a draft of a new message', () => {
     const tree = SkinDeep.shallowRender(
       <ThreadHeader
           {...props }
           isNewMessage/>
     );
-    expect(tree.subTree('.messaging-thread-title')).to.be.false;
+    expect(tree.subTree('.messaging-thread-title.show-for-small-only')).to.be.ok;
   });
 });


### PR DESCRIPTION
### Changes
* Display the preview of the draft like a regular message in the thread on mobile. Closes department-of-veterans-affairs/messaging-fe#207.
* Fixed broken mobile header bar when only the 'Back' button is showing.
* Hide redundant or missing fields in expanded message details. No sent date when not available and no 'From' or 'To' on mobile.
* Show message title above the message for new message drafts only on mobile.
* Added unit tests for Message and MessageDetails components.

### Preview
> <img width="359" alt="screen shot 2017-01-10 at 7 21 23 pm" src="https://cloud.githubusercontent.com/assets/1067024/21830413/84988e48-d76a-11e6-830c-04dfe8c0a7f2.png">
