### PR TITLE
Add a spinner to forms that are lazily loading

### DIFF
--- a/src/js/common/components/asyncLoader.jsx
+++ b/src/js/common/components/asyncLoader.jsx
@@ -1,3 +1,4 @@
+// Adapted from https://gist.github.com/acdlite/a68433004f9d6b4cbc83b5cc3990c194
 import React from 'react';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
 

--- a/src/js/edu-benefits/components/asyncLoader.jsx
+++ b/src/js/edu-benefits/components/asyncLoader.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
+
+export default function asyncLoader(getComponent, message) {
+  return class AsyncComponent extends React.Component {
+    static Component = null;
+    state = { Component: AsyncComponent.Component };
+
+    componentWillMount() {
+      if (!this.state.Component) {
+        getComponent().then(Component => {
+          AsyncComponent.Component = Component;
+          this.setState({ Component });
+        });
+      }
+    }
+    render() {
+      const { Component } = this.state;
+      if (Component) {
+        return <Component {...this.props}/>;
+      }
+      return (
+        <div className="async-loader">
+          <LoadingIndicator message={message || 'Loading page'}/>
+        </div>
+      );
+    }
+  };
+}

--- a/src/js/edu-benefits/routes.jsx
+++ b/src/js/edu-benefits/routes.jsx
@@ -1,7 +1,7 @@
 import EduBenefitsApp from './1990/containers/EduBenefitsApp';
 import routes1990 from './1990/routes';
 import form1990 from './1990/reducers';
-import asyncLoader from './components/asyncLoader';
+import asyncLoader from '../common/components/asyncLoader';
 
 export default function createRoutes(store) {
   // It will be confusing to have multiple forms in one app living side by side

--- a/src/js/edu-benefits/routes.jsx
+++ b/src/js/edu-benefits/routes.jsx
@@ -1,6 +1,7 @@
 import EduBenefitsApp from './1990/containers/EduBenefitsApp';
 import routes1990 from './1990/routes';
 import form1990 from './1990/reducers';
+import asyncLoader from './components/asyncLoader';
 
 export default function createRoutes(store) {
   // It will be confusing to have multiple forms in one app living side by side
@@ -20,12 +21,14 @@ export default function createRoutes(store) {
     {
       path: '1995',
       indexRoute: { onEnter: (nextState, replace) => replace('/1995/introduction') },
-      getComponent(nextState, callback) {
-        require.ensure([], (require) => {
-          store.replaceReducer(require('./1995/reducer').default);
-          callback(null, require('./1995/Form1995App').default);
-        }, 'edu-1995');
-      },
+      component: asyncLoader(() => {
+        return new Promise((resolve) => {
+          require.ensure([], (require) => {
+            store.replaceReducer(require('./1995/reducer').default);
+            resolve(require('./1995/Form1995App').default);
+          }, 'edu-1995');
+        });
+      }, 'Loading Form 22-1995'),
       getChildRoutes(partialNextState, callback) {
         require.ensure([], (require) => {
           callback(null, require('./1995/routes').default);

--- a/src/js/edu-benefits/routes.jsx
+++ b/src/js/edu-benefits/routes.jsx
@@ -42,12 +42,14 @@ export default function createRoutes(store) {
       {
         path: '1990e',
         indexRoute: { onEnter: (nextState, replace) => replace('/1990e/introduction') },
-        getComponent(nextState, callback) {
-          require.ensure([], (require) => {
-            store.replaceReducer(require('./1990e/reducer').default);
-            callback(null, require('./1990e/Form1990eApp').default);
-          }, 'edu-1990e');
-        },
+        component: asyncLoader(() => {
+          return new Promise((resolve) => {
+            require.ensure([], (require) => {
+              store.replaceReducer(require('./1990e/reducer').default);
+              resolve(require('./1990e/Form1990eApp').default);
+            }, 'edu-1990e');
+          });
+        }, 'Loading Form 22-1990E'),
         getChildRoutes(partialNextState, callback) {
           require.ensure([], (require) => {
             callback(null, require('./1990e/routes').default);

--- a/src/js/edu-benefits/routes.jsx
+++ b/src/js/edu-benefits/routes.jsx
@@ -59,12 +59,14 @@ export default function createRoutes(store) {
       {
         path: '5490',
         indexRoute: { onEnter: (nextState, replace) => replace('/5490/introduction') },
-        getComponent(nextState, callback) {
-          require.ensure([], (require) => {
-            store.replaceReducer(require('./5490/reducer').default);
-            callback(null, require('./5490/Form5490App').default);
-          }, 'edu-5490');
-        },
+        component: asyncLoader(() => {
+          return new Promise((resolve) => {
+            require.ensure([], (require) => {
+              store.replaceReducer(require('./5490/reducer').default);
+              resolve(require('./5490/Form5490App').default);
+            }, 'edu-5490');
+          });
+        }, 'Loading Form 22-5490'),
         getChildRoutes(partialNextState, callback) {
           require.ensure([], (require) => {
             callback(null, require('./5490/routes').default);

--- a/src/sass/modules/_m-loading-indicator.scss
+++ b/src/sass/modules/_m-loading-indicator.scss
@@ -11,3 +11,7 @@
     }
   }
 }
+
+.async-loader {
+  padding-bottom: 1em;
+}

--- a/test/common/components/asyncLoader.unit.spec.jsx
+++ b/test/common/components/asyncLoader.unit.spec.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { expect } from 'chai';
+import { findDOMNode } from 'react-dom';
+import ReactTestUtils from 'react-addons-test-utils';
+
+import asyncLoader from '../../../src/js/common/components/asyncLoader';
+
+describe('asyncLoader', () => {
+  it('should display loading indicator while waiting', () => {
+    const Component = asyncLoader(() => {
+      return new Promise(f => f);
+    }, 'Test loading');
+
+    const page = ReactTestUtils.renderIntoDocument(<Component/>);
+    const pageDOM = findDOMNode(page);
+
+    expect(pageDOM.textContent).to.contain('Test loading');
+  });
+
+  it('should display component returned from promise', (done) => {
+    const promise = Promise.resolve(() => {
+      return <div>Test component</div>;
+    });
+    const Component = asyncLoader(() => {
+      return promise;
+    }, 'Test loading');
+
+    const page = ReactTestUtils.renderIntoDocument(<Component/>);
+    // this allows setState to be called first
+    setTimeout(() => {
+      const pageDOM = findDOMNode(page);
+      expect(pageDOM.textContent).to.contain('Test component');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Related to [1110](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1110)

This adds a spinner while the lazily loaded form bundles are loading. This isn't noticeable in dev unless you add a timeout, but it does show up in staging some.

This will become more useful when we do multiform, since this spinner will be the feedback a user gets when they continue to a specific form.

![screen shot 2017-03-02 at 4 39 43 pm](https://cloud.githubusercontent.com/assets/634932/23528305/5e5f4e5e-ff67-11e6-9404-171a6cbe5b7e.png)
