### PR TITLE
Fix node version for Heroku builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,8 +183,8 @@
     "fsevents": "^1.0.7"
   },
   "engines": {
-    "node": "4.4.7",
-    "npm": "3.8.9"
+    "node": "6.10.3",
+    "yarn": "0.21.3"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Heroku builds are failing after the merge of https://github.com/department-of-veterans-affairs/vets-website/pull/5504 . It's pulling node version from package.json which is now out of date.

       Node.js version (mininum): v6.10.3
       Node.js version (installed): v4.4.7

Bumping this up to be in sync. Also added in yarn version to stay in sync as well.