### PR TITLE
Fixed broken SM headers in mobile.

### DIFF
--- a/src/js/messaging/containers/Settings.jsx
+++ b/src/js/messaging/containers/Settings.jsx
@@ -18,7 +18,7 @@ export class Settings extends React.Component {
               onClick={this.props.toggleFolderNav}>
             Menu
           </button>
-          <h2>Settings</h2>
+          <h3>Settings</h3>
         </div>
         <div id="messaging-settings">
           <ul className="va-tabs" role="tablist">

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -391,7 +391,7 @@ export class Thread extends React.Component {
                 onClick={this.props.toggleThreadForm}>
               Cancel
             </a>
-            <h2>{isNewMessage ? 'Edit draft' : 'Reply'}</h2>
+            <h3>{isNewMessage ? 'Edit draft' : 'Reply'}</h3>
             <button
                 className="messaging-send-button"
                 type="button"

--- a/src/sass/messaging/partials/_messaging-app.scss
+++ b/src/sass/messaging/partials/_messaging-app.scss
@@ -154,17 +154,18 @@
 }
 
 #messaging-content-header {
-  h2 {
+  h3 {
+    font-size: 2rem;
     padding: 0 !important;
   }
 
-  @media (max-width: $medium-screen) {
+  @include media-maxwidth($medium-screen) {
     align-items: center;
     background: $color-gray-lightest;
     display: flex;
     position: relative;
 
-    h2 {
+    h3 {
       flex: 1;
       line-height: inherit !important;
       overflow: hidden;
@@ -177,7 +178,7 @@
     &.messaging-folder-header {
       margin: 0;
 
-      h2 {
+      h3 {
         max-width: 65%;
       }
     }


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#2738.

@bshyong: I looked into the history of changes for the files, because the headers were originally `h2` and are styled by the `.messaging-content-header h2` rule. It looks like you had made the change due to findings at a 508 audit. Didn't seem like there was more info given about why we had to change from `h2` to `h3`.

After quickly searching through the page hierarchy, `h2` seemed like it would make sense, but I changed pages with the mobile header to use `h3` anyway in case changing back to `h2` would break 508.

> <img width="320" alt="screen shot 2017-05-31 at 9 14 55 pm" src="https://cloud.githubusercontent.com/assets/1067024/26661272/b5bcbf4a-464a-11e7-8e37-081989730c3e.png">

> <img width="320" alt="screen shot 2017-05-31 at 9 15 17 pm" src="https://cloud.githubusercontent.com/assets/1067024/26661276/b9697da4-464a-11e7-8353-2bf171d1f60a.png">

> <img width="320" alt="screen shot 2017-05-31 at 9 34 28 pm" src="https://cloud.githubusercontent.com/assets/1067024/26661282/beb2da76-464a-11e7-9dc9-89a1882be79a.png">

I also made it so that the header in desktop is the same size that it was originally intended to be, even though it's now `h3`. On another note, it seems strange to me that `h2` should be smaller than `h3` according to the default style rules, but anyway...
> <img width="450" alt="screen shot 2017-05-31 at 9 33 44 pm" src="https://cloud.githubusercontent.com/assets/1067024/26661285/c2a11b34-464a-11e7-9b76-6a564701b981.png">
