### PR TITLE
GIBCT content, copy, and link changes

### DIFF
--- a/src/js/gi/components/content/VideoSidebar.jsx
+++ b/src/js/gi/components/content/VideoSidebar.jsx
@@ -11,22 +11,23 @@ class VideoSidebar extends React.Component {
         </p>
         <iframe width="100%" src="https://www.youtube.com/embed/Z1ttkv9oRI4"
             title="Know Before You Go" frameBorder="0" allowFullScreen></iframe>
-        <h5>Ready to apply?</h5>
-        <p>
-          <a href="http://www.benefits.va.gov/gibill/careerscope.asp" target="_blank">
-            Explore your career
-          </a>
-        </p>
-        <p>
-          <a href="http://www.benefits.va.gov/gibill/choosing_a_school.asp" target="_blank">
-            Choose a school
-          </a>
-        </p>
-        <p>
-          <a href="/education/apply/" target="_blank">
-            Apply for education benefits
-          </a>
-        </p>
+        <div>
+          <p>
+            <a href="http://www.benefits.va.gov/gibill/careerscope.asp" target="_blank">
+              Explore your career
+            </a>
+          </p>
+          <p>
+            <a href="http://www.benefits.va.gov/gibill/choosing_a_school.asp" target="_blank">
+              Choose a school guide
+            </a>
+          </p>
+          <p>
+            <a href="/education/apply/" target="_blank">
+              Apply for education benefits
+            </a>
+          </p>
+        </div>
       </div>
     );
   }

--- a/src/js/gi/components/profile/CalculatorForm.jsx
+++ b/src/js/gi/components/profile/CalculatorForm.jsx
@@ -120,7 +120,7 @@ class CalculatorForm extends React.Component {
       <div>
         <RadioButtons
             label={this.renderLearnMoreLabel({
-              text: 'Are you a current Yellow Ribbon recipient?',
+              text: 'Will you be a Yellow Ribbon recipient?',
               modal: 'calcYr'
             })}
             name="yellowRibbonRecipient"

--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -14,7 +14,7 @@ const AdditionalResources = () => (
     </p>
     <p>
       <a href="http://www.benefits.va.gov/gibill/choosing_a_school.asp" target="_blank">
-        Choose a school
+        Choose a school guide
       </a>
     </p>
     <p>

--- a/src/js/gi/components/profile/Programs.jsx
+++ b/src/js/gi/components/profile/Programs.jsx
@@ -12,7 +12,7 @@ export class Programs extends React.Component {
         modal: 'yribbon',
         text: 'Yellow Ribbon',
         link: {
-          href: `http://www.benefits.va.gov/gibill/yellow_ribbon/2015/states/${institution.state}.asp`,
+          href: `http://www.benefits.va.gov/gibill/yellow_ribbon/2016/states/${institution.state}.asp`,
           text: 'See rates',
         }
       },

--- a/src/js/gi/selectors/calculator.js
+++ b/src/js/gi/selectors/calculator.js
@@ -807,17 +807,21 @@ export const getCalculatedBenefits = createSelector(
     };
 
     calculatedBenefits.outputs = {
+      giBillPaysToSchool: {
+        visible: true,
+        value: `${formatCurrency(derived.totalToSchool)}/yr`
+      },
       tuitionAndFeesCharged: {
         visible: true,
         value: formatCurrency(form.tuitionFees)
       },
-      giBillPaysToSchool: {
-        visible: true,
-        value: formatCurrency(derived.totalToSchool)
-      },
       yourScholarships: {
         visible: true,
         value: formatCurrency(derived.totalScholarshipTa)
+      },
+      outOfPocketTuition: {
+        visible: true,
+        value: formatCurrency(derived.totalLeftToPay)
       },
       housingAllowance: {
         visible: true,
@@ -825,11 +829,7 @@ export const getCalculatedBenefits = createSelector(
       },
       bookStipend: {
         visible: true,
-        value: `${formatCurrency(derived.bookStipendTotal)}${institutionType === 'ojt' ? '/mo' : ''}`
-      },
-      outOfPocketTuition: {
-        visible: true,
-        value: formatCurrency(derived.totalLeftToPay)
+        value: `${formatCurrency(derived.bookStipendTotal)}${institutionType === 'ojt' ? '/mo' : '/yr'}`
       },
       totalPaidToYou: {
         visible: true,

--- a/src/js/gi/selectors/calculator.js
+++ b/src/js/gi/selectors/calculator.js
@@ -862,6 +862,47 @@ export const getCalculatedBenefits = createSelector(
             },
           ],
         },
+        yellowRibbon: {
+          visible: true,
+          title: 'Yellow Ribbon',
+          terms: [
+            {
+              label: `${derived.nameOfTerm1} (paid by school)`,
+              value: formatCurrency(derived.yrBenSchoolTerm1),
+              visible: true
+            },
+            {
+              label: `${derived.nameOfTerm1} (paid by VA)`,
+              value: formatCurrency(derived.yrBenVaTerm1),
+              visible: true
+            },
+            {
+              label: `${derived.nameOfTerm2} (paid by school)`,
+              value: formatCurrency(derived.yrBenSchoolTerm2),
+              visible: true
+            },
+            {
+              label: `${derived.nameOfTerm2} (paid by VA)`,
+              value: formatCurrency(derived.yrBenVaTerm2),
+              visible: true
+            },
+            {
+              label: `${derived.nameOfTerm3} (paid by school)`,
+              value: formatCurrency(derived.yrBenSchoolTerm3),
+              visible: true
+            },
+            {
+              label: `${derived.nameOfTerm3} (paid by VA)`,
+              value: formatCurrency(derived.yrBenVaTerm3),
+              visible: true
+            },
+            {
+              label: 'Total per year',
+              value: formatCurrency(derived.yrBenSchoolTotal + derived.yrBenVaTotal),
+              visible: true
+            },
+          ]
+        },
         housingAllowance: {
           visible: true,
           title: 'Housing allowance',
@@ -914,47 +955,6 @@ export const getCalculatedBenefits = createSelector(
             },
           ],
         },
-        yellowRibbon: {
-          visible: true,
-          title: 'Yellow Ribbon',
-          terms: [
-            {
-              label: `${derived.nameOfTerm1} (paid by school)`,
-              value: formatCurrency(derived.yrBenSchoolTerm1),
-              visible: true
-            },
-            {
-              label: `${derived.nameOfTerm1} (paid by VA)`,
-              value: formatCurrency(derived.yrBenVaTerm1),
-              visible: true
-            },
-            {
-              label: `${derived.nameOfTerm2} (paid by school)`,
-              value: formatCurrency(derived.yrBenSchoolTerm2),
-              visible: true
-            },
-            {
-              label: `${derived.nameOfTerm2} (paid by VA)`,
-              value: formatCurrency(derived.yrBenVaTerm2),
-              visible: true
-            },
-            {
-              label: `${derived.nameOfTerm3} (paid by school)`,
-              value: formatCurrency(derived.yrBenSchoolTerm3),
-              visible: true
-            },
-            {
-              label: `${derived.nameOfTerm3} (paid by VA)`,
-              value: formatCurrency(derived.yrBenVaTerm3),
-              visible: true
-            },
-            {
-              label: 'Total per year',
-              value: formatCurrency(derived.yrBenSchoolTotal + derived.yrBenVaTotal),
-              visible: true
-            },
-          ]
-        }
       }
     };
 


### PR DESCRIPTION
### Changes
* Added '/yr' in amounts for important rows of estimated benefits. Resolves #5390.
* Moved Yellow Ribbon section of per-term breakdown to below Tuition / Fees. Reworded YR question. Resolves #5391.
* Updated link for Yellow Ribbon rates to 2016. Resolves #5392.
* Removed 'Ready to apply' header on landing page. Changed ' Choose a school' to 'Choose a school guide' (also in Additional Resources section in profiles). Resolves #5393.

> <img width="309" alt="screen shot 2017-04-21 at 5 47 42 pm" src="https://cloud.githubusercontent.com/assets/1067024/25297514/462336a8-26bc-11e7-8fc4-a2e7ef5dfb41.png">

> <img width="886" alt="screen shot 2017-04-21 at 5 51 17 pm" src="https://cloud.githubusercontent.com/assets/1067024/25297515/4ee62d40-26bc-11e7-8c17-673bb72d63c4.png">
