### PR TITLE
Fixed issues with GIBCT outcomes section in profiles.

### DIFF
--- a/src/js/gi/components/profile/AdditionalInformation.jsx
+++ b/src/js/gi/components/profile/AdditionalInformation.jsx
@@ -55,7 +55,7 @@ export class AdditionalInformation extends React.Component {
     return (
       <div className="additional-information row">
         <div className="medium-6 columns">
-          <div>
+          <div className="institution-summary">
             <h3>Institution summary</h3>
             <p>
               <strong>
@@ -118,7 +118,7 @@ export class AdditionalInformation extends React.Component {
               </p>
             </div>
           </div>
-          <div>
+          <div className="institution-codes">
             <h3>Institution codes</h3>
             <p>
               <strong>

--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -72,11 +72,15 @@ export class CautionaryInformation extends React.Component {
         <AlertBox content={flagContent} isVisible={!!it.cautionFlag} status="warning"/>
 
         <div className="student-complaints">
-          <h4>
-            {it.complaints.mainCampusRollUp}&nbsp;
-            <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints" target="_blank">student complaints</a>
-          </h4>
-          <span>(<a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#sourcedata" target="_blank">Source</a>)</span>
+          <div className="link-header">
+            <h3>
+              {it.complaints.mainCampusRollUp}&nbsp;
+              <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints" target="_blank">student complaints</a>
+            </h3>
+            <span>
+              &nbsp;(<a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#sourcedata" target="_blank">Source</a>)
+            </span>
+          </div>
         </div>
 
         <div className="table">

--- a/src/js/gi/components/profile/Outcomes.jsx
+++ b/src/js/gi/components/profile/Outcomes.jsx
@@ -24,26 +24,34 @@ class Outcomes extends React.Component {
     return (
       <div className="outcomes row">
         <div className="medium-6 large-6 column">
-          <h3>Retention rate</h3>
-          <p className="lml">(<a onClick={this.props.onShowModal.bind(this, 'retention')}>Learn more</a>)</p>
+          <div className="link-header">
+            <h3>Retention rate</h3>
+            &nbsp;(<a onClick={this.props.onShowModal.bind(this, 'retention')}>Learn more</a>)
+          </div>
           <Graph veterans={retention.rate} all={retention.all} average={retention.average} decimals={1}/>
         </div>
 
         <div className="medium-6 large-6 column">
-          <h3>Graduation rate</h3>
-          <p className="lml">(<a onClick={this.props.onShowModal.bind(this, 'gradrates')}>Learn more</a>)</p>
+          <div className="link-header">
+            <h3>Graduation rate</h3>
+            &nbsp;(<a onClick={this.props.onShowModal.bind(this, 'gradrates')}>Learn more</a>)
+          </div>
           <Graph veterans={graduation.rate} all={graduation.all} average={graduation.average} decimals={1}/>
         </div>
 
         <div className="medium-6 large-6 column">
-          <h3>Average salaries</h3>
-          <p className="lml">(<a onClick={this.props.onShowModal.bind(this, 'salaries')}>Learn more</a>)</p>
+          <div className="link-header">
+            <h3>Average salaries</h3>
+            &nbsp;(<a onClick={this.props.onShowModal.bind(this, 'salaries')}>Learn more</a>)
+          </div>
           <Graph decimals={0} max={100000} average={salary.average} all={salary.all}/>
         </div>
 
         <div className="medium-6 large-6 column">
-          <h3>Repayment rate</h3>
-          <p className="lml">(<a onClick={this.props.onShowModal.bind(this, 'repayment')}>Learn more</a>)</p>
+          <div className="link-header">
+            <h3>Repayment rate</h3>
+            &nbsp;(<a onClick={this.props.onShowModal.bind(this, 'repayment')}>Learn more</a>)
+          </div>
           <Graph average={repayment.average} veterans={repayment.rate} all={repayment.all} decimals={1}/>
         </div>
 

--- a/src/js/gi/selectors/outcomes.js
+++ b/src/js/gi/selectors/outcomes.js
@@ -24,6 +24,8 @@ const whenDataAvailable = (n1, n2, obj) => {
   };
 };
 
+const percentOrNull = (value) => (isFinite(value) ? value * 100 : null);
+
 export const outcomeNumbers = createSelector(
   [getConstants, getRequiredAttributes],
   (constant, institution) => {
@@ -41,8 +43,8 @@ export const outcomeNumbers = createSelector(
       veteranRetentionRate,
       allStudentRetentionRate,
       {
-        rate: isFinite(veteranRetentionRate) ? Number(veteranRetentionRate * 100) : null,
-        all: isFinite(allStudentRetentionRate) ? Number(allStudentRetentionRate * 100) : null,
+        rate: percentOrNull(veteranRetentionRate),
+        all: percentOrNull(allStudentRetentionRate),
         average: constant.AVERETENTIONRATE,
       }
     );
@@ -51,8 +53,8 @@ export const outcomeNumbers = createSelector(
       institution.graduationRateVeteran,
       institution.graduationRateAllStudents,
       {
-        rate: Number(institution.graduationRateVeteran * 100),
-        all: Number(institution.graduationRateAllStudents * 100),
+        rate: percentOrNull(institution.graduationRateVeteran),
+        all: percentOrNull(institution.graduationRateAllStudents),
         average: constant.AVEGRADRATE,
       }
     );
@@ -71,7 +73,7 @@ export const outcomeNumbers = createSelector(
       institution.repaymentRateAllStudents,
       {
         rate: null,
-        all: Number(institution.repaymentRateAllStudents * 100),
+        all: percentOrNull(institution.repaymentRateAllStudents),
         average: constant.AVEREPAYMENTRATE,
       }
     );

--- a/src/sass/gi/gi.scss
+++ b/src/sass/gi/gi.scss
@@ -11,7 +11,6 @@
 @import "partials/gi-landing-page";
 @import "partials/gi-search-page";
 @import "partials/gi-profile-page";
-@import "partials/gi-graphs";
 
 .gi-app {
 

--- a/src/sass/gi/partials/_gi-graphs.scss
+++ b/src/sass/gi/partials/_gi-graphs.scss
@@ -1,4 +1,0 @@
-
-div.graph-component {
-  margin: 1em;
-}

--- a/src/sass/gi/partials/_gi-profile-page.scss
+++ b/src/sass/gi/partials/_gi-profile-page.scss
@@ -1,5 +1,18 @@
 .gi-app .profile-page {
 
+  h3 {
+    font-size: 1.35em;
+  }
+
+  .link-header {
+    h3 {
+      display: inline-block;
+      padding: 0;
+    }
+
+    padding-bottom: .5em;
+  }
+
   li button.usa-accordion-button {
     text-align: left;
 
@@ -10,13 +23,8 @@
   }
 
   .calculate-your-benefits {
-    h3 {
-      font-size: 1.35em;
-    }
-
     div.eligibility-details h2 {
       display: none;
-      visibility: hidden;
     }
 
     button {
@@ -46,12 +54,10 @@
   }
 
   .programs.row {
-    h3 {
-      font-size: 1.35em;
-    }
     .fa-check {
       color: $color-green;
     }
+
     .fa-remove {
       color: $color-gray-medium;
     }
@@ -78,24 +84,6 @@
 
   .usa-alert {
     background-size: 3rem;
-  }
-
-  .outcomes.row {
-    h3 {
-      font-size: 1.35em;
-    }
-  }
-
-  .outcomes .lml {
-    display: block;
-    float: left;
-    margin-left: 0.5em;
-    margin-top: 0.2em;
-  }
-
-  .outcomes .column > h3 {
-    display: block;
-    float: left;
   }
 
   .outcomes .graph-component {
@@ -128,57 +116,34 @@
     @media screen and (min-width: $medium-screen) {
       .list {
         display: none;
-        visibility: hidden;
       }
     }
 
     @include media-maxwidth($medium-screen) {
       .table {
         display: none;
-        visibility: hidden;
-      }
-    }
-  }
-
-  .student-complaints {
-    margin: 1rem 0;
-
-    @media screen and (min-width: $medium-screen) {
-      h4, span {
-        float: left;
-        line-height: 4rem;
-      }
-
-      span {
-        margin-left: 0.5em;
-        margin-top: 0.2em;
       }
     }
   }
 
   .additional-information {
-    h3 {
-      font-size: 1.35em;
-      padding-top: 1.5em !important;
-    }
-
     .historical-information.list {
-      div {
-        margin-bottom: 0.5em;
+      margin: 2rem 0;
+
+      @media screen and (min-width: $medium-screen) {
+        display: none;
       }
     }
 
-    @media screen and (min-width: $medium-screen) {
-      .historical-information.list {
-        display: none;
-        visibility: hidden;
+    .institution-codes {
+      @media screen and (min-width: $medium-screen) {
+        margin-top: 2rem;
       }
     }
 
     @include media-maxwidth($medium-screen) {
       .historical-information.table {
         display: none;
-        visibility: hidden;
       }
     }
   }

--- a/src/sass/gi/partials/_gi-profile-page.scss
+++ b/src/sass/gi/partials/_gi-profile-page.scss
@@ -87,6 +87,7 @@
   }
 
   .outcomes .graph-component {
+    margin: 1em auto;
     clear: both;
   }
 


### PR DESCRIPTION
Resolves #5210, #5222.

#### Changes
* Null values should display 'No data' in graphs.
* Increases size of graphs by decreasing side margins so they're more readable at lower screen widths.
* Refactored styling of headers with links next to them in profile page. Removes the vertical spacing when the headers are broken into two lines.

> <img width="317" alt="screen shot 2017-04-03 at 8 31 22 pm" src="https://cloud.githubusercontent.com/assets/1067024/24637192/489ce644-18ad-11e7-93c4-41fe9bd698b5.png">
