### PR TITLE
Change postal code to zip code for USA addresses on HCA

### DIFF
--- a/src/js/common/schemaform/definitions/address.js
+++ b/src/js/common/schemaform/definitions/address.js
@@ -39,7 +39,8 @@ export function schema(currentSchema, isRequired = false) {
       },
       state: {
         title: 'State',
-        type: 'string'
+        type: 'string',
+        maxLength: 51
       },
       postalCode: {
         type: 'string',

--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -215,7 +215,7 @@ export function transformForSubmit(formConfig, form) {
   return JSON.stringify(withoutViewFields, (key, value) => {
     // an object with country is an address
     if (value && typeof value.country !== 'undefined' &&
-      (!value.street || !value.city || !value.postalCode)) {
+      (!value.street || !value.city || (!value.postalCode && !value.zipcode))) {
       return undefined;
     }
 

--- a/src/js/hca-rjsf/helpers.jsx
+++ b/src/js/hca-rjsf/helpers.jsx
@@ -3,8 +3,27 @@ import _ from 'lodash/fp';
 import { transformForSubmit } from '../common/schemaform/helpers';
 import { vaMedicalFacilities } from '../common/utils/options-for-select.js';
 
+function fixAddress(address) {
+  if (address.country === 'USA') {
+    const newAddress = _.set('zipcode', address.postalCode, address);
+    delete newAddress.postalCode;
+    return newAddress;
+  }
+
+  return address;
+}
+
 export function transform(formConfig, form) {
-  const formData = transformForSubmit(formConfig, form);
+  let updatedForm = _.set('data.veteranAddress', fixAddress(form.data.veteranAddress), form);
+  if (_.get('data.view:spouseContactInformation.spouseAddress', form)) {
+    updatedForm = _.set(
+      'data.view:spouseContactInformation.spouseAddress',
+      fixAddress(form.data['view:spouseContactInformation'].spouseAddress),
+      updatedForm
+    );
+  }
+  const formData = transformForSubmit(formConfig, updatedForm);
+
   return JSON.stringify({
     form: formData
   });

--- a/src/js/hca-rjsf/helpers.jsx
+++ b/src/js/hca-rjsf/helpers.jsx
@@ -3,7 +3,7 @@ import _ from 'lodash/fp';
 import { transformForSubmit } from '../common/schemaform/helpers';
 import { vaMedicalFacilities } from '../common/utils/options-for-select.js';
 
-function fixAddress(address) {
+function changePostalToZip(address) {
   if (address.country === 'USA') {
     const newAddress = _.set('zipcode', address.postalCode, address);
     delete newAddress.postalCode;
@@ -14,11 +14,15 @@ function fixAddress(address) {
 }
 
 export function transform(formConfig, form) {
-  let updatedForm = _.set('data.veteranAddress', fixAddress(form.data.veteranAddress), form);
+  let updatedForm = _.set(
+    'data.veteranAddress',
+    changePostalToZip(form.data.veteranAddress),
+    form
+  );
   if (_.get('data.view:spouseContactInformation.spouseAddress', form)) {
     updatedForm = _.set(
       'data.view:spouseContactInformation.spouseAddress',
-      fixAddress(form.data['view:spouseContactInformation'].spouseAddress),
+      changePostalToZip(form.data['view:spouseContactInformation'].spouseAddress),
       updatedForm
     );
   }

--- a/test/hca-rjsf/schema/foreign-address-test.json
+++ b/test/hca-rjsf/schema/foreign-address-test.json
@@ -1,0 +1,40 @@
+{
+  "data": {
+    "view:preferredFacility": {
+      "view:facilityState": "MA",
+      "vaMedicalFacility": "631"
+    },
+    "view:locator": {},
+    "isCoveredByHealthInsurance": false,
+    "isMedicaidEligible": false,
+    "isEnrolledMedicarePartA": false,
+    "discloseFinancialInformation": false,
+    "compensableVaServiceConnected": false,
+    "isVaServiceConnected": false,
+    "receivesVaPension": false,
+    "lastServiceBranch": "marine corps",
+    "lastEntryDate": "2006-01-01",
+    "lastDischargeDate": "2007-01-04",
+    "dischargeType": "honorable",
+    "veteranAddress": {
+      "street": "123 elm st",
+      "city": "Northampton",
+      "country": "UK",
+      "state": "MA",
+      "postalCode": "01060"
+    },
+    "gender": "F",
+    "maritalStatus": "Never Married",
+    "view:demographicCategories": {},
+    "veteranDateOfBirth": "1990-01-01",
+    "veteranSocialSecurityNumber": "234243444",
+    "view:placeOfBirth": {},
+    "veteranFullName": {
+      "first": "Jane",
+      "last": "Doe"
+    },
+    "privacyAgreementAccepted": true,
+    "isSpanishHispanicLatino": false,
+    "spouseFullName": {}
+  }
+}

--- a/test/hca-rjsf/schema/schema.unit.spec.js
+++ b/test/hca-rjsf/schema/schema.unit.spec.js
@@ -28,6 +28,10 @@ describe('hca schema tests', () => {
           expect(data.veteranAddress.zipcode).to.not.be.empty;
           expect(data.veteranAddress.postalCode).not.to.be.defined;
         }
+        if (data.veteranAddress.country !== 'USA') {
+          expect(data.veteranAddress.postalCode).to.not.be.empty;
+          expect(data.veteranAddress.zipcode).not.to.be.defined;
+        }
         if (data.spouseAddress && data.spouseAddress.country === 'USA') {
           expect(data.spouseAddress.zipcode).to.not.be.empty;
           expect(data.spouseAddress.postalCode).not.to.be.defined;

--- a/test/hca-rjsf/schema/schema.unit.spec.js
+++ b/test/hca-rjsf/schema/schema.unit.spec.js
@@ -16,12 +16,21 @@ describe('hca schema tests', () => {
       it(`should validate ${file}`, () => {
         const contents = JSON.parse(fs.readFileSync(path.join(__dirname, file), 'utf8'));
         const submitData = JSON.parse(transform(formConfig, contents)).form;
+        const data = JSON.parse(submitData);
         const result = v.validate(
-          JSON.parse(submitData),
+          data,
           fullSchemaHca
         );
         if (!result.valid) {
           console.log(result.errors); // eslint-disable-line
+        }
+        if (data.veteranAddress.country === 'USA') {
+          expect(data.veteranAddress.zipcode).to.not.be.empty;
+          expect(data.veteranAddress.postalCode).not.to.be.defined;
+        }
+        if (data.spouseAddress && data.spouseAddress.country === 'USA') {
+          expect(data.spouseAddress.zipcode).to.not.be.empty;
+          expect(data.spouseAddress.postalCode).not.to.be.defined;
         }
         expect(result.valid).to.be.true;
       });


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2904

The HCA backend expects `zipcode` instead of `postalCode` for USA addresses, so this adds some code to convert them before sending the form off to the backend.