### PR TITLE
Use local version of leaflet.css

### DIFF
--- a/content/includes/header.html
+++ b/content/includes/header.html
@@ -49,9 +49,6 @@
 <!-- CSS -->
 {% if entryname %}
 <link rel="stylesheet" href="/generated/{{ entryname }}.css">
-{% if entryname == 'facilities' %}
-<link href="https://npmcdn.com/leaflet@1.0.0-rc.3/dist/leaflet.css" type="text/css" rel="stylesheet">
-{% endif %}
 
 {% else %}
 <link rel="stylesheet" href="/generated/no-react.css">
@@ -122,7 +119,7 @@ window.webpackManifest = 'CHUNK_MANIFEST_PLACEHOLDER';
       </a>
     </div>
     {% if body_class != 'page-playbook' %}
-      <div id="vetnav-controls"> 
+      <div id="vetnav-controls">
         <button aria-controls="vetnav" aria-expanded="false" hidden type="button" class="vetnav-controller-close">
           <span class="va-flex">
             {% include "assets/img/icons/close.svg" %}
@@ -137,16 +134,16 @@ window.webpackManifest = 'CHUNK_MANIFEST_PLACEHOLDER';
         </button>
       </div>
     {% endif %}
-  
+
     <div id="login-root" class="vet-toolbar"></div>
- 
+
 
     {% if body_class != 'page-playbook' %}
     {% include "content/includes/veteran-navigation.html" %}
-    {% endif %}  
+    {% endif %}
   </div>
 
-  
+
 </header>
 
 <script src="/js/usa-search.js"></script>

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "react-datepicker": "^0.29.0",
     "react-dom": "^15.5.4",
     "react-jsonschema-form": "0.43.0",
-    "react-leaflet": "^1.0.0-beta.3",
+    "react-leaflet": "^1.2.0",
     "react-redux": "4.4.8",
     "react-router": "3",
     "react-scroll": "1.5",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "react-redux": "4.4.8",
     "react-router": "3",
     "react-scroll": "1.5",
-    "react-tabs": "^0.7.0",
+    "react-tabs": "^1.0.0",
     "react-test-renderer": "^15.5.4",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "jsdom": "^9.4.2",
     "json-loader": "^0.5.4",
     "jsonschema": "^1.1.1",
-    "leaflet": "^1.0.0-rc.3",
+    "leaflet": "^1.0.3",
     "leaflet-control-geocoder": "^1.5.1",
     "libxmljs": "^0.18.0",
     "lodash": "^4.5.1",

--- a/src/js/facility-locator/containers/VAMap.jsx
+++ b/src/js/facility-locator/containers/VAMap.jsx
@@ -55,8 +55,6 @@ class VAMap extends Component {
     } else {
       this.props.searchWithBounds(currentQuery.bounds, currentQuery.facilityType, currentQuery.serviceType, currentQuery.currentPage);
     }
-
-    Tabs.setUseDefaultStyles(false);
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/sass/facility-locator.scss
+++ b/src/sass/facility-locator.scss
@@ -1,6 +1,8 @@
 @import "style";
 @import "modules/va-pagination";
+
 @import "~leaflet/dist/leaflet.css";
+@import '~react-tabs/style/react-tabs.scss';
 
 .facility-locator {
   // TODO(css): Fix when #content .section h* is fixed
@@ -120,7 +122,15 @@
     border: solid 1px $color-black;
     border-radius: 0 !important;
 
-    &.ReactTabs__Tab--selected {
+    display: inline-block;
+    border-bottom: none;
+    bottom: -1px;
+    position: relative;
+    list-style: none;
+    padding: 6px 12px;
+    cursor: pointer;
+
+    &.react-tabs__tab--selected {
       border-top: solid 3px $color-primary;
       background: $color-white;
       border-bottom: none;
@@ -132,7 +142,7 @@
     border-right-color: $color-black;
   }
 
-  .ReactTabs__Tab + .ReactTabs__Tab {
+  .react-tabs__tab + .react-tabs__tab {
     border-left: none;
   }
 

--- a/src/sass/facility-locator.scss
+++ b/src/sass/facility-locator.scss
@@ -1,5 +1,6 @@
 @import "style";
 @import "modules/va-pagination";
+@import "~leaflet/dist/leaflet.css";
 
 .facility-locator {
   // TODO(css): Fix when #content .section h* is fixed

--- a/src/sass/facility-locator.scss
+++ b/src/sass/facility-locator.scss
@@ -2,7 +2,7 @@
 @import "modules/va-pagination";
 
 @import "~leaflet/dist/leaflet.css";
-@import '~react-tabs/style/react-tabs.scss';
+@import "~react-tabs/style/react-tabs.scss";
 
 .facility-locator {
   // TODO(css): Fix when #content .section h* is fixed

--- a/yarn.lock
+++ b/yarn.lock
@@ -4369,10 +4369,6 @@ js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 
-js-stylesheet@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/js-stylesheet/-/js-stylesheet-0.0.1.tgz#12cc1451220e454184b46de3b098c0d154762c38"
-
 js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
@@ -6749,12 +6745,12 @@ react-scroll@1.5:
     object-assign "^4.1.1"
     prop-types "^15.5.8"
 
-react-tabs@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-0.7.0.tgz#4da6a43315fa0c54fc011333b2a4aec21684c77c"
+react-tabs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-1.0.0.tgz#f150c9f9102dd65dbc94a5a0e1e019d5e3814a7f"
   dependencies:
     classnames "^2.2.0"
-    js-stylesheet "^0.0.1"
+    prop-types "^15.5.0"
 
 react-test-renderer@^15.5.4:
   version "15.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2543,7 +2543,7 @@ enhanced-resolve@^0.7.6:
     memory-fs "~0.1.0"
     tapable "0.1.x"
 
-enhanced-resolve@^3.0.0, enhanced-resolve@^3.1.0:
+enhanced-resolve@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz#9f4b626f577245edcf4b2ad83d86e17f4f421dec"
   dependencies:
@@ -6698,9 +6698,9 @@ react-jsonschema-form@0.43.0:
     lodash.topath "^4.5.2"
     setimmediate "^1.0.5"
 
-react-leaflet@^1.0.0-beta.3:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/react-leaflet/-/react-leaflet-1.1.6.tgz#a3a42cbe1d32168223f7e47e6d9f89a52fa358ab"
+react-leaflet@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-leaflet/-/react-leaflet-1.2.0.tgz#2829395564cd9d543d8bb3697431804e2f642601"
   dependencies:
     lodash "^4.0.0"
     prop-types "^15.5.0"
@@ -7791,7 +7791,7 @@ supports-color@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-1.2.0.tgz#ff1ed1e61169d06b3cf2d588e188b18d8847e17e"
 
-supports-color@3.1.2, supports-color@^3.1.0, supports-color@^3.1.1:
+supports-color@3.1.2, supports-color@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -7805,7 +7805,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.1.1, supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -8410,7 +8410,7 @@ webpack-dev-middleware@^1.10.2:
     path-is-absolute "^1.0.0"
     range-parser "^1.0.3"
 
-webpack-dev-server@1.16:
+webpack-dev-server@^1.14.1:
   version "1.16.5"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz#0cbd5f2d2ac8d4e593aacd5c9702e7bbd5e59892"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4528,7 +4528,7 @@ leaflet-control-geocoder@^1.5.1:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/leaflet-control-geocoder/-/leaflet-control-geocoder-1.5.4.tgz#8f977dba9da0cbbebfa19659cbf0f49f6e268620"
 
-leaflet@^1.0.0-rc.3:
+leaflet@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.0.3.tgz#1f401b98b45c8192134c6c8d69686253805007c8"
 
@@ -5356,13 +5356,13 @@ metalsmith-webpack-dev-server@department-of-veterans-affairs/metalsmith-webpack-
     chalk "^1.1.1"
     metalsmith "^1.7.0"
     webpack "^2.4.1"
-    webpack-dev-server "1.16"
+    webpack-dev-server "^1.14.1"
 
 metalsmith-webpack@department-of-veterans-affairs/metalsmith-webpack:
   version "1.0.3"
   resolved "https://codeload.github.com/department-of-veterans-affairs/metalsmith-webpack/tar.gz/6130e9bccbf6f558f58041f63f07382d049f66bf"
   dependencies:
-    enhanced-resolve "^3.1.0"
+    enhanced-resolve "^0.7.6"
     webpack "^2.4.1"
 
 metalsmith@^1.7.0:
@@ -7791,7 +7791,7 @@ supports-color@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-1.2.0.tgz#ff1ed1e61169d06b3cf2d588e188b18d8847e17e"
 
-supports-color@3.1.2, supports-color@^3.1.0:
+supports-color@3.1.2, supports-color@^3.1.0, supports-color@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -7805,7 +7805,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.1, supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7787,7 +7787,7 @@ supports-color@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-1.2.0.tgz#ff1ed1e61169d06b3cf2d588e188b18d8847e17e"
 
-supports-color@3.1.2, supports-color@^3.1.0:
+supports-color@3.1.2, supports-color@^3.1.0, supports-color@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -7801,7 +7801,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.1, supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:


### PR DESCRIPTION
- Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1885
- Upgrades React Tabs to address PropType deprecation warnings

@patrickvinograd we are free to remove the leaflet entry from the CSP once this fix is merged to production
https://github.com/department-of-veterans-affairs/devops/pull/1615