### PR TITLE
Add spouse marriage fields to pensions

### DIFF
--- a/src/js/common/schemaform/FieldTemplate.jsx
+++ b/src/js/common/schemaform/FieldTemplate.jsx
@@ -55,7 +55,10 @@ export default function FieldTemplate(props) {
     'usa-input-error form-error-date': isDateField && hasErrors
   });
 
-  return (schema.type === 'object' || schema.type === 'array' || (schema.type === 'boolean' && !uiSchema['ui:widget'])) && !showFieldLabel
+  return (schema.type === 'object'
+    || schema.type === 'array'
+    || (schema.type === 'boolean' && !uiSchema['ui:widget'])
+  ) && !showFieldLabel
     ? children
     : (<div className={containerClassNames}>
       <div className={errorClass}>

--- a/src/js/pensions/config/form.js
+++ b/src/js/pensions/config/form.js
@@ -800,16 +800,7 @@ const formConfig = {
           schema: {
             type: 'object',
             properties: {
-              spouseNetWorth: _.assign(netWorth, {
-                required: [
-                  'bank',
-                  'interestBank',
-                  'ira',
-                  'stocks',
-                  'realProperty',
-                  'otherProperty'
-                ]
-              })
+              spouseNetWorth: netWorth
             }
           },
           uiSchema: {
@@ -827,16 +818,7 @@ const formConfig = {
           schema: {
             type: 'object',
             properties: {
-              spouseMonthlyIncome: _.assign(monthlyIncome, {
-                required: [
-                  'socialSecurity',
-                  'civilService',
-                  'railroad',
-                  'blackLung',
-                  'serviceRetirement',
-                  'ssi'
-                ]
-              })
+              spouseMonthlyIncome: monthlyIncome
             }
           },
           uiSchema: {
@@ -854,13 +836,7 @@ const formConfig = {
           schema: {
             type: 'object',
             properties: {
-              spouseExpectedIncome: _.assign(expectedIncome, {
-                required: [
-                  'salary',
-                  'interest',
-                  'other'
-                ]
-              })
+              spouseExpectedIncome: expectedIncome
             }
           },
           uiSchema: {

--- a/src/js/pensions/config/form.js
+++ b/src/js/pensions/config/form.js
@@ -24,6 +24,7 @@ import phoneUI from '../../common/schemaform/definitions/phone';
 import fullNameUI from '../../common/schemaform/definitions/fullName';
 import dateRangeUI from '../../common/schemaform/definitions/dateRange';
 import ArrayCountWidget from '../../common/schemaform/widgets/ArrayCountWidget';
+import ssnUI from '../../common/schemaform/definitions/ssn';
 
 const {
   nationalGuardActivation,
@@ -35,6 +36,13 @@ const {
   placeOfSeparation,
   powDateRange,
   severancePay,
+  spouseDateOfBirth,
+  spouseSocialSecurityNumber,
+  spouseVaFileNumber,
+  liveWithSpouse,
+  reasonForNotLivingWithSpouse,
+  spouseIsVeteran,
+  monthlySpousePayment
 } = fullSchemaPensions.properties;
 
 const {
@@ -46,11 +54,17 @@ const {
   netWorth,
   maritalStatus,
   marriages,
-  expectedIncome
+  expectedIncome,
+  ssn,
+  vaFileNumber
 } = fullSchemaPensions.definitions;
 
 function isUnder65(formData) {
   return moment().startOf('day').subtract(65, 'years').isBefore(formData.veteranDateOfBirth);
+}
+
+function isMarried(form) {
+  return form.maritalStatus === 'Married';
 }
 
 function isCurrentMarriage(form, index) {
@@ -60,6 +74,41 @@ function isCurrentMarriage(form, index) {
 }
 
 const marriageProperties = marriages.items.properties;
+
+const marriageType = _.assign(marriageProperties.marriageType, {
+  'enum': [
+    'Ceremonial',
+    'Common-law',
+    'Proxy',
+    'Tribal',
+    'Other'
+  ]
+});
+
+const reasonForSeparation = _.assign(marriageProperties.reasonForSeparation, {
+  'enum': [
+    'Widowed',
+    'Divorced'
+  ]
+});
+
+function createSpouseLabelSelector(nameTemplate) {
+  return createSelector(form => {
+    return (form.marriages && form.marriages.length)
+      ? form.marriages[form.marriages.length - 1].spouseFullName
+      : null;
+  }, spouseFullName => {
+    if (spouseFullName) {
+      return {
+        title: nameTemplate(spouseFullName)
+      };
+    }
+
+    return {
+      title: null
+    };
+  });
+}
 
 const formConfig = {
   urlPrefix: '/527EZ/',
@@ -76,7 +125,9 @@ const formConfig = {
     date,
     dateRange,
     usaPhone,
-    fullName
+    fullName,
+    ssn,
+    vaFileNumber
   },
   chapters: {
     applicantInformation: {
@@ -465,29 +516,212 @@ const formConfig = {
                     spouseFullName: marriageProperties.spouseFullName,
                     dateOfMarriage: marriageProperties.dateOfMarriage,
                     locationOfMarriage: marriageProperties.locationOfMarriage,
-                    marriageType: _.assign(marriageProperties.marriageType, {
-                      'enum': [
-                        'Ceremonial',
-                        'Common-law',
-                        'Proxy',
-                        'Tribal',
-                        'Other'
-                      ]
-                    }),
+                    marriageType,
                     otherExplanation: marriageProperties.otherExplanation,
                     'view:pastMarriage': {
                       type: 'object',
                       properties: {
-                        reasonForSeparation: _.assign(marriageProperties.reasonForSeparation, {
-                          'enum': [
-                            'Widowed',
-                            'Divorced'
-                          ]
-                        }),
+                        reasonForSeparation,
                         dateOfSeparation: marriageProperties.dateOfSeparation,
                         locationOfSeparation: marriageProperties.locationOfSeparation
                       }
                     }
+                  }
+                }
+              }
+            }
+          }
+        },
+        spouseInfo: {
+          title: 'Spouse information',
+          path: 'household/spouse-info',
+          depends: isMarried,
+          uiSchema: {
+            'ui:title': 'Spouse information',
+            spouseDateOfBirth: _.merge(currentOrPastDateUI(''), {
+              'ui:options': {
+                updateSchema: createSpouseLabelSelector(spouseName =>
+                  `${spouseName.first} ${spouseName.last}’s date of birth`)
+              }
+            }),
+            spouseSocialSecurityNumber: _.merge(ssnUI, {
+              'ui:title': '',
+              'ui:options': {
+                updateSchema: createSpouseLabelSelector(spouseName =>
+                  `${spouseName.first} ${spouseName.last}’s Social Security number`)
+              }
+            }),
+            spouseIsVeteran: {
+              'ui:widget': 'yesNo',
+              'ui:options': {
+                updateSchema: createSpouseLabelSelector(spouseName =>
+                  `Is ${spouseName.first} ${spouseName.last} also a Veteran?`)
+              }
+            },
+            spouseVaFileNumber: {
+              'ui:title': 'What is their File Number?',
+              'ui:options': {
+                expandUnder: 'spouseIsVeteran'
+              },
+              'ui:required': form => form.spouseIsVeteran === true,
+              'ui:errorMessages': {
+                pattern: 'File number must be 8 digits'
+              }
+            },
+            liveWithSpouse: {
+              'ui:widget': 'yesNo',
+              'ui:options': {
+                updateSchema: createSpouseLabelSelector(spouseName =>
+                  `Do you live with ${spouseName.first} ${spouseName.last}?`)
+              }
+            },
+            spouseAddress: _.merge(address.uiSchema('Spouse address', false, form => form.liveWithSpouse === false),
+              {
+                'ui:options': {
+                  expandUnder: 'liveWithSpouse',
+                  expandUnderCondition: false
+                }
+              }
+            ),
+            reasonForNotLivingWithSpouse: {
+              'ui:title': 'What is the reason you do not live with your spouse?',
+              'ui:required': form => form.liveWithSpouse === false,
+              'ui:options': {
+                expandUnder: 'liveWithSpouse',
+                expandUnderCondition: false
+              }
+            },
+            monthlySpousePayment: {
+              // TODO: bold contribute monthly
+              'ui:title': 'How much do you contribute monthly to your spouse’s support?',
+              'ui:required': form => form.liveWithSpouse === false,
+              'ui:options': {
+                expandUnder: 'liveWithSpouse',
+                expandUnderCondition: false
+              }
+            },
+            'view:spousePreviousMarried': {
+              'ui:title': 'Has your spouse been married before?',
+              'ui:widget': 'yesNo'
+            },
+            spouseMarriages: {
+              'ui:title': 'How many times has your spouse been married before? (Not including current marriage)',
+              'ui:widget': ArrayCountWidget,
+              'ui:field': 'StringField',
+              'ui:required': form => !!form['view:spousePreviousMarried'],
+              'ui:options': {
+                showFieldLabel: true,
+                keepInPageOnReview: true,
+                expandUnder: 'view:spousePreviousMarried',
+              },
+              'ui:errorMessages': {
+                required: 'You must enter at least 1 marriage'
+              }
+            }
+          },
+          schema: {
+            type: 'object',
+            required: [
+              'spouseDateOfBirth',
+              'spouseSocialSecurityNumber',
+              'view:spousePreviousMarried',
+              'spouseIsVeteran',
+              'liveWithSpouse'
+            ],
+            properties: {
+              spouseDateOfBirth,
+              spouseSocialSecurityNumber,
+              spouseIsVeteran,
+              spouseVaFileNumber,
+              liveWithSpouse,
+              spouseAddress: address.schema(fullSchemaPensions),
+              reasonForNotLivingWithSpouse,
+              monthlySpousePayment,
+              'view:spousePreviousMarried': {
+                type: 'boolean'
+              },
+              spouseMarriages: marriages
+            }
+          }
+        },
+        spouseMarriageHistory: {
+          title: (form, { pagePerItemIndex }) => getMarriageTitle(pagePerItemIndex),
+          path: 'household/spouse-marriages/:index',
+          depends: isMarried,
+          showPagePerItem: true,
+          arrayPath: 'spouseMarriages',
+          uiSchema: {
+            spouseMarriages: {
+              items: {
+                'ui:title': MarriageTitle,
+                spouseFullName: _.merge(fullNameUI, {
+                  first: {
+                    'ui:title': 'Their spouse’s first name'
+                  },
+                  last: {
+                    'ui:title': 'Their spouse’s last name'
+                  },
+                  middle: {
+                    'ui:title': 'Their spouse’s middle name'
+                  },
+                  suffix: {
+                    'ui:title': 'Their spouse’s suffix',
+                  }
+                }),
+                dateOfMarriage: _.merge(currentOrPastDateUI(''), {
+                  'ui:options': {
+                    updateSchema: createSpouseLabelSelector(spouseName =>
+                      `Date of ${spouseName.first} ${spouseName.last}’s marriage`)
+                  }
+                }),
+                locationOfMarriage: {
+                  'ui:options': {
+                    updateSchema: createSpouseLabelSelector(spouseName =>
+                      `Place of ${spouseName.first} ${spouseName.last}’s marriage`)
+                  }
+                },
+                marriageType: {
+                  'ui:title': 'Type of marriage',
+                  'ui:widget': 'radio'
+                },
+                otherExplanation: {
+                  'ui:title': 'Please specify',
+                  'ui:required': (form, index) => {
+                    return _.get(['spouseMarriages', index, 'marriageType'], form) === 'Other';
+                  },
+                  'ui:options': {
+                    expandUnder: 'marriageType',
+                    expandUnderCondition: 'Other'
+                  }
+                },
+                reasonForSeparation: {
+                  'ui:title': 'Why did the marriage end?',
+                  'ui:widget': 'radio'
+                }
+              }
+            }
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              spouseMarriages: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: [
+                    'spouseFullName',
+                    'dateOfMarriage',
+                    'marriageType',
+                    'locationOfMarriage',
+                    'reasonForSeparation'
+                  ],
+                  properties: {
+                    dateOfMarriage: marriageProperties.dateOfMarriage,
+                    locationOfMarriage: marriageProperties.locationOfMarriage,
+                    spouseFullName: marriageProperties.spouseFullName,
+                    marriageType,
+                    otherExplanation: marriageProperties.otherExplanation,
+                    reasonForSeparation
                   }
                 }
               }
@@ -560,106 +794,79 @@ const formConfig = {
         spouseNetWorth: {
           path: 'financial-disclosure/net-worth/spouse',
           title: 'Spouse net worth',
-          // TODO: Update with spouse check
-          depends: () => true,
+          depends: isMarried,
           initialData: {
           },
           schema: {
             type: 'object',
             properties: {
-              spouseNetWorth: netWorth
+              spouseNetWorth: _.assign(netWorth, {
+                required: [
+                  'bank',
+                  'interestBank',
+                  'ira',
+                  'stocks',
+                  'realProperty',
+                  'otherProperty'
+                ]
+              })
             }
           },
           uiSchema: {
             'ui:title': createDisclosureTitle('spouseFullName', 'Net worth'),
             'ui:description': 'Bank accounts, investments, and property',
-            spouseNetWorth: _.merge(netWorthUI, {
-              // TODO Update with spouse check
-              bank: {
-                'ui:required': () => true
-              },
-              interestBank: {
-                'ui:required': () => true
-              },
-              ira: {
-                'ui:required': () => true
-              },
-              stocks: {
-                'ui:required': () => true
-              },
-              realProperty: {
-                'ui:required': () => true
-              },
-              otherProperty: {
-                'ui:required': () => true
-              }
-            })
+            spouseNetWorth: netWorthUI
           }
         },
         spouseMonthlyIncome: {
           path: 'financial-disclosure/monthly-income/spouse',
           title: 'Spouse monthly income',
-          depends: () => true,
+          depends: isMarried,
           initialData: {
           },
           schema: {
             type: 'object',
             properties: {
-              spouseMonthlyIncome: monthlyIncome
+              spouseMonthlyIncome: _.assign(monthlyIncome, {
+                required: [
+                  'socialSecurity',
+                  'civilService',
+                  'railroad',
+                  'blackLung',
+                  'serviceRetirement',
+                  'ssi'
+                ]
+              })
             }
           },
           uiSchema: {
             'ui:title': createDisclosureTitle('spouseFullName', 'Monthly income'),
             'ui:description': 'Social Security or other pensions',
-            spouseMonthlyIncome: _.merge(monthlyIncomeUI, {
-              // TODO Update with spouse check
-              socialSecurity: {
-                'ui:required': () => true
-              },
-              civilService: {
-                'ui:required': () => true
-              },
-              railroad: {
-                'ui:required': () => true
-              },
-              blackLung: {
-                'ui:required': () => true
-              },
-              serviceRetirement: {
-                'ui:required': () => true
-              },
-              ssi: {
-                'ui:required': () => true
-              }
-            })
+            spouseMonthlyIncome: monthlyIncomeUI
           }
         },
         spouseExpectedIncome: {
           path: 'financial-disclosure/expected-income/spouse',
           title: 'Spouse expected income',
-          depends: () => true,
+          depends: isMarried,
           initialData: {
           },
           schema: {
             type: 'object',
             properties: {
-              spouseExpectedIncome: expectedIncome
+              spouseExpectedIncome: _.assign(expectedIncome, {
+                required: [
+                  'salary',
+                  'interest',
+                  'other'
+                ]
+              })
             }
           },
           uiSchema: {
             'ui:title': createDisclosureTitle('spouseFullName', 'Expected income'),
             'ui:description': 'Any income you expect your spouse to receive in the next 12 months',
-            spouseExpectedIncome: _.merge(expectedIncomeUI, {
-              salary: {
-                'ui:required': () => true
-              },
-              interest: {
-                'ui:required': () => true
-              },
-              other: {
-                'ui:required': () => true
-              }
-            })
+            spouseExpectedIncome: expectedIncomeUI
           }
         },
         dependentsNetWorth: {

--- a/src/js/pensions/config/form.js
+++ b/src/js/pensions/config/form.js
@@ -6,7 +6,7 @@ import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
 
 import * as address from '../../common/schemaform/definitions/address';
 import applicantInformation from '../../common/schemaform/pages/applicantInformation';
-import { transform, employmentDescription, getMarriageTitle } from '../helpers';
+import { transform, employmentDescription, getMarriageTitle, spouseContribution } from '../helpers';
 import IntroductionPage from '../components/IntroductionPage';
 import DisabilityField from '../components/DisabilityField';
 import MarriageTitle from '../components/MarriageTitle';
@@ -592,8 +592,7 @@ const formConfig = {
               }
             },
             monthlySpousePayment: {
-              // TODO: bold contribute monthly
-              'ui:title': 'How much do you contribute monthly to your spouse’s support?',
+              'ui:title': spouseContribution,
               'ui:required': form => form.liveWithSpouse === false,
               'ui:options': {
                 expandUnder: 'liveWithSpouse',

--- a/src/js/pensions/helpers.jsx
+++ b/src/js/pensions/helpers.jsx
@@ -28,3 +28,5 @@ export function getMarriageTitle(index) {
 
   return desc ? `${desc} marriage` : `Marriage ${index + 1}`;
 }
+
+export const spouseContribution = <span>How much do you <strong>contribute monthly</strong> to your spouse’s support?</span>;

--- a/test/pensions/config/marriageHistory.unit.spec.jsx
+++ b/test/pensions/config/marriageHistory.unit.spec.jsx
@@ -1,19 +1,10 @@
 import React from 'react';
-import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
+import { DefinitionTester, submitForm, getFormDOM } from '../../util/schemaform-utils.jsx';
 import formConfig from '../../../src/js/pensions/config/form';
-
-function fillData(formDOM, id, value) {
-  ReactTestUtils.Simulate.change(formDOM.querySelector(id), {
-    target: {
-      value
-    }
-  });
-}
 
 describe('Pensions marriage history', () => {
   const marriageHistory = formConfig.chapters.householdInformation.pages.marriageHistory;
@@ -27,7 +18,7 @@ describe('Pensions marriage history', () => {
           definitions={formConfig.defaultDefinitions}
           uiSchema={uiSchema}/>
     );
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
     expect(formDOM.querySelectorAll('input,select').length).to.equal(19);
   });
@@ -82,7 +73,7 @@ describe('Pensions marriage history', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
     submitForm(form);
 
@@ -100,21 +91,21 @@ describe('Pensions marriage history', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    fillData(formDOM, '#root_spouseFullName_first', 'test');
-    fillData(formDOM, '#root_spouseFullName_last', 'test');
-    fillData(formDOM, '#root_dateOfMarriageMonth', '3');
-    fillData(formDOM, '#root_dateOfMarriageDay', '3');
-    fillData(formDOM, '#root_dateOfMarriageYear', '2001');
-    fillData(formDOM, '#root_locationOfMarriage', 'The Pacific');
-    fillData(formDOM, '#root_marriageType_4', 'Other');
-    fillData(formDOM, '#root_otherExplanation', 'Something');
-    fillData(formDOM, '#root_view\\:pastMarriage_reasonForSeparation_1', 'Divorced');
-    fillData(formDOM, '#root_view\\:pastMarriage_dateOfSeparationMonth', '3');
-    fillData(formDOM, '#root_view\\:pastMarriage_dateOfSeparationDay', '3');
-    fillData(formDOM, '#root_view\\:pastMarriage_dateOfSeparationYear', '2001');
-    fillData(formDOM, '#root_view\\:pastMarriage_locationOfSeparation', 'The Atlantic');
+    formDOM.fillData('#root_spouseFullName_first', 'test');
+    formDOM.fillData('#root_spouseFullName_last', 'test');
+    formDOM.fillData('#root_dateOfMarriageMonth', '3');
+    formDOM.fillData('#root_dateOfMarriageDay', '3');
+    formDOM.fillData('#root_dateOfMarriageYear', '2001');
+    formDOM.fillData('#root_locationOfMarriage', 'The Pacific');
+    formDOM.fillData('#root_marriageType_4', 'Other');
+    formDOM.fillData('#root_otherExplanation', 'Something');
+    formDOM.fillData('#root_view\\:pastMarriage_reasonForSeparation_1', 'Divorced');
+    formDOM.fillData('#root_view\\:pastMarriage_dateOfSeparationMonth', '3');
+    formDOM.fillData('#root_view\\:pastMarriage_dateOfSeparationDay', '3');
+    formDOM.fillData('#root_view\\:pastMarriage_dateOfSeparationYear', '2001');
+    formDOM.fillData('#root_view\\:pastMarriage_locationOfSeparation', 'The Atlantic');
 
     submitForm(form);
 

--- a/test/pensions/config/marriageInfo.unit.spec.jsx
+++ b/test/pensions/config/marriageInfo.unit.spec.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
+import formConfig from '../../../src/js/pensions/config/form';
+
+function fillData(formDOM, id, value) {
+  ReactTestUtils.Simulate.change(formDOM.querySelector(id), {
+    target: {
+      value
+    }
+  });
+}
+
+describe('Pensions marriage info', () => {
+  const { schema, uiSchema } = formConfig.chapters.householdInformation.pages.marriageInfo;
+
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(5);
+  });
+
+  it('should render marriage count', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          onSubmit={onSubmit}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    fillData(formDOM, '#root_maritalStatus_0', 'Married');
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(6);
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should not submit empty form', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should submit with valid data', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    fillData(formDOM, '#root_maritalStatus_1', 'Never Married');
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+});

--- a/test/pensions/config/marriageInfo.unit.spec.jsx
+++ b/test/pensions/config/marriageInfo.unit.spec.jsx
@@ -1,19 +1,10 @@
 import React from 'react';
-import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
+import { DefinitionTester, submitForm, getFormDOM } from '../../util/schemaform-utils.jsx';
 import formConfig from '../../../src/js/pensions/config/form';
-
-function fillData(formDOM, id, value) {
-  ReactTestUtils.Simulate.change(formDOM.querySelector(id), {
-    target: {
-      value
-    }
-  });
-}
 
 describe('Pensions marriage info', () => {
   const { schema, uiSchema } = formConfig.chapters.householdInformation.pages.marriageInfo;
@@ -25,7 +16,7 @@ describe('Pensions marriage info', () => {
           definitions={formConfig.defaultDefinitions}
           uiSchema={uiSchema}/>
     );
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
     expect(formDOM.querySelectorAll('input,select').length).to.equal(5);
   });
@@ -39,9 +30,9 @@ describe('Pensions marriage info', () => {
           definitions={formConfig.defaultDefinitions}
           uiSchema={uiSchema}/>
     );
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    fillData(formDOM, '#root_maritalStatus_0', 'Married');
+    formDOM.fillData('#root_maritalStatus_0', 'Married');
 
     submitForm(form);
 
@@ -60,7 +51,7 @@ describe('Pensions marriage info', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
     submitForm(form);
 
@@ -78,9 +69,9 @@ describe('Pensions marriage info', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    fillData(formDOM, '#root_maritalStatus_1', 'Never Married');
+    formDOM.fillData('#root_maritalStatus_1', 'Never Married');
 
     submitForm(form);
 

--- a/test/pensions/config/spouseMarriageHistory.unit.spec.jsx
+++ b/test/pensions/config/spouseMarriageHistory.unit.spec.jsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
+import formConfig from '../../../src/js/pensions/config/form';
+
+function fillData(formDOM, id, value) {
+  ReactTestUtils.Simulate.change(formDOM.querySelector(id), {
+    target: {
+      value
+    }
+  });
+}
+
+describe('Pensions spouse marriage history', () => {
+  const marriageHistory = formConfig.chapters.householdInformation.pages.spouseMarriageHistory;
+  const uiSchema = marriageHistory.uiSchema.spouseMarriages.items;
+  const schema = marriageHistory.schema.properties.spouseMarriages.items;
+  const depends = marriageHistory.depends;
+
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(15);
+  });
+
+  it('should render labels with spouse name', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{
+            marriages: [{
+              spouseFullName: {
+                first: 'Jane',
+                last: 'Doe'
+              }
+            }]
+          }}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelector('label[for="root_dateOfMarriage"]').textContent).to.contain('Jane Doe');
+    expect(formDOM.querySelector('label[for="root_locationOfMarriage"]').textContent).to.contain('Jane Doe');
+  });
+
+  describe('page title', () => {
+    const pageTitle = marriageHistory.title;
+    it('uses word for index', () => {
+      expect(pageTitle({}, { pagePerItemIndex: 0 })).to.equal('First marriage');
+    });
+    it('uses number when at index ten or greater', () => {
+      expect(pageTitle({}, { pagePerItemIndex: 10 })).to.equal('Marriage 11');
+    });
+  });
+
+  it('should not submit empty form', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(6);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should submit with valid data', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    fillData(formDOM, '#root_spouseFullName_first', 'test');
+    fillData(formDOM, '#root_spouseFullName_last', 'test');
+    fillData(formDOM, '#root_dateOfMarriageMonth', '3');
+    fillData(formDOM, '#root_dateOfMarriageDay', '3');
+    fillData(formDOM, '#root_dateOfMarriageYear', '2001');
+    fillData(formDOM, '#root_locationOfMarriage', 'The Pacific');
+    fillData(formDOM, '#root_marriageType_4', 'Other');
+    fillData(formDOM, '#root_otherExplanation', 'Something');
+    fillData(formDOM, '#root_reasonForSeparation_1', 'Divorced');
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+
+  it('depends should return true if married', () => {
+    const result = depends({ maritalStatus: 'Married' });
+
+    expect(result).to.be.true;
+  });
+});

--- a/test/pensions/config/spouseMarriageHistory.unit.spec.jsx
+++ b/test/pensions/config/spouseMarriageHistory.unit.spec.jsx
@@ -1,19 +1,10 @@
 import React from 'react';
-import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
+import { DefinitionTester, submitForm, getFormDOM } from '../../util/schemaform-utils.jsx';
 import formConfig from '../../../src/js/pensions/config/form';
-
-function fillData(formDOM, id, value) {
-  ReactTestUtils.Simulate.change(formDOM.querySelector(id), {
-    target: {
-      value
-    }
-  });
-}
 
 describe('Pensions spouse marriage history', () => {
   const marriageHistory = formConfig.chapters.householdInformation.pages.spouseMarriageHistory;
@@ -28,7 +19,7 @@ describe('Pensions spouse marriage history', () => {
           definitions={formConfig.defaultDefinitions}
           uiSchema={uiSchema}/>
     );
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
     expect(formDOM.querySelectorAll('input,select').length).to.equal(15);
   });
@@ -48,7 +39,7 @@ describe('Pensions spouse marriage history', () => {
           definitions={formConfig.defaultDefinitions}
           uiSchema={uiSchema}/>
     );
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
     expect(formDOM.querySelector('label[for="root_dateOfMarriage"]').textContent).to.contain('Jane Doe');
     expect(formDOM.querySelector('label[for="root_locationOfMarriage"]').textContent).to.contain('Jane Doe');
@@ -74,7 +65,7 @@ describe('Pensions spouse marriage history', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
     submitForm(form);
 
@@ -92,17 +83,17 @@ describe('Pensions spouse marriage history', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    fillData(formDOM, '#root_spouseFullName_first', 'test');
-    fillData(formDOM, '#root_spouseFullName_last', 'test');
-    fillData(formDOM, '#root_dateOfMarriageMonth', '3');
-    fillData(formDOM, '#root_dateOfMarriageDay', '3');
-    fillData(formDOM, '#root_dateOfMarriageYear', '2001');
-    fillData(formDOM, '#root_locationOfMarriage', 'The Pacific');
-    fillData(formDOM, '#root_marriageType_4', 'Other');
-    fillData(formDOM, '#root_otherExplanation', 'Something');
-    fillData(formDOM, '#root_reasonForSeparation_1', 'Divorced');
+    formDOM.fillData('#root_spouseFullName_first', 'test');
+    formDOM.fillData('#root_spouseFullName_last', 'test');
+    formDOM.fillData('#root_dateOfMarriageMonth', '3');
+    formDOM.fillData('#root_dateOfMarriageDay', '3');
+    formDOM.fillData('#root_dateOfMarriageYear', '2001');
+    formDOM.fillData('#root_locationOfMarriage', 'The Pacific');
+    formDOM.fillData('#root_marriageType_4', 'Other');
+    formDOM.fillData('#root_otherExplanation', 'Something');
+    formDOM.fillData('#root_reasonForSeparation_1', 'Divorced');
 
     submitForm(form);
 

--- a/test/pensions/config/spouseMarriageInfo.unit.spec.jsx
+++ b/test/pensions/config/spouseMarriageInfo.unit.spec.jsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
+import formConfig from '../../../src/js/pensions/config/form';
+
+function fillData(formDOM, id, value) {
+  ReactTestUtils.Simulate.change(formDOM.querySelector(id), {
+    target: {
+      value
+    }
+  });
+}
+
+describe('Pensions spouse info', () => {
+  const { schema, uiSchema, depends } = formConfig.chapters.householdInformation.pages.spouseInfo;
+
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{
+            marriages: [{
+              spouseFullName: {
+                first: 'Jane',
+                last: 'Doe'
+              }
+            }]
+          }}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
+    expect(formDOM.querySelector('label[for="root_spouseDateOfBirth"]').textContent).to.contain('Jane Doe');
+    expect(formDOM.querySelector('label[for="root_spouseSocialSecurityNumber"]').textContent).to.contain('Jane Doe');
+  });
+
+  it('should render spouse address and contrib fields', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{
+            marriages: [{
+              spouseFullName: {
+                first: 'Jane',
+                last: 'Doe'
+              }
+            }]
+          }}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
+
+    fillData(formDOM, '#root_liveWithSpouseNo', 'N');
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(18);
+
+    submitForm(form);
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(10);
+  });
+
+  it('should render file number', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{
+            marriages: [{
+              spouseFullName: {
+                first: 'Jane',
+                last: 'Doe'
+              }
+            }]
+          }}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
+
+    fillData(formDOM, '#root_spouseIsVeteranYes', 'Y');
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(11);
+  });
+
+  it('should render marriage count', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{
+            marriages: [{
+              spouseFullName: {
+                first: 'Jane',
+                last: 'Doe'
+              }
+            }]
+          }}
+          onSubmit={onSubmit}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = findDOMNode(form);
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
+
+    fillData(formDOM, '#root_view\\:spousePreviousMarriedYes', 'Y');
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(11);
+
+    submitForm(form);
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(5);
+  });
+
+  it('should not submit empty form', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(5);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should submit with valid data', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = findDOMNode(form);
+
+    fillData(formDOM, '#root_spouseDateOfBirthMonth', '2');
+    fillData(formDOM, '#root_spouseDateOfBirthDay', '2');
+    fillData(formDOM, '#root_spouseDateOfBirthYear', '2000');
+    fillData(formDOM, '#root_spouseSocialSecurityNumber', '234432444');
+    fillData(formDOM, '#root_spouseIsVeteranNo', 'N');
+    fillData(formDOM, '#root_liveWithSpouseYes', 'Y');
+    fillData(formDOM, '#root_view\\:spousePreviousMarriedNo', 'N');
+
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+
+  it('depends should return true if married', () => {
+    const result = depends({ maritalStatus: 'Married' });
+
+    expect(result).to.be.true;
+  });
+});

--- a/test/pensions/config/spouseMarriageInfo.unit.spec.jsx
+++ b/test/pensions/config/spouseMarriageInfo.unit.spec.jsx
@@ -1,19 +1,10 @@
 import React from 'react';
-import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
+import { DefinitionTester, submitForm, getFormDOM } from '../../util/schemaform-utils.jsx';
 import formConfig from '../../../src/js/pensions/config/form';
-
-function fillData(formDOM, id, value) {
-  ReactTestUtils.Simulate.change(formDOM.querySelector(id), {
-    target: {
-      value
-    }
-  });
-}
 
 describe('Pensions spouse info', () => {
   const { schema, uiSchema, depends } = formConfig.chapters.householdInformation.pages.spouseInfo;
@@ -33,7 +24,7 @@ describe('Pensions spouse info', () => {
           definitions={formConfig.defaultDefinitions}
           uiSchema={uiSchema}/>
     );
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
     expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
     expect(formDOM.querySelector('label[for="root_spouseDateOfBirth"]').textContent).to.contain('Jane Doe');
@@ -55,11 +46,11 @@ describe('Pensions spouse info', () => {
           definitions={formConfig.defaultDefinitions}
           uiSchema={uiSchema}/>
     );
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
     expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
 
-    fillData(formDOM, '#root_liveWithSpouseNo', 'N');
+    formDOM.fillData('#root_liveWithSpouseNo', 'N');
 
     expect(formDOM.querySelectorAll('input,select').length).to.equal(18);
 
@@ -82,11 +73,11 @@ describe('Pensions spouse info', () => {
           definitions={formConfig.defaultDefinitions}
           uiSchema={uiSchema}/>
     );
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
     expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
 
-    fillData(formDOM, '#root_spouseIsVeteranYes', 'Y');
+    formDOM.fillData('#root_spouseIsVeteranYes', 'Y');
 
     expect(formDOM.querySelectorAll('input,select').length).to.equal(11);
   });
@@ -108,11 +99,11 @@ describe('Pensions spouse info', () => {
           definitions={formConfig.defaultDefinitions}
           uiSchema={uiSchema}/>
     );
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
     expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
 
-    fillData(formDOM, '#root_view\\:spousePreviousMarriedYes', 'Y');
+    formDOM.fillData('#root_view\\:spousePreviousMarriedYes', 'Y');
 
     expect(formDOM.querySelectorAll('input,select').length).to.equal(11);
 
@@ -130,7 +121,7 @@ describe('Pensions spouse info', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
     submitForm(form);
 
@@ -148,15 +139,15 @@ describe('Pensions spouse info', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    fillData(formDOM, '#root_spouseDateOfBirthMonth', '2');
-    fillData(formDOM, '#root_spouseDateOfBirthDay', '2');
-    fillData(formDOM, '#root_spouseDateOfBirthYear', '2000');
-    fillData(formDOM, '#root_spouseSocialSecurityNumber', '234432444');
-    fillData(formDOM, '#root_spouseIsVeteranNo', 'N');
-    fillData(formDOM, '#root_liveWithSpouseYes', 'Y');
-    fillData(formDOM, '#root_view\\:spousePreviousMarriedNo', 'N');
+    formDOM.fillData('#root_spouseDateOfBirthMonth', '2');
+    formDOM.fillData('#root_spouseDateOfBirthDay', '2');
+    formDOM.fillData('#root_spouseDateOfBirthYear', '2000');
+    formDOM.fillData('#root_spouseSocialSecurityNumber', '234432444');
+    formDOM.fillData('#root_spouseIsVeteranNo', 'N');
+    formDOM.fillData('#root_liveWithSpouseYes', 'Y');
+    formDOM.fillData('#root_view\\:spousePreviousMarriedNo', 'N');
 
     submitForm(form);
 

--- a/test/util/schemaform-utils.jsx
+++ b/test/util/schemaform-utils.jsx
@@ -3,6 +3,7 @@ import Form from 'react-jsonschema-form';
 import ReactTestUtils from 'react-dom/test-utils';
 
 import React from 'react';
+import { findDOMNode } from 'react-dom';
 import SchemaForm from '../../src/js/common/schemaform/SchemaForm';
 
 import {
@@ -78,4 +79,22 @@ export function submitForm(form) {
   ReactTestUtils.findRenderedComponentWithType(form, Form).onSubmit({
     preventDefault: f => f
   });
+}
+
+export function getFormDOM(form) {
+  const formDOM = findDOMNode(form);
+
+  formDOM.fillData = function fillData(id, value) {
+    ReactTestUtils.Simulate.change(this.querySelector(id), {
+      target: {
+        value
+      }
+    });
+  };
+
+  formDOM.submitForm = () => {
+    submitForm(form);
+  };
+
+  return formDOM;
 }


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3195

Adds spouse marriage pages, pretty similarly to the regular marriage pages.

I also updated the spouse financials pages to have a proper married check and added some missing tests from the regular marriage pages.

This form is huge.

![screen shot 2017-06-13 at 4 27 53 pm](https://user-images.githubusercontent.com/634932/27103063-6b6ede72-5055-11e7-9134-2a15530ad56e.png)
![screen shot 2017-06-13 at 4 28 21 pm](https://user-images.githubusercontent.com/634932/27103065-6b7065e4-5055-11e7-94ac-8e7830b9bc33.png)
![screen shot 2017-06-13 at 4 28 30 pm](https://user-images.githubusercontent.com/634932/27103066-6b74010e-5055-11e7-9ae5-2f590026f240.png)
![screen shot 2017-06-13 at 4 29 07 pm](https://user-images.githubusercontent.com/634932/27103062-6b6e1e38-5055-11e7-96f1-29d1637da2b8.png)
![screen shot 2017-06-13 at 4 28 51 pm](https://user-images.githubusercontent.com/634932/27103064-6b6eda08-5055-11e7-83cf-2e8a7196e57e.png)
![screen shot 2017-06-13 at 4 28 59 pm](https://user-images.githubusercontent.com/634932/27103067-6b749434-5055-11e7-8084-52efe4453c1c.png)



