### PR TITLE
Use specified node version, use npm-shrinkwrap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN set -ex \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
   ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+    gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys "$key"; \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,58 @@
-FROM node
+# based on https://github.com/nodejs/docker-node/blob/master/4.7/slim/Dockerfile
 
-RUN npm install -g nsp && \
-    npm install -g s3-cli && \
-      apt-get update && \
-      apt-get install -y netcat default-jre
+FROM buildpack-deps:jessie
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+# gpg keys listed at https://github.com/nodejs/node
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 4.4.7
+ENV NPM_VERSION 3.8.9
+ENV NODE_ENV production
+
+RUN buildDeps='xz-utils' \
+    && set -x \
+    && apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+    && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+    && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+    && apt-get purge -y --auto-remove $buildDeps \
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+    && npm install -g npm@$NPM_VERSION \
+    && npm install -g nsp \
+    && npm install -g s3-cli
+
+RUN apt-get update && apt-get install -y netcat default-jre --no-install-recommends
 
 WORKDIR /application
 
+# Install required npm dependencies
+
 COPY package.json .
+COPY npm-shrinkwrap.json .
 
 RUN npm install
 RUN npm run selenium:bootstrap
+
+# Copy application source to image
 
 COPY . .

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,5 @@
 def envNames = ['development', 'staging', 'production']
 
-def isPushNotificationOnFeature = {
-  !env.CHANGE_TARGET && !['master', 'production'].contains(env.BRANCH_NAME)
-}
-
 def isContentTeamUpdate = {
   env.BRANCH_NAME ==~ /^content\/wip\/.*/
 }
@@ -31,10 +27,6 @@ node('vets-website-linting') {
   // Checkout source, create output directories, build container
 
   stage('Setup') {
-    if (isPushNotificationOnFeature()) {
-      return
-    }
-
     checkout scm
 
     sh "mkdir -p build"
@@ -47,7 +39,7 @@ node('vets-website-linting') {
   // Check package.json for known vulnerabilities
 
   stage('Security') {
-    if (isContentTeamUpdate() || isPushNotificationOnFeature()) {
+    if (isContentTeamUpdate()) {
       return
     }
 
@@ -59,7 +51,7 @@ node('vets-website-linting') {
   // Check source for syntax issues
 
   stage('Lint') {
-    if (isContentTeamUpdate() || isPushNotificationOnFeature()) {
+    if (isContentTeamUpdate()) {
       return
     }
 
@@ -69,7 +61,7 @@ node('vets-website-linting') {
   }
 
   stage('Unit') {
-    if (isContentTeamUpdate() || isPushNotificationOnFeature()) {
+    if (isContentTeamUpdate()) {
       return
     }
 
@@ -81,10 +73,6 @@ node('vets-website-linting') {
   // Perform a build for each required build type
 
   stage('Build') {
-    if (isPushNotificationOnFeature()) {
-      return
-    }
-
     def buildList = ['production']
 
     if (isContentTeamUpdate()) {
@@ -121,7 +109,7 @@ node('vets-website-linting') {
   // Run E2E and accessibility tests
 
   stage('Integration') {
-    if (isContentTeamUpdate() || isPushNotificationOnFeature()) {
+    if (isContentTeamUpdate()) {
       return
     }
 
@@ -147,7 +135,7 @@ node('vets-website-linting') {
 
     if (!isDeployable()) {
       return
-    } 
+    }
 
     def targets = [
       'master': [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,5 @@
 def envNames = ['development', 'staging', 'production']
 
-env.NODE_ENV = 'production'
-
 def isPushNotificationOnFeature = {
   !env.CHANGE_TARGET && !['master', 'production'].contains(env.BRANCH_NAME)
 }
@@ -54,7 +52,7 @@ node('vets-website-linting') {
     }
 
     dockerImage.inside(args) {
-      sh "cd /application && nsp check" 
+      sh "cd /application && nsp check"
     }
   }
 


### PR DESCRIPTION
Previous builds used node version not specified in .nvmrc, and ignored
the npm-shrinkwrap.json file. This updates to run tests with same
versions currently running under Travis.