### PR TITLE
Add chunkfilename so names match

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -46,7 +46,8 @@ const configGenerator = (options) => {
     output: {
       path: path.join(__dirname, `../build/${options.buildtype}/generated`),
       publicPath: '/generated/',
-      filename: (options.buildtype === 'development') ? '[name].entry.js' : '[name].entry.[chunkhash].js'
+      filename: (options.buildtype === 'development') ? '[name].entry.js' : '[name].entry.[chunkhash].js',
+      chunkFilename: (options.buildtype === 'development') ? '[name].entry.js' : '[name].entry.[chunkhash].js'
     },
     module: {
       loaders: [


### PR DESCRIPTION
Webpack is creating a 1995 bundle using a different filename from what's in the chunk-manifest.json file. Adding a `chunkFilename` that matches our normal `filename` parameter makes these match up.

To test this run:

```
`NODE_ENV=production npm run build -- --buildtype staging`
cd build/staging
php -S localhost:3333
```

Open http://localhost:3333/education/apply-for-education-benefits/application/1995/introduction