### PR TITLE
Separate out uploader library

### DIFF
--- a/src/js/disability-benefits/reducers/uploads.js
+++ b/src/js/disability-benefits/reducers/uploads.js
@@ -10,7 +10,8 @@ import {
   UPDATE_FIELD,
   SHOW_MAIL_OR_FAX,
   CANCEL_UPLOAD,
-  SET_FIELDS_DIRTY
+  SET_FIELDS_DIRTY,
+  SET_UPLOADER
 } from '../actions';
 
 import { makeField, dirtyAllFields } from '../../common/model/fields';
@@ -49,6 +50,11 @@ export default function claimDetailReducer(state = initialState, action) {
         uploading: action.uploading,
         uploadError: false,
         uploadComplete: false,
+        uploader: action.uploader
+      });
+    }
+    case SET_UPLOADER: {
+      return _.assign(state, {
         uploader: action.uploader
       });
     }

--- a/test/disability-benefits/reducers/uploads.unit.spec.jsx
+++ b/test/disability-benefits/reducers/uploads.unit.spec.jsx
@@ -6,6 +6,7 @@ import {
   ADD_FILE,
   REMOVE_FILE,
   SET_UPLOADING,
+  SET_UPLOADER,
   SET_PROGRESS,
   DONE_UPLOADING,
   SET_UPLOAD_ERROR,
@@ -68,6 +69,17 @@ describe('Uploads reducer', () => {
     expect(state.uploading).to.be.true;
     expect(state.uploadError).to.be.false;
     expect(state.uploadComplete).to.be.false;
+    expect(state.uploader).to.eql(uploader);
+  });
+
+  it('set uploader in state', () => {
+    const uploader = {};
+    const state = uploads({
+    }, {
+      type: SET_UPLOADER,
+      uploader
+    });
+
     expect(state.uploader).to.eql(uploader);
   });
 


### PR DESCRIPTION
Related to [1377](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1377)

This puts the require call for fine-uploader inside a `require.ensure` call, which will cause Webpack to put it in a separate bundle. This keeps it out of the bundles for the rest of our apps, since we use a common store and the action files for many of the apps are pulled in for every application.