### PR TITLE
Relabel the name fields for previous benefit sponsor

### DIFF
--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -301,7 +301,12 @@ const formConfig = {
                     }
                     return nonRequiredFullName;
                   }
-                }
+                },
+                // Re-label the inputs to add 'sponsor'
+                first: { 'ui:title': 'Sponsor first name' },
+                last: { 'ui:title': 'Sponsor last name' },
+                middle: { 'ui:title': 'Sponsor middle name' },
+                suffix: { 'ui:title': 'Sponsor suffix' },
               }),
               veteranSocialSecurityNumber: _.merge(ssn.uiSchema, {
                 'ui:title': 'Sponsor\'s Social Security number',

--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -309,7 +309,7 @@ const formConfig = {
                 suffix: { 'ui:title': 'Sponsor suffix' },
               }),
               veteranSocialSecurityNumber: _.merge(ssn.uiSchema, {
-                'ui:title': 'Sponsor\'s Social Security number',
+                'ui:title': 'Sponsor Social Security number',
                 'ui:required': (formData) => _.get('previousBenefits.view:claimedSponsorService', formData),
                 'ui:options': {
                   expandUnder: 'view:claimedSponsorService'


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1925

![image](https://cloud.githubusercontent.com/assets/12970166/24562453/b652bc8c-15ff-11e7-8cef-f3a7662b18ca.png)

Having the possessive on the SSN label is inconsistent. Should we change that?