### PR TITLE
Change failed submission language

### DIFF
--- a/src/js/common/components/NavButtons.jsx
+++ b/src/js/common/components/NavButtons.jsx
@@ -113,8 +113,9 @@ export default class NavButtons extends React.Component {
         submitMessage = (
           <div className="usa-alert usa-alert-error">
             <div className="usa-alert-body">
-              <p><strong>Due to a system error, we weren't able to process your application. Please try again later.</strong></p>
-              <p>We apologize for the inconvenience. If you'd like to complete this form by phone, please call 877-222-VETS (8387) and press 2, M-F 7:00 a.m.to 7:00 p.m. (CST), Sat 9:00 a.m. to 5:30 p.m. (CST).</p>
+              <p><strong>There is currently an issue with submitting this form. We apologize for the inconvenience.</strong></p>
+              <p>Please call 855-574-7286, M-F 8:00 a.m.to 8:00 p.m. (ET) for assistance.</p>
+              <p>TTY: 800-829-4833.</p>
             </div>
           </div>
         );


### PR DESCRIPTION
Connected to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2636.

Changing the failed submission language in the `NavButtons` component. Currently this is only used by the 1990. If we want to create a way to customize the language, we can do that in a separate PR.

The call center number we changed this to is the Vets.gov technical help line, so it should be generic enough to work for any app.

<img width="655" alt="screen shot 2017-05-04 at 11 24 07 am" src="https://cloud.githubusercontent.com/assets/25183456/25711836/e6934546-30bd-11e7-9c2e-7892ffeba746.png">