### PR TITLE
Resize the checkbox

### DIFF
--- a/src/sass/modules/_m-form-elements.scss
+++ b/src/sass/modules/_m-form-elements.scss
@@ -75,9 +75,9 @@ button.form-button-disabled {
   // See 18F/web-design-standards#1490
   // This fixes things in the meantime.
   [type="checkbox"] {
-    height: auto !important;
+    height: 1.8rem !important;
     margin: 0;
-    width: auto !important;
+    width: 1.8rem !important;
   }
   > input[type="checkbox"] + label::before {
     display: block;


### PR DESCRIPTION
Connects to department-of-veterans-affairs/vets.gov-team#1206

Resizes the `input` size according to the label's `::before` size. It leaves a little space at the bottom, but I didn't want to finagle it too much to keep cross-browser testing down.

Chrome:

---
![image](https://cloud.githubusercontent.com/assets/12970166/23000628/3b5ee388-f396-11e6-95b1-b81a03788e95.png)

---
Firefox:

---
![image](https://cloud.githubusercontent.com/assets/12970166/23000644/4d8e5f34-f396-11e6-93bc-d58260202d36.png)
