### PR TITLE
change education info to be dependent on discontinued status

### DIFF
--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -13,7 +13,6 @@ import {
 } from '../helpers';
 
 import {
-  hoursTypeLabels,
   stateLabels
 } from '../../utils/helpers';
 
@@ -414,7 +413,7 @@ const formConfig = {
                   'ui:options': {
                     hideIf: form => {
                       const status = _.get('highSchool.status', form);
-                      return status !== 'graduated' && status !== 'ged';
+                      return status !== 'graduated';
                     },
                     expandUnder: 'status'
                   }
@@ -424,7 +423,7 @@ const formConfig = {
                 'ui:options': {
                   hideIf: form => {
                     const status = _.get('highSchool.status', form);
-                    return status === 'neverAttended';
+                    return status !== 'discontinued';
                   },
                   expandUnder: 'status'
                 },
@@ -440,28 +439,7 @@ const formConfig = {
                     labels: stateLabels
                   }
                 },
-              },
-              'view:highSchoolCompleted': {
-                'ui:options': {
-                  hideIf: form => {
-                    const status = _.get('highSchool.status', form);
-                    return status !== 'graduated';
-                  },
-                  expandUnder: 'status'
-                },
                 dateRange: uiSchemaDateRange(),
-                hours: {
-                  'ui:title': 'Hours completed'
-                },
-                hoursType: {
-                  'ui:title': 'Type of hours',
-                  'ui:options': {
-                    labels: hoursTypeLabels
-                  }
-                },
-                degreeReceived: {
-                  'ui:title': 'Degree, diploma, or certificate received'
-                }
               }
             },
             'view:hasTrainings': {
@@ -486,16 +464,8 @@ const formConfig = {
                     properties: {
                       name: highSchool.properties.name,
                       city: highSchool.properties.city,
-                      state: highSchool.properties.state
-                    }
-                  },
-                  'view:highSchoolCompleted': {
-                    type: 'object',
-                    properties: {
+                      state: highSchool.properties.state,
                       dateRange: highSchool.properties.dateRange,
-                      hours: highSchool.properties.hours,
-                      hoursType: highSchool.properties.hoursType,
-                      degreeReceived: highSchool.properties.degreeReceived
                     }
                   },
                   'view:highSchoolOrGedCompletionDate': date.schema,

--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -13,12 +13,14 @@ import {
 } from '../helpers';
 
 import {
+  hoursTypeLabels,
   stateLabels
 } from '../../utils/helpers';
 
 import * as address from '../../../common/schemaform/definitions/address';
 import * as currentOrPastDate from '../../../common/schemaform/definitions/currentOrPastDate';
 import * as date from '../../../common/schemaform/definitions/date';
+import { uiSchema as uiSchemaDateRange } from '../../../common/schemaform/definitions/dateRange';
 import { uiSchema as fullNameUISchema } from '../../../common/schemaform/definitions/fullName';
 import * as phone from '../../../common/schemaform/definitions/phone';
 import * as ssn from '../../../common/schemaform/definitions/ssn';
@@ -407,20 +409,22 @@ const formConfig = {
                   expandUnderClassNames: 'schemaform-expandUnder-indent'
                 }
               },
-              highSchoolOrGedCompletionDate: _.assign(
+              'view:highSchoolOrGedCompletionDate': _.assign(
                 date.uiSchema('When did you earn your high school diploma?'), {
                   'ui:options': {
                     hideIf: form => {
                       const status = _.get('highSchool.status', form);
                       return status !== 'graduated' && status !== 'ged';
-                    }
+                    },
+                    expandUnder: 'status'
                   }
-                }),
+                }
+              ),
               'view:hasHighSchool': {
                 'ui:options': {
                   hideIf: form => {
                     const status = _.get('highSchool.status', form);
-                    return status !== 'discontinued';
+                    return status === 'neverAttended';
                   },
                   expandUnder: 'status'
                 },
@@ -435,6 +439,28 @@ const formConfig = {
                   'ui:options': {
                     labels: stateLabels
                   }
+                },
+              },
+              'view:highSchoolCompleted': {
+                'ui:options': {
+                  hideIf: form => {
+                    const status = _.get('highSchool.status', form);
+                    return status !== 'graduated';
+                  },
+                  expandUnder: 'status'
+                },
+                dateRange: uiSchemaDateRange(),
+                hours: {
+                  'ui:title': 'Hours completed'
+                },
+                hoursType: {
+                  'ui:title': 'Type of hours',
+                  'ui:options': {
+                    labels: hoursTypeLabels
+                  }
+                },
+                degreeReceived: {
+                  'ui:title': 'Degree, diploma, or certificate received'
                 }
               }
             },
@@ -455,7 +481,6 @@ const formConfig = {
                 type: 'object',
                 properties: {
                   status: highSchool.properties.status,
-                  highSchoolOrGedCompletionDate: date.schema,
                   'view:hasHighSchool': {
                     type: 'object',
                     properties: {
@@ -463,7 +488,17 @@ const formConfig = {
                       city: highSchool.properties.city,
                       state: highSchool.properties.state
                     }
-                  }
+                  },
+                  'view:highSchoolCompleted': {
+                    type: 'object',
+                    properties: {
+                      dateRange: highSchool.properties.dateRange,
+                      hours: highSchool.properties.hours,
+                      hoursType: highSchool.properties.hoursType,
+                      degreeReceived: highSchool.properties.degreeReceived
+                    }
+                  },
+                  'view:highSchoolOrGedCompletionDate': date.schema,
                 }
               },
               'view:hasTrainings': {

--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -13,14 +13,12 @@ import {
 } from '../helpers';
 
 import {
-  hoursTypeLabels,
   stateLabels
 } from '../../utils/helpers';
 
 import * as address from '../../../common/schemaform/definitions/address';
 import * as currentOrPastDate from '../../../common/schemaform/definitions/currentOrPastDate';
 import * as date from '../../../common/schemaform/definitions/date';
-import { uiSchema as uiSchemaDateRange } from '../../../common/schemaform/definitions/dateRange';
 import { uiSchema as fullNameUISchema } from '../../../common/schemaform/definitions/fullName';
 import * as phone from '../../../common/schemaform/definitions/phone';
 import * as ssn from '../../../common/schemaform/definitions/ssn';
@@ -405,7 +403,8 @@ const formConfig = {
               status: {
                 'ui:title': 'What\'s your current high school status?',
                 'ui:options': {
-                  labels: highSchoolStatusLabels
+                  labels: highSchoolStatusLabels,
+                  expandUnderClassNames: 'schemaform-expandUnder-indent'
                 }
               },
               highSchoolOrGedCompletionDate: _.assign(
@@ -421,8 +420,9 @@ const formConfig = {
                 'ui:options': {
                   hideIf: form => {
                     const status = _.get('highSchool.status', form);
-                    return status !== 'graduationExpected';
-                  }
+                    return status !== 'discontinued';
+                  },
+                  expandUnder: 'status'
                 },
                 name: {
                   'ui:title': 'Name of high school'
@@ -435,19 +435,6 @@ const formConfig = {
                   'ui:options': {
                     labels: stateLabels
                   }
-                },
-                dateRange: uiSchemaDateRange(),
-                hours: {
-                  'ui:title': 'Hours completed'
-                },
-                hoursType: {
-                  'ui:title': 'Type of hours',
-                  'ui:options': {
-                    labels: hoursTypeLabels
-                  }
-                },
-                degreeReceived: {
-                  'ui:title': 'Degree, diploma, or certificate received'
                 }
               }
             },
@@ -474,11 +461,7 @@ const formConfig = {
                     properties: {
                       name: highSchool.properties.name,
                       city: highSchool.properties.city,
-                      state: highSchool.properties.state,
-                      dateRange: highSchool.properties.dateRange,
-                      hours: highSchool.properties.hours,
-                      hoursType: highSchool.properties.hoursType,
-                      degreeReceived: highSchool.properties.degreeReceived
+                      state: highSchool.properties.state
                     }
                   }
                 }

--- a/test/edu-benefits/5490/config/educationHistory.unit.spec.jsx
+++ b/test/edu-benefits/5490/config/educationHistory.unit.spec.jsx
@@ -62,11 +62,11 @@ describe('Edu 5490 educationHistory', () => {
 
     ReactTestUtils.Simulate.change(formDOM.querySelector('select'), {
       target: {
-        value: 'graduationExpected'
+        value: 'discontinued'
       }
     });
 
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(15);
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(6);
   });
 
   it('should have no required inputs', () => {

--- a/test/edu-benefits/5490/config/educationHistory.unit.spec.jsx
+++ b/test/edu-benefits/5490/config/educationHistory.unit.spec.jsx
@@ -39,15 +39,7 @@ describe('Edu 5490 educationHistory', () => {
       }
     });
 
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(18);
-
-    ReactTestUtils.Simulate.change(formDOM.querySelector('select'), {
-      target: {
-        value: 'ged'
-      }
-    });
-
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(9);
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(6);
   });
 
   it('should render high school questions', () => {
@@ -66,26 +58,7 @@ describe('Edu 5490 educationHistory', () => {
       }
     });
 
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(6);
-  });
-
-  it('should render completed high school questions if graduated', () => {
-    const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester
-          schema={schema}
-          data={{}}
-          definitions={formConfig.defaultDefinitions}
-          uiSchema={uiSchema}/>
-    );
-    const formDOM = findDOMNode(form);
-
-    ReactTestUtils.Simulate.change(formDOM.querySelector('select'), {
-      target: {
-        value: 'graduated'
-      }
-    });
-
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(18);
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(12);
   });
 
   it('should have no required inputs', () => {

--- a/test/edu-benefits/5490/config/educationHistory.unit.spec.jsx
+++ b/test/edu-benefits/5490/config/educationHistory.unit.spec.jsx
@@ -39,7 +39,7 @@ describe('Edu 5490 educationHistory', () => {
       }
     });
 
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(6);
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(18);
 
     ReactTestUtils.Simulate.change(formDOM.querySelector('select'), {
       target: {
@@ -47,7 +47,7 @@ describe('Edu 5490 educationHistory', () => {
       }
     });
 
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(6);
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(9);
   });
 
   it('should render high school questions', () => {
@@ -67,6 +67,25 @@ describe('Edu 5490 educationHistory', () => {
     });
 
     expect(formDOM.querySelectorAll('input,select').length).to.equal(6);
+  });
+
+  it('should render completed high school questions if graduated', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    ReactTestUtils.Simulate.change(formDOM.querySelector('select'), {
+      target: {
+        value: 'graduated'
+      }
+    });
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(18);
   });
 
   it('should have no required inputs', () => {


### PR DESCRIPTION
Closes: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1793

Makes the reveal of high school information fields dependent on whether high school status is "discontinued". Also removes some questions from high school information fields, updates the styles, and updates tests.

<img width="796" alt="screen shot 2017-03-23 at 1 54 39 pm" src="https://cloud.githubusercontent.com/assets/25183456/24263296/25a0e614-0fd3-11e7-9214-eb7ca0b23eda.png">
