### PR TITLE
Actually default children array in hca rjsf

### DIFF
--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -204,7 +204,7 @@ export function filterInactivePages(pages, form) {
   }, form.data);
 }
 
-export function stringifyForm(key, value) {
+export function stringifyFormReplacer(key, value) {
   // an object with country is an address
   if (value && typeof value.country !== 'undefined' &&
     (!value.street || !value.city || (!value.postalCode && !value.zipcode))) {
@@ -230,7 +230,7 @@ export function transformForSubmit(formConfig, form) {
   const withoutInactivePages = filterInactivePages(inactivePages, form);
   const withoutViewFields = filterViewFields(withoutInactivePages);
 
-  return JSON.stringify(withoutViewFields, stringifyForm) || '{}';
+  return JSON.stringify(withoutViewFields, stringifyFormReplacer) || '{}';
 }
 
 function isHiddenField(schema) {

--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -204,6 +204,24 @@ export function filterInactivePages(pages, form) {
   }, form.data);
 }
 
+export function stringifyForm(key, value) {
+  // an object with country is an address
+  if (value && typeof value.country !== 'undefined' &&
+    (!value.street || !value.city || (!value.postalCode && !value.zipcode))) {
+    return undefined;
+  }
+
+  // clean up empty objects, which we have no reason to send
+  if (typeof value === 'object') {
+    const fields = Object.keys(value);
+    if (fields.length === 0 || fields.every(field => value[field] === undefined)) {
+      return undefined;
+    }
+  }
+
+  return value;
+}
+
 /*
  * Normal transform for schemaform data
  */
@@ -212,23 +230,7 @@ export function transformForSubmit(formConfig, form) {
   const withoutInactivePages = filterInactivePages(inactivePages, form);
   const withoutViewFields = filterViewFields(withoutInactivePages);
 
-  return JSON.stringify(withoutViewFields, (key, value) => {
-    // an object with country is an address
-    if (value && typeof value.country !== 'undefined' &&
-      (!value.street || !value.city || (!value.postalCode && !value.zipcode))) {
-      return undefined;
-    }
-
-    // clean up empty objects, which we have no reason to send
-    if (typeof value === 'object') {
-      const fields = Object.keys(value);
-      if (fields.length === 0 || fields.every(field => value[field] === undefined)) {
-        return undefined;
-      }
-    }
-
-    return value;
-  }) || '{}';
+  return JSON.stringify(withoutViewFields, stringifyForm) || '{}';
 }
 
 function isHiddenField(schema) {

--- a/src/js/hca-rjsf/helpers.jsx
+++ b/src/js/hca-rjsf/helpers.jsx
@@ -38,11 +38,13 @@ export function transform(formConfig, form) {
   const withoutInactivePages = filterInactivePages(inactivePages, updatedForm);
   let withoutViewFields = filterViewFields(withoutInactivePages);
 
+  // add back children here, because it could have been removed in filterViewFields
   if (!withoutViewFields.children) {
     withoutViewFields = _.set('children', [], withoutViewFields);
   }
 
   const formData = JSON.stringify(withoutViewFields, (key, value) => {
+    // Don't let children be removed in the normal empty object clean up
     if (key === 'children') {
       return value;
     }

--- a/src/js/hca-rjsf/helpers.jsx
+++ b/src/js/hca-rjsf/helpers.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import _ from 'lodash/fp';
 
 import {
-  stringifyForm,
+  stringifyFormReplacer,
   filterViewFields,
   filterInactivePages,
   createFormPageList
@@ -49,7 +49,7 @@ export function transform(formConfig, form) {
       return value;
     }
 
-    return stringifyForm(key, value);
+    return stringifyFormReplacer(key, value);
   }) || '{}';
 
   return JSON.stringify({

--- a/test/hca-rjsf/schema/schema.unit.spec.js
+++ b/test/hca-rjsf/schema/schema.unit.spec.js
@@ -26,17 +26,17 @@ describe('hca schema tests', () => {
         }
         if (data.veteranAddress.country === 'USA') {
           expect(data.veteranAddress.zipcode).to.not.be.empty;
-          expect(data.veteranAddress.postalCode).not.to.be.defined;
+          expect(typeof data.veteranAddress.postalCode).to.equal('undefined');
         }
         if (data.veteranAddress.country !== 'USA') {
           expect(data.veteranAddress.postalCode).to.not.be.empty;
-          expect(data.veteranAddress.zipcode).not.to.be.defined;
+          expect(typeof data.veteranAddress.zipcode).to.equal('undefined');
         }
         if (data.spouseAddress && data.spouseAddress.country === 'USA') {
           expect(data.spouseAddress.zipcode).to.not.be.empty;
-          expect(data.spouseAddress.postalCode).not.to.be.defined;
+          expect(typeof data.spouseAddress.postalCode).to.equal('undefined');
         }
-        expect(data.children).to.be.defined;
+        expect(typeof data.children).not.to.equal('undefined');
         expect(result.valid).to.be.true;
       });
     });


### PR DESCRIPTION
I fixed this before, but multiple failures caused me to miss it:

1. The `children` array is only being checked if financial disclosure is true and/or is only stripped on the front end in that case
2. Chai's `to.be.defined` check was returning false positives.

The fix is is a pain, because we have multiple steps where this particular array can be removed from the output. I gave up trying to make some kind of interface to do this when calling `transformForSubmit` and just had hca overwrite the whole thing.