### PR TITLE
Fix ALL_CLAIMS_ENABLED boolean flag

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -100,7 +100,7 @@ const configGenerator = (options) => {
     plugins: [
       new webpack.DefinePlugin({
         __BUILDTYPE__: JSON.stringify(options.buildtype),
-        __ALL_CLAIMS_ENABLED__: (JSON.stringify(options.buildtype) === 'development' || process.env.ALL_CLAIMS_ENABLED === 'true'),
+        __ALL_CLAIMS_ENABLED__: (options.buildtype === 'development' || process.env.ALL_CLAIMS_ENABLED === 'true'),
         __SAMPLE_ENABLED__: (process.env.SAMPLE_ENABLED === 'true'),
         'process.env': {
           NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development'),


### PR DESCRIPTION
This didn't require the JSON.stringify, since we're not looking to convert to a JS value for webpack define replacement.