### PR TITLE
Addressed GIBCT design review items related to profile pages.

### DIFF
--- a/src/js/gi/components/Dropdown.jsx
+++ b/src/js/gi/components/Dropdown.jsx
@@ -6,9 +6,12 @@ class Dropdown extends React.Component {
     if (!this.props.visible) {
       return null;
     }
+
     return (
       <div className={this.props.className}>
-        {this.props.children}
+        <label htmlFor={this.props.name}>
+          {this.props.label || this.props.children}
+        </label>
         <select
             id={this.props.name}
             name={this.props.name}
@@ -28,7 +31,10 @@ class Dropdown extends React.Component {
 Dropdown.propTypes = {
   visible: React.PropTypes.bool.isRequired,
   name: React.PropTypes.string.isRequired,
-  children: React.PropTypes.node,
+  label: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.element
+  ]),
   options: React.PropTypes.arrayOf(
     React.PropTypes.shape({
       label: React.PropTypes.string,

--- a/src/js/gi/components/Dropdown.jsx
+++ b/src/js/gi/components/Dropdown.jsx
@@ -10,7 +10,7 @@ class Dropdown extends React.Component {
     return (
       <div className={this.props.className}>
         <label htmlFor={this.props.name}>
-          {this.props.label || this.props.children}
+          {this.props.label}
         </label>
         <select
             id={this.props.name}
@@ -34,7 +34,7 @@ Dropdown.propTypes = {
   label: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.element
-  ]),
+  ]).isRequired,
   options: React.PropTypes.arrayOf(
     React.PropTypes.shape({
       label: React.PropTypes.string,

--- a/src/js/gi/components/profile/Calculator.jsx
+++ b/src/js/gi/components/profile/Calculator.jsx
@@ -14,9 +14,10 @@ const EligibilityDetails = ({ expanded, toggle }) => (
     <button onClick={toggle} className="usa-button-outline">
       {expanded ? 'Hide' : 'Edit'} eligibility details
     </button>
-    <div className="form-expanding-group-open">
-      {expanded ? <EligibilityForm/> : null}
-    </div>
+    {expanded ?
+      <div className="form-expanding-group-open">
+        <EligibilityForm/>
+      </div> : null}
   </div>
 );
 
@@ -25,13 +26,14 @@ const CalculatorInputs = ({ expanded, toggle, inputs, displayedInputs, onInputCh
     <button onClick={toggle} className="usa-button-outline">
       {expanded ? 'Hide' : 'Edit'} calculator fields
     </button>
-    <div className="form-expanding-group-open">
-      {expanded ? <CalculatorForm
-          inputs={inputs}
-          displayedInputs={displayedInputs}
-          onShowModal={onShowModal}
-          onInputChange={onInputChange}/> : null}
-    </div>
+    {expanded ?
+      <div className="form-expanding-group-open">
+        <CalculatorForm
+            inputs={inputs}
+            displayedInputs={displayedInputs}
+            onShowModal={onShowModal}
+            onInputChange={onInputChange}/>
+      </div> : null}
   </div>
 );
 

--- a/src/js/gi/components/profile/CalculatorForm.jsx
+++ b/src/js/gi/components/profile/CalculatorForm.jsx
@@ -56,7 +56,10 @@ class CalculatorForm extends React.Component {
       <div className="row">
         <div className="small-12 columns">
           <label htmlFor="tuitionFees">
-            {this.renderLearnMoreLabel({ text: 'Tuition and fees per year', modal: 'calcTuition' })}
+            {this.renderLearnMoreLabel({
+              text: 'Tuition and fees per year',
+              modal: 'calcTuition'
+            })}
           </label>
           <input
               type="text"
@@ -111,7 +114,10 @@ class CalculatorForm extends React.Component {
         <div className="row">
           <div className="small-12 columns">
             <RadioButtons
-                label={this.renderLearnMoreLabel({ text: 'Are you a current Yellow Ribbon recipient?', modal: 'calcYr' })}
+                label={this.renderLearnMoreLabel({
+                  text: 'Are you a current Yellow Ribbon recipient?',
+                  modal: 'calcYr'
+                })}
                 name="yellowRibbonRecipient"
                 options={[
                   { value: 'yes', label: 'Yes' },
@@ -132,7 +138,10 @@ class CalculatorForm extends React.Component {
       <div className="row">
         <div className="small-12 columns">
           <label htmlFor="scholarships">
-            {this.renderLearnMoreLabel({ text: 'Scholarships (excluding Pell)', modal: 'calcScholarships' })}
+            {this.renderLearnMoreLabel({
+              text: 'Scholarships (excluding Pell)',
+              modal: 'calcScholarships'
+            })}
           </label>
           <input
               type="text"
@@ -150,7 +159,10 @@ class CalculatorForm extends React.Component {
       <div className="row">
         <div className="small-12 columns">
           <label htmlFor="tuitionAssist">
-            {this.renderLearnMoreLabel({ text: 'How much are you receiving in military tuition assistance', modal: 'calcTuitionAssist' })}
+            {this.renderLearnMoreLabel({
+              text: 'How much are you receiving in military tuition assistance',
+              modal: 'calcTuitionAssist'
+            })}
           </label>
           <input
               type="text"
@@ -197,7 +209,10 @@ class CalculatorForm extends React.Component {
       <div className="row">
         <div className="small-12 columns">
           <Dropdown
-              label={this.renderLearnMoreLabel({ text: 'Enrolled', modal: 'calcEnrolled' })}
+              label={this.renderLearnMoreLabel({
+                text: 'Enrolled',
+                modal: 'calcEnrolled'
+              })}
               name={name}
               alt="Enrolled"
               options={options}
@@ -220,6 +235,7 @@ class CalculatorForm extends React.Component {
           <div className="row">
             <div className="small-12 columns">
               <Dropdown
+                  label="How many terms per year?"
                   name="numberNontradTerms"
                   alt="How many terms per year?"
                   options={[
@@ -229,16 +245,13 @@ class CalculatorForm extends React.Component {
                   ]}
                   visible
                   value={this.props.inputs.numberNontradTerms}
-                  onChange={this.props.onInputChange}>
-                <label htmlFor="numberNontradTerms">
-                  How many terms per year?
-                </label>
-              </Dropdown>
+                  onChange={this.props.onInputChange}/>
             </div>
           </div>
           <div className="row">
             <div className="small-12 columns">
               <Dropdown
+                  label="How long is each term?"
                   name="lengthNontradTerms"
                   alt="How long is each term?"
                   options={[
@@ -257,11 +270,7 @@ class CalculatorForm extends React.Component {
                   ]}
                   visible
                   value={this.props.inputs.lengthNontradTerms}
-                  onChange={this.props.onInputChange}>
-                <label htmlFor="lengthNontradTerms">
-                  How long is each term?
-                </label>
-              </Dropdown>
+                  onChange={this.props.onInputChange}/>
             </div>
           </div>
         </div>
@@ -273,7 +282,10 @@ class CalculatorForm extends React.Component {
         <div className="row">
           <div className="small-12 columns">
             <Dropdown
-                label={this.renderLearnMoreLabel({ text: 'School Calendar', modal: 'calcSchoolCalendar' })}
+                label={this.renderLearnMoreLabel({
+                  text: 'School Calendar',
+                  modal: 'calcSchoolCalendar'
+                })}
                 name="calendar"
                 alt="School calendar"
                 options={[
@@ -316,7 +328,10 @@ class CalculatorForm extends React.Component {
         <div className="row">
           <div className="small-12 columns">
             <RadioButtons
-                label={this.renderLearnMoreLabel({ text: 'Eligible for kicker bonus?', modal: 'calcKicker' })}
+                label={this.renderLearnMoreLabel({
+                  text: 'Eligible for kicker bonus?',
+                  modal: 'calcKicker'
+                })}
                 name="kickerEligible"
                 options={[
                   { value: 'yes', label: 'Yes' },
@@ -377,6 +392,7 @@ class CalculatorForm extends React.Component {
       <div className="row">
         <div className="small-12 columns">
           <Dropdown
+              label="Will be working"
               name="working"
               alt="Will be working"
               options={[
@@ -398,12 +414,7 @@ class CalculatorForm extends React.Component {
               ]}
               visible
               value={this.props.inputs.working}
-              onChange={this.props.onInputChange}>
-            <label htmlFor="working">
-              {/* TODO: identify correct modal <LearnMoreLabel text="Will be working" modal="calcSchoolCalendar"/> */}
-              Will be working
-            </label>
-          </Dropdown>
+              onChange={this.props.onInputChange}/>
         </div>
       </div>
     );

--- a/src/js/gi/components/profile/CalculatorForm.jsx
+++ b/src/js/gi/components/profile/CalculatorForm.jsx
@@ -32,41 +32,33 @@ class CalculatorForm extends React.Component {
   renderInState() {
     if (!this.props.displayedInputs.inState) return null;
     return (
-      <div>
-        <div className="row">
-          <div className="small-12 columns">
-            <RadioButtons
-                label="Are you an in-state student?"
-                name="inState"
-                options={[
-                  { value: 'yes', label: 'Yes' },
-                  { value: 'no', label: 'No' }
-                ]}
-                value={this.props.inputs.inState}
-                onChange={this.props.onInputChange}/>
-          </div>
-        </div>
-      </div>
+      <RadioButtons
+          label="Are you an in-state student?"
+          name="inState"
+          options={[
+            { value: 'yes', label: 'Yes' },
+            { value: 'no', label: 'No' }
+          ]}
+          value={this.props.inputs.inState}
+          onChange={this.props.onInputChange}/>
     );
   }
 
   renderTuition() {
     if (!this.props.displayedInputs.tuition) return null;
     return (
-      <div className="row">
-        <div className="small-12 columns">
-          <label htmlFor="tuitionFees">
-            {this.renderLearnMoreLabel({
-              text: 'Tuition and fees per year',
-              modal: 'calcTuition'
-            })}
-          </label>
-          <input
-              type="text"
-              name="tuitionFees"
-              value={formatCurrency(this.props.inputs.tuitionFees)}
-              onChange={this.props.onInputChange}/>
-        </div>
+      <div>
+        <label htmlFor="tuitionFees">
+          {this.renderLearnMoreLabel({
+            text: 'Tuition and fees per year',
+            modal: 'calcTuition'
+          })}
+        </label>
+        <input
+            type="text"
+            name="tuitionFees"
+            value={formatCurrency(this.props.inputs.tuitionFees)}
+            onChange={this.props.onInputChange}/>
       </div>
     );
   }
@@ -74,15 +66,13 @@ class CalculatorForm extends React.Component {
   renderBooks() {
     if (!this.props.displayedInputs.books) return null;
     return (
-      <div className="row">
-        <div className="small-12 columns">
-          <label htmlFor="books">Books and supplies per year</label>
-          <input
-              type="text"
-              name="books"
-              value={formatCurrency(this.props.inputs.books)}
-              onChange={this.props.onInputChange}/>
-        </div>
+      <div>
+        <label htmlFor="books">Books and supplies per year</label>
+        <input
+            type="text"
+            name="books"
+            value={formatCurrency(this.props.inputs.books)}
+            onChange={this.props.onInputChange}/>
       </div>
     );
   }
@@ -94,39 +84,33 @@ class CalculatorForm extends React.Component {
 
     if (this.props.inputs.yellowRibbonRecipient === 'yes') {
       amountInput = (
-        <div className="row">
-          <div className="small-12 columns">
-            <label htmlFor="yellowRibbonAmount">
-              Yellow Ribbon Amount From School per year
-            </label>
-            <input
-                type="text"
-                name="yellowRibbonAmount"
-                value={formatCurrency(this.props.inputs.yellowRibbonAmount)}
-                onChange={this.props.onInputChange}/>
-          </div>
+        <div>
+          <label htmlFor="yellowRibbonAmount">
+            Yellow Ribbon Amount From School per year
+          </label>
+          <input
+              type="text"
+              name="yellowRibbonAmount"
+              value={formatCurrency(this.props.inputs.yellowRibbonAmount)}
+              onChange={this.props.onInputChange}/>
         </div>
       );
     }
 
     return (
       <div>
-        <div className="row">
-          <div className="small-12 columns">
-            <RadioButtons
-                label={this.renderLearnMoreLabel({
-                  text: 'Are you a current Yellow Ribbon recipient?',
-                  modal: 'calcYr'
-                })}
-                name="yellowRibbonRecipient"
-                options={[
-                  { value: 'yes', label: 'Yes' },
-                  { value: 'no', label: 'No' }
-                ]}
-                value={this.props.inputs.yellowRibbonRecipient}
-                onChange={this.props.onInputChange}/>
-          </div>
-        </div>
+        <RadioButtons
+            label={this.renderLearnMoreLabel({
+              text: 'Are you a current Yellow Ribbon recipient?',
+              modal: 'calcYr'
+            })}
+            name="yellowRibbonRecipient"
+            options={[
+              { value: 'yes', label: 'Yes' },
+              { value: 'no', label: 'No' }
+            ]}
+            value={this.props.inputs.yellowRibbonRecipient}
+            onChange={this.props.onInputChange}/>
         {amountInput}
       </div>
     );
@@ -135,20 +119,18 @@ class CalculatorForm extends React.Component {
   renderScholarships() {
     if (!this.props.displayedInputs.scholarships) return null;
     return (
-      <div className="row">
-        <div className="small-12 columns">
-          <label htmlFor="scholarships">
-            {this.renderLearnMoreLabel({
-              text: 'Scholarships (excluding Pell)',
-              modal: 'calcScholarships'
-            })}
-          </label>
-          <input
-              type="text"
-              name="scholarships"
-              value={formatCurrency(this.props.inputs.scholarships)}
-              onChange={this.props.onInputChange}/>
-        </div>
+      <div>
+        <label htmlFor="scholarships">
+          {this.renderLearnMoreLabel({
+            text: 'Scholarships (excluding Pell)',
+            modal: 'calcScholarships'
+          })}
+        </label>
+        <input
+            type="text"
+            name="scholarships"
+            value={formatCurrency(this.props.inputs.scholarships)}
+            onChange={this.props.onInputChange}/>
       </div>
     );
   }
@@ -156,20 +138,18 @@ class CalculatorForm extends React.Component {
   renderTuitionAssist() {
     if (!this.props.displayedInputs.tuitionAssist) return null;
     return (
-      <div className="row">
-        <div className="small-12 columns">
-          <label htmlFor="tuitionAssist">
-            {this.renderLearnMoreLabel({
-              text: 'How much are you receiving in military tuition assistance',
-              modal: 'calcTuitionAssist'
-            })}
-          </label>
-          <input
-              type="text"
-              name="tuitionAssist"
-              value={formatCurrency(this.props.inputs.tuitionAssist)}
-              onChange={this.props.onInputChange}/>
-        </div>
+      <div>
+        <label htmlFor="tuitionAssist">
+          {this.renderLearnMoreLabel({
+            text: 'How much are you receiving in military tuition assistance',
+            modal: 'calcTuitionAssist'
+          })}
+        </label>
+        <input
+            type="text"
+            name="tuitionAssist"
+            value={formatCurrency(this.props.inputs.tuitionAssist)}
+            onChange={this.props.onInputChange}/>
       </div>
     );
   }
@@ -206,20 +186,18 @@ class CalculatorForm extends React.Component {
     const value = shouldRenderEnrolled ? enrolledValue : enrolledOldValue;
 
     return (
-      <div className="row">
-        <div className="small-12 columns">
-          <Dropdown
-              label={this.renderLearnMoreLabel({
-                text: 'Enrolled',
-                modal: 'calcEnrolled'
-              })}
-              name={name}
-              alt="Enrolled"
-              options={options}
-              visible
-              value={value}
-              onChange={this.props.onInputChange}/>
-        </div>
+      <div>
+        <Dropdown
+            label={this.renderLearnMoreLabel({
+              text: 'Enrolled',
+              modal: 'calcEnrolled'
+            })}
+            name={name}
+            alt="Enrolled"
+            options={options}
+            visible
+            value={value}
+            onChange={this.props.onInputChange}/>
       </div>
     );
   }
@@ -232,72 +210,60 @@ class CalculatorForm extends React.Component {
     if (this.props.inputs.calendar === 'nontraditional') {
       dependentDropdowns = (
         <div>
-          <div className="row">
-            <div className="small-12 columns">
-              <Dropdown
-                  label="How many terms per year?"
-                  name="numberNontradTerms"
-                  alt="How many terms per year?"
-                  options={[
-                    { value: '3', label: 'Three' },
-                    { value: '2', label: 'Two' },
-                    { value: '1', label: 'One' }
-                  ]}
-                  visible
-                  value={this.props.inputs.numberNontradTerms}
-                  onChange={this.props.onInputChange}/>
-            </div>
-          </div>
-          <div className="row">
-            <div className="small-12 columns">
-              <Dropdown
-                  label="How long is each term?"
-                  name="lengthNontradTerms"
-                  alt="How long is each term?"
-                  options={[
-                    { value: '1', label: '1 month' },
-                    { value: '2', label: '2 months' },
-                    { value: '3', label: '3 months' },
-                    { value: '4', label: '4 months' },
-                    { value: '5', label: '5 months' },
-                    { value: '6', label: '6 months' },
-                    { value: '7', label: '7 months' },
-                    { value: '8', label: '8 months' },
-                    { value: '9', label: '9 months' },
-                    { value: '10', label: '10 months' },
-                    { value: '11', label: '11 months' },
-                    { value: '12', label: '12 months' }
-                  ]}
-                  visible
-                  value={this.props.inputs.lengthNontradTerms}
-                  onChange={this.props.onInputChange}/>
-            </div>
-          </div>
+          <Dropdown
+              label="How many terms per year?"
+              name="numberNontradTerms"
+              alt="How many terms per year?"
+              options={[
+                { value: '3', label: 'Three' },
+                { value: '2', label: 'Two' },
+                { value: '1', label: 'One' }
+              ]}
+              visible
+              value={this.props.inputs.numberNontradTerms}
+              onChange={this.props.onInputChange}/>
+          <Dropdown
+              label="How long is each term?"
+              name="lengthNontradTerms"
+              alt="How long is each term?"
+              options={[
+                { value: '1', label: '1 month' },
+                { value: '2', label: '2 months' },
+                { value: '3', label: '3 months' },
+                { value: '4', label: '4 months' },
+                { value: '5', label: '5 months' },
+                { value: '6', label: '6 months' },
+                { value: '7', label: '7 months' },
+                { value: '8', label: '8 months' },
+                { value: '9', label: '9 months' },
+                { value: '10', label: '10 months' },
+                { value: '11', label: '11 months' },
+                { value: '12', label: '12 months' }
+              ]}
+              visible
+              value={this.props.inputs.lengthNontradTerms}
+              onChange={this.props.onInputChange}/>
         </div>
       );
     }
 
     return (
       <div>
-        <div className="row">
-          <div className="small-12 columns">
-            <Dropdown
-                label={this.renderLearnMoreLabel({
-                  text: 'School Calendar',
-                  modal: 'calcSchoolCalendar'
-                })}
-                name="calendar"
-                alt="School calendar"
-                options={[
-                  { value: 'semesters', label: 'Semesters' },
-                  { value: 'quarters', label: 'Quarters' },
-                  { value: 'nontraditional', label: 'Non-Traditional' }
-                ]}
-                visible
-                value={this.props.inputs.calendar}
-                onChange={this.props.onInputChange}/>
-          </div>
-        </div>
+        <Dropdown
+            label={this.renderLearnMoreLabel({
+              text: 'School Calendar',
+              modal: 'calcSchoolCalendar'
+            })}
+            name="calendar"
+            alt="School calendar"
+            options={[
+              { value: 'semesters', label: 'Semesters' },
+              { value: 'quarters', label: 'Quarters' },
+              { value: 'nontraditional', label: 'Non-Traditional' }
+            ]}
+            visible
+            value={this.props.inputs.calendar}
+            onChange={this.props.onInputChange}/>
         {dependentDropdowns}
       </div>
     );
@@ -310,37 +276,31 @@ class CalculatorForm extends React.Component {
 
     if (this.props.inputs.kickerEligible === 'yes') {
       amountInput = (
-        <div className="row">
-          <div className="small-12 columns">
-            <label htmlFor="kickerAmount">How much is your kicker?</label>
-            <input
-                type="text"
-                name="kickerAmount"
-                value={formatCurrency(this.props.inputs.kickerAmount)}
-                onChange={this.props.onInputChange}/>
-          </div>
+        <div>
+          <label htmlFor="kickerAmount">How much is your kicker?</label>
+          <input
+              type="text"
+              name="kickerAmount"
+              value={formatCurrency(this.props.inputs.kickerAmount)}
+              onChange={this.props.onInputChange}/>
         </div>
       );
     }
 
     return (
       <div>
-        <div className="row">
-          <div className="small-12 columns">
-            <RadioButtons
-                label={this.renderLearnMoreLabel({
-                  text: 'Eligible for kicker bonus?',
-                  modal: 'calcKicker'
-                })}
-                name="kickerEligible"
-                options={[
-                  { value: 'yes', label: 'Yes' },
-                  { value: 'no', label: 'No' }
-                ]}
-                value={this.props.inputs.kickerEligible}
-                onChange={this.props.onInputChange}/>
-          </div>
-        </div>
+        <RadioButtons
+            label={this.renderLearnMoreLabel({
+              text: 'Eligible for kicker bonus?',
+              modal: 'calcKicker'
+            })}
+            name="kickerEligible"
+            options={[
+              { value: 'yes', label: 'Yes' },
+              { value: 'no', label: 'No' }
+            ]}
+            value={this.props.inputs.kickerEligible}
+            onChange={this.props.onInputChange}/>
         {amountInput}
       </div>
     );
@@ -353,34 +313,28 @@ class CalculatorForm extends React.Component {
 
     if (this.props.inputs.buyUp === 'yes') {
       amountInput = (
-        <div className="row">
-          <div className="small-12 columns">
-            <label htmlFor="buyUpAmount">How much did you pay toward buy-up?</label>
-            <input
-                type="text"
-                name="buyUpAmount"
-                value={formatCurrency(this.props.inputs.buyUpAmount)}
-                onChange={this.props.onInputChange}/>
-          </div>
+        <div>
+          <label htmlFor="buyUpAmount">How much did you pay toward buy-up?</label>
+          <input
+              type="text"
+              name="buyUpAmount"
+              value={formatCurrency(this.props.inputs.buyUpAmount)}
+              onChange={this.props.onInputChange}/>
         </div>
       );
     }
 
     return (
       <div>
-        <div className="row">
-          <div className="small-12 columns">
-            <RadioButtons
-                label="Participate in buy-up program?"
-                name="buyUp"
-                options={[
-                  { value: 'yes', label: 'Yes' },
-                  { value: 'no', label: 'No' }
-                ]}
-                value={this.props.inputs.buyUp}
-                onChange={this.props.onInputChange}/>
-          </div>
-        </div>
+        <RadioButtons
+            label="Participate in buy-up program?"
+            name="buyUp"
+            options={[
+              { value: 'yes', label: 'Yes' },
+              { value: 'no', label: 'No' }
+            ]}
+            value={this.props.inputs.buyUp}
+            onChange={this.props.onInputChange}/>
         {amountInput}
       </div>
     );
@@ -389,33 +343,31 @@ class CalculatorForm extends React.Component {
   renderWorking() {
     if (!this.props.displayedInputs.working) return null;
     return (
-      <div className="row">
-        <div className="small-12 columns">
-          <Dropdown
-              label="Will be working"
-              name="working"
-              alt="Will be working"
-              options={[
-                { value: '30', label: '30+ hrs / week' },
-                { value: '28', label: '28 hrs / week' },
-                { value: '26', label: '26 hrs / week' },
-                { value: '24', label: '24 hrs / week' },
-                { value: '22', label: '22 hrs / week' },
-                { value: '20', label: '20 hrs / week' },
-                { value: '18', label: '18 hrs / week' },
-                { value: '16', label: '16 hrs / week' },
-                { value: '14', label: '14 hrs / week' },
-                { value: '12', label: '12 hrs / week' },
-                { value: '10', label: '10 hrs / week' },
-                { value: '8', label: '8 hrs / week' },
-                { value: '6', label: '6 hrs / week' },
-                { value: '4', label: '4 hrs / week' },
-                { value: '2', label: '2 hrs / week' }
-              ]}
-              visible
-              value={this.props.inputs.working}
-              onChange={this.props.onInputChange}/>
-        </div>
+      <div>
+        <Dropdown
+            label="Will be working"
+            name="working"
+            alt="Will be working"
+            options={[
+              { value: '30', label: '30+ hrs / week' },
+              { value: '28', label: '28 hrs / week' },
+              { value: '26', label: '26 hrs / week' },
+              { value: '24', label: '24 hrs / week' },
+              { value: '22', label: '22 hrs / week' },
+              { value: '20', label: '20 hrs / week' },
+              { value: '18', label: '18 hrs / week' },
+              { value: '16', label: '16 hrs / week' },
+              { value: '14', label: '14 hrs / week' },
+              { value: '12', label: '12 hrs / week' },
+              { value: '10', label: '10 hrs / week' },
+              { value: '8', label: '8 hrs / week' },
+              { value: '6', label: '6 hrs / week' },
+              { value: '4', label: '4 hrs / week' },
+              { value: '2', label: '2 hrs / week' }
+            ]}
+            visible
+            value={this.props.inputs.working}
+            onChange={this.props.onInputChange}/>
       </div>
     );
   }

--- a/src/js/gi/components/profile/CalculatorForm.jsx
+++ b/src/js/gi/components/profile/CalculatorForm.jsx
@@ -56,9 +56,7 @@ class CalculatorForm extends React.Component {
       <div className="row">
         <div className="small-12 columns">
           <label htmlFor="tuitionFees">
-            Tuition and fees per year (
-            <a onClick={this.props.onShowModal.bind(this, 'calcTuition')}>
-            Learn more</a>)
+            {this.renderLearnMoreLabel({ text: 'Tuition and fees per year', modal: 'calcTuition' })}
           </label>
           <input
               type="text"
@@ -134,9 +132,7 @@ class CalculatorForm extends React.Component {
       <div className="row">
         <div className="small-12 columns">
           <label htmlFor="scholarships">
-            Scholarships (excluding Pell) (
-            <a onClick={this.props.onShowModal.bind(this, 'calcScholarships')}>
-            Learn more</a>)
+            {this.renderLearnMoreLabel({ text: 'Scholarships (excluding Pell)', modal: 'calcScholarships' })}
           </label>
           <input
               type="text"
@@ -154,9 +150,7 @@ class CalculatorForm extends React.Component {
       <div className="row">
         <div className="small-12 columns">
           <label htmlFor="tuitionAssist">
-            How much are you receiving in military tuition assistance (
-            <a onClick={this.props.onShowModal.bind(this, 'calcTuitionAssist')}>
-            Learn more</a>)
+            {this.renderLearnMoreLabel({ text: 'How much are you receiving in military tuition assistance', modal: 'calcTuitionAssist' })}
           </label>
           <input
               type="text"
@@ -203,14 +197,13 @@ class CalculatorForm extends React.Component {
       <div className="row">
         <div className="small-12 columns">
           <Dropdown
+              label={this.renderLearnMoreLabel({ text: 'Enrolled', modal: 'calcEnrolled' })}
               name={name}
               alt="Enrolled"
               options={options}
               visible
               value={value}
-              onChange={this.props.onInputChange}>
-            {this.renderLearnMoreLabel({ text: 'Enrolled', modal: 'calcEnrolled' })}
-          </Dropdown>
+              onChange={this.props.onInputChange}/>
         </div>
       </div>
     );
@@ -280,6 +273,7 @@ class CalculatorForm extends React.Component {
         <div className="row">
           <div className="small-12 columns">
             <Dropdown
+                label={this.renderLearnMoreLabel({ text: 'School Calendar', modal: 'calcSchoolCalendar' })}
                 name="calendar"
                 alt="School calendar"
                 options={[
@@ -289,9 +283,7 @@ class CalculatorForm extends React.Component {
                 ]}
                 visible
                 value={this.props.inputs.calendar}
-                onChange={this.props.onInputChange}>
-              {this.renderLearnMoreLabel({ text: 'School Calendar', modal: 'calcSchoolCalendar' })}
-            </Dropdown>
+                onChange={this.props.onInputChange}/>
           </div>
         </div>
         {dependentDropdowns}

--- a/src/js/gi/components/profile/Graph.jsx
+++ b/src/js/gi/components/profile/Graph.jsx
@@ -102,7 +102,7 @@ class Graph extends React.Component {
             </Underbar>
             <ValueLabel y="22" text={this.format(veterans)}/>
 
-            {averagePercent === null || averagePercent === undefined ?
+            {averagePercent ?
               <AverageMark
                   percent={averagePercent}
                   text={this.format(averageObject)}/> : null}

--- a/src/js/gi/components/profile/Graph.jsx
+++ b/src/js/gi/components/profile/Graph.jsx
@@ -102,7 +102,10 @@ class Graph extends React.Component {
             </Underbar>
             <ValueLabel y="22" text={this.format(veterans)}/>
 
-            <AverageMark percent={averagePercent} text={this.format(averageObject)}/>
+            {averagePercent === null || averagePercent === undefined ?
+              <AverageMark
+                  percent={averagePercent}
+                  text={this.format(averageObject)}/> : null}
           </g>
         </svg>
       </div>

--- a/src/js/gi/components/profile/Outcomes.jsx
+++ b/src/js/gi/components/profile/Outcomes.jsx
@@ -36,6 +36,13 @@ class Outcomes extends React.Component {
         </div>
 
         <div className="medium-12 column">
+          <svg>
+            <rect x="0" y="0" width="40" height="40" fill="#F1F1F1"/>
+            <line x1="20" x2="20" y1="0" y2="40" stroke="#323A45" strokeWidth="2"/>
+            <text x="50" y="30" fontFamily="SourceSansPro-Regular, Source Sans Pro" fontSize="16" fill="#323A45">
+              <tspan>National average</tspan>
+            </text>
+          </svg>
           <p>
             Access a comprehensive spreadsheet of <a title="Veteran Outcome Measures"
                 href={download.link} target="_blank">Veteran Outcome Measures ({download.info})</a>

--- a/src/js/gi/components/profile/Outcomes.jsx
+++ b/src/js/gi/components/profile/Outcomes.jsx
@@ -36,12 +36,12 @@ class Outcomes extends React.Component {
         </div>
 
         <div className="medium-12 column">
-          <svg height="60">
+          <svg className="graph-key" viewBox="0 0 650 50">
             <g>
-              <rect x="0" y="0" width="40" height="40" fill="#F1F1F1"/>
-              <line x1="20" x2="20" y1="0" y2="40" stroke="#323A45" strokeWidth="2"/>
-              <text x="50" y="30" fontFamily="SourceSansPro-Regular, Source Sans Pro" fontSize="22" fill="#323A45">
-                <tspan>National average</tspan>
+              <rect x="0" y="0" width="30" height="30" fill="#F1F1F1"/>
+              <line x1="15" x2="15" y1="0" y2="30" stroke="#323A45" strokeWidth="2"/>
+              <text fontFamily="SourceSansPro-Regular, Source Sans Pro" fontSize="16" fill="#323A45">
+                <tspan x="40" y="20">National average</tspan>
               </text>
             </g>
           </svg>

--- a/src/js/gi/components/profile/Outcomes.jsx
+++ b/src/js/gi/components/profile/Outcomes.jsx
@@ -36,12 +36,14 @@ class Outcomes extends React.Component {
         </div>
 
         <div className="medium-12 column">
-          <svg>
-            <rect x="0" y="0" width="40" height="40" fill="#F1F1F1"/>
-            <line x1="20" x2="20" y1="0" y2="40" stroke="#323A45" strokeWidth="2"/>
-            <text x="50" y="30" fontFamily="SourceSansPro-Regular, Source Sans Pro" fontSize="16" fill="#323A45">
-              <tspan>National average</tspan>
-            </text>
+          <svg height="60">
+            <g>
+              <rect x="0" y="0" width="40" height="40" fill="#F1F1F1"/>
+              <line x1="20" x2="20" y1="0" y2="40" stroke="#323A45" strokeWidth="2"/>
+              <text x="50" y="30" fontFamily="SourceSansPro-Regular, Source Sans Pro" fontSize="22" fill="#323A45">
+                <tspan>National average</tspan>
+              </text>
+            </g>
           </svg>
           <p>
             Access a comprehensive spreadsheet of <a title="Veteran Outcome Measures"

--- a/src/js/gi/components/profile/Outcomes.jsx
+++ b/src/js/gi/components/profile/Outcomes.jsx
@@ -1,6 +1,18 @@
 import React from 'react';
 import Graph from './Graph';
 
+const GraphKey = () => (
+  <svg className="graph-key" viewBox="0 0 650 50">
+    <g>
+      <rect x="0" y="0" width="30" height="30" fill="#F1F1F1"/>
+      <line x1="15" x2="15" y1="0" y2="30" stroke="#323A45" strokeWidth="2"/>
+      <text fontFamily="SourceSansPro-Regular, Source Sans Pro" fontSize="16" fill="#323A45">
+        <tspan x="40" y="20">National average</tspan>
+      </text>
+    </g>
+  </svg>
+);
+
 class Outcomes extends React.Component {
 
   render() {
@@ -36,15 +48,7 @@ class Outcomes extends React.Component {
         </div>
 
         <div className="medium-12 column">
-          <svg className="graph-key" viewBox="0 0 650 50">
-            <g>
-              <rect x="0" y="0" width="30" height="30" fill="#F1F1F1"/>
-              <line x1="15" x2="15" y1="0" y2="30" stroke="#323A45" strokeWidth="2"/>
-              <text fontFamily="SourceSansPro-Regular, Source Sans Pro" fontSize="16" fill="#323A45">
-                <tspan x="40" y="20">National average</tspan>
-              </text>
-            </g>
-          </svg>
+          <GraphKey/>
           <p>
             Access a comprehensive spreadsheet of <a title="Veteran Outcome Measures"
                 href={download.link} target="_blank">Veteran Outcome Measures ({download.info})</a>

--- a/src/js/gi/components/profile/Programs.jsx
+++ b/src/js/gi/components/profile/Programs.jsx
@@ -73,7 +73,7 @@ export class Programs extends React.Component {
       <div className="programs row">
         <If condition={available.length > 0}>
           <div className="medium-6 large-6 column">
-            <h3>Veteran programs available at this campus</h3>
+            <h3>Available at this campus</h3>
             {available.map((program) => this.renderProgramLabel.bind(this, program, true)())}
             <br/>
           </div>

--- a/src/js/gi/components/search/EligibilityForm.jsx
+++ b/src/js/gi/components/search/EligibilityForm.jsx
@@ -8,12 +8,26 @@ import RadioButtons from '../RadioButtons';
 
 export class EligibilityForm extends React.Component {
 
+  constructor(props) {
+    super(props);
+    this.renderLearnMoreLabel = this.renderLearnMoreLabel.bind(this);
+  }
+
+  renderLearnMoreLabel({ text, modal }) {
+    return (
+      <span>
+        {text} (<a onClick={this.props.showModal.bind(this, modal)}>Learn more</a>)
+      </span>
+    );
+  }
+
   render() {
     return (
       <div className="eligibility-form">
         <h2>Your eligibility</h2>
 
         <Dropdown
+            label="What is your military status?"
             name="militaryStatus"
             options={[
               { value: 'veteran', label: 'Veteran' },
@@ -25,13 +39,10 @@ export class EligibilityForm extends React.Component {
             value={this.props.eligibility.militaryStatus}
             alt="What is your military status?"
             visible={this.props.eligibility.dropdowns.militaryStatus}
-            onChange={this.props.eligibilityChange}>
-          <label htmlFor="militaryStatus">
-            What is your military status?
-          </label>
-        </Dropdown>
+            onChange={this.props.eligibilityChange}/>
 
         <Dropdown
+            label="Is your spouse on active duty?"
             name="spouseActiveDuty"
             options={[
               { value: 'yes', label: 'Yes' },
@@ -40,13 +51,13 @@ export class EligibilityForm extends React.Component {
             value={this.props.eligibility.spouseActiveDuty}
             alt="Is your spouse on active duty?"
             visible={this.props.eligibility.dropdowns.spouseActiveDuty}
-            onChange={this.props.eligibilityChange}>
-          <label htmlFor="spouseActiveDuty">
-            Is your spouse on active duty?
-          </label>
-        </Dropdown>
+            onChange={this.props.eligibilityChange}/>
 
         <Dropdown
+            label={this.renderLearnMoreLabel({
+              text: 'Which GI Bill benefit do you want to use?',
+              modal: 'giBillChapter'
+            })}
             name="giBillChapter"
             options={[
               { value: '33', label: 'Post-9/11 GI Bill (Ch 33)' },
@@ -59,14 +70,7 @@ export class EligibilityForm extends React.Component {
             value={this.props.eligibility.giBillChapter}
             alt="Which GI Bill benefit do you want to use?"
             visible={this.props.eligibility.dropdowns.giBillChapter}
-            onChange={this.props.eligibilityChange}>
-          <label htmlFor="giBillChapter">
-            Which GI Bill benefit do you want to use?
-            (<a onClick={() => this.props.showModal('giBillChapter')} className="info-icons">
-              learn more
-            </a>)
-          </label>
-        </Dropdown>
+            onChange={this.props.eligibilityChange}/>
 
         <If condition={
             this.props.eligibility.militaryStatus === 'active duty' &&
@@ -83,6 +87,10 @@ export class EligibilityForm extends React.Component {
         </If>
 
         <Dropdown
+            label={this.renderLearnMoreLabel({
+              text: 'Cumulative Post-9/11 active duty service',
+              modal: 'cumulativeService'
+            })}
             name="cumulativeService"
             options={[
               { value: '1.0', label: '36+ months: 100% (includes BASIC)' }, // notice not 1.00
@@ -99,16 +107,13 @@ export class EligibilityForm extends React.Component {
             value={this.props.eligibility.cumulativeService}
             alt="Cumulative Post-9/11 active duty service"
             visible={this.props.eligibility.dropdowns.cumulativeService}
-            onChange={this.props.eligibilityChange}>
-          <label htmlFor="cumulativeService">
-            Cumulative Post-9/11 active duty service
-            (<a onClick={() => this.props.showModal('cumulativeService')} className="info-icons">
-              learn more
-            </a>)
-          </label>
-        </Dropdown>
+            onChange={this.props.eligibilityChange}/>
 
         <Dropdown
+            label={this.renderLearnMoreLabel({
+              text: 'Completed an enlistment of:',
+              modal: 'enlistmentService'
+            })}
             name="enlistmentService"
             options={[
               { value: '3', label: '3 or more years' },
@@ -117,16 +122,13 @@ export class EligibilityForm extends React.Component {
             value={this.props.eligibility.enlistmentService}
             alt="Completed an enlistment of:"
             visible={this.props.eligibility.dropdowns.enlistmentService}
-            onChange={this.props.eligibilityChange}>
-          <label htmlFor="enlistmentService">
-            Completed an enlistment of:
-            (<a onClick={() => this.props.showModal('enlistmentService')} className="info-icons">
-              learn more
-            </a>)
-          </label>
-        </Dropdown>
+            onChange={this.props.eligibilityChange}/>
 
         <Dropdown
+            label={this.renderLearnMoreLabel({
+              text: 'Length of longest active duty tour:',
+              modal: 'consecutiveService'
+            })}
             name="consecutiveService"
             options={[
               { value: '0.8', label: '2+ years of consecutive service: 80%' },
@@ -136,16 +138,10 @@ export class EligibilityForm extends React.Component {
             value={this.props.eligibility.consecutiveService}
             alt="Length of longest active duty tour:"
             visible={this.props.eligibility.dropdowns.consecutiveService}
-            onChange={this.props.eligibilityChange}>
-          <label htmlFor="consecutiveService">
-            Length of longest active duty tour:
-            (<a onClick={() => this.props.showModal('consecutiveService')} className="info-icons">
-              learn more
-            </a>)
-          </label>
-        </Dropdown>
+            onChange={this.props.eligibilityChange}/>
 
         <Dropdown
+            label="Are you eligible for the Post-9/11 GI Bill?"
             name="eligForPostGiBill"
             options={[
               { value: 'yes', label: 'Yes' },
@@ -154,13 +150,10 @@ export class EligibilityForm extends React.Component {
             value={this.props.eligibility.eligForPostGiBill}
             alt="Are you eligible for the Post-9/11 GI Bill?"
             visible={this.props.eligibility.dropdowns.eligForPostGiBill}
-            onChange={this.props.eligibilityChange}>
-          <label htmlFor="eligForPostGiBill">
-            Are you eligible for the Post-9/11 GI Bill?
-          </label>
-        </Dropdown>
+            onChange={this.props.eligibilityChange}/>
 
         <Dropdown
+            label="How many dependents do you have?"
             name="numberOfDependents"
             options={[
               { value: '0', label: '0 Dependents' },
@@ -173,12 +166,7 @@ export class EligibilityForm extends React.Component {
             value={this.props.eligibility.numberOfDependents}
             alt="How many dependents do you have?"
             visible={this.props.eligibility.dropdowns.numberOfDependents}
-            onChange={this.props.eligibilityChange}
-            showLabel={this.props.labels}>
-          <label htmlFor="numberOfDependents">
-            How many dependents do you have?
-          </label>
-        </Dropdown>
+            onChange={this.props.eligibilityChange}/>
 
         <RadioButtons
             label="How do you want to take classes?"

--- a/src/js/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/js/gi/components/search/InstitutionFilterForm.jsx
@@ -55,16 +55,13 @@ class InstitutionFilterForm extends React.Component {
 
     return (
       <Dropdown
+          label="Country"
           name="country"
           options={options}
           value={this.props.filters.country}
           alt="Filter results by country"
           visible
-          onChange={this.handleDropdownChange}>
-        <label htmlFor="country">
-          Country
-        </label>
-      </Dropdown>
+          onChange={this.handleDropdownChange}/>
     );
   }
 
@@ -79,16 +76,13 @@ class InstitutionFilterForm extends React.Component {
 
     return (
       <Dropdown
+          label="State"
           name="state"
           options={options}
           value={this.props.filters.state}
           alt="Filter results by state"
           visible
-          onChange={this.handleDropdownChange}>
-        <label htmlFor="state">
-          State
-        </label>
-      </Dropdown>
+          onChange={this.handleDropdownChange}/>
     );
   }
 
@@ -138,16 +132,13 @@ class InstitutionFilterForm extends React.Component {
 
     return (
       <Dropdown
+          label="Institution type"
           name="type"
           options={options}
           value={this.props.filters.type}
           alt="Filter results by institution type"
           visible
-          onChange={this.handleDropdownChange}>
-        <label htmlFor="type">
-          Institution type
-        </label>
-      </Dropdown>
+          onChange={this.handleDropdownChange}/>
     );
   }
 

--- a/src/js/gi/containers/ProfilePage.jsx
+++ b/src/js/gi/containers/ProfilePage.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import Scroll from 'react-scroll';
 import _ from 'lodash';
 
+import LoadingIndicator from '../../common/components/LoadingIndicator';
+import { getScrollOptions } from '../../common/utils/helpers';
 import { fetchProfile, setPageTitle, showModal } from '../actions';
 import AccordionItem from '../components/AccordionItem';
 import If from '../components/If';
@@ -12,6 +15,8 @@ import Calculator from '../components/profile/Calculator';
 import CautionaryInformation from '../components/profile/CautionaryInformation';
 import AdditionalInformation from '../components/profile/AdditionalInformation';
 import { outcomeNumbers } from '../selectors/outcomes';
+
+const { Element: ScrollElement, scroller } = Scroll;
 
 export class ProfilePage extends React.Component {
 
@@ -25,7 +30,8 @@ export class ProfilePage extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const institutionName = _.get(this.props.profile, 'attributes.name');
+    const { profile } = this.props;
+    const institutionName = _.get(profile, 'attributes.name');
     const shouldUpdateTitle = !_.isEqual(
       institutionName,
       _.get(prevProps.profile, 'attributes.name'),
@@ -33,6 +39,10 @@ export class ProfilePage extends React.Component {
 
     if (shouldUpdateTitle) {
       this.props.setPageTitle(`${institutionName} - GI Bill Comparison Tool`);
+    }
+
+    if (profile.inProgress !== prevProps.profile.inProgress) {
+      scroller.scrollTo('profilePage', getScrollOptions());
     }
   }
 
@@ -42,39 +52,52 @@ export class ProfilePage extends React.Component {
 
   render() {
     const { constants, outcomes, profile } = this.props;
-    return (
-      <div className="profile-page">
-        <HeadingSummary
-            institution={this.props.profile.attributes}
-            onLearnMore={this.props.showModal.bind(this, 'gibillstudents')}
-            onViewWarnings={this.handleViewWarnings}/>
-        <div className="usa-accordion">
-          <ul>
-            <AccordionItem button="Estimate your benefits" expanded>
-              <Calculator/>
-            </AccordionItem>
-            <AccordionItem button="Veteran programs">
-              <Programs/>
-            </AccordionItem>
-            <AccordionItem button="Student outcomes">
-              <If condition={!!profile.attributes.facilityCode && !!constants} comment="TODO">
-                <Outcomes
-                    graphing={outcomes}
-                    showModal={this.props.showModal}/>
-              </If>
-            </AccordionItem>
-            <a name="viewWarnings"></a>
-            <AccordionItem
-                button="Cautionary information"
-                ref={c => { this._cautionaryInfo = c; }}>
-              <CautionaryInformation/>
-            </AccordionItem>
-            <AccordionItem button="Additional information">
-              <AdditionalInformation/>
-            </AccordionItem>
-          </ul>
+
+    let content;
+
+    if (profile.inProgress) {
+      content = <LoadingIndicator message="Loading profile..."/>;
+    } else {
+      content = (
+        <div>
+          <HeadingSummary
+              institution={this.props.profile.attributes}
+              onLearnMore={this.props.showModal.bind(this, 'gibillstudents')}
+              onViewWarnings={this.handleViewWarnings}/>
+          <div className="usa-accordion">
+            <ul>
+              <AccordionItem button="Estimate your benefits" expanded>
+                <Calculator/>
+              </AccordionItem>
+              <AccordionItem button="Veteran programs">
+                <Programs/>
+              </AccordionItem>
+              <AccordionItem button="Student outcomes">
+                <If condition={!!profile.attributes.facilityCode && !!constants} comment="TODO">
+                  <Outcomes
+                      graphing={outcomes}
+                      showModal={this.props.showModal}/>
+                </If>
+              </AccordionItem>
+              <a name="viewWarnings"></a>
+              <AccordionItem
+                  button="Cautionary information"
+                  ref={c => { this._cautionaryInfo = c; }}>
+                <CautionaryInformation/>
+              </AccordionItem>
+              <AccordionItem button="Additional information">
+                <AdditionalInformation/>
+              </AccordionItem>
+            </ul>
+          </div>
         </div>
-      </div>
+      );
+    }
+
+    return (
+      <ScrollElement name="profilePage" className="profile-page">
+        {content}
+      </ScrollElement>
     );
   }
 

--- a/src/js/gi/containers/ProfilePage.jsx
+++ b/src/js/gi/containers/ProfilePage.jsx
@@ -48,30 +48,32 @@ export class ProfilePage extends React.Component {
             institution={this.props.profile.attributes}
             onLearnMore={this.props.showModal.bind(this, 'gibillstudents')}
             onViewWarnings={this.handleViewWarnings}/>
-        <ul className="usa-accordion">
-          <AccordionItem button="Estimate your benefits" expanded>
-            <Calculator/>
-          </AccordionItem>
-          <AccordionItem button="Veteran programs">
-            <Programs/>
-          </AccordionItem>
-          <AccordionItem button="Student outcomes">
-            <If condition={!!profile.attributes.facilityCode && !!constants} comment="TODO">
-              <Outcomes
-                  graphing={outcomes}
-                  showModal={this.props.showModal}/>
-            </If>
-          </AccordionItem>
-          <a name="viewWarnings"></a>
-          <AccordionItem
-              button="Cautionary information"
-              ref={c => { this._cautionaryInfo = c; }}>
-            <CautionaryInformation/>
-          </AccordionItem>
-          <AccordionItem button="Additional information">
-            <AdditionalInformation/>
-          </AccordionItem>
-        </ul>
+        <div className="usa-accordion">
+          <ul>
+            <AccordionItem button="Estimate your benefits" expanded>
+              <Calculator/>
+            </AccordionItem>
+            <AccordionItem button="Veteran programs">
+              <Programs/>
+            </AccordionItem>
+            <AccordionItem button="Student outcomes">
+              <If condition={!!profile.attributes.facilityCode && !!constants} comment="TODO">
+                <Outcomes
+                    graphing={outcomes}
+                    showModal={this.props.showModal}/>
+              </If>
+            </AccordionItem>
+            <a name="viewWarnings"></a>
+            <AccordionItem
+                button="Cautionary information"
+                ref={c => { this._cautionaryInfo = c; }}>
+              <CautionaryInformation/>
+            </AccordionItem>
+            <AccordionItem button="Additional information">
+              <AdditionalInformation/>
+            </AccordionItem>
+          </ul>
+        </div>
       </div>
     );
   }

--- a/src/js/gi/containers/SearchPage.jsx
+++ b/src/js/gi/containers/SearchPage.jsx
@@ -200,7 +200,9 @@ export class SearchPage extends React.Component {
 
         <div className="row">
           <div className="column">
-            <h1>{(count || 0).toLocaleString()} Search Results</h1>
+            <h1>
+              {!search.inProgress && `${(count || 0).toLocaleString()} `}Search Results
+            </h1>
           </div>
         </div>
 

--- a/src/sass/gi/partials/_gi-profile-page.scss
+++ b/src/sass/gi/partials/_gi-profile-page.scss
@@ -102,6 +102,14 @@
     clear: both;
   }
 
+  .graph-key {
+    margin-top: 1rem;
+
+    @include media-maxwidth($medium-large-screen) {
+      width: 200%;
+    }
+  }
+
   .cautionary-information {
     .table .number {
       text-align: left;

--- a/src/sass/gi/partials/_gi-profile-page.scss
+++ b/src/sass/gi/partials/_gi-profile-page.scss
@@ -25,8 +25,10 @@
       padding: 1rem 2rem;
     }
 
-    @media screen and (min-width: $small-screen) {
-      .calculator-inputs .form-expanding-group-open {
+    .form-expanding-group-open {
+      margin-bottom: 3rem;
+
+      @media screen and (min-width: $small-screen) {
         border-left: none;
         padding-left: 0;
       }

--- a/src/sass/gi/partials/_gi-profile-page.scss
+++ b/src/sass/gi/partials/_gi-profile-page.scss
@@ -1,16 +1,11 @@
 .gi-app .profile-page {
 
-  ul.usa-accordion {
-    margin: 0;
-    list-style-type: none;
-    padding: 0;
-  }
-
   li button.usa-accordion-button {
     text-align: left;
 
     h2 {
-      font-size: 1em;
+      font-size: 1.35em;
+      padding: 0;
     }
   }
 

--- a/src/sass/gi/partials/_gi-profile-page.scss
+++ b/src/sass/gi/partials/_gi-profile-page.scss
@@ -9,7 +9,7 @@
     }
   }
 
-  .calculate-your-benefits.row {
+  .calculate-your-benefits {
     h3 {
       font-size: 1.35em;
     }
@@ -21,12 +21,14 @@
 
     button {
       color: $color-primary;
-      margin: 0.5em;
+      margin: 0.5em 0;
+      padding: 1rem 2rem;
     }
 
     @media screen and (min-width: $small-screen) {
       .calculator-inputs .form-expanding-group-open {
         border-left: none;
+        padding-left: 0;
       }
     }
 

--- a/src/sass/gi/partials/_gi-search-page.scss
+++ b/src/sass/gi/partials/_gi-search-page.scss
@@ -4,11 +4,9 @@
     h2 {
       font-size: 1.15em;
     }
+
     label {
       margin-top: 1em;
-    }
-    a.info-icons {
-      white-space: nowrap;
     }
 
     .institution-filter-form, .eligibility-form {


### PR DESCRIPTION
Related to profile section of department-of-veterans-affairs/vets.gov-team#1507.

### Changes
* Scroll to top of profile page when loading and after loading finishes.
* Hide "No Data" if there's no national average line in outcome graphs.
* Fixed funky padding issues.
* Other style details pictured below.

#### Consistent spacing between inputs of calculator form. As a bonus, blue line is also aligned with the button.
> <img width="356" alt="screen shot 2017-03-29 at 7 49 53 pm" src="https://cloud.githubusercontent.com/assets/1067024/24481589/496a0d24-14b9-11e7-8b24-b46a9bb10f6e.png">

#### Spacing between accordion sections. Header font sizes match headers within the sections. "Veteran programs available at this campus" -> "Available at this campus".
> <img width="992" alt="screen shot 2017-03-29 at 7 51 12 pm" src="https://cloud.githubusercontent.com/assets/1067024/24481614/7b7fa076-14b9-11e7-995a-9241d42dece0.png">

#### National Average key for outcome graphs.
> <img width="386" alt="screen shot 2017-03-29 at 7 51 25 pm" src="https://cloud.githubusercontent.com/assets/1067024/24481622/90bb857c-14b9-11e7-9280-cf4311656c53.png">
