### PR TITLE
Fix PropType warnings from messaging unit tests

### DIFF
--- a/test/messaging/components/FolderNav.unit.spec.jsx
+++ b/test/messaging/components/FolderNav.unit.spec.jsx
@@ -50,6 +50,7 @@ const props = {
   onCreateNewFolder: () => {},
   onToggleFolders: () => {},
   toggleFolderNav: () => {},
+  router: () => {}
 };
 
 describe('<FolderNav>', () => {

--- a/test/messaging/components/NewMessageForm.unit.spec.jsx
+++ b/test/messaging/components/NewMessageForm.unit.spec.jsx
@@ -12,6 +12,7 @@ const props = {
     recipient: {},
     subject: {},
   },
+  onAttachmentsClose: () => {},
   onSaveMessage: () => {},
   onSendMessage: () => {},
   toggleConfirmDelete: () => {},

--- a/test/messaging/components/ReplyForm.unit.spec.jsx
+++ b/test/messaging/components/ReplyForm.unit.spec.jsx
@@ -11,6 +11,7 @@ const props = {
   },
   recipient: '',
   subject: '',
+  onAttachmentsClose: () => {},
   onSaveReply: () => {},
   onSendReply: () => {},
 };

--- a/test/messaging/components/ThreadHeader.unit.spec.jsx
+++ b/test/messaging/components/ThreadHeader.unit.spec.jsx
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import ThreadHeader from '../../../src/js/messaging/components/ThreadHeader';
 
 const props = {
-  currentFolder: { name: 'Inbox' },
+  currentFolder: { folderId: 0, name: 'Inbox', count: 3, unreadCount: 0 },
   currentMessageNumber: 1,
   folderMessageCount: 1,
   folders: [{ folderId: 0, name: 'Inbox' }],
@@ -13,7 +13,11 @@ const props = {
   message: { messageId: 123, subject: 'Subject' },
   messagesCollapsed: true,
   moveToIsOpen: false,
-  threadMessageCount: 2
+  threadMessageCount: 2,
+  onChooseFolder: () => {},
+  onCreateFolder: () => {},
+  onDeleteMessage: () => {},
+  onToggleMoveTo: () => {}
 };
 
 describe('ThreadHeader', () => {

--- a/test/messaging/components/compose/MessageSend.unit.spec.jsx
+++ b/test/messaging/components/compose/MessageSend.unit.spec.jsx
@@ -13,6 +13,9 @@ const props = {
   maxFiles: 1,
   maxFileSize: 1000000,
   maxTotalFileSize: 10000000,
+  onSave: () => {},
+  onSend: () => {},
+  onDelete: () => {}
 };
 
 describe('<MessageSend>', () => {

--- a/test/messaging/components/compose/MessageSubjectGroup.unit.spec.jsx
+++ b/test/messaging/components/compose/MessageSubjectGroup.unit.spec.jsx
@@ -6,8 +6,10 @@ import MessageSubjectGroup from '../../../../src/js/messaging/components/compose
 
 const props = {
   categories: ['recipient1'],
+  category: {},
   charMax: 100,
-  cssErrorClass: 'errorClass'
+  cssErrorClass: 'errorClass',
+  subject: {}
 };
 
 describe('<MessageSubjectGroup>', () => {

--- a/test/messaging/components/compose/MessageUploadedAttachment.unit.spec.jsx
+++ b/test/messaging/components/compose/MessageUploadedAttachment.unit.spec.jsx
@@ -9,6 +9,7 @@ const props = {
   fileName: 'fileName',
   fileSize: '1000',
   cssClass: 'cssClass',
+  onClose: () => {}
 };
 
 describe('<MessageUploadedAttachment>', () => {

--- a/test/messaging/components/compose/MessageWriteGroup.unit.spec.jsx
+++ b/test/messaging/components/compose/MessageWriteGroup.unit.spec.jsx
@@ -7,7 +7,15 @@ import MessageWriteGroup from '../../../../src/js/messaging/components/compose/M
 const props = {
   messageText: {
     value: 'messageTextValue',
-  }
+  },
+  onAttachmentsClose: () => {},
+  onAttachmentUpload: () => {},
+  onAttachmentsError: () => {},
+  onSend: () => {},
+  onSave: () => {},
+  onDelete: () => {},
+  onTextChange: () => {},
+  files: []
 };
 
 describe('<MessageWriteGroup>', () => {

--- a/test/messaging/containers/Folder.unit.spec.jsx
+++ b/test/messaging/containers/Folder.unit.spec.jsx
@@ -7,7 +7,9 @@ import { Folder } from '../../../src/js/messaging/containers/Folder';
 const props = {
   attributes: {
     folderId: 0,
-    name: 'Inbox'
+    name: 'Inbox',
+    unreadCount: 0,
+    count: 3
   },
   filter: {},
   folders: new Map([
@@ -43,8 +45,12 @@ const props = {
     value: 'sentDate',
     order: 'DESC'
   },
-
-  // No-op function to override dispatch
+  moveMessageToFolder: () => {},
+  openMoveToNewFolderModal: () => {},
+  toggleAdvancedSearch: () => {},
+  setSearchParam: () => {},
+  setDateRange: () => {},
+  openAlert: () => {},
   dispatch: () => {},
   router: () => {}
 };

--- a/test/messaging/containers/Settings.unit.spec.jsx
+++ b/test/messaging/containers/Settings.unit.spec.jsx
@@ -9,8 +9,7 @@ const props = {
     { folderId: 101, name: 'Personal folder 1', count: 1 },
     { folderId: 102, name: 'Personal folder 2', count: 0 }
   ],
-
-  // No-op function to override dispatch
+  deleteFolder: () => {},
   dispatch: () => {}
 };
 


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2670

These are kind of a pain to track down. Usually the warning comes from a test for a parent component of the component with the required prop. There are many more throughout vets-website code (I only fixed these b/c I was trying to figure out where they come from and how easy/painful they are to fix).
