### PR TITLE
Minor form/login performance improvements

### DIFF
--- a/src/js/common/schemaform/reducers/index.js
+++ b/src/js/common/schemaform/reducers/index.js
@@ -55,16 +55,17 @@ export default function createSchemaFormReducer(formConfig) {
       schema = updateItemsSchema(schema);
       const data = getDefaultFormState(schema, page.initialData, schema.definitions);
 
-      return _.merge(state, {
-        pages: {
-          [page.pageKey]: {
-            uiSchema: page.uiSchema,
-            schema,
-            editMode: false
-          }
-        },
-        data
-      });
+      /* eslint-disable no-param-reassign */
+      state.pages[page.pageKey] = {
+        uiSchema: page.uiSchema,
+        schema,
+        editMode: false
+      };
+
+      state.data = _.merge(state.data, data);
+      /* eslint-enable no-param-reassign */
+
+      return state;
     }, {
       data: {
         privacyAgreementAccepted: false,

--- a/src/js/login/components/SearchHelpSignIn.jsx
+++ b/src/js/login/components/SearchHelpSignIn.jsx
@@ -71,5 +71,5 @@ const mapDispatchToProps = (dispatch) => {
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps, undefined, { pure: false })(SearchHelpSignIn);
+export default connect(mapStateToProps, mapDispatchToProps)(SearchHelpSignIn);
 export { SearchHelpSignIn };

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -167,5 +167,5 @@ const mapDispatchToProps = (dispatch) => {
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps, undefined, { pure: false })(Main);
+export default connect(mapStateToProps, mapDispatchToProps)(Main);
 export { Main };


### PR DESCRIPTION
I was testing out HCA to see if there were any performance issues and found a couple things.

The biggest one is that the start up code in the schema form reducer was taking 125ms on my desktop, and 650ms when I throttled it to a low-end device. Removing the `_.merge` call improved that time on a low end device by around half a second.

I also found that the login/profile components were re-rendering after any Redux action, even if it didn't affect them, because `pure` was set to false. That's not necessary unless you're doing something very strange in your components and we aren't as far as I can tell.