### PR TITLE
Add code climate config to reduce duplication issues

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,10 @@
 engines:
   duplication:
-      enabled: false
+    enabled: true
+    config:
+      languages:
+        javascript:
+          mass_threshold: 100
 ratings:
   paths:
   - src/js/**

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,6 +3,9 @@ engines:
       enabled: false
 ratings:
   paths:
-  - src/**
+  - src/js/**
 exclude_paths:
 - test/**/*
+- config/**/*
+- vendor/**/*
+- script/**/*

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,8 +8,3 @@ engines:
 ratings:
   paths:
   - src/js/**
-exclude_paths:
-- test/**/*
-- config/**/*
-- vendor/**/*
-- script/**/*

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,3 +8,8 @@ engines:
 ratings:
   paths:
   - src/js/**
+exclude_paths:
+- test/**/*
+- config/**/*
+- vendor/**/*
+- script/**/*

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,8 @@
+engines:
+  duplication:
+      enabled: false
+ratings:
+  paths:
+  - src/**
+exclude_paths:
+- test/**/*


### PR DESCRIPTION
We get a lot of codeclimate duplication errors, this updates the paths and increases the thresholds for those issues.