### PR TITLE
GIBCT preview mode

### DIFF
--- a/src/js/gi/actions/index.js
+++ b/src/js/gi/actions/index.js
@@ -67,8 +67,9 @@ function withPreview(dispatch, action) {
   dispatch(action);
 }
 
-export function fetchConstants(preview = false) {
-  const url = `${api.url}/calculator_constants${preview ? 'version=preview' : ''}`;
+export function fetchConstants(version) {
+  const queryString = version ? `?version=${version}` : '';
+  const url = `${api.url}/calculator_constants${queryString}`;
 
   return dispatch => {
     dispatch({ type: FETCH_CONSTANTS_STARTED });
@@ -89,12 +90,13 @@ export function updateAutocompleteSearchTerm(searchTerm) {
   };
 }
 
-export function fetchAutocompleteSuggestions(text) {
-  const previewVersion = '1'; // TODO
-  const url = [
-    `${api.url}/institutions/autocomplete?preview=${previewVersion}`,
-    `term=${text}`
-  ].join('&');
+export function fetchAutocompleteSuggestions(text, version) {
+  const queryString = [
+    `term=${text}`,
+    (version ? `version=${version}` : '')
+  ].filter(q => q).join('&');
+
+  const url = `${api.url}/institutions/autocomplete?${queryString}`;
 
   return dispatch => {
     dispatch({ type: AUTOCOMPLETE_STARTED });
@@ -127,11 +129,10 @@ export function institutionFilterChange(filter) {
 }
 
 export function fetchSearchResults(query = {}) {
-  const fullQuery = { ...query, version: 1 };
   const queryString =
-    Object.keys(fullQuery).reduce((str, key) => {
+    Object.keys(query).reduce((str, key) => {
       const sep = str ? '&' : '';
-      return `${str}${sep}${snakeCase(key)}=${fullQuery[key]}`;
+      return `${str}${sep}${snakeCase(key)}=${query[key]}`;
     }, '');
 
   const url = `${api.url}/institutions/search?${queryString}`;
@@ -148,8 +149,9 @@ export function fetchSearchResults(query = {}) {
   };
 }
 
-export function fetchProfile(facilityCode, version = 1) {
-  const url = `${api.url}/institutions/${facilityCode}?version=${version}`;
+export function fetchProfile(facilityCode, version) {
+  const queryString = version ? `?version=${version}` : '';
+  const url = `${api.url}/institutions/${facilityCode}${queryString}`;
 
   return dispatch => {
     dispatch({ type: FETCH_PROFILE_STARTED });

--- a/src/js/gi/actions/index.js
+++ b/src/js/gi/actions/index.js
@@ -67,9 +67,8 @@ function withPreview(dispatch, action) {
   dispatch(action);
 }
 
-export function fetchConstants() {
-  const previewVersion = ''; // TODO
-  const url = `${api.url}/calculator_constants?preview=${previewVersion}`;
+export function fetchConstants(preview = false) {
+  const url = `${api.url}/calculator_constants${preview ? 'version=preview' : ''}`;
 
   return dispatch => {
     dispatch({ type: FETCH_CONSTANTS_STARTED });
@@ -77,7 +76,7 @@ export function fetchConstants() {
     return fetch(url, api.settings)
       .then(res => res.json())
       .then(
-        payload => dispatch({ type: FETCH_CONSTANTS_SUCCEEDED, payload }),
+        payload => withPreview(dispatch, { type: FETCH_CONSTANTS_SUCCEEDED, payload }),
         err => dispatch({ type: FETCH_CONSTANTS_FAILED, err })
       );
   };
@@ -149,8 +148,8 @@ export function fetchSearchResults(query = {}) {
   };
 }
 
-export function fetchProfile(facilityCode) {
-  const url = `${api.url}/institutions/${facilityCode}?version=1`;
+export function fetchProfile(facilityCode, version = 1) {
+  const url = `${api.url}/institutions/${facilityCode}?version=${version}`;
 
   return dispatch => {
     dispatch({ type: FETCH_PROFILE_STARTED });

--- a/src/js/gi/actions/index.js
+++ b/src/js/gi/actions/index.js
@@ -6,6 +6,7 @@ export const DISPLAY_MODAL = 'DISPLAY_MODAL';
 export const SET_PAGE_TITLE = 'SET_PAGE_TITLE';
 export const ENTER_PREVIEW_MODE = 'ENTER_PREVIEW_MODE';
 export const EXIT_PREVIEW_MODE = 'EXIT_PREVIEW_MODE';
+export const SET_VERSION = 'SET_VERSION';
 export const FETCH_CONSTANTS_STARTED = 'FETCH_CONSTANTS_STARTED';
 export const FETCH_CONSTANTS_FAILED = 'FETCH_CONSTANTS_FAILED';
 export const FETCH_CONSTANTS_SUCCEEDED = 'FETCH_CONSTANTS_SUCCEEDED';
@@ -63,7 +64,13 @@ function withPreview(dispatch, action) {
       type: ENTER_PREVIEW_MODE,
       version
     });
+  } else if (version.createdAt) {
+    dispatch({
+      type: SET_VERSION,
+      version
+    });
   }
+
   dispatch(action);
 }
 

--- a/src/js/gi/components/heading/Breadcrumbs.jsx
+++ b/src/js/gi/components/heading/Breadcrumbs.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 class Breadcrumbs extends React.Component {
   render() {
-    const { location: { pathname } } = this.props;
+    const { pathname, query: { version } } = this.props.location;
 
     const crumbs = [
       <a href="/" key="home">Home</a>,
@@ -12,7 +12,9 @@ class Breadcrumbs extends React.Component {
     ];
 
     if (pathname.match(/search|profile/)) {
-      crumbs.push(<Link to="/" key="main">GI Bill® Comparison Tool</Link>);
+      crumbs.push(<Link to="/" query={(version ? { version } : {})} key="main">
+        GI Bill® Comparison Tool
+      </Link>);
     } else {
       crumbs.push(<span key="gibct"><strong>GI Bill® Comparison Tool</strong></span>);
     }

--- a/src/js/gi/components/heading/Breadcrumbs.jsx
+++ b/src/js/gi/components/heading/Breadcrumbs.jsx
@@ -12,9 +12,8 @@ class Breadcrumbs extends React.Component {
     ];
 
     if (pathname.match(/search|profile/)) {
-      crumbs.push(<Link to="/" query={(version ? { version } : {})} key="main">
-        GI Bill® Comparison Tool
-      </Link>);
+      const root = { pathname: '/', query: (version ? { version } : {}) };
+      crumbs.push(<Link to={root} key="main">GI Bill® Comparison Tool</Link>);
     } else {
       crumbs.push(<span key="gibct"><strong>GI Bill® Comparison Tool</strong></span>);
     }

--- a/src/js/gi/components/heading/PreviewBanner.jsx
+++ b/src/js/gi/components/heading/PreviewBanner.jsx
@@ -10,17 +10,18 @@ class PreviewBanner extends React.Component {
 
     return (
       <div className="gi-preview-banner">
-        <div className="outer"/>
-        <div className="inner">
-          <h5>Preview draft</h5>
-          <p>
-            This is what the version of this data from {when} will look like.
-            <span className="actions">
-              <a onClick={this.props.onViewLiveVersion}>View live version</a>
-              &nbsp;&nbsp;|&nbsp;&nbsp;
-              <a href={this.props.toolUrl}>Go back to the data tool</a>
-            </span>
-          </p>
+        <div className="outer small-12 medium-12 large-9">
+          <div className="inner">
+            <h5>Preview draft</h5>
+            <p>
+              This is what the version of this data from {when} will look like.&nbsp;
+              <span className="actions">
+                <a onClick={this.props.onViewLiveVersion}>View live version</a>
+                &nbsp;&nbsp;|&nbsp;&nbsp;
+                <a href={this.props.toolUrl}>Go back to the data tool</a>
+              </span>
+            </p>
+          </div>
         </div>
       </div>
     );

--- a/src/js/gi/components/heading/PreviewBanner.jsx
+++ b/src/js/gi/components/heading/PreviewBanner.jsx
@@ -25,9 +25,9 @@ class PreviewBanner extends React.Component {
           <p>
             This is what the version of this data from {when} will look like.
             <span className="actions">
-              <a onClick={this.props.exitPreviewMode}>View live version</a>
+              <a onClick={this.props.onViewLiveVersion}>View live version</a>
               &nbsp;&nbsp;|&nbsp;&nbsp;
-              <a href={this.props.toolURL}>Go back to the data tool</a>
+              <a href={this.props.toolUrl}>Go back to the data tool</a>
             </span>
           </p>
         </div>
@@ -39,20 +39,12 @@ class PreviewBanner extends React.Component {
 PreviewBanner.propTypes = {
   show: React.PropTypes.bool.isRequired,
   version: React.PropTypes.object.isRequired,
-  toolURL: React.PropTypes.string.isRequired,
+  toolUrl: React.PropTypes.string.isRequired,
+  onViewLiveVersion: React.PropTypes.func.isRequired
 };
 
 PreviewBanner.defaultProps = {
-  toolURL: 'http://www.usds.gov', // TODO
+  toolUrl: '/gids'
 };
 
-const mapStateToProps = (state) => state;
-const mapDispatchToProps = (dispatch) => {
-  return {
-    exitPreviewMode: () => {
-      dispatch(actions.exitPreviewMode());
-    }
-  };
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(PreviewBanner);
+export default PreviewBanner;

--- a/src/js/gi/components/heading/PreviewBanner.jsx
+++ b/src/js/gi/components/heading/PreviewBanner.jsx
@@ -5,18 +5,11 @@ class PreviewBanner extends React.Component {
     if (!this.props.show) {
       return null;
     }
-
-    const headerDisplacementCSS = `
-      div.header {
-        margin-top: 4em;
-      }
-    `;
     const tz = { timeZone: 'America/New_York' };
     const when = new Date(this.props.version.createdAt).toLocaleString('us', tz);
 
     return (
       <div className="gi-preview-banner">
-        <style>{headerDisplacementCSS}</style>
         <div className="outer"/>
         <div className="inner">
           <h5>Preview draft</h5>

--- a/src/js/gi/components/heading/PreviewBanner.jsx
+++ b/src/js/gi/components/heading/PreviewBanner.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
+import moment from 'moment';
 
 class PreviewBanner extends React.Component {
   render() {
-    if (!this.props.show) {
-      return null;
-    }
-    const tz = { timeZone: 'America/New_York' };
-    const when = new Date(this.props.version.createdAt).toLocaleString('us', tz);
+    const when = moment(this.props.version.createdAt).format('MMM D, YYYY [at] h:mm a [EST]');
 
     return (
       <div className="gi-preview-banner">
@@ -29,7 +26,6 @@ class PreviewBanner extends React.Component {
 }
 
 PreviewBanner.propTypes = {
-  show: React.PropTypes.bool.isRequired,
   version: React.PropTypes.object.isRequired,
   toolUrl: React.PropTypes.string.isRequired,
   onViewLiveVersion: React.PropTypes.func.isRequired

--- a/src/js/gi/components/heading/PreviewBanner.jsx
+++ b/src/js/gi/components/heading/PreviewBanner.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import * as actions from '../../actions';
 
 class PreviewBanner extends React.Component {
   render() {

--- a/src/js/gi/components/search/KeywordSearch.jsx
+++ b/src/js/gi/components/search/KeywordSearch.jsx
@@ -1,20 +1,12 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import Autosuggest from 'react-autosuggest';
 
-import {
-  fetchAutocompleteSuggestions,
-  clearAutocompleteSuggestions,
-  updateAutocompleteSearchTerm
-} from '../../actions';
-
 export class KeywordSearch extends React.Component {
-
   constructor(props) {
     super(props);
-
     this.clickedSuggestionValue = this.clickedSuggestionValue.bind(this);
     this.handleChange = this.handleChange.bind(this);
+    this.handleFetchSuggestion = this.handleFetchSuggestion.bind(this);
     this.handleKeyUp = this.handleKeyUp.bind(this);
     this.handleSuggestionSelected = this.handleSuggestionSelected.bind(this);
     this.renderSuggestion = this.renderSuggestion.bind(this);
@@ -37,7 +29,12 @@ export class KeywordSearch extends React.Component {
   }
 
   handleChange(event, data) {
-    this.props.updateAutocompleteSearchTerm(data.newValue);
+    this.props.onUpdateAutocompleteSearchTerm(data.newValue);
+  }
+
+  handleFetchSuggestion({ value }) {
+    const { version } = this.props.location.query;
+    this.props.onFetchAutocompleteSuggestions(value, version);
   }
 
   handleSuggestionSelected(event, data) {
@@ -71,9 +68,9 @@ export class KeywordSearch extends React.Component {
         <Autosuggest
             getSuggestionValue={this.clickedSuggestionValue}
             highlightFirstSuggestion
-            onSuggestionsClearRequested={this.props.onSuggestionsClearRequested}
+            onSuggestionsClearRequested={this.props.onClearAutocompleteSuggestions}
             onSuggestionSelected={this.handleSuggestionSelected}
-            onSuggestionsFetchRequested={this.props.onSuggestionsFetchRequested}
+            onSuggestionsFetchRequested={this.handleFetchSuggestion}
             renderSuggestion={this.renderSuggestion}
             shouldRenderSuggestions={this.shouldRenderSuggestions}
             suggestions={suggestions}
@@ -85,7 +82,6 @@ export class KeywordSearch extends React.Component {
       </div>
     );
   }
-
 }
 
 KeywordSearch.defaultProps = {
@@ -94,25 +90,11 @@ KeywordSearch.defaultProps = {
 };
 
 KeywordSearch.propTypes = {
+  label: React.PropTypes.string,
+  onClearAutocompleteSuggestions: React.PropTypes.func,
+  onFetchAutocompleteSuggestions: React.PropTypes.func,
   onFilterChange: React.PropTypes.func,
+  onUpdateAutocompleteSearchTerm: React.PropTypes.func
 };
 
-const mapStateToProps = (state) => {
-  const { autocomplete } = state;
-  return { autocomplete };
-};
-const mapDispatchToProps = (dispatch) => {
-  return {
-    onSuggestionsFetchRequested: ({ value }) => {
-      dispatch(fetchAutocompleteSuggestions(value));
-    },
-    onSuggestionsClearRequested: () => {
-      dispatch(clearAutocompleteSuggestions());
-    },
-    updateAutocompleteSearchTerm: (newValue) => {
-      dispatch(updateAutocompleteSearchTerm(newValue));
-    },
-  };
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(KeywordSearch);
+export default KeywordSearch;

--- a/src/js/gi/components/search/SearchResult.jsx
+++ b/src/js/gi/components/search/SearchResult.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Link, withRouter } from 'react-router';
+import { Link } from 'react-router';
 
 import { estimatedBenefits } from '../../selectors/estimator';
 import { formatCurrency } from '../../utils/helpers';
@@ -38,6 +38,10 @@ export class SearchResult extends React.Component {
     };
 
     const { version } = this.props;
+    const linkTo = {
+      pathname: `profile/${this.props.facilityCode}`,
+      query: version ? { version } : {}
+    };
 
     return (
       <div className="search-result">
@@ -45,13 +49,7 @@ export class SearchResult extends React.Component {
           <CautionFlag/>
           <div className="inner row">
             <div className="small-12 medium-7 columns">
-              <h2>
-                <Link
-                    to={`profile/${this.props.facilityCode}`}
-                    query={(version ? { version } : {})}>
-                  {this.props.name}
-                </Link>
-              </h2>
+              <h2><Link to={linkTo}>{this.props.name}</Link></h2>
               <div style={{ position: 'relative', bottom: 0 }}>
                 <p className="locality">
                   {this.props.city}, {this.props.state || this.props.country}
@@ -105,4 +103,4 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = {};
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(SearchResult));
+export default connect(mapStateToProps, mapDispatchToProps)(SearchResult);

--- a/src/js/gi/components/search/SearchResult.jsx
+++ b/src/js/gi/components/search/SearchResult.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router';
+import { Link, withRouter } from 'react-router';
 
 import { estimatedBenefits } from '../../selectors/estimator';
 import { formatCurrency } from '../../utils/helpers';
@@ -37,13 +37,21 @@ export class SearchResult extends React.Component {
       );
     };
 
+    const { version } = this.props;
+
     return (
       <div className="search-result">
         <div className="outer">
           <CautionFlag/>
           <div className="inner row">
             <div className="small-12 medium-7 columns">
-              <h2><Link to={`profile/${this.props.facilityCode}`}>{this.props.name}</Link></h2>
+              <h2>
+                <Link
+                    to={`profile/${this.props.facilityCode}`}
+                    query={(version ? { version } : {})}>
+                  {this.props.name}
+                </Link>
+              </h2>
               <div style={{ position: 'relative', bottom: 0 }}>
                 <p className="locality">
                   {this.props.city}, {this.props.state || this.props.country}
@@ -97,4 +105,4 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = {};
 
-export default connect(mapStateToProps, mapDispatchToProps)(SearchResult);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(SearchResult));

--- a/src/js/gi/components/search/SearchResult.jsx
+++ b/src/js/gi/components/search/SearchResult.jsx
@@ -56,7 +56,7 @@ export class SearchResult extends React.Component {
                 <p className="locality">
                   {this.props.city}, {this.props.state || this.props.country}
                 </p>
-                <p className="count">{this.props.studentCount.toLocaleString()} GI Bill Students</p>
+                <p className="count">{(+this.props.studentCount).toLocaleString()} GI Bill Students</p>
               </div>
             </div>
             <div className="small-12 medium-5 columns estimated-benefits">

--- a/src/js/gi/config.js
+++ b/src/js/gi/config.js
@@ -6,8 +6,7 @@ module.exports = {
     url: `${environment.API_URL}/v0/gi`,
     settings: {
       headers: {
-        'Content-Type': 'application/json',
-        // 'X-Key-Inflection': 'camel',
+        'X-Key-Inflection': 'camel'
       }
     }
   }

--- a/src/js/gi/containers/GiBillApp.jsx
+++ b/src/js/gi/containers/GiBillApp.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
 
 import { fetchConstants } from '../actions';
 import Modals from '../containers/Modals';
@@ -16,8 +17,30 @@ const Disclaimer = () => {
 };
 
 class GiBillApp extends React.Component {
+  constructor(props) {
+    super(props);
+    this.exitPreviewMode = this.exitPreviewMode.bind(this);
+  }
+
   componentDidMount() {
     this.props.fetchConstants(this.props.location.query.preview);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { preview } = this.props.location.query;
+    const shouldSwitchPreviewMode =
+      prevProps.location.query.preview !== preview;
+
+    if (shouldSwitchPreviewMode) {
+      if (!preview) { this.props.exitPreviewMode(); }
+      this.props.fetchConstants(preview);
+    }
+  }
+
+  exitPreviewMode() {
+    const location = { ...this.props.location };
+    delete location.query.preview;
+    this.props.router.push(location);
   }
 
   render() {
@@ -27,8 +50,13 @@ class GiBillApp extends React.Component {
       <div className="gi-app">
         <div className="row">
           <div className="columns small-12">
-            <PreviewBanner show={preview.display} version={preview.version}/>
-            <Breadcrumbs location={this.props.location} profileName={profile.attributes.name}/>
+            <PreviewBanner
+                show={preview.display}
+                version={preview.version}
+                onViewLiveVersion={this.exitPreviewMode}/>
+            <Breadcrumbs
+                location={this.props.location}
+                profileName={profile.attributes.name}/>
             {this.props.children}
             <AboutThisTool/>
             <Disclaimer/>
@@ -53,4 +81,4 @@ const mapDispatchToProps = {
   fetchConstants
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(GiBillApp);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(GiBillApp));

--- a/src/js/gi/containers/GiBillApp.jsx
+++ b/src/js/gi/containers/GiBillApp.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
-import { fetchConstants } from '../actions';
+import { exitPreviewMode, fetchConstants } from '../actions';
 import Modals from '../containers/Modals';
 import PreviewBanner from '../components/heading/PreviewBanner';
 import Breadcrumbs from '../components/heading/Breadcrumbs';
@@ -23,23 +23,23 @@ class GiBillApp extends React.Component {
   }
 
   componentDidMount() {
-    this.props.fetchConstants(this.props.location.query.preview);
+    this.props.fetchConstants(this.props.location.query.version);
   }
 
   componentDidUpdate(prevProps) {
-    const { preview } = this.props.location.query;
-    const shouldSwitchPreviewMode =
-      prevProps.location.query.preview !== preview;
+    const { version } = this.props.location.query;
+    const shouldSwitchVersion =
+      prevProps.location.query.version !== version;
 
-    if (shouldSwitchPreviewMode) {
-      if (!preview) { this.props.exitPreviewMode(); }
-      this.props.fetchConstants(preview);
+    if (shouldSwitchVersion) {
+      if (!version) { this.props.exitPreviewMode(); }
+      this.props.fetchConstants(version);
     }
   }
 
   exitPreviewMode() {
     const location = { ...this.props.location };
-    delete location.query.preview;
+    delete location.query.version;
     this.props.router.push(location);
   }
 
@@ -78,6 +78,7 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = {
+  exitPreviewMode,
   fetchConstants
 };
 

--- a/src/js/gi/containers/GiBillApp.jsx
+++ b/src/js/gi/containers/GiBillApp.jsx
@@ -32,12 +32,12 @@ class GiBillApp extends React.Component {
       location: { query: { version: uuid } }
     } = this.props;
 
-    const shouldHidePreviewMode = preview.display && !uuid;
-    const shouldShowPreviewMode = !preview.display && uuid && preview.version.createdAt;
+    const shouldExitPreviewMode = preview.display && !uuid;
+    const shouldEnterPreviewMode = !preview.display && uuid && preview.version.createdAt;
 
-    if (shouldHidePreviewMode) {
+    if (shouldExitPreviewMode) {
       this.props.exitPreviewMode();
-    } else if (shouldShowPreviewMode) {
+    } else if (shouldEnterPreviewMode) {
       this.props.enterPreviewMode();
     }
 

--- a/src/js/gi/containers/GiBillApp.jsx
+++ b/src/js/gi/containers/GiBillApp.jsx
@@ -43,9 +43,10 @@ class GiBillApp extends React.Component {
   }
 
   exitPreviewMode() {
-    const location = { ...this.props.location };
-    delete location.query.version;
-    this.props.router.push(location);
+    const { location } = this.props;
+    const query = { ...location.query };
+    delete query.version;
+    this.props.router.push({ ...location, query });
   }
 
   render() {

--- a/src/js/gi/containers/GiBillApp.jsx
+++ b/src/js/gi/containers/GiBillApp.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
-import { exitPreviewMode, fetchConstants } from '../actions';
+import { enterPreviewMode, exitPreviewMode, fetchConstants } from '../actions';
 import Modals from '../containers/Modals';
 import PreviewBanner from '../components/heading/PreviewBanner';
 import Breadcrumbs from '../components/heading/Breadcrumbs';
@@ -26,14 +26,19 @@ class GiBillApp extends React.Component {
     this.props.fetchConstants(this.props.location.query.version);
   }
 
-  componentDidUpdate(prevProps) {
-    const { version } = this.props.location.query;
-    const shouldSwitchVersion =
-      prevProps.location.query.version !== version;
+  componentDidUpdate() {
+    const {
+      preview,
+      location: { query: { version: uuid } }
+    } = this.props;
 
-    if (shouldSwitchVersion) {
-      if (!version) { this.props.exitPreviewMode(); }
-      this.props.fetchConstants(version);
+    const shouldHidePreviewMode = preview.display && !uuid;
+    const shouldShowPreviewMode = !preview.display && uuid && preview.version.createdAt;
+
+    if (shouldHidePreviewMode) {
+      this.props.exitPreviewMode();
+    } else if (shouldShowPreviewMode) {
+      this.props.enterPreviewMode();
     }
   }
 
@@ -50,10 +55,12 @@ class GiBillApp extends React.Component {
       <div className="gi-app">
         <div className="row">
           <div className="columns small-12">
-            <PreviewBanner
-                show={preview.display}
-                version={preview.version}
-                onViewLiveVersion={this.exitPreviewMode}/>
+            {
+              preview.display &&
+              (<PreviewBanner
+                  version={preview.version}
+                  onViewLiveVersion={this.exitPreviewMode}/>)
+            }
             <Breadcrumbs
                 location={this.props.location}
                 profileName={profile.attributes.name}/>
@@ -78,6 +85,7 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = {
+  enterPreviewMode,
   exitPreviewMode,
   fetchConstants
 };

--- a/src/js/gi/containers/GiBillApp.jsx
+++ b/src/js/gi/containers/GiBillApp.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import * as actions from '../actions';
 
+import { fetchConstants } from '../actions';
 import Modals from '../containers/Modals';
 import PreviewBanner from '../components/heading/PreviewBanner';
 import Breadcrumbs from '../components/heading/Breadcrumbs';
@@ -16,18 +16,19 @@ const Disclaimer = () => {
 };
 
 class GiBillApp extends React.Component {
-
-  componentWillMount() {
-    this.props.updateConstants();
+  componentDidMount() {
+    this.props.fetchConstants(this.props.location.query.preview);
   }
 
   render() {
+    const { preview, profile } = this.props;
+
     return (
       <div className="gi-app">
         <div className="row">
           <div className="columns small-12">
-            <PreviewBanner show={this.props.preview.display} version={this.props.preview.version}/>
-            <Breadcrumbs location={this.props.location} profileName={this.props.profile.attributes.name}/>
+            <PreviewBanner show={preview.display} version={preview.version}/>
+            <Breadcrumbs location={this.props.location} profileName={profile.attributes.name}/>
             {this.props.children}
             <AboutThisTool/>
             <Disclaimer/>
@@ -37,26 +38,19 @@ class GiBillApp extends React.Component {
       </div>
     );
   }
-
 }
 
 GiBillApp.propTypes = {
   children: React.PropTypes.element.isRequired
 };
 
-const mapStateToProps = (state) => state;
-const mapDispatchToProps = (dispatch) => {
-  return {
-    setPageTitle: (title) => {
-      dispatch(actions.setPageTitle(title));
-    },
-    enterPreviewMode: (version) => {
-      dispatch(actions.enterPreviewMode(version));
-    },
-    updateConstants: () => {
-      dispatch(actions.fetchConstants());
-    }
-  };
+const mapStateToProps = (state) => {
+  const { preview, profile } = state;
+  return { preview, profile };
+};
+
+const mapDispatchToProps = {
+  fetchConstants
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(GiBillApp);

--- a/src/js/gi/containers/GiBillApp.jsx
+++ b/src/js/gi/containers/GiBillApp.jsx
@@ -26,7 +26,7 @@ class GiBillApp extends React.Component {
     this.props.fetchConstants(this.props.location.query.version);
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     const {
       preview,
       location: { query: { version: uuid } }
@@ -39,6 +39,12 @@ class GiBillApp extends React.Component {
       this.props.exitPreviewMode();
     } else if (shouldShowPreviewMode) {
       this.props.enterPreviewMode();
+    }
+
+    const shouldRefetchConstants = prevProps.location.query.version !== uuid;
+
+    if (shouldRefetchConstants) {
+      this.props.fetchConstants(uuid);
     }
   }
 

--- a/src/js/gi/containers/LandingPage.jsx
+++ b/src/js/gi/containers/LandingPage.jsx
@@ -20,8 +20,14 @@ export class LandingPage extends React.Component {
 
   handleSubmit(event) {
     event.preventDefault();
-    const { searchTerm: name } = this.props.autocomplete;
-    const query = name ? { name } : null;
+
+    const query = {
+      name: this.props.searchTerm,
+      version: this.props.location.query.version
+    };
+
+    if (!query.name) { delete query.name; }
+    if (!query.version) { delete query.version; }
     this.props.router.push({ pathname: 'search', query });
   }
 
@@ -55,10 +61,14 @@ export class LandingPage extends React.Component {
 }
 
 const mapStateToProps = (state) => {
-  return {
-    autocomplete: state.autocomplete,
-  };
+  const {
+    autocomplete: { searchTerm },
+    preview: { version }
+  } = state;
+
+  return { searchTerm, version };
 };
+
 const mapDispatchToProps = {
   setPageTitle
 };

--- a/src/js/gi/containers/LandingPage.jsx
+++ b/src/js/gi/containers/LandingPage.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
-import { setPageTitle } from '../actions';
+
+import {
+  clearAutocompleteSuggestions,
+  fetchAutocompleteSuggestions,
+  setPageTitle,
+  updateAutocompleteSearchTerm
+} from '../actions';
 
 import VideoSidebar from '../components/content/VideoSidebar';
 import KeywordSearch from '../components/search/KeywordSearch';
@@ -22,7 +28,7 @@ export class LandingPage extends React.Component {
     event.preventDefault();
 
     const query = {
-      name: this.props.searchTerm,
+      name: this.props.autocomplete.searchTerm,
       version: this.props.location.query.version
     };
 
@@ -42,7 +48,12 @@ export class LandingPage extends React.Component {
 
             <form onSubmit={this.handleSubmit}>
               <EligibilityForm/>
-              <KeywordSearch/>
+              <KeywordSearch
+                  autocomplete={this.props.autocomplete}
+                  location={this.props.location}
+                  onClearAutocompleteSuggestions={this.props.clearAutocompleteSuggestions}
+                  onFetchAutocompleteSuggestions={this.props.fetchAutocompleteSuggestions}
+                  onUpdateAutocompleteSearchTerm={this.props.updateAutocompleteSearchTerm}/>
               <button className="usa-button-big" type="submit" id="search-button">
                 <span>Search Schools</span>
               </button>
@@ -61,16 +72,15 @@ export class LandingPage extends React.Component {
 }
 
 const mapStateToProps = (state) => {
-  const {
-    autocomplete: { searchTerm },
-    preview: { version }
-  } = state;
-
-  return { searchTerm, version };
+  const { autocomplete } = state;
+  return { autocomplete };
 };
 
 const mapDispatchToProps = {
-  setPageTitle
+  clearAutocompleteSuggestions,
+  fetchAutocompleteSuggestions,
+  setPageTitle,
+  updateAutocompleteSearchTerm
 };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(LandingPage));

--- a/src/js/gi/containers/ProfilePage.jsx
+++ b/src/js/gi/containers/ProfilePage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
 import Scroll from 'react-scroll';
 import _ from 'lodash';
 
@@ -26,7 +27,10 @@ export class ProfilePage extends React.Component {
   }
 
   componentDidMount() {
-    this.props.fetchProfile(this.props.params.facilityCode);
+    this.props.fetchProfile(
+      this.props.params.facilityCode,
+      this.props.location.query.version
+    );
   }
 
   componentDidUpdate(prevProps) {
@@ -119,4 +123,4 @@ const mapDispatchToProps = {
   showModal
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(ProfilePage);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(ProfilePage));

--- a/src/js/gi/containers/ProfilePage.jsx
+++ b/src/js/gi/containers/ProfilePage.jsx
@@ -34,7 +34,12 @@ export class ProfilePage extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { profile } = this.props;
+    const {
+      location: { query: { version: uuid } },
+      params: { facilityCode },
+      profile
+    } = this.props;
+
     const institutionName = _.get(profile, 'attributes.name');
     const shouldUpdateTitle = !_.isEqual(
       institutionName,
@@ -47,6 +52,10 @@ export class ProfilePage extends React.Component {
 
     if (profile.inProgress !== prevProps.profile.inProgress) {
       scroller.scrollTo('profilePage', getScrollOptions());
+    }
+
+    if (prevProps.location.query.version !== uuid) {
+      this.props.fetchProfile(facilityCode, uuid);
     }
   }
 

--- a/src/js/gi/containers/ProfilePage.jsx
+++ b/src/js/gi/containers/ProfilePage.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
 import Scroll from 'react-scroll';
 import _ from 'lodash';
 
@@ -132,4 +131,4 @@ const mapDispatchToProps = {
   showModal
 };
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(ProfilePage));
+export default connect(mapStateToProps, mapDispatchToProps)(ProfilePage);

--- a/src/js/gi/containers/SearchPage.jsx
+++ b/src/js/gi/containers/SearchPage.jsx
@@ -6,10 +6,13 @@ import _ from 'lodash';
 import classNames from 'classnames';
 
 import {
-  setPageTitle,
+  clearAutocompleteSuggestions,
+  fetchAutocompleteSuggestions,
   fetchSearchResults,
   institutionFilterChange,
-  toggleFilter
+  setPageTitle,
+  toggleFilter,
+  updateAutocompleteSearchTerm
 } from '../actions';
 
 import LoadingIndicator from '../../common/components/LoadingIndicator';
@@ -210,9 +213,13 @@ export class SearchPage extends React.Component {
               {search.filterOpened && <h1>Filter your search</h1>}
               <h2>Keywords</h2>
               <KeywordSearch
-                  location={this.props.location}
+                  autocomplete={this.props.autocomplete}
                   label="City, school, or employer"
-                  onFilterChange={this.handleFilterChange}/>
+                  location={this.props.location}
+                  onClearAutocompleteSuggestions={this.props.clearAutocompleteSuggestions}
+                  onFetchAutocompleteSuggestions={this.props.fetchAutocompleteSuggestions}
+                  onFilterChange={this.handleFilterChange}
+                  onUpdateAutocompleteSearchTerm={this.props.updateAutocompleteSearchTerm}/>
               <InstitutionFilterForm
                   search={search}
                   filters={filters}
@@ -242,10 +249,13 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = {
-  setPageTitle,
+  clearAutocompleteSuggestions,
+  fetchAutocompleteSuggestions,
   fetchSearchResults,
   institutionFilterChange,
-  toggleFilter
+  setPageTitle,
+  toggleFilter,
+  updateAutocompleteSearchTerm
 };
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(SearchPage));

--- a/src/js/gi/containers/SearchPage.jsx
+++ b/src/js/gi/containers/SearchPage.jsx
@@ -162,6 +162,7 @@ export class SearchPage extends React.Component {
             {search.results.map((result) => {
               return (
                 <SearchResult
+                    version={this.props.location.query.version}
                     key={result.facilityCode}
                     name={result.name}
                     facilityCode={result.facilityCode}

--- a/src/js/gi/containers/SearchPage.jsx
+++ b/src/js/gi/containers/SearchPage.jsx
@@ -67,6 +67,7 @@ export class SearchPage extends React.Component {
     ];
 
     const query = _.pick(this.props.location.query, [
+      'version',
       'page',
       'name',
       'category',

--- a/src/js/gi/reducers/preview.js
+++ b/src/js/gi/reducers/preview.js
@@ -1,4 +1,4 @@
-import { ENTER_PREVIEW_MODE, EXIT_PREVIEW_MODE } from '../actions';
+import { ENTER_PREVIEW_MODE, EXIT_PREVIEW_MODE, SET_VERSION } from '../actions';
 
 const INITIAL_STATE = {
   display: false,
@@ -7,13 +7,23 @@ const INITIAL_STATE = {
 
 export default function (state = INITIAL_STATE, action) {
   switch (action.type) {
-    case ENTER_PREVIEW_MODE:
-      return {
-        display: true,
-        version: action.version
-      };
+    case ENTER_PREVIEW_MODE: {
+      const { version } = action;
+      const newState = { ...state, display: true };
+
+      if (version) {
+        newState.version = version;
+      }
+
+      return newState;
+    }
     case EXIT_PREVIEW_MODE:
       return INITIAL_STATE;
+    case SET_VERSION:
+      return {
+        ...state,
+        version: action.version
+      };
     default:
       return state;
   }

--- a/src/sass/gi/partials/_gi-preview-banner.scss
+++ b/src/sass/gi/partials/_gi-preview-banner.scss
@@ -1,21 +1,18 @@
 .gi-preview-banner {
+  background: $color-gold;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 100;
+
   div.outer {
-    background: $color-gold;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 4em;
-    z-index: 1000;
+    margin: auto;
+    position: relative;
   }
 
   div.inner {
-    margin: 0;
-    padding: 0.8em 0;
-    position: fixed;
-    top: 0;
-    width: 100%;
-    z-index: 1100;
+    padding: 0.8em;
 
     h5 {
       font-size: 0.8em;
@@ -28,10 +25,11 @@
       margin: 0;
 
       .actions {
-        bottom: 0;
-        position: absolute;
-        right: 2em;
-        white-space: nowrap;
+        @media screen and (min-width: $medium-screen) {
+          bottom: 0;
+          position: absolute;
+          right: 1em;
+        }
       }
     }
   }

--- a/src/sass/gi/partials/_gi-preview-banner.scss
+++ b/src/sass/gi/partials/_gi-preview-banner.scss
@@ -10,11 +10,12 @@
   }
 
   div.inner {
-    z-index: 1100;
-    position: fixed;
-    top: 0;
     margin: 0;
     padding: 0.8em 0;
+    position: fixed;
+    top: 0;
+    width: 100%;
+    z-index: 1100;
 
     h5 {
       font-size: 0.8em;
@@ -27,8 +28,10 @@
       margin: 0;
 
       .actions {
+        bottom: 0;
+        position: absolute;
+        right: 2em;
         white-space: nowrap;
-        margin: auto 2em;
       }
     }
   }


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#1986.

There was some existing work for `PreviewBanner`, but I made a bunch of fixes and changes to make it appear based on the existence of a `?version=<uuid>` query parameter. Any API requests will also provide the same UUID. The idea is that admins can access a version of the app that uses preview data.

There is also a bunch of added logic to handle carrying over the query param (or dropping it when exiting preview mode) while navigating through the app.

> <img width="933" alt="screen shot 2017-04-11 at 8 05 39 pm" src="https://cloud.githubusercontent.com/assets/1067024/24935784/2511d7b6-1ef2-11e7-9151-7587b4578869.png">
