### PR TITLE
Fix bad variable override

### DIFF
--- a/src/sass/base/_b-element-overrides.scss
+++ b/src/sass/base/_b-element-overrides.scss
@@ -1,0 +1,3 @@
+// This file contains variables that override ones
+// in the USWDS element/component files
+$usa-form-width:      32em;

--- a/src/sass/base/_b-variables.scss
+++ b/src/sass/base/_b-variables.scss
@@ -20,7 +20,6 @@ $font-serif:          "Roboto Slab", serif;
 //===================================
 
 $text-max-width:      70rem; // Note: USWDS value is 53rem;
-$usa-form-width:      32em;
 $site-max-width:      100rem; // Worksout to about 1000px. USWDS value is 1040px
 
 //===================================

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -49,7 +49,7 @@
 @import "~uswds/src/stylesheets/components/sidenav";
 
 // ----- VA BASE (VARIABLES/HELPERS) ---- //
-
+@import "base/b-element-overrides";
 @import "base/b-mixins";
 @import "base/b-functions";
 @import "base/b-utils";


### PR DESCRIPTION
A recent change moved our variables above the uswds element/component imports, which meant that a variable we were overriding is no longer overridden. This adds a spot to override element/component variables and moves the one affected to that file.