### PR TITLE
Redirect old routes for education to the root route

### DIFF
--- a/src/js/edu-benefits/routes.jsx
+++ b/src/js/edu-benefits/routes.jsx
@@ -39,6 +39,11 @@ export default function createRoutes(store) {
     );
   }
 
+  childRoutes.push({
+    path: '*',
+    onEnter: (nextState, replace) => replace('/')
+  });
+
   return {
     path: '/',
     indexRoute: { onEnter: (nextState, replace) => replace('/1990/introduction') },


### PR DESCRIPTION
Solves an issue where the VONAPP team was linking to an old education route that no longer exists. This addition will redirect all routes that are not matched to the root route.