### PR TITLE
1990e Chapter 3

### DIFF
--- a/src/js/edu-benefits/1990e/config/form.js
+++ b/src/js/edu-benefits/1990e/config/form.js
@@ -168,6 +168,7 @@ const formConfig = {
             properties: {
               sponsorVeteran: {
                 type: 'object',
+                required: ['veteranFullName', 'veteranSocialSecurityNumber'],
                 properties: {
                   veteranFullName: fullName,
                   veteranSocialSecurityNumber: ssn,

--- a/src/js/edu-benefits/1990e/config/form.js
+++ b/src/js/edu-benefits/1990e/config/form.js
@@ -10,8 +10,9 @@ import directDeposit from '../../pages/directDeposit';
 import createSchoolSelectionPage from '../../pages/schoolSelection';
 
 import * as currentOrPastDate from '../../../common/schemaform/definitions/currentOrPastDate';
-import * as fullName from '../../../common/schemaform/definitions/fullName';
-import * as ssn from '../../../common/schemaform/definitions/ssn';
+import * as fullNameCommon from '../../../common/schemaform/definitions/fullName';
+import * as ssnCommon from '../../../common/schemaform/definitions/ssn';
+import * as address from '../../../common/schemaform/definitions/address';
 
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
@@ -24,11 +25,15 @@ import {
 
 const {
   gender,
-  relationship
+  relationship,
+  fullName,
+  ssn
 } = fullSchema1990e.definitions;
 
 const {
   benefit,
+  serviceBranch,
+  civilianBenefitsAssistance
 } = fullSchema1990e.properties;
 
 const {
@@ -58,8 +63,8 @@ const formConfig = {
           title: 'Applicant information',
           initialData: {},
           uiSchema: {
-            relativeFullName: fullName.uiSchema,
-            relativeSocialSecurityNumber: ssn.uiSchema,
+            relativeFullName: fullNameCommon.uiSchema,
+            relativeSocialSecurityNumber: ssnCommon.uiSchema,
             relativeDateOfBirth: currentOrPastDate.uiSchema('Date of birth'),
             gender: {
               'ui:widget': 'radio',
@@ -80,8 +85,8 @@ const formConfig = {
             type: 'object',
             required: ['relativeFullName'],
             properties: {
-              relativeFullName: fullName.schema,
-              relativeSocialSecurityNumber: ssn.schema,
+              relativeFullName: fullNameCommon.schema,
+              relativeSocialSecurityNumber: ssnCommon.schema,
               relativeDateOfBirth: currentOrPastDate.schema,
               gender,
               relationship
@@ -124,6 +129,38 @@ const formConfig = {
     sponsorVeteran: {
       title: 'Sponsor Veteran',
       pages: {
+        sponsorVeteran: {
+          title: 'Sponsor Veteran',
+          path: 'sponsor-veteran',
+          uiSchema: {
+            sponsorVeteran: {
+              veteranFullName: fullNameCommon.uiSchema,
+              veteranSocialSecurityNumber: ssnCommon.uiSchema,
+              veteranAddress: address.uiSchema(),
+              serviceBranch: {
+                'ui:title': 'Branch of Service'
+              },
+              civilianBenefitsAssistance: {
+                'ui:title': 'I am receiving benefits from the U.S. Government as a civilian employee during the same time as I am seeking benefits from VA.'
+              }
+            }
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              sponsorVeteran: {
+                type: 'object',
+                properties: {
+                  veteranFullName: fullName,
+                  veteranSocialSecurityNumber: ssn,
+                  veteranAddress: address.schema(false),
+                  serviceBranch,
+                  civilianBenefitsAssistance
+                },
+              }
+            }
+          }
+        }
       }
     },
     educationHistory: {

--- a/src/js/edu-benefits/1990e/config/form.js
+++ b/src/js/edu-benefits/1990e/config/form.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'lodash/fp';
 
 import {
   transform,
@@ -12,7 +12,7 @@ import directDeposit from '../../pages/directDeposit';
 import createSchoolSelectionPage from '../../pages/schoolSelection';
 
 import * as currentOrPastDate from '../../../common/schemaform/definitions/currentOrPastDate';
-import * as fullNameCommon from '../../../common/schemaform/definitions/fullName';
+import { uiSchema as fullNameUiSchema } from '../../../common/schemaform/definitions/fullName';
 import * as ssnCommon from '../../../common/schemaform/definitions/ssn';
 import * as address from '../../../common/schemaform/definitions/address';
 
@@ -65,7 +65,7 @@ const formConfig = {
           title: 'Applicant information',
           initialData: {},
           uiSchema: {
-            relativeFullName: fullNameCommon.uiSchema,
+            relativeFullName: fullNameUiSchema,
             relativeSocialSecurityNumber: ssnCommon.uiSchema,
             relativeDateOfBirth: currentOrPastDate.uiSchema('Date of birth'),
             gender: {
@@ -87,7 +87,7 @@ const formConfig = {
             type: 'object',
             required: ['relativeFullName'],
             properties: {
-              relativeFullName: fullNameCommon.schema,
+              relativeFullName: fullName,
               relativeSocialSecurityNumber: ssnCommon.schema,
               relativeDateOfBirth: currentOrPastDate.schema,
               gender,
@@ -153,7 +153,7 @@ const formConfig = {
                   }
                 }
               },
-              veteranSocialSecurityNumber: _.set(ssnCommon.uiSchema, ['ui:title'], 'Veteran Social Security number'),
+              veteranSocialSecurityNumber: _.set(['ui:title'], 'Veteran Social Security number', ssnCommon.uiSchema),
               veteranAddress: address.uiSchema('Veteran Address'),
               serviceBranch: {
                 'ui:title': 'Branch of Service'

--- a/src/js/edu-benefits/1990e/config/form.js
+++ b/src/js/edu-benefits/1990e/config/form.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 import {
   transform,
   eligibilityDescription
@@ -134,9 +136,25 @@ const formConfig = {
           path: 'sponsor-veteran',
           uiSchema: {
             sponsorVeteran: {
-              veteranFullName: fullNameCommon.uiSchema,
-              veteranSocialSecurityNumber: ssnCommon.uiSchema,
-              veteranAddress: address.uiSchema(),
+              veteranFullName: {
+                first: {
+                  'ui:title': 'Veteran first name'
+                },
+                last: {
+                  'ui:title': 'Veteran last name'
+                },
+                middle: {
+                  'ui:title': 'Veteran middle name'
+                },
+                suffix: {
+                  'ui:title': 'Veteran suffix',
+                  'ui:options': {
+                    widgetClassNames: 'form-select-medium'
+                  }
+                }
+              },
+              veteranSocialSecurityNumber: _.set(ssnCommon.uiSchema, ['ui:title'], 'Veteran Social Security number'),
+              veteranAddress: address.uiSchema('Veteran Address'),
               serviceBranch: {
                 'ui:title': 'Branch of Service'
               },
@@ -153,7 +171,7 @@ const formConfig = {
                 properties: {
                   veteranFullName: fullName,
                   veteranSocialSecurityNumber: ssn,
-                  veteranAddress: address.schema(false),
+                  veteranAddress: address.schema(),
                   serviceBranch,
                   civilianBenefitsAssistance
                 },

--- a/test/edu-benefits/1990e/config/sponsorVeteran.unit.spec.jsx
+++ b/test/edu-benefits/1990e/config/sponsorVeteran.unit.spec.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-addons-test-utils';
+
+import { DefinitionTester, submitForm } from '../../../util/schemaform-utils.jsx';
+import formConfig from '../../../../src/js/edu-benefits/1990e/config/form';
+
+describe('Edu 1990e sponsorVeteran', () => {
+  const { schema, uiSchema } = formConfig.chapters.sponsorVeteran.pages.sponsorVeteran;
+  const definitions = formConfig.defaultDefinitions;
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}
+          definitions={definitions}/>
+    );
+
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input'))
+      .to.not.be.empty;
+  });
+  it('should show errors when required fields are empty', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          onSubmit={onSubmit}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+    submitForm(form);
+    expect(Array.from(formDOM.querySelectorAll('.usa-input-error'))).not.to.be.empty;
+    expect(onSubmit.called).not.to.be.true;
+  });
+  it('should show no errors when all required fields are filled', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          onSubmit={onSubmit}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+    const find = formDOM.querySelector.bind(formDOM);
+    ReactTestUtils.Simulate.change(find('#root_sponsorVeteran_veteranFullName_first'), {
+      target: {
+        value: 'Veteran'
+      }
+    });
+    ReactTestUtils.Simulate.change(find('#root_sponsorVeteran_veteranFullName_last'), {
+      target: {
+        value: 'Veteran'
+      }
+    });
+
+    submitForm(form);
+    expect(Array.from(formDOM.querySelectorAll('.usa-input-error'))).to.be.empty;
+    expect(onSubmit.called).to.be.true;
+  });
+});

--- a/test/edu-benefits/1990e/config/sponsorVeteran.unit.spec.jsx
+++ b/test/edu-benefits/1990e/config/sponsorVeteran.unit.spec.jsx
@@ -19,8 +19,11 @@ describe('Edu 1990e sponsorVeteran', () => {
           definitions={definitions}/>
     );
 
-    expect(ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input'))
-      .to.not.be.empty;
+    const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input');
+    const selects = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'select');
+
+    expect(inputs.length).to.equal(10);
+    expect(selects.length).to.equal(3);
   });
   it('should show errors when required fields are empty', () => {
     const onSubmit = sinon.spy();

--- a/test/edu-benefits/1990e/config/sponsorVeteran.unit.spec.jsx
+++ b/test/edu-benefits/1990e/config/sponsorVeteran.unit.spec.jsx
@@ -62,6 +62,12 @@ describe('Edu 1990e sponsorVeteran', () => {
       }
     });
 
+    ReactTestUtils.Simulate.change(find('#root_sponsorVeteran_veteranSocialSecurityNumber'), {
+      target: {
+        value: '111-22-3333'
+      }
+    });
+
     submitForm(form);
     expect(Array.from(formDOM.querySelectorAll('.usa-input-error'))).to.be.empty;
     expect(onSubmit.called).to.be.true;


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/635.

After talking to @goldenmeanie we're not including the `relationship` question here (that is being included in Chapter 1 instead).

A few questions for @goldenmeanie:
1. Even though veteran first and last name aren't indicated as being required in the issue, do you want to make them required? Seems like that is useful and obvious information that should be in there?
2. Is it clear that these fields are in reference to the veteran/sponsor and not the applicant? Wonder if it would help to change the labels to be more specific (e.g., "Veteran first name" instead of "First name").

And thanks @raquelromano-gov for the unit tests! Copied and amended from your work on Chapter 1 :)

Screenshot:
![screencapture-localhost-3001-education-apply-for-education-benefits-application-1990e-sponsor-veteran-1489087333150](https://cloud.githubusercontent.com/assets/25183456/23766704/ea881214-04d3-11e7-9eaa-e6bccd338a76.png)