### PR TITLE
Remove temporary local GIDS API override

### DIFF
--- a/src/js/gi/config.js
+++ b/src/js/gi/config.js
@@ -1,17 +1,9 @@
 import environment from '../common/helpers/environment';
 
-// Temporary hack to use GIDS on localhost directly
-// (instead of vets-api)
-function getAPIUrl(useLocalGidsURL) {
-  const localGidsApiURL = 'https://dev-api.vets.gov/v0/gi'; // 'http://localhost:5000/v0';
-  const it = useLocalGidsURL ? localGidsApiURL : `${environment.API_URL}/v0/gi`;
-  return it;
-}
-
 module.exports = {
   // Base URL to be used in API requests.
   api: {
-    url: getAPIUrl(true),
+    url: `${environment.API_URL}/v0/gi`,
     settings: {
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
Fixes broken GIBCT in staging. Whole helper method with hard-coded param and was not pointing to localhost anyway...if needed somebody can locally overwrite exports url directly. 

