### PR TITLE
Remove unnecessary first-of-type rules

### DIFF
--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -481,6 +481,7 @@ h6 {
     padding-top: 0;
     margin-top: 0;
   }
+}
 
 .va-introtext {
   color: $color-primary-darker;

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -482,16 +482,6 @@ h6 {
     margin-top: 0;
   }
 
-  li p:first-of-type,
-  ul+p
-   {
-    font-weight: normal !important;
-    color: $color-gray-dark;
-    font-size: 1em;
-    padding-bottom: 0;
-  }
-}
-
 .va-introtext {
   color: $color-primary-darker;
   letter-spacing: normal;


### PR DESCRIPTION
First-of-type rules for lists are no longer needed now that we have the `.va-introtext` class to manually apply the style.