### PR TITLE
Exit with failure if node version incompatible

### DIFF
--- a/script/build.js
+++ b/script/build.js
@@ -46,7 +46,7 @@ if (semver.compare(process.env.npm_package_engines_npm, minimumNpmVersion) === -
   process.stdout.write(
     `NPM version (mininum): ${minimumNpmVersion}\n`);
   process.stdout.write(`NPM version (installed): ${process.env.npm_package_engines_npm}\n`);
-  process.exit();
+  process.exit(1);
 }
 
 if (semver.compare(process.version, minimumNodeVersion) === -1) {

--- a/script/build.js
+++ b/script/build.js
@@ -52,7 +52,7 @@ if (semver.compare(process.env.npm_package_engines_npm, minimumNpmVersion) === -
 if (semver.compare(process.version, minimumNodeVersion) === -1) {
   process.stdout.write(`Node.js version (mininum): v${minimumNodeVersion}\n`);
   process.stdout.write(`Node.js version (installed): ${process.version}\n`);
-  process.exit();
+  process.exit(1);
 }
 
 const smith = Metalsmith(__dirname); // eslint-disable-line new-cap


### PR DESCRIPTION
Resolves issues with CI and review instance deployments which ran an older version of node (4.4.4). These would not exit with a failure, which resulted in builds not containing any output. This would result in issues in with subsequent processes that required the output to exist.