### PR TITLE
Split GIBCT complaints table (all and by type) with some copy and style tweaks.

### DIFF
--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -8,10 +8,10 @@ const TableRow = ({ description, thisCampus, allCampuses }) => {
   return (
     <tr>
       <th><strong>{description}</strong></th>
-      <td className="number">
+      <td>
         {bold ? <strong>{thisCampus}</strong> : thisCampus}
       </td>
-      <td className="number">
+      <td>
         {bold ? <strong>{allCampuses}</strong> : allCampuses}
       </td>
     </tr>
@@ -101,7 +101,7 @@ export class CautionaryInformation extends React.Component {
 
         {it.complaints.mainCampusRollUp && (<div>
           <div className="table">
-            <table className="usa-table-borderless">
+            <table className="all-complaints usa-table-borderless">
               <thead>
                 <tr>
                   <th></th>
@@ -120,10 +120,10 @@ export class CautionaryInformation extends React.Component {
                     allCampuses={allComplaints.allCampuses}/>
               </tbody>
             </table>
-            <table className="usa-table-borderless">
+            <table className="complaints-by-type usa-table-borderless">
               <thead>
                 <tr>
-                  <th>Complaint type</th>
+                  <th>Complaints by type <span>(Each complaint can have multiple types)</span></th>
                   <th>This campus</th>
                   <th>
                     <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses" target="_blank">

--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -49,6 +49,12 @@ export class CautionaryInformation extends React.Component {
       </div>
     );
 
+    const allCampusesLink = (
+      <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses" target="_blank">
+        All campuses
+      </a>
+    );
+
     const complaintData = [
       { type: 'Financial Issues (e.g., Tuition/Fee charges)', key: 'financial' },
       { type: 'Quality of Education', key: 'quality' },
@@ -106,11 +112,7 @@ export class CautionaryInformation extends React.Component {
                 <tr>
                   <th></th>
                   <th>This campus</th>
-                  <th>
-                    <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses" target="_blank">
-                      All campuses
-                    </a>
-                  </th>
+                  <th>{allCampusesLink}</th>
                 </tr>
               </thead>
               <tbody>
@@ -125,11 +127,7 @@ export class CautionaryInformation extends React.Component {
                 <tr>
                   <th>Complaints by type <span>(Each complaint can have multiple types)</span></th>
                   <th>This campus</th>
-                  <th>
-                    <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses" target="_blank">
-                      All campuses
-                    </a>
-                  </th>
+                  <th>{allCampusesLink}</th>
                 </tr>
               </thead>
               <tbody>
@@ -144,11 +142,7 @@ export class CautionaryInformation extends React.Component {
             <h4>This campus</h4>
             {complaints.map((c) =>
               <ListRow key={c.description} description={c.description} value={c.thisCampus}/>)}
-            <h4>
-              <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses" target="_blank">
-                All campuses
-              </a>
-            </h4>
+            <h4>{allCampusesLink}</h4>
             {complaints.map((c) =>
               <ListRow key={c.description} description={c.description} value={c.allCampuses}/>)}
           </div>

--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -91,7 +91,7 @@ export class CautionaryInformation extends React.Component {
           <div className="link-header">
             <h3>
               {+it.complaints.mainCampusRollUp}&nbsp;
-              <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints" target="_blank">total complaints</a>
+              <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints" target="_blank">student complaints</a>
             </h3>
             <span>
               &nbsp;(<a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#sourcedata" target="_blank">Source</a>)

--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -76,6 +76,8 @@ export class CautionaryInformation extends React.Component {
       return [...hydratedComplaints, hydratedComplaint];
     }, []);
 
+    const allComplaints = complaints.pop();
+
     return (
       <div className="cautionary-information">
         <div className="caution-flag">
@@ -99,6 +101,25 @@ export class CautionaryInformation extends React.Component {
 
         {it.complaints.mainCampusRollUp && (<div>
           <div className="table">
+            <table className="usa-table-borderless">
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>This campus</th>
+                  <th>
+                    <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses" target="_blank">
+                      All campuses
+                    </a>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <TableRow
+                    description="All student complaints"
+                    thisCampus={allComplaints.thisCampus}
+                    allCampuses={allComplaints.allCampuses}/>
+              </tbody>
+            </table>
             <table className="usa-table-borderless">
               <thead>
                 <tr>

--- a/src/sass/gi/partials/_gi-profile-page.scss
+++ b/src/sass/gi/partials/_gi-profile-page.scss
@@ -110,8 +110,26 @@
       margin: 0 0 1.5em 0;
     }
 
-    .table .number {
-      text-align: left;
+    .table {
+      table {
+        margin: 1em 0;
+      }
+
+      th:first-child {
+        width: 60%;
+      }
+
+      tr:last-child {
+        th, td {
+          border-bottom: 0;
+        }
+      }
+    }
+
+    .complaints-by-type {
+      th:first-child span {
+        font-weight: normal;
+      }
     }
 
     .list {


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#2251.

### Changes
* Changed "# total complaints" to "# student complaints".
* Split complaints table into two (all and by type). By type table doesn't include all complaints row.
* Modified first column header of complaints by type table.
* Removed borders at bottoms of tables.

> <img width="878" alt="screen shot 2017-04-18 at 8 06 27 pm" src="https://cloud.githubusercontent.com/assets/1067024/25157967/e3297f94-2472-11e7-89f5-4cb3de034a00.png">
