### PR TITLE
Auto-hide #va-modal

### DIFF
--- a/content/includes/modal.html
+++ b/content/includes/modal.html
@@ -50,9 +50,7 @@ content.
 (function($){
   // TODO: eliminate jQuery dependency
   var modal = $('#va-modal');
-  // Start hidden and only open if the hash is found
-  // Alternatively, use the css #va-modal { display: none }
-  // modal.hide();
+  // Note: Hidden by default by the css
   if (document.location.hash === '#modal'){
     open();
   }

--- a/content/includes/modal.html
+++ b/content/includes/modal.html
@@ -25,7 +25,7 @@ content.
             <li>A candidate for <b>National Call to Service</b></li>
           </ul>
           <div class="show-for-small-only">
-            <a href="https://www.ebenefits.va.gov/ebenefits/vonapp" class="usa-button-primary usa-button-big usa-button-outline">Apply on eBenefits <span class="exit-icon">&nbsp;</span></a> 
+            <a href="https://www.ebenefits.va.gov/ebenefits/vonapp" class="usa-button-primary usa-button-big usa-button-outline">Apply on eBenefits <span class="exit-icon">&nbsp;</span></a>
           </div>
         </div>
       </div>
@@ -38,7 +38,7 @@ content.
           </div>
           <div class="va-modal-split-divider"></div>
           <div class="va-modal-split-right">
-            <a href="https://www.ebenefits.va.gov/ebenefits/vonapp" class="usa-button-primary usa-button-big usa-button-outline">Apply on eBenefits <span class="exit-icon">&nbsp;</span></a> 
+            <a href="https://www.ebenefits.va.gov/ebenefits/vonapp" class="usa-button-primary usa-button-big usa-button-outline">Apply on eBenefits <span class="exit-icon">&nbsp;</span></a>
           </div>
         </div>
       </div>
@@ -50,22 +50,25 @@ content.
 (function($){
   // TODO: eliminate jQuery dependency
   var modal = $('#va-modal').focus();
+  // Start hidden and only open if the hash is found
+  // Alternatively, use the css #va-modal { display: none }
+  // modal.hide();
   if (document.location.hash === '#modal'){
-    open(); 
+    open();
   }
-  
+
   $('.va-modal-close-button').click(close);
 
-  function open(){ 
+  function open(){
     modal.show();
   }
 
-  function close(){ 
+  function close(){
     if(window.history.pushState) {
       window.history.pushState('', '/', window.location.pathname)
     } else {
       window.location.hash = '';
-    } 
+    }
     modal.hide();
     $('#content').focus();
   }

--- a/content/includes/modal.html
+++ b/content/includes/modal.html
@@ -49,7 +49,7 @@ content.
 <script>
 (function($){
   // TODO: eliminate jQuery dependency
-  var modal = $('#va-modal').focus();
+  var modal = $('#va-modal');
   // Start hidden and only open if the hash is found
   // Alternatively, use the css #va-modal { display: none }
   // modal.hide();
@@ -61,6 +61,7 @@ content.
 
   function open(){
     modal.show();
+    modal.focus();
   }
 
   function close(){

--- a/src/sass/modules/_m-modal.scss
+++ b/src/sass/modules/_m-modal.scss
@@ -1,6 +1,12 @@
 // Styles for application modals
 // Used in prescriptions, messaging.
 
+// Hide initially, to be shown if url contains #modal
+// Alternatively, modal.hide() in content/includes/modal.html
+#va-modal {
+  display: none;
+}
+
 .va-modal {
   background: rgba($color-primary-darkest, .8);
   content: ' ';
@@ -35,7 +41,7 @@
       padding: 0 20px;
       @media #{$small-only} {
         flex: none;
-        padding: 0; 
+        padding: 0;
       }
     }
     &-title { margin-top: 0; }
@@ -62,7 +68,7 @@
         }
       }
     }
-    
+
     @media #{$small-only} {
       &-container {
         flex-flow: column;
@@ -121,7 +127,7 @@
 
 .va-modal button {
   white-space: nowrap;
-} 
+}
 
 .va-modal-close {
   background-color: inherit;
@@ -133,10 +139,9 @@
   right: 0;
   top: 0;
   width: auto;
-  
+
   &:hover {
     background-color: inherit;
     color: $color-base;
   }
-} 
-
+}


### PR DESCRIPTION
Adds CSS rule to hide `#va-modal` to be opened if '#modal' is found in the url (content/includes/modal.html).

I wasn't sure if calling `modal.hide()` would be a better solution if `#va-modal` is used elsewhere, so I kept that as a comment in modal.html.

I looked for other uses of both `#va-moda`l and `modal.html`, but couldn't find any. Still, at this point don't know if it's safe, so somebody more familiar with the codebase should probably do some more thorough testing.

Also, Atom likes to remove trailing spaces, so that's what the seemingly-unchanged lines are. Sorry for the noise.

Closes department-of-veterans-affairs/vets.gov-team#965