### PR TITLE
Formats the phone number on the review page

### DIFF
--- a/src/js/common/schemaform/definitions/phone.js
+++ b/src/js/common/schemaform/definitions/phone.js
@@ -1,9 +1,13 @@
 import commonDefinitions from 'vets-json-schema/dist/definitions.json';
+import PhoneNumberWidget from '../widgets/PhoneNumberWidget';
+import PhoneNumberReviewWidget from '../review/PhoneNumberWidget';
 
 export const schema = commonDefinitions.phone;
 
 export const uiSchema = (title = 'Phone') => {
   return {
+    'ui:widget': PhoneNumberWidget,
+    'ui:reviewWidget': PhoneNumberReviewWidget,
     'ui:title': title,
     'ui:options': {
       widgetClassNames: 'home-phone va-input-medium-large',

--- a/src/js/common/schemaform/review/PhoneNumberWidget.jsx
+++ b/src/js/common/schemaform/review/PhoneNumberWidget.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+// When coming from a PhoneNumberWidget (not review), value will be only numbers
+export default function PhoneNumberWidget({ value }) {
+  let formatted = value;
+  if (value && value.length === 10) {
+    formatted = `(${value.substr(0, 3)}) ${value.substr(3, 3)}-${value.substr(6)}`;
+  }
+
+  return <span>{formatted}</span>;
+}

--- a/src/js/common/schemaform/widgets/PhoneNumberWidget.jsx
+++ b/src/js/common/schemaform/widgets/PhoneNumberWidget.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import TextWidget from './TextWidget';
+
+/*
+ * Handles removing dashes from SSNs by keeping the user input in local state
+ * and saving the transformed version instead
+ */
+export default class PhoneNumberWidget extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { val: props.value };
+  }
+  handleChange = (val) => {
+    const stripped = val.replace(/[\D]/g, '');
+    this.setState({ val }, () => {
+      this.props.onChange(stripped);
+    });
+  }
+  render() {
+    return <TextWidget {...this.props} value={this.state.val} onChange={this.handleChange}/>;
+  }
+}

--- a/src/js/common/schemaform/widgets/PhoneNumberWidget.jsx
+++ b/src/js/common/schemaform/widgets/PhoneNumberWidget.jsx
@@ -11,7 +11,11 @@ export default class PhoneNumberWidget extends React.Component {
     this.state = { val: props.value };
   }
   handleChange = (val) => {
-    const stripped = val.replace(/[\D]/g, '');
+    let stripped;
+    if (val) {
+      stripped = val.replace(/[ \-\(\)x+]/g, '');
+    }
+
     this.setState({ val }, () => {
       this.props.onChange(stripped);
     });

--- a/test/common/schemaform/review/PhoneNumberWidget.unit.spec.jsx
+++ b/test/common/schemaform/review/PhoneNumberWidget.unit.spec.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { expect } from 'chai';
+import SkinDeep from 'skin-deep';
+
+import PhoneNumberWidget from '../../../../src/js/common/schemaform/review/PhoneNumberWidget';
+
+describe('Schemaform review <PhoneNumberWidget>', () => {
+  it('should format phone number', () => {
+    const tree = SkinDeep.shallowRender(
+      <PhoneNumberWidget value="1234567890"/>
+    );
+
+    expect(tree.text()).to.equal('(123) 456-7890');
+  });
+  it('should render empty value', () => {
+    const tree = SkinDeep.shallowRender(
+      <PhoneNumberWidget/>
+    );
+
+    expect(tree.text()).to.equal('');
+  });
+});

--- a/test/common/schemaform/widgets/PhoneNumberWidget.unit.spec.jsx
+++ b/test/common/schemaform/widgets/PhoneNumberWidget.unit.spec.jsx
@@ -13,14 +13,24 @@ describe('Schemaform <PhoneNumberWidget>', () => {
     );
     expect(tree.subTree('TextWidget').props.value).to.equal('1234567890');
   });
-  it('should remove all non-digit characters on change', () => {
+  it('should strip spaces, (, ), -, +, and x on change', () => {
     const onChange = sinon.spy();
     const tree = SkinDeep.shallowRender(
       <PhoneNumberWidget
           value=""
           onChange={onChange}/>
     );
-    tree.subTree('TextWidget').props.onChange('(154945 -5677');
+    tree.subTree('TextWidget').props.onChange('+(154) 945-56x77');
     expect(onChange.calledWith('1549455677')).to.be.true;
+  });
+  it('should call onChange with undefined if value is blank', () => {
+    const onChange = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <PhoneNumberWidget
+          value="1231231234"
+          onChange={onChange}/>
+    );
+    tree.subTree('TextWidget').props.onChange('');
+    expect(onChange.calledWith(undefined)).to.be.true;
   });
 });

--- a/test/common/schemaform/widgets/PhoneNumberWidget.unit.spec.jsx
+++ b/test/common/schemaform/widgets/PhoneNumberWidget.unit.spec.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { expect } from 'chai';
+import SkinDeep from 'skin-deep';
+import sinon from 'sinon';
+
+import PhoneNumberWidget from '../../../../src/js/common/schemaform/widgets/PhoneNumberWidget';
+
+describe('Schemaform <PhoneNumberWidget>', () => {
+  it('should render', () => {
+    const tree = SkinDeep.shallowRender(
+      <PhoneNumberWidget
+          value="1234567890"/>
+    );
+    expect(tree.subTree('TextWidget').props.value).to.equal('1234567890');
+  });
+  it('should remove all non-digit characters on change', () => {
+    const onChange = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <PhoneNumberWidget
+          value=""
+          onChange={onChange}/>
+    );
+    tree.subTree('TextWidget').props.onChange('(154945 -5677');
+    expect(onChange.calledWith('1549455677')).to.be.true;
+  });
+});


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets-website/issues/3433

Formats the phone numbers on the review page:

---
![image](https://cloud.githubusercontent.com/assets/12970166/23087500/a3bff9f0-f529-11e6-818d-b58be7ea4e2e.png)

---
**Note:** If the number has more than 10 digits (validation requires that it has at least 10), it doesn't get formatted. Instead, all the non-numeric characters are just stripped away (as part of the formatting process).

---
![image](https://cloud.githubusercontent.com/assets/12970166/23087540/ec772cc2-f529-11e6-8102-98d9f47cbf37.png)

---
This means it doesn't format international numbers too kindly. I didn't worry about international formatting for now because there are just [so many different formats](https://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers), but if it's required, I can certainly look into a more comprehensive solution.
