### PR TITLE
Fix ignoreList, see if this is what was blocking print page on staging

### DIFF
--- a/script/build.js
+++ b/script/build.js
@@ -125,7 +125,7 @@ smith.metadata({ buildtype: options.buildtype });
 const ignore = require('metalsmith-ignore');
 const ignoreList = [];
 if (options.buildtype === 'production') {
-  ignoreList.push('education/gi-bill/post-9-11/status/*');
+  ignoreList.push('education/gi-bill/post-9-11/status.md');
   ignoreList.push('pensions/application.md');
   ignoreList.push('burials-and-memorials/application.md');
   ignoreList.push('va-letters/*');


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3340

The print page is being blocked on staging when it shouldn't be. Similarly, the status page isn't being properly blocked in production. I believe this change will fix that.