### PR TITLE
Timestamp assets

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -12,7 +12,7 @@ const _ = require('lodash');
 
 require('babel-polyfill');
 
-timestamp = new Date().getTime();
+const timestamp = new Date().getTime();
 
 const entryFiles = {
   'disability-benefits': './src/js/disability-benefits/disability-benefits-entry.jsx',

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -12,6 +12,8 @@ const _ = require('lodash');
 
 require('babel-polyfill');
 
+timestamp = new Date().getTime();
+
 const entryFiles = {
   'disability-benefits': './src/js/disability-benefits/disability-benefits-entry.jsx',
   'edu-benefits': './src/js/edu-benefits/edu-benefits-entry.jsx',
@@ -47,8 +49,8 @@ const configGenerator = (options) => {
     output: {
       path: path.join(__dirname, `../build/${options.buildtype}/generated`),
       publicPath: '/generated/',
-      filename: (options.buildtype === 'development') ? '[name].entry.js' : '[name].entry.[chunkhash].js',
-      chunkFilename: (options.buildtype === 'development') ? '[name].entry.js' : '[name].entry.[chunkhash].js'
+      filename: (options.buildtype === 'development') ? '[name].entry.js' : `[name].entry.[chunkhash]-${timestamp}.js`,
+      chunkFilename: (options.buildtype === 'development') ? '[name].entry.js' : `[name].entry.[chunkhash]-${timestamp}.js`
     },
     module: {
       loaders: [
@@ -145,12 +147,12 @@ const configGenerator = (options) => {
         'window.jQuery': 'jquery'
       }),
 
-      new ExtractTextPlugin((options.buildtype === 'development') ? '[name].css' : '[name].[chunkhash].css'),
+      new ExtractTextPlugin((options.buildtype === 'development') ? '[name].css' : `[name].[chunkhash]-${timestamp}.css`),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
 
       new webpack.optimize.CommonsChunkPlugin(
         'vendor',
-        (options.buildtype === 'development') ? 'vendor.js' : 'vendor.[chunkhash].js',
+        (options.buildtype === 'development') ? 'vendor.js' : `vendor.[chunkhash]-${timestamp}.js`,
         Infinity
       ),
     ],


### PR DESCRIPTION
This adds a timestamp to the end of asset filenames. There is a bug where the contents are being updated but not the hashes, and this will fix that by allowing caching within a build but busting the cache between builds.