### PR TITLE
Form config test for military service page

### DIFF
--- a/test/edu-benefits/1995/config/militaryService.unit.spec.jsx
+++ b/test/edu-benefits/1995/config/militaryService.unit.spec.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-addons-test-utils';
+import Form from 'react-jsonschema-form';
+
+import { DefinitionTester } from '../../../util/schemaform-utils.jsx';
+import formConfig from '../../../../src/js/edu-benefits/1995/config/form';
+
+describe('Edu 1995 militaryService servicePeriods', () => {
+  const { schema, uiSchema } = formConfig.chapters.militaryService.pages.servicePeriods;
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input'))
+      .to.not.be.empty;
+  });
+
+  it('should have no required inputs', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          onSubmit={onSubmit}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+    ReactTestUtils.findRenderedComponentWithType(form, Form).onSubmit({
+      preventDefault: f => f
+    });
+    expect(Array.from(formDOM.querySelectorAll('.usa-input-error'))).to.be.empty;
+
+    ReactTestUtils.findRenderedComponentWithType(form, Form).onSubmit({
+      preventDefault: f => f
+    });
+
+    expect(onSubmit.called).to.be.true;
+  });
+});

--- a/test/edu-benefits/1995/config/militaryService.unit.spec.jsx
+++ b/test/edu-benefits/1995/config/militaryService.unit.spec.jsx
@@ -10,12 +10,14 @@ import formConfig from '../../../../src/js/edu-benefits/1995/config/form';
 
 describe('Edu 1995 militaryService servicePeriods', () => {
   const { schema, uiSchema } = formConfig.chapters.militaryService.pages.servicePeriods;
+  const definitions = formConfig.defaultDefinitions;
   it('should render', () => {
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
           schema={schema}
           data={{}}
-          uiSchema={uiSchema}/>
+          uiSchema={uiSchema}
+          definitions={definitions}/>
     );
 
     expect(ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input'))
@@ -29,7 +31,8 @@ describe('Edu 1995 militaryService servicePeriods', () => {
           schema={schema}
           onSubmit={onSubmit}
           data={{}}
-          uiSchema={uiSchema}/>
+          uiSchema={uiSchema}
+          definitions={definitions}/>
     );
     const formDOM = findDOMNode(form);
     ReactTestUtils.findRenderedComponentWithType(form, Form).onSubmit({

--- a/test/util/schemaform-utils.jsx
+++ b/test/util/schemaform-utils.jsx
@@ -17,9 +17,7 @@ export class DefinitionTester extends React.Component {
     const uiSchema = props.uiSchema;
     const data = props.data;
     let schema = updateRequiredFields(props.schema, uiSchema, data, state);
-    if (props.definitions) {
-      schema = _.assign({ definitions: props.definitions }, schema);
-    }
+    schema = _.merge(schema, { definitions: props.definitions });
     // Update the schema with any fields that are now hidden because of the data change
     schema = setHiddenFields(schema, uiSchema, data, state);
     // Update the schema with any general updates based on the new data

--- a/test/util/schemaform-utils.jsx
+++ b/test/util/schemaform-utils.jsx
@@ -17,7 +17,7 @@ export class DefinitionTester extends React.Component {
     const uiSchema = props.uiSchema;
     const data = props.data;
     let schema = updateRequiredFields(props.schema, uiSchema, data, state);
-    schema = _.merge(schema, { definitions: props.definitions });
+    schema = _.merge({ definitions: props.definitions }, schema);
     // Update the schema with any fields that are now hidden because of the data change
     schema = setHiddenFields(schema, uiSchema, data, state);
     // Update the schema with any general updates based on the new data

--- a/test/util/schemaform-utils.jsx
+++ b/test/util/schemaform-utils.jsx
@@ -1,3 +1,5 @@
+import _ from 'lodash/fp';
+
 import React from 'react';
 import SchemaForm from '../../src/js/common/schemaform/SchemaForm';
 
@@ -16,7 +18,7 @@ export class DefinitionTester extends React.Component {
     const data = props.data;
     let schema = updateRequiredFields(props.schema, uiSchema, data, state);
     if (props.definitions) {
-      schema.definitions = props.definitions;
+      schema = _.assign({ definitions: props.definitions }, schema);
     }
     // Update the schema with any fields that are now hidden because of the data change
     schema = setHiddenFields(schema, uiSchema, data, state);

--- a/test/util/schemaform-utils.jsx
+++ b/test/util/schemaform-utils.jsx
@@ -15,6 +15,9 @@ export class DefinitionTester extends React.Component {
     const uiSchema = props.uiSchema;
     const data = props.data;
     let schema = updateRequiredFields(props.schema, uiSchema, data, state);
+    if (props.definitions) {
+      schema.definitions = props.definitions;
+    }
     // Update the schema with any fields that are now hidden because of the data change
     schema = setHiddenFields(schema, uiSchema, data, state);
     // Update the schema with any general updates based on the new data


### PR DESCRIPTION
Hi Jeff,
This isn't ready to review, but wondering if you can unblock me. I can't seem to be able to figure out track down this missing reference to #/definitions/dateRange

Would this be something in the vets-json-schema repo that needs to be updated? I'm not clear on how/whether the json files in dist/ are kept in sync with the definitions.

Thanks in advance for any help!
Raquel

```
1) Edu 1995 militaryService servicePeriods should render:
     Error: Could not find a definition for #/definitions/dateRange.
      at findSchemaDefinition (node_modules/react-jsonschema-form/lib/utils.js:368:9)
      at retrieveSchema (node_modules/react-jsonschema-form/lib/utils.js:379:20)
      at toIdSchema (node_modules/react-jsonschema-form/lib/utils.js:480:19)
      at toIdSchema (node_modules/react-jsonschema-form/lib/utils.js:492:22)
      at toIdSchema (node_modules/react-jsonschema-form/lib/utils.js:484:12)
      at toIdSchema (node_modules/react-jsonschema-form/lib/utils.js:492:22)
      at Form.getStateFromProps (node_modules/react-jsonschema-form/lib/components/Form.js:131:44)
      at new Form (node_modules/react-jsonschema-form/lib/components/Form.js:102:25)
      at node_modules/react/lib/ReactCompositeComponent.js:294:18
      at measureLifeCyclePerf (node_modules/react/lib/ReactCompositeComponent.js:74:12)
      at [object Object].ReactCompositeComponentMixin._constructComponentWithoutOwner (node_modules/react/lib/ReactCompositeComponent.js:293:16)
      at [object Object].ReactCompositeComponentMixin._constructComponent (node_modules/react/lib/ReactCompositeComponent.js:279:21)
      at [object Object].ReactCompositeComponentMixin.mountComponent (node_modules/react/lib/ReactCompositeComponent.js:187:21)
      at Object.ReactReconciler.mountComponent (node_modules/react/lib/ReactReconciler.js:47:35)
      at ReactDOMComponent.ReactMultiChild.Mixin.mountChildren (node_modules/react/lib/ReactMultiChild.js:240:44)
      at ReactDOMComponent.Mixin._createInitialChildren (node_modules/react/lib/ReactDOMComponent.js:699:32)
      at ReactDOMComponent.Mixin.mountComponent (node_modules/react/lib/ReactDOMComponent.js:524:12)
      at Object.ReactReconciler.mountComponent (node_modules/react/lib/ReactReconciler.js:47:35)
      at [object Object].ReactCompositeComponentMixin.performInitialMount (node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at [object Object].ReactCompositeComponentMixin.mountComponent (node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.ReactReconciler.mountComponent (node_modules/react/lib/ReactReconciler.js:47:35)
      at [object Object].ReactCompositeComponentMixin.performInitialMount (node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at [object Object].ReactCompositeComponentMixin.mountComponent (node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.ReactReconciler.mountComponent (node_modules/react/lib/ReactReconciler.js:47:35)
      at [object Object].ReactCompositeComponentMixin.performInitialMount (node_modules/react/lib/ReactCompositeComponent.js:370:34)
      at [object Object].ReactCompositeComponentMixin.mountComponent (node_modules/react/lib/ReactCompositeComponent.js:257:21)
      at Object.ReactReconciler.mountComponent (node_modules/react/lib/ReactReconciler.js:47:35)
      at mountComponentIntoNode (node_modules/react/lib/ReactMount.js:105:32)
      at ReactReconcileTransaction.Mixin.perform (node_modules/react/lib/Transaction.js:138:20)
      at batchedMountComponentIntoNode (node_modules/react/lib/ReactMount.js:127:15)
      at ReactDefaultBatchingStrategyTransaction.Mixin.perform (node_modules/react/lib/Transaction.js:138:20)
      at Object.ReactDefaultBatchingStrategy.batchedUpdates (node_modules/react/lib/ReactDefaultBatchingStrategy.js:63:19)
      at Object.batchedUpdates (node_modules/react/lib/ReactUpdates.js:98:20)
      at Object.ReactMount._renderNewRootComponent (node_modules/react/lib/ReactMount.js:321:18)
      at Object.ReactMount._renderSubtreeIntoContainer (node_modules/react/lib/ReactMount.js:402:32)
      at Object.ReactMount.render (node_modules/react/lib/ReactMount.js:423:23)
      at Object.ReactTestUtils.renderIntoDocument (node_modules/react/lib/ReactTestUtils.js:84:21)
      at Context.<anonymous> (test/edu-benefits/1995/config/militaryService.unit.spec.jsx:14:33)
```