### PR TITLE
Move config behind flag

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -142,15 +142,6 @@ const configGenerator = (options) => {
         'vendor',
         (options.buildtype === 'development') ? 'vendor.js' : 'vendor.[chunkhash].js'
       ),
-      new WebpackMd5Hash(),
-      new ManifestPlugin({
-        fileName: 'file-manifest.json'
-      }),
-      new ChunkManifestPlugin({
-        filename: 'chunk-manifest.json',
-        manifestVariable: 'webpackManifest'
-      }),
-      new webpack.optimize.OccurenceOrderPlugin()
     ],
   };
 
@@ -169,6 +160,14 @@ const configGenerator = (options) => {
       loader: 'null'
     });
 
+    baseConfig.plugins.push(new WebpackMd5Hash());
+    baseConfig.plugins.push(new ManifestPlugin({
+      fileName: 'file-manifest.json'
+    }));
+    baseConfig.plugins.push(new ChunkManifestPlugin({
+      filename: 'chunk-manifest.json',
+      manifestVariable: 'webpackManifest'
+    }));
     baseConfig.plugins.push(new webpack.optimize.DedupePlugin());
     baseConfig.plugins.push(new webpack.optimize.OccurrenceOrderPlugin(true));
     baseConfig.plugins.push(new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
The config changes for writing the webpack manifest to our html were made in build.js for non-development build types, but in webpack.config.js for all build types. This was breaking the app in development/watch mode. This moves the webpack changes behind the prod/staging build type check.