### PR TITLE
Fix back error on dependent pages

### DIFF
--- a/src/js/common/schemaform/FormPage.jsx
+++ b/src/js/common/schemaform/FormPage.jsx
@@ -75,7 +75,10 @@ class FormPage extends React.Component {
 
   goBack() {
     const { eligiblePageList, pageIndex } = this.getEligiblePages();
-    this.props.router.push(eligiblePageList[pageIndex - 1].path);
+    // if we found the current page, go to previous one
+    // if not, go back to the beginning because they shouldn't be here
+    const page = pageIndex >= 0 ? pageIndex - 1 : 0;
+    this.props.router.push(eligiblePageList[page].path);
   }
 
   render() {

--- a/test/common/schemaform/FormPage.unit.spec.jsx
+++ b/test/common/schemaform/FormPage.unit.spec.jsx
@@ -113,4 +113,50 @@ describe('Schemaform <FormPage>', () => {
       expect(router.push.calledWith('previous-page'));
     });
   });
+  it('should go back to the beginning if current page isn\'t found', () => {
+    const route = {
+      pageConfig: {
+        pageKey: 'testPage',
+        schema: {},
+        uiSchema: {},
+        errorMessages: {},
+        title: ''
+      },
+      pageList: [
+        {
+          path: 'first-page'
+        },
+        {
+          path: 'previous-page'
+        },
+        {
+          path: 'testing',
+          pageKey: 'testPage'
+        }
+      ]
+    };
+    const form = {
+      pages: {
+        testPage: {
+          depends: () => false,
+          schema: {},
+          uiSchema: {},
+        }
+      },
+      data: {}
+    };
+    const router = {
+      push: sinon.spy()
+    };
+
+    const tree = SkinDeep.shallowRender(
+      <FormPage
+          router={router}
+          form={form} route={route}/>
+    );
+
+    tree.getMountedInstance().goBack();
+
+    expect(router.push.calledWith('first-page'));
+  });
 });


### PR DESCRIPTION
Connected to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2479

To fix this, I'm sending users back to the beginning of the form when this happens. I think this is the best option because they shouldn't be on this page in the first place without entering other data. If they are, it's probably because they refreshed, in which case they need to start from the beginning anyway.