### PR TITLE
Return empty object when GIBCT constants are not yet populated.

### DIFF
--- a/src/js/gi/selectors/estimator.js
+++ b/src/js/gi/selectors/estimator.js
@@ -184,6 +184,8 @@ function calculateBooks(constant, eligibility, institution, derived) {
 export const estimatedBenefits = createSelector(
   [getConstants, getEligibilityDetails, getRequiredAttributes],
   (constant, eligibility, attribute) => {
+    if (constant === undefined) return {};
+
     const derived = getDerivedAttributes(constant, eligibility, attribute);
     const tuition = calculateTuition(constant, eligibility, attribute, derived);
     const housing = calculateHousing(constant, eligibility, attribute, derived);


### PR DESCRIPTION
Fixes error in calculating estimated benefits when constants haven't been fetched and are undefined, which results in displaying loading indicator forever.