### PR TITLE
Fix info message on applicant info

### DIFF
--- a/src/js/common/schemaform/pages/applicantInformation.jsx
+++ b/src/js/common/schemaform/pages/applicantInformation.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import _ from 'lodash/fp';
 
 import currentOrPastDateUI from '../definitions/currentOrPastDate';
@@ -52,7 +53,7 @@ export default function applicantInformation(schema, options) {
     initialData: {},
     uiSchema: _.assign({
       'ui:order': fields,
-      'ui:description': '<p>You aren’t required to fill in <strong>all</strong> fields, but VA can evaluate your claim faster if you provide more information.</p>',
+      'ui:description': <p>You aren’t required to fill in <strong>all</strong> fields, but VA can evaluate your claim faster if you provide more information.</p>,
       [`${prefix}FullName`]: fullNameUI,
       [`${prefix}DateOfBirth`]: _.assign(currentOrPastDateUI('Date of birth'),
         {


### PR DESCRIPTION
I wasn't clear on what I meant earlier. We can put jsx in the description fields if we need to by changing the file extension, importing react, and not using quotes around the field.