### PR TITLE
Suppress wcag2a rules for aXe checks due to a aXe API bug

### DIFF
--- a/test/gibct/00-required.e2e.spec.js
+++ b/test/gibct/00-required.e2e.spec.js
@@ -15,7 +15,8 @@ module.exports = E2eHelpers.createE2eTest(
     client
       .waitForElementVisible('body', Timeouts.normal)
       .waitForElementVisible('.gi-app', Timeouts.slow)
-      .axeCheck('.main');
+      // do not run 'wcag2a' rules because of open aXe bug https://github.com/dequelabs/axe-core/issues/214
+      .axeCheck('.main', { rules: ['section508'] });
 
     client
       .clearValue('.keyword-search input[type="text"]')
@@ -24,7 +25,8 @@ module.exports = E2eHelpers.createE2eTest(
     client
       .click('#search-button')
       .waitForElementVisible('.search-page', Timeouts.normal)
-      .axeCheck('.main');
+      // do not run 'wcag2a' rules because of open aXe bug https://github.com/dequelabs/axe-core/issues/214
+      .axeCheck('.main', { rules: ['section508'] });
 
     client
       .click('.search-result a')


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2198

An open bug in the aXe API (https://github.com/dequelabs/axe-core/issues/160 and, possibly related, https://github.com/dequelabs/axe-core/issues/214) keeps these 2 checks from passing WCAG 2.0 rules, so explicitly configure the check to only run `section508` rules so that when we enable `wacag2a` on all e2e tests, this will continue to pass. Right now it should be a no-op.
