### PR TITLE
GIBCT cautionary info fixes.

### DIFF
--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -3,6 +3,30 @@ import { connect } from 'react-redux';
 import { showModal } from '../../actions';
 import AlertBox from '../../../common/components/AlertBox';
 
+const TableRow = ({ description, thisCampus, allCampuses }) => {
+  return (
+    <tr>
+      <th><strong>{description}</strong></th>
+      <td className="number">{thisCampus}</td>
+      <td className="number">{allCampuses}</td>
+    </tr>
+  );
+};
+
+const ListRow = ({ description, value }) => {
+  if (value < 1) return null;
+  return (
+    <div className="row">
+      <div className="small-11 columns">
+        <p>{description}:</p>
+      </div>
+      <div className="small-1 columns">
+        <p className="number">{value}</p>
+      </div>
+    </div>
+  );
+};
+
 export class CautionaryInformation extends React.Component {
   render() {
     const it = this.props.profile.attributes;
@@ -15,6 +39,7 @@ export class CautionaryInformation extends React.Component {
         <a onClick={this.props.showModal.bind(this, 'cautionInfo')}>Learn more about these warnings</a>
       </p>
     );
+
     const complaintData = [
       { type: 'Financial Issues (e.g., Tuition/Fee charges)', key: 'financial' },
       { type: 'Quality of Education', key: 'quality' },
@@ -30,6 +55,7 @@ export class CautionaryInformation extends React.Component {
       { type: 'Other', key: 'other' },
       { type: 'Student Complaints', totals: ['facilityCode', 'mainCampusRollUp'] }
     ];
+
     const complaints = complaintData.reduce((hydratedComplaints, complaint) => {
       const totals = complaint.totals || {};
       const { type, key, totalKey } = complaint;
@@ -41,37 +67,16 @@ export class CautionaryInformation extends React.Component {
       return [...hydratedComplaints, hydratedComplaint];
     }, []);
 
-    const TableRow = ({ description, thisCampus, allCampuses }) => {
-      return (
-        <tr>
-          <th><strong>{description}</strong></th>
-          <td className="number">{thisCampus}</td>
-          <td className="number">{allCampuses}</td>
-        </tr>
-      );
-    };
-
-    const ListRow = ({ description, value }) => {
-      if (value < 1) return null;
-      return (
-        <div className="row">
-          <div className="small-11 columns">
-            <p>{description}:</p>
-          </div>
-          <div className="small-1 columns">
-            <p className="number">{value}</p>
-          </div>
-        </div>
-      );
-    };
-
     return (
       <div className="cautionary-information">
         <AlertBox content={flagContent} isVisible={!!it.cautionFlag} status="warning"/>
 
-        <div className="table">
+        <div className="student-complaints">
           <h3>{it.complaints.mainCampusRollUp} student complaints</h3>
-          <p>(<a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#sourcedata" target="_blank">Source</a>)</p>
+          <span>(<a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#sourcedata" target="_blank">Source</a>)</span>
+        </div>
+
+        <div className="table">
           <table className="usa-table-borderless">
             <thead>
               <tr>

--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -72,7 +72,7 @@ export class CautionaryInformation extends React.Component {
         <AlertBox content={flagContent} isVisible={!!it.cautionFlag} status="warning"/>
 
         <div className="student-complaints">
-          <h3>{it.complaints.mainCampusRollUp} student complaints</h3>
+          <h4>{it.complaints.mainCampusRollUp} student complaints</h4>
           <span>(<a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#sourcedata" target="_blank">Source</a>)</span>
         </div>
 

--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import _ from 'lodash';
-import { connect } from 'react-redux';
-import { showModal } from '../../actions';
 import AlertBox from '../../../common/components/AlertBox';
 
-export class AdditionalInformation extends React.Component {
+class HeadingSummary extends React.Component {
 
   render() {
-    const it = this.props.profile.attributes;
+    const it = this.props.institution;
     const schoolSize = (enrollment) => {
       if (!enrollment) return 'Unknown';
       if (enrollment <= 2000) {
@@ -26,12 +24,12 @@ export class AdditionalInformation extends React.Component {
         <div className="small-12 column">
           <h1>{it.name}</h1>
           <AlertBox
-              content={(<p>VA has concerns about this school. <a href="#viewWarnings">View warnings</a></p>)}
+              content={(<p>VA has concerns about this school. <a href="#viewWarnings" onClick={this.props.onViewWarnings}>View warnings</a></p>)}
               isVisible={!!it.cautionFlag}
               status="warning"/>
           <p style={{ marginBottom: '1.5em' }}>
             <strong>{it.studentCount}</strong> GI Bill students
-            (<a onClick={this.props.showModal.bind(this, 'gibillstudents')}>Learn more</a>)
+            (<a onClick={this.props.onLearnMore}>Learn more</a>)
           </p>
           <div className="small-12 medium-4 column">
             <p>
@@ -80,10 +78,10 @@ export class AdditionalInformation extends React.Component {
 
 }
 
-const mapStateToProps = (state) => state;
-
-const mapDispatchToProps = {
-  showModal,
+HeadingSummary.propTypes = {
+  institution: React.PropTypes.object,
+  onLearnMore: React.PropTypes.func,
+  onViewWarnings: React.PropTypes.func
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(AdditionalInformation);
+export default HeadingSummary;

--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -6,6 +6,7 @@ class HeadingSummary extends React.Component {
 
   render() {
     const it = this.props.institution;
+
     const schoolSize = (enrollment) => {
       if (!enrollment) return 'Unknown';
       if (enrollment <= 2000) {
@@ -15,16 +16,18 @@ class HeadingSummary extends React.Component {
       }
       return 'Large';
     };
+
     const IconWithInfo = ({ icon, children, present }) => {
       if (!present) return null;
       return <span><i className={`fa fa-${icon}`}/>&nbsp;{children}</span>;
     };
+
     return (
       <div className="heading row">
         <div className="small-12 column">
           <h1>{it.name}</h1>
           <AlertBox
-              content={(<p>VA has concerns about this school. <a href="#viewWarnings" onClick={this.props.onViewWarnings}>View warnings</a></p>)}
+              content={(<a href="#viewWarnings" onClick={this.props.onViewWarnings}>View cautionary information about this school</a>)}
               isVisible={!!it.cautionFlag}
               status="warning"/>
           <p style={{ marginBottom: '1.5em' }}>

--- a/src/js/gi/containers/ProfilePage.jsx
+++ b/src/js/gi/containers/ProfilePage.jsx
@@ -14,6 +14,11 @@ import AdditionalInformation from '../components/profile/AdditionalInformation';
 import { outcomeNumbers } from '../selectors/outcomes';
 
 export class ProfilePage extends React.Component {
+  
+  constructor(props) {
+    super(props);
+    this.handleViewWarnings = this.handleViewWarnings.bind(this);
+  }
 
   componentDidMount() {
     this.props.fetchProfile(this.props.params.facilityCode);
@@ -31,11 +36,18 @@ export class ProfilePage extends React.Component {
     }
   }
 
+  handleViewWarnings() {
+    this._cautionaryInfo.setState({ expanded: true });
+  }
+
   render() {
     const { constants, outcomes, profile } = this.props;
     return (
       <div className="profile-page">
-        <HeadingSummary/>
+        <HeadingSummary
+            institution={this.props.profile.attributes}
+            onLearnMore={this.props.showModal.bind(this, 'gibillstudents')}
+            onViewWarnings={this.handleViewWarnings}/>
         <ul className="usa-accordion">
           <AccordionItem button="Estimate your benefits" expanded>
             <Calculator/>
@@ -51,7 +63,9 @@ export class ProfilePage extends React.Component {
             </If>
           </AccordionItem>
           <a name="viewWarnings"></a>
-          <AccordionItem button="Cautionary information">
+          <AccordionItem
+              button="Cautionary information"
+              ref={c => { this._cautionaryInfo = c; }}>
             <CautionaryInformation/>
           </AccordionItem>
           <AccordionItem button="Additional information">

--- a/src/js/gi/containers/ProfilePage.jsx
+++ b/src/js/gi/containers/ProfilePage.jsx
@@ -14,7 +14,7 @@ import AdditionalInformation from '../components/profile/AdditionalInformation';
 import { outcomeNumbers } from '../selectors/outcomes';
 
 export class ProfilePage extends React.Component {
-  
+
   constructor(props) {
     super(props);
     this.handleViewWarnings = this.handleViewWarnings.bind(this);

--- a/src/sass/gi/partials/_gi-profile-page.scss
+++ b/src/sass/gi/partials/_gi-profile-page.scss
@@ -137,7 +137,7 @@
     margin: 1rem 0;
 
     @media screen and (min-width: $small-screen) {
-      h3, span {
+      h4, span {
         float: left;
         line-height: 4rem;
       }

--- a/src/sass/gi/partials/_gi-profile-page.scss
+++ b/src/sass/gi/partials/_gi-profile-page.scss
@@ -93,27 +93,17 @@
     margin-left: 0.5em;
     margin-top: 0.2em;
   }
+
   .outcomes .column > h3 {
     display: block;
     float: left;
   }
+
   .outcomes .graph-component {
     clear: both;
   }
 
   .cautionary-information {
-    .table > h3 {
-      padding-top: 1em !important;
-      float: left;
-    }
-
-    .table > p {
-      padding-top: 2.25em !important;
-      float: left;
-      margin-left: 0.5em;
-      margin-top: 0.2em;
-    }
-
     .table .number {
       text-align: left;
     }
@@ -139,6 +129,22 @@
       .table {
         display: none;
         visibility: hidden;
+      }
+    }
+  }
+
+  .student-complaints {
+    margin: 1rem 0;
+
+    @media screen and (min-width: $small-screen) {
+      h3, span {
+        float: left;
+        line-height: 4rem;
+      }
+
+      span {
+        margin-left: 0.5em;
+        margin-top: 0.2em;
       }
     }
   }

--- a/src/sass/gi/partials/_gi-search-page.scss
+++ b/src/sass/gi/partials/_gi-search-page.scss
@@ -131,7 +131,7 @@
       font-size: 0.9em;
       font-weight: bold;
       display: inline;
-      padding: 0.1em 0.5em;
+      padding: 0.1em 1.5em;
       margin: 0 0 0 1em;
 
       i.fa {


### PR DESCRIPTION
Related to Profile -> Cautionary flags bullet of department-of-veterans-affairs/vets.gov-team#1507.
Fixes remaining issues in department-of-veterans-affairs/vets.gov-team#780.

#### Display number of student complaints in mobile.
> <img width="356" alt="screen shot 2017-03-27 at 10 22 40 pm" src="https://cloud.githubusercontent.com/assets/1067024/24386185/3e087250-133c-11e7-8249-bcb92d0d4ab8.png">


#### Modified alert in header of profile to be a full link.
> <img width="359" alt="screen shot 2017-03-27 at 10 25 13 pm" src="https://cloud.githubusercontent.com/assets/1067024/24386196/495ba5dc-133c-11e7-9b6f-450b40986310.png">

### Additional padding on caution flags in search results.
> <img width="353" alt="screen shot 2017-03-27 at 10 25 31 pm" src="https://cloud.githubusercontent.com/assets/1067024/24386214/5d681eb6-133c-11e7-8a56-b478474dcc67.png">

