### PR TITLE
Load hca confirmation page even if there's an error

### DIFF
--- a/src/js/hca/containers/ConfirmationPage.jsx
+++ b/src/js/hca/containers/ConfirmationPage.jsx
@@ -34,9 +34,11 @@ class ConfirmationPage extends React.Component {
         </div>
         <div>
           <p>We are processing your application. The Department of Veterans Affairs will contact you when we finish our review.</p>
-          <div className="success-alert-box">
-            <p className="success-copy">Form submitted: {time && moment(time).format('MMMM D, YYYY, h:mm a')}</p>
-          </div>
+          {time &&
+            <div className="success-alert-box">
+              <p className="success-copy">Form submitted: {moment(time).format('MMMM D, YYYY, h:mm a')}</p>
+            </div>
+          }
           <p>Please print this page for your records.</p>
           <p>If you have questions, call 1-877-222-VETS (8387) and press 2.</p>
         </div>

--- a/src/js/hca/containers/ConfirmationPage.jsx
+++ b/src/js/hca/containers/ConfirmationPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import _ from 'lodash/fp';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
@@ -21,7 +22,7 @@ class ConfirmationPage extends React.Component {
   }
 
   render() {
-    const time = this.props.form.submission.response.timestamp;
+    const time = _.get('form.submission.response.timestamp', this.props);
 
     return (
       <div>
@@ -34,7 +35,7 @@ class ConfirmationPage extends React.Component {
         <div>
           <p>We are processing your application. The Department of Veterans Affairs will contact you when we finish our review.</p>
           <div className="success-alert-box">
-            <p className="success-copy">Form submitted: {moment(time).format('MMMM D, YYYY, h:mm a')}</p>
+            <p className="success-copy">Form submitted: {time && moment(time).format('MMMM D, YYYY, h:mm a')}</p>
           </div>
           <p>Please print this page for your records.</p>
           <p>If you have questions, call 1-877-222-VETS (8387) and press 2.</p>

--- a/test/e2e/hca-helpers.js
+++ b/test/e2e/hca-helpers.js
@@ -178,15 +178,12 @@ function completeVaInsuranceInformation(client, data) {
 }
 
 function initApplicationSubmitMock() {
-  // TODO: Fully migrate to v1
   mock(null, {
     path: '/v0/health_care_applications',
     verb: 'post',
     value: {
-      data: {
-        formSubmissionId: '123fake-submission-id-567',
-        timeStamp: '2016-05-16'
-      }
+      formSubmissionId: '123fake-submission-id-567',
+      timestamp: '2016-05-16'
     }
   });
 }

--- a/test/hca/containers/ConfirmationPage.unit.spec.jsx
+++ b/test/hca/containers/ConfirmationPage.unit.spec.jsx
@@ -21,4 +21,13 @@ describe('hca <ConfirmationPage>', () => {
     expect(tree.subTree('h4').text()).to.contain('successfully submitted');
     expect(tree.subTree('.success-alert-box').text()).to.contain('January 1, 2010');
   });
+  it('should render without time', () => {
+    const tree = SkinDeep.shallowRender(
+      <ConfirmationPage form={{
+        submission: {}
+      }}/>
+    );
+
+    expect(tree.subTree('h4').text()).to.contain('successfully submitted');
+  });
 });


### PR DESCRIPTION
Sentry error: http://sentry.vetsgov-internal/vets-gov/website-production/issues/7204/

It looks like people are refreshing the confirmation page on hca, which is now an error due to how we changed the page. This avoids the error and hides the date if you refresh.