### PR TITLE
Update vets-json-schema version

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,6 +192,6 @@
   "dependencies": {
     "camelcase-keys-recursive": "^0.8.2",
     "reselect": "^2.5.4",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#de9bef075350509c9bde1d9296c1a91d2355fd26"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#15fc19ac79de09b7b8a0957fe49d53fc9d3c2d69"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8300,9 +8300,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#de9bef075350509c9bde1d9296c1a91d2355fd26":
-  version "3.0.19"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#de9bef075350509c9bde1d9296c1a91d2355fd26"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#15fc19ac79de09b7b8a0957fe49d53fc9d3c2d69":
+  version "3.0.21"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#15fc19ac79de09b7b8a0957fe49d53fc9d3c2d69"
 
 vinyl-assign@^1.0.1:
   version "1.2.1"


### PR DESCRIPTION
References https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3646

Zero default values are now required.
As this change involves a newer version of vets-json-schema, this [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/5916), related to an earlier change made to vets-json-schema should be merged first.

<img width="354" alt="screen shot 2017-06-29 at 6 07 26 pm" src="https://user-images.githubusercontent.com/16051172/27716958-c170a960-5cf6-11e7-9813-98d74081adae.png">

<img width="369" alt="screen shot 2017-06-29 at 6 08 49 pm" src="https://user-images.githubusercontent.com/16051172/27716962-c60a98c8-5cf6-11e7-8a44-b37ecd8d63d3.png">
