### PR TITLE
Add ability to specify expandUnder condition on schemaforms

### DIFF
--- a/docs/schemaform/form-config.md
+++ b/docs/schemaform/form-config.md
@@ -238,6 +238,11 @@ We've also been adding some additional uiSchema functionality not found in the r
     // the expandUnder field as the first question.
     expandUnder: '',
 
+    // If you need to match on a specific value, you can use this option to specify a value
+    // that the expandUnder field's data should equal. This can also be a function, which
+    // receives the expandUnder field's data as an argument
+    expandUnderCondition: 'someValue',
+
     // If you're using the expandUnder option, you can set this option on the field specified
     // by expandUnder and it will add classes to the div that wraps all of the fields when
     // they are expanded. See cookbook for an example use case.

--- a/docs/schemaform/form-config.md
+++ b/docs/schemaform/form-config.md
@@ -239,9 +239,10 @@ We've also been adding some additional uiSchema functionality not found in the r
     expandUnder: '',
 
     // If you need to match on a specific value, you can use this option to specify a value
-    // that the expandUnder field's data should equal. This can also be a function, which
-    // receives the expandUnder field's data as an argument
+    // that the expandUnder field's data should equal. 
     expandUnderCondition: 'someValue',
+    // This can also be a function, which receives the expandUnder field's data as an argument
+    expandUnderCondition: (field) => field === 'someValue' || field === 'someOtherValue',
 
     // If you're using the expandUnder option, you can set this option on the field specified
     // by expandUnder and it will add classes to the div that wraps all of the fields when

--- a/src/js/common/schemaform/ObjectField.jsx
+++ b/src/js/common/schemaform/ObjectField.jsx
@@ -202,17 +202,22 @@ class ObjectField extends React.Component {
           {this.orderedProperties.map((objectFields, index) => {
             if (objectFields.length > 1) {
               const [first, ...rest] = objectFields;
+              const visible = rest.filter(prop => !_.get(['properties', prop, 'ui:collapsed'], schema));
               return (
-                <ExpandingGroup open={!!formData[objectFields[0]]} key={index}>
+                <ExpandingGroup open={visible.length > 0} key={index}>
                   {renderProp(first)}
                   <div className={_.get([first, 'ui:options', 'expandUnderClassNames'], uiSchema)}>
-                    {rest.map(renderProp)}
+                    {visible.map(renderProp)}
                   </div>
                 </ExpandingGroup>
               );
             }
 
-            return renderProp(objectFields[0], index);
+            // if fields have expandUnder, but are the only item, that means the
+            // field they're expanding under is hidden, and they should be hidden, too
+            return !_.get([objectFields[0], 'ui:options', 'expandUnder'], uiSchema)
+              ? renderProp(objectFields[0], index)
+              : undefined;
           })
           }
         </div>

--- a/src/js/common/schemaform/formState.js
+++ b/src/js/common/schemaform/formState.js
@@ -65,6 +65,16 @@ export function updateRequiredFields(schema, uiSchema, formData, index = null) {
   return schema;
 }
 
+export function isContentExpanded(data, matcher) {
+  if (typeof matcher === 'undefined') {
+    return !!data;
+  } else if (typeof matcher === 'function') {
+    return matcher(data);
+  }
+
+  return data === matcher;
+}
+
 /*
  * This steps through a schema and sets any fields to hidden, based on a
  * hideIf function from uiSchema and the current page data. Sets 'ui:hidden'
@@ -95,7 +105,8 @@ export function setHiddenFields(schema, uiSchema, formData, path = []) {
   }
 
   const expandUnder = _.get(['ui:options', 'expandUnder'], uiSchema);
-  if (expandUnder && !containingObject[expandUnder]) {
+  const expandUnderCondition = _.get(['ui:options', 'expandUnderCondition'], uiSchema);
+  if (expandUnder && !isContentExpanded(containingObject[expandUnder], expandUnderCondition)) {
     if (!updatedSchema['ui:collapsed']) {
       updatedSchema = _.set('ui:collapsed', true, updatedSchema);
     }

--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -473,10 +473,7 @@ const formConfig = {
               highSchoolOrGedCompletionDate: _.assign(
                 dateUI(null), {
                   'ui:options': {
-                    hideIf: form => {
-                      const status = _.get('highSchool.status', form);
-                      return status !== 'graduated' && status !== 'graduationExpected';
-                    },
+                    expandUnderCondition: status => status === 'graduated' || status === 'graduationExpected',
                     expandUnder: 'status',
                     updateSchema: (form) => {
                       const status = _.get('highSchool.status', form);
@@ -496,10 +493,7 @@ const formConfig = {
               ),
               'view:hasHighSchool': {
                 'ui:options': {
-                  hideIf: form => {
-                    const status = _.get('highSchool.status', form);
-                    return status !== 'discontinued';
-                  },
+                  expandUnderCondition: status => status === 'discontinued',
                   expandUnder: 'status'
                 },
                 name: {
@@ -530,10 +524,10 @@ const formConfig = {
             postHighSchoolTrainings: _.merge(postHighSchoolTrainingsUi, {
               'ui:options': {
                 expandUnder: 'view:hasTrainings',
-                hideIf: form => {
-                  const status = _.get('highSchool.status', form);
-                  return status === 'discontinued' || status === 'graduationExpected' || status === 'neverAttended';
-                }
+                // hideIf: form => {
+                //   const status = _.get('highSchool.status', form);
+                //   return status === 'discontinued' || status === 'graduationExpected' || status === 'neverAttended';
+                // }
               }
             })
           },

--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -523,11 +523,7 @@ const formConfig = {
             },
             postHighSchoolTrainings: _.merge(postHighSchoolTrainingsUi, {
               'ui:options': {
-                expandUnder: 'view:hasTrainings',
-                hideIf: form => {
-                  const status = _.get('highSchool.status', form);
-                  return status === 'discontinued' || status === 'graduationExpected' || status === 'neverAttended';
-                }
+                expandUnder: 'view:hasTrainings'
               }
             })
           },

--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -524,10 +524,10 @@ const formConfig = {
             postHighSchoolTrainings: _.merge(postHighSchoolTrainingsUi, {
               'ui:options': {
                 expandUnder: 'view:hasTrainings',
-                // hideIf: form => {
-                //   const status = _.get('highSchool.status', form);
-                //   return status === 'discontinued' || status === 'graduationExpected' || status === 'neverAttended';
-                // }
+                hideIf: form => {
+                  const status = _.get('highSchool.status', form);
+                  return status === 'discontinued' || status === 'graduationExpected' || status === 'neverAttended';
+                }
               }
             })
           },

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -581,8 +581,6 @@ const formConfig = {
               'ui:options': {
                 expandUnder: 'sameAddress',
                 expandUnderCondition: false
-                // // Only show if 'No' is selected for sameAddress
-                // hideIf: (formData) => formData.sameAddress !== false
               },
               spouseAddress: _.merge(addressUI('', true), {
                 'ui:options': {

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -560,10 +560,6 @@ const formConfig = {
             dateOfMarriage: {
               'ui:title': 'Date of marriage'
             },
-            sameAddress: {
-              'ui:title': 'Do you have the same address as your spouse?',
-              'ui:widget': 'yesNo'
-            },
             cohabitedLastYear: {
               'ui:title': 'Did your spouse live with you last year?',
               'ui:widget': 'yesNo'
@@ -572,15 +568,21 @@ const formConfig = {
               'ui:title': 'If your spouse did not live with you last year, did you provide financial support?',
               'ui:widget': 'yesNo',
               'ui:options': {
-                // Only show if 'No' is selected for cohabitedLastYear
-                hideIf: (formData) => formData.cohabitedLastYear !== false
+                expandUnder: 'cohabitedLastYear',
+                expandUnderCondition: false
               }
+            },
+            sameAddress: {
+              'ui:title': 'Do you have the same address as your spouse?',
+              'ui:widget': 'yesNo'
             },
             'view:spouseContactInformation': {
               'ui:title': 'Spouse’s address and telephone number',
               'ui:options': {
-                // Only show if 'No' is selected for sameAddress
-                hideIf: (formData) => formData.sameAddress !== false
+                expandUnder: 'sameAddress',
+                expandUnderCondition: false
+                // // Only show if 'No' is selected for sameAddress
+                // hideIf: (formData) => formData.sameAddress !== false
               },
               spouseAddress: _.merge(addressUI('', true), {
                 'ui:options': {
@@ -609,9 +611,9 @@ const formConfig = {
               spouseSocialSecurityNumber,
               spouseDateOfBirth,
               dateOfMarriage,
-              sameAddress,
               cohabitedLastYear,
               provideSupportLastYear,
+              sameAddress,
               'view:spouseContactInformation': {
                 type: 'object',
                 properties: {

--- a/test/common/schemaform/ObjectField.unit.spec.jsx
+++ b/test/common/schemaform/ObjectField.unit.spec.jsx
@@ -159,7 +159,8 @@ describe('Schemaform: ObjectField', () => {
           type: 'boolean'
         },
         test2: {
-          type: 'string'
+          type: 'string',
+          'ui:collapsed': true
         }
       }
     };

--- a/test/common/schemaform/formState.unit.spec.js
+++ b/test/common/schemaform/formState.unit.spec.js
@@ -201,6 +201,52 @@ describe('Schemaform formState:', () => {
       expect(newSchema.properties.field['ui:collapsed']).to.be.true;
       expect(newSchema).not.to.equal(schema);
     });
+    it('should set collapsed on expandUnder field with value condition', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          field: {},
+          field2: {}
+        }
+      };
+      const uiSchema = {
+        field: {
+          'ui:options': {
+            expandUnder: 'field2',
+            expandUnderCondition: 'blah'
+          }
+        }
+      };
+      const data = { field: '', field2: 'bleh' };
+
+      const newSchema = setHiddenFields(schema, uiSchema, data);
+
+      expect(newSchema.properties.field['ui:collapsed']).to.be.true;
+      expect(newSchema).not.to.equal(schema);
+    });
+    it('should set collapsed on expandUnder field with function condition', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          field: {},
+          field2: {}
+        }
+      };
+      const uiSchema = {
+        field: {
+          'ui:options': {
+            expandUnder: 'field2',
+            expandUnderCondition: () => false
+          }
+        }
+      };
+      const data = { field: '', field2: 'bleh' };
+
+      const newSchema = setHiddenFields(schema, uiSchema, data);
+
+      expect(newSchema.properties.field['ui:collapsed']).to.be.true;
+      expect(newSchema).not.to.equal(schema);
+    });
     it('should set collapsed on nested expandUnder field', () => {
       const schema = {
         type: 'object',


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2046

This adds an `expandUnderCondition` option to fields using `expandUnder`, so you can specify specific values or a function that need to match/be true for fields to expand underneath. I also updated this to hide fields if they use `expandUnder` and the field specified is hidden.