### PR TITLE
Always display calendar picker below input regardless of scroll height.

### DIFF
--- a/src/js/health-records/containers/Main.jsx
+++ b/src/js/health-records/containers/Main.jsx
@@ -226,6 +226,7 @@ export class Main extends React.Component {
                     selected={startDate}
                     disabled={datePickerDisabled}
                     maxDate={endDate}
+                    tetherConstraints={[{ to: 'scrollParent', attachment: 'none' }]}
                     className={!datePickerDisabled && this.state.startDateError ? 'date-range-error' : ''}/>
                 <span>&nbsp;to&nbsp;</span>
                 <DatePicker
@@ -239,6 +240,7 @@ export class Main extends React.Component {
                     disabled={datePickerDisabled}
                     minDate={startDate}
                     maxDate={moment()}
+                    tetherConstraints={[{ to: 'scrollParent', attachment: 'none' }]}
                     className={!datePickerDisabled && this.state.endDateError ? 'date-range-error' : ''}/>
               </div>
             </div>


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#2809.

Apparently `react-datepicker` uses Tether, so I updated the `tetherConstraints` prop accordingly. http://tether.io/#constraints

Considered upgrading `react-datepicker` on the way, as it's up to 0.47.0 now, but it has a small font size that would require overriding in CSS to fix, so forwent it. The relevant props to the component haven't changed anyway.