### PR TITLE
Confirm navigating away when preferences have changed.

### DIFF
--- a/src/js/messaging/containers/EmailNotifications.jsx
+++ b/src/js/messaging/containers/EmailNotifications.jsx
@@ -20,6 +20,7 @@ export class EmailNotifications extends React.Component {
   constructor(props) {
     super(props);
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.promptLeavePage = this.promptLeavePage.bind(this);
     this.renderSaveButtons = this.renderSaveButtons.bind(this);
 
     this.state = { discardChanges: false };
@@ -27,6 +28,8 @@ export class EmailNotifications extends React.Component {
 
   componentDidMount() {
     this.props.fetchPreferences();
+    this.props.router.setRouteLeaveHook(this.props.route, this.promptLeavePage);
+    window.addEventListener('beforeunload', this.promptLeavePage);
   }
 
   handleSubmit(e) {
@@ -40,6 +43,19 @@ export class EmailNotifications extends React.Component {
       event: 'sm-notification-setting',
       'sm-notify-freq': frequency,
     });
+  }
+
+  promptLeavePage(event) {
+    const { emailAddress, frequency } = this.props.preferences;
+    const isSaveable = emailAddress.dirty || frequency.dirty;
+    let message;
+
+    if (isSaveable) {
+      message = 'You haven\'t saved your changes. Are you sure you want to leave this page without saving?';
+      event.returnValue = message; // eslint-disable-line no-param-reassign
+    }
+
+    return message;
   }
 
   renderSaveButtons() {

--- a/src/js/rx/containers/Settings.jsx
+++ b/src/js/rx/containers/Settings.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
 import classNames from 'classnames';
 
 import AlertBox from '../../common/components/AlertBox';
@@ -24,6 +25,7 @@ export class Settings extends React.Component {
   constructor(props) {
     super(props);
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.promptLeavePage = this.promptLeavePage.bind(this);
     this.renderSaveButtons = this.renderSaveButtons.bind(this);
 
     this.state = { discardChanges: false };
@@ -31,6 +33,12 @@ export class Settings extends React.Component {
 
   componentDidMount() {
     this.props.fetchPreferences();
+    this.props.router.setRouteLeaveHook(this.props.route, this.promptLeavePage);
+    window.addEventListener('beforeunload', this.promptLeavePage);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.promptLeavePage);
   }
 
   handleSubmit(e) {
@@ -44,6 +52,19 @@ export class Settings extends React.Component {
       event: 'rx-notification-setting',
       'rx-notify': flag.value,
     });
+  }
+
+  promptLeavePage(event) {
+    const { email, flag } = this.props;
+    const isSaveable = email.dirty || flag.dirty;
+    let message;
+
+    if (isSaveable) {
+      message = 'You haven\'t saved your changes. Are you sure you want to leave this page without saving?';
+      event.returnValue = message; // eslint-disable-line no-param-reassign
+    }
+
+    return message;
   }
 
   renderSaveButtons() {
@@ -162,4 +183,4 @@ const mapDispatchToProps = {
   setNotificationFlag
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Settings);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Settings));


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#2780.

Because of how different browsers and versions handle custom messages when leaving pages, there can be different messages when navigating away from unsaved changes.

Below, the first scenario is handled by React Router and the latter is by plain JS, but some browsers that allow the custom message may show the former.

#### When navigating within app.
> <img width="527" alt="screen shot 2017-06-05 at 7 34 20 pm" src="https://cloud.githubusercontent.com/assets/1067024/26807700/0f35c862-4a26-11e7-938e-045795c077e7.png">

#### When navigating out of app.
> <img width="565" alt="screen shot 2017-05-31 at 8 02 58 pm" src="https://cloud.githubusercontent.com/assets/1067024/26659109/696eb3cc-463c-11e7-8237-eeff59a5c04b.png">