### PR TITLE
Add a target for the linter to only work on changed files

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,3 +1,3 @@
 #!/bin/sh
 # Lint everything before commit, just in case our text editor isn't doing it for us
-npm run lint
+npm run lint:changed

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "heroku-serve": "http-server",
     "heroku-postbuild": "npm run build -- --buildtype development",
     "lint": "npm run lint:js && npm run lint:sass",
+    "lint:changed": "npm run lint:js:changed && npm run lint:sass",
     "lint:js": "eslint --quiet --ext .js --ext .jsx .",
     "lint:js:changed": "LIST=`git diff-index --name-only HEAD | grep .*\\.js | grep -v json`; if [ \"$LIST\" ]; then eslint --quiet $LIST; fi",
     "lint:sass": "sass-lint -c config/sass-lint.yml",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "heroku-postbuild": "npm run build -- --buildtype development",
     "lint": "npm run lint:js && npm run lint:sass",
     "lint:js": "eslint --quiet --ext .js --ext .jsx .",
+    "lint:js:changed": "LIST=`git diff-index --name-only HEAD | grep .*\\.js | grep -v json`; if [ \"$LIST\" ]; then eslint --quiet $LIST; fi",
     "lint:sass": "sass-lint -c config/sass-lint.yml",
     "nightwatch": "nightwatch -c config/nightwatch.js",
     "test": "npm run test:unit && npm run test:e2e",

--- a/script/build.js
+++ b/script/build.js
@@ -32,8 +32,8 @@ const minimumNpmVersion = '3.8.9';
 const minimumNodeVersion = '4.4.7';
 // Make sure git pre-commit hooks are installed
 ['pre-commit'].forEach(hook => {
-  const src = `../hooks/${hook}`;
-  const dest = `../.git/hooks/${hook}`;
+  const src = path.join(__dirname, `../hooks/${hook}`);
+  const dest = path.join(__dirname, `../.git/hooks/${hook}`);
   if (fs.existsSync(src)) {
     if (!fs.existsSync(dest)) {
       // Install hooks


### PR DESCRIPTION
This adds the option for `npm lint:js:changed`, which only operates on files that have updates in git. It will make it a lot faster to lint your changes before pushing them up.

Closes department-of-veterans-affairs/vets.gov-team#1244