### PR TITLE
Pull out vendor JS code into a separate, cacheable file

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -27,7 +27,7 @@ const configGenerator = (options) => {
   if (options.entry) {
     filesToBuild = _.pick(entryFiles, options.entry.split(',').map(x => x.trim()));
   }
-  filesToBuild['vendor'] = [
+  filesToBuild.vendor = [
     'core-js',
     'history',
     'lodash',

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -3,6 +3,7 @@
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const ChunkManifestPlugin = require('chunk-manifest-webpack-plugin');
+const WebpackMd5Hash = require('webpack-md5-hash');
 const bourbon = require('bourbon').includePaths;
 const neat = require('bourbon-neat').includePaths;
 const path = require('path');
@@ -135,17 +136,20 @@ const configGenerator = (options) => {
 
       new ExtractTextPlugin((options.buildtype === 'development') ? '[name].css' : '[name].[chunkhash].css'),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
-      new ManifestPlugin({
-        fileName: 'file-manifest.json'
-      }),
+
       new webpack.optimize.CommonsChunkPlugin(
         'vendor',
         (options.buildtype === 'development') ? 'vendor.js' : 'vendor.[chunkhash].js'
       ),
+      new WebpackMd5Hash(),
+      new ManifestPlugin({
+        fileName: 'file-manifest.json'
+      }),
       new ChunkManifestPlugin({
         filename: 'chunk-manifest.json',
         manifestVariable: 'webpackManifest'
-      })
+      }),
+      new webpack.optimize.OccurenceOrderPlugin()
     ],
   };
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -27,6 +27,18 @@ const configGenerator = (options) => {
   if (options.entry) {
     filesToBuild = _.pick(entryFiles, options.entry.split(',').map(x => x.trim()));
   }
+  filesToBuild['vendor'] = [
+    'core-js',
+    'history',
+    'lodash',
+    'jquery',
+    'react',
+    'react-dom',
+    'react-redux',
+    'react-router',
+    'redux',
+    'redux-thunk'
+  ];
   const baseConfig = {
     entry: filesToBuild,
     output: {
@@ -125,7 +137,11 @@ const configGenerator = (options) => {
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
       new ManifestPlugin({
         fileName: 'file-manifest.json'
-      })
+      }),
+      new webpack.optimize.CommonsChunkPlugin(
+        'vendor',
+        (options.buildtype === 'development') ? 'vendor.js' : 'vendor.[chunkhash].js'
+      )
     ],
   };
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -30,7 +30,6 @@ const configGenerator = (options) => {
   filesToBuild.vendor = [
     'core-js',
     'history',
-    'lodash',
     'jquery',
     'react',
     'react-dom',

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -2,6 +2,7 @@
 
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
+const ChunkManifestPlugin = require('chunk-manifest-webpack-plugin');
 const bourbon = require('bourbon').includePaths;
 const neat = require('bourbon-neat').includePaths;
 const path = require('path');
@@ -140,7 +141,11 @@ const configGenerator = (options) => {
       new webpack.optimize.CommonsChunkPlugin(
         'vendor',
         (options.buildtype === 'development') ? 'vendor.js' : 'vendor.[chunkhash].js'
-      )
+      ),
+      new ChunkManifestPlugin({
+        filename: 'chunk-manifest.json',
+        manifestVariable: 'webpackManifest'
+      })
     ],
   };
 

--- a/content/includes/header.html
+++ b/content/includes/header.html
@@ -69,6 +69,7 @@
 <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
 <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA" id="_fed_an_ua_tag"></script>
 
+<script src="/generated/vendor.js"></script>
 {% if entryname %}
 <script src="/generated/{{ entryname }}.entry.js"></script>
 {% else %}
@@ -139,7 +140,7 @@
         {% include "assets/img/svglogo.svg" %}
       </a>
     </div>
-    
+
     {% if search != 'false' %}
       <div class="hide-for-small-only">
         <div class="menu">

--- a/content/includes/header.html
+++ b/content/includes/header.html
@@ -69,6 +69,12 @@
 <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
 <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA" id="_fed_an_ua_tag"></script>
 
+<script>
+//<![CDATA[
+window.webpackManifest = 'CHUNK_MANIFEST_PLACEHOLDER';
+//]]>
+</script>
+
 <script src="/generated/vendor.js"></script>
 {% if entryname %}
 <script src="/generated/{{ entryname }}.entry.js"></script>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1252,6 +1252,12 @@
       "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.2.tgz",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "from": "charenc@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "dev": true
+    },
     "cheerio": {
       "version": "0.19.0",
       "from": "cheerio@>=0.19.0 <0.20.0",
@@ -1676,6 +1682,12 @@
       "version": "2.2.4",
       "from": "cross-spawn-async@>=2.1.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.4.tgz",
+      "dev": true
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "from": "crypt@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "dev": true
     },
     "cryptiles": {
@@ -5764,6 +5776,12 @@
       "version": "1.2.14",
       "from": "math-expression-evaluator@>=1.2.14 <2.0.0",
       "resolved": "http://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.14.tgz",
+      "dev": true
+    },
+    "md5": {
+      "version": "2.2.1",
+      "from": "md5@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
       "dev": true
     },
     "mdurl": {
@@ -11038,6 +11056,12 @@
           "dev": true
         }
       }
+    },
+    "webpack-md5-hash": {
+      "version": "0.0.5",
+      "from": "webpack-md5-hash@latest",
+      "resolved": "https://registry.npmjs.org/webpack-md5-hash/-/webpack-md5-hash-0.0.5.tgz",
+      "dev": true
     },
     "webpack-sources": {
       "version": "0.1.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1324,6 +1324,26 @@
         }
       }
     },
+    "chunk-manifest-webpack-plugin": {
+      "version": "0.0.1",
+      "from": "chunk-manifest-webpack-plugin@0.0.1",
+      "resolved": "https://registry.npmjs.org/chunk-manifest-webpack-plugin/-/chunk-manifest-webpack-plugin-0.0.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@>=0.1.38 <0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "dev": true
+        },
+        "webpack-core": {
+          "version": "0.4.8",
+          "from": "webpack-core@>=0.4.8 <0.5.0",
+          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.4.8.tgz",
+          "dev": true
+        }
+      }
+    },
     "circular-json": {
       "version": "0.3.1",
       "from": "circular-json@>=0.3.1 <0.4.0",
@@ -5809,7 +5829,7 @@
         "async": {
           "version": "0.9.2",
           "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "dev": true
         },
         "chalk": {
@@ -6291,7 +6311,7 @@
             "async": {
               "version": "0.9.2",
               "from": "async@>=0.9.0 <0.10.0",
-              "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
               "dev": true
             }
           }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "bourbon-neat": "^1.7.4",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
+    "chunk-manifest-webpack-plugin": "0.0.1",
     "classlist-polyfill": "^1.0.3",
     "classnames": "^2.2.5",
     "command-line-args": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema#ae08be8e67ac550f2fd400445f3c89c324fa9a79",
     "webpack": "^1.13.1",
     "webpack-manifest-plugin": "^1.1.0",
+    "webpack-md5-hash": "0.0.5",
     "whatwg-fetch": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz",
     "winston": "^2.2.0"
   },

--- a/script/build.js
+++ b/script/build.js
@@ -313,7 +313,7 @@ if (options.buildtype !== 'development') {
     const manifest = {};
     Object.keys(originalManifest).forEach((originalManifestKey) => {
       const matchData = originalManifestKey.match(/(.*)\.js$/);
-      if (matchData !== null) {
+      if (matchData !== null && matchData[1] !== 'vendor') {
         const newKey = `${matchData[1]}.entry.js`;
         manifest[newKey] = originalManifest[originalManifestKey];
       } else {

--- a/script/build.js
+++ b/script/build.js
@@ -337,6 +337,24 @@ if (options.buildtype !== 'development') {
     });
     done();
   });
+
+  smith.use((files, metalsmith, done) => {
+    // Read in the data from the manifest file.
+    const chunkManifestKey = Object.keys(files).find((filename) => {
+      return filename.match(/chunk-manifest.json$/) !== null;
+    });
+    const chunkManifest = files[chunkManifestKey].contents.toString();
+
+    Object.keys(files).forEach((filename) => {
+      if (filename.match(/\.html$/) !== null) {
+        const file = files[filename];
+        const contents = file.contents.toString();
+        const regex = new RegExp("'CHUNK_MANIFEST_PLACEHOLDER'", 'g');
+        file.contents = new Buffer(contents.replace(regex, chunkManifest));
+      }
+    });
+    done();
+  });
 }
 
 smith.use(redirect({


### PR DESCRIPTION
department-of-veterans-affairs/vets.gov-team#928

The JS code we bring in from vendors doesn't change very often. For that reason, it makes sense to pull it out into its own javascript file so the browser can cache it and hold onto the cache for longer than it would the individual entry files that include our code. Doing so also has the benefit of making the entry files much smaller, so that if a user went to multiple entries then they would download much less code.

Annoyingly, this requires us to specify which libraries we want to include in the vendor package, so that if that list changes then we have to update it manually in the WebPack config. But other than that the change is pretty straightforward.