### PR TITLE
Block indexing of scorecard

### DIFF
--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,4 +1,4 @@
 User-Agent: *
-Disallow:
+Disallow: /scorecard
 
 Sitemap: https://www.vets.gov/sitemap.xml


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3419

Indexing should also be blocked through metatag on the scorecard pages. Adding here as well for defense in depth against different crawlers' behavior.