### PR TITLE
Update file names from json schema

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8938,9 +8938,9 @@
       "resolved": "http://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "vets-json-schema": {
-      "version": "1.9.1",
-      "from": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git#22b76f0ff40ba90aba1d962f2709469ee9302e51",
-      "resolved": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git#22b76f0ff40ba90aba1d962f2709469ee9302e51"
+      "version": "2.0.0",
+      "from": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git#e0de10f658092f07b056e6e9f529354b3427900a",
+      "resolved": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git#e0de10f658092f07b056e6e9f529354b3427900a"
     },
     "vinyl": {
       "version": "1.2.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8938,9 +8938,9 @@
       "resolved": "http://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "vets-json-schema": {
-      "version": "2.0.0",
-      "from": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git#e0de10f658092f07b056e6e9f529354b3427900a",
-      "resolved": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git#e0de10f658092f07b056e6e9f529354b3427900a"
+      "version": "2.1.1",
+      "from": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git#7ef76dfb7e334a23db5b663a8c0dff15747748f6",
+      "resolved": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git#7ef76dfb7e334a23db5b663a8c0dff15747748f6"
     },
     "vinyl": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "tinyliquid": "^0.2.33",
     "url-loader": "^0.5.7",
     "uswds": "^1.0.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema#22b76f0ff40ba90aba1d962f2709469ee9302e51",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema#e0de10f658092f07b056e6e9f529354b3427900a",
     "webpack": "^1.13.1",
     "webpack-manifest-plugin": "^1.1.0",
     "webpack-md5-hash": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "tinyliquid": "^0.2.33",
     "url-loader": "^0.5.7",
     "uswds": "^1.0.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema#e0de10f658092f07b056e6e9f529354b3427900a",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema#7ef76dfb7e334a23db5b663a8c0dff15747748f6",
     "webpack": "^1.13.1",
     "webpack-manifest-plugin": "^1.1.0",
     "webpack-md5-hash": "0.0.5",

--- a/src/js/edu-benefits/1990e/config/form.js
+++ b/src/js/edu-benefits/1990e/config/form.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 
-import fullSchema1990e from 'vets-json-schema/dist/transfer-benefits-schema.json';
+import fullSchema1990e from 'vets-json-schema/dist/22-1990E-schema.json';
 
 import additionalBenefits from '../../pages/additionalBenefits';
 import applicantInformation from '../../pages/applicantInformation';

--- a/src/js/edu-benefits/1990n/config/form.js
+++ b/src/js/edu-benefits/1990n/config/form.js
@@ -1,6 +1,6 @@
 // import _ from 'lodash/fp';
 
-// import fullSchema1990n from 'vets-json-schema/dist/ncs-benefits-schema.json';
+// import fullSchema1990n from 'vets-json-schema/dist/22-1990N-schema.json';
 
 // import pages from '../../pages/';
 

--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -31,14 +31,14 @@ const {
   civilianBenefitsAssistance,
   educationObjective,
   nonVaAssistance,
-  reasonForChange,
-  bankAccountChange
+  reasonForChange
 } = fullSchema1995.properties;
 
 const {
   preferredContactMethod,
   school,
-  educationType
+  educationType,
+  bankAccountChange
 } = fullSchema1995.definitions;
 
 const formConfig = {

--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 
-import fullSchema1995 from 'vets-json-schema/dist/change-of-program-schema.json';
+import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
 
 import {
   bankAccountChangeLabels,

--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 
-import fullSchema5490 from 'vets-json-schema/dist/dependents-benefits-schema.json';
+import fullSchema5490 from 'vets-json-schema/dist/22-5490-schema.json';
 
 // benefitsLabels should be imported from utils/helpers, but for now, they don't
 //  all have links, so for consistency, use the set in ../helpers

--- a/src/js/edu-benefits/5495/config/form.js
+++ b/src/js/edu-benefits/5495/config/form.js
@@ -1,6 +1,6 @@
 // import _ from 'lodash/fp';
 
-// import fullSchema5495 from 'vets-json-schema/dist/dependents-change-of-program-schema.json';
+// import fullSchema5495 from 'vets-json-schema/dist/22-5495-schema.json';
 
 // import pages from '../../pages/';
 

--- a/test/edu-benefits/1990/schema/schema.unit.spec.js
+++ b/test/edu-benefits/1990/schema/schema.unit.spec.js
@@ -179,8 +179,7 @@ function createTestVeteran() {
 }
 
 describe('Edu benefits json schema', () => {
-  it.only('should have matching test veteran and blank veteran shape', () => {
-    console.log(schema); // eslint-disable-line
+  it('should have matching test veteran and blank veteran shape', () => {
     const testForm = qc.objectLike(createTestVeteran())(1);
     const blankForm = createVeteran();
 

--- a/test/edu-benefits/1990/schema/schema.unit.spec.js
+++ b/test/edu-benefits/1990/schema/schema.unit.spec.js
@@ -179,7 +179,8 @@ function createTestVeteran() {
 }
 
 describe('Edu benefits json schema', () => {
-  it('should have matching test veteran and blank veteran shape', () => {
+  it.only('should have matching test veteran and blank veteran shape', () => {
+    console.log(schema);
     const testForm = qc.objectLike(createTestVeteran())(1);
     const blankForm = createVeteran();
 

--- a/test/edu-benefits/1990/schema/schema.unit.spec.js
+++ b/test/edu-benefits/1990/schema/schema.unit.spec.js
@@ -180,7 +180,7 @@ function createTestVeteran() {
 
 describe('Edu benefits json schema', () => {
   it.only('should have matching test veteran and blank veteran shape', () => {
-    console.log(schema);
+    console.log(schema); // eslint-disable-line
     const testForm = qc.objectLike(createTestVeteran())(1);
     const blankForm = createVeteran();
 

--- a/test/edu-benefits/1990/schema/schema.unit.spec.js
+++ b/test/edu-benefits/1990/schema/schema.unit.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import Ajv from 'ajv';
-import { eduBenefits as schema } from 'vets-json-schema';
+import schema from 'vets-json-schema/dist/22-1990-schema.json';
 import qc from 'quick_check';
 import _ from 'lodash';
 

--- a/test/edu-benefits/1990e/schema/schema.unit.spec.js
+++ b/test/edu-benefits/1990e/schema/schema.unit.spec.js
@@ -5,7 +5,7 @@ import { Validator } from 'jsonschema';
 
 import { transform } from '../../../../src/js/edu-benefits/1990e/helpers';
 import formConfig from '../../../../src/js/edu-benefits/1990e/config/form';
-import fullSchema1990e from 'vets-json-schema/dist/transfer-benefits-schema.json';
+import fullSchema1990e from 'vets-json-schema/dist/22-1990E-schema.json';
 
 describe('1990e schema tests', () => {
   const v = new Validator();

--- a/test/edu-benefits/1995/schema/schema.unit.spec.js
+++ b/test/edu-benefits/1995/schema/schema.unit.spec.js
@@ -5,7 +5,7 @@ import { Validator } from 'jsonschema';
 
 import { transform } from '../../../../src/js/edu-benefits/1995/helpers';
 import formConfig from '../../../../src/js/edu-benefits/1995/config/form';
-import fullSchema1995 from 'vets-json-schema/dist/change-of-program-schema.json';
+import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
 
 describe('1995 schema tests', () => {
   const v = new Validator();

--- a/test/edu-benefits/5490/schema/schema.unit.spec.js
+++ b/test/edu-benefits/5490/schema/schema.unit.spec.js
@@ -5,7 +5,7 @@ import { Validator } from 'jsonschema';
 
 import { transform } from '../../../../src/js/edu-benefits/5490/helpers';
 import formConfig from '../../../../src/js/edu-benefits/5490/config/form';
-import fullSchema5490 from 'vets-json-schema/dist/dependents-benefits-schema.json';
+import fullSchema5490 from 'vets-json-schema/dist/22-5490-schema.json';
 
 describe('5490 schema tests', () => {
   const v = new Validator();

--- a/test/edu-benefits/pages/applicantInformation.unit.spec.jsx
+++ b/test/edu-benefits/pages/applicantInformation.unit.spec.jsx
@@ -9,8 +9,8 @@ import ReactTestUtils from 'react-addons-test-utils';
 import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
 import applicantInformation from '../../../src/js/edu-benefits/pages/applicantInformation.js';
 
-import fullSchema1990e from 'vets-json-schema/dist/transfer-benefits-schema.json';
-import fullSchema5490 from 'vets-json-schema/dist/dependents-benefits-schema.json';
+import fullSchema1990e from 'vets-json-schema/dist/22-1990E-schema.json';
+import fullSchema5490 from 'vets-json-schema/dist/22-5490-schema.json';
 
 function fillInformation(find) {
   ReactTestUtils.Simulate.change(find('#root_relativeFullName_first'), {

--- a/test/edu-benefits/pages/schoolSelection.unit.spec.jsx
+++ b/test/edu-benefits/pages/schoolSelection.unit.spec.jsx
@@ -7,8 +7,8 @@ import ReactTestUtils from 'react-addons-test-utils';
 import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
 import formConfig from '../../../src/js/edu-benefits/pages/schoolSelection.js';
 
-import fullSchema1990e from 'vets-json-schema/dist/transfer-benefits-schema.json';
-import fullSchema5490 from 'vets-json-schema/dist/dependents-benefits-schema.json';
+import fullSchema1990e from 'vets-json-schema/dist/22-1990E-schema.json';
+import fullSchema5490 from 'vets-json-schema/dist/22-5490-schema.json';
 
 describe('Edu 1990e schoolSelection', () => {
   const { schema, uiSchema } = formConfig(fullSchema1990e, {


### PR DESCRIPTION
After this PR was merged to update the file names in vets-json-schema (https://github.com/department-of-veterans-affairs/vets-json-schema/pull/78), wanted to make sure those file names were updated here as well.

Also includes a change to `bankAccountChange`: moving it to be imported from `properties` instead of `definitions` because the change in this PR (https://github.com/department-of-veterans-affairs/vets-json-schema/pull/75/files#diff-dd7516d6db2bea9ee53d8ead45def186L422) to move it to `definitions` causes it not to be found.