### PR TITLE
Nav buttons trimmed path

### DIFF
--- a/src/js/common/components/NavButtons.jsx
+++ b/src/js/common/components/NavButtons.jsx
@@ -81,7 +81,7 @@ export default class NavButtons extends React.Component {
     );
 
     let buttons;
-    if (path.match(/review-and-submit(\/)?$/)) {
+    if (path.endsWith('review-and-submit')) {
       let submitButton;
       let submitMessage;
 
@@ -147,7 +147,7 @@ export default class NavButtons extends React.Component {
           </div>
         </div>
       </div>);
-    } else if (path.match(/submit-message(\/)?$/)) {
+    } else if (path.endsWith('submit-message')) {
       buttons = (
         <div className="row form-progress-buttons">
           <div className="small-6 medium-5 columns">
@@ -157,7 +157,7 @@ export default class NavButtons extends React.Component {
           </div>
         </div>
       );
-    } else if (path.match(/introduction(\/)?$/)) {
+    } else if (path.endsWith('introduction')) {
       buttons = (
         <div className="row form-progress-buttons">
           <div className="small-6 medium-5 columns">

--- a/src/js/common/schemaform/FormApp.jsx
+++ b/src/js/common/schemaform/FormApp.jsx
@@ -25,10 +25,11 @@ export default class FormApp extends React.Component {
   onbeforeunload = e => {
     const { currentLocation } = this.props;
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
-    const isIntro = trimmedPathname.endsWith('introduction');
-    const isConfirmation = trimmedPathname.endsWith('confirmation');
+    const isIntroductionPage = trimmedPathname.endsWith('introduction');
+    const isConfirmationPage = trimmedPathname.endsWith('confirmation');
+
     let message;
-    if (!(isIntro || isConfirmation)) {
+    if (!(isIntroductionPage || isConfirmationPage)) {
       message = 'Are you sure you wish to leave this application? All progress will be lost.';
       // Chrome requires this to be set
       e.returnValue = message;     // eslint-disable-line no-param-reassign
@@ -43,11 +44,11 @@ export default class FormApp extends React.Component {
   render() {
     const { currentLocation, formConfig, children } = this.props;
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
-    const isIntro = trimmedPathname.endsWith('introduction');
-    const isConfirmation = trimmedPathname.endsWith('confirmation');
+    const isIntroductionPage = trimmedPathname.endsWith('introduction');
+    const isConfirmationPage = trimmedPathname.endsWith('confirmation');
 
     let content;
-    if (isIntro || isConfirmation) {
+    if (isIntroductionPage || isConfirmationPage) {
       content = children;
     } else {
       content = (
@@ -65,7 +66,7 @@ export default class FormApp extends React.Component {
       <div className="row">
         <Element name="topScrollElement"/>
         <div className="usa-width-two-thirds medium-8 columns">
-          {formConfig.title && !isIntro && <FormTitle title={formConfig.title} subTitle={formConfig.subTitle}/>}
+          {formConfig.title && !isIntroductionPage && <FormTitle title={formConfig.title} subTitle={formConfig.subTitle}/>}
           {content}
         </div>
         <div className="usa-width-one-third medium-4 columns show-for-medium-up">

--- a/src/js/common/schemaform/FormApp.jsx
+++ b/src/js/common/schemaform/FormApp.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import Scroll from 'react-scroll';
 
-import _ from 'lodash';
-
 import FormNav from './FormNav';
 import FormTitle from './FormTitle';
 
@@ -25,9 +23,12 @@ export default class FormApp extends React.Component {
   }
 
   onbeforeunload = e => {
-    const endpoint = this.props.currentLocation.pathname.split('/').pop();
+    const { currentLocation } = this.props;
+    const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
+    const isIntro = trimmedPathname.endsWith('introduction');
+    const isConfirmation = trimmedPathname.endsWith('confirmation');
     let message;
-    if (!_.includes(['introduction', 'confirmation'], endpoint)) {
+    if (!(isIntro || isConfirmation)) {
       message = 'Are you sure you wish to leave this application? All progress will be lost.';
       // Chrome requires this to be set
       e.returnValue = message;     // eslint-disable-line no-param-reassign
@@ -41,8 +42,9 @@ export default class FormApp extends React.Component {
 
   render() {
     const { currentLocation, formConfig, children } = this.props;
-    const isIntro = currentLocation.pathname.endsWith('introduction');
-    const isConfirmation = currentLocation.pathname.endsWith('confirmation');
+    const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
+    const isIntro = trimmedPathname.endsWith('introduction');
+    const isConfirmation = trimmedPathname.endsWith('confirmation');
 
     let content;
     if (isIntro || isConfirmation) {
@@ -50,7 +52,7 @@ export default class FormApp extends React.Component {
     } else {
       content = (
         <div>
-          <FormNav formConfig={formConfig} currentPath={currentLocation.pathname}/>
+          <FormNav formConfig={formConfig} currentPath={trimmedPathname}/>
           <div className="progress-box progress-box-schemaform">
             {children}
           </div>
@@ -68,7 +70,7 @@ export default class FormApp extends React.Component {
         </div>
         <div className="usa-width-one-third medium-4 columns show-for-medium-up">
         </div>
-        <span className="js-test-location hidden" data-location={currentLocation.pathname} hidden></span>
+        <span className="js-test-location hidden" data-location={trimmedPathname} hidden></span>
       </div>
     );
   }

--- a/src/js/common/schemaform/FormApp.jsx
+++ b/src/js/common/schemaform/FormApp.jsx
@@ -4,6 +4,8 @@ import Scroll from 'react-scroll';
 import FormNav from './FormNav';
 import FormTitle from './FormTitle';
 
+import { isInProgress } from '../utils/helpers';
+
 const Element = Scroll.Element;
 
 /*
@@ -25,11 +27,9 @@ export default class FormApp extends React.Component {
   onbeforeunload = e => {
     const { currentLocation } = this.props;
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
-    const isIntroductionPage = trimmedPathname.endsWith('introduction');
-    const isConfirmationPage = trimmedPathname.endsWith('confirmation');
 
     let message;
-    if (!(isIntroductionPage || isConfirmationPage)) {
+    if (isInProgress(trimmedPathname)) {
       message = 'Are you sure you wish to leave this application? All progress will be lost.';
       // Chrome requires this to be set
       e.returnValue = message;     // eslint-disable-line no-param-reassign
@@ -45,10 +45,9 @@ export default class FormApp extends React.Component {
     const { currentLocation, formConfig, children } = this.props;
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
     const isIntroductionPage = trimmedPathname.endsWith('introduction');
-    const isConfirmationPage = trimmedPathname.endsWith('confirmation');
 
     let content;
-    if (isIntroductionPage || isConfirmationPage) {
+    if (!isInProgress(trimmedPathname)) {
       content = children;
     } else {
       content = (

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -42,6 +42,10 @@ export function groupPagesIntoChapters(routes, prefix = '') {
   });
 }
 
+export function isInProgress(trimmedPathname) {
+  return !(trimmedPathname.endsWith('introduction') || trimmedPathname.endsWith('confirmation'));
+}
+
 export function isActivePage(page, data) {
   if (typeof page.depends === 'function') {
     return page.depends(data);

--- a/src/js/edu-benefits/1990/containers/EduBenefitsApp.jsx
+++ b/src/js/edu-benefits/1990/containers/EduBenefitsApp.jsx
@@ -22,7 +22,7 @@ import RoutesDropdown from '../components/debug/RoutesDropdown';
 import { isValidPage, isValidForm } from '../utils/validations';
 import { ensurePageInitialized, updateCompletedStatus, submitForm, veteranUpdateField, setAttemptedSubmit } from '../actions/index';
 
-import { getScrollOptions } from '../../../common/utils/helpers';
+import { getScrollOptions, isInProgress } from '../../../common/utils/helpers';
 
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
@@ -59,10 +59,9 @@ class EduBenefitsApp extends React.Component {
   onbeforeunload(e) {
     const { currentLocation } = this.props;
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
-    const isIntroductionPage = trimmedPathname.endsWith('introduction');
-    const isConfirmationPage = trimmedPathname.endsWith('confirmation');
+
     let message;
-    if (!(isIntroductionPage || isConfirmationPage)) {
+    if (isInProgress(trimmedPathname)) {
       message = 'Are you sure you wish to leave this application? All progress will be lost.';
       // Chrome requires this to be set
       e.returnValue = message;     // eslint-disable-line no-param-reassign
@@ -82,8 +81,7 @@ class EduBenefitsApp extends React.Component {
     };
 
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
-    const endpoint = trimmedPathname.split('/').pop();
-    const isIntroductionPage = endpoint === 'introduction';
+    const isIntroductionPage = trimmedPathname.endsWith('introduction');
 
     // Until we come up with a common code base between this and the schemaform
     //  forms, the following is borrowed from NavHeader

--- a/src/js/edu-benefits/1990/containers/EduBenefitsApp.jsx
+++ b/src/js/edu-benefits/1990/containers/EduBenefitsApp.jsx
@@ -78,8 +78,7 @@ class EduBenefitsApp extends React.Component {
     };
 
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
-    const pathList = trimmedPathname.split('/');
-    const endpoint = pathList.pop();
+    const endpoint = trimmedPathname.split('/').pop();
     const isIntroductionPage = endpoint === 'introduction';
 
     // Until we come up with a common code base between this and the schemaform

--- a/src/js/edu-benefits/1990/containers/EduBenefitsApp.jsx
+++ b/src/js/edu-benefits/1990/containers/EduBenefitsApp.jsx
@@ -78,6 +78,7 @@ class EduBenefitsApp extends React.Component {
     };
 
     const pathList = currentLocation.pathname.split('/');
+    const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
     let endpoint = pathList.pop();
     endpoint = (endpoint.length) ? endpoint : pathList.pop();
     const isIntroductionPage = endpoint === 'introduction';
@@ -136,7 +137,7 @@ class EduBenefitsApp extends React.Component {
                 data={data}
                 submission={submission}
                 pages={pages}
-                path={currentLocation.pathname}
+                path={trimmedPathname}
                 isValid={isValidPage(currentLocation.pathname, data)}
                 canSubmit={isValidForm(data)}
                 dirtyPage={dirtyPage}

--- a/src/js/edu-benefits/1990/containers/EduBenefitsApp.jsx
+++ b/src/js/edu-benefits/1990/containers/EduBenefitsApp.jsx
@@ -57,8 +57,12 @@ class EduBenefitsApp extends React.Component {
   }
 
   onbeforeunload(e) {
+    const { currentLocation } = this.props;
+    const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
+    const isIntroductionPage = trimmedPathname.endsWith('introduction');
+    const isConfirmationPage = trimmedPathname.endsWith('confirmation');
     let message;
-    if (this.props.location.pathname !== '/1990/introduction') {
+    if (!(isIntroductionPage || isConfirmationPage)) {
       message = 'Are you sure you wish to leave this application? All progress will be lost.';
       // Chrome requires this to be set
       e.returnValue = message;     // eslint-disable-line no-param-reassign

--- a/src/js/edu-benefits/1990/containers/EduBenefitsApp.jsx
+++ b/src/js/edu-benefits/1990/containers/EduBenefitsApp.jsx
@@ -77,10 +77,9 @@ class EduBenefitsApp extends React.Component {
       submitBenefitsForm(this.props.data);
     };
 
-    const pathList = currentLocation.pathname.split('/');
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
-    let endpoint = pathList.pop();
-    endpoint = (endpoint.length) ? endpoint : pathList.pop();
+    const pathList = trimmedPathname.split('/');
+    const endpoint = pathList.pop();
     const isIntroductionPage = endpoint === 'introduction';
 
     // Until we come up with a common code base between this and the schemaform
@@ -109,10 +108,10 @@ class EduBenefitsApp extends React.Component {
     let contentClass = classNames(
       'progress-box',
       'progress-box-schemaform',
-      { 'intro-content': endpoint === 'introduction' }
+      { 'intro-content': isIntroductionPage }
     );
 
-    const ombInfo = endpoint === 'introduction' ?
+    const ombInfo = isIntroductionPage ?
       // .row.edu-intro-spacing for the bottom spacing, columns for the padding
       (<div className="row edu-intro-spacing columns">
         <OMBInfo resBurden={15} ombNumber="2900-0154" expDate="12/31/2019"/>


### PR DESCRIPTION
Connects to department-of-veterans-affairs/vets-website#5508

This change makes it unnecessary to handle trailing slashes in the NavButtons component (since it is now being provided with the trimmed pathname).

Also, although the original issue (department-of-veterans-affairs/vets.gov-team#2278) specified the "Get Started" button on the 1990 form in particular, it also indicated that other forms should be checked, and although other forms (e.g. 1990e, 5490) do not use the NavButton component, they do not handle the slash properly, and have been updated as well.