### PR TITLE
Avoid parallel requests when loading messaging app

### DIFF
--- a/src/js/messaging/containers/Compose.jsx
+++ b/src/js/messaging/containers/Compose.jsx
@@ -14,6 +14,7 @@ import {
   addComposeAttachments,
   deleteComposeAttachment,
   deleteComposeMessage,
+  fetchRecipients,
   openAttachmentsModal,
   resetMessage,
   saveDraft,
@@ -32,6 +33,7 @@ export class Compose extends React.Component {
     this.sendMessage = this.sendMessage.bind(this);
     this.saveDraft = this.saveDraft.bind(this);
     this.saveDraftIfNoAttachments = this.saveDraftIfNoAttachments.bind(this);
+    this.loadApp = this.loadApp.bind(this);
   }
 
   componentDidMount() {
@@ -43,7 +45,7 @@ export class Compose extends React.Component {
       });
       return;
     }
-
+    this.loadApp();
     this.props.resetMessage();
   }
 
@@ -55,6 +57,11 @@ export class Compose extends React.Component {
         state: { preserveAlert: true }
       });
     }
+  }
+
+  loadApp() {
+    const { recipients } = this.props;
+    if (!recipients) { this.props.fetchRecipients(); }
   }
 
   apiFormattedMessage() {
@@ -192,6 +199,7 @@ const mapDispatchToProps = {
   addComposeAttachments,
   deleteComposeAttachment,
   deleteComposeMessage,
+  fetchRecipients,
   openAttachmentsModal,
   resetMessage,
   saveDraft,

--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -12,7 +12,6 @@ import {
   closeCreateFolderModal,
   createFolderAndMoveMessage,
   createNewFolder,
-  fetchRecipients,
   fetchFolders,
   openCreateFolderModal,
   setNewFolderName,
@@ -40,9 +39,8 @@ export class Main extends React.Component {
   }
 
   loadApp() {
-    const { folders, recipients } = this.props;
+    const { folders } = this.props;
     if (!folders || !folders.length) { this.props.fetchFolders(); }
-    if (!recipients) { this.props.fetchRecipients(); }
   }
 
   handleFolderChange() {
@@ -68,11 +66,11 @@ export class Main extends React.Component {
   render() {
     const loading = this.props.loading;
 
-    if (loading.folders || loading.recipients) {
+    if (loading.folders) {
       return <LoadingIndicator message="Loading your application..."/>;
     }
 
-    if (!this.props.folders || !this.props.folders.length || !this.props.recipients) {
+    if (!this.props.folders || !this.props.folders.length) {
       return (
         <p>
           The application failed to load.
@@ -168,7 +166,6 @@ const mapStateToProps = (state) => {
     isVisibleAdvancedSearch: msgState.search.advanced.visible,
     loading: msgState.loading,
     nav: msgState.folders.ui.nav,
-    recipients: msgState.recipients.data,
   };
 };
 
@@ -179,7 +176,6 @@ const mapDispatchToProps = {
   createFolderAndMoveMessage,
   createNewFolder,
   fetchFolders,
-  fetchRecipients,
   openCreateFolderModal,
   setNewFolderName,
   toggleFolderNav,


### PR DESCRIPTION
Temporary fix for issue described in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3591. Tested locally. 

Would like confirmation that the ordering of steps in componentDidMount is okay - I don't quite understand what that redirect stuff is doing. And also confirmation that I don't need a similar call in componentDidUpdate. 
