### PR TITLE
Add commitments link to employers index

### DIFF
--- a/content/pages/employment/index.md
+++ b/content/pages/employment/index.md
@@ -12,6 +12,9 @@ majorlinks:
   - url: https://www.dol.gov/veterans/hireaveteran/
     title: Hire a Veteran
     description: Post jobs and learn about hiring qualified Veterans.
+  - url: /employment/commitments
+    title: Commit to Hiring Veterans
+    description: Share your organization's commitment to hiring Veterans and their spouses.
 secondarylinkstitle: "Explore other ways to start a career"
 secondarylinks:
   - url: /employment/job-seekers/start

--- a/content/pages/employment/index.md
+++ b/content/pages/employment/index.md
@@ -14,7 +14,7 @@ majorlinks:
     description: Post jobs and learn about hiring qualified Veterans.
   - url: /employment/commitments
     title: Commit to Hiring Veterans
-    description: Share your organization's commitment to hiring Veterans and their spouses.
+    description: Share your company's commitment to hiring Veterans and their spouses.
 secondarylinkstitle: "Explore other ways to start a career"
 secondarylinks:
   - url: /employment/job-seekers/start


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3099

Adds a third blue card to the Employment index page pointing to Commitments:

https://vetsgov-pr-5695.herokuapp.com/employment/

Please review copy, especially the choice of the word "organization" vs. "company" @bethpotts pointed out in the original issue.

(Adding exit icons to the 2 DOL links will be addressed [separately](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2989) in the new template design, to be released in the next sprint)