### PR TITLE
Add error banner for SM when there are no triage teams

### DIFF
--- a/src/js/messaging/components/ComposeButton.jsx
+++ b/src/js/messaging/components/ComposeButton.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 
 class ComposeButton extends React.Component {
   constructor(props) {
@@ -11,10 +12,18 @@ class ComposeButton extends React.Component {
   }
 
   render() {
+    const { disabled } = this.props;
+    const classes = classNames({
+      'messaging-compose-button': true,
+      'va-button-primary': !disabled,
+      'usa-button-disabled': disabled,
+    });
+
     return (
       <button
+          disabled={disabled}
           onClick={this.goToComposeMessage}
-          className="va-button-primary messaging-compose-button">
+          className={classes}>
         Compose a message
       </button>
     );
@@ -22,7 +31,8 @@ class ComposeButton extends React.Component {
 }
 
 ComposeButton.contextTypes = {
-  router: React.PropTypes.object.isRequired
+  router: React.PropTypes.object.isRequired,
+  disabled: React.PropTypes.bool,
 };
 
 export default ComposeButton;

--- a/src/js/messaging/containers/Compose.jsx
+++ b/src/js/messaging/containers/Compose.jsx
@@ -13,7 +13,6 @@ import {
   addComposeAttachments,
   deleteComposeAttachment,
   deleteComposeMessage,
-  fetchRecipients,
   openAttachmentsModal,
   resetMessage,
   saveDraft,
@@ -46,7 +45,6 @@ export class Compose extends React.Component {
     }
 
     this.props.resetMessage();
-    this.props.fetchRecipients();
   }
 
   componentDidUpdate() {
@@ -194,7 +192,6 @@ const mapDispatchToProps = {
   addComposeAttachments,
   deleteComposeAttachment,
   deleteComposeMessage,
-  fetchRecipients,
   openAttachmentsModal,
   resetMessage,
   saveDraft,

--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -19,7 +19,6 @@ import {
   toggleManagedFolders
 } from '../actions';
 
-import { isEmpty } from 'lodash';
 import ButtonClose from '../components/buttons/ButtonClose';
 import ComposeButton from '../components/ComposeButton';
 import FolderNav from '../components/FolderNav';
@@ -108,7 +107,7 @@ export class Main extends React.Component {
           <ButtonClose
               className="messaging-folder-nav-close"
               onClick={this.props.toggleFolderNav}/>
-          <ComposeButton disabled={isEmpty(this.props.recipients)}/>
+          <ComposeButton disabled={_.isEmpty(this.props.recipients)}/>
           <FolderNav
               currentFolderId={this.props.currentFolderId}
               folders={this.props.folders}

--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -11,6 +11,7 @@ import {
   closeCreateFolderModal,
   createFolderAndMoveMessage,
   createNewFolder,
+  fetchRecipients,
   fetchFolders,
   openCreateFolderModal,
   setNewFolderName,
@@ -18,6 +19,7 @@ import {
   toggleManagedFolders
 } from '../actions';
 
+import { isEmpty } from 'lodash';
 import ButtonClose from '../components/buttons/ButtonClose';
 import ComposeButton from '../components/ComposeButton';
 import FolderNav from '../components/FolderNav';
@@ -34,6 +36,7 @@ export class Main extends React.Component {
 
   componentDidMount() {
     this.props.fetchFolders();
+    this.props.fetchRecipients();
   }
 
   handleFolderChange() {
@@ -105,7 +108,7 @@ export class Main extends React.Component {
           <ButtonClose
               className="messaging-folder-nav-close"
               onClick={this.props.toggleFolderNav}/>
-          <ComposeButton/>
+          <ComposeButton disabled={isEmpty(this.props.recipients)}/>
           <FolderNav
               currentFolderId={this.props.currentFolderId}
               folders={this.props.folders}
@@ -161,7 +164,8 @@ const mapStateToProps = (state) => {
     folders,
     isVisibleAdvancedSearch: msgState.search.advanced.visible,
     loading: msgState.loading,
-    nav: msgState.folders.ui.nav
+    nav: msgState.folders.ui.nav,
+    recipients: msgState.recipients.data,
   };
 };
 
@@ -172,6 +176,7 @@ const mapDispatchToProps = {
   createFolderAndMoveMessage,
   createNewFolder,
   fetchFolders,
+  fetchRecipients,
   openCreateFolderModal,
   setNewFolderName,
   toggleFolderNav,

--- a/src/js/messaging/containers/MessagingApp.jsx
+++ b/src/js/messaging/containers/MessagingApp.jsx
@@ -35,7 +35,7 @@ class MessagingApp extends React.Component {
         <div>
           <h4>Currently not assigned to a health care team</h4>
           <p>
-            You will not be able to create a new message or reply to any messages without being assigned to a health care team. Please contact the help desk at 1-855-574-7286.
+            You can't send secure messages because you're not assigned to a VA health care team right now. Please call the Vets.gov Help Desk at 1-855-574-7286, Monday - Friday, 8:00 a.m. - 8:00 p.m. (ET).
           </p>
         </div>
       );

--- a/src/js/messaging/containers/MessagingApp.jsx
+++ b/src/js/messaging/containers/MessagingApp.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import AlertBox from '../../common/components/AlertBox';
 import RequiredLoginView from '../../common/components/RequiredLoginView';
 import { closeAlert } from '../actions';
+import { isEmpty } from 'lodash';
 
 // This needs to be a React component for RequiredLoginView to pass down
 // the isDataAvailable prop, which is only passed on failure.
@@ -27,6 +28,30 @@ function AppContent({ children, isDataAvailable }) {
 }
 
 class MessagingApp extends React.Component {
+  // this warning is rendered if the user has no triage teams
+  renderWarningBanner() {
+    if (isEmpty(this.props.recipients)) {
+      const alertContent = (
+        <div>
+          <h4>Currently not assigned to a health care team</h4>
+          <p>
+            You will not be able to create a new message or reply to any messages without being assigned to a health care team. Please contact the help desk at 1-855-574-7286.
+          </p>
+        </div>
+      );
+
+      return (
+        <div className="messaging-warning-banner">
+          <AlertBox
+              content={alertContent}
+              isVisible
+              status="warning"/>
+        </div>
+        );
+    }
+    return null;
+  }
+
   render() {
     return (
       <RequiredLoginView authRequired={3} serviceRequired={"messaging"}>
@@ -39,6 +64,7 @@ class MessagingApp extends React.Component {
                 scrollOnShow
                 status={this.props.alert.status}/>
             <h1>Message your health care team</h1>
+            {this.renderWarningBanner()}
           </div>
           {this.props.children}
         </AppContent>
@@ -52,8 +78,11 @@ MessagingApp.propTypes = {
 };
 
 const mapStateToProps = (state) => {
+  const msgState = state.health.msg;
+
   return {
-    alert: state.health.msg.alert
+    alert: msgState.alert,
+    recipients: msgState.recipients.data,
   };
 };
 

--- a/src/sass/messaging/partials/_messaging-app.scss
+++ b/src/sass/messaging/partials/_messaging-app.scss
@@ -21,6 +21,10 @@
   width: 100%;
 }
 
+.messaging-warning-banner {
+  margin: 1em 0 2em;
+}
+
 // TODO: Refactor these styles so that they're
 // reusable across projects.
 #messaging-nav {

--- a/test/messaging/components/ComposeButton.unit.spec.jsx
+++ b/test/messaging/components/ComposeButton.unit.spec.jsx
@@ -11,9 +11,21 @@ describe('<ComposeButton>', () => {
     expect(tree.getRenderOutput()).to.exist;
   });
 
-  it('should have the expected classname', () => {
+  it('should have the expected default classname', () => {
     const tree = SkinDeep.shallowRender(<ComposeButton/>);
 
-    expect(tree.props.className).to.equal('va-button-primary messaging-compose-button');
+    expect(tree.props.className).to.equal('messaging-compose-button va-button-primary');
+  });
+
+  it('should have the expected classname when disabled', () => {
+    const tree = SkinDeep.shallowRender(<ComposeButton disabled/>);
+
+    expect(tree.props.className).to.equal('messaging-compose-button usa-button-disabled');
+  });
+
+  it('should render disabled button when disabled', () => {
+    const tree = SkinDeep.shallowRender(<ComposeButton disabled/>);
+
+    expect(tree.subTree('button').props.disabled).to.equal(true);
   });
 });


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1003

This PR adds error message copy, warning banner, and disabled the Compose Message button if the user has no triage teams.

Screenshot:
![screen shot 2017-02-09 at 11 47 14 am](https://cloud.githubusercontent.com/assets/303289/22800705/0cdcedf6-eebf-11e6-8390-ccf070b89895.png)
