### PR TITLE
Set the environment as a tagmanager variable

### DIFF
--- a/content/includes/footer.html
+++ b/content/includes/footer.html
@@ -16,7 +16,7 @@
       <dd><a href="https://www.vets.gov/disability-benefits/track-claims/your-claims/">Check disability claim status</a></dd>
       <dd><a href="https://www.vets.gov/gi-bill-comparison-tool/">Education benefits by school</a></dd>
       <dd><a href="https://www.vets.gov/healthcare/prescriptions/">Refill prescriptions</a></dd>
-    </dl>   
+    </dl>
     <ul class="va-footer-linkgroup va-list--plain" id="footer-contact">
       <li><h4 class="va-footer-linkgroup-title">Contact</h4></li>
       <li><a href="/facilities/">Find nearby VA locations</a></dt>
@@ -96,11 +96,22 @@ visit <a href="https://www.veteranscrisisline.net/">VeteransCrisisLine.net</a> f
 <script src="/js/user-voice.js"></script>
 
 <!-- htmllint attr-bans="[]" -->
-<!-- Google Tag Manager -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WFJWBD"
-height="0" width="0" class="csp-inline-patch-footer"></iframe></noscript>
-<script src="/js/google-analytics.js"></script>
-<!-- End Google Tag Manager -->
+{% if buildtype === 'development' %}
+  <script>
+    window.dataLayer = [];
+  </script>
+{% else %}
+  <!-- Google Tag Manager -->
+  <script>
+    dataLayer = [{
+      'environment': '{{ buildtype }}'
+    }];
+  </script>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WFJWBD"
+  height="0" width="0" class="csp-inline-patch-footer"></iframe></noscript>
+  <script src="/js/google-analytics.js"></script>
+  <!-- End Google Tag Manager -->
+{% endif %}
 <!-- htmllint attr-bans="$previous" -->
 
 <!--

--- a/script/build.js
+++ b/script/build.js
@@ -112,6 +112,9 @@ liquid.filters.humanizeDate = (dt) => moment(dt).format('MMMM D, YYYY');
 smith.source(sourceDir);
 smith.destination(`../build/${options.buildtype}`);
 
+// This lets us access the {{buildtype}} variable within liquid templates.
+smith.metadata({ buildtype: options.buildtype });
+
 // TODO(awong): Verify that memorial-benefits should still be in the source tree.
 //    https://github.com/department-of-veterans-affairs/vets-website/issues/2721
 

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -67,13 +67,11 @@ class Main extends React.Component {
   handleLogin() {
     window.dataLayer.push({
       event: 'login-link-clicked',
-      environment: `${__BUILDTYPE__}`
     });
     const myLoginUrl = this.props.login.loginUrl.first;
     if (myLoginUrl) {
       window.dataLayer.push({
         event: 'login-link-opened',
-        environment: `${__BUILDTYPE__}`
       });
       const receiver = window.open(`${myLoginUrl}&op=signin`, '_blank', 'resizable=yes,scrollbars=1,top=50,left=500,width=500,height=750');
       receiver.focus();
@@ -83,13 +81,11 @@ class Main extends React.Component {
   handleSignup() {
     window.dataLayer.push({
       event: 'register-link-clicked',
-      environment: `${__BUILDTYPE__}`
     });
     const myLoginUrl = this.props.login.loginUrl.first;
     if (myLoginUrl) {
       window.dataLayer.push({
         event: 'register-link-opened',
-        environment: `${__BUILDTYPE__}`
       });
       const receiver = window.open(`${myLoginUrl}&op=signup`, '_blank', 'resizable=yes,scrollbars=1,top=50,left=500,width=500,height=750');
       receiver.focus();
@@ -99,13 +95,11 @@ class Main extends React.Component {
   handleLogout() {
     window.dataLayer.push({
       event: 'logout-link-clicked',
-      environment: `${__BUILDTYPE__}`
     });
     const myLogoutUrl = this.state.logoutUrl;
     if (myLogoutUrl) {
       window.dataLayer.push({
         event: 'logout-link-opened',
-        environment: `${__BUILDTYPE__}`
       });
       const receiver = window.open(myLogoutUrl, '_blank', 'resizable=yes,scrollbars=1,top=50,left=500,width=500,height=750');
       receiver.focus();


### PR DESCRIPTION
We shouldn't need to pass the environment with every event we record in tagmanager because it's a variable and so only needs to be set once. This follows Google's suggestions about how to preset such a variable. In addition, it stops loading GA at all in development mode.

Closes #1439

Google's documentation on the subject is [here](https://developers.google.com/tag-manager/devguide). On the subject of setting variables, it says: "Each of the variables declared within the data layer object will persist as long as the visitor remains on the current page."