### PR TITLE
Fix review page array fields on schemaforms

### DIFF
--- a/src/js/common/schemaform/review/ArrayField.jsx
+++ b/src/js/common/schemaform/review/ArrayField.jsx
@@ -173,7 +173,7 @@ class ArrayField extends React.Component {
                           ? <h5>New {uiSchema['ui:options'].itemName}</h5>
                           : null}
                       <SchemaForm
-                          pageData={item}
+                          data={item}
                           schema={this.getItemSchema(index)}
                           uiSchema={arrayPageConfig.uiSchema}
                           title={pageTitle}


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets-website/issues/5572

We were passing in a bad prop name, so no data was ever showing up on the review page array field rows.