### PR TITLE
Update children question on dependents page of 1995

### DIFF
--- a/src/js/common/schemaform/FieldTemplate.jsx
+++ b/src/js/common/schemaform/FieldTemplate.jsx
@@ -12,8 +12,10 @@ export default function FieldTemplate(props) {
   const label = uiSchema['ui:title'] || props.label;
   const isDateField = uiSchema['ui:widget'] === 'date';
   const showFieldLabel = uiSchema['ui:options'] && uiSchema['ui:options'].showFieldLabel;
-  const hasTextDescription = typeof uiSchema['ui:description'] === 'string';
-  const DescriptionField = !hasTextDescription && typeof uiSchema['ui:description'] === 'function'
+
+  const description = uiSchema['ui:description'];
+  const textDescription = typeof description === 'string' ? description : null;
+  const DescriptionField = typeof description === 'function'
     ? uiSchema['ui:description']
     : null;
 
@@ -33,8 +35,9 @@ export default function FieldTemplate(props) {
     : (<div className={containerClassNames}>
       <div className={errorClass}>
         <label className={hasErrors && !isDateField ? 'usa-input-error-label' : null} htmlFor={id}>{label}{requiredSpan}</label>
-        {hasTextDescription && <p>{uiSchema['ui:description']}</p>}
+        {textDescription && <p>{textDescription}</p>}
         {DescriptionField && <DescriptionField options={uiSchema['ui:options']}/>}
+        {!textDescription && !DescriptionField && description}
         {errorSpan}
         {<div className={isDateField && hasErrors ? 'usa-input-error form-error-date' : null}>{children}</div>}
         {help}

--- a/src/js/common/schemaform/FieldTemplate.jsx
+++ b/src/js/common/schemaform/FieldTemplate.jsx
@@ -12,6 +12,10 @@ export default function FieldTemplate(props) {
   const label = uiSchema['ui:title'] || props.label;
   const isDateField = uiSchema['ui:widget'] === 'date';
   const showFieldLabel = uiSchema['ui:options'] && uiSchema['ui:options'].showFieldLabel;
+  const hasTextDescription = typeof uiSchema['ui:description'] === 'string';
+  const DescriptionField = !hasTextDescription && typeof uiSchema['ui:description'] === 'function'
+    ? uiSchema['ui:description']
+    : null;
 
   let errorSpanId;
   let errorSpan;
@@ -29,6 +33,8 @@ export default function FieldTemplate(props) {
     : (<div className={containerClassNames}>
       <div className={errorClass}>
         <label className={hasErrors && !isDateField ? 'usa-input-error-label' : null} htmlFor={id}>{label}{requiredSpan}</label>
+        {hasTextDescription && <p>{uiSchema['ui:description']}</p>}
+        {DescriptionField && <DescriptionField options={uiSchema['ui:options']}/>}
         {errorSpan}
         {<div className={isDateField && hasErrors ? 'usa-input-error form-error-date' : null}>{children}</div>}
         {help}

--- a/src/js/common/schemaform/ObjectField.jsx
+++ b/src/js/common/schemaform/ObjectField.jsx
@@ -122,10 +122,13 @@ class ObjectField extends React.Component {
     // description and title setup
     const showFieldLabel = uiSchema['ui:options'] && uiSchema['ui:options'].showFieldLabel;
     const title = uiSchema['ui:title'] || schema.title;
-    const hasTextDescription = typeof uiSchema['ui:description'] === 'string';
-    const DescriptionField = !hasTextDescription && typeof uiSchema['ui:description'] === 'function'
+
+    const description = uiSchema['ui:description'];
+    const textDescription = typeof description === 'string' ? description : null;
+    const DescriptionField = typeof description === 'function'
       ? uiSchema['ui:description']
       : null;
+
     const isRoot = idSchema.$id === 'root';
 
     let containerClassNames = classNames({
@@ -161,8 +164,9 @@ class ObjectField extends React.Component {
                   title={title}
                   required={required}
                   formContext={formContext}/> : null}
-          {hasTextDescription && <p>{uiSchema['ui:description']}</p>}
+          {textDescription && <p>{textDescription}</p>}
           {DescriptionField && <DescriptionField options={uiSchema['ui:options']}/>}
+          {!textDescription && !DescriptionField && description}
           {this.orderedProperties.map((objectFields, index) => {
             if (objectFields.length > 1) {
               return (

--- a/src/js/common/schemaform/review/ReviewFieldTemplate.jsx
+++ b/src/js/common/schemaform/review/ReviewFieldTemplate.jsx
@@ -7,8 +7,19 @@ import React from 'react';
 export default function ReviewFieldTemplate(props) {
   const { children, uiSchema, schema } = props;
   const label = uiSchema['ui:title'] || props.label;
+  const hasTextDescription = typeof uiSchema['ui:description'] === 'string';
+  const DescriptionField = !hasTextDescription && typeof uiSchema['ui:description'] === 'function'
+    ? uiSchema['ui:description']
+    : null;
 
   return schema.type === 'object' || schema.type === 'array'
     ? children
-    : <div className="review-row"><dt>{label}</dt><dd>{children}</dd></div>;
+    : <div className="review-row">
+      <dt>
+        {label}
+        {hasTextDescription && <p>{uiSchema['ui:description']}</p>}
+        {DescriptionField && <DescriptionField options={uiSchema['ui:options']}/>}
+      </dt>
+      <dd>{children}</dd>
+    </div>;
 }

--- a/src/js/common/schemaform/review/ReviewFieldTemplate.jsx
+++ b/src/js/common/schemaform/review/ReviewFieldTemplate.jsx
@@ -7,8 +7,9 @@ import React from 'react';
 export default function ReviewFieldTemplate(props) {
   const { children, uiSchema, schema } = props;
   const label = uiSchema['ui:title'] || props.label;
-  const hasTextDescription = typeof uiSchema['ui:description'] === 'string';
-  const DescriptionField = !hasTextDescription && typeof uiSchema['ui:description'] === 'function'
+  const description = uiSchema['ui:description'];
+  const textDescription = typeof description === 'string' ? description : null;
+  const DescriptionField = typeof description === 'function'
     ? uiSchema['ui:description']
     : null;
 
@@ -17,8 +18,9 @@ export default function ReviewFieldTemplate(props) {
     : <div className="review-row">
       <dt>
         {label}
-        {hasTextDescription && <p>{uiSchema['ui:description']}</p>}
+        {textDescription && <p>{textDescription}</p>}
         {DescriptionField && <DescriptionField options={uiSchema['ui:options']}/>}
+        {!textDescription && !DescriptionField && description}
       </dt>
       <dd>{children}</dd>
     </div>;

--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -20,6 +20,8 @@ import * as dateRange from '../../../common/schemaform/definitions/dateRange';
 import * as phone from '../../../common/schemaform/definitions/phone';
 import * as address from '../../../common/schemaform/definitions/address';
 
+import * as serviceBefore1977 from '../../definitions/serviceBefore1977';
+
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import ServicePeriodView from '../components/ServicePeriodView';
@@ -39,7 +41,6 @@ const {
 const {
   educationType,
   preferredContactMethod,
-  serviceBefore1977,
   school
 } = fullSchema1995.definitions;
 
@@ -331,25 +332,12 @@ const formConfig = {
             }
           },
           uiSchema: {
-            serviceBefore1977: {
-              married: {
-                'ui:title': 'Are you currently married?',
-                'ui:widget': 'yesNo'
-              },
-              haveDependents: {
-                'ui:title': 'Do you have any children who are under age 18? Or do you have any children who are over age 18 but under 23, not married, and attending school? Or do you have any children of any age who are permanently disabled for mental or physical reasons?',
-                'ui:widget': 'yesNo'
-              },
-              parentDependent: {
-                'ui:title': 'Do you have a parent who is dependent on your financial support?',
-                'ui:widget': 'yesNo'
-              }
-            }
+            serviceBefore1977: serviceBefore1977.uiSchema
           },
           schema: {
             type: 'object',
             properties: {
-              serviceBefore1977
+              serviceBefore1977: serviceBefore1977.schema
             }
           }
         },

--- a/src/js/edu-benefits/definitions/serviceBefore1977.jsx
+++ b/src/js/edu-benefits/definitions/serviceBefore1977.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import commonDefinitions from 'vets-json-schema/dist/definitions.json';
+
+export const schema = commonDefinitions.serviceBefore1977;
+
+export const uiSchema = {
+  married: {
+    'ui:title': 'Are you currently married?',
+    'ui:widget': 'yesNo'
+  },
+  haveDependents: {
+    'ui:title': 'Do you have any children who fall into these categories?',
+    'ui:description': () => (
+      <ul className="edu-benefits-dependents-desc">
+        <li>Under age 18</li>
+        <li>Between the ages of 18 and 22, not married, and attending school</li>
+        <li>Any age who are permanently disabled for mental or physical reasons</li>
+      </ul>
+    ),
+    'ui:widget': 'yesNo'
+  },
+  parentDependent: {
+    'ui:title': 'Do you have a parent who is dependent on your financial support?',
+    'ui:widget': 'yesNo'
+  }
+};

--- a/src/js/edu-benefits/definitions/serviceBefore1977.jsx
+++ b/src/js/edu-benefits/definitions/serviceBefore1977.jsx
@@ -10,7 +10,7 @@ export const uiSchema = {
   },
   haveDependents: {
     'ui:title': 'Do you have any children who fall into these categories?',
-    'ui:description': () => (
+    'ui:description': (
       <ul className="edu-benefits-dependents-desc">
         <li>Under age 18</li>
         <li>Between the ages of 18 and 22, not married, and attending school</li>

--- a/src/sass/edu-benefits.scss
+++ b/src/sass/edu-benefits.scss
@@ -318,3 +318,7 @@ form.rjsf {
 .intro-content {
   margin-left: -2rem;
 }
+
+.edu-benefits-dependents-desc {
+  margin-top: 5px;
+}

--- a/test/common/schemaform/FieldTemplate.unit.spec.jsx
+++ b/test/common/schemaform/FieldTemplate.unit.spec.jsx
@@ -121,4 +121,50 @@ describe('Schemaform <FieldTemplate>', () => {
     expect(tree.subTree('.usa-input-error-message').text()).to.equal('Some error');
     expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
   });
+  it('should render description', () => {
+    const schema = {
+      type: 'string'
+    };
+    const uiSchema = {
+      'ui:title': 'Title',
+      'ui:description': 'Blah'
+    };
+    const formContext = {};
+    const errors = ['Some error'];
+    const tree = SkinDeep.shallowRender(
+      <FieldTemplate
+          id="test"
+          schema={schema}
+          uiSchema={uiSchema}
+          rawErrors={errors}
+          formContext={formContext}>
+        <div className="field-child"/>
+      </FieldTemplate>
+    );
+
+    expect(tree.subTree('p').text()).to.equal('Blah');
+  });
+  it('should render description component', () => {
+    const schema = {
+      type: 'string'
+    };
+    const uiSchema = {
+      'ui:title': 'Title',
+      'ui:description': () => <someTag>Blah</someTag>
+    };
+    const formContext = {};
+    const errors = ['Some error'];
+    const tree = SkinDeep.shallowRender(
+      <FieldTemplate
+          id="test"
+          schema={schema}
+          uiSchema={uiSchema}
+          rawErrors={errors}
+          formContext={formContext}>
+        <div className="field-child"/>
+      </FieldTemplate>
+    );
+
+    expect(tree.text()).to.contain('uiDescription');
+  });
 });

--- a/test/common/schemaform/FieldTemplate.unit.spec.jsx
+++ b/test/common/schemaform/FieldTemplate.unit.spec.jsx
@@ -144,6 +144,29 @@ describe('Schemaform <FieldTemplate>', () => {
 
     expect(tree.subTree('p').text()).to.equal('Blah');
   });
+  it('should render element description', () => {
+    const schema = {
+      type: 'string'
+    };
+    const uiSchema = {
+      'ui:title': 'Title',
+      'ui:description': <div>Blah</div>
+    };
+    const formContext = {};
+    const errors = ['Some error'];
+    const tree = SkinDeep.shallowRender(
+      <FieldTemplate
+          id="test"
+          schema={schema}
+          uiSchema={uiSchema}
+          rawErrors={errors}
+          formContext={formContext}>
+        <div className="field-child"/>
+      </FieldTemplate>
+    );
+
+    expect(tree.text()).to.contain('Blah');
+  });
   it('should render description component', () => {
     const schema = {
       type: 'string'

--- a/test/common/schemaform/ObjectField.unit.spec.jsx
+++ b/test/common/schemaform/ObjectField.unit.spec.jsx
@@ -52,6 +52,56 @@ describe('Schemaform: ObjectField', () => {
 
     expect(tree.text()).to.contain('Blah');
   });
+  it('should render jsx description', () => {
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+    const schema = {
+      properties: {
+        test: {
+          type: 'string'
+        }
+      }
+    };
+    const uiSchema = {
+      'ui:description': <div className="test-class"/>
+    };
+    const tree = SkinDeep.shallowRender(
+      <ObjectField
+          uiSchema={uiSchema}
+          schema={schema}
+          idSchema={{}}
+          formData={{}}
+          onChange={onChange}
+          onBlur={onBlur}/>
+    );
+
+    expect(tree.everySubTree('.test-class')).not.to.be.empty;
+  });
+  it('should render component description', () => {
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+    const schema = {
+      properties: {
+        test: {
+          type: 'string'
+        }
+      }
+    };
+    const uiSchema = {
+      'ui:description': () => <div className="test-class"/>
+    };
+    const tree = SkinDeep.shallowRender(
+      <ObjectField
+          uiSchema={uiSchema}
+          schema={schema}
+          idSchema={{}}
+          formData={{}}
+          onChange={onChange}
+          onBlur={onBlur}/>
+    );
+
+    expect(tree.text()).to.contain('uiDescription');
+  });
   it('should render title', () => {
     const onChange = sinon.spy();
     const onBlur = sinon.spy();

--- a/test/common/schemaform/review/ReviewFieldTemplate.unit.spec.jsx
+++ b/test/common/schemaform/review/ReviewFieldTemplate.unit.spec.jsx
@@ -16,6 +16,34 @@ describe('Schemaform ReviewFieldTemplate', () => {
     expect(tree.subTree('dt').text()).to.equal('Label');
     expect(tree.everySubTree('dd')).to.not.be.empty;
   });
+  it('should render description', () => {
+    const uiSchema = {
+      'ui:title': 'Label',
+      'ui:description': 'Blah'
+    };
+    const tree = SkinDeep.shallowRender(
+      <ReviewFieldTemplate
+          schema={{ type: 'string' }}
+          uiSchema={uiSchema}/>
+    );
+
+    expect(tree.subTree('dt').text()).to.contain('Label');
+    expect(tree.subTree('p').text()).to.equal('Blah');
+  });
+  it('should render description component', () => {
+    const uiSchema = {
+      'ui:title': 'Label',
+      'ui:description': () => <span>Blah</span>
+    };
+    const tree = SkinDeep.shallowRender(
+      <ReviewFieldTemplate
+          schema={{ type: 'string' }}
+          uiSchema={uiSchema}/>
+    );
+
+    expect(tree.subTree('dt').text()).to.contain('Label');
+    expect(tree.subTree('dt').text()).to.contain('uiDescription');
+  });
   it('should render just children for object type', () => {
     const tree = SkinDeep.shallowRender(
       <ReviewFieldTemplate

--- a/test/common/schemaform/review/ReviewFieldTemplate.unit.spec.jsx
+++ b/test/common/schemaform/review/ReviewFieldTemplate.unit.spec.jsx
@@ -30,6 +30,20 @@ describe('Schemaform ReviewFieldTemplate', () => {
     expect(tree.subTree('dt').text()).to.contain('Label');
     expect(tree.subTree('p').text()).to.equal('Blah');
   });
+  it('should render element description', () => {
+    const uiSchema = {
+      'ui:title': 'Label',
+      'ui:description': <div>Blah</div>
+    };
+    const tree = SkinDeep.shallowRender(
+      <ReviewFieldTemplate
+          schema={{ type: 'string' }}
+          uiSchema={uiSchema}/>
+    );
+
+    expect(tree.subTree('dt').text()).to.contain('Label');
+    expect(tree.text()).to.contain('Blah');
+  });
   it('should render description component', () => {
     const uiSchema = {
       'ui:title': 'Label',


### PR DESCRIPTION
Related to [1091](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1091)

![screen shot 2017-02-10 at 11 59 17 am](https://cloud.githubusercontent.com/assets/634932/22836178/56608ddc-ef89-11e6-8bcd-2e94eb767c32.png)
![screen shot 2017-02-10 at 10 36 27 am](https://cloud.githubusercontent.com/assets/634932/22836179/5660de90-ef89-11e6-8e03-0b5cb4004316.png)

I moved these questions into a common definition in the edu-benefits folder because it's common to edu forms, though we only use this code on 1995 right now.

Most of the code changes are to show a description in the FieldTemplate. We had this code for object fields in ObjectField, but not on regular string/boolean fields.