### PR TITLE
Use production build settings for staging

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -121,7 +121,7 @@ const configGenerator = (options) => {
     ],
   };
 
-  if (options.buildtype === 'production') {
+  if (options.buildtype === 'production' || options.buildtype === 'staging') {
     baseConfig.devtool = '#source-map';
     baseConfig.module.loaders.push({
       test: /debug\/PopulateVeteranButton/,


### PR DESCRIPTION
Removes debug toolbars and sets up standard source-map generation (without eval) for the staging environment. Parity improvement for staging/production.

Enables better testing of CSP header on staging environment (to avoid an `unsafe-eval` declaration).

Part of work for https://github.com/department-of-veterans-affairs/vets.gov-team/issues/611