### PR TITLE
Fix text length on prescription glossary modals

### DIFF
--- a/src/sass/rx/partials/_rx-glossary.scss
+++ b/src/sass/rx/partials/_rx-glossary.scss
@@ -1,5 +1,5 @@
 .rx-glossary-section {
-  @extend .medium-8;
+  width: 100%;
   clear: both;
 }
 

--- a/src/sass/rx/partials/_rx-modal.scss
+++ b/src/sass/rx/partials/_rx-modal.scss
@@ -6,13 +6,12 @@
     font-size: 2.4rem;
     font-weight: bold;
   }
-  
+
   &-rxnumber {
     font-weight: bold;
   }
-    
+
   .rx-glossary {
     margin: 0 auto;
   }
 }
-


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1040

Screenshot:
<img width="423" alt="screen shot 2017-02-08 at 2 32 10 pm" src="https://cloud.githubusercontent.com/assets/303289/22760469/6c639f9a-ee0b-11e6-8d81-67ed6b7b27f5.png">
