### PR TITLE
Switch to more restrictive ssn validation for forms

### DIFF
--- a/src/js/common/utils/validations.js
+++ b/src/js/common/utils/validations.js
@@ -232,7 +232,7 @@ function isValidSSN(value) {
     return false;
   }
 
-  const noBadSameDigitNumber = _.without(_.range(0, 10), 2, 4, 5)
+  const noBadSameDigitNumber = _.range(0, 10)
     .every(i => {
       const sameDigitRegex = new RegExp(`${i}{3}-?${i}{2}-?${i}{4}`);
       return !sameDigitRegex.test(value);

--- a/test/common/utils/validations.unit.spec.js
+++ b/test/common/utils/validations.unit.spec.js
@@ -32,10 +32,6 @@ describe('Validations unit tests', () => {
       expect(isValidSSN('900-22-1234')).to.be.true;
       expect(isValidSSN('111221234')).to.be.true;
       expect(isValidSSN('111111112')).to.be.true;
-
-      // Values with all the same digit are allowed in some cases
-      expect(isValidSSN('222222222')).to.be.true;
-      expect(isValidSSN('444-44-4444')).to.be.true;
     });
 
     it('rejects invalid ssn format', () => {
@@ -68,6 +64,8 @@ describe('Validations unit tests', () => {
       // Values with all the same digit are not allowed
       expect(isValidSSN('111111111')).to.be.false;
       expect(isValidSSN('999-99-9999')).to.be.false;
+      expect(isValidSSN('222222222')).to.be.false;
+      expect(isValidSSN('444-44-4444')).to.be.false;
     });
   });
 


### PR DESCRIPTION
Related to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3026

Since we're getting a backend error, use the more restrictive validation everywhere.