### PR TITLE
Add general military history page to pensions

### DIFF
--- a/src/js/pensions/components/FullNameField.jsx
+++ b/src/js/pensions/components/FullNameField.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 export default function FullNameField({ formData }) {
+  const { first, middle, last, suffix } = formData;
   return (
     <div>
-      <strong>{formData.first} {formData.middle} {formData.last}{formData.suffix && `, ${formData.suffix}`}</strong>
+      <strong>{first} {middle && `${middle} `}{last}{suffix && `, ${suffix}`}</strong>
     </div>
   );
 }

--- a/src/js/pensions/components/FullNameField.jsx
+++ b/src/js/pensions/components/FullNameField.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 export default function FullNameField({ formData }) {
   return (
     <div>
-      <strong>{formData.first} {formData.middle} {formData.last}</strong>
+      <strong>{formData.first} {formData.middle} {formData.last}{formData.suffix && `, ${formData.suffix}`}</strong>
     </div>
   );
 }

--- a/src/js/pensions/components/FullNameField.jsx
+++ b/src/js/pensions/components/FullNameField.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function FullNameField({ formData }) {
+  return (
+    <div>
+      <strong>{formData.first} {formData.middle} {formData.last}</strong>
+    </div>
+  );
+}

--- a/src/js/pensions/config/form.js
+++ b/src/js/pensions/config/form.js
@@ -1,4 +1,6 @@
 import _ from 'lodash/fp';
+import moment from 'moment';
+import { createSelector } from 'reselect';
 
 import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
 
@@ -6,10 +8,25 @@ import applicantInformation from '../../common/schemaform/pages/applicantInforma
 import { transform } from '../helpers';
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
+import FullNameField from '../components/FullNameField';
 import createDisclosureTitle from '../components/DisclosureTitle';
 import { netWorthSchema, netWorthUI } from '../definitions/netWorth';
 import { monthlyIncomeSchema, monthlyIncomeUI } from '../definitions/monthlyIncome';
 import { expectedIncomeSchema, expectedIncomeUI } from '../definitions/expectedIncome';
+import fullNameUI from '../../common/schemaform/definitions/fullName';
+import dateRangeUI from '../../common/schemaform/definitions/dateRange';
+
+const {
+  previousNames,
+  combatSince911,
+  placeOfSeparation
+} = fullSchemaPensions.properties;
+
+const {
+  fullName,
+  dateRange,
+  date
+} = fullSchemaPensions.definitions;
 
 const formConfig = {
   urlPrefix: '/527EZ/',
@@ -23,7 +40,10 @@ const formConfig = {
   defaultDefinitions: {
     additionalSources: {
       type: 'string'
-    }
+    },
+    fullName,
+    date,
+    dateRange
   },
   chapters: {
     applicantInformation: {
@@ -44,6 +64,74 @@ const formConfig = {
           isVeteran: true
         }),
       }
+    },
+    militaryHistory: {
+      title: 'Military History',
+      pages: {
+        general: {
+          path: 'military/history',
+          title: 'General history',
+          uiSchema: {
+            previousNames: {
+              'ui:options': {
+                expandUnder: 'view:serveUnderOtherNames',
+                viewField: FullNameField
+              },
+              items: fullNameUI
+            },
+            'view:serveUnderOtherNames': {
+              'ui:title': 'Did you serve under another name?',
+              'ui:widget': 'yesNo'
+            },
+            activeServiceDateRange: dateRangeUI(
+              'Date entered active service',
+              'Date left active service',
+              'Date entered service must be before date left service'
+            ),
+            placeOfSeparation: {
+              'ui:title': 'Place of last or anticipated separation'
+            },
+            combatSince911: (() => {
+              const rangeExcludes911 = createSelector(
+                _.get('activeServiceDateRange.from'),
+                _.get('activeServiceDateRange.to'),
+                (from, to) => {
+                  const isFullDate = /^\d{4}-\d{2}-\d{2}$/;
+
+                  return !isFullDate.test(from)
+                    || !isFullDate.test(to)
+                    || !moment('2001-09-11').isBetween(from, to, 'day');
+                }
+              );
+
+              return {
+                'ui:title': 'Did you serve in a combat zone after 9/11/2001?',
+                'ui:widget': 'yesNo',
+                'ui:required': formData => !rangeExcludes911(formData),
+                'ui:options': {
+                  hideIf: rangeExcludes911
+                }
+              };
+            })()
+          },
+          schema: {
+            type: 'object',
+            required: ['activeServiceDateRange', 'view:serveUnderOtherNames'],
+            properties: {
+              'view:serveUnderOtherNames': {
+                type: 'boolean'
+              },
+              previousNames,
+              activeServiceDateRange: _.assign(dateRange, {
+                required: ['from', 'to']
+              }),
+              placeOfSeparation,
+              combatSince911
+            }
+          }
+        }
+      }
+
     },
     financialDisclosure: {
       title: 'Financial Disclosure',

--- a/src/js/pensions/config/form.js
+++ b/src/js/pensions/config/form.js
@@ -93,14 +93,11 @@ const formConfig = {
             },
             combatSince911: (() => {
               const rangeExcludes911 = createSelector(
-                _.get('activeServiceDateRange.from'),
                 _.get('activeServiceDateRange.to'),
-                (from, to) => {
+                (to) => {
                   const isFullDate = /^\d{4}-\d{2}-\d{2}$/;
 
-                  return !isFullDate.test(from)
-                    || !isFullDate.test(to)
-                    || !moment('2001-09-11').isBetween(from, to, 'day');
+                  return !isFullDate.test(to) || !moment('2001-09-11').isBefore(to);
                 }
               );
 
@@ -121,7 +118,9 @@ const formConfig = {
               'view:serveUnderOtherNames': {
                 type: 'boolean'
               },
-              previousNames,
+              previousNames: _.assign(previousNames, {
+                minItems: 1
+              }),
               activeServiceDateRange: _.assign(dateRange, {
                 required: ['from', 'to']
               }),

--- a/src/js/pensions/config/form.js
+++ b/src/js/pensions/config/form.js
@@ -72,6 +72,7 @@ const formConfig = {
           path: 'military/history',
           title: 'General history',
           uiSchema: {
+            'ui:title': 'General history',
             previousNames: {
               'ui:options': {
                 expandUnder: 'view:serveUnderOtherNames',

--- a/test/pensions/config/generalMilitaryHistory.unit.spec.jsx
+++ b/test/pensions/config/generalMilitaryHistory.unit.spec.jsx
@@ -123,17 +123,35 @@ describe('Pensions general military history', () => {
 
     ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toMonth'), {
       target: {
-        value: '1'
+        value: '9'
       }
     });
     ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toDay'), {
       target: {
-        value: '1'
+        value: '11'
       }
     });
     ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toYear'), {
       target: {
-        value: '2002'
+        value: '2001'
+      }
+    });
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(9);
+
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toMonth'), {
+      target: {
+        value: '9'
+      }
+    });
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toDay'), {
+      target: {
+        value: '12'
+      }
+    });
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toYear'), {
+      target: {
+        value: '2001'
       }
     });
 

--- a/test/pensions/config/generalMilitaryHistory.unit.spec.jsx
+++ b/test/pensions/config/generalMilitaryHistory.unit.spec.jsx
@@ -1,0 +1,208 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
+import formConfig from '../../../src/js/pensions/config/form';
+
+describe('Pensions general military history', () => {
+  const { schema, uiSchema } = formConfig.chapters.militaryHistory.pages.general;
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(9);
+  });
+
+  it('should not submit empty form', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(3);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should reveal name fields', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(9);
+
+    ReactTestUtils.Simulate.change(formDOM.querySelector('input[type="radio"]'), {
+      target: {
+        value: 'Y'
+      }
+    });
+
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(13);
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(4);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should add another name', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(9);
+
+    ReactTestUtils.Simulate.change(formDOM.querySelector('input[type="radio"]'), {
+      target: {
+        value: 'Y'
+      }
+    });
+
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_previousNames_0_first'), {
+      target: {
+        value: 'Jane'
+      }
+    });
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_previousNames_0_last'), {
+      target: {
+        value: 'Doe'
+      }
+    });
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_previousNames_0_suffix'), {
+      target: {
+        value: 'Jr.'
+      }
+    });
+    ReactTestUtils.Simulate.click(formDOM.querySelector('.va-growable-add-btn'));
+
+    expect(formDOM.querySelector('.va-growable-background').textContent)
+      .to.contain('Jane Doe, Jr.');
+  });
+  it('should required combat after 9/11 question', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(9);
+
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toMonth'), {
+      target: {
+        value: '1'
+      }
+    });
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toDay'), {
+      target: {
+        value: '1'
+      }
+    });
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toYear'), {
+      target: {
+        value: '2002'
+      }
+    });
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(11);
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(3);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should submit with valid data', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    ReactTestUtils.Simulate.change(Array.from(formDOM.querySelectorAll('input[type="radio"]'))[1], {
+      target: {
+        value: 'N'
+      }
+    });
+
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toMonth'), {
+      target: {
+        value: '1'
+      }
+    });
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toDay'), {
+      target: {
+        value: '1'
+      }
+    });
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toYear'), {
+      target: {
+        value: '2003'
+      }
+    });
+
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_fromMonth'), {
+      target: {
+        value: '1'
+      }
+    });
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_fromDay'), {
+      target: {
+        value: '1'
+      }
+    });
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_fromYear'), {
+      target: {
+        value: '2002'
+      }
+    });
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_combatSince911Yes'), {
+      target: {
+        value: 'Y'
+      }
+    });
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+});


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2221

Adds general military history page:

![screen shot 2017-05-30 at 2 40 40 pm](https://cloud.githubusercontent.com/assets/634932/26599300/1a53fcb2-4546-11e7-9979-7b9e8a8eae04.png)
![screen shot 2017-05-30 at 2 40 45 pm](https://cloud.githubusercontent.com/assets/634932/26599297/1a4b72f4-4546-11e7-9178-330ff5f2ae1d.png)
![screen shot 2017-05-30 at 2 41 00 pm](https://cloud.githubusercontent.com/assets/634932/26599299/1a4de584-4546-11e7-9be3-37f4d3b687c0.png)
