### PR TITLE
5490 Launch Changes

### DIFF
--- a/content/pages/education/apply.md
+++ b/content/pages/education/apply.md
@@ -77,9 +77,9 @@ If you need to make a change (for example, you’re moving to a new school), man
 ##### Forms 22-1990N and 22-5495
 
 You must apply for education benefits using eBenefits if you're:
-- A dependent whose sponsor is permanently and totally disabled
-- A dependent whose sponsor is deceased, MIA, or a POW
-- A candidate for the National Call to Service program
+- A dependent, **moving their benefit**, whose sponsor is permanently and totally disabled
+- A dependent, **moving their benefit**, whose sponsor is deceased, MIA, or a POW
+- A candidate for the National Call to Service program applying for a new benefit
 
 <div markdown="0">
 	<a class="usa-button-primary usa-button-outline usa-button-outline-exit transparent" href="https://www.ebenefits.va.gov/ebenefits/vonapp">Apply on eBenefits</a>

--- a/content/pages/education/apply.md
+++ b/content/pages/education/apply.md
@@ -42,7 +42,7 @@ If you’re a Servicemember, Veteran, or family member interested in education a
 ### Ready to apply?
 
 #### Applying for a new benefit
-Apply online with Form 22-1990 or 22-1990E:
+Apply online with Form 22-1990, 22-1990E, or 22-5490:
 
 <button id="apply-expander-button" class="usa-button-primary va-button-primary expander-button">Apply for Benefits</button>
 
@@ -55,12 +55,10 @@ Apply online with Form 22-1990 or 22-1990E:
         <label for="form-22-1990">Veterans applying for a <strong>new benefit</strong> (22-1990)</label>
         <input type="radio" name="form-selection" id="form-22-1990e" value="1990e">
         <label for="form-22-1990e">Dependents applying for a <strong>transferred benefit</strong> (22-1990E)</label>
-        <!--
         <input type="radio" name="form-selection" id="form-22-5490" value="5490">
         <label for="form-22-5490">Dependent applying for a new benefit where your <strong>sponsor is permanently and totally disabled</strong> (22-5490)</label>
         <input type="radio" name="form-selection" id="form-22-5490" value="5490">
         <label for="form-22-5490">Dependent applying for a new benefit where your <strong>sponsor is deceased, MIA, or a POW</strong> (22-5490)</label>
-        -->
       </div>
       <a id="apply-go-button" class="usa-button-primary va-button-primary">Apply Now</a>
     </div>
@@ -76,7 +74,7 @@ If you need to make a change (for example, you’re moving to a new school), man
 <div class="usa-alert usa-alert-warning usa-content va-alert" markdown="1">
 	<div class="usa-alert-body">
 
-##### Forms 22-1990N, 22-5490, and 22-5495
+##### Forms 22-1990N and 22-5495
 
 You must apply for education benefits using eBenefits if you're:
 - A dependent whose sponsor is permanently and totally disabled

--- a/content/pages/education/apply.md
+++ b/content/pages/education/apply.md
@@ -55,10 +55,10 @@ Apply online with Form 22-1990, 22-1990E, or 22-5490:
         <label for="form-22-1990">Veterans applying for a <strong>new benefit</strong> (22-1990)</label>
         <input type="radio" name="form-selection" id="form-22-1990e" value="1990e">
         <label for="form-22-1990e">Dependents applying for a <strong>transferred benefit</strong> (22-1990E)</label>
-        <input type="radio" name="form-selection" id="form-22-5490" value="5490">
-        <label for="form-22-5490">Dependent applying for a new benefit where your <strong>sponsor is permanently and totally disabled</strong> (22-5490)</label>
-        <input type="radio" name="form-selection" id="form-22-5490" value="5490">
-        <label for="form-22-5490">Dependent applying for a new benefit where your <strong>sponsor is deceased, MIA, or a POW</strong> (22-5490)</label>
+        <input type="radio" name="form-selection" id="form-22-5490-1" value="5490">
+        <label for="form-22-5490-1">Dependent applying for a new benefit where your <strong>sponsor is permanently and totally disabled</strong> (22-5490)</label>
+        <input type="radio" name="form-selection" id="form-22-5490-2" value="5490">
+        <label for="form-22-5490-2">Dependent applying for a new benefit where your <strong>sponsor is deceased, MIA, or a POW</strong> (22-5490)</label>
       </div>
       <a id="apply-go-button" class="usa-button-primary va-button-primary">Apply Now</a>
     </div>

--- a/src/js/edu-benefits/routes.jsx
+++ b/src/js/edu-benefits/routes.jsx
@@ -52,6 +52,23 @@ export default function createRoutes(store) {
         }, 'edu-1990e');
       },
     },
+    {
+      path: '5490',
+      indexRoute: { onEnter: (nextState, replace) => replace('/5490/introduction') },
+      component: asyncLoader(() => {
+        return new Promise((resolve) => {
+          require.ensure([], (require) => {
+            store.replaceReducer(require('./5490/reducer').default);
+            resolve(require('./5490/Form5490App').default);
+          }, 'edu-5490');
+        });
+      }, 'Loading Form 22-5490'),
+      getChildRoutes(partialNextState, callback) {
+        require.ensure([], (require) => {
+          callback(null, require('./5490/routes').default);
+        }, 'edu-5490');
+      },
+    }
   ];
 
   if (__BUILDTYPE__ !== 'production') {
@@ -71,23 +88,6 @@ export default function createRoutes(store) {
           require.ensure([], (require) => {
             callback(null, require('./1990n/routes').default);
           }, 'edu-1990n');
-        },
-      },
-      {
-        path: '5490',
-        indexRoute: { onEnter: (nextState, replace) => replace('/5490/introduction') },
-        component: asyncLoader(() => {
-          return new Promise((resolve) => {
-            require.ensure([], (require) => {
-              store.replaceReducer(require('./5490/reducer').default);
-              resolve(require('./5490/Form5490App').default);
-            }, 'edu-5490');
-          });
-        }, 'Loading Form 22-5490'),
-        getChildRoutes(partialNextState, callback) {
-          require.ensure([], (require) => {
-            callback(null, require('./5490/routes').default);
-          }, 'edu-5490');
         },
       },
       {


### PR DESCRIPTION
Getting the 5490 ready for launch. Does 2 things:

1. Moves the 5490 routes to the prod routes for education
2. Makes changes on the process apply page to include links to the 5490

Should be merged once the 5490 is actually ready to deploy.