### PR TITLE
Docker build backup keyservers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN set -ex \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
   ; do \
-    gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys "$key" ||
-      gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ||
-      gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key"
+    gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+      gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
+      gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" \
       ; \
   done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,10 @@ RUN set -ex \
     B9AE9905FFD7803F25714661B63B535A4C206CA9 \
     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
   ; do \
-    gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys "$key"; \
+    gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys "$key" ||
+      gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ||
+      gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key"
+      ; \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info


### PR DESCRIPTION
Use alternates in case of timeout for the node js signing keys.