### PR TITLE
Avoid double prorating kicker benefit in GIBCT calculation of monthly rate.

### DIFF
--- a/src/js/gi/selectors/calculator.js
+++ b/src/js/gi/selectors/calculator.js
@@ -274,7 +274,7 @@ const getDerivedValues = createSelector(
     }
 
     // Calculate Housing Allowance Rate Final - getMonthlyRateFinal
-    const monthlyRateFinal = ropOld * (monthlyRate + buyUpRate + kickerBenefit); // TODO: double check order of operations
+    const monthlyRateFinal = ropOld * (monthlyRate + buyUpRate) + kickerBenefit;
 
     // Calculate the names of Terms 1-4
     if (isOJT) {


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#2154.

While kicker benefit gets prorated with different rates of pursuit (`ropOjt`, `ropOld`, `rop`) depending on various factors, `monthlyRate` and `buyUpRate` are always going to be prorated with `ropOld`.

I'm not sure if those two values should also apply a different rate of pursuit, but at least this change will ensure that `kickerBenefit` doesn't factor in `ropOld` on top of the rate of pursuit it was prorated by in the earlier calculation.