### PR TITLE
Remove references to foundation-sites and jQuery

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -40,7 +40,6 @@ const configGenerator = (options) => {
   filesToBuild.vendor = [
     './src/js/common/polyfills',
     'history',
-    'jquery',
     'react',
     'react-dom',
     'react-redux',
@@ -168,8 +167,7 @@ const configGenerator = (options) => {
     },
     resolve: {
       alias: {
-        modernizr$: path.resolve(__dirname, './modernizrrc'),
-        jquery: 'jquery/src/jquery'
+        modernizr$: path.resolve(__dirname, './modernizrrc')
       },
       extensions: ['*', '.js', '.jsx']
     },
@@ -184,13 +182,6 @@ const configGenerator = (options) => {
           API_URL: process.env.API_URL ? JSON.stringify(process.env.API_URL) : null,
           BASE_URL: process.env.BASE_URL ? JSON.stringify(process.env.BASE_URL) : null,
         }
-      }),
-
-      // See http://stackoverflow.com/questions/28969861/managing-jquery-plugin-dependency-in-webpack
-      new webpack.ProvidePlugin({
-        $: 'jquery',
-        jQuery: 'jquery',
-        'window.jQuery': 'jquery'
       }),
 
       new ExtractTextPlugin({

--- a/src/js/no-react-entry.js
+++ b/src/js/no-react-entry.js
@@ -6,9 +6,6 @@ require('../sass/no-react.scss');
 
 require('./common');
 
-// Bring in foundation and custom libraries.
-require('foundation-sites');
-
 // Used in the footer.
 require('./legacy/menu.js');
 require('./common/utils/sticky-action-box.js');


### PR DESCRIPTION
Connects to department-of-veterans-affairs/vets.gov-team#2872

Steps kindly outlined by @jbalboni:

- Remove foundation-sites import from common js code.
- Remove all jquery references from webpack config.
- Take another pass through our codebase searching for $., $(, or jquery.
- Use webpack-bundle-analyzer or the Webpack analyzer site to verify that jquery is no longer in any of the bundles.
- Make sure unit/e2e tests pass, have people do manual testing on apps.