### PR TITLE
Add preliminary list of blue button report mappings

### DIFF
--- a/src/js/blue-button/config.js
+++ b/src/js/blue-button/config.js
@@ -1,162 +1,198 @@
 module.exports = {
   reportTypes: {
-    appointments: [
-      {
-        value: 'futureappointment',
-        label: 'Future VA Appointments',
-      },
-      {
-        value: 'pastappointment',
-        label: 'Past VA Appointments (limited to past 2 years)',
-      },
-    ],
-    medications: [
-      {
-        value: 'prescription',
-        label: 'VA Medication History',
-      },
-      {
-        value: 'medication',
-        label: 'Medications and Supplements, Self-Reported',
-      },
-    ],
-    labs: [
-      {
-        value: 'labsandtest',
-        label: 'VA Laboratory Results',
-        hold: 3,
-      },
-      {
-        value: 'vapatholog',
-        label: 'VA Pathology Reports',
-        hold: 14,
-      },
-      {
-        value: 'varadiolog',
-        label: 'VA Radiology Reports',
-        hold: 3,
-      },
-      {
-        value: 'vaek',
-        label: 'VA Electrocardiogram (EKG) History performed at VA Treating Facilities',
-      },
-      {
-        value: '',
-        label: 'Labs and Tests, Self-Reported',
-      },
-    ],
-    ehr: [
-      {
-        value: 'vaproblemlis',
-        label: 'VA Problem List',
-        hold: 3,
-      },
-      {
-        value: 'vaadmissionsanddischarge',
-        label: 'VA Admissions and Discharges',
-        hold: 3,
-      },
-      {
-        value: 'vaprogressnote',
-        label: 'VA Notes from Jan 01, 2013 forward',
-        hold: 3,
-      },
-      {
-        value: 'wellnes',
-        label: 'VA Wellness Reminders',
-      },
-    ],
-    allergies: [
-      {
-        value: 'vaallergie',
-        label: 'VA Allergies',
-      },
-      {
-        value: 'seiallergie',
-        label: 'Allergies, Self-Reported',
-      },
-    ],
-    immunizations: [
-      {
-        value: 'vaimmunization',
-        label: 'VA Immunizations',
-      },
-      {
-        value: 'seiimmunization',
-        label: 'Immunizations, Self-Reported',
-      },
-    ],
-    vitals: [
-      {
-        value: 'vitalsandreading',
-        label: 'VA Vitals and Readings',
-      },
-      {
-        value: '',
-        label: 'Vitals and Readings, Self-Reported',
-      },
-    ],
-    selfReported: [
-      {
-        value: 'medicalevent',
-        label: 'Medical Events, Self-Reported',
-      },
-      {
-        value: 'familyhealthhistor',
-        label: 'Family Health History, Self-Reported',
-      },
-      {
-        value: 'militaryhealthhistor',
-        label: 'Military Health History, Self-Reported',
-      },
-      {
-        value: 'treatmentfacilitie',
-        label: 'Treatment Facilities, Self-Reported',
-      },
-      {
-        value: 'healthcareprovider',
-        label: 'Health Care Providers, Self-Reported',
-      },
-    ],
-    food: [
-      {
-        value: 'seiactivityjourna',
-        label: 'Activity Journal, Self-Reported',
-      },
-      {
-        value: 'seifoodjourna',
-        label: 'Food Journal, Self-Reported',
-      },
-    ],
-    goals: [
-      {
-        value: 'seimygoalscurren',
-        label: 'My Goals: Current Goals, Self-Reported',
-      },
-      {
-        value: 'seimygoalscomplete',
-        label: 'My Goals: Completed Goals, Self-Reported',
-      },
-    ],
-    demographics: [
-      {
-        value: 'vademographic',
-        label: 'VA Demographics from VA Treating Facilities in the last 3 years',
-      },
-      {
-        value: 'seidemographic',
-        label: 'Demographics, Self-Reported',
-      },
-      {
-        value: 'healthinsuranc',
-        label: 'Health Insurance, Self-Reported',
-      },
-    ],
-    dod: [
-      {
-        value: 'dodmilitaryservic',
-        label: 'Military Service Information',
-      },
-    ]
+    appointments: {
+      title: 'Appointments',
+      children: [
+        {
+          value: 'futureappointment',
+          label: 'Future VA Appointments',
+        },
+        {
+          value: 'pastappointment',
+          label: 'Past VA Appointments (limited to past 2 years)',
+        },
+      ],
+    },
+    medications: {
+      title: 'Medications (automatically includes Allergy information)',
+      children: [
+        {
+          value: 'prescription',
+          label: 'VA Medication History',
+        },
+        {
+          value: 'medication',
+          label: 'Medications and Supplements, Self-Reported',
+        },
+      ],
+    },
+    labs: {
+      title: 'Labs and Tests',
+      children: [
+        {
+          value: 'labsandtest',
+          label: 'VA Laboratory Results',
+          hold: 3,
+        },
+        {
+          value: 'vapatholog',
+          label: 'VA Pathology Reports',
+          hold: 14,
+        },
+        {
+          value: 'varadiolog',
+          label: 'VA Radiology Reports',
+          hold: 3,
+        },
+        {
+          value: 'vaek',
+          label: 'VA Electrocardiogram (EKG) History performed at VA Treating Facilities',
+        },
+        {
+          value: '',
+          label: 'Labs and Tests, Self-Reported',
+        },
+      ],
+    },
+    ehr: {
+      title: 'VA Electronic Health Record History and Wellness Reminders',
+      children: [
+        {
+          value: 'vaproblemlis',
+          label: 'VA Problem List',
+          hold: 3,
+        },
+        {
+          value: 'vaadmissionsanddischarge',
+          label: 'VA Admissions and Discharges',
+          hold: 3,
+        },
+        {
+          value: 'vaprogressnote',
+          label: 'VA Notes from Jan 01, 2013 forward',
+          hold: 3,
+        },
+        {
+          value: 'wellnes',
+          label: 'VA Wellness Reminders',
+        },
+      ],
+    },
+    allergies: {
+      title: 'Allergies',
+      children: [
+        {
+          value: 'vaallergie',
+          label: 'VA Allergies',
+        },
+        {
+          value: 'seiallergie',
+          label: 'Allergies, Self-Reported',
+        },
+      ],
+    },
+    immunizations: {
+      title: 'Immunizations',
+      children: [
+        {
+          value: 'vaimmunization',
+          label: 'VA Immunizations',
+        },
+        {
+          value: 'seiimmunization',
+          label: 'Immunizations, Self-Reported',
+        },
+      ],
+    },
+    vitals: {
+      title: 'Vitals and Readings',
+      children: [
+        {
+          value: 'vitalsandreading',
+          label: 'VA Vitals and Readings',
+        },
+        {
+          value: '',
+          label: 'Vitals and Readings, Self-Reported',
+        },
+      ],
+    },
+    selfReported: {
+      title: 'Self-Reported Health History',
+      children: [
+        {
+          value: 'medicalevent',
+          label: 'Medical Events, Self-Reported',
+        },
+        {
+          value: 'familyhealthhistor',
+          label: 'Family Health History, Self-Reported',
+        },
+        {
+          value: 'militaryhealthhistor',
+          label: 'Military Health History, Self-Reported',
+        },
+        {
+          value: 'treatmentfacilitie',
+          label: 'Treatment Facilities, Self-Reported',
+        },
+        {
+          value: 'healthcareprovider',
+          label: 'Health Care Providers, Self-Reported',
+        },
+      ],
+    },
+    food: {
+      title: 'Food and Activity Journals',
+      children: [
+        {
+          value: 'seiactivityjourna',
+          label: 'Activity Journal, Self-Reported',
+        },
+        {
+          value: 'seifoodjourna',
+          label: 'Food Journal, Self-Reported',
+        },
+      ],
+    },
+    goals: {
+      title: 'Goals',
+      children: [
+        {
+          value: 'seimygoalscurren',
+          label: 'My Goals: Current Goals, Self-Reported',
+        },
+        {
+          value: 'seimygoalscomplete',
+          label: 'My Goals: Completed Goals, Self-Reported',
+        },
+      ],
+    },
+    demographics: {
+      title: 'Demographics and Health Insurance',
+      children: [
+        {
+          value: 'vademographic',
+          label: 'VA Demographics from VA Treating Facilities in the last 3 years',
+        },
+        {
+          value: 'seidemographic',
+          label: 'Demographics, Self-Reported',
+        },
+        {
+          value: 'healthinsuranc',
+          label: 'Health Insurance, Self-Reported',
+        },
+      ],
+    },
+    dod: {
+      title: 'Department of Defense',
+      children: [
+        {
+          value: 'dodmilitaryservic',
+          label: 'Military Service Information',
+        },
+      ]
+    },
   }
 };

--- a/src/js/blue-button/config.js
+++ b/src/js/blue-button/config.js
@@ -4,11 +4,11 @@ module.exports = {
       title: 'Appointments',
       children: [
         {
-          value: 'futureappointment',
+          value: 'futureappointments',
           label: 'Future VA Appointments',
         },
         {
-          value: 'pastappointment',
+          value: 'pastappointments',
           label: 'Past VA Appointments (limited to past 2 years)',
         },
       ],
@@ -17,11 +17,11 @@ module.exports = {
       title: 'Medications (automatically includes Allergy information)',
       children: [
         {
-          value: 'prescription',
+          value: 'prescriptions',
           label: 'VA Medication History',
         },
         {
-          value: 'medication',
+          value: 'medications',
           label: 'Medications and Supplements, Self-Reported',
         },
       ],
@@ -30,22 +30,22 @@ module.exports = {
       title: 'Labs and Tests',
       children: [
         {
-          value: 'labsandtest',
+          value: 'labsandtests',
           label: 'VA Laboratory Results',
           hold: 3,
         },
         {
-          value: 'vapatholog',
+          value: 'vapathology',
           label: 'VA Pathology Reports',
           hold: 14,
         },
         {
-          value: 'varadiolog',
+          value: 'varadiology',
           label: 'VA Radiology Reports',
           hold: 3,
         },
         {
-          value: 'vaek',
+          value: 'vaekg',
           label: 'VA Electrocardiogram (EKG) History performed at VA Treating Facilities',
         },
         {
@@ -58,22 +58,22 @@ module.exports = {
       title: 'VA Electronic Health Record History and Wellness Reminders',
       children: [
         {
-          value: 'vaproblemlis',
+          value: 'vaproblemlist',
           label: 'VA Problem List',
           hold: 3,
         },
         {
-          value: 'vaadmissionsanddischarge',
+          value: 'vaadmissionsanddischarges',
           label: 'VA Admissions and Discharges',
           hold: 3,
         },
         {
-          value: 'vaprogressnote',
+          value: 'vaprogressnotes',
           label: 'VA Notes from Jan 01, 2013 forward',
           hold: 3,
         },
         {
-          value: 'wellnes',
+          value: 'wellness',
           label: 'VA Wellness Reminders',
         },
       ],
@@ -82,11 +82,11 @@ module.exports = {
       title: 'Allergies',
       children: [
         {
-          value: 'vaallergie',
+          value: 'vaallergies',
           label: 'VA Allergies',
         },
         {
-          value: 'seiallergie',
+          value: 'seiallergies',
           label: 'Allergies, Self-Reported',
         },
       ],
@@ -95,11 +95,11 @@ module.exports = {
       title: 'Immunizations',
       children: [
         {
-          value: 'vaimmunization',
+          value: 'vaimmunizations',
           label: 'VA Immunizations',
         },
         {
-          value: 'seiimmunization',
+          value: 'seiimmunizations',
           label: 'Immunizations, Self-Reported',
         },
       ],
@@ -108,7 +108,7 @@ module.exports = {
       title: 'Vitals and Readings',
       children: [
         {
-          value: 'vitalsandreading',
+          value: 'vitalsandreadings',
           label: 'VA Vitals and Readings',
         },
         {
@@ -121,23 +121,23 @@ module.exports = {
       title: 'Self-Reported Health History',
       children: [
         {
-          value: 'medicalevent',
+          value: 'medicalevents',
           label: 'Medical Events, Self-Reported',
         },
         {
-          value: 'familyhealthhistor',
+          value: 'familyhealthhistory',
           label: 'Family Health History, Self-Reported',
         },
         {
-          value: 'militaryhealthhistor',
+          value: 'militaryhealthhistory',
           label: 'Military Health History, Self-Reported',
         },
         {
-          value: 'treatmentfacilitie',
+          value: 'treatmentfacilities',
           label: 'Treatment Facilities, Self-Reported',
         },
         {
-          value: 'healthcareprovider',
+          value: 'healthcareproviders',
           label: 'Health Care Providers, Self-Reported',
         },
       ],
@@ -146,11 +146,11 @@ module.exports = {
       title: 'Food and Activity Journals',
       children: [
         {
-          value: 'seiactivityjourna',
+          value: 'seiactivityjournal',
           label: 'Activity Journal, Self-Reported',
         },
         {
-          value: 'seifoodjourna',
+          value: 'seifoodjournal',
           label: 'Food Journal, Self-Reported',
         },
       ],
@@ -159,11 +159,11 @@ module.exports = {
       title: 'Goals',
       children: [
         {
-          value: 'seimygoalscurren',
+          value: 'seimygoalscurrent',
           label: 'My Goals: Current Goals, Self-Reported',
         },
         {
-          value: 'seimygoalscomplete',
+          value: 'seimygoalscompleted',
           label: 'My Goals: Completed Goals, Self-Reported',
         },
       ],
@@ -172,15 +172,15 @@ module.exports = {
       title: 'Demographics and Health Insurance',
       children: [
         {
-          value: 'vademographic',
+          value: 'vademographics',
           label: 'VA Demographics from VA Treating Facilities in the last 3 years',
         },
         {
-          value: 'seidemographic',
+          value: 'seidemographics',
           label: 'Demographics, Self-Reported',
         },
         {
-          value: 'healthinsuranc',
+          value: 'healthinsurance',
           label: 'Health Insurance, Self-Reported',
         },
       ],
@@ -189,7 +189,7 @@ module.exports = {
       title: 'Department of Defense',
       children: [
         {
-          value: 'dodmilitaryservic',
+          value: 'dodmilitaryservice',
           label: 'Military Service Information',
         },
       ]

--- a/src/js/blue-button/config.js
+++ b/src/js/blue-button/config.js
@@ -1,0 +1,162 @@
+module.exports = {
+  reportTypes: {
+    appointments: [
+      {
+        value: 'futureappointment',
+        label: 'Future VA Appointments',
+      },
+      {
+        value: 'pastappointment',
+        label: 'Past VA Appointments (limited to past 2 years)',
+      },
+    ],
+    medications: [
+      {
+        value: 'prescription',
+        label: 'VA Medication History',
+      },
+      {
+        value: 'medication',
+        label: 'Medications and Supplements, Self-Reported',
+      },
+    ],
+    labs: [
+      {
+        value: 'labsandtest',
+        label: 'VA Laboratory Results',
+        hold: 3,
+      },
+      {
+        value: 'vapatholog',
+        label: 'VA Pathology Reports',
+        hold: 14,
+      },
+      {
+        value: 'varadiolog',
+        label: 'VA Radiology Reports',
+        hold: 3,
+      },
+      {
+        value: 'vaek',
+        label: 'VA Electrocardiogram (EKG) History performed at VA Treating Facilities',
+      },
+      {
+        value: '',
+        label: 'Labs and Tests, Self-Reported',
+      },
+    ],
+    ehr: [
+      {
+        value: 'vaproblemlis',
+        label: 'VA Problem List',
+        hold: 3,
+      },
+      {
+        value: 'vaadmissionsanddischarge',
+        label: 'VA Admissions and Discharges',
+        hold: 3,
+      },
+      {
+        value: 'vaprogressnote',
+        label: 'VA Notes from Jan 01, 2013 forward',
+        hold: 3,
+      },
+      {
+        value: 'wellnes',
+        label: 'VA Wellness Reminders',
+      },
+    ],
+    allergies: [
+      {
+        value: 'vaallergie',
+        label: 'VA Allergies',
+      },
+      {
+        value: 'seiallergie',
+        label: 'Allergies, Self-Reported',
+      },
+    ],
+    immunizations: [
+      {
+        value: 'vaimmunization',
+        label: 'VA Immunizations',
+      },
+      {
+        value: 'seiimmunization',
+        label: 'Immunizations, Self-Reported',
+      },
+    ],
+    vitals: [
+      {
+        value: 'vitalsandreading',
+        label: 'VA Vitals and Readings',
+      },
+      {
+        value: '',
+        label: 'Vitals and Readings, Self-Reported',
+      },
+    ],
+    selfReported: [
+      {
+        value: 'medicalevent',
+        label: 'Medical Events, Self-Reported',
+      },
+      {
+        value: 'familyhealthhistor',
+        label: 'Family Health History, Self-Reported',
+      },
+      {
+        value: 'militaryhealthhistor',
+        label: 'Military Health History, Self-Reported',
+      },
+      {
+        value: 'treatmentfacilitie',
+        label: 'Treatment Facilities, Self-Reported',
+      },
+      {
+        value: 'healthcareprovider',
+        label: 'Health Care Providers, Self-Reported',
+      },
+    ],
+    food: [
+      {
+        value: 'seiactivityjourna',
+        label: 'Activity Journal, Self-Reported',
+      },
+      {
+        value: 'seifoodjourna',
+        label: 'Food Journal, Self-Reported',
+      },
+    ],
+    goals: [
+      {
+        value: 'seimygoalscurren',
+        label: 'My Goals: Current Goals, Self-Reported',
+      },
+      {
+        value: 'seimygoalscomplete',
+        label: 'My Goals: Completed Goals, Self-Reported',
+      },
+    ],
+    demographics: [
+      {
+        value: 'vademographic',
+        label: 'VA Demographics from VA Treating Facilities in the last 3 years',
+      },
+      {
+        value: 'seidemographic',
+        label: 'Demographics, Self-Reported',
+      },
+      {
+        value: 'healthinsuranc',
+        label: 'Health Insurance, Self-Reported',
+      },
+    ],
+    dod: [
+      {
+        value: 'dodmilitaryservic',
+        label: 'Military Service Information',
+      },
+    ]
+  }
+};


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/963

List of ambiguities here that we will resolve later this week with MHV:
- missing MHV key for `Labs and Tests, Self-Reported`
- missing MHV key for `Vitals and Readings, Self-Reported`
- what is the difference between `prescription` and `medication`?
- what does `vachemlab` map to?
- what does `vahth` map to?