### PR TITLE
Small design tweaks for GIB status

### DIFF
--- a/src/js/post-911-gib-status/components/EnrollmentHistory.jsx
+++ b/src/js/post-911-gib-status/components/EnrollmentHistory.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import InfoPair from './InfoPair';
 import EnrollmentPeriod from './EnrollmentPeriod';
 
 import { formatDateShort, formatDateLong } from '../utils/helpers';
@@ -41,9 +40,6 @@ class EnrollmentHistory extends React.Component {
     return (
       <div>
         <h3 className="section-header">Enrollment History</h3>
-        <InfoPair label="Total months received" value={enrollmentData.originalEntitlement}/>
-        <InfoPair label="Used" value={enrollmentData.usedEntitlement}/>
-        <InfoPair label="Remaining" value={enrollmentData.remainingEntitlement}/>
         {expirationWarning}
         {trainingWarning}
         {enrollmentHistory}

--- a/src/js/post-911-gib-status/components/InfoPair.jsx
+++ b/src/js/post-911-gib-status/components/InfoPair.jsx
@@ -6,10 +6,9 @@ class InfoPair extends React.Component {
   render() {
     const { spacingClass } = this.props;
 
-    let gridRowClasses = 'usa-grid-full';
-    if (spacingClass) {
-      gridRowClasses = `usa-grid-full ${this.props.spacingClass}`;
-    }
+    const gridRowClasses = spacingClass ?
+        `usa-grid-full ${this.props.spacingClass}`
+        : 'usa-grid-full';
 
     return (
       this.props.value &&

--- a/src/js/post-911-gib-status/components/InfoPair.jsx
+++ b/src/js/post-911-gib-status/components/InfoPair.jsx
@@ -4,9 +4,16 @@ import PropTypes from 'prop-types';
 
 class InfoPair extends React.Component {
   render() {
+    const { spacingClass } = this.props;
+
+    let gridRowClasses = 'usa-grid-full';
+    if (spacingClass) {
+      gridRowClasses = `usa-grid-full ${this.props.spacingClass}`;
+    }
+
     return (
       this.props.value &&
-        <div className="usa-grid-full section-line">
+        <div className={gridRowClasses}>
           <div className="usa-width-one-third">
             <span><strong>{this.props.label}: </strong></span>
           </div>
@@ -20,7 +27,8 @@ class InfoPair extends React.Component {
 
 InfoPair.propTypes = {
   label: PropTypes.string.isRequired,
-  value: PropTypes.any
+  value: PropTypes.any,
+  spacingClass: PropTypes.string
 };
 
 export default InfoPair;

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -28,11 +28,23 @@ class UserInfoSection extends React.Component {
     return (
       <div>
         {currentAsOfAlert}
-        <InfoPair label="Name" value={fullName}/>
-        <InfoPair label="Date of Birth" value={formatDateShort(enrollmentData.dateOfBirth)}/>
+        <InfoPair
+            label="Name"
+            value={fullName}
+            spacingClass="section-line"/>
+        <InfoPair
+            label="Date of Birth"
+            value={formatDateShort(enrollmentData.dateOfBirth)}
+            spacingClass="section-line"/>
         {/* TODO: find out whether this should be only partially displayed  xxxx1234 */}
-        <InfoPair label="VA File Number" value={enrollmentData.vaFileNumber}/>
-        <InfoPair label="Regional Processing Office" value={enrollmentData.regionalProcessingOffice}/>
+        <InfoPair
+            label="VA File Number"
+            value={enrollmentData.vaFileNumber}
+            spacingClass="section-line"/>
+        <InfoPair
+            label="Regional Processing Office"
+            value={enrollmentData.regionalProcessingOffice}
+            spacingClass="section-line"/>
         <div>
           <h4>When You Can Receive Benefits</h4>
           <div className="section-line">
@@ -45,6 +57,9 @@ class UserInfoSection extends React.Component {
             You are eligible to receive benefits at a rate of <strong>{percentageBenefit}</strong>.
           </div>
         </div>
+        <InfoPair label="Total months received" value={enrollmentData.originalEntitlement}/>
+        <InfoPair label="Used" value={enrollmentData.usedEntitlement}/>
+        <InfoPair label="Remaining" value={enrollmentData.remainingEntitlement}/>
       </div>
     );
   }

--- a/src/js/post-911-gib-status/containers/PrintPage.jsx
+++ b/src/js/post-911-gib-status/containers/PrintPage.jsx
@@ -18,12 +18,8 @@ class PrintPage extends React.Component {
           <img src="/img/design/logo/va-logo.png" alt="VA logo" width="300"/>
           <h1 className="section-header">Post-9/11 GI Bill Certificate of Eligibility</h1>
           <UserInfoSection enrollmentData={enrollmentData}/>
-          <h3 className="section-header">Enrollment History</h3>
-          <p>This information is current as of {todayFormatted}.</p>
-          <InfoPair label="Total months received" value={enrollmentData.originalEntitlement}/>
-          <InfoPair label="Used" value={enrollmentData.usedEntitlement}/>
-          <InfoPair label="Remaining" value={enrollmentData.remainingEntitlement}/>
           <InfoPair label="Benefits expire on" value={formatDateLong(enrollmentData.delimitingDate)}/>
+          <p>This information is current as of {todayFormatted}.</p>
         </div>
       </div>
     );

--- a/src/js/post-911-gib-status/containers/StatusPage.jsx
+++ b/src/js/post-911-gib-status/containers/StatusPage.jsx
@@ -19,7 +19,7 @@ class StatusPage extends React.Component {
 
     return (
       <div>
-        <FormTitle title="Post-9/11 GI Bill Status"/>
+        <FormTitle title="Post-9/11 GI Bill Enrollment Information"/>
         <div className="va-introtext">
           <p>
             View your Post-9/11 GI Bill enrollment information below. This is the same information
@@ -36,9 +36,7 @@ class StatusPage extends React.Component {
         <EnrollmentHistory enrollmentData={enrollmentData}/>
         <div className="feature help-desk">
           <h2>Need help?</h2>
-          <div>Call the Vets.gov Help Desk</div>
-          <div>1-855-574-7286</div>
-          <div>Monday - Friday, 8:00am - 8:00pm (ET)</div>
+          <div>Call 888-442-4551 (888-GI-BILL-1) from 8:00 a.m. to 7:00 p.m. (ET)</div>
         </div>
       </div>
     );

--- a/src/sass/post-911-gib-status.scss
+++ b/src/sass/post-911-gib-status.scss
@@ -2,7 +2,7 @@
 
 h3 {
   border-bottom: 1px solid $color-gray-light;
-  margin: 0 0 .5em 0;
+  margin: 1em 0 .5em 0;
   padding: 0 0 .25em 0;
 }
 


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3200

Merging into my `gib-print-page` branch for now so it's easier to read the diff. Will switch to merge into `master` once that other branch is merged.

Main changes are:
1. Changing the title of the page
2. Moving the entitlement info out of `EnrollmentHistory` and into `UserInfoSection`
3. Adding a conditional prop to `InfoPair` to accept a class to address different styling in different places
4. Updating "Need help?" message at the bottom of the page