### PR TITLE
Add max length for middle name and maiden name on hca

### DIFF
--- a/src/js/hca/config/form.js
+++ b/src/js/hca/config/form.js
@@ -152,7 +152,7 @@ const formConfig = {
             type: 'object',
             properties: {
               veteranFullName,
-              mothersMaidenName: _.set('maxLength', 30, mothersMaidenName)
+              mothersMaidenName: _.set('maxLength', 35, mothersMaidenName)
             }
           }
         },

--- a/src/js/hca/config/form.js
+++ b/src/js/hca/config/form.js
@@ -88,6 +88,7 @@ const {
   veteranGrossIncome,
   veteranNetIncome,
   veteranOtherIncome,
+  veteranFullName,
   spouseGrossIncome,
   spouseNetIncome,
   spouseOtherIncome,
@@ -121,7 +122,7 @@ const formConfig = {
   defaultDefinitions: {
     date,
     provider,
-    fullName,
+    fullName: _.set('properties.middle.maxLength', 35, fullName),
     ssn: ssn.oneOf[0], // Mmm...not a fan.
     phone,
     child: childSchema,
@@ -150,8 +151,8 @@ const formConfig = {
           schema: {
             type: 'object',
             properties: {
-              veteranFullName: fullName,
-              mothersMaidenName
+              veteranFullName,
+              mothersMaidenName: _.set('maxLength', 35, mothersMaidenName)
             }
           }
         },

--- a/src/js/hca/config/form.js
+++ b/src/js/hca/config/form.js
@@ -122,7 +122,7 @@ const formConfig = {
   defaultDefinitions: {
     date,
     provider,
-    fullName: _.set('properties.middle.maxLength', 35, fullName),
+    fullName: _.set('properties.middle.maxLength', 30, fullName),
     ssn: ssn.oneOf[0], // Mmm...not a fan.
     phone,
     child: childSchema,
@@ -152,7 +152,7 @@ const formConfig = {
             type: 'object',
             properties: {
               veteranFullName,
-              mothersMaidenName: _.set('maxLength', 35, mothersMaidenName)
+              mothersMaidenName: _.set('maxLength', 30, mothersMaidenName)
             }
           }
         },

--- a/test/hca/config/spouseInformation.unit.spec.jsx
+++ b/test/hca/config/spouseInformation.unit.spec.jsx
@@ -19,6 +19,7 @@ describe('Hca spouse information', () => {
     );
     const formDOM = findDOMNode(form);
 
+    expect(formDOM.querySelector('#root_spouseFullName_middle').maxLength).to.equal(35);
     expect(formDOM.querySelectorAll('input, select').length)
       .to.equal(15);
   });

--- a/test/hca/config/spouseInformation.unit.spec.jsx
+++ b/test/hca/config/spouseInformation.unit.spec.jsx
@@ -19,7 +19,7 @@ describe('Hca spouse information', () => {
     );
     const formDOM = findDOMNode(form);
 
-    expect(formDOM.querySelector('#root_spouseFullName_middle').maxLength).to.equal(35);
+    expect(formDOM.querySelector('#root_spouseFullName_middle').maxLength).to.equal(30);
     expect(formDOM.querySelectorAll('input, select').length)
       .to.equal(15);
   });

--- a/test/hca/config/veteranInformation.unit.spec.jsx
+++ b/test/hca/config/veteranInformation.unit.spec.jsx
@@ -15,6 +15,7 @@ describe('HCA veteranInformation', () => {
       <DefinitionTester
           schema={schema}
           data={{}}
+          definitions={formConfig.defaultDefinitions}
           onSubmit={onSubmit}
           uiSchema={uiSchema}/>
     );
@@ -22,6 +23,8 @@ describe('HCA veteranInformation', () => {
 
     expect(formDOM.querySelectorAll('input, select').length).to.equal(5);
     expect(formDOM.querySelector('#root_veteranFullName_first')).not.to.be.null;
+    expect(formDOM.querySelector('#root_veteranFullName_middle').maxLength).to.equal(35);
+    expect(formDOM.querySelector('#root_mothersMaidenName').maxLength).to.equal(35);
 
     submitForm(form);
 

--- a/test/hca/config/veteranInformation.unit.spec.jsx
+++ b/test/hca/config/veteranInformation.unit.spec.jsx
@@ -24,7 +24,7 @@ describe('HCA veteranInformation', () => {
     expect(formDOM.querySelectorAll('input, select').length).to.equal(5);
     expect(formDOM.querySelector('#root_veteranFullName_first')).not.to.be.null;
     expect(formDOM.querySelector('#root_veteranFullName_middle').maxLength).to.equal(30);
-    expect(formDOM.querySelector('#root_mothersMaidenName').maxLength).to.equal(30);
+    expect(formDOM.querySelector('#root_mothersMaidenName').maxLength).to.equal(35);
 
     submitForm(form);
 

--- a/test/hca/config/veteranInformation.unit.spec.jsx
+++ b/test/hca/config/veteranInformation.unit.spec.jsx
@@ -23,8 +23,8 @@ describe('HCA veteranInformation', () => {
 
     expect(formDOM.querySelectorAll('input, select').length).to.equal(5);
     expect(formDOM.querySelector('#root_veteranFullName_first')).not.to.be.null;
-    expect(formDOM.querySelector('#root_veteranFullName_middle').maxLength).to.equal(35);
-    expect(formDOM.querySelector('#root_mothersMaidenName').maxLength).to.equal(35);
+    expect(formDOM.querySelector('#root_veteranFullName_middle').maxLength).to.equal(30);
+    expect(formDOM.querySelector('#root_mothersMaidenName').maxLength).to.equal(30);
 
     submitForm(form);
 


### PR DESCRIPTION
The ES backend has a max length of 30 for some name fields, so we need to set that.

We may want to set this on the backend, too, but this is ok for now.