### PR TITLE
Expound on the view: fields

### DIFF
--- a/docs/schemaform/form-config.md
+++ b/docs/schemaform/form-config.md
@@ -366,3 +366,61 @@ You can use 'ui:description' to show text or a custom component before the field
   }
 }
 ```
+### I want to conditionally hide a group of fields
+
+We may have some fields that are siblings to others, but need to be hidden conditionally. Take the following schema snippet (from the education benefits form 22-5490):
+
+```json
+"previousBenefits": {
+  "type": "object",
+  "properties": {
+    "disability": { "type": "boolean" },
+    "dic": { "type": "boolean" },
+    "chapter31": { "type": "boolean" },
+    "ownServiceBenefits": { "type": "string" },
+    "chapter35": { "type": "boolean" },
+    "chapter33": { "type": "boolean" },
+    "transferOfEntitlement": { "type": "boolean" },
+    "other": { "type": "string" },
+    "veteranFullName": { "$ref": "#/definitions/fullName" },
+    "veteranSocialSecurityNumber": { "$ref": "#/definitions/ssn" }
+  }
+}
+```
+
+Only `chapter35`, `chapter33`, `transferOfEntitlement`, `veteranFullName`, and `veteranSocialSecurityNumber` need to be hidden conditionally, so we can make the `schema` and `uiSchema` like so:
+
+```js
+// schema
+{
+  disability: { ... },
+  dic: { ... },
+  chapter31: { ... },
+  ownServiceBenefits: { ... },
+  'view:sponsorServiceOptions': {
+    chapter35: { ... },
+    chapter33: { ... },
+    transferOfEntitlement: { ... },
+    veteranFullName: { ... },
+    veteranSocialSecurityNumber: { ... }
+  },
+  other: { ... }
+}
+
+// uiSchema
+{
+  disability: { ... },
+  dic: { ... },
+  chapter31: { ... },
+  ownServiceBenefits: { ... },
+  'view:sponsorServiceOptions': {
+    hideIf: () => /* Some condition here */,
+    chapter35: { ... },
+    chapter33: { ... },
+    transferOfEntitlement: { ... },
+    veteranFullName: { ... },
+    veteranSocialSecurityNumber: { ... }
+  },
+  other: { ... }
+}
+```

--- a/docs/schemaform/form-config.md
+++ b/docs/schemaform/form-config.md
@@ -66,9 +66,23 @@ Forms are created by creating a page that uses FormApp from the schemaform folde
           // Objects that start with view: will not be sent, but their children will be merged
           // into the parent object and will be sent
           // These can be used to remove fields from what is sent to the server, like if we have
-          // a question that is only used to reveal other questions
+          // a question that is only used to reveal other questions or group related questions
+          // together to be conditionally revealed that aren't in an object in the schema
           'view:field2': {
             type: 'string'
+          },
+          'view:artificialGroup'{
+            type: 'object',
+            properties: {
+              // view:artificialGroup will be flattened; subField1 and subField2 will be
+              // siblings of field1 when sent to the api
+              subField1: {
+                type: 'string'
+              },
+              subField2: {
+                type: 'boolean'
+              }
+            }
           }
         }
       },

--- a/docs/schemaform/form-config.md
+++ b/docs/schemaform/form-config.md
@@ -424,3 +424,5 @@ Only `chapter35`, `chapter33`, `transferOfEntitlement`, `veteranFullName`, and `
   other: { ... }
 }
 ```
+
+When this form is sent to the backend, the fields in the `view:sponsorServiceOptions` object will be moved up one level and sent alongside `dic` and `chapter31`. The back end will never see objects with names that start with `view:`, but it will get all the fields inside of them.


### PR DESCRIPTION
Gives another example of what the `view:` fields can be used for.