### PR TITLE
Update fetch to go to vets-api

### DIFF
--- a/script/build.js
+++ b/script/build.js
@@ -129,7 +129,7 @@ if (options.buildtype === 'production') {
   ignoreList.push('pensions/application.md');
   ignoreList.push('burials-and-memorials/application.md');
   ignoreList.push('burials-and-memorials/burial-planning/application.md');
-  ignoreList.push('va-letters/*');
+  ignoreList.push('va-letters/index.md');
 }
 smith.use(ignore(ignoreList));
 

--- a/src/js/va-letters/actions/letters.js
+++ b/src/js/va-letters/actions/letters.js
@@ -1,73 +1,18 @@
-// import { apiRequest } from '../utils/helpers';
-
-// TODO: remove this hard-coded response once we can fetch from a vets-api endpoint
-const letterListResponse = {
-  letterDestination: {
-    addressLine1: '2476 Main Street',
-    addressLine2: 'Ste #12',
-    addressLine3: 'West',
-    city: 'Reston',
-    country: 'US',
-    foreignCode: '865',
-    fullName: 'Mark Webb',
-    state: 'VA',
-    zipCode: '12345'
-  },
-  letters: [
-    {
-      letterName: 'Commissary Letter',
-      letterType: 'commissary'
-    },
-    {
-      letterName: 'Proof of Service Letter',
-      letterType: 'proof_of_service'
-    },
-    {
-      letterName: 'Proof of Creditable Prescription Drug Coverage Letter',
-      letterType: 'medicare_partd'
-    },
-    {
-      letterName: 'Proof of Minimum Essential Coverage Letter',
-      letterType: 'minimum_essential_coverage'
-    },
-    {
-      letterName: 'Service Verification Letter',
-      letterType: 'service_verification'
-    },
-    {
-      letterName: 'Civil Service Preference Letter',
-      letterType: 'civil_service'
-    },
-    {
-      letterName: 'Benefit Summary Letter',
-      letterType: 'benefit_summary'
-    },
-    {
-      letterName: 'Benefit Verification Letter',
-      letterType: 'benefit_verification'
-    }
-  ]
-};
+import { apiRequest } from '../utils/helpers';
 
 export function getLetterList() {
   return (dispatch) => {
-    return dispatch({
-      type: 'GET_LETTERS_SUCCESS',
-      data: letterListResponse
-    });
-    /*
-    apiRequest('/v0/va_letters/letters',
+    apiRequest('/v0/letters',
                null,
       (response) => {
         return dispatch({
           type: 'GET_LETTERS_SUCCESS',
-          data: response.data,
+          data: response,
         });
       },
       () => dispatch({
         type: 'GET_LETTERS_FAILURE'
       })
     );
-    */
   };
 }

--- a/src/js/va-letters/components/LetterList.jsx
+++ b/src/js/va-letters/components/LetterList.jsx
@@ -7,7 +7,7 @@ class LetterList extends React.Component {
     const letterItems = (this.props.letters || []).map((letter) => {
       return (
         <li key={letter.letterType}>
-          <a href="#">{letter.letterName}</a>
+          <a href="#">{letter.name}</a>
         </li>
       );
     });

--- a/src/js/va-letters/reducers/index.js
+++ b/src/js/va-letters/reducers/index.js
@@ -11,8 +11,8 @@ function letters(state = initialState, action) {
     case 'GET_LETTERS_SUCCESS':
       return {
         ...state,
-        letters: action.data.letters,
-        destination: action.data.letterDestination,
+        letters: action.data.data.attributes.letters,
+        destination: action.data.meta.address,
         available: true
       };
     case 'GET_LETTERS_FAILURE':

--- a/test/va-letters/reducers/index.unit.spec.js
+++ b/test/va-letters/reducers/index.unit.spec.js
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+
+import lettersReducer from '../../../src/js/va-letters/reducers';
+
+const initialState = {
+  letters: [],
+  destination: {},
+  available: false
+};
+
+describe('letters reducer', () => {
+  it('should handle failure to fetch letters', () => {
+    const state = lettersReducer.letters(
+      initialState,
+      { type: 'GET_LETTERS_FAILURE' }
+    );
+
+    expect(state.letters).to.be.empty;
+    expect(state.available).to.be.false;
+  });
+
+  it('should handle a successful request for letters', () => {
+    const state = lettersReducer.letters(
+      initialState,
+      {
+        type: 'GET_LETTERS_SUCCESS',
+        data: {
+          data: {
+            attributes: {
+              letters: [
+                {
+                  letterType: 'commissary',
+                  name: 'Commissary Letter'
+                },
+                {
+                  letterType: 'proof_of_service',
+                  name: 'Proof of Service Letter'
+                }
+              ]
+            }
+          },
+          meta: {
+            address: {
+              addressLine1: '2476 MAIN STREET',
+              addressLine2: 'STE # 12',
+              addressLine3: 'West',
+              city: 'RESTON',
+              country: 'US',
+              foreignCode: '865',
+              fullName: 'MARK WEBB',
+              state: 'VA',
+              zipCode: '12345'
+            }
+          }
+        }
+      }
+    );
+
+    expect(state.letters[0].name).to.eql('Commissary Letter');
+    expect(state.destination.addressLine1).to.eql('2476 MAIN STREET');
+    expect(state.available).to.be.true;
+  });
+});


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3190

This PR does 3 things:
1. Fetches data from vets-api endpoint (and has to change some other things due to the different response structure)
2. Adds a test for the reducer
3. Fixes the `ignoreList` addition for letters

This will have to be updated again once @raquelromano-gov's PR (https://github.com/department-of-veterans-affairs/vets-website/pull/5804) is merged, but wanted to get it up for now. 