### PR TITLE
[WIP] Use BUILD_NUMBER for docker image tag instead of BUILD_ID

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ node('vets-website-linting') {
     sh "mkdir -p logs/selenium"
     sh "mkdir -p coverage"
 
-    dockerImage = docker.build("vets-website:${env.BUILD_TAG}")
+    dockerImage = docker.build("vets-website:${env.BUILD_NUMBER}")
     args = "-u root:root -v ${pwd()}/build:/application/build -v ${pwd()}/logs:/application/logs -v ${pwd()}/coverage:/application/coverage"
   }
 


### PR DESCRIPTION
This solves an issue when the branch name includes characters that
aren't valid docker image tags, such as

http://jenkins.vetsgov-internal/blue/organizations/jenkins/department-of-veterans-affairs%2Fvets-website/detail/content%2Fwip%2Feducation-plain-language-update/3/pipeline