### PR TITLE
Add validation for current-or-past dates

### DIFF
--- a/src/js/common/schemaform/definitions/currentOrPastDate.js
+++ b/src/js/common/schemaform/definitions/currentOrPastDate.js
@@ -1,0 +1,17 @@
+import { validateCurrentOrPastDate } from '../validation';
+import commonDefinitions from 'vets-json-schema/dist/definitions.json';
+
+export const schema = commonDefinitions.date;
+
+export const uiSchema = (title = 'Date') => {
+  return {
+    'ui:title': title,
+    'ui:widget': 'date',
+    'ui:validations': [
+      validateCurrentOrPastDate
+    ],
+    'ui:errorMessages': {
+      pattern: 'Please provide a valid current or past date'
+    }
+  };
+};

--- a/src/js/common/schemaform/validation.js
+++ b/src/js/common/schemaform/validation.js
@@ -191,7 +191,7 @@ export function validateCurrentOrPastDate(errors, dateString) {
   validateDate(errors, dateString);
   const { day, month, year } = parseISODate(dateString);
   if (!isValidCurrentOrPastDate(day, month, year)) {
-    errors.addError('Please provide a valid date in the past');
+    errors.addError('Please provide a valid current or past date');
   }
 }
 

--- a/src/js/common/schemaform/validation.js
+++ b/src/js/common/schemaform/validation.js
@@ -3,7 +3,16 @@ import { Validator } from 'jsonschema';
 
 import { retrieveSchema } from 'react-jsonschema-form/lib/utils';
 
-import { isValidSSN, isValidPartialDate, isValidCurrentOrPastDate, isValidDateRange, isValidRoutingNumber, isValidUSZipCode, isValidCanPostalCode } from '../utils/validations';
+import {
+  isValidSSN,
+  isValidPartialDate,
+  isValidCurrentOrPastDate,
+  isValidDateRange,
+  isValidRoutingNumber,
+  isValidUSZipCode,
+  isValidCanPostalCode
+} from '../utils/validations';
+
 import { parseISODate } from './helpers';
 import { isActivePage } from '../utils/helpers';
 

--- a/src/js/common/schemaform/validation.js
+++ b/src/js/common/schemaform/validation.js
@@ -3,7 +3,7 @@ import { Validator } from 'jsonschema';
 
 import { retrieveSchema } from 'react-jsonschema-form/lib/utils';
 
-import { isValidSSN, isValidPartialDate, isValidDateRange, isValidRoutingNumber, isValidUSZipCode, isValidCanPostalCode } from '../utils/validations';
+import { isValidSSN, isValidPartialDate, isValidCurrentOrPastDate, isValidDateRange, isValidRoutingNumber, isValidUSZipCode, isValidCanPostalCode } from '../utils/validations';
 import { parseISODate } from './helpers';
 import { isActivePage } from '../utils/helpers';
 
@@ -184,6 +184,14 @@ export function validateDate(errors, dateString) {
   const { day, month, year } = parseISODate(dateString);
   if (!isValidPartialDate(day, month, year)) {
     errors.addError('Please provide a valid date');
+  }
+}
+
+export function validateCurrentOrPastDate(errors, dateString) {
+  validateDate(errors, dateString);
+  const { day, month, year } = parseISODate(dateString);
+  if (!isValidCurrentOrPastDate(day, month, year)) {
+    errors.addError('Please provide a valid date in the past');
   }
 }
 

--- a/src/js/common/utils/validations.js
+++ b/src/js/common/utils/validations.js
@@ -171,12 +171,11 @@ function isValidPartialMonthYearInPast(month, year) {
     throw new Error('Pass a month and a year to function');
   }
   const momentDate = moment({ year, month: month ? parseInt(month, 10) - 1 : null });
-
   return !year || isValidPartialMonthYear(month, year) && momentDate.isValid() && momentDate.isSameOrBefore(moment().startOf('month'));
 }
 
 function isValidCurrentOrPastDate(day, month, year) {
-  const momentDate = moment({ day: day, month: parseInt(month, 10) - 1, year: year });
+  const momentDate = moment({ day, month: parseInt(month, 10) - 1, year });
   return momentDate.isSameOrBefore(moment().endOf('day'), 'day');
 }
 

--- a/src/js/common/utils/validations.js
+++ b/src/js/common/utils/validations.js
@@ -175,6 +175,11 @@ function isValidPartialMonthYearInPast(month, year) {
   return !year || isValidPartialMonthYear(month, year) && momentDate.isValid() && momentDate.isSameOrBefore(moment().startOf('month'));
 }
 
+function isValidCurrentOrPastDate(day, month, year) {
+  const momentDate = moment({ day: day, month: parseInt(month, 10) - 1, year: year });
+  return momentDate.isSameOrBefore(moment().endOf('day'), 'day');
+}
+
 function isBlankMonthYear(field) {
   return isBlank(field.month.value) && isBlank(field.year.value);
 }
@@ -324,6 +329,7 @@ export {
   isValidAnyDate,
   isValidCanPostalCode,
   isValidCurrentOrPastYear,
+  isValidCurrentOrPastDate,
   isValidDate,
   isValidDateField,
   isValidDateOver17,

--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -2,6 +2,7 @@ import _ from 'lodash/fp';
 
 import fullSchema1995 from 'vets-json-schema/dist/change-of-program-schema.json';
 
+import { validateCurrentOrPastDate } from '../../../common/schemaform/validation';
 import { validateMatch } from '../../../common/schemaform/validation';
 import {
   benefitsLabels,
@@ -258,7 +259,9 @@ const formConfig = {
               },
               address: address.uiSchema()
             },
-            trainingEndDate: date.uiSchema('When did you stop taking classes or participating in the training program?'),
+            trainingEndDate: _.merge(date.uiSchema('When did you stop taking classes or participating in the training program?'), {
+              'ui:validations': [ validateCurrentOrPastDate ]
+            }),
             reasonForChange: {
               'ui:title': 'Why did you stop taking classes or participating in the training program? (for example, “I graduated” or “I moved” or “The program wasn’t right for me.”)'
             }

--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -2,7 +2,6 @@ import _ from 'lodash/fp';
 
 import fullSchema1995 from 'vets-json-schema/dist/change-of-program-schema.json';
 
-import { validateCurrentOrPastDate } from '../../../common/schemaform/validation';
 import { validateMatch } from '../../../common/schemaform/validation';
 import {
   benefitsLabels,
@@ -261,7 +260,7 @@ const formConfig = {
               address: address.uiSchema()
             },
             trainingEndDate: currentOrPastDate.uiSchema('When did you stop taking classes or participating in the training program?'),
-          reasonForChange: {
+            reasonForChange: {
               'ui:title': 'Why did you stop taking classes or participating in the training program? (for example, “I graduated” or “I moved” or “The program wasn’t right for me.”)'
             }
           },

--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -16,6 +16,7 @@ import * as fullName from '../../../common/schemaform/definitions/fullName';
 import * as ssn from '../../../common/schemaform/definitions/ssn';
 import * as date from '../../../common/schemaform/definitions/date';
 import * as dateRange from '../../../common/schemaform/definitions/dateRange';
+import * as currentOrPastDate from '../../../common/schemaform/definitions/currentOrPastDate';
 import * as phone from '../../../common/schemaform/definitions/phone';
 import * as address from '../../../common/schemaform/definitions/address';
 
@@ -259,10 +260,8 @@ const formConfig = {
               },
               address: address.uiSchema()
             },
-            trainingEndDate: _.merge(date.uiSchema('When did you stop taking classes or participating in the training program?'), {
-              'ui:validations': [ validateCurrentOrPastDate ]
-            }),
-            reasonForChange: {
+            trainingEndDate: currentOrPastDate.uiSchema('When did you stop taking classes or participating in the training program?'),
+          reasonForChange: {
               'ui:title': 'Why did you stop taking classes or participating in the training program? (for example, “I graduated” or “I moved” or “The program wasn’t right for me.”)'
             }
           },

--- a/test/common/utils/validations.unit.spec.js
+++ b/test/common/utils/validations.unit.spec.js
@@ -71,28 +71,28 @@ describe('Validations unit tests', () => {
 
   describe('isValidDate', () => {
     it('validate february separately cause its a special snowflake', () => {
-      // 28 should work always.
-      expect(isValidDate(28, 2, 2015)).to.be.true;
+      // feb 28 should work always.
+      expect(isValidDate('28', '2', '2015')).to.be.true;
 
       // 2015 is not a leap year.
-      expect(isValidDate(29, 2, 2015)).to.be.false;
+      expect(isValidDate('29', '2', '2015')).to.be.false;
 
       // 2016 is a leap year.
-      expect(isValidDate(29, 2, 2016)).to.be.true;
+      expect(isValidDate('29', '2', '2016')).to.be.true;
 
-      // 30 is always bad.
-      expect(isValidDate(30, 2, 2016)).to.be.false;
+      // feb 30 is always bad.
+      expect(isValidDate('30', '2', '2016')).to.be.false;
 
-      // 1 is always fine.
-      expect(isValidDate(1, 2, 2016)).to.be.true;
+      // feb 1 is always fine.
+      expect(isValidDate('1', '2', '2016')).to.be.true;
 
-      // 0 is always bad.
-      expect(isValidDate(0, 2, 2016)).to.be.false;
+      // feb 0 is always bad.
+      expect(isValidDate('0', '2', '2016')).to.be.false;
     });
 
     it('validate future dates', () => {
       // future dates are bad.
-      expect(isValidDate(1, 1, 2050)).to.be.false;
+      expect(isValidDate('1', '1', '2050')).to.be.false;
     });
   });
 
@@ -100,29 +100,29 @@ describe('Validations unit tests', () => {
     it('validates if to date is after from date', () => {
       const fromDate = {
         day: {
-          value: 3,
+          value: '3',
           dirty: true
         },
         month: {
-          value: 3,
+          value: '3',
           dirty: true
         },
         year: {
-          value: 2006,
+          value: '2006',
           dirty: true
         }
       };
       const toDate = {
         day: {
-          value: 3,
+          value: '3',
           dirty: true
         },
         month: {
-          value: 4,
+          value: '4',
           dirty: true
         },
         year: {
-          value: 2006,
+          value: '2006',
           dirty: true
         }
       };
@@ -131,29 +131,29 @@ describe('Validations unit tests', () => {
     it('does not validate to date is before from date', () => {
       const fromDate = {
         day: {
-          value: 3,
+          value: '3',
           dirty: true
         },
         month: {
-          value: 3,
+          value: '3',
           dirty: true
         },
         year: {
-          value: 2006,
+          value: '2006',
           dirty: true
         }
       };
       const toDate = {
         day: {
-          value: 3,
+          value: '3',
           dirty: true
         },
         month: {
-          value: 4,
+          value: '4',
           dirty: true
         },
         year: {
-          value: 2005,
+          value: '2005',
           dirty: true
         }
       };
@@ -166,11 +166,11 @@ describe('Validations unit tests', () => {
           dirty: true
         },
         month: {
-          value: 3,
+          value: '3',
           dirty: true
         },
         year: {
-          value: 2006,
+          value: '2006',
           dirty: true
         }
       };
@@ -184,7 +184,7 @@ describe('Validations unit tests', () => {
           dirty: true
         },
         year: {
-          value: 2008,
+          value: '2008',
           dirty: true
         }
       };
@@ -196,16 +196,16 @@ describe('Validations unit tests', () => {
     it('should validate partial range', () => {
       const fromDate = {
         month: {
-          value: 2
+          value: '2'
         },
         year: {
-          value: 2001
+          value: '2001'
         }
       };
 
       const toDate = {
         month: {
-          value: 3
+          value: '3'
         },
         year: {
           value: ''
@@ -217,19 +217,19 @@ describe('Validations unit tests', () => {
     it('should not validate invalid range', () => {
       const fromDate = {
         month: {
-          value: 2
+          value: '2'
         },
         year: {
-          value: 2002
+          value: '2002'
         }
       };
 
       const toDate = {
         month: {
-          value: 3
+          value: '3'
         },
         year: {
-          value: 2001
+          value: '2001'
         }
       };
 
@@ -238,19 +238,19 @@ describe('Validations unit tests', () => {
     it('should validate same date range', () => {
       const fromDate = {
         month: {
-          value: 2
+          value: '2'
         },
         year: {
-          value: 2001
+          value: '2001'
         }
       };
 
       const toDate = {
         month: {
-          value: 2
+          value: '2'
         },
         year: {
-          value: 2001
+          value: '2001'
         }
       };
 
@@ -262,7 +262,7 @@ describe('Validations unit tests', () => {
           value: ''
         },
         year: {
-          value: 2001
+          value: '2001'
         }
       };
 
@@ -271,7 +271,7 @@ describe('Validations unit tests', () => {
           value: ''
         },
         year: {
-          value: 2002
+          value: '2002'
         }
       };
 
@@ -281,13 +281,17 @@ describe('Validations unit tests', () => {
 
   describe('isValidCurrentOrPastDate', () => {
     it('should validate past date', () => {
-      expect(isValidCurrentOrPastDate(2, 2, 2000)).to.be.true;
+      expect(isValidCurrentOrPastDate('2', '2', '2000')).to.be.true;
     });
     it('should validate current date', () => {
-      expect(isValidCurrentOrPastDate(moment().date(), moment().month() + 1, moment().year())).to.be.true;
+      expect(isValidCurrentOrPastDate(moment().date().toString(),
+                                      (moment().month() + 1).toString(),
+                                      moment().year().toString())).to.be.true;
     });
     it('should not validate date in future', () => {
-      expect(isValidCurrentOrPastDate(moment().date() + 1, moment().month() + 1, moment().year())).to.be.false;
+      expect(isValidCurrentOrPastDate((moment().date() + 1).toString(),
+                                      (moment().month() + 1).toString(),
+                                      moment().year().toString())).to.be.false;
     });
   });
 
@@ -342,38 +346,42 @@ describe('Validations unit tests', () => {
   describe('isValidDateOver17', () => {
     it('validates turning 17 today', () => {
       const date = moment().startOf('day').subtract(17, 'years');
-      expect(isValidDateOver17(date.date(), date.month() + 1, date.year())).to.be.true;
+      expect(isValidDateOver17(date.date().toString(),
+                               (date.month() + 1).toString(),
+                               date.year().toString())).to.be.true;
     });
 
     it('does not validate turning 17 tomorrow', () => {
       const date = moment().startOf('day').subtract(17, 'years').add(1, 'days');
-      expect(isValidDateOver17(date.date(), date.month() + 1, date.year())).to.be.false;
+      expect(isValidDateOver17(date.date().toString(),
+                               (date.month() + 1).toString(),
+                               date.year().toString())).to.be.false;
     });
   });
   describe('isValidPartialDate', () => {
     it('should validate complete date', () => {
-      expect(isValidPartialDate(5, 10, 2010)).to.be.true;
+      expect(isValidPartialDate('5', '10', '2010')).to.be.true;
     });
     it('should validate empty date', () => {
       expect(isValidPartialDate('', '', '')).to.be.true;
     });
     it('should validate month year date', () => {
-      expect(isValidPartialDate('', 10, 2050)).to.be.true;
+      expect(isValidPartialDate('', '10', '2050')).to.be.true;
     });
     it('should validate month day date', () => {
-      expect(isValidPartialDate(10, 10, '')).to.be.true;
+      expect(isValidPartialDate('10', '10', '')).to.be.true;
     });
     it('should validate day year date', () => {
-      expect(isValidPartialDate(20, '', 2010)).to.be.true;
+      expect(isValidPartialDate('20', '', '2010')).to.be.true;
     });
     it('should validate day date', () => {
-      expect(isValidPartialDate(20, '', '')).to.be.true;
+      expect(isValidPartialDate('20', '', '')).to.be.true;
     });
     it('should validate year date', () => {
-      expect(isValidPartialDate('', '', 2010)).to.be.true;
+      expect(isValidPartialDate('', '', '2010')).to.be.true;
     });
     it('should not validate year before 1900', () => {
-      expect(isValidPartialDate('', '', 1899)).to.be.false;
+      expect(isValidPartialDate('', '', '1899')).to.be.false;
     });
     it('should not validate year more than 100 years in future', () => {
       expect(isValidPartialDate('', '', moment().add(101, 'year').year())).to.be.false;
@@ -414,24 +422,27 @@ describe('Validations unit tests', () => {
   });
   describe('isValidPartialMonthYear', () => {
     it('should validate month and year', () => {
-      expect(isValidPartialMonthYear(2, moment().add(5, 'year').year())).to.be.true;
+      expect(isValidPartialMonthYear('2',
+                                     (moment().add(5, 'year').year()).toString())).to.be.true;
     });
     it('should not validate bad year', () => {
-      expect(isValidPartialMonthYear(2, 2500)).to.be.false;
+      expect(isValidPartialMonthYear('2', '2500')).to.be.false;
     });
     it('should not validate bad month', () => {
-      expect(isValidPartialMonthYear(20, 2001)).to.be.false;
+      expect(isValidPartialMonthYear('20', '2001')).to.be.false;
     });
   });
   describe('isValidPartialMonthYearInPast', () => {
     it('should validate month and year in past', () => {
-      expect(isValidPartialMonthYearInPast(2, 2001)).to.be.true;
+      expect(isValidPartialMonthYearInPast('2', '2001')).to.be.true;
     });
     it('should validate month and year that is current', () => {
-      expect(isValidPartialMonthYearInPast(moment().month(), moment().year())).to.be.true;
+      expect(isValidPartialMonthYearInPast(moment().month().toString(),
+                                           moment().year().toString())).to.be.true;
     });
     it('should not validate month and year that is in the future', () => {
-      expect(isValidPartialMonthYearInPast(2, moment().add(2, 'year').year())).to.be.false;
+      expect(isValidPartialMonthYearInPast('2',
+                                           (moment().add(2, 'year').year()).toString())).to.be.false;
     });
   });
 });

--- a/test/common/utils/validations.unit.spec.js
+++ b/test/common/utils/validations.unit.spec.js
@@ -4,9 +4,9 @@ import moment from 'moment';
 import {
   isBlank,
   isNotBlank,
-  isValidCurrentOrPastDate,    
+  isValidCurrentOrPastDate,
   isValidDate,
-  isValidDateOver17,    
+  isValidDateOver17,
   isValidDateRange,
   isValidMonetaryValue,
   isValidName,

--- a/test/common/utils/validations.unit.spec.js
+++ b/test/common/utils/validations.unit.spec.js
@@ -2,19 +2,20 @@ import { expect } from 'chai';
 import moment from 'moment';
 
 import {
-  isValidDate,
-  isValidDateRange,
-  isValidSSN,
-  isValidName,
-  isNotBlank,
   isBlank,
+  isNotBlank,
+  isValidCurrentOrPastDate,    
+  isValidDate,
+  isValidDateOver17,    
+  isValidDateRange,
   isValidMonetaryValue,
-  isValidDateOver17,
+  isValidName,
   isValidPartialDate,
-  validateCustomFormComponent,
   isValidPartialMonthYear,
+  isValidPartialMonthYearInPast,
   isValidPartialMonthYearRange,
-  isValidPartialMonthYearInPast
+  isValidSSN,
+  validateCustomFormComponent
 } from '../../../src/js/common/utils/validations.js';
 
 describe('Validations unit tests', () => {
@@ -195,16 +196,16 @@ describe('Validations unit tests', () => {
     it('should validate partial range', () => {
       const fromDate = {
         month: {
-          value: '2'
+          value: 2
         },
         year: {
-          value: '2001'
+          value: 2001
         }
       };
 
       const toDate = {
         month: {
-          value: '3'
+          value: 3
         },
         year: {
           value: ''
@@ -216,19 +217,19 @@ describe('Validations unit tests', () => {
     it('should not validate invalid range', () => {
       const fromDate = {
         month: {
-          value: '2'
+          value: 2
         },
         year: {
-          value: '2002'
+          value: 2002
         }
       };
 
       const toDate = {
         month: {
-          value: '3'
+          value: 3
         },
         year: {
-          value: '2001'
+          value: 2001
         }
       };
 
@@ -237,19 +238,19 @@ describe('Validations unit tests', () => {
     it('should validate same date range', () => {
       const fromDate = {
         month: {
-          value: '2'
+          value: 2
         },
         year: {
-          value: '2001'
+          value: 2001
         }
       };
 
       const toDate = {
         month: {
-          value: '2'
+          value: 2
         },
         year: {
-          value: '2001'
+          value: 2001
         }
       };
 
@@ -261,7 +262,7 @@ describe('Validations unit tests', () => {
           value: ''
         },
         year: {
-          value: '2001'
+          value: 2001
         }
       };
 
@@ -270,11 +271,23 @@ describe('Validations unit tests', () => {
           value: ''
         },
         year: {
-          value: '2002'
+          value: 2002
         }
       };
 
       expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.true;
+    });
+  });
+
+  describe('isValidCurrentOrPastDate', () => {
+    it('should validate past date', () => {
+      expect(isValidCurrentOrPastDate(2, 2, 2000)).to.be.true;
+    });
+    it('should validate current date', () => {
+      expect(isValidCurrentOrPastDate(moment().date(), moment().month() + 1, moment().year())).to.be.true;
+    });
+    it('should not validate date in future', () => {
+      expect(isValidCurrentOrPastDate(moment().date() + 1, moment().month() + 1, moment().year())).to.be.false;
     });
   });
 
@@ -338,29 +351,29 @@ describe('Validations unit tests', () => {
     });
   });
   describe('isValidPartialDate', () => {
-    it('should valid complete date', () => {
+    it('should validate complete date', () => {
       expect(isValidPartialDate(5, 10, 2010)).to.be.true;
     });
     it('should validate empty date', () => {
       expect(isValidPartialDate('', '', '')).to.be.true;
     });
     it('should validate month year date', () => {
-      expect(isValidPartialDate('', '10', 2050)).to.be.true;
+      expect(isValidPartialDate('', 10, 2050)).to.be.true;
     });
     it('should validate month day date', () => {
-      expect(isValidPartialDate('10', '10', '')).to.be.true;
+      expect(isValidPartialDate(10, 10, '')).to.be.true;
     });
     it('should validate day year date', () => {
-      expect(isValidPartialDate('20', '', '2010')).to.be.true;
+      expect(isValidPartialDate(20, '', 2010)).to.be.true;
     });
     it('should validate day date', () => {
-      expect(isValidPartialDate('20', '', '')).to.be.true;
+      expect(isValidPartialDate(20, '', '')).to.be.true;
     });
     it('should validate year date', () => {
-      expect(isValidPartialDate('', '', '2010')).to.be.true;
+      expect(isValidPartialDate('', '', 2010)).to.be.true;
     });
     it('should not validate year before 1900', () => {
-      expect(isValidPartialDate('', '', '1899')).to.be.false;
+      expect(isValidPartialDate('', '', 1899)).to.be.false;
     });
     it('should not validate year more than 100 years in future', () => {
       expect(isValidPartialDate('', '', moment().add(101, 'year').year())).to.be.false;
@@ -401,10 +414,10 @@ describe('Validations unit tests', () => {
   });
   describe('isValidPartialMonthYear', () => {
     it('should validate month and year', () => {
-      expect(isValidPartialMonthYear('2', moment().add(5, 'year').year())).to.be.true;
+      expect(isValidPartialMonthYear(2, moment().add(5, 'year').year())).to.be.true;
     });
     it('should not validate bad year', () => {
-      expect(isValidPartialMonthYear('2', '2500')).to.be.false;
+      expect(isValidPartialMonthYear(2, 2500)).to.be.false;
     });
     it('should not validate bad month', () => {
       expect(isValidPartialMonthYear(20, 2001)).to.be.false;
@@ -412,13 +425,13 @@ describe('Validations unit tests', () => {
   });
   describe('isValidPartialMonthYearInPast', () => {
     it('should validate month and year in past', () => {
-      expect(isValidPartialMonthYearInPast('2', '2001')).to.be.true;
+      expect(isValidPartialMonthYearInPast(2, 2001)).to.be.true;
     });
     it('should validate month and year that is current', () => {
       expect(isValidPartialMonthYearInPast(moment().month(), moment().year())).to.be.true;
     });
     it('should not validate month and year that is in the future', () => {
-      expect(isValidPartialMonthYearInPast('2', moment().add(2, 'year').year())).to.be.false;
+      expect(isValidPartialMonthYearInPast(2, moment().add(2, 'year').year())).to.be.false;
     });
   });
 });


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1233

This adds a validator and unit test,and updates 1 field in the UI (see below screenshot)

Still todo: use the current-or-past validator for the service period date range, but will open a separate PR for that.

Note: I need to commit some time to getting e2e tests running locally, so I won't merge this until that's done and they're passing.

Screenshots:
![image](https://cloud.githubusercontent.com/assets/25439097/23076361/fd940c1c-f4f4-11e6-9432-0cc88ae04075.png)
![image](https://cloud.githubusercontent.com/assets/25439097/23076368/03274068-f4f5-11e6-9e5f-922def2f8fa3.png)

