### PR TITLE
Fixed caution flag color in cautionary info section of GIBCT profile.

### DIFF
--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -78,7 +78,12 @@ export class CautionaryInformation extends React.Component {
 
     return (
       <div className="cautionary-information">
-        <AlertBox content={flagContent} isVisible={!!it.cautionFlag} status="warning"/>
+        <div className="caution-flag">
+          <AlertBox
+              content={flagContent}
+              isVisible={!!it.cautionFlag}
+              status="warning"/>
+        </div>
 
         <div className="student-complaints">
           <div className="link-header">


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#2249.

Forgot to change this flag in a previous change that changed the color of the one in header. AFAIK, these are the only two.

> <img width="306" alt="screen shot 2017-04-18 at 1 33 11 pm" src="https://cloud.githubusercontent.com/assets/1067024/25146841/6d5d0f3a-2443-11e7-9e4e-3c358dfd10c2.png">
