### PR TITLE
Fix missing bracket in wizard page

### DIFF
--- a/src/js/edu-benefits/education-wizard.js
+++ b/src/js/edu-benefits/education-wizard.js
@@ -44,7 +44,7 @@ function reInitWidget() {
     const otherChoice = radio.dataset.alternate;
     const otherNextQuestion = container.querySelector(`#${otherChoice}`).dataset.nextQuestion;
     if (otherNextQuestion) {
-      const otherNextQuestionElement = container.querySelector(`[data-question=${otherNextQuestion}`);
+      const otherNextQuestionElement = container.querySelector(`[data-question=${otherNextQuestion}]`);
       closeStateAndCheckChild(otherNextQuestionElement, container);
     }
     if ((apply.dataset.state === 'open') && !radio.dataset.selectedForm) {


### PR DESCRIPTION
Safari is throwing an error, not sure why other browsers allowed it.