### PR TITLE
Pv terms soft launch

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -29,6 +29,7 @@ const entryFiles = {
   auth: './src/js/auth/auth-entry.jsx',
   'va-letters': './src/js/va-letters/va-letters-entry.jsx',
   pensions: './src/js/pensions/pensions-entry.jsx',
+  'health-beta': './src/js/health-beta/health-beta-entry.jsx',
 };
 
 const configGenerator = (options) => {

--- a/content/pages/health-beta/index.md
+++ b/content/pages/health-beta/index.md
@@ -1,0 +1,23 @@
+---
+title: Your Vets.gov Account
+layout: page-react.html
+entryname: health-beta
+---
+<div id="main">
+  <nav class="va-nav-breadcrumbs">
+    <ul class="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
+      <li><a href="/">Home</a></li>
+      <li class="active">Beta Enrollment</li>
+    </ul>
+  </nav>
+
+  <div class="section">
+    <div id="react-root">
+      <div class="loading-message">
+        <h3>Please wait while we load the application for you.</h3>
+        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+      </div>
+    </div>
+  </div>
+  <!-- Health Beta End -->
+</div>

--- a/src/js/common/components/RequiredTermsAcceptanceView.jsx
+++ b/src/js/common/components/RequiredTermsAcceptanceView.jsx
@@ -12,9 +12,8 @@ import AcceptTermsPrompt from './AcceptTermsPrompt';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
 
 export class RequiredTermsAcceptanceView extends React.Component {
-  componentWillMount() {
+  componentDidMount() {
     if (this.props.termsNeeded) {
-      // this.props.checkAcceptance(this.props.termsName);
       this.props.fetchLatestTerms(this.props.termsName);
       window.scrollTo(0, 0);
     }

--- a/src/js/common/components/RequiredTermsAcceptanceView.jsx
+++ b/src/js/common/components/RequiredTermsAcceptanceView.jsx
@@ -13,8 +13,8 @@ import LoadingIndicator from '../../common/components/LoadingIndicator';
 
 export class RequiredTermsAcceptanceView extends React.Component {
   componentWillMount() {
-    if (!this.props.terms.acceptance) {
-      this.props.checkAcceptance(this.props.termsName);
+    if (this.props.termsNeeded) {
+      // this.props.checkAcceptance(this.props.termsName);
       this.props.fetchLatestTerms(this.props.termsName);
       window.scrollTo(0, 0);
     }
@@ -22,13 +22,22 @@ export class RequiredTermsAcceptanceView extends React.Component {
 
   render() {
     const { terms } = this.props;
+    const enabled = this.props.isDataAvailable === true || typeof this.props.isDataAvailable === 'undefined';
 
     let view;
 
     if (terms.loading === true) {
       view = <LoadingIndicator setFocus message="Loading your information"/>;
-    } else if (terms.acceptance) {
-      view = this.props.children;
+    } else if (!this.props.termsNeeded) {
+      view = React.Children.map(this.props.children,
+        (child) => {
+          let props = null;
+          if (typeof child.type === 'function') {
+            props = { isDataAvailable: enabled };
+          }
+          return React.cloneElement(child, props);
+        }
+      );
     } else {
       view = <AcceptTermsPrompt terms={terms} onAccept={this.props.acceptTerms}/>;
     }

--- a/src/js/common/components/SystemDownView.jsx
+++ b/src/js/common/components/SystemDownView.jsx
@@ -6,7 +6,7 @@ class SystemDownView extends React.Component {
     return (
       <div className="row">
         <div className="small-12 columns">
-          <div className="react-conatiner">
+          <div className="react-container">
             <h3>{this.props.messageLine1}</h3>
             <h4>{this.props.messageLine2}</h4>
             <a href="/"><button>Go Back to Vets.gov</button></a>

--- a/src/js/common/components/authentication/LoginPrompt.jsx
+++ b/src/js/common/components/authentication/LoginPrompt.jsx
@@ -36,7 +36,7 @@ class LoginPrompt extends React.Component {
     return (
       <div className="row primary">
         <div className="medium-12 small-12 columns">
-          <div className="react-conatiner">
+          <div className="react-container">
             <h1>Sign In to Your Vets.gov Account</h1>
             <p>Vets.gov is a new VA website offering online services for Veterans.</p>
             <p>Sign in to:</p>

--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -36,6 +36,7 @@ export function getUserData(dispatch) {
       dispatch(updateProfileField('dob', userData.birth_date));
       dispatch(updateProfileField('status', json.data.attributes.va_profile.status));
       dispatch(updateProfileField('services', json.data.attributes.services));
+      dispatch(updateProfileField('healthTermsCurrent', json.data.attributes.health_terms_current));
       dispatch(updateLoggedInStatus(true));
     }
   });

--- a/src/js/health-beta/actions/index.js
+++ b/src/js/health-beta/actions/index.js
@@ -1,0 +1,29 @@
+import { apiRequest } from '../../common/helpers/api';
+
+export const BETA_REGISTERING = 'BETA_REGISTERING';
+export const BETA_REGISTER_SUCCESS = 'BETA_REGISTER_SUCCESS';
+export const BETA_REGISTER_FAILURE = 'BETA_REGISTER_FAILURE';
+
+export function registerBeta() {
+  return dispatch => {
+    dispatch({ type: BETA_REGISTERING });
+
+    const settings = {
+      method: 'POST',
+    };
+
+    apiRequest('/health_beta_registrations',
+      settings,
+      response => dispatch({
+        type: BETA_REGISTER_SUCCESS,
+        username: response.user,
+        stats: 'succeeded',
+      }),
+      () => dispatch({
+        type: BETA_REGISTER_FAILURE,
+        stats: 'failed'
+      })
+    );
+  };
+}
+

--- a/src/js/health-beta/containers/HealthBetaEnrollment.jsx
+++ b/src/js/health-beta/containers/HealthBetaEnrollment.jsx
@@ -6,7 +6,7 @@ import { registerBeta } from '../actions';
 
 class HealthBetaEnrollment extends React.Component {
 
-  componentWillMount() {
+  componentDidMount() {
     this.props.registerBeta();
   }
 

--- a/src/js/health-beta/containers/HealthBetaEnrollment.jsx
+++ b/src/js/health-beta/containers/HealthBetaEnrollment.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import RequiredLoginView from '../../common/components/RequiredLoginView';
+import { registerBeta } from '../actions';
+
+class HealthBetaEnrollment extends React.Component {
+
+  componentWillMount() {
+    this.props.registerBeta();
+  }
+
+  render() {
+    let message;
+
+    if (this.props.loading === true) {
+      message = 'Activating beta features...';
+    }
+    if (this.props.stats === 'failed') {
+      message = 'Activation failed, please contact beta product manager.';
+    } else {
+      message = 'Beta features activated for user '.concat(this.props.username).concat('. Thank you.');
+    }
+    let view;
+
+    view = (
+      <div className="row">
+        <div className="usa-width-two-thirds medium-8 small-12 columns">
+          <h1>Health Beta Registration</h1>
+          <div>
+            <p>{message}</p>
+          </div>
+        </div>
+      </div>
+    );
+
+    return (
+      <div>
+        <RequiredLoginView
+            authRequired={1}
+            serviceRequired={"user-profile"}
+            userProfile={this.props.profile}
+            loginUrl={this.props.loginUrl}
+            verifyUrl={this.props.verifyUrl}>
+          {view}
+        </RequiredLoginView>
+      </div>
+      );
+  }
+}
+
+const mapStateToProps = (state) => {
+  const hbState = state.healthbeta;
+  const userState = state.user;
+  return {
+    profile: userState.profile,
+    loginUrl: userState.login.loginUrl,
+    verifyUrl: userState.login.verifyUrl,
+    username: hbState.beta.username,
+    stats: hbState.beta.stats,
+    isLoading: hbState.beta.loading,
+  };
+};
+
+const mapDispatchToProps = {
+  registerBeta,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(HealthBetaEnrollment);
+export { HealthBetaEnrollment };

--- a/src/js/health-beta/health-beta-entry.jsx
+++ b/src/js/health-beta/health-beta-entry.jsx
@@ -19,20 +19,6 @@ const commonStore = createCommonStore(reducer);
 createLoginWidget(commonStore);
 
 function init() {
-  /*
-   * Invoked when the URL changes. A way to handle query
-   * string data.
-   *
-   * Plan is to make this trigger a sort when the query
-   * parameter is `sortby`.
-   */
-  const handleChangedURL = (event) => {
-    // Here so eslint doesn't tell us about an unused variable.
-    return event;
-  };
-  browserHistory.listen(handleChangedURL);
-  // End URL listening
-
   ReactDOM.render((
     <Provider store={commonStore}>
       <Router history={browserHistory} routes={routes}/>

--- a/src/js/health-beta/health-beta-entry.jsx
+++ b/src/js/health-beta/health-beta-entry.jsx
@@ -1,0 +1,43 @@
+import 'core-js';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { Router, browserHistory } from 'react-router';
+import { Provider } from 'react-redux';
+
+import initReact from '../common/init-react';
+import routes from './routes';
+import reducer from './reducers';
+import createCommonStore from '../common/store';
+import createLoginWidget from '../login/login-entry';
+
+require('../common');  // Bring in the common javascript.
+require('../../sass/rx/rx.scss');
+require('../../sass/user-profile.scss');
+
+const commonStore = createCommonStore(reducer);
+createLoginWidget(commonStore);
+
+function init() {
+  /*
+   * Invoked when the URL changes. A way to handle query
+   * string data.
+   *
+   * Plan is to make this trigger a sort when the query
+   * parameter is `sortby`.
+   */
+  const handleChangedURL = (event) => {
+    // Here so eslint doesn't tell us about an unused variable.
+    return event;
+  };
+  browserHistory.listen(handleChangedURL);
+  // End URL listening
+
+  ReactDOM.render((
+    <Provider store={commonStore}>
+      <Router history={browserHistory} routes={routes}/>
+    </Provider>
+    ), document.getElementById('react-root'));
+}
+
+initReact(init);

--- a/src/js/health-beta/reducers/beta.js
+++ b/src/js/health-beta/reducers/beta.js
@@ -1,0 +1,39 @@
+
+import {
+  BETA_REGISTERING,
+  BETA_REGISTER_SUCCESS,
+  BETA_REGISTER_FAILURE
+} from '../actions';
+
+const initialState = {
+  username: null,
+  stats: null,
+  loading: false
+};
+
+function beta(state = initialState, action) {
+  switch (action.type) {
+    case BETA_REGISTERING:
+      return {
+        ...state,
+        loading: true
+      };
+    case BETA_REGISTER_SUCCESS:
+      return {
+        ...state,
+        username: action.username,
+        stats: action.stats,
+        loading: false
+      };
+    case BETA_REGISTER_FAILURE:
+      return {
+        ...state,
+        stats: action.stats,
+        loading: false
+      };
+    default:
+      return state;
+  }
+}
+
+export default beta;

--- a/src/js/health-beta/reducers/index.js
+++ b/src/js/health-beta/reducers/index.js
@@ -1,0 +1,7 @@
+import { combineReducers } from 'redux';
+
+import beta from './beta';
+
+export default {
+  healthbeta: combineReducers({ beta })
+};

--- a/src/js/health-beta/routes.jsx
+++ b/src/js/health-beta/routes.jsx
@@ -1,0 +1,9 @@
+import HealthBetaEnrollment from './containers/HealthBetaEnrollment';
+
+const routes = {
+  path: '/health-beta',
+  component: HealthBetaEnrollment,
+};
+
+export default routes;
+

--- a/src/js/health-records/containers/HealthRecordsApp.jsx
+++ b/src/js/health-records/containers/HealthRecordsApp.jsx
@@ -42,7 +42,9 @@ export class HealthRecordsApp extends React.Component {
           userProfile={this.props.profile}
           loginUrl={this.props.loginUrl}
           verifyUrl={this.props.verifyUrl}>
-        <RequiredTermsAcceptanceView termsName={"mhvac"}>
+        <RequiredTermsAcceptanceView
+            termsName={"mhvac"}
+            termsNeeded={!this.props.profile.healthTermsCurrent}>
           <AppContent>
             <div>
               <div className="row">

--- a/src/js/messaging/containers/MessagingApp.jsx
+++ b/src/js/messaging/containers/MessagingApp.jsx
@@ -63,7 +63,9 @@ class MessagingApp extends React.Component {
           userProfile={this.props.profile}
           loginUrl={this.props.loginUrl}
           verifyUrl={this.props.verifyUrl}>
-        <RequiredTermsAcceptanceView termsName={"mhvac"}>
+        <RequiredTermsAcceptanceView
+            termsName={"mhvac"}
+            termsNeeded={!this.props.profile.healthTermsCurrent}>
           <AppContent>
             <div id="messaging-app-header">
               <AlertBox

--- a/src/js/rx/containers/RxRefillsApp.jsx
+++ b/src/js/rx/containers/RxRefillsApp.jsx
@@ -48,7 +48,9 @@ class RxRefillsApp extends React.Component {
           userProfile={this.props.profile}
           loginUrl={this.props.loginUrl}
           verifyUrl={this.props.verifyUrl}>
-        <RequiredTermsAcceptanceView termsName={"mhvac"}>
+        <RequiredTermsAcceptanceView
+            termsName={"mhvac"}
+            termsNeeded={!this.props.profile.healthTermsCurrent}>
           <AppContent>
             <Breadcrumbs location={this.props.location} prescription={this.props.prescription}/>
             {this.props.children}

--- a/src/js/user-profile/actions/index.js
+++ b/src/js/user-profile/actions/index.js
@@ -68,12 +68,11 @@ export function acceptTerms(termsName) {
     apiRequest(
       `/terms_and_conditions/${termsName}/versions/latest/user_data`,
       settings,
-      () => dispatch({
-        type: ACCEPTING_LATEST_MHV_TERMS_SUCCESS,
-      }),
+      () => {
+        dispatch({ type: ACCEPTING_LATEST_MHV_TERMS_SUCCESS });
+        getUserData(dispatch);
+      },
       () => dispatch({ type: ACCEPTING_LATEST_MHV_TERMS_FAILURE })
     );
-
-    getUserData(dispatch);
   };
 }

--- a/src/js/user-profile/actions/index.js
+++ b/src/js/user-profile/actions/index.js
@@ -1,4 +1,5 @@
 import { apiRequest } from '../../common/helpers/api';
+import { getUserData } from '../../common/helpers/login-helpers';
 
 export const UPDATE_PROFILE_FIELD = 'UPDATE_PROFILE_FIELD';
 export const FETCHING_MHV_TERMS_ACCEPTANCE = 'FETCHING_MHV_TERMS_ACCEPTANCE';
@@ -72,5 +73,7 @@ export function acceptTerms(termsName) {
       }),
       () => dispatch({ type: ACCEPTING_LATEST_MHV_TERMS_FAILURE })
     );
+
+    getUserData(dispatch);
   };
 }

--- a/src/js/user-profile/components/UserDataSection.jsx
+++ b/src/js/user-profile/components/UserDataSection.jsx
@@ -22,7 +22,7 @@ class UserDataSection extends React.Component {
     return (
       <div className="profile-section medium-12 columns">
         <h4 className="section-header">Account Information</h4>
-        <div className="info-conatiner usa-width-two-thirds medium-8 columns">
+        <div className="info-container usa-width-two-thirds medium-8 columns">
           {content}
           <p><span className="label usa-width-one-third medium-4 columns">Email Address:</span>{this.props.profile.email} <a href="https://wallet.id.me/settings" target="_blank">Change</a></p>
           <p><span className="label usa-width-one-third medium-4 columns">Password:</span><a href="https://wallet.id.me/settings" target="_blank">Change</a></p>

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -1501,6 +1501,10 @@ pre[class*="language-"]  {
   padding: 2em 0;
 }
 
+.react-container {
+  padding: 2em 0;
+}
+
 p.info-message {
   font-size: 1.5em;
 }

--- a/test/common/components/RequiredTermsAcceptance.unit.spec.jsx
+++ b/test/common/components/RequiredTermsAcceptance.unit.spec.jsx
@@ -22,7 +22,7 @@ describe('<RequiredTermsAcceptanceView>', () => {
     const tree = SkinDeep.shallowRender(
       <RequiredTermsAcceptanceView {...defaultProps}/>
     );
-    tree.getMountedInstance().componentWillMount();
+    tree.getMountedInstance().componentDidMount();
 
     expect(defaultProps.fetchLatestTerms.called).to.be.true;
   });

--- a/test/common/components/RequiredTermsAcceptance.unit.spec.jsx
+++ b/test/common/components/RequiredTermsAcceptance.unit.spec.jsx
@@ -11,6 +11,7 @@ const defaultProps = {
   checkAcceptance: sinon.spy(),
   fetchLatestTerms: sinon.spy(),
   acceptTerms: sinon.spy(),
+  termsNeeded: true,
   terms: {
     acceptance: false,
   }
@@ -23,7 +24,6 @@ describe('<RequiredTermsAcceptanceView>', () => {
     );
     tree.getMountedInstance().componentWillMount();
 
-    expect(defaultProps.checkAcceptance.called).to.be.true;
     expect(defaultProps.fetchLatestTerms.called).to.be.true;
   });
 
@@ -44,6 +44,7 @@ describe('<RequiredTermsAcceptanceView>', () => {
   it('should properly render children if terms accepted', () => {
     const props = {
       ...defaultProps,
+      termsNeeded: false,
       terms: {
         acceptance: true,
       }

--- a/test/e2e/login-helpers.js
+++ b/test/e2e/login-helpers.js
@@ -40,6 +40,7 @@ function initUserMock(token, level) {
             birth_date: '1985-01-01'
           },
           services: ['facilities', 'hca', 'edu-benefits', 'evss-claims', 'user-profile', 'rx', 'messaging'],
+          health_terms_current: true,
           va_profile: {
             status: 'OK',
             birth_date: '19511118',

--- a/test/health-records/containers/HealthRecordsApp.unit.spec.jsx
+++ b/test/health-records/containers/HealthRecordsApp.unit.spec.jsx
@@ -10,7 +10,10 @@ const props = {
     title: '',
     visible: false
   },
-  closeModal: () => {}
+  closeModal: () => {},
+  profile: {
+    healthTermsCurrent: true
+  }
 };
 
 describe('<HealthRecordsApp>', () => {


### PR DESCRIPTION
Fixes implementation of terms acceptance. 

Adds an endpoint that logged-in users can visit to activate themselves for the beta features. The beta features are all conditionalized on the backend, frontend code does not need to vary. 

The only area that's not super-accurate for beta vs. not is the error messages for e.g. an ineligible non-patient. 