### PR TITLE
Remove tuition top up from 1990n education types

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
     "tinyliquid": "^0.2.33",
     "url-loader": "^0.5.7",
     "uswds": "0.10.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema#3d7c8e8b47443dfd2b494a3a4151aa2afaa63118",
     "webpack": "^1.13.1",
     "webpack-manifest-plugin": "^1.1.0",
     "webpack-md5-hash": "0.0.5",
@@ -184,6 +183,7 @@
   "dependencies": {
     "camelcase-keys-recursive": "^0.8.2",
     "react-autosuggest": "^8.0.0",
-    "reselect": "^2.5.4"
+    "reselect": "^2.5.4",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ee444b33dd221524c71b3b0201beda250a0ffd65"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8104,9 +8104,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema#3d7c8e8b47443dfd2b494a3a4151aa2afaa63118":
-  version "2.5.2"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema#3d7c8e8b47443dfd2b494a3a4151aa2afaa63118"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#ee444b33dd221524c71b3b0201beda250a0ffd65":
+  version "2.5.3"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ee444b33dd221524c71b3b0201beda250a0ffd65"
 
 vinyl-assign@^1.0.1:
   version "1.2.1"


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2317

Just pulls in a schema update that removed the item from the enum.