### PR TITLE
Top entry in GIBCT autocomplete suggestions doesn't change to current selection.

### DIFF
--- a/src/js/gi/components/search/KeywordSearch.jsx
+++ b/src/js/gi/components/search/KeywordSearch.jsx
@@ -60,14 +60,6 @@ export class KeywordSearch extends React.Component {
 
   render() {
     const { suggestions, searchTerm } = this.props.autocomplete;
-    const suggestionsList = [
-      {
-        id: null,
-        value: searchTerm,
-        label: searchTerm
-      },
-      ...suggestions
-    ];
 
     return (
       <div className="keyword-search">
@@ -84,7 +76,7 @@ export class KeywordSearch extends React.Component {
             onSuggestionsFetchRequested={this.props.onSuggestionsFetchRequested}
             renderSuggestion={this.renderSuggestion}
             shouldRenderSuggestions={this.shouldRenderSuggestions}
-            suggestions={suggestionsList}
+            suggestions={suggestions}
             inputProps={{
               value: searchTerm,
               onChange: this.handleChange,

--- a/src/js/gi/reducers/autocomplete.js
+++ b/src/js/gi/reducers/autocomplete.js
@@ -21,7 +21,8 @@ export default function (state = INITIAL_STATE, action) {
     case AUTOCOMPLETE_STARTED:
       return {
         ...state,
-        inProgress: true
+        inProgress: true,
+        suggestions: [],
       };
     case AUTOCOMPLETE_FAILED:
       return {
@@ -32,9 +33,25 @@ export default function (state = INITIAL_STATE, action) {
       };
     case AUTOCOMPLETE_SUCCEEDED:
       const camelPayload = camelCaseKeysRecursive(action.payload);
+      const suggestions = camelPayload.data;
+
+      const { searchTerm } = state;
+      const shouldIncludeSearchTerm =
+        searchTerm &&
+        suggestions.length &&
+        searchTerm !== suggestions[0].label;
+
+      if (shouldIncludeSearchTerm) {
+        suggestions.unshift({
+          id: null,
+          value: searchTerm,
+          label: searchTerm
+        });
+      }
+
       return {
         ...state,
-        suggestions: camelPayload.data,
+        suggestions,
         previewVersion: camelPayload.meta.version,
         inProgress: false
       };


### PR DESCRIPTION
The first entry should be the current search term the user has typed, but pressing 'Up' and 'Down' in the list was making it change to the selected entry instead. This is because it was changing the `searchTerm` in state, which was getting prepended to the list on render. So instead, we're now prepending the `searchTerm` upon receiving a new suggestion list and storing the result of that in state.

Also added a check to avoid duplicate entries when a suggestion is selected and becomes the `searchTerm` as the content of the input changes to it. The list won't include the institution name twice (as both the `searchTerm` and the result from the autocomplete API response).