### PR TITLE
Fixed unintended GIBCT calculator elements from appearing with NaN values.

### DIFF
--- a/src/js/gi/reducers/calculator.js
+++ b/src/js/gi/reducers/calculator.js
@@ -78,11 +78,11 @@ export default function (state = INITIAL_STATE, action) {
 
       return {
         ...INITIAL_STATE,
-        tuitionInState,
-        tuitionOutOfState,
-        tuitionFees: tuitionInState,
-        books,
-        calendar
+        tuitionInState: tuitionInState || 0,
+        tuitionOutOfState: tuitionOutOfState || 0,
+        tuitionFees: tuitionInState || 0,
+        books: books || 0,
+        calendar: calendar || 'semesters'
       };
     }
 

--- a/src/js/gi/selectors/calculator.js
+++ b/src/js/gi/selectors/calculator.js
@@ -21,7 +21,10 @@ const getDerivedValues = createSelector(
   getInstitution,
   getFormInputs,
   (constant, eligibility, institution, inputs) => {
-    if (constant === undefined) return {};
+    if ([constant, eligibility, institution, inputs].some(e => !e || isEmpty(e))) {
+      return {};
+    }
+
     let monthlyRate;
     let numberOfTerms;
     let ropOld;
@@ -71,7 +74,7 @@ const getDerivedValues = createSelector(
     const spouseActiveDuty = eligibility.spouseActiveDuty === 'yes';
     const serviceDischarge = cumulativeService === 'service discharge';
 
-    const isOJT = institution.type === 'ojt';
+    const isOJT = institution.type.toLowerCase() === 'ojt';
     const isFlight = institution.type === 'flight';
     const isCorrespondence = institution.type === 'correspondence';
     const isFlightOrCorrespondence = isFlight || isCorrespondence;
@@ -163,11 +166,11 @@ const getDerivedValues = createSelector(
     }
 
     // Set the net price (Payer of Last Resort) - getTuitionNetPrice
-    const tuitionNetPrice = Math.max(0, Math.min(
+    const tuitionNetPrice = Math.max(0,
       inputs.tuitionFees -
       inputs.scholarships -
       inputs.tuitionAssist
-    ));
+    );
 
     // Set the proper tuition/fees cap - getTuitionFeesCap
     if (isFlight) {
@@ -777,7 +780,7 @@ export const getCalculatedBenefits = createSelector(
   (eligibility, institution, form, derived) => {
     const calculatedBenefits = {};
 
-    if ([eligibility, institution, derived].some(e => !e || isEmpty(e))) {
+    if ([eligibility, institution, form, derived].some(e => !e || isEmpty(e))) {
       return calculatedBenefits;
     }
 
@@ -962,7 +965,7 @@ export const getCalculatedBenefits = createSelector(
       };
     }
 
-    if (institution.type === 'ojt') {
+    if (institution.type.toLowerCase() === 'ojt') {
       calculatedBenefits.inputs = {
         ...calculatedBenefits.inputs,
         tuition: false,

--- a/src/js/gi/selectors/calculator.js
+++ b/src/js/gi/selectors/calculator.js
@@ -81,6 +81,8 @@ const getDerivedValues = createSelector(
     const isFlightOrCorrespondence = isFlight || isCorrespondence;
     const isPublic = institutionType === 'public';
 
+    const institutionCountry = institution.country.toLowerCase();
+
     // VRE and post-9/11 eligibility
     const vre911Eligible = (giBillChapter === 31 && eligForPostGiBill === 'yes');
 
@@ -178,7 +180,7 @@ const getDerivedValues = createSelector(
       tuitionFeesCap = constant.FLTTFCAP;
     } else if (isCorrespondence) {
       tuitionFeesCap = constant.CORRESPONDTFCAP;
-    } else if (isPublic && institution.country === 'usa') {
+    } else if (isPublic && institutionCountry === 'usa') {
       tuitionFeesCap = inputs.inState === 'yes'
                      ? institution.tuitionInState
                      : institution.tuitionOutOfState;
@@ -481,7 +483,7 @@ const getDerivedValues = createSelector(
     } else if (onlineClasses === 'yes') {
       housingAllowTerm1 =
         termLength * rop * (tier * constant.AVGBAH / 2 + kickerBenefit);
-    } else if (institution.country !== 'usa') {
+    } else if (institutionCountry !== 'usa') {
       housingAllowTerm1 =
         termLength * rop * ((tier * constant.AVGBAH) + kickerBenefit);
     } else {
@@ -530,7 +532,7 @@ const getDerivedValues = createSelector(
     } else if (onlineClasses === 'yes') {
       housingAllowTerm2 =
         termLength * rop * (tier * constant.AVGBAH / 2 + kickerBenefit);
-    } else if (institution.country !== 'usa') {
+    } else if (institutionCountry !== 'usa') {
       housingAllowTerm2 =
         termLength * rop * (tier * constant.AVGBAH + kickerBenefit);
     } else {
@@ -581,7 +583,7 @@ const getDerivedValues = createSelector(
     } else if (onlineClasses === 'yes') {
       housingAllowTerm3 =
         termLength * rop * (tier * constant.AVGBAH / 2 + kickerBenefit);
-    } else if (institution.country !== 'usa') {
+    } else if (institutionCountry !== 'usa') {
       housingAllowTerm3 =
         termLength * rop * (tier * constant.AVGBAH + kickerBenefit);
     } else {

--- a/src/js/gi/selectors/calculator.js
+++ b/src/js/gi/selectors/calculator.js
@@ -74,11 +74,12 @@ const getDerivedValues = createSelector(
     const spouseActiveDuty = eligibility.spouseActiveDuty === 'yes';
     const serviceDischarge = cumulativeService === 'service discharge';
 
-    const isOJT = institution.type.toLowerCase() === 'ojt';
-    const isFlight = institution.type === 'flight';
-    const isCorrespondence = institution.type === 'correspondence';
+    const institutionType = institution.type.toLowerCase();
+    const isOJT = institutionType === 'ojt';
+    const isFlight = institutionType === 'flight';
+    const isCorrespondence = institutionType === 'correspondence';
     const isFlightOrCorrespondence = isFlight || isCorrespondence;
-    const isPublic = institution.type === 'public';
+    const isPublic = institutionType === 'public';
 
     // VRE and post-9/11 eligibility
     const vre911Eligible = (giBillChapter === 31 && eligForPostGiBill === 'yes');
@@ -953,6 +954,7 @@ export const getCalculatedBenefits = createSelector(
 
     const { militaryStatus } = eligibility;
     const giBillChapter = +eligibility.giBillChapter;
+    const institutionType = institution.type.toLowerCase();
 
     if (giBillChapter === 31 && !derived.onlyVRE) {
       calculatedBenefits.inputs = {
@@ -965,7 +967,7 @@ export const getCalculatedBenefits = createSelector(
       };
     }
 
-    if (institution.type.toLowerCase() === 'ojt') {
+    if (institutionType === 'ojt') {
       calculatedBenefits.inputs = {
         ...calculatedBenefits.inputs,
         tuition: false,
@@ -994,7 +996,7 @@ export const getCalculatedBenefits = createSelector(
       };
     }
 
-    if (institution.type === 'flight' || institution.type === 'correspondence') {
+    if (institutionType === 'flight' || institutionType === 'correspondence') {
       calculatedBenefits.inputs = {
         ...calculatedBenefits.inputs,
         enrolled: false,
@@ -1004,7 +1006,7 @@ export const getCalculatedBenefits = createSelector(
       };
     }
 
-    if (institution.type === 'public') {
+    if (institutionType === 'public') {
       calculatedBenefits.inputs = {
         ...calculatedBenefits.inputs,
         inState: true
@@ -1070,7 +1072,7 @@ export const getCalculatedBenefits = createSelector(
       calculatedBenefits.outputs.perTerm.yellowRibbon.terms[5].visible = false;
     }
 
-    if (derived.numberOfTerms < 3 && institution.type !== 'ojt') {
+    if (derived.numberOfTerms < 3 && institutionType !== 'ojt') {
       // Hide all term 3 calculations.
       calculatedBenefits.outputs.perTerm.tuitionAndFees.terms[2].visible = false;
       calculatedBenefits.outputs.perTerm.housingAllowance.terms[2].visible = false;


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#1819.

Some of the `NaN` issues started occurring when some profile attributes from API responses changed to uppercase, since we weren't doing case-insensitive matching on some calculations. As far as I can tell, we only have string matching with two institution attributes, which are `country` and `type`, so I made the changes for those.

There are also other cases when the institution has null values for things that are still relevant for calculation, in which case we will set default options in the form (set upon successful fetch in the reducer).