### PR TITLE
Make 1995 benefits selection "Learn more" links clickable

### DIFF
--- a/src/sass/modules/_m-form-elements.scss
+++ b/src/sass/modules/_m-form-elements.scss
@@ -1,6 +1,11 @@
 .form-radio-buttons {
   label {
     margin-top: 1em;
+
+    // Make links in radio button labels clickable
+    a {
+      position: relative;
+    }
   }
 }
 
@@ -146,7 +151,7 @@ button.form-button-disabled {
   padding-left: 2rem;
 }
 
-.form-expanding-group-open { 
+.form-expanding-group-open {
   padding-left: calc(2rem - 7px);
   border-left: 7px solid $color-primary-alt-light;
 }
@@ -157,7 +162,7 @@ button.form-button-disabled {
     content: "+";
     font-size: 20px;
     position: absolute;
-    right: 0; 
+    right: 0;
     top: 0;
   }
 }


### PR DESCRIPTION
References department-of-veterans-affairs/vets.gov-team#1127

If I'm honest, I'm not sure why exactly this works, but I was experimenting with z-index and found I didn't need it when `position: relative`.