### PR TITLE
Add command line to run e2e tests against wcag2a accessibility rules

### DIFF
--- a/config/nightwatch.js
+++ b/config/nightwatch.js
@@ -57,23 +57,11 @@ module.exports = {
       },
     },
     accessibility: {
-      filter: './test/accessibility/*.spec.js',
+      filter: './test/accessibility/*.spec.js'
+    },
+    wcag2a: {
       globals: {
-        asyncHookTimeout: 20000,
-      },
-      desiredCapabilities: {
-        browserName: 'chrome',
-        javascriptEnabled: true,
-        acceptSslCerts: true,
-        webStorageEnabled: true,
-        chromeOptions: {
-          binary: electron,
-          args: ['--window-size=1024,768']
-        }
-      },
-      test_workers: {
-        enabled: false,
-        workers: parseInt(process.env.CONCURRENCY || 1, 10)
+        rules: ['section508', 'wcag2a']
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "npm run test:unit && npm run test:e2e",
     "test:e2e": "./script/run-nightwatch.sh",
     "test:accessibility": "./script/run-nightwatch.sh --env accessibility",
+    "test:wcag2a": "./script/run-nightwatch.sh --env wcag2a",
     "test:unit": "BABEL_ENV=test mocha --recursive 'test/**/*.unit.spec.js?(x)' ",
     "test:coverage": "NODE_ENV=test nyc --all --reporter=lcov --reporter=text --reporter=html mocha --no-color --recursive 'test/**/*.unit.spec.js?(x)' ",
     "test:unit:edu": "BABEL_ENV=test mocha --recursive 'test/edu-benefits/**/*.unit.spec.js?(x)' ",

--- a/test/util/nightwatch-commands/axeCheck.js
+++ b/test/util/nightwatch-commands/axeCheck.js
@@ -18,23 +18,17 @@ export function command(context, config, _callback) {
     document.head.appendChild(script);
   }, [axeSource]);
 
-  const runAxe = (innerContext, done) => {
+  // Run axe checks and report
+  this.executeAsync((innerContext, rules, done) => {
     axe.run(document.querySelector(innerContext) || document, { // eslint-disable-line no-undef
       runOnly: {
         type: 'tag',
-        values: (config || {}).rules || ['section508']
+        values: rules
       }
     }, (err, results) => {
       done({ err, results });
     });
-  };
-
-  // Run axe checks and report
-  this.executeAsync((innerContext, axeRunFn, done) => {
-    (axeRunFn(innerContext, done));
-  },
-  [context, runAxe],
-  response => {
+  }, [context, this.globals.rules || ['section508']], response => {
     if (response.state !== 'success') {
       this.verify.fail(`${response.state}: ${JSON.stringify(response)}`);
       return;

--- a/test/util/nightwatch-commands/axeCheck.js
+++ b/test/util/nightwatch-commands/axeCheck.js
@@ -18,18 +18,23 @@ export function command(context, config, _callback) {
     document.head.appendChild(script);
   }, [axeSource]);
 
-  // Run axe checks and report
-  const rules = (config || {}).rules || ['section508'];
-  this.executeAsync((innerContext, done) => {
+  const runAxe = (innerContext, done) => {
     axe.run(document.querySelector(innerContext) || document, { // eslint-disable-line no-undef
       runOnly: {
         type: 'tag',
-        values: rules
+        values: (config || {}).rules || ['section508']
       }
     }, (err, results) => {
       done({ err, results });
     });
-  }, [context], response => {
+  };
+
+  // Run axe checks and report
+  this.executeAsync((innerContext, axeRunFn, done) => {
+    (axeRunFn(innerContext, done));
+  },
+  [context, runAxe],
+  response => {
     if (response.state !== 'success') {
       this.verify.fail(`${response.state}: ${JSON.stringify(response)}`);
       return;

--- a/test/util/nightwatch-commands/axeCheck.js
+++ b/test/util/nightwatch-commands/axeCheck.js
@@ -19,11 +19,12 @@ export function command(context, config, _callback) {
   }, [axeSource]);
 
   // Run axe checks and report
+  const rules = (config || {}).rules || ['section508'];
   this.executeAsync((innerContext, done) => {
     axe.run(document.querySelector(innerContext) || document, { // eslint-disable-line no-undef
       runOnly: {
         type: 'tag',
-        values: ['section508']
+        values: rules
       }
     }, (err, results) => {
       done({ err, results });

--- a/test/util/nightwatch-commands/axeCheck.js
+++ b/test/util/nightwatch-commands/axeCheck.js
@@ -28,7 +28,7 @@ export function command(context, config, _callback) {
     }, (err, results) => {
       done({ err, results });
     });
-  }, [context, this.globals.rules || ['section508']], response => {
+  }, [context, (config || {}).rules || this.globals.rules || ['section508']], response => {
     if (response.state !== 'success') {
       this.verify.fail(`${response.state}: ${JSON.stringify(response)}`);
       return;

--- a/test/util/nightwatch-commands/axeCheckStrict.js
+++ b/test/util/nightwatch-commands/axeCheckStrict.js
@@ -1,0 +1,6 @@
+import {} from './axeCheck';
+
+export function command(context) {
+  const config = { rules: ['section508', 'wcag2a'] };
+  return this.axeCheck(context, config);
+}

--- a/test/util/nightwatch-commands/axeCheckStrict.js
+++ b/test/util/nightwatch-commands/axeCheckStrict.js
@@ -1,6 +1,0 @@
-import {} from './axeCheck';
-
-export function command(context) {
-  const config = { rules: ['section508', 'wcag2a'] };
-  return this.axeCheck(context, config);
-}


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2945

Allows developers to run
```
npm run test:wcag2a -- path/to/test.e2e.spec.js
```
to see where tests need updating to satisfy WCAG 2.0 standards

Also allows the rule set to be specified as part of the `axeCheck` config argument (which will override the global set by the above command, e.g.
```
.axeCheck('.main', { rules: ['section508', 'wcag2a'] })
```