### PR TITLE
Touches up some styles on 1995

### DIFF
--- a/src/js/edu-benefits/1995/containers/ConfirmationPage.jsx
+++ b/src/js/edu-benefits/1995/containers/ConfirmationPage.jsx
@@ -83,7 +83,7 @@ class ConfirmationPage extends React.Component {
             </li>
           </ul>
         </div>
-        <div id="collapsiblePanel" className="usa-accordion-bordered form-review-panel">
+        <div id="collapsiblePanel" className="usa-accordion-bordered">
           <ul className="usa-unstyled-list">
             <li>
               <div className="accordion-header clearfix">

--- a/src/js/edu-benefits/1995/containers/ConfirmationPage.jsx
+++ b/src/js/edu-benefits/1995/containers/ConfirmationPage.jsx
@@ -3,7 +3,6 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import ExpandingGroup from '../../../common/components/form-elements/ExpandingGroup';
 import { focusElement } from '../../../common/utils/helpers';
 
 import { benefitsLabels } from '../helpers';

--- a/src/js/edu-benefits/1995/containers/ConfirmationPage.jsx
+++ b/src/js/edu-benefits/1995/containers/ConfirmationPage.jsx
@@ -40,6 +40,17 @@ class ConfirmationPage extends React.Component {
     const name = form.veteranInformation.data.veteranFullName;
     const benefit = form.benefitSelection.data.benefit;
 
+    const docExplanation = this.state.isExpanded
+      ? (<div className="usa-accordion-content">
+        <p>In the future, you might need:</p>
+        <ul>
+          <li>Your reserve kicker</li>
+          <li>Documentation of additional contributions that would increase your monthly benefits.</li>
+        </ul>
+        <p>Documents can be uploaded using the <a href="https://gibill.custhelp.com/app/utils/login_form/redirect/account%252">GI Bill site</a>.</p>
+      </div>)
+      : null;
+
     return (
       <div className="edu-benefits-submit-success">
         <h3 className="edu-page-title">Claim received</h3>
@@ -71,26 +82,27 @@ class ConfirmationPage extends React.Component {
             </li>
           </ul>
         </div>
-        <div className="inset secondary expandable">
-          <ExpandingGroup open={this.state.isExpanded} showPlus>
-            <div onClick={this.handleClick} className="clickable">
-              <b>No documents required at this time</b>
-            </div>
-            <div>
-              <p>In the future, you might need:</p>
-              <ul>
-                <li>Your reserve kicker</li>
-                <li>Documentation of additional contributions that would increase your monthly benefits.</li>
-              </ul>
-              <p>Documents can be uploaded using the <a href="https://gibill.custhelp.com/app/utils/login_form/redirect/account%252">GI Bill site</a>.</p>
-            </div>
-          </ExpandingGroup>
+        <div id="collapsiblePanel" className="usa-accordion-bordered form-review-panel">
+          <ul className="usa-unstyled-list">
+            <li>
+              <div className="accordion-header clearfix">
+                <button
+                    className="usa-button-unstyled"
+                    aria-expanded={this.state.isExpanded ? 'true' : 'false'}
+                    aria-controls="collapsible-document-explanation"
+                    onClick={this.handleClick}>
+                  No documents required at this time
+                </button>
+              </div>
+              {docExplanation}
+            </li>
+          </ul>
         </div>
         <p>Need help? If you have questions, call 888-442-4551 (888-GI-BILL-1) from 8:00 a.m. - 7:00 p.m. ET Mon - Fri.</p>
         <div className="row form-progress-buttons schemaform-back-buttons">
           <div className="small-6 medium-6 columns">
             <a href="/">
-              <button className="usa-button-primary">Go back to Vets.gov</button>
+              <button className="usa-button-primary">Go Back to Vets.gov</button>
             </a>
           </div>
         </div>

--- a/src/sass/_normalize.scss
+++ b/src/sass/_normalize.scss
@@ -1,0 +1,12 @@
+// Ideally all of this will go in uswds/src/stylesheets/lib/normalize, but until
+//  it does, normalizing css goes in here.
+
+dl {
+  display: block;
+  -webkit-margin-before: 0px;
+  -webkit-margin-after: 0px;
+  -webkit-margin-start: 0px;
+  -webkit-margin-end: 0px;
+  margin-top: 1em;
+  margin-bottom: 1em;
+}

--- a/src/sass/edu-benefits.scss
+++ b/src/sass/edu-benefits.scss
@@ -253,10 +253,13 @@ form.rjsf {
   max-width: 100%;
 }
 
-.va-growable-expanded > div > fieldset > div > .first-field label,
-.va-growable-expanded > div > fieldset > div > .first-field .usa-input-error {
-  margin-top: 0;
-}
+// If the ArrayField is the first element in the page, it'll be spaced down too
+//  far without this, which was the original reason behind this, so we need to
+//  figure out a way to accommodate that too, but for now...
+// .va-growable-expanded > div > fieldset > div > .first-field label,
+// .va-growable-expanded > div > fieldset > div > .first-field .usa-input-error {
+//   margin-top: 0;
+// }
 
 .va-growable-review {
   margin-top: 16px;

--- a/src/sass/edu-benefits.scss
+++ b/src/sass/edu-benefits.scss
@@ -304,3 +304,22 @@ form.rjsf {
     padding: 0px;
   }
 }
+
+// Even up the spacing between multi-line labels and their respective elements
+label {
+  + div {
+    // Space above the date fields
+    .form-datefield-month, .form-datefield-day, .usa-form-group-year,
+    // And the inputs uswds sets a top margin for
+    input,
+    input[type="text"], input[type="email"],
+    input[type="password"], input[type="url"],
+    input[type="tel"], input[type="number"],
+    input[type="search"], input[type="file"],
+    input[type="date"], input[type="datetime-local"],
+    input[type="month"], input[type="time"],
+    input[type="week"], textarea, select {
+      margin-top: 0.5em;
+    }
+  }
+}

--- a/src/sass/modules/_m-form-elements.scss
+++ b/src/sass/modules/_m-form-elements.scss
@@ -186,21 +186,3 @@ button.form-button-disabled {
     }
   }
 }
-
-// Even up the spacing between multi-line labels and their respective elements
-label {
-  + div {
-    // Space above the date fields too
-    .form-datefield-month, .form-datefield-day, .usa-form-group-year,
-    input,
-    input[type="text"], input[type="email"],
-    input[type="password"], input[type="url"],
-    input[type="tel"], input[type="number"],
-    input[type="search"], input[type="file"],
-    input[type="date"], input[type="datetime-local"],
-    input[type="month"], input[type="time"],
-    input[type="week"], textarea, select {
-      margin-top: 0.5em;
-    }
-  }
-}

--- a/src/sass/modules/_m-form-elements.scss
+++ b/src/sass/modules/_m-form-elements.scss
@@ -186,3 +186,12 @@ button.form-button-disabled {
     }
   }
 }
+
+// Even up the spacing between multi-line labels and their respective elements
+label {
+  + div {
+    input[type=text], input[type=email], input[type=number], input[type=tel], select, textarea {
+      margin-top: 0.5em;
+    }
+  }
+}

--- a/src/sass/modules/_m-form-elements.scss
+++ b/src/sass/modules/_m-form-elements.scss
@@ -190,7 +190,16 @@ button.form-button-disabled {
 // Even up the spacing between multi-line labels and their respective elements
 label {
   + div {
-    input[type=text], input[type=email], input[type=number], input[type=tel], select, textarea {
+    // Space above the date fields too
+    .form-datefield-month, .form-datefield-day, .usa-form-group-year,
+    input,
+    input[type="text"], input[type="email"],
+    input[type="password"], input[type="url"],
+    input[type="tel"], input[type="number"],
+    input[type="search"], input[type="file"],
+    input[type="date"], input[type="datetime-local"],
+    input[type="month"], input[type="time"],
+    input[type="week"], textarea, select {
       margin-top: 0.5em;
     }
   }

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -51,6 +51,7 @@
 // ----- VA GENERAL (MAIN FILE/OTHER) ---- //
 
 @import 'base/va';
+@import 'normalize';
 
 // ----- VA MODULES (BUTTONS/CARDS/TABLES) ---- //
 @import 'modules/m-card';

--- a/test/edu-benefits/1995/containers/ConfirmationPage.unit.spec.jsx
+++ b/test/edu-benefits/1995/containers/ConfirmationPage.unit.spec.jsx
@@ -4,31 +4,29 @@ import SkinDeep from 'skin-deep';
 
 import { ConfirmationPage } from '../../../../src/js/edu-benefits/1995/containers/ConfirmationPage';
 
+const form = {
+  submission: {
+    response: {
+      attributes: {}
+    }
+  },
+  veteranInformation: {
+    data: {
+      veteranFullName: {
+        first: 'Jane',
+        last: 'Doe'
+      }
+    }
+  },
+  benefitSelection: {
+    data: {
+      benefit: 'chapter30'
+    }
+  }
+};
+
 describe('<ConfirmationPage>', () => {
   it('should render', () => {
-    const form = {
-      submission: {
-        response: {
-          attributes: {
-
-          }
-        }
-      },
-      veteranInformation: {
-        data: {
-          veteranFullName: {
-            first: 'Jane',
-            last: 'Doe'
-          }
-        }
-      },
-      benefitSelection: {
-        data: {
-          benefit: 'chapter30'
-        }
-      }
-    };
-
     const tree = SkinDeep.shallowRender(
       <ConfirmationPage form={form}/>
     );
@@ -36,38 +34,18 @@ describe('<ConfirmationPage>', () => {
     expect(tree.subTree('.edu-page-title').text()).to.equal('Claim received');
     expect(tree.everySubTree('span')[1].text().trim()).to.equal('for Jane Doe');
   });
+
   it('should expand documents', () => {
-    const form = {
-      submission: {
-        response: {
-          attributes: {
-
-          }
-        }
-      },
-      veteranInformation: {
-        data: {
-          veteranFullName: {
-            first: 'Jane',
-            last: 'Doe'
-          }
-        }
-      },
-      benefitSelection: {
-        data: {
-          benefit: 'chapter30'
-        }
-      }
-    };
-
     const tree = SkinDeep.shallowRender(
       <ConfirmationPage form={form}/>
     );
 
-    expect(tree.subTree('ExpandingGroup').props.open).to.be.false;
+    // Check to see that div.usa-accordion-content doesn't exist
+    expect(tree.subTree('.usa-accordion-content')).to.be.false;
 
     tree.getMountedInstance().handleClick({ preventDefault: f => f });
 
-    expect(tree.subTree('ExpandingGroup').props.open).to.be.true;
+    // Check to see that div.usa-accordion-content exists after expanding
+    expect(tree.subTree('.usa-accordion-content')).to.be.an('object');
   });
 });


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1349

---
> Space above branch of service label should match other fields

![image](https://cloud.githubusercontent.com/assets/12970166/23281268/80b0755a-f9d1-11e6-9e03-9c95f1b49ef1.png)

---
> On the review page, the page edit button is touching the bottom border in Firefox

![image](https://cloud.githubusercontent.com/assets/12970166/23281324/a8c5bc44-f9d1-11e6-9202-e28153e44a67.png)

---
> The line spacing in a multi line label doesn't match the space between the label and a text field/area.  This makes fields like our education objective textarea look a little weird. We should even that spacing up.

The change I made affects the spacing of non-multi-line labels as well, but only for labels before tel / email / text `input`s, `textarea`s, and `select` boxes:

![image](https://cloud.githubusercontent.com/assets/12970166/23281361/d47471e6-f9d1-11e6-98d3-c2b872976a5a.png)

---
> Accordion styling on confirmation page should match normal accordion styles

![image](https://cloud.githubusercontent.com/assets/12970166/23281150/fcf55870-f9d0-11e6-9b88-fe0b14d0fe61.png)

![image](https://cloud.githubusercontent.com/assets/12970166/23281170/11aefdf2-f9d1-11e6-962b-5ef77ed42ab8.png)

---
> Capitalize "back" in button on confirmation page

![image](https://cloud.githubusercontent.com/assets/12970166/23281213/46f2115c-f9d1-11e6-98a3-6c283cccf2dc.png)
