### PR TITLE
GIB currently disallowed alert

### DIFF
--- a/src/js/post-911-gib-status/components/EnrollmentHistory.jsx
+++ b/src/js/post-911-gib-status/components/EnrollmentHistory.jsx
@@ -10,7 +10,7 @@ class EnrollmentHistory extends React.Component {
     const enrollmentData = this.props.enrollmentData || {};
     const enrollments = enrollmentData.enrollments || [];
     const todayFormatted = formatDateShort(new Date());
-    const currentlyDisallowed = enrollmentData.percentageBenefit !== 0 && enrollmentData.originalEntitlement !== 0;
+    const currentlyAllowed = enrollmentData.percentageBenefit !== 0 && enrollmentData.originalEntitlement !== 0;
 
     // TODO: find out when this warning should be shown.
     /*
@@ -60,7 +60,7 @@ class EnrollmentHistory extends React.Component {
     });
 
     let sectionContent;
-    if (currentlyDisallowed) {
+    if (currentlyAllowed) {
       sectionContent = (
         <div>
           <h3 className="section-header">Enrollment History</h3>

--- a/src/js/post-911-gib-status/components/EnrollmentHistory.jsx
+++ b/src/js/post-911-gib-status/components/EnrollmentHistory.jsx
@@ -10,7 +10,7 @@ class EnrollmentHistory extends React.Component {
     const enrollmentData = this.props.enrollmentData || {};
     const enrollments = enrollmentData.enrollments || [];
     const todayFormatted = formatDateShort(new Date());
-    const currentlyAllowed = enrollmentData.percentageBenefit !== 0 && enrollmentData.originalEntitlement !== 0;
+    const currentlyAllowed = enrollmentData.percentageBenefit !== 0 || enrollmentData.originalEntitlement !== 0;
 
     // TODO: find out when this warning should be shown.
     /*

--- a/src/js/post-911-gib-status/components/EnrollmentHistory.jsx
+++ b/src/js/post-911-gib-status/components/EnrollmentHistory.jsx
@@ -10,6 +10,7 @@ class EnrollmentHistory extends React.Component {
     const enrollmentData = this.props.enrollmentData || {};
     const enrollments = enrollmentData.enrollments || [];
     const todayFormatted = formatDateShort(new Date());
+    const currentlyDisallowed = enrollmentData.percentageBenefit !== 0 && enrollmentData.originalEntitlement !== 0;
 
     // TODO: find out when this warning should be shown.
     /*
@@ -58,12 +59,21 @@ class EnrollmentHistory extends React.Component {
       );
     });
 
+    let sectionContent;
+    if (currentlyDisallowed) {
+      sectionContent = (
+        <div>
+          <h3 className="section-header">Enrollment History</h3>
+          This information is current as of {todayFormatted}
+          {historyExplanationBox}
+          {enrollmentHistory}
+        </div>
+      );
+    }
+
     return (
       <div>
-        <h3 className="section-header">Enrollment History</h3>
-        This information is current as of {todayFormatted}
-        {historyExplanationBox}
-        {enrollmentHistory}
+        {sectionContent}
       </div>
     );
   }

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -27,20 +27,7 @@ class UserInfoSection extends React.Component {
     }
 
     let entitlementInfo;
-    if (!currentlyAllowed) {
-      entitlementInfo = (
-        <div>
-          <h4>When You Can Receive Benefits</h4>
-          <div className="usa-alert usa-alert-warning usa-content">
-            <div className="usa-alert-body">
-              <h2>Currently Not Qualified</h2>
-              We have received your application and have determined that you are not currently eligible
-              for Post-9/11 GI Bill benefits. Additional service time could change this determination.
-            </div>
-          </div>
-        </div>
-      );
-    } else {
+    if (currentlyAllowed) {
       entitlementInfo = (
         <div>
           <div>
@@ -58,6 +45,19 @@ class UserInfoSection extends React.Component {
           <InfoPair label="Total months received" value={enrollmentData.originalEntitlement}/>
           <InfoPair label="Used" value={enrollmentData.usedEntitlement}/>
           <InfoPair label="Remaining" value={enrollmentData.remainingEntitlement}/>
+        </div>
+      );
+    } else {
+      entitlementInfo = (
+        <div>
+          <h4>When You Can Receive Benefits</h4>
+          <div className="usa-alert usa-alert-warning usa-content">
+            <div className="usa-alert-body">
+              <h2>Currently Not Qualified</h2>
+              We have received your application and have determined that you are not currently eligible
+              for Post-9/11 GI Bill benefits. Additional service time could change this determination.
+            </div>
+          </div>
         </div>
       );
     }

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -33,7 +33,7 @@ class UserInfoSection extends React.Component {
           <h4>When You Can Receive Benefits</h4>
           <div className="usa-alert usa-alert-warning usa-content">
             <div className="usa-alert-body">
-              <h2>Currently Disallowed</h2>
+              <h2>Currently Not Qualified</h2>
               We have received your application and have determined that you are not currently eligible
               for Post-9/11 GI Bill benefits. Additional service time could change this determination.
             </div>

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -25,6 +25,42 @@ class UserInfoSection extends React.Component {
       );
     }
 
+    let entitlementInfo;
+    if (enrollmentData.percentageBenefit === 0 && enrollmentData.originalEntitlement === 0) {
+      entitlementInfo = (
+        <div>
+          <h4>When You Can Receive Benefits</h4>
+          <div className="usa-alert usa-alert-warning usa-content">
+            <div className="usa-alert-body">
+              <h2>Currently Disallowed</h2>
+              We have received your application and have determined that you are not currently eligible
+              for Post-9/11 GI Bill benefits. Additional service time could change this determination.
+            </div>
+          </div>
+        </div>
+      );
+    } else {
+      entitlementInfo = (
+        <div>
+          <div>
+            <h4>When You Can Receive Benefits</h4>
+            <div className="section-line">
+              You are eligible to receive benefits between <strong>{formatDateShort(enrollmentData.eligibilityDate)}</strong> and <strong>{formatDateShort(enrollmentData.delimitingDate)}</strong>.
+            </div>
+          </div>
+          <div>
+            <h4>Your Benefit Level</h4>
+            <div className="section-line">
+              You are eligible to receive benefits at a rate of <strong>{percentageBenefit}</strong>.
+            </div>
+          </div>
+          <InfoPair label="Total months received" value={enrollmentData.originalEntitlement}/>
+          <InfoPair label="Used" value={enrollmentData.usedEntitlement}/>
+          <InfoPair label="Remaining" value={enrollmentData.remainingEntitlement}/>
+        </div>
+      );
+    }
+
     return (
       <div>
         {currentAsOfAlert}
@@ -45,21 +81,7 @@ class UserInfoSection extends React.Component {
             label="Regional Processing Office"
             value={enrollmentData.regionalProcessingOffice}
             spacingClass="section-line"/>
-        <div>
-          <h4>When You Can Receive Benefits</h4>
-          <div className="section-line">
-            You are eligible to receive benefits between <strong>{formatDateShort(enrollmentData.eligibilityDate)}</strong> and <strong>{formatDateShort(enrollmentData.delimitingDate)}</strong>.
-          </div>
-        </div>
-        <div>
-          <h4>Your Benefit Level</h4>
-          <div className="section-line">
-            You are eligible to receive benefits at a rate of <strong>{percentageBenefit}</strong>.
-          </div>
-        </div>
-        <InfoPair label="Total months received" value={enrollmentData.originalEntitlement}/>
-        <InfoPair label="Used" value={enrollmentData.usedEntitlement}/>
-        <InfoPair label="Remaining" value={enrollmentData.remainingEntitlement}/>
+        {entitlementInfo}
       </div>
     );
   }

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -13,6 +13,7 @@ class UserInfoSection extends React.Component {
     const todayFormatted = formatDateShort(new Date());
     const percentageBenefit = formatPercent(enrollmentData.percentageBenefit) || 'unavailable';
     const fullName = `${enrollmentData.firstName} ${enrollmentData.lastName}`;
+    const currentlyAllowed = enrollmentData.percentageBenefit !== 0 || enrollmentData.originalEntitlement !== 0;
 
     let currentAsOfAlert;
     if (this.props.showCurrentAsOfAlert) {
@@ -26,7 +27,7 @@ class UserInfoSection extends React.Component {
     }
 
     let entitlementInfo;
-    if (enrollmentData.percentageBenefit === 0 && enrollmentData.originalEntitlement === 0) {
+    if (!currentlyAllowed) {
       entitlementInfo = (
         <div>
           <h4>When You Can Receive Benefits</h4>


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3297

This is the solution for case 1 in the list:
1. "Currently disallowed" (due to ineligibility) **(@annekainicUSDS taking this)**   
\- https://marvelapp.com/8d6igd9/screen/29244254
\- when `percentageBenefit === 0` and `originalEntitlement === 0`

Data I used for this:
```
:body:
  chapter33_education_info:
    first_name: Srikanth
    last_name: Vanapalli
    name_suffix: II
    date_of_birth: '1995-11-12T06:00:00.000+0000'    
    regional_processing_office: Central Office Washington, DC
    va_file_number: '12345678'
    eligibility_date: '2016-12-01T05:00:00.000+0000'
    delimiting_date: '2017-12-07T05:00:00.000+0000'
    original_entitlement: '0'
    used_entitlement: '75'
    remaining_entitlement: '25'
    percentage_benefit: '0'
  
:status: 200
```

<img width="764" alt="screen shot 2017-06-16 at 9 06 37 am" src="https://user-images.githubusercontent.com/25183456/27227955-ac8d8d0c-5273-11e7-8d16-6d095174ed2e.png">