### PR TITLE
GIBCT profile fixes (OPE code, for profit school -> institution, cautionary info)

### DIFF
--- a/src/js/gi/components/profile/AdditionalInformation.jsx
+++ b/src/js/gi/components/profile/AdditionalInformation.jsx
@@ -139,7 +139,7 @@ export class AdditionalInformation extends React.Component {
                 <a onClick={this.props.onShowModal.bind(this, 'opeCode')}>ED OPE code:</a>
                 &nbsp;
               </strong>
-              {it.ope6 || 'N/A'}
+              {it.ope || 'N/A'}
             </p>
           </div>
         </div>

--- a/src/js/gi/components/profile/AdditionalInformation.jsx
+++ b/src/js/gi/components/profile/AdditionalInformation.jsx
@@ -125,21 +125,21 @@ export class AdditionalInformation extends React.Component {
                 <a onClick={this.props.onShowModal.bind(this, 'facilityCode')}>VA facility code:</a>
                 &nbsp;
               </strong>
-              {+it.facilityCode === 0 ? 'N/A' : +it.facilityCode}
+              {it.facilityCode || 'N/A'}
             </p>
             <p>
               <strong>
                 <a onClick={this.props.onShowModal.bind(this, 'ipedsCode')}>ED IPEDS code:</a>
                 &nbsp;
               </strong>
-              {+it.cross === 0 ? 'N/A' : +it.cross}
+              {it.cross || 'N/A'}
             </p>
             <p>
               <strong>
                 <a onClick={this.props.onShowModal.bind(this, 'opeCode')}>ED OPE code:</a>
                 &nbsp;
               </strong>
-              {+it.ope6 === 0 ? 'N/A' : +it.ope6}
+              {it.ope6 || 'N/A'}
             </p>
           </div>
         </div>

--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { showModal } from '../../actions';
+
 import AlertBox from '../../../common/components/AlertBox';
 
 const TableRow = ({ description, thisCampus, allCampuses }) => {
@@ -36,14 +35,14 @@ const ListRow = ({ description, value }) => {
 
 export class CautionaryInformation extends React.Component {
   render() {
-    const it = this.props.profile.attributes;
+    const it = this.props.institution;
     if (!it.complaints) { return null; }
 
     const flagContent = (
       <div>
         {it.cautionFlagReason}
         <p>
-          <a onClick={this.props.showModal.bind(this, 'cautionInfo')}>
+          <a onClick={this.props.onShowModal.bind(this, 'cautionInfo')}>
             Learn more about these warnings
           </a>
         </p>
@@ -136,10 +135,9 @@ export class CautionaryInformation extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => state;
-
-const mapDispatchToProps = {
-  showModal,
+CautionaryInformation.propTypes = {
+  institution: React.PropTypes.object,
+  onShowModal: React.PropTypes.func
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(CautionaryInformation);
+export default CautionaryInformation;

--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -7,12 +7,12 @@ const TableRow = ({ description, thisCampus, allCampuses }) => {
   const bold = description === 'Total Complaints';
   return (
     <tr>
-      <th><b>{description}</b></th>
+      <th><strong>{description}</strong></th>
       <td className="number">
-        {bold ? <b>{thisCampus}</b> : thisCampus}
+        {bold ? <strong>{thisCampus}</strong> : thisCampus}
       </td>
       <td className="number">
-        {bold ? <b>{allCampuses}</b> : allCampuses}
+        {bold ? <strong>{allCampuses}</strong> : allCampuses}
       </td>
     </tr>
   );
@@ -24,10 +24,10 @@ const ListRow = ({ description, value }) => {
   return (
     <div className="row">
       <div className="small-11 columns">
-        <p>{bold ? <b>{description}:</b> : `${description}:`}</p>
+        <p>{bold ? <strong>{description}:</strong> : `${description}:`}</p>
       </div>
       <div className="small-1 columns">
-        <p className="number">{bold ? <b>{value}</b> : value}</p>
+        <p className="number">{bold ? <strong>{value}</strong> : value}</p>
       </div>
     </div>
   );

--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -4,24 +4,31 @@ import { showModal } from '../../actions';
 import AlertBox from '../../../common/components/AlertBox';
 
 const TableRow = ({ description, thisCampus, allCampuses }) => {
+  if (!thisCampus && !allCampuses) return null;
+  const bold = description === 'Total Complaints';
   return (
     <tr>
-      <th><strong>{description}</strong></th>
-      <td className="number">{thisCampus}</td>
-      <td className="number">{allCampuses}</td>
+      <th><b>{description}</b></th>
+      <td className="number">
+        {bold ? <b>{thisCampus}</b> : thisCampus}
+      </td>
+      <td className="number">
+        {bold ? <b>{allCampuses}</b> : allCampuses}
+      </td>
     </tr>
   );
 };
 
 const ListRow = ({ description, value }) => {
   if (value < 1) return null;
+  const bold = description === 'Total Complaints';
   return (
     <div className="row">
       <div className="small-11 columns">
-        <p>{description}:</p>
+        <p>{bold ? <b>{description}:</b> : `${description}:`}</p>
       </div>
       <div className="small-1 columns">
-        <p className="number">{value}</p>
+        <p className="number">{bold ? <b>{value}</b> : value}</p>
       </div>
     </div>
   );
@@ -53,7 +60,7 @@ export class CautionaryInformation extends React.Component {
       { type: 'Post-Graduation Job Opportunities', key: 'job', totalKey: 'jobs' },
       { type: 'Release of Transcripts', key: 'transcript' },
       { type: 'Other', key: 'other' },
-      { type: 'Student Complaints', totals: ['facilityCode', 'mainCampusRollUp'] }
+      { type: 'Total Complaints', totals: ['facilityCode', 'mainCampusRollUp'] }
     ];
 
     const complaints = complaintData.reduce((hydratedComplaints, complaint) => {
@@ -74,8 +81,8 @@ export class CautionaryInformation extends React.Component {
         <div className="student-complaints">
           <div className="link-header">
             <h3>
-              {it.complaints.mainCampusRollUp}&nbsp;
-              <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints" target="_blank">student complaints</a>
+              {+it.complaints.mainCampusRollUp}&nbsp;
+              <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints" target="_blank">total complaints</a>
             </h3>
             <span>
               &nbsp;(<a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#sourcedata" target="_blank">Source</a>)
@@ -83,39 +90,34 @@ export class CautionaryInformation extends React.Component {
           </div>
         </div>
 
-        <div className="table">
-          <table className="usa-table-borderless">
-            <thead>
-              <tr>
-                <th>Complaint type</th>
-                <th>This campus</th>
-                <th>
-                  <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses" target="_blank">
-                    All campuses
-                  </a>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {complaints.map((c) =>
-                <TableRow key={c.description} description={c.description}
-                    thisCampus={c.thisCampus} allCampuses={c.allCampuses}/>)}
-            </tbody>
-          </table>
-        </div>
+        {
+          it.complaints.mainCampusRollUp &&
+          (<div className="table">
+            <table className="usa-table-borderless">
+              <thead>
+                <tr>
+                  <th>Complaint type</th>
+                  <th>This campus</th>
+                  <th>
+                    <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses" target="_blank">
+                      All campuses
+                    </a>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {complaints.map((c) =>
+                  <TableRow key={c.description} description={c.description}
+                      thisCampus={c.thisCampus} allCampuses={c.allCampuses}/>)}
+              </tbody>
+            </table>
+          </div>)
+        }
 
         <div className="list">
           <h4>This campus</h4>
           {complaints.map((c) =>
             <ListRow key={c.description} description={c.description} value={c.thisCampus}/>)}
-          <div className="row">
-            <div className="small-11 columns">
-              <p><strong>Total complaints:</strong></p>
-            </div>
-            <div className="small-1 columns">
-              <p className="number"><strong>{it.complaints.facilityCode}</strong></p>
-            </div>
-          </div>
           <h4>
             <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses" target="_blank">
               All campuses
@@ -123,14 +125,6 @@ export class CautionaryInformation extends React.Component {
           </h4>
           {complaints.map((c) =>
             <ListRow key={c.description} description={c.description} value={c.allCampuses}/>)}
-          <div className="row">
-            <div className="small-11 columns">
-              <p><strong>Total complaints:</strong></p>
-            </div>
-            <div className="small-1 columns">
-              <p className="number"><strong>{it.complaints.mainCampusRollUp}</strong></p>
-            </div>
-          </div>
         </div>
 
         <p>*Each complaint can have multiple types</p>

--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -40,11 +40,14 @@ export class CautionaryInformation extends React.Component {
     if (!it.complaints) { return null; }
 
     const flagContent = (
-      <p>
+      <div>
         {it.cautionFlagReason}
-        <br/>
-        <a onClick={this.props.showModal.bind(this, 'cautionInfo')}>Learn more about these warnings</a>
-      </p>
+        <p>
+          <a onClick={this.props.showModal.bind(this, 'cautionInfo')}>
+            Learn more about these warnings
+          </a>
+        </p>
+      </div>
     );
 
     const complaintData = [

--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -92,9 +92,8 @@ export class CautionaryInformation extends React.Component {
           </div>
         </div>
 
-        {
-          it.complaints.mainCampusRollUp &&
-          (<div className="table">
+        {it.complaints.mainCampusRollUp && (<div>
+          <div className="table">
             <table className="usa-table-borderless">
               <thead>
                 <tr>
@@ -113,23 +112,23 @@ export class CautionaryInformation extends React.Component {
                       thisCampus={c.thisCampus} allCampuses={c.allCampuses}/>)}
               </tbody>
             </table>
-          </div>)
-        }
+          </div>
 
-        <div className="list">
-          <h4>This campus</h4>
-          {complaints.map((c) =>
-            <ListRow key={c.description} description={c.description} value={c.thisCampus}/>)}
-          <h4>
-            <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses" target="_blank">
-              All campuses
-            </a>
-          </h4>
-          {complaints.map((c) =>
-            <ListRow key={c.description} description={c.description} value={c.allCampuses}/>)}
-        </div>
+          <div className="list">
+            <h4>This campus</h4>
+            {complaints.map((c) =>
+              <ListRow key={c.description} description={c.description} value={c.thisCampus}/>)}
+            <h4>
+              <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses" target="_blank">
+                All campuses
+              </a>
+            </h4>
+            {complaints.map((c) =>
+              <ListRow key={c.description} description={c.description} value={c.allCampuses}/>)}
+          </div>
 
-        <p>*Each complaint can have multiple types</p>
+          <p>*Each complaint can have multiple types</p>
+        </div>)}
       </div>
     );
   }

--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -12,6 +12,7 @@ class HeadingSummary extends React.Component {
 
   render() {
     const it = this.props.institution;
+    it.type = it.type && it.type.toLowerCase();
 
     const schoolSize = (enrollment) => {
       if (!enrollment) return 'Unknown';
@@ -60,7 +61,7 @@ class HeadingSummary extends React.Component {
             </p>
             <p>
               <IconWithInfo icon="institution" present={it.type && it.type !== 'ojt'}>
-                {_.capitalize(it.type)} institution
+                {_.capitalize(it.type)} school
               </IconWithInfo>
             </p>
             <p>

--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -61,7 +61,8 @@ class HeadingSummary extends React.Component {
             </p>
             <p>
               <IconWithInfo icon="institution" present={it.type && it.type !== 'ojt'}>
-                {_.capitalize(it.type)} school
+                {_.capitalize(it.type)}&nbsp;
+                {it.type === 'for profit' ? 'school' : 'institution'}
               </IconWithInfo>
             </p>
             <p>

--- a/src/js/gi/containers/Modals.jsx
+++ b/src/js/gi/containers/Modals.jsx
@@ -401,7 +401,7 @@ export class Modals extends React.Component {
             served (2 year enlistment vs. 3+ year enlistment) will impact your
             monthly payment amount when using the Montgomery GI Bill. To learn
             more about MGIB please visit
-            <a href="http://www.benefits.va.gov/gibill/mgib_ad.asp"
+            &nbsp;<a href="http://www.benefits.va.gov/gibill/mgib_ad.asp"
                 id="anch_399" target="_blank">
               http://www.benefits.va.gov/gibill/mgib_ad.asp
             </a>.
@@ -418,7 +418,7 @@ export class Modals extends React.Component {
             based on length of consecutive days of active duty service with
             rates increasing at one year and again at two years of consecutive
             service. To learn more about REAP please visit
-            <a href="http://www.benefits.va.gov/gibill/reap.asp"
+            &nbsp;<a href="http://www.benefits.va.gov/gibill/reap.asp"
                 id="anch_403" target="_blank">
               http://www.benefits.va.gov/gibill/reap.asp
             </a>.

--- a/src/js/gi/containers/ProfilePage.jsx
+++ b/src/js/gi/containers/ProfilePage.jsx
@@ -97,7 +97,9 @@ export class ProfilePage extends React.Component {
               <AccordionItem
                   button="Cautionary information"
                   ref={c => { this._cautionaryInfo = c; }}>
-                <CautionaryInformation/>
+                <CautionaryInformation
+                    institution={this.props.profile.attributes}
+                    onShowModal={this.props.showModal}/>
               </AccordionItem>
               <AccordionItem button="Additional information">
                 <AdditionalInformation

--- a/src/sass/gi/partials/_gi-profile-page.scss
+++ b/src/sass/gi/partials/_gi-profile-page.scss
@@ -100,6 +100,10 @@
   }
 
   .cautionary-information {
+    .va-alert {
+      margin: 0 0 1.5em 0;
+    }
+
     .table .number {
       text-align: left;
     }


### PR DESCRIPTION
### Changes
* Display facility, IPEDS, and OPES codes as they are without converting to numbers in order to preserve leading zeros. Resolves #5294.
    > <img width="190" alt="screen shot 2017-04-12 at 9 32 54 pm" src="https://cloud.githubusercontent.com/assets/1067024/24986356/c0f43c16-1fc7-11e7-8a34-b8a617451a16.png">

* Display "For profit school" and "[school type] institution" for any other school type. Resolves department-of-veterans-affairs/vets.gov-team#2082.
    > <img width="627" alt="screen shot 2017-04-12 at 9 28 25 pm" src="https://cloud.githubusercontent.com/assets/1067024/24986371/dc34c982-1fc7-11e7-8d81-51006a4331e7.png">

* Hide table as well and the list (in smaller or mobile view) and disclaimer when there are zero student complaints. Hide any rows that have 0 complaints (screenshot in change below). Resolves department-of-veterans-affairs/vets.gov-team#2097.
    > <img width="322" alt="screen shot 2017-04-12 at 9 27 18 pm" src="https://cloud.githubusercontent.com/assets/1067024/24986398/ff131df0-1fc7-11e7-8c9e-90366014aa89.png">

* Changed "Student Complaints" to "Total Complaints" and bolded the row. Resolves department-of-veterans-affairs/vets.gov-team#2118.
    > <img width="803" alt="screen shot 2017-04-12 at 9 28 03 pm" src="https://cloud.githubusercontent.com/assets/1067024/24986432/27ebab52-1fc8-11e7-9def-f3a1b4635c9e.png">
