### PR TITLE
Update fetch polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "webpack": "^2.4.1",
     "webpack-manifest-plugin": "^1.1.0",
     "webpack-md5-hash": "0.0.5",
-    "whatwg-fetch": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz",
+    "whatwg-fetch": "^2.0.3",
     "winston": "^2.2.0"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "libxmljs": "^0.18.0",
     "lodash": "^4.5.1",
     "lodash-deep": "^2.0.0",
-    "mapbox": "^1.0.0-beta5",
+    "mapbox": "1.0.0-beta7",
     "metalsmith": "^2.1.0",
     "metalsmith-archive": "^0.1.1",
     "metalsmith-assets": "^0.1.0",

--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -59,7 +59,6 @@ export function submitForm(formConfig, form) {
 
     const fetchOptions = {
       method: 'POST',
-      mode: 'cors',
       headers: {
         'Content-Type': 'application/json',
         'X-Key-Inflection': 'camel'

--- a/src/js/edu-benefits/1990/actions/index.js
+++ b/src/js/edu-benefits/1990/actions/index.js
@@ -105,7 +105,6 @@ export function submitForm(data) {
     });
     fetch(`${environment.API_URL}/v0/education_benefits_claims`, {
       method: 'POST',
-      mode: 'cors',
       headers: {
         'Content-Type': 'application/json',
         'X-Key-Inflection': 'camel'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2543,7 +2543,7 @@ enhanced-resolve@^0.7.6:
     memory-fs "~0.1.0"
     tapable "0.1.x"
 
-enhanced-resolve@^3.0.0, enhanced-resolve@^3.1.0:
+enhanced-resolve@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz#9f4b626f577245edcf4b2ad83d86e17f4f421dec"
   dependencies:
@@ -5106,7 +5106,7 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-mapbox@^1.0.0-beta7:
+mapbox@^1.0.0-beta5:
   version "1.0.0-beta7"
   resolved "https://registry.yarnpkg.com/mapbox/-/mapbox-1.0.0-beta7.tgz#b076b1149c5cd3e3dbf69d3492cc1ddbd9a783ed"
   dependencies:
@@ -5358,7 +5358,7 @@ metalsmith-webpack@department-of-veterans-affairs/metalsmith-webpack:
   version "1.0.3"
   resolved "https://codeload.github.com/department-of-veterans-affairs/metalsmith-webpack/tar.gz/6130e9bccbf6f558f58041f63f07382d049f66bf"
   dependencies:
-    enhanced-resolve "^0.7.6"
+    enhanced-resolve "^3.1.0"
     webpack "^2.4.1"
 
 metalsmith@^1.7.0:
@@ -8493,9 +8493,13 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-fetch@>=0.10.0, "whatwg-fetch@http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz":
+whatwg-fetch@>=0.10.0:
   version "1.0.0"
   resolved "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz#01c2ac4df40e236aaa18480e3be74bd5c8eb798e"
+
+whatwg-fetch@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 whatwg-url@^4.3.0:
   version "4.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2543,7 +2543,7 @@ enhanced-resolve@^0.7.6:
     memory-fs "~0.1.0"
     tapable "0.1.x"
 
-enhanced-resolve@^3.0.0:
+enhanced-resolve@^3.0.0, enhanced-resolve@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz#9f4b626f577245edcf4b2ad83d86e17f4f421dec"
   dependencies:
@@ -5106,7 +5106,7 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-mapbox@^1.0.0-beta5:
+mapbox@1.0.0-beta7:
   version "1.0.0-beta7"
   resolved "https://registry.yarnpkg.com/mapbox/-/mapbox-1.0.0-beta7.tgz#b076b1149c5cd3e3dbf69d3492cc1ddbd9a783ed"
   dependencies:
@@ -8493,11 +8493,7 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-fetch@>=0.10.0:
-  version "1.0.0"
-  resolved "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-1.0.0.tgz#01c2ac4df40e236aaa18480e3be74bd5c8eb798e"
-
-whatwg-fetch@^2.0.3:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3168

We're seeing some failures in IE11 when posting forms and I want to make sure we're not hitting bugs because we use an older version of the fetch polyfill. This change affects primarily IE11, but also some older iOS and Android devices.

The only breaking change listed for the fetch polyfill in 2.0 is using `getAll()` with the Headers object, which I can't find any instances of us doing.

I also removed some instances of `mode: 'cors'` because that's the default and is unnecessary.