### PR TITLE
Make sure the button is a button

### DIFF
--- a/src/js/common/schemaform/ArrayField.jsx
+++ b/src/js/common/schemaform/ArrayField.jsx
@@ -222,7 +222,7 @@ export default class ArrayField extends React.Component {
                             {!isLast && <button className="float-left" onClick={() => this.handleUpdate(index)}>Update</button>}
                           </div>
                           <div className="small-6 right columns">
-                            <button className="usa-button-outline float-right" onClick={() => this.handleRemove(index)}>Remove</button>
+                            <button className="usa-button-outline float-right" type="button" onClick={() => this.handleRemove(index)}>Remove</button>
                           </div>
                         </div>}
                     </div>
@@ -285,4 +285,3 @@ ArrayField.propTypes = {
     formContext: React.PropTypes.object.isRequired,
   })
 };
-


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1618

It was defaulting to submit the form, so making sure type="button" ensures that it has no default behavior (i.e. submitting the form).

I have no idea why it was only acting like a submit when it was the first or last item in the array, but there it is.