### PR TITLE
Skip conditional pages when their dependencies haven't been satisfied.

### DIFF
--- a/src/js/common/schemaform/FormPage.jsx
+++ b/src/js/common/schemaform/FormPage.jsx
@@ -127,6 +127,10 @@ class FormPage extends React.Component {
     }
   }
 
+  /*
+   * Returns the page list without conditional pages that have not satisfied
+   * their dependencies and therefore should be skipped.
+   */
   getEligiblePages() {
     const { form, route: { pageConfig, pageList } } = this.props;
     const eligiblePageList = getActivePages(pageList, form);

--- a/src/js/common/schemaform/review/ReviewCollapsibleChapter.jsx
+++ b/src/js/common/schemaform/review/ReviewCollapsibleChapter.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Scroll from 'react-scroll';
 import _ from 'lodash';
 
-import { focusElement } from '../../utils/helpers';
+import { focusElement, getActivePages } from '../../utils/helpers';
 import FormPage from '../FormPage';
 import { getArrayFields, hasFieldsOtherThanArray } from '../helpers';
 import ArrayField from './ArrayField';
@@ -65,11 +65,14 @@ export default class ReviewCollapsibleChapter extends React.Component {
 
   render() {
     let pageContent = null;
+
     if (this.state.open) {
+      const { data, pages } = this.props;
+
       pageContent = (
         <div id={`collapsible-${this.id}`} className="usa-accordion-content">
-          {this.props.pages.map(page => {
-            const editing = this.props.data[page.pageKey].editMode;
+          {getActivePages(pages, data).map(page => {
+            const editing = data[page.pageKey].editMode;
             // Our pattern is to separate out array fields (growable tables) from
             // the normal page and display them separately. The review version of
             // ObjectField will hide them in the main section.
@@ -84,7 +87,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
                 {hasNonArrayFields &&
                   <FormPage
                       reviewPage
-                      hideTitle={this.props.pages.length === 1}
+                      hideTitle={pages.length === 1}
                       onEdit={() => this.handleEdit(page.pageKey, !editing)}
                       onSubmit={() => this.handleEdit(page.pageKey, false)}
                       reviewMode={!editing}
@@ -98,8 +101,8 @@ export default class ReviewCollapsibleChapter extends React.Component {
                   <ArrayField
                       pageKey={page.pageKey}
                       pageTitle={page.title}
-                      arrayData={_.get(this.props.data[page.pageKey].data, arrayField.path)}
-                      formData={this.props.data[page.pageKey].data}
+                      arrayData={_.get(data[page.pageKey].data, arrayField.path)}
+                      formData={data[page.pageKey].data}
                       key={arrayField.path}
                       pageConfig={page}
                       schema={arrayField.schema}

--- a/src/js/common/schemaform/review/ReviewCollapsibleChapter.jsx
+++ b/src/js/common/schemaform/review/ReviewCollapsibleChapter.jsx
@@ -68,10 +68,11 @@ export default class ReviewCollapsibleChapter extends React.Component {
 
     if (this.state.open) {
       const { data, pages } = this.props;
+      const activePages = getActivePages(pages, data);
 
       pageContent = (
         <div id={`collapsible-${this.id}`} className="usa-accordion-content">
-          {getActivePages(pages, data).map(page => {
+          {activePages.map(page => {
             const editing = data[page.pageKey].editMode;
             // Our pattern is to separate out array fields (growable tables) from
             // the normal page and display them separately. The review version of
@@ -87,7 +88,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
                 {hasNonArrayFields &&
                   <FormPage
                       reviewPage
-                      hideTitle={pages.length === 1}
+                      hideTitle={activePages.length === 1}
                       onEdit={() => this.handleEdit(page.pageKey, !editing)}
                       onSubmit={() => this.handleEdit(page.pageKey, false)}
                       reviewMode={!editing}

--- a/src/js/common/schemaform/validation.js
+++ b/src/js/common/schemaform/validation.js
@@ -64,7 +64,7 @@ export function transformErrors(errors, uiSchema) {
   return newErrors;
 }
 
-/**
+/*
  * This pulls custom validations specified in the uiSchema and validates the formData
  * against them.
  *

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -41,6 +41,7 @@ export function groupPagesIntoChapters(routes, prefix = '') {
     };
   });
 }
+
 export function isActivePage(page, data) {
   if (typeof page.depends === 'function') {
     return page.depends(data);

--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -369,7 +369,9 @@ const formConfig = {
           initialData: {},
           depends: {
             militaryHistory: {
-              hasServiceBefore1978: true
+              data: {
+                hasServiceBefore1978: true
+              }
             }
           },
           uiSchema: {

--- a/test/common/schemaform/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/test/common/schemaform/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -37,6 +37,7 @@ describe('<ReviewCollapsibleChapter>', () => {
 
     expect(tree.everySubTree('.form-review-panel-page')).not.to.be.empty;
   });
+
   it('should handle editing', () => {
     const onEdit = sinon.spy();
     const pages = [{
@@ -62,5 +63,105 @@ describe('<ReviewCollapsibleChapter>', () => {
     tree.getMountedInstance().handleEdit('test', true);
 
     expect(onEdit.calledWith('test', true)).to.be.true;
+  });
+
+  it('should not display conditional pages with unfulfilled conditions', () => {
+    const pages = [{
+      pageKey: 'test1',
+      schema: {
+        properties: {
+          condition1: 'boolean',
+          condition2: 'boolean'
+        }
+      }
+    }, {
+      pageKey: 'test2',
+      depends: {
+        test1: {
+          data: {
+            condition1: true,
+            condition2: true
+          }
+        }
+      },
+      schema: {}
+    }];
+    const chapterKey = 'test';
+    const chapter = {};
+    const data = {
+      test1: {
+        editMode: false,
+        data: {
+          condition1: true,
+          condition2: false
+        }
+      },
+      test2: {
+        editMode: false
+      }
+    };
+
+    const tree = SkinDeep.shallowRender(
+      <ReviewCollapsibleChapter
+          onEdit={() => {}}
+          pages={pages}
+          chapterKey={chapterKey}
+          chapter={chapter}
+          data={data}/>
+    );
+
+    tree.getMountedInstance().toggleChapter();
+
+    expect(tree.everySubTree('.form-review-panel-page')).to.have.length(1);
+  });
+
+  it('should display condition pages with fulfilled conditions', () => {
+    const pages = [{
+      pageKey: 'test1',
+      schema: {
+        properties: {
+          condition1: 'boolean',
+          condition2: 'boolean'
+        }
+      }
+    }, {
+      pageKey: 'test2',
+      depends: {
+        test1: {
+          data: {
+            condition1: true,
+            condition2: true
+          }
+        }
+      },
+      schema: {}
+    }];
+    const chapterKey = 'test';
+    const chapter = {};
+    const data = {
+      test1: {
+        editMode: false,
+        data: {
+          condition1: true,
+          condition2: true
+        }
+      },
+      test2: {
+        editMode: false
+      }
+    };
+
+    const tree = SkinDeep.shallowRender(
+      <ReviewCollapsibleChapter
+          onEdit={() => {}}
+          pages={pages}
+          chapterKey={chapterKey}
+          chapter={chapter}
+          data={data}/>
+    );
+
+    tree.getMountedInstance().toggleChapter();
+
+    expect(tree.everySubTree('.form-review-panel-page')).to.have.length(2);
   });
 });


### PR DESCRIPTION
Closes department-of-veterans-affairs/vets.gov-team#868.

#### Changes:
* Going back or forward will skip conditional pages that haven't passed their conditions.
* Conditional pages that haven't passed their conditions won't appear in expanded review chapters.
* Added `data` object in `depends` object in form config to reflect the structure of the form data that it's compared with.