### PR TITLE
Use sessionStorage for first_name to prevent flicker

### DIFF
--- a/content/pages/logout.md
+++ b/content/pages/logout.md
@@ -17,8 +17,7 @@ title: Logout
 
 <script>
 if (location.search.substring(1) === 'success=true') {
-  window.opener.sessionStorage.removeItem('userToken');
-  window.opener.sessionStorage.removeItem('entryTime');
+  window.opener.sessionStorage.clear();
   window.opener.location.reload();
   window.close();
 }

--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -39,6 +39,7 @@ export function getUserData() {
   }).then(json => {
     if (json.data) {
       const userData = json.data.attributes.profile;
+      sessionStorage.setItem('userFirstName', userData.first_name);
       commonStore.dispatch(updateProfileField('accountType', userData.loa.current));
       commonStore.dispatch(updateProfileField('email', userData.email));
       commonStore.dispatch(updateProfileField('userFullName.first', userData.first_name));

--- a/src/js/login/components/SearchHelpSignIn.jsx
+++ b/src/js/login/components/SearchHelpSignIn.jsx
@@ -11,14 +11,13 @@ import { updateLoggedInStatus, toggleSearchHelpUserMenu } from '../actions';
 class SearchHelpSignIn extends React.Component {
   render() {
     let content;
-    let greeting;
     const login = this.props.login;
 
     if (login.currentlyLoggedIn) {
       const firstName = _.startCase(_.toLower(
         this.props.profile.userFullName.first || sessionStorage.userFirstName
       ));
-      greeting = firstName || this.props.profile.email;
+      const greeting = firstName || this.props.profile.email;
 
       content = (<SignInProfileMenu
           clickHandler={() => {

--- a/src/js/login/components/SearchHelpSignIn.jsx
+++ b/src/js/login/components/SearchHelpSignIn.jsx
@@ -15,12 +15,10 @@ class SearchHelpSignIn extends React.Component {
     const login = this.props.login;
 
     if (login.currentlyLoggedIn) {
-      if (this.props.profile.userFullName.first) {
-        const firstName = _.startCase(_.toLower(this.props.profile.userFullName.first));
-        greeting = firstName;
-      } else {
-        greeting = this.props.profile.email;
-      }
+      const firstName = _.startCase(_.toLower(
+        this.props.profile.userFullName.first || sessionStorage.userFirstName
+      ));
+      greeting = firstName || this.props.profile.email;
 
       content = (<SignInProfileMenu
           clickHandler={() => {

--- a/test/login/login.e2e.spec.js
+++ b/test/login/login.e2e.spec.js
@@ -21,7 +21,7 @@ module.exports = E2eHelpers.createE2eTest(
     // log out button reads "Sign Out"
     client.expect.element('#accountMenu > ul > li:nth-child(2) > a').text.to.equal('Sign Out');
 
-    // click Sign Out & verify new window is opened & has correct logout url
+    // click Sign Out & verify new window is opened & has correct logout URL
     client
       .click('#accountMenu > ul > li:nth-child(2) > a')
       .windowHandles(function windowHandlesCallback(result) {

--- a/test/login/login.e2e.spec.js
+++ b/test/login/login.e2e.spec.js
@@ -7,7 +7,7 @@ module.exports = E2eHelpers.createE2eTest(
     const token = LoginHelpers.getUserToken();
     const logoutUrl = LoginHelpers.getLogoutUrl();
 
-    // log in and wait for little person icon to appear next to the username
+    // log in & wait for little person icon to appear next to the username
     LoginHelpers.logIn(token, client, '/', 3)
       .assert.title('Vets.gov')
       .waitForElementVisible('#login-root button[aria-controls="accountMenu"]', Timeouts.slow);

--- a/test/login/login.e2e.spec.js
+++ b/test/login/login.e2e.spec.js
@@ -18,7 +18,7 @@ module.exports = E2eHelpers.createE2eTest(
     // logout button is there
     client.expect.element('#accountMenu > ul > li:nth-child(2) > a').to.be.visible;
 
-    // logout button reads "Sign Out"
+    // log out button reads "Sign Out"
     client.expect.element('#accountMenu > ul > li:nth-child(2) > a').text.to.equal('Sign Out');
 
     // click Sign Out & verify new window is opened & has correct logout url


### PR DESCRIPTION
**Issue**
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/622
![image](https://cloud.githubusercontent.com/assets/3077884/24691586/5c604b8a-19a2-11e7-8bea-a9f6ef7b6428.png)

**Root Cause**
The response to `GET /v0/user` updates this field with `response.user.first_name`.  

**Solution**

1. Use `sessionStorage` to store the `first_name`
1. When rendering, use the following preference order: `jsonResponse.user.first_name` -> `sessionStorage.userFirstName` -> `jsonResponse.user.email`