### PR TITLE
Updated strategy for 1995 OMB, et al

### DIFF
--- a/src/js/common/components/OMBInfo.jsx
+++ b/src/js/common/components/OMBInfo.jsx
@@ -8,7 +8,6 @@ const modalContents = (
   </div>
 );
 
-// export default function OMBInfo({ resBurden, ombNumber, expDate }) {
 class OMBInfo extends React.Component {
   constructor(props) {
     super(props);

--- a/src/js/common/components/OMBInfo.jsx
+++ b/src/js/common/components/OMBInfo.jsx
@@ -1,12 +1,53 @@
 import React from 'react';
+import Modal from './Modal';
 
-export default function OMBInfo({ resBurden, ombNumber, expDate }) {
-  return (
-    <div className="omb-info">
-      <div>Respondent burden: <strong>{resBurden} minutes</strong></div>
-      <div>OMB Control # <strong>{ombNumber}</strong></div>
-      <div>Expiration date: <strong>{expDate}</strong></div>
-      <div><a href="#">Privacy Act Statement</a></div>
-    </div>
-  );
+const modalContents = (
+  <div>
+    <p><strong>Respondent Burden:</strong> We need this information to determine your eligibility for education benefits (38 U.S.C. 3471). Title 38, United States Code, allows us to ask for this information. We estimate that you will need an average of 15 minutes to review the instructions, find the information, and complete this form. The VA cannot conduct or sponsor a collection of information unless a valid OMB (Office of Management and Budget) control number is displayed. You are not required to respond to a collection of information if this number is not displayed. Valid OMB control numbers can be located on the OMB Internet Page at www.reginfo.gov/public/do/PRAMain. If desired, you can call 1-800-827-1000 to get information on where to send comments or suggestions about this form.</p>
+    <p><strong>Privacy Act Notice:</strong> The VA will not disclose information collected on this form to any source other than what has been authorized under the Privacy Act of 1974 or title 38, Code of Federal Regulations, section 1.576 for routine uses (e.g., the VA sends educational forms or letters with a veteran’s identifying information to the Veteran’s school or training establishment to (1) assist the veteran in the completion of claims forms or (2) for the VA to obtain further information as may be necessary from the school for VA to properly process the Veteran’s education claim or to monitor his or her progress during training) as identified in the VA system of records, 58VA21/22/28, Compensation, Pension, Education, and Vocational Rehabilitation and Employment Records - VA, and published in the Federal Register. Your obligation to respond is required to obtain or retain education benefits. Giving us your SSN account information is voluntary. Refusal to provide your SSN by itself will not result in the denial of benefits. The VA will not deny an individual benefits for refusing to provide his or her SSN unless the disclosure of the SSN is required by a Federal Statute of law enacted before January 1, 1975, and still in effect. The requested information is considered relevant and necessary to determine the maximum benefits under the law. While you do not have to respond, VA cannot process your claim for education assistance unless the information is furnished as required by existing law (38 U.S.C. 3471). The responses you submit are considered confidential (38 U.S.C. 5701). Any information provided by applicants, recipients, and others may be subject to verification through computer matching programs with other agencies.</p>
+  </div>
+);
+
+// export default function OMBInfo({ resBurden, ombNumber, expDate }) {
+class OMBInfo extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { modalOpen: false };
+  }
+
+  openModal = () => {
+    this.setState({ modalOpen: true });
+  }
+
+  closeModal = () => {
+    this.setState({ modalOpen: false });
+  }
+
+  render() {
+    const { resBurden, ombNumber, expDate } = this.props;
+
+    return (
+      <div className="omb-info">
+        <div>Respondent burden: <strong>{resBurden} minutes</strong></div>
+        <div>OMB Control # <strong>{ombNumber}</strong></div>
+        <div>Expiration date: <strong>{expDate}</strong></div>
+        <div><a onClick={this.openModal}>Privacy Act Statement</a></div>
+        <Modal
+            cssClass="va-modal-large"
+            contents={modalContents}
+            id="omb-modal"
+            visible={this.state.modalOpen}
+            onClose={() => this.closeModal()}/>
+      </div>
+    );
+  }
 }
+
+OMBInfo.propTypes = {
+  resBurden: React.PropTypes.number,
+  ombNumber: React.PropTypes.string,
+  expDate: React.PropTypes.string
+};
+
+export default OMBInfo;

--- a/src/js/common/components/OMBInfo.jsx
+++ b/src/js/common/components/OMBInfo.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function OMBInfo({ resBurden, ombNumber, expDate }) {
+  return (
+    <div className="omb-info">
+      <div>Respondent burden: <strong>{resBurden} minutes</strong></div>
+      <div>OMB Control # <strong>{ombNumber}</strong></div>
+      <div>Expiration date: <strong>{expDate}</strong></div>
+      <div><a href="#">Privacy Act Statement</a></div>
+    </div>
+  );
+}

--- a/src/js/edu-benefits/1995/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/1995/components/IntroductionPage.jsx
@@ -75,7 +75,7 @@ class IntroductionPage extends React.Component {
           </div>
         </div>
         <div className="omb-info--container">
-          <OMBInfo resBurden={20} ombNumber="2900-0074" expDate="05-31-2018"/>
+          <OMBInfo resBurden={20} ombNumber="2900-0074" expDate="05/31/2018"/>
         </div>
       </div>
     );

--- a/src/js/edu-benefits/1995/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/1995/components/IntroductionPage.jsx
@@ -15,7 +15,7 @@ class IntroductionPage extends React.Component {
   render() {
     return (
       <div className="schemaform-intro">
-        <FormTitle title="Manage Your Education Benefits" subTitle="OMB Control No. 2900-0074"/>
+        <FormTitle title="Manage Your Education Benefits"/>
         <p>This application is equivalent to Form 22-1995 (Request for Change of Program or Place of Training) and Form 22-5495 (Dependents' Request for Change of Program or Place of Training).</p>
         <div className="process schemaform-process">
           <ol>

--- a/src/js/edu-benefits/1995/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/1995/components/IntroductionPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { withRouter } from 'react-router';
 import { focusElement } from '../../../common/utils/helpers';
 import ProgressButton from '../../../common/components/form-elements/ProgressButton';
+import OMBInfo from '../../../common/components/OMBInfo';
 import FormTitle from '../../../common/schemaform/FormTitle';
 
 class IntroductionPage extends React.Component {
@@ -72,6 +73,9 @@ class IntroductionPage extends React.Component {
                 buttonClass="usa-button-primary"
                 afterText="»"/>
           </div>
+        </div>
+        <div className="omb-info--container">
+          <OMBInfo resBurden={20} ombNumber="2900-0074" expDate="05-31-2018"/>
         </div>
       </div>
     );

--- a/src/sass/edu-benefits.scss
+++ b/src/sass/edu-benefits.scss
@@ -5,6 +5,7 @@
 @import 'modules/m-progress-bar';
 @import 'modules/m-schemaform';
 @import 'modules/m-modal';
+@import 'modules/m-omb-info';
 
 $button-stroke: inset 0 0 0 1px;
 
@@ -107,21 +108,11 @@ ul.claim-list{
   }
 }
 
-// Align with navigation buttons
-.omb-info--container {
-  padding-left: 2rem;
-}
-
 @media (max-width: 40.063em) {
   .progress-box {
     border:none;
     padding-left: 2rem - .9375rem;
     padding-right: 2rem - .9375rem;
-  }
-
-  // Match the OMB Info section padding
-  .omb-info--container {
-    padding-left: 2rem - .9375rem;
   }
 }
 

--- a/src/sass/edu-benefits.scss
+++ b/src/sass/edu-benefits.scss
@@ -4,6 +4,7 @@
 @import 'modules/m-form-process';
 @import 'modules/m-progress-bar';
 @import 'modules/m-schemaform';
+@import 'modules/m-modal';
 
 $button-stroke: inset 0 0 0 1px;
 

--- a/src/sass/edu-benefits.scss
+++ b/src/sass/edu-benefits.scss
@@ -106,11 +106,21 @@ ul.claim-list{
   }
 }
 
+// Align with navigation buttons
+.omb-info--container {
+  padding-left: 2rem;
+}
+
 @media (max-width: 40.063em) {
   .progress-box {
     border:none;
     padding-left: 2rem - .9375rem;
     padding-right: 2rem - .9375rem;
+  }
+
+  // Match the OMB Info section padding
+  .omb-info--container {
+    padding-left: 2rem - .9375rem;
   }
 }
 
@@ -260,12 +270,6 @@ form.rjsf {
   margin-top: 16px;
 }
 
-.schemaform-array-row {
-  outline: none;
-}
-.schemaform-array-row {
-  outline: none;
-}
 .edu-benefits-dependents-desc {
   margin-top: 5px;
 }

--- a/src/sass/modules/_m-modal.scss
+++ b/src/sass/modules/_m-modal.scss
@@ -116,6 +116,18 @@
     }
   }
 
+  &-large {
+    .va-modal-inner {
+      max-width: 75rem;
+      width: 75vw;
+
+      .va-modal-body {
+        max-height: 95vh;
+        overflow-y: auto;
+      }
+    }
+  }
+
   span.exit-icon {
     background-image: url(/img/icons/exit-icon-primary.png);
     background-position: 100% 50%;

--- a/src/sass/modules/_m-modal.scss
+++ b/src/sass/modules/_m-modal.scss
@@ -16,7 +16,7 @@
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: 3;
+  z-index: 6;
 
   // "Forked" modal styles
   &-split {

--- a/src/sass/modules/_m-omb-info.scss
+++ b/src/sass/modules/_m-omb-info.scss
@@ -1,0 +1,16 @@
+// To avoid double-importing, we're not importing _m-modal.scss,
+//  but if this file is being imported, you'll probably want to include
+//  the modal module as well.
+
+// Align with navigation buttons
+.omb-info--container {
+  padding-left: 2rem;
+}
+
+// This media query is matched to the one wrapping .progress-box in edu-benefits.scss
+@media (max-width: 40.063em) {
+  // Match the OMB Info section padding
+  .omb-info--container {
+    padding-left: 2rem - .9375rem;
+  }
+}

--- a/src/sass/modules/_m-schemaform.scss
+++ b/src/sass/modules/_m-schemaform.scss
@@ -70,3 +70,10 @@
     margin-left: -0.5em;
   }
 }
+
+.schemaform-array-row {
+  outline: none;
+}
+.schemaform-array-row {
+  outline: none;
+}


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1256

Removes OMB Number from subtitle and adds it to the bottom of the intro page along with respondent burden, expiration date, and privacy act statement link.

Adds modal containing the privacy act notice and respondent burden explanation.

![image](https://cloud.githubusercontent.com/assets/12970166/23150439/58806246-f7a8-11e6-99c5-c5b9f4c5a7c2.png)

When the screen is small enough, the close button overlaps the modal body's scrollbar, making it a bit wonky:

![image](https://cloud.githubusercontent.com/assets/12970166/23150464/871db34c-f7a8-11e6-866e-ea25cb4b8804.png)

But it does play nicely with smaller screens:

![image](https://cloud.githubusercontent.com/assets/12970166/23150489/a560490a-f7a8-11e6-9868-6d2472aef330.png)
