### PR TITLE
Improve form error handling and tracking

### DIFF
--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -1,3 +1,4 @@
+import Raven from 'raven-js';
 import { transformForSubmit } from './helpers';
 import environment from '../helpers/environment.js';
 
@@ -79,14 +80,16 @@ export function submitForm(formConfig, form) {
         });
         return res.json();
       }
+
+      return Promise.reject(new Error(res.statusText));
+    })
+    .then(resp => dispatch(setSubmitted(resp)))
+    .catch(error => {
+      Raven.captureException(error);
       window.dataLayer.push({
         event: `${formConfig.trackingPrefix}-submission-failed`,
       });
-      return Promise.reject(res.statusText);
-    })
-    .then(
-      (resp) => dispatch(setSubmitted(resp)),
-      () => dispatch(setSubmission('status', 'error'))
-    );
+      dispatch(setSubmission('status', 'error'));
+    });
   };
 }

--- a/src/js/edu-benefits/1990/actions/index.js
+++ b/src/js/edu-benefits/1990/actions/index.js
@@ -1,3 +1,4 @@
+import Raven from 'raven-js';
 import { veteranToApplication } from '../utils/veteran';
 
 import environment from '../../../common/helpers/environment';
@@ -118,18 +119,20 @@ export function submitForm(data) {
     .then(res => {
       if (res.ok) {
         window.dataLayer.push({
-          event: 'edu-submission-successful',
+          event: 'edu-submission-successful'
         });
         return res.json();
       }
-      window.dataLayer.push({
-        event: 'edu-submission-failed',
-      });
-      return Promise.reject(res.statusText);
+
+      return Promise.reject(new Error(res.statusText));
     })
-    .then(
-      (resp) => dispatch(updateSubmissionDetails(resp.data.attributes)),
-      () => dispatch(updateSubmissionStatus('error'))
-    );
+    .then((resp) => dispatch(updateSubmissionDetails(resp.data.attributes)))
+    .catch(error => {
+      Raven.captureException(error);
+      window.dataLayer.push({
+        event: 'edu-submission-successful'
+      });
+      dispatch(updateSubmissionStatus('error'));
+    });
   };
 }

--- a/src/js/edu-benefits/1990/actions/index.js
+++ b/src/js/edu-benefits/1990/actions/index.js
@@ -130,7 +130,7 @@ export function submitForm(data) {
     .catch(error => {
       Raven.captureException(error);
       window.dataLayer.push({
-        event: 'edu-submission-successful'
+        event: 'edu-submission-failed'
       });
       dispatch(updateSubmissionStatus('error'));
     });


### PR DESCRIPTION
This should stop swallowing errors that happen during the submission process and send them to Sentry and GA.

The main difference is now there's an overall `catch` callback which is explicitly tracking errors through Sentry. Before, I think the second callback passed to `then` was either swallowing errors or Raven's unhandled promise rejection code was missing them.