### PR TITLE
Gib status user info component

### DIFF
--- a/content/layouts/page-react.html
+++ b/content/layouts/page-react.html
@@ -1,6 +1,6 @@
 {% include "content/includes/header.html" %}
 
-{% if gatePage == true %}
+{% if includeBreadcrumbs == true %}
   {% include "content/includes/breadcrumbs.html" %}
 {% endif %}
 

--- a/content/pages/disability-benefits/track-claims/index.md
+++ b/content/pages/disability-benefits/track-claims/index.md
@@ -3,6 +3,7 @@ title: Track Claims
 entryname: disability-benefits
 layout: page-react.html
 gatePage: true
+includeBreadcrumbs: true
 ---
 <div id="main">
   <div class="section">

--- a/content/pages/education/gi-bill/post-9-11/status.md
+++ b/content/pages/education/gi-bill/post-9-11/status.md
@@ -2,7 +2,7 @@
 title: Post-9/11 GI Bill Status
 entryname: post-911-gib-status
 layout: page-react.html
-gatePage: true
+includeBreadcrumbs: true
 in_maintenance: false
 maintenance_line1: We're sorry. The page you are looking for is currently down while we fix a few things. We will be back up as soon as we can.
 maintenance_line2: In the meantime, please try the search box above or one of the options listed below to find more information.

--- a/content/pages/healthcare/messaging/index.md
+++ b/content/pages/healthcare/messaging/index.md
@@ -3,6 +3,7 @@ title: Send a message to your provider
 layout: page-react.html
 entryname: messaging
 gatePage: true
+includeBreadcrumbs: true
 ---
 
 <div id="main">

--- a/src/js/post-911-gib-status/actions/post-911-gib-status.js
+++ b/src/js/post-911-gib-status/actions/post-911-gib-status.js
@@ -1,12 +1,46 @@
 // TODO: remove this hard-coded response once we can fetch from a vets-api endpoint
 const post911GIBStatusResponse = {
   chapter33EducationInfo: {
-    dateOfBirth: '1977-10-01T04:00:00.000+0000',
     firstName: 'Jean',
     lastName: 'Picard',
+    nameSuffix: 'string',
+    dateOfBirth: '1977-10-01T04:00:00.000+0000',
     regionalProcessingOffice: 'Central Office Washington, DC',
     vaFileNumber: '301010301',
+    eligibilityDate: '2017-06-06T17:01:03.925Z',
+    delimitingDate: '2017-06-06T17:01:03.925Z',
+    percentageBenefit: 0,
+    originalEntitlement: 0,
+    usedEntitlement: 0,
+    remainingEntitlement: 0,
     enrollmentList: [
+      {
+        beginDate: '2017-06-06T17:01:03.925Z',
+        endDate: '2017-06-06T17:01:03.925Z',
+        facilityCode: 'string',
+        facilityName: 'string',
+        participantId: 'string',
+        trainingType: 'string',
+        termID: 'string',
+        hourType: 'string',
+        fullTimeHours: 0,
+        fullTimeCreditHourUnderGrad: 0,
+        vacationDayCount: 0,
+        residenceHours: 0,
+        distanceHours: 0,
+        yellowRibbonAmount: 0,
+        status: 'string',
+        amendmentList: [
+          {
+            residenceHours: 0,
+            distanceHours: 0,
+            yellowRibbonAmount: 0,
+            type: 'string',
+            status: 'string',
+            changeEffectiveDate: '2017-06-06T17:01:03.926Z'
+          }
+        ]
+      },
       {
         beginDate: '2012-11-01T04:00:00.000+0000',
         endDate: '2012-12-01T05:00:00.000+0000',

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import moment from 'moment';
+
+class UserInfoSection extends React.Component {
+  render() {
+    const { userData } = this.props;
+
+    // Used to get today's date to show information current of
+    const today = new Date();
+    const todayFormatted = moment(today).format('MM/DD/YYYY');
+
+    return (
+      <div className="gibstatus">
+        <h3 className="section-header">{userData.firstName} {userData.lastName}</h3>
+        <div className="usa-alert usa-alert-info">
+          <div className="usa-alert-body">
+            <h4 className="usa-alert-heading">This information is current as of {todayFormatted}</h4>
+          </div>
+        </div>
+        <div className="usa-grid-full section-line">
+          <div className="usa-width-one-third">
+            <span><strong>Date of Birth: </strong></span>
+          </div>
+          <div className="usa-width-one-third">
+            {userData.dateOfBirth}
+          </div>
+        </div>
+        <div className="usa-grid-full section-line">
+          <div className="usa-width-one-third">
+            <span><strong>VA File Number: </strong></span>
+          </div>
+          <div className="usa-width-one-third">
+            {userData.vaFileNumber}
+          </div>
+        </div>
+        <div className="usa-grid-full section-line">
+          <div className="usa-width-one-third">
+            <span><strong>Regional Processing Office: </strong></span>
+          </div>
+          <div className="usa-width-one-third">
+            {userData.regionalProcessingOffice}
+          </div>
+        </div>
+        <div>
+          <h4>When You Can Receive Benefits</h4>
+          <div className="section-line">You are eligible to receive benefits between <strong>{userData.eligibilityDate}</strong> and <strong>{userData.delimitingDate}</strong></div>
+        </div>
+        <div>
+          <h4>Your Benefit Level</h4>
+          <div className="section-line">You are eligible to receive benefits at a rate of <strong>{userData.percentageBenefit}</strong></div>
+        </div>
+      </div>
+    );
+  }
+}
+
+UserInfoSection.propTypes = {
+  userData: PropTypes.object
+};
+
+export default UserInfoSection;

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -1,24 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getDateFormatted, getPercentFormatted } from '../utils/helpers';
+import { formatDate, formatPercent } from '../utils/helpers';
 
 class UserInfoSection extends React.Component {
   render() {
     const { userData } = this.props;
 
     // Used to get today's date to show information current of
-    const today = new Date();
-    const todayFormatted = getDateFormatted(today);
+    const todayFormatted = formatDate(new Date());
 
     // Check if percent is a number
-    let percentageBenefit = 'unavailable';
-    if (getPercentFormatted(userData.percentageBenefit)) {
-      percentageBenefit = getPercentFormatted(userData.percentageBenefit);
-    }
+    const percentageBenefit = formatPercent(userData.percentageBenefit) || 'unavailable';
+
+    // TODO: Figure out what will be sent to us if the user is ineligible so we can
+    // conditionally show "Currently Disallowed" message
 
     return (
-      <div className="gibstatus">
+      <div>
         <h3 className="section-header">{userData.firstName} {userData.lastName}</h3>
         <div className="usa-alert usa-alert-info">
           <div className="usa-alert-body">
@@ -30,7 +29,7 @@ class UserInfoSection extends React.Component {
             <span><strong>Date of Birth: </strong></span>
           </div>
           <div className="usa-width-one-third">
-            {getDateFormatted(userData.dateOfBirth)}
+            {formatDate(userData.dateOfBirth)}
           </div>
         </div>
         <div className="usa-grid-full section-line">
@@ -49,9 +48,10 @@ class UserInfoSection extends React.Component {
             {userData.regionalProcessingOffice}
           </div>
         </div>
+
         <div>
           <h4>When You Can Receive Benefits</h4>
-          <div className="section-line">You are eligible to receive benefits between <strong>{getDateFormatted(userData.eligibilityDate)}</strong> and <strong>{getDateFormatted(userData.delimitingDate)}</strong></div>
+          <div className="section-line">You are eligible to receive benefits between <strong>{formatDate(userData.eligibilityDate)}</strong> and <strong>{formatDate(userData.delimitingDate)}</strong></div>
         </div>
         <div>
           <h4>Your Benefit Level</h4>

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import moment from 'moment';
+import { getDateFormatted, getPercentFormatted } from '../utils/helpers';
 
 class UserInfoSection extends React.Component {
   render() {
@@ -9,7 +9,13 @@ class UserInfoSection extends React.Component {
 
     // Used to get today's date to show information current of
     const today = new Date();
-    const todayFormatted = moment(today).format('MM/DD/YYYY');
+    const todayFormatted = getDateFormatted(today);
+
+    // Check if percent is a number
+    let percentageBenefit = 'unavailable';
+    if (getPercentFormatted(userData.percentageBenefit)) {
+      percentageBenefit = getPercentFormatted(userData.percentageBenefit);
+    }
 
     return (
       <div className="gibstatus">
@@ -24,7 +30,7 @@ class UserInfoSection extends React.Component {
             <span><strong>Date of Birth: </strong></span>
           </div>
           <div className="usa-width-one-third">
-            {userData.dateOfBirth}
+            {getDateFormatted(userData.dateOfBirth)}
           </div>
         </div>
         <div className="usa-grid-full section-line">
@@ -45,11 +51,11 @@ class UserInfoSection extends React.Component {
         </div>
         <div>
           <h4>When You Can Receive Benefits</h4>
-          <div className="section-line">You are eligible to receive benefits between <strong>{userData.eligibilityDate}</strong> and <strong>{userData.delimitingDate}</strong></div>
+          <div className="section-line">You are eligible to receive benefits between <strong>{getDateFormatted(userData.eligibilityDate)}</strong> and <strong>{getDateFormatted(userData.delimitingDate)}</strong></div>
         </div>
         <div>
           <h4>Your Benefit Level</h4>
-          <div className="section-line">You are eligible to receive benefits at a rate of <strong>{userData.percentageBenefit}</strong></div>
+          <div className="section-line">You are eligible to receive benefits at a rate of <strong>{percentageBenefit}</strong></div>
         </div>
       </div>
     );

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -18,10 +18,18 @@ class UserInfoSection extends React.Component {
 
     return (
       <div>
-        <h3 className="section-header">{userData.firstName} {userData.lastName}</h3>
+        <h3 className="section-header">Chapter 33 Benefit Information</h3>
         <div className="usa-alert usa-alert-info">
           <div className="usa-alert-body">
             <h4 className="usa-alert-heading">This information is current as of {todayFormatted}</h4>
+          </div>
+        </div>
+        <div className="usa-grid-full section-line">
+          <div className="usa-width-one-third">
+            <span><strong>Name: </strong></span>
+          </div>
+          <div className="usa-width-one-third">
+            {userData.firstName} {userData.lastName}
           </div>
         </div>
         <div className="usa-grid-full section-line">

--- a/src/js/post-911-gib-status/containers/Post911GIBStatusApp.jsx
+++ b/src/js/post-911-gib-status/containers/Post911GIBStatusApp.jsx
@@ -5,6 +5,7 @@ import FormTitle from '../../common/schemaform/FormTitle';
 import RequiredLoginView from '../../common/components/RequiredLoginView';
 
 import { getEnrollmentData } from '../actions/post-911-gib-status';
+import UserInfoSection from '../components/UserInfoSection';
 
 // This needs to be a React component for RequiredLoginView to pass down
 // the isDataAvailable prop, which is only passed on failure.
@@ -37,8 +38,6 @@ class Post911GIBStatusApp extends React.Component {
     // TODO: change the service name below from "user-profile" to
     // something like "post-911-gib-status" once its defined in vets-api
     const { enrollmentState } = this.props;
-    const name = enrollmentState ? `${enrollmentState.firstName} ${enrollmentState.lastName}` : '';
-
     return (
       <RequiredLoginView
           authRequired={3}
@@ -57,10 +56,7 @@ class Post911GIBStatusApp extends React.Component {
                   print a copy of this screen for benefit and eligibility verification.
                 </p>
               </div>
-              <div className="info-container usa-width-two-thirds medium-8 columns">
-                Placeholder content: {name}
-              </div>
-              {this.props.children}
+              <UserInfoSection userData={enrollmentState}/>
             </div>
           </div>
         </AppContent>

--- a/src/js/post-911-gib-status/containers/Post911GIBStatusApp.jsx
+++ b/src/js/post-911-gib-status/containers/Post911GIBStatusApp.jsx
@@ -22,7 +22,7 @@ function AppContent({ children, isDataAvailable }) {
     view = children;
   }
   return (
-    <div className="usa-grid">
+    <div>
       {view}
     </div>
   );
@@ -47,9 +47,16 @@ class Post911GIBStatusApp extends React.Component {
           loginUrl={this.props.loginUrl}
           verifyUrl={this.props.verifyUrl}>
         <AppContent>
-          <div className="usa-grid">
-            <div className="usa-width-two-thirds">
+          <div className="row">
+            <div className="usa-width-two-thirds medium-8 columns">
               <FormTitle title="Post-9/11 GI Bill Status"/>
+              <div className="va-introtext">
+                <p>
+                  View your Post-9/11 GI Bill enrollment information below. This is the same information
+                  in your Certificate of Eligibility (COE) letter. In lieu of a COE letter, you can
+                  print a copy of this screen for benefit and eligibility verification.
+                </p>
+              </div>
               <div className="info-container usa-width-two-thirds medium-8 columns">
                 Placeholder content: {name}
               </div>

--- a/src/js/post-911-gib-status/utils/helpers.js
+++ b/src/js/post-911-gib-status/utils/helpers.js
@@ -8,7 +8,7 @@ export function formatPercent(percent) {
   let validPercent = undefined;
 
   if (!isNaN(parseInt(percent, 10))) {
-    validPercent = `${Math.round(percent * 100)}%`;
+    validPercent = `${Math.round(percent)}%`;
   }
 
   return validPercent;

--- a/src/js/post-911-gib-status/utils/helpers.js
+++ b/src/js/post-911-gib-status/utils/helpers.js
@@ -1,0 +1,15 @@
+import moment from 'moment';
+
+export function getDateFormatted(date) {
+  return moment(date).format('MM/DD/YYYY');
+}
+
+export function getPercentFormatted(percent) {
+  let validPercent = undefined;
+
+  if (!isNaN(parseInt(percent, 10))) {
+    validPercent = `${Math.round(percent * 100)}%`;
+  }
+
+  return validPercent;
+}

--- a/src/js/post-911-gib-status/utils/helpers.js
+++ b/src/js/post-911-gib-status/utils/helpers.js
@@ -1,10 +1,10 @@
 import moment from 'moment';
 
-export function getDateFormatted(date) {
+export function formatDate(date) {
   return moment(date).format('MM/DD/YYYY');
 }
 
-export function getPercentFormatted(percent) {
+export function formatPercent(percent) {
   let validPercent = undefined;
 
   if (!isNaN(parseInt(percent, 10))) {

--- a/src/sass/post-911-gib-status.scss
+++ b/src/sass/post-911-gib-status.scss
@@ -1,1 +1,17 @@
 @import "style";
+
+h3 {
+	border-bottom: 1px solid #aeb0b5;
+}
+
+h4 {
+	margin-top: 1em;
+}
+
+.section-line {
+	margin-bottom: 1em;
+}
+
+.usa-alert {
+	margin: 1em 0 1em 0;
+}

--- a/src/sass/post-911-gib-status.scss
+++ b/src/sass/post-911-gib-status.scss
@@ -1,17 +1,17 @@
 @import "style";
 
 h3 {
-	border-bottom: 1px solid #aeb0b5;
+  border-bottom: 1px solid #aeb0b5;
 }
 
 h4 {
-	margin-top: 1em;
+  margin-top: 1em;
 }
 
 .section-line {
-	margin-bottom: 1em;
+  margin-bottom: 1em;
 }
 
 .usa-alert {
-	margin: 1em 0 1em 0;
+  margin: 1em 0 1em 0;
 }


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3101

This PR does a few things:
1. Adds the general message at the top of the page about being able to use this in place of the COE

2. Creates a component for the user information section
There is still more work to do here because I'm waiting on 2 things:
- Updated UI from MarvelApp: might result in slight tweaks
- Updated mock data from vets-api: depending on what the data looks like, we'll need to transform it to be formatted as we want when it is displayed to the user. I'm not tackling that yet as I don't yet know the final version of the data.

3. Fixes an issue with the `gatePage` flag
Background on this issue: I noticed that the bottom margin on the breadcrumbs on this page was being collapsed. I traced this to a class called `va-nav-breadcrumbs--gate` that was being set on the breadcrumbs if the `gatePage` flag was set to true (https://github.com/department-of-veterans-affairs/vets-website/blob/master/content/includes/breadcrumbs.html#L1). This `gatePage` flag was also used to determine whether or not to render the breadcrumbs entirely in the `page-react` layout (https://github.com/department-of-veterans-affairs/vets-website/blob/master/content/layouts/page-react.html#L3).

I wanted to include the breadcrumbs, but I didn't want to add that extra class to collapse the margin. Because the same flag was used to control both, I needed to create a separate flag, `includeBreadcrumbs`, just to control whether or not breadcrumbs should be included. I kept the `gatePage` flag to add that class; I removed it from this app specifically so it wouldn't be set.

<img width="828" alt="screen shot 2017-06-08 at 11 19 57 am" src="https://user-images.githubusercontent.com/25183456/26936381-8c19436e-4c3c-11e7-8ee1-e0696af6a13b.png">