### PR TITLE
[Rx] Sorting fixes and unit tests.

### DIFF
--- a/src/js/common/components/SortableTable.jsx
+++ b/src/js/common/components/SortableTable.jsx
@@ -43,7 +43,7 @@ class SortableTable extends React.Component {
 
     return (
       <th key={field.value}>
-        <a href="#" role="button" onClick={this.handleSort(field.value, nextSortOrder)}>
+        <a role="button" tabIndex="0" onClick={this.handleSort(field.value, nextSortOrder)}>
           {field.label}
           {sortIcon}
         </a>

--- a/src/js/rx/components/SortMenu.jsx
+++ b/src/js/rx/components/SortMenu.jsx
@@ -6,12 +6,19 @@ import React from 'react';
 import _ from 'lodash';
 import classNames from 'classnames';
 
+const isDateAttribute = (option) => {
+  return [
+    'refillSubmitDate',
+    'lastSubmitDate',
+    'refillDate'
+  ].includes(option);
+};
+
 class SortMenu extends React.Component {
   constructor(props) {
     super(props);
     this.handleChange = this.handleChange.bind(this);
     this.handleClick = this.handleClick.bind(this);
-    this.isDateAttribute = this.isDateAttribute.bind(this);
   }
 
   componentWillMount() {
@@ -21,7 +28,7 @@ class SortMenu extends React.Component {
   handleChange(event) {
     const { value } = event.target;
     // By default, sort dates by most recent.
-    const order = this.isDateAttribute(value) ? 'DESC' : 'ASC';
+    const order = isDateAttribute(value) ? 'DESC' : 'ASC';
     this.props.onChange(value, order);
   }
 
@@ -32,18 +39,10 @@ class SortMenu extends React.Component {
     };
   }
 
-  isDateAttribute(option) {
-    return [
-      'refillSubmitDate',
-      'lastSubmitDate',
-      'refillDate'
-    ].includes(option);
-  }
-
   renderSortLinks() {
     const { selected: { value, order } } = this.props;
 
-    const options = this.isDateAttribute(value) ? {
+    const options = isDateAttribute(value) ? {
       'Newest to Oldest': 'DESC',
       'Oldest to Newest': 'ASC'
     } : {

--- a/src/js/rx/components/SortMenu.jsx
+++ b/src/js/rx/components/SortMenu.jsx
@@ -99,10 +99,13 @@ SortMenu.propTypes = {
   onChange: React.PropTypes.func,
   onClick: React.PropTypes.func,
   options: React.PropTypes.arrayOf(React.PropTypes.shape({
-    value: React.PropTypes.string,
     label: React.PropTypes.string,
+    value: React.PropTypes.string
   })),
-  selected: React.PropTypes.object
+  selected: React.PropTypes.shape({
+    order: React.PropTypes.string,
+    value: React.PropTypes.string
+  })
 };
 
 export default SortMenu;

--- a/src/js/rx/components/SortMenu.jsx
+++ b/src/js/rx/components/SortMenu.jsx
@@ -7,11 +7,11 @@ import _ from 'lodash';
 import classNames from 'classnames';
 
 const isDateAttribute = (option) => {
-  return [
+  return _.includes([
     'refillSubmitDate',
     'lastSubmitDate',
     'refillDate'
-  ].includes(option);
+  ], option);
 };
 
 class SortMenu extends React.Component {

--- a/src/js/rx/components/SortMenu.jsx
+++ b/src/js/rx/components/SortMenu.jsx
@@ -6,19 +6,12 @@ import React from 'react';
 import _ from 'lodash';
 import classNames from 'classnames';
 
-const isDateAttribute = (option) => {
-  return [
-    'refillSubmitDate',
-    'lastSubmitDate',
-    'refillDate'
-  ].includes(option);
-};
-
 class SortMenu extends React.Component {
   constructor(props) {
     super(props);
     this.handleChange = this.handleChange.bind(this);
     this.handleClick = this.handleClick.bind(this);
+    this.isDateAttribute = this.isDateAttribute.bind(this);
   }
 
   componentWillMount() {
@@ -28,7 +21,7 @@ class SortMenu extends React.Component {
   handleChange(event) {
     const { value } = event.target;
     // By default, sort dates by most recent.
-    const order = isDateAttribute(value) ? 'DESC' : 'ASC';
+    const order = this.isDateAttribute(value) ? 'DESC' : 'ASC';
     this.props.onChange(value, order);
   }
 
@@ -39,10 +32,18 @@ class SortMenu extends React.Component {
     };
   }
 
+  isDateAttribute(option) {
+    return [
+      'refillSubmitDate',
+      'lastSubmitDate',
+      'refillDate'
+    ].includes(option);
+  }
+
   renderSortLinks() {
     const { selected: { value, order } } = this.props;
 
-    const options = isDateAttribute(value) ? {
+    const options = this.isDateAttribute(value) ? {
       'Newest to Oldest': 'DESC',
       'Oldest to Newest': 'ASC'
     } : {

--- a/src/js/rx/containers/Active.jsx
+++ b/src/js/rx/containers/Active.jsx
@@ -48,6 +48,24 @@ class Active extends React.Component {
     window.addEventListener('resize', this.checkWindowSize);
   }
 
+  componentDidUpdate() {
+    const { prescriptions, sort: currentSort } = this.props;
+    const requestedSort = this.props.location.query.sort || 'prescriptionName';
+    const sortOrder = requestedSort[0] === '-' ? 'DESC' : 'ASC';
+    const sortValue = sortOrder === 'DESC'
+                    ? requestedSort.slice(1)
+                    : requestedSort;
+
+    const shouldSort =
+      !_.isEmpty(prescriptions) &&
+      (currentSort.value !== sortValue ||
+      currentSort.order !== sortOrder);
+
+    if (shouldSort) {
+      this.props.sortPrescriptions(sortValue, sortOrder);
+    }
+  }
+
   componentWillUnmount() {
     window.removeEventListener('resize', this.checkWindowSize);
   }
@@ -59,13 +77,12 @@ class Active extends React.Component {
     });
   }
 
-  handleSort(sortKey, order) {
-    const sortParam = order === 'DESC' ? `-${sortKey}` : sortKey;
+  handleSort(sortKey, sortOrder) {
+    const sort = sortOrder === 'DESC' ? `-${sortKey}` : sortKey;
     this.context.router.push({
       ...this.props.location,
-      query: { sort: sortParam }
+      query: { sort }
     });
-    this.props.sortPrescriptions(sortKey, order);
   }
 
   renderViewSwitch() {

--- a/src/sass/rx/partials/_rx-table.scss
+++ b/src/sass/rx/partials/_rx-table.scss
@@ -23,27 +23,6 @@
       &:before {
         font-weight: bold;
       }
-
-      &:nth-child(2) {
-        &:before{
-          content: 'Submit Date: ',
-        }
-      }
-      &:nth-child(3) {
-        &:before{
-          content: 'Fill Date: ',
-        }
-      }
-      &:nth-child(4) {
-        &:before{
-          content: 'Facility: ',
-        }
-      }
-      &:nth-child(5) {
-        &:before{
-          content: 'Refills Left: ',
-        }
-      }
     }
   }
 }

--- a/test/rx/components/SortMenu.unit.spec.jsx
+++ b/test/rx/components/SortMenu.unit.spec.jsx
@@ -47,4 +47,27 @@ describe('<SortMenu>', () => {
       expect(option.props.value).to.equal(value);
     });
   });
+
+  it('should render the sort links for string-based sorts', () => {
+    const tree = SkinDeep.shallowRender(<SortMenu {...props}/>).dive(['ul']);
+    const links = tree.everySubTree('li');
+    expect(links).to.have.length(2);
+    expect(links[0].text()).to.equal('A-Z');
+    expect(links[1].text()).to.equal('Z-A');
+  });
+
+  it('should render the sort links for date-based sorts', () => {
+    const tree = SkinDeep.shallowRender(
+      <SortMenu
+          {...props}
+          selected={{
+            order: 'ASC',
+            value: 'refillDate'
+          }}/>
+    ).dive(['ul']);
+    const links = tree.everySubTree('li');
+    expect(links).to.have.length(2);
+    expect(links[0].text()).to.equal('Newest to Oldest');
+    expect(links[1].text()).to.equal('Oldest to Newest');
+  });
 });

--- a/test/rx/components/SortMenu.unit.spec.jsx
+++ b/test/rx/components/SortMenu.unit.spec.jsx
@@ -38,8 +38,9 @@ describe('<SortMenu>', () => {
   });
 
   it('should render the correct options', () => {
-    const tree = SkinDeep.shallowRender(<SortMenu {...props}/>);
+    const tree = SkinDeep.shallowRender(<SortMenu {...props}/>).dive(['select']);
     const options = tree.everySubTree('option');
+    expect(options).to.have.length(props.options.length);
     options.forEach((option, index) => {
       const { label, value } = props.options[index];
       expect(option.text()).to.equal(label);

--- a/test/rx/components/SortMenu.unit.spec.jsx
+++ b/test/rx/components/SortMenu.unit.spec.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+
+import SortMenu from '../../../src/js/rx/components/SortMenu';
+
+const props = {
+  onChange: () => {},
+  onClick: () => {},
+  options: [
+    {
+      label: 'Prescription name',
+      value: 'prescriptionName'
+    },
+    {
+      label: 'Facility name',
+      value: 'facilityName'
+    },
+    {
+      label: 'Last submit date',
+      value: 'lastSubmitDate'
+    },
+    {
+      label: 'Last fill date',
+      value: 'refillDate'
+    }
+  ],
+  selected: {
+    order: 'ASC',
+    value: 'prescriptionName'
+  }
+};
+
+describe('<SortMenu>', () => {
+  it('should render', () => {
+    const tree = SkinDeep.shallowRender(<SortMenu {...props}/>);
+    expect(tree.getRenderOutput()).to.exist;
+  });
+
+  it('should render the correct options', () => {
+    const tree = SkinDeep.shallowRender(<SortMenu {...props}/>);
+    const options = tree.everySubTree('option');
+    options.forEach((option, index) => {
+      const { label, value } = props.options[index];
+      expect(option.text()).to.equal(label);
+      expect(option.props.value).to.equal(value);
+    });
+  });
+});

--- a/test/rx/components/SortMenu.unit.spec.jsx
+++ b/test/rx/components/SortMenu.unit.spec.jsx
@@ -70,4 +70,53 @@ describe('<SortMenu>', () => {
     expect(links[0].text()).to.equal('Newest to Oldest');
     expect(links[1].text()).to.equal('Oldest to Newest');
   });
+
+  it('should set the string-based ascending order link to active', () => {
+    const tree = SkinDeep.shallowRender(<SortMenu {...props}/>);
+    const activeLink = tree.subTree('.rx-sort-active');
+    expect(activeLink).to.be.ok;
+    expect(activeLink.text()).to.equal('A-Z');
+  });
+
+  it('should set the string-based descending order link to active', () => {
+    const tree = SkinDeep.shallowRender(
+      <SortMenu
+          {...props}
+          selected={{
+            order: 'DESC',
+            value: 'prescriptionName'
+          }}/>
+    );
+    const activeLink = tree.subTree('.rx-sort-active');
+    expect(activeLink).to.be.ok;
+    expect(activeLink.text()).to.equal('Z-A');
+  });
+
+  it('should set the date-based ascending order link to active', () => {
+    const tree = SkinDeep.shallowRender(
+      <SortMenu
+          {...props}
+          selected={{
+            order: 'ASC',
+            value: 'lastSubmitDate'
+          }}/>
+    );
+    const activeLink = tree.subTree('.rx-sort-active');
+    expect(activeLink).to.be.ok;
+    expect(activeLink.text()).to.equal('Oldest to Newest');
+  });
+
+  it('should set the date-based descending order link to active', () => {
+    const tree = SkinDeep.shallowRender(
+      <SortMenu
+          {...props}
+          selected={{
+            order: 'DESC',
+            value: 'lastSubmitDate'
+          }}/>
+    );
+    const activeLink = tree.subTree('.rx-sort-active');
+    expect(activeLink).to.be.ok;
+    expect(activeLink.text()).to.equal('Newest to Oldest');
+  });
 });


### PR DESCRIPTION
### Changes
* Sort query parameters on Active page are applied when directly accessing URL with them. Closes department-of-veterans-affairs/vets.gov-team#743.
* Removed incorrect 'Fill Date' label next to prescription name in mobile version of History table. Closes department-of-veterans-affairs/vets.gov-team#747.
* Removed `href` from sortable table header links (no fragment in URL after selecting a column to sort on). Added `tabIndex` to keep it accessible.
* Added SortMenu unit tests.