### PR TITLE
Fix future date message check in current data validation

### DIFF
--- a/src/js/common/schemaform/validation.js
+++ b/src/js/common/schemaform/validation.js
@@ -214,11 +214,12 @@ export function validateDate(errors, dateString) {
  *
  * The message it adds can be customized in uiSchema.errorMessages.futureDate
  */
-export function validateCurrentOrPastDate(errors, dateString, formData, schema, errorMessages) {
+export function validateCurrentOrPastDate(errors, dateString, formData, schema, errorMessages = {}) {
+  const { futureDate = 'Please provide a valid current or past date' } = errorMessages;
   validateDate(errors, dateString);
   const { day, month, year } = parseISODate(dateString);
   if (!isValidCurrentOrPastDate(day, month, year)) {
-    errors.addError(errorMessages.futureDate || 'Please provide a valid current or past date');
+    errors.addError(futureDate);
   }
 }
 

--- a/test/common/schemaform/validation.unit.spec.js
+++ b/test/common/schemaform/validation.unit.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import moment from 'moment';
 import sinon from 'sinon';
 
 import {
@@ -6,6 +7,7 @@ import {
   uiSchemaValidate,
   validateSSN,
   validateDate,
+  validateCurrentOrPastDate,
   validateMatch,
   validateDateRange,
   validateFileField
@@ -239,6 +241,24 @@ describe('Schemaform validations', () => {
       validateDate(errors, 'asdf-01-03');
 
       expect(errors.addError.callCount).to.equal(1);
+    });
+  });
+  describe('validateCurrentOrPastDate', () => {
+    it('should set message if invalid', () => {
+      const errors = { addError: sinon.spy() };
+      const futureDate = moment().add(2, 'year').format('YYYY-MM-DD');
+      validateCurrentOrPastDate(errors, futureDate);
+
+      expect(errors.addError.callCount).to.equal(1);
+      expect(errors.addError.firstCall.args[0]).to.equal('Please provide a valid current or past date');
+    });
+    it('should use custom message', () => {
+      const errors = { addError: sinon.spy() };
+      const futureDate = moment().add(2, 'year').format('YYYY-MM-DD');
+      validateCurrentOrPastDate(errors, futureDate, null, null, { futureDate: 'Blah blah' });
+
+      expect(errors.addError.callCount).to.equal(1);
+      expect(errors.addError.firstCall.args[0]).to.equal('Blah blah');
     });
   });
   describe('validateMatch', () => {


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3258

This fixes how we handle the custom message for `validateCurrentOrPastDate`. This was causing errors in hca, though I don't think it stopped anyone from continuing if they fixed the date to be in the past.