### PR TITLE
SSN returns undefined if blank

### DIFF
--- a/src/js/common/schemaform/widgets/SSNWidget.jsx
+++ b/src/js/common/schemaform/widgets/SSNWidget.jsx
@@ -11,6 +11,7 @@ export default class SSNWidget extends React.Component {
     this.state = { val: props.value };
   }
   handleChange = (val) => {
+    // If val is blank or undefined, pass undefined to onChange
     let strippedSSN;
     if (val) {
       strippedSSN = val.replace(/[\- ]/g, '');

--- a/src/js/common/schemaform/widgets/SSNWidget.jsx
+++ b/src/js/common/schemaform/widgets/SSNWidget.jsx
@@ -11,7 +11,11 @@ export default class SSNWidget extends React.Component {
     this.state = { val: props.value };
   }
   handleChange = (val) => {
-    const strippedSSN = val.replace(/[\- ]/g, '');
+    let strippedSSN;
+    if (val) {
+      strippedSSN = val.replace(/[\- ]/g, '');
+    }
+
     this.setState({ val }, () => {
       this.props.onChange(strippedSSN);
     });

--- a/src/js/common/schemaform/widgets/TextWidget.jsx
+++ b/src/js/common/schemaform/widgets/TextWidget.jsx
@@ -12,7 +12,7 @@ export default function TextWidget(props) {
         maxLength={props.schema.maxLength}
         autoComplete={props.options.autocomplete || false}
         className={props.options.widgetClassNames}
-        value={props.value || ''}
+        value={props.value}
         onBlur={() => props.onBlur(props.id)}
         onChange={(event) => props.onChange(event.target.value ? event.target.value : undefined)}/>
   );

--- a/test/common/schemaform/review/SSNWidget.unit.spec.jsx
+++ b/test/common/schemaform/review/SSNWidget.unit.spec.jsx
@@ -17,6 +17,7 @@ describe('Schemaform review <SSNWidget>', () => {
       <SSNWidget/>
     );
 
+    // The only time it will equal '' is when initializing it with value=''
     expect(tree.text()).to.equal('');
   });
 });

--- a/test/common/schemaform/widgets/SSNWidget.unit.spec.jsx
+++ b/test/common/schemaform/widgets/SSNWidget.unit.spec.jsx
@@ -23,4 +23,14 @@ describe('Schemaform <SSNWidget>', () => {
     tree.subTree('TextWidget').props.onChange('123-45-5677');
     expect(onChange.calledWith('123455677')).to.be.true;
   });
+  it('should call onChange with undefined if the value is blank', () => {
+    const onChange = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <SSNWidget
+          value="123121234"
+          onChange={onChange}/>
+    );
+    tree.subTree('TextWidget').props.onChange('');
+    expect(onChange.calledWith(undefined)).to.be.true;
+  });
 });


### PR DESCRIPTION
Connected to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1266

Basically, this just turns `''` into `undefined` so the value doesn't "pop" back if deleted.