### PR TITLE
Add title, progress bar, and nav header

### DIFF
--- a/src/js/common/components/NavHeader.jsx
+++ b/src/js/common/components/NavHeader.jsx
@@ -1,30 +1,22 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import { getCurrentFormStep, getCurrentPageName } from '../utils/helpers';
+
 export default class NavHeader extends React.Component {
   render() {
     const { chapters, path, className } = this.props;
     const total = chapters.length;
 
-    let step;
-    let name;
-    chapters
-      .forEach((chapter, index) => {
-        if (chapter.pages.some(page => page.path === path)) {
-          step = index + 1;
-          name = chapter.name;
-        }
-      });
-
-    return step
+    return getCurrentFormStep(chapters, path)
       ? <h4
           role="progressbar"
-          aria-valuenow={step}
+          aria-valuenow={getCurrentFormStep(chapters, path)}
           aria-valuemin="1"
-          aria-valuetext={`Step ${step} of ${total}: ${name}`}
+          aria-valuetext={`Step ${getCurrentFormStep(chapters, path)} of ${total}: ${getCurrentPageName(chapters, path)}`}
           aria-valuemax={total}
           className={`nav-header ${className}`}>
-        <span className="form-process-step current">{step}</span> of {total} {name}
+        <span className="form-process-step current">{getCurrentFormStep(chapters, path)}</span> of {total} {getCurrentPageName(chapters, path)}
       </h4>
       : null;
   }

--- a/src/js/common/components/NavHeader.jsx
+++ b/src/js/common/components/NavHeader.jsx
@@ -7,16 +7,18 @@ export default class NavHeader extends React.Component {
   render() {
     const { chapters, path, className } = this.props;
     const total = chapters.length;
+    const step = getCurrentFormStep(chapters, path);
+    const name = getCurrentPageName(chapters, path);
 
-    return getCurrentFormStep(chapters, path)
+    return step
       ? <h4
           role="progressbar"
-          aria-valuenow={getCurrentFormStep(chapters, path)}
+          aria-valuenow={step}
           aria-valuemin="1"
-          aria-valuetext={`Step ${getCurrentFormStep(chapters, path)} of ${total}: ${getCurrentPageName(chapters, path)}`}
+          aria-valuetext={`Step ${step} of ${total}: ${name}`}
           aria-valuemax={total}
           className={`nav-header ${className}`}>
-        <span className="form-process-step current">{getCurrentFormStep(chapters, path)}</span> of {total} {getCurrentPageName(chapters, path)}
+        <span className="form-process-step current">{step}</span> of {total} {name}
       </h4>
       : null;
   }

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -66,15 +66,26 @@ export function getInactivePages(pages, data) {
   return pages.filter(page => !isActivePage(page, data));
 }
 
-export function getCurrentFormStep(chapters, location) {
+export function getCurrentFormStep(chapters, path) {
   let step;
   chapters.forEach((chapter, index) => {
-    if (chapter.pages.some(page => page.path === location.pathname)) {
+    if (chapter.pages.some(page => page.path === path)) {
       step = index + 1;
     }
   });
 
   return step;
+}
+
+export function getCurrentPageName(chapters, path) {
+  let name;
+  chapters.forEach((chapter) => {
+    if (chapter.pages.some(page => page.path === path)) {
+      name = chapter.name;
+    }
+  });
+
+  return name;
 }
 
 export function dateToMoment(dateField) {

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -66,6 +66,17 @@ export function getInactivePages(pages, data) {
   return pages.filter(page => !isActivePage(page, data));
 }
 
+export function getCurrentFormStep(chapters, location) {
+  let step;
+  chapters.forEach((chapter, index) => {
+    if (chapter.pages.some(page => page.path === location.pathname)) {
+      step = index + 1;
+    }
+  });
+
+  return step;
+}
+
 export function dateToMoment(dateField) {
   return moment({
     year: dateField.year.value,

--- a/src/js/hca/components/HealthCareApp.jsx
+++ b/src/js/hca/components/HealthCareApp.jsx
@@ -366,7 +366,7 @@ class HealthCareApp extends React.Component {
           <div className="usa-width-two-thirds medium-8 columns">
             <FormTitle title="Apply online for health care with the 10-10ez" subTitle="OMB No. 2900-0091"/>
             <div>
-              {!_.includes(['/introduction', '/submit-message'], this.props.location.pathname) && <SegmentedProgressBar total={chapters.length} current={getCurrentFormStep(chapters, this.props.location)}/>}
+              {!_.includes(['/introduction', '/submit-message'], this.props.location.pathname) && <SegmentedProgressBar total={chapters.length} current={getCurrentFormStep(chapters, this.props.location.pathname)}/>}
               <div className="schemaform-chapter-progress">
                 <NavHeader path={this.props.location.pathname} chapters={chapters} className="nav-header-schemaform"/>
               </div>

--- a/src/js/hca/components/HealthCareApp.jsx
+++ b/src/js/hca/components/HealthCareApp.jsx
@@ -16,7 +16,7 @@ import FormTitle from '../../common/schemaform/FormTitle.jsx';
 import ProgressButton from '../../common/components/form-elements/ProgressButton';
 import { ensureFieldsInitialized, updateCompletedStatus, updateSubmissionStatus, updateSubmissionId, updateSubmissionTimestamp, setAttemptedSubmit } from '../actions';
 import { veteranToApplication } from '../../common/model/veteran';
-import { getScrollOptions } from '../../common/utils/helpers';
+import { getScrollOptions, getCurrentFormStep } from '../../common/utils/helpers';
 import * as validations from '../utils/validations';
 import { chapters } from '../routes';
 
@@ -343,15 +343,6 @@ class HealthCareApp extends React.Component {
     //   }
     // }
 
-    // Until we come up with a common code base between this and the schemaform
-    //  forms, the following is borrowed from NavHeader
-    let step;
-    chapters.forEach((chapter, index) => {
-      if (chapter.pages.some(page => page.path === this.props.location.pathname)) {
-        step = index + 1;
-      }
-    });
-
     let contentClass = classNames(
       'progress-box',
       'progress-box-schemaform',
@@ -375,7 +366,7 @@ class HealthCareApp extends React.Component {
           <div className="usa-width-two-thirds medium-8 columns">
             <FormTitle title="Apply online for health care with the 10-10ez" subTitle="OMB No. 2900-0091"/>
             <div>
-              {!_.includes(['/introduction', '/submit-message'], this.props.location.pathname) && <SegmentedProgressBar total={chapters.length} current={step}/>}
+              {!_.includes(['/introduction', '/submit-message'], this.props.location.pathname) && <SegmentedProgressBar total={chapters.length} current={getCurrentFormStep(chapters, this.props.location)}/>}
               <div className="schemaform-chapter-progress">
                 <NavHeader path={this.props.location.pathname} chapters={chapters} className="nav-header-schemaform"/>
               </div>

--- a/src/js/va-letters/containers/VALettersApp.jsx
+++ b/src/js/va-letters/containers/VALettersApp.jsx
@@ -1,11 +1,30 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import FormTitle from '../../common/schemaform/FormTitle';
+import { getCurrentFormStep } from '../../common/utils/helpers';
+import SegmentedProgressBar from '../../common/components/SegmentedProgressBar';
+import NavHeader from '../../common/components/NavHeader';
+
+import { chapters } from '../routes';
+
 class VALettersApp extends React.Component {
   render() {
-    const { children } = this.props;
+    const { children, location } = this.props;
+
     return (
-      <div>{children}</div>
+      <div className="usa-grid">
+        <div className="usa-width-two-thirds medium-8 columns">
+          <FormTitle title="Download VA Letters"/>
+          <SegmentedProgressBar total={chapters.length} current={getCurrentFormStep(chapters, location)}/>
+          <div className="schemaform-chapter-progress">
+            <NavHeader path={location.pathname} chapters={chapters} className="nav-header-schemaform"/>
+          </div>
+          <div className="form-panel">
+            {children}
+          </div>
+        </div>
+      </div>
     );
   }
 }

--- a/src/js/va-letters/containers/VALettersApp.jsx
+++ b/src/js/va-letters/containers/VALettersApp.jsx
@@ -14,7 +14,7 @@ class VALettersApp extends React.Component {
 
     return (
       <div className="usa-grid">
-        <div className="usa-width-two-thirds medium-8 columns">
+        <div className="usa-width-two-thirds">
           <FormTitle title="Download VA Letters"/>
           <SegmentedProgressBar total={chapters.length} current={getCurrentFormStep(chapters, location.pathname)}/>
           <div className="schemaform-chapter-progress">

--- a/src/js/va-letters/containers/VALettersApp.jsx
+++ b/src/js/va-letters/containers/VALettersApp.jsx
@@ -16,7 +16,7 @@ class VALettersApp extends React.Component {
       <div className="usa-grid">
         <div className="usa-width-two-thirds medium-8 columns">
           <FormTitle title="Download VA Letters"/>
-          <SegmentedProgressBar total={chapters.length} current={getCurrentFormStep(chapters, location)}/>
+          <SegmentedProgressBar total={chapters.length} current={getCurrentFormStep(chapters, location.pathname)}/>
           <div className="schemaform-chapter-progress">
             <NavHeader path={location.pathname} chapters={chapters} className="nav-header-schemaform"/>
           </div>

--- a/src/js/va-letters/routes.jsx
+++ b/src/js/va-letters/routes.jsx
@@ -1,18 +1,29 @@
 import React from 'react';
 import { Route } from 'react-router';
 
+import { groupPagesIntoChapters, getPageList } from '../common/utils/helpers';
+
 import ConfirmAddress from './containers/ConfirmAddress.jsx';
 import DownloadLetters from './containers/DownloadLetters.jsx';
+import { chapterNames } from './utils/helpers';
 
 const routes = [
   <Route
       component={ConfirmAddress}
+      chapter={chapterNames.confirmAddress}
+      name="Confirm Address"
       key="/confirm-address"
       path="/confirm-address"/>,
   <Route
       component={DownloadLetters}
+      chapter={chapterNames.downloadLetters}
+      name="Download Letters"
       key="/download-letters"
       path="/download-letters"/>
 ];
 
 export default routes;
+
+// Chapters are groups of form pages that correspond to the steps in the navigation components
+export const chapters = groupPagesIntoChapters(routes.map(r => r.props));
+export const pages = getPageList(routes.map(r => r.props));

--- a/src/js/va-letters/utils/helpers.js
+++ b/src/js/va-letters/utils/helpers.js
@@ -1,0 +1,4 @@
+export const chapterNames = {
+  confirmAddress: 'Confirm Address',
+  downloadLetters: 'Download Letters'
+};

--- a/src/sass/va-letters.scss
+++ b/src/sass/va-letters.scss
@@ -1,1 +1,4 @@
 @import "style";
+@import "modules/m-form-process";
+@import "modules/m-progress-bar";
+@import "modules/m-schemaform";

--- a/test/va-letters/containers/VALettersApp.unit.spec.jsx
+++ b/test/va-letters/containers/VALettersApp.unit.spec.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+import { createStore } from 'redux';
+
+import VALettersApp from '../../../src/js/va-letters/containers/VALettersApp';
+import reducer from '../../../src/js/common/reducers';
+
+const store = createStore(reducer);
+
+describe('<VALettersApp>', () => {
+  it('should render', () => {
+    const mockRoutes = [{ path: '/fake' }];
+    const tree = SkinDeep.shallowRender(<VALettersApp store={store} location={{ pathname: '/blah' }} route={{ childRoutes: mockRoutes }}/>);
+    const vdom = tree.getRenderOutput();
+    expect(vdom).to.not.be.undefined;
+  });
+});


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2806

This PR does a few things:
1. Adds a title, progress bar, and nav header
2. Extracts out some shared logic around the nav header that was also being used for HCA
3. Adds a basic test of the main `VALettersApp` component (should have added it in my scaffolding PR)

It doesn't look perfect, but I think how it should look will change based on which Marvel App version we end up going with.
<img width="894" alt="screen shot 2017-05-17 at 10 25 39 am" src="https://cloud.githubusercontent.com/assets/25183456/26158936/3de5df3e-3aeb-11e7-920e-76aedc057040.png">
