### PR TITLE
Add tests for personal info chapter

### DIFF
--- a/test/edu-benefits/1995/config/contactInformation.unit.spec.jsx
+++ b/test/edu-benefits/1995/config/contactInformation.unit.spec.jsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-addons-test-utils';
+import Form from 'react-jsonschema-form';
+
+import { DefinitionTester } from '../../../util/schemaform-utils.jsx';
+import formConfig from '../../../../src/js/edu-benefits/1995/config/form';
+
+describe('Edu 1995 contactInformation', () => {
+  const { schema, uiSchema } = formConfig.chapters.personalInformation.pages.contactInformation;
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+
+    const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input').concat(
+      ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'select')
+    );
+
+    expect(inputs.filter(input => input.id.startsWith('root_preferredContactMethod')).length)
+      .to.equal(3);
+    expect(inputs.filter(input => input.id.startsWith('root_veteranAddress')).length)
+      .to.equal(6);
+    expect(inputs.filter(input => input.id.startsWith('root_view:otherContactInfo')).length)
+      .to.equal(4);
+  });
+  it('should not render confirm email on review page', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{
+            'view:otherContactInfo': {
+              'view:confirmEmail': 'test@test.com'
+            }
+          }}
+          reviewMode
+          uiSchema={uiSchema}/>
+    );
+
+    expect(findDOMNode(form).textContent).not.to.contain('test@test.com');
+  });
+  it('should conditionally require phone number', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          formData={{}}
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    ReactTestUtils.findRenderedComponentWithType(form, Form).onSubmit({
+      preventDefault: f => f
+    });
+
+    // jsdom has issues with colons in attributes
+    let errors = Array.from(formDOM.querySelectorAll('.usa-input-error > label'));
+    let phoneError = errors.find(errorLabel => errorLabel.getAttribute('for').endsWith('homePhone'));
+    expect(phoneError).to.be.undefined;
+
+    const phoneMethod = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input')
+      .find(input => input.getAttribute('id') === 'root_preferredContactMethod_2');
+    ReactTestUtils.Simulate.change(phoneMethod, {
+      target: {
+        value: 'phone'
+      }
+    });
+
+    errors = Array.from(formDOM.querySelectorAll('.usa-input-error > label'));
+    phoneError = errors.find(errorLabel => errorLabel.getAttribute('for').endsWith('homePhone'));
+    expect(phoneError).not.to.be.undefined;
+  });
+  it('should show error if emails do not match', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          formData={{}}
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+    const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input');
+    const emailInput = inputs.find(input => input.id.endsWith('email'));
+    const confirmEmailInput = inputs.find(input => input.id.endsWith('confirmEmail'));
+
+    ReactTestUtils.Simulate.change(emailInput, {
+      target: {
+        value: 'test@test.com'
+      }
+    });
+    ReactTestUtils.Simulate.change(confirmEmailInput, {
+      target: {
+        value: 'test@test.com'
+      }
+    });
+    ReactTestUtils.Simulate.blur(emailInput);
+    ReactTestUtils.Simulate.blur(confirmEmailInput);
+
+    expect(formDOM.querySelectorAll('.usa-input-error')).to.be.empty;
+
+    ReactTestUtils.Simulate.change(confirmEmailInput, {
+      target: {
+        value: 'test@test.org'
+      }
+    });
+
+    expect(formDOM.querySelectorAll('.usa-input-error')).not.to.be.empty;
+  });
+  it('should have no errors with all info filled in', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          onSubmit={onSubmit}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+    ReactTestUtils.findRenderedComponentWithType(form, Form).onSubmit({
+      preventDefault: f => f
+    });
+    const find = (id) => {
+      return Array.from(formDOM.querySelectorAll('input,select')).find(input => input.id === id);
+    };
+    expect(Array.from(formDOM.querySelectorAll('.usa-input-error')).length).to.equal(6);
+
+    ReactTestUtils.Simulate.change(find('root_veteranAddress_street'), {
+      target: {
+        value: 'Test'
+      }
+    });
+    ReactTestUtils.Simulate.change(find('root_veteranAddress_city'), {
+      target: {
+        value: 'Test'
+      }
+    });
+    ReactTestUtils.Simulate.change(find('root_veteranAddress_state'), {
+      target: {
+        value: 'MT'
+      }
+    });
+    ReactTestUtils.Simulate.change(find('root_veteranAddress_postalCode'), {
+      target: {
+        value: '01070'
+      }
+    });
+    ReactTestUtils.Simulate.change(find('root_view:otherContactInfo_email'), {
+      target: {
+        value: 'test@test.com'
+      }
+    });
+    ReactTestUtils.Simulate.change(find('root_view:otherContactInfo_view:confirmEmail'), {
+      target: {
+        value: 'test@test.com'
+      }
+    });
+
+    expect(Array.from(formDOM.querySelectorAll('.usa-input-error'))).to.be.empty;
+    ReactTestUtils.findRenderedComponentWithType(form, Form).onSubmit({
+      preventDefault: f => f
+    });
+
+    expect(onSubmit.called).to.be.true;
+  });
+});

--- a/test/edu-benefits/1995/config/contactInformation.unit.spec.jsx
+++ b/test/edu-benefits/1995/config/contactInformation.unit.spec.jsx
@@ -28,7 +28,7 @@ describe('Edu 1995 contactInformation', () => {
     expect(inputs.filter(input => input.id.startsWith('root_view:otherContactInfo')).length)
       .to.equal(4);
   });
-  it('should render required fields', () => {
+  it('should render validation errors for required fields', () => {
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
           schema={schema}
@@ -42,21 +42,6 @@ describe('Edu 1995 contactInformation', () => {
     });
 
     expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(6);
-  });
-  it('should not render confirm email on review page', () => {
-    const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester
-          schema={schema}
-          data={{
-            'view:otherContactInfo': {
-              'view:confirmEmail': 'test@test.com'
-            }
-          }}
-          reviewMode
-          uiSchema={uiSchema}/>
-    );
-
-    expect(findDOMNode(form).textContent).not.to.contain('test@test.com');
   });
   it('should conditionally require phone number', () => {
     const form = ReactTestUtils.renderIntoDocument(
@@ -101,8 +86,8 @@ describe('Edu 1995 contactInformation', () => {
 
     const formDOM = findDOMNode(form);
     const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input');
-    const emailInput = inputs.find(input => input.id.endsWith('email'));
-    const confirmEmailInput = inputs.find(input => input.id.endsWith('confirmEmail'));
+    const emailInput = inputs.find(input => input.id === 'root_view:otherContactInfo_email');
+    const confirmEmailInput = inputs.find(input => input.id === 'root_view:otherContactInfo_view:confirmEmail');
 
     ReactTestUtils.Simulate.change(emailInput, {
       target: {
@@ -126,5 +111,22 @@ describe('Edu 1995 contactInformation', () => {
     });
 
     expect(formDOM.querySelectorAll('.usa-input-error')).not.to.be.empty;
+  });
+  describe('review page', () => {
+    it('should not render confirm email', () => {
+      const form = ReactTestUtils.renderIntoDocument(
+        <DefinitionTester
+            schema={schema}
+            data={{
+              'view:otherContactInfo': {
+                'view:confirmEmail': 'test@test.com'
+              }
+            }}
+            reviewMode
+            uiSchema={uiSchema}/>
+      );
+
+      expect(findDOMNode(form).textContent).not.to.contain('test@test.com');
+    });
   });
 });

--- a/test/edu-benefits/1995/config/contactInformation.unit.spec.jsx
+++ b/test/edu-benefits/1995/config/contactInformation.unit.spec.jsx
@@ -28,6 +28,21 @@ describe('Edu 1995 contactInformation', () => {
     expect(inputs.filter(input => input.id.startsWith('root_view:otherContactInfo')).length)
       .to.equal(4);
   });
+  it('should render required fields', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+    ReactTestUtils.findRenderedComponentWithType(form, Form).onSubmit({
+      preventDefault: f => f
+    });
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(6);
+  });
   it('should not render confirm email on review page', () => {
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester

--- a/test/edu-benefits/1995/config/contactInformation.unit.spec.jsx
+++ b/test/edu-benefits/1995/config/contactInformation.unit.spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
-import sinon from 'sinon';
 import ReactTestUtils from 'react-addons-test-utils';
 import Form from 'react-jsonschema-form';
 
@@ -112,61 +111,5 @@ describe('Edu 1995 contactInformation', () => {
     });
 
     expect(formDOM.querySelectorAll('.usa-input-error')).not.to.be.empty;
-  });
-  it('should have no errors with all info filled in', () => {
-    const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester
-          schema={schema}
-          onSubmit={onSubmit}
-          data={{}}
-          uiSchema={uiSchema}/>
-    );
-    const formDOM = findDOMNode(form);
-    ReactTestUtils.findRenderedComponentWithType(form, Form).onSubmit({
-      preventDefault: f => f
-    });
-    const find = (id) => {
-      return Array.from(formDOM.querySelectorAll('input,select')).find(input => input.id === id);
-    };
-    expect(Array.from(formDOM.querySelectorAll('.usa-input-error')).length).to.equal(6);
-
-    ReactTestUtils.Simulate.change(find('root_veteranAddress_street'), {
-      target: {
-        value: 'Test'
-      }
-    });
-    ReactTestUtils.Simulate.change(find('root_veteranAddress_city'), {
-      target: {
-        value: 'Test'
-      }
-    });
-    ReactTestUtils.Simulate.change(find('root_veteranAddress_state'), {
-      target: {
-        value: 'MT'
-      }
-    });
-    ReactTestUtils.Simulate.change(find('root_veteranAddress_postalCode'), {
-      target: {
-        value: '01070'
-      }
-    });
-    ReactTestUtils.Simulate.change(find('root_view:otherContactInfo_email'), {
-      target: {
-        value: 'test@test.com'
-      }
-    });
-    ReactTestUtils.Simulate.change(find('root_view:otherContactInfo_view:confirmEmail'), {
-      target: {
-        value: 'test@test.com'
-      }
-    });
-
-    expect(Array.from(formDOM.querySelectorAll('.usa-input-error'))).to.be.empty;
-    ReactTestUtils.findRenderedComponentWithType(form, Form).onSubmit({
-      preventDefault: f => f
-    });
-
-    expect(onSubmit.called).to.be.true;
   });
 });

--- a/test/edu-benefits/1995/config/dependents.unit.spec.jsx
+++ b/test/edu-benefits/1995/config/dependents.unit.spec.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import { expect } from 'chai';
+import ReactTestUtils from 'react-addons-test-utils';
+import Form from 'react-jsonschema-form';
+
+import { DefinitionTester } from '../../../util/schemaform-utils.jsx';
+import formConfig from '../../../../src/js/edu-benefits/1995/config/form';
+
+describe('Edu 1995 dependents', () => {
+  const { schema, uiSchema } = formConfig.chapters.personalInformation.pages.dependents;
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input').length).to.equal(6);
+  });
+  it('should have all fields set as required', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+    ReactTestUtils.findRenderedComponentWithType(form, Form).onSubmit({
+      preventDefault: f => f
+    });
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(3);
+  });
+});

--- a/test/edu-benefits/1995/config/directDeposit.unit.spec.jsx
+++ b/test/edu-benefits/1995/config/directDeposit.unit.spec.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import { expect } from 'chai';
+import ReactTestUtils from 'react-addons-test-utils';
+
+import { DefinitionTester } from '../../../util/schemaform-utils.jsx';
+import formConfig from '../../../../src/js/edu-benefits/1995/config/form';
+
+describe('Edu 1995 directDeposit', () => {
+  const { schema, uiSchema } = formConfig.chapters.personalInformation.pages.directDeposit;
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input').length).to.equal(3);
+  });
+  it('should render stop message', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_bankAccountChange_2'), {
+      target: {
+        value: 'stop'
+      }
+    });
+
+    expect(formDOM.textContent).to.contain('The Department of Treasury requires');
+  });
+  it('should render bank account fields', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_bankAccountChange_1'), {
+      target: {
+        value: 'startUpdate'
+      }
+    });
+
+    expect(formDOM.querySelectorAll('input').length).to.equal(7);
+  });
+  it('should show error on bad routing number', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_bankAccountChange_1'), {
+      target: {
+        value: 'startUpdate'
+      }
+    });
+    const routingNumber = formDOM.querySelector('#root_bankAccount_routingNumber');
+    ReactTestUtils.Simulate.blur(routingNumber);
+
+    expect(formDOM.querySelector('.usa-input-error #root_bankAccount_routingNumber')).to.be.null;
+
+    ReactTestUtils.Simulate.change(routingNumber, {
+      target: {
+        value: '01234567'
+      }
+    });
+
+    expect(formDOM.querySelector('.usa-input-error #root_bankAccount_routingNumber')).not.to.be.null;
+  });
+});


### PR DESCRIPTION
Related to [1320](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1320)

Adds tests for the form config for the personal information chapter.