### PR TITLE
Fixed loading GIBCT profile pages for accredited institutions with null accreditation type.

### DIFF
--- a/src/js/gi/components/profile/AdditionalInformation.jsx
+++ b/src/js/gi/components/profile/AdditionalInformation.jsx
@@ -8,7 +8,7 @@ export class AdditionalInformation extends React.Component {
     const it = this.props.profile.attributes;
     const accredited = !!it.cross;
     const TypeOfAccreditation = () => {
-      if (!accredited) return null;
+      if (!accredited || !it.accreditationType) return null;
       return (
         <p>
           <strong>Type of accreditation:&nbsp;</strong>

--- a/src/js/gi/components/profile/AdditionalInformation.jsx
+++ b/src/js/gi/components/profile/AdditionalInformation.jsx
@@ -1,30 +1,26 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { showModal } from '../../actions';
 
 export class AdditionalInformation extends React.Component {
 
   render() {
-    const it = this.props.profile.attributes;
-    const accredited = !!it.cross;
-    const TypeOfAccreditation = () => {
-      if (!accredited || !it.accreditationType) return null;
-      return (
+    const it = this.props.institution;
+
+    const typeOfAccreditation =
+      it.accredited &&
+      it.accreditationType && (
         <p>
           <strong>Type of accreditation:&nbsp;</strong>
           {it.accreditationType.toUpperCase()}
         </p>
       );
-    };
-    const VetTuitionPolicy = () => {
-      if (!it.vetTuitionPolicyUrl) return null;
-      return (
+
+    const vetTuitionPolicy =
+      it.vetTuitionPolicyUrl && (
         <p>
           <strong>Veterans tuition policy:&nbsp;</strong>
           <a href={`http://${it.vetTuitionPolicyUrl}`} target="_blank">View policy</a>
         </p>
       );
-    };
 
     // Formats positive and negative currency values in USD
     const formatCurrency = (num) => {
@@ -53,10 +49,10 @@ export class AdditionalInformation extends React.Component {
             <h3>Institution summary</h3>
             <p>
               <strong>Accredited:&nbsp;</strong>
-              {accredited ? 'Yes' : 'No'}
+              {it.accredited ? 'Yes' : 'No'}
             </p>
-            <TypeOfAccreditation/>
-            <VetTuitionPolicy/>
+            {typeOfAccreditation}
+            {vetTuitionPolicy}
             <p>
               <strong>Single point of contact for veterans:&nbsp;</strong>
               {!!it.vetPoc ? 'Yes' : 'No'}
@@ -101,21 +97,21 @@ export class AdditionalInformation extends React.Component {
             <h3>Institution codes</h3>
             <p>
               <strong>
-                <a onClick={this.props.showModal.bind(this, 'facilityCode')}>VA facility code:</a>
+                <a onClick={this.props.onShowModal.bind(this, 'facilityCode')}>VA facility code:</a>
                 &nbsp;
               </strong>
               {+it.facilityCode === 0 ? 'N/A' : +it.facilityCode}
             </p>
             <p>
               <strong>
-                <a onClick={this.props.showModal.bind(this, 'ipedsCode')}>ED IPEDS code:</a>
+                <a onClick={this.props.onShowModal.bind(this, 'ipedsCode')}>ED IPEDS code:</a>
                 &nbsp;
               </strong>
               {+it.cross === 0 ? 'N/A' : +it.cross}
             </p>
             <p>
               <strong>
-                <a onClick={this.props.showModal.bind(this, 'opeCode')}>ED OPE code:</a>
+                <a onClick={this.props.onShowModal.bind(this, 'opeCode')}>ED OPE code:</a>
                 &nbsp;
               </strong>
               {+it.ope6 === 0 ? 'N/A' : +it.ope6}
@@ -153,10 +149,9 @@ export class AdditionalInformation extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => state;
-
-const mapDispatchToProps = {
-  showModal,
+AdditionalInformation.propTypes = {
+  institution: React.PropTypes.object,
+  onShowModal: React.PropTypes.func
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(AdditionalInformation);
+export default AdditionalInformation;

--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 import _ from 'lodash';
 import AlertBox from '../../../common/components/AlertBox';
 
+const IconWithInfo = ({ icon, children, present }) => {
+  if (!present) return null;
+  return <span><i className={`fa fa-${icon}`}/>&nbsp;{children}</span>;
+};
+
 class HeadingSummary extends React.Component {
 
   render() {
@@ -15,11 +20,6 @@ class HeadingSummary extends React.Component {
         return 'Medium';
       }
       return 'Large';
-    };
-
-    const IconWithInfo = ({ icon, children, present }) => {
-      if (!present) return null;
-      return <span><i className={`fa fa-${icon}`}/>&nbsp;{children}</span>;
     };
 
     return (

--- a/src/js/gi/components/profile/Outcomes.jsx
+++ b/src/js/gi/components/profile/Outcomes.jsx
@@ -25,25 +25,25 @@ class Outcomes extends React.Component {
       <div className="outcomes row">
         <div className="medium-6 large-6 column">
           <h3>Retention rate</h3>
-          <p className="lml">(<a onClick={this.props.showModal.bind(this, 'retention')}>Learn more</a>)</p>
+          <p className="lml">(<a onClick={this.props.onShowModal.bind(this, 'retention')}>Learn more</a>)</p>
           <Graph veterans={retention.rate} all={retention.all} average={retention.average}/>
         </div>
 
         <div className="medium-6 large-6 column">
           <h3>Graduation rate</h3>
-          <p className="lml">(<a onClick={this.props.showModal.bind(this, 'gradrates')}>Learn more</a>)</p>
+          <p className="lml">(<a onClick={this.props.onShowModal.bind(this, 'gradrates')}>Learn more</a>)</p>
           <Graph veterans={graduation.rate} all={graduation.all} average={graduation.average}/>
         </div>
 
         <div className="medium-6 large-6 column">
           <h3>Average salaries</h3>
-          <p className="lml">(<a onClick={this.props.showModal.bind(this, 'salaries')}>Learn more</a>)</p>
+          <p className="lml">(<a onClick={this.props.onShowModal.bind(this, 'salaries')}>Learn more</a>)</p>
           <Graph decimals={0} max={100000} average={salary.average} all={salary.all}/>
         </div>
 
         <div className="medium-6 large-6 column">
           <h3>Repayment rate</h3>
-          <p className="lml">(<a onClick={this.props.showModal.bind(this, 'repayment')}>Learn more</a>)</p>
+          <p className="lml">(<a onClick={this.props.onShowModal.bind(this, 'repayment')}>Learn more</a>)</p>
           <Graph average={repayment.average} veterans={repayment.rate} all={repayment.all}/>
         </div>
 
@@ -81,7 +81,7 @@ Outcomes.propTypes = {
       average: React.PropTypes.number
     }),
   }),
-  showModal: React.PropTypes.func,
+  onShowModal: React.PropTypes.func,
 };
 
 export default Outcomes;

--- a/src/js/gi/containers/ProfilePage.jsx
+++ b/src/js/gi/containers/ProfilePage.jsx
@@ -76,7 +76,7 @@ export class ProfilePage extends React.Component {
                 <If condition={!!profile.attributes.facilityCode && !!constants} comment="TODO">
                   <Outcomes
                       graphing={outcomes}
-                      showModal={this.props.showModal}/>
+                      onShowModal={this.props.showModal}/>
                 </If>
               </AccordionItem>
               <a name="viewWarnings"></a>

--- a/src/js/gi/containers/ProfilePage.jsx
+++ b/src/js/gi/containers/ProfilePage.jsx
@@ -86,7 +86,9 @@ export class ProfilePage extends React.Component {
                 <CautionaryInformation/>
               </AccordionItem>
               <AccordionItem button="Additional information">
-                <AdditionalInformation/>
+                <AdditionalInformation
+                    institution={this.props.profile.attributes}
+                    onShowModal={this.props.showModal}/>
               </AccordionItem>
             </ul>
           </div>


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#1843.

Loading the pages took multiple clicks because of an error from calling `toUpperCase()` on a `null` `accreditationType` when `accredited` is `true`. First click triggers error, second click does a full page load of the linked URL.

Also did some light refactoring on the way.