### PR TITLE
Hide states that don't have facilities

### DIFF
--- a/src/js/hca/config/form.js
+++ b/src/js/hca/config/form.js
@@ -41,6 +41,7 @@ import { validateServiceDates, validateMarriageDate } from '../validation';
 
 const childSchema = createChildSchema(fullSchemaHca);
 const childIncomeSchema = createChildIncomeSchema(fullSchemaHca);
+const emptyFacilityList = [];
 
 const {
   mothersMaidenName,
@@ -804,12 +805,12 @@ const formConfig = {
                     const state = _.get('view:preferredFacility.view:facilityState', form);
                     if (state) {
                       return {
-                        'enum': medicalCentersByState[state]
+                        'enum': medicalCentersByState[state] || emptyFacilityList
                       };
                     }
 
                     return {
-                      'enum': []
+                      'enum': emptyFacilityList
                     };
                   }
                 }
@@ -833,10 +834,12 @@ const formConfig = {
                 properties: {
                   'view:facilityState': {
                     type: 'string',
-                    'enum': states.USA.map(state => state.value)
+                    'enum': states.USA
+                      .map(state => state.value)
+                      .filter(state => !!medicalCentersByState[state])
                   },
                   vaMedicalFacility: _.assign(vaMedicalFacility, {
-                    'enum': []
+                    'enum': emptyFacilityList
                   })
                 }
               },


### PR DESCRIPTION
Sentry error: http://sentry.vetsgov-internal/vets-gov/website-production/issues/7246/
(There are several other related ones)

If you pick a state on the va facility page that doesn't have any facilities, we throw an error. They're stopped by validation and they can pick another state, but it's cluttering Sentry and it's likely confusing why we even show those states. This filters out those states without facilities (this is what the old HCA app was doing).