### PR TITLE
Move things out of local state for 1995

### DIFF
--- a/src/js/common/schemaform/ArrayField.jsx
+++ b/src/js/common/schemaform/ArrayField.jsx
@@ -26,7 +26,7 @@ export default class ArrayField extends React.Component {
      */
 
     this.state = {
-      editing: this.props.formData ? this.props.formData.map(() => false) : [true]
+      editing: props.formData ? props.formData.map(() => false) : [true]
     };
 
     this.onItemChange = this.onItemChange.bind(this);

--- a/src/js/common/schemaform/ArrayField.jsx
+++ b/src/js/common/schemaform/ArrayField.jsx
@@ -21,25 +21,12 @@ export default class ArrayField extends React.Component {
     super(props);
 
     /*
-     * We always want to show one empty item in the array, so add that if necessary
-     *
-     * It will not get saved unless a user changes data in it
-     */
-    const formData = Array.isArray(props.formData) ? props.formData : null;
-    let items;
-    if (!formData || formData.length === 0) {
-      items = [getDefaultFormState(props.schema.items, null, props.registry.definitions) || {}];
-    } else {
-      items = getDefaultFormState(props.schema, formData, props.registry.definitions) || [];
-    }
-
-    /*
      * We're keeping the editing state in local state because it's easier to manage and
      * doesn't need to persist from page to page
      */
+
     this.state = {
-      items,
-      editing: items.map(() => false)
+      editing: this.props.formData ? this.props.formData.map(() => false) : [true]
     };
 
     this.onItemChange = this.onItemChange.bind(this);
@@ -52,36 +39,19 @@ export default class ArrayField extends React.Component {
     this.scrollToRow = this.scrollToRow.bind(this);
   }
 
-  /*
-   * This is a performance optimization to avoid extra renders. Because we mirror
-   * formData in local state, each form data change will trigger two renders: one when
-   * local state is updated and another when that change is reflected in formData. This check
-   * skips the second render if no other props or state has changed
-   */
   shouldComponentUpdate(nextProps, nextState) {
-    const propsWithoutDataUnchanged = deepEquals(_.omit('formData', this.props), _.omit('formData', nextProps));
-    const stateUnchanged = deepEquals(this.state, nextState);
-
-    if (propsWithoutDataUnchanged && stateUnchanged && deepEquals(nextProps.formData, nextState.items)) {
-      return false;
-    }
-
-    return true;
+    return !deepEquals(this.props, nextProps) || nextState !== this.state;
   }
 
   onItemChange(indexToChange, value) {
-    // Replace the item in local state first
-    const newState = _.set('items', this.state.items.map(
+    const newItems = this.props.formData.map(
       (current, index) => {
         return index === indexToChange
           ? value
           : current;
       }
-    ), this.state);
-    // Then, update the actual form data
-    this.setState(newState, () => {
-      this.props.onChange(newState.items);
-    });
+    );
+    this.props.onChange(newItems);
   }
 
   onItemBlur(index, path = []) {
@@ -140,7 +110,7 @@ export default class ArrayField extends React.Component {
    * Clicking Add Another
    */
   handleAdd() {
-    const lastIndex = this.state.items.length - 1;
+    const lastIndex = this.props.formData.length - 1;
     if (errorSchemaIsValid(this.props.errorSchema[lastIndex])) {
       // When we add another, we want to change the editing state of the currently
       // last item, but not ones above it
@@ -150,12 +120,12 @@ export default class ArrayField extends React.Component {
           : val;
       });
       const newState = _.assign(this.state, {
-        items: this.state.items.concat(getDefaultFormState(this.props.schema.items, undefined, this.props.registry.definitions) || {}),
         editing: newEditing.concat(false)
       });
       this.setState(newState, () => {
+        const newFormData = this.props.formData.concat(getDefaultFormState(this.props.schema.items, undefined, this.props.registry.definitions) || {});
+        this.props.onChange(newFormData);
         this.scrollToRow(`${this.props.idSchema.$id}_${lastIndex + 1}`);
-        this.props.onChange(newState.items);
       });
     } else {
       const touchedSchema = _.set(lastIndex, true, this.state.touchedSchema);
@@ -169,12 +139,12 @@ export default class ArrayField extends React.Component {
    * Clicking Remove on an item in edit mode
    */
   handleRemove(indexToRemove) {
+    const newItems = this.props.formData.filter((val, index) => index !== indexToRemove);
     const newState = _.assign(this.state, {
-      items: this.state.items.filter((val, index) => index !== indexToRemove),
       editing: this.state.editing.filter((val, index) => index !== indexToRemove),
     });
+    this.props.onChange(newItems);
     this.setState(newState, () => {
-      this.props.onChange(newState.items);
       this.scrollToTop();
     });
   }
@@ -184,6 +154,7 @@ export default class ArrayField extends React.Component {
       uiSchema,
       errorSchema,
       idSchema,
+      formData,
       disabled,
       readonly,
       registry,
@@ -202,6 +173,11 @@ export default class ArrayField extends React.Component {
       ? uiSchema['ui:description']
       : null;
 
+    // if we have form data, use that, otherwise use an array with a single default object
+    const items = (formData && formData.length)
+      ? formData
+      : [getDefaultFormState(schema, undefined, registry.definitions)];
+
     return (
       <div>
         {title
@@ -213,7 +189,7 @@ export default class ArrayField extends React.Component {
         {DescriptionField && <DescriptionField options={uiSchema['ui:options']}/>}
         <div className="va-growable">
           <Element name={`topOfTable_${idSchema.$id}`}/>
-          {this.state.items.map((item, index) => {
+          {items.map((item, index) => {
             // This is largely copied from the default ArrayField
             const itemIdPrefix = `${idSchema.$id}_${index}`;
             const itemIdSchema = toIdSchema(itemsSchema, itemIdPrefix, definitions);
@@ -221,9 +197,9 @@ export default class ArrayField extends React.Component {
             if (this.state.touchedSchema && typeof this.state.touchedSchema[index] !== 'undefined') {
               itemTouched = this.state.touchedSchema[index];
             }
-            const isLast = this.state.items.length === (index + 1);
+            const isLast = items.length === (index + 1);
             const isEditing = this.state.editing[index];
-            const notLastOrMultipleRows = !isLast || this.state.items.length > 1;
+            const notLastOrMultipleRows = !isLast || items.length > 1;
 
             if (isLast || isEditing) {
               return (
@@ -231,7 +207,7 @@ export default class ArrayField extends React.Component {
                   <Element name={`table_${itemIdPrefix}`}/>
                   <div className="row small-collapse">
                     <div className="small-12 columns va-growable-expanded">
-                      {isLast && this.state.items.length > 1 && uiSchema['ui:options'].itemName
+                      {isLast && items.length > 1 && uiSchema['ui:options'].itemName
                           ? <h5>New {uiSchema['ui:options'].itemName}</h5>
                           : null}
                       <div className="input-section">

--- a/src/js/common/schemaform/FormPage.jsx
+++ b/src/js/common/schemaform/FormPage.jsx
@@ -16,7 +16,6 @@ import ArrayField from './ArrayField';
 import ReviewObjectField from './review/ObjectField';
 import { focusElement } from '../utils/helpers';
 import { setData } from './actions';
-import { updateRequiredFields } from './helpers';
 
 const fields = {
   ObjectField,
@@ -90,8 +89,6 @@ class FormPage extends React.Component {
       this.setState(this.getEmptyState(newProps.route.pageConfig), () => {
         focusForm();
       });
-    } else if (newProps.schema !== this.props.schema) {
-      this.setState({ schema: newProps.schema });
     }
   }
   componentDidUpdate(prevProps) {
@@ -101,10 +98,6 @@ class FormPage extends React.Component {
   }
   onChange({ formData }) {
     this.props.setData(this.props.route.pageConfig.pageKey, formData);
-    const newSchema = updateRequiredFields(this.state.schema, this.props.route.pageConfig.uiSchema, formData);
-    if (newSchema !== this.state.schema) {
-      this.setState({ schema: newSchema });
-    }
   }
   onError() {
     const formContext = _.set('submitted', true, this.state.formContext);
@@ -120,12 +113,9 @@ class FormPage extends React.Component {
       this.props.router.push(pageList[pageIndex + 1].path);
     }
   }
-  getEmptyState(pageConfig) {
-    const { form, onEdit, hideTitle } = this.props;
-    const { uiSchema, schema } = pageConfig;
-    const formData = form[pageConfig.pageKey].data;
+  getEmptyState() {
+    const { onEdit, hideTitle } = this.props;
     return {
-      schema: updateRequiredFields(schema, uiSchema, formData),
       formContext: {
         touched: {},
         submitted: false,
@@ -151,7 +141,7 @@ class FormPage extends React.Component {
   }
   render() {
     const { uiSchema } = this.props.route.pageConfig;
-    const formData = this.props.form[this.props.route.pageConfig.pageKey].data;
+    const { data, schema } = this.props.form[this.props.route.pageConfig.pageKey];
     const { reviewPage, reviewMode, children } = this.props;
     return (
       <div className={reviewPage ? null : 'form-panel'}>
@@ -163,11 +153,11 @@ class FormPage extends React.Component {
             onError={this.onError}
             onChange={this.onChange}
             onSubmit={this.onSubmit}
-            schema={this.state.schema}
+            schema={schema}
             uiSchema={uiSchema}
             validate={this.validate}
             showErrorList={false}
-            formData={formData}
+            formData={data}
             widgets={reviewMode ? reviewWidgets : widgets}
             fields={reviewMode ? reviewFields : fields}
             transformErrors={this.transformErrors}>

--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -1,6 +1,9 @@
 import _ from 'lodash/fp';
 import FormPage from './FormPage';
 import ReviewPage from './review/ReviewPage';
+import shouldUpdate from 'recompose/shouldUpdate';
+
+import { deepEquals } from 'react-jsonschema-form/lib/utils';
 
 export function createFormPageList(formConfig) {
   return Object.keys(formConfig.chapters)
@@ -253,3 +256,6 @@ export function updateRequiredFields(schema, uiSchema, formData) {
   return schema;
 }
 
+export const pureWithDeepEquals = shouldUpdate((props, nextProps) => {
+  return !deepEquals(props, nextProps);
+});

--- a/src/js/common/schemaform/validation.js
+++ b/src/js/common/schemaform/validation.js
@@ -115,7 +115,7 @@ export function uiSchemaValidate(errors, uiSchema, formData, formContext, path =
     }
 
     const validations = uiSchema['ui:validations'];
-    if (validations) {
+    if (validations && currentData) {
       validations.forEach(validation => {
         const pathErrors = path ? _.get(path, errors) : errors;
         if (typeof validation === 'function') {

--- a/src/js/common/schemaform/widgets/SelectWidget.jsx
+++ b/src/js/common/schemaform/widgets/SelectWidget.jsx
@@ -10,7 +10,7 @@ function processValue({ type, items }, value) {
   } else if (type === 'number') {
     return asNumber(value);
   }
-  return value;
+  return value === '' ? undefined : value;
 }
 
 function getValue(event, multiple) {
@@ -36,7 +36,8 @@ function SelectWidget({
   multiple,
   autofocus,
   onChange,
-  onBlur
+  onBlur,
+  placeholder
 }) {
   const { enumOptions } = options;
   return (
@@ -44,7 +45,7 @@ function SelectWidget({
         id={id}
         multiple={multiple}
         className={options.widgetClassNames}
-        value={value}
+        value={value || ''}
         required={required}
         disabled={disabled}
         readOnly={readonly}
@@ -57,8 +58,9 @@ function SelectWidget({
           const newValue = getValue(event, multiple);
           onChange(processValue(schema, newValue));
         }}>
-      {enumOptions.map(({ val, label }, i) => {
-        return <option key={i} value={val}>{label}</option>;
+      <option value="">{placeholder}</option>
+      {enumOptions.map((option, i) => {
+        return <option key={i} value={option.value}>{option.label}</option>;
       })
     }</select>
   );
@@ -68,5 +70,4 @@ export default onlyUpdateForKeys([
   'id',
   'value',
   'schema',
-  'required'
 ])(SelectWidget);

--- a/src/js/edu-benefits/1990/components/debug/PerfPanel.jsx
+++ b/src/js/edu-benefits/1990/components/debug/PerfPanel.jsx
@@ -1,3 +1,4 @@
+/* eslint no-console: 0 */
 import React from 'react';
 import Perf from 'react-addons-perf';
 
@@ -13,10 +14,14 @@ class PerfPanel extends React.Component {
   handleStop() {
     Perf.stop();
     const measurements = Perf.getLastMeasurements();
+    console.log('Inclusive');
     Perf.printInclusive(measurements);
+    console.log('Exclusive');
     Perf.printExclusive(measurements);
+    console.log('Wasted');
     Perf.printWasted(measurements);
-    Perf.printDOM(measurements);
+    console.log('DOM');
+    Perf.printOperations(measurements);
   }
 
   render() {

--- a/test/common/schemaform/ArrayField.unit.spec.jsx
+++ b/test/common/schemaform/ArrayField.unit.spec.jsx
@@ -163,9 +163,8 @@ describe('Schemaform ArrayField', () => {
 
       tree.getMountedInstance().handleAdd();
 
-      expect(onChange.called).to.be.true;
-      expect(tree.everySubTree('SchemaField').length).to.equal(1);
-      expect(tree.everySubTree('.va-growable-background').length).to.equal(3);
+      expect(onChange.firstCall.args[0].length).to.equal(3);
+      expect(tree.getMountedInstance().state.editing[2]).to.be.false;
     });
   });
 });

--- a/test/common/schemaform/ObjectField.unit.spec.jsx
+++ b/test/common/schemaform/ObjectField.unit.spec.jsx
@@ -10,6 +10,7 @@ describe('Schemaform: ObjectField', () => {
     const onChange = sinon.spy();
     const onBlur = sinon.spy();
     const schema = {
+      type: 'object',
       properties: {
         test: {
           type: 'string'
@@ -20,12 +21,11 @@ describe('Schemaform: ObjectField', () => {
       <ObjectField
           schema={schema}
           idSchema={{}}
-          formData={{}}
           onChange={onChange}
           onBlur={onBlur}/>
     );
 
-    expect(tree.everySubTree('SchemaField')).not.to.be.empty;
+    expect(tree.everySubTree('shouldUpdate(SchemaField)')).not.to.be.empty;
   });
   it('should render description', () => {
     const onChange = sinon.spy();

--- a/test/common/schemaform/reducers/index.unit.spec.js
+++ b/test/common/schemaform/reducers/index.unit.spec.js
@@ -16,10 +16,17 @@ describe('schemaform createSchemaFormReducer', () => {
         test: {
           pages: {
             page1: {
-              initialData: { field: 'test' }
+              initialData: { field: 'test' },
+              schema: {
+                type: 'object',
+                properties: {
+                  field: {}
+                }
+              }
             },
             page2: {
-              initialData: {}
+              initialData: {},
+              schema: {}
             }
           }
         }
@@ -30,7 +37,7 @@ describe('schemaform createSchemaFormReducer', () => {
 
     expect(state.submission).to.be.defined;
     expect(state.privacyAgreementAccepted).to.be.false;
-    expect(state.page1).to.eql({ data: formConfig.chapters.test.pages.page1.initialData, editMode: false });
+    expect(state.page1.data.field).to.eql(formConfig.chapters.test.pages.page1.initialData.field);
     expect(state.page2).to.be.defined;
   });
   describe('reducer', () => {
@@ -39,7 +46,13 @@ describe('schemaform createSchemaFormReducer', () => {
         test: {
           pages: {
             page1: {
-              initialData: { field: 'test' }
+              initialData: { field: 'test' },
+              schema: {
+                type: 'object',
+                properties: {
+                  field: {}
+                }
+              }
             },
           }
         }
@@ -47,7 +60,7 @@ describe('schemaform createSchemaFormReducer', () => {
     };
     const reducer = createSchemaFormReducer(formConfig);
 
-    it('should set data and valid state', () => {
+    it('should set data state', () => {
       const state = reducer({
         page1: {
           isValid: true,
@@ -60,7 +73,6 @@ describe('schemaform createSchemaFormReducer', () => {
       });
 
       expect(state.page1.data.field).to.equal('test2');
-      expect(state.page1.isValid).to.be.false;
     });
     it('should set edit mode', () => {
       const state = reducer({


### PR DESCRIPTION
Closes [871](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/871)

This removes our use of local state for the schema in FormPage and form data in the object and array field components. It also adds some performance optimizations, because I was seeing some sluggishness when typing into form fields on a slow Android phone. Seems pretty solid now, especially when built in prod mode.

