### PR TITLE
Fixed BAH estimations for GIBCT search results.

### DIFF
--- a/src/js/gi/selectors/estimator.js
+++ b/src/js/gi/selectors/estimator.js
@@ -8,9 +8,13 @@ const getEligibilityDetails = (state) => {
   return details;
 };
 
-const getRequiredAttributes = (_state, props) => {
-  const { type, bah } = props;
-  return { type, bah };
+const getRequiredAttributes = (state, props) => {
+  const { type, bah, country } = props;
+  return {
+    type: type && type.toLowerCase(),
+    bah,
+    country: country && country.toLowerCase()
+  };
 };
 
 function getDerivedAttributes(constant, eligibility, institution) {


### PR DESCRIPTION
With Georgetown University as a test and setting classes to in-person for eligibility, it was showing a default $1,611 housing allowance (average BAH, which is the default estimate for foreign schools) when it had $2,301 for its `bah` attribute.

Two issues are addressed with this fix: (1) `country` attribute wasn't being selected from the institution, so it came up as `undefined` in conditionals and (2) checking for `type` (and now `country`) were case sensitive.