### PR TITLE
Fix flashing on intro page

### DIFF
--- a/src/js/burials/config/form.js
+++ b/src/js/burials/config/form.js
@@ -65,7 +65,7 @@ const formConfig = {
   transformForSubmit: transform,
   formId: '21P-530',
   version: 0,
-  savedFormErrorMessages: {
+  savedFormMessages: {
     notFound: 'Please start over to apply for burial benefits.',
     noAuth: 'Please sign in again to resume your application for burial benefits.'
   },

--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -1,6 +1,6 @@
 import environment from './environment.js';
 import { updateLoggedInStatus } from '../../login/actions';
-import { updateProfileField } from '../../user-profile/actions';
+import { updateProfileField, profileLoadingFinished } from '../../user-profile/actions';
 
 export function handleVerify(verifyUrl) {
   window.dataLayer.push({ event: 'verify-link-clicked' });
@@ -39,6 +39,8 @@ export function getUserData(dispatch) {
       dispatch(updateProfileField('status', json.data.attributes.va_profile.status));
       dispatch(updateProfileField('services', json.data.attributes.services));
       dispatch(updateLoggedInStatus(true));
+    } else {
+      dispatch(profileLoadingFinished());
     }
   });
 }

--- a/src/js/common/schemaform/FormSaved.jsx
+++ b/src/js/common/schemaform/FormSaved.jsx
@@ -35,6 +35,7 @@ class FormSaved extends React.Component {
     const { profile } = this.props.user;
     const lastSavedDate = this.props.lastSavedDate;
     const prefillAvailable = !!(profile && profile.prefillsAvailable.includes(this.props.formId));
+    const { success } = this.props.route.formConfig.savedFormMessages || {};
 
     return (
       <div>
@@ -42,8 +43,7 @@ class FormSaved extends React.Component {
           <div className="usa-alert-body">
             <strong>Your application has been saved!</strong><br/>
             {!!lastSavedDate && <p>Last saved on {moment(lastSavedDate).format('M/D/YYYY [at] h:mma')}.</p>}
-
-            <p>To resume the application when you come back, either bookmark this page or come back to the <a href="/health-care/apply/application">health care application page</a>.</p>
+            {success}
             If you're on a public computer, please sign out before you leave to ensure your data is secure.
           </div>
         </div>
@@ -67,7 +67,8 @@ FormSaved.propTypes = {
   route: PropTypes.shape({
     pageList: PropTypes.arrayOf(PropTypes.shape({
       path: PropTypes.string
-    }))
+    })),
+    formConfig: PropTypes.object.isRequired
   }),
   lastSavedDate: PropTypes.number.isRequired,
 };

--- a/src/js/common/schemaform/FormStartControls.jsx
+++ b/src/js/common/schemaform/FormStartControls.jsx
@@ -46,6 +46,8 @@ class FormStartControls extends React.Component {
   }
 
   render() {
+    const { startOver } = this.props.messages || {};
+
     if (this.props.formSaved) {
       return (
         <div>
@@ -63,7 +65,7 @@ class FormStartControls extends React.Component {
               id="start-over-modal"
               onClose={this.toggleModal}
               visible={this.state.modalOpen}>
-            <h4>Starting over would erase all your previous information.</h4>
+            <h4>{startOver || 'Starting over would erase your in progress form.'}</h4>
             <p>Are you sure you want to start over?</p>
             <ProgressButton
                 onButtonClick={this.startOver}

--- a/src/js/common/schemaform/SaveInProgressErrorPage.jsx
+++ b/src/js/common/schemaform/SaveInProgressErrorPage.jsx
@@ -52,7 +52,7 @@ class SaveInProgressErrorPage extends React.Component {
 
   render() {
     const { loadedStatus } = this.props;
-    const { noAuth, notFound } = this.props.route.formConfig.savedFormErrorMessages || {};
+    const { noAuth, notFound } = this.props.route.formConfig.savedFormMessages || {};
     let content;
 
     switch (loadedStatus) {
@@ -112,7 +112,7 @@ class SaveInProgressErrorPage extends React.Component {
 
 SaveInProgressErrorPage.propTypes = {
   loadedStatus: PropTypes.string.isRequired,
-  savedFormErrorMessages: PropTypes.shape({
+  savedFormMessages: PropTypes.shape({
     notFound: PropTypes.string,
     noAuth: PropTypes.string
   }),

--- a/src/js/common/schemaform/SaveInProgressIntro.jsx
+++ b/src/js/common/schemaform/SaveInProgressIntro.jsx
@@ -55,7 +55,7 @@ export default class SaveInProgressIntro extends React.Component {
     if (profile.loading) {
       return (
         <div>
-          <LoadingIndicator message="Please wait while we check for an in progress form."/>
+          <LoadingIndicator message="We’re checking to see if you have a saved version of this application"/>
           <br/>
         </div>
       );

--- a/src/js/common/schemaform/SaveInProgressIntro.jsx
+++ b/src/js/common/schemaform/SaveInProgressIntro.jsx
@@ -6,6 +6,7 @@ import moment from 'moment';
 import { updateLogInUrl } from '../../login/actions';
 import { fetchInProgressForm, removeInProgressForm } from './save-load-actions';
 import SignInLink from '../components/SignInLink';
+import LoadingIndicator from '../components/LoadingIndicator';
 import FormStartControls from './FormStartControls';
 
 export default class SaveInProgressIntro extends React.Component {
@@ -50,6 +51,15 @@ export default class SaveInProgressIntro extends React.Component {
     const { profile } = this.props.user;
     const savedForm = profile && profile.savedForms.find(f => f.form === this.props.formId);
     const prefillAvailable = !!(profile && profile.prefillsAvailable.includes(this.props.formId));
+
+    if (profile.loading) {
+      return (
+        <div>
+          <LoadingIndicator message="Please wait while we check for an in progress form."/>
+          <br/>
+        </div>
+      );
+    }
 
     return (
       <div>

--- a/src/js/common/schemaform/SaveInProgressIntro.jsx
+++ b/src/js/common/schemaform/SaveInProgressIntro.jsx
@@ -65,6 +65,7 @@ export default class SaveInProgressIntro extends React.Component {
       <div>
         {this.getAlert(savedForm)}
         <FormStartControls
+            messages={this.props.messages}
             startPage={this.props.pageList[1].path}
             formId={this.props.formId}
             returnUrl={this.props.returnUrl}
@@ -81,6 +82,7 @@ export default class SaveInProgressIntro extends React.Component {
 
 SaveInProgressIntro.propTypes = {
   formId: PropTypes.string.isRequired,
+  messages: PropTypes.object,
   migrations: PropTypes.array,
   returnUrl: PropTypes.string,
   lastSavedDate: PropTypes.number,

--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -87,6 +87,7 @@ export function createRoutes(formConfig) {
       {
         path: 'introduction',
         component: formConfig.introduction,
+        formConfig,
         pageList
       }
     ].concat(routes);

--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -96,7 +96,8 @@ export function createRoutes(formConfig) {
     routes.push({
       path: 'form-saved',
       component: FormSaved,
-      pageList
+      pageList,
+      formConfig
     });
   }
 

--- a/src/js/hca/components/SIPIntroductionPage.jsx
+++ b/src/js/hca/components/SIPIntroductionPage.jsx
@@ -29,6 +29,7 @@ class IntroductionPage extends React.Component {
         </p>
         <SaveInProgressIntro
             pageList={this.props.route.pageList}
+            messages={this.props.route.formConfig.savedFormMessages}
             {...this.props.saveInProgressActions}
             {...this.props.saveInProgress}>
           Complete the form before submitting to apply for health care with the 10-10EZ.

--- a/src/js/hca/config/form.js
+++ b/src/js/hca/config/form.js
@@ -21,7 +21,8 @@ import {
   medicalCenterLabels,
   financialDisclosureText,
   incomeDescription,
-  disclosureWarning
+  disclosureWarning,
+  resumeMessage
 } from '../helpers';
 
 import IntroductionPage from '../components/IntroductionPage';
@@ -120,9 +121,9 @@ const formConfig = {
   version: 0,
   // Disable save in progress for production
   disableSave: __BUILDTYPE__ === 'production',
-  savedFormErrorMessages: {
     notFound: 'Please start over to apply for health care.',
-    noAuth: 'Please sign in again to resume your application for health care.'
+    noAuth: 'Please sign in again to resume your application for health care.',
+    success: resumeMessage
   },
   transformForSubmit: transform,
   // Use the old intro page for production, but SiP for dev and staging

--- a/src/js/hca/config/form.js
+++ b/src/js/hca/config/form.js
@@ -121,9 +121,11 @@ const formConfig = {
   version: 0,
   // Disable save in progress for production
   disableSave: __BUILDTYPE__ === 'production',
+  savedFormMessages: {
     notFound: 'Please start over to apply for health care.',
     noAuth: 'Please sign in again to resume your application for health care.',
-    success: resumeMessage
+    success: resumeMessage,
+    startOver: 'This will remove anything you have put into the Health Care Application.'
   },
   transformForSubmit: transform,
   // Use the old intro page for production, but SiP for dev and staging

--- a/src/js/hca/helpers.jsx
+++ b/src/js/hca/helpers.jsx
@@ -159,3 +159,7 @@ export const disclosureWarning = (
     </div>
   </div>
 );
+
+export const resumeMessage = (
+  <p>To resume the application when you come back, either bookmark this page or come back to the <a href="/health-care/apply/application">health care application page</a>.</p>
+);

--- a/src/js/pensions/config/form.js
+++ b/src/js/pensions/config/form.js
@@ -156,7 +156,7 @@ const formConfig = {
   confirmation: ConfirmationPage,
   formId: '21P-527EZ',
   version: 0,
-  savedFormErrorMessages: {
+  savedFormMessages: {
     notFound: 'Please start over to apply for pension benefits.',
     noAuth: 'Please sign in again to resume your application for pension benefits.'
   },

--- a/src/js/user-profile/actions/index.js
+++ b/src/js/user-profile/actions/index.js
@@ -1,9 +1,16 @@
 export const UPDATE_PROFILE_FIELD = 'UPDATE_PROFILE_FIELD';
+export const PROFILE_LOADING_FINISHED = 'PROFILE_LOADING_FINISHED';
 
 export function updateProfileField(propertyPath, value) {
   return {
     type: UPDATE_PROFILE_FIELD,
     propertyPath,
     value
+  };
+}
+
+export function profileLoadingFinished() {
+  return {
+    type: PROFILE_LOADING_FINISHED
   };
 }

--- a/src/js/user-profile/reducers/profile.js
+++ b/src/js/user-profile/reducers/profile.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp';
 
-import { UPDATE_PROFILE_FIELD } from '../actions';
+import { UPDATE_PROFILE_FIELD, PROFILE_LOADING_FINISHED } from '../actions';
+import { UPDATE_LOGGEDIN_STATUS } from '../../login/actions';
 
 // TODO(crew): Romove before this goes to production.
 const initialState = {
@@ -15,13 +16,20 @@ const initialState = {
   gender: null,
   accountType: null,
   savedForms: [],
-  prefillsAvailable: []
+  prefillsAvailable: [],
+  loading: true
 };
 
 function profileInformation(state = initialState, action) {
   switch (action.type) {
     case UPDATE_PROFILE_FIELD: {
       return _.set(action.propertyPath, action.value, state);
+    }
+    case PROFILE_LOADING_FINISHED: {
+      return _.set('loading', false, state);
+    }
+    case UPDATE_LOGGEDIN_STATUS: {
+      return _.set('loading', false, state);
     }
 
     default:

--- a/test/common/schemaform/FormSaved.unit.spec.jsx
+++ b/test/common/schemaform/FormSaved.unit.spec.jsx
@@ -14,7 +14,9 @@ describe('Schemaform <FormSaved>', () => {
         {
           path: 'testing'
         }
-      ]
+      ],
+      formConfig: {
+      }
     };
     const user = {
       profile: {

--- a/test/common/schemaform/SaveInProgressIntro.unit.spec.jsx
+++ b/test/common/schemaform/SaveInProgressIntro.unit.spec.jsx
@@ -103,4 +103,29 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     expect(tree.subTree('.usa-alert')).to.be.false;
     expect(tree.subTree('withRouter(FormStartControls)')).not.to.be.false;
   });
+
+  it('should render loading indicator while profile is loading', () => {
+    const user = {
+      profile: {
+        savedForms: [
+          { form: '1010ez' }
+        ],
+        prefillsAvailable: [],
+        loading: true
+      },
+      login: {
+        currentlyLoggedIn: false
+      }
+    };
+
+    const tree = SkinDeep.shallowRender(
+      <SaveInProgressIntro
+          pageList={pageList}
+          formId="1010ez"
+          user={user}/>
+    );
+
+    expect(tree.subTree('LoadingIndicator')).not.to.be.false;
+    expect(tree.subTree('withRouter(FormStartControls)')).to.be.false;
+  });
 });

--- a/test/user-profile/reducers/profile.unit.spec.js
+++ b/test/user-profile/reducers/profile.unit.spec.js
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+
+import reducer from '../../../src/js/user-profile/reducers/profile.js';
+import { UPDATE_LOGGEDIN_STATUS } from '../../../src/js/login/actions';
+import { PROFILE_LOADING_FINISHED } from '../../../src/js/user-profile/actions';
+
+describe('Profile reducer', () => {
+  it('should set loading to false when profile is done loading', () => {
+    const state = reducer({}, {
+      type: PROFILE_LOADING_FINISHED
+    });
+
+    expect(state.loading).to.be.false;
+  });
+  it('should set loading to false when logged in status changes', () => {
+    const state = reducer({}, {
+      type: UPDATE_LOGGEDIN_STATUS
+    });
+
+    expect(state.loading).to.be.false;
+  });
+});


### PR DESCRIPTION
We get some flashing of content on form intro pages with save in progress, because we couldn't tell when we were waiting for profile info from the server vs a user had an expired session and the request received a 401 error.

This addresses that by creating a loading flag in the profile state and setting it when the login status changes (or on a specific action).

While the profile is loading, we display this:

![screen shot 2017-06-28 at 3 59 48 pm](https://user-images.githubusercontent.com/634932/27657505-dfa6b5e6-5c1a-11e7-97f4-363b79a2d03d.png)
