### PR TITLE
Use array item schema properly in schemaform

### DIFF
--- a/src/js/common/schemaform/review/ArrayField.jsx
+++ b/src/js/common/schemaform/review/ArrayField.jsx
@@ -37,6 +37,15 @@ class ArrayField extends React.Component {
     this.scrollToRow = this.scrollToRow.bind(this);
   }
 
+  getItemSchema(index) {
+    const schema = this.props.schema;
+    if (schema.items.length > index) {
+      return schema.items[index];
+    }
+
+    return schema.additionalItems;
+  }
+
   scrollToTop() {
     setTimeout(() => {
       scroller.scrollTo(`topOfTable_${this.props.path[this.props.path.length - 1]}`, {
@@ -75,7 +84,7 @@ class ArrayField extends React.Component {
    */
   handleAdd() {
     const newState = {
-      items: this.state.items.concat(getDefaultFormState(this.props.schema.items, undefined, this.props.schema.definitions) || {}),
+      items: this.state.items.concat(getDefaultFormState(this.getItemSchema(this.state.items.length), undefined, this.props.schema.definitions) || {}),
       editing: this.state.editing.concat(true)
     };
     this.setState(newState, () => {
@@ -136,7 +145,6 @@ class ArrayField extends React.Component {
     const fieldName = path[path.length - 1];
     const title = _.get('ui:title', uiSchema) || pageTitle;
     const arrayPageConfig = {
-      schema: _.assign(schema.items, { definitions: schema.definitions }),
       uiSchema: uiSchema.items,
       pageKey: fieldName
     };
@@ -165,7 +173,7 @@ class ArrayField extends React.Component {
                           : null}
                       <SchemaForm
                           pageData={item}
-                          schema={arrayPageConfig.schema}
+                          schema={this.getItemSchema(index)}
                           uiSchema={arrayPageConfig.uiSchema}
                           title={pageTitle}
                           hideTitle
@@ -193,7 +201,7 @@ class ArrayField extends React.Component {
                   <SchemaForm
                       reviewMode
                       pageData={item}
-                      schema={arrayPageConfig.schema}
+                      schema={this.getItemSchema(index)}
                       uiSchema={arrayPageConfig.uiSchema}
                       title={pageTitle}
                       hideTitle

--- a/test/common/schemaform/review/ArrayField.unit.spec.jsx
+++ b/test/common/schemaform/review/ArrayField.unit.spec.jsx
@@ -97,7 +97,22 @@ describe('Schemaform review <ArrayField>', () => {
     const idSchema = {};
     const schema = {
       type: 'array',
-      items: {
+      items: [{
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string'
+          }
+        }
+      }, {
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string'
+          }
+        }
+      }],
+      additionalItems: {
         type: 'object',
         properties: {
           field: {
@@ -140,7 +155,15 @@ describe('Schemaform review <ArrayField>', () => {
     beforeEach(() => {
       const schema = {
         type: 'array',
-        items: {
+        items: [{
+          type: 'object',
+          properties: {
+            field: {
+              type: 'string'
+            }
+          }
+        }],
+        additionalItems: {
           type: 'object',
           properties: {
             field: {


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2469

I missed updating some review page components with the change to an array based `schema.items` format, and that's now causing production errors. The error was happening when you clicked "Add Another" on the review page.