### PR TITLE
Silence uglifyjs warnings

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -138,7 +138,11 @@ const configGenerator = (options) => {
 
     baseConfig.plugins.push(new webpack.optimize.DedupePlugin());
     baseConfig.plugins.push(new webpack.optimize.OccurrenceOrderPlugin(true));
-    baseConfig.plugins.push(new webpack.optimize.UglifyJsPlugin({ warnings: false }));
+    baseConfig.plugins.push(new webpack.optimize.UglifyJsPlugin({
+      beautify: false,
+      compress: { warnings: false },
+      comments: false
+    }));
   } else {
     baseConfig.devtool = '#eval-source-map';
   }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -138,7 +138,7 @@ const configGenerator = (options) => {
 
     baseConfig.plugins.push(new webpack.optimize.DedupePlugin());
     baseConfig.plugins.push(new webpack.optimize.OccurrenceOrderPlugin(true));
-    baseConfig.plugins.push(new webpack.optimize.UglifyJsPlugin());
+    baseConfig.plugins.push(new webpack.optimize.UglifyJsPlugin({ warnings: false }));
   } else {
     baseConfig.devtool = '#eval-source-map';
   }

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "url-loader": "^0.5.7",
     "uswds": "^0.10.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema#ae08be8e67ac550f2fd400445f3c89c324fa9a79",
-    "webpack": "^1.13.1", 
+    "webpack": "^1.13.1",
     "whatwg-fetch": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz",
     "winston": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "url-loader": "^0.5.7",
     "uswds": "^0.10.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema#ae08be8e67ac550f2fd400445f3c89c324fa9a79",
-    "webpack": "http://registry.npmjs.org/webpack/-/webpack-1.13.2.tgz",
+    "webpack": "^1.13.1", 
     "whatwg-fetch": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz",
     "winston": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "url-loader": "^0.5.7",
     "uswds": "^0.10.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema#ae08be8e67ac550f2fd400445f3c89c324fa9a79",
-    "webpack": "^1.13.1",
+    "webpack": "http://registry.npmjs.org/webpack/-/webpack-1.13.2.tgz",
     "whatwg-fetch": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz",
     "winston": "^2.2.0"
   },


### PR DESCRIPTION
Our travis logs are overrun with warnings from uglifyjs.  This should fix that.