### PR TITLE
Only check query object before updating URL and refreshing GIBCT search results.

### DIFF
--- a/src/js/gi/containers/SearchPage.jsx
+++ b/src/js/gi/containers/SearchPage.jsx
@@ -42,7 +42,10 @@ export class SearchPage extends React.Component {
 
     const shouldUpdateSearchResults =
       !currentlyInProgress &&
-      !_.isEqual(this.props.location, prevProps.location);
+      !_.isEqual(
+        this.props.location.query,
+        prevProps.location.query
+      );
 
     if (shouldUpdateSearchResults) {
       this.updateSearchResults();


### PR DESCRIPTION
Fixes issue where the search results would refresh even if the user clicked an already selected radio button. Before, the update logic was incorrectly looking at the entire `location` object, which includes keys like unique id and operation types that threw the whole conditional off. So now we're only looking for changes to the query params.