### PR TITLE
Remove cooperative training from 5490 education type dropdown

### DIFF
--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -613,7 +613,8 @@ const formConfig = {
               },
               educationType: {
                 'ui:options': {
-                  updateSchema: ((edTypes) => {
+                  updateSchema: (() => {
+                    const edTypes = educationType.enum;
                     // Using reselect here avoids running the filter code
                     // and creating a new object unless either benefit or
                     // relationship has changed
@@ -636,7 +637,7 @@ const formConfig = {
                       });
 
                     return (pageData, form) => filterEducationType(form);
-                  })(educationType.enum)
+                  })()
                 }
               }
             }

--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -1,4 +1,5 @@
 import _ from 'lodash/fp';
+import { createSelector } from 'reselect';
 
 import fullSchema5490 from 'vets-json-schema/dist/22-5490-schema.json';
 
@@ -69,7 +70,6 @@ const ssnSchema = fullSchema5490.definitions.ssn;
 const nonRequiredFullName = _.assign(fullName, {
   required: []
 });
-
 
 const formConfig = {
   urlPrefix: '/5490/',
@@ -613,26 +613,30 @@ const formConfig = {
               },
               educationType: {
                 'ui:options': {
-                  updateSchema: (pageData, form, schema) => {
-                    const newSchema = _.cloneDeep(schema);
-                    const benefitData = _.get('benefitSelection.data.benefit', form);
-                    const relationshipData = _.get('applicantInformation.data.relationship', form);
-                    const edTypeLabels = Object.keys(_.get('schoolSelection.uiSchema.educationProgram.educationType.ui:options.labels', form));
+                  updateSchema: ((edTypes) => {
+                    // Using reselect here avoids running the filter code
+                    // and creating a new object unless either benefit or
+                    // relationship has changed
+                    const filterEducationType = createSelector(
+                      _.get('benefitSelection.data.benefit'),
+                      _.get('applicantInformation.data.relationship'),
+                      (benefitData, relationshipData) => {
+                        // Remove tuition top-up
+                        const filterOut = ['tuitionTopUp'];
+                        // Correspondence not available to Chapter 35 (DEA) children
+                        if (benefitData === 'chapter35' && relationshipData === 'child') {
+                          filterOut.push('correspondence');
+                        }
+                        // Flight training available to Chapter 33 (Fry Scholarships) only
+                        if (benefitData && benefitData !== 'chapter33') {
+                          filterOut.push('flightTraining');
+                        }
 
-                    // Remove tuition top-up
-                    const filterOut = ['tuitionTopUp'];
-                    // Correspondence not available to Chapter 35 (DEA) children
-                    if (benefitData === 'chapter35' && relationshipData === 'child') {
-                      filterOut.push('correspondence');
-                    }
-                    // Flight training available to Chapter 33 (Fry Scholarships) only
-                    if (benefitData && benefitData !== 'chapter33') {
-                      filterOut.push('flightTraining');
-                    }
+                        return { 'enum': _.without(filterOut, edTypes) };
+                      });
 
-                    newSchema.enum = _.without(filterOut)(edTypeLabels);
-                    return newSchema;
-                  }
+                    return (pageData, form) => filterEducationType(form);
+                  })(educationType.enum)
                 }
               }
             }


### PR DESCRIPTION
Connects to [1946](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1946)

This removes cooperativeTraining from the educationType dropdown. The actual change for that is to use the enum property from the educationType definition for 5490, instead of the labels object. I also changed the code to use a reselect selector, since that will avoid running the filter for every change and avoid unnecessary re-renders on the school selection page.

![screen shot 2017-04-07 at 4 07 17 pm](https://cloud.githubusercontent.com/assets/634932/24817884/4cc22ee4-1bac-11e7-9f3c-0b5c847d3de5.png)
