### PR TITLE
Initial events for account creation

### DIFF
--- a/src/js/common/components/RequiredTermsAcceptanceView.jsx
+++ b/src/js/common/components/RequiredTermsAcceptanceView.jsx
@@ -16,8 +16,8 @@ export class RequiredTermsAcceptanceView extends React.Component {
       this.props.fetchLatestTerms(this.props.termsName);
       window.scrollTo(0, 0);
     }
-    const app = window.location.pathname.split('/').pop()
-    window.dataLayer.push({event: `terms-shown-${app}`});
+    const app = window.location.pathname.split('/').pop();
+    window.dataLayer.push({ event: `terms-shown-${app}` });
   }
 
   render() {

--- a/src/js/common/components/RequiredTermsAcceptanceView.jsx
+++ b/src/js/common/components/RequiredTermsAcceptanceView.jsx
@@ -16,6 +16,8 @@ export class RequiredTermsAcceptanceView extends React.Component {
       this.props.fetchLatestTerms(this.props.termsName);
       window.scrollTo(0, 0);
     }
+    const app = window.location.pathname.split('/').pop()
+    window.dataLayer.push({event: `terms-shown-${app}`});
   }
 
   render() {

--- a/src/js/user-profile/actions/index.js
+++ b/src/js/user-profile/actions/index.js
@@ -43,6 +43,7 @@ export function fetchLatestTerms(termsName) {
 export function acceptTerms(termsName) {
   return dispatch => {
     dispatch({ type: ACCEPTING_LATEST_MHV_TERMS });
+    window.dataLayer.push({ event: 'terms-accepted' });
 
     const settings = {
       method: 'POST',

--- a/src/js/user-profile/components/UserDataSection.jsx
+++ b/src/js/user-profile/components/UserDataSection.jsx
@@ -19,6 +19,7 @@ class UserDataSection extends React.Component {
   }
 
   openModal = () => {
+    window.dataLayer.push({event: 'terms-shown-profile'});
     this.setState({ modalOpen: true });
   }
 

--- a/src/js/user-profile/components/UserDataSection.jsx
+++ b/src/js/user-profile/components/UserDataSection.jsx
@@ -19,7 +19,7 @@ class UserDataSection extends React.Component {
   }
 
   openModal = () => {
-    window.dataLayer.push({event: 'terms-shown-profile'});
+    window.dataLayer.push({ event: 'terms-shown-profile' });
     this.setState({ modalOpen: true });
   }
 


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3469

Tracks acceptances of the terms
Tracks how many times it is shown. It uses the end of the URL to differentiate which app caused it to be shown (per requested analytics). Seems to be the best proxy for that.
By taking # shown - # accepted we can get # of those who did not accept.

Per @leannammiller i'm tagging @bshyong and @patrickvinograd for review

I'll add in the config to report these events through to GA as well now. Once this is merged, I'll verify things on staging.