### PR TITLE
EVSS route and service name change

### DIFF
--- a/src/js/disability-benefits/actions/index.js
+++ b/src/js/disability-benefits/actions/index.js
@@ -37,7 +37,7 @@ export function setNotification(message) {
 
 export function getClaims() {
   return (dispatch) => {
-    makeAuthRequest('/v0/disability_claims',
+    makeAuthRequest('/v0/evss_claims',
       null,
       dispatch,
       claims => dispatch({ type: SET_CLAIMS, claims: claims.data, meta: claims.meta }),
@@ -64,7 +64,7 @@ export function getClaimDetail(id, router) {
     dispatch({
       type: GET_CLAIM_DETAIL
     });
-    makeAuthRequest(`/v0/disability_claims/${id}`,
+    makeAuthRequest(`/v0/evss_claims/${id}`,
       null,
       dispatch,
       resp => dispatch({ type: SET_CLAIM_DETAIL, claim: resp.data, meta: resp.meta }),
@@ -84,7 +84,7 @@ export function submitRequest(id) {
     dispatch({
       type: SUBMIT_DECISION_REQUEST
     });
-    makeAuthRequest(`/v0/disability_claims/${id}/request_decision`,
+    makeAuthRequest(`/v0/evss_claims/${id}/request_decision`,
       { method: 'POST' },
       dispatch,
       () => {
@@ -144,7 +144,7 @@ export function submitFiles(claimId, trackedItem, files) {
   return (dispatch) => {
     const uploader = new FineUploaderBasic({
       request: {
-        endpoint: `${environment.API_URL}/v0/disability_claims/${claimId}/documents`,
+        endpoint: `${environment.API_URL}/v0/evss_claims/${claimId}/documents`,
         inputName: 'file',
         customHeaders: {
           'X-Key-Inflection': 'camel',

--- a/src/js/disability-benefits/containers/DisabilityBenefitsApp.jsx
+++ b/src/js/disability-benefits/containers/DisabilityBenefitsApp.jsx
@@ -45,7 +45,7 @@ class DisabilityBenefitsApp extends React.Component {
     const { available, synced, authorized } = this.props;
 
     return (
-      <RequiredLoginView authRequired={3} serviceRequired={"disability-benefits"}>
+      <RequiredLoginView authRequired={3} serviceRequired={"evss-claims"}>
         <AppContent
             authorized={authorized}
             available={available}

--- a/test/disability-benefits/components/DisabilityBenefitsApp.unit.spec.jsx
+++ b/test/disability-benefits/components/DisabilityBenefitsApp.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('<DisabilityBenefitsApp>', () => {
 
     expect(tree.everySubTree('.test-child')).not.to.be.empty;
     expect(tree.everySubTree('RequiredLoginView')).not.to.be.empty;
-    expect(tree.subTree('RequiredLoginView').props.serviceRequired).to.equal('disability-benefits');
+    expect(tree.subTree('RequiredLoginView').props.serviceRequired).to.equal('evss-claims');
     expect(tree.subTree('RequiredLoginView').props.authRequired).to.equal(3);
   });
   it('should render children', () => {

--- a/test/util/disability-helpers.js
+++ b/test/util/disability-helpers.js
@@ -4,7 +4,7 @@ const mock = require('./mock-helpers');
 
 function initAskVAMock(token) {
   mock(token, {
-    path: '/v0/disability_claims/11/request_decision',
+    path: '/v0/evss_claims/11/request_decision',
     verb: 'post',
     value: {}
   });
@@ -12,13 +12,13 @@ function initAskVAMock(token) {
 
 function initClaimsListMock(token) {
   mock(token, {
-    path: '/v0/disability_claims',
+    path: '/v0/evss_claims',
     verb: 'get',
     value: {
       data: [
         {
           id: 11,
-          type: 'disability_claims',
+          type: 'evss_claims',
           attributes: {
             evssId: 189685,
             dateFiled: '2008-09-23',
@@ -36,7 +36,7 @@ function initClaimsListMock(token) {
         },
         {
           id: 12,
-          type: 'disability_claims',
+          type: 'evss_claims',
           attributes: {
             evssId: 189685,
             dateFiled: '2008-09-23',
@@ -62,12 +62,12 @@ function initClaimsListMock(token) {
 
 function initClaimDetailMocks(token, decisionLetterSent, documentsNeeded, waiverSubmitted, phase, estDate) {
   mock(token, {
-    path: '/v0/disability_claims/11',
+    path: '/v0/evss_claims/11',
     verb: 'get',
     value: {
       data: {
         id: '11',
-        type: 'disability_claims',
+        type: 'evss_claims',
         attributes: {
           evssId: 189685,
           dateFiled: '2008-09-23',

--- a/test/util/login-helpers.js
+++ b/test/util/login-helpers.js
@@ -35,7 +35,7 @@ function initUserMock(token, level) {
             gender: 'F',
             birth_date: '1985-01-01'
           },
-          services: ['facilities', 'hca', 'edu-benefits', 'disability-benefits', 'user-profile', 'rx', 'messaging'],
+          services: ['facilities', 'hca', 'edu-benefits', 'evss-claims', 'user-profile', 'rx', 'messaging'],
           va_profile: {
             status: 'OK',
             birth_date: '19511118',


### PR DESCRIPTION
As part of changing to doing all claims, we will change the URL and service name away from "disability-claims". This must not be merged until after that change is live, but I am opening it now to keep us from forgetting to merge later.