### PR TITLE
Add schema tests for 1995

### DIFF
--- a/test/edu-benefits/1995/schema/maximal-test.json
+++ b/test/edu-benefits/1995/schema/maximal-test.json
@@ -1,0 +1,120 @@
+{
+  "privacyAgreementAccepted": true,
+  "veteranInformation": {
+    "data": {
+      "veteranFullName": {
+        "first": "asdf",
+        "middle": "t",
+        "last": "asdf",
+        "suffix": "Jr."
+      },
+      "veteranSocialSecurityNumber": "123333333",
+      "view:noSSN": true,
+      "vaFileNumber": "C12345678"
+    }
+  },
+  "benefitSelection": {
+    "data": {
+      "benefit": "chapter30"
+    }
+  },
+  "servicePeriods": {
+    "data": {
+      "toursOfDuty": [
+        {
+          "serviceBranch": "Army",
+          "dateRange": {
+            "from": "2010-01-01",
+            "to": "2010-01-02"
+          }
+        },
+        {
+          "serviceBranch": "Navy",
+          "dateRange": {
+            "from": "2009-01-01",
+            "to": "2010-01-01"
+          }
+        }
+      ]
+    }
+  },
+  "militaryHistory": {
+    "data": {
+      "view:hasServiceBefore1978": true
+    }
+  },
+  "newSchool": {
+    "data": {
+      "educationType": "college",
+      "newSchool": {
+        "name": "Testing",
+        "address": {
+          "country": "USA",
+          "street": "123 one st",
+          "street2": "Apt 3",
+          "city": "Big city",
+          "state": "MA",
+          "postalCode": "01010"
+        }
+      },
+      "educationObjective": "Get a degree",
+      "nonVaAssistance": true,
+      "civilianBenefitsAssistance": true
+    }
+  },
+  "oldSchool": {
+    "data": {
+      "oldSchool": {
+        "name": "Testing",
+        "address": {
+          "country": "USA",
+          "street": "123 one st",
+          "street2": "Apt 3",
+          "city": "Big city",
+          "state": "MA",
+          "postalCode": "01010"
+        }
+      },
+      "trainingEndDate": "2005-03-12",
+      "reasonForChange": "Bad school"
+    }
+  },
+  "contactInformation": {
+    "data": {
+      "preferredContactMethod": "phone",
+      "veteranAddress": {
+        "country": "USA",
+        "street": "123 one st",
+        "street2": "Apt 3",
+        "city": "Big city",
+        "state": "MA",
+        "postalCode": "01010"
+      },
+      "view:otherContactInfo": {
+        "email": "test@test.com",
+        "view:confirmEmail": "test@test.com",
+        "homePhone": "1233345454",
+        "mobilePhone": "3332213233"
+      }
+    }
+  },
+  "dependents": {
+    "data": {
+      "serviceBefore1977": {
+        "married": true,
+        "haveDependents": true,
+        "parentDependent": true
+      }
+    }
+  },
+  "directDeposit": {
+    "data": {
+      "bankAccountChange": "stop",
+      "bankAccount": {
+        "accountType": "checking",
+        "accountNumber": "1234344",
+        "routingNumber": "114923756"
+      }
+    }
+  }
+}

--- a/test/edu-benefits/1995/schema/minimal-test.json
+++ b/test/edu-benefits/1995/schema/minimal-test.json
@@ -1,0 +1,57 @@
+{
+  "privacyAgreementAccepted": true,
+  "veteranInformation": {
+    "data": {
+      "veteranFullName": {
+        "first": "asdf",
+        "last": "asdf"
+      },
+      "veteranSocialSecurityNumber": "123333333"
+    }
+  },
+  "benefitSelection": {
+    "data": {}
+  },
+  "servicePeriods": {
+    "data": {}
+  },
+  "militaryHistory": {
+    "data": {}
+  },
+  "newSchool": {
+    "data": {
+      "newSchool": {
+        "address": {
+          "country": "USA"
+        }
+      }
+    }
+  },
+  "oldSchool": {
+    "data": {
+      "oldSchool": {
+        "address": {
+          "country": "USA"
+        }
+      }
+    }
+  },
+  "contactInformation": {
+    "data": {
+      "veteranAddress": {
+        "country": "USA"
+      },
+      "view:otherContactInfo": {}
+    }
+  },
+  "dependents": {
+    "data": {
+      "serviceBefore1977": {}
+    }
+  },
+  "directDeposit": {
+    "data": {
+      "bankAccount": {}
+    }
+  }
+}

--- a/test/edu-benefits/1995/schema/schema.unit.spec.js
+++ b/test/edu-benefits/1995/schema/schema.unit.spec.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+import { Validator } from 'jsonschema';
+
+import { transform } from '../../../../src/js/edu-benefits/1995/helpers';
+import formConfig from '../../../../src/js/edu-benefits/1995/config/form';
+import fullSchema1995 from 'vets-json-schema/dist/change-of-program-schema.json';
+
+describe('1995 schema tests', () => {
+  const v = new Validator();
+  const files = fs.readdirSync(__dirname);
+  files
+    .filter(file => file.endsWith('json'))
+    .forEach((file) => {
+      it(`should validate ${file}`, () => {
+        const contents = JSON.parse(fs.readFileSync(path.join(__dirname, file), 'utf8'));
+        const submitData = JSON.parse(transform(formConfig, contents)).educationBenefitsClaim.form;
+        const result = v.validate(
+          JSON.parse(submitData),
+          fullSchema1995
+        );
+
+        if (!result.valid) {
+          console.log(result.errors); // eslint-disable-line
+        }
+        expect(result.valid).to.be.true;
+      });
+    });
+});


### PR DESCRIPTION
Closes [1098](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1098)

This adds a couple tests to run against the backend schema. This is not as extensive as what we did on 1990 for a few reasons: 

1. Since we're directly sharing most of the schema, there is less risk in us sending bad data to the backend. 
2. None of the schema mismatch errors we saw in production could have been caught by what we were doing before. 
3. Since we're not actually using the form to generate the test cases, it's not actually testing a whole lot. We would get much better mileage out of true e2e tests like we've talked about.

So instead I've done something simpler that we can add test cases for if we need to.