### PR TITLE
Avoid sending null services param for benefits facilities

### DIFF
--- a/src/js/facility-locator/actions/index.js
+++ b/src/js/facility-locator/actions/index.js
@@ -50,7 +50,7 @@ export function searchWithBounds(bounds, facilityType, serviceType, page = 1) {
   const params = compact([
     ...bounds.map(c => `bbox[]=${c}`),
     facilityType ? `type=${facilityType}` : null,
-    facilityType === 'benefits' ? `services[]=${serviceType}` : null,
+    facilityType === 'benefits' && serviceType ? `services[]=${serviceType}` : null,
     `page=${page}`
   ]).join('&');
   const url = `${api.url}?${params}`;


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3345

Restores the added condition that removes the services query param. 

Tested locally with testing all the filter permutations I could think of. 