### PR TITLE
Logic fix for appeals access

### DIFF
--- a/src/js/common/components/RequiredLoginView.jsx
+++ b/src/js/common/components/RequiredLoginView.jsx
@@ -57,10 +57,23 @@ class RequiredLoginView extends React.Component {
         }
       } else if (this.props.authRequired === 3) {
         if (this.props.userProfile.accountType === 3) {
-          if (this.props.userProfile.status === 'SERVER_ERROR') {
+          // TODO: Delete the logic around attemptingAppealsAccess once we
+          // resolve the MVI/Appeals Users issues.
+          // if app we are trying to access includes appeals,
+          // bypass the checks for userProfile status
+          const requiredApp = this.props.serviceRequired;
+          let attemptingAppealsAccess;
+
+          if (Array.isArray(requiredApp)) {
+            attemptingAppealsAccess = requiredApp.indexOf('appeals-status') !== -1;
+          } else {
+            attemptingAppealsAccess = requiredApp === 'appeals-status';
+          }
+
+          if (this.props.userProfile.status === 'SERVER_ERROR' && !attemptingAppealsAccess) {
             // If va_profile is null, show a system down message.
             view = <SystemDownView messageLine1="Sorry, our system is temporarily down while we fix a few things. Please try again later."/>;
-          } else if (this.props.userProfile.status === 'NOT_FOUND') {
+          } else if (this.props.userProfile.status === 'NOT_FOUND' && !attemptingAppealsAccess) {
             // If va_profile is "not found", show message that we cannot find the user
             // in our system.
             view = <SystemDownView messageLine1="We couldn't find your records with that information." messageLine2="Please call the Vets.gov Help Desk at 1-855-574-7286. We're open Monday‒Friday, 8:00 a.m.‒8:00 p.m. (ET)."/>;

--- a/src/js/disability-benefits/containers/DisabilityBenefitsApp.jsx
+++ b/src/js/disability-benefits/containers/DisabilityBenefitsApp.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import Breadcrumbs from '../components/Breadcrumbs';
 import RequiredLoginView from '../../common/components/RequiredLoginView';
+import ClaimsUnavailable from '../components/ClaimsUnavailable';
 
 // This needs to be a React component for RequiredLoginView to pass down
 // the isDataAvailable prop, which is only passed on failure.
@@ -10,6 +11,7 @@ function AppContent({ children, isDataAvailable }) {
   const canUseApp = isDataAvailable === true || typeof isDataAvailable === 'undefined';
   return (
     <div className="disability-benefits-content">
+      {!canUseApp && <ClaimsUnavailable/>}
       {canUseApp &&
         <div>
           {children}


### PR DESCRIPTION
- logic to bypass a check for `va_profile` if a user is trying to access appeals

Currently, we check for LOA3 and also existence of a `va_profile`. Appeals test users have LOA3 access but do not have `va_profile` so they cannot access the app even with access to `appeals-status` in their profile. 

This logic can be deleted in the future