### PR TITLE
End-of-training date validation

### DIFF
--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -259,7 +259,7 @@ const formConfig = {
               },
               address: address.uiSchema()
             },
-            trainingEndDate: date.uiSchema('When did you stop taking classes or participating in the training program?'),
+            trainingEndDate: date.uiSchema('When did you stop taking classes or participating in the training program? (Future dates are ok)'),
             reasonForChange: {
               'ui:title': 'Why did you stop taking classes or participating in the training program? (for example, “I graduated” or “I moved” or “The program wasn’t right for me.”)'
             }

--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -16,7 +16,6 @@ import * as fullName from '../../../common/schemaform/definitions/fullName';
 import * as ssn from '../../../common/schemaform/definitions/ssn';
 import * as date from '../../../common/schemaform/definitions/date';
 import * as dateRange from '../../../common/schemaform/definitions/dateRange';
-import * as currentOrPastDate from '../../../common/schemaform/definitions/currentOrPastDate';
 import * as phone from '../../../common/schemaform/definitions/phone';
 import * as address from '../../../common/schemaform/definitions/address';
 
@@ -260,7 +259,7 @@ const formConfig = {
               },
               address: address.uiSchema()
             },
-            trainingEndDate: currentOrPastDate.uiSchema('When did you stop taking classes or participating in the training program?'),
+            trainingEndDate: date.uiSchema('When did you stop taking classes or participating in the training program?'),
             reasonForChange: {
               'ui:title': 'Why did you stop taking classes or participating in the training program? (for example, “I graduated” or “I moved” or “The program wasn’t right for me.”)'
             }


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1380

Now it only throws a validation error if the date is 100 years before or after the current date.

*Note:* This also means that incomplete dates won't throw a validation error. The following is perfectly valid as far as validation goes.

---
![image](https://cloud.githubusercontent.com/assets/12970166/23382272/68ab5e66-fcf6-11e6-9b10-7467721c92af.png)
