### PR TITLE
Fixed GIBCT filtering on values that should not be converted to camelCase.

### DIFF
--- a/src/js/gi/reducers/search.js
+++ b/src/js/gi/reducers/search.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-case-declarations */
-import { SEARCH_STARTED, SEARCH_FAILED, SEARCH_SUCCEEDED } from '../actions';
+import { camelCase } from 'lodash';
 import camelCaseKeysRecursive from 'camelcase-keys-recursive';
+import { SEARCH_STARTED, SEARCH_FAILED, SEARCH_SUCCEEDED } from '../actions';
 
 const INITIAL_STATE = {
   facets: {
@@ -41,7 +42,7 @@ function uppercaseKeys(obj) {
   return Object.keys(obj).reduce((result, key) => {
     return {
       ...result,
-      [key.toUpperCase()]: obj[key]
+      [key.toUpperCase().replace(/_/g, '-')]: obj[key]
     };
   }, {});
 }
@@ -80,7 +81,16 @@ export default function (state = INITIAL_STATE, action) {
         inProgress: false
       };
     case SEARCH_SUCCEEDED:
+      const { payload: { meta: { facets } } } = action;
       const camelPayload = camelCaseKeysRecursive(action.payload);
+
+      // In order to properly use facets for filtering, we need to
+      // keep the values from the original payload without any case conversion.
+      Object.keys(facets).forEach(facet => {
+        const camelFacet = camelCase(facet);
+        camelPayload.meta.facets[camelFacet] = facets[facet];
+      });
+
       const results = camelPayload.data.reduce((acc, result) => {
         const attributes = normalizedAttributes(result.attributes);
         return [...acc, attributes];


### PR DESCRIPTION
So found an edge case here… With the `/v0/gi/institutions/search` resource, we get a list of countries in the `meta.facets.country` object, and `bosnia_herzegovina` is one of them. However, trying to filter with it doesn’t return any results: `/v0/institutions?country=BOSNIA_HERZEGOVINA&version=1`.

Furthermore, we convert to camelCase on the front end, so it actually removes the underscore and would get us `bosniaHerzegovina`. It seems that the correct filter would be `country=bosnia-herzegovina` with the hyphen.

Trying to standardize on a case messes up searching on the other countries that have spaces (and parentheses) instead of hyphens, so the solution here seems to be to keep the values from the original payload's facets (without case conversion). For this specific case, we also need to replace the underscore with a hyphen, but assuming here that the normalized facets are generally expected to have hyphens in place of underscores.