### PR TITLE
Additional Resources section in GIBCT profile pages

### DIFF
--- a/src/js/gi/components/content/VideoSidebar.jsx
+++ b/src/js/gi/components/content/VideoSidebar.jsx
@@ -12,7 +12,7 @@ class VideoSidebar extends React.Component {
         <iframe width="100%" src="https://www.youtube.com/embed/Z1ttkv9oRI4"
             title="Know Before You Go" frameBorder="0" allowFullScreen></iframe>
         <h5>Ready to apply?</h5>
-        <a href="https://www.vets.gov/education/apply/" target="_blank">
+        <a href="/education/apply/" target="_blank">
           Apply for education benefits
         </a>
       </div>

--- a/src/js/gi/components/content/VideoSidebar.jsx
+++ b/src/js/gi/components/content/VideoSidebar.jsx
@@ -12,9 +12,21 @@ class VideoSidebar extends React.Component {
         <iframe width="100%" src="https://www.youtube.com/embed/Z1ttkv9oRI4"
             title="Know Before You Go" frameBorder="0" allowFullScreen></iframe>
         <h5>Ready to apply?</h5>
-        <a href="/education/apply/" target="_blank">
-          Apply for education benefits
-        </a>
+        <p>
+          <a href="http://www.benefits.va.gov/gibill/careerscope.asp" target="_blank">
+            Explore your career
+          </a>
+        </p>
+        <p>
+          <a href="http://www.benefits.va.gov/gibill/choosing_a_school.asp" target="_blank">
+            Choose a school
+          </a>
+        </p>
+        <p>
+          <a href="/education/apply/" target="_blank">
+            Apply for education benefits
+          </a>
+        </p>
       </div>
     );
   }

--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -4,6 +4,27 @@ import _ from 'lodash';
 import AlertBox from '../../../common/components/AlertBox';
 import { formatNumber } from '../../utils/helpers';
 
+const AdditionalResources = () => (
+  <div className="medium-4 small-12 column">
+    <h4 className="highlight">Additional Resources</h4>
+    <p>
+      <a href="http://www.benefits.va.gov/gibill/careerscope.asp" target="_blank">
+        Explore your career
+      </a>
+    </p>
+    <p>
+      <a href="http://www.benefits.va.gov/gibill/choosing_a_school.asp" target="_blank">
+        Choose a school
+      </a>
+    </p>
+    <p>
+      <a href="/education/apply" target="_blank">
+        Apply for education benefits
+      </a>
+    </p>
+  </div>
+);
+
 const IconWithInfo = ({ icon, children, present }) => {
   if (!present) return null;
   return <span><i className={`fa fa-${icon}`}/>&nbsp;{children}</span>;
@@ -27,7 +48,7 @@ class HeadingSummary extends React.Component {
 
     return (
       <div className="heading row">
-        <div className="small-12 column">
+        <div className="medium-8 small-12 column">
           <h1>{it.name}</h1>
           <div className="caution-flag">
             <AlertBox
@@ -81,6 +102,7 @@ class HeadingSummary extends React.Component {
           </div>
           <div className="small-12 medium-4 column"></div>
         </div>
+        <AdditionalResources/>
       </div>
     );
   }

--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -5,7 +5,7 @@ import AlertBox from '../../../common/components/AlertBox';
 import { formatNumber } from '../../utils/helpers';
 
 const AdditionalResources = () => (
-  <div className="medium-4 small-12 column">
+  <div className="additional-resources medium-4 small-12 column">
     <h4 className="highlight">Additional Resources</h4>
     <p>
       <a href="http://www.benefits.va.gov/gibill/careerscope.asp" target="_blank">
@@ -27,7 +27,11 @@ const AdditionalResources = () => (
 
 const IconWithInfo = ({ icon, children, present }) => {
   if (!present) return null;
-  return <span><i className={`fa fa-${icon}`}/>&nbsp;{children}</span>;
+  return (
+    <p className="icon-with-info">
+      <i className={`fa fa-${icon}`}/>&nbsp;{children}
+    </p>
+  );
 };
 
 class HeadingSummary extends React.Component {
@@ -56,50 +60,38 @@ class HeadingSummary extends React.Component {
                 isVisible={!!it.cautionFlag}
                 status="warning"/>
           </div>
-          <p style={{ marginBottom: '1.5em' }}>
-            <strong>{formatNumber(it.studentCount)}</strong> GI Bill students
-            (<a onClick={this.props.onLearnMore}>Learn more</a>)
-          </p>
+          <div className="column">
+            <p>
+              <strong>{formatNumber(it.studentCount)}</strong> GI Bill students
+              (<a onClick={this.props.onLearnMore}>Learn more</a>)
+            </p>
+          </div>
           <div>
             <div className="small-12 medium-6 column">
-              <p>
-                <IconWithInfo icon="map-marker" present={it.city && it.country}>
-                  {it.city}, {it.state || it.country}
-                </IconWithInfo>
-              </p>
-              <p style={{ display: 'block' }}>
-                <IconWithInfo icon="globe" present={it.website}>
-                  <a href={it.website} target="_blank">{it.website}</a>
-                </IconWithInfo>
-              </p>
-              <p>
-                <IconWithInfo icon="calendar-o" present={it.type !== 'ojt' && it.highestDegree}>
-                  {_.isFinite(it.highestDegree) ? `${it.highestDegree} year` : it.highestDegree} program
-                </IconWithInfo>
-              </p>
+              <IconWithInfo icon="map-marker" present={it.city && it.country}>
+                {it.city}, {it.state || it.country}
+              </IconWithInfo>
+              <IconWithInfo icon="globe" present={it.website}>
+                <a href={it.website} target="_blank">{it.website}</a>
+              </IconWithInfo>
+              <IconWithInfo icon="calendar-o" present={it.type !== 'ojt' && it.highestDegree}>
+                {_.isFinite(it.highestDegree) ? `${it.highestDegree} year` : it.highestDegree} program
+              </IconWithInfo>
             </div>
             <div className="small-12 medium-6 column">
-              <p>
-                <IconWithInfo icon="briefcase" present={it.type === 'ojt'}>
-                  On-the-job training
-                </IconWithInfo>
-              </p>
-              <p>
-                <IconWithInfo icon="institution" present={it.type && it.type !== 'ojt'}>
-                  {_.capitalize(it.type)}&nbsp;
-                  {it.type === 'for profit' ? 'school' : 'institution'}
-                </IconWithInfo>
-              </p>
-              <p>
-                <IconWithInfo icon="map" present={it.localeType && it.type && it.type !== 'ojt'}>
-                  {_.capitalize(it.localeType)} locale
-                </IconWithInfo>
-              </p>
-              <p>
-                <IconWithInfo icon="group" present={it.type && it.type !== 'ojt'}>
-                  {schoolSize(it.undergradEnrollment)} size
-                </IconWithInfo>
-              </p>
+              <IconWithInfo icon="briefcase" present={it.type === 'ojt'}>
+                On-the-job training
+              </IconWithInfo>
+              <IconWithInfo icon="institution" present={it.type && it.type !== 'ojt'}>
+                {_.capitalize(it.type)}&nbsp;
+                {it.type === 'for profit' ? 'school' : 'institution'}
+              </IconWithInfo>
+              <IconWithInfo icon="map" present={it.localeType && it.type && it.type !== 'ojt'}>
+                {_.capitalize(it.localeType)} locale
+              </IconWithInfo>
+              <IconWithInfo icon="group" present={it.type && it.type !== 'ojt'}>
+                {schoolSize(it.undergradEnrollment)} size
+              </IconWithInfo>
             </div>
           </div>
         </div>

--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -60,47 +60,48 @@ class HeadingSummary extends React.Component {
             <strong>{formatNumber(it.studentCount)}</strong> GI Bill students
             (<a onClick={this.props.onLearnMore}>Learn more</a>)
           </p>
-          <div className="small-12 medium-4 column">
-            <p>
-              <IconWithInfo icon="map-marker" present={it.city && it.country}>
-                {it.city}, {it.state || it.country}
-              </IconWithInfo>
-            </p>
-            <p style={{ display: 'block' }}>
-              <IconWithInfo icon="globe" present={it.website}>
-                <a href={it.website} target="_blank">{it.website}</a>
-              </IconWithInfo>
-            </p>
-            <p>
-              <IconWithInfo icon="calendar-o" present={it.type !== 'ojt' && it.highestDegree}>
-                {_.isFinite(it.highestDegree) ? `${it.highestDegree} year` : it.highestDegree} program
-              </IconWithInfo>
-            </p>
+          <div>
+            <div className="small-12 medium-6 column">
+              <p>
+                <IconWithInfo icon="map-marker" present={it.city && it.country}>
+                  {it.city}, {it.state || it.country}
+                </IconWithInfo>
+              </p>
+              <p style={{ display: 'block' }}>
+                <IconWithInfo icon="globe" present={it.website}>
+                  <a href={it.website} target="_blank">{it.website}</a>
+                </IconWithInfo>
+              </p>
+              <p>
+                <IconWithInfo icon="calendar-o" present={it.type !== 'ojt' && it.highestDegree}>
+                  {_.isFinite(it.highestDegree) ? `${it.highestDegree} year` : it.highestDegree} program
+                </IconWithInfo>
+              </p>
+            </div>
+            <div className="small-12 medium-6 column">
+              <p>
+                <IconWithInfo icon="briefcase" present={it.type === 'ojt'}>
+                  On-the-job training
+                </IconWithInfo>
+              </p>
+              <p>
+                <IconWithInfo icon="institution" present={it.type && it.type !== 'ojt'}>
+                  {_.capitalize(it.type)}&nbsp;
+                  {it.type === 'for profit' ? 'school' : 'institution'}
+                </IconWithInfo>
+              </p>
+              <p>
+                <IconWithInfo icon="map" present={it.localeType && it.type && it.type !== 'ojt'}>
+                  {_.capitalize(it.localeType)} locale
+                </IconWithInfo>
+              </p>
+              <p>
+                <IconWithInfo icon="group" present={it.type && it.type !== 'ojt'}>
+                  {schoolSize(it.undergradEnrollment)} size
+                </IconWithInfo>
+              </p>
+            </div>
           </div>
-          <div className="small-12 medium-4 column">
-            <p>
-              <IconWithInfo icon="briefcase" present={it.type === 'ojt'}>
-                On-the-job training
-              </IconWithInfo>
-            </p>
-            <p>
-              <IconWithInfo icon="institution" present={it.type && it.type !== 'ojt'}>
-                {_.capitalize(it.type)}&nbsp;
-                {it.type === 'for profit' ? 'school' : 'institution'}
-              </IconWithInfo>
-            </p>
-            <p>
-              <IconWithInfo icon="map" present={it.localeType && it.type && it.type !== 'ojt'}>
-                {_.capitalize(it.localeType)} locale
-              </IconWithInfo>
-            </p>
-            <p>
-              <IconWithInfo icon="group" present={it.type && it.type !== 'ojt'}>
-                {schoolSize(it.undergradEnrollment)} size
-              </IconWithInfo>
-            </p>
-          </div>
-          <div className="small-12 medium-4 column"></div>
         </div>
         <AdditionalResources/>
       </div>

--- a/src/sass/gi/partials/_gi-profile-page.scss
+++ b/src/sass/gi/partials/_gi-profile-page.scss
@@ -21,7 +21,7 @@
 
   .additional-resources {
     @include media-maxwidth($medium-large-screen) {
-      margin: 1rem 0;
+      display: none;
     }
   }
 

--- a/src/sass/gi/partials/_gi-profile-page.scss
+++ b/src/sass/gi/partials/_gi-profile-page.scss
@@ -19,6 +19,16 @@
     }
   }
 
+  .additional-resources {
+    @include media-maxwidth($medium-large-screen) {
+      margin: 1rem 0;
+    }
+  }
+
+  .icon-with-info {
+    margin-top: 0;
+  }
+
   li button.usa-accordion-button {
     text-align: left;
 


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#2253.

In addition to the new section in the header, I also tweaked some of the margins between the icon-with-info rows to be more consistent.

#### Desktop
> <img width="998" alt="screen shot 2017-04-19 at 8 32 06 pm" src="https://cloud.githubusercontent.com/assets/1067024/25207962/98fd3442-253f-11e7-9c0a-b09c7499ec47.png">

#### Mobile
> <img width="320" alt="screen shot 2017-04-19 at 8 32 35 pm" src="https://cloud.githubusercontent.com/assets/1067024/25207966/9cd71876-253f-11e7-9de2-048e4ae7e413.png">
