### PR TITLE
Hide certain fields in GIBCT calculator that should not be appearing for OJT institutions.

### DIFF
--- a/src/js/gi/selectors/calculator.js
+++ b/src/js/gi/selectors/calculator.js
@@ -787,6 +787,10 @@ export const getCalculatedBenefits = createSelector(
       return calculatedBenefits;
     }
 
+    const { militaryStatus } = eligibility;
+    const giBillChapter = +eligibility.giBillChapter;
+    const institutionType = institution.type.toLowerCase();
+
     calculatedBenefits.inputs = {
       inState: false,
       tuition: true,
@@ -821,7 +825,7 @@ export const getCalculatedBenefits = createSelector(
       },
       bookStipend: {
         visible: true,
-        value: formatCurrency(derived.bookStipendTotal)
+        value: `${formatCurrency(derived.bookStipendTotal)}${institutionType === 'ojt' ? '/mo' : ''}`
       },
       outOfPocketTuition: {
         visible: true,
@@ -953,10 +957,6 @@ export const getCalculatedBenefits = createSelector(
         }
       }
     };
-
-    const { militaryStatus } = eligibility;
-    const giBillChapter = +eligibility.giBillChapter;
-    const institutionType = institution.type.toLowerCase();
 
     if (giBillChapter === 31 && !derived.onlyVRE) {
       calculatedBenefits.inputs = {

--- a/src/js/gi/selectors/calculator.js
+++ b/src/js/gi/selectors/calculator.js
@@ -969,29 +969,6 @@ export const getCalculatedBenefits = createSelector(
       };
     }
 
-    if (institutionType === 'ojt') {
-      calculatedBenefits.inputs = {
-        ...calculatedBenefits.inputs,
-        tuition: false,
-        books: false,
-        yellowRibbon: false,
-        scholarships: false,
-        tuitionAssist: false,
-        enrolled: false,
-        enrolledOld: false,
-        working: true,
-        calendar: false,
-      };
-
-      calculatedBenefits.outputs.tuitionAndFeesCharged.visible = false;
-      calculatedBenefits.outputs.giBillPaysToSchool.visible = false;
-      calculatedBenefits.outputs.yourScholarships.visible = false;
-      calculatedBenefits.outputs.outOfPocketTuition.visible = false;
-      calculatedBenefits.outputs.totalPaidToYou.visible = false;
-      calculatedBenefits.outputs.perTerm.tuitionAndFees.visible = false;
-      calculatedBenefits.outputs.perTerm.yellowRibbon.visible = false;
-    }
-
     if (giBillChapter === 35) {
       calculatedBenefits.inputs = {
         ...calculatedBenefits.inputs,
@@ -1082,6 +1059,29 @@ export const getCalculatedBenefits = createSelector(
       calculatedBenefits.outputs.perTerm.bookStipend.terms[2].visible = false;
       calculatedBenefits.outputs.perTerm.yellowRibbon.terms[4].visible = false;
       calculatedBenefits.outputs.perTerm.yellowRibbon.terms[5].visible = false;
+    }
+
+    if (institutionType === 'ojt') {
+      calculatedBenefits.inputs = {
+        ...calculatedBenefits.inputs,
+        tuition: false,
+        books: false,
+        yellowRibbon: false,
+        scholarships: false,
+        tuitionAssist: false,
+        enrolled: false,
+        enrolledOld: false,
+        calendar: false,
+        working: true,
+      };
+
+      calculatedBenefits.outputs.tuitionAndFeesCharged.visible = false;
+      calculatedBenefits.outputs.giBillPaysToSchool.visible = false;
+      calculatedBenefits.outputs.yourScholarships.visible = false;
+      calculatedBenefits.outputs.outOfPocketTuition.visible = false;
+      calculatedBenefits.outputs.totalPaidToYou.visible = false;
+      calculatedBenefits.outputs.perTerm.tuitionAndFees.visible = false;
+      calculatedBenefits.outputs.perTerm.yellowRibbon.visible = false;
     }
 
     return calculatedBenefits;

--- a/src/js/gi/selectors/calculator.js
+++ b/src/js/gi/selectors/calculator.js
@@ -988,6 +988,7 @@ export const getCalculatedBenefits = createSelector(
       calculatedBenefits.outputs.yourScholarships.visible = false;
       calculatedBenefits.outputs.outOfPocketTuition.visible = false;
       calculatedBenefits.outputs.totalPaidToYou.visible = false;
+      calculatedBenefits.outputs.perTerm.tuitionAndFees.visible = false;
       calculatedBenefits.outputs.perTerm.yellowRibbon.visible = false;
     }
 


### PR DESCRIPTION
### Notes
The logic is largely copied from an existing app that we're replacing, but I tried to minimize code spaghetti-ness in the process, so some bugs such as these arose from that refactoring.

These changes are to hide certain fields that are irrelevant to calculating benefits when viewing the profile page of an employer instead of a school. Variables such as tuition fees aren't taken into account, so those inputs and calculated values shouldn't be shown. All of the calculation is done in this `reselect` selector, so the changes were limited to one file here.

### Changes
* Hide tuition and fees per term section for OJT schools. Resolves department-of-veterans-affairs/vets.gov-team#2103.
* Append '/mo' to the book stipend value (which is monthly) for OJT schools. Resolves department-of-veterans-affairs/vets.gov-team#2104.
* Hide books and supplies field for OJT schools. Resolves department-of-veterans-affairs/vets.gov-team#2105.

#### Calculator results when choosing "VR&E" in eligibility on an OJT school's page. No books and supplies field. No tuition fees section in the per-term breakdown. "<amount>/mo" for the books row.
> <img width="913" alt="screen shot 2017-04-12 at 7 40 48 pm" src="https://cloud.githubusercontent.com/assets/1067024/24983972/6d504e74-1fb8-11e7-898d-ca1b2c6718c6.png">
