### PR TITLE
Use right address field on contact information page for 1990e and 5490

### DIFF
--- a/src/js/edu-benefits/1990e/config/form.js
+++ b/src/js/edu-benefits/1990e/config/form.js
@@ -7,7 +7,7 @@ import {
 
 import fullSchema1990e from 'vets-json-schema/dist/transfer-benefits-schema.json';
 
-import contactInformation from '../../pages/contactInformation';
+import createContactInformationPage from '../../pages/contactInformation';
 import directDeposit from '../../pages/directDeposit';
 import createSchoolSelectionPage from '../../pages/schoolSelection';
 
@@ -205,7 +205,7 @@ const formConfig = {
     personalInformation: {
       title: 'Personal Information',
       pages: {
-        contactInformation,
+        contactInformation: createContactInformationPage('relativeAddress'),
         directDeposit
       }
     }

--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -19,7 +19,7 @@ import educationTypeUISchema from '../../definitions/educationType';
 import * as serviceBefore1977 from '../../definitions/serviceBefore1977';
 import { uiSchema as toursOfDutyUI } from '../../definitions/toursOfDuty';
 
-import contactInformation from '../../pages/contactInformation';
+import createContactInformationPage from '../../pages/contactInformation';
 
 import { showSchoolAddress, benefitsLabels } from '../../utils/helpers';
 import IntroductionPage from '../components/IntroductionPage';
@@ -260,7 +260,7 @@ const formConfig = {
     personalInformation: {
       title: 'Personal Information',
       pages: {
-        contactInformation,
+        contactInformation: createContactInformationPage(),
         dependents: {
           title: 'Dependents',
           path: 'personal-information/depedents',

--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -18,7 +18,7 @@ import * as phone from '../../../common/schemaform/definitions/phone';
 import * as ssn from '../../../common/schemaform/definitions/ssn';
 import * as toursOfDuty from '../../definitions/toursOfDuty';
 
-import contactInformation from '../../pages/contactInformation';
+import createContactInformationPage from '../../pages/contactInformation';
 import directDeposit from '../../pages/directDeposit';
 import createSchoolSelectionPage from '../../pages/schoolSelection';
 
@@ -398,7 +398,7 @@ const formConfig = {
     personalInformation: {
       title: 'Personal Information',
       pages: {
-        contactInformation,
+        contactInformation: createContactInformationPage('relativeAddress'),
         secondaryContact: {
           title: 'Secondary contact',
           path: 'personal-information/secondary-contact',

--- a/src/js/edu-benefits/pages/contactInformation.js
+++ b/src/js/edu-benefits/pages/contactInformation.js
@@ -15,63 +15,63 @@ const {
 import * as phone from '../../common/schemaform/definitions/phone';
 import * as address from '../../common/schemaform/definitions/address';
 
-const contactInformation = {
-  title: 'Contact information',
-  path: 'personal-information/contact-information',
-  initialData: {},
-  uiSchema: {
-    preferredContactMethod: {
-      'ui:title': 'How would you like to be contacted if we have questions about your application?',
-      'ui:widget': 'radio',
-      'ui:options': {
-        labels: preferredContactMethodLabels
+export default function createContactInformationPage(addressField = 'veteranAddress') {
+  return {
+    title: 'Contact information',
+    path: 'personal-information/contact-information',
+    initialData: {},
+    uiSchema: {
+      preferredContactMethod: {
+        'ui:title': 'How would you like to be contacted if we have questions about your application?',
+        'ui:widget': 'radio',
+        'ui:options': {
+          labels: preferredContactMethodLabels
+        }
+      },
+      [addressField]: address.uiSchema(),
+      'view:otherContactInfo': {
+        'ui:title': 'Other contact information',
+        'ui:description': 'Please enter as much contact information as possible so we can get in touch with you, if necessary.',
+        'ui:validations': [
+          validateMatch('email', 'view:confirmEmail')
+        ],
+        email: {
+          'ui:title': 'Email address'
+        },
+        'view:confirmEmail': {
+          'ui:title': 'Re-enter email address',
+          'ui:options': {
+            hideOnReview: true
+          }
+        },
+        homePhone: _.assign(phone.uiSchema('Primary telephone number'), {
+          'ui:required': (form) => form.preferredContactMethod === 'phone'
+        }),
+        mobilePhone: phone.uiSchema('Mobile telephone number')
       }
     },
-    veteranAddress: address.uiSchema(),
-    'view:otherContactInfo': {
-      'ui:title': 'Other contact information',
-      'ui:description': 'Please enter as much contact information as possible so we can get in touch with you, if necessary.',
-      'ui:validations': [
-        validateMatch('email', 'view:confirmEmail')
-      ],
-      email: {
-        'ui:title': 'Email address'
-      },
-      'view:confirmEmail': {
-        'ui:title': 'Re-enter email address',
-        'ui:options': {
-          hideOnReview: true
-        }
-      },
-      homePhone: _.assign(phone.uiSchema('Primary telephone number'), {
-        'ui:required': (form) => form.preferredContactMethod === 'phone'
-      }),
-      mobilePhone: phone.uiSchema('Mobile telephone number')
-    }
-  },
-  schema: {
-    type: 'object',
-    properties: {
-      preferredContactMethod,
-      veteranAddress: address.schema(true),
-      'view:otherContactInfo': {
-        type: 'object',
-        required: ['email', 'view:confirmEmail'],
-        properties: {
-          email: {
-            type: 'string',
-            format: 'email'
-          },
-          'view:confirmEmail': {
-            type: 'string',
-            format: 'email'
-          },
-          homePhone: phone.schema,
-          mobilePhone: phone.schema
+    schema: {
+      type: 'object',
+      properties: {
+        preferredContactMethod,
+        [addressField]: address.schema(true),
+        'view:otherContactInfo': {
+          type: 'object',
+          required: ['email', 'view:confirmEmail'],
+          properties: {
+            email: {
+              type: 'string',
+              format: 'email'
+            },
+            'view:confirmEmail': {
+              type: 'string',
+              format: 'email'
+            },
+            homePhone: phone.schema,
+            mobilePhone: phone.schema
+          }
         }
       }
     }
-  }
-};
-
-export default contactInformation;
+  };
+}

--- a/test/edu-benefits/pages/contactInformation.unit.spec.jsx
+++ b/test/edu-benefits/pages/contactInformation.unit.spec.jsx
@@ -4,10 +4,10 @@ import { expect } from 'chai';
 import ReactTestUtils from 'react-addons-test-utils';
 
 import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
-import formConfig from '../../../src/js/edu-benefits/pages/contactInformation.js';
+import createContactInformationPage from '../../../src/js/edu-benefits/pages/contactInformation.js';
 
 describe('Edu pages contactInformation', () => {
-  const { schema, uiSchema } = formConfig;
+  const { schema, uiSchema } = createContactInformationPage();
   it('should render', () => {
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
@@ -26,6 +26,21 @@ describe('Edu pages contactInformation', () => {
       .to.equal(6);
     expect(inputs.filter(input => input.id.startsWith('root_view:otherContactInfo')).length)
       .to.equal(4);
+  });
+  it('should render address field from parameter', () => {
+    const page = createContactInformationPage('relativeAddress');
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={page.schema}
+          data={{}}
+          uiSchema={page.uiSchema}/>
+    );
+    const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input').concat(
+      ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'select')
+    );
+
+    expect(inputs.filter(input => input.id.startsWith('root_relativeAddress')).length)
+      .to.equal(6);
   });
   it('should render validation errors for required fields', () => {
     const form = ReactTestUtils.renderIntoDocument(


### PR DESCRIPTION
We're using the wrong address field on 1990e and 5490 for the contact information page. It should be relativeAddress. The 1995 should be veteranAddress.