### PR TITLE
Better browser-agnostic scrolling

### DIFF
--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -91,7 +91,9 @@ export function getScrollOptions(additionalOptions) {
 export function scrollToFirstError() {
   const errorEl = document.querySelector('.usa-input-error, .input-error-date');
   if (errorEl) {
-    const position = errorEl.getBoundingClientRect().top + document.body.scrollTop;
+    // document.body.scrollTop doesn't work with all browsers, so we'll cover them all like so:
+    const currentPosition = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+    const position = errorEl.getBoundingClientRect().top + currentPosition;
     Scroll.animateScroll.scrollTo(position - 10, {
       duration: 500,
       delay: 0,
@@ -102,7 +104,8 @@ export function scrollToFirstError() {
 }
 
 export function scrollAndFocus(errorEl) {
-  const position = errorEl.getBoundingClientRect().top + document.body.scrollTop;
+  const currentPosition = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+  const position = errorEl.getBoundingClientRect().top + currentPosition;
   Scroll.animateScroll.scrollTo(position - 10, getScrollOptions());
   focusElement(errorEl);
 }


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1317

Should work in most browsers now, but can you test IE, @annekainicUSDS (or anybody else)?

Turns out Firefox always returns `0` for `document.body.scrollTop` (and my tests showed that it returned `0` for any element's `scrollTop`, which was odd).