### PR TITLE
Refactor 1995 to use applicantInformation page

### DIFF
--- a/src/js/edu-benefits/1995/config/form.js
+++ b/src/js/edu-benefits/1995/config/form.js
@@ -6,17 +6,16 @@ import {
   transform,
 } from '../helpers';
 
-import fullNameUI from '../../../common/schemaform/definitions/fullName';
 import * as address from '../../../common/schemaform/definitions/address';
 
 import educationTypeUISchema from '../../definitions/educationType';
 import serviceBefore1977UI from '../../definitions/serviceBefore1977';
 import * as toursOfDuty from '../../definitions/toursOfDuty';
-import * as personId from '../../definitions/personId';
 
 import createContactInformationPage from '../../pages/contactInformation';
 import createOldSchoolPage from '../../pages/oldSchool';
 import createDirectDepositChangePage from '../../pages/directDepositChange';
+import createApplicantInformationPage from '../../pages/applicantInformation';
 
 import { showSchoolAddress } from '../../utils/helpers';
 import { benefitsLabels } from '../../utils/labels';
@@ -35,8 +34,7 @@ const {
   educationType,
   date,
   dateRange,
-  serviceBefore1977,
-  fullName
+  serviceBefore1977
 } = fullSchema1995.definitions;
 
 const formConfig = {
@@ -55,26 +53,19 @@ const formConfig = {
   title: 'Update your Education Benefits',
   subTitle: 'Form 22-1995',
   chapters: {
-    veteranInformation: {
-      title: 'Veteran Information',
+    applicantInformation: {
+      title: 'Applicant Information',
       pages: {
-        veteranInformation: {
-          path: 'veteran/information',
-          title: 'Veteran information',
-          initialData: {},
-          uiSchema: {
-            veteranFullName: fullNameUI,
-            'view:veteranId': personId.uiSchema()
-          },
-          schema: {
-            type: 'object',
-            required: ['veteranFullName'],
-            properties: {
-              veteranFullName: fullName,
-              'view:veteranId': personId.schema(fullSchema1995)
-            }
-          }
-        }
+        applicantInformation: createApplicantInformationPage(fullSchema1995, {
+          isVeteran: true,
+          fields: [
+            'veteranFullName',
+            'veteranSocialSecurityNumber',
+            'view:noSSN',
+            'vaFileNumber'
+          ],
+          required: ['veteranFullName']
+        })
       }
     },
     benefitSelection: {

--- a/test/e2e/edu-helpers.js
+++ b/test/e2e/edu-helpers.js
@@ -54,30 +54,20 @@ function completeVeteranInformation(client, data, root = 'root') {
   }
 }
 
-function completeRelativeInformation(client, data) {
-  const dobFields = data.relativeDateOfBirth.split('-');
-  client
-    .clearValue('input[name="root_relativeFullName_first"]')
-    .setValue('input[name="root_relativeFullName_first"]', data.relativeFullName.first)
-    .clearValue('input[name="root_relativeFullName_last"]')
-    .setValue('input[name="root_relativeFullName_last"]', data.relativeFullName.last)
-    .clearValue('input[name="root_relativeSocialSecurityNumber"]')
-    .setValue('input[name="root_relativeSocialSecurityNumber"]', data.relativeSocialSecurityNumber)
-    .clearValue('input[name="root_relativeDateOfBirthYear"]')
-    .setValue('input[name="root_relativeDateOfBirthYear"]', parseInt(dobFields[0], 10).toString());
-  selectDropdown(client, 'root_relativeDateOfBirthMonth', parseInt(dobFields[1], 10).toString());
-  selectDropdown(client, 'root_relativeDateOfBirthDay', parseInt(dobFields[2], 10).toString());
-
-  if (typeof data.relationship !== 'undefined') {
+function completeApplicantInformation(client, data, prefix = 'relative') {
+  const fullName = data[`${prefix}FullName`];
+  if (fullName) {
     client
-      .click('input[name="root_relationship_0"]');
+      .fill(`input[name="root_${prefix}FullName_first"]`, fullName.first)
+      .setValue(`input[name="root_${prefix}FullName_middle"]`, fullName.middle)
+      .fill(`input[name="root_${prefix}FullName_last"]`, fullName.last)
+      .selectDropdown(`root_${prefix}FullName_suffix`, fullName.suffix);
   }
 
-  client
-    .setValue('input[name="root_relativeFullName_middle"]', data.relativeFullName.middle)
-    .click(data.gender === 'M' ? 'input[name=root_gender_0' : 'input[name=root_gender_1');
-  selectDropdown(client, 'root_relativeFullName_suffix', data.relativeFullName.suffix);
-
+  const ssn = data[`${prefix}SocialSecurityNumber`];
+  if (ssn) {
+    client.fill(`input[name="root_${prefix}SocialSecurityNumber"]`, ssn);
+  }
   if (data.relativeVaFileNumber) {
     client
       .click('input[name="root_view:noSSN"]')
@@ -86,6 +76,20 @@ function completeRelativeInformation(client, data) {
     client
       .click('input[name="root_view:noSSN"]')
       .fill('input[name="root_vaFileNumber"]', data.vaFileNumber);
+  }
+
+  const dob = data[`${prefix}DateOfBirth`];
+  if (dob) {
+    client.fillDate(`root_${prefix}DateOfBirth`, dob);
+  }
+
+  if (typeof data.relationship !== 'undefined') {
+    client
+      .click('input[name="root_relationship_0"]');
+  }
+
+  if (data.gender) {
+    client.click(data.gender === 'M' ? 'input[name=root_gender_0' : 'input[name=root_gender_1');
   }
 }
 
@@ -222,7 +226,7 @@ function completeEmploymentHistory(client, data) {
 module.exports = {
   initApplicationSubmitMock,
   completeVeteranInformation,
-  completeRelativeInformation,
+  completeApplicantInformation,
   completeAdditionalBenefits,
   completeBenefitsSelection,
   completeServicePeriods,

--- a/test/edu-benefits/1990e/01-all-fields.e2e.spec.js
+++ b/test/edu-benefits/1990e/01-all-fields.e2e.spec.js
@@ -23,7 +23,7 @@ module.exports = E2eHelpers.createE2eTest(
     // Applicant information page
     client
       .waitForElementVisible('input[name="root_relativeFullName_first"]', Timeouts.slow);
-    EduHelpers.completeRelativeInformation(client, testData.data);
+    EduHelpers.completeApplicantInformation(client, testData.data);
     client
       .axeCheck('.main')
       .click('.form-progress-buttons .usa-button-primary');

--- a/test/edu-benefits/1995/01-all-fields.e2e.spec.js
+++ b/test/edu-benefits/1995/01-all-fields.e2e.spec.js
@@ -23,11 +23,11 @@ module.exports = E2eHelpers.createE2eTest(
     // Veteran information page.
     client
       .waitForElementVisible('input[name="root_veteranFullName_first"]', Timeouts.slow);
-    EduHelpers.completeVeteranInformation(client, testData.data);
+    EduHelpers.completeApplicantInformation(client, testData.data, 'veteran');
     client
       .axeCheck('.main')
       .click('.form-progress-buttons .usa-button-primary');
-    E2eHelpers.expectNavigateAwayFrom(client, '/veteran/information');
+    E2eHelpers.expectNavigateAwayFrom(client, '/applicant/information');
 
     // Benefits eligibility page.
     client

--- a/test/edu-benefits/1995/config/applicantInformation.unit.spec.jsx
+++ b/test/edu-benefits/1995/config/applicantInformation.unit.spec.jsx
@@ -39,15 +39,15 @@ describe('Edu 1995 applicantInformation', () => {
 
     // VA file number input is not visible; error is shown for empty SSN input
     const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input');
-    expect(inputs.find(input => input.id === 'root_view:veteranId_veteranSocialSecurityNumber')).to.be.ok;
-    expect(inputs.find(input => input.id === 'root_view:veteranId_vaFileNumber')).not.to.be.ok;
+    expect(inputs.find(input => input.id === 'root_veteranSocialSecurityNumber')).to.be.ok;
+    expect(inputs.find(input => input.id === 'root_vaFileNumber')).not.to.be.ok;
 
     const errors = ReactTestUtils.scryRenderedDOMComponentsWithClass(form, 'usa-input-error-message');
-    expect(errors.find(input => input.id.includes('root_view:veteranId_veteranSocialSecurityNumber'))).to.be.ok;
+    expect(errors.find(input => input.id.includes('root_veteranSocialSecurityNumber'))).to.be.ok;
 
     // Check no-SSN box
     const noSSNBox = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input')
-                                   .find(input => input.id === 'root_view:veteranId_view:noSSN');
+                                   .find(input => input.id === 'root_view:noSSN');
     ReactTestUtils.Simulate.change(noSSNBox,
       {
         target: {
@@ -57,8 +57,8 @@ describe('Edu 1995 applicantInformation', () => {
 
     // No error is shown for empty SSN input; error is shown for empty file number input
     const newErrors = ReactTestUtils.scryRenderedDOMComponentsWithClass(form, 'usa-input-error-message');
-    expect(newErrors.find(input => input.id.includes('root_view:veteranId_veteranSocialSecurityNumber'))).not.to.be.ok;
-    expect(newErrors.find(input => input.id.includes('root_view:veteranId_vaFileNumber'))).to.be.ok;
+    expect(newErrors.find(input => input.id.includes('root_veteranSocialSecurityNumber'))).not.to.be.ok;
+    expect(newErrors.find(input => input.id.includes('root_vaFileNumber'))).to.be.ok;
   });
   it('should submit with no errors with all required fields filled in', () => {
     const onSubmit = sinon.spy();
@@ -86,7 +86,7 @@ describe('Edu 1995 applicantInformation', () => {
       }
     });
     const ssn = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input')
-                              .find(input => input.id === 'root_view:veteranId_veteranSocialSecurityNumber');
+                              .find(input => input.id === 'root_veteranSocialSecurityNumber');
     ReactTestUtils.Simulate.change(ssn, {
       target: {
         value: '123456788'

--- a/test/edu-benefits/1995/config/applicantInformation.unit.spec.jsx
+++ b/test/edu-benefits/1995/config/applicantInformation.unit.spec.jsx
@@ -9,8 +9,8 @@ import formConfig from '../../../../src/js/edu-benefits/1995/config/form';
 
 const definitions = formConfig.defaultDefinitions;
 
-describe('Edu 1995 veteranInformation', () => {
-  const { schema, uiSchema } = formConfig.chapters.veteranInformation.pages.veteranInformation;
+describe('Edu 1995 applicantInformation', () => {
+  const { schema, uiSchema } = formConfig.chapters.applicantInformation.pages.applicantInformation;
   it('should render', () => {
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester

--- a/test/edu-benefits/1995/schema/maximal-test.json
+++ b/test/edu-benefits/1995/schema/maximal-test.json
@@ -7,11 +7,9 @@
       "last": "asdf",
       "suffix": "Jr."
     },
-    "view:veteranId": {
-      "veteranSocialSecurityNumber": "123333333",
-      "view:noSSN": true,
-      "vaFileNumber": "C12345678"
-    },
+    "veteranSocialSecurityNumber": "123333333",
+    "view:noSSN": true,
+    "vaFileNumber": "C12345678",
     "benefit": "chapter30",
     "toursOfDuty": [
       {

--- a/test/edu-benefits/5490/01-all-fields.e2e.spec.js
+++ b/test/edu-benefits/5490/01-all-fields.e2e.spec.js
@@ -23,7 +23,7 @@ module.exports = E2eHelpers.createE2eTest(
     // Applicant information page
     client
       .waitForElementVisible('input[name="root_relativeFullName_first"]', Timeouts.slow);
-    EduHelpers.completeRelativeInformation(client, {
+    EduHelpers.completeApplicantInformation(client, {
       relationship: testData.data.relationship,
       ...testData.data
     });

--- a/test/edu-benefits/5495/01-all-fields.e2e.spec.js
+++ b/test/edu-benefits/5495/01-all-fields.e2e.spec.js
@@ -23,7 +23,7 @@ module.exports = E2eHelpers.createE2eTest(
     // Applicant information page.
     client
       .waitForElementVisible('input[name="root_relativeFullName_first"]', Timeouts.slow);
-    EduHelpers.completeRelativeInformation(client, testData.data);
+    EduHelpers.completeApplicantInformation(client, testData.data);
     client
       .axeCheck('.main')
       .click('.form-progress-buttons .usa-button-primary');


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2158

There are some minor UI changes. Namely, the path is different (`applicant/information` instead of `veteran/information`) and the title is `Applicant information` instead of `Veteran information`.

![image](https://cloud.githubusercontent.com/assets/12970166/26227261/14d6bed2-3be6-11e7-814c-9469e6cef44f.png)
