### PR TITLE
Add in step to clean working directory after build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -193,10 +193,10 @@ node('vets-website-linting') {
 
     parallel builds
   }
-}
-
-post {
+  
+  post {
         always {
             deleteDir() /* clean up our workspace */
         }
+  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -194,3 +194,9 @@ node('vets-website-linting') {
     parallel builds
   }
 }
+
+post {
+        always {
+            deleteDir() /* clean up our workspace */
+        }
+}


### PR DESCRIPTION
This will prevent the Jenkins hosts from getting filled with old working directories