### PR TITLE
Fixed column widths of header summary in GIBCT profile pages.

### DIFF
--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -5,7 +5,7 @@ import AlertBox from '../../../common/components/AlertBox';
 import { formatNumber } from '../../utils/helpers';
 
 const AdditionalResources = () => (
-  <div className="additional-resources medium-4 small-12 column">
+  <div className="additional-resources usa-width-one-third medium-4 small-12 column">
     <h4 className="highlight">Additional Resources</h4>
     <p>
       <a href="http://www.benefits.va.gov/gibill/careerscope.asp" target="_blank">
@@ -52,7 +52,7 @@ class HeadingSummary extends React.Component {
 
     return (
       <div className="heading row">
-        <div className="medium-8 small-12 column">
+        <div className="usa-width-two-thirds medium-8 small-12 column">
           <h1>{it.name}</h1>
           <div className="caution-flag">
             <AlertBox
@@ -67,7 +67,7 @@ class HeadingSummary extends React.Component {
             </p>
           </div>
           <div>
-            <div className="small-12 medium-6 column">
+            <div className="usa-width-one-half medium-6 small-12 column">
               <IconWithInfo icon="map-marker" present={it.city && it.country}>
                 {it.city}, {it.state || it.country}
               </IconWithInfo>
@@ -79,7 +79,7 @@ class HeadingSummary extends React.Component {
               </IconWithInfo>
             </div>
 
-            <div className="usa-width-one-half column">
+            <div className="usa-width-one-half medium-6 small-12 column">
               <IconWithInfo icon="briefcase" present={it.type === 'ojt'}>
                 On-the-job training
               </IconWithInfo>


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#2443.

Foundation grid class names were removed accidentally during the intermediate set of changes to transition to USWDS grid classes (#5335). This should bring the icons with info section back to two columns.