### PR TITLE
Fix loading error on GIBCT profile page

### DIFF
--- a/src/js/gi/containers/ProfilePage.jsx
+++ b/src/js/gi/containers/ProfilePage.jsx
@@ -67,7 +67,7 @@ export class ProfilePage extends React.Component {
 
     let content;
 
-    if (profile.inProgress) {
+    if (profile.inProgress || _.isEmpty(profile.attributes)) {
       content = <LoadingIndicator message="Loading profile..."/>;
     } else {
       content = (


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2263

In the initial render of the `ProfilePage` component, the profile attributes are empty, causing there to be an error. This PR adds a catch for the initial render.