### PR TITLE
login status should remain false if session has expired

### DIFF
--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -31,15 +31,17 @@ export function getUserData() {
   }).then(response => {
     return response.json();
   }).then(json => {
-    const userData = json.data.attributes.profile;
-    commonStore.dispatch(updateProfileField('accountType', userData.loa.current));
-    commonStore.dispatch(updateProfileField('email', userData.email));
-    commonStore.dispatch(updateProfileField('userFullName.first', userData.first_name));
-    commonStore.dispatch(updateProfileField('userFullName.middle', userData.middle_name));
-    commonStore.dispatch(updateProfileField('userFullName.last', userData.last_name));
-    commonStore.dispatch(updateProfileField('gender', userData.gender));
-    commonStore.dispatch(updateProfileField('dob', userData.birth_date));
-    commonStore.dispatch(updateLoggedInStatus(true));
+    if (json.data) {
+      const userData = json.data.attributes.profile;
+      commonStore.dispatch(updateProfileField('accountType', userData.loa.current));
+      commonStore.dispatch(updateProfileField('email', userData.email));
+      commonStore.dispatch(updateProfileField('userFullName.first', userData.first_name));
+      commonStore.dispatch(updateProfileField('userFullName.middle', userData.middle_name));
+      commonStore.dispatch(updateProfileField('userFullName.last', userData.last_name));
+      commonStore.dispatch(updateProfileField('gender', userData.gender));
+      commonStore.dispatch(updateProfileField('dob', userData.birth_date));
+      commonStore.dispatch(updateLoggedInStatus(true));
+    }
   });
 }
 

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -89,8 +89,9 @@ class Main extends React.Component {
           this.handleLogout();
         }
       } else {
-        this.props.onUpdateLoggedInStatus(true);
-        this.getUserData();
+        if (this.getUserData()) {
+          this.props.onUpdateLoggedInStatus(true);
+        }
       }
     } else {
       this.props.onUpdateLoggedInStatus(false);


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/623

`this.props.onUpdateLoggedInStatus(true)` was being called even thought the session had expired. login-helpers.js also tried to update profile fields when the server returned unauthorized.