### PR TITLE
Adding support for og:description

### DIFF
--- a/content/includes/header.html
+++ b/content/includes/header.html
@@ -26,6 +26,7 @@
 {% endif %}
 {% if description %}
 <meta content="{{ description }}" property="og:description">
+<meta content="{{ description }}" name="description">
 {% endif %}
 <meta content="https://www.vets.gov/img/design/logo/og-image.jpg" property="og:image">
 {% if tags %}

--- a/content/includes/header.html
+++ b/content/includes/header.html
@@ -24,6 +24,9 @@
 {% if path %}
 <meta content="https://www.vets.gov/{{ path }}" property="og:url">
 {% endif %}
+{% if description %}
+<meta content="{{ description }}" property="og:description">
+{% endif %}
 <meta content="https://www.vets.gov/img/design/logo/og-image.jpg" property="og:image">
 {% if tags %}
 {% for tag in tags %}

--- a/content/pages/gi-bill-comparison-tool/index.md
+++ b/content/pages/gi-bill-comparison-tool/index.md
@@ -1,6 +1,7 @@
 ---
 title: GI Bill Comparison Tool
 display_title: Compare GI Bill Benefits
+description: Learn about education programs and compare benefits by school
 layout: page-react.html
 entryname: gi
 collection: education


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/vets-website/issues/5889
Closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3601
Part of https://github.com/department-of-veterans-affairs/vets.gov-team/issues/612

Adds support for og:description meta tags in our headers
Puts an initial description on the GIBCT landing page