### PR TITLE
Fix date UI on 1995 old school information page

### DIFF
--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -251,7 +251,7 @@ const formConfig = {
               },
               address: address.uiSchema()
             },
-            trainingEndDate: _.merge(date.uiSchema, { 'ui:title': 'When did you stop taking classes or participating in the training program?' }),
+              trainingEndDate: date.uiSchema('When did you stop taking classes or participating in the training program?'),
             reasonForChange: {
               'ui:title': 'Why did you stop taking classes or participating in the training program? (for example, “I graduated” or “I moved” or “The program wasn’t right for me.”)'
             }

--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -251,7 +251,7 @@ const formConfig = {
               },
               address: address.uiSchema()
             },
-              trainingEndDate: date.uiSchema('When did you stop taking classes or participating in the training program?'),
+            trainingEndDate: date.uiSchema('When did you stop taking classes or participating in the training program?'),
             reasonForChange: {
               'ui:title': 'Why did you stop taking classes or participating in the training program? (for example, “I graduated” or “I moved” or “The program wasn’t right for me.”)'
             }


### PR DESCRIPTION
Connects to  https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1123

@jbalboni It looks like this uses the date validation function in `src/js/common/schemaform/validation.js` which uses some but not all of the date validation's in `src/js/common/utils/validations.js`  Seems like we should beef up the schemaform date validation to at least use `isValidCurrentOrPastYear()`, and probably something less coarse. Is that just work in progress as we flesh out the schemaform framework?

![image](https://cloud.githubusercontent.com/assets/25439097/22990486/3285215a-f36e-11e6-8e28-f4659ccff22f.png)

