### PR TITLE
Content/wip/edu apply buttons

### DIFF
--- a/content/pages/disability-benefits/apply.md
+++ b/content/pages/disability-benefits/apply.md
@@ -28,10 +28,9 @@ For the first disability claim you file, please provide:
 
 - Discharge papers (DD214 or other separation documents) 
 - Service treatment records
+  - [Order service records through the National Archives](https://www.archives.gov/veterans/military-service-records).
 
-[Order service records through the National Archives](https://www.archives.gov/veterans/military-service-records).
-
-For all disability claims, please provide:
+**For all disability claims, please provide:**
 
 - VA medical records and hospital records that relate to your claimed illnesses or injuries
 - Private medical records and hospital reports that relate to your claimed illnesses or injuries
@@ -53,7 +52,7 @@ You can work with an accredited representative who can help you file a claim.  [
 
 #### Apply in person
 
-[Go to a Regional Benefits Office]http://www.benefits.va.gov/benefits/offices.asp
+[Go to a Regional Benefits Office](http://www.benefits.va.gov/benefits/offices.asp)
 
 ### Already applied?
 
@@ -65,6 +64,8 @@ Optional text about managing or tracking this benefit
 
 ### What happens after I apply?
 
-You don't need to do anything while you're waiting unless we send you a letter asking for more information. If we schedule exams for you, be sure not to miss them.  [Learn what happens after you apply].
+You don't need to do anything while you're waiting unless we send you a letter asking for more information. If we schedule exams for you, be sure not to miss them.
+
+[Learn what happens after you apply](/disability-benefits/after-you-apply).
 
 <div markdown="0"><br></div>

--- a/content/pages/disability-benefits/eligibility.md
+++ b/content/pages/disability-benefits/eligibility.md
@@ -36,9 +36,8 @@ Who's covered?
 ### Ready to apply?
 
 [Learn about the application process](/disability-benefits/apply), or
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation">Go to eBenefits to apply</a>
 
-[Learn about the application process](/disability-benefits/apply)
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation">Go to eBenefits to apply</a>
 
 <div markdown="0"><br></div>
 

--- a/content/pages/education/apply.md
+++ b/content/pages/education/apply.md
@@ -70,12 +70,12 @@ You must apply for education benefits using eBenefits.va.gov if you're:
 - Work with your school’s VA certifying official. This person is usually in the Registrar or Financial Aid office at the school.
 
 #### By mail
-- Call 888-442-4551 (888-GI-BILL-1) from 8:00 a.m. - 7:00 p.m. ET Mon - Fri, to request that we send the application to you. Fill it out and mail it to the VA regional claims processing office that’s in the same location as your school. [See a list of regional claims processing offices](http://www.benefits.va.gov/gibill/regional_processing.asp).
+- Call <a href="tel:+18884424551">888-442-4551</a> (888-GI-BILL-1) from 8:00 a.m. - 7:00 p.m. ET Mon - Fri, to request that we send the application to you. Fill it out and mail it to the VA regional claims processing office that’s in the same location as your school. [See a list of regional claims processing offices](http://www.benefits.va.gov/gibill/regional_processing.asp).
 
 ### Already applied?
 
 - You can't make changes to your application
-- For questions about Education Benefits please call 888-442-4551 (888-GI-BILL-1) from 8:00 a.m. - 7:00 p.m. ET Mon - Fri.
+- For questions about Education Benefits please call <a href="tel:+18884424551">888-442-4551</a> (888-GI-BILL-1) from 8:00 a.m. - 7:00 p.m. ET Mon - Fri.
 - If we've asked for documents, please upload them through the GI Bill site. <a class="usa-button-primary" href="https://gibill.custhelp.com/app/home">Go to the GI Bill site</a>
 
 <div markdown="0"><br></div>

--- a/content/pages/education/apply.md
+++ b/content/pages/education/apply.md
@@ -34,16 +34,20 @@ If you’re a Servicemember, Veteran, or family member interested in education a
 
 </div>
 
-Choose **Apply online** if you are a first time applicant.
-Includes Form 22-1990
+### Apply
 
-Choose **Manage Benefits** if you need to make a change to your current education benefits (for example, you’re moving to a new school).
-Includes Form 22-1995
+#### For first-time applicants
 
-<a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/application/1990/introduction">Apply online</a>
-<a href="/education/apply-for-education-benefits/application/1995" class="usa-button-primary usa-button-outline">Manage Benefits</a>
+Apply online with Form 22-1990
 
-<div markdown="0"><br></div>
+<a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/application/1990/introduction">Apply for benefits</a>
+
+#### To make a change to your current education benefits
+
+If you need to make a change (for example, you’re moving to a new school), manage your benefits with Form 22-1195
+
+<a href="/education/apply-for-education-benefits/application/1995" class="usa-button-primary usa-button-outline">Manage benefits</a>
+
 <div class="usa-alert usa-alert-warning usa-content secondary" markdown="1">
 	<div class="usa-alert-body">
 

--- a/content/pages/healthcare/after-you-apply.md
+++ b/content/pages/healthcare/after-you-apply.md
@@ -20,7 +20,7 @@ After you’ve applied for VA health care, we’ll send you a letter in the mail
 <div class="call-out" markdown="0">
 
 <h3 style="padding:0">Less than 1 week</h3>
-<p style="padding:0">Average time to process claims. If more than a week has passed since you gave us your application and you haven’t heard back, please don’t apply again. Call 855-574-7286.</p>
+<p style="padding:0">Average time to process claims. If more than a week has passed since you gave us your application and you haven’t heard back, please don’t apply again. Call <a href="tel:+18555747286">855-574-7286</a>.</p>
 
 </div>
 

--- a/content/pages/healthcare/apply.md
+++ b/content/pages/healthcare/apply.md
@@ -51,7 +51,7 @@ Some optional text about the online application.
 
 #### By phone
 
-Call the Vets.gov Help Desk at 855-574-7286, Monday through Friday, 8:00 a.m. to 8:00 p.m. (ET) to get help with your application.
+Call the Vets.gov Help Desk at <a href="tel:+18555747286">855-574-7286</a>, Monday through Friday, 8:00 a.m. to 8:00 p.m. (ET) to get help with your application.
 
 #### By mail
 


### PR DESCRIPTION
This ties into the work in https://github.com/department-of-veterans-affairs/vets-website/pull/5043

Proposed layout update on `/education/apply` to make the use cases easier to scan.

@goldenmeanie @mollyblake notwithstanding further content finessing by Molly, thoughts on the approach? Is this helpful? Is it worth the extra vertical space to lay it out this way?

Current layout as seen at https://vetsgov-pr-5043.herokuapp.com/education/apply/:

![image](https://cloud.githubusercontent.com/assets/4106356/23817310/0c1a918a-05a7-11e7-9446-186211aca47c.png)

Proposed change:

![image](https://cloud.githubusercontent.com/assets/4106356/23817292/ddda1c5a-05a6-11e7-8131-26fb4c047d2e.png)
