### PR TITLE
HCA rjsf fixes from testing in staging

### DIFF
--- a/src/js/common/schemaform/definitions/phone.js
+++ b/src/js/common/schemaform/definitions/phone.js
@@ -6,6 +6,9 @@ export default function uiSchema(title = 'Phone') {
     'ui:widget': PhoneNumberWidget,
     'ui:reviewWidget': PhoneNumberReviewWidget,
     'ui:title': title,
+    'ui:errorMessages': {
+      pattern: 'Phone numbers must be 10 digits'
+    },
     'ui:options': {
       widgetClassNames: 'home-phone va-input-medium-large',
       inputType: 'tel'

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -30,6 +30,7 @@ import InsuranceProviderView from '../components/InsuranceProviderView';
 import ChildView from '../components/ChildView';
 
 import fullNameUI from '../../common/schemaform/definitions/fullName';
+import phoneUI from '../../common/schemaform/definitions/phone';
 import { schema as addressSchema, uiSchema as addressUI } from '../../common/schemaform/definitions/address';
 
 import { createChildSchema, uiSchema as childUI, createChildIncomeSchema, childIncomeUiSchema } from '../definitions/child';
@@ -536,9 +537,7 @@ const formConfig = {
                 expandUnderCondition: false
               },
               spouseAddress: addressUI('', true, (formData) => formData.sameAddress === false),
-              spousePhone: {
-                'ui:title': 'Phone'
-              }
+              spousePhone: phoneUI()
             }
           },
           schema: {

--- a/src/js/hca-rjsf/config/form.js
+++ b/src/js/hca-rjsf/config/form.js
@@ -311,18 +311,8 @@ const formConfig = {
                 pattern: 'Please put your email in this format x@x.xxx'
               }
             },
-            homePhone: {
-              'ui:title': 'Home telephone number',
-              'ui:errorMessages': {
-                pattern: 'Phone number must be 10 digits'
-              }
-            },
-            mobilePhone: {
-              'ui:title': 'Mobile telephone number',
-              'ui:errorMessages': {
-                pattern: 'Phone number must be 10 digits'
-              }
-            }
+            homePhone: phoneUI('Home telephone number'),
+            mobilePhone: phoneUI('Mobile telephone number')
           },
           schema: {
             type: 'object',

--- a/src/js/hca-rjsf/definitions/child.js
+++ b/src/js/hca-rjsf/definitions/child.js
@@ -17,7 +17,8 @@ export const createChildSchema = (hcaSchema) => {
       'childSocialSecurityNumber',
       'childDateOfBirth',
       'childBecameDependent',
-      'childEducationExpenses'
+      'childEducationExpenses',
+      'childDisabledBefore18'
     ],
     properties: {
       'view:childSupportDescription': {

--- a/src/js/hca-rjsf/definitions/child.js
+++ b/src/js/hca-rjsf/definitions/child.js
@@ -18,7 +18,8 @@ export const createChildSchema = (hcaSchema) => {
       'childDateOfBirth',
       'childBecameDependent',
       'childEducationExpenses',
-      'childDisabledBefore18'
+      'childDisabledBefore18',
+      'childCohabitedLastYear'
     ],
     properties: {
       'view:childSupportDescription': {

--- a/src/js/hca-rjsf/helpers.jsx
+++ b/src/js/hca-rjsf/helpers.jsx
@@ -26,6 +26,11 @@ export function transform(formConfig, form) {
       updatedForm
     );
   }
+
+  if (!updatedForm.data.children) {
+    updatedForm = _.set('data.children', [], updatedForm);
+  }
+
   const formData = transformForSubmit(formConfig, updatedForm);
 
   return JSON.stringify({

--- a/test/hca-rjsf/config/childInformation.unit.spec.jsx
+++ b/test/hca-rjsf/config/childInformation.unit.spec.jsx
@@ -127,6 +127,16 @@ describe('Hca child information', () => {
         value: '123123123'
       }
     });
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_children_0_childCohabitedLastYearYes'), {
+      target: {
+        value: 'Y'
+      }
+    });
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_children_0_childDisabledBefore18Yes'), {
+      target: {
+        value: 'Y'
+      }
+    });
 
     fillDate(formDOM, 'root_children_0_childDateOfBirth', '12-12-2012');
     fillDate(formDOM, 'root_children_0_childBecameDependent', '12-12-2012');

--- a/test/hca-rjsf/schema/schema.unit.spec.js
+++ b/test/hca-rjsf/schema/schema.unit.spec.js
@@ -36,6 +36,7 @@ describe('hca schema tests', () => {
           expect(data.spouseAddress.zipcode).to.not.be.empty;
           expect(data.spouseAddress.postalCode).not.to.be.defined;
         }
+        expect(data.children).to.be.defined;
         expect(result.valid).to.be.true;
       });
     });


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2964

This makes a couple of fields required that the backend ES needs, which were being defaulted before. It also updates the error message for phones that use `pattern` instead of max characters, like the edu forms. Finally, it defaults the `children` field to an empty array, since the backend relies on that currently.