### PR TITLE
Display fixes for FL wait time section

### DIFF
--- a/src/js/facility-locator/components/AppointmentInfo.jsx
+++ b/src/js/facility-locator/components/AppointmentInfo.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import pluralize from 'pluralize';
-import { startCase } from 'lodash';
+import { pull, startCase } from 'lodash';
 import classNames from 'classnames';
 
 export default class AppointmentInfo extends Component {
@@ -26,7 +26,9 @@ export default class AppointmentInfo extends Component {
 
     const healthAccessAttrs = facility.attributes.access.health;
     const specialtyKeys = healthAccessAttrs && Object.keys(healthAccessAttrs);
-    delete specialtyKeys.primaryCare;
+    pull(specialtyKeys, 'primaryCare');
+    pull(specialtyKeys, 'effectiveDate');
+    specialtyKeys.sort();
 
     if (specialtyKeys && specialtyKeys.length === 0) {
       return null;
@@ -68,7 +70,7 @@ export default class AppointmentInfo extends Component {
           <div>
             {this.state[showHideKey] && <div>
               {lastToEnd.map(k => {
-                return renderStat(startCase(k.replace(/([A-Z])/g, ' $1')), healthAccessAttrs[k][existing ? 'existing' : 'new']);
+                return renderStat(startCase(k.replace(/([A-Z])/g, ' $1')), healthAccessAttrs[k][existing ? 'established' : 'new']);
               })}
             </div>}
             <a onClick={onClick} className={seeMoreClasses}>See {this.state[showHideKey] ? 'less' : 'more'}</a>
@@ -81,9 +83,9 @@ export default class AppointmentInfo extends Component {
           Specialty care:
           <ul>
             {firstThree.map(k => {
-              return renderStat(startCase(k.replace(/([A-Z])/g, ' $1')), healthAccessAttrs[k][existing ? 'existing' : 'new']);
+              return renderStat(startCase(k.replace(/([A-Z])/g, ' $1')), healthAccessAttrs[k][existing ? 'established' : 'new']);
             })}
-            {renderMoreTimes()}
+            {(lastToEnd.length > 0) && renderMoreTimes()}
           </ul>
         </li>
       );
@@ -100,11 +102,11 @@ export default class AppointmentInfo extends Component {
             {renderSpecialtyTimes()}
           </ul>
         </div>
-        {healthAccessAttrs.primaryCare.existing && <div className="mb2">
+        {healthAccessAttrs.primaryCare.established && <div className="mb2">
           <h4>Existing patient wait times</h4>
           <p>The average number of days a patient who has already been to this location has to wait for a non-urgent appointment.</p>
           <ul>
-            {renderStat('Primary Care', healthAccessAttrs.primaryCare.existing)}
+            {renderStat('Primary Care', healthAccessAttrs.primaryCare.established)}
             {renderSpecialtyTimes(true)}
           </ul>
         </div>}

--- a/src/js/facility-locator/components/SearchControls.jsx
+++ b/src/js/facility-locator/components/SearchControls.jsx
@@ -1,6 +1,6 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { truncate } from 'lodash';
+import { truncate, kebabCase } from 'lodash';
 import { updateSearchQuery } from '../actions';
 import React, { Component } from 'react';
 import { benefitsServices, facilityTypes } from '../config';
@@ -30,7 +30,7 @@ class SearchControls extends Component {
   handleFilterChange = (e) => {
     const { facilityType } = this.props.currentQuery;
 
-    if (facilityType === 'va_benefits_facility' && e.target.value === 'All') {
+    if (facilityType === 'benefits' && e.target.value === 'All') {
       this.props.updateSearchQuery({
         [e.target.name]: null,
       });
@@ -44,7 +44,7 @@ class SearchControls extends Component {
   handleServiceFilterSelect(serviceType) {
     const { facilityType } = this.props.currentQuery;
 
-    if (facilityType === 'va_benefits_facility' && serviceType === 'All') {
+    if (facilityType === 'benefits' && serviceType === 'All') {
       this.props.updateSearchQuery({
         serviceType: null,
       });
@@ -77,7 +77,7 @@ class SearchControls extends Component {
 
   toggleServiceDropdown() {
     const { currentQuery: { facilityType } } = this.props;
-    if (facilityType === 'va_benefits_facility') {
+    if (facilityType === 'benefits') {
       this.setState({
         serviceDropdownActive: !this.state.serviceDropdownActive,
         facilityDropdownActive: false,
@@ -87,7 +87,7 @@ class SearchControls extends Component {
 
   handleFacilityFilterSelect(facilityType) {
     return () => {
-      if (facilityType === 'va_benefits_facility') {
+      if (facilityType === 'benefits') {
         this.props.updateSearchQuery({
           facilityType,
         });
@@ -104,7 +104,7 @@ class SearchControls extends Component {
     const { currentQuery: { facilityType } } = this.props;
 
     switch (facilityType) {
-      case 'va_benefits_facility':
+      case 'benefits':
         return (
           <ul className="dropdown">
             {
@@ -127,19 +127,10 @@ class SearchControls extends Component {
   }
 
   renderSelectOptionWithIcon(facilityType) {
-    /* eslint-disable camelcase */
-    const classMappings = {
-      va_health_facility: 'health',
-      va_cemetery: 'cemetery',
-      va_benefits_facility: 'benefits',
-      vet_center: 'vet-center',
-    };
-    /* eslint-enable camelcase */
-
     if (facilityType) {
       return (
         <button type="button" className="facility-option">
-          <span className="flex-center"><span className={`legend ${classMappings[facilityType]}-icon`}></span>{facilityTypes[facilityType]}</span>
+          <span className="flex-center"><span className={`legend ${kebabCase(facilityType)}-icon`}></span>{facilityTypes[facilityType]}</span>
         </button>
       );
     }
@@ -195,16 +186,16 @@ class SearchControls extends Component {
               </div>
               <ul className="dropdown">
                 <li onClick={this.handleFacilityFilterSelect()}>{this.renderSelectOptionWithIcon()}</li>
-                <li onClick={this.handleFacilityFilterSelect('va_health_facility')}>{this.renderSelectOptionWithIcon('va_health_facility')}</li>
-                <li onClick={this.handleFacilityFilterSelect('va_benefits_facility')}>{this.renderSelectOptionWithIcon('va_benefits_facility')}</li>
-                <li onClick={this.handleFacilityFilterSelect('va_cemetery')}>{this.renderSelectOptionWithIcon('va_cemetery')}</li>
+                <li onClick={this.handleFacilityFilterSelect('health')}>{this.renderSelectOptionWithIcon('health')}</li>
+                <li onClick={this.handleFacilityFilterSelect('benefits')}>{this.renderSelectOptionWithIcon('benefits')}</li>
+                <li onClick={this.handleFacilityFilterSelect('cemetery')}>{this.renderSelectOptionWithIcon('cemetery')}</li>
                 <li onClick={this.handleFacilityFilterSelect('vet_center')}>{this.renderSelectOptionWithIcon('vet_center')}</li>
               </ul>
             </div>
           </div>
           <div className="columns usa-width-one-fourth medium-3">
             <label htmlFor="serviceType">Select Service Type</label>
-            <div tabIndex="2" className={`facility-dropdown-wrapper ${serviceDropdownActive ? 'active' : ''} ${currentQuery.facilityType === 'va_benefits_facility' ? '' : 'disabled'}`} onClick={this.toggleServiceDropdown}>
+            <div tabIndex="2" className={`facility-dropdown-wrapper ${serviceDropdownActive ? 'active' : ''} ${currentQuery.facilityType === 'benefits' ? '' : 'disabled'}`} onClick={this.toggleServiceDropdown}>
               <div className="flex-center">
                 {this.renderServiceSelectOption(currentQuery.serviceType)}
               </div>

--- a/src/js/facility-locator/config.js
+++ b/src/js/facility-locator/config.js
@@ -16,6 +16,9 @@ export const facilityTypes = {
   va_cemetery: 'Cemetery',
   va_benefits_facility: 'Benefits',
   vet_center: 'Vet Center',
+  health: 'Health',
+  cemetery: 'Cemetery',
+  benefits: 'Benefits',
 };
 /* eslint-enable camelcase */
 


### PR DESCRIPTION
- Removes Primary Care from being duplicated under Specialty care subhead
- Allows established patient wait times to show by fixing key lookup (`existing` -> `established`)
- Avoids showing "See more" unless there are more elements to show.
- Alphabetizes specialty care categories for consistent ordering.