### PR TITLE
Display state instead of country for locations of US institutions in GIBCT search results and profiles.

### DIFF
--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -37,7 +37,7 @@ class HeadingSummary extends React.Component {
           <div className="small-12 medium-4 column">
             <p>
               <IconWithInfo icon="map-marker" present={it.city && it.country}>
-                {it.city}, {it.country === 'usa' ? it.state : it.country}
+                {it.city}, {it.state || it.country}
               </IconWithInfo>
             </p>
             <p style={{ display: 'block' }}>

--- a/src/js/gi/components/search/SearchResult.jsx
+++ b/src/js/gi/components/search/SearchResult.jsx
@@ -46,7 +46,7 @@ export class SearchResult extends React.Component {
               <h2><Link to={`profile/${this.props.facilityCode}`}>{this.props.name}</Link></h2>
               <div style={{ position: 'relative', bottom: 0 }}>
                 <p className="locality">
-                  {this.props.city}, {this.props.country === 'usa' ? this.props.state : this.props.country}
+                  {this.props.city}, {this.props.state || this.props.country}
                 </p>
                 <p className="count">{this.props.studentCount.toLocaleString()} GI Bill Students</p>
               </div>


### PR DESCRIPTION
Resolves #5207 and department-of-veterans-affairs/vets.gov-team#1939.

Shows "[city], [state]" instead of "[city], [country]" for institutions in the US.