### PR TITLE
Explain defaultDefinitions

### DIFF
--- a/docs/schemaform/form-config.md
+++ b/docs/schemaform/form-config.md
@@ -25,9 +25,7 @@ Forms are created by creating a page that uses FormApp from the schemaform folde
   // Schema definitions that can be referenced on any page. These are added to each page's schema
   // in the reducer code, so that you don't have to put all of the common fields in the definitions
   // property in each page schema.
-  // In a schema's properties, there are references: "homePhone": { "$ref": "#/definitions/phone" }
-  // In the config file, the definition for phone would then need to be added into
-  // defaultDefinitions for it to be parsed correctly and added to homePhone
+  // For more information on definitions, see schema.definitions below.
   defaultDefinitions: {}, 
 
   // Object containing the configuration for each chapter. Each property is the key for a chapter
@@ -54,6 +52,11 @@ Forms are created by creating a page that uses FormApp from the schemaform folde
       // JSON schema object for the page. Follows the JSON Schema format.
       schema: {
         type: 'object',
+        // In a schema's properties, there are references to definitions. For example:
+        //   "homePhone": { "$ref": "#/definitions/phone" }
+        // In the config file, the definition for phone would then need to be added into definitions
+        // for it to be parsed correctly and added to homePhone.
+        definitions: {},
         properties: {
           field1: {
             type: 'string'

--- a/docs/schemaform/form-config.md
+++ b/docs/schemaform/form-config.md
@@ -25,6 +25,9 @@ Forms are created by creating a page that uses FormApp from the schemaform folde
   // Schema definitions that can be referenced on any page. These are added to each page's schema
   // in the reducer code, so that you don't have to put all of the common fields in the definitions
   // property in each page schema.
+  // In a schema's properties, there are references: "homePhone": { "$ref": "#/definitions/phone" }
+  // In the config file, the definition for phone would then need to be added into
+  // defaultDefinitions for it to be parsed correctly and added to homePhone
   defaultDefinitions: {}, 
 
   // Object containing the configuration for each chapter. Each property is the key for a chapter


### PR DESCRIPTION
I was unclear what this `defaultDefinitions` was for, so I added an example of why it's needed. It's probably not worded very well as-is, but I at least wanted to note that the `"$ref"`s in the `schema.properties` were referring to what goes into `defaultDefinitions`.