### PR TITLE
Add letter of denial reference to intro pages

### DIFF
--- a/src/js/edu-benefits/1990/containers/IntroductionPage.jsx
+++ b/src/js/edu-benefits/1990/containers/IntroductionPage.jsx
@@ -51,6 +51,7 @@ class IntroductionPage extends React.Component {
                   <div><h5>Decision</h5></div>
                   <ul><li>We usually process claims within 30 days.</li></ul>
                   <ul><li>You’ll get a Certificate of Eligibility (COE) or Award Letter in the mail if your application was approved.</li></ul>
+                  <ul><li>If your application was not approved, you’ll get a denial letter in the mail.</li></ul>
                 </li>
               </ol>
             </div>

--- a/src/js/edu-benefits/1990e/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/1990e/components/IntroductionPage.jsx
@@ -57,6 +57,7 @@ class IntroductionPage extends React.Component {
               <div><h5>Decision</h5></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
               <ul><li>You’ll get a Certificate of Eligibility (COE) or Award Letter in the mail if your application was approved.</li></ul>
+              <ul><li>If your application was not approved, you’ll get a denial letter in the mail.</li></ul>
             </li>
           </ol>
         </div>

--- a/src/js/edu-benefits/1995/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/1995/components/IntroductionPage.jsx
@@ -57,6 +57,7 @@ class IntroductionPage extends React.Component {
               <div><h5>Decision</h5></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
               <ul><li>You’ll get a COE or Award Letter in the mail if your application was approved. Bring this to the VA certifying official at your school.</li></ul>
+              <ul><li>If your application was not approved, you’ll get a denial letter in the mail.</li></ul>
             </li>
           </ol>
         </div>

--- a/src/js/edu-benefits/5490/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/5490/components/IntroductionPage.jsx
@@ -16,7 +16,7 @@ class IntroductionPage extends React.Component {
     return (
       <div className="schemaform-intro">
         <FormTitle title="Apply for education benefits as an eligible dependent"/>
-        <p>This application is equivalent to Form 22-5490 (Dependents' Application for VA Education Benefits).</p>
+        <p>This application is equivalent to Form 22-5490 (Dependents’ Application for VA Education Benefits).</p>
         <div className="process schemaform-process">
           <ol>
             <li className="step one">
@@ -24,7 +24,7 @@ class IntroductionPage extends React.Component {
               <div><h6>What you need to fill out this application</h6></div>
               <ul>
                 <li>Your Social Security number (required)</li>
-                <li>Your sponsor's Social Security number (required)</li>
+                <li>Your sponsor’s Social Security number (required)</li>
                 <li>Basic information about the school or training facility where you want to attend</li>
                 <li>Bank account direct deposit information</li>
                 <li>Education history</li>
@@ -57,6 +57,7 @@ class IntroductionPage extends React.Component {
               <div><h5>Decision</h5></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
               <ul><li>You’ll get a Certificate of Eligibility (COE) or Award Letter in the mail if your application was approved.</li></ul>
+              <ul><li>If your application was not approved, you’ll get a denial letter in the mail.</li></ul>
             </li>
           </ol>
         </div>

--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -226,7 +226,7 @@ const formConfig = {
                 'ui:title': 'Disability Compensation or Pension'
               },
               dic: {
-                'ui:title': 'Dependents\' Indemnity Compensation (DIC)'
+                'ui:title': 'Dependents’ Indemnity Compensation (DIC)'
               },
               chapter31: {
                 'ui:title': 'Vocational Rehabilitation benefits (Chapter 31)'

--- a/src/js/edu-benefits/5495/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/5495/components/IntroductionPage.jsx
@@ -16,7 +16,7 @@ class IntroductionPage extends React.Component {
     return (
       <div className="schemaform-intro">
         <FormTitle title="Manage your education benefits"/>
-        <p>This application is equivalent to Form 22-5495 (Dependent's Request for Change of Program or Place of Training).</p>
+        <p>This application is equivalent to Form 22-5495 (Dependent’s Request for Change of Program or Place of Training).</p>
         <div className="process schemaform-process">
           <ol>
             <li className="step one">
@@ -56,6 +56,7 @@ class IntroductionPage extends React.Component {
               <div><h5>Decision</h5></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
               <ul><li>You’ll get a COE or Award Letter in the mail if your application was approved. Bring this to the VA certifying official at your school.</li></ul>
+              <ul><li>If your application was not approved, you’ll get a denial letter in the mail.</li></ul>
             </li>
           </ol>
         </div>


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2324

Added the following to each edu form intro page except 1990n (which was done [here](https://github.com/department-of-veterans-affairs/vets-website/pull/5383)):
![image](https://cloud.githubusercontent.com/assets/12970166/25363181/8fbf3048-290d-11e7-9b1a-fa7a545b5e9c.png)
