### PR TITLE
Gracefully handle no data e.g. due to running against old API

### DIFF
--- a/src/js/facility-locator/components/AppointmentInfo.jsx
+++ b/src/js/facility-locator/components/AppointmentInfo.jsx
@@ -25,11 +25,8 @@ export default class AppointmentInfo extends Component {
     }
 
     const healthAccessAttrs = facility.attributes.access.health;
-    const specialtyKeys = healthAccessAttrs && Object.keys(healthAccessAttrs);
-    pull(specialtyKeys, 'primaryCare', 'effectiveDate');
-    specialtyKeys.sort();
 
-    if (specialtyKeys && specialtyKeys.length === 0) {
+    if (!healthAccessAttrs.primaryCare || !healthAccessAttrs.primaryCare.new) {
       return null;
     }
 
@@ -44,6 +41,14 @@ export default class AppointmentInfo extends Component {
     };
 
     const renderSpecialtyTimes = (existing = false) => {
+      const specialtyKeys = healthAccessAttrs && Object.keys(healthAccessAttrs);
+      pull(specialtyKeys, 'primaryCare', 'effectiveDate');
+      specialtyKeys.sort();
+
+      if (specialtyKeys && specialtyKeys.length === 0) {
+        return null;
+      }
+
       const firstThree = specialtyKeys.slice(0, 3);
       const lastToEnd = specialtyKeys.slice(3);
       let showHideKey;


### PR DESCRIPTION
Replaces #5749. Allows facility detail page to render even if running against old API. Tested locally by downgrading my local vets-api. 