### PR TITLE
Avoid npm run build requirement for e2e tests

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -123,7 +123,7 @@ const configGenerator = (options) => {
         __SAMPLE_ENABLED__: (process.env.SAMPLE_ENABLED === 'true'),
         'process.env': {
           NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development'),
-          API_PORT: (process.env.API_PORT || 4000),
+          API_PORT: (process.env.API_PORT || 3000),
           WEB_PORT: (process.env.WEB_PORT || 3333),
           API_URL: process.env.API_URL ? JSON.stringify(process.env.API_URL) : null,
           BASE_URL: process.env.BASE_URL ? JSON.stringify(process.env.BASE_URL) : null,

--- a/script/run-nightwatch.sh
+++ b/script/run-nightwatch.sh
@@ -9,8 +9,14 @@ trap 'kill $(jobs -p)' EXIT
 
 BUILDTYPE=${BUILDTYPE:-development}
 
-# Run the api server
-node src/test-support/mockapi.js &
+# Check to see if we already have an API server running on port 3000
+if [ `nc -z localhost 3000; echo $?` -ne 0 ]; then
+  echo "Starting mockapi.js..."
+  node src/test-support/mockapi.js &
+else
+  echo "Error: Port 3000 is already in use.  If you're sure that's OK, tests will continue in 5 seconds..."
+  sleep 5;
+fi
 
 # Check to see if we already have a server running on port 3001 (as with 'npm run build')
 if [ `nc -z localhost 3001; echo $?` -ne 0 ]; then
@@ -24,7 +30,7 @@ fi
 
 # Wait for api server and web server to begin accepting connections
 # via http://unix.stackexchange.com/questions/5277
-while ! echo exit | nc localhost ${API_PORT:-4000}; do sleep 3; done
+while ! echo exit | nc localhost ${API_PORT:-3000}; do sleep 3; done
 while ! echo exit | nc localhost ${WEB_PORT:-3333}; do sleep 3; done
 
 # Webpack dev server blocks when attempting to read a generated file

--- a/script/run-nightwatch.sh
+++ b/script/run-nightwatch.sh
@@ -9,9 +9,18 @@ trap 'kill $(jobs -p)' EXIT
 
 BUILDTYPE=${BUILDTYPE:-development}
 
-# Run the api server and the webserver.
+# Run the api server
 node src/test-support/mockapi.js &
-node src/test-support/test-server.js --buildtype ${BUILDTYPE} &
+
+# Check to see if we already have a server running on port 3001 (as with 'npm run build')
+if [ `nc -z localhost 3001; echo $?` -ne 0 ]; then
+  echo "Starting test-server.js..."
+  node src/test-support/test-server.js --buildtype ${BUILDTYPE} &
+else
+  echo "Using webpack-dev-server as test server on port 3001"
+  export WEB_PORT=3001
+fi
+
 
 # Wait for api server and web server to begin accepting connections
 # via http://unix.stackexchange.com/questions/5277

--- a/src/js/common/helpers/environment.js
+++ b/src/js/common/helpers/environment.js
@@ -3,7 +3,7 @@ const _Environments = {
   staging: { API_URL: 'https://staging-api.vets.gov', BASE_URL: 'https://staging.vets.gov' },
   development: { API_URL: (process.env.API_URL || 'https://dev-api.vets.gov'), BASE_URL: (process.env.BASE_URL || 'https://dev.vets.gov') },
   local: { API_URL: `http://${location.hostname}:3000`, BASE_URL: `http://${location.hostname}:3001` },
-  e2e: { API_URL: `http://localhost:${process.env.API_PORT || 4000}`, BASE_URL: `http://localhost:${process.env.WEB_PORT || 3333}` }
+  e2e: { API_URL: `http://localhost:${process.env.API_PORT || 3000}`, BASE_URL: `http://localhost:${process.env.WEB_PORT || 3333}` }
 };
 
 function getEnvironment() {

--- a/src/test-support/mockapi.js
+++ b/src/test-support/mockapi.js
@@ -15,7 +15,7 @@ const winston = require('winston');
 
 const optionDefinitions = [
   { name: 'buildtype', type: String, defaultValue: 'development' },
-  { name: 'port', type: Number, defaultValue: +(process.env.API_PORT || 4000) },
+  { name: 'port', type: Number, defaultValue: +(process.env.API_PORT || 3000) },
 
   // Catch-all for bad arguments.
   { name: 'unexpected', type: String, multile: true, defaultOption: true },

--- a/test/util/e2e-helpers.js
+++ b/test/util/e2e-helpers.js
@@ -29,7 +29,7 @@ function overrideVetsGovApi(client) {
     });
     return window.VetsGov;
   },
-  [`http://localhost:${process.env.API_PORT || 4000}`],
+  [`http://localhost:${process.env.API_PORT || 3000}`],
   (val) => {
     // eslint-disable-next-line no-console
     console.log(`Result of overriding VetsGov.api.url${JSON.stringify(val)}`);
@@ -118,7 +118,7 @@ function expectInputToNotBeSelected(client, field) {
 
 module.exports = {
   baseUrl: `http://localhost:${process.env.WEB_PORT || 3333}`,
-  apiUrl: `http://localhost:${process.env.API_PORT || 4000}`,
+  apiUrl: `http://localhost:${process.env.API_PORT || 3000}`,
   createE2eTest,
   expectNavigateAwayFrom,
   expectValueToBeBlank,


### PR DESCRIPTION
Fixes [#1245](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1245).

This PR allows developers to run the e2e suite on top of `webpack-dev-server` (aka `npm run watch`).

The neat part about this is that you no longer have to run a full build each time you want to run e2e tests!  As long as your dev server is running, you will be testing against the most recent code under `/src`.

One thing to note is that I've changed the mock API to use port 3000.  This simplifies things a bit at the expense of developers who want to run `vets-api` locally along with the e2e tests.  If anyone finds this objectionable, please make a note of it-- I can definitely approach the issue in another way if needed.