### PR TITLE
Added in-state tuition fees input to GIBCT calculator, modified buy up amount label, and corrected calculations accordingly.

### DIFF
--- a/src/js/gi/components/profile/CalculatorForm.jsx
+++ b/src/js/gi/components/profile/CalculatorForm.jsx
@@ -46,6 +46,24 @@ class CalculatorForm extends React.Component {
 
   renderTuition() {
     if (!this.props.displayedInputs.tuition) return null;
+
+    const inStateTuitionInput =
+      this.props.inputs.inState === 'no' && (
+        <div>
+          <label htmlFor="inStateTuitionFees">
+            {this.renderLearnMoreLabel({
+              text: 'In-state tuition and fees per year',
+              modal: 'calcInStateTuition'
+            })}
+          </label>
+          <input
+              type="text"
+              name="inStateTuitionFees"
+              value={formatCurrency(this.props.inputs.inStateTuitionFees)}
+              onChange={this.props.onInputChange}/>
+        </div>
+      );
+
     return (
       <div>
         <label htmlFor="tuitionFees">
@@ -59,6 +77,7 @@ class CalculatorForm extends React.Component {
             name="tuitionFees"
             value={formatCurrency(this.props.inputs.tuitionFees)}
             onChange={this.props.onInputChange}/>
+        {inStateTuitionInput}
       </div>
     );
   }

--- a/src/js/gi/components/profile/CalculatorForm.jsx
+++ b/src/js/gi/components/profile/CalculatorForm.jsx
@@ -314,7 +314,7 @@ class CalculatorForm extends React.Component {
     if (this.props.inputs.buyUp === 'yes') {
       amountInput = (
         <div>
-          <label htmlFor="buyUpAmount">How much did you pay toward buy-up?</label>
+          <label htmlFor="buyUpAmount">How much did you pay toward buy-up (up to $600)?</label>
           <input
               type="text"
               name="buyUpAmount"

--- a/src/js/gi/containers/Modals.jsx
+++ b/src/js/gi/containers/Modals.jsx
@@ -278,9 +278,16 @@ export class Modals extends React.Component {
       <span>
         <Modal onClose={this.props.hideModal} visible={this.shouldDisplayModal('calcTuition')}>
           <h2>Tuition and fees per year</h2>
-          <p>Enter the total tuition/fees, you will be charged for the academic year.</p>
+          <p>Enter the total tuition/fees you will be charged for the academic year.</p>
           <p>When you select some schools, we import the average tuition/fees for an undergraduate student as reported by the school to the Department of Education through <a href="http://nces.ed.gov/ipeds/datacenter/" id="anch_442" target="blank">IPEDS</a>. This is the same information that is published on <a href="http://nces.ed.gov/collegenavigator/" id="anch_443" target="blank">College Navigator</a>.</p>
           <p>To learn more, please review our "<a href={'http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#yellow_ribbon_from_school'} target="_blank">About This Tool</a>" page.</p>
+        </Modal>
+
+        <Modal onClose={this.props.hideModal} visible={this.shouldDisplayModal('calcInStateTuition')}>
+          <h2>In-state tuition and fees per year</h2>
+          <p>Enter the amount of tuition/fees your school charges in-state students.</p>
+          <p>When you select some schools, we import the average in-state tuition/fees for an undergraduate student as reported by the school to the Department of Education through IPEDS. This is the same information that is published on College Navigator.</p>
+          <p>Generally, in-state residents are charged a discounted rate of tuition and fees.VA pays the in-state tuition & fee rate at public schools. <a href="http://www.benefits.va.gov/gibill/resources/benefits_resources/rate_tables.asp#ch33#TUITION" target="_blank">Click here for more information.</a></p>
         </Modal>
 
         <Modal onClose={this.props.hideModal} visible={this.shouldDisplayModal('calcYr')}>
@@ -328,7 +335,8 @@ export class Modals extends React.Component {
           </p>
           <p>
             For more information about MHA increases or decreases,
-            visit <a href="For more information about MHA increases or decreases click here"
+            visit <a title="For more information about MHA increases or decreases click here"
+                href="https://gibill.custhelp.com/app/answers/detail/a_id/1412"
                 target="_blank">this page</a>.
           </p>
         </Modal>

--- a/src/js/gi/containers/Modals.jsx
+++ b/src/js/gi/containers/Modals.jsx
@@ -287,7 +287,7 @@ export class Modals extends React.Component {
           <h2>In-state tuition and fees per year</h2>
           <p>Enter the amount of tuition/fees your school charges in-state students.</p>
           <p>When you select some schools, we import the average in-state tuition/fees for an undergraduate student as reported by the school to the Department of Education through IPEDS. This is the same information that is published on College Navigator.</p>
-          <p>Generally, in-state residents are charged a discounted rate of tuition and fees.VA pays the in-state tuition & fee rate at public schools. <a href="http://www.benefits.va.gov/gibill/resources/benefits_resources/rate_tables.asp#ch33#TUITION" target="_blank">Click here for more information.</a></p>
+          <p>Generally, in-state residents are charged a discounted rate of tuition and fees. VA pays the in-state tuition & fee rate at public schools. <a href="http://www.benefits.va.gov/gibill/resources/benefits_resources/rate_tables.asp#ch33#TUITION" target="_blank">Click here for more information.</a></p>
         </Modal>
 
         <Modal onClose={this.props.hideModal} visible={this.shouldDisplayModal('calcYr')}>

--- a/src/js/gi/reducers/calculator.js
+++ b/src/js/gi/reducers/calculator.js
@@ -11,6 +11,7 @@ const INITIAL_STATE = {
   tuitionInState: 0,
   tuitionOutOfState: 0,
   tuitionFees: 0,
+  inStateTuitionFees: 0,
   books: 0,
   yellowRibbonRecipient: 'no',
   yellowRibbonAmount: 0,
@@ -36,6 +37,7 @@ export default function (state = INITIAL_STATE, action) {
 
       const isDollarAmount = [
         'tuitionFees',
+        'inStateTuitionFees',
         'books',
         'yellowRibbonAmount',
         'scholarships',
@@ -58,6 +60,8 @@ export default function (state = INITIAL_STATE, action) {
           value === 'yes' ?
           state.tuitionInState :
           state.tuitionOutOfState;
+
+        newState.inStateTuitionFees = state.tuitionInState;
       }
 
       return {
@@ -81,6 +85,7 @@ export default function (state = INITIAL_STATE, action) {
         tuitionInState: tuitionInState || 0,
         tuitionOutOfState: tuitionOutOfState || 0,
         tuitionFees: tuitionInState || 0,
+        inStateTuitionFees: tuitionInState || 0,
         books: books || 0,
         calendar: calendar || 'semesters'
       };

--- a/src/js/gi/selectors/calculator.js
+++ b/src/js/gi/selectors/calculator.js
@@ -270,7 +270,7 @@ const getDerivedValues = createSelector(
     if (inputs.buyUp === 'no' || giBillChapter !== 30) {
       buyUpRate = 0;
     } else {
-      buyUpRate = +inputs.buyUpAmount / 4;
+      buyUpRate = Math.min(+inputs.buyUpAmount, 600) / 4;
     }
 
     // Calculate Housing Allowance Rate Final - getMonthlyRateFinal

--- a/src/js/gi/selectors/calculator.js
+++ b/src/js/gi/selectors/calculator.js
@@ -182,8 +182,8 @@ const getDerivedValues = createSelector(
       tuitionFeesCap = constant.CORRESPONDTFCAP;
     } else if (isPublic && institutionCountry === 'usa') {
       tuitionFeesCap = inputs.inState === 'yes'
-                     ? institution.tuitionInState
-                     : institution.tuitionOutOfState;
+                     ? +inputs.tuitionFees
+                     : +inputs.inStateTuitionFees;
     } else {
       // Default cap for private, foreign, and for-profit institutions.
       tuitionFeesCap = constant.TFCAP;


### PR DESCRIPTION
Resolves #5208, #5209.

If the user selects "no" for "in-state student", an input for in-state tuition fees will appear pre-populated with the value we have for the given school. It will default to this when it appears, even if it has been modified previously and then hidden.

> <img width="388" alt="screen shot 2017-04-04 at 2 28 54 pm" src="https://cloud.githubusercontent.com/assets/1067024/24673223/83a15ef8-1945-11e7-9459-2534a2dbb509.png">

Modal for the learn more link on the in-state tuition fees input is taken from [here](http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#tuition_fees_instate_input). The modal in production seems incorrect, as it talks about retention rates instead, so hoping this is the right one.

> <img width="598" alt="screen shot 2017-04-04 at 2 29 20 pm" src="https://cloud.githubusercontent.com/assets/1067024/24673247/92a832fa-1945-11e7-9c9c-75295f5529bd.png">

If the user enters buy-up amount that exceeds 600, calculations will appear as if it were capped at 600. So a higher amount won't be reflected in the calculations.

> <img width="377" alt="screen shot 2017-04-04 at 2 51 04 pm" src="https://cloud.githubusercontent.com/assets/1067024/24673358/07638dc4-1946-11e7-9ac5-17a2594cd2a7.png">
