### PR TITLE
Fix IE error on education apply page

### DIFF
--- a/content/pages/education/apply.md
+++ b/content/pages/education/apply.md
@@ -124,7 +124,8 @@ If you need to make a change (for example, you’re moving to a new school), man
   }
 
   // Toggle the expandable apply fields
-  document.querySelectorAll('.expander-container').forEach(function(container) {
+  const containers = Array.prototype.slice.call(document.querySelectorAll('.expander-container'));
+  containers.forEach(function(container) {
     var button = container.querySelector('.expander-button');
     var openButton = container.querySelector('.apply-go-button');
     var content = container.querySelector('.expander-content');


### PR DESCRIPTION
Sentry: http://sentry.vetsgov-internal/vets-gov/website-production/issues/5450/

IE/Edge are throwing errors because I was calling `forEach` on a NodeList, which is wrong (but works in Chrome).