### PR TITLE
Clean up the hours on FL in cases where they look funny

### DIFF
--- a/src/js/facility-locator/components/FacilityHours.jsx
+++ b/src/js/facility-locator/components/FacilityHours.jsx
@@ -31,15 +31,34 @@ export default class FacilityHours extends Component {
       return null;
     }
 
-    const hourRows = Object.keys(hours).map(h => {
-      if (h !== 'notes' && hours[h] && hours[h] !== '') {
+    function colonizeTime(time) {
+      const found = time.match(/(\d?\d)(\d\d)(\w\w)/);
+      return `${found[1]}:${found[2]}${found[3]}`;
+    }
+
+    const mappedHours = {};
+    Object.keys(hours).forEach(k => {
+      mappedHours[k] = hours[k];
+      if (hours[k] === '-') {
+        mappedHours[k] = 'Closed';
+      } else if (hours[k]) {
+        const regex = /(\d+\w\w)-(\d+\w\w)/;
+        const found = hours[k].match(regex);
+        if (found) {
+          mappedHours[k] = `${colonizeTime(found[1])}-${colonizeTime(found[2])}`;
+        }
+      }
+    });
+
+    const hourRows = Object.keys(mappedHours).map(h => {
+      if (h !== 'notes' && mappedHours[h] && mappedHours[h] !== '') {
         return (
           <div className="row" key={h}>
             <div className="small-6 columns">
               {capitalize(h)}:
             </div>
             <div className="small-6 columns">
-              {capitalize(hours[h])}
+              {capitalize(mappedHours[h])}
             </div>
           </div>
         );


### PR DESCRIPTION
Closes #department-of-veterans-affairs/vets.gov-team/issues/3177

This finds cases where the hours are listed as "-" and replaces that with "Closed" and cases where they are listed like "800am-430pm" and puts colons in the hours for those. So it'll look like this:

<img width="329" alt="screen shot 2017-06-13 at 9 21 18 am" src="https://user-images.githubusercontent.com/2895/27084429-e57ecb82-5019-11e7-9bd2-caad5695caea.png">
