### PR TITLE
Get HCA e2e test working in both dev and production

### DIFF
--- a/test/hca/00-all-fields.e2e.spec.js
+++ b/test/hca/00-all-fields.e2e.spec.js
@@ -13,7 +13,7 @@ module.exports = E2eHelpers.createE2eTest(
       .waitForElementVisible('body', Timeouts.normal)
       .assert.title('Apply for Health Care: Vets.gov')
       .waitForElementVisible('.schemaform-title', Timeouts.slow)  // First render of React may be slow.
-      .click('.schemaform-buttons .usa-button-primary');
+      .click('.usa-button-primary');
 
     E2eHelpers.overrideVetsGovApi(client);
     E2eHelpers.overrideSmoothScrolling(client);


### PR DESCRIPTION
HCA currently has save in progress behind a build type flag, so it loads the SIPIntroduction page if we're not in production, and the "regular" intro page if we are in production.

The selector for that first `.click()` had `.schemaform-buttons`which isn't used in the SIPIntroduction page.

FYI: @aub