### PR TITLE
Add intro text styling to content pages

### DIFF
--- a/content/pages/disability-benefits/after-you-apply.md
+++ b/content/pages/disability-benefits/after-you-apply.md
@@ -13,7 +13,11 @@ relatedlinks:
    description: "Find out what happens after you get your decision notice with your rating."
 ---
 
+<div class="va-introtext">
+
 Find out what happens to your claim after you apply for disability benefits. 
+
+</div>
 
 ### How long does it take VA to make a decision?
 

--- a/content/pages/disability-benefits/apply-for-benefits/help.md
+++ b/content/pages/disability-benefits/apply-for-benefits/help.md
@@ -17,9 +17,13 @@ relatedlinks:
     title: How does VA decide when my disability compensation starts?
 ---
 
+<div class="va-introtext">
+
 If you need help filing a disability claim, you may want to work with an accredited representative. We trust these professionals because they're trained in the claims process and can help you with VA-related needs.
 
 Most accredited representatives work for Veterans Service Organizations (VSOs). These private nonprofit groups advocate on behalf of Veterans and Servicemembers as well as their dependents and survivors. 
+
+</div>
 
 <div class="call-out" markdown="0">
 

--- a/content/pages/disability-benefits/apply-for-benefits/one-year.md
+++ b/content/pages/disability-benefits/apply-for-benefits/one-year.md
@@ -22,9 +22,14 @@ relatedlinks:
     description: ""
 ---
 
-You may be able to get disability benefits if you have signs of an illness like hypertension (high blood pressure), arthritis, diabetes, or peptic ulcers that started within a year after you were discharged from active military service. 
+<div class="va-introtext">
+
+You may be able to get disability benefits if you have signs of an illness like hypertension (high blood pressure), arthritis, diabetes, or peptic ulcers that started within a year after you were discharged from active military service.
+
 
 If your symptoms appear within 1 year after discharge—even if they weren't there while you were serving—we'll conclude that they're related to your service. [See the complete list of covered illnesses](http://www.benefits.va.gov/warms/docs/regs/38CFR/BOOKB/PART3/S3_309.doc).
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/apply-for-benefits/ways.md
+++ b/content/pages/disability-benefits/apply-for-benefits/ways.md
@@ -21,7 +21,11 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 Choose 1 of 3 ways to file your disability claim:
+
+</div>
 
 1.	[Apply online through eBenefits]( https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation), **or**
 

--- a/content/pages/disability-benefits/apply.md
+++ b/content/pages/disability-benefits/apply.md
@@ -19,7 +19,11 @@ relatedlinks:
    description: "Find out how to work with a trained professional called an accredited representative."
 ---
 
+<div class="va-introtext">
+
 You can apply for disability benefits online. We've listed all the steps below so when you're ready, you can apply for this tax-free monetary benefit. Find out how to apply. 
+
+</div>
 
 ### Prepare
 

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -13,7 +13,11 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 You have the right to appeal any disability benefits decision made by the Veterans Benefits Administration (VBA). The appeals process is set in law and is different from other judicial appeals processes. Keep reading below to find out how to file an appeal.  
+
+</div>
 
 <div class="call-out" markdown="0">
 

--- a/content/pages/disability-benefits/claims-appeal/court-appeals-veterans-claims.md
+++ b/content/pages/disability-benefits/claims-appeal/court-appeals-veterans-claims.md
@@ -7,9 +7,13 @@ plainlanguage: 11-4-16 certified in compliance with the Plain Writing Act
 template: 6-info-page
 ---
 
+<div class="va-introtext">
+
 If the Board of Veterans’ Appeals (BVA or the "Board") has sent you a final disability benefits claim decision that you disagree with, you still have a way to appeal. You can take your appeal to the United States Court of Appeals for Veterans Claims (the "Court"). The Court reviews Board decisions appealed by those who believe the Board made a mistake in its decision. You'll need to wait until you have a final decision from the Board—not the regional office—before you can appeal to this Court. [Appeal a Board of Veterans' Appeals Decision](https://www.uscourts.cavc.gov/index.php). 
 
 If you aren't sure about your claim status, call the BVA status line at <span class="tel">800-923-8387</span>.
+
+</div>
 
 <div class="call-out" markdown="0">
 

--- a/content/pages/disability-benefits/claims-appeal/veterans-appeals-board.md
+++ b/content/pages/disability-benefits/claims-appeal/veterans-appeals-board.md
@@ -7,10 +7,13 @@ concurrence: complete
 source: http://www.bva.va.gov/index.asp
 ---
 
+<div class="va-introtext">
+
 If you don't agree with the Statement of the Case, you can file	a	Substantive Appeal (using VA Form 9) with the Board	of Veterans’ Appeals. Make sure you read through all the instructions on the Statement of the Case. [Download and print out VA Form 9](http://www.va.gov/vaforms/va/pdf/VA9.pdf). 
 
 [Find your regional office](http://www.benefits.va.gov/benefits/offices.asp).
 
+</div>
 
 <div class="call-out" markdown="0">
 

--- a/content/pages/disability-benefits/claims-process.md
+++ b/content/pages/disability-benefits/claims-process.md
@@ -24,9 +24,12 @@ relatedlinks:
     description: ""   
 ---
 
+<div class="va-introtext">
 
 A disability claim is a formal legal request for benefits (like compensation and health care). It’s very important to understand the process and prepare carefully before applying. 
 
 An accredited representative (a trained professional trusted to help with VA-related claims) can help you through the process. [Find an accredited representative](/disability-benefits/apply-for-benefits/help/index.html).
 
 See below for answers to some common questions about how we process disability claims.
+
+<div class="va-introtext">

--- a/content/pages/disability-benefits/claims-process/claim-types.md
+++ b/content/pages/disability-benefits/claims-process/claim-types.md
@@ -34,7 +34,11 @@ relatedlinks:
 template: 6-info-page
 ---
 
+<div class="va-introtext">
+
 Disability claims can be based on disabilities that:
+
+</div>
 
 - Were there before you started serving in the military but got worse because of your service, **or**
 - Happened while you were serving in the military, **or**

--- a/content/pages/disability-benefits/claims-process/claim-types/fully-developed-claim.md
+++ b/content/pages/disability-benefits/claims-process/claim-types/fully-developed-claim.md
@@ -34,7 +34,13 @@ relatedlinks:
     description: ""
 ---
 
-You can use the Fully Developed Claims (FDC) program to get a faster decision on your disability benefits claim. With this program, you send in all the evidence (supporting documents) you have—or can easily get—when you file your claim. This may include:
+<div class="va-introtext">
+
+You can use the Fully Developed Claims (FDC) program to get a faster decision on your disability benefits claim. With this program, you send in all the evidence (supporting documents) you have—or can easily get—when you file your claim. 
+
+</div>
+
+This may include:
 - Records of medical treatment you've received for the claimed illness or injury (also known as a condition) while serving in the military
 - Military personnel records that relate to the claimed condition
 - Private medical records related to the claimed condition, like reports from your own doctor or X-rays or other test results from a non-VA hospital or other treatment center

--- a/content/pages/disability-benefits/claims-process/claim-types/in-service.md
+++ b/content/pages/disability-benefits/claims-process/claim-types/in-service.md
@@ -34,4 +34,8 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 You can file an in-service disability claim if your disability was caused by an illness or injury (also known as a condition) that you got in the line of duty and not because of willful misconduct or alcohol or drug abuse. [File a claim now](/disability-benefits/apply-for-benefits/).
+
+</div>

--- a/content/pages/disability-benefits/claims-process/claim-types/new-claim.md
+++ b/content/pages/disability-benefits/claims-process/claim-types/new-claim.md
@@ -35,7 +35,11 @@ template: 6-info-page
 ---
 
 
+<div class="va-introtext">
+
 If you're already getting disability benefits but think you may qualify for more, you can file a new claim. [File a claim now](/disability-benefits/apply-for-benefits/).
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/claims-process/claim-types/original-claim.md
+++ b/content/pages/disability-benefits/claims-process/claim-types/original-claim.md
@@ -34,4 +34,8 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 If you're a Veteran, a survivor of a Veteran, or a Servicemember with a disability who's within 180 days of ending military service, you can file a claim to get benefits for that disability. The first claim you file for a certain disability is known as the original claim for that disability. [File a claim now](/disability-benefits/apply-for-benefits/).
+
+</div>

--- a/content/pages/disability-benefits/claims-process/claim-types/post-service.md
+++ b/content/pages/disability-benefits/claims-process/claim-types/post-service.md
@@ -34,7 +34,11 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 If you have a disability that's related to your military service but didn't appear until after you ended your service, you can file a postservice claim for disability benefits. [File a claim now](/disability-benefits/apply-for-benefits/).
+
+</div>
 
 ### What kinds of postservice disabilities qualify you for benefits?
 

--- a/content/pages/disability-benefits/claims-process/claim-types/pre-service.md
+++ b/content/pages/disability-benefits/claims-process/claim-types/pre-service.md
@@ -35,19 +35,11 @@ relatedlinks:
     description: ""
 ---
 
-
-<div class="section one" markdown="0">
-<div class="primary" markdown="0">
-<div class="row" markdown="0">
-<div class="small-12 columns usa-content" markdown="1">
+<div class="va-introtext">
 
 If you already had a disability when you started serving in the military—and that disability got worse because of your service—you can file a preservice claim for disability benefits. [File a claim now](/disability-benefits/apply-for-benefits/).
 
+</div>
+
 ### How much compensation will I get for a preservice claim?
 If you get disability benefits for a preservice claim, the amount of compensation (monthly payments) you'll get will be based on the level of aggravation, or how much worse your service made your disability. For example, if you had an illness or injury (also known as a condition) that was 10% disabling when you entered the military, and it became 20% disabling due to service, then the level of aggravation would be 10%.
-
-</div>
-</div>
-</div>
-</div>
-</div>

--- a/content/pages/disability-benefits/claims-process/claim-types/predischarge-claim.md
+++ b/content/pages/disability-benefits/claims-process/claim-types/predischarge-claim.md
@@ -35,7 +35,12 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 If you have a disability and you're currently in predischarge status, you can file a claim for disability benefits up to 180 days before any of these changes to your status:
+
+</div>
+
 - Separation from active duty
 - Retirement from active duty
 - Release from full-time Reserve duty

--- a/content/pages/disability-benefits/claims-process/claim-types/predischarge-claim/bdd.md
+++ b/content/pages/disability-benefits/claims-process/claim-types/predischarge-claim/bdd.md
@@ -6,7 +6,12 @@ plainlanguage: 11-8-16 certified in compliance with the Plain Writing Act
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 If you're a Servicemember with a disability, the Benefits Delivery at Discharge (BDD) program can help you get your VA benefits sooner. Through this program, you can start your claim for disability benefits 60 to 180 days before:
+
+</div>
+
 - Separation 
 - Retirement
 - Release from active duty

--- a/content/pages/disability-benefits/claims-process/claim-types/predischarge-claim/overseas.md
+++ b/content/pages/disability-benefits/claims-process/claim-types/predischarge-claim/overseas.md
@@ -7,8 +7,11 @@ plainlanguage: 11-8-16 certified in compliance with the Plain Writing Act
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
 
 You can file a disability claim while you're stationed overseas. 
+
+</div>
 
 ### Within the Kaiserslautern Military Community (KMC)
 

--- a/content/pages/disability-benefits/claims-process/claim-types/predischarge-claim/quick-start.md
+++ b/content/pages/disability-benefits/claims-process/claim-types/predischarge-claim/quick-start.md
@@ -5,7 +5,11 @@ plainlanguage: 11-9-16 certified in compliance with the Plain Writing Act
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 If you're in predischarge status, Quick Start can help you get your VA benefits sooner. Through Quick Start, you can start your claim for disability benefits 1 to 59 days before:
+
+</div>
 
 - Separation (ending your military service)
 - Retirement

--- a/content/pages/disability-benefits/claims-process/claim-types/reopened-claim.md
+++ b/content/pages/disability-benefits/claims-process/claim-types/reopened-claim.md
@@ -34,12 +34,12 @@ relatedlinks:
 template: 6-info-page
 ---
 
-<div class="section one" markdown="0">
-<div class="primary" markdown="0">
-<div class="row" markdown="0">
-<div class="small-12 columns" markdown="1">    
+<div class="va-introtext">
 
 If you've had a claim for disability benefits denied in the past, you can file a reopened claim to get a new decision if all of these are true:
+
+</div>
+
 - We denied your claim at least 1 or more years ago, **and**
 - You didn't file an appeal at that time, **and**
 - You have new and material evidence (new supporting documents like a doctor's report or medical test results) that we haven't seen before and that's directly related to your claim
@@ -50,8 +50,3 @@ If you've had a claim for disability benefits denied in the past, you can file a
 A Veteran was treated several times during service for pain in his right elbow. He filed a claim for disability benefits. His claim wasn’t granted because a VA doctor examined him and didn’t find a problem. 
 
 Then, 2 years later, the Veteran’s non-VA doctor x-rayed his elbow and found signs of arthritis (a painful swelling and sometimes wearing down of a joint). The Veteran applied to reopen his VA claim. He sent his doctor’s exam and X-ray results as new evidence related to the claim. Because the recent exam showed his current elbow pain was likely an after-effect of his in-service elbow problems, we reopened his claim.
-
-</div>
-</div>
-</div>
-</div>

--- a/content/pages/disability-benefits/claims-process/claim-types/secondary-claim.md
+++ b/content/pages/disability-benefits/claims-process/claim-types/secondary-claim.md
@@ -33,12 +33,11 @@ relatedlinks:
     description: ""
 ---
 
-<div class="section one" markdown="0">
-<div class="primary" markdown="0">
-<div class="row" markdown="0">
-<div class="small-12 columns usa-content" markdown="1">
+<div class="va-introtext">
 
 Sometimes, a disability related to your military service (called service connected) can cause another disability—or make worse a disability that you already have. Even if this other disability isn't service connected, you can file a secondary claim for added disability benefits. [File a claim now](/disability-benefits/apply-for-benefits/).
+
+</div>
 
 ### What are some examples of secondary claims?
 
@@ -47,9 +46,3 @@ A Veteran has a service-connected knee injury that makes him walk with a limp. B
 
 **Example 2**<br>
 A Veteran served in the Army for 20 years. While serving, she was diagnosed with hypertension (high blood pressure). After ending her service, she got disability benefits for her high blood pressure, which proved to be connected to her service. She was later diagnosed with coronary artery disease (the most common type of heart disease) caused by her high blood pressure. She can now file a secondary claim to show that her heart disease is also connected to her service.
-
-
-</div>
-</div>
-</div>
-</div>

--- a/content/pages/disability-benefits/claims-process/claim-types/standard-claim.md
+++ b/content/pages/disability-benefits/claims-process/claim-types/standard-claim.md
@@ -34,9 +34,14 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 If you'd like us to help you gather evidence (supporting documents like a doctor's report and medical test results) to support your disability benefits claim, please file a standard claim. [File a claim now](/disability-benefits/apply-for-benefits/).
 
 With a standard claim, we'll get your permission to gather any needed evidence for you. This may include medical records from:
+
+</div>
+
 - Your non-VA doctor
 - Other non-VA health care providers
 - State and local governments

--- a/content/pages/disability-benefits/claims-process/date.md
+++ b/content/pages/disability-benefits/claims-process/date.md
@@ -22,10 +22,13 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 When we decide we’ll pay a disability benefit based on a claim, we assign an effective date to that claim.
 
 The effective date is the day you can start getting your disability benefits. This varies with the type of benefit you’re applying for and the nature of your claim.
 
+</div>
 
 <div class="call-out usa-content" markdown="1">
 

--- a/content/pages/disability-benefits/claims-process/evidence.md
+++ b/content/pages/disability-benefits/claims-process/evidence.md
@@ -5,7 +5,11 @@ plainlanguage: 11-9-16 certified in compliance with the Plain Writing Act
 template: 6-info-page
 ---
 
+<div class="va-introtext">
+
 When you file a claim for disability benefits, you'll need to gather all related evidence (supporting documents like a doctor's report or medical test results) so we can decide on your claim. You may have some of these documents—or be able to easily get them—but we'll need your permission to get others. [File a claim now](/disability-benefits/apply-for-benefits/).
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/claims-process/presumed-disability.md
+++ b/content/pages/disability-benefits/claims-process/presumed-disability.md
@@ -6,7 +6,11 @@ plainlanguage: 11-9-16 certified in compliance with the Plain Writing Act
 template: 6-info-page
 ---
 
+<div class="va-introtext">
+
 A presumed disability is a disability that's been diagnosed by a doctor and that we consider to be related to a Veteran’s military service because of specific aspects of service. 
+
+</div>
 
 This usually applies to a chronic (long-lasting) illness that appears within 1 year after discharge, or illnesses caused by contact with:
 - Certain contaminants (toxic chemicals), **or**

--- a/content/pages/disability-benefits/claims-process/ratings.md
+++ b/content/pages/disability-benefits/claims-process/ratings.md
@@ -5,9 +5,13 @@ plainlanguage: 11-9-16 certified in compliance with the Plain Writing Act
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 For each disability claim, we assign a severity rating from 0% to 100% in 10% increments (for example, 10%, 20%, 30%). We base this rating on the evidence—supporting documents like a doctor's report or medical test results—you give us as well as other information we may get from other sources like federal agencies. [File a claim now](/disability-benefits/apply-for-benefits/).
 
 See the Combined Ratings page to learn how we calculate disability percentage for more than 1 disability. [See Combined Ratings](http://www.benefits.va.gov/COMPENSATION/rates-index.asp#combined).
+
+</div>
 
 ### You may be paid added amounts in certain instances if:
 

--- a/content/pages/disability-benefits/claims-process/what-happens-after-rating.md
+++ b/content/pages/disability-benefits/claims-process/what-happens-after-rating.md
@@ -5,7 +5,11 @@ plainlanguage: 11-02-16 certified in compliance with the Plain Writing Act
 template: 6-info-page
 ---
 
+<div class="va-introtext">
+
 If you got a decision notice from us that confirms your disability rating (the rating that measures the severity of your disability), you may be able to get disability compensation or benefits. Find out what benefits you can get. 
+
+</div>
 
 <div class="call-out usa-content" markdown="1">
 

--- a/content/pages/disability-benefits/conditions.md
+++ b/content/pages/disability-benefits/conditions.md
@@ -19,8 +19,11 @@ relatedlinks:
     description: Get help with needs such as special equipment, hospital or rehab care, dental care, being unable to work, and more.
 ---
 
+<div class="va-introtext">
 
 Do you have illnesses or injuries that started—or got worse—while you were serving in the military?  Find out if you can  get disability compensation or benefits.
+
+<div>
 
 <div class="call-out" markdown="0">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials.md
@@ -33,4 +33,8 @@ relatedlinks:
     description: If you served in Iraq, Afghanistan, Djibouti, or near Atsugi, Japan, you may have had contact with toxic particles or pollutants.
 ---
 
+<div class="va-introtext">
+
 Find out if you can get disability compensation or benefits for illnesses or other conditions, like the ones listed below, believed to be caused by contact with harmful chemicals or other hazardous materials while serving in the military.
+
+</div>

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange.md
@@ -5,7 +5,11 @@ plainlanguage: 10-21-16 certified in compliance with the Plain Writing Act
 template: 3-panel-filters
 ---
 
+<div class="va-introtext">
+
 The U.S. military used Agent Orange to clear plants and trees during the Vietnam War. If you served in or near Vietnam during the Vietnam War Era—or in certain related jobs—you may have had contact with this toxic chemical. Find out if you can get disability compensation or benefits for illnesses believed to be caused by Agent Orange.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/c-123.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/c-123.md
@@ -4,7 +4,11 @@ title: C-123 Aircraft
 template: 4-action-page
 ---
 
+<div class="va-introtext">
+
 If you flew on—or worked with—C-123 aircraft in Vietnam or other locations, you may have had contact with Agent Orange. The U.S. military used this toxic chemical to clear trees and plants during the Vietnam War. C-123 aircraft sprayed Agent Orange during the war, and the planes still had traces of the chemical in them afterward while they were being used, up until 1986. Find out if you can get disability compensation or benefits for illnesses believed to be caused by contact with Agent Orange.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/diseases.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/diseases.md
@@ -5,7 +5,11 @@ plainlanguage: 10-26-16 certified in compliance with the Plain Writing Act
 template: 6-info-page
 ---
 
+<div class="va-introtext">
+
 We believe that contact with Agent Orange, a toxic chemical used to clear trees and plants during the Vietnam War, likely causes several illnesses. Find out if you can get disability compensation or benefits if you had contact with Agent Orange while serving in the military and now have 1 or more of the illnesses listed below.
+
+</div>
 
 ### Cancers believed to be caused by contact with Agent Orange
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/navy-coast-guard.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/navy-coast-guard.md
@@ -6,7 +6,11 @@ plainlanguage: 10-26-16 certified in compliance with the Plain Writing Act
 template: 4-action-page
 ---
 
+<div class="va-introtext">
+
 If you served on a Navy or Coast Guard ship in or around Vietnam during the Vietnam War Era, you may have had contact with Agent Orange, a toxic chemical used to clear trees and plants during the war. Find out if you can get disability compensation or benefits for illnesses believed to be caused by Agent Orange. 
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/non-hodgkins.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/non-hodgkins.md
@@ -6,7 +6,11 @@ template: 4-action-page
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 Non-Hodgkin’s lymphoma is a type of cancer of the lymph glands and other lymphatic tissue—a part of your body’s immune system that helps to fight infection and illness. We believe that non-Hodgkin’s lymphoma can be caused by contact with Agent Orange, a toxic chemical used to clear trees and plants during the Vietnam War. If you had contact with Agent Orange while serving in the military—and now have non-Hodgkin’s lymphoma—you can get disability compensation or benefits.
+
+</div>
 
 ##### Signs of non-Hodgkin’s lymphoma include:
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/registry-health-exam.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/registry-health-exam.md
@@ -6,7 +6,11 @@ plainlanguage: 10-26-16 certified in compliance with the Plain Language Act
 template: 4-action-page
 ---
 
+<div class="va-introtext">
+
 If you think you had contact with Agent Orange, a toxic chemical used to clear trees and plants during the Vietnam War, or other herbicides while serving in the military, you can request a VA Agent Orange Registry health exam. Even if you don’t have a known illness, the exam could alert you to illnesses that may be related to contact with herbicides. By being part of this registry, you're also helping your fellow Veterans by giving us information so we can better understand and serve those affected by Agent Orange–related illnesses.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/service-inside.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/service-inside.md
@@ -6,7 +6,11 @@ plainlanguage: 10-26-16 certified in compliance with the Plain Language Act
 template: 4-action-page
 ---
 
+<div class="va-introtext">
+
 Did you serve in Vietnam (including aboard a ship on the inland waterways) or in the Korean Demilitarized Zone during the Vietnam War Era? If you did, you likely had contact with Agent Orange, a toxic chemical the U.S. military used to clear plants and trees during the war. Find out if you can get disability compensation or benefits for illnesses believed to be caused by Agent Orange.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/service-outside.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/service-outside.md
@@ -6,7 +6,11 @@ plainlanguage: 10-26-16 certified in compliance with the Plain Writing Act
 template: 4-action-page
 ---
 
+<div class="va-introtext">
+
 You may have had contact with Agent Orange even if you did not serve in Vietnam or in the Korean Demilitarized Zone. Agent Orange is a toxic chemical used to clear trees and plants during the Vietnam War. Find out if you can get disability compensation or benefits for illnesses believed to be caused by contact with Agent Orange.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/test-storage.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/test-storage.md
@@ -6,7 +6,11 @@ template: 4-action-page
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 Were you part of testing or storing Agent Orange on bases in the United States or elsewhere? Agent Orange is a toxic chemical the U.S. military used to clear trees and plants during the Vietnam War. Find out if you can get disability compensation or benefits for illnesses believed to be caused by Agent Orange.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/thailand-military-bases.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/thailand-military-bases.md
@@ -6,7 +6,11 @@ plainlanguage: 10-26-16 certified in compliance with the Plain Writing Act
 template: 4-action-page
 ---
 
+<div class="va-introtext">
+
 If you had regular security duty on the fenced-in perimeters of a U.S. military base in Thailand or Royal Thai Air Force Bases between January 9, 1962, and May 7, 1975, you may have had contact with Agent Orange. The U.S. military used this toxic chemical to clear trees and plants during the Vietnam War. Find out if you can get disability compensation or benefits for illnesses believed to be caused by contact with Agent Orange.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/water-vietnam.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/water-vietnam.md
@@ -6,7 +6,13 @@ plainlanguage: 10-26-16 certified in compliance with the Plain Language Act
 template: 4-action-page
 ---
 
-If you served on a Blue Water Navy ship on the **inland waterways** of Vietnam between January 9, 1962, and May 7, 1975—or you ever came ashore in Vietnam—you likely had contact with Agent Orange. The U.S. military used this toxic chemical to clear trees and plants during the war. Find out if you can get disability compensation or benefits for illnesses believed to be caused by contact with Agent Orange. If you served on the **coastal waterways** of Vietnam between January 9, 1962, and May 7, 1975—and you can prove you came ashore—you also likely had contact with Agent Orange, and you may be able to get disability benefits. 
+<div class="va-introtext">
+
+If you served on a Blue Water Navy ship on the **inland waterways** of Vietnam between January 9, 1962, and May 7, 1975—or you ever came ashore in Vietnam—you likely had contact with Agent Orange. The U.S. military used this toxic chemical to clear trees and plants during the war. Find out if you can get disability compensation or benefits for illnesses believed to be caused by contact with Agent Orange. 
+
+If you served on the **coastal waterways** of Vietnam between January 9, 1962, and May 7, 1975—and you can prove you came ashore—you also likely had contact with Agent Orange, and you may be able to get disability benefits. 
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/asbestos.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/asbestos.md
@@ -7,7 +7,11 @@ plainlanguage: 10-21-16 certified in compliance with the Plain Language Act
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 Asbestos is a material that was once used in many buildings and products. If you served in Iraq or other countries in the Middle East and Southeast Asia, you may have had contact with asbestos when old buildings got damaged, releasing toxic chemicals into the air. Or, you may have had contact with asbestos if you worked in certain jobs or settings, like shipyards, construction, or vehicle repair. Find out if you can get disability compensation or benefits for illnesses believed to be caused by asbestos.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/birth-defects.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/birth-defects.md
@@ -7,7 +7,11 @@ plainlanguage: 10-21-16 certified in compliance with the Plain Language Act
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 Spina bifida is a spinal cord birth defect. A baby develops spina bifida while still in the womb. In some cases, a parent's past contact with specific chemicals causes this birth defect. If you served in South Vietnam or the Republic of Korea—and your child has spina bifida or certain other birth defects—your child may be able to get disability benefits. Find out if your child qualifies for benefits.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/contaminated-drinking-water-at-camp-lejeune.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/contaminated-drinking-water-at-camp-lejeune.md
@@ -5,7 +5,11 @@ source: http://benefits.va.gov/compensation/claims-postservice-exposures-camp_le
 template: 4-action-page
 ---
 
+<div class="va-introtext">
+
 If you served at Marine Corps Base Camp Lejeune or Marine Corps Air Station (MCAS) New River in North Carolina, you may have had contact with contaminants in the drinking water there. Scientific and medical evidence has shown an association between exposure to these contaminants during military service and development of certain diseases later on. If you have qualifying service at Camp Lejeune and a current diagnosis of 1 of the conditions listed below, you may be able to get disability benefits.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/gulf-war-illness-from-service-in-afghanistan.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/gulf-war-illness-from-service-in-afghanistan.md
@@ -7,9 +7,13 @@ plainlanguage:
 template: 4-action-page
 ---
 
+<div class="va-introtext">
+
 If you served in Afghanistan, you may suffer from illnesses or other conditions related to service in this region. Find out if you can get disability compensation or benefits.
 
 [Learn about service in the Southwest Asia theater of military operations and Gulf War Illness](/disability-benefits/conditions/exposure-to-hazardous-materials/gulf-war-illness/).
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/gulf-war-illness.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/gulf-war-illness.md
@@ -7,10 +7,13 @@ plainlanguage: 10-28-16 certified in compliance with the Plain Language Act
 template: 4-action-page
 ---
 
+<div class="va-introtext">
+
 If you served in the Southwest Asia theater of military operations, you may suffer from illnesses or other conditions related to service in this region. Find out if you can get disability compensation or benefits.
 
 [Learn about service in Afghanistan and Gulf War Illness](/disability-benefits/conditions/exposure-to-hazardous-materials/gulf-war-illness-from-service-in-afghanistan).  
 
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/mustard-gas.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/mustard-gas.md
@@ -6,7 +6,11 @@ plainlanguage: 10-28-16 certified in compliance with the Plain Language Act
 template: 4-action-page
 ---
 
+<div class="va-introtext">
+
 If you had contact with mustard gas (also known as sulfur mustard, yperite, or nitrogen mustard) or lewisite, a natural compound that contains the poison arsenic, you may have certain related long-term illnesses. Find out if you can get disability compensation or benefits.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/project112-SHAD.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/project112-SHAD.md
@@ -6,7 +6,11 @@ plainlanguage: 10-21-16 certified in compliance with the Plain Language Act
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 If you were part of chemical and biological warfare testing for Projects 112 or Shipboard Hazard and Defense (SHAD) from 1962 to 1974, you may be at risk for illnesses believed to be caused by the testing. Find out if you can get disability compensation or benefits.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/radiation-exposure.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/radiation-exposure.md
@@ -6,9 +6,13 @@ plainlanguage: 10-28-16 certified in compliance with the Plain Language Act
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 Find out if you can get disability compensation or benefits for illnesses—including some cancers—believed to be caused by contact with radiation during military service. 
 
 [Learn about radiation-related illnesses](http://www.ecfr.gov/cgi-bin/text-idx?rgn=div5&node=38:1.0.1.1.4#se38.1.3_1309). 
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/specific-environmental-hazards.md
+++ b/content/pages/disability-benefits/conditions/exposure-to-hazardous-materials/specific-environmental-hazards.md
@@ -5,7 +5,11 @@ plainlanguage: 10-28-16 certified in compliance with the Plain Language Act
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 If you had contact with certain environmental hazards while serving in Iraq, Afghanistan, and other areas, you may have illnesses or other conditions believed to be caused by these toxic chemicals in the air, water, or soil. Find out if you can get disability compensation or benefits.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/pow.md
+++ b/content/pages/disability-benefits/conditions/pow.md
@@ -7,7 +7,11 @@ plainlanguage: 10-28-16 certified in compliance with the Plain Language Act
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 Are you a former POW now living with a disability? Find out if you can get disability compensation or benefits.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/service-connected.md
+++ b/content/pages/disability-benefits/conditions/service-connected.md
@@ -3,16 +3,14 @@ layout: page-breadcrumbs.html
 title: Disabilities Linked to Military Service
 source: https://eauth.va.gov/ebenefits/learn/compensation
 plainlanguage: 10-28-16 certified in compliance with the Plain Language Act
+template: 1-topic-landing
 ---
 
+<div class="va-introtext">
 
-<div class="section one" markdown="0">
-<div class="primary" markdown="0">
-<div class="row" markdown="0">
-<div class="small-12 columns usa-content" markdown="1">
+Do you have a disability caused by an illness or injury that happened—or got worse—while you were actively serving in the military? If you do, you may be able to get disability compensation or benefits, no matter when or where you served.
 
-
-Do you have a disability caused by an illness or injury that happened—or got worse—while you were actively serving in the military? If you do, you may be able to get disability compensation or benefits, no matter when or where you served. 
+</div>
 
 ### Can I get disability benefits from VA?
 

--- a/content/pages/disability-benefits/conditions/special-claims.md
+++ b/content/pages/disability-benefits/conditions/special-claims.md
@@ -26,4 +26,8 @@ relatedlinks:
 ---
 
 
+<div class="va-introtext">
+
 Do you have a disability that isn't listed on this site as being linked to military service? You may still be able to get disability compensation or benefits. If you're a Veteran with a disability believed to be caused by your service in the military, you may be able to get special compensation to help with disabilities like the ones listed below.
+
+</div>

--- a/content/pages/disability-benefits/conditions/special-claims/automobile.md
+++ b/content/pages/disability-benefits/conditions/special-claims/automobile.md
@@ -6,7 +6,11 @@ plainlanguage: 10-28-16 certified in compliance with the Plain Language Act
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 Do you have a disability related to your military service that prevents you from driving? If you do, you may be able to get disability compensation or benefits. 
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/special-claims/clothing.md
+++ b/content/pages/disability-benefits/conditions/special-claims/clothing.md
@@ -6,7 +6,11 @@ plainlanguage: 10-28-16 certified in compliance with the Plain Writing Act
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 Has your clothing been damaged by your prosthetic or orthopedic device (such as a wheelchair) or by the medicine you’re taking for a skin condition? If it has, you may be able to get money each year to help you buy new clothes. This is a disability compensation benefit known as an annual clothing allowance. Find out if you can get this benefit. 
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/special-claims/convalescence.md
+++ b/content/pages/disability-benefits/conditions/special-claims/convalescence.md
@@ -7,7 +7,11 @@ plainlanguage: 10-28-16 certified in compliance with the Plain Writing Act
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 Are you recovering from surgery or a disability related to your military service that's left you unable to move? You may be able to get a temporary 100% disability rating and disability compensation or benefits if you have this kind of immobilizing  disability. Find out if you can get this benefit. 
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/special-claims/dentistry.md
+++ b/content/pages/disability-benefits/conditions/special-claims/dentistry.md
@@ -7,8 +7,12 @@ plainlanguage: 10-28-16 certified in compliance with the Plain Writing Act
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 If you're a Veteran, you may be able to get VA dental care. 
 
 Dental benefits are not the same as other VA medical benefits. We look at many factors to decide who qualifies for VA dental care—and which dental care benefits each Veteran may receive. Both the Veterans Benefits Administration (VBA) and the Veterans Health Administration (VHA) may make decisions about dental benefits and treatment. 
 
 Check our Dental Benefits for Veterans fact sheet to see if you may be able to get dental care from VA. [Download the Dental Benefits for Veterans fact sheet](http://www.va.gov/healthbenefits/resources/publications/IB10-442_dental_benefits_for_veterans_2_14.pdf).
+
+</div>

--- a/content/pages/disability-benefits/conditions/special-claims/hospitalization.md
+++ b/content/pages/disability-benefits/conditions/special-claims/hospitalization.md
@@ -6,7 +6,11 @@ plainlanguage: 10-28-16 certified in compliance with the Plain Writing Act
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 Did you spend time in a VA hospital or a VA-approved hospital for a disability related to your military service (called a service-connected disability)? If you did, you may be able to get added disability compensation or benefits with a temporary 100% disability rating for the time you spent in the hospital. Find out if you can get this benefit.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/special-claims/individual-unemployability.md
+++ b/content/pages/disability-benefits/conditions/special-claims/individual-unemployability.md
@@ -7,7 +7,11 @@ plainlanguage: 11-2-16 certified in compliance with the Plain Writing Act
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 If you can't work because of a disability related to your service in the military (a service-connected disability), you may qualify for what's called individual unemployability. This means you may be able to get disability compensation or benefits at the same level as a Veteran who has a 100% disability rating.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/special-claims/prestabilization.md
+++ b/content/pages/disability-benefits/conditions/special-claims/prestabilization.md
@@ -7,9 +7,13 @@ plainlanguage: 11-2-16 certified in compliance with the Plain Writing Act
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 If you recently ended your active military service and you have a disability related to your service (called a service-connected disability), you may be able to get temporary disability compensation or benefits right away.
 
 If you qualify for these benefits, you'll get what's called a prestabilization rating. This rating may be 50% or 100%, depending on the severity of your disability. Your prestabilization rating will continue for 1 year after your discharge from active service.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/conditions/special-claims/title-38-USC-1151.md
+++ b/content/pages/disability-benefits/conditions/special-claims/title-38-USC-1151.md
@@ -6,8 +6,11 @@ plainlanguage: 11-2-16 certified in compliance with the Plain Writing Act
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 If you suffered an added disability while getting VA medical care or taking part in a VA program designed to help you find, get, or keep a job, you may be able to get compensation.
 
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/disability-benefits/eligibility.md
+++ b/content/pages/disability-benefits/eligibility.md
@@ -13,7 +13,11 @@ relatedlinks:
    description: "Find out why some chronic (long-lasting) conditions may qualify you for disability benefits." 
 ---
 
+<div class="va-introtext">
+
 If you have a disability that was caused by—or got worse because of—your active military service, you may be able to get disability benefits from VA. Find out if you can get financial support and other benefits like health care.
+
+</div>
 
 <div class="feature" markdown="1">
 

--- a/content/pages/disability-benefits/index.md
+++ b/content/pages/disability-benefits/index.md
@@ -28,6 +28,10 @@ relatedlinks:
     description: Find out what to do if you disagree with your disability rating decision.
 ---
 
+<div class="va-introtext">
+
 If you have a disability that was caused by—or got worse because of—your active military service, you may be able to get disability benefits from VA. A disability can be a physical illness or injury (like cancer or damage to a knee) or a mental-health condition (like anxiety or PTSD). Even when a condition doesn’t appear until years after your service ends, if it was the result of an injury or illness that happened during active military service, you may qualify for disability compensation. Find out if you can get financial support and other benefits like health care.
+
+</div>
 
 <a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation">Go to eBenefits to Apply</a>

--- a/content/pages/education/advanced-training-and-certifications.md
+++ b/content/pages/education/advanced-training-and-certifications.md
@@ -18,4 +18,8 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 You can use the GI Bill for more than just academic programs. This benefit will help you pay the fees for advanced training and certifications in your area of expertise.
+
+</div>

--- a/content/pages/education/advanced-training-and-certifications/entrepreneurship-training.md
+++ b/content/pages/education/advanced-training-and-certifications/entrepreneurship-training.md
@@ -4,9 +4,13 @@ title: Entrepreneurship Training
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 If you qualify for any of the GI Bill or educational assistance programs, and you are interested in starting or improving a business, VA provides entrepreneurship training through its Center for Veterans Enterprise and the Small Business Administration.
 
 You do not have to use GI Bill funding to participate in this program.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/education/advanced-training-and-certifications/flight-training.md
+++ b/content/pages/education/advanced-training-and-certifications/flight-training.md
@@ -5,7 +5,11 @@ template: 1-topic-landing
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 If you want to pursue a career in the aviation industry as a pilot, VA offers benefits to help you achieve your goal.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/education/advanced-training-and-certifications/licensing-certification.md
+++ b/content/pages/education/advanced-training-and-certifications/licensing-certification.md
@@ -5,7 +5,12 @@ template: 4-action-page-pending
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 If you are a Veteran looking for employment in a field that requires a license or certification, you may be eligible for GI Bill reimbursement for licensing or certification exams.
+
+</div>
+
 <div class="call-out" markdown="1">
 
 ### Are you eligible for compensation?

--- a/content/pages/education/advanced-training-and-certifications/national-testing-program.md
+++ b/content/pages/education/advanced-training-and-certifications/national-testing-program.md
@@ -5,7 +5,12 @@ template: 4-action-page-pending
 concurrence: complete
 ---
 
+<div class="va-introtext">
+
 If you are pursuing higher education that requires testing as part of the application process, you may be eligible for reimbursement from VA.
+
+</div>
+
 <div class="call-out" markdown="1">
 
 ### Are you eligible for compensation?

--- a/content/pages/education/after-you-apply.md
+++ b/content/pages/education/after-you-apply.md
@@ -10,7 +10,11 @@ relatedlinks:
    description: "Transitioning out of active service? Get free help taking the next steps in your education and career."
 ---
 
+<div class="va-introtext">
+
 Getting a degree, certificate, or other professional license can help you make a sucessful transition from military to civilian life. Find out what happens after you apply for education benefits. 
+
+</div>
 
 ### How long does it take VA to make a decision?
 

--- a/content/pages/education/apply-for-education-benefits/regional-office.md
+++ b/content/pages/education/apply-for-education-benefits/regional-office.md
@@ -5,14 +5,11 @@ concurrence: incomplete
 template: 4-action-page-pending
 ---
 
-
-
-<div class="section one" markdown="0">
-<div class="primary" markdown="0">
-<div class="row" markdown="0">
-<div class="small-12 columns usa-content" markdown="1">
+<div class="va-introtext">
 
 If you need help with GI Bill claims, contact your VA Regional Processing Office (RPO). VA has four RPOs in the United States, all of which correspond to regional jurisdictions. Here are the locations:
+
+</div>
 
 #### Atlanta, Georgia
 <p>P.O. Box 100022<br>

--- a/content/pages/education/apply.md
+++ b/content/pages/education/apply.md
@@ -13,7 +13,11 @@ relatedlinks:
    description: "The GI Bill can pay for more than just academic programs. Use it to help cover the costs of becoming a licensed or certified professional (like a mechanic or medical technician) or a business owner."
 ---
 
+<div class="va-introtext">
+
 If you’re a Servicemember, Veteran, or family member interested in education and training opportunities, you can apply for your Certificate of Eligibility (COE). You can also manage your current benefits.
+
+</div>
 
 ### Prepare
 

--- a/content/pages/education/eligibility.md
+++ b/content/pages/education/eligibility.md
@@ -16,7 +16,11 @@ relatedlinks:
    description: "Get help making the most of your options as you transition from military to civilian life."
 ---
 
+<div class="va-introtext">
+
 If you're an active duty Servicemember or Veteran, a member of the National Guard or Reserves, or a qualified survivor or dependent, you may be able to get help from VA to pay your tuition, pick out a school, choose a career, and more. Find out if you qualify for VA education benefits through the GI Bill program and other educational assistance programs.
+
+</div>
 
 <div class="feature" markdown="1">
 

--- a/content/pages/education/gi-bill.md
+++ b/content/pages/education/gi-bill.md
@@ -42,8 +42,12 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 Since 1944, the GI Bill has helped millions of Veterans pay for college so they can have successful civilian careers. The Post-9/11 GI Bill, available for Veterans with active-duty service after September 11, 2001, also offers a living allowance, money for books, and the option to transfer education benefits you don't use to your spouse or children.
 
 You have several options from which to choose. [Veterans Service Organizations](http://www.va.gov/vso/) and the [GI Bill Comparison Tool](/gi-bill-comparison-tool/) can help you pick the best program for you.
+
+</div>
 
 <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a> <a class="usa-button-primary va-button-secondary" href="/gi-bill-comparison-tool/">GI Bill Comparison Tool</a>

--- a/content/pages/education/gi-bill/buy-up-program.md
+++ b/content/pages/education/gi-bill/buy-up-program.md
@@ -5,7 +5,11 @@ template: 4-action-page-pending
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 If you participate in the $600 Montgomery GI Bill Buy-Up program, your GI Bill monthly payments will increase.
+
+</div>
 
 ### How it works
 

--- a/content/pages/education/gi-bill/foreign-programs.md
+++ b/content/pages/education/gi-bill/foreign-programs.md
@@ -5,7 +5,11 @@ template: 4-action-page-pending
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 If you plan to study at a foreign school, you can use VA benefits to cover your tuition and fees.
+
+</div>
 
 ### Are you eligible for compensation?
 Yes, if:

--- a/content/pages/education/gi-bill/higher-learning.md
+++ b/content/pages/education/gi-bill/higher-learning.md
@@ -5,9 +5,13 @@ template: 4-action-page-pending
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 If you would like to earn an undergraduate or graduate degree at an institution of higher learning, including four-year universities, community colleges, and schools offering advanced degrees, VA education and training benefits may be available to you.
 
 The number of classes you attend and the accompanying hours spent in those classes determine your payments.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/education/gi-bill/montgomery-active-duty.md
+++ b/content/pages/education/gi-bill/montgomery-active-duty.md
@@ -5,7 +5,11 @@ template: 4-action-page-pending
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 If you served at least two years on active duty, you may be eligible for the MGIB-AD program.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/education/gi-bill/montgomery-selected-reserve.md
+++ b/content/pages/education/gi-bill/montgomery-selected-reserve.md
@@ -5,9 +5,14 @@ concurrence: complete
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 If you are an eligible member of the Army Reserve, Navy Reserve, Air Force Reserve, Marine Corps Reserve, Coast Guard Reserve, Army National Guard, or Air National Guard, you may receive up to 36 months of education and training benefits under the MGIB-SR program.
 
 View [current payment rates](http://www.benefits.va.gov/gibill/resources/benefits_resources/rate_tables.asp#ch1606).
+
+</div>
+
 <div class="call-out" markdown="1">
 
 ### Are you eligible for this program?

--- a/content/pages/education/gi-bill/post-9-11.md
+++ b/content/pages/education/gi-bill/post-9-11.md
@@ -5,8 +5,11 @@ template: 1-topic-landing
 concurrence: complete
 ---
 
+<div class="va-introtext">
 
 If you are seeking education or training opportunities and have served on active duty after September 10, 2001, you may be eligible for the Post-9/11 GI Bill. The Post-9/11 GI Bill is the largest expansion of education benefits since the Montgomery GI Bill.
+
+</div>
 
 <div class="call-out usa-content" markdown="1">
 

--- a/content/pages/education/gi-bill/survivors-dependent-assistance.md
+++ b/content/pages/education/gi-bill/survivors-dependent-assistance.md
@@ -5,7 +5,12 @@ concurrence: incomplete
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 If you are a dependent or survivor of a Veteran, you may be eligible for educational assistance through a GI Bill program.
+
+</div>
+
 <div class="call-out" markdown="1">
 
 ### Are you eligible for benefits?

--- a/content/pages/education/gi-bill/survivors-dependent-assistance/dependents-education.md
+++ b/content/pages/education/gi-bill/survivors-dependent-assistance/dependents-education.md
@@ -5,7 +5,11 @@ template: 1-topic-landing
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 If you are the dependent of a Veteran who was permanently and totally disabled on active duty or due to a service-related condition, you may be eligible for 45 months of degree and certificate courses, apprenticeship, and on-the-job training under the Survivors' and Dependents’ Educational Assistance (DEA) program.
+
+</div>
 
 <div class="call-out usa-content" markdown="1">
 

--- a/content/pages/education/gi-bill/survivors-dependent-assistance/fry-scholarship.md
+++ b/content/pages/education/gi-bill/survivors-dependent-assistance/fry-scholarship.md
@@ -5,7 +5,11 @@ concurrence: incomplete
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 The Marine Gunnery Sergeant John David Fry Scholarship (Fry Scholarship) provides Post-9/11 GI Bill benefits to the children and surviving spouses of Servicemembers who died in the line of duty while on active duty after September 10, 2001. If you qualify, you may receive up to 36 months of benefits at the 100% level. Full in-state tuition costs are covered at public institutions; up to $21,084.89 per year will be paid for training at private institutions.
+
+</div>
 
 Are you eligible for Fry Scholarship benefits?
 : Yes, if:

--- a/content/pages/education/gi-bill/transfer.md
+++ b/content/pages/education/gi-bill/transfer.md
@@ -5,9 +5,14 @@ template: 1-topic-landing
 concurrence: complete
 ---
 
+<div class="va-introtext">
+
 If you have not used all of your Post-9/11 GI Bill benefits, you may be eligible to transfer up to 36 months of benefits to your spouse or dependent children. Once the Department of Defense (DOD) approves the transfer, the new beneficiaries can apply for VA benefits.
 
 **Note:** The Department of Defense (DOD) determines whether or not you can transfer benefits to your family.
+
+</div>
+
 <div class="call-out" markdown="1">
 
 ### Are you eligible to transfer benefits?

--- a/content/pages/education/gi-bill/tuition-assistance.md
+++ b/content/pages/education/gi-bill/tuition-assistance.md
@@ -5,8 +5,12 @@ concurrence: incomplete
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
 
 If your tuition amounts to more than what’s covered by the Tuition Assistance (TA) program, you may be eligible for additional assistance. Tuition Assistance Top-Up covers the difference between the full cost of a college course and the amount covered under active-duty TA for up to 36 months.
+
+</div>
+
 <div class="call-out" markdown="1">
 
 ### Are you eligible for compensation?

--- a/content/pages/education/gi-bill/tutorial-assistance.md
+++ b/content/pages/education/gi-bill/tutorial-assistance.md
@@ -5,7 +5,11 @@ template: 4-action-page-pending
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 If you are using VA educational assistance, and you’re struggling with the course work, you may be eligible for a financial supplement to pay for a tutor.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/education/gi-bill/yellow-ribbon.md
+++ b/content/pages/education/gi-bill/yellow-ribbon.md
@@ -5,7 +5,12 @@ template: 1-topic-landing
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 If your school participates in the Yellow Ribbon Program, you may be able to reduce or eliminate your education costs that are not covered by the [Post-9/11 GI Bill](/education/gi-bill/post-9-11/index.html), such as higher tuition at private colleges or out-of-state schools.
+
+</div>
+
 <div class="call-out" markdown="1">
 
 ### Are you eligible for benefits?

--- a/content/pages/education/index.md
+++ b/content/pages/education/index.md
@@ -33,6 +33,10 @@ relatedlinks:
    description: Learn about REAP, VEAP, and Call to Service.
 ---
 
+<div class="va-introtext">
+
 VA gives Veterans, Servicemembers, and their families generous education benefits and opportunities, including help paying tuition, picking out a school, career counseling, and more.
+
+</div>
 
 <a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/application/1990/introduction">Apply for Education Benefits</a> <a href="/education/apply-for-education-benefits/application/1995" class="usa-button-primary usa-button-outline">Manage Benefits</a>

--- a/content/pages/education/other-educational-assistance-programs.md
+++ b/content/pages/education/other-educational-assistance-programs.md
@@ -15,6 +15,10 @@ relatedlinks:
     description: "A government match program for educational assistance."
 ---
 
+<div class="va-introtext">
+
 Guardsmen, Reservists, and previous generations of Veterans not eligible for the Post-9/11 GI Bill can access education benefits through REAP, VEAP, and the National Call to Service program.
 
 [An accredited representative](/disability-benefits/apply-for-benefits/help/index.html) with a Veteran Service Organization (VSO) can help you pick the right program.
+
+</div>

--- a/content/pages/education/other-educational-assistance-programs/call-to-service.md
+++ b/content/pages/education/other-educational-assistance-programs/call-to-service.md
@@ -4,7 +4,12 @@ title: National Call to Service Program
 concurrence: incomplete
 template: 1-topic-landing
 ---
+
+<div class="va-introtext">
+
 If you performed a period of national service, you may be eligible for the National Call to Service program, which allows you to choose an education benefit as an alternative to the Montgomery GI Bill.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/education/other-educational-assistance-programs/reap.md
+++ b/content/pages/education/other-educational-assistance-programs/reap.md
@@ -5,4 +5,10 @@ concurrence: incomplete
 template: 1-topic-landing
 ---
 
-[REAP ended](http://www.benefits.va.gov/gibill/reap.asp) on November 25, 2015, but under the National Defense Authorization Act of 2016, some REAP benefits will remain in place for three more years. The [Post-9/11 GI Bill](/education/gi-bill/post-9-11/) has replaced REAP, providing educational assistance benefits for Reserve and National Guard members called to active duty on or after September 11, 2001. If you applied for REAP on or after November 25, 2015, your application will be reviewed and appropriate benefits will be applied, including the Post-9/11 GI Bill. If you would like to discontinue using REAP and use the Post-9/11 GI Bill instead, call 1-888-442-4551 (1-888-GI-BILL-1) from 8:00 a.m. - 7:00 p.m. ET Mon - Fri.
+<div class="va-introtext">
+
+[REAP ended](http://www.benefits.va.gov/gibill/reap.asp) on November 25, 2015, but under the National Defense Authorization Act of 2016, some REAP benefits will remain in place for three more years.
+
+</div>
+
+The [Post-9/11 GI Bill](/education/gi-bill/post-9-11/) has replaced REAP, providing educational assistance benefits for Reserve and National Guard members called to active duty on or after September 11, 2001. If you applied for REAP on or after November 25, 2015, your application will be reviewed and appropriate benefits will be applied, including the Post-9/11 GI Bill. If you would like to discontinue using REAP and use the Post-9/11 GI Bill instead, call 1-888-442-4551 (1-888-GI-BILL-1) from 8:00 a.m. - 7:00 p.m. ET Mon - Fri.

--- a/content/pages/education/other-educational-assistance-programs/veap.md
+++ b/content/pages/education/other-educational-assistance-programs/veap.md
@@ -5,7 +5,11 @@ concurrence: complete
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 If you are interested in pursuing continuing-education programs, and are willing to make contributions from your military pay, the VEAP is a $2-to-$1 government-match program for educational assistance.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/education/rates.md
+++ b/content/pages/education/rates.md
@@ -5,6 +5,10 @@ concurrence: incomplete
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 VA provides education benefits to qualifying Veterans and their family members. See the tables below for information about the available education benefits and corresponding rates.
 
 [Rate Tables](http://www.benefits.va.gov/GIBILL/resources/benefits_resources/rate_tables.asp#ch33)
+
+</div>

--- a/content/pages/education/tools-programs.md
+++ b/content/pages/education/tools-programs.md
@@ -19,4 +19,8 @@ relatedlinks:
 
 ---
 
+<div class="va-introtext">
+
 Navigating your transition from military to civilian life can be challenging. VA offers tools and counseling programs to help you make the most of your options.
+
+</div>

--- a/content/pages/education/tools-programs/careerscope.md
+++ b/content/pages/education/tools-programs/careerscope.md
@@ -5,7 +5,11 @@ template: 4-action-page-pending
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 Besides getting career counseling, you can use CareerScope, a tool that measures your interests and skill levels. Use CareerScope to help you figure out the best career path when you move into civilian life. [Get started with CareerScope](https://va.careerscope.net/gibill).
+
+</div>
 
 CareerScope recommends careers you may enjoy and jobs in which you're likely to do well. The tool also recommends courses or training programs that can help you go after those careers.
 

--- a/content/pages/education/tools-programs/education-career-counseling.md
+++ b/content/pages/education/tools-programs/education-career-counseling.md
@@ -5,7 +5,11 @@ template: 4-action-page-pending
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 If you are transitioning out of active service soon, you are entitled to free educational and career counseling services.
+
+</div>
 
 ### Are you eligible for services?
 

--- a/content/pages/education/tools-programs/locate-a-school.md
+++ b/content/pages/education/tools-programs/locate-a-school.md
@@ -5,6 +5,10 @@ template: 1-topic-landing
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 Not all schools and vocational institutions are eligible for use with VA benefits. Use the [school search tool](http://inquiry.vba.va.gov/weamspub/buildSearchInstitutionCriteria.do;jsessionid=qtMbSxQFpzyL7GpnQrtnNGv6G9CGQQvb2YqM9Cvw3vB2pv2lXhfJ!-1531379871) to locate institutions that are approved for use with VA education benefits. You can also locate institutions of higher education participating in the [Yellow Ribbon Program](/education/gi-bill/yellow-ribbon/), which may offer additional education-related costs not covered by VA.
 
 Use the [GI Bill Comparison Tool](/gi-bill-comparison-tool/).
+
+</div>

--- a/content/pages/education/tools-programs/principles-excellence-program.md
+++ b/content/pages/education/tools-programs/principles-excellence-program.md
@@ -5,7 +5,11 @@ template: 1-topic-landing
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 The Principles of Excellence program requires participating educational institutions to:
+
+</div>
 
 - Provide a personalized form to help you understand the total cost of your educational program, including:
   - Costs covered by your benefits.

--- a/content/pages/education/work-learn.md
+++ b/content/pages/education/work-learn.md
@@ -22,4 +22,8 @@ relatedlinks:
 
 ---
 
+<div class="va-introtext">
+
 You are in charge of designing your own education. VA education benefits, including the GI Bill, give you a wide range of options, including on-the-job-training, apprenticeships, overseas schools, and correspondence training.
+
+</div>

--- a/content/pages/education/work-learn/co-op-training.md
+++ b/content/pages/education/work-learn/co-op-training.md
@@ -5,7 +5,11 @@ concurrence: complete
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 If you are enrolled at an approved Institution of Higher Learning (IHL) that provides cooperative (co-op) training, you may use VA educational assistance benefits to cover your costs. Co-op training is an educational program requiring periods of full-time work or training alternating with periods of full-time instruction.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/education/work-learn/job-and-apprenticeship.md
+++ b/content/pages/education/work-learn/job-and-apprenticeship.md
@@ -5,7 +5,11 @@ concurrence: incomplete
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 If you want to learn a trade or skill through on-the-job training or apprenticeships, there are VA benefits that can help.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/education/work-learn/non-college-degree-program.md
+++ b/content/pages/education/work-learn/non-college-degree-program.md
@@ -5,7 +5,11 @@ concurrence: incomplete
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 If you are a Veteran, Servicemember, or eligible dependent interested in non-college degree programs (such as EMT, HVAC repair, truck driving, and more), the GI Bill may pay all or a portion of your tuition.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/education/work-learn/non-traditional.md
+++ b/content/pages/education/work-learn/non-traditional.md
@@ -15,4 +15,8 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 You may find that mainstream college programs aren't a good fit for you. If you qualify for the GI Bill, you can use your benefit in a variety of non-traditional ways.
+
+</div>

--- a/content/pages/education/work-learn/non-traditional/accelerated-payments.md
+++ b/content/pages/education/work-learn/non-traditional/accelerated-payments.md
@@ -5,7 +5,11 @@ template: 4-action-page-pending
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 If you’re enrolled in a high-tech program and intend to work in a high-tech industry, you may be eligible to receive a lump-sum payment of 60% of tuition and fees. VA issues accelerated payment to you instead of the monthly benefits you would otherwise receive. This program covers the higher per-month costs associated with these courses of study.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/education/work-learn/non-traditional/correspondence-training.md
+++ b/content/pages/education/work-learn/non-traditional/correspondence-training.md
@@ -5,7 +5,11 @@ template: 4-action-page-pending
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 If you would like to learn at home or are located in a remote area, correspondence training may be a good option for you. This type of training does not have to be completed within a quarter, semester, or term. You receive coursework assignments in the mail and send them back when completed.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/education/work-learn/non-traditional/independent-distance-learning.md
+++ b/content/pages/education/work-learn/non-traditional/independent-distance-learning.md
@@ -5,4 +5,8 @@ template: 4-action-page-pending
 concurrence: incomplete
 ---
 
+<div class="va-introtext">
+
 You can use the GI Bill for independent and distance-learning online training. If you are using your Post-9/11 GI Bill benefits while taking only distance-learning courses, you will be paid a housing allowance based on 50% of the national average. [View current payment rates](http://www.benefits.va.gov/gibill/resources/benefits_resources/rate_tables.asp)
+
+</div>

--- a/content/pages/education/work-learn/workstudy.md
+++ b/content/pages/education/work-learn/workstudy.md
@@ -5,7 +5,11 @@ concurrence: incomplete
 template: 4-action-page-pending
 ---
 
+<div class="va-introtext">
+
 If you are a full-time or three-quarter-time college, vocational, or professional student using VA education benefits, you may be eligible for the work-study program.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/employment/employers/apprenticeship.md
+++ b/content/pages/employment/employers/apprenticeship.md
@@ -5,7 +5,11 @@ concurrence: complete
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 Employers can set up an apprenticeship program that is approved for the GI Bill.
+
+</div>
 
 Employers provide Veterans with a job at an acceptable wage, as well as training, development, hands-on learning, and technical instruction. VA may give a stipend to Veterans. At the end of the program, Veterans receive job certification or journeyman status.
 

--- a/content/pages/employment/employers/post-a-job.md
+++ b/content/pages/employment/employers/post-a-job.md
@@ -6,7 +6,11 @@ template: 4-action-page-pending
 ---
 <link href="/assets/css/vendor/prism.css" type="text/css" rel="stylesheet">
 
+<div class="va-introtext">
+
 Thank you for your interest in hiring Veterans, transitioning Servicemembers, and their families through the Veterans Employment Center (VEC). Maximize your exposure by posting jobs directly from your website to the Veterans Job Bank through the [National Labor Exchange (NLX)](https://us.jobs/postajobpartner.asp?partner=ebenefits).
+
+</div>
 
 <dl markdown="1" class="va-callout">
 <dt>Who can post a job?</dt>

--- a/content/pages/employment/employers/support-veteran-employees.md
+++ b/content/pages/employment/employers/support-veteran-employees.md
@@ -10,7 +10,11 @@ relatedlinks:
     title: Post a Job
 ---
 
+<div class="va-introtext">
+
 Veterans are civic assets who can draw on their experiences to improve your business. When a Servicemember first joins a private-sector company, there may be a transition period for both the Veteran and the company. This [web-based tutorial](http://www.va.gov/VETSINWORKPLACE/training/EAP/default.htm) provides tips on how you can support Veterans, Reservists, and National Guardsmen in your workplace.
+
+</div>
 
 If your company has not previously hired Veterans, learn about how you can design and implement a [Veterans hiring initiative](http://www.dol.gov/vets/ahaw/index.htm). A [Vocational Rehabilitation & Employment (VR&E) Employment Coordinator](http://www.benefits.va.gov/VOCREHAB/docs/EmploymentCoordinators.xls) can help you if you are interested in hiring service-disabled Veterans. There may be [tax credits]( https://www.doleta.gov/business/incentives/opptax/eligible.cfm#Veterans) of up to $9,600 for every eligible Veteran hired through the Work Opportunity Tax Credit, which is administered by the Department of Labor.
 

--- a/content/pages/employment/index.md
+++ b/content/pages/employment/index.md
@@ -27,4 +27,8 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 We can support you in all stages of your job search. We've teamed up with the Department of Labor to give you career advice, help building your résumé, and access to employers who want to hire Veterans and military spouses.
+
+</div>

--- a/content/pages/employment/job-seekers.md
+++ b/content/pages/employment/job-seekers.md
@@ -4,7 +4,11 @@ title: Job Seekers
 template: 4-action-page
 ---
 
+<div class="va-introtext">
+
 Wherever you are in the transition process, the Veterans Employment Center provides career advice, résumé-building assistance, and access to employers who are committed to hiring Veterans and military spouses.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/employment/job-seekers/alternative.md
+++ b/content/pages/employment/job-seekers/alternative.md
@@ -18,7 +18,11 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 There are many ways for you to launch your civilian career and continue your education at the same time, and many options other than traditional education programs.
+
+</div>
 
 [**Work Study**](/education/work-learn/workstudy/)
 : This program allows you to use your GI Bill for higher education while working for VA.

--- a/content/pages/employment/job-seekers/career-fairs.md
+++ b/content/pages/employment/job-seekers/career-fairs.md
@@ -14,7 +14,11 @@ relatedlinks:
     title: Unemployment Support
 ---
 
+<div class="va-introtext">
+
 Career fairs are an important first step in the search for employment. In-person or online, job fairs let you directly and efficiently network with hiring managers from a variety of companies.
+
+</div>
 
 ### Being well prepared is critical to your success
 

--- a/content/pages/employment/job-seekers/employment-support.md
+++ b/content/pages/employment/job-seekers/employment-support.md
@@ -24,7 +24,11 @@ relatedlinks:
     title: VECI
 ---
 
+<div class="va-introtext">
+
 As you navigate the civilian marketplace, you may encounter challenges. The Veterans Employment Center can help.
+
+</div>
 
 More private-sector businesses are committing each day to hire Veterans and military family members. Review the latest [commitments](/employment/commitments) and search the [Veterans Job Bank](/employment/job-seekers/search-jobs) for new job openings. Or if you are considering pursuing [education, licensure, or certifications](/education/advanced-training-and-certifications/licensing-certification/), VA can help guide you through the process.
 

--- a/content/pages/employment/job-seekers/family-members.md
+++ b/content/pages/employment/job-seekers/family-members.md
@@ -20,7 +20,11 @@ relatedlinks:
     title: Unemployment Support
 ---
 
+<div class="va-introtext">
+
 The Veterans Employment Center can help spouses and other family members access valuable career resources.
+
+</div>
 
 Through the Department of Defense’s [Spouse Education Career Opportunities](https://myseco.militaryonesource.mil/Portal/) (SECO) program, spouses can use government-sponsored career and education resources, take advantage of networking opportunities, and work with employment counselors. SECO also partners with the [Military Spouse Employment Partnership](https://msepjobs.militaryonesource.mil/msep/) (MSEP) and [My Career Advancement Account](https://myseco.militaryonesource.mil/Portal/Media/Default/Collaterals_Catalog/Program_Overview/MyCAA-Helping-Spouses-Reach-Career-Goals.pdf) (MyCAA) scholarship program. These organizations and others (such as [Blue Star Families](https://www.bluestarfam.org/)) offer assistance for spouses interested in the following:
 

--- a/content/pages/employment/job-seekers/federal-employment.md
+++ b/content/pages/employment/job-seekers/federal-employment.md
@@ -5,7 +5,11 @@ concurrence: incomplete
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 Federal jobs, including those at VA, offer outstanding opportunities to Veterans and their spouses. Skills learned in the military are easily transferrable to many positions, and by working for a federal agency, you can continue to serve your country. In addition, your military service counts toward a civilian pension.
+
+</div>
 
 The federal job-application process is very detailed compared with most civilian organizations. Federal positions are listed, with very few exceptions, on [USAJobs](http://www.usajobs.gov).
 

--- a/content/pages/employment/job-seekers/interest-profiler.md
+++ b/content/pages/employment/job-seekers/interest-profiler.md
@@ -5,7 +5,11 @@ concurrence: incomplete
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 You can use tools like [O&#42;Net Interest Profiler](http://www.mynextmove.org/explore/ip) to identify the kind of work you enjoy. After taking the short questionnaire, use the results (called an O&#42;Net code) in [targeted job-search engines](http://jobcenter.usa.gov/find-a-job) that may ultimately help you identify a career that fits with the kind of work you enjoy.
+
+</div>
 
 Similarly, the [VA CareerScope Assessment Profile](https://va.careerscope.net/gibill) provides a detailed report on interest areas such as humanitarian, mechanical, scientific, or artistic. This should be used in conjunction with your O&#42;Net results and shared with your career counselor. Together you may be able to more accurately target employment opportunities.
 

--- a/content/pages/employment/job-seekers/military-transcripts.md
+++ b/content/pages/employment/job-seekers/military-transcripts.md
@@ -5,7 +5,11 @@ concurrence: complete
 template: 1-topic-landing
 ---
 
+<div class="va-introtext">
+
 Military transcripts are certified documents that active-duty Servicemembers and Army, Coast Guard, Marine Corps, and Navy Veterans can show to potential employers. The transcripts, most often used to determine whether military courses or jobs will count toward college credit, may help a hiring manager better understand your qualifications.
+
+</div>
 
 To request that transcripts be sent to a hiring manager, fill out an official JST [Special Mail Request form](https://jst.doded.mil/JST_SPEC.pdf), complete with the employer’s contact information, and email it to <a href="mailto:jst@doded.mil">jst@doded.mil</a>.
 

--- a/content/pages/employment/job-seekers/one-on-one.md
+++ b/content/pages/employment/job-seekers/one-on-one.md
@@ -18,7 +18,11 @@ relatedlinks:
    title: Military Transcripts
 ---
 
+<div class="va-introtext">
+
 One-on-one assistance can help you transition by providing current perspectives on workplaces, targeted job-search techniques, coaching, and résumé building.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/employment/job-seekers/service-disabled.md
+++ b/content/pages/employment/job-seekers/service-disabled.md
@@ -18,7 +18,11 @@ relatedlinks:
     title: Military Transcripts
 ---
 
+<div class="va-introtext">
+
 As a service-disabled Veteran, there are many ways for you to pursue your personal and professional goals through both government and private-sector employment.
+
+</div>
 
 ### Federal Job Preference
 

--- a/content/pages/employment/job-seekers/start.md
+++ b/content/pages/employment/job-seekers/start.md
@@ -13,7 +13,11 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 VA and the [Small Business Administration](https://www.sba.gov/content/veteran-service-disabled-veteran-owned) (SBA), as well as other government organizations, provide you and your spouse with resources that can help you make a new or existing business a success.
+
+</div>
 
 VA can guide you through the process of [registering](http://www.va.gov/osdbu/) as a Veteran-owned or service-disabled Veteran-owned business. Once you get your certification, you are eligible for certain assistance and benefits. If you are already open for business and want to sell to the federal government, the [Procurement Technical Assistance Center](http://www.aptac-us.org) (PTAC) can help with all of the required documentation and registration to bid on government contracts.  
 

--- a/content/pages/employment/job-seekers/start/counseling.md
+++ b/content/pages/employment/job-seekers/start/counseling.md
@@ -10,6 +10,12 @@ relatedlinks:
    title: Entrepreneurship Counseling
 ---
 
-The [Small Business Administration](https://www.sba.gov/content/veteran-service-disabled-veteran-owned) and VA’s Office of Small and Disadvantaged Business Utilization in collaboration with [Business USA](http://business.usa.gov/) have resources to support you in starting a new business or growing an existing one. These resources help you with business-plan writing, funding, licensure and permits, mentoring, marketing, how to contract with the government, and more.
+<div class="va-introtext">
+
+The [Small Business Administration](https://www.sba.gov/content/veteran-service-disabled-veteran-owned) and VA’s Office of Small and Disadvantaged Business Utilization in collaboration with [Business USA](http://business.usa.gov/) have resources to support you in starting a new business or growing an existing one.
+
+</div>
+
+These resources help you with business-plan writing, funding, licensure and permits, mentoring, marketing, how to contract with the government, and more.
 
 Your SBA representative may also be able to help you find and register for other state and federal start-up assistance, such as [Veteran-owned small-business preference](/employment/job-seekers/service-disabled).

--- a/content/pages/employment/job-seekers/start/register.md
+++ b/content/pages/employment/job-seekers/start/register.md
@@ -10,7 +10,13 @@ relatedlinks:
     title: Entrepreneurship Counseling
 ---
 
-There are many advantages to registering your small business with VA as a Veteran-Owned Small Business (VOSB) or Service-Disabled Veteran-Owned Small Business (SDVOSB) through VA’s Veterans First Verification Program, including contract-bidding advantages with state and federal governments. You also get:
+<div class="va-introtext">
+
+There are many advantages to registering your small business with VA as a Veteran-Owned Small Business (VOSB) or Service-Disabled Veteran-Owned Small Business (SDVOSB) through VA’s Veterans First Verification Program, including contract-bidding advantages with state and federal governments.
+
+</div>
+
+You also get:
 
 - Tax relief
 - Improved access to capital

--- a/content/pages/employment/job-seekers/unemployment-support.md
+++ b/content/pages/employment/job-seekers/unemployment-support.md
@@ -24,7 +24,11 @@ relatedlinks:
     description: ""
 ---
 
+<div class="va-introtext">
+
 If you can’t find a job after you separate from active-duty service, you may be eligible for unemployment benefits through the Unemployment Compensation for Ex-Servicemembers (UCX) program.
+
+</div>
 
 <div class="call-out" markdown="1">
 

--- a/content/pages/employment/job-seekers/veci.md
+++ b/content/pages/employment/job-seekers/veci.md
@@ -18,7 +18,11 @@ relatedlinks:
     title: Military Transcripts
 ---
 
+<div class="va-introtext">
+
 Representatives from the Veterans Economic Community Initiative (VECI) are available in 25 cities.
+
+</div>
 
 - If you are looking for a job, VECI regional liaisons can help you connect to local business leaders, schools, and nonprofit groups to maximize your education and economic opportunities.
 

--- a/content/pages/healthcare/after-you-apply.md
+++ b/content/pages/healthcare/after-you-apply.md
@@ -13,7 +13,11 @@ relatedlinks:
    description: "Need help paying for college or professional training, picking a school, or exploring career options? Find out if you can get financial support and counseling from VA."
 ---
 
+<div class="va-introtext">
+
 After you apply for VA health care, we’ll send you a letter in the mail to let you know if your application’s been approved. 
+
+</div>
 
 ### How long does it take VA to make a decision?
 

--- a/content/pages/healthcare/apply.md
+++ b/content/pages/healthcare/apply.md
@@ -13,7 +13,11 @@ relatedlinks:
    description: "Find out when to expect a decision and what to do if you don’t hear back or don’t get approved."
 ---
 
+<div class="va-introtext">
+
 Once you’ve figured out if you qualify, applying for VA health care benefits is easy. Find out how to apply.
+
+</div>
 
 ### Prepare
 - Find out if you qualify. [Check your eligibility](/healthcare/eligibility/).

--- a/content/pages/healthcare/eligibility.md
+++ b/content/pages/healthcare/eligibility.md
@@ -13,7 +13,11 @@ relatedlinks:
    description: "Track the status of your disability claim."
 ---
 
+<div class="va-introtext">
+
 If you're a U.S. Veteran, you may qualify for VA health care benefits. Find out if you can get VA health care benefits. 
+
+</div>
 
 <div class="feature" markdown="1">
 

--- a/content/pages/healthcare/index.md
+++ b/content/pages/healthcare/index.md
@@ -19,6 +19,10 @@ majorlinks:
     description: Send a secure, private note to your doctor or other members of your VA health care team.
 ---
 
+<div class="va-introtext">
+
 With VA health care, you're covered for regular checkups with your primary care doctor and appointments with specialists (like cardiologists, gynecologists, and mental health providers). You also gain access to home health and elder care, plus medical equipment, prosthetics, and prescriptions.
+
+</div>
 
 <a class="usa-button-primary va-button-primary" href="/healthcare/apply/application/introduction">Apply for VA Health Care</a>


### PR DESCRIPTION
To be merged into https://github.com/department-of-veterans-affairs/vets-website/tree/department-of-veterans-affairs/vets.gov-team-619 as part of #5145

After removing the `first-of-type` rule that automatically applies intro text styling, this adds it back to applicable intro paragraphs across all content pages.