### PR TITLE
Stop form from breaking if help isn't specified

### DIFF
--- a/src/js/burials/BurialsApp.jsx
+++ b/src/js/burials/BurialsApp.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import FormApp from '../common/schemaform/FormApp';
 import formConfig from './config/form';
 
-export default function HealthCareEntry({ location, children }) {
+export default function BurialsEntry({ location, children }) {
   return (
     <FormApp formConfig={formConfig} currentLocation={location}>
       {children}

--- a/src/js/common/schemaform/FormApp.jsx
+++ b/src/js/common/schemaform/FormApp.jsx
@@ -74,7 +74,7 @@ export default class FormApp extends React.Component {
           </div>
         </div>
         {!isConfirmationPage && <AskVAQuestions>
-          <GetFormHelp/>
+          {!!GetFormHelp && <GetFormHelp/>}
         </AskVAQuestions>}
         <span className="js-test-location hidden" data-location={trimmedPathname} hidden></span>
       </div>


### PR DESCRIPTION
Burials and pensions are broken in staging because they don't have help text.