### PR TITLE
Only show triage team error if folders load

### DIFF
--- a/src/js/messaging/containers/MessagingApp.jsx
+++ b/src/js/messaging/containers/MessagingApp.jsx
@@ -30,7 +30,7 @@ function AppContent({ children, isDataAvailable }) {
 class MessagingApp extends React.Component {
   // this warning is rendered if the user has no triage teams
   renderWarningBanner() {
-    if (isEmpty(this.props.recipients) && !this.props.loading.recipients) {
+    if (this.props.folders && this.props.folders.length && isEmpty(this.props.recipients) && !this.props.loading.recipients) {
       const alertContent = (
         <div>
           <h4>Currently not assigned to a health care team</h4>


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1255

The triage team error should only show when recipients fail to load. If there is an application level error, i.e. no folders load, only the standard loading error should be shown.

![screen shot 2017-02-20 at 11 24 45 am](https://cloud.githubusercontent.com/assets/303289/23140505/e518df18-f766-11e6-984c-f976e15f27b6.png)

