### PR TITLE
Displays the answer given for financial disclosure

### DIFF
--- a/src/js/hca/components/household-information/FinancialDisclosureSection.jsx
+++ b/src/js/hca/components/household-information/FinancialDisclosureSection.jsx
@@ -33,7 +33,7 @@ class FinancialDisclosureSection extends React.Component {
           <tr>
             <td>I understand VA is not currently enrolling new applicants who decline to
             provide their financial information unless they have other qualifying eligibility factors: </td>
-            <td>{`${this.props.data.discloseFinancialInformation.value ? 'Yes' : 'No'}`}</td>
+            <td>{`${this.props.data.discloseFinancialInformation.value === 'Y' ? 'Yes' : 'No'}`}</td>
           </tr>
         </tbody>
       </table>);


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1237

Just missed a `=== 'Y'` is all.

![image](https://cloud.githubusercontent.com/assets/12970166/24478903/a340a5ec-1491-11e7-86ae-8ec11249ce29.png)