### PR TITLE
Move hca to new endpoint for prod

### DIFF
--- a/src/js/hca/components/HealthCareApp.jsx
+++ b/src/js/hca/components/HealthCareApp.jsx
@@ -132,9 +132,6 @@ class HealthCareApp extends React.Component {
     const veteran = this.props.data;
     const path = this.props.location.pathname;
     const apiUrl = `${environment.API_URL}/v0/health_care_applications`;
-    // let formSubmissionId;
-    // let timestamp;
-    // const testBuild = __BUILDTYPE__ === 'development' || __BUILDTYPE__ === 'staging';
     const submissionPost = {
       method: 'POST',
       headers: {
@@ -155,18 +152,6 @@ class HealthCareApp extends React.Component {
       submissionPost.headers.Authorization = `Token token=${userToken}`;
     }
 
-    // In order to test the new Rails API in staging, we are temporarily changing the
-    // endpoints to submit to the new API. Keeping the same endpoints for production.
-    // if (testBuild) {
-    //   // Allow e2e tests to override API URL
-    //   // Remove the need for a separate code path here
-    //   apiUrl = window.VetsGov.api.url === ''
-    //     ? `${environment.API_URL}/v0/health_care_applications`
-    //     : `${window.VetsGov.api.url}/v0/health_care_applications`;
-
-    //   submissionPost.body = JSON.stringify({ form: submissionPost.body });
-    // }
-
     if (formIsValid && veteran.privacyAgreementAccepted) {
       this.props.onUpdateSubmissionStatus('submitPending');
 
@@ -180,14 +165,6 @@ class HealthCareApp extends React.Component {
         this.removeOnbeforeunload();
 
         response.json().then(data => {
-          // if (testBuild) {
-          //   formSubmissionId = data.formSubmissionId;
-          //   timestamp = data.timestamp;
-          // } else {
-          //   formSubmissionId = data.response.formSubmissionId;
-          //   timestamp = data.response.timeStamp;
-          // }
-
           this.props.onUpdateSubmissionStatus('applicationSubmitted', data);
           this.props.onCompletedStatus(path);
           this.props.onUpdateSubmissionId(data.formSubmissionId);

--- a/src/js/hca/components/HealthCareApp.jsx
+++ b/src/js/hca/components/HealthCareApp.jsx
@@ -131,7 +131,9 @@ class HealthCareApp extends React.Component {
     e.preventDefault();
     const veteran = this.props.data;
     const path = this.props.location.pathname;
-    const apiUrl = `${environment.API_URL}/v0/health_care_applications`;
+    const apiUrl = window.VetsGov.api.url === ''
+        ? `${environment.API_URL}/v0/health_care_applications`
+        : `${window.VetsGov.api.url}/v0/health_care_applications`;
     const submissionPost = {
       method: 'POST',
       headers: {

--- a/src/js/hca/components/HealthCareApp.jsx
+++ b/src/js/hca/components/HealthCareApp.jsx
@@ -131,10 +131,10 @@ class HealthCareApp extends React.Component {
     e.preventDefault();
     const veteran = this.props.data;
     const path = this.props.location.pathname;
-    let apiUrl = `${window.VetsGov.api.url}/api/hca/v1/application`;
-    let formSubmissionId;
-    let timestamp;
-    const testBuild = __BUILDTYPE__ === 'development' || __BUILDTYPE__ === 'staging';
+    let apiUrl = `${environment.API_URL}/v0/health_care_applications`;
+    // let formSubmissionId;
+    // let timestamp;
+    // const testBuild = __BUILDTYPE__ === 'development' || __BUILDTYPE__ === 'staging';
     const submissionPost = {
       method: 'POST',
       headers: {
@@ -144,6 +144,8 @@ class HealthCareApp extends React.Component {
       timeout: 10000, // 10 seconds
       body: veteranToApplication(veteran)
     };
+
+    submissionPost.body = JSON.stringify({ form: submissionPost.body });
 
     window.dataLayer.push({ event: 'submit-button-clicked' });
     const formIsValid = validations.isValidForm(veteran);
@@ -155,15 +157,15 @@ class HealthCareApp extends React.Component {
 
     // In order to test the new Rails API in staging, we are temporarily changing the
     // endpoints to submit to the new API. Keeping the same endpoints for production.
-    if (testBuild) {
-      // Allow e2e tests to override API URL
-      // Remove the need for a separate code path here
-      apiUrl = window.VetsGov.api.url === ''
-        ? `${environment.API_URL}/v0/health_care_applications`
-        : `${window.VetsGov.api.url}/v0/health_care_applications`;
+    // if (testBuild) {
+    //   // Allow e2e tests to override API URL
+    //   // Remove the need for a separate code path here
+    //   apiUrl = window.VetsGov.api.url === ''
+    //     ? `${environment.API_URL}/v0/health_care_applications`
+    //     : `${window.VetsGov.api.url}/v0/health_care_applications`;
 
-      submissionPost.body = JSON.stringify({ form: submissionPost.body });
-    }
+    //   submissionPost.body = JSON.stringify({ form: submissionPost.body });
+    // }
 
     if (formIsValid && veteran.privacyAgreementAccepted) {
       this.props.onUpdateSubmissionStatus('submitPending');
@@ -178,18 +180,18 @@ class HealthCareApp extends React.Component {
         this.removeOnbeforeunload();
 
         response.json().then(data => {
-          if (testBuild) {
-            formSubmissionId = data.formSubmissionId;
-            timestamp = data.timestamp;
-          } else {
-            formSubmissionId = data.response.formSubmissionId;
-            timestamp = data.response.timeStamp;
-          }
+          // if (testBuild) {
+          //   formSubmissionId = data.formSubmissionId;
+          //   timestamp = data.timestamp;
+          // } else {
+          //   formSubmissionId = data.response.formSubmissionId;
+          //   timestamp = data.response.timeStamp;
+          // }
 
           this.props.onUpdateSubmissionStatus('applicationSubmitted', data);
           this.props.onCompletedStatus(path);
-          this.props.onUpdateSubmissionId(formSubmissionId);
-          this.props.onUpdateSubmissionTimestamp(timestamp);
+          this.props.onUpdateSubmissionId(data.formSubmissionId);
+          this.props.onUpdateSubmissionTimestamp(data.timestamp);
 
           window.dataLayer.push({
             event: 'submission-successful',

--- a/src/js/hca/components/HealthCareApp.jsx
+++ b/src/js/hca/components/HealthCareApp.jsx
@@ -131,7 +131,7 @@ class HealthCareApp extends React.Component {
     e.preventDefault();
     const veteran = this.props.data;
     const path = this.props.location.pathname;
-    let apiUrl = `${environment.API_URL}/v0/health_care_applications`;
+    const apiUrl = `${environment.API_URL}/v0/health_care_applications`;
     // let formSubmissionId;
     // let timestamp;
     // const testBuild = __BUILDTYPE__ === 'development' || __BUILDTYPE__ === 'staging';
@@ -195,7 +195,7 @@ class HealthCareApp extends React.Component {
 
           window.dataLayer.push({
             event: 'submission-successful',
-            submissionID: formSubmissionId
+            submissionID: data.formSubmissionId
           });
         });
 

--- a/test/e2e/hca-helpers.js
+++ b/test/e2e/hca-helpers.js
@@ -440,14 +440,14 @@ function initApplicationSubmitMock() {
       }
     }
   });
-  mock(null, {
-    path: '/api/hca/v1/application',
-    verb: 'post',
-    value: {
-      formSubmissionId: '123fake-submission-id-567',
-      timeStamp: '2016-05-16'
-    }
-  });
+  // mock(null, {
+  //   path: '/api/hca/v1/application',
+  //   verb: 'post',
+  //   value: {
+  //     formSubmissionId: '123fake-submission-id-567',
+  //     timeStamp: '2016-05-16'
+  //   }
+  // });
 }
 
 module.exports = {

--- a/test/e2e/hca-helpers.js
+++ b/test/e2e/hca-helpers.js
@@ -440,14 +440,6 @@ function initApplicationSubmitMock() {
       }
     }
   });
-  // mock(null, {
-  //   path: '/api/hca/v1/application',
-  //   verb: 'post',
-  //   value: {
-  //     formSubmissionId: '123fake-submission-id-567',
-  //     timeStamp: '2016-05-16'
-  //   }
-  // });
 }
 
 module.exports = {


### PR DESCRIPTION
Undo previous code change where we submitted to one endpoint (vets-api) if the environment was dev or staging and another endpoint (healthcare-application) if the environment was production. Original PR here: https://github.com/department-of-veterans-affairs/vets-website/pull/4723

Now all submissions, regardless of environment, will go to vets-api. 

This should only be merged once we're ready to deploy the vets-api switchover, and thorough testing in staging should be done before a deploy to prod. I was not able to create a successful submission when testing this locally.