### PR TITLE
Add back functionality to ReviewPage

### DIFF
--- a/src/js/common/schemaform/review/ReviewPage.jsx
+++ b/src/js/common/schemaform/review/ReviewPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Scroll from 'react-scroll';
+import _ from 'lodash/fp';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
@@ -7,7 +8,7 @@ import ReviewCollapsibleChapter from './ReviewCollapsibleChapter';
 import SubmitButtons from './SubmitButtons';
 import PrivacyAgreement from '../../components/questions/PrivacyAgreement';
 import { isValidForm } from '../validation';
-import { focusElement } from '../../utils/helpers';
+import { focusElement, getActivePages } from '../../utils/helpers';
 import { createPageListByChapter } from '../helpers';
 import { setData, setPrivacyAgreement, setEditMode, setSubmission, submitForm } from '../actions';
 
@@ -25,6 +26,7 @@ class ReviewPage extends React.Component {
   constructor(props) {
     super(props);
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.goBack = this.goBack.bind(this);
     // this only needs to be run once
     this.pagesByChapter = createPageListByChapter(this.props.route.formConfig);
   }
@@ -40,6 +42,22 @@ class ReviewPage extends React.Component {
     if (nextStatus !== previousStatus && nextStatus === 'applicationSubmitted') {
       this.props.router.push(`${nextProps.route.formConfig.urlPrefix}confirmation`);
     }
+  }
+
+  /*
+   * Returns the page list without conditional pages that have not satisfied
+   * their dependencies and therefore should be skipped.
+   */
+  getEligiblePages() {
+    const { form, route: { pageList, path } } = this.props;
+    const eligiblePageList = getActivePages(pageList, form);
+    const pageIndex = _.findIndex(item => item.pageKey === path, eligiblePageList);
+    return { eligiblePageList, pageIndex };
+  }
+
+  goBack() {
+    const { eligiblePageList, pageIndex } = this.getEligiblePages();
+    this.props.router.push(eligiblePageList[pageIndex - 1].path);
   }
 
   handleSubmit() {
@@ -76,6 +94,7 @@ class ReviewPage extends React.Component {
             checked={form.privacyAgreementAccepted}
             showError={form.submission.hasAttemptedSubmit}/>
         <SubmitButtons
+            onBack={this.goBack}
             onSubmit={this.handleSubmit}
             submission={form.submission}/>
       </div>

--- a/test/common/schemaform/review/ReviewPage.unit.spec.jsx
+++ b/test/common/schemaform/review/ReviewPage.unit.spec.jsx
@@ -34,6 +34,74 @@ describe('Schemaform review: ReviewPage', () => {
 
     expect(tree.everySubTree('ReviewCollapsibleChapter').length).to.equal(2);
   });
+  it('should go back', () => {
+    const setData = sinon.spy();
+    const onSubmit = sinon.spy();
+    const router = {
+      push: sinon.spy()
+    };
+    const route = {
+      path: 'testPage',
+      pageList: [
+        {
+          path: 'previous-page'
+        },
+        {
+          path: 'testing',
+          pageKey: 'testPage'
+        },
+        {
+          path: 'next-page'
+        }
+      ],
+      formConfig: {
+        chapters: {
+          chapter1: {
+            pages: {
+              page1: {
+                schema: {}
+              }
+            }
+          },
+          chapter2: {
+            pages: {
+              page2: {
+              }
+            }
+          }
+        }
+      }
+    };
+    const form = {
+      submission: {
+        hasAttemptedSubmit: false
+      },
+      page1: {
+        schema: {},
+        data: {
+        }
+      },
+      page2: {
+        schema: {},
+        data: {
+        }
+      },
+      privacyAgreementAccepted: true
+    };
+
+    const tree = SkinDeep.shallowRender(
+      <ReviewPage
+          router={router}
+          setData={setData}
+          form={form}
+          onSubmit={onSubmit}
+          route={route}/>
+    );
+
+    tree.getMountedInstance().goBack();
+
+    expect(router.push.calledWith('previous-page'));
+  });
   it('should submit when valid', () => {
     const formConfig = {
       chapters: {


### PR DESCRIPTION
The back button wasn't working on the `ReviewPage` because the `goBack` functionality wasn't being passed to the `SubmitButtons` component. Copied the functionality from `FormPage`, with a slight tweak (comparing `item.pageKey === path` instead of `item.pageKey === pageConfig.pageKey` because `pageConfig` isn't available in `ReviewPage`).

Closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1164