### PR TITLE
Multiple service periods and required national guard fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,6 @@
   "dependencies": {
     "camelcase-keys-recursive": "^0.8.2",
     "reselect": "^2.5.4",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d4f32a9477cbdd53cdaa610ece8002e821f04734"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#f91824ba7555b242a009fe590e3ba79a142395f9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -193,6 +193,6 @@
   "dependencies": {
     "camelcase-keys-recursive": "^0.8.2",
     "reselect": "^2.5.4",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#f91824ba7555b242a009fe590e3ba79a142395f9"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#8fbfee24b1126e6d8a2cb07c4d37ec9f21a1fdb4"
   }
 }

--- a/src/js/common/schemaform/definitions/address.js
+++ b/src/js/common/schemaform/definitions/address.js
@@ -75,7 +75,6 @@ export function uiSchema(label = 'Address', useStreet3 = false, isRequired = nul
       };
       const country = currentCountry || addressSchema.properties.country.default;
       const required = addressSchema.required.length > 0;
-      // if we pass in an array for isRequired, don't ever change it
 
       let stateList;
       let labelList;
@@ -136,7 +135,7 @@ export function uiSchema(label = 'Address', useStreet3 = false, isRequired = nul
     'ui:options': {
       updateSchema: (formData, addressSchema, addressUiSchema, index, path) => {
         let currentSchema = addressSchema;
-        if (isRequired && typeof isRequired === 'function') {
+        if (isRequired) {
           const required = isRequired(formData, index);
           if (required && currentSchema.required.length === 0) {
             currentSchema = _.set('required', requiredFields, currentSchema);

--- a/src/js/common/schemaform/definitions/address.js
+++ b/src/js/common/schemaform/definitions/address.js
@@ -57,6 +57,8 @@ export function schema(currentSchema, isRequired = false) {
  * @param {boolean} useStreet3 - Show a third line in the address
  * @param {function} isRequired - A function for conditionally setting if an address is required.
  *   Receives formData and an index (if in an array item)
+ * @param {boolean} ignoreRequired - Ignore the required fields array, to avoid overwriting form specific
+ *   customizations
  */
 export function uiSchema(label = 'Address', useStreet3 = false, isRequired = null, ignoreRequired = false) {
   let fieldOrder = ['country', 'street', 'street2', 'street3', 'city', 'state', 'postalCode'];

--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -248,12 +248,12 @@ export function stringifyFormReplacer(key, value) {
 /*
  * Normal transform for schemaform data
  */
-export function transformForSubmit(formConfig, form) {
+export function transformForSubmit(formConfig, form, replacer = stringifyFormReplacer) {
   const inactivePages = getInactivePages(createFormPageList(formConfig), form.data);
   const withoutInactivePages = filterInactivePages(inactivePages, form);
   const withoutViewFields = filterViewFields(withoutInactivePages);
 
-  return JSON.stringify(withoutViewFields, stringifyFormReplacer) || '{}';
+  return JSON.stringify(withoutViewFields, replacer) || '{}';
 }
 
 function isHiddenField(schema) {

--- a/src/js/pensions/components/ServicePeriodView.jsx
+++ b/src/js/pensions/components/ServicePeriodView.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { formatReviewDate } from '../../common/schemaform/helpers';
+
+export default function ServicePeriodView({ formData }) {
+  let from = '';
+  let to = '';
+  if (formData.activeServiceDateRange) {
+    from = formatReviewDate(formData.activeServiceDateRange.from);
+    to = formatReviewDate(formData.activeServiceDateRange.to);
+  }
+
+  return (
+    <div>
+      <strong>{formData.serviceBranch}</strong><br/>
+      {from} &mdash; {to}
+    </div>
+  );
+}

--- a/src/js/pensions/config/form.js
+++ b/src/js/pensions/config/form.js
@@ -24,6 +24,7 @@ import ConfirmationPage from '../containers/ConfirmationPage';
 import FullNameField from '../../common/schemaform/FullNameField';
 import DependentField from '../components/DependentField';
 import EmploymentField from '../components/EmploymentField';
+import ServicePeriodView from '../components/ServicePeriodView';
 import createHouseholdMemberTitle from '../components/DisclosureTitle';
 import netWorthUI from '../definitions/netWorth';
 import monthlyIncomeUI from '../definitions/monthlyIncome';
@@ -233,21 +234,37 @@ const formConfig = {
               'ui:title': 'Did you serve under another name?',
               'ui:widget': 'yesNo'
             },
-            activeServiceDateRange: dateRangeUI(
-              'Date entered active service',
-              'Date left active service',
-              'Date entered service must be before date left service'
-            ),
+            servicePeriods: {
+              'ui:title': 'Service periods',
+              'ui:options': {
+                viewField: ServicePeriodView,
+                reviewTitle: 'Service periods'
+              },
+              items: {
+                serviceBranch: {
+                  'ui:title': 'Branch of service'
+                },
+                activeServiceDateRange: dateRangeUI(
+                  'Date entered active service',
+                  'Date left active service',
+                  'Date entered service must be before date left service'
+                )
+              }
+            },
             placeOfSeparation: {
               'ui:title': 'Place of last or anticipated separation (city and state or foreign country)'
             },
             combatSince911: (() => {
               const rangeExcludes911 = createSelector(
-                _.get('activeServiceDateRange.to'),
-                (to) => {
-                  const isFullDate = /^\d{4}-\d{2}-\d{2}$/;
+                form => form.servicePeriods,
+                (periods) => {
+                  return (periods || []).every(period => {
+                    const isFullDate = /^\d{4}-\d{2}-\d{2}$/;
 
-                  return !isFullDate.test(to) || !moment('2001-09-11').isBefore(to);
+                    return !period.activeServiceDateRange ||
+                      !isFullDate.test(period.activeServiceDateRange.to) ||
+                      !moment('2001-09-11').isBefore(period.activeServiceDateRange.to);
+                  });
                 }
               );
 
@@ -263,7 +280,7 @@ const formConfig = {
           },
           schema: {
             type: 'object',
-            required: ['activeServiceDateRange', 'view:serveUnderOtherNames'],
+            required: ['view:serveUnderOtherNames'],
             properties: {
               'view:serveUnderOtherNames': {
                 type: 'boolean'
@@ -271,9 +288,22 @@ const formConfig = {
               previousNames: _.assign(previousNames, {
                 minItems: 1
               }),
-              activeServiceDateRange: _.assign(dateRange, {
-                required: ['from', 'to']
-              }),
+              servicePeriods: {
+                type: 'array',
+                minItems: 1,
+                items: {
+                  type: 'object',
+                  required: ['serviceBranch', 'activeServiceDateRange'],
+                  properties: {
+                    serviceBranch: {
+                      type: 'string'
+                    },
+                    activeServiceDateRange: _.assign(dateRange, {
+                      required: ['from', 'to']
+                    })
+                  }
+                }
+              },
               placeOfSeparation,
               combatSince911
             }
@@ -294,8 +324,13 @@ const formConfig = {
               },
               name: {
                 'ui:title': 'Name of Reserve/National Guard unit',
+                'ui:required': form => form.nationalGuardActivation === true
               },
-              address: address.uiSchema('Unit address'),
+              address: _.merge(address.uiSchema('Unit address', false, false, true), {
+                state: {
+                  'ui:required': form => form.nationalGuardActivation === true
+                }
+              }),
               phone: phoneUI('Unit phone number'),
               date: dateUI('Service Activation Date')
             }

--- a/src/js/pensions/config/form.js
+++ b/src/js/pensions/config/form.js
@@ -217,25 +217,12 @@ const formConfig = {
     militaryHistory: {
       title: 'Military History',
       pages: {
-        general: {
+        servicePeriods: {
           path: 'military/history',
-          title: 'General history',
+          title: 'Service Periods',
           uiSchema: {
-            'ui:title': 'General history',
-            previousNames: {
-              'ui:options': {
-                expandUnder: 'view:serveUnderOtherNames',
-                viewField: FullNameField,
-                reviewTitle: 'Previous names'
-              },
-              items: fullNameUI
-            },
-            'view:serveUnderOtherNames': {
-              'ui:title': 'Did you serve under another name?',
-              'ui:widget': 'yesNo'
-            },
+            'ui:title': 'Service periods',
             servicePeriods: {
-              'ui:title': 'Service periods',
               'ui:options': {
                 viewField: ServicePeriodView,
                 reviewTitle: 'Service periods'
@@ -250,6 +237,45 @@ const formConfig = {
                   'Date entered service must be before date left service'
                 )
               }
+            }
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              servicePeriods: {
+                type: 'array',
+                minItems: 1,
+                items: {
+                  type: 'object',
+                  required: ['serviceBranch', 'activeServiceDateRange'],
+                  properties: {
+                    serviceBranch: {
+                      type: 'string'
+                    },
+                    activeServiceDateRange: _.assign(dateRange, {
+                      required: ['from', 'to']
+                    })
+                  }
+                }
+              }
+            }
+          }
+        },
+        general: {
+          path: 'military/general',
+          title: 'General History',
+          uiSchema: {
+            'view:serveUnderOtherNames': {
+              'ui:title': 'Did you serve under another name?',
+              'ui:widget': 'yesNo'
+            },
+            previousNames: {
+              'ui:options': {
+                expandUnder: 'view:serveUnderOtherNames',
+                viewField: FullNameField,
+                reviewTitle: 'Previous names'
+              },
+              items: fullNameUI
             },
             placeOfSeparation: {
               'ui:title': 'Place of last or anticipated separation (city and state or foreign country)'
@@ -288,22 +314,6 @@ const formConfig = {
               previousNames: _.assign(previousNames, {
                 minItems: 1
               }),
-              servicePeriods: {
-                type: 'array',
-                minItems: 1,
-                items: {
-                  type: 'object',
-                  required: ['serviceBranch', 'activeServiceDateRange'],
-                  properties: {
-                    serviceBranch: {
-                      type: 'string'
-                    },
-                    activeServiceDateRange: _.assign(dateRange, {
-                      required: ['from', 'to']
-                    })
-                  }
-                }
-              },
               placeOfSeparation,
               combatSince911
             }

--- a/src/js/pensions/helpers.jsx
+++ b/src/js/pensions/helpers.jsx
@@ -1,10 +1,27 @@
 import React from 'react';
 import { transformForSubmit } from '../common/schemaform/helpers';
 
+function replacer(key, value) {
+  // if the containing object has a name, we're in the national guard object
+  // and we want to keep addresses no matter what
+  if (!this.name && typeof value.country !== 'undefined' &&
+    (!value.street || !value.city || (!value.postalCode && !value.zipcode))) {
+    return undefined;
+  }
+
+  // clean up empty objects, which we have no reason to send
+  if (typeof value === 'object') {
+    const fields = Object.keys(value);
+    if (fields.length === 0 || fields.every(field => value[field] === undefined)) {
+      return undefined;
+    }
+  }
+
+  return value;
+}
+
 export function transform(formConfig, form) {
-  // delete form.data.privacyAgreementAccepted;
-  // delete form.data.hasVisitedVAMC;
-  const formData = transformForSubmit(formConfig, form);
+  const formData = transformForSubmit(formConfig, form, replacer);
   return JSON.stringify({
     pensionClaim: {
       form: formData

--- a/test/pensions/config/generalMilitaryHistory.unit.spec.jsx
+++ b/test/pensions/config/generalMilitaryHistory.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('Pensions general military history', () => {
     );
     const formDOM = getFormDOM(form);
 
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(3);
   });
 
   it('should not submit empty form', () => {
@@ -34,7 +34,7 @@ describe('Pensions general military history', () => {
 
     formDOM.submitForm();
 
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(4);
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
     expect(onSubmit.called).to.be.false;
   });
 
@@ -50,7 +50,7 @@ describe('Pensions general military history', () => {
 
     const formDOM = getFormDOM(form);
 
-    expect(formDOM.querySelectorAll('input, select').length).to.equal(10);
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(3);
 
     ReactTestUtils.Simulate.change(formDOM.querySelector('input[type="radio"]'), {
       target: {
@@ -58,11 +58,11 @@ describe('Pensions general military history', () => {
       }
     });
 
-    expect(formDOM.querySelectorAll('input, select').length).to.equal(14);
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(7);
 
     formDOM.submitForm();
 
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(5);
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(2);
     expect(onSubmit.called).to.be.false;
   });
 
@@ -78,7 +78,7 @@ describe('Pensions general military history', () => {
 
     const formDOM = getFormDOM(form);
 
-    expect(formDOM.querySelectorAll('input, select').length).to.equal(10);
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(3);
 
     ReactTestUtils.Simulate.change(formDOM.querySelector('input[type="radio"]'), {
       target: {
@@ -111,6 +111,14 @@ describe('Pensions general military history', () => {
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
           schema={schema}
+          data={{
+            servicePeriods: [{
+              activeServiceDateRange: {
+                to: '2006-05-06',
+                from: '2007-03-04'
+              }
+            }]
+          }}
           definitions={formConfig.defaultDefinitions}
           onSubmit={onSubmit}
           uiSchema={uiSchema}/>
@@ -118,77 +126,14 @@ describe('Pensions general military history', () => {
 
     const formDOM = getFormDOM(form);
 
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
-
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_servicePeriods_0_activeServiceDateRange_toMonth'), {
-      target: {
-        value: '9'
-      }
-    });
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_servicePeriods_0_activeServiceDateRange_toDay'), {
-      target: {
-        value: '11'
-      }
-    });
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_servicePeriods_0_activeServiceDateRange_toYear'), {
-      target: {
-        value: '2001'
-      }
-    });
-
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
-
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_servicePeriods_0_activeServiceDateRange_toMonth'), {
-      target: {
-        value: '9'
-      }
-    });
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_servicePeriods_0_activeServiceDateRange_toDay'), {
-      target: {
-        value: '12'
-      }
-    });
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_servicePeriods_0_activeServiceDateRange_toYear'), {
-      target: {
-        value: '2001'
-      }
-    });
-
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(12);
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(5);
 
     formDOM.submitForm();
 
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(4);
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(2);
     expect(onSubmit.called).to.be.false;
   });
 
-  it('should add another service period', () => {
-    const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester
-          schema={schema}
-          definitions={formConfig.defaultDefinitions}
-          onSubmit={onSubmit}
-          uiSchema={uiSchema}/>
-    );
-
-    const formDOM = getFormDOM(form);
-
-    expect(formDOM.querySelectorAll('input, select').length).to.equal(10);
-
-    formDOM.fillData('#root_servicePeriods_0_serviceBranch', 'Army');
-    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toMonth', '1');
-    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toDay', '1');
-    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toYear', '2003');
-    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromMonth', '1');
-    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromDay', '1');
-    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromYear', '2002');
-
-    ReactTestUtils.Simulate.click(formDOM.querySelector('.va-growable-add-btn'));
-
-    expect(formDOM.querySelector('.va-growable-background').textContent)
-      .to.contain('Army');
-  });
 
   it('should submit with valid data', () => {
     const onSubmit = sinon.spy();
@@ -203,15 +148,6 @@ describe('Pensions general military history', () => {
     const formDOM = getFormDOM(form);
 
     formDOM.fillData('#root_view\\:serveUnderOtherNamesNo', 'N');
-
-    formDOM.fillData('#root_servicePeriods_0_serviceBranch', 'Army');
-    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toMonth', '1');
-    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toDay', '1');
-    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toYear', '2003');
-    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromMonth', '1');
-    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromDay', '1');
-    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromYear', '2002');
-    formDOM.fillData('#root_combatSince911Yes', 'Y');
 
     formDOM.submitForm();
 

--- a/test/pensions/config/generalMilitaryHistory.unit.spec.jsx
+++ b/test/pensions/config/generalMilitaryHistory.unit.spec.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
+import { DefinitionTester, getFormDOM } from '../../util/schemaform-utils.jsx';
 import formConfig from '../../../src/js/pensions/config/form';
 
 describe('Pensions general military history', () => {
@@ -16,9 +15,9 @@ describe('Pensions general military history', () => {
           definitions={formConfig.defaultDefinitions}
           uiSchema={uiSchema}/>
     );
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(9);
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
   });
 
   it('should not submit empty form', () => {
@@ -31,11 +30,11 @@ describe('Pensions general military history', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    submitForm(form);
+    formDOM.submitForm();
 
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(3);
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(4);
     expect(onSubmit.called).to.be.false;
   });
 
@@ -49,9 +48,9 @@ describe('Pensions general military history', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    expect(formDOM.querySelectorAll('input, select').length).to.equal(9);
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(10);
 
     ReactTestUtils.Simulate.change(formDOM.querySelector('input[type="radio"]'), {
       target: {
@@ -59,11 +58,11 @@ describe('Pensions general military history', () => {
       }
     });
 
-    expect(formDOM.querySelectorAll('input, select').length).to.equal(13);
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(14);
 
-    submitForm(form);
+    formDOM.submitForm();
 
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(4);
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(5);
     expect(onSubmit.called).to.be.false;
   });
 
@@ -77,9 +76,9 @@ describe('Pensions general military history', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    expect(formDOM.querySelectorAll('input, select').length).to.equal(9);
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(10);
 
     ReactTestUtils.Simulate.change(formDOM.querySelector('input[type="radio"]'), {
       target: {
@@ -107,7 +106,7 @@ describe('Pensions general military history', () => {
     expect(formDOM.querySelector('.va-growable-background').textContent)
       .to.contain('Jane Doe, Jr.');
   });
-  it('should required combat after 9/11 question', () => {
+  it('should require combat after 9/11 question', () => {
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
@@ -117,50 +116,78 @@ describe('Pensions general military history', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(9);
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
 
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toMonth'), {
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_servicePeriods_0_activeServiceDateRange_toMonth'), {
       target: {
         value: '9'
       }
     });
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toDay'), {
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_servicePeriods_0_activeServiceDateRange_toDay'), {
       target: {
         value: '11'
       }
     });
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toYear'), {
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_servicePeriods_0_activeServiceDateRange_toYear'), {
       target: {
         value: '2001'
       }
     });
 
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(9);
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(10);
 
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toMonth'), {
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_servicePeriods_0_activeServiceDateRange_toMonth'), {
       target: {
         value: '9'
       }
     });
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toDay'), {
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_servicePeriods_0_activeServiceDateRange_toDay'), {
       target: {
         value: '12'
       }
     });
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toYear'), {
+    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_servicePeriods_0_activeServiceDateRange_toYear'), {
       target: {
         value: '2001'
       }
     });
 
-    expect(formDOM.querySelectorAll('input,select').length).to.equal(11);
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(12);
 
-    submitForm(form);
+    formDOM.submitForm();
 
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(3);
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(4);
     expect(onSubmit.called).to.be.false;
+  });
+
+  it('should add another service period', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = getFormDOM(form);
+
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(10);
+
+    formDOM.fillData('#root_servicePeriods_0_serviceBranch', 'Army');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toMonth', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toDay', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toYear', '2003');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromMonth', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromDay', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromYear', '2002');
+
+    ReactTestUtils.Simulate.click(formDOM.querySelector('.va-growable-add-btn'));
+
+    expect(formDOM.querySelector('.va-growable-background').textContent)
+      .to.contain('Army');
   });
 
   it('should submit with valid data', () => {
@@ -173,52 +200,20 @@ describe('Pensions general military history', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    ReactTestUtils.Simulate.change(Array.from(formDOM.querySelectorAll('input[type="radio"]'))[1], {
-      target: {
-        value: 'N'
-      }
-    });
+    formDOM.fillData('#root_view\\:serveUnderOtherNamesNo', 'N');
 
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toMonth'), {
-      target: {
-        value: '1'
-      }
-    });
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toDay'), {
-      target: {
-        value: '1'
-      }
-    });
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_toYear'), {
-      target: {
-        value: '2003'
-      }
-    });
+    formDOM.fillData('#root_servicePeriods_0_serviceBranch', 'Army');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toMonth', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toDay', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toYear', '2003');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromMonth', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromDay', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromYear', '2002');
+    formDOM.fillData('#root_combatSince911Yes', 'Y');
 
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_fromMonth'), {
-      target: {
-        value: '1'
-      }
-    });
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_fromDay'), {
-      target: {
-        value: '1'
-      }
-    });
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_activeServiceDateRange_fromYear'), {
-      target: {
-        value: '2002'
-      }
-    });
-    ReactTestUtils.Simulate.change(formDOM.querySelector('#root_combatSince911Yes'), {
-      target: {
-        value: 'Y'
-      }
-    });
-
-    submitForm(form);
+    formDOM.submitForm();
 
     expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
     expect(onSubmit.called).to.be.true;

--- a/test/pensions/config/reserveAndNationalGuardMilitaryHistory.unit.spec.jsx
+++ b/test/pensions/config/reserveAndNationalGuardMilitaryHistory.unit.spec.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import { DefinitionTester, submitForm } from '../../util/schemaform-utils.jsx';
+import { DefinitionTester, getFormDOM } from '../../util/schemaform-utils.jsx';
 import formConfig from '../../../src/js/pensions/config/form';
 
 describe('Pensions Reserve and National Guard', () => {
@@ -16,7 +15,7 @@ describe('Pensions Reserve and National Guard', () => {
           definitions={formConfig.defaultDefinitions}
           uiSchema={uiSchema}/>
     );
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
     expect(formDOM.querySelectorAll('input,select').length).to.equal(2);
   });
@@ -31,9 +30,9 @@ describe('Pensions Reserve and National Guard', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    submitForm(form);
+    formDOM.submitForm();
 
     expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
     expect(onSubmit.called).to.be.false;
@@ -49,13 +48,9 @@ describe('Pensions Reserve and National Guard', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    ReactTestUtils.Simulate.change(formDOM.querySelector('input[type="radio"]'), {
-      target: {
-        value: 'Y'
-      }
-    });
+    formDOM.fillData('#root_nationalGuardActivationYes', 'Y');
 
     expect(formDOM.querySelectorAll('input, select').length).to.equal(13);
   });
@@ -70,15 +65,11 @@ describe('Pensions Reserve and National Guard', () => {
           uiSchema={uiSchema}/>
     );
 
-    const formDOM = findDOMNode(form);
+    const formDOM = getFormDOM(form);
 
-    ReactTestUtils.Simulate.change(formDOM.querySelector('input[type="radio"]'), {
-      target: {
-        value: 'N'
-      }
-    });
+    formDOM.fillData('#root_nationalGuardActivationNo', 'N');
 
-    submitForm(form);
+    formDOM.submitForm();
 
     expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
     expect(onSubmit.called).to.be.true;

--- a/test/pensions/config/servicePeriods.unit.spec.jsx
+++ b/test/pensions/config/servicePeriods.unit.spec.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import { DefinitionTester, getFormDOM } from '../../util/schemaform-utils.jsx';
+import formConfig from '../../../src/js/pensions/config/form';
+
+describe('Pensions service periods', () => {
+  const { schema, uiSchema } = formConfig.chapters.militaryHistory.pages.servicePeriods;
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = getFormDOM(form);
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(7);
+  });
+
+  it('should not submit empty form', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = getFormDOM(form);
+
+    formDOM.submitForm();
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(3);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should add another service period', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = getFormDOM(form);
+
+    expect(formDOM.querySelectorAll('input, select').length).to.equal(7);
+
+    formDOM.fillData('#root_servicePeriods_0_serviceBranch', 'Army');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toMonth', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toDay', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toYear', '2003');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromMonth', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromDay', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromYear', '2002');
+
+    ReactTestUtils.Simulate.click(formDOM.querySelector('.va-growable-add-btn'));
+
+    expect(formDOM.querySelector('.va-growable-background').textContent)
+      .to.contain('Army');
+  });
+
+  it('should submit with valid data', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          onSubmit={onSubmit}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = getFormDOM(form);
+
+    formDOM.fillData('#root_servicePeriods_0_serviceBranch', 'Army');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toMonth', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toDay', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_toYear', '2003');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromMonth', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromDay', '1');
+    formDOM.fillData('#root_servicePeriods_0_activeServiceDateRange_fromYear', '2002');
+
+    formDOM.submitForm();
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8300,9 +8300,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#d4f32a9477cbdd53cdaa610ece8002e821f04734":
-  version "3.0.23"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d4f32a9477cbdd53cdaa610ece8002e821f04734"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#f91824ba7555b242a009fe590e3ba79a142395f9":
+  version "3.0.24"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#f91824ba7555b242a009fe590e3ba79a142395f9"
 
 vinyl-assign@^1.0.1:
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8300,9 +8300,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#f91824ba7555b242a009fe590e3ba79a142395f9":
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#8fbfee24b1126e6d8a2cb07c4d37ec9f21a1fdb4":
   version "3.0.24"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#f91824ba7555b242a009fe590e3ba79a142395f9"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#8fbfee24b1126e6d8a2cb07c4d37ec9f21a1fdb4"
 
 vinyl-assign@^1.0.1:
   version "1.2.1"


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3648

Had to change the address definition code to allow us to tell it to ignore required fields, so it can be customized in the form config without being overwritten.

Also, per Alex, I split the military page into two, since it was pretty long.

![screencapture-localhost-3001-pension-application-527ez-military-reserve-national-guard-1499101623255](https://user-images.githubusercontent.com/634932/27802209-5697a3ee-5ff0-11e7-95a2-b9b4d7224569.png)
![screen shot 2017-07-03 at 5 01 18 pm](https://user-images.githubusercontent.com/634932/27807785-1244a1c6-6011-11e7-879b-78f85235bf73.png)
![screen shot 2017-07-03 at 5 01 13 pm](https://user-images.githubusercontent.com/634932/27807786-1245d44c-6011-11e7-9288-df990cc93e63.png)

