### PR TITLE
Pass the logout function to SignInProfileMenu component

### DIFF
--- a/src/js/login/components/SearchHelpSignIn.jsx
+++ b/src/js/login/components/SearchHelpSignIn.jsx
@@ -27,7 +27,8 @@ class SearchHelpSignIn extends React.Component {
             this.props.onClickSearchHelpSignIn('account', !login.utilitiesMenuIsOpen.account);
           }}
           greeting={greeting}
-          isOpen={login.utilitiesMenuIsOpen.account}/>);
+          isOpen={login.utilitiesMenuIsOpen.account}
+          onUserLogout={this.props.onUserLogout}/>);
     } else {
       content = (<div>
         <a href="#" onClick={this.props.onUserLogin}>Sign In</a><span className="signin-spacer">|</span><a href="#" onClick={this.props.onUserSignup}>Register</a>

--- a/src/js/login/components/SignInProfileMenu.jsx
+++ b/src/js/login/components/SignInProfileMenu.jsx
@@ -29,7 +29,8 @@ SignInProfileMenu.propTypes = {
   clickHandler: React.PropTypes.func.isRequired,
   cssClass: React.PropTypes.string,
   greeting: React.PropTypes.node,
-  isOpen: React.PropTypes.bool.isRequired
+  isOpen: React.PropTypes.bool.isRequired,
+  onUserLogout: React.PropTypes.func.isRequired
 };
 
 export default SignInProfileMenu;


### PR DESCRIPTION
The `handleLogout` function is not being called when clicked because the function is not being passed as a property to the `SignInProfileMenu` component.

See https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1872