### PR TITLE
Added links (apply, learn more) to GIBCT.

### DIFF
--- a/src/js/gi/components/content/VideoSidebar.jsx
+++ b/src/js/gi/components/content/VideoSidebar.jsx
@@ -11,6 +11,10 @@ class VideoSidebar extends React.Component {
         </p>
         <iframe width="100%" src="https://www.youtube.com/embed/Z1ttkv9oRI4"
             title="Know Before You Go" frameBorder="0" allowFullScreen></iframe>
+        <h5>Ready to apply?</h5>
+        <a href="https://www.vets.gov/education/apply/">
+          Apply for education benefits
+        </a>
       </div>
     );
   }

--- a/src/js/gi/components/content/VideoSidebar.jsx
+++ b/src/js/gi/components/content/VideoSidebar.jsx
@@ -12,7 +12,7 @@ class VideoSidebar extends React.Component {
         <iframe width="100%" src="https://www.youtube.com/embed/Z1ttkv9oRI4"
             title="Know Before You Go" frameBorder="0" allowFullScreen></iframe>
         <h5>Ready to apply?</h5>
-        <a href="https://www.vets.gov/education/apply/">
+        <a href="https://www.vets.gov/education/apply/" target="_blank">
           Apply for education benefits
         </a>
       </div>

--- a/src/js/gi/components/profile/Calculator.jsx
+++ b/src/js/gi/components/profile/Calculator.jsx
@@ -77,9 +77,16 @@ export class Calculator extends React.Component {
       const { visible, title, terms } = this.props.calculated.outputs.perTerm[section];
       if (!visible) return null;
 
+      const learnMoreLink = `http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#${section.toLowerCase()}`;
+
       return (
         <div key={section} className="per-term-section">
-          <h5>{title}</h5>
+          <div className="link-header">
+            <h5>{title}</h5>
+            &nbsp;(<a href={learnMoreLink} target="_blank">
+              Learn more
+            </a>)
+          </div>
           {terms.map(term =>
             <CalculatorResultRow
                 key={`${section}${term.label}`}

--- a/src/js/gi/components/profile/CalculatorForm.jsx
+++ b/src/js/gi/components/profile/CalculatorForm.jsx
@@ -364,7 +364,10 @@ class CalculatorForm extends React.Component {
     return (
       <div>
         <Dropdown
-            label="Will be working"
+            label={this.renderLearnMoreLabel({
+              text: 'Will be working',
+              modal: 'calcWorking'
+            })}
             name="working"
             alt="Will be working"
             options={[

--- a/src/js/gi/containers/Modals.jsx
+++ b/src/js/gi/containers/Modals.jsx
@@ -193,14 +193,14 @@ export class Modals extends React.Component {
         <Modal onClose={this.props.hideModal} visible={this.shouldDisplayModal('accredited')}>
           <h2>Is your school accredited</h2>
           <p>Accreditation matters if you plan to start school at one institution and transfer to another to complete your degree. Be sure to ask any potential school about their credit transfer policy. The U.S. Department of Education (ED) maintains a&nbsp;<a href="http://ope.ed.gov/accreditation/" id="anch_384" target="_blank">database</a>&nbsp;of accredited postsecondary institutions and programs. Accreditation is a recognized credential for schools and some programs. As stated by the ED, the goal of accreditation is to ensure that the education provided by institutions of higher education meets acceptable levels of quality.</p>
-          <p>To learn more about accreditaion, visit the <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#accreditation" target="_blank"> about this tool</a> page. </p>
+          <p>To learn more about accreditation, visit the <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#accreditation" target="_blank"> about this tool</a> page. </p>
         </Modal>
 
         <Modal onClose={this.props.hideModal} visible={this.shouldDisplayModal('typeAccredited')}>
           <h2>Accreditation types (Regional vs. National vs Hybrid)</h2>
           <p>Is the school regionally or nationally accredited at the institution level?</p>
           <p>Schools are accredited by private educational associations of regional or national scope. While the Department of Education does not say whether regional or national accreditation is better, a recent ED study revealed that, “Nearly 90 percent of all student credit transfer opportunities occurred between institutions that were regionally, rather than nationally, accredited.” <a href="http://nces.ed.gov/pubs2014/2014163.pdf" id="anch_386">http://nces.ed.gov/pubs2014/2014163.pdf</a></p>
-          <p> To learn more about accreditaion, visit the <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#accreditation_type" target="_blank"> about this tool</a> page. </p>
+          <p>To learn more about accreditation, visit the <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#accreditation_type" target="_blank"> about this tool</a> page. </p>
         </Modal>
 
         <Modal onClose={this.props.hideModal} visible={this.shouldDisplayModal('tuitionPolicy')}>

--- a/src/js/gi/containers/Modals.jsx
+++ b/src/js/gi/containers/Modals.jsx
@@ -355,6 +355,13 @@ export class Modals extends React.Component {
             visit <a href="https://gibill.custhelp.com/app/answers/detail/a_id/97"
                 target="_blank">this page</a>.</p>
         </Modal>
+
+        <Modal onClose={this.props.hideModal} visible={this.shouldDisplayModal('calcWorking')}>
+          <h2>Will be working</h2>
+          <p>
+            How many hours per week will you be working on your OJT / Apprenticeship? Beneficiaries working less than 120 hours/month (or approximately 30 hours/week) receive a prorated monthly housing allowance.
+          </p>
+        </Modal>
       </span>
     );
   }

--- a/src/js/gi/containers/Modals.jsx
+++ b/src/js/gi/containers/Modals.jsx
@@ -200,7 +200,7 @@ export class Modals extends React.Component {
           <h2>Accreditation types (Regional vs. National vs Hybrid)</h2>
           <p>Is the school regionally or nationally accredited at the institution level?</p>
           <p>Schools are accredited by private educational associations of regional or national scope. While the Department of Education does not say whether regional or national accreditation is better, a recent ED study revealed that, “Nearly 90 percent of all student credit transfer opportunities occurred between institutions that were regionally, rather than nationally, accredited.” <a href="http://nces.ed.gov/pubs2014/2014163.pdf" id="anch_386">http://nces.ed.gov/pubs2014/2014163.pdf</a></p>
-          <p>To learn more about accreditation, visit the <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#accreditation_type" target="_blank"> about this tool</a> page. </p>
+          <p>To learn more about accreditation types, visit the <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#accreditation_type" target="_blank"> about this tool</a> page. </p>
         </Modal>
 
         <Modal onClose={this.props.hideModal} visible={this.shouldDisplayModal('tuitionPolicy')}>

--- a/src/js/gi/selectors/calculator.js
+++ b/src/js/gi/selectors/calculator.js
@@ -836,7 +836,7 @@ export const getCalculatedBenefits = createSelector(
         value: formatCurrency(derived.totalToYou)
       },
       perTerm: {
-        tuitionAndFees: {
+        tuitionFees: {
           visible: true,
           title: 'Tuition and fees',
           terms: [

--- a/src/js/gi/selectors/calculator.js
+++ b/src/js/gi/selectors/calculator.js
@@ -1040,8 +1040,8 @@ export const getCalculatedBenefits = createSelector(
 
     if (derived.numberOfTerms === 1) {
       // Hide all term 2 and 3 calculations.
-      calculatedBenefits.outputs.perTerm.tuitionAndFees.terms[1].visible = false;
-      calculatedBenefits.outputs.perTerm.tuitionAndFees.terms[2].visible = false;
+      calculatedBenefits.outputs.perTerm.tuitionFees.terms[1].visible = false;
+      calculatedBenefits.outputs.perTerm.tuitionFees.terms[2].visible = false;
       calculatedBenefits.outputs.perTerm.housingAllowance.terms[1].visible = false;
       calculatedBenefits.outputs.perTerm.housingAllowance.terms[2].visible = false;
       calculatedBenefits.outputs.perTerm.bookStipend.terms[1].visible = false;
@@ -1054,7 +1054,7 @@ export const getCalculatedBenefits = createSelector(
 
     if (derived.numberOfTerms < 3 && institutionType !== 'ojt') {
       // Hide all term 3 calculations.
-      calculatedBenefits.outputs.perTerm.tuitionAndFees.terms[2].visible = false;
+      calculatedBenefits.outputs.perTerm.tuitionFees.terms[2].visible = false;
       calculatedBenefits.outputs.perTerm.housingAllowance.terms[2].visible = false;
       calculatedBenefits.outputs.perTerm.bookStipend.terms[2].visible = false;
       calculatedBenefits.outputs.perTerm.yellowRibbon.terms[4].visible = false;
@@ -1080,7 +1080,7 @@ export const getCalculatedBenefits = createSelector(
       calculatedBenefits.outputs.yourScholarships.visible = false;
       calculatedBenefits.outputs.outOfPocketTuition.visible = false;
       calculatedBenefits.outputs.totalPaidToYou.visible = false;
-      calculatedBenefits.outputs.perTerm.tuitionAndFees.visible = false;
+      calculatedBenefits.outputs.perTerm.tuitionFees.visible = false;
       calculatedBenefits.outputs.perTerm.yellowRibbon.visible = false;
     }
 

--- a/src/sass/gi/partials/_gi-landing-page.scss
+++ b/src/sass/gi/partials/_gi-landing-page.scss
@@ -11,4 +11,9 @@
     visibility: hidden;
   }
 
+  .video-sidebar h5 {
+    margin-top: .5em;
+    padding: 0;
+  }
+
 }

--- a/src/sass/gi/partials/_gi-profile-page.scss
+++ b/src/sass/gi/partials/_gi-profile-page.scss
@@ -5,7 +5,7 @@
   }
 
   .link-header {
-    h3 {
+    h3, h5 {
       display: inline-block;
       padding: 0;
     }


### PR DESCRIPTION
### Changes
* Added apply link to video sidebar. Resolves department-of-veterans-affairs/vets.gov-team#2081.

    > <img width="312" alt="screen shot 2017-04-13 at 9 38 22 pm" src="https://cloud.githubusercontent.com/assets/1067024/25030191/60114bf8-2091-11e7-80bb-eec28658389b.png">
* Added learn more links to headers in per-term calculation breakdown. Resolves department-of-veterans-affairs/vets.gov-team#2113.
    > <img width="290" alt="screen shot 2017-04-13 at 9 37 49 pm" src="https://cloud.githubusercontent.com/assets/1067024/25030199/67e9efb0-2091-11e7-8b2d-d4850df7309b.png">
* Added learn more link (and modal) for working field in OJT profiles. Resolves department-of-veterans-affairs/vets.gov-team#2115.

    > <img width="363" alt="screen shot 2017-04-13 at 9 37 11 pm" src="https://cloud.githubusercontent.com/assets/1067024/25030204/70ea744a-2091-11e7-9bc5-ab5b86dc7290.png">

    > <img width="597" alt="screen shot 2017-04-13 at 9 36 51 pm" src="https://cloud.githubusercontent.com/assets/1067024/25030207/7621391c-2091-11e7-8fa9-bb593fa6d979.png">