### PR TITLE
Fix click target for radio

### DIFF
--- a/src/sass/edu-benefits.scss
+++ b/src/sass/edu-benefits.scss
@@ -303,7 +303,7 @@ label {
     // Space above the date fields
     .form-datefield-month, .form-datefield-day, .usa-form-group-year,
     // And the inputs uswds sets a top margin for
-    input,
+    input:not([type="radio"]),
     input[type="text"], input[type="email"],
     input[type="password"], input[type="url"],
     input[type="tel"], input[type="number"],


### PR DESCRIPTION
Related to [1437](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1437)

The margin change we made the other day is pushing down the clickable area for radio buttons. This removes the margin for radio buttons (which doesn't affect anything visually).

You can tests this by trying to click on the upper half of the radio button circle.

