### PR TITLE
Prep for CSP implementation

### DIFF
--- a/assets/js/google-analytics.js
+++ b/assets/js/google-analytics.js
@@ -1,0 +1,5 @@
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-WFJWBD');

--- a/assets/js/usa-search.js
+++ b/assets/js/usa-search.js
@@ -1,0 +1,21 @@
+var usasearch_config = { siteHandle:"vets.gov_search" };
+var script = document.createElement("script");
+script.src = "https://search.usa.gov/javascripts/remote.loader.js";
+document.getElementsByTagName("head")[0].appendChild(script);
+
+(function() {
+  var domReady = function(callback) {
+    document.readyState === "interactive" || document.readyState === "complete" ? callback() : document.addEventListener("DOMContentLoaded", callback);
+  };
+
+  domReady(function() {
+    // check whether browser is IE10 and older
+    if (window.navigator.userAgent.indexOf('MSIE ') > 0) {
+      var browserWarning = document.getElementsByClassName("incompatible-browser-warning")[0];
+
+      if (browserWarning) {
+        browserWarning.classList.add("visible");
+      }
+    }
+  });
+})();

--- a/assets/js/user-voice.js
+++ b/assets/js/user-voice.js
@@ -1,0 +1,6 @@
+UserVoice=window.UserVoice||[];(function(){var uv=document.createElement('script');uv.type='text/javascript';uv.async=true;uv.nonce='EqfyqZFQCKLmLMcdCyziDqosi6wTGa';uv.src='https://widget.uservoice.com/NDkEKHU7ZuU64RQKkUL9Q.js';var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(uv,s)})();
+
+UserVoice.push(['identify', {
+}]);
+
+UserVoice.push(['autoprompt', {}]);

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -121,7 +121,7 @@ const configGenerator = (options) => {
     ],
   };
 
-  if (options.buildtype === 'production') {
+  if (options.buildtype === 'production' || options.buildtype === 'staging') {
     baseConfig.devtool = '#source-map';
     baseConfig.module.loaders.push({
       test: /debug\/PopulateVeteranButton/,

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -74,7 +74,7 @@ const configGenerator = (options) => {
         {
           test: /\.scss$/,
           loader: ExtractTextPlugin.extract('style-loader', `css!resolve-url!sass?includePaths[]=${bourbon}&includePaths[]=${neat}&includePaths[]=~/uswds/src/stylesheets&sourceMap`)
-        }, 
+        },
         { test: /\.(jpe?g|png|gif)$/i,
           loader: 'url?limit=10000!img?progressive=true&-minimize'
         },

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -74,7 +74,7 @@ const configGenerator = (options) => {
         {
           test: /\.scss$/,
           loader: ExtractTextPlugin.extract('style-loader', `css!resolve-url!sass?includePaths[]=${bourbon}&includePaths[]=${neat}&includePaths[]=~/uswds/src/stylesheets&sourceMap`)
-        },
+        }, 
         { test: /\.(jpe?g|png|gif)$/i,
           loader: 'url?limit=10000!img?progressive=true&-minimize'
         },

--- a/content/includes/L2-section-landing.html
+++ b/content/includes/L2-section-landing.html
@@ -4,9 +4,9 @@
       <div class="row">
         <div class="small-12 columns usa-content">
         {% if path == 'employment' %}
-          <div style="margin-bottom:1em;">
-          <h1 style="display: inline-block; margin-bottom:0em;">Careers and Employment</h1>
-          <h6 style="display: inline-block;"> in partnership with 
+          <div id="csp-inline-patch-L2-section-landing">
+          <h1 id="csp-inline-patch-L2-section-landing-1">Careers and Employment</h1>
+          <h6 id="csp-inline-patch-L2-section-landing-2"> in partnership with 
             <a href="https://www.dol.gov/vets/" class="external"> 
               United States Department of Labor
             </a>

--- a/content/includes/L2-section-landing.html
+++ b/content/includes/L2-section-landing.html
@@ -4,9 +4,9 @@
       <div class="row">
         <div class="small-12 columns usa-content">
         {% if path == 'employment' %}
-          <div id="csp-inline-patch-L2-section-landing">
-          <h1 id="csp-inline-patch-L2-section-landing-1">Careers and Employment</h1>
-          <h6 id="csp-inline-patch-L2-section-landing-2"> in partnership with 
+          <div class="csp-inline-patch-L2-section-landing">
+          <h1 class="csp-inline-patch-L2-section-landing-1">Careers and Employment</h1>
+          <h6 class="csp-inline-patch-L2-section-landing-2"> in partnership with 
             <a href="https://www.dol.gov/vets/" class="external"> 
               United States Department of Labor
             </a>

--- a/content/includes/footer.html
+++ b/content/includes/footer.html
@@ -116,24 +116,13 @@ visit <a href="https://www.veteranscrisisline.net/">VeteransCrisisLine.net</a> f
   {% include "content/includes/modal.html" %}
 {% endif %}
 
-<script>
-UserVoice=window.UserVoice||[];(function(){var uv=document.createElement('script');uv.type='text/javascript';uv.async=true;uv.src='//widget.uservoice.com/NDkEKHU7ZuU64RQKkUL9Q.js';var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(uv,s)})();
-
-UserVoice.push(['identify', {
-}]);
-
-UserVoice.push(['autoprompt', {}]);
-</script>
+<script src="/js/user-voice.js"></script>
 
 <!-- htmllint attr-bans="[]" -->
 <!-- Google Tag Manager -->
-<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-WFJWBD"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-WFJWBD');</script>
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WFJWBD"
+height="0" width="0" id="csp-inline-patch-footer"></iframe></noscript>
+<script src="/js/google-analytics.js"></script>
 <!-- End Google Tag Manager -->
 <!-- htmllint attr-bans="$previous" -->
 

--- a/content/includes/footer.html
+++ b/content/includes/footer.html
@@ -121,7 +121,7 @@ visit <a href="https://www.veteranscrisisline.net/">VeteransCrisisLine.net</a> f
 <!-- htmllint attr-bans="[]" -->
 <!-- Google Tag Manager -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WFJWBD"
-height="0" width="0" id="csp-inline-patch-footer"></iframe></noscript>
+height="0" width="0" class="csp-inline-patch-footer"></iframe></noscript>
 <script src="/js/google-analytics.js"></script>
 <!-- End Google Tag Manager -->
 <!-- htmllint attr-bans="$previous" -->

--- a/content/includes/header.html
+++ b/content/includes/header.html
@@ -159,7 +159,7 @@
           <button type="button" class="va-mobile-searchclose va-overlay-close" aria-label="close search form - mobile only">Close</button>
           <div class="menu">
             <form accept-charset="UTF-8" action="https://search.vets.gov/search" id="search_form" method="get">
-              <div style="margin:0;padding:0;display:inline">
+              <div id="csp-inline-patch-header">
                 <input name="utf8" type="hidden" value="&#x2713;" />
               </div>
               <input id="affiliate" name="affiliate" type="hidden" value="vets.gov_search" />
@@ -185,26 +185,4 @@
   </div>
 </div>
 
-<script>
-  var usasearch_config = { siteHandle:"vets.gov_search" };
-  var script = document.createElement("script");
-  script.src = "https://search.usa.gov/javascripts/remote.loader.js";
-  document.getElementsByTagName("head")[0].appendChild(script);
-
-  (function() {
-    var domReady = function(callback) {
-      document.readyState === "interactive" || document.readyState === "complete" ? callback() : document.addEventListener("DOMContentLoaded", callback);
-    };
-
-    domReady(function() {
-      // check whether browser is IE10 and older
-      if (window.navigator.userAgent.indexOf('MSIE ') > 0) {
-        var browserWarning = document.getElementsByClassName("incompatible-browser-warning")[0];
-
-        if (browserWarning) {
-          browserWarning.classList.add("visible");
-        }
-      }
-    });
-  })();
-</script>
+<script src="/js/usa-search.js"></script>

--- a/content/includes/header.html
+++ b/content/includes/header.html
@@ -159,7 +159,7 @@
           <button type="button" class="va-mobile-searchclose va-overlay-close" aria-label="close search form - mobile only">Close</button>
           <div class="menu">
             <form accept-charset="UTF-8" action="https://search.vets.gov/search" id="search_form" method="get">
-              <div id="csp-inline-patch-header">
+              <div class="csp-inline-patch-header">
                 <input name="utf8" type="hidden" value="&#x2713;" />
               </div>
               <input id="affiliate" name="affiliate" type="hidden" value="vets.gov_search" />

--- a/content/includes/modal.html
+++ b/content/includes/modal.html
@@ -3,7 +3,7 @@ This modal is used on /education/apply-for-education-benefits/
 and should be extended as needed around the non-react vets.gov
 content.
 {% endcomment %}
-<section class="va-modal va-modal-split" style="display:none;" id="va-modal" role="alertdialog" tabIndex="-1">
+<section class="va-modal va-modal-split" id="va-modal csp-inline-patch-modal" role="alertdialog" tabIndex="-1">
   <div class="va-modal-inner">
     <h3 class="va-modal-title">Which form do you need to use?</h3>
 

--- a/content/includes/modal.html
+++ b/content/includes/modal.html
@@ -3,7 +3,7 @@ This modal is used on /education/apply-for-education-benefits/
 and should be extended as needed around the non-react vets.gov
 content.
 {% endcomment %}
-<section class="va-modal va-modal-split" id="va-modal csp-inline-patch-modal" role="alertdialog" tabIndex="-1">
+<section class="va-modal va-modal-split csp-inline-patch-modal" id="va-modal" role="alertdialog" tabIndex="-1">
   <div class="va-modal-inner">
     <h3 class="va-modal-title">Which form do you need to use?</h3>
 

--- a/content/layouts/page-breadcrumbs.html
+++ b/content/layouts/page-breadcrumbs.html
@@ -14,10 +14,10 @@
 
   {% if path contains 'healthcare' %}    
     {% if showtempbar == true %}
-    <div class="va-action-bar--header" style="background-color: #FAC922; text-align:center;">
+    <div class="va-action-bar--header" id="csp-inline-patch-page-breadcrumbs">
       <div class="row">
         <div class="small-12 columns">
-          <h6 style="margin: 0;">Are you a caregiver? This form’s not quite ready for you yet. <a href="#additional-forms"> Find the form you need.</a></h6>
+          <h6 id="csp-inline-patch-page-breadcrumbs-2">Are you a caregiver? This form’s not quite ready for you yet. <a href="#additional-forms"> Find the form you need.</a></h6>
         </div>
       </div>
     </div>

--- a/content/layouts/page-react.html
+++ b/content/layouts/page-react.html
@@ -5,7 +5,7 @@
     <div class="section main-menu">
       <div class="row">
         <div class="small-12 columns">
-          <div style="padding: 2em 0;">
+          <div id="csp-inline-patch-page-react">
           <h3>{{ maintenance_line1 }}</h3>
           <h4>{{ maintenance_line2 }}</h4>
           <a href="/"><button>Go back to Vets.gov</button></a>

--- a/content/layouts/page-react.html
+++ b/content/layouts/page-react.html
@@ -5,7 +5,7 @@
     <div class="section main-menu">
       <div class="row">
         <div class="small-12 columns">
-          <div id="csp-inline-patch-page-react">
+          <div class="csp-inline-patch-page-react">
           <h3>{{ maintenance_line1 }}</h3>
           <h4>{{ maintenance_line2 }}</h4>
           <a href="/"><button>Go back to Vets.gov</button></a>

--- a/content/layouts/post-single.html
+++ b/content/layouts/post-single.html
@@ -2,7 +2,7 @@
 {% assign post_name = title %}
 <div id="content">
   <div id="experience" role="main">
-    <div class="splash splash--blog{% if splash_image %} splash--hasimg" style="background-image: url(/img/content/posts/{{splash_image}});{% endif %}">
+    <div class="splash splash--blog">
       <h2 class="va-headingflag"><a href="/experience/">Experience</a></h2>
     </div>
     <div class="primary">

--- a/content/pages/404.md
+++ b/content/pages/404.md
@@ -25,7 +25,7 @@ permalink: false
           </p>
           <div class="call-out">
             <form accept-charset="UTF-8" action="https://search.vets.gov/search" id="search_form" class="full-width" method="get">
-              <div style="margin:0;padding:0;display:inline">
+              <div id="csp-inline-patch-404">
                 <input name="utf8" type="hidden" value="&#x2713;" /></div>
               <input id="affiliate" name="affiliate" type="hidden" value="vets.gov_search" />
               <label for="mobile-query">Search:</label>
@@ -48,9 +48,4 @@ permalink: false
   {% include "content/includes/common-and-popular.html" %}
 </div>
 
-<script>
-  var usasearch_config = { siteHandle:"vets.gov_search" };
-  var script = document.createElement("script");
-  script.src = "https://search.usa.gov/javascripts/remote.loader.js";
-  document.getElementsByTagName("head")[0].appendChild(script);
-</script>
+<script src="/js/usa-search.js"></script>

--- a/content/pages/404.md
+++ b/content/pages/404.md
@@ -25,7 +25,7 @@ permalink: false
           </p>
           <div class="call-out">
             <form accept-charset="UTF-8" action="https://search.vets.gov/search" id="search_form" class="full-width" method="get">
-              <div id="csp-inline-patch-404">
+              <div class="csp-inline-patch-404">
                 <input name="utf8" type="hidden" value="&#x2713;" /></div>
               <input id="affiliate" name="affiliate" type="hidden" value="vets.gov_search" />
               <label for="mobile-query">Search:</label>

--- a/content/pages/education/apply-for-education-benefits/application.md
+++ b/content/pages/education/apply-for-education-benefits/application.md
@@ -28,7 +28,7 @@ layout: page-react.html
     <div class="section main-menu">
       <div class="row">
         <div class="small-12 columns">
-          <div id="csp-inline-patch-application">
+          <div class="csp-inline-patch-application">
           <h3>We're sorry. The education benefits application is currently down while we fix a few things. We will be back up as soon as we can.</h3>
           <h4>In the meantime, you can still call 1-877-222-VETS(8387) and press 2 to complete this application over the phone.</h4>
           <a href="/"><button>Go back to Vets.gov</button></a>

--- a/content/pages/education/apply-for-education-benefits/application.md
+++ b/content/pages/education/apply-for-education-benefits/application.md
@@ -28,7 +28,7 @@ layout: page-react.html
     <div class="section main-menu">
       <div class="row">
         <div class="small-12 columns">
-          <div style="padding: 2em 0;">
+          <div id="csp-inline-patch-application">
           <h3>We're sorry. The education benefits application is currently down while we fix a few things. We will be back up as soon as we can.</h3>
           <h4>In the meantime, you can still call 1-877-222-VETS(8387) and press 2 to complete this application over the phone.</h4>
           <a href="/"><button>Go back to Vets.gov</button></a>

--- a/content/pages/logout.md
+++ b/content/pages/logout.md
@@ -7,7 +7,7 @@ title: Logout
   <div class="section main-menu">
     <div class="row">
       <div class="small-12 columns">
-        <div id="csp-inline-patch-logout">
+        <div class="csp-inline-patch-logout">
         <h3>Signing out of Vets.gov...</h3>
         </div>
       </div>

--- a/content/pages/logout.md
+++ b/content/pages/logout.md
@@ -7,7 +7,7 @@ title: Logout
   <div class="section main-menu">
     <div class="row">
       <div class="small-12 columns">
-        <div style="padding: 2em 0;">
+        <div id="csp-inline-patch-logout">
         <h3>Signing out of Vets.gov...</h3>
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "metalsmith-webpack": "^1.0.3",
     "metalsmith-webpack-dev-server": "^1.0.0",
     "mocha": "^3.0.0",
-    "modernizr": "^3.3.1",
+    "modernizr": "=3.3.1",
     "modernizr-loader": "0.0.5",
     "moment": "^2.15.1",
     "morgan": "^1.7.0",

--- a/script/build.js
+++ b/script/build.js
@@ -197,16 +197,18 @@ if (options.watch) {
 
 smith.use(assets({ source: '../assets', destination: './' }));
 
-const destination = path.resolve(__dirname, `../build/${options.buildtype}`)
+const destination = path.resolve(__dirname, `../build/${options.buildtype}`);
 
 // Webpack paths are absolute, convert to relative
-smith.use(function (files, metalsmith, done) {
-  Object.keys(files).forEach(function(file) {
+smith.use((files, metalsmith, done) => {
+  Object.keys(files).forEach((file) => {
     if (file.indexOf(destination) === 0) {
+      /* eslint-disable no-param-reassign */
       files[file.substr(destination.length + 1)] = files[file];
       delete files[file];
+      /* esling-enable no-param-reassign */
     }
-  })
+  });
 
   done();
 });

--- a/script/build.js
+++ b/script/build.js
@@ -22,6 +22,7 @@ const webpackConfigGenerator = require('../config/webpack.config');
 const webpackDevServer = require('metalsmith-webpack-dev-server');
 
 const fs = require('fs');
+const path = require('path');
 
 const sourceDir = '../content/pages';
 
@@ -117,68 +118,6 @@ smith.use(collections());
 smith.use(dateInFilename(true));
 smith.use(archive());  // TODO(awong): Can this be removed?
 
-// Liquid substitution must occur before markdown is run otherwise markdown will escape the
-// bits of liquid commands (eg., quotes) and break things.
-//
-// Unfortunately this must come before permalinks and navgation because of limitation in both
-// modules regarding what files they understand. The consequence here is that liquid templates
-// *within* a single file do NOT have access to the final path that they will be rendered under
-// or any other metadata added by the permalinks() and navigation() filters.
-//
-// Thus far this has not been a problem because the only references to such paths are in the
-// includes which are handled by the layout module. The layout module, luckily, can be run
-// near the end of the filter chain and therefore has access to all the metadata.
-//
-// If this becomes a barrier in the future, permalinks should be patched to understand
-// translating .md files which would allow inPlace() and markdown() to be moved under the
-// permalinks() and navigation() filters making the variable stores uniform between inPlace()
-// and layout().
-smith.use(inPlace({ engine: 'liquid', pattern: '*.{md,html}' }));
-smith.use(markdown({
-  typographer: true,
-  html: true
-}));
-
-// Responsible for create permalink structure. Most commonly used change foo.md to foo/index.html.
-//
-// This must come before navigation module, otherwise breadcrunmbs will see the wrong URLs.
-//
-// It also must come AFTER the markdown() module because it only recognizes .html files. See
-// comment above the inPlace() module for explanation of effects on the metadata().
-smith.use(permalinks({
-  relative: false,
-  linksets: [{
-    match: { collection: 'posts' },
-    pattern: ':date/:slug'
-  }]
-}));
-
-smith.use(navigation({
-  navConfigs: {
-    sortByNameFirst: true,
-    breadcrumbProperty: 'breadcrumb_path',
-    pathProperty: 'nav_path',
-    includeDirs: true
-  }, navSettings: {} }));
-
-smith.use(assets({ source: '../assets', destination: './' }));
-
-// Note that there is no default layout specified.
-// All pages must explicitly declare a layout or else it will be rendered as raw html.
-smith.use(layouts({
-  engine: 'liquid',
-  directory: '../content/layouts/',
-  // Only apply layouts to markdown and html files.
-  pattern: '**/*.{md,html}'
-}));
-
-// TODO(awong): This URL needs to change based on target environment.
-smith.use(sitemap({
-  hostname: 'http://www.vets.gov',
-  omitIndex: true
-}));
-// TODO(awong): Does anything even use the results of this plugin?
-
 if (options.watch) {
   // TODO(awong): Enable live reload of metalsmith pages per instructions at
   //   https://www.npmjs.com/package/metalsmith-watch
@@ -252,6 +191,89 @@ if (options.watch) {
 } else {
   // Broken link checking does not work well with watch. It continually shows broken links
   // for permalink processed files. Only run outside of watch mode.
+
+  smith.use(webpack(webpackConfig));
+}
+
+smith.use(assets({ source: '../assets', destination: './' }));
+
+const destination = path.resolve(__dirname, `../build/${options.buildtype}`)
+
+// Webpack paths are absolute, convert to relative
+smith.use(function (files, metalsmith, done) {
+  Object.keys(files).forEach(function(file) {
+    if (file.indexOf(destination) === 0) {
+      files[file.substr(destination.length + 1)] = files[file];
+      delete files[file];
+    }
+  })
+
+  done();
+});
+
+// smith.use(cspHash({ pattern: ['js/*.js', 'generated/*.css', 'generated/*.js'] }))
+
+// Liquid substitution must occur before markdown is run otherwise markdown will escape the
+// bits of liquid commands (eg., quotes) and break things.
+//
+// Unfortunately this must come before permalinks and navgation because of limitation in both
+// modules regarding what files they understand. The consequence here is that liquid templates
+// *within* a single file do NOT have access to the final path that they will be rendered under
+// or any other metadata added by the permalinks() and navigation() filters.
+//
+// Thus far this has not been a problem because the only references to such paths are in the
+// includes which are handled by the layout module. The layout module, luckily, can be run
+// near the end of the filter chain and therefore has access to all the metadata.
+//
+// If this becomes a barrier in the future, permalinks should be patched to understand
+// translating .md files which would allow inPlace() and markdown() to be moved under the
+// permalinks() and navigation() filters making the variable stores uniform between inPlace()
+// and layout().
+smith.use(inPlace({ engine: 'liquid', pattern: '*.{md,html}' }));
+smith.use(markdown({
+  typographer: true,
+  html: true
+}));
+
+// Responsible for create permalink structure. Most commonly used change foo.md to foo/index.html.
+//
+// This must come before navigation module, otherwise breadcrunmbs will see the wrong URLs.
+//
+// It also must come AFTER the markdown() module because it only recognizes .html files. See
+// comment above the inPlace() module for explanation of effects on the metadata().
+smith.use(permalinks({
+  relative: false,
+  linksets: [{
+    match: { collection: 'posts' },
+    pattern: ':date/:slug'
+  }]
+}));
+
+smith.use(navigation({
+  navConfigs: {
+    sortByNameFirst: true,
+    breadcrumbProperty: 'breadcrumb_path',
+    pathProperty: 'nav_path',
+    includeDirs: true
+  }, navSettings: {} }));
+
+// Note that there is no default layout specified.
+// All pages must explicitly declare a layout or else it will be rendered as raw html.
+smith.use(layouts({
+  engine: 'liquid',
+  directory: '../content/layouts/',
+  // Only apply layouts to markdown and html files.
+  pattern: '**/*.{md,html}'
+}));
+
+// TODO(awong): This URL needs to change based on target environment.
+smith.use(sitemap({
+  hostname: 'http://www.vets.gov',
+  omitIndex: true
+}));
+// TODO(awong): Does anything even use the results of this plugin?
+
+if (!options.watch) {
   smith.use(blc({
     allowRedirects: true,  // Don't require trailing slash for index.html links.
     warn: false,           // Throw an Error when encountering the first broken link not just a warning.
@@ -265,8 +287,6 @@ if (options.watch) {
           '/education/apply-for-education-benefits/application',
           '/healthcare/apply/application'].join('|'))
   }));
-
-  smith.use(webpack(webpackConfig));
 }
 
 smith.use(redirect({

--- a/src/sass/_shame.scss
+++ b/src/sass/_shame.scss
@@ -82,3 +82,60 @@ body .row {
     font-size: 1.9rem;
   }
 }
+
+/* inline declarations moved here as a result of CSP rules */
+
+#csp-inline-patch-L2-section-landing {
+  margin-bottom: 1em;
+}
+
+#csp-inline-patch-L2-section-landing-1 {
+  display: inline-block;
+  margin-bottom: 0em;
+}
+
+#csp-inline-patch-L2-section-landing-2 {
+  display: inline-block;
+}
+
+#csp-inline-patch-footer {
+  display: none;
+  visibility: hidden;
+}
+
+#csp-inline-patch-header {
+  margin: 0;
+  padding: 0;
+  display: inline;
+}
+
+#csp-inline-patch-modal {
+  display: none;
+}
+
+#csp-inline-patch-page-breadcrumbs {
+  background-color: #FAC922;
+  text-align: center;
+}
+
+#csp-inline-patch-page-breadcrumbs-2 {
+  margin: 0;
+}
+
+#csp-inline-patch-page-react {
+  padding: 2em 0;
+}
+
+#csp-inline-patch-404 {
+  margin: 0;
+  padding: 0;
+  display: inline;
+}
+
+#csp-inline-patch-application {
+  padding: 2em 0;
+}
+
+#csp-inline-patch-logout {
+  padding: 2em 0;
+}

--- a/src/sass/_shame.scss
+++ b/src/sass/_shame.scss
@@ -85,57 +85,57 @@ body .row {
 
 /* inline declarations moved here as a result of CSP rules */
 
-#csp-inline-patch-L2-section-landing {
+.csp-inline-patch-L2-section-landing {
   margin-bottom: 1em;
 }
 
-#csp-inline-patch-L2-section-landing-1 {
+.csp-inline-patch-L2-section-landing-1 {
   display: inline-block;
   margin-bottom: 0em;
 }
 
-#csp-inline-patch-L2-section-landing-2 {
+.csp-inline-patch-L2-section-landing-2 {
   display: inline-block;
 }
 
-#csp-inline-patch-footer {
+.csp-inline-patch-footer {
   display: none;
   visibility: hidden;
 }
 
-#csp-inline-patch-header {
+.csp-inline-patch-header {
   margin: 0;
   padding: 0;
   display: inline;
 }
 
-#csp-inline-patch-modal {
+.csp-inline-patch-modal {
   display: none;
 }
 
-#csp-inline-patch-page-breadcrumbs {
+.csp-inline-patch-page-breadcrumbs {
   background-color: #FAC922;
   text-align: center;
 }
 
-#csp-inline-patch-page-breadcrumbs-2 {
+.csp-inline-patch-page-breadcrumbs-2 {
   margin: 0;
 }
 
-#csp-inline-patch-page-react {
+.csp-inline-patch-page-react {
   padding: 2em 0;
 }
 
-#csp-inline-patch-404 {
+.csp-inline-patch-404 {
   margin: 0;
   padding: 0;
   display: inline;
 }
 
-#csp-inline-patch-application {
+.csp-inline-patch-application {
   padding: 2em 0;
 }
 
-#csp-inline-patch-logout {
+.csp-inline-patch-logout {
   padding: 2em 0;
 }


### PR DESCRIPTION
Changes that will be required to address CSP violations.

* Removes inline scripts
* Removes inline styles
* Moves webpack closer to the beginning of the metalsmith build, will permit configuring fingerprinting and hashes for better script control (such as `identity` attributes on script tags, and `sha256-X` CSP declarations).
* Uses production build settings for staging. Goal to ensure we can test CSP header on staging environment without requiring eval-based source map.

Part of https://github.com/department-of-veterans-affairs/vets.gov-team/issues/611