### PR TITLE
Resolved missing data in header summary of GIBCT profiles.

### DIFF
--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -70,7 +70,7 @@ class HeadingSummary extends React.Component {
               </IconWithInfo>
             </p>
             <p>
-              <IconWithInfo icon="group" present={it.undergradEnrollment && it.type && it.type !== 'ojt'}>
+              <IconWithInfo icon="group" present={it.type && it.type !== 'ojt'}>
                 {schoolSize(it.undergradEnrollment)} size
               </IconWithInfo>
             </p>

--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
+
 import AlertBox from '../../../common/components/AlertBox';
 import { formatNumber } from '../../utils/helpers';
 
@@ -47,8 +48,8 @@ class HeadingSummary extends React.Component {
               </IconWithInfo>
             </p>
             <p>
-              <IconWithInfo icon="calendar-o" present={it.type !== 'ojt' && (it.highestDegree === 2 || it.highestDegree === 4)}>
-                {it.highestDegree} year program
+              <IconWithInfo icon="calendar-o" present={it.type !== 'ojt' && it.highestDegree}>
+                {_.isFinite(it.highestDegree) ? `${it.highestDegree} year` : it.highestDegree} program
               </IconWithInfo>
             </p>
           </div>


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#2100.

Two issues being fixed here. First is that `highestDegree` values that weren't `2` or `4` weren't being handled, and it could have a value of `'Certificate'`. I generalized it to handle any non-empty values.

Second is that we need to show "Unknown size" if the institution has a `null` value for `undergradEnrollment`. It wasn't showing anything before if the attribute was unavailable.

> <img width="486" alt="screen shot 2017-04-13 at 10 16 48 pm" src="https://cloud.githubusercontent.com/assets/1067024/25030930/d76facf8-2096-11e7-8530-8848d9032938.png">
