### PR TITLE
Show any appointments data available; dont use primary care as indicator

### DIFF
--- a/src/js/facility-locator/components/AppointmentInfo.jsx
+++ b/src/js/facility-locator/components/AppointmentInfo.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { pull, startCase } from 'lodash';
+import { some, pull, startCase } from 'lodash';
 import classNames from 'classnames';
 import moment from 'moment';
 
@@ -11,6 +11,15 @@ export default class AppointmentInfo extends Component {
       newPatientTimesExpanded: false,
       existingPatientTimesExpanded: false,
     };
+  }
+
+  anyWaitTimes(accessAttrs, category) {
+    return some(Object.keys(accessAttrs),
+        (key) => {
+          return (typeof accessAttrs[key][category] !== 'undefined' &&
+             accessAttrs[key][category] !== null);
+        }
+        );
   }
 
   render() {
@@ -25,8 +34,7 @@ export default class AppointmentInfo extends Component {
     }
 
     const healthAccessAttrs = facility.attributes.access.health;
-
-    if (!healthAccessAttrs.primaryCare || !healthAccessAttrs.primaryCare.new) {
+    if (!this.anyWaitTimes(healthAccessAttrs, 'new') && !this.anyWaitTimes(healthAccessAttrs, 'established')) {
       return null;
     }
 
@@ -100,15 +108,15 @@ export default class AppointmentInfo extends Component {
       <div className="mb2">
         <h4 className="highlight">Appointments</h4>
         <p>Current as of <strong>{moment(healthAccessAttrs.effectiveDate, 'YYYY-MM-DD').format('MMMM, YYYY')}</strong></p>
-        <div className="mb2">
+        {this.anyWaitTimes(healthAccessAttrs, 'new') && <div className="mb2">
           <h4>New patient wait times</h4>
           <p>The average number of days a Veteran who hasn't been to this location has to wait for a non-urgent appointment</p>
           <ul>
             {renderStat('Primary Care', healthAccessAttrs.primaryCare.new)}
             {renderSpecialtyTimes()}
           </ul>
-        </div>
-        {healthAccessAttrs.primaryCare.established !== null && <div className="mb2">
+        </div>}
+        {this.anyWaitTimes(healthAccessAttrs, 'established') && <div className="mb2">
           <h4>Existing patient wait times</h4>
           <p>The average number of days a patient who has already been to this location has to wait for a non-urgent appointment.</p>
           <ul>


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3313

Determine whether to display overall component and new/established subsections based on whether any data is present rather than keying off of primary care. 

With this fix, we get just the existing patient wait times for a facility with no data for any new patient wait times (http://localhost:3001/facilities/facility/vha_635GF): 
<img width="668" alt="screen shot 2017-06-14 at 4 19 41 pm" src="https://user-images.githubusercontent.com/20694532/27158731-57e44c70-511d-11e7-959e-1a9b9a601ba0.png">
