### PR TITLE
Add detail page to exceptions for piano key inclusion

### DIFF
--- a/content/layouts/page-breadcrumbs.html
+++ b/content/layouts/page-breadcrumbs.html
@@ -43,7 +43,7 @@
     {{ contents }}
   {% endcase %}
 
-  {% if path != 'employment' AND template != 'level2-index' AND template != 'topic-landing' %}
+  {% if path != 'employment' AND template != 'level2-index' AND template != 'topic-landing' AND template != 'detail-page' %}
   {% include "content/includes/general-related-links.html" %}
   {% endif %}
 </div>


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2763

Adding the detail-page template as an exception from including the piano keys.

After all content goes live with the new templates, the `general-related-links` include won't be in use anywhere and should be revisited as part of https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2157