### PR TITLE
Update GA "Learn More" tracking

### DIFF
--- a/src/js/gi/actions/index.js
+++ b/src/js/gi/actions/index.js
@@ -32,10 +32,12 @@ export function updateRoute(location) {
 }
 
 export function showModal(modal) {
-  window.dataLayer.push({
-    event: 'gibct-learn-more',
-    'gibct-modal-displayed': modal,
-  });
+  if (modal) {
+    window.dataLayer.push({
+      event: 'gibct-learn-more',
+      'gibct-modal-displayed': modal,
+    });
+  }
   return {
     type: DISPLAY_MODAL,
     modal


### PR DESCRIPTION
Only fire the event for showing a modal (a "learn more" event) when a modal is being shown. Ignore the null case when a modal is being closed.