### PR TITLE
First pass changes for pensions form

### DIFF
--- a/src/js/pensions/config/form.js
+++ b/src/js/pensions/config/form.js
@@ -231,7 +231,7 @@ const formConfig = {
                 expandUnder: 'nationalGuardActivation',
               },
               name: {
-                'ui:title': 'Name of Reserve/NG unit',
+                'ui:title': 'Name of Reserve/National Guard unit',
               },
               address: address.uiSchema('Unit address'),
               phone: phoneUI('Unit phone number'),

--- a/src/sass/modules/_m-schemaform.scss
+++ b/src/sass/modules/_m-schemaform.scss
@@ -186,12 +186,15 @@ label {
 }
 
 .schemaform-block-header {
-  margin-bottom: 0.5em;
+  margin-bottom: 0.7em;
   > legend, > h5, > p {
     padding-bottom: 0 !important;
     margin-bottom: 0 !important;
   }
   > p {
+    margin-top: 0;
+  }
+  > .schemaform-block-title + p {
     margin-top: 0.5em;
   }
 }


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3183

Minor changes to spell out National Guard and tweak the spacing on description fields. There are other changes in that issue, but we're still talking about them.

![screen shot 2017-06-20 at 9 51 38 am](https://user-images.githubusercontent.com/634932/27336624-2175023a-559e-11e7-80a7-32089ff0011c.png)
![screen shot 2017-06-20 at 9 51 15 am](https://user-images.githubusercontent.com/634932/27336625-217b39c0-559e-11e7-9819-3088a08a75df.png)

