### PR TITLE
Schemaform review array bug fix

### DIFF
--- a/src/js/common/schemaform/SchemaForm.jsx
+++ b/src/js/common/schemaform/SchemaForm.jsx
@@ -50,6 +50,8 @@ class SchemaForm extends React.Component {
   componentWillReceiveProps(newProps) {
     if (newProps.name !== this.props.name) {
       this.setState(this.getEmptyState(newProps));
+    } else if (newProps.title !== this.props.title) {
+      this.setState({ formContext: _.set('pageTitle', newProps.title, this.state.formContext) });
     }
   }
 

--- a/src/js/common/schemaform/review/ArrayField.jsx
+++ b/src/js/common/schemaform/review/ArrayField.jsx
@@ -152,6 +152,7 @@ class ArrayField extends React.Component {
 
     // TODO: Make this better; it's super hacky for now.
     const itemCountLocked = uiSchema['ui:field'] === 'BasicArrayField';
+    const items = itemCountLocked ? this.props.arrayData : this.state.items;
 
     return (
       <div>
@@ -164,10 +165,10 @@ class ArrayField extends React.Component {
           </div>}
         <div className="va-growable va-growable-review">
           <Element name={`topOfTable_${fieldName}`}/>
-          {this.state.items.map((item, index) => {
-            const isLast = this.state.items.length === (index + 1);
+          {items.map((item, index) => {
+            const isLast = items.length === (index + 1);
             const isEditing = this.state.editing[index];
-            const showReviewButton = !itemCountLocked && (!schema.minItems || this.state.items.length > schema.minItems);
+            const showReviewButton = !itemCountLocked && (!schema.minItems || items.length > schema.minItems);
             const itemSchema = this.getItemSchema(index);
             const itemTitle = itemSchema ? itemSchema.title : '';
 
@@ -177,7 +178,7 @@ class ArrayField extends React.Component {
                   <Element name={`table_${fieldName}_${index}`}/>
                   <div className="row small-collapse schemaform-array-row" id={`table_${fieldName}_${index}`}>
                     <div className="small-12 columns va-growable-expanded">
-                      {isLast && uiSchema['ui:options'].itemName && this.state.items.length > 1
+                      {isLast && uiSchema['ui:options'].itemName && items.length > 1
                           ? <h5>New {uiSchema['ui:options'].itemName}</h5>
                           : null}
                       <SchemaForm

--- a/src/js/common/schemaform/review/ArrayField.jsx
+++ b/src/js/common/schemaform/review/ArrayField.jsx
@@ -36,6 +36,7 @@ class ArrayField extends React.Component {
     this.handleSetData = this.handleSetData.bind(this);
     this.scrollToTop = this.scrollToTop.bind(this);
     this.scrollToRow = this.scrollToRow.bind(this);
+    this.isLocked = this.isLocked.bind(this);
   }
 
   getItemSchema(index) {
@@ -49,7 +50,9 @@ class ArrayField extends React.Component {
 
   scrollToTop() {
     setTimeout(() => {
-      scroller.scrollTo(`topOfTable_${this.props.path[this.props.path.length - 1]}`, {
+      // Hacky; won't work if the array field is used in two pages and one isn't
+      //  a BasicArrayField nor if the array field is used in three pages.
+      scroller.scrollTo(`topOfTable_${this.props.path[this.props.path.length - 1]}${this.isLocked() ? '_locked' : ''}`, {
         duration: 500,
         delay: 0,
         smooth: true,
@@ -136,6 +139,10 @@ class ArrayField extends React.Component {
     });
   }
 
+  isLocked() {
+    return this.props.uiSchema['ui:field'] === 'BasicArrayField';
+  }
+
   render() {
     const {
       schema,
@@ -151,7 +158,7 @@ class ArrayField extends React.Component {
     };
 
     // TODO: Make this better; it's super hacky for now.
-    const itemCountLocked = uiSchema['ui:field'] === 'BasicArrayField';
+    const itemCountLocked = this.isLocked();
     const items = itemCountLocked ? this.props.arrayData : this.state.items;
 
     return (
@@ -164,7 +171,7 @@ class ArrayField extends React.Component {
             }
           </div>}
         <div className="va-growable va-growable-review">
-          <Element name={`topOfTable_${fieldName}`}/>
+          <Element name={`topOfTable_${fieldName}${itemCountLocked ? '_locked' : ''}`}/>
           {items.map((item, index) => {
             const isLast = items.length === (index + 1);
             const isEditing = this.state.editing[index];

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -33,7 +33,7 @@ import { createChildSchema, uiSchema as childUI, createChildIncomeSchema, childI
 import currentOrPastDateUI from '../../common/schemaform/definitions/currentOrPastDate';
 import ssnUI from '../../common/schemaform/definitions/ssn';
 
-// import testData from '../../../../test/hca-rjsf/test-data.json';
+import testData from '../../../../test/hca-rjsf/test-data.json';
 
 const childSchema = createChildSchema(fullSchemaHca);
 const childIncomeSchema = createChildIncomeSchema(fullSchemaHca);
@@ -655,7 +655,7 @@ const formConfig = {
         annualIncome: {
           path: 'household-information/annual-income',
           title: 'Annual income',
-          // initialData: testData, // FOR TESTING ONLY
+          initialData: testData, // FOR TESTING ONLY
           depends: (data) => data.discloseFinancialInformation,
           uiSchema: {
             'ui:title': 'Annual income',


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2852

Per @jbalboni's [suggestion](https://github.com/department-of-veterans-affairs/vets-website/pull/5553#issuecomment-302427388), I switch between `this.props.arrayData` and `this.state.items` depending on whether or not the items count is locked.

Note: This does do a weird thing where when I add another item to the array, the `updateSchema` is only called once and the title below (if one is set, as it is in this case) doesn't get updated to what it should be. Turns out like this:
![image](https://cloud.githubusercontent.com/assets/12970166/26225319/7646848c-3bdb-11e7-8871-cf2d4ccb0b91.png)

Only the first letter of the first name makes it, but after I edit, the title is right as rain. Not sure what the deal is there, exactly.