### PR TITLE
Fixed bugs in failure cases when saving preferences in Rx and SM

### DIFF
--- a/src/js/messaging/actions/preferences.js
+++ b/src/js/messaging/actions/preferences.js
@@ -44,7 +44,10 @@ export function savePreferences(preferences) {
       baseUrl,
       settings,
       () => dispatch({ type: SM_SAVE_PREFERENCES_SUCCESS }),
-      () => dispatch({ type: SM_SAVE_PREFERENCES_FAILURE })
+      response => dispatch({
+        type: SM_SAVE_PREFERENCES_FAILURE,
+        errors: response.errors
+      })
     );
   };
 }

--- a/src/js/messaging/actions/preferences.js
+++ b/src/js/messaging/actions/preferences.js
@@ -21,9 +21,9 @@ export function fetchPreferences() {
     apiRequest(
       baseUrl,
       null,
-      data => dispatch({
+      response => dispatch({
         type: SM_FETCH_PREFERENCES_SUCCESS,
-        preferences: data.data.attributes
+        preferences: response.data.attributes
       }),
       () => dispatch({ type: SM_FETCH_PREFERENCES_FAILURE })
     );

--- a/src/js/messaging/reducers/alert.js
+++ b/src/js/messaging/reducers/alert.js
@@ -123,11 +123,19 @@ export default function alert(state = initialState, action) {
       );
     }
 
-    case SM_SAVE_PREFERENCES_FAILURE:
+    case SM_SAVE_PREFERENCES_FAILURE: {
+      const { errors } = action;
+      const invalidEmail = errors && errors.filter(e =>
+          e.title === 'Email address is invalid'
+        ).length > 0;
       return createAlert(
-        <b>Failed to save changes.</b>,
+        (<b>
+          Failed to save changes.
+          {invalidEmail && ' Please enter a valid email address.'}
+        </b>),
         alertStatus.ERROR
       );
+    }
 
     case SM_SAVE_PREFERENCES_SUCCESS:
       return createAlert(

--- a/src/js/messaging/reducers/alert.js
+++ b/src/js/messaging/reducers/alert.js
@@ -125,14 +125,9 @@ export default function alert(state = initialState, action) {
 
     case SM_SAVE_PREFERENCES_FAILURE: {
       const { errors } = action;
-      const invalidEmail = errors && errors.filter(e =>
-          e.title === 'Email address is invalid'
-        ).length > 0;
+      const error = errors.length && `${errors[0].title}.`;
       return createAlert(
-        (<b>
-          Failed to save changes.
-          {invalidEmail && ' Please enter a valid email address.'}
-        </b>),
+        <b>Failed to save changes. {error}</b>,
         alertStatus.ERROR
       );
     }

--- a/src/js/messaging/utils/helpers.js
+++ b/src/js/messaging/utils/helpers.js
@@ -52,7 +52,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
                  : Promise.resolve(response);
 
       if (!response.ok) {
-      // Refresh to show login view when requests are unauthorized.
+        // Refresh to show login view when requests are unauthorized.
         if (response.status === 401) { return window.location.reload(); }
         return data.then(Promise.reject.bind(Promise));
       }

--- a/src/js/messaging/utils/helpers.js
+++ b/src/js/messaging/utils/helpers.js
@@ -47,15 +47,17 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
 
   return fetch(url, settings)
     .then((response) => {
+      const data = isJson(response)
+                 ? response.json()
+                 : Promise.resolve(response);
+
       if (!response.ok) {
-        // Refresh to show login view when requests are unauthorized.
+      // Refresh to show login view when requests are unauthorized.
         if (response.status === 401) { return window.location.reload(); }
-        return Promise.reject(response);
-      } else if (isJson(response)) {
-        return response.json();
+        return data.then(Promise.reject.bind(Promise));
       }
 
-      return Promise.resolve(response);
+      return data;
     })
     .then(success, error);
 }

--- a/src/js/rx/actions/preferences.js
+++ b/src/js/rx/actions/preferences.js
@@ -9,9 +9,9 @@ export function fetchPreferences() {
     apiRequest(
       baseUrl,
       null,
-      data => dispatch({
+      response => dispatch({
         type: 'RX_FETCH_PREFERENCES_SUCCESS',
-        preferences: data.data.attributes
+        preferences: response.data.attributes
       }),
       () => dispatch({ type: 'RX_FETCH_PREFERENCES_FAILURE' })
     );
@@ -32,7 +32,10 @@ export function savePreferences(preferences) {
       baseUrl,
       settings,
       () => dispatch({ type: 'RX_SAVE_PREFERENCES_SUCCESS' }),
-      () => dispatch({ type: 'RX_SAVE_PREFERENCES_FAILURE' })
+      response => dispatch({
+        type: 'RX_SAVE_PREFERENCES_FAILURE',
+        errors: response.errors
+      })
     );
   };
 }

--- a/src/js/rx/reducers/alert.js
+++ b/src/js/rx/reducers/alert.js
@@ -19,14 +19,14 @@ export default function alert(state = initialState, action) {
     case 'CLOSE_ALERT':
       return initialState;
 
-    case 'SAVE_PREFERENCES_FAILURE':
+    case 'RX_SAVE_PREFERENCES_FAILURE':
       return {
         content: <b>Failed to save your changes.</b>,
         status: 'error',
         visible: true
       };
 
-    case 'SAVE_PREFERENCES_SUCCESS':
+    case 'RX_SAVE_PREFERENCES_SUCCESS':
       return {
         content: <b>Your changes have been saved.</b>,
         status: 'success',

--- a/src/js/rx/reducers/alert.js
+++ b/src/js/rx/reducers/alert.js
@@ -25,15 +25,9 @@ export default function alert(state = initialState, action) {
 
     case 'RX_SAVE_PREFERENCES_FAILURE': {
       const { errors } = action;
-      const invalidEmail = errors && errors.filter(e =>
-          e.title === 'Email address is invalid'
-        ).length > 0;
-
+      const error = errors.length && `${errors[0].title}.`;
       return {
-        content: (<b>
-          Failed to save changes.
-          {invalidEmail && ' Please enter a valid email address.'}
-        </b>),
+        content: <b>Failed to save changes. {error}</b>,
         status: 'error',
         visible: true
       };

--- a/src/js/rx/reducers/alert.js
+++ b/src/js/rx/reducers/alert.js
@@ -31,7 +31,8 @@ export default function alert(state = initialState, action) {
 
       return {
         content: (<b>
-          Failed to save your changes. {invalidEmail && 'Please enter a valid email address.'}
+          Failed to save changes.
+          {invalidEmail && ' Please enter a valid email address.'}
         </b>),
         status: 'error',
         visible: true

--- a/src/js/rx/reducers/alert.js
+++ b/src/js/rx/reducers/alert.js
@@ -23,12 +23,20 @@ export default function alert(state = initialState, action) {
     case 'RX_SAVING_PREFERENCES':
       return initialState;
 
-    case 'RX_SAVE_PREFERENCES_FAILURE':
+    case 'RX_SAVE_PREFERENCES_FAILURE': {
+      const { errors } = action;
+      const invalidEmail = errors && errors.filter(e =>
+          e.title === 'Email address is invalid'
+        ).length > 0;
+
       return {
-        content: <b>Failed to save your changes.</b>,
+        content: (<b>
+          Failed to save your changes. {invalidEmail && 'Please enter a valid email address.'}
+        </b>),
         status: 'error',
         visible: true
       };
+    }
 
     case 'RX_SAVE_PREFERENCES_SUCCESS':
       return {

--- a/src/js/rx/reducers/alert.js
+++ b/src/js/rx/reducers/alert.js
@@ -19,6 +19,10 @@ export default function alert(state = initialState, action) {
     case 'CLOSE_ALERT':
       return initialState;
 
+    case 'RX_LOADING_PREFERENCES':
+    case 'RX_SAVING_PREFERENCES':
+      return initialState;
+
     case 'RX_SAVE_PREFERENCES_FAILURE':
       return {
         content: <b>Failed to save your changes.</b>,

--- a/src/js/rx/reducers/preferences.js
+++ b/src/js/rx/reducers/preferences.js
@@ -15,6 +15,12 @@ export default function preferences(state = initialState, action) {
     case 'RX_SAVING_PREFERENCES':
       return { ...state, saving: true };
 
+    case 'RX_FETCH_PREFERENCES_FAILURE':
+      return { ...state, loading: false };
+
+    case 'RX_SAVE_PREFERENCES_FAILURE':
+      return { ...state, saving: false };
+
     case 'RX_FETCH_PREFERENCES_SUCCESS': {
       const { emailAddress: email, rxFlag: flag } = action.preferences;
       return {

--- a/src/js/rx/utils/helpers.js
+++ b/src/js/rx/utils/helpers.js
@@ -51,11 +51,13 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
       const data = isJson(response)
                  ? response.json()
                  : Promise.resolve(response);
+
       if (!response.ok) {
       // Refresh to show login view when requests are unauthorized.
         if (response.status === 401) { return window.location.reload(); }
         return data.then(Promise.reject.bind(Promise));
       }
+
       return data;
     })
     .then(success, error);

--- a/src/js/rx/utils/helpers.js
+++ b/src/js/rx/utils/helpers.js
@@ -48,14 +48,15 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
 
   return fetch(url, settings)
     .then((response) => {
+      const data = isJson(response)
+                 ? response.json()
+                 : Promise.resolve(response);
       if (!response.ok) {
-        // Refresh to show login view when requests are unauthorized.
+      // Refresh to show login view when requests are unauthorized.
         if (response.status === 401) { return window.location.reload(); }
-        return Promise.reject(response);
-      } else if (isJson(response)) {
-        return response.json();
+        return data.then(Promise.reject.bind(Promise));
       }
-      return Promise.resolve(response);
+      return data;
     })
     .then(success, error);
 }

--- a/src/js/rx/utils/helpers.js
+++ b/src/js/rx/utils/helpers.js
@@ -53,7 +53,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
                  : Promise.resolve(response);
 
       if (!response.ok) {
-      // Refresh to show login view when requests are unauthorized.
+        // Refresh to show login view when requests are unauthorized.
         if (response.status === 401) { return window.location.reload(); }
         return data.then(Promise.reject.bind(Promise));
       }

--- a/test/messaging/reducers/alert.unit.spec.js
+++ b/test/messaging/reducers/alert.unit.spec.js
@@ -175,7 +175,10 @@ describe('alert reducer', () => {
   });
 
   it('should alert when failing to save preferences', () => {
-    const state = alertReducer(initialState, { type: SM_SAVE_PREFERENCES_FAILURE });
+    const state = alertReducer(initialState, {
+      type: SM_SAVE_PREFERENCES_FAILURE,
+      errors: [{ title: 'Email address is invalid' }]
+    });
     expect(state.visible).to.be.true;
     expect(state.status).to.eql('error');
   });

--- a/test/rx/reducers/alert.unit.spec.js
+++ b/test/rx/reducers/alert.unit.spec.js
@@ -38,7 +38,10 @@ describe('alert reducer', () => {
       visible: false,
       content: '',
       status: 'info'
-    }, { type: 'RX_SAVE_PREFERENCES_FAILURE' });
+    }, {
+      type: 'RX_SAVE_PREFERENCES_FAILURE',
+      errors: [{ title: 'Email address is invalid' }]
+    });
 
     expect(state.visible).to.be.true;
     expect(state.content).to.be.not.empty;

--- a/test/rx/reducers/alert.unit.spec.js
+++ b/test/rx/reducers/alert.unit.spec.js
@@ -23,12 +23,22 @@ describe('alert reducer', () => {
     expect(state.visible).to.be.false;
   });
 
+  it('should dismiss alerts when loading preferences', () => {
+    const state = alertReducer(undefined, { type: 'RX_LOADING_PREFERENCES' });
+    expect(state.visible).to.be.false;
+  });
+
+  it('should dismiss alerts when saving preferences', () => {
+    const state = alertReducer(undefined, { type: 'RX_SAVING_PREFERENCES' });
+    expect(state.visible).to.be.false;
+  });
+
   it('should alert an error for failing to save preferences', () => {
     const state = alertReducer({
       visible: false,
       content: '',
       status: 'info'
-    }, { type: 'SAVE_PREFERENCES_FAILURE' });
+    }, { type: 'RX_SAVE_PREFERENCES_FAILURE' });
 
     expect(state.visible).to.be.true;
     expect(state.content).to.be.not.empty;
@@ -40,7 +50,7 @@ describe('alert reducer', () => {
       visible: false,
       content: '',
       status: 'info'
-    }, { type: 'SAVE_PREFERENCES_SUCCESS' });
+    }, { type: 'RX_SAVE_PREFERENCES_SUCCESS' });
 
     expect(state.visible).to.be.true;
     expect(state.content).to.be.not.empty;

--- a/test/rx/reducers/preferences.unit.spec.js
+++ b/test/rx/reducers/preferences.unit.spec.js
@@ -18,6 +18,11 @@ describe('preferencesducer', () => {
     expect(state.saving).to.be.true;
   });
 
+  it('should handle failure to load preferences', () => {
+    const state = preferencesReducer(undefined, { type: 'RX_FETCH_PREFERENCES_FAILURE' });
+    expect(state.loading).to.be.false;
+  });
+
   it('should handle successfully loading preferences', () => {
     const state = preferencesReducer(undefined, {
       type: 'RX_FETCH_PREFERENCES_SUCCESS',
@@ -29,6 +34,11 @@ describe('preferencesducer', () => {
     expect(state.email.value).to.eql('test@vets.gov');
     expect(state.flag.value).to.eql('true');
     expect(state.loading).to.be.false;
+  });
+
+  it('should handle failure to save preferences', () => {
+    const state = preferencesReducer(undefined, { type: 'RX_SAVE_PREFERENCES_FAILURE' });
+    expect(state.saving).to.be.false;
   });
 
   it('should handle successfully saving preferences', () => {


### PR DESCRIPTION
### Changes
* Fixed stuck loading indicator when saving Rx preferences and getting error response.
    * Resolves department-of-veterans-affairs/vets.gov-team#2766.
* Show specific error when saving preferences with blank email. Resolves department-of-veterans-affairs/vets.gov-team#2790.
    > <img width="927" alt="screen shot 2017-05-15 at 8 24 54 pm" src="https://cloud.githubusercontent.com/assets/1067024/26084758/a9799df2-39ac-11e7-86c8-bfdea6db5bd0.png">
* Show specific error when saving preferences with invalid email. Resolves department-of-veterans-affairs/vets.gov-team#2791.
    > <img width="920" alt="screen shot 2017-05-15 at 8 25 08 pm" src="https://cloud.githubusercontent.com/assets/1067024/26084761/ae96e4c0-39ac-11e7-9a43-95ee88ff708f.png">
