### PR TITLE
WIP: Add metalsmith-linkcheck plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
   "private": true,
   "dependencies": {
     "camelcase-keys-recursive": "^0.8.2",
+    "metalsmith-linkcheck": "^0.3.0",
     "react-autosuggest": "^8.0.0",
     "reselect": "^2.5.4",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d0e327cd0ee93a82988914778cc4342dbf013cb4"

--- a/script/build.js
+++ b/script/build.js
@@ -418,7 +418,8 @@ smith.use(redirect({
 // generated? metalsmith-linkcheck only checks HTML files
 // https://github.com/gchallen/code.metalsmith-linkcheck
 smith.use(linkcheck({
-  failMissing: true
+  verbose: true,
+  timeout: '30s'
 }));
 
 /* eslint-disable no-console */

--- a/script/build.js
+++ b/script/build.js
@@ -322,7 +322,6 @@ smith.use(sitemap({
   hostname: 'http://www.vets.gov',
   omitIndex: true
 }));
-// TODO(awong): Does anything even use the results of this plugin?
 
 if (!options.watch) {
   smith.use(blc({
@@ -415,10 +414,12 @@ smith.use(redirect({
   '/education/apply-for-education-benefits/': '/education/apply/'
 }));
 
-// TODO: what is the earliest place in this script where we can guarantee all HTML has been built?
-// metalsmith-linkcheck only checks HTML files
+// TODO: what is the earliest place in this script where we can guarantee all HTML files have been
+// generated? metalsmith-linkcheck only checks HTML files
 // https://github.com/gchallen/code.metalsmith-linkcheck
-smith.use(linkcheck());
+smith.use(linkcheck({
+  failMissing: true
+}));
 
 /* eslint-disable no-console */
 smith.build((err) => {

--- a/script/build.js
+++ b/script/build.js
@@ -4,6 +4,7 @@ const Metalsmith = require('metalsmith');
 const archive = require('metalsmith-archive');
 const assets = require('metalsmith-assets');
 const blc = require('metalsmith-broken-link-checker');
+const linkcheck = require('metalsmith-linkcheck');
 const collections = require('metalsmith-collections');
 const commandLineArgs = require('command-line-args');
 const dateInFilename = require('metalsmith-date-in-filename');
@@ -118,17 +119,7 @@ smith.destination(`../build/${options.buildtype}`);
 // This lets us access the {{buildtype}} variable within liquid templates.
 smith.metadata({ buildtype: options.buildtype });
 
-// TODO(awong): Verify that memorial-benefits should still be in the source tree.
-//    https://github.com/department-of-veterans-affairs/vets-website/issues/2721
-
-// To use:
-// const ignore = require('metalsmith-ignore');
-// const ignoreList = [];
-// if (options.buildtype === 'production') {
-//   ignoreList.push('disability-benefits/track-claims/*');
-// }
-// smith.use(ignore(ignoreList));
-
+// File patterns that should not be live in production
 const ignore = require('metalsmith-ignore');
 const ignoreList = [];
 if (options.buildtype === 'production') {
@@ -423,6 +414,11 @@ smith.use(redirect({
   '/2015/11/11/why-we-are-designing-in-beta.html': '/2015/11/11/why-we-are-designing-in-beta/',
   '/education/apply-for-education-benefits/': '/education/apply/'
 }));
+
+// TODO: what is the earliest place in this script where we can guarantee all HTML has been built?
+// metalsmith-linkcheck only checks HTML files
+// https://github.com/gchallen/code.metalsmith-linkcheck
+smith.use(linkcheck());
 
 /* eslint-disable no-console */
 smith.build((err) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5302,6 +5302,21 @@ metalsmith-layouts@^1.6.5:
     lodash.omit "^4.0.2"
     multimatch "^2.0.0"
 
+metalsmith-linkcheck@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/metalsmith-linkcheck/-/metalsmith-linkcheck-0.3.0.tgz#eadb5f3a91f1e412722ddf40bdba0c5a12a722f2"
+  dependencies:
+    async "^2.1.4"
+    cheerio "^0.22.0"
+    debug "^2.6.0"
+    dev-null "^0.1.1"
+    fs "0.0.2"
+    jsonfile "^2.4.0"
+    request "^2.79.0"
+    resolve-pathname "^2.0.2"
+    underscore "^1.8.3"
+    validator "^6.2.1"
+
 metalsmith-markdownit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/metalsmith-markdownit/-/metalsmith-markdownit-0.4.0.tgz#c74604b23dbb5cd6901d5f5919949d276d8da6bc"


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1691

I ran this locally and need to chat with someone on devops about whether anything special is needed to get this to be useful for jenkins builds. Locally, building with this plugin generates 2 files (`content/pages/.links_checked.json` and `content/pages/links_failed.json`) but still passes, so we need to fail if the failed links array isn't empty.

Currently, `links_failed.json` shows 16 external broken links, pasted below, and (unhelpfully) 744 internal broken links, so I'm looking into how to configure it to suppress validation of internal links since that should be taken care of by `metalsmith-broken-link-checker` According to the `metalsmith-linkcheck` README, "...relative and root-relative local links are checked by looking for them in the metalsmith files array, and so this may not work if you [are] using local links to things not included in your Metalsmith build."

Failed external links:
```
"https://www.dmdc.osd.mil/mfh/getLinks.do?tab=Services",
"https://www.virtualjobscout.org/",
"http://veteranrecruiting.com/",
"https://myseco.militaryonesource.mil/Portal/",
"https://msepjobs.militaryonesource.mil/msep/",
"https://myseco.militaryonesource.mil/Portal/Media/Default/Collaterals_Catalog/Program_Overview/MyCAA-Helping-Spouses-Reach-Career-Goals.pdf",
"https://jkodirect.jten.mil",
"https://www.score.org/topics/veteran_guards_reservists",
"https://myseco.militaryonesource.mil/Portal/Content/View/2622",
"https://dodtap.mil/index.html",
"https://jst.doded.mil/JST_SPEC.pdf",
"http://vaforvets.va.gov/",
"http://vaforvets.va.gov/hr/RVECS/pages/rvecs-map.asp",
"https://www.dmdc.osd.mil/milconnect",
"https://www.dmdc.osd.mil/milconnect/faces/faqs?_adf.ctrl-state=c4t1chkk8_4",
"https://ermc.amedd.army.mil/landstuhl/services.cfm?MTFinfo_id=733"
```