### PR TITLE
Use modified BUILD_TAG docker image tag instead of BUILD_NUMBER

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ node('vets-website-linting') {
     sh "mkdir -p logs/selenium"
     sh "mkdir -p coverage"
 
-    dockerImage = docker.build("vets-website:${env.BUILD_TAG}")
+    dockerImage = docker.build("vets-website:${env.BUILD_NUMBER}")
     args = "-u root:root -v ${pwd()}/build:/application/build -v ${pwd()}/logs:/application/logs -v ${pwd()}/coverage:/application/coverage"
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ node('vets-website-linting') {
     sh "mkdir -p logs/selenium"
     sh "mkdir -p coverage"
 
-    dockerImage = docker.build("vets-website:${env.BUILD_NUMBER}")
+    dockerImage = docker.build("vets-website:${env.BUILD_NUMBER}-${env.GIT_COMMIT}")
     args = "-u root:root -v ${pwd()}/build:/application/build -v ${pwd()}/logs:/application/logs -v ${pwd()}/coverage:/application/coverage"
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,9 @@ node('vets-website-linting') {
     sh "mkdir -p logs/selenium"
     sh "mkdir -p coverage"
 
-    dockerImage = docker.build("vets-website:${env.BUILD_NUMBER}-${env.GIT_COMMIT}")
+    def imageTag = java.net.URLDecoder.decode(env.BUILD_TAG).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
+
+    dockerImage = docker.build("vets-website:${imageTag}")
     args = "-u root:root -v ${pwd()}/build:/application/build -v ${pwd()}/logs:/application/logs -v ${pwd()}/coverage:/application/coverage"
   }
 


### PR DESCRIPTION
BUILD_NUMBER is sequential and unique per branch. We need an additional identifier to prevent multiple branches from sharing the same docker container.

A date-based BUILD_ID was deprecated in Jenkins v1.597, but would have made a good candidate for this.