### PR TITLE
Fix premature date validations by switching from DateInput to Errorable* components

### DIFF
--- a/src/js/edu-benefits/1990/components/military-history/MilitaryServiceTour.jsx
+++ b/src/js/edu-benefits/1990/components/military-history/MilitaryServiceTour.jsx
@@ -38,7 +38,7 @@ export default class MilitaryServiceTour extends React.Component {
           <ErrorableDate
               validation={{
                 valid: isValidDateRange(tour.dateRange.from, tour.dateRange.to),
-                message: 'End of service must be after start of service'
+                message: "End of service must be after start of service"
               }}
               label="End of service period:"
               name="toDate"

--- a/src/js/edu-benefits/1990/components/military-history/MilitaryServiceTour.jsx
+++ b/src/js/edu-benefits/1990/components/military-history/MilitaryServiceTour.jsx
@@ -38,7 +38,7 @@ export default class MilitaryServiceTour extends React.Component {
           <ErrorableDate
               validation={{
                 valid: isValidDateRange(tour.dateRange.from, tour.dateRange.to),
-                message: "End of service must be after start of service"
+                message: 'End of service must be after start of service'
               }}
               label="End of service period:"
               name="toDate"

--- a/src/js/hca/components/household-information/Child.jsx
+++ b/src/js/hca/components/household-information/Child.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import ErrorableDate from '../../../common/components/form-elements/ErrorableDate';
 import ErrorableCurrentOrPastDate from '../../../common/components/form-elements/ErrorableCurrentOrPastDate';
 import ErrorableSelect from '../../../common/components/form-elements/ErrorableSelect';
 import ErrorableTextInput from '../../../common/components/form-elements/ErrorableTextInput';
@@ -85,7 +84,7 @@ class Child extends React.Component {
 
           <div className="row">
             <div className="small-12 columns">
-              <ErrorableDate required
+              <ErrorableCurrentOrPastDate required
                   validation={{
                     valid: isValidDependentDateField(this.props.data.childBecameDependent, this.props.data.childDateOfBirth),
                     message: 'Child cannot be a dependent before child\'s date of birth'

--- a/src/js/hca/components/household-information/Child.jsx
+++ b/src/js/hca/components/household-information/Child.jsx
@@ -87,7 +87,7 @@ class Child extends React.Component {
               <ErrorableCurrentOrPastDate required
                   validation={{
                     valid: isValidDependentDateField(this.props.data.childBecameDependent, this.props.data.childDateOfBirth),
-                    message: 'Child cannot be a dependent before child\'s date of birth'
+                    message: 'This date must come after the child\'s birth date'
                   }}
                   label="Date child became dependent"
                   name="childBecameDependent"

--- a/src/js/hca/components/household-information/Child.jsx
+++ b/src/js/hca/components/household-information/Child.jsx
@@ -86,10 +86,10 @@ class Child extends React.Component {
           <div className="row">
             <div className="small-12 columns">
               <ErrorableDate required
-	          validation={{
-		    valid: isValidDependentDateField(this.props.data.childBecameDependent, this.props.data.childDateOfBirth),
-		    message: "Child cannot be a dependent before child's date of birth"
-		  }}
+                  validation={{
+                    valid: isValidDependentDateField(this.props.data.childBecameDependent, this.props.data.childDateOfBirth),
+                    message: 'Child cannot be a dependent before child\'s date of birth'
+                  }}
                   label="Date child became dependent"
                   name="childBecameDependent"
                   date={this.props.data.childBecameDependent}

--- a/src/js/hca/components/household-information/Child.jsx
+++ b/src/js/hca/components/household-information/Child.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
+import ErrorableDate from '../../../common/components/form-elements/ErrorableDate';
+import ErrorableCurrentOrPastDate from '../../../common/components/form-elements/ErrorableCurrentOrPastDate';
 import ErrorableSelect from '../../../common/components/form-elements/ErrorableSelect';
 import ErrorableTextInput from '../../../common/components/form-elements/ErrorableTextInput';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
-import DateInput from '../../../common/components/form-elements/DateInput';
 import FullName from '../../../common/components/questions/FullName';
 import SocialSecurityNumber from '../../../common/components/questions/SocialSecurityNumber';
 
@@ -74,26 +75,24 @@ class Child extends React.Component {
 
           <div className="row">
             <div className="small-12 columns">
-              <DateInput required
+              <ErrorableCurrentOrPastDate required
                   label="Child’s date of birth"
                   name="childBirth"
-                  day={this.props.data.childDateOfBirth.day}
-                  month={this.props.data.childDateOfBirth.month}
-                  year={this.props.data.childDateOfBirth.year}
+                  date={this.props.data.childDateOfBirth}
                   onValueChange={(update) => {this.props.onValueChange('childDateOfBirth', update);}}/>
             </div>
           </div>
 
           <div className="row">
             <div className="small-12 columns">
-              <DateInput required
-                  errorMessage="Child cannot be a dependent before child's date of birth"
-                  validation={isValidDependentDateField(this.props.data.childBecameDependent, this.props.data.childDateOfBirth)}
+              <ErrorableDate required
+	          validation={{
+		    valid: isValidDependentDateField(this.props.data.childBecameDependent, this.props.data.childDateOfBirth),
+		    message: "Child cannot be a dependent before child's date of birth"
+		  }}
                   label="Date child became dependent"
                   name="childBecameDependent"
-                  day={this.props.data.childBecameDependent.day}
-                  month={this.props.data.childBecameDependent.month}
-                  year={this.props.data.childBecameDependent.year}
+                  date={this.props.data.childBecameDependent}
                   onValueChange={(update) => {this.props.onValueChange('childBecameDependent', update);}}/>
             </div>
           </div>

--- a/src/js/hca/components/household-information/SpouseInformationSection.jsx
+++ b/src/js/hca/components/household-information/SpouseInformationSection.jsx
@@ -103,7 +103,7 @@ class SpouseInformationSection extends React.Component {
               validation={{
                 valid: isValidMarriageDate(this.props.data.dateOfMarriage, this.props.data.veteranDateOfBirth, this.props.data.spouseDateOfBirth),
                 message: "Date of marriage cannot be before the Veteran's or the spouse's date of birth"
-              }}	      
+              }}
               label="Date of marriage"
               name="marriage"
               date={this.props.data.dateOfMarriage}

--- a/src/js/hca/components/household-information/SpouseInformationSection.jsx
+++ b/src/js/hca/components/household-information/SpouseInformationSection.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import Address from '../Address';
-import ErrorableDate from '../../../common/components/form-elements/ErrorableDate';
 import ErrorableCurrentOrPastDate from '../../../common/components/form-elements/ErrorableCurrentOrPastDate';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
 import FullName from '../../../common/components/questions/FullName';
@@ -99,7 +98,7 @@ class SpouseInformationSection extends React.Component {
               date={this.props.data.spouseDateOfBirth}
               onValueChange={(update) => {this.props.onStateChange('spouseDateOfBirth', update);}}/>
 
-          <ErrorableDate required
+          <ErrorableCurrentOrPastDate required
               validation={{
                 valid: isValidMarriageDate(this.props.data.dateOfMarriage, this.props.data.veteranDateOfBirth, this.props.data.spouseDateOfBirth),
                 message: "Date of marriage cannot be before the Veteran's or the spouse's date of birth"

--- a/src/js/hca/components/household-information/SpouseInformationSection.jsx
+++ b/src/js/hca/components/household-information/SpouseInformationSection.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import Address from '../Address';
-import DateInput from '../../../common/components/form-elements/DateInput';
+import ErrorableDate from '../../../common/components/form-elements/ErrorableDate';
+import ErrorableCurrentOrPastDate from '../../../common/components/form-elements/ErrorableCurrentOrPastDate';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
 import FullName from '../../../common/components/questions/FullName';
 import Phone from '../../../common/components/questions/Phone';
@@ -92,22 +93,20 @@ class SpouseInformationSection extends React.Component {
               ssn={this.props.data.spouseSocialSecurityNumber}
               onValueChange={(update) => {this.props.onStateChange('spouseSocialSecurityNumber', update);}}/>
 
-          <DateInput required
+          <ErrorableCurrentOrPastDate required
               label="Spouse’s date of birth"
               name="spouseBirth"
-              day={this.props.data.spouseDateOfBirth.day}
-              month={this.props.data.spouseDateOfBirth.month}
-              year={this.props.data.spouseDateOfBirth.year}
+              date={this.props.data.spouseDateOfBirth}
               onValueChange={(update) => {this.props.onStateChange('spouseDateOfBirth', update);}}/>
 
-          <DateInput required
-              errorMessage="Date of marriage cannot be before the Veteran's or the spouse's date of birth"
-              validation={isValidMarriageDate(this.props.data.dateOfMarriage, this.props.data.veteranDateOfBirth, this.props.data.spouseDateOfBirth)}
+          <ErrorableDate required
+              validation={{
+                valid: isValidMarriageDate(this.props.data.dateOfMarriage, this.props.data.veteranDateOfBirth, this.props.data.spouseDateOfBirth),
+                message: "Date of marriage cannot be before the Veteran's or the spouse's date of birth"
+              }}	      
               label="Date of marriage"
               name="marriage"
-              day={this.props.data.dateOfMarriage.day}
-              month={this.props.data.dateOfMarriage.month}
-              year={this.props.data.dateOfMarriage.year}
+              date={this.props.data.dateOfMarriage}
               onValueChange={(update) => {this.props.onStateChange('dateOfMarriage', update);}}/>
 
           <ErrorableRadioButtons required

--- a/src/js/hca/components/insurance-information/MedicareMedicaidSection.jsx
+++ b/src/js/hca/components/insurance-information/MedicareMedicaidSection.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import DateInput from '../../../common/components/form-elements/DateInput';
+import ErrorableCurrentOrPastDate from '../../../common/components/form-elements/ErrorableCurrentOrPastDate';
 import ErrorableRadioButtons from '../../../common/components/form-elements/ErrorableRadioButtons';
 import { yesNo } from '../../../common/utils/options-for-select';
 import { validateIfDirty, isNotBlank } from '../../../common/utils/validations';
@@ -30,13 +30,10 @@ class MedicareMedicaidSection extends React.Component {
       dateRequired = true;
 
       medicarePartADateInput = (
-        <DateInput required={dateRequired}
-            errorMessage="Please enter a vaild date."
+        <ErrorableCurrentOrPastDate required={dateRequired}
             label="If so, what is your Medicare Part A effective date?"
             name="medicarePartAEffective"
-            day={this.props.data.medicarePartAEffectiveDate.day}
-            month={this.props.data.medicarePartAEffectiveDate.month}
-            year={this.props.data.medicarePartAEffectiveDate.year}
+            date={this.props.data.medicarePartAEffectiveDate}
             onValueChange={(update) => {this.props.onStateChange('medicarePartAEffectiveDate', update);}}/>);
     }
 

--- a/src/js/hca/components/insurance-information/MedicareMedicaidSection.jsx
+++ b/src/js/hca/components/insurance-information/MedicareMedicaidSection.jsx
@@ -17,7 +17,6 @@ class MedicareMedicaidSection extends React.Component {
     let content;
     let medicarePartADateInput;
     let medicarePartADateReview;
-    let dateRequired;
 
     if (this.props.data.isEnrolledMedicarePartA.value === 'Y') {
       medicarePartADateReview = (<tr>
@@ -27,10 +26,8 @@ class MedicareMedicaidSection extends React.Component {
         {this.props.data.medicarePartAEffectiveDate.year.value}</td>
       </tr>);
 
-      dateRequired = true;
-
       medicarePartADateInput = (
-        <ErrorableCurrentOrPastDate required={dateRequired}
+        <ErrorableCurrentOrPastDate required
             label="If so, what is your Medicare Part A effective date?"
             name="medicarePartAEffective"
             date={this.props.data.medicarePartAEffectiveDate}

--- a/src/js/hca/components/military-service/ServiceInformationSection.jsx
+++ b/src/js/hca/components/military-service/ServiceInformationSection.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import ErrorableDate from '../../../common/components/form-elements/ErrorableDate';
+import ErrorableCurrentOrPastDate from '../../../common/components/form-elements/ErrorableCurrentOrPastDate';
 import ErrorableSelect from '../../../common/components/form-elements/ErrorableSelect';
 import { branchesServed, dischargeTypes } from '../../../common/utils/options-for-select.js';
 import { validateIfDirty, isNotBlank } from '../../../common/utils/validations';
@@ -58,7 +58,7 @@ class ServiceInformationSection extends React.Component {
               value={this.props.data.lastServiceBranch}
               onValueChange={(update) => {this.props.onStateChange('lastServiceBranch', update);}}/>
 
-          <ErrorableDate required
+          <ErrorableCurrentOrPastDate required
               validation={{
                 valid: isValidEntryDateField(this.props.data.lastEntryDate, this.props.data.veteranDateOfBirth),
                 message: 'You must have been at least 15 years old when you entered the service'
@@ -68,10 +68,10 @@ class ServiceInformationSection extends React.Component {
               date={this.props.data.lastEntryDate}
               onValueChange={(update) => {this.props.onStateChange('lastEntryDate', update);}}/>
 
-          <ErrorableDate required
+          <ErrorableCurrentOrPastDate required
               validation={{
                 valid: isValidDischargeDateField(this.props.data.lastDischargeDate, this.props.data.lastEntryDate),
-                message: 'Discharge date must be after entry date and before today'
+                message: 'Discharge date must be after start of service period date and before today'
               }}
               label="Date of discharge"
               name="lastDischarge"

--- a/src/js/hca/components/military-service/ServiceInformationSection.jsx
+++ b/src/js/hca/components/military-service/ServiceInformationSection.jsx
@@ -61,21 +61,21 @@ class ServiceInformationSection extends React.Component {
           <ErrorableDate required
               validation={{
                 valid: isValidEntryDateField(this.props.data.lastEntryDate, this.props.data.veteranDateOfBirth),
-                message: "You must have been at least 15 years old when you entered the service"
-              }}		     
+                message: 'You must have been at least 15 years old when you entered the service'
+              }}
               label="Start of service period"
               name="lastEntry"
-              date={this.props.data.lastEntryDate}	 
+              date={this.props.data.lastEntryDate}
               onValueChange={(update) => {this.props.onStateChange('lastEntryDate', update);}}/>
 
           <ErrorableDate required
               validation={{
                 valid: isValidDischargeDateField(this.props.data.lastDischargeDate, this.props.data.lastEntryDate),
-                message: "Discharge date must be after entry date and before today"
-	      }}
+                message: 'Discharge date must be after entry date and before today'
+              }}
               label="Date of discharge"
               name="lastDischarge"
-              date={this.props.data.lastDischargeDate} 
+              date={this.props.data.lastDischargeDate}
               onValueChange={(update) => {this.props.onStateChange('lastDischargeDate', update);}}/>
 
           <ErrorableSelect required

--- a/src/js/hca/components/military-service/ServiceInformationSection.jsx
+++ b/src/js/hca/components/military-service/ServiceInformationSection.jsx
@@ -61,7 +61,7 @@ class ServiceInformationSection extends React.Component {
           <ErrorableDate required
               validation={{
                 valid: isValidEntryDateField(this.props.data.lastEntryDate, this.props.data.veteranDateOfBirth),
-                message: 'You must have been at least 15 years old when you entered the service'
+                message: "You must have been at least 15 years old when you entered the service"
               }}		     
               label="Start of service period"
               name="lastEntry"
@@ -71,7 +71,7 @@ class ServiceInformationSection extends React.Component {
           <ErrorableDate required
               validation={{
                 valid: isValidDischargeDateField(this.props.data.lastDischargeDate, this.props.data.lastEntryDate),
-                message: 'Discharge date must be after entry date and before today'
+                message: "Discharge date must be after entry date and before today"
 	      }}
               label="Date of discharge"
               name="lastDischarge"

--- a/src/js/hca/components/military-service/ServiceInformationSection.jsx
+++ b/src/js/hca/components/military-service/ServiceInformationSection.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import DateInput from '../../../common/components/form-elements/DateInput';
+import ErrorableDate from '../../../common/components/form-elements/ErrorableDate';
 import ErrorableSelect from '../../../common/components/form-elements/ErrorableSelect';
 import { branchesServed, dischargeTypes } from '../../../common/utils/options-for-select.js';
 import { validateIfDirty, isNotBlank } from '../../../common/utils/validations';
@@ -58,29 +58,29 @@ class ServiceInformationSection extends React.Component {
               value={this.props.data.lastServiceBranch}
               onValueChange={(update) => {this.props.onStateChange('lastServiceBranch', update);}}/>
 
-          <DateInput required
-              errorMessage="Entry date must be greater than 15 years of age"
-              validation={isValidEntryDateField(this.props.data.lastEntryDate, this.props.data.veteranDateOfBirth)}
-              label="Last entry date"
+          <ErrorableDate required
+              validation={{
+                valid: isValidEntryDateField(this.props.data.lastEntryDate, this.props.data.veteranDateOfBirth),
+                message: 'You must have been at least 15 years old when you entered the service'
+              }}		     
+              label="Start of service period"
               name="lastEntry"
-              day={this.props.data.lastEntryDate.day}
-              month={this.props.data.lastEntryDate.month}
-              year={this.props.data.lastEntryDate.year}
+              date={this.props.data.lastEntryDate}	 
               onValueChange={(update) => {this.props.onStateChange('lastEntryDate', update);}}/>
 
-          <DateInput required
-              errorMessage="Discharge date must be after entry date and before today"
-              validation={isValidDischargeDateField(this.props.data.lastDischargeDate, this.props.data.lastEntryDate)}
-              label="Last discharge date"
+          <ErrorableDate required
+              validation={{
+                valid: isValidDischargeDateField(this.props.data.lastDischargeDate, this.props.data.lastEntryDate),
+                message: 'Discharge date must be after entry date and before today'
+	      }}
+              label="Date of discharge"
               name="lastDischarge"
-              day={this.props.data.lastDischargeDate.day}
-              month={this.props.data.lastDischargeDate.month}
-              year={this.props.data.lastDischargeDate.year}
+              date={this.props.data.lastDischargeDate} 
               onValueChange={(update) => {this.props.onStateChange('lastDischargeDate', update);}}/>
 
           <ErrorableSelect required
               errorMessage={validateIfDirty(this.props.data.dischargeType, isNotBlank) ? undefined : 'Please select a discharge type'}
-              label="Discharge Type"
+              label="Character of discharge"
               name="dischargeType"
               options={dischargeTypes}
               value={this.props.data.dischargeType}

--- a/src/js/hca/components/veteran-information/BirthInformationSection.jsx
+++ b/src/js/hca/components/veteran-information/BirthInformationSection.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import DateInput from '../../../common/components/form-elements/DateInput';
+import ErrorableCurrentOrPastDate from '../../../common/components/form-elements/ErrorableCurrentOrPastDate';
 import ErrorableSelect from '../../../common/components/form-elements/ErrorableSelect';
 import ErrorableTextInput from '../../../common/components/form-elements/ErrorableTextInput';
 import SocialSecurityNumber from '../../../common/components/questions/SocialSecurityNumber';
@@ -39,11 +39,9 @@ class BirthInformationSection extends React.Component {
         <legend>Birth Information</legend>
         <p>(<span className="hca-required-span">*</span>) Indicates a required field</p>
         <div className="input-section">
-          <DateInput required
+          <ErrorableCurrentOrPastDate required
               name="veteranBirth"
-              day={this.props.data.veteranDateOfBirth.day}
-              month={this.props.data.veteranDateOfBirth.month}
-              year={this.props.data.veteranDateOfBirth.year}
+              date={this.props.data.veteranDateOfBirth}
               onValueChange={(update) => {this.props.onStateChange('veteranDateOfBirth', update);}}/>
           <SocialSecurityNumber required
               ssn={this.props.data.veteranSocialSecurityNumber}


### PR DESCRIPTION
- Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1211 (premature date validation problem)
- Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1212 (language changes; some still to be confirmed, pending @mollyblake's feedback)

![image](https://cloud.githubusercontent.com/assets/25439097/22961859/0852a1ca-f2fe-11e6-9247-778b322201ac.png)

![image](https://cloud.githubusercontent.com/assets/25439097/22961883/30be90b0-f2fe-11e6-8973-4438abac411f.png)

![image](https://cloud.githubusercontent.com/assets/25439097/22961916/5f8c7844-f2fe-11e6-8177-94c205f83227.png)


