### PR TITLE
Disable hook installation for Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "name":"vets-website",
   "scripts":{},
   "env":{
+    "INSTALL_HOOKS": "no"
   },
   "addons":[],
   "buildpacks": [

--- a/script/build.js
+++ b/script/build.js
@@ -30,17 +30,20 @@ const path = require('path');
 const sourceDir = '../content/pages';
 const minimumNpmVersion = '3.8.9';
 const minimumNodeVersion = '4.4.7';
-// Make sure git pre-commit hooks are installed
-['pre-commit'].forEach(hook => {
-  const src = path.join(__dirname, `../hooks/${hook}`);
-  const dest = path.join(__dirname, `../.git/hooks/${hook}`);
-  if (fs.existsSync(src)) {
-    if (!fs.existsSync(dest)) {
-      // Install hooks
-      fs.linkSync(src, dest);
+
+if (!(process.env.INSTALL_HOOKS === 'no')) {
+  // Make sure git pre-commit hooks are installed
+  ['pre-commit'].forEach(hook => {
+    const src = path.join(__dirname, `../hooks/${hook}`);
+    const dest = path.join(__dirname, `../.git/hooks/${hook}`);
+    if (fs.existsSync(src)) {
+      if (!fs.existsSync(dest)) {
+        // Install hooks
+        fs.linkSync(src, dest);
+      }
     }
-  }
-});
+  });
+}
 
 if (semver.compare(process.env.npm_package_engines_npm, minimumNpmVersion) === -1) {
   process.stdout.write(


### PR DESCRIPTION
Fixes review instance failures due to pre-commit hook installation. 

```
Error: ENOENT: no such file or directory, link '/tmp/build_7846ac836bfc677e346e9e9c91e61942/department-of-veterans-affairs-vets-website-d709a2e/hooks/pre-commit' -> '/tmp/build_7846ac836bfc677e346e9e9c91e61942/department-of-veterans-affairs-vets-website-d709a2e/.git/hooks/pre-commit'
    at Error (native)
    at Object.fs.linkSync (fs.js:918:18)
    at /tmp/build_7846ac836bfc677e346e9e9c91e61942/department-of-veterans-affairs-vets-website-d709a2e/script/build.js:40:10
    at Array.forEach (native)
    at Object.<anonymous> (/tmp/build_7846ac836bfc677e346e9e9c91e61942/department-of-veterans-affairs-vets-website-d709a2e/script/build.js:34:16)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:139:18)
    at node.js:968:3
```