### PR TITLE
Make effective date only required when relationship is child

### DIFF
--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -186,7 +186,8 @@ const formConfig = {
             benefitsRelinquishedDate: _.merge(date.uiSchema('Effective date'), {
               'ui:options': {
                 hideIf: form => _.get('relationship', form) !== 'child'
-              }
+              },
+              'ui:required': form => _.get('relationship', form) === 'child'
             }),
             'view:benefitsRelinquishedWarning': {
               'ui:description': benefitsRelinquishedWarning,


### PR DESCRIPTION
When relationship was `spouse`, the benefit selection page wouldn't let you advance because the `benefitRelinquishedDate` was still required, even though it was not expanded. Fix is to change the required status of the `benefitRelinquishedDate` to only be true if the relationship is `child`.