### PR TITLE
Vendor bundle contains things not in the vendor list

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -150,7 +150,8 @@ const configGenerator = (options) => {
 
       new webpack.optimize.CommonsChunkPlugin(
         'vendor',
-        (options.buildtype === 'development') ? 'vendor.js' : 'vendor.[chunkhash].js'
+        (options.buildtype === 'development') ? 'vendor.js' : 'vendor.[chunkhash].js',
+        Infinity
       ),
     ],
   };


### PR DESCRIPTION
Webpack is weird, so the commons chunk plugin is not putting only the libraries listed in `filesToBuild.vendor` in the vendor bundle. It is putting those libraries, plus any other code that's common to all the other chunks in it. This isn't a terrible result, but it does keep the vendor bundle from being completely stable and cacheable for long periods of time.

The fix for this is to set the `minChunks` (the third parameter) to `Infinity`, which tells the commons chunk plugin to not put anything in the chunk, other than what's listed.

Here's the [before](https://jbalboni.github.io/vetsgovperf/original-report.html) and [after](https://jbalboni.github.io/vetsgovperf/report.html) of what's in our bundles. It's not a huge change, but I think this is the original intent of the vendor bundle change. It also makes the size difference between the vendor bundle and our other bundles smaller, which could positively impact page load, since they're downloaded in parallel.


