### PR TITLE
Show messages for unavailable tracking info. Unit tests for TrackPackage.

### DIFF
--- a/src/js/rx/containers/TrackPackage.jsx
+++ b/src/js/rx/containers/TrackPackage.jsx
@@ -3,12 +3,12 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import moment from 'moment';
 
-import { rxStatuses } from '../config';
 import SortableTable from '../../common/components/SortableTable';
-import { formatDate } from '../utils/helpers';
 import TrackPackageLink from '../components/TrackPackageLink';
+import { rxStatuses } from '../config';
+import { formatDate } from '../utils/helpers';
 
-class TrackPackage extends React.Component {
+export class TrackPackage extends React.Component {
   constructor(props) {
     super(props);
     this.renderTable = this.renderTable.bind(this);

--- a/test/rx/containers/TrackPackage.unit.spec.jsx
+++ b/test/rx/containers/TrackPackage.unit.spec.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+// import { set } from 'lodash/fp';
+
+import { TrackPackage } from '../../../src/js/rx/containers/TrackPackage';
+import { trackings } from '../../e2e/rx-helpers.js';
+
+const props = {
+  isPending: false,
+  items: trackings.data
+};
+
+describe('<TrackPackage>', () => {
+  it('should render', () => {
+    const tree = SkinDeep.shallowRender(<TrackPackage {...props}/>);
+    const vdom = tree.getRenderOutput();
+    expect(vdom).to.be.ok;
+  });
+
+  it('should render tracking info when available', () => {
+    const tree = SkinDeep.shallowRender(<TrackPackage {...props}/>);
+    expect(tree.dive(['.rx-tab-explainer']).text()).to.equal(
+      'Tracking information for each order expires 30 days after shipment.'
+    );
+
+    const table = tree.dive(['.rx-detail-history']);
+    const rows = table.dive(['tbody']).everySubTree('tr');
+
+    expect(table).to.be.ok;
+    rows.forEach((row, rowIndex) => {
+      const attrs = trackings.data[rowIndex].attributes;
+
+      expect(row.dive(['TrackPackageLink']).text())
+        .to.equal(attrs.trackingNumber);
+
+      rows[rowIndex].everySubTree('div').forEach((div, divIndex) => {
+        if (divIndex === 0) {
+          expect(div.text()).to.equal(attrs.prescriptionName);
+        } else {
+          expect(div.text()).to.equal(attrs.otherPrescriptions[divIndex - 1].prescriptionName);
+        }
+      });
+    });
+  });
+});

--- a/test/rx/containers/TrackPackage.unit.spec.jsx
+++ b/test/rx/containers/TrackPackage.unit.spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
-// import { set } from 'lodash/fp';
 
 import { TrackPackage } from '../../../src/js/rx/containers/TrackPackage';
 import { trackings } from '../../e2e/rx-helpers.js';

--- a/test/rx/containers/TrackPackage.unit.spec.jsx
+++ b/test/rx/containers/TrackPackage.unit.spec.jsx
@@ -43,4 +43,18 @@ describe('<TrackPackage>', () => {
       });
     });
   });
+
+  it('should show a message when tracking info is not yet available', () => {
+    const tree = SkinDeep.shallowRender(<TrackPackage isPending items={[]}/>);
+    expect(tree.dive(['.rx-tab-explainer']).text()).to.equal(
+      'You recently submitted a refill, and the tracking information isn\'t available yet.'
+    );
+  });
+
+  it('should show a message when tracking info has expired', () => {
+    const tree = SkinDeep.shallowRender(<TrackPackage items={[]}/>);
+    expect(tree.dive(['.rx-tab-explainer']).text()).to.equal(
+      'Your prescription shipped more than 30 days ago, and tracking information is no longer available.'
+    );
+  });
 });

--- a/test/rx/containers/TrackPackage.unit.spec.jsx
+++ b/test/rx/containers/TrackPackage.unit.spec.jsx
@@ -29,10 +29,14 @@ describe('<TrackPackage>', () => {
 
     expect(table).to.be.ok;
     rows.forEach((row, rowIndex) => {
-      const attrs = trackings.data[rowIndex].attributes;
+      const {
+        attributes: attrs,
+        links: { trackingUrl }
+      } = trackings.data[rowIndex];
 
-      expect(row.dive(['TrackPackageLink']).text())
-        .to.equal(attrs.trackingNumber);
+      const link = row.dive(['TrackPackageLink']);
+      expect(link.text()).to.equal(attrs.trackingNumber);
+      expect(link.props.href).to.equal(trackingUrl);
 
       rows[rowIndex].everySubTree('div').forEach((div, divIndex) => {
         if (divIndex === 0) {


### PR DESCRIPTION
### Changes
* Different messages when tracking info is unavailable. Resolves department-of-veterans-affairs/vets.gov-team#2909.
* Added unit tests for `TrackPackage.jsx`. Resolves department-of-veterans-affairs/vets.gov-team#2898.

Will merge this to `kudos-launch` branch separately when this is approved so it can be tested on dev.