### PR TITLE
Fix missing styles on Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "node script/build.js",
     "heroku-serve": "http-server",
-    "heroku-postbuild": "node script/build.js --entry no-react",
+    "heroku-postbuild": "node script/build.js --entry no-react,style",
     "lint": "npm run lint:js && npm run lint:sass",
     "lint:changed": "npm run lint:js:changed && npm run lint:sass",
     "lint:js": "eslint --quiet --ext .js --ext .jsx .",


### PR DESCRIPTION
The refactor of styles into its own entrypoint meant Heroku wasn't building them. This adds style as an explicit entrypoint so that the Heroku review apps for static content will render correctly.