### PR TITLE
Refactor health-beta to avoid RequiredLoginView conflict

### DIFF
--- a/src/js/health-beta/containers/HealthBetaEnrollment.jsx
+++ b/src/js/health-beta/containers/HealthBetaEnrollment.jsx
@@ -2,38 +2,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import RequiredLoginView from '../../common/components/RequiredLoginView';
-import { registerBeta } from '../actions';
 
 class HealthBetaEnrollment extends React.Component {
 
-  componentDidMount() {
-    this.props.registerBeta();
-  }
-
   render() {
-    let message;
-
-    if (this.props.loading === true) {
-      message = 'Activating beta features...';
-    }
-    if (this.props.stats === 'failed') {
-      message = 'Activation failed, please contact beta product manager.';
-    } else {
-      message = 'Beta features activated for user '.concat(this.props.username).concat('. Thank you.');
-    }
-    let view;
-
-    view = (
-      <div className="row">
-        <div className="usa-width-two-thirds medium-8 small-12 columns">
-          <h1>Health Beta Registration</h1>
-          <div>
-            <p>{message}</p>
-          </div>
-        </div>
-      </div>
-    );
-
     return (
       <div>
         <RequiredLoginView
@@ -42,7 +14,7 @@ class HealthBetaEnrollment extends React.Component {
             userProfile={this.props.profile}
             loginUrl={this.props.loginUrl}
             verifyUrl={this.props.verifyUrl}>
-          {view}
+          {this.props.children}
         </RequiredLoginView>
       </div>
       );
@@ -62,9 +34,5 @@ const mapStateToProps = (state) => {
   };
 };
 
-const mapDispatchToProps = {
-  registerBeta,
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(HealthBetaEnrollment);
+export default connect(mapStateToProps)(HealthBetaEnrollment);
 export { HealthBetaEnrollment };

--- a/src/js/health-beta/containers/Main.jsx
+++ b/src/js/health-beta/containers/Main.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { registerBeta } from '../actions';
+
+class Main extends React.Component {
+
+  componentDidMount() {
+    this.props.registerBeta();
+  }
+
+  render() {
+    let message;
+
+    if (this.props.loading === true) {
+      message = 'Activating beta features...';
+    }
+    if (this.props.stats === 'failed') {
+      message = 'Activation failed, please contact beta product manager.';
+    } else {
+      message = 'Beta features activated for user '.concat(this.props.username).concat('. Thank you.');
+    }
+    let view;
+
+    view = (
+      <div className="row">
+        <div className="usa-width-two-thirds medium-8 small-12 columns">
+          <h1>Health Beta Registration</h1>
+          <div>
+            <p>{message}</p>
+          </div>
+        </div>
+      </div>
+    );
+
+    return (
+      <div>
+          {view}
+      </div>
+      );
+  }
+}
+
+const mapStateToProps = (state) => {
+  const hbState = state.healthbeta;
+  const userState = state.user;
+  return {
+    profile: userState.profile,
+    loginUrl: userState.login.loginUrl,
+    verifyUrl: userState.login.verifyUrl,
+    username: hbState.beta.username,
+    stats: hbState.beta.stats,
+    isLoading: hbState.beta.loading,
+  };
+};
+
+const mapDispatchToProps = {
+  registerBeta,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Main);
+export { Main };

--- a/src/js/health-beta/routes.jsx
+++ b/src/js/health-beta/routes.jsx
@@ -1,8 +1,10 @@
 import HealthBetaEnrollment from './containers/HealthBetaEnrollment';
+import Main from './containers/Main';
 
 const routes = {
   path: '/health-beta',
   component: HealthBetaEnrollment,
+  indexRoute: { component: Main },
 };
 
 export default routes;


### PR DESCRIPTION
Fixes the health-beta registration app. 

Problem was that I was doing everything in HealthBetaApp, but RequiredLoginView was rendering its view which cause a refresh of HealthBetaApp which cause RequiredLoginView to go again...putting the betaRegistration stuff inside a child container (Main) fixes that. 