### PR TITLE
Add all 5 pages of Chapter 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:js:changed": "LIST=`git diff-index --name-only HEAD | grep .*\\.js | grep -v json`; if [ \"$LIST\" ]; then eslint --quiet $LIST; fi",
     "lint:sass": "sass-lint -c config/sass-lint.yml --verbose",
     "nightwatch": "nightwatch -c config/nightwatch.js",
-    "reset:env" : "./script/reset-environment.sh",
+    "reset:env": "./script/reset-environment.sh",
     "test": "npm run test:unit && npm run test:e2e",
     "test:e2e": "./script/run-nightwatch.sh",
     "test:accessibility": "./script/run-nightwatch.sh --env accessibility",
@@ -189,6 +189,6 @@
     "camelcase-keys-recursive": "^0.8.2",
     "react-autosuggest": "^8.0.0",
     "reselect": "^2.5.4",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ee444b33dd221524c71b3b0201beda250a0ffd65"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d0e327cd0ee93a82988914778cc4342dbf013cb4"
   }
 }

--- a/src/js/common/schemaform/Address.jsx
+++ b/src/js/common/schemaform/Address.jsx
@@ -171,6 +171,20 @@ class Address extends React.Component {
             formContext={formContext}
             onChange={(update) => {this.handleChange('street2', update);}}
             onBlur={onBlur}/>
+
+        {schema.properties.street3 ? <SchemaField
+            name="street3"
+            required={this.isRequired('street3')}
+            schema={schema.properties.street3}
+            uiSchema={uiSchema.street3}
+            idSchema={idSchema.street3}
+            formData={formData.street3}
+            errorSchema={errorSchema.street3}
+            registry={registry}
+            formContext={formContext}
+            onChange={(update) => {this.handleChange('street3', update);}}
+            onBlur={onBlur}/> : null}
+
         <SchemaField
             name="city"
             required={this.isRequired('city')}

--- a/src/js/common/schemaform/definitions/address.js
+++ b/src/js/common/schemaform/definitions/address.js
@@ -48,6 +48,9 @@ export function uiSchema(label = 'Address') {
     street2: {
       'ui:title': 'Line 2'
     },
+    street3: {
+      'ui:title': 'Line 3'
+    },
     city: {
       'ui:title': 'City'
     },

--- a/src/js/common/schemaform/validation.js
+++ b/src/js/common/schemaform/validation.js
@@ -224,8 +224,6 @@ export function validateCurrentOrPastDate(errors, dateString, formData, schema, 
 
 /**
  * Adds an error message to errors if a date is an invalid date or in the past.
- *
- * The message it adds can be customized in uiSchema.errorMessages.pastDate
  */
 export function validateFutureDateIfExpectedGrad(errors, dateString, formData) {
   validateDate(errors, dateString);

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -29,6 +29,7 @@ import { uiSchema as fullNameUISchema } from '../../common/schemaform/definition
 import * as ssn from '../../common/schemaform/definitions/ssn';
 
 const {
+  mothersMaidenName,
   cityOfBirth,
   isSpanishHispanicLatino,
   isAmericanIndianOrAlaskanNative,
@@ -107,16 +108,8 @@ const formConfig = {
           schema: {
             type: 'object',
             properties: {
-              veteranFullName: _.merge(fullName, {
-                properties: {
-                  suffix: {
-                    type: 'string'
-                  }
-                }
-              }),
-              mothersMaidenName: {
-                type: 'string'
-              }
+              veteranFullName: fullName,
+              mothersMaidenName
             }
           }
         },
@@ -235,12 +228,10 @@ const formConfig = {
               address: _.merge(address.schema(true), {
                 properties: {
                   street: {
-                    type: 'string',
                     minLength: 1,
                     maxLength: 30
                   },
                   street2: {
-                    type: 'string',
                     minLength: 1,
                     maxLength: 30
                   },
@@ -250,7 +241,6 @@ const formConfig = {
                     maxLength: 30
                   },
                   city: {
-                    type: 'string',
                     minLength: 1,
                     maxLength: 30
                   }
@@ -448,7 +438,6 @@ const formConfig = {
                     'enum': states.USA.map(state => state.value)
                   },
                   vaMedicalFacility: _.assign(vaMedicalFacility, {
-                    type: 'string',
                     'enum': []
                   })
                 }
@@ -523,10 +512,10 @@ const formConfig = {
           schema: {
             type: 'object',
             properties: {
-              lastServiceBranch: _.assign(lastServiceBranch, { type: 'string' }),
+              lastServiceBranch,
               lastEntryDate,
               lastDischargeDate,
-              dischargeType: _.assign(dischargeType, { type: 'string' })
+              dischargeType
             },
             required: [
               'lastServiceBranch',

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -21,7 +21,6 @@ import { uiSchema as dateUI } from '../../common/schemaform/definitions/currentO
 
 const {
   cityOfBirth,
-  stateOfBirth,
   lastEntryDate,
   lastDischargeDate,
   lastServiceBranch,
@@ -135,9 +134,11 @@ const formConfig = {
                 type: 'object',
                 properties: {
                   cityOfBirth,
-                  stateOfBirth: _.merge(stateOfBirth, {
-                    type: 'string'
-                  })
+                  stateOfBirth: {
+                    type: 'string',
+                    'enum': states.USA.map(state => state.value),
+                    enumNames: states.USA.map(state => state.label)
+                  }
                 }
               }
             }

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -225,11 +225,7 @@ const formConfig = {
           title: 'Permanent address',
           initialData: {},
           uiSchema: {
-            address: _.merge(address.uiSchema('Permanent address'), {
-              street3: {
-                'ui:title': 'Line 3'
-              }
-            })
+            address: address.uiSchema('Permanent address')
           },
           schema: {
             type: 'object',

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -2,7 +2,12 @@ import _ from 'lodash/fp';
 
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 
-import { states } from '../../common/utils/options-for-select';
+import {
+  states,
+  genders,
+  maritalStatuses
+} from '../../common/utils/options-for-select';
+
 import { createUSAStateLabels } from '../../common/schemaform/helpers';
 
 import {
@@ -23,6 +28,12 @@ import * as ssn from '../../common/schemaform/definitions/ssn';
 
 const {
   cityOfBirth,
+  isSpanishHispanicLatino,
+  isAmericanIndianOrAlaskanNative,
+  isBlackOrAfricanAmerican,
+  isNativeHawaiianOrOtherPacificIslander,
+  isAsian,
+  isWhite,
   lastEntryDate,
   lastDischargeDate,
   lastServiceBranch,
@@ -147,8 +158,62 @@ const formConfig = {
           path: 'veteran-information/demographic-information',
           title: 'Veteran information',
           initialData: {},
-          uiSchema: {},
-          schema: {}
+          uiSchema: {
+            gender: {
+              'ui:title': 'Gender'
+            },
+            maritalStatus: {
+              'ui:title': 'Marital status'
+            },
+            'view:demographicCategories': {
+              'ui:title': 'Which categories best describe you?',
+              'ui:description': 'You may check more than one.',
+              isSpanishHispanicLatino: {
+                'ui:title': 'Spanish, Hispanic, or Latino'
+              },
+              isAmericanIndianOrAlaskanNative: {
+                'ui:title': 'American Indian or Alaskan Native'
+              },
+              isBlackOrAfricanAmerican: {
+                'ui:title': 'Black or African American'
+              },
+              isNativeHawaiianOrOtherPacificIslander: {
+                'ui:title': 'Native Hawaiian or Other Pacific Islander'
+              },
+              isAsian: {
+                'ui:title': 'Asian'
+              },
+              isWhite: {
+                'ui:title': 'White'
+              }
+            }
+          },
+          schema: {
+            type: 'object',
+            required: ['gender', 'maritalStatus'],
+            properties: {
+              gender: {
+                type: 'string',
+                'enum': genders.map(gender => gender.value),
+                enumNames: genders.map(gender => gender.label)
+              },
+              maritalStatus: {
+                type: 'string',
+                'enum': maritalStatuses
+              },
+              'view:demographicCategories': {
+                type: 'object',
+                properties: {
+                  isSpanishHispanicLatino,
+                  isAmericanIndianOrAlaskanNative,
+                  isBlackOrAfricanAmerican,
+                  isNativeHawaiianOrOtherPacificIslander,
+                  isAsian,
+                  isWhite
+                }
+              }
+            }
+          }
         },
         veteranAddress: {
           path: 'veteran-information/veteran-address',

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -20,6 +20,8 @@ import InsuranceProviderView from '../components/InsuranceProviderView';
 import { uiSchema as dateUI } from '../../common/schemaform/definitions/currentOrPastDate';
 
 const {
+  cityOfBirth,
+  stateOfBirth,
   lastEntryDate,
   lastDischargeDate,
   lastServiceBranch,
@@ -46,6 +48,7 @@ const {
 } = fullSchemaHca.properties;
 
 const {
+  fullName,
   date,
   provider
 } = fullSchemaHca.definitions;
@@ -54,16 +57,6 @@ const stateLabels = createUSAStateLabels(states);
 
 import { uiSchema as fullNameUISchema } from '../../common/schemaform/definitions/fullName';
 import * as ssn from '../../common/schemaform/definitions/ssn';
-
-const {
-  fullName,
-  date
-} = fullSchemaHca.definitions;
-
-const {
-  cityOfBirth,
-  stateOfBirth
-} = fullSchemaHca.properties;
 
 const formConfig = {
   urlPrefix: '/',
@@ -122,11 +115,14 @@ const formConfig = {
               'ui:title': 'Date of birth'
             },
             veteranSocialSecurityNumber: ssn.uiSchema,
-            cityOfBirth: {
-              'ui:title': 'City of birth'
-            },
-            stateOfBirth: {
-              'ui:title': 'State of birth'
+            'view:placeOfBirth': {
+              'ui:title': 'Place of birth',
+              cityOfBirth: {
+                'ui:title': 'City'
+              },
+              stateOfBirth: {
+                'ui:title': 'State'
+              }
             }
           },
           schema: {
@@ -135,10 +131,15 @@ const formConfig = {
             properties: {
               veteranDateOfBirth: date,
               veteranSocialSecurityNumber: ssn.schema,
-              cityOfBirth,
-              stateOfBirth: _.merge(stateOfBirth, {
-                type: 'string'
-              })
+              'view:placeOfBirth': {
+                type: 'object',
+                properties: {
+                  cityOfBirth,
+                  stateOfBirth: _.merge(stateOfBirth, {
+                    type: 'string'
+                  })
+                }
+              }
             }
           }
         },

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -8,6 +8,7 @@ import {
   maritalStatuses
 } from '../../common/utils/options-for-select';
 
+import { validateMatch } from '../../common/schemaform/validation';
 import { createUSAStateLabels } from '../../common/schemaform/helpers';
 
 import {
@@ -34,6 +35,7 @@ const {
   isNativeHawaiianOrOtherPacificIslander,
   isAsian,
   isWhite,
+  email,
   lastEntryDate,
   lastDischargeDate,
   lastServiceBranch,
@@ -62,7 +64,8 @@ const {
 const {
   fullName,
   date,
-  provider
+  provider,
+  phone
 } = fullSchemaHca.definitions;
 
 const stateLabels = createUSAStateLabels(states);
@@ -77,7 +80,8 @@ const formConfig = {
   subTitle: 'Form 10-10ez',
   defaultDefinitions: {
     date,
-    provider
+    provider,
+    phone
   },
   chapters: {
     veteranInformation: {
@@ -226,8 +230,44 @@ const formConfig = {
           path: 'veteran-information/contact-information',
           title: 'Contact information',
           initialData: {},
-          uiSchema: {},
-          schema: {}
+          uiSchema: {
+            'ui:validations': [
+              validateMatch('email', 'view:emailConfirmation')
+            ],
+            email: {
+              'ui:title': 'Email address',
+              'ui:errorMessages': {
+                pattern: 'Please put your email in this format x@x.xxx'
+              }
+            },
+            'view:emailConfirmation': {
+              'ui:title': 'Re-enter email address',
+              'ui:errorMessages': {
+                pattern: 'Please put your email in this format x@x.xxx'
+              }
+            },
+            homePhone: {
+              'ui:title': 'Home telephone number',
+              'ui:errorMessages': {
+                pattern: 'Phone number must be 10 digits'
+              }
+            },
+            mobilePhone: {
+              'ui:title': 'Mobile telephone number',
+              'ui:errorMessages': {
+                pattern: 'Phone number must be 10 digits'
+              }
+            }
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              email,
+              'view:emailConfirmation': email,
+              homePhone: phone,
+              mobilePhone: phone
+            }
+          }
         }
       }
     },

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -87,7 +87,7 @@ const formConfig = {
           initialData: {},
           uiSchema: {
             veteranFullName: _.merge(fullNameUISchema, {
-              first: {
+              last: {
                 'ui:errorMessages': {
                   minLength: 'Please provide a valid name. Must be at least 2 characters.'
                 }

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -52,6 +52,19 @@ const {
 
 const stateLabels = createUSAStateLabels(states);
 
+import { uiSchema as fullNameUISchema } from '../../common/schemaform/definitions/fullName';
+import * as ssn from '../../common/schemaform/definitions/ssn';
+
+const {
+  fullName,
+  date
+} = fullSchemaHca.definitions;
+
+const {
+  cityOfBirth,
+  stateOfBirth
+} = fullSchemaHca.properties;
+
 const formConfig = {
   urlPrefix: '/',
   submitUrl: '',
@@ -69,8 +82,83 @@ const formConfig = {
       title: 'Veteran Information',
       pages: {
         veteranInformation: {
-          path: 'veteran/information',
+          path: 'veteran-information/personal-information',
           title: 'Veteran information',
+          initialData: {},
+          uiSchema: {
+            veteranFullName: _.merge(fullNameUISchema, {
+              first: {
+                'ui:errorMessages': {
+                  minLength: 'Please provide a valid name. Must be at least 2 characters.'
+                }
+              }
+            }),
+            mothersMaidenName: {
+              'ui:title': 'Mother’s maiden name'
+            }
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              veteranFullName: _.merge(fullName, {
+                properties: {
+                  suffix: {
+                    type: 'string'
+                  }
+                }
+              }),
+              mothersMaidenName: {
+                type: 'string'
+              }
+            }
+          }
+        },
+        birthInformation: {
+          path: 'veteran-information/birth-information',
+          title: 'Veteran information',
+          initialData: {},
+          uiSchema: {
+            veteranDateOfBirth: {
+              'ui:title': 'Date of birth'
+            },
+            veteranSocialSecurityNumber: ssn.uiSchema,
+            cityOfBirth: {
+              'ui:title': 'City of birth'
+            },
+            stateOfBirth: {
+              'ui:title': 'State of birth'
+            }
+          },
+          schema: {
+            type: 'object',
+            required: ['veteranDateOfBirth', 'veteranSocialSecurityNumber'],
+            properties: {
+              veteranDateOfBirth: date,
+              veteranSocialSecurityNumber: ssn.schema,
+              cityOfBirth,
+              stateOfBirth: _.merge(stateOfBirth, {
+                type: 'string'
+              })
+            }
+          }
+        },
+        demographicInformation: {
+          path: 'veteran-information/demographic-information',
+          title: 'Veteran information',
+          initialData: {},
+          uiSchema: {},
+          schema: {}
+        },
+        veteranAddress: {
+          path: 'veteran-information/veteran-address',
+          title: 'Permanent address',
+          initialData: {},
+          uiSchema: {},
+          schema: {}
+        },
+        contactInformation: {
+          path: 'veteran-information/contact-information',
+          title: 'Contact information',
           initialData: {},
           uiSchema: {},
           schema: {}

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -10,6 +10,7 @@ import {
 
 import { validateMatch } from '../../common/schemaform/validation';
 import { createUSAStateLabels } from '../../common/schemaform/helpers';
+import * as address from '../../common/schemaform/definitions/address';
 
 import {
   transform,
@@ -223,8 +224,42 @@ const formConfig = {
           path: 'veteran-information/veteran-address',
           title: 'Permanent address',
           initialData: {},
-          uiSchema: {},
-          schema: {}
+          uiSchema: {
+            address: _.merge(address.uiSchema('Permanent address'), {
+              street3: {
+                'ui:title': 'Line 3'
+              }
+            })
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              address: _.merge(address.schema(true), {
+                properties: {
+                  street: {
+                    type: 'string',
+                    minLength: 1,
+                    maxLength: 30
+                  },
+                  street2: {
+                    type: 'string',
+                    minLength: 1,
+                    maxLength: 30
+                  },
+                  street3: {
+                    type: 'string',
+                    minLength: 1,
+                    maxLength: 30
+                  },
+                  city: {
+                    type: 'string',
+                    minLength: 1,
+                    maxLength: 30
+                  }
+                }
+              })
+            }
+          }
         },
         contactInformation: {
           path: 'veteran-information/contact-information',

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -135,7 +135,10 @@ const formConfig = {
                 'ui:title': 'City'
               },
               stateOfBirth: {
-                'ui:title': 'State'
+                'ui:title': 'State',
+                'ui:options': {
+                  labels: stateLabels
+                }
               }
             }
           },
@@ -151,8 +154,7 @@ const formConfig = {
                   cityOfBirth,
                   stateOfBirth: {
                     type: 'string',
-                    'enum': states.USA.map(state => state.value),
-                    enumNames: states.USA.map(state => state.label)
+                    'enum': states.USA.map(state => state.value)
                   }
                 }
               }

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -18,6 +18,8 @@ import IntroductionPage from '../components/IntroductionPage';
 import InsuranceProviderView from '../components/InsuranceProviderView';
 
 import { uiSchema as dateUI } from '../../common/schemaform/definitions/currentOrPastDate';
+import { uiSchema as fullNameUISchema } from '../../common/schemaform/definitions/fullName';
+import * as ssn from '../../common/schemaform/definitions/ssn';
 
 const {
   cityOfBirth,
@@ -53,9 +55,6 @@ const {
 } = fullSchemaHca.definitions;
 
 const stateLabels = createUSAStateLabels(states);
-
-import { uiSchema as fullNameUISchema } from '../../common/schemaform/definitions/fullName';
-import * as ssn from '../../common/schemaform/definitions/ssn';
 
 const formConfig = {
   urlPrefix: '/',

--- a/src/js/hca-rjsf/hca-rjsf-entry.jsx
+++ b/src/js/hca-rjsf/hca-rjsf-entry.jsx
@@ -23,7 +23,7 @@ if (__BUILDTYPE__ === 'development' && window.devToolsExtension) {
   store = createStore(reducer, compose(applyMiddleware(thunk)));
 }
 
-// TODO: Change the basename path once we replace hca with this form
+// Change the basename path once we replace hca with this form
 // (should be 'healthcare/appy/application')
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/healthcare/rjsf'

--- a/src/js/hca-rjsf/hca-rjsf-entry.jsx
+++ b/src/js/hca-rjsf/hca-rjsf-entry.jsx
@@ -12,6 +12,7 @@ import reducer from './reducer';
 
 require('../common');
 require('../../sass/hca.scss');
+require('../../sass/edu-benefits.scss');
 
 require('../login/login-entry.jsx');
 

--- a/src/js/hca-rjsf/hca-rjsf-entry.jsx
+++ b/src/js/hca-rjsf/hca-rjsf-entry.jsx
@@ -22,6 +22,8 @@ if (__BUILDTYPE__ === 'development' && window.devToolsExtension) {
   store = createStore(reducer, compose(applyMiddleware(thunk)));
 }
 
+// TODO: Change the basename path once we replace hca with this form
+// (should be 'healthcare/appy/application')
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/healthcare/rjsf'
 });

--- a/test/hca-rjsf/config/veteranInformation.unit.spec.jsx
+++ b/test/hca-rjsf/config/veteranInformation.unit.spec.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import { expect } from 'chai';
+import ReactTestUtils from 'react-addons-test-utils';
+
+import { DefinitionTester } from '../../util/schemaform-utils.jsx';
+import formConfig from '../../../src/js/hca-rjsf/config/form.js';
+
+describe('HCA veteranInformation', () => {
+  it('should render veteranInformation page', () => {
+    const { schema, uiSchema } = formConfig.chapters.veteranInformation.pages.veteranInformation;
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(5);
+    expect(formDOM.querySelector('#root_veteranFullName_first')).not.to.be.null;
+  });
+
+  it('should render birthInformation page', () => {
+    const { schema, uiSchema } = formConfig.chapters.veteranInformation.pages.birthInformation;
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(6);
+    expect(formDOM.querySelector('#root_veteranSocialSecurityNumber')).not.to.be.null;
+  });
+});

--- a/test/hca-rjsf/config/veteranInformation.unit.spec.jsx
+++ b/test/hca-rjsf/config/veteranInformation.unit.spec.jsx
@@ -34,4 +34,32 @@ describe('HCA veteranInformation', () => {
     expect(formDOM.querySelectorAll('input, select').length).to.equal(6);
     expect(formDOM.querySelector('#root_veteranSocialSecurityNumber')).not.to.be.null;
   });
+
+  it('should render demographicInformation page', () => {
+    const { schema, uiSchema } = formConfig.chapters.veteranInformation.pages.demographicInformation;
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(8);
+    expect(formDOM.querySelector('#root_gender')).not.to.be.null;
+  });
+
+  it('should render contactInformation page', () => {
+    const { schema, uiSchema } = formConfig.chapters.veteranInformation.pages.contactInformation;
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(4);
+    expect(formDOM.querySelector('#root_email')).not.to.be.null;
+  });
 });

--- a/test/hca-rjsf/config/veteranInformation.unit.spec.jsx
+++ b/test/hca-rjsf/config/veteranInformation.unit.spec.jsx
@@ -49,6 +49,20 @@ describe('HCA veteranInformation', () => {
     expect(formDOM.querySelector('#root_gender')).not.to.be.null;
   });
 
+  it('should render veteranAddress page', () => {
+    const { schema, uiSchema } = formConfig.chapters.veteranInformation.pages.veteranAddress;
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(7);
+    expect(formDOM.querySelector('#root_address_country')).not.to.be.null;
+  });
+
   it('should render contactInformation page', () => {
     const { schema, uiSchema } = formConfig.chapters.veteranInformation.pages.contactInformation;
     const form = ReactTestUtils.renderIntoDocument(

--- a/test/hca-rjsf/config/veteranInformation.unit.spec.jsx
+++ b/test/hca-rjsf/config/veteranInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
-import ReactTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 
 import { DefinitionTester } from '../../util/schemaform-utils.jsx';
 import formConfig from '../../../src/js/hca-rjsf/config/form.js';

--- a/test/hca-rjsf/config/veteranInformation.unit.spec.jsx
+++ b/test/hca-rjsf/config/veteranInformation.unit.spec.jsx
@@ -2,65 +2,94 @@ import React from 'react';
 import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
 import ReactTestUtils from 'react-dom/test-utils';
+import sinon from 'sinon';
 
-import { DefinitionTester } from '../../util/schemaform-utils.jsx';
+import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
 import formConfig from '../../../src/js/hca-rjsf/config/form.js';
 
 describe('HCA veteranInformation', () => {
   it('should render veteranInformation page', () => {
+    const onSubmit = sinon.spy();
     const { schema, uiSchema } = formConfig.chapters.veteranInformation.pages.veteranInformation;
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
           schema={schema}
           data={{}}
+          onSubmit={onSubmit}
           uiSchema={uiSchema}/>
     );
     const formDOM = findDOMNode(form);
 
     expect(formDOM.querySelectorAll('input, select').length).to.equal(5);
     expect(formDOM.querySelector('#root_veteranFullName_first')).not.to.be.null;
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(2);
+    expect(onSubmit.called).to.be.false;
   });
 
   it('should render birthInformation page', () => {
+    const onSubmit = sinon.spy();
     const { schema, uiSchema } = formConfig.chapters.veteranInformation.pages.birthInformation;
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
           schema={schema}
           data={{}}
+          onSubmit={onSubmit}
           uiSchema={uiSchema}/>
     );
     const formDOM = findDOMNode(form);
 
     expect(formDOM.querySelectorAll('input, select').length).to.equal(6);
     expect(formDOM.querySelector('#root_veteranSocialSecurityNumber')).not.to.be.null;
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(2);
+    expect(onSubmit.called).to.be.false;
   });
 
   it('should render demographicInformation page', () => {
+    const onSubmit = sinon.spy();
     const { schema, uiSchema } = formConfig.chapters.veteranInformation.pages.demographicInformation;
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
           schema={schema}
           data={{}}
+          onSubmit={onSubmit}
           uiSchema={uiSchema}/>
     );
     const formDOM = findDOMNode(form);
 
     expect(formDOM.querySelectorAll('input, select').length).to.equal(8);
     expect(formDOM.querySelector('#root_gender')).not.to.be.null;
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(2);
+    expect(onSubmit.called).to.be.false;
   });
 
   it('should render veteranAddress page', () => {
+    const onSubmit = sinon.spy();
     const { schema, uiSchema } = formConfig.chapters.veteranInformation.pages.veteranAddress;
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
           schema={schema}
           data={{}}
+          onSubmit={onSubmit}
           uiSchema={uiSchema}/>
     );
     const formDOM = findDOMNode(form);
 
     expect(formDOM.querySelectorAll('input, select').length).to.equal(7);
     expect(formDOM.querySelector('#root_address_country')).not.to.be.null;
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(4);
+    expect(onSubmit.called).to.be.false;
   });
 
   it('should render contactInformation page', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8308,9 +8308,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#ee444b33dd221524c71b3b0201beda250a0ffd65":
-  version "2.5.3"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ee444b33dd221524c71b3b0201beda250a0ffd65"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#d0e327cd0ee93a82988914778cc4342dbf013cb4":
+  version "2.5.5"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d0e327cd0ee93a82988914778cc4342dbf013cb4"
 
 vinyl-assign@^1.0.1:
   version "1.2.1"


### PR DESCRIPTION
Adding all 5 pages of Chapter 1. Connected to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2230.

### Veteran Information
<img width="686" alt="screen shot 2017-04-20 at 2 36 10 pm" src="https://cloud.githubusercontent.com/assets/25183456/25246799/c500d304-25d6-11e7-81c8-b1af2acde397.png">

### Birth information
<img width="784" alt="screen shot 2017-05-01 at 1 12 11 pm" src="https://cloud.githubusercontent.com/assets/25183456/25586978/e64d71c4-2e6f-11e7-9cc7-2763b52616df.png">

Pages 3-5 added here: https://github.com/department-of-veterans-affairs/vets-website/pull/5463

### Questions
1. When navigating to each page, the first element on the page is styled as active. I can't figure out why.
<img width="509" alt="screen shot 2017-04-20 at 2 31 56 pm" src="https://cloud.githubusercontent.com/assets/25183456/25246612/33c446a0-25d6-11e7-910e-9da2d76e31c8.png">

2. I tried applying a custom error message to first name (see code), but it isn't appearing. Can't figure out why.
<img width="499" alt="screen shot 2017-04-20 at 2 33 02 pm" src="https://cloud.githubusercontent.com/assets/25183456/25246644/4ca04318-25d6-11e7-817c-36fec550da95.png">

3. I'm keeping the paths as they currently are. We probably want to clean them up though. Related to this ticket: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1746

4. In order to get this to work, I had to amend the schema in a few places. Permanent fixes to the schema are in this PR: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/87

5. On the birthInformation page, I couldn't figure out how to add another title of "Place of Birth" in the middle of the page, before `City of Birth` and `State of Birth`. Looks like it might involve creating the `uiSchema` in a separate file and adding a `ui:title` there (adding it directly in `config.js` just added it at the top of the page.
