### PR TITLE
Direct all Edu apply links to /education/apply/

### DIFF
--- a/content/pages/education/advanced-training-and-certifications/flight-training.md
+++ b/content/pages/education/advanced-training-and-certifications/flight-training.md
@@ -51,6 +51,6 @@ The benefits depend on the benefit program you use:
 
 ### How do I get these benefits? 
 
-You'll need to apply for benefits. [Apply for education benefits](/education/apply-for-education-benefits/).
+You'll need to apply for benefits. [Apply for education benefits](/education/apply/).
 
 

--- a/content/pages/education/eligibility.md
+++ b/content/pages/education/eligibility.md
@@ -75,7 +75,7 @@ Also, if you haven't used all of your Post-9/11 GI Bill benefits, you may be abl
 
 ### Ready to apply?
 
-<a class="usa-button-primary va-button-primary" href="/education/apply-for-education-benefits/application/1990/introduction">Apply for Benefits</a>
+<a class="usa-button-primary va-button-primary" href="/education/apply/">Apply for Benefits</a>
 
 [Learn about the application process](/education/apply). 
 

--- a/content/pages/education/gi-bill/foreign-programs.md
+++ b/content/pages/education/gi-bill/foreign-programs.md
@@ -65,7 +65,7 @@ Use the GI Bill Comparison Tool to see what benefits you can get at the school y
 <ol class="process">
 <li class="process-step list-one">
 
-After we approve the school, you'll need to apply. [Apply for benefits](/education/apply-for-education-benefits/). 
+After we approve the school, you'll need to apply. [Apply for benefits](/education/apply/). 
 
 Turn in your application to us at least 90 days before you leave for your new school. We'll decide what benefits you get based on your school’s location. 
 

--- a/content/pages/education/gi-bill/montgomery-active-duty.md
+++ b/content/pages/education/gi-bill/montgomery-active-duty.md
@@ -67,7 +67,7 @@ Money for tuition or training
 -----
 
 ### How do I get these benefits?
-You'll need to apply. [Apply for benefits](/education/apply-for-education-benefits/). 
+You'll need to apply. [Apply for benefits](/education/apply/). 
 
 You may get up to 36 months of education benefits. We pay the benefits monthly and the amount depends on the following factors:
 

--- a/content/pages/education/gi-bill/montgomery-selected-reserve.md
+++ b/content/pages/education/gi-bill/montgomery-selected-reserve.md
@@ -55,7 +55,7 @@ We'll give you up to $368 per month in compensation (payments) for these types o
 
 ### How do I get these benefits? 
 
-You'll need to apply. [Apply for benefits](/education/apply-for-education-benefits/).
+You'll need to apply. [Apply for benefits](/education/apply/).
 
 ### Get more information
 - [Ask questions on the GI Bill customer service page](http://gibill.custhelp.com/). You can also search frequently asked questions. 

--- a/content/pages/education/gi-bill/post-9-11.md
+++ b/content/pages/education/gi-bill/post-9-11.md
@@ -40,7 +40,7 @@ If you qualify for more than one VA education benefit, you'll have to pick which
 
 ### How do I get these benefits?
 
-You'll need to apply. [Apply for education benefits](/education/apply-for-education-benefits/). 
+You'll need to apply. [Apply for education benefits](/education/apply/). 
 
 The benefit amount depends on which school you go to, how much active-duty service you've had since September 10, 2001, and how many credits or training hours you're taking.
 

--- a/content/pages/education/gi-bill/post-9-11/yellow-ribbon-program.md
+++ b/content/pages/education/gi-bill/post-9-11/yellow-ribbon-program.md
@@ -42,7 +42,7 @@ Money for tuition
 
 ##### Apply for benefits
 
-[Apply for for Post-9/11 GI Bill benefits](/education/apply-for-education-benefits/). If you qualify for benefits, you'll get a Certificate of Eligibility (COE).
+[Apply for for Post-9/11 GI Bill benefits](/education/apply/). If you qualify for benefits, you'll get a Certificate of Eligibility (COE).
 
 </li>
 

--- a/content/pages/education/gi-bill/survivors-dependent-assistance.md
+++ b/content/pages/education/gi-bill/survivors-dependent-assistance.md
@@ -48,7 +48,7 @@ If you're a dependent who doesn't meet the above criteria, you may still qualify
 
 ### How do I get these benefits?
 
-You'll need to apply. [Apply for education benefits](/education/apply-for-education-benefits).
+You'll need to apply. [Apply for education benefits](/education/apply/).
 
 There are 2 main GI Bill programs offering educational assistance to survivors and dependents of Veterans:
 

--- a/content/pages/education/gi-bill/transfer.md
+++ b/content/pages/education/gi-bill/transfer.md
@@ -67,7 +67,7 @@ Your dependents may still qualify even if a child marries or you and your spouse
 While you're still on active duty, you'll request to transfer, change, or revoke a Transfer of Entitlement (TOE) through milConnect. You can't apply for a TOE through us. [Transfer, change, or revoke a TOE](https://www.dmdc.osd.mil/milconnect/). 
 
 If DOD approves the TOE, family members may apply for benefits. 
-- [Apply online](/education/apply-for-education-benefits/application/1990e/introduction/). 
+- [Apply online](/education/apply/). 
 - Apply by mail. You'll need to fill out and mail VA Form 22-1990E to the nearest VA regional office. [Download Form 22-1990e](http://www.vba.va.gov/pubs/forms/VBA-22-1990e-ARE.pdf). 
 
 [Find a nearby VA facility](/facilities/).

--- a/content/pages/education/gi-bill/yellow-ribbon.md
+++ b/content/pages/education/gi-bill/yellow-ribbon.md
@@ -46,7 +46,7 @@ Money for tuition
 
 ##### Apply for benefits
 
-[Apply for Post-9/11 GI Bill benefits](/education/apply-for-education-benefits/). If you qualify for benefits, you'll get a Certificate of Eligibility (COE).
+[Apply for Post-9/11 GI Bill benefits](/education/apply/). If you qualify for benefits, you'll get a Certificate of Eligibility (COE).
 
 </li>
 

--- a/content/pages/education/other-educational-assistance-programs/veap.md
+++ b/content/pages/education/other-educational-assistance-programs/veap.md
@@ -32,7 +32,7 @@ Money for tuition
 
 ### How do I get this benefit?
 
-You'll need to apply. [Apply for benefits](/education/apply-for-education-benefits/). 
+You'll need to apply. [Apply for benefits](/education/apply/). 
 
 You can use VEAP benefits for these programs:
 

--- a/content/pages/education/work-learn/non-college-degree-program.md
+++ b/content/pages/education/work-learn/non-college-degree-program.md
@@ -38,7 +38,7 @@ You can get education benefits through the GI Bill if:
 
 ### How do I get these benefits?
 
-You'll need to apply for benefits. [Apply for education benefits](/education/apply-for-education-benefits/). 
+You'll need to apply for benefits. [Apply for education benefits](/education/apply/). 
 
 ### How much money will I get? 
 

--- a/content/pages/education/work-learn/non-traditional/correspondence-training.md
+++ b/content/pages/education/work-learn/non-traditional/correspondence-training.md
@@ -35,7 +35,7 @@ We'll pay you back for the cost of your correspondence training classes if you'r
 
 ### How do I get these benefits? 
 
-- You'll need to apply for benefits. [Apply for education benefits](/education/apply-for-education-benefits/). 
+- You'll need to apply for benefits. [Apply for education benefits](/education/apply/). 
 
 - We base payment amounts on the specific GI Bill program you're using. If you're enrolled in correspondence training, we decide your payment amount and then pay it quarterly after your school lets us know that you've finished your course of study. 
 


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2991

- Changes general “Apply” links and buttons that pointed directly to the 1990 application to instead point to the apply page `/education/apply/`
- Changes links to the old `/education/apply-for-education-benefits/` URL to the current `education/apply/`