### PR TITLE
Change feature flag constant to rely on buildtype option

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -100,7 +100,7 @@ const configGenerator = (options) => {
     plugins: [
       new webpack.DefinePlugin({
         __BUILDTYPE__: JSON.stringify(options.buildtype),
-        __ALL_CLAIMS_ENABLED__: (process.env.BUILDTYPE === 'development' || process.env.ALL_CLAIMS_ENABLED === 'true'),
+        __ALL_CLAIMS_ENABLED__: (JSON.stringify(options.buildtype) === 'development' || process.env.ALL_CLAIMS_ENABLED === 'true'),
         __SAMPLE_ENABLED__: (process.env.SAMPLE_ENABLED === 'true'),
         'process.env': {
           NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development'),

--- a/test/disability-benefits/components/YourClaimsPage.unit.spec.jsx
+++ b/test/disability-benefits/components/YourClaimsPage.unit.spec.jsx
@@ -40,6 +40,7 @@ describe('<YourClaimsPage>', () => {
     const tree = SkinDeep.shallowRender(
       <YourClaimsPage
           loading
+          allClaims={false}
           claims={claims}
           page={page}
           pages={pages}
@@ -58,6 +59,7 @@ describe('<YourClaimsPage>', () => {
 
     const tree = SkinDeep.shallowRender(
       <YourClaimsPage
+          allClaims={false}
           claims={claims}
           page={page}
           pages={pages}
@@ -76,6 +78,7 @@ describe('<YourClaimsPage>', () => {
 
     const tree = SkinDeep.shallowRender(
       <YourClaimsPage
+          allClaims={false}
           claims={claims}
           page={page}
           pages={pages}

--- a/test/util/mocha-setup.js
+++ b/test/util/mocha-setup.js
@@ -3,7 +3,7 @@ import chaiAsPromised from 'chai-as-promised';
 import jsdom from 'jsdom';
 
 global.__BUILDTYPE__ = process.env.BUILDTYPE || 'development';
-global.__ALL_CLAIMS_ENABLED__ = (process.env.BUILDTYPE === 'development' || process.env.ALL_CLAIMS_ENABLED === 'true');
+global.__ALL_CLAIMS_ENABLED__ = (global.__BUILDTYPE__ === 'development' || process.env.ALL_CLAIMS_ENABLED === 'true');
 global.__SAMPLE_ENABLED__ = (process.env.SAMPLE_ENABLED === 'true');
 
 chai.use(chaiAsPromised);


### PR DESCRIPTION
Instead of the environment variable BUILDTYPE, which isn't defined
explicitly when defining the build's type for both local development or
fro the CI/CD pipeline.