### PR TITLE
Fix uncontrolled input warning

### DIFF
--- a/src/js/common/schemaform/widgets/TextWidget.jsx
+++ b/src/js/common/schemaform/widgets/TextWidget.jsx
@@ -13,7 +13,7 @@ export default function TextWidget(props) {
         maxLength={props.schema.maxLength}
         autoComplete={props.options.autocomplete || false}
         className={props.options.widgetClassNames}
-        value={props.value}
+        value={props.value || ''}
         onBlur={() => props.onBlur(props.id)}
         onChange={(event) => props.onChange(event.target.value ? event.target.value : undefined)}/>
   );

--- a/test/common/schemaform/widgets/TextWidget.unit.spec.jsx
+++ b/test/common/schemaform/widgets/TextWidget.unit.spec.jsx
@@ -21,6 +21,19 @@ describe('Schemaform <TextWidget>', () => {
     expect(tree.subTree('input').props.value).to.equal('testing');
     expect(tree.subTree('input').props.type).to.equal('text');
   });
+  it('should render empty string when undefined', () => {
+    const onChange = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <TextWidget
+          id="1"
+          schema={{ type: 'string' }}
+          required
+          disabled={false}
+          onChange={onChange}
+          options={{}}/>
+    );
+    expect(tree.subTree('input').props.value).to.equal('');
+  });
   it('should render number', () => {
     const onChange = sinon.spy();
     const tree = SkinDeep.shallowRender(


### PR DESCRIPTION
Related to [1385](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1385)

TextWidget should be setting value to a string always, so React doesn't switch between modes.