### PR TITLE
Updated handling of country facets in GIBCT after fix for filtering with hyphens.

### DIFF
--- a/src/js/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/js/gi/components/search/InstitutionFilterForm.jsx
@@ -50,15 +50,14 @@ class InstitutionFilterForm extends React.Component {
   }
 
   renderCountryFilter() {
-    const countryFacets = {
-      ALL: this.props.search.count,
-      ...this.props.search.facets.country
-    };
-    const options = Object.keys(countryFacets).reduce((opts, country) => {
-      const total = Number(countryFacets[country]);
-      const label = `${country} (${total.toLocaleString()})`;
-      return [...opts, { value: country, label }];
-    }, []);
+    const options = [
+      { value: 'ALL', label: `ALL (${this.props.search.count})` },
+      ...this.props.search.facets.country.map(country => ({
+        value: country.name,
+        label: `${country.name} (${country.count.toLocaleString()})`
+      }))
+    ];
+
     return (
       <Dropdown
           name="country"

--- a/src/js/gi/reducers/search.js
+++ b/src/js/gi/reducers/search.js
@@ -7,7 +7,7 @@ const INITIAL_STATE = {
     type: {},
     typeName: {},
     state: {},
-    country: {},
+    country: [],
     cautionFlag: {},
     studentVetGroup: {},
     yellowRibbonScholarship: {},
@@ -48,12 +48,10 @@ function uppercaseKeys(obj) {
 
 function normalizedFacets(facets) {
   const state = uppercaseKeys(facets.state);
-  const country = uppercaseKeys(facets.country);
   const typeName = uppercaseKeys(facets.typeName);
   return {
     ...facets,
     state,
-    country,
     typeName
   };
 }


### PR DESCRIPTION
Related to department-of-veterans-affairs/gibct-data-service#224.

This fix is to be combined with this change in GIDS: department-of-veterans-affairs/gibct-data-service#234.

`meta.facets.country` is becoming a list of `{ name, count }` objects instead of just being one object with country names as keys and counts as values. This avoids any messiness with camel-casing everything. Will apply camel-casing in all API responses separately from this PR at some point.