### PR TITLE
Removed extraneous 0 in GIBCT cautionary info.

### DIFF
--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -105,7 +105,7 @@ export class CautionaryInformation extends React.Component {
           </div>
         </div>
 
-        {it.complaints.mainCampusRollUp && (<div>
+        {!!it.complaints.mainCampusRollUp && (<div>
           <div className="table">
             <table className="all-complaints usa-table-borderless">
               <thead>


### PR DESCRIPTION
Resolves #5431.

Stricter truthy checking to determine whether to display data.