### PR TITLE
Fix va file number collisions on 5495

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,6 @@
     "camelcase-keys-recursive": "^0.8.2",
     "react-autosuggest": "^8.0.0",
     "reselect": "^2.5.4",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d0e327cd0ee93a82988914778cc4342dbf013cb4"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#916ef2b374ed52aa6053a461045ed4acab5e5a88"
   }
 }

--- a/src/js/edu-benefits/5495/config/form.js
+++ b/src/js/edu-benefits/5495/config/form.js
@@ -62,7 +62,7 @@ const formConfig = {
             'gender',
             'relativeSocialSecurityNumber',
             'view:noSSN',
-            'vaFileNumber'
+            'relativeVaFileNumber'
           ]
         }),
         applicantService: applicantServicePage()

--- a/src/js/edu-benefits/pages/applicantInformation.js
+++ b/src/js/edu-benefits/pages/applicantInformation.js
@@ -38,6 +38,7 @@ export default function applicantInformation(schema, options) {
   const prefix = (options && options.isVeteran) ? 'veteran' : 'relative';
   const mergedOptions = _.assign(defaults(prefix), options);
   const { fields, required, labels } = mergedOptions;
+  const fileNumberProp = prefix === 'relative' ? 'relativeVaFileNumber' : 'vaFileNumber';
 
   const possibleProperties = _.assign(schema.properties, {
     'view:noSSN': {
@@ -58,7 +59,7 @@ export default function applicantInformation(schema, options) {
       'view:noSSN': {
         'ui:title': 'I don’t have a Social Security number',
       },
-      vaFileNumber: {
+      [fileNumberProp]: {
         'ui:required': (formData) => !!_.get('view:noSSN', formData),
         'ui:title': 'File number',
         'ui:errorMessages': {

--- a/test/e2e/edu-helpers.js
+++ b/test/e2e/edu-helpers.js
@@ -81,7 +81,11 @@ function completeRelativeInformation(client, data, onlyRequiredFields) {
       .click(data.gender === 'M' ? 'input[name=root_gender_0' : 'input[name=root_gender_1');
     selectDropdown(client, 'root_relativeFullName_suffix', data.relativeFullName.suffix);
 
-    if (data.vaFileNumber) {
+    if (data.relativeVaFileNumber) {
+      client
+        .click('input[name="root_view:noSSN"]')
+        .fill('input[name="root_relativeVaFileNumber"]', data.relativeVaFileNumber);
+    } else if (data.vaFileNumber) {
       client
         .click('input[name="root_view:noSSN"]')
         .fill('input[name="root_vaFileNumber"]', data.vaFileNumber);

--- a/test/edu-benefits/5495/config/applicantInformation.unit.spec.jsx
+++ b/test/edu-benefits/5495/config/applicantInformation.unit.spec.jsx
@@ -54,6 +54,6 @@ describe('Edu 5495 applicantInformation', () => {
     });
 
     const formDOM = findDOMNode(form);
-    expect(formDOM.querySelector('#root_vaFileNumber')).not.to.be.null;
+    expect(formDOM.querySelector('#root_relativeVaFileNumber')).not.to.be.null;
   });
 });

--- a/test/edu-benefits/5495/schema/maximal-test.json
+++ b/test/edu-benefits/5495/schema/maximal-test.json
@@ -12,6 +12,7 @@
     "view:noSSN": true,
     "relativeSocialSecurityNumber": "213333212",
     "vaFileNumber": "12312313",
+    "relativeVaFileNumber": "99999999",
     "view:applicantServed": true,
     "toursOfDuty": [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8308,9 +8308,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#d0e327cd0ee93a82988914778cc4342dbf013cb4":
-  version "2.5.5"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d0e327cd0ee93a82988914778cc4342dbf013cb4"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#916ef2b374ed52aa6053a461045ed4acab5e5a88":
+  version "2.6.1"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#916ef2b374ed52aa6053a461045ed4acab5e5a88"
 
 vinyl-assign@^1.0.1:
   version "1.2.1"


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2733

This updates the file number in the applicant section to be relativeVaFileNumber, instead of just vaFileNumber, which is used on the sponsor page.