### PR TITLE
Added GIBCT missing links.

### DIFF
--- a/src/js/gi/components/profile/AdditionalInformation.jsx
+++ b/src/js/gi/components/profile/AdditionalInformation.jsx
@@ -19,14 +19,14 @@ export class AdditionalInformation extends React.Component {
       );
 
     const vetTuitionPolicy =
-      it.vetTuitionPolicyUrl && (
+      it.vetWebsiteLink && (
         <p>
           <strong>
             <a onClick={this.props.onShowModal.bind(this, 'tuitionPolicy')}>
               Veterans tuition policy:
             </a>
           </strong>
-          &nbsp;<a href={`http://${it.vetTuitionPolicyUrl}`} target="_blank">
+          &nbsp;<a href={`http://${it.vetWebsiteLink}`} target="_blank">
             View policy
           </a>
         </p>

--- a/src/js/gi/components/profile/AdditionalInformation.jsx
+++ b/src/js/gi/components/profile/AdditionalInformation.jsx
@@ -9,16 +9,24 @@ export class AdditionalInformation extends React.Component {
       it.accredited &&
       it.accreditationType && (
         <p>
-          <strong>Type of accreditation:&nbsp;</strong>
-          {it.accreditationType.toUpperCase()}
+          <strong>
+            <a onClick={this.props.onShowModal.bind(this, 'typeAccredited')}>
+              Type of accreditation:
+            </a>
+          </strong>
+          &nbsp;{it.accreditationType.toUpperCase()}
         </p>
       );
 
     const vetTuitionPolicy =
       it.vetTuitionPolicyUrl && (
         <p>
-          <strong>Veterans tuition policy:&nbsp;</strong>
-          <a href={`http://${it.vetTuitionPolicyUrl}`} target="_blank">
+          <strong>
+            <a onClick={this.props.onShowModal.bind(this, 'tuitionPolicy')}>
+              Veterans tuition policy:
+            </a>
+          </strong>
+          &nbsp;<a href={`http://${it.vetTuitionPolicyUrl}`} target="_blank">
             View policy
           </a>
         </p>
@@ -50,8 +58,12 @@ export class AdditionalInformation extends React.Component {
           <div>
             <h3>Institution summary</h3>
             <p>
-              <strong>Accredited:&nbsp;</strong>
-              {it.accredited ?
+              <strong>
+                <a onClick={this.props.onShowModal.bind(this, 'accredited')}>
+                  Accredited:
+                </a>
+              </strong>
+              &nbsp;{it.accredited ?
                 <span>Yes (<a href={`http://nces.ed.gov/collegenavigator/?id=${it.cross}#accred`} target="_blank">
                   See accreditors
                 </a>)</span> : 'No'}
@@ -59,12 +71,20 @@ export class AdditionalInformation extends React.Component {
             {typeOfAccreditation}
             {vetTuitionPolicy}
             <p>
-              <strong>Single point of contact for veterans:&nbsp;</strong>
-              {!!it.vetPoc ? 'Yes' : 'No'}
+              <strong>
+                <a onClick={this.props.onShowModal.bind(this, 'singleContact')}>
+                  Single point of contact for veterans:
+                </a>
+              </strong>
+              &nbsp;{!!it.vetPoc ? 'Yes' : 'No'}
             </p>
             <p>
-              <strong>Credit for military training:&nbsp;</strong>
-              {!!it.creditForMilTraining ? 'Yes' : 'No'}
+              <strong>
+                <a onClick={this.props.onShowModal.bind(this, 'creditTraining')}>
+                  Credit for military training:
+                </a>
+              </strong>
+              &nbsp;{!!it.creditForMilTraining ? 'Yes' : 'No'}
             </p>
           </div>
           <div className="historical-information list">

--- a/src/js/gi/components/profile/AdditionalInformation.jsx
+++ b/src/js/gi/components/profile/AdditionalInformation.jsx
@@ -18,7 +18,9 @@ export class AdditionalInformation extends React.Component {
       it.vetTuitionPolicyUrl && (
         <p>
           <strong>Veterans tuition policy:&nbsp;</strong>
-          <a href={`http://${it.vetTuitionPolicyUrl}`} target="_blank">View policy</a>
+          <a href={`http://${it.vetTuitionPolicyUrl}`} target="_blank">
+            View policy
+          </a>
         </p>
       );
 
@@ -49,7 +51,10 @@ export class AdditionalInformation extends React.Component {
             <h3>Institution summary</h3>
             <p>
               <strong>Accredited:&nbsp;</strong>
-              {it.accredited ? 'Yes' : 'No'}
+              {it.accredited ?
+                <span>Yes (<a href={`http://nces.ed.gov/collegenavigator/?id=${it.cross}#accred`} target="_blank">
+                  See accreditors
+                </a>)</span> : 'No'}
             </p>
             {typeOfAccreditation}
             {vetTuitionPolicy}

--- a/src/js/gi/components/profile/AdditionalInformation.jsx
+++ b/src/js/gi/components/profile/AdditionalInformation.jsx
@@ -79,7 +79,7 @@ export class AdditionalInformation extends React.Component {
                 {formatNumber(it.p911Recipients)}
               </p>
               <p>
-                <strong>Total paid (2014):&nbsp;</strong>
+                <strong>Total paid (2016):&nbsp;</strong>
                 {formatCurrency(it.p911TuitionFees)}
               </p>
             </div>
@@ -93,7 +93,7 @@ export class AdditionalInformation extends React.Component {
                 {formatNumber(it.p911YrRecipients)}
               </p>
               <p>
-                <strong>Total paid (2014):&nbsp;</strong>
+                <strong>Total paid (2016):&nbsp;</strong>
                 {formatCurrency(it.p911YellowRibbon)}
               </p>
             </div>
@@ -131,7 +131,7 @@ export class AdditionalInformation extends React.Component {
                 <tr>
                   <th>Benefit</th>
                   <th>Recipients</th>
-                  <th>Total paid (2014)</th>
+                  <th>Total paid (2016)</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/js/gi/components/profile/AdditionalInformation.jsx
+++ b/src/js/gi/components/profile/AdditionalInformation.jsx
@@ -99,7 +99,7 @@ export class AdditionalInformation extends React.Component {
                 {formatNumber(it.p911Recipients)}
               </p>
               <p>
-                <strong>Total paid (2016):&nbsp;</strong>
+                <strong>Total paid (FY 2016):&nbsp;</strong>
                 {formatCurrency(it.p911TuitionFees)}
               </p>
             </div>
@@ -113,7 +113,7 @@ export class AdditionalInformation extends React.Component {
                 {formatNumber(it.p911YrRecipients)}
               </p>
               <p>
-                <strong>Total paid (2016):&nbsp;</strong>
+                <strong>Total paid (FY 2016):&nbsp;</strong>
                 {formatCurrency(it.p911YellowRibbon)}
               </p>
             </div>
@@ -151,7 +151,7 @@ export class AdditionalInformation extends React.Component {
                 <tr>
                   <th>Benefit</th>
                   <th>Recipients</th>
-                  <th>Total paid (2016)</th>
+                  <th>Total paid (FY 2016)</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -72,7 +72,10 @@ export class CautionaryInformation extends React.Component {
         <AlertBox content={flagContent} isVisible={!!it.cautionFlag} status="warning"/>
 
         <div className="student-complaints">
-          <h4>{it.complaints.mainCampusRollUp} student complaints</h4>
+          <h4>
+            {it.complaints.mainCampusRollUp}&nbsp;
+            <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints" target="_blank">student complaints</a>
+          </h4>
           <span>(<a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#sourcedata" target="_blank">Source</a>)</span>
         </div>
 
@@ -82,7 +85,11 @@ export class CautionaryInformation extends React.Component {
               <tr>
                 <th>Complaint type</th>
                 <th>This campus</th>
-                <th>All campuses</th>
+                <th>
+                  <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses" target="_blank">
+                    All campuses
+                  </a>
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -105,7 +112,11 @@ export class CautionaryInformation extends React.Component {
               <p className="number"><strong>{it.complaints.facilityCode}</strong></p>
             </div>
           </div>
-          <h4>All campuses</h4>
+          <h4>
+            <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses" target="_blank">
+              All campuses
+            </a>
+          </h4>
           {complaints.map((c) =>
             <ListRow key={c.description} description={c.description} value={c.allCampuses}/>)}
           <div className="row">


### PR DESCRIPTION
Resolves #5212, #5213, #5223.

Awaiting confirmation on questions about vets tuition policy URL being provided from the API and about the historical info header copy.

#### Missing links for cautionary info
> <img width="341" alt="screen shot 2017-03-31 at 9 28 51 pm" src="https://cloud.githubusercontent.com/assets/1067024/24573935/0fc4f8d0-1659-11e7-93dc-e460987f9b3a.png">

#### Missing links for additional information
> <img width="341" alt="screen shot 2017-03-31 at 9 27 55 pm" src="https://cloud.githubusercontent.com/assets/1067024/24573933/0df83a44-1659-11e7-8edf-1a39d6f6aa67.png">