### PR TITLE
Add visibility so inputs don't block manage button on edu benefits page

### DIFF
--- a/src/sass/_shame.scss
+++ b/src/sass/_shame.scss
@@ -180,6 +180,7 @@ body .row {
   //  with the border to expand that without the opacity
   &.expander-content-closed {
     max-height: 0em !important; // To override the id selector height
+    visibility: hidden;
 
     .expander-content-inner {
       opacity: 0;


### PR DESCRIPTION
Connects to [2079](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2079)

Makes the entire button clickable again. Animation still works.
