### PR TITLE
HCA fixes from testing

### DIFF
--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -40,7 +40,7 @@ export function setPrivacyAgreement(privacyAgreementAccepted) {
 export function setSubmitted(response) {
   return {
     type: SET_SUBMITTED,
-    response
+    response: typeof response.data !== 'undefined' ? response.data : response
   };
 }
 
@@ -76,7 +76,7 @@ export function submitForm(formConfig, form) {
       return Promise.reject(res.statusText);
     })
     .then(
-      (resp) => dispatch(setSubmitted(resp.data)),
+      (resp) => dispatch(setSubmitted(resp)),
       () => dispatch(setSubmission('status', 'error'))
     );
   };

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -19,7 +19,8 @@ import {
   medicalCentersByState,
   medicalCenterLabels,
   financialDisclosureText,
-  incomeDescription
+  incomeDescription,
+  disclosureWarning
 } from '../helpers';
 
 import IntroductionPage from '../components/IntroductionPage';
@@ -473,13 +474,23 @@ const formConfig = {
             discloseFinancialInformation: {
               'ui:title': 'Do you want to provide your financial information?',
               'ui:widget': 'yesNo'
+            },
+            'view:noDiscloseWarning': {
+              'ui:description': disclosureWarning,
+              'ui:options': {
+                hideIf: (form) => form.discloseFinancialInformation !== false
+              }
             }
           },
           schema: {
             type: 'object',
             required: ['discloseFinancialInformation'],
             properties: {
-              discloseFinancialInformation
+              discloseFinancialInformation,
+              'view:noDiscloseWarning': {
+                type: 'object',
+                properties: {}
+              }
             }
           }
         },
@@ -775,6 +786,9 @@ const formConfig = {
         vaFacility: {
           path: 'insurance-information/va-facility',
           title: 'VA Facility',
+          initialData: {
+            isEssentialAcaCoverage: false
+          },
           uiSchema: {
             'ui:title': 'VA Facility',
             isEssentialAcaCoverage: {

--- a/src/js/hca-rjsf/helpers.jsx
+++ b/src/js/hca-rjsf/helpers.jsx
@@ -127,3 +127,11 @@ export const incomeDescription = (
     <p><strong>Other income:</strong> This includes retirement and pension income; Social Security Retirement and Social Security Disability income; compensation benefits such as VA disability, unemployment, Workers, and black lung; cash gifts; interest and dividends, including tax exempt earnings and distributions from Individual Retirement Accounts (IRAs) or annuities.</p>
   </div>
 );
+
+export const disclosureWarning = (
+  <div className="usa-alert usa-alert-info">
+    <div className="usa-alert-body">
+      <span>If you don't provide your financial information and you don't have another qualifying eligibility factor, VA can't enroll you.</span>
+    </div>
+  </div>
+);

--- a/test/common/schemaform/actions.unit.spec.js
+++ b/test/common/schemaform/actions.unit.spec.js
@@ -64,6 +64,13 @@ describe('Schemaform actions:', () => {
       expect(action.response).to.equal(response);
       expect(action.type).to.equal(SET_SUBMITTED);
     });
+    it('should return action with response.data', () => {
+      const response = { data: false };
+      const action = setSubmitted(response);
+
+      expect(action.response).to.equal(response.data);
+      expect(action.type).to.equal(SET_SUBMITTED);
+    });
   });
   describe('submitForm', () => {
     let fetchMock;

--- a/test/hca-rjsf/config/financialDisclosure.unit.spec.js
+++ b/test/hca-rjsf/config/financialDisclosure.unit.spec.js
@@ -61,4 +61,24 @@ describe('Hca financial disclosure', () => {
     expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
   });
+  it('should show a warning if No is selected', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={definitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+    expect(Array.from(formDOM.querySelectorAll('.usa-alert-info')).length).to.equal(1);
+
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_discloseFinancialInformationNo'), {
+      target: {
+        value: 'N'
+      }
+    });
+
+    expect(Array.from(formDOM.querySelectorAll('.usa-alert-info')).length).to.equal(2);
+  });
 });


### PR DESCRIPTION
This fixes a few things we've found during testing:

- Default isEssentialAcaCoverage to false, so that we always send some value for that field. ES requires this.
- Pass the right data to the submit page, so the submitted date shows up.
- Show a warning when choosing No on the financial disclosure page

![screen shot 2017-05-23 at 10 24 44 pm](https://cloud.githubusercontent.com/assets/634932/26384394/ef0c4760-4006-11e7-88a1-13df228dde2b.png)

