### PR TITLE
Remove employmentHistory object

### DIFF
--- a/src/js/edu-benefits/1990e/config/form.js
+++ b/src/js/edu-benefits/1990e/config/form.js
@@ -176,26 +176,19 @@ const formConfig = {
           title: 'Employment history',
           path: 'employment/history',
           uiSchema: {
-            employmentHistory: {
-              'view:hasNonMilitaryJobs': {
-                'ui:title': 'Have you ever held a license of journeyman rating (for example, as a contractor or plumber) to practice a profession?',
-                'ui:widget': 'yesNo'
-              },
-              nonMilitaryJobs: _.set(['ui:options', 'expandUnder'], 'view:hasNonMilitaryJobs', nonMilitaryJobsUi)
-            }
+            'view:hasNonMilitaryJobs': {
+              'ui:title': 'Have you ever held a license of journeyman rating (for example, as a contractor or plumber) to practice a profession?',
+              'ui:widget': 'yesNo'
+            },
+            nonMilitaryJobs: _.set(['ui:options', 'expandUnder'], 'view:hasNonMilitaryJobs', nonMilitaryJobsUi)
           },
           schema: {
             type: 'object',
             properties: {
-              employmentHistory: {
-                type: 'object',
-                properties: {
-                  'view:hasNonMilitaryJobs': {
-                    type: 'boolean'
-                  },
-                  nonMilitaryJobs: _.unset('items.properties.postMilitaryJob', nonMilitaryJobs)
-                }
-              }
+              'view:hasNonMilitaryJobs': {
+                type: 'boolean'
+              },
+              nonMilitaryJobs: _.unset('items.properties.postMilitaryJob', nonMilitaryJobs)
             }
           }
         }


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1863

Not much to say here. Flattens out the `employmentHistory` object in the `employmentHistory` page in the `employmentHistory` chapter since `employmentHistory` isn't a property in the schema.

How many times can I say `employmentHistory`? I think I'll stop there.