### PR TITLE
5495 intro change

### DIFF
--- a/src/js/edu-benefits/5495/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/5495/components/IntroductionPage.jsx
@@ -25,13 +25,12 @@ class IntroductionPage extends React.Component {
               <ul>
                 <li>Social Security number (required)</li>
                 <li>Basic information about the school or training facility where you want to attend (required)</li>
-                <li>Military history</li>
                 <li>Bank account direct deposit information</li>
                 <li>Education history</li>
               </ul>
               <div className="usa-alert usa-alert-info">
                 <div className="usa-alert-body">
-                  <span><strong>You won’t be able to save your work or come back to finish.</strong> So before you start, it’s a good idea to gather information about your military and education history, and the school you want to attend.</span>
+                  <span><strong>You won’t be able to save your work or come back to finish.</strong> So before you start, it’s a good idea to gather information about your education history and the school you want to attend.</span>
                 </div>
               </div>
               <p><a href="http://www.va.gov/ogc/apps/accreditation/index.asp">An accredited representative</a> with a Veterans Service Organization (VSO) can help you pick the right program.</p>

--- a/src/js/edu-benefits/5495/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/5495/components/IntroductionPage.jsx
@@ -48,7 +48,7 @@ class IntroductionPage extends React.Component {
               <div><h6>How long does it take VA to make a decision?</h6></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
               <div><h6>What should I do while I wait?</h6></div>
-              <ul><li>The transition from military to civilian life can be challenging. VA offers <a href="/education/tools-programs/education-career-counseling/">tools and counseling programs</a> to help you make the most of your educational options.</li></ul>
+              <ul><li>We offer tools and counseling programs to help you make the most of your educational options. <a href="/education/tools-programs/">Learn about career counseling options.</a></li></ul>
               <div><h6>What if VA needs more information?</h6></div>
               <ul><li>We will contact you if we need more information.</li></ul>
             </li>


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2245

![image](https://cloud.githubusercontent.com/assets/12970166/25154525/d5ef08d0-2445-11e7-8364-d7a3bb46a885.png)

I replaced the civilian life transition text with what was in the 1990n per @jbalboni's suggestion. Does that look right, @J-Quag?
![image](https://cloud.githubusercontent.com/assets/12970166/25190040/ebb49e42-24df-11e7-85d2-5687de2ddd52.png)
