### PR TITLE
Update to use babel env preset and only necessary polyfills

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,13 @@
 {
   // Javascript settings.
   "presets": [
-    "es2015",
+    ["env", {
+      "targets": {
+        "uglify": true,
+        "browsers": ["last 2 versions", "ie 11", "not ie 10"]
+      },
+      "useBuiltIns": true
+    }],
     "react",
     "stage-2",
   ],

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -34,7 +34,7 @@ const configGenerator = (options) => {
     filesToBuild = _.pick(entryFiles, options.entry.split(',').map(x => x.trim()));
   }
   filesToBuild.vendor = [
-    'core-js',
+    './src/js/common/polyfills',
     'history',
     'jquery',
     'react',

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1771,6 +1771,170 @@
         }
       }
     },
+    "babel-preset-env": {
+      "version": "1.3.3",
+      "from": "babel-preset-env@>=1.3.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.3.3.tgz",
+      "dependencies": {
+        "babel-code-frame": {
+          "version": "6.22.0",
+          "from": "babel-code-frame@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz"
+        },
+        "babel-helper-call-delegate": {
+          "version": "6.24.1",
+          "from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz"
+        },
+        "babel-helper-define-map": {
+          "version": "6.24.1",
+          "from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz"
+        },
+        "babel-helper-function-name": {
+          "version": "6.24.1",
+          "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz"
+        },
+        "babel-helper-get-function-arity": {
+          "version": "6.24.1",
+          "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+        },
+        "babel-helper-hoist-variables": {
+          "version": "6.24.1",
+          "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz"
+        },
+        "babel-helper-optimise-call-expression": {
+          "version": "6.24.1",
+          "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
+        },
+        "babel-helper-replace-supers": {
+          "version": "6.24.1",
+          "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz"
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "from": "babel-messages@>=6.23.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-block-scoping@>=6.23.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz"
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-classes@>=6.23.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz"
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-destructuring@>=6.23.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz"
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-for-of@>=6.23.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz"
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.23.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz"
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.23.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz"
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-modules-umd@>=6.23.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+          "dependencies": {
+            "babel-plugin-transform-es2015-modules-amd": {
+              "version": "6.24.1",
+              "from": "babel-plugin-transform-es2015-modules-amd@>=6.24.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz"
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-parameters@>=6.23.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz"
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.23.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz"
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz"
+        },
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "babel-template": {
+          "version": "6.24.1",
+          "from": "babel-template@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz"
+        },
+        "babel-traverse": {
+          "version": "6.24.1",
+          "from": "babel-traverse@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz"
+        },
+        "babel-types": {
+          "version": "6.24.1",
+          "from": "babel-types@>=6.24.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz"
+        },
+        "babylon": {
+          "version": "6.16.1",
+          "from": "babylon@>=6.11.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz"
+        },
+        "browserslist": {
+          "version": "1.7.7",
+          "from": "browserslist@>=1.4.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz"
+        },
+        "caniuse-db": {
+          "version": "1.0.30000649",
+          "from": "caniuse-db@>=1.0.30000639 <2.0.0",
+          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000649.tgz"
+        },
+        "globals": {
+          "version": "9.17.0",
+          "from": "globals@>=9.0.0 <10.0.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "from": "invariant@>=2.2.2 <3.0.0",
+          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
+        },
+        "js-tokens": {
+          "version": "3.0.1",
+          "from": "js-tokens@>=3.0.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.3",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz"
+        }
+      }
+    },
     "babel-preset-es2015": {
       "version": "6.22.0",
       "from": "babel-preset-es2015@>=6.9.0 <7.0.0",
@@ -1821,7 +1985,7 @@
         "babel-code-frame": {
           "version": "6.22.0",
           "from": "babel-code-frame@>=6.22.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz"
+          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz"
         },
         "babel-messages": {
           "version": "6.23.0",
@@ -2002,7 +2166,7 @@
         "http-errors": {
           "version": "1.5.1",
           "from": "http-errors@>=1.5.1 <1.6.0",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz"
+          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz"
         },
         "ms": {
           "version": "0.7.2",
@@ -3156,6 +3320,11 @@
       "from": "electron-prebuilt@>=1.4.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/electron-prebuilt/-/electron-prebuilt-1.4.13.tgz"
     },
+    "electron-to-chromium": {
+      "version": "1.3.3",
+      "from": "electron-to-chromium@>=1.2.7 <2.0.0",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.3.tgz"
+    },
     "element-dataset": {
       "version": "1.3.0",
       "from": "element-dataset@>=1.3.0 <2.0.0",
@@ -3752,7 +3921,7 @@
         "statuses": {
           "version": "1.3.1",
           "from": "statuses@~1.3.1",
-          "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
         }
       }
     },
@@ -7865,7 +8034,7 @@
         "statuses": {
           "version": "1.3.1",
           "from": "statuses@~1.3.1",
-          "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "babel-plugin-lodash": "^3.2.8",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-polyfill": "^6.13.0",
-    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-env": "^1.3.3",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-2": "^6.13.0",
     "babel-register": "^6.18.0",

--- a/src/js/common/index.js
+++ b/src/js/common/index.js
@@ -1,31 +1,5 @@
-// Common Javascript environment setup to be used by all entrypoints.
-//
-// Keep this short. It should mostly be polyfills, global site style, and any
-// truly pervasive libraries. Be careful if you are tempted to put jquery or
-// other such libraries in here. Most of the site does not use these legacy
-// frameworks and it belongs in a lower-level module.
-
-// TODO(awong): This shouldn't be required with the correct babel transform, yet IE9 broke
-// without it. Test.
-require('babel-polyfill');
-
-// Basic polyfills.
-// TODO(awong): These do NOT correctly conditionally load the polyfill.
-// The polyfill is always loaded. require.ensure() should be used instead but
-// then load ordering needs to be worked out. Fix later.
-const Modernizr = require('modernizr');
-if (!Modernizr.classlist) {
-  require('classlist-polyfill'); // DOM element classList support.
-}
-if (!Modernizr.dataset) {
-  require('dataset');  // dataSet accessor support.
-}
-if (!Modernizr.fetch) {
-  require('whatwg-fetch');  // dataSet accessor support.
-}
-
-// This polyfill has its own test logic so no need to conditionally require.
-require('polyfill-function-prototype-bind');
+// polyfills are loaded in vendor chunk
+require('./polyfills');
 
 require('./sentry.js');
 

--- a/src/js/common/polyfills.js
+++ b/src/js/common/polyfills.js
@@ -1,0 +1,26 @@
+// Common Javascript environment setup to be used by all entrypoints.
+//
+// Keep this short. It should mostly be polyfills, global site style, and any
+// truly pervasive libraries. Be careful if you are tempted to put jquery or
+// other such libraries in here. Most of the site does not use these legacy
+// frameworks and it belongs in a lower-level module.
+
+require('babel-polyfill');
+
+// Basic polyfills.
+// TODO(awong): These do NOT correctly conditionally load the polyfill.
+// The polyfill is always loaded. require.ensure() should be used instead but
+// then load ordering needs to be worked out. Fix later.
+const Modernizr = require('modernizr');
+if (!Modernizr.classlist) {
+  require('classlist-polyfill'); // DOM element classList support.
+}
+if (!Modernizr.dataset) {
+  require('dataset');  // dataSet accessor support.
+}
+if (!Modernizr.fetch) {
+  require('whatwg-fetch');  // dataSet accessor support.
+}
+
+// This polyfill has its own test logic so no need to conditionally require.
+require('polyfill-function-prototype-bind');


### PR DESCRIPTION
Connects to #4232 

This updates us to the newer env preset from Babel, which includes es2015, 2016, and 2017. We were already transpiling those features due to the stage-2 preset, which is a superset of 2017 and lower. So I've left it alone because there are a handful of plugins in there that aren't in env (pretty sure we don't use them, but just to be safe).

The bigger change for this is around polyfills. The `useBuiltIns` option in the env preset does an autoprefixer-like check to only include polyfills you need for the browsers you support. Enabling this gets rid of some older polyfills, plus some stage-1/0 ones that we don't need, and reduces the size of core-js by 25kb (minified).