### PR TITLE
Move schemaform styles into separate files for hca

### DIFF
--- a/src/js/hca-rjsf/hca-rjsf-entry.jsx
+++ b/src/js/hca-rjsf/hca-rjsf-entry.jsx
@@ -11,8 +11,7 @@ import route from './routes';
 import reducer from './reducer';
 
 require('../common');
-require('../../sass/hca.scss');
-require('../../sass/edu-benefits.scss');
+require('../../sass/hca-rjsf.scss');
 
 require('../login/login-entry.jsx');
 

--- a/src/sass/_shame.scss
+++ b/src/sass/_shame.scss
@@ -3,6 +3,11 @@
 // is for this file to be empty, but some times you just have to throw that
 // hack in there to get it working.
 
+// message while loading react app
+.loading-message {
+  text-align: center;
+  padding: 2em 0;
+}
 
 body .row {
   max-width: 62.5em;

--- a/src/sass/edu-benefits.scss
+++ b/src/sass/edu-benefits.scss
@@ -7,88 +7,20 @@
 @import "modules/m-schemaform";
 @import "modules/m-modal";
 @import "modules/m-omb-info";
+@import "modules/m-form-confirmation";
 
-$button-stroke: inset 0 0 0 1px;
-
-@media screen and (min-width: 600px) {
-  form {
-    max-width: 32em;
-  }
+// Also in 1990 review
+.edu-benefits-pre {
+  white-space: pre-wrap;
 }
 
-select {
-  background-image: url("/img/arrow-down.png");
-  background-image: url("/img/arrow-down.svg");
-}
-
-.loading-message {
-  text-align: center;
-  padding: 2em 0;
-}
-
-legend {
-  color: $color-primary-darkest;
-  font-size: 1.35em;
-  font-weight: 700;
-  line-height: 1.5;
-  margin: 0;
-  padding: 0 0 .5em 0;
-}
-
-.form-indent {
-  padding-left: 2rem;
-}
-
-.form-checkbox-group-label {
-  margin-top: 3rem;
-}
-
-.inset {
-  margin: 2rem 0rem;
-  padding: 2rem 3rem;
-  line-height: 2.2rem;
-  background-color: $color-inset-bg;
-  &.secondary {
-    background-color: $color-gray-light-alt;
-  }
-  &.expandable {
-    .form-expanding-group,
-    .form-expanding-group-open {
-      padding-left: 0;
-      border-left: 0;
-    }
-    .clickable {
-      cursor: pointer;
-    }
-  }
-}
-
-.additional {
-  font-weight: normal;
-}
-
-ul.claim-list{
-  list-style: none;
-  padding-left: 0;
-  li {
-    margin-bottom: 1rem;
-  }
-}
-
+// 1990
 .edu-benefits-info-no-icon,
 .usa-alert-info.edu-benefits-info-no-icon {
   background-image: none;
 }
 
-.edu-benefits-no-top-margin {
-  label:first-child {
-    margin-top: 0;
-  }
-}
-
-.edu-benefits-pre {
-  white-space: pre-wrap;
-}
+// 1990
 .edu-benefits-list {
   margin-top: 0;
   margin-bottom: 1em;
@@ -99,6 +31,7 @@ ul.claim-list{
   }
 }
 
+// 1990
 .edu-benefits-first-label {
   label {
     margin-top: 0;
@@ -108,17 +41,10 @@ ul.claim-list{
   }
 }
 
+// 1990
 .va-growable-background .edu-benefits-first-label {
   label {
     margin-top: 0;
-  }
-}
-
-@media (max-width: 40.063em) {
-  .progress-box {
-    border: none;
-    padding-left: 2rem - .9375rem;
-    padding-right: 2rem - .9375rem;
   }
 }
 
@@ -161,28 +87,22 @@ ul.claim-list{
   margin-top: -16px;
 }
 
+// 1990
 .edu-benefits-active-group{
   margin-left: 20px;
 }
-// Overriding a way too broad style in the base va sass
-.form-review-panel {
-  ul li p {
-    margin-top: 16px;
-    margin-bottom: 16px;
-  }
-  .edu-benefits-save-note {
-    display: none;
-  }
-}
 
+// 1990
 .no-pad-left {
   padding-left: 0 !important;
 }
 
+// 1990
 .no-pad-right {
   padding-right: 0 !important;
 }
-// Testing a slightly modified required asterisk
+
+// 1990
 .form-required-span {
   font-size: 1.7em;
   line-height: 0;
@@ -190,10 +110,12 @@ ul.claim-list{
   top: 10px;
 }
 
+// 1990
 .edu-growable-expanded {
   display: none;
 }
 
+//1990
 .form-review-panel-page {
   .edu-growable-expanded {
     display: table-row-group;
@@ -204,67 +126,29 @@ ul.claim-list{
     }
   }
 }
-.form-review-panel-page .va-growable-add-btn {
-  display: none;
-}
 
+// 1990
 .edu-growable-review-header {
   margin-bottom: 1em;
 }
 
+// 1990
 table.review td {
   padding-left: 0;
   padding-right: 0;
 }
 
+// 1990
 .edu-growable-form {
   table.review td {
     padding: 0;
   }
 }
 
-.va-nav-breadcrumbs-list, legend, .nav-header, .edu-page-title, .usa-input-error, .input-error-date {
+.edu-page-title {
   &:focus {
     outline: none;
   }
-}
-
-.form-error-date .input-date-label {
-  font-weight: bold;
-  font-size: 1.7rem;
-  font-weight: 700;
-}
-
-dl.review {
-  .review-row {
-    display: flex;
-    justify-content: space-between;
-    border-top: 1px solid $color-gray-light;
-    padding: 1.5rem;
-    padding-left: 0;
-    &> dd {
-      font-weight: bold;
-      padding-left: 5px;
-      min-width: 100px;
-      text-align: left;
-    }
-    &> dt {
-      max-width: 60%;
-    }
-    &> dt > p {
-      margin-top: 0;
-      margin-bottom: 0;
-    }
-  }
-  border-bottom: 1px solid $color-gray-light;
-}
-
-form.rjsf {
-  max-width: 100%;
-}
-
-.va-growable-review {
-  margin-top: 16px;
 }
 
 .edu-benefits-dependents-desc {
@@ -275,63 +159,8 @@ form.rjsf {
   margin-top: 3rem;
 }
 
-
-// ---- Additional print rules ---- //
-
-@media print {
-  // The + for on the confirmation page
-  // Will have to change when #4953 gets merged
-  .form-expanding-group-plus::after {
-    display: none;
-  }
-  .form-expanding-group {
-    margin-left: 0px;
-  }
-
-  .form-progress-buttons {
-    display: none;
-  }
-
-  .schemaform-title {
-    margin-bottom: 1rem;
-    justify-content: center;
-  }
-
-  .edu-benefits-submit-success > h3 {
-    text-align: center;
-  }
-
-  .inset {
-    margin: 1rem 0rem;
-    padding: 0px;
-  }
-}
-
-// Even up the spacing between multi-line labels and their respective elements
-label {
-  + div {
-    // Space above the date fields
-    .form-datefield-month, .form-datefield-day, .usa-form-group-year,
-    // And the inputs uswds sets a top margin for
-    input:not([type="radio"]),
-    input[type="text"], input[type="email"],
-    input[type="password"], input[type="url"],
-    input[type="tel"], input[type="number"],
-    input[type="search"], input[type="file"],
-    input[type="date"], input[type="datetime-local"],
-    input[type="month"], input[type="time"],
-    input[type="week"], textarea, select {
-      margin-top: 0.5em;
-    }
-  }
-}
-
 .row .edu-intro-spacing {
   margin-bottom: 7rem;
-}
-
-.usa-alert ul:first-child {
-  margin-top: 0;
 }
 
 .edu-benefits-alert {

--- a/src/sass/hca-rjsf.scss
+++ b/src/sass/hca-rjsf.scss
@@ -1,0 +1,11 @@
+// Variables
+
+@import "style";
+@import "modules/m-process-list";
+@import "modules/m-form-process";
+@import "modules/m-progress-bar";
+@import "modules/m-schemaform";
+@import "modules/m-modal";
+@import "modules/m-omb-info";
+@import "modules/m-form-confirmation";
+

--- a/src/sass/modules/_m-form-confirmation.scss
+++ b/src/sass/modules/_m-form-confirmation.scss
@@ -1,0 +1,62 @@
+.inset {
+  margin: 2rem 0rem;
+  padding: 2rem 3rem;
+  line-height: 2.2rem;
+  background-color: $color-inset-bg;
+  &.secondary {
+    background-color: $color-gray-light-alt;
+  }
+  &.expandable {
+    .form-expanding-group,
+    .form-expanding-group-open {
+      padding-left: 0;
+      border-left: 0;
+    }
+    .clickable {
+      cursor: pointer;
+    }
+  }
+}
+
+.additional {
+  font-weight: normal;
+}
+
+ul.claim-list{
+  list-style: none;
+  padding-left: 0;
+  li {
+    margin-bottom: 1rem;
+  }
+}
+
+// ---- Additional print rules ---- //
+
+@media print {
+  // The + for on the confirmation page
+  // Will have to change when #4953 gets merged
+  .form-expanding-group-plus::after {
+    display: none;
+  }
+  .form-expanding-group {
+    margin-left: 0px;
+  }
+
+  .form-progress-buttons {
+    display: none;
+  }
+
+  .schemaform-title {
+    margin-bottom: 1rem;
+    justify-content: center;
+  }
+
+  .edu-benefits-submit-success > h3 {
+    text-align: center;
+  }
+
+  .inset {
+    margin: 1rem 0rem;
+    padding: 0px;
+  }
+}

--- a/src/sass/modules/_m-schemaform.scss
+++ b/src/sass/modules/_m-schemaform.scss
@@ -1,5 +1,101 @@
 // Style for schemaform
 
+legend {
+  color: $color-primary-darkest;
+  font-size: 1.35em;
+  font-weight: 700;
+  line-height: 1.5;
+  margin: 0;
+  padding: 0 0 .5em 0;
+}
+
+@media (max-width: 40.063em) {
+  .progress-box {
+    border: none;
+    padding-left: 2rem - .9375rem;
+    padding-right: 2rem - .9375rem;
+  }
+}
+
+// Overriding a way too broad style in the base va sass
+.form-review-panel {
+  ul li p {
+    margin-top: 16px;
+    margin-bottom: 16px;
+  }
+}
+
+.form-review-panel-page .va-growable-add-btn {
+  display: none;
+}
+
+.va-nav-breadcrumbs-list, legend, .nav-header, .usa-input-error, .input-error-date {
+  &:focus {
+    outline: none;
+  }
+}
+
+.form-error-date .input-date-label {
+  font-weight: bold;
+  font-size: 1.7rem;
+  font-weight: 700;
+}
+
+dl.review {
+  .review-row {
+    display: flex;
+    justify-content: space-between;
+    border-top: 1px solid $color-gray-light;
+    padding: 1.5rem;
+    padding-left: 0;
+    &> dd {
+      font-weight: bold;
+      padding-left: 5px;
+      min-width: 100px;
+      text-align: left;
+    }
+    &> dt {
+      max-width: 60%;
+    }
+    &> dt > p {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+  border-bottom: 1px solid $color-gray-light;
+}
+
+form.rjsf {
+  max-width: 100%;
+}
+
+.va-growable-review {
+  margin-top: 16px;
+}
+
+// Even up the spacing between multi-line labels and their respective elements
+label {
+  + div {
+    // Space above the date fields
+    .form-datefield-month, .form-datefield-day, .usa-form-group-year,
+    // And the inputs uswds sets a top margin for
+    input:not([type="radio"]),
+    input[type="text"], input[type="email"],
+    input[type="password"], input[type="url"],
+    input[type="tel"], input[type="number"],
+    input[type="search"], input[type="file"],
+    input[type="date"], input[type="datetime-local"],
+    input[type="month"], input[type="time"],
+    input[type="week"], textarea, select {
+      margin-top: 0.5em;
+    }
+  }
+}
+
+.usa-alert ul:first-child {
+  margin-top: 0;
+}
+
 .schemaform-buttons {
   [type="submit"] {
     margin-top: 0.5em;


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2445

Despite this being all sass changes, screenshot doesn't make sense.

I went through the entire edu-benefits.scss file and moved the parts relevant to rjsf forms into the the schemaform file. I also moved styles related to the confirmation pages into their own file.

I tried to annotate some of the edu file so that we can remove styles that are used on the old style 1990 form when we're ready.