### PR TITLE
Handle empty keyword searches in GIBCT properly.

### DIFF
--- a/src/js/gi/actions/index.js
+++ b/src/js/gi/actions/index.js
@@ -154,7 +154,7 @@ export function fetchSearchResults(query = {}) {
   const url = `${api.url}/institutions/search?${queryString}`;
 
   return dispatch => {
-    dispatch({ type: SEARCH_STARTED, name: query.name });
+    dispatch({ type: SEARCH_STARTED, name: query.name || '' });
 
     return fetch(url, api.settings)
       .then(res => res.json())


### PR DESCRIPTION
Quick fix for empty keyword searches in GIBCT. It was getting set to `undefined` when the query didn't have a name, causing errors in string-related operations in `KeywordSearch` for empty searches.