### PR TITLE
Terms of service tweaks

### DIFF
--- a/src/js/common/components/AcceptTermsPrompt.jsx
+++ b/src/js/common/components/AcceptTermsPrompt.jsx
@@ -82,7 +82,7 @@ class AcceptTermsPrompt extends React.Component {
           </div>
           <div>
             {submitButton}
-            <a href="/healthcare" className="usa-button usa-button-outline">
+            <a href={this.props.cancelPath} className="usa-button usa-button-outline">
               Cancel
             </a>
           </div>

--- a/src/js/common/components/RequiredTermsAcceptanceView.jsx
+++ b/src/js/common/components/RequiredTermsAcceptanceView.jsx
@@ -37,7 +37,7 @@ export class RequiredTermsAcceptanceView extends React.Component {
         }
       );
     } else {
-      view = <AcceptTermsPrompt terms={terms} onAccept={this.props.acceptTerms}/>;
+      view = <AcceptTermsPrompt terms={terms} cancelPath={this.props.cancelPath} onAccept={this.props.acceptTerms}/>;
     }
 
     return (
@@ -50,7 +50,8 @@ export class RequiredTermsAcceptanceView extends React.Component {
 }
 
 RequiredTermsAcceptanceView.propTypes = {
-  termsName: PropTypes.string.isRequired
+  termsName: PropTypes.string.isRequired,
+  cancelPath: PropTypes.string.isRequired
 };
 
 

--- a/src/js/health-records/containers/HealthRecordsApp.jsx
+++ b/src/js/health-records/containers/HealthRecordsApp.jsx
@@ -44,6 +44,7 @@ export class HealthRecordsApp extends React.Component {
           verifyUrl={this.props.verifyUrl}>
         <RequiredTermsAcceptanceView
             termsName={"mhvac"}
+            cancelPath={"/healthcare"}
             termsNeeded={!this.props.profile.healthTermsCurrent}>
           <AppContent>
             <div>

--- a/src/js/messaging/containers/MessagingApp.jsx
+++ b/src/js/messaging/containers/MessagingApp.jsx
@@ -65,6 +65,7 @@ class MessagingApp extends React.Component {
           verifyUrl={this.props.verifyUrl}>
         <RequiredTermsAcceptanceView
             termsName={"mhvac"}
+            cancelPath={"/healthcare"}
             termsNeeded={!this.props.profile.healthTermsCurrent}>
           <AppContent>
             <div id="messaging-app-header">

--- a/src/js/rx/containers/RxRefillsApp.jsx
+++ b/src/js/rx/containers/RxRefillsApp.jsx
@@ -52,6 +52,7 @@ class RxRefillsApp extends React.Component {
           verifyUrl={this.props.verifyUrl}>
         <RequiredTermsAcceptanceView
             termsName={"mhvac"}
+            cancelPath={"/healthcare"}
             topContent={breadcrumbs}
             termsNeeded={!this.props.profile.healthTermsCurrent}>
           <AppContent>

--- a/src/js/user-profile/components/AccountManagementSection.jsx
+++ b/src/js/user-profile/components/AccountManagementSection.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import AcceptTermsPrompt from '../../common/components/AcceptTermsPrompt';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
 import Modal from '../../common/components/Modal';
 
 import {
@@ -12,10 +13,6 @@ class AccountManagementSection extends React.Component {
   constructor(props) {
     super(props);
     this.state = { modalOpen: false };
-  }
-
-  componentDidMount() {
-    this.props.fetchLatestTerms('mhvac');
   }
 
   openModal = () => {
@@ -34,7 +31,14 @@ class AccountManagementSection extends React.Component {
   renderModalContents() {
     const { terms } = this.props;
     const termsAccepted = this.props.profile.healthTermsCurrent;
-    if (termsAccepted) {
+    if (!termsAccepted && this.state.modalOpen && terms.loading === false && !terms.termsContent) {
+      setTimeout(() => {
+        this.props.fetchLatestTerms('mhvac');
+      }, 100);
+      return <LoadingIndicator setFocus message="Loading your information"/>;
+    } else if (!termsAccepted && this.state.modalOpen && terms.loading === true) {
+      return <LoadingIndicator setFocus message="Loading your information"/>;
+    } else if (termsAccepted) {
       return (
         <div>
           <h3>
@@ -46,7 +50,8 @@ class AccountManagementSection extends React.Component {
         </div>
       );
     }
-    return <AcceptTermsPrompt terms={terms} onAccept={this.acceptAndClose}/>;
+
+    return <AcceptTermsPrompt terms={terms} cancelPath="/profile" onAccept={this.acceptAndClose}/>;
   }
 
   render() {


### PR DESCRIPTION
This fixes two issues from department-of-veterans-affairs/vets.gov-team#3423, namely:

* It makes the path that you get to when hitting cancel on the terms of service dialog be configurable, and then uses that to stop sending users to the healthcare page when cancelling from the profile page.

* On the profile page, it stops us from automatically loading in the terms and conditions data every time the page is opened. Now it will only load them in when the user clicks the link to bring up the dialog.