### PR TITLE
Set and validate date range inputs

### DIFF
--- a/src/js/blue-button/containers/Main.jsx
+++ b/src/js/blue-button/containers/Main.jsx
@@ -14,21 +14,43 @@ import {
 } from '../actions/form';
 import { openModal } from '../actions/modal';
 
+function isValidDateRange(startDate, endDate) {
+  if (!startDate || !endDate) {
+    return true;
+  }
+  return startDate.isBefore(endDate);
+}
+
 class Main extends React.Component {
   constructor(props) {
     super(props);
+
+    this.state = {
+      invalidStartDate: false,
+      invalidEndDate: false
+    };
 
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleStartDateChange = this.handleStartDateChange.bind(this);
     this.handleEndDateChange = this.handleEndDateChange.bind(this);
   }
 
-  handleStartDateChange() {
-    // use this.props.setDate(date, true) to change start date
+  handleStartDateChange(startDate) {
+    let invalidDate = true;
+    if (isValidDateRange(startDate, this.props.form.dateRange.end)) {
+      this.props.setDate(startDate, true);
+      invalidDate = false;
+    }
+    this.setState({ invalidStartDate: invalidDate });
   }
 
-  handleEndDateChange() {
-    // use this.props.setDate(date, false) to change start date
+  handleEndDateChange(endDate) {
+    let invalidDate = true;
+    if (isValidDateRange(this.props.form.dateRange.start, endDate)) {
+      this.props.setDate(endDate, false);
+      invalidDate = false;
+    }
+    this.setState({ invalidEndDate: invalidDate });
   }
 
   handleSubmit(e) {
@@ -96,13 +118,15 @@ class Main extends React.Component {
                     id="custom-date-start"
                     onChange={this.handleStartDateChange}
                     placeholderText="MM/DD/YYYY"
-                    selected={null}/>
+                    selected={this.props.form.dateRange.start}
+                    className={this.state.invalidStartDate ? 'date-range-error' : ''}/>
                 <span>&nbsp;to&nbsp;</span>
                 <DatePicker
                     id="custom-date-end"
                     onChange={this.handleEndDateChange}
                     placeholderText="MM/DD/YYYY"
-                    selected={null}/>
+                    selected={this.props.form.dateRange.end}
+                    className={this.state.invalidEndDate ? 'date-range-error' : ''}/>
               </div>
             </div>
           ),

--- a/src/js/blue-button/reducers/form.js
+++ b/src/js/blue-button/reducers/form.js
@@ -14,7 +14,7 @@ const initialState = {
   dateOption: null,
   dateRange: {
     start: null,
-    end: new Date().toISOString(),
+    end: null,
   },
   reportTypes: reportTypeValues,
 };
@@ -22,9 +22,9 @@ const initialState = {
 export default function disclaimer(state = initialState, action) {
   switch (action.type) {
     case 'START_DATE_CHANGED':
-      return set('dateRange.start', action.date.toISOString(), state);
+      return set('dateRange.start', action.date, state);
     case 'END_DATE_CHANGED':
-      return set('dateRange.end', action.date.toISOString(), state);
+      return set('dateRange.end', action.date, state);
     case 'DATE_OPTION_CHANGED':
       return set('dateOption', action.dateOption, state);
     case 'REPORT_TYPE_TOGGLED':

--- a/src/sass/blue-button/blue-button.scss
+++ b/src/sass/blue-button/blue-button.scss
@@ -78,3 +78,8 @@
     width: 16rem;
   }
 }
+
+// match uswds input error
+input.date-range-error {
+  border: 3px solid #cd2026;
+}


### PR DESCRIPTION
Related to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1024

react-datepicker uses moment objects, so leaving those date properties as moment objects for the time being, could convert back and forth if we want to have them in a separate format in the store

The common validations expect date fields objects but we are using the datepicker and moment objects