### PR TITLE
Housing content design updates (proposed)

### DIFF
--- a/content/pages/housing-assistance/home-loans/apply-for-certificate-of-eligibility.md
+++ b/content/pages/housing-assistance/home-loans/apply-for-certificate-of-eligibility.md
@@ -23,17 +23,56 @@ The first step in getting a VA-backed home loan is to apply for a Certificate of
 <ol class="process">
 <li class="step one">
 
-**Gather the information you’ll need to apply for your COE.**
+#### Gather the information you’ll need to apply for your COE
 
-| If you’re: | You’ll need: | 
-| --- | --- | 
-| A Veteran | Your DD214 |
-| An active-duty Servicemember | A statement of service—signed by your commander, adjutant, or personnel officer—showing this information:<br><ul><li>Your full name</li><li>Your Social Security number</li><li>Your date of birth</li><li>The date you entered duty</li><li>The duration of any lost time</li><li>The name of the command providing the information</li></ul> |
-| A current or former **activated** National Guard or Reserve member | Your DD214 |
-| A current member of the National Guard or Reserves, **and** have never been activated | A statement of service—signed by your commander, adjutant, or personnel officer—showing this information:<br><ul><li>Your full name</li><li>Your Social Security number</li><li>Your date of birth</li><li>The date you entered duty</li><li>Your total number of creditable years of service</li><li>The duration of any lost time</li><li>The name of the command providing the information</li></ul> |
-| A discharged member of the National Guard, **and** were never activated | <ul><li>Your NGB Form 22 (Report of Separation and Record of Service) for each period of National Guard service, **or**</li><li>Your NGB Form 23 (Retirement Points Statement) and proof of the character of service</li></ul> |
-| A discharged member of the Reserves **and** were never activated | <ul><li>A copy of your latest annual retirement points, **and**</li><li>Proof of your honorable service</li></ul> |
-| The surviving spouse of a Veteran who died on active duty or who had a service-connected disability | <ul><li>The Veteran’s discharge documents (DD214), **and**</li><li>**If you’re receiving Dependency &amp; Indemnity Compensation (DIC),** you’ll also need to fill out and send VA Form 26-1817 (Request for Determination of Loan Guaranty Eligibility—Unmarried Surviving Spouses). [Download Form 26-1817](http://www.vba.va.gov/pubs/forms/VBA-26-1817-ARE.pdf).</li><li>**If you’re not receiving DIC benefits,** you’ll need to fill out and send VA Form 21-534 (Application for Dependency and Indemnity Compensation, Death Pension and Accrued Benefits by a Surviving Spouse or Child), **and**<ul><li>A copy of your marriage license, **and**</li><li>The Veteran's death certificate<br>[Download Form 21-534](http://www.vba.va.gov/pubs/forms/VBA-21-534-ARE.pdf).</li></ul> |
+<br>
+
+If you're a **Veteran**, you'll need:
+
+- Your DD214
+
+If you're an **active-duty Servicemember**, you'll need:
+
+- A statement of service—signed by your commander, adjutant, or personnel officer—showing this information:
+  - Your full name
+  - Your Social Security number
+  - Your date of birth
+  - The date you entered duty
+  - The duration of any lost time
+  - The name of the command providing the information
+
+If you're a **current or former activated National Guard or Reserve member**, you'll need:
+
+- Your DD214
+
+If you're a **current member of the National Guard or Reserves**, and have **never been activated**, you'll need:
+
+- A statement of service—signed by your commander, adjutant, or personnel officer—showing this information:
+  - Your full name
+  - Your Social Security number
+  - Your date of birth
+  - The date you entered duty
+  - Your total number of creditable years of service
+  - The duration of any lost time
+  - The name of the command providing the information
+
+If you're a **discharged member of the National Guard**, and were **never activated**, you'll need:
+
+- Your NGB Form 22 (Report of Separation and Record of Service) for each period of National Guard service, **or**
+- Your NGB Form 23 (Retirement Points Statement) and proof of the character of service
+
+If you're a **discharged member of the Reserves** and were **never activated**, you'll need:
+
+- A copy of your latest annual retirement points, **and**
+- Proof of your honorable service
+
+If you're the **surviving spouse** of a Veteran who died on active duty or who had a service-connected disability, you'll need:
+
+- The Veteran’s discharge documents (DD214), **and**
+- **If you’re receiving Dependency &amp; Indemnity Compensation (DIC),** you’ll also need to fill out and send VA Form 26-1817 (Request for Determination of Loan Guaranty Eligibility—Unmarried Surviving Spouses). [Download Form 26-1817](http://www.vba.va.gov/pubs/forms/VBA-26-1817-ARE.pdf).
+- **If you’re not receiving DIC benefits,** you’ll need to fill out and send VA Form 21-534 (Application for Dependency and Indemnity Compensation, Death Pension and Accrued Benefits by a Surviving Spouse or Child), **and**
+  - A copy of your marriage license, **and**
+  - The Veteran's death certificate<br>[Download Form 21-534](http://www.vba.va.gov/pubs/forms/VBA-21-534-ARE.pdf).
 
 [Get your military service records online](http://www.archives.gov/veterans/military-service-records/).
 
@@ -41,7 +80,7 @@ The first step in getting a VA-backed home loan is to apply for a Certificate of
 
 <li class="step last two">
 
-**Apply for your COE.**
+#### Apply for your COE.
 
 You can apply in 1 of 3 ways:
 

--- a/content/pages/housing-assistance/home-loans/apply-for-certificate-of-eligibility.md
+++ b/content/pages/housing-assistance/home-loans/apply-for-certificate-of-eligibility.md
@@ -84,7 +84,9 @@ If you're the **surviving spouse** of a Veteran who died on active duty or who h
 
 You can apply in 1 of 3 ways:
 
-**Online through eBenefits:** We recommend applying for your COE online. [Apply through eBenefits](http://www.ebenefits.va.gov/).
+**Online through eBenefits:** We recommend applying for your COE online.
+
+<a class="usa-button-primary va-button-primary" href="http://www.ebenefits.va.gov/">Go to eBenefits to Apply</a>
 
 **Through our Web LGY system:** In some cases, you can get your COE through your lender using our Web LGY system. Ask your lender about this option.
 

--- a/content/pages/housing-assistance/home-loans/eligibility.md
+++ b/content/pages/housing-assistance/home-loans/eligibility.md
@@ -70,7 +70,7 @@ You may be able to get a COE if you were discharged under conditions other than 
 
 ### Ready to apply?
 
-[Apply for your COE](/housing-assistance/home-loans/apply-for-certificate-of-eligibility).
+<a class="usa-button-primary va-button-primary" href="/housing-assistance/home-loans/apply-for-certificate-of-eligibility">Apply for your COE</a>
 
 ### What if I don’t meet the minimum service requirements?
 

--- a/content/pages/housing-assistance/home-loans/eligibility.md
+++ b/content/pages/housing-assistance/home-loans/eligibility.md
@@ -70,7 +70,7 @@ You may be able to get a COE if you were discharged under conditions other than 
 
 ### Ready to apply?
 
-<a class="usa-button-primary va-button-primary" href="/housing-assistance/home-loans/apply-for-certificate-of-eligibility">Apply for your COE</a>
+[Apply for your COE](/housing-assistance/home-loans/apply-for-certificate-of-eligibility)
 
 ### What if I don’t meet the minimum service requirements?
 

--- a/content/pages/housing-assistance/home-loans/va-backed-loans/cash-out-refinance.md
+++ b/content/pages/housing-assistance/home-loans/va-backed-loans/cash-out-refinance.md
@@ -62,8 +62,7 @@ You’ll go through a private bank or mortgage company—not directly through us
 
 You’ll need to show your COE to your lender as proof that you qualify for the home loan benefit. <br />
 [Find out if you qualify for a COE](/housing-assistance/home-loans/eligibility). <br />
-
-<a class="usa-button-primary va-button-primary" href="/housing-assistance/home-loans/apply-for-certificate-of-eligibility">Apply for your COE now</a>
+[Apply for your COE now](/housing-assistance/home-loans/apply-for-certificate-of-eligibility).
 
 </li>
 

--- a/content/pages/housing-assistance/home-loans/va-backed-loans/cash-out-refinance.md
+++ b/content/pages/housing-assistance/home-loans/va-backed-loans/cash-out-refinance.md
@@ -50,21 +50,28 @@ You'll want to keep closing costs in mind when refinancing a loan, as they can a
 <ol class="process">
 <li class="step one">
 
-**Find a lender.** You’ll go through a private bank or mortgage company—not directly through us—to get a cash-out refinance loan. Terms and fees may vary, so contact several lenders to check out your options.
+#### Find a lender.
+
+You’ll go through a private bank or mortgage company—not directly through us—to get a cash-out refinance loan. Terms and fees may vary, so contact several lenders to check out your options.
 
 </li>
 
 <li class="step two">
 
-**Apply for your VA-backed home loan Certificate of Eligibility (COE).** You’ll need to show your COE to your lender as proof that you qualify for the home loan benefit. <br />
+#### Apply for your VA-backed home loan Certificate of Eligibility (COE).
+
+You’ll need to show your COE to your lender as proof that you qualify for the home loan benefit. <br />
 [Find out if you qualify for a COE](/housing-assistance/home-loans/eligibility). <br />
-[Apply for your COE now](/housing-assistance/home-loans/apply-for-certificate-of-eligibility).
+
+<a class="usa-button-primary va-button-primary" href="/housing-assistance/home-loans/apply-for-certificate-of-eligibility">Apply for your COE now</a>
 
 </li>
 
 <li class="step three">
 
-**Give your lender any needed information.** In addition to your COE, you’ll need to give your lender:
+#### Give your lender any needed information.
+
+In addition to your COE, you’ll need to give your lender:
 -	Copies of paycheck stubs for the most recent 30-day period
 -	W-2 forms for the previous 2 years
 -	A copy of your federal income tax returns for the previous 2 years (required by many, but not all lenders)
@@ -76,7 +83,7 @@ You'll want to keep closing costs in mind when refinancing a loan, as they can a
 
 <li class="step last four">
 
-**Follow your lender’s process for closing on the loan, and pay your closing costs.** 
+#### Follow your lender’s process for closing on the loan, and pay your closing costs.
 
 </li>
 </ol>

--- a/content/pages/housing-assistance/home-loans/va-backed-loans/nadl.md
+++ b/content/pages/housing-assistance/home-loans/va-backed-loans/nadl.md
@@ -56,7 +56,8 @@ A NADL often offers better terms than a home loan from a private bank or mortgag
 First, apply for a VA home loan Certificate of Eligibility (COE). This certification confirms that you qualify for the VA home loan benefit. <br />
 [Find out if you can get a COE based on your service history and duty status](/housing-assistance/home-loans/eligibility/). 
 <br />
-[Apply for your COE](/housing-assistance/home-loans/apply-for-certificate-of-eligibility/).
+
+<a class="usa-button-primary va-button-primary" href="/housing-assistance/home-loans/apply-for-certificate-of-eligibility">Apply for your COE</a>
 
 </li>
 

--- a/content/pages/housing-assistance/home-loans/va-backed-loans/nadl.md
+++ b/content/pages/housing-assistance/home-loans/va-backed-loans/nadl.md
@@ -57,7 +57,7 @@ First, apply for a VA home loan Certificate of Eligibility (COE). This certifica
 [Find out if you can get a COE based on your service history and duty status](/housing-assistance/home-loans/eligibility/). 
 <br />
 
-<a class="usa-button-primary va-button-primary" href="/housing-assistance/home-loans/apply-for-certificate-of-eligibility">Apply for your COE</a>
+[Apply for your COE](/housing-assistance/home-loans/apply-for-certificate-of-eligibility/).
 
 </li>
 

--- a/content/pages/housing-assistance/home-loans/va-backed-loans/purchase-loan.md
+++ b/content/pages/housing-assistance/home-loans/va-backed-loans/purchase-loan.md
@@ -87,7 +87,7 @@ You’ll need to show your COE to your lender as proof that you qualify for the 
 
 [Find out if you qualify for a COE](/housing-assistance/home-loans/eligibility/). <br />
 
-<a class="usa-button-primary va-button-primary" href="/housing-assistance/home-loans/apply-for-certificate-of-eligibility">Apply for your COE now</a>
+[Apply for your COE now](/housing-assistance/home-loans/apply-for-certificate-of-eligibility/).
 
 </li>
 

--- a/content/pages/housing-assistance/home-loans/va-backed-loans/purchase-loan.md
+++ b/content/pages/housing-assistance/home-loans/va-backed-loans/purchase-loan.md
@@ -66,34 +66,44 @@ Buying a home is a complex process, and getting a VA-backed home loan is only on
 <ol class="process">
 <li class="step one">
 
-**Look at your current finances.** Go over your credit score, income, expenses, and monthly budget. Make sure you’re ready to buy a home—and decide how much you want to spend on a mortgage. Don’t forget to include closing costs. [Get more advice from the Consumer Financial Protection Bureau](http://www.consumerfinance.gov/owning-a-home/process/prepare/). 
+##### Look at your current finances.
+Go over your credit score, income, expenses, and monthly budget. Make sure you’re ready to buy a home—and decide how much you want to spend on a mortgage. Don’t forget to include closing costs. [Get more advice from the Consumer Financial Protection Bureau](http://www.consumerfinance.gov/owning-a-home/process/prepare/). 
 
 </li>
 
 <li class="step two">
 
-**Find a lender.** You’ll go through a private bank or mortgage company—not through us—to get your loan. Lenders offer different loan interest rates and fees, so shop around for the loan that best meets your needs. 
+##### Find a lender.
+
+You’ll go through a private bank or mortgage company—not through us—to get your loan. Lenders offer different loan interest rates and fees, so shop around for the loan that best meets your needs. 
 
 </li>
 
 <li class="step three">
 
-**Apply for your VA-backed home loan Certificate of Eligibility (COE).** You’ll need to show your COE to your lender as proof that you qualify for the home loan benefit. <br />
+##### Apply for your VA-backed home loan Certificate of Eligibility (COE).
+
+You’ll need to show your COE to your lender as proof that you qualify for the home loan benefit. <br />
 
 [Find out if you qualify for a COE](/housing-assistance/home-loans/eligibility/). <br />
-[Apply for your COE now](/housing-assistance/home-loans/apply-for-certificate-of-eligibility/).
+
+<a class="usa-button-primary va-button-primary" href="/housing-assistance/home-loans/apply-for-certificate-of-eligibility">Apply for your COE now</a>
 
 </li>
 
 <li class="step four">
 
-**Find a real estate agent.** Read all agreements—and make sure you understand any charges, fees, and commissions—before signing with an agent.
+##### Find a real estate agent.
+
+Read all agreements—and make sure you understand any charges, fees, and commissions—before signing with an agent.
 
 </li>
 
 <li class="step last five">
 
-**Shop for a home.** Look at houses in your price range until you find one that works for you.
+##### Shop for a home.
+
+Look at houses in your price range until you find one that works for you.
 
 </li>
 </ol>
@@ -105,42 +115,54 @@ Once you’ve found the house you want to buy:
 <ol class="process">
 <li class="step one">
 
-**Work with your agent to put together and sign a purchase agreement.** Be sure the sales contract includes the “VA Escape Clause.” This voids the contract if the property doesn’t appraise for the contract price. 
+##### Work with your agent to put together and sign a purchase agreement.
+
+Be sure the sales contract includes the “VA Escape Clause.” This voids the contract if the property doesn’t appraise for the contract price. 
 
 </li>
 
 <li class="step two">
 
-**Have the house appraised and inspected.** A VA-approved appraiser will appraise the house to make sure it meets basic property condition requirements. You’ll also want to hire a certified inspector to check for any major defects.
+##### Have the house appraised and inspected.
+
+A VA-approved appraiser will appraise the house to make sure it meets basic property condition requirements. You’ll also want to hire a certified inspector to check for any major defects.
 
 </li>
 
 <li class="step three">
 
-**Read the Closing Disclosure.** Your lender must give you a Closing Disclosure at least 3 business days before closing. Read this carefully. It includes loan terms, fees, closing costs, and your estimated monthly mortgage payments.
+##### Read the Closing Disclosure.
+
+Your lender must give you a Closing Disclosure at least 3 business days before closing. Read this carefully. It includes loan terms, fees, closing costs, and your estimated monthly mortgage payments.
 
 </li>
 
 <li class="step four">
 
-**Complete all paperwork from your lender.** You may need to provide more information or documents to your lender during this phase.  
+##### Complete all paperwork from your lender.
+
+You may need to provide more information or documents to your lender during this phase.  
 
 </li>
 
 <li class="step five">
 
-**Go to the closing meeting.** This may be held at a title company, escrow office, or attorney’s office. Be prepared to sign a lot of documents—and be sure to take the time to read everything before you sign.
+##### Go to the closing meeting.
+
+This may be held at a title company, escrow office, or attorney’s office. Be prepared to sign a lot of documents—and be sure to take the time to read everything before you sign.
 
 </li>
 
 <li class="step last six">
 
-**Move in.** After closing, you’re ready to move in to your new home. Congratulations!  
+##### Move in.
+
+After closing, you’re ready to move in to your new home. Congratulations!  
 
 </li>
 </ol>
 
-If you need more help:
+#### If you need more help:
 
 [Look for workshops from Department of Housing and Urban Development–approved housing counseling agencies](http://www.hud.gov/offices/hsg/sfh/hcc/hcs.cfm?weblistaction=summary).
 


### PR DESCRIPTION
Related: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2789

This PR proposes some small design changes for the WIP Housing content. Changes include:

~~[Eligibility](https://vetsgov-pr-5574.herokuapp.com/housing-assistance/home-loans/eligibility/), [Purchase Loan](https://vetsgov-pr-5574.herokuapp.com/housing-assistance/home-loans/va-backed-loans/purchase-loan/), [NADL](https://vetsgov-pr-5574.herokuapp.com/housing-assistance/home-loans/va-backed-loans/nadl/), [Cash-Out Refinance Loan](https://vetsgov-pr-5574.herokuapp.com/housing-assistance/home-loans/va-backed-loans/cash-out-refinance/),~~ (EDIT: reverted these back to text links) [Apply for COE](https://vetsgov-pr-5574.herokuapp.com/housing-assistance/home-loans/apply-for-certificate-of-eligibility/)

- changed "Apply" link to the standard green button

[Apply for COE](https://vetsgov-pr-5574.herokuapp.com/housing-assistance/home-loans/apply-for-certificate-of-eligibility/), [Cash-Out Refinance Loan](https://vetsgov-pr-5574.herokuapp.com/housing-assistance/home-loans/va-backed-loans/cash-out-refinance/), [Purchase Loan](https://vetsgov-pr-5574.herokuapp.com/housing-assistance/home-loans/va-backed-loans/purchase-loan/)

- Gave subway map steps H4 headings

[Apply for COE](https://vetsgov-pr-5574.herokuapp.com/housing-assistance/home-loans/apply-for-certificate-of-eligibility/)

- Converted table to plain text for mobile-friendliness