### PR TITLE
Add auth header to schemaform submissions

### DIFF
--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -54,7 +54,8 @@ export function submitForm(formConfig, form) {
     window.dataLayer.push({
       event: `${formConfig.trackingPrefix}-submission`,
     });
-    return fetch(`${environment.API_URL}${formConfig.submitUrl}`, {
+
+    const fetchOptions = {
       method: 'POST',
       mode: 'cors',
       headers: {
@@ -62,7 +63,14 @@ export function submitForm(formConfig, form) {
         'X-Key-Inflection': 'camel'
       },
       body
-    })
+    };
+
+    const userToken = sessionStorage.userToken;
+    if (userToken) {
+      fetchOptions.headers.Authorization = `Token token=${userToken}`;
+    }
+
+    return fetch(`${environment.API_URL}${formConfig.submitUrl}`, fetchOptions)
     .then(res => {
       if (res.ok) {
         window.dataLayer.push({

--- a/test/common/schemaform/actions.unit.spec.js
+++ b/test/common/schemaform/actions.unit.spec.js
@@ -124,6 +124,36 @@ describe('Schemaform actions:', () => {
         });
       });
     });
+    it('should submit with auth header', () => {
+      const formConfig = {
+        chapters: {}
+      };
+      const form = {
+        pages: {
+          testing: {},
+        },
+        data: {
+          test: 1
+        }
+      };
+      global.sessionStorage = { userToken: 'testing' };
+      const thunk = submitForm(formConfig, form);
+      const dispatch = sinon.spy();
+      const response = { data: {} };
+      fetchMock.returns({
+        then: (fn) => fn(
+          {
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve(response)
+          }
+        )
+      });
+
+      return thunk(dispatch).then(() => {
+        expect(fetchMock.firstCall.args[1].headers.Authorization).to.equal('Token token=testing');
+      });
+    });
     it('should set submission error', () => {
       const formConfig = {
         chapters: {}


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2963

Old HCA sends the auth header so it can be used on the backend, but the rjsf forms don't send this by default. It shouldn't break anything to send it for everything.