### PR TITLE
Post benefit summary letter options

### DIFF
--- a/src/js/letters/components/DownloadLetterLink.jsx
+++ b/src/js/letters/components/DownloadLetterLink.jsx
@@ -12,52 +12,17 @@ export class DownloadLetterLink extends React.Component {
     this.downloadLetter = this.downloadLetter.bind(this);
   }
 
-  // This opens a duplicate window for some inexplicable reason,
-  // possibly related to some blob response nuance.
-  /*
-  downloadLetter() {
-    const requestUrl = `/v0/letters/${this.props.letterType}`;
-    apiRequest(
-      requestUrl,
-      { method: 'POST' },
-      response => {
-        response.blob().then(blob => {
-        });
-      });
-  */
-
-  // This opens a new duplicate window, focuses on it, and then opens
-  // the PDF in the original window (so it appears in the browser tab to
-  // the left of the current tab, which is weird.
-  /*
-  downloadLetter() {
-    const requestUrl = `/v0/letters/${this.props.letterType}`;
-    apiRequest(
-      requestUrl,
-      { method: 'POST' },
-      response => {
-        response.blob().then(blob => {
-          window.URL = window.URL || window.webkitURL;
-          const downloadUrl = window.URL.createObjectURL(blob);
-          window.location.href = downloadUrl;
-        });
-      });
-  }
-  */
-
-  // This opens a new blank window and renders the pdf in it (to the
-  // right of the current browser as expected, but also tries to open
-  // a window from the original window as above (which may be blocked
-  // by the popup blocker, or if not blocked will pop up an extra window
-  // for no apparent reason).
-  downloadLetter() {
+  // Either download the pdf or open it in a new window, depending on the browser.
+  // Needs to bbe manually tested on a variety of vets.gov-supported
+  // platforms, particularly iOS/Safari
+  downloadLetter(e) {
+    e.preventDefault();
     window.dataLayer.push({
       event: 'letter-download',
       'letter-type': this.props.letterType
     });
-    const requestUrl = `/v0/letters/${this.props.letterType}`;
-    const downloadWindow = window.open();
 
+    const requestUrl = `/v0/letters/${this.props.letterType}`;
     let settings;
     if (this.props.letterType === 'benefit_summary') {
       settings = {
@@ -71,77 +36,47 @@ export class DownloadLetterLink extends React.Component {
       };
     }
 
+    // We handle IE10 separately but assume all other vets.gov-supported
+    // browsers have blob URL support. We may want to explicitly check
+    // for that with something like
+    // const blobSupported = !!(/^blob:/.exec(downloadUrl));
+    const ie10 = !!window.navigator.msSaveOrOpenBlob;
+    const save = document.createElement('a');
+    let downloadWindow;
+    const downloadSupported = typeof save.download !== 'undefined';
+    if (!downloadSupported) {
+      // Instead of giving the file a readable name and downloading
+      // it directly, open it in a new window with an ugly hash URL
+      downloadWindow = window.open();
+    }
+    let downloadUrl;
+
     apiRequest(
       requestUrl,
       settings,
       response => {
         response.blob().then(blob => {
-          const URLobj = window.URL || window.webkitURL;
-          // const URLobj = downloadWindow.URL || downloadWindow.webkitURL;
-          const downloadUrl = URLobj.createObjectURL(blob);
-          downloadWindow.location.href = downloadUrl;
-        });
-      });
-  }
-
-  // This is a longer solution that handles various browsers and also
-  // gives the file a nicer name, but does not render it in a window.
-  // Instead, it opens a blank window and downloads the nicely named
-  // file. It suffers from the same issue above that it attempts to
-  // open an extra duplicate window. This should be manually tested on
-  // multiple browsers before launching.
-  /*
-  downloadLetter() {
-    const requestUrl = `/v0/letters/${this.props.letterType}`;
-    const ie10 = !!window.navigator.msSaveOrOpenBlob;
-    let downloadWindow;
-    if (!ie10) {
-      downloadWindow = window.open();
-    }
-
-    // TODO: in addition to the new blank browser window, this tries to
-    // pop up a duplicate window which may or may not be suppressed
-    // by the user's browser content settings.
-    apiRequest(
-      requestUrl,
-      { method: 'POST' },
-      response => {
-        response.blob().then(blob => {
           if (ie10) {
             window.navigator.msSaveOrOpenBlob(blob, this.props.letterName);
-            return Promise.resolve();
-          }
-          window.URL = window.URL || window.webkitURL;
-          const downloadUrl = window.URL.createObjectURL(blob);
-          // Make sure blob URLs are supported
-          const blobSupported = !!(/^blob:/.exec(downloadUrl));
-          if (blobSupported) {
-            // Try to give the file a nice name instead of an ugly hash
-            // by creating a new link element and setting its download attribute.
-            const link = document.createElement('a');
-            if (typeof link.download !== 'undefined') {
-              document.body.appendChild(link);
-              // downloadWindow.document.body.appendChild(link);
-              link.style = 'display: none';
-              link.target = '_blank';
-              link.href = downloadUrl;
-              link.download = this.props.letterName;
-              link.click();
+          } else {
+            window.URL = window.URL || window.webkitURL;
+            downloadUrl = window.URL.createObjectURL(blob);
+            if (downloadSupported) {
+              // Give the file a readable name if the download attribute is supported
+              save.download = this.props.letterName;
+              save.href = downloadUrl;
+              save.target = '_blank';
+              document.body.appendChild(save);
+              save.click();
+              document.body.removeChild(save);
             } else {
-              // The download attribute is not supported on IE11 or
-              // iOS Safari, so live with the ugly hash name.
               downloadWindow.location.href = downloadUrl;
             }
-            // document.body.removeChild(link);
-            // urlObj.revokeObjectURL(downloadUrl);
-            return Promise.resolve();
           }
-          // Make sure this gets to sentry
-          return Promise.reject(new Error('Cannot download pdf blob'));
         });
       });
+    window.URL.revokeObjectURL(downloadUrl);
   }
-  */
 
   render() {
     return (

--- a/src/js/letters/components/DownloadLetterLink.jsx
+++ b/src/js/letters/components/DownloadLetterLink.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import { Link } from 'react-router';
 
 import { apiRequest } from '../utils/helpers';
 
-class DownloadLetterLink extends React.Component {
+export class DownloadLetterLink extends React.Component {
   constructor(props) {
     super(props);
     this.downloadLetter = this.downloadLetter.bind(this);
@@ -56,9 +57,23 @@ class DownloadLetterLink extends React.Component {
     });
     const requestUrl = `/v0/letters/${this.props.letterType}`;
     const downloadWindow = window.open();
+
+    let settings;
+    if (this.props.letterType === 'benefit_summary') {
+      settings = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(this.props.letterOptions)
+      };
+    } else {
+      settings = {
+        method: 'POST'
+      };
+    }
+
     apiRequest(
       requestUrl,
-      { method: 'POST' },
+      settings,
       response => {
         response.blob().then(blob => {
           const URLobj = window.URL || window.webkitURL;
@@ -140,9 +155,18 @@ class DownloadLetterLink extends React.Component {
   }
 }
 
+function mapStateToProps(state, ownProps) {
+  return {
+    letterType: ownProps.letterType,
+    letterName: ownProps.letterName,
+    letterOptions: state.letters.optionsToInclude
+  };
+}
+
 DownloadLetterLink.PropTypes = {
   letterType: PropTypes.string.required,
   letterName: PropTypes.string.required
 };
 
-export default DownloadLetterLink;
+export default connect(mapStateToProps)(DownloadLetterLink);
+

--- a/src/js/letters/components/DownloadLetterLink.jsx
+++ b/src/js/letters/components/DownloadLetterLink.jsx
@@ -12,9 +12,9 @@ export class DownloadLetterLink extends React.Component {
     this.downloadLetter = this.downloadLetter.bind(this);
   }
 
-  // Either download the pdf or open it in a new window, depending on the browser.
-  // Needs to bbe manually tested on a variety of vets.gov-supported
-  // platforms, particularly iOS/Safari
+  // Either download the pdf or open it in a new window, depending on the
+  // browser. Needs to be manually tested on a variety of
+  // vets.gov-supported platforms, particularly iOS/Safari
   downloadLetter(e) {
     e.preventDefault();
     window.dataLayer.push({
@@ -37,8 +37,9 @@ export class DownloadLetterLink extends React.Component {
     }
 
     // We handle IE10 separately but assume all other vets.gov-supported
-    // browsers have blob URL support. We may want to explicitly check
-    // for that with something like
+    // browsers have blob URL support.
+    // TODO: possibly want to explicitly
+    // check for blob URL support with something like
     // const blobSupported = !!(/^blob:/.exec(downloadUrl));
     const ie10 = !!window.navigator.msSaveOrOpenBlob;
     const save = document.createElement('a');
@@ -62,7 +63,8 @@ export class DownloadLetterLink extends React.Component {
             window.URL = window.URL || window.webkitURL;
             downloadUrl = window.URL.createObjectURL(blob);
             if (downloadSupported) {
-              // Give the file a readable name if the download attribute is supported
+              // Give the file a readable name if the download attribute
+              // is supported.
               save.download = this.props.letterName;
               save.href = downloadUrl;
               save.target = '_blank';

--- a/test/letters/components/DownloadLetterLink.unit.spec.js
+++ b/test/letters/components/DownloadLetterLink.unit.spec.js
@@ -3,43 +3,33 @@ import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import DownloadLetterLink from '../../../src/js/letters/components/DownloadLetterLink.jsx';
+import { DownloadLetterLink } from '../../../src/js/letters/components/DownloadLetterLink.jsx';
 
 const defaultProps = {
   letterName: 'Commissary Letter',
   letterType: 'commissary'
 };
 
-
 let oldWindow;
 let oldFetch;
+
+// TODO: fix this warning and improve test coverage for various scenarios:
+//   UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1):
+//   TypeError: Cannot read property 'ok' of undefined"
 
 const setup = () => {
   oldFetch = global.fetch;
   oldWindow = global.window;
-
-  // This needs work:
-  //   UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1):
-  //   TypeError: Cannot read property 'ok' of undefined"
-  // Figure out how to avoid defining all keys of the returned Promise chain
   global.fetch = sinon.spy(() => {
     return Promise.resolve();
   });
-
-  /*
-  global.fetch = sinon.stub();
-  global.fetch.returns({
-    then: (fn) => fn({
-      ok: true,
-      blob: () => {return Promise.resolve(); }
-    })
-  });
-  */
-
   global.window = {
     navigator: {},
     open: sinon.spy(),
-    dataLayer: []
+    dataLayer: [],
+    URL: {
+      revokeObjectURL: () => {}
+    }
   };
   global.sessionStorage = {
     userToken: 'abc'


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3599
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3634
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3597

Got this working (ish) locally, connecting to CI, although they are not returning valid BSL or COE pdfs (all others look fine). Requesting the BSL or COE returns this response instead of a PDF blob.

Also fixes problem of extra window opening when download is clicked.

For COE:
```
{
  "messages" : [ {
    "key" : "lettergenerator.serviceError",
    "severity" : "ERROR",
    "text" : "Error calling external service"
  } ]
}
```
For BSL:
```
<!DOCTYPE html>
<html>
        <head>
                <title>Unexpected Error</title>
        </head>
        <body>
                Unexpected Error
        </body>
</html>
```

Also get the above `lettergenerator.serviceError` when fetching the BSL from dev and staging without any options in the request from the command-line:
```
$ curl  --request POST  --header "Authorization: Token token=<token-copied-from-dev-tools>" https://dev-api.vets.gov/v0/letters/benefit_summary
``` 

Also built a review instance, but something is not configured correctly because the vets-website review instance is getting a CORS error for hitting the vets-api review instance:
```
Fetch API cannot load http://48dcc38cb8fb4069a8962c60858cade7-api.review.vetsgov-internal/v0/sessions/new?level=1.
No 'Access-Control-Allow-Origin' header is present on the requested resource.
Origin 'http://48dcc38cb8fb4069a8962c60858cade7.review.vetsgov-internal' is therefore not allowed access.
The response had HTTP status code 502.
If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```


Also tested against the mock service just to see if the request is handled with a generic PDF but `POST http://localhost:3000/v0/letters/benefit_summary` returns a 500.

This is the request payload:
```
{"hasNonServiceConnectedPension":false,"hasServiceConnectedDisabilities":true,"hasSurvivorsIndemnityCompensationAward":false,"hasSurvivorsPensionAward":false,"monthlyAwardAmount":true,"serviceConnectedPercentage":true,"awardEffectiveDate":false,"hasAdaptedHousing":false,"hasChapter35Eligibility":false,"hasDeathResultOfDisability":false,"hasIndividualUnemployabilityGranted":false,"hasSpecialMonthlyCompensation":false}
```
And this is the beginning of the vets-api stack trace:
```
{"errors":[{"title":"Internal server error","detail":"Internal server error","code":"500","status":"500","meta":{"exception":"no implicit conversion of nil into String","backtrace":["/usr/local/Cellar/ruby/2.3.1_2/lib/ruby/2.3.0/pathname.rb:409:in `initialize'","/usr/local/Cellar/ruby/2.3.1_2/lib/ruby/2.3.0/pathname.rb:409:in `new'","/usr/local/Cellar/ruby/2.3.1_2/lib/ruby/2.3.0/pathname.rb:409:in `join'","/Users/romano/dsva/vets-api/lib/evss/letters/mock_service.rb:48:in `download_by_type'","/Users/romano/dsva/vets-api/app/controllers/v0/letters_controller.rb:21:in `download'"
```