### PR TITLE
Use flag to pick up nav breadcrumbs

### DIFF
--- a/content/pages/va-letters/index.md
+++ b/content/pages/va-letters/index.md
@@ -2,19 +2,13 @@
 title: Download VA Letters
 entryname: va-letters
 layout: page-react.html
+gatePage: true
 in_maintenance: false
-maintenance_line1: We're sorry. The healthcare application is currently down while we fix a few things. We will be back up as soon as we can.
-maintenance_line2: In the meantime, you can still call 1-877-222-VETS(8387) and press 2 to complete this application over the phone.
+maintenance_line1: We're sorry. The page you are looking for is currently down while we fix a few things. We will be back up as soon as we can.
+maintenance_line2: In the meantime, please try the search box above or one of the options listed below to find more information.
 ---
 <div id="main">
-  <nav class="va-nav-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
-      <li><a href="/">Home</a></li>
-      <li class="parent"><a href="/profile">Profile</a></li>
-      <li class="active">Download VA Letters</li>
-    </ul>
-  </nav>
-
+  <!-- VA Letters Application Begin -->
   <div class="section">
     <div id="react-root">
       <div class="loading-message">

--- a/content/pages/va-letters/index.md
+++ b/content/pages/va-letters/index.md
@@ -2,7 +2,7 @@
 title: Download VA Letters
 entryname: va-letters
 layout: page-react.html
-gatePage: true
+includeBreadcrumbs: true
 in_maintenance: false
 maintenance_line1: We're sorry. The page you are looking for is currently down while we fix a few things. We will be back up as soon as we can.
 maintenance_line2: In the meantime, please try the search box above or one of the options listed below to find more information.


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3120

@phiden non-urgent question about navigation for VA letters (if it's not decided yet, no worries--we will shelve this for now):

The URL for now will be www.vets.gov/va-letters (you can see it on staging), so if that's fine, then should the nav breadcrumbs be
![image](https://user-images.githubusercontent.com/25439097/26957684-869f7d74-4c7b-11e7-8957-5ddf3824d506.png)
or should they reflect that this is discoverable from the profile page:
![image](https://user-images.githubusercontent.com/25439097/26957681-7edc161a-4c7b-11e7-9cd0-4e6c4c9836d3.png)

