### PR TITLE
Show Login Failure Message if Login Attempt Fails

### DIFF
--- a/src/js/auth/containers/AuthApp.jsx
+++ b/src/js/auth/containers/AuthApp.jsx
@@ -84,7 +84,7 @@ class AuthApp extends React.Component {
         <div>
           <h3>We are sorry that we could not successfully log you in.</h3>
           <h3>Please call the Vets.gov Help Desk at 1-855-574-7286. We're open Monday‒Friday, 8:00 a.m.‒8:00 p.m. (ET).</h3>
-          <button onClick={window.close()}>Close</button>
+          <button onClick={window.close}>Close</button>
         </div>
       );
     }


### PR DESCRIPTION
This little bug was _executing_ `window.close()` instead of passing the function as an object to `onClick`