### PR TITLE
Missing type in schemaform doc

### DIFF
--- a/docs/schemaform/form-config.md
+++ b/docs/schemaform/form-config.md
@@ -327,6 +327,7 @@ You can use 'ui:description' to show text or a custom component before the field
   type: 'object',
   properties: {
     'view:textObject': {
+      type: 'object',
       properties: {}
     }
   }


### PR DESCRIPTION
I just tried without the type and it was invalid schema. Only works properly with a type in there.