### PR TITLE
Always hide noSSN on review

### DIFF
--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -76,7 +76,7 @@ const formConfig = {
             'view:noSSN': {
               'ui:title': 'I don’t have a Social Security number',
               'ui:options': {
-                hideOnReviewIfFalse: true
+                hideOnReview: true
               }
             },
             vaFileNumber: {


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1209

noSSN checked:

---
![image](https://cloud.githubusercontent.com/assets/12970166/23046191/0614d508-f45d-11e6-8dcd-d9d1ee9ee989.png)

---
noSSN not checked:

---
![image](https://cloud.githubusercontent.com/assets/12970166/23046206/207112c2-f45d-11e6-953b-035287a3c999.png)

---
The "I don’t have a Social Security number" question doesn't show up in either case now.