### PR TITLE
Avoid presenting a no-op modal for terms and conditions

### DIFF
--- a/src/js/user-profile/components/AccountManagementSection.jsx
+++ b/src/js/user-profile/components/AccountManagementSection.jsx
@@ -54,11 +54,22 @@ class AccountManagementSection extends React.Component {
     return <AcceptTermsPrompt terms={terms} cancelPath="/profile" onAccept={this.acceptAndClose}/>;
   }
 
+  renderTermsLink() {
+    if (this.props.profile.healthTermsCurrent) {
+      return (
+        <p>You have accepted the latest health terms and conditions for this site.</p>
+      );
+    }
+    return (
+      <p><a onClick={this.openModal}>Terms and Conditions for Health Tools</a></p>
+    );
+  }
+
   render() {
     return (
       <div className="profile-section medium-12 columns">
         <h4 className="section-header">Account Management</h4>
-        <p><a onClick={this.openModal}>Terms and Conditions for Health Tools</a></p>
+        {this.renderTermsLink()}
         <div className="button-container medium-12 columns">
           <a href="https://wallet.id.me/settings" target="_blank" className="warn-exit usa-button-primary usa-button-outline usa-button-outline-exit transparent">
             Delete Your Account


### PR DESCRIPTION
Near-term solution for https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3452

After this is beyond beta we can switch to a modal that shows the accepted terms, but for now that would be misleading for non-beta users. 