### PR TITLE
Modal overflow fixes

### DIFF
--- a/src/sass/gi/partials/_gi-modal.scss
+++ b/src/sass/gi/partials/_gi-modal.scss
@@ -6,11 +6,6 @@
     .va-modal-inner {
       max-width: 600px;
 
-      @include media-maxwidth($small-screen) {
-        transform: none;
-        top: 0;
-      }
-
       .va-modal-close {
         margin: 12.5px 12.5px 12.5px 0;
       }

--- a/src/sass/modules/_m-modal.scss
+++ b/src/sass/modules/_m-modal.scss
@@ -98,6 +98,11 @@
     transform: translateY(-50%);
     width: 100%;
     cursor: auto;
+
+    @include media-maxwidth($small-screen) {
+      transform: none;
+      top: 0;
+    }
   }
 
   &-body {

--- a/src/sass/modules/_m-modal.scss
+++ b/src/sass/modules/_m-modal.scss
@@ -93,7 +93,6 @@
     background: $color-white;
     margin: auto;
     max-width: 40rem;
-    min-width: 320px;
     position: relative;
     top: 50%;
     transform: translateY(-50%);

--- a/src/sass/modules/_m-modal.scss
+++ b/src/sass/modules/_m-modal.scss
@@ -102,7 +102,10 @@
   }
 
   &-body {
+    overflow-wrap: break-word;
     padding: 2rem;
+    word-break: break-word;
+    word-wrap: break-word;
   }
 
   &-button-group {


### PR DESCRIPTION
### Changes
* Prevents modal content from overflowing out of the box. Resolves department-of-veterans-affairs/vets.gov-team#2139.
* Moved fix to put modals at top of viewport in mobile from #5271. Generalized the behavior instead of limiting it to GIBCT.
* Removed `min-width: 320px` since it could make the modal horizontally overflow (with padding) a small screen that has 320px width, such as iPhone 5. Although this is a general fix, this is related to the remaining GIBCT issue in department-of-veterans-affairs/vets.gov-team#1507.

#### GIBCT modal in iPhone 5. Modal doesn't touch the right edge of the screen, and the link doesn't overflow.
> <img width="318" alt="screen shot 2017-04-17 at 8 24 39 pm" src="https://cloud.githubusercontent.com/assets/1067024/25109587/c25221ee-23ab-11e7-80a4-cd88d9b3bcd0.png">
