### PR TITLE
Update edu form intro pages for new process list styles

### DIFF
--- a/src/js/edu-benefits/1990/containers/IntroductionPage.jsx
+++ b/src/js/edu-benefits/1990/containers/IntroductionPage.jsx
@@ -13,7 +13,7 @@ class IntroductionPage extends React.Component {
             <p>This application is equivalent to Form 22-1990 (Application for VA Education Benefits).</p>
             <div className="process schemaform-process">
               <ol>
-                <li className="step one">
+                <li className="process-step list-one">
                   <div><h5>Prepare</h5></div>
                   <div><h6>What you need to fill out this application</h6></div>
                   <ul>
@@ -34,11 +34,11 @@ class IntroductionPage extends React.Component {
                     <li>See what benefits you’ll get at the school you want to attend. <a href="/gi-bill-comparison-tool/">Use the GI Bill Comparison Tool</a>.</li>
                   </ul>
                 </li>
-                <li className="step two">
+                <li className="process-step list-two">
                   <div><h5>Apply to manage your Benefit</h5></div>
                   <p>Complete this form.</p>
                 </li>
-                <li className="step three">
+                <li className="process-step list-three">
                   <div><h5>VA Review</h5></div>
                   <div><h6>How long does it take VA to make a decision?</h6></div>
                   <ul><li>We usually process claims within 30 days.</li></ul>
@@ -47,7 +47,7 @@ class IntroductionPage extends React.Component {
                   <div><h6>What if VA needs more information?</h6></div>
                   <ul><li>We will contact you if we need more information.</li></ul>
                 </li>
-                <li className="step four last">
+                <li className="process-step list-four">
                   <div><h5>Decision</h5></div>
                   <ul><li>We usually process claims within 30 days.</li></ul>
                   <ul><li>You’ll get a Certificate of Eligibility (COE) or Award Letter in the mail if your application was approved.</li></ul>

--- a/src/js/edu-benefits/1990e/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/1990e/components/IntroductionPage.jsx
@@ -19,7 +19,7 @@ class IntroductionPage extends React.Component {
         <p>This application is equivalent to Form 22-1990e (Application for Family Member to Use Transferred Benefits).</p>
         <div className="process schemaform-process">
           <ol>
-            <li className="step one">
+            <li className="process-step list-one">
               <div><h5>Prepare</h5></div>
               <div><h6>What you need to fill out this application</h6></div>
               <ul>
@@ -40,11 +40,11 @@ class IntroductionPage extends React.Component {
                 <li>See what benefits you’ll get at the school you want to attend. <a href="/gi-bill-comparison-tool/">Use the GI Bill Comparison Tool</a>.</li>
               </ul>
             </li>
-            <li className="step two">
+            <li className="process-step list-two">
               <div><h5>Apply for Benefits</h5></div>
               <p>Complete this form.</p>
             </li>
-            <li className="step three">
+            <li className="process-step list-three">
               <div><h5>VA Review</h5></div>
               <div><h6>How long does it take VA to make a decision?</h6></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
@@ -53,7 +53,7 @@ class IntroductionPage extends React.Component {
               <div><h6>What if VA needs more information?</h6></div>
               <ul><li>We'll contact you if we need more information.</li></ul>
             </li>
-            <li className="step four last">
+            <li className="process-step list-four">
               <div><h5>Decision</h5></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
               <ul><li>You’ll get a Certificate of Eligibility (COE) or Award Letter in the mail if your application was approved.</li></ul>

--- a/src/js/edu-benefits/1990n/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/1990n/components/IntroductionPage.jsx
@@ -19,7 +19,7 @@ class IntroductionPage extends React.Component {
         <p>This application is equivalent to Form 22-1990N (Application for VA Education Benefits Under the National Call to Service (NCS) Program).</p>
         <div className="process schemaform-process">
           <ol>
-            <li className="step one">
+            <li className="process-step list-one">
               <div><h5>Prepare</h5></div>
               <div><h6>What you need to fill out this application</h6></div>
               <ul>
@@ -39,11 +39,11 @@ class IntroductionPage extends React.Component {
                 <li>See what benefits you’ll get at the school you want to attend. <a href="/gi-bill-comparison-tool/">Use the GI Bill Comparison Tool</a>.</li>
               </ul>
             </li>
-            <li className="step two">
+            <li className="process-step list-two">
               <div><h5>Apply for Benefits</h5></div>
               <p>Complete this form.</p>
             </li>
-            <li className="step three">
+            <li className="process-step list-three">
               <div><h5>VA Review</h5></div>
               <div><h6>How long does it take VA to make a decision?</h6></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
@@ -52,7 +52,7 @@ class IntroductionPage extends React.Component {
               <div><h6>What if VA needs more information?</h6></div>
               <ul><li>We'll contact you if we need more information.</li></ul>
             </li>
-            <li className="step four last">
+            <li className="process-step list-four">
               <div><h5>Decision</h5></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
               <ul><li>You’ll get a Certificate of Eligibility (COE) or Award Letter in the mail if your application was approved.</li></ul>

--- a/src/js/edu-benefits/1995/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/1995/components/IntroductionPage.jsx
@@ -19,7 +19,7 @@ class IntroductionPage extends React.Component {
         <p>This application is equivalent to Form 22-1995 (Request for Change of Program or Place of Training).</p>
         <div className="process schemaform-process">
           <ol>
-            <li className="step one">
+            <li className="process-step list-one">
               <div><h5>Prepare</h5></div>
               <div><h6>What you need to fill out this application</h6></div>
               <ul>
@@ -40,11 +40,11 @@ class IntroductionPage extends React.Component {
                 <li>See what benefits you’ll get at the school you want to attend. <a href="/gi-bill-comparison-tool/">Use the GI Bill Comparison Tool</a>.</li>
               </ul>
             </li>
-            <li className="step two">
+            <li className="process-step list-two">
               <div><h5>Apply to manage your benefits</h5></div>
               <p>Complete this form.</p>
             </li>
-            <li className="step three">
+            <li className="process-step list-three">
               <div><h5>VA Review</h5></div>
               <div><h6>How long does it take VA to make a decision?</h6></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
@@ -53,7 +53,7 @@ class IntroductionPage extends React.Component {
               <div><h6>What if VA needs more information?</h6></div>
               <ul><li>We will contact you if we need more information.</li></ul>
             </li>
-            <li className="step four last">
+            <li className="process-step list-four">
               <div><h5>Decision</h5></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
               <ul><li>You’ll get a COE or Award Letter in the mail if your application was approved. Bring this to the VA certifying official at your school.</li></ul>

--- a/src/js/edu-benefits/5490/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/5490/components/IntroductionPage.jsx
@@ -19,7 +19,7 @@ class IntroductionPage extends React.Component {
         <p>This application is equivalent to Form 22-5490 (Dependents’ Application for VA Education Benefits).</p>
         <div className="process schemaform-process">
           <ol>
-            <li className="step one">
+            <li className="process-step list-one">
               <div><h5>Prepare</h5></div>
               <div><h6>What you need to fill out this application</h6></div>
               <ul>
@@ -40,11 +40,11 @@ class IntroductionPage extends React.Component {
                 <li>See what benefits you’ll get at the school you want to attend. <a href="/gi-bill-comparison-tool/">Use the GI Bill Comparison Tool</a>.</li>
               </ul>
             </li>
-            <li className="step two">
+            <li className="process-step list-two">
               <div><h5>Apply for benefits</h5></div>
               <p>Complete this form.</p>
             </li>
-            <li className="step three">
+            <li className="process-step list-three">
               <div><h5>VA Review</h5></div>
               <div><h6>How long does it take VA to make a decision?</h6></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
@@ -53,7 +53,7 @@ class IntroductionPage extends React.Component {
               <div><h6>What if VA needs more information?</h6></div>
               <ul><li>We'll contact you if we need more information.</li></ul>
             </li>
-            <li className="step four last">
+            <li className="process-step list-four">
               <div><h5>Decision</h5></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
               <ul><li>You’ll get a Certificate of Eligibility (COE) or Award Letter in the mail if your application was approved.</li></ul>

--- a/src/js/edu-benefits/5495/components/IntroductionPage.jsx
+++ b/src/js/edu-benefits/5495/components/IntroductionPage.jsx
@@ -19,7 +19,7 @@ class IntroductionPage extends React.Component {
         <p>This application is equivalent to Form 22-5495 (Dependent’s Request for Change of Program or Place of Training).</p>
         <div className="process schemaform-process">
           <ol>
-            <li className="step one">
+            <li className="process-step list-one">
               <div><h5>Prepare</h5></div>
               <div><h6>What you need to fill out this application</h6></div>
               <ul>
@@ -39,11 +39,11 @@ class IntroductionPage extends React.Component {
                 <li>See what benefits you’ll get at the school you want to attend. <a href="/gi-bill-comparison-tool/">Use the GI Bill Comparison Tool</a>.</li>
               </ul>
             </li>
-            <li className="step two">
+            <li className="process-step list-two">
               <div><h5>Apply to manage your benefits</h5></div>
               <p>Complete this form.</p>
             </li>
-            <li className="step three">
+            <li className="process-step list-three">
               <div><h5>VA Review</h5></div>
               <div><h6>How long does it take VA to make a decision?</h6></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
@@ -52,7 +52,7 @@ class IntroductionPage extends React.Component {
               <div><h6>What if VA needs more information?</h6></div>
               <ul><li>We will contact you if we need more information.</li></ul>
             </li>
-            <li className="step four last">
+            <li className="process-step list-four">
               <div><h5>Decision</h5></div>
               <ul><li>We usually process claims within 30 days.</li></ul>
               <ul><li>You’ll get a COE or Award Letter in the mail if your application was approved. Bring this to the VA certifying official at your school.</li></ul>

--- a/src/sass/edu-benefits.scss
+++ b/src/sass/edu-benefits.scss
@@ -1,6 +1,7 @@
 // Variables
 
 @import "style";
+@import "modules/m-process-list";
 @import "modules/m-form-process";
 @import "modules/m-progress-bar";
 @import "modules/m-schemaform";


### PR DESCRIPTION
Fixes some edu issues that resulted from process list style clean up. The subway map styling disappeared from the edu intro pages.

Before:
![screen shot 2017-05-01 at 3 15 32 pm](https://cloud.githubusercontent.com/assets/634932/25591053/0ce5e62a-2e81-11e7-8fc9-c50639caac13.png)

After:
![screen shot 2017-05-01 at 3 15 20 pm](https://cloud.githubusercontent.com/assets/634932/25591055/0cf343e2-2e81-11e7-9e85-613e686f5696.png)



