### PR TITLE
NOD and SOC event statuses

### DIFF
--- a/content/pages/disability-benefits-beta/claims-appeal.md
+++ b/content/pages/disability-benefits-beta/claims-appeal.md
@@ -12,6 +12,7 @@ You have the right to appeal any disability benefits decision made by the Vetera
 </div>
 
 <div class="feature" markdown="0">
+
 ### Have you already filed an appeal?
 
 When the Regional Office (RO) receives your Notice of Disagreement (NOD), you'll be able to check the status of your appeal on Vets.gov.

--- a/content/pages/disability-benefits-beta/claims-appeal.md
+++ b/content/pages/disability-benefits-beta/claims-appeal.md
@@ -17,7 +17,7 @@ You have the right to appeal any disability benefits decision made by the Vetera
 
 When the Regional Office (RO) receives your Notice of Disagreement (NOD), you'll be able to check the status of your appeal on Vets.gov.
 
-<a class="usa-button-primary" href="/disability-benefits/your-claims">Track your appeal</a>
+<a class="usa-button-primary" href="/track-claims">Track your appeal</a>
 </div>
 
 ### Appeals Process Overview

--- a/content/pages/disability-benefits-beta/index.md
+++ b/content/pages/disability-benefits-beta/index.md
@@ -14,7 +14,7 @@ majorlinks:
     - url: /disability-benefits/apply/
       title: Application Process
       description: Apply online now, or find out how to apply in person or get help from a trained professional.
-    - url: /disability-benefits/track-claims/
+    - url: /track-claims/your-claims
       title: Check Your Claim and Appeal Status
       description: Track the status of your disability claims and appeals.
     - url: /disability-benefits/conditions/

--- a/content/pages/disability-benefits-beta/index.md
+++ b/content/pages/disability-benefits-beta/index.md
@@ -14,7 +14,7 @@ majorlinks:
     - url: /disability-benefits/apply/
       title: Application Process
       description: Apply online now, or find out how to apply in person or get help from a trained professional.
-    - url: /track-claims/your-claims
+    - url: /track-claims/
       title: Check Your Claim and Appeal Status
       description: Track the status of your disability claims and appeals.
     - url: /disability-benefits/conditions/

--- a/src/js/disability-benefits/components/AppealListItem.jsx
+++ b/src/js/disability-benefits/components/AppealListItem.jsx
@@ -16,9 +16,9 @@ export default function AppealListItem({ appeal }) {
   return (
     <Link className="claim-list-item" to={`appeals/${appeal.id}/status`}>
       <h4 className="claim-list-item-header">Compensation Appeal – Last updated {moment(lastEvent.date).format('MMMM D, YYYY')}</h4>
-      <p className="status"><span className="claim-item-label">Status:</span> {appealStatusDescriptions(lastEvent.type).status.title}</p>
+      <p className="status"><span className="claim-item-label">Status:</span> {appealStatusDescriptions[lastEvent.type].status.title}</p>
       <div className="communications">
-        {appealStatusDescriptions(lastEvent.type).nextAction.title}
+        {appealStatusDescriptions[lastEvent.type].nextAction.title}
       </div>
       <p><span className="claim-item-label">Appeal received:</span> {moment(firstEvent.date).format('MMM D, YYYY')}</p>
     </Link>

--- a/src/js/disability-benefits/containers/AppealStatusPage.jsx
+++ b/src/js/disability-benefits/containers/AppealStatusPage.jsx
@@ -25,7 +25,7 @@ class AppealStatusPage extends React.Component {
       case 'form9':
         break;
       case 'soc':
-        title = title.concat(` ${moment(lastEvent.date).add(60, 'days').format('MMM DD, YYYY')}`);
+        title = `${title} ${moment(lastEvent.date).add(60, 'days').format('MMM DD, YYYY')}`;
         break;
       default:
         break;

--- a/src/js/disability-benefits/containers/AppealStatusPage.jsx
+++ b/src/js/disability-benefits/containers/AppealStatusPage.jsx
@@ -15,6 +15,49 @@ class AppealStatusPage extends React.Component {
     }
   }
 
+  renderStatusNextAction(eventType) {
+    const { nextAction } = appealStatusDescriptions[eventType];
+    switch (eventType) {
+      case 'form9':
+        return (
+          <div className="next-action">
+            <h5>{nextAction.title}</h5>
+            {nextAction.description}
+          </div>
+        );
+      default:
+        return null;
+    }
+  }
+
+  renderPreviousActivity(lastEvent, eventHistory) {
+    if (lastEvent.type === 'nod') {
+      return (
+        <div>
+          <p>
+            The NOD is the first step in your appeal. As your appeal moves through the process, the history of your appeal will be added here. On average, Veterans with appeals in the NOD stage, wait about 532 days for VBA to complete the necessary action.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <table className="events-list">
+        <tbody>
+          {eventHistory.map((e, i) => {
+            return (
+              <tr key={i}>
+                <td><i className="fa fa-check-circle"></i></td>
+                <td><strong>{moment(e.date).format('MMM DD, YYYY')}</strong></td>
+                <td>{appealStatusDescriptions[e.type].status.title}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    );
+  }
+
   render() {
     if (!this.props.appeal) {
       return null;
@@ -25,23 +68,20 @@ class AppealStatusPage extends React.Component {
       return moment(e.date).unix();
     }], ['desc']);
     const lastEvent = events[0];
-    const { status, nextAction } = appealStatusDescriptions(lastEvent.type);
+    const { status } = appealStatusDescriptions[lastEvent.type];
 
     return (
       <div className="claims-status">
         <div className="row">
           <div>
-            <h1>Your Compensation Appeal Status {this.props.params.id}</h1>
+            <h1>Your Compensation Appeal Status</h1>
             <p>This information is accurate as of {moment().format('MMM DD, YYYY')}</p>
           </div>
         </div>
         <div className="row">
           <div className="small-12 usa-width-two-thirds medium-8 columns">
             <div className="row">
-              <div className="next-action">
-                <h5>{nextAction.title}</h5>
-                {nextAction.description}
-              </div>
+              {this.renderStatusNextAction(lastEvent.type)}
             </div>
             <div className="row">
               <div className="last-status">
@@ -58,19 +98,7 @@ class AppealStatusPage extends React.Component {
             <div className="row">
               <div className="previous-activity">
                 <h4>Previous Activity for Your Appeal</h4>
-                <table className="events-list">
-                  <tbody>
-                    {events.slice(1).map((e, i) => {
-                      return (
-                        <tr key={i}>
-                          <td><i className="fa fa-check-circle"></i></td>
-                          <td><strong>{moment(e.date).format('MMM DD, YYYY')}</strong></td>
-                          <td>{appealStatusDescriptions(e.type).status.title}</td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
+                {this.renderPreviousActivity(lastEvent, events.slice(1))}
               </div>
             </div>
           </div>

--- a/src/js/disability-benefits/containers/AppealStatusPage.jsx
+++ b/src/js/disability-benefits/containers/AppealStatusPage.jsx
@@ -15,19 +15,28 @@ class AppealStatusPage extends React.Component {
     }
   }
 
-  renderStatusNextAction(eventType) {
+  renderStatusNextAction(lastEvent) {
+    const eventType = lastEvent.type;
     const { nextAction } = appealStatusDescriptions[eventType];
+    const className = `next-action ${eventType}`;
+    let title = nextAction.title;
+
     switch (eventType) {
       case 'form9':
-        return (
-          <div className="next-action">
-            <h5>{nextAction.title}</h5>
-            {nextAction.description}
-          </div>
-        );
+        break;
+      case 'soc':
+        title = title.concat(` ${moment(lastEvent.date).add(60, 'days').format('MMM DD, YYYY')}`);
+        break;
       default:
-        return null;
+        break;
     }
+
+    return (
+      <div className={className}>
+        <h5>{title}</h5>
+        {nextAction.description}
+      </div>
+    );
   }
 
   renderPreviousActivity(lastEvent, eventHistory) {
@@ -48,7 +57,9 @@ class AppealStatusPage extends React.Component {
             return (
               <tr key={i}>
                 <td><i className="fa fa-check-circle"></i></td>
-                <td><strong>{moment(e.date).format('MMM DD, YYYY')}</strong></td>
+                <td className="date">
+                  <strong>{moment(e.date).format('MMM DD, YYYY')}</strong>
+                </td>
                 <td>{appealStatusDescriptions[e.type].status.title}</td>
               </tr>
             );
@@ -81,7 +92,9 @@ class AppealStatusPage extends React.Component {
         <div className="row">
           <div className="small-12 usa-width-two-thirds medium-8 columns">
             <div className="row">
-              {this.renderStatusNextAction(lastEvent.type)}
+              <div className="next-action-container">
+                {this.renderStatusNextAction(lastEvent)}
+              </div>
             </div>
             <div className="row">
               <div className="last-status">

--- a/src/js/disability-benefits/utils/appeal-helpers.jsx
+++ b/src/js/disability-benefits/utils/appeal-helpers.jsx
@@ -29,12 +29,20 @@ export const appealStatusDescriptions = {
   },
   soc: {
     status: {
-      title: 'SOC status title',
-      description: <p>SOC description.</p>,
+      title: 'Your Statement of the Case (SOC) was Prepared by the Regional Office (RO)',
+      description: <div>
+        <p>The Veterans Benefits Administration (VBA) RO has mailed you the SOC for your appeal. Included with your SOC is a Form 9, which you can use to ask for your appeal to continue.</p>
+        <p>
+          To continue your appeal, you need to complete and send back your Form 9 by July 28, 2017. If you do not send back a Form 9 in time, your appeal will be closed.
+        </p>
+      </div>,
     },
     nextAction: {
-      title: 'SOC next action title.',
-      description: 'SOC next action description.'
+      title: 'To continue with your appeal, we need your Form 9 by',
+      description: <div>
+        <p>The Form 9 asks you to review the SOC and confirm the issues you want to appeal and why you want to appeal them. You can also let the Board know if you would like a hearing for your appeal.</p>
+        <p><a href="#">Learn more about hearings.</a></p>
+      </div>,
     }
   },
   nod: {

--- a/src/js/disability-benefits/utils/appeal-helpers.jsx
+++ b/src/js/disability-benefits/utils/appeal-helpers.jsx
@@ -1,64 +1,60 @@
 import React from 'react';
 
-export const appealStatusDescriptions = (eventType) => {
-  const definitionMap = {
-    form9: {
-      status: {
-        title: 'form9 Your Form 9 was received by the Regional Office (RO)',
-        description: <div>
-          <p>The Veterans Benefits Administration (VBA) RO has received your Form 9, and is now completing the final steps in the processing of your appeal before it is sent to the Board.</p>
-          <ul>
-            <li>If you didn't submit any new evidence with your Form 9, your appeal is now waiting for the RO to certify it to the Board.</li>
-            <li>If you, your legal representative, or your healthcare provider added new evidence, the RO will review the evidence and another SSOC will be developed.</li>
-          </ul>
-        </div>,
-      },
-      nextAction: {
-        title: 'You have asked for a videoconference hearing on your Form 9.',
-        description: 'You will get a letter in the mail at least 30 days before your hearing is scheduled letting you know the date, time, and location of the hearing.'
-      }
+export const appealStatusDescriptions = {
+  form9: {
+    status: {
+      title: 'form9 Your Form 9 was received by the Regional Office (RO)',
+      description: <div>
+        <p>The Veterans Benefits Administration (VBA) RO has received your Form 9, and is now completing the final steps in the processing of your appeal before it is sent to the Board.</p>
+        <ul>
+          <li>If you didn't submit any new evidence with your Form 9, your appeal is now waiting for the RO to certify it to the Board.</li>
+          <li>If you, your legal representative, or your healthcare provider added new evidence, the RO will review the evidence and another SSOC will be developed.</li>
+        </ul>
+      </div>,
     },
-    ssoc: {
-      status: {
-        title: 'SSOC status title',
-        description: <p>SSOC description.</p>,
-      },
-      nextAction: {
-        title: 'SSOC next action title.',
-        description: 'SSOC next action description.'
-      }
+    nextAction: {
+      title: 'You have asked for a videoconference hearing on your Form 9.',
+      description: 'You will get a letter in the mail at least 30 days before your hearing is scheduled letting you know the date, time, and location of the hearing.'
+    }
+  },
+  ssoc: {
+    status: {
+      title: 'SSOC status title',
+      description: <p>SSOC description.</p>,
     },
-    soc: {
-      status: {
-        title: 'SOC status title',
-        description: <p>SOC description.</p>,
-      },
-      nextAction: {
-        title: 'SOC next action title.',
-        description: 'SOC next action description.'
-      }
+    nextAction: {
+      title: 'SSOC next action title.',
+      description: 'SSOC next action description.'
+    }
+  },
+  soc: {
+    status: {
+      title: 'SOC status title',
+      description: <p>SOC description.</p>,
     },
-    nod: {
-      status: {
-        title: 'NOD status title',
-        description: <p>NOD description.</p>,
-      },
-      nextAction: {
-        title: 'NOD next action title.',
-        description: 'NOD next action description.'
-      }
+    nextAction: {
+      title: 'SOC next action title.',
+      description: 'SOC next action description.'
+    }
+  },
+  nod: {
+    status: {
+      title: 'Your NOD has been received by the Veterans Benefits Administration (VBA) RO.',
+      description: <p>Your NOD has been received by the RO. The RO will make a decision or develop the Statement of the Case (SOC) for your appeal. This means they review all of the evidence related to your appeal, including any new evidence you submit. When the SOC is prepared, you will receive a copy of it in the mail.</p>,
     },
-    bva_final_decision: { // eslint-disable-line camelcase
-      status: {
-        title: 'bva_final_decision status title',
-        description: <p>bva_final_decision description.</p>,
-      },
-      nextAction: {
-        title: 'bva_final_decision next action title.',
-        description: 'bva_final_decision next action description.'
-      }
+    nextAction: {
+      title: 'NOD next action title.',
+      description: 'NOD next action description.'
+    }
+  },
+  bva_final_decision: { // eslint-disable-line camelcase
+    status: {
+      title: 'bva_final_decision status title',
+      description: <p>bva_final_decision description.</p>,
     },
-  };
-
-  return definitionMap[eventType];
+    nextAction: {
+      title: 'bva_final_decision next action title.',
+      description: 'bva_final_decision next action description.'
+    }
+  },
 };

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -270,9 +270,40 @@ a.claim-list-item {
     font-size: 1.25em;
   }
 
+  .next-action-container {
+    padding-right: 1em;
+  }
+
   .next-action {
     padding: 1em;
-    background: $color-inset-bg;
+    position: relative;
+
+    p {
+      margin-top: 0;
+    }
+
+    &.form9 {
+      background: $color-inset-bg;
+    }
+
+    &.soc {
+      background: $color-gibill-accent;
+      padding-left: 2.5em;
+
+      &:before {
+        left: 1em;
+        top: 1.5em;
+        position: absolute;
+        font-size: 1.25em;
+        display: inline-block;
+        font: normal normal normal 14px/1 FontAwesome;
+        font-size: inherit;
+        text-rendering: auto;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        content: "\F071";
+      }
+    }
   }
 
   .last-status {
@@ -308,6 +339,11 @@ a.claim-list-item {
         border: none;
         border-bottom: solid thin $color-gray-light;
         vertical-align: middle;
+        padding: 0 0.5em;
+
+        &.date {
+          min-width: 7em;
+        }
 
         i.fa {
           color: $color-gray;

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -250,7 +250,8 @@ a.claim-list-item {
 }
 
 .your-claims, .claims-status {
-  padding-top: 1em;
+  padding: 1em 0 3em 0;
+
   h3 {
     margin-top: 1em;
   }
@@ -276,7 +277,7 @@ a.claim-list-item {
 
   .last-status {
     margin-top: 1em;
-    padding: 1em;
+    padding: 0 1em 1em 0;
 
     h4:first-of-type {
       padding: 0;


### PR DESCRIPTION
Adds content/styling for NOD and SOC last event statuses

Uses latest content in these issues:
resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3215
resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3216

@NatalieEMoore can you confirm that the "we need your Form 9 by..." in the yellow box on the SOC status is **60 calendar days from SOC event date?**

### SOC
![screen shot 2017-06-23 at 7 23 26 pm](https://user-images.githubusercontent.com/303289/27504972-9d1604c2-5849-11e7-8cdf-cafa575b29b6.png)

### NOD
![screen shot 2017-06-23 at 5 57 31 pm](https://user-images.githubusercontent.com/303289/27504971-9d14c652-5849-11e7-8821-b9b874d17f3f.png)
