### PR TITLE
Use better key in schemaform ObjectField

### DIFF
--- a/src/js/common/schemaform/ObjectField.jsx
+++ b/src/js/common/schemaform/ObjectField.jsx
@@ -165,9 +165,9 @@ class ObjectField extends React.Component {
       'schemaform-block': title && !isRoot
     });
 
-    const renderProp = (propName, index) => {
+    const renderProp = (propName) => {
       return (
-        <div key={index}>
+        <div key={propName}>
           <SchemaField
               name={propName}
               required={this.isRequired(propName)}

--- a/src/js/common/schemaform/review/ObjectField.jsx
+++ b/src/js/common/schemaform/review/ObjectField.jsx
@@ -75,9 +75,9 @@ class ObjectField extends React.Component {
     const isRoot = idSchema.$id === 'root';
     const formData = this.props.formData || {};
 
-    const renderField = (propName, index) => {
+    const renderField = (propName) => {
       return (
-        <SchemaField key={index}
+        <SchemaField key={propName}
             name={propName}
             schema={schema.properties[propName]}
             uiSchema={uiSchema[propName]}


### PR DESCRIPTION
Related to [1530](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1530)

This is good cautionary tale about using index keys. Since each property's SchemaField component is inside a div with an index key, those divs are not changed when the set of properties being rendered changes. The SchemaField component DOM just moves up or down to the next div. On the page mentioned in the issue, this meant that some new fields were being added inside a div that had the first field class (which wasn't removed because it's not set with React and is set on the containing div).

The solution to this is to use `propName` as a key, which should re-use divs properly.

![screen shot 2017-03-08 at 2 11 48 pm](https://cloud.githubusercontent.com/assets/634932/23719584/fbe7ec20-0409-11e7-8ce2-861727438e13.png)
