### PR TITLE
Switch between health care urls

### DIFF
--- a/src/js/hca/hca-entry.jsx
+++ b/src/js/hca/hca-entry.jsx
@@ -16,10 +16,12 @@ require('../../sass/hca.scss');
 const store = createCommonStore(reducer);
 createLoginWidget(store);
 
-// Change the basename path once we replace hca with this form
-// (should be 'healthcare/appy/application')
+const folderName = window.location.pathname.indexOf('health-care/') >= 0
+  ? 'health-care'
+  : 'healthcare';
+
 const browserHistory = useRouterHistory(createHistory)({
-  basename: '/healthcare/apply/application'
+  basename: `/${folderName}/apply/application`
 });
 
 function init() {


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2981

The content team is going to be switching the health care urls from `healthcare` to `health-care`, which means the base url for hca needs to change. The change in here is what we did while we switched urls for the claim status app: checking the current url to see what's being used and match it.