### PR TITLE
Disable broken link check on Heroku review app build

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,6 +5,7 @@
   },
   "env":{
     "INSTALL_HOOKS": "no",
+    "CHECK_BROKEN_LINKS": "no",
     "YARN_PRODUCTION":{
       "required": true
     }

--- a/script/build.js
+++ b/script/build.js
@@ -339,7 +339,7 @@ smith.use(sitemap({
 }));
 // TODO(awong): Does anything even use the results of this plugin?
 
-if (!options.watch) {
+if (!options.watch && !(process.env.CHECK_BROKEN_LINKS === 'no')) {
   smith.use(blc({
     allowRedirects: true,  // Don't require trailing slash for index.html links.
     warn: false,           // Throw an Error when encountering the first broken link not just a warning.


### PR DESCRIPTION
Link check will still be performed in CI environment. This provides functionality provided for the fast-track option defined in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2695.