### PR TITLE
1990e Chapter 5 Employment History

### DIFF
--- a/src/js/common/schemaform/definitions/nonMilitaryJobs.js
+++ b/src/js/common/schemaform/definitions/nonMilitaryJobs.js
@@ -19,7 +19,6 @@ export const uiSchema = {
   'ui:options': {
     itemName: 'Employment Period',
     viewField: EmploymentPeriodView,
-    hideTitle: true,
-    expandUnder: 'view:hasNonMilitaryJobs'
+    hideTitle: true
   }
 };

--- a/src/js/common/schemaform/definitions/nonMilitaryJobs.js
+++ b/src/js/common/schemaform/definitions/nonMilitaryJobs.js
@@ -1,0 +1,25 @@
+import commonDefinitions from 'vets-json-schema/dist/definitions.json';
+
+import EmploymentPeriodView from '../../../edu-benefits/components/EmploymentPeriodView';
+
+export const schema = commonDefinitions.nonMilitaryJobs;
+
+export const uiSchema = {
+  items: {
+    name: {
+      'ui:title': 'Main job'
+    },
+    months: {
+      'ui:title': 'Number of months worked'
+    },
+    licenseOrRating: {
+      'ui:title': 'Licenses or rating'
+    }
+  },
+  'ui:options': {
+    itemName: 'Employment Period',
+    viewField: EmploymentPeriodView,
+    hideTitle: true,
+    expandUnder: 'view:hasNonMilitaryJobs'
+  }
+};

--- a/src/js/edu-benefits/1990e/config/form.js
+++ b/src/js/edu-benefits/1990e/config/form.js
@@ -18,6 +18,7 @@ import * as address from '../../../common/schemaform/definitions/address';
 
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
+// import EmploymentPeriodView from '../../5490/components/EmploymentPeriodView';
 
 import {
   benefitsLabels,
@@ -29,13 +30,15 @@ const {
   gender,
   relationship,
   fullName,
-  ssn
+  ssn,
+  nonMilitaryJobs
 } = fullSchema1990e.definitions;
 
 const {
   benefit,
   serviceBranch,
-  civilianBenefitsAssistance
+  civilianBenefitsAssistance,
+  licenseOrRating
 } = fullSchema1990e.properties;
 
 const {
@@ -190,6 +193,51 @@ const formConfig = {
     employmentHistory: {
       title: 'Employment History',
       pages: {
+        employmentHistory: {
+          title: 'Employment History',
+          path: 'employment-history',
+          uiSchema: {
+            employmentHistory: {
+              licenseOrRating: {
+                'ui:title': 'Have you ever held a license of journeyman rating (for example, as a contractor or plumber) to practice a profession?'
+              },
+              nonMilitaryJobs: {
+                items: {
+                  name: {
+                    'ui:title': 'Main job'
+                  },
+                  months: {
+                    'ui:title': 'Number of months worked'
+                  },
+                  licenseOrRating: {
+                    'ui:title': 'Licenses or rating'
+                  }
+                },
+                'ui:options': {
+                  itemName: 'Employment Period',
+                  // viewField: EmploymentPeriodView,
+                  hideTitle: true,
+                  expandUnder: 'view:licenseOrRating'
+                }
+              }
+            }
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              employmentHistory: {
+                type: 'object',
+                properties: {
+                  'view:licenseOrRating': {
+                    type: 'boolean'
+                  },
+                  nonMilitaryJobs
+                  // nonMilitaryJobs: _.unset(nonMilitaryJobs, 'items.properties.postMilitaryJob')
+                }
+              }
+            }
+          }
+        }
       }
     },
     schoolSelection: {

--- a/src/js/edu-benefits/1990e/config/form.js
+++ b/src/js/edu-benefits/1990e/config/form.js
@@ -15,10 +15,10 @@ import * as currentOrPastDate from '../../../common/schemaform/definitions/curre
 import { uiSchema as fullNameUiSchema } from '../../../common/schemaform/definitions/fullName';
 import * as ssnCommon from '../../../common/schemaform/definitions/ssn';
 import * as address from '../../../common/schemaform/definitions/address';
+import { uiSchema as nonMilitaryJobsUiSchema } from '../../../common/schemaform/definitions/nonMilitaryJobs';
 
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
-// import EmploymentPeriodView from '../../5490/components/EmploymentPeriodView';
 
 import {
   benefitsLabels,
@@ -37,8 +37,7 @@ const {
 const {
   benefit,
   serviceBranch,
-  civilianBenefitsAssistance,
-  licenseOrRating
+  civilianBenefitsAssistance
 } = fullSchema1990e.properties;
 
 const {
@@ -198,28 +197,10 @@ const formConfig = {
           path: 'employment-history',
           uiSchema: {
             employmentHistory: {
-              licenseOrRating: {
+              'view:hasNonMilitaryJobs': {
                 'ui:title': 'Have you ever held a license of journeyman rating (for example, as a contractor or plumber) to practice a profession?'
               },
-              nonMilitaryJobs: {
-                items: {
-                  name: {
-                    'ui:title': 'Main job'
-                  },
-                  months: {
-                    'ui:title': 'Number of months worked'
-                  },
-                  licenseOrRating: {
-                    'ui:title': 'Licenses or rating'
-                  }
-                },
-                'ui:options': {
-                  itemName: 'Employment Period',
-                  // viewField: EmploymentPeriodView,
-                  hideTitle: true,
-                  expandUnder: 'view:licenseOrRating'
-                }
-              }
+              nonMilitaryJobs: nonMilitaryJobsUiSchema
             }
           },
           schema: {
@@ -228,11 +209,10 @@ const formConfig = {
               employmentHistory: {
                 type: 'object',
                 properties: {
-                  'view:licenseOrRating': {
+                  'view:hasNonMilitaryJobs': {
                     type: 'boolean'
                   },
-                  nonMilitaryJobs
-                  // nonMilitaryJobs: _.unset(nonMilitaryJobs, 'items.properties.postMilitaryJob')
+                  nonMilitaryJobs: _.unset('items.properties.postMilitaryJob', nonMilitaryJobs)
                 }
               }
             }

--- a/src/js/edu-benefits/1990e/config/form.js
+++ b/src/js/edu-benefits/1990e/config/form.js
@@ -200,7 +200,7 @@ const formConfig = {
               'view:hasNonMilitaryJobs': {
                 'ui:title': 'Have you ever held a license of journeyman rating (for example, as a contractor or plumber) to practice a profession?'
               },
-              nonMilitaryJobs: nonMilitaryJobsUiSchema
+              nonMilitaryJobs: _.set(['ui:options', 'expandUnder'], 'view:hasNonMilitaryJobs', nonMilitaryJobsUiSchema)
             }
           },
           schema: {

--- a/src/js/edu-benefits/5490/components/EmploymentPeriodView.jsx
+++ b/src/js/edu-benefits/5490/components/EmploymentPeriodView.jsx
@@ -1,9 +1,0 @@
-import React from 'react';
-
-export default function EmploymentPeriodView({ formData }) {
-  return (
-    <div>
-      <strong>{formData.name}</strong>
-    </div>
-  );
-}

--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -17,13 +17,13 @@ import { uiSchema as fullNameUISchema } from '../../../common/schemaform/definit
 import * as phone from '../../../common/schemaform/definitions/phone';
 import * as ssn from '../../../common/schemaform/definitions/ssn';
 import * as toursOfDuty from '../../definitions/toursOfDuty';
+import { uiSchema as nonMilitaryJobsUiSchema } from '../../../common/schemaform/definitions/nonMilitaryJobs';
 
 import contactInformation from '../../pages/contactInformation';
 import directDeposit from '../../pages/directDeposit';
 import createSchoolSelectionPage from '../../pages/schoolSelection';
 
 import IntroductionPage from '../components/IntroductionPage';
-import EmploymentPeriodView from '../components/EmploymentPeriodView';
 import ConfirmationPage from '../containers/ConfirmationPage';
 
 const {
@@ -353,24 +353,7 @@ const formConfig = {
           title: 'Employment history',
           path: 'employment-history',
           uiSchema: {
-            nonMilitaryJobs: {
-              items: {
-                name: {
-                  'ui:title': 'Main job'
-                },
-                months: {
-                  'ui:title': 'Number of months worked'
-                },
-                licenseOrRating: {
-                  'ui:title': 'Licenses or rating'
-                }
-              },
-              'ui:options': {
-                itemName: 'Employment Period',
-                viewField: EmploymentPeriodView,
-                hideTitle: true
-              }
-            }
+            nonMilitaryJobs: nonMilitaryJobsUiSchema
           },
           schema: {
             type: 'object',

--- a/src/js/edu-benefits/components/EmploymentPeriodView.jsx
+++ b/src/js/edu-benefits/components/EmploymentPeriodView.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function EmploymentPeriodView({ formData }) {
+  return (
+    <div>
+      <strong>{formData.name}</strong>
+    </div>
+  );
+}

--- a/test/common/schemaform/definitions/nonMilitaryJobs.unit.spec.jsx
+++ b/test/common/schemaform/definitions/nonMilitaryJobs.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import ReactTestUtils from 'react-addons-test-utils';
 
 import { DefinitionTester } from '../../../util/schemaform-utils.jsx';
@@ -19,5 +20,26 @@ describe('Schemaform definition nonMilitaryJobs', () => {
     const inputs = formDOM.querySelectorAll('input');
 
     expect(inputs.length).to.equal(4);
+  });
+
+  xit('should add another', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          onSubmit={onSubmit}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+    ReactTestUtils.Simulate.change(formDOM.querySelector('input'), {
+      target: {
+        value: 'A job title'
+      }
+    });
+    ReactTestUtils.Simulate.click(formDOM.querySelector('.va-growable-add-btn'));
+
+    expect(formDOM.querySelector('.va-growable-background').textContent)
+      .to.contain('A job title');
   });
 });

--- a/test/common/schemaform/definitions/nonMilitaryJobs.unit.spec.jsx
+++ b/test/common/schemaform/definitions/nonMilitaryJobs.unit.spec.jsx
@@ -22,13 +22,12 @@ describe('Schemaform definition nonMilitaryJobs', () => {
     expect(inputs.length).to.equal(4);
   });
 
-  xit('should add another', () => {
+  it('should add another', () => {
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
           schema={schema}
           onSubmit={onSubmit}
-          data={{}}
           uiSchema={uiSchema}/>
     );
     const formDOM = findDOMNode(form);

--- a/test/common/schemaform/definitions/nonMilitaryJobs.unit.spec.jsx
+++ b/test/common/schemaform/definitions/nonMilitaryJobs.unit.spec.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import { expect } from 'chai';
+import ReactTestUtils from 'react-addons-test-utils';
+
+import { DefinitionTester } from '../../../util/schemaform-utils.jsx';
+import { schema, uiSchema } from '../../../../src/js/common/schemaform/definitions/nonMilitaryJobs';
+
+describe('Schemaform definition nonMilitaryJobs', () => {
+  it('should render nonMilitaryJobs', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    const inputs = formDOM.querySelectorAll('input');
+
+    expect(inputs.length).to.equal(4);
+  });
+});

--- a/test/edu-benefits/1990e/config/employmentHistory.unit.spec.jsx
+++ b/test/edu-benefits/1990e/config/employmentHistory.unit.spec.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-// import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
-// import sinon from 'sinon';
 import ReactTestUtils from 'react-addons-test-utils';
 
 import { DefinitionTester } from '../../../util/schemaform-utils.jsx';

--- a/test/edu-benefits/1990e/config/employmentHistory.unit.spec.jsx
+++ b/test/edu-benefits/1990e/config/employmentHistory.unit.spec.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+// import { findDOMNode } from 'react-dom';
+import { expect } from 'chai';
+// import sinon from 'sinon';
+import ReactTestUtils from 'react-addons-test-utils';
+
+import { DefinitionTester } from '../../../util/schemaform-utils.jsx';
+import formConfig from '../../../../src/js/edu-benefits/1990e/config/form';
+
+describe('Edu 1990e employmentHistory', () => {
+  const { schema, uiSchema } = formConfig.chapters.employmentHistory.pages.employmentHistory;
+  const definitions = formConfig.defaultDefinitions;
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}
+          definitions={definitions}/>
+    );
+
+    const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input');
+
+    expect(inputs.length).to.equal(1);
+  });
+});


### PR DESCRIPTION
Closes: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/641

Created a shared schema definition for the employment history fields. Need to set the `expandUnder` property, though. Changed 5490 as well to use the shared definition.

![screencapture-localhost-3001-education-apply-for-education-benefits-application-1990e-employment-history-1489414853101](https://cloud.githubusercontent.com/assets/25183456/23858464/e25fa5c4-07d6-11e7-8b18-30ac766ae7b5.png)
