### PR TITLE
Fix some sluggishness on pages with addresses

### DIFF
--- a/src/js/common/schemaform/Address.jsx
+++ b/src/js/common/schemaform/Address.jsx
@@ -4,17 +4,37 @@ import { set, assign } from 'lodash/fp';
 
 import { getDefaultFormState } from 'react-jsonschema-form/lib/utils';
 
+import * as address from './definitions/address';
 import { states } from '../utils/options-for-select';
+import { pureWithDeepEquals } from './helpers';
+
+const defaultStateSchema = address.schema().properties.state;
+
+const militaryStates = states.USA.filter(state => state.value === 'AE' || state.value === 'AP' || state.value === 'AA');
+const militaryStateSchema = assign(defaultStateSchema, {
+  'enum': militaryStates.map(state => state.value),
+  enumNames: militaryStates.map(state => state.label)
+});
+
+const stateSchemas = Object.keys(states).reduce((options, country) => {
+  return assign(options, {
+    [country]: assign(defaultStateSchema, {
+      'enum': states[country].map(state => state.value),
+      enumNames: states[country].map(state => state.label)
+    })
+  });
+}, {});
 
 /**
  * Input component for an address.
  */
 class Address extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.handleChange = this.handleChange.bind(this);
     this.onPropertyBlur = this.onPropertyBlur.bind(this);
     this.isRequired = this.isRequired.bind(this);
+    this.SchemaField = pureWithDeepEquals(props.registry.fields.SchemaField);
   }
 
   componentWillMount() {
@@ -53,7 +73,6 @@ class Address extends React.Component {
   }
 
   render() {
-    let stateList = [];
     const {
       errorSchema,
       formContext,
@@ -66,7 +85,7 @@ class Address extends React.Component {
     const formData = this.props.formData
       ? this.props.formData
       : getDefaultFormState(schema, undefined, registry.definitions);
-    const SchemaField = registry.fields.SchemaField;
+    const SchemaField = this.SchemaField;
     const TitleField = registry.fields.TitleField;
     const selectedCountry = formData.country;
     const title = uiSchema['ui:title'];
@@ -82,17 +101,10 @@ class Address extends React.Component {
       postalCodeUiSchema = set('ui:title', 'ZIP code', postalCodeUiSchema);
     }
 
-    // const hasErrors = (formContext.submitted || touchedSchema) && rawErrors && rawErrors.length;
-    if (states[selectedCountry]) {
-      stateList = states[selectedCountry];
-      if (formData.city && this.isMilitaryCity(formData.city)) {
-        stateList = stateList.filter(state => state.value === 'AE' || state.value === 'AP' || state.value === 'AA');
-      }
-
-      stateSchema = assign(stateSchema, {
-        'enum': stateList.map(state => state.value),
-        enumNames: stateList.map(state => state.label)
-      });
+    if (selectedCountry === 'USA' && formData.city && this.isMilitaryCity(formData.city)) {
+      stateSchema = militaryStateSchema;
+    } else if (stateSchemas[selectedCountry]) {
+      stateSchema = stateSchemas[selectedCountry];
     }
 
     return (


### PR DESCRIPTION
Related to [1313](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1313)

The Address component was missing some optimizations that ObjectField has. I also updated it to calculate the different state schemas outside of the render method, so we can switch between them and take advantage of the SelectWidget skipping updates when the schema is shallowly equal.

Before (time spent in `render()` that resulted in no visual changes when typing 3 characters into the street address field and then removing them):
![screen shot 2017-02-22 at 4 47 08 pm](https://cloud.githubusercontent.com/assets/634932/23234315/af2c5140-f91f-11e6-8537-384e98d8669c.png)

After:
![screen shot 2017-02-22 at 4 49 17 pm](https://cloud.githubusercontent.com/assets/634932/23234316/af2c81ce-f91f-11e6-8914-da177aab9a8f.png)

This is on a slow Android phone. It's not really noticeable on desktop or new phones.