### PR TITLE
Fix timeline styling on claim status

### DIFF
--- a/src/js/disability-benefits/components/ClaimPhase.jsx
+++ b/src/js/disability-benefits/components/ClaimPhase.jsx
@@ -17,15 +17,15 @@ const COMPLETE_PHASE = 5;
 const INITIAL_ACTIVITY_ROWS = 5;
 
 function getClasses(phase, current) {
-  const processClass = 'step';
+  const processClass = 'process-step';
   const stepClass = stepClasses[phase];
   if (phase === current) {
-    return `${stepClass} ${processClass} section-current`;
+    return `${processClass} list-${stepClass} section-current`;
   } else if (current > phase) {
-    return `${stepClass} ${processClass} section-complete`;
+    return `${processClass} list-${stepClass} section-complete`;
   }
 
-  return `${stepClass} ${processClass}`;
+  return `${processClass} list-${stepClass}`;
 }
 
 

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -1,4 +1,5 @@
 @import "style";
+@import "modules/m-process-list";
 @import "modules/va-pagination";
 @import "modules/m-modal";
 @import "modules/m-progress-bar";

--- a/test/disability-benefits/e2e/01.claim-status.e2e.spec.js
+++ b/test/disability-benefits/e2e/01.claim-status.e2e.spec.js
@@ -32,27 +32,27 @@ module.exports = E2eHelpers.createE2eTest(
 
     // timeline
     client
-      .expect.element('.five.last.step.section-current').to.be.present;
+      .expect.element('.list-five.section-current').to.be.present;
     client
-      .expect.element('.one.step.section-complete').to.be.present;
+      .expect.element('.list-one.section-complete').to.be.present;
     client
-      .expect.element('.two.step.section-complete').to.be.present;
+      .expect.element('.list-two.section-complete').to.be.present;
     client
-      .expect.element('.three.step.section-complete').to.be.present;
+      .expect.element('.list-three.section-complete').to.be.present;
     client
-      .expect.element('.four.step.section-complete').to.be.present;
+      .expect.element('.list-four.section-complete').to.be.present;
 
     // timeline expand
     client
-      .click('li.step.one')
-      .waitForElementVisible('li.step.one .claims-evidence', Timeouts.slow);
+      .click('li.list-one')
+      .waitForElementVisible('li.list-one .claims-evidence', Timeouts.slow);
     client
       .expect.element('.claims-evidence:nth-child(3) .claims-evidence-item').text.equals('Your claim is closed');
     client
       .expect.element('button.older-updates').to.be.present;
     client
-      .click('li.step.one')
-      .waitForElementNotPresent('li.step.one .claims-evidence', Timeouts.slow);
+      .click('li.list-one')
+      .waitForElementNotPresent('li.list-one .claims-evidence', Timeouts.slow);
 
     // files needed
     client


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2930

These styles were missed in the process list updates, I think because they're dynamically generated and hard to search for.

![screen shot 2017-05-23 at 12 45 38 pm](https://cloud.githubusercontent.com/assets/634932/26365737/7a7c76f4-3fb6-11e7-952f-6b1173bda8de.png)

