### PR TITLE
Remove nth child rule on body text in callouts

### DIFF
--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -511,12 +511,6 @@ h6 {
     font: inherit !important;
     margin-bottom: 0;
     padding-bottom: .5em;
-
-    &:nth-child(1) {
-      font-size: 1.25em !important;
-      color: $color-gray-dark !important;
-      padding-bottom: inherit;
-    }
   }
 
   h3 {


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2787

Removes a rule that makes some body text larger in blue callouts on static content pages. This rule isn't necessary now with the ability to manually apply the `.va-introtext` class where needed.

Before:

![image](https://cloud.githubusercontent.com/assets/4106356/26119668/e2733002-3a22-11e7-8ca3-b9ebacd54c6a.png)

After:

![image](https://cloud.githubusercontent.com/assets/4106356/26119682/edc22198-3a22-11e7-9559-d1d00a44a313.png)

FYI @DanielleSoCompany @bethpotts this will fix this formatting issue in the health care PR: https://vetsgov-pr-5436.herokuapp.com/healthcare/eligibility/