### PR TITLE
Adding custom events to claims status

### DIFF
--- a/src/js/disability-benefits/actions/index.js
+++ b/src/js/disability-benefits/actions/index.js
@@ -158,6 +158,9 @@ export function submitFiles(claimId, trackedItem, files) {
   const totalSize = files.reduce((sum, file) => sum + file.file.size, 0);
   const totalFiles = files.length;
   const trackedItemId = trackedItem ? trackedItem.trackedItemId : null;
+  window.dataLayer.push({
+    event: 'claims-upload-start',
+  });
 
   return (dispatch) => {
     const uploader = new FineUploaderBasic({
@@ -177,6 +180,9 @@ export function submitFiles(claimId, trackedItem, files) {
       callbacks: {
         onAllComplete: () => {
           if (!hasError) {
+            window.dataLayer.push({
+              event: 'claims-upload-success',
+            });
             dispatch({
               type: DONE_UPLOADING,
             });
@@ -185,6 +191,9 @@ export function submitFiles(claimId, trackedItem, files) {
               body: `Thank you for filing ${trackedItem ? trackedItem.displayName : 'additional evidence'}. We'll let you know when we've reviewed it.`
             }));
           } else {
+            window.dataLayer.push({
+              event: 'claims-upload-failure',
+            });
             dispatch({
               type: SET_UPLOAD_ERROR
             });
@@ -263,6 +272,9 @@ export function showMailOrFaxModal(visible) {
 export function cancelUpload() {
   return (dispatch, getState) => {
     const uploader = getState().uploads.uploader;
+    window.dataLayer.push({
+      event: 'claims-upload-cancel',
+    });
 
     if (uploader) {
       uploader.cancelAll();

--- a/src/js/disability-benefits/components/AddFilesForm.jsx
+++ b/src/js/disability-benefits/components/AddFilesForm.jsx
@@ -79,6 +79,9 @@ class AddFilesForm extends React.Component {
         <div className="mail-or-fax-files">
           <p><a href onClick={(evt) => {
             evt.preventDefault();
+            window.dataLayer.push({
+              event: 'claims-mailfax-modal',
+            });
             this.props.onShowMailOrFax(true);
           }}>Need to mail or fax your files</a>?</p>
         </div>

--- a/src/js/disability-benefits/components/ClaimPhase.jsx
+++ b/src/js/disability-benefits/components/ClaimPhase.jsx
@@ -139,6 +139,9 @@ export default class ClaimPhase extends React.Component {
     event.stopPropagation();
   }
   expandCollapse() {
+    window.dataLayer.push({
+      event: 'claims-expandcollapse',
+    });
     if (this.props.phase <= this.props.current) {
       this.setState({ open: !this.state.open });
     }

--- a/src/js/disability-benefits/containers/YourClaimsPage.jsx
+++ b/src/js/disability-benefits/containers/YourClaimsPage.jsx
@@ -119,6 +119,9 @@ class YourClaimsPage extends React.Component {
             <p>
               <a href className="claims-combined" onClick={(evt) => {
                 evt.preventDefault();
+                window.dataLayer.push({
+                  event: 'claims-consolidated-modal',
+                });
                 this.props.showConsolidatedMessage(true);
               }}>Find out why we sometimes combine claims.</a>
             </p>


### PR DESCRIPTION
Added:

1.	Clicks on links that launch modals Events: claims-consolidated-modal, claims-mailfax-modal
2.	Expand / collapse status timeline Event: claims-expandcollapse
3.	How often is there a failure in uploading a file vs. how often is succeeds? Events: claims-upload-start, claims-upload-success, claims-upload-failure, claims-upload-cancel