### PR TITLE
Pension content design updates (proposed)

### DIFF
--- a/content/pages/pension/apply.md
+++ b/content/pages/pension/apply.md
@@ -30,19 +30,23 @@ You can apply in person or by mail for VA pension benefits. Follow these 2 steps
 - Find out if you qualify. [Check your eligibility](/pension/eligibility/).
 - Gather the documents listed below that you’ll need to fill out your pension application.
 
-**What documents and information do I need to apply?**
+<div class="feature">
+
+#### What documents and information do I need to apply?
 
 - Military history
 - Your financial information and the financial information of your dependents (required)
 - Work history 
 - Direct deposit information 
-- Medical information 
+- Medical information
 
-**Apply**
+</div>
+
+### Apply
 
 You can apply in 1 of 3 ways:
 
-**Apply by mail**
+#### Apply by mail
 
 Fill out Form 21P-527EZ (Application for Pension). [Download Form 21P-527EZ](https://www.vba.va.gov/pubs/forms/VBA-21P-527EZ-ARE.pdf). 
 
@@ -50,15 +54,15 @@ Mail it to the Pension Management Center (PMC) for your state. [Find your PMC](/
 
 [Find out how to apply for the Survivors Pension program](/pension/survivors-pension/).
 
-**Work with a trained professional**
+#### Work with a trained professional
 
 You can work with a trained professional called an accredited representative to get help applying for VA pension benefits.  [Find an accredited representative](/disability-benefits/apply/help/).
 
-**Apply in person**
+#### Apply in person
 
 Bring your application to a Regional Benefits Office near you. [Find a Regional Benefits Office](/facilities/). 
 
-**How long does it take VA to make a decision?**
+### How long does it take VA to make a decision?
 
 Claims are processed in the order in which they are received unless priority processing is required.   
 

--- a/content/pages/pension/eligibility/aid-attendance-housebound.md
+++ b/content/pages/pension/eligibility/aid-attendance-housebound.md
@@ -3,7 +3,6 @@ layout: page-breadcrumbs.html
 title: Aid and Attendance or Housebound Allowance
 concurrence: "" 
 template: 1-topic-landing
-relatedlinks: []
 ---
 
 <div class="va-introtext">
@@ -14,9 +13,9 @@ If you need help with your daily activities, or you’re housebound, you may qua
 
 <div class="feature" markdown=“1”>
 
-<strong>Can I get Aid and Attendance (A&A) or Housebound benefits from VA?</strong>
+### Can I get Aid and Attendance (A&A) or Housebound benefits from VA?
 
-You may qualify for <strong>A&A</strong> if you get a VA pension, <strong>and</strong> you:
+You may qualify for **A&A** if you get a VA pension, **and** you:
 
 - Need another person to help you perform daily activities, like bathing, feeding, and dressing, or
 - Have to stay in bed—or spend a large portion of the day in bed—because of illness, or
@@ -25,19 +24,19 @@ You may qualify for <strong>A&A</strong> if you get a VA pension, <strong>and</s
 
 You may qualify for **housebound benefits** if you get VA pension, **and** you spend most of your time in your home because of a permanent disability (a disability that doesn’t go away). 
 
-<strong>Note:</strong> You can’t get A&A benefits and housebound benefits at the same time.
+**Note:** You can’t get A&A benefits and housebound benefits at the same time.
 
-<strong>Who’s covered:</strong>
+#### Who’s covered:
 - Qualified Veterans
 - Qualified surviving spouses 
 
 </div>
 
-**How do I get this benefit?** 
+### How do I get this benefit?
 
 There are 2 ways you can get this benefit:
 
-**Write to your Pension Management Center (PMC)**
+#### Write to your Pension Management Center (PMC)
 
 You can write to the PMC for your state. [Find your PMC](/pension/pension-management-center/). 
 
@@ -46,10 +45,12 @@ Include this information:
 - Details about what you normally do during the day and how you get places
 - Details that help show what kind of illness, injury, or mental or physical disability affects your ability to do things, like take a bath, on your own 
 
-**Or, apply in person**
+#### Or, apply in person
 
 You can bring your information to a Regional Benefits Office near you. [Find a Regional Benefits Office](/facilities/). 
 
-**How long does it take VA to make a decision?**
+### How long does it take VA to make a decision?
 
 Claims are processed in the order in which they are received unless priority processing is required.  
+
+<br>

--- a/content/pages/pension/pension-management-center.md
+++ b/content/pages/pension/pension-management-center.md
@@ -24,11 +24,11 @@ We have 3 Regional Pension Management Centers. Look at the lists below to find t
 
 </div>
 
-**Philadelphia VA Regional Benefit Office**
+### Philadelphia VA Regional Benefit Office
 
 This office serves:
 
-<div class="small-18 columns">
+<div class="small-6 columns">
 <ul>
 <li>Connecticut</li>
 <li>Florida</li>
@@ -39,6 +39,11 @@ This office serves:
 <li>Puerto Rico</li>
 <li>South Carolina</li>
 <li>Virginia</li>
+</ul>
+</div>
+
+<div class="small-6 columns">
+<ul>
 <li>Delaware</li>
 <li>Georgia</li>
 <li>Maryland</li>
@@ -64,11 +69,11 @@ To submit a pension application to this office, mail it to:
 
 [Get more information about the Philadelphia VA Regional Benefit Office](http://www.benefits.va.gov/philadelphia/). 
 
-**Milwaukee VA Pension Center**
+### Milwaukee VA Pension Center
 
 This office serves:
 
-<div class="small-12 columns">
+<div class="small-6 columns">
 <ul>
 <li>Alabama</li>
 <li>Illinois</li>
@@ -76,6 +81,11 @@ This office serves:
 <li>Michigan</li>
 <li>Missouri</li>
 <li>Tennessee</li>
+</ul>
+</div>
+
+<div class="small-6 columns">
+<ul>
 <li>Arkansas</li>
 <li>Indiana</li>
 <li>Louisiana</li>
@@ -98,11 +108,11 @@ To submit a pension application to this office, mail it to:
 
 [Get more information about the Milwaukee VA Regional Benefit Office](http://www.benefits.va.gov/milwaukee/). 
 
-**St. Paul VA Regional Benefit Office**
+### St. Paul VA Regional Benefit Office
 
 This office serves:
 
-<div class="small-22 columns">
+<div class="small-6 columns">
 <ul>
 <li>Alaska</li>
 <li>California</li>
@@ -115,6 +125,11 @@ This office serves:
 <li>South Dakota</li>
 <li>Utah</li>
 <li>Wyoming</li>
+</ul>
+</div>
+
+<div class="small-6 columns">
+<ul>
 <li>Arizona</li>
 <li>Colorado</li>
 <li>Idaho</li>

--- a/content/pages/pension/pension-management-center.md
+++ b/content/pages/pension/pension-management-center.md
@@ -28,30 +28,30 @@ We have 3 Regional Pension Management Centers. Look at the lists below to find t
 
 This office serves:
 
-<div class="small-6 columns">
+<div class="small-12 usa-width-one-half medium-6 columns">
 <ul>
 <li>Connecticut</li>
+<li>Delaware</li>
 <li>Florida</li>
+<li>Georgia</li>
 <li>Maine</li>
+<li>Maryland</li>
 <li>Massachusetts</li>
+<li>New Hampshire</li>
 <li>New Jersey</li>
-<li>North Carolina</li>
-<li>Puerto Rico</li>
-<li>South Carolina</li>
-<li>Virginia</li>
 </ul>
 </div>
 
-<div class="small-6 columns">
+<div class="small-12 usa-width-one-half medium-6 columns">
 <ul>
-<li>Delaware</li>
-<li>Georgia</li>
-<li>Maryland</li>
-<li>New Hampshire</li>
 <li>New York</li>
+<li>North Carolina</li>
 <li>Pennsylvania</li>
+<li>Puerto Rico</li>
 <li>Rhode Island</li>
+<li>South Carolina</li>
 <li>Vermont</li>
+<li>Virginia</li>
 <li>West Virginia</li>
 </ul>
 </div>
@@ -73,24 +73,24 @@ To submit a pension application to this office, mail it to:
 
 This office serves:
 
-<div class="small-6 columns">
+<div class="small-12 usa-width-one-half medium-6 columns">
 <ul>
 <li>Alabama</li>
+<li>Arkansas</li>
+<li>Indiana</li>
 <li>Illinois</li>
 <li>Kentucky</li>
-<li>Michigan</li>
-<li>Missouri</li>
-<li>Tennessee</li>
+<li>Louisiana</li>
 </ul>
 </div>
 
-<div class="small-6 columns">
+<div class="small-12 usa-width-one-half medium-6 columns">
 <ul>
-<li>Arkansas</li>
-<li>Indiana</li>
-<li>Louisiana</li>
+<li>Michigan</li>
 <li>Mississippi</li>
+<li>Missouri</li>
 <li>Ohio</li>
+<li>Tennessee</li>
 <li>Wisconsin</li>
 </ul>
 </div>
@@ -112,35 +112,39 @@ To submit a pension application to this office, mail it to:
 
 This office serves:
 
-<div class="small-6 columns">
+<div class="usa-grid-full">
+
+<div class="small-12 usa-width-one-half medium-6 columns">
 <ul>
 <li>Alaska</li>
+<li>Arizona</li>
 <li>California</li>
+<li>Colorado</li>
 <li>Hawaii</li>
+<li>Idaho</li>
 <li>Iowa</li>
+<li>Kansas</li>
 <li>Minnesota</li>
+<li>Montana</li>
 <li>Nebraska</li>
+</ul>
+</div>
+
+<div class="small-12 usa-width-one-half medium-6 columns">
+<ul>
+<li>Nevada</li>
 <li>New Mexico</li>
+<li>North Dakota</li>
 <li>Oklahoma</li>
+<li>Oregon</li>
 <li>South Dakota</li>
+<li>Texas</li>
 <li>Utah</li>
+<li>Washington</li>
 <li>Wyoming</li>
 </ul>
 </div>
 
-<div class="small-6 columns">
-<ul>
-<li>Arizona</li>
-<li>Colorado</li>
-<li>Idaho</li>
-<li>Kansas</li>
-<li>Montana</li>
-<li>North Dakota</li>
-<li>Nevada</li>
-<li>Oregon</li>
-<li>Texas</li>
-<li>Washington</li>
-</ul>
 </div>
 
 To submit a pension application to this office, mail it to:

--- a/content/pages/pension/rates.md
+++ b/content/pages/pension/rates.md
@@ -41,7 +41,7 @@ Your VA pension = $15,525 for the year (or $1,293.75 paid each month)
 *Increase Factor: .3%*
 *Standard Medicare Deduction: Actual amount will be determined by SSA based on individual income.*
 
-**For Veterans with at least 1 dependent spouse or child:**
+#### For Veterans with at least 1 dependent spouse or child:
 
 | **If you have 1 dependent and…** | **Your MAPR amount is:** |
 | --- | --- | 
@@ -54,7 +54,7 @@ Your VA pension = $15,525 for the year (or $1,293.75 paid each month)
 - **If you have a child who works,** you may exclude their income up to $10,400 for 2017.
 - **If you have medical expenses,** you may deduct only the amount that’s above 5% of your MAPR amount ($845 for a Veteran with 1 dependent).
 
-**For Veterans with no dependents:**
+#### For Veterans with no dependents:
 
 | **If you have no dependents and…** | **Your MARP amount is:** | 
 | --- | --- | 
@@ -65,7 +65,7 @@ Your VA pension = $15,525 for the year (or $1,293.75 paid each month)
 **Note:**
 - **If you have medical expenses,** you may deduct only the amount that’s above 5% of your MAPR amount ($645 for a Veteran with no spouse or child).
 
-**For 2 Veterans who are married to each other:**
+#### For 2 Veterans who are married to each other:
 
 | **If you're 2 Veterans who are married to each other and:** | **Your MARP amount is:** |
 | --- | --- | 

--- a/content/pages/pension/survivors-pension.md
+++ b/content/pages/pension/survivors-pension.md
@@ -21,7 +21,7 @@ Survivors pension is a tax-free monetary benefit. If you’re a low-income survi
 
 <div class="feature" markdown=“1”>
 
-**Can I get this benefit as a surviving spouse?** 
+### Can I get this benefit as a surviving spouse?
 
 You may be able to get this benefit if your income and net worth meet certain levels set by Congress. Your net worth equals the value of everything you own (like your house and any stocks) plus your income minus any debt you owe. You may qualify if you meet these requirements and if the deceased Veteran:
 
@@ -31,9 +31,7 @@ You may be able to get this benefit if your income and net worth meet certain le
   - Served at least 24 months or the full period for which called or ordered to active duty, with at least 1 day during a wartime period, **and** 
   - Was discharged from service under other conditions than dishonorable
 
-<div class="feature" markdown=“1”>
-
-**Can I get this benefit as the child of a deceased wartime Veteran?**
+### Can I get this benefit as the child of a deceased wartime Veteran?
 
 You may be able to get this benefit if you’re: 
 - Under age 18, **or**
@@ -50,14 +48,14 @@ Mail it to the Pension Management Center (PMC) for your state. [Find your PMC](/
 
 ### Other ways to apply
 
-**Work with a trained professional**
+#### Work with a trained professional
 
 You can work with a trained professional called an accredited representative to get help applying for survivors pension benefits. [Find an accredited representative](/disability-benefits/apply/help/)
 
-**Apply in person**
+#### Apply in person
 
 Bring your application to a Regional Benefits Office near you. [Find a Regional Benefits Office](/facilities/). 
 
-**How long does it take VA to make a decision?**
+### How long does it take VA to make a decision?
 
 Claims are processed in the order in which they are received unless priority processing is required.   

--- a/content/pages/pension/survivors-pension/rates.md
+++ b/content/pages/pension/survivors-pension/rates.md
@@ -41,7 +41,7 @@ Your VA pension = $6,506 for the year (or $542.17 paid each month)
 *Increase Factor: .3%*
 *Standard Medicare Deduction: Actual amount will be determined by SSA based on individual income.*
 
-**For qualified surviving spouses with at least 1 dependent:**
+#### For qualified surviving spouses with at least 1 dependent:
 
 | **If you have 1 dependent child and…** | **Your MAPR amount is:** | 
 | --- | --- | 
@@ -56,7 +56,7 @@ Your VA pension = $6,506 for the year (or $542.17 paid each month)
 - **If you have a child who works,** you may exclude their income up to $10,400 for 2017.
 - **If you have medical expenses,** you may deduct only the amount that’s above 5% of your MAPR amount ($566 for a surviving spouse with 1 dependent).
 
-**For qualified surviving spouses with no dependents:**
+#### For qualified surviving spouses with no dependents:
 
 | **If you have no dependents and…** | **Your MARP amount is:** |
 | --- | --- |
@@ -69,7 +69,7 @@ Your VA pension = $6,506 for the year (or $542.17 paid each month)
 - The Survivor Benefit Plan (SBP)/Minimum Income Annuity (MIW) limitation is $8,656.
 - **If you have medical expenses,** you may deduct only the amount that’s above 5% of your MAPR amount ($432 for a surviving spouse with no dependent child). 
 
-**For qualified surviving children:**
+#### For qualified surviving children:
 
 | **If you’re…**| **Your MARP amount is:** |
 | --- | --- | 


### PR DESCRIPTION
Related: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2789

This PR proposes some small design changes for the WIP Pensions content. Changes include:

[Application Process](https://vetsgov-pr-5562.herokuapp.com/pension/apply/)

- Changed bolded text to headings

[Aid and Attendance](https://vetsgov-pr-5562.herokuapp.com/pension/eligibility/aid-attendance-housebound/)

- Changed bolded text to headings
- Removed extra gray container at bottom showing up w/o any piano key content

[Pension Management Center](https://vetsgov-pr-5562.herokuapp.com/pension/pension-management-center/)

- Made states list two-column for space efficiency on desktop
- Changed PMC names to headings

[Rates](https://vetsgov-pr-5562.herokuapp.com/pension/rates/)

- Changed text above rate tables to headings

[Survivors Pension](https://vetsgov-pr-5562.herokuapp.com/pension/survivors-pension/)

- Broke out content not intended to be in the blue callout
- Changed bolded text to headings

[Survivors Pension Rates](https://vetsgov-pr-5562.herokuapp.com/pension/survivors-pension/rates/)

- Changed text above rate tables to headings