### PR TITLE
1990e remove learn more links

### DIFF
--- a/src/js/edu-benefits/1990e/config/form.js
+++ b/src/js/edu-benefits/1990e/config/form.js
@@ -20,12 +20,13 @@ import ConfirmationPage from '../containers/ConfirmationPage';
 
 import {
   transform,
-  eligibilityDescription
+  eligibilityDescription,
+  benefitsLabels
 } from '../helpers';
 
-import {
-  benefitsLabels
-} from '../../utils/helpers';
+// import {
+//   benefitsLabels
+// } from '../../utils/helpers';
 
 const {
   benefit,

--- a/src/js/edu-benefits/1990e/config/form.js
+++ b/src/js/edu-benefits/1990e/config/form.js
@@ -24,10 +24,6 @@ import {
   benefitsLabels
 } from '../helpers';
 
-// import {
-//   benefitsLabels
-// } from '../../utils/helpers';
-
 const {
   benefit,
   faaFlightCertificatesInformation,

--- a/src/js/edu-benefits/1990e/helpers.jsx
+++ b/src/js/edu-benefits/1990e/helpers.jsx
@@ -19,6 +19,7 @@ export function eligibilityDescription() {
           <li>You may be eligible for more than 1 education benefit program.</li>
           <li>You can only get payments from 1 program at a time.</li>
           <li>You can’t get more than 48 months of benefits under any combination of VA education programs.</li>
+          <li>If you are unsure of what benefit has been transferred to you, please contact your Sponsor.</li>
         </ul>
       </div>
     </div>

--- a/src/js/edu-benefits/1990e/helpers.jsx
+++ b/src/js/edu-benefits/1990e/helpers.jsx
@@ -24,3 +24,8 @@ export function eligibilityDescription() {
     </div>
   );
 }
+
+export const benefitsLabels = {
+  chapter33: <p>Post-9/11 GI Bill (Chapter 33)</p>,
+  chapter30: <p>Montgomery GI Bill (MGIB-AD, Chapter 30)</p>,
+};


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1785

Creates custom benefit options for the 1990e in order to remove the learn more links. Seemed like the cleanest way of doing this as opposed to altering the common list. Also added language to the warning box.

One question for @raquelromano-gov: the alert box looks kind of far down. It has some top margin applied to it right now that I would like to get rid of. I tried adding a custom `className` to the `uiSchema` on the view field `view:benefitDescription`, but that did not work. Not sure if you happen to know of a way to do this easily?

<img width="714" alt="screen shot 2017-03-24 at 2 42 07 pm" src="https://cloud.githubusercontent.com/assets/25183456/24308941/52610aee-10a0-11e7-8ba6-c1cd46fb73b4.png">
