### PR TITLE
Fix benefit summary request body keys and conditional option text

### DIFF
--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -5,12 +5,10 @@ export function getLetterList() {
     apiRequest(
       '/v0/letters',
       null,
-      (response) => {
-        return dispatch({
-          type: 'GET_LETTERS_SUCCESS',
-          data: response,
-        });
-      },
+      response => dispatch({
+        type: 'GET_LETTERS_SUCCESS',
+        data: response,
+      }),
       () => dispatch({ type: 'GET_LETTERS_FAILURE' })
     );
   };
@@ -21,16 +19,75 @@ export function getBenefitSummaryOptions() {
     apiRequest(
       '/v0/letters/beneficiary',
       null,
-      (response) => {
-        return dispatch({
-          type: 'GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS',
-          data: response,
-        });
-      },
+      response => dispatch({
+        type: 'GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS',
+        data: response,
+      }),
       () => dispatch({ type: 'GET_BENEFIT_SUMMARY_OPTIONS_FAILURE' })
     );
   };
 }
+
+export function getLetterPdf(letterType, letterName, letterOptions) {
+  let settings;
+  if (letterType === 'benefit_summary') {
+    settings = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(letterOptions)
+    };
+  } else {
+    settings = {
+      method: 'POST'
+    };
+  }
+
+  // We handle IE10 separately but assume all other vets.gov-supported
+  // browsers have blob URL support.
+  // TODO: possibly want to explicitly check for blob URL support with something like
+  // const blobSupported = !!(/^blob:/.exec(downloadUrl));
+  const ie10 = !!window.navigator.msSaveOrOpenBlob;
+  const save = document.createElement('a');
+  let downloadWindow;
+  const downloadSupported = typeof save.download !== 'undefined';
+  if (!downloadSupported) {
+    // Instead of giving the file a readable name and downloading
+    // it directly, open it in a new window with an ugly hash URL
+    downloadWindow = window.open();
+  }
+  let downloadUrl;
+  return (dispatch) => {
+    apiRequest(
+      `/v0/letters/${letterType}`,
+      settings,
+      response => {
+        response.blob().then(blob => {
+          if (ie10) {
+            window.navigator.msSaveOrOpenBlob(blob, letterName);
+          } else {
+            window.URL = window.URL || window.webkitURL;
+            downloadUrl = window.URL.createObjectURL(blob);
+            if (downloadSupported) {
+              // Give the file a readable name if the download attribute is supported.
+              save.download = letterName;
+              save.href = downloadUrl;
+              save.target = '_blank';
+              document.body.appendChild(save);
+              save.click();
+              document.body.removeChild(save);
+            } else {
+              downloadWindow.location.href = downloadUrl;
+            }
+          }
+        });
+        window.URL.revokeObjectURL(downloadUrl); // make sure this doesn't cause problems
+        dispatch({ type: 'GET_LETTER_PDF_SUCCESS' });
+      },
+      () => dispatch({ type: 'GET_LETTER_PDF_FAILURE', data: letterType }) // add something to reducer
+    );
+  };
+}
+
 
 export function updateBenefitSummaryOption(propertyPath, value) {
   return {

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -89,9 +89,9 @@ export function getLetterPdf(letterType, letterName, letterOptions) {
 }
 
 
-export function updateBenefitSummaryOption(propertyPath, value) {
+export function updateBenefitSummaryRequestOption(propertyPath, value) {
   return {
-    type: 'UPDATE_BENEFIT_SUMMARY_OPTION',
+    type: 'UPDATE_BENFIT_SUMMARY_REQUEST_OPTION',
     propertyPath,
     value
   };

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -83,7 +83,7 @@ export function getLetterPdf(letterType, letterName, letterOptions) {
         window.URL.revokeObjectURL(downloadUrl); // make sure this doesn't cause problems
         dispatch({ type: 'GET_LETTER_PDF_SUCCESS' });
       },
-      () => dispatch({ type: 'GET_LETTER_PDF_FAILURE', data: letterType }) // add something to reducer
+      () => dispatch({ type: 'GET_LETTER_PDF_FAILURE', data: letterType })
     );
   };
 }

--- a/src/js/letters/components/DownloadLetterLink.jsx
+++ b/src/js/letters/components/DownloadLetterLink.jsx
@@ -25,9 +25,7 @@ export class DownloadLetterLink extends React.Component {
 
   render() {
     return (
-      <Link
-          onClick={this.downloadLetter}
-          to="/" target="_blank"
+      <Link onClick={this.downloadLetter} to="/" target="_blank"
           className="usa-button-primary va-button-primary">
         Download Letter
       </Link>

--- a/src/js/letters/components/DownloadLetterLink.jsx
+++ b/src/js/letters/components/DownloadLetterLink.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-
 import { Link } from 'react-router';
 
-import { apiRequest } from '../utils/helpers';
+import { getLetterPdf } from '../actions/letters';
 
 export class DownloadLetterLink extends React.Component {
   constructor(props) {
@@ -21,63 +20,7 @@ export class DownloadLetterLink extends React.Component {
       event: 'letter-download',
       'letter-type': this.props.letterType
     });
-
-    const requestUrl = `/v0/letters/${this.props.letterType}`;
-
-    let settings;
-    if (this.props.letterType === 'benefit_summary') {
-      settings = {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(this.props.letterOptions)
-      };
-    } else {
-      settings = {
-        method: 'POST'
-      };
-    }
-
-    // We handle IE10 separately but assume all other vets.gov-supported
-    // browsers have blob URL support.
-    // TODO: possibly want to explicitly
-    // check for blob URL support with something like
-    // const blobSupported = !!(/^blob:/.exec(downloadUrl));
-    const ie10 = !!window.navigator.msSaveOrOpenBlob;
-    const save = document.createElement('a');
-    let downloadWindow;
-    const downloadSupported = typeof save.download !== 'undefined';
-    if (!downloadSupported) {
-      // Instead of giving the file a readable name and downloading
-      // it directly, open it in a new window with an ugly hash URL
-      downloadWindow = window.open();
-    }
-    let downloadUrl;
-    apiRequest(
-      requestUrl,
-      settings,
-      response => {
-        response.blob().then(blob => {
-          if (ie10) {
-            window.navigator.msSaveOrOpenBlob(blob, this.props.letterName);
-          } else {
-            window.URL = window.URL || window.webkitURL;
-            downloadUrl = window.URL.createObjectURL(blob);
-            if (downloadSupported) {
-              // Give the file a readable name if the download attribute
-              // is supported.
-              save.download = this.props.letterName;
-              save.href = downloadUrl;
-              save.target = '_blank';
-              document.body.appendChild(save);
-              save.click();
-              document.body.removeChild(save);
-            } else {
-              downloadWindow.location.href = downloadUrl;
-            }
-          }
-        });
-      });
-    window.URL.revokeObjectURL(downloadUrl);
+    this.props.getLetterPdf(this.props.letterType, this.props.letterName, this.props.letterOptions);
   }
 
   render() {
@@ -105,5 +48,9 @@ DownloadLetterLink.PropTypes = {
   letterName: PropTypes.string.required
 };
 
-export default connect(mapStateToProps)(DownloadLetterLink);
+const mapDispatchToProps = {
+  getLetterPdf
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(DownloadLetterLink);
 

--- a/src/js/letters/components/DownloadLetterLink.jsx
+++ b/src/js/letters/components/DownloadLetterLink.jsx
@@ -56,7 +56,6 @@ export class DownloadLetterLink extends React.Component {
       downloadWindow = window.open();
     }
     let downloadUrl;
-
     apiRequest(
       requestUrl,
       settings,

--- a/src/js/letters/components/DownloadLetterLink.jsx
+++ b/src/js/letters/components/DownloadLetterLink.jsx
@@ -24,9 +24,6 @@ export class DownloadLetterLink extends React.Component {
 
     const requestUrl = `/v0/letters/${this.props.letterType}`;
 
-    // Temporarily suppress sending request body for usability testing purposes.
-    const settings = { method: 'POST' };
-    /*
     let settings;
     if (this.props.letterType === 'benefit_summary') {
       settings = {
@@ -39,7 +36,6 @@ export class DownloadLetterLink extends React.Component {
         method: 'POST'
       };
     }
-    */
 
     // We handle IE10 separately but assume all other vets.gov-supported
     // browsers have blob URL support.
@@ -100,7 +96,7 @@ function mapStateToProps(state, ownProps) {
   return {
     letterType: ownProps.letterType,
     letterName: ownProps.letterName,
-    letterOptions: state.letters.optionsToInclude
+    letterOptions: state.letters.requestOptions
   };
 }
 

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -47,11 +47,10 @@ class VeteranBenefitSummaryLetter extends React.Component {
       // customization checkbox is always displayed.
       const value = benefitInfo[key];
       const displayOption = optionsToAlwaysDisplay.includes(key) || value !== false;
-      const optionText = getBenefitOptionText(key, value, true);  // for now, assume user is a veteran
-
-      // Currently, if the benefit key is not in bnefitOptionText
-      // the benefit is not for veterans and should not be displayed. This
-      // will change once we support both dependent and veteran useres.
+      // TODO: find out if there is anything in the profile or from EVSS that can tell
+      // us whether the user is a veteran or a user. For now we just pass in
+      // true for the isVeteran parameter
+      const optionText = getBenefitOptionText(key, value, true);
       if (optionText && displayOption) {
         vaBenefitInfoRows.push(
           <tr key={`option${key}`}>

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import _ from 'lodash';
+import _ from 'lodash/fp';
 
 import { updateBenefitSummaryOption } from '../actions/letters';
 import {

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { updateBenefitSummaryOption } from '../actions/letters';
+import { updateBenefitSummaryRequestOption } from '../actions/letters';
 import {
   benefitOptionsMap,
   characterOfServiceContent,
@@ -17,8 +17,9 @@ class VeteranBenefitSummaryLetter extends React.Component {
   }
 
   handleChange(domEvent) {
-    this.props.updateBenefitSummaryOption(benefitOptionsMap[domEvent.target.id],
-                                          domEvent.target.checked);
+    this.props.updateBenefitSummaryRequestOption(
+      benefitOptionsMap[domEvent.target.id],
+      domEvent.target.checked);
   }
 
   render() {
@@ -161,7 +162,7 @@ function mapStateToProps(state) {
 }
 
 const mapDispatchToProps = {
-  updateBenefitSummaryOption
+  updateBenefitSummaryRequestOption
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(VeteranBenefitSummaryLetter);

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -22,28 +22,7 @@ class VeteranBenefitSummaryLetter extends React.Component {
   }
 
   render() {
-    // Hard-coding this for now for the purposes of user testing, revert after user testing
-    // const serviceInfo = this.props.benefitSummaryOptions.serviceInfo || [];
-    const serviceInfo = [
-      {
-        branch: 'AIR FORCE',
-        characterOfService: 'HONORABLE',
-        enteredDate: '2001-01-01T05:00:00.000+00:00',
-        releasedDate: '2001-12-01T04:00:00.000+00:00'
-      },
-      {
-        branch: 'AIR FORCE RESERVE',
-        characterOfService: 'OTHER_THAN_HONORABLE',
-        enteredDate: '1990-01-01T05:00:00.000+00:00',
-        releasedDate: '1990-12-01T04:00:00.000+00:00'
-      },
-      {
-        branch: 'AIR FORCE',
-        characterOfService: 'HONORABLE',
-        enteredDate: '1980-01-01T05:00:00.000+00:00',
-        releasedDate: '1980-12-01T04:00:00.000+00:00'
-      }
-    ];
+    const serviceInfo = this.props.benefitSummaryOptions.serviceInfo || [];
     const militaryServiceRows = serviceInfo.map((service, index) => {
       return (
         <tr key={`service${index}`}>
@@ -86,7 +65,7 @@ class VeteranBenefitSummaryLetter extends React.Component {
                   type="checkbox"
                   onChange={this.handleChange}/>
             </th>
-            <td><label id={`${key}Label`}>{getBenefitOptionText(key, value)}</label></td>
+            <td><label id={`${key}Label`}>{optionText}</label></td>
           </tr>
         );
       }

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
-
 import _ from 'lodash/fp';
 
 import { updateBenefitSummaryOption } from '../actions/letters';
 import {
+  benefitOptionsMap,
   characterOfServiceContent,
   veteranBenefitSummaryOptionText
 } from '../utils/helpers';
@@ -17,7 +17,8 @@ class VeteranBenefitSummaryLetter extends React.Component {
   }
 
   handleChange(domEvent) {
-    this.props.updateBenefitSummaryOption(domEvent.target.id, domEvent.target.checked);
+    this.props.updateBenefitSummaryOption(benefitOptionsMap[domEvent.target.id],
+                                          domEvent.target.checked);
   }
 
   render() {
@@ -62,7 +63,7 @@ class VeteranBenefitSummaryLetter extends React.Component {
     let vaBenefitInformation;
     let vaBenefitInfoRows = [];
 
-    _.forIn(benefitInfo, (value, key) => {
+    _.forIn((value, key) => {
       const optionText = veteranBenefitSummaryOptionText(key, value);
 
       // There are 2 conditions this is checking for
@@ -89,7 +90,7 @@ class VeteranBenefitSummaryLetter extends React.Component {
           </tr>
         );
       }
-    });
+    }, benefitInfo);
 
     if (this.props.optionsAvailable) {
       vaBenefitInformation = (
@@ -129,14 +130,15 @@ class VeteranBenefitSummaryLetter extends React.Component {
         <div className="form-checkbox">
           <input
               autoComplete="false"
-              id="serviceInfoCheckboxId"
-              name="serviceInfoCheckbox"
+              checked={optionsToInclude.militarySevice}
+              id="militaryService"
+              name="militaryService"
               type="checkbox"
               onChange={this.handleChange}/>
           <label
               className="schemaform-label"
-              name="serviceInfoCheckbox-label"
-              htmlFor="serviceInfoCheckboxId">
+              name="militaryService-label"
+              htmlFor="militaryService">
             Include all periods of service
           </label>
         </div>

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -10,7 +10,7 @@ import {
 } from '../utils/helpers';
 import { formatDateShort } from '../../common/utils/helpers';
 
-class VeteranBenefitSummaryLetter extends React.Component {
+export class VeteranBenefitSummaryLetter extends React.Component {
   constructor() {
     super();
     this.handleChange = this.handleChange.bind(this);
@@ -43,6 +43,12 @@ class VeteranBenefitSummaryLetter extends React.Component {
     let vaBenefitInfoRows = [];
 
     Object.keys(benefitInfo).forEach(key => {
+      // Need to verify with EVSS and vets-api: values should be true, false, or
+      // some value other than null or undefined, so this check should not be
+      // necessary, or should log a Sentry error.
+      if (benefitInfo[key] === null) {
+        return;
+      }
       // For some options, the customization checkbox is only displayed
       // if the benefit information value is not false. For others, the
       // customization checkbox is always displayed.
@@ -73,7 +79,7 @@ class VeteranBenefitSummaryLetter extends React.Component {
 
     if (this.props.optionsAvailable) {
       vaBenefitInformation = (
-        <table className="usa-table-borderless">
+        <table className="usa-table-borderless" id="benefitInfoTable">
           <thead>
             <tr>
               <th scope="col">Include</th>
@@ -121,7 +127,7 @@ class VeteranBenefitSummaryLetter extends React.Component {
             Include all periods of service
           </label>
         </div>
-        <table className="usa-table-borderless">
+        <table className="usa-table-borderless" id="militaryServiceTable">
           <thead>
             <tr>
               <th scope="col">Branch of Service</th>

--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -41,7 +41,7 @@ function letters(state = initialState, action) {
       };
     }
     case 'GET_LETTERS_FAILURE':
-      return set('lettersAvailability', 'unavailable', state);
+      return _.set('lettersAvailability', 'unavailable', state);
     case 'GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS': {
       // Gather all possible displayed options that the user may toggle on/off.
       const benefitInfo = action.data.data.attributes.benefitInformation;

--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -47,7 +47,7 @@ function letters(state = initialState, action) {
       const benefitInfo = action.data.data.attributes.benefitInformation;
       const possibleOptions = [];
       Object.keys(benefitInfo).forEach(key => {
-        if (optionsToAlwaysDisplay.includes(key) || (benefitInfo[key] !== false) &&
+        if ((optionsToAlwaysDisplay.includes(key) || (benefitInfo[key] !== false)) &&
             !possibleOptions.includes[key]) {
           possibleOptions.push(key);
         }

--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -41,8 +41,6 @@ function letters(state = initialState, action) {
       };
     }
     case 'GET_LETTERS_FAILURE':
-      // We are currently ignoring this; consider removing once we're sure we've handled
-      // the various error scenarios
       return set('lettersAvailability', 'unavailable', state);
     case 'GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS': {
       // Gather all possible displayed options that the user may have toggled on/off.
@@ -73,8 +71,6 @@ function letters(state = initialState, action) {
       };
     }
     case 'GET_BENEFIT_SUMMARY_OPTIONS_FAILURE':
-      // We are currently ignoring this; consider removing once we're sure we've handled
-      // the various error scenarios
       return _.set('optionsAvailable', false, state);
     case 'UPDATE_BENEFIT_SUMMARY_OPTION':
       return _.set(['requestOptions', action.propertyPath], action.value, state);

--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -43,7 +43,7 @@ function letters(state = initialState, action) {
     case 'GET_LETTERS_FAILURE':
       return set('lettersAvailability', 'unavailable', state);
     case 'GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS': {
-      // Gather all possible displayed options that the user may have toggled on/off.
+      // Gather all possible displayed options that the user may toggle on/off.
       const benefitInfo = action.data.data.attributes.benefitInformation;
       const possibleOptions = [];
       Object.keys(benefitInfo).forEach(key => {
@@ -53,8 +53,8 @@ function letters(state = initialState, action) {
         }
       });
 
-      // Initialize the benefit summary letter POST request body by setting mapping
-      // each option in possibleOptions to its corresponding request option key.
+      // Initialize the benefit summary letter request body by mapping each
+      // option in possibleOptions to its corresponding request option key.
       // Set all request body options to true so that on page load, all options
       // are checked.
       const requestOptions = { militaryService: true };

--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -72,7 +72,7 @@ function letters(state = initialState, action) {
     }
     case 'GET_BENEFIT_SUMMARY_OPTIONS_FAILURE':
       return _.set('optionsAvailable', false, state);
-    case 'UPDATE_BENEFIT_SUMMARY_OPTION':
+    case 'UPDATE_BENFIT_SUMMARY_REQUEST_OPTION':
       return _.set(['requestOptions', action.propertyPath], action.value, state);
     default:
       return state;

--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -1,6 +1,5 @@
-import set from 'lodash/fp/set';
-import mapValues from 'lodash/mapValues';
 import _ from 'lodash/fp';
+// import { benefitOptionsMap } from '../utils/helpers';
 
 const initialState = {
   letters: [],
@@ -45,15 +44,19 @@ function letters(state = initialState, action) {
       // the various error scenarios
       return set('lettersAvailability', 'unavailable', state);
     case 'GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS':
-      // Create object for which options to include in post for summary letter
-      // Default all options to true so they appear checked in the UI
-      options = mapValues(action.data.data.attributes.benefitInformation, (value) => {
-        // If the value of the benefit option is not false, it means the user
-        // is eligible for that value. Default benefit options they are eligible for
-        // to true. Keep benefit options that have a value of false as false, so
-        // they are sent as false in the request for the pdf.
+      // Create object for which options to include in the benefit summary letter POST
+      // request body, and initialize all options to true so they appear checked in the UI.
+      // If the value of the benefit option is anything but false, the user is
+      // eligible for that value, so so the request body option is set to true.
+      // Otherwise, the request body option is set to false.
+
+
+      // plus 'militaryService'
+      options = _.mapValues((value) => {
         return value !== false;
-      });
+      }, action.data.data.attributes.benefitInformation);
+      // WIP: not quite a zip
+      // options = _.zipObject(_.values(benefitOptionsMap),
 
       return {
         ...state,
@@ -65,9 +68,9 @@ function letters(state = initialState, action) {
     case 'GET_BENEFIT_SUMMARY_OPTIONS_FAILURE':
       // We are currently ignoring this; consider removing once we're sure we've handled
       // the various error scenarios
-      return set('optionsAvailable', false, state);
+      return _.set('optionsAvailable', false, state);
     case 'UPDATE_BENEFIT_SUMMARY_OPTION':
-      return set(['optionsToInclude', action.propertyPath], action.value, state);
+      return _.set(['optionsToInclude', action.propertyPath], action.value, state);
     default:
       return state;
   }

--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -1,5 +1,8 @@
 import _ from 'lodash/fp';
-// import { benefitOptionsMap } from '../utils/helpers';
+import {
+  benefitOptionsMap,
+  optionsToAlwaysDisplay
+} from '../utils/helpers';
 
 const initialState = {
   letters: [],
@@ -8,17 +11,14 @@ const initialState = {
   benefitInfo: {},
   serviceInfo: [],
   optionsAvailable: false,
-  optionsToInclude: {}
+  requestOptions: {}
 };
 
 function letters(state = initialState, action) {
-  let options = {};
-
-  let letterList;
   switch (action.type) {
-    case 'GET_LETTERS_SUCCESS':
+    case 'GET_LETTERS_SUCCESS': {
       // Hard-code a few extra letters for usability testing purposes. Revert after testing.
-      letterList = action.data.data.attributes.letters;
+      let letterList = action.data.data.attributes.letters;
       if (_.findIndex({ letterType: 'medicare_partd' }, letterList) < 0) {
         letterList = _.concat(letterList, [{
           name: 'Proof of Creditable Prescription Drug Coverage Letter',
@@ -39,38 +39,45 @@ function letters(state = initialState, action) {
         destination: action.data.meta.address,
         lettersAvailability: 'available'
       };
+    }
     case 'GET_LETTERS_FAILURE':
       // We are currently ignoring this; consider removing once we're sure we've handled
       // the various error scenarios
       return set('lettersAvailability', 'unavailable', state);
-    case 'GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS':
-      // Create object for which options to include in the benefit summary letter POST
-      // request body, and initialize all options to true so they appear checked in the UI.
-      // If the value of the benefit option is anything but false, the user is
-      // eligible for that value, so so the request body option is set to true.
-      // Otherwise, the request body option is set to false.
+    case 'GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS': {
+      // Gather all possible displayed options that the user may have toggled on/off.
+      const benefitInfo = action.data.data.attributes.benefitInformation;
+      const possibleOptions = [];
+      Object.keys(benefitInfo).forEach(key => {
+        if (optionsToAlwaysDisplay.includes(key) || (benefitInfo[key] !== false) &&
+            !possibleOptions.includes[key]) {
+          possibleOptions.push(key);
+        }
+      });
 
-
-      // plus 'militaryService'
-      options = _.mapValues((value) => {
-        return value !== false;
-      }, action.data.data.attributes.benefitInformation);
-      // WIP: not quite a zip
-      // options = _.zipObject(_.values(benefitOptionsMap),
+      // Initialize the benefit summary letter POST request body by setting mapping
+      // each option in possibleOptions to its corresponding request option key.
+      // Set all request body options to true so that on page load, all options
+      // are checked.
+      const requestOptions = { militaryService: true };
+      _.forEach((option) => {
+        requestOptions[benefitOptionsMap[option]] = true;
+      }, possibleOptions);
 
       return {
         ...state,
         benefitInfo: action.data.data.attributes.benefitInformation,
         serviceInfo: action.data.data.attributes.militaryService,
         optionsAvailable: true,
-        optionsToInclude: options
+        requestOptions
       };
+    }
     case 'GET_BENEFIT_SUMMARY_OPTIONS_FAILURE':
       // We are currently ignoring this; consider removing once we're sure we've handled
       // the various error scenarios
       return _.set('optionsAvailable', false, state);
     case 'UPDATE_BENEFIT_SUMMARY_OPTION':
-      return _.set(['optionsToInclude', action.propertyPath], action.value, state);
+      return _.set(['requestOptions', action.propertyPath], action.value, state);
     default:
       return state;
   }

--- a/src/js/letters/utils/helpers.js
+++ b/src/js/letters/utils/helpers.js
@@ -103,11 +103,11 @@ const benefitOptionText = {
   hasChapter35Eligibility: {
     'true': {
       veteran: <div>You <strong>are</strong> considered to be totally and permanently disabled solely due to your service-connected disabilities.</div>,
-      dependent: <div>You <strong>are</strong> eligible for Dependents' Educational Assistance (Chapter 35).</div>
+      dependent: <div>The veteran <strong>was</strong> totally and permanently disabled.</div>
     },
     'false': {
       veteran: <div>You <strong>are not</strong> considered to be totally and permanently disabled solely due to your service-connected disabilities.</div>,
-      dependent: <div>You <strong>are not</strong> eligible for Dependents' Educational Assistance (Chapter 35).</div>
+      dependent: <div>The veteran <strong>was not</strong> totally and permanently disabled.</div>
     }
   },
   hasDeathResultOfDisability: {

--- a/src/js/letters/utils/helpers.js
+++ b/src/js/letters/utils/helpers.js
@@ -76,3 +76,25 @@ export function veteranBenefitSummaryOptionText(currentOption, currentValue) {
 
   return textForAllOptions[currentOption];
 }
+
+// Lookup table to convert the benefit and military service options returned by the benefit summary letter
+// response to the expected request body options for customizing the benefit summary letter.
+// TODO: point to API docs once they're ready.
+export const benefitOptionsMap = {
+  awardEffectiveDate: 'awardEffectiveDate', // guessing
+  hasAdaptedHousing: 'adaptedHousing',
+  hasChapter35Eligibility: 'chapter35Eligibility',
+  hasNonServiceConnectedPension: 'nonServiceConnectedPension',
+  hasServiceConnectedDisabilities: 'serviceConnectedDisabilities',
+  // There is an expected 'survivorsAward' option, but it's not clear whether
+  // it corresponds to the idemnity compensation or the pension award or neither.
+  hasSurvivorsIndemnityCompensationAward: 'survivorsAward', // fix
+  hasSurvivorsPensionAward: 'survivorsAward', // fix
+  monthlyAwardAmount: 'monthlyAward',
+  serviceConnectedPercentage: 'serviceConnectedEvaluation', // guessing
+  hasIndividualUnemployabilityGranted: 'individualUnemployabilityGranted', // guessing
+  hasSpecialMonthlyCompensation: 'specialMonthlyCompensation', // guessing
+  militaryService: 'militaryService',
+  hasUnemployable: 'unemployable', // guessing, look at EVSS swagger
+  hasDeathResultOfDisability: 'deathResultOfDisability' // guessing, look at EVSS swagger
+};

--- a/src/js/letters/utils/helpers.js
+++ b/src/js/letters/utils/helpers.js
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { apiRequest as commonApiClient } from '../../common/helpers/api';
 import environment from '../../common/helpers/environment';
+import { formatDateShort } from '../../common/utils/helpers';
 
 export function apiRequest(resource, optionalSettings = {}, success, error) {
   const baseUrl = `${environment.API_URL}`;
@@ -152,10 +153,17 @@ export function getBenefitOptionText(option, value, isVeteran) {
     valueString = value;
   }
 
-  if (!['monthlyAwardAmount', 'serviceConnectedPercentage'].includes(option)) {
+  if (!['awardEffectiveDate', 'monthlyAwardAmount', 'serviceConnectedPercentage'].includes(option)) {
     return benefitOptionText[option][valueString][personType];
   }
   switch (option) {
+    case 'awardEffectiveDate': {
+      if (value) {
+        return (<div>The effective date of the last change to your current award was <strong>{formatDateShort(value)}</strong></div>);
+      }
+      return undefined;
+    }
+
     case 'monthlyAwardAmount': {
       if (value && value !== 'unavailable') {
         return (<div>Your current monthly award amount is <strong>${value}</strong>.</div>);
@@ -194,6 +202,7 @@ export const benefitOptionsMap = {
   hasSurvivorsIndemnityCompensationAward: 'survivorsAward',
   hasSurvivorsPensionAward: 'survivorsAward',
   monthlyAwardAmount: 'monthlyAward',
+  awardEffectiveDate: 'monthlyAward',
   serviceConnectedPercentage: 'serviceConnectedEvaluation',
   militaryService: 'militaryService'
 };

--- a/src/js/letters/utils/helpers.js
+++ b/src/js/letters/utils/helpers.js
@@ -3,7 +3,6 @@ import React from 'react';
 
 import { apiRequest as commonApiClient } from '../../common/helpers/api';
 import environment from '../../common/helpers/environment';
-import { formatDateShort } from '../../common/utils/helpers';
 
 export function apiRequest(resource, optionalSettings = {}, success, error) {
   const baseUrl = `${environment.API_URL}`;
@@ -39,7 +38,7 @@ export const letterContent = {
 
 // Options returned by the benefit summary letter request that should be offered in
 // the checkbox list regardless of their values (e.g., true, false, 'unavailable', or other)
-// All other options are conditionall displayed, depending on the value
+// All other options are conditionally displayed, depending on the value
 export const optionsToAlwaysDisplay = [
   'hasChapter35Eligibility',
   'hasDeathResultOfDisability',
@@ -52,7 +51,7 @@ export const optionsToAlwaysDisplay = [
 const benefitOptionText = {
   hasNonServiceConnectedPension: {
     'true': {
-      veteran: <div>Your non-service connected pension information</div>,
+      veteran: <div>You <strong>are</strong> receiving non-service connected pension.</div>,
       dependent: undefined
     },
     'false': {
@@ -62,37 +61,37 @@ const benefitOptionText = {
   },
   hasServiceConnectedDisabilities: {
     'true': {
-      veteran: <div>You have one or more service-connected disabilities</div>,
+      veteran: <div>You <strong>have</strong> one or more service-connected disabilities.</div>,
       dependent: undefined
     },
     'false': {
-      veteran: <div>You <strong>do not</strong> have one or more service-connected disabilities</div>,
+      veteran: <div>You <strong>do not have</strong> one or more service-connected disabilities.</div>,
       dependent: undefined
     }
   },
   hasSurvivorsIndemnityCompensationAward: {
     'true': {
       veteran: undefined,
-      dependent: <div>You <strong>are</strong> receiving Dependency and Indemnity Compensation</div>
+      dependent: <div>You <strong>are</strong> receiving Dependency and Indemnity Compensation.</div>
     },
     'false': {
       veteran: undefined,
-      dependent: <div>You <strong>are not</strong> receiving Dependency and Indemnity Compensation</div>
+      dependent: <div>You <strong>are not</strong> receiving Dependency and Indemnity Compensation.</div>
     }
   },
   hasSurvivorsPensionAward: {
     'true': {
       veteran: undefined,
-      dependent: <div>You <strong>are</strong> receiving Survivors Pension></div>
+      dependent: <div>You <strong>are</strong> receiving Survivors Pension.</div>
     },
     'false': {
       veteran: undefined,
-      dependent: <div>You <strong>are not</strong> receiving Survivors Pension></div>
+      dependent: <div>You <strong>are not</strong> receiving Survivors Pension.</div>
     }
   },
   hasAdaptedHousing: {
     'true': {
-      veteran: <div>You <strong>have</strong> been found entitled to a Specially Adapted Housing (SAH) and/or Special Home Adaptation (SHA) grant</div>,
+      veteran: <div>You <strong>have been found entitled</strong> to a Specially Adapted Housing (SAH) and/or Special Home Adaptation (SHA) grant.</div>,
       dependent: undefined
     },
     'false': {
@@ -102,29 +101,27 @@ const benefitOptionText = {
   },
   hasChapter35Eligibility: {
     'true': {
-      veteran: <div>You are considered to be totally and permanently disabled solely due to your service-connected disabilities</div>,
+      veteran: <div>You <strong>are</strong> considered to be totally and permanently disabled solely due to your service-connected disabilities.</div>,
       dependent: <div>You <strong>are</strong> eligible for Dependents' Educational Assistance (Chapter 35).</div>
     },
     'false': {
-      // This doesn't look right: getting clarification in
-      // https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3685
-      veteran: <div>Information on your totally and permanently disabled status which resulted from service-connected disabilities</div>,
+      veteran: <div>You <strong>are not</strong> considered to be totally and permanently disabled solely due to your service-connected disabilities.</div>,
       dependent: <div>You <strong>are not</strong> eligible for Dependents' Educational Assistance (Chapter 35).</div>
     }
   },
   hasDeathResultOfDisability: {
     'true': {
       veteran: undefined,
-      dependent: <div>The Veteran died as a result of a service-connected disability</div>
+      dependent: <div>The Veteran died as a result of a service-connected disability.</div>
     },
     'false': {
       veteran: undefined,
-      dependent: <div>The Veteran did not die as a result of a service-connected disability</div>
+      dependent: <div>The Veteran <strong>did not</strong> die as a result of a service-connected disability.</div>
     }
   },
   hasIndividualUnemployabilityGranted: {
     'true': {
-      veteran: <div>You are being paid at the 100 percent rate because you are unemployable due to your service-connected disabilities</div>,
+      veteran: <div>You <strong>are</strong> being paid at the 100 percent rate because you are unemployable due to your service-connected disabilities.</div>,
       dependent: undefined
     },
     'false': {
@@ -134,7 +131,7 @@ const benefitOptionText = {
   },
   hasSpecialMonthlyCompensation: {
     'true': {
-      veteran: <div>You are service-connected for loss of or loss of use of a limb, or you are totally blind in or missing at least one eye</div>,
+      veteran: <div>You <strong>are</strong> service-connected for loss of or loss of use of a limb, or you are totally blind in or missing at least one eye.</div>,
       dependent: undefined
     },
     'false': {
@@ -155,37 +152,35 @@ export function getBenefitOptionText(option, value, isVeteran) {
     valueString = value;
   }
 
-  if (!['awardEffectiveDate', 'monthlyAwardAmount', 'serviceConnectedPercentage'].includes(option)) {
+  if (!['monthlyAwardAmount', 'serviceConnectedPercentage'].includes(option)) {
     return benefitOptionText[option][valueString][personType];
   }
   switch (option) {
-    case 'awardEffectiveDate':
-      // TODO: verify that this value must be defined to show this option
-      if (value) {
-        return (<div>The effective date of the last change to your current award was <strong>{formatDateShort(value)}</strong></div>);
-      }
-      return undefined;
-    case 'monthlyAwardAmount':
+    case 'monthlyAwardAmount': {
       if (value && value !== 'unavailable') {
-        return (<div>Your current monthly award amount is <strong>${value}</strong></div>);
+        return (<div>Your current monthly award amount is <strong>${value}</strong>.</div>);
       }
       return undefined;
-    case 'serviceConnectedPercentage':
+    }
+
+    case 'serviceConnectedPercentage': {
       if (value && value !== 'unavailable') {
         if (isVeteran) {
-          return (<div>Your combined service-connected evaluation is <strong>{value}%</strong></div>);
+          return (<div>Your combined service-connected evaluation is <strong>{value}%</strong>.</div>);
         }
-        return (<div>The Veteran's combined service-connected evaluation is <strong>{value}%</strong></div>);
+        return (<div>The Veterans combined service-connected evaluation is <strong>{value}%</strong>.</div>);
       }
-      break;
+      return undefined;
+    }
+
     default:
       return undefined;
   }
-  return undefined;
 }
 
-// Lookup table to convert the benefit and military service options returned by the benefit summary letter
-// response to the expected request body options for customizing the benefit summary letter.
+// Lookup table to convert the benefit and military service options
+// returned by the benefit summary letter response to the expected
+// request body options for customizing the benefit summary letter.
 export const benefitOptionsMap = {
   hasAdaptedHousing: 'adaptedHousing',
   hasChapter35Eligibility: 'chapter35Eligibility',
@@ -198,7 +193,6 @@ export const benefitOptionsMap = {
   // so both map to the same request body option
   hasSurvivorsIndemnityCompensationAward: 'survivorsAward',
   hasSurvivorsPensionAward: 'survivorsAward',
-  awardEffectiveDate: 'monthlyAward',
   monthlyAwardAmount: 'monthlyAward',
   serviceConnectedPercentage: 'serviceConnectedEvaluation',
   militaryService: 'militaryService'

--- a/src/js/letters/utils/helpers.js
+++ b/src/js/letters/utils/helpers.js
@@ -37,8 +37,9 @@ export const letterContent = {
   benefit_verification: 'This letter shows what benefits you\'re receiving from the VA. It is different from the benefit summary because it includes [x] and does not give you the option to choose what is included in the letter.'
 };
 
-// Options returned by the benefit summary letter request that should be offered in the checkbox
-// list regardless of the value (e.g., true, false, 'unavailable', or other)
+// Options returned by the benefit summary letter request that should be offered in
+// the checkbox list regardless of their values (e.g., true, false, 'unavailable', or other)
+// All other options are conditionall displayed, depending on the value
 export const optionsToAlwaysDisplay = [
   'hasChapter35Eligibility',
   'hasDeathResultOfDisability',
@@ -189,8 +190,8 @@ export const benefitOptionsMap = {
   hasNonServiceConnectedPension: 'nonServiceConnectedPension',
   hasServiceConnectedDisabilities: 'serviceConnectedDisabilities',
   hasSpecialMonthlyCompensation: 'specialMonthlyCompensation',
-  // User should only see one of these survivor award options; both
-  // map to the same request body option
+  // A given user should only see one of these survivor award options and never both,
+  // so both map to the same request body option
   hasSurvivorsIndemnityCompensationAward: 'survivorsAward',
   hasSurvivorsPensionAward: 'survivorsAward',
   awardEffectiveDate: 'monthlyAward',

--- a/src/js/letters/utils/helpers.js
+++ b/src/js/letters/utils/helpers.js
@@ -160,14 +160,18 @@ export function getBenefitOptionText(option, value, isVeteran) {
   }
   switch (option) {
     case 'awardEffectiveDate':
-      return (<div>The effective date of the last change to your current award was <strong>{formatDateShort(value)}</strong></div>);
+      // TODO: verify that this value must be defined to show this option
+      if (value) {
+        return (<div>The effective date of the last change to your current award was <strong>{formatDateShort(value)}</strong></div>);
+      }
+      return undefined;
     case 'monthlyAwardAmount':
-      if (value && value !== 'unavaliable') {
+      if (value && value !== 'unavailable') {
         return (<div>Your current monthly award amount is <strong>${value}</strong></div>);
       }
       return undefined;
     case 'serviceConnectedPercentage':
-      if (value && value !== 'unavaliable') {
+      if (value && value !== 'unavailable') {
         if (isVeteran) {
           return (<div>Your combined service-connected evaluation is <strong>{value}%</strong></div>);
         }

--- a/src/js/letters/utils/helpers.js
+++ b/src/js/letters/utils/helpers.js
@@ -58,43 +58,75 @@ export const letterContent = {
   benefit_verification: 'This letter shows what benefits you\'re receiving from the VA. It is different from the benefit summary because it includes [x] and does not give you the option to choose what is included in the letter.'
 };
 
-export function veteranBenefitSummaryOptionText(currentOption, currentValue) {
-  const textForAllOptions = {
+export const optionsToAlwaysDisplay = [
+  'hasChapter35Eligibility',
+  'hasDeathResultOfDisability',
+  'hasServiceConnectedDisabilities',
+  'hasSurvivorsIndemnityCompensationAward',
+  'hasSurvivorsPensionAward',
+  'serviceConnectedPercentage'
+];
+
+export function getBenefitOptionText(currentOption, currentValue, isVeteran) {
+  const optionText = {
     awardEffectiveDate: <div>The effective date of the last change to your current award was <strong>{formatDateShort(currentValue)}</strong></div>,
-    hasAdaptedHousing: <div>You <strong>have</strong> been found entitled to a Specially Adapted Housing (SAH) and/or Special Home Adaptation (SHA) grant</div>,
-    hasChapter35Eligibility: <div>You <strong>are</strong> considered to be totally and permanently disabled solely due to your service-connected disabilities</div>,
-    hasDeathResultOfDisability: <div></div>,
-    hasIndividualUnemployabilityGranted: <div>You <strong>are</strong> being paid at the 100 percent rate because you are unemployable due to your service-connected disabilities</div>,
-    hasNonServiceConnectedPension: <div>Your non-service connected pension information</div>,
-    hasServiceConnectedDisabilities: <div>You have one or more service-connected disabilities</div>,
-    hasSpecialMonthlyCompensation: <div>You <strong>are</strong> service-connected for loss of or loss of use of a limb, or you are totally blind in or missing at least one eye</div>,
-    hasSurvivorsIndemnityCompensationAward: <div></div>,
-    hasSurvivorsPensionAward: <div></div>,
-    monthlyAwardAmount: <div>Your current monthly award amount is <strong>${currentValue}</strong></div>,
-    serviceConnectedPercentage: <div>Your combined service-connected evaluation is <strong>{currentValue}%</strong></div>,
+    hasChapter35Eligibility: currentValue ?
+      <div>You are considered to be totally and permanently disabled solely due to your service-connected disabilities</div> :
+      <div>Information on your totally and permanently disabled status which resulted from service-connected disabilities</div>, // This doeson't look right; clarify in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3685
+    monthlyAwardAmount: (currentValue && currentValue !== 'unavailable') ?
+      <div>Your current monthly award amount is <strong>${currentValue}</strong></div> : undefined
   };
 
-  return textForAllOptions[currentOption];
+  if (isVeteran) {
+    merge({
+      hasAdaptedHousing: currentValue ?
+        <div>You have been found entitled to a Specially Adapted Housing (SAH) and/or Special Home Adaptation (SHA) grant</div> : undefined,
+      hasNonServiceConnectedPension: <div>Your non-service connected pension information</div>,
+      hasServiceConnectedDisabilities: currentValue ?
+        <div>You have one or more service-connected disabilities</div> :
+        <div>You do not have one or more service-connected disabilities</div>,
+      serviceConnectedPercentage: (currentValue && currentValue !== 'unavailable') ?
+        <div>Your combined service-connected evaluation is <strong>{currentValue}%</strong></div> : undefined,
+      hasSpecialMonthlyCompensation: currentValue ?
+        <div>You are service-connected for loss of or loss of use of a limb, or you are totally blind in or missing at least one eye</div> : undefined,
+      hasIndividualUnemployabilityGranted: currentValue ?
+        <div>You are being paid at the 100 percent rate because you are unemployable due to your service-connected disabilities</div> : undefined
+    }, {}, optionText);
+  } else {
+    merge({
+      hasSurvivorsIndemnityCompensationAward: currentValue ?
+        <div>You are receiving Dependency and Indemnity Compensation</div> :
+        <div>You are not receiving Dependency and Indemnity Compensation</div>,
+      hasSurvivorsPensionAward: currentValue ?
+        <div>You are receiving Survivors Pension></div> :
+        <div>You are not receiving Survivors Pension></div>,
+      serviceConnectedPercentage: (currentValue && currentValue !== 'unavailable') ?
+        <div>The Veteran's combined service-connected evaluation is <strong>{currentValue}%</strong></div> : undefined,
+      hasDeathResultOfDisability: currentValue ?
+        <div>The Veteran died as a result of a service-connected disability</div> :
+        <div>The Veteran did not die as a result of a service-connected disability</div>
+    }, {}, optionText);
+  }
+
+  return optionText[currentOption];
 }
 
 // Lookup table to convert the benefit and military service options returned by the benefit summary letter
 // response to the expected request body options for customizing the benefit summary letter.
-// TODO: point to API docs once they're ready.
 export const benefitOptionsMap = {
-  awardEffectiveDate: 'awardEffectiveDate', // guessing
   hasAdaptedHousing: 'adaptedHousing',
   hasChapter35Eligibility: 'chapter35Eligibility',
+  hasDeathResultOfDisability: 'deathResultOfDisability',
+  hasIndividualUnemployabilityGranted: 'unemployable',
   hasNonServiceConnectedPension: 'nonServiceConnectedPension',
   hasServiceConnectedDisabilities: 'serviceConnectedDisabilities',
-  // There is an expected 'survivorsAward' option, but it's not clear whether
-  // it corresponds to the idemnity compensation or the pension award or neither.
-  hasSurvivorsIndemnityCompensationAward: 'survivorsAward', // fix
-  hasSurvivorsPensionAward: 'survivorsAward', // fix
+  hasSpecialMonthlyCompensation: 'specialMonthlyCompensation',
+  // User should only see one of these survivor award options; both
+  // map to the same request body option
+  hasSurvivorsIndemnityCompensationAward: 'survivorsAward',
+  hasSurvivorsPensionAward: 'survivorsAward',
+  awardEffectiveDate: 'monthlyAward',
   monthlyAwardAmount: 'monthlyAward',
-  serviceConnectedPercentage: 'serviceConnectedEvaluation', // guessing
-  hasIndividualUnemployabilityGranted: 'individualUnemployabilityGranted', // guessing
-  hasSpecialMonthlyCompensation: 'specialMonthlyCompensation', // guessing
-  militaryService: 'militaryService',
-  hasUnemployable: 'unemployable', // guessing, look at EVSS swagger
-  hasDeathResultOfDisability: 'deathResultOfDisability' // guessing, look at EVSS swagger
+  serviceConnectedPercentage: 'serviceConnectedEvaluation',
+  militaryService: 'militaryService'
 };

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -50,6 +50,6 @@
 
   th[scope="row"] {
     padding-top: 0;
-    padding-bottom: 0;
+    padding-bottom: 0; 
   }
 }

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -50,6 +50,6 @@
 
   th[scope="row"] {
     padding-top: 0;
-    padding-bottom: 0; 
+    padding-bottom: 0;
   }
 }

--- a/test/letters/components/DownloadLetterLink.unit.spec.js
+++ b/test/letters/components/DownloadLetterLink.unit.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
-import sinon from 'sinon';
+// import sinon from 'sinon';
 
 import { DownloadLetterLink } from '../../../src/js/letters/components/DownloadLetterLink.jsx';
 
@@ -10,13 +10,13 @@ const defaultProps = {
   letterType: 'commissary'
 };
 
+/*
 let oldWindow;
 let oldFetch;
 
 // TODO: fix this warning and improve test coverage for various scenarios:
 //   UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1):
 //   TypeError: Cannot read property 'ok' of undefined"
-
 const setup = () => {
   oldFetch = global.fetch;
   oldWindow = global.window;
@@ -40,6 +40,7 @@ const teardown = () => {
   global.window = oldWindow;
   global.fetch = oldFetch;
 };
+*/
 
 describe('<DownloadLetterLink>', () => {
   it('should render', () => {

--- a/test/letters/components/DownloadLetterLink.unit.spec.js
+++ b/test/letters/components/DownloadLetterLink.unit.spec.js
@@ -10,7 +10,6 @@ const defaultProps = {
   letterType: 'commissary'
 };
 
-
 let oldWindow;
 let oldFetch;
 
@@ -42,7 +41,6 @@ const teardown = () => {
   global.fetch = oldFetch;
 };
 
-
 describe('<DownloadLetterLink>', () => {
   it('should render', () => {
     const tree = SkinDeep.shallowRender(<DownloadLetterLink {...defaultProps}/>);
@@ -58,16 +56,5 @@ describe('<DownloadLetterLink>', () => {
   it('should show download button', () => {
     const tree = SkinDeep.shallowRender(<DownloadLetterLink {...defaultProps}/>);
     expect(tree.dive(['.usa-button-primary']).text()).to.equal('Download Letter');
-  });
-
-  it('should call download function on click', () => {
-    setup();
-    const tree = SkinDeep.shallowRender(<DownloadLetterLink {...defaultProps}/>);
-    const link = tree.subTree('Link');
-    link.props.onClick({
-      preventDefault() {}
-    });
-    expect(global.fetch.args[0][0]).to.contain('/v0/letters/');
-    teardown();
   });
 });

--- a/test/letters/components/DownloadLetterLink.unit.spec.js
+++ b/test/letters/components/DownloadLetterLink.unit.spec.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
-import { expect } from 'chai';
 import sinon from 'sinon';
 import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
 import _ from 'lodash/fp';
 
 import { DownloadLetterLink } from '../../../src/js/letters/components/DownloadLetterLink.jsx';

--- a/test/letters/components/DownloadLetterLink.unit.spec.js
+++ b/test/letters/components/DownloadLetterLink.unit.spec.js
@@ -1,7 +1,9 @@
 import React from 'react';
-import SkinDeep from 'skin-deep';
+// import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
 // import sinon from 'sinon';
+import SkinDeep from 'skin-deep';
+// import ReactTestUtils from 'react-dom/test-utils';
 
 import { DownloadLetterLink } from '../../../src/js/letters/components/DownloadLetterLink.jsx';
 
@@ -9,38 +11,6 @@ const defaultProps = {
   letterName: 'Commissary Letter',
   letterType: 'commissary'
 };
-
-/*
-let oldWindow;
-let oldFetch;
-
-// TODO: fix this warning and improve test coverage for various scenarios:
-//   UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1):
-//   TypeError: Cannot read property 'ok' of undefined"
-const setup = () => {
-  oldFetch = global.fetch;
-  oldWindow = global.window;
-  global.fetch = sinon.spy(() => {
-    return Promise.resolve();
-  });
-  global.window = {
-    navigator: {},
-    open: sinon.spy(),
-    dataLayer: [],
-    URL: {
-      revokeObjectURL: () => {}
-    }
-  };
-  global.sessionStorage = {
-    userToken: 'abc'
-  };
-};
-
-const teardown = () => {
-  global.window = oldWindow;
-  global.fetch = oldFetch;
-};
-*/
 
 describe('<DownloadLetterLink>', () => {
   it('should render', () => {
@@ -58,4 +28,23 @@ describe('<DownloadLetterLink>', () => {
     const tree = SkinDeep.shallowRender(<DownloadLetterLink {...defaultProps}/>);
     expect(tree.dive(['.usa-button-primary']).text()).to.equal('Download Letter');
   });
+  /*
+  it('should call getLetterPdf when clicked', () => {
+    const oldWindow = global.window;
+    global.window = {
+      dataLayer: [],
+    };
+    const getLetterPdf = sinon.spy();
+    const tree = ReactTestUtils.renderIntoDocument(
+      <DownloadLetterLink {...defaultProps}/>);
+    const findDOM = findDOMNode(tree);
+
+    const link = findDOM.querySelector('a');
+    expect(link).to.exist;
+    ReactTestUtils.Simulate.click(findDOM.querySelector('a'));
+    expect(getLetterPdf.calledOnce).to.be.true;
+
+    global.window = oldWindow;
+  });
+  */
 });

--- a/test/letters/components/DownloadLetterLink.unit.spec.js
+++ b/test/letters/components/DownloadLetterLink.unit.spec.js
@@ -1,9 +1,9 @@
 import React from 'react';
-// import { findDOMNode } from 'react-dom';
+import ReactTestUtils from 'react-dom/test-utils';
 import { expect } from 'chai';
-// import sinon from 'sinon';
+import sinon from 'sinon';
 import SkinDeep from 'skin-deep';
-// import ReactTestUtils from 'react-dom/test-utils';
+import _ from 'lodash/fp';
 
 import { DownloadLetterLink } from '../../../src/js/letters/components/DownloadLetterLink.jsx';
 
@@ -28,23 +28,19 @@ describe('<DownloadLetterLink>', () => {
     const tree = SkinDeep.shallowRender(<DownloadLetterLink {...defaultProps}/>);
     expect(tree.dive(['.usa-button-primary']).text()).to.equal('Download Letter');
   });
-  /*
+
   it('should call getLetterPdf when clicked', () => {
     const oldWindow = global.window;
     global.window = {
       dataLayer: [],
     };
     const getLetterPdf = sinon.spy();
-    const tree = ReactTestUtils.renderIntoDocument(
-      <DownloadLetterLink {...defaultProps}/>);
-    const findDOM = findDOMNode(tree);
-
-    const link = findDOM.querySelector('a');
-    expect(link).to.exist;
-    ReactTestUtils.Simulate.click(findDOM.querySelector('a'));
+    const props = _.set('getLetterPdf', getLetterPdf, defaultProps);
+    const component = (ReactTestUtils.renderIntoDocument(<DownloadLetterLink {...props}/>));
+    const link = ReactTestUtils.findRenderedDOMComponentWithTag(component, 'a');
+    ReactTestUtils.Simulate.click(link);
     expect(getLetterPdf.calledOnce).to.be.true;
-
+    expect(global.window.dataLayer).not.to.be.empty;
     global.window = oldWindow;
   });
-  */
 });

--- a/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
+++ b/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import ReactTestUtils from 'react-dom/test-utils';
+import sinon from 'sinon';
 import SkinDeep from 'skin-deep';
+import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
+import _ from 'lodash/fp';
 
-import VeteranBenefitSummaryLetter from '../../../src/js/letters/containers/VeteranBenefitSummaryLetter';
+import { VeteranBenefitSummaryLetter } from '../../../src/js/letters/containers/VeteranBenefitSummaryLetter';
 
 import reducer from '../../../src/js/letters/reducers/index.js';
 import createCommonStore from '../../../src/js/common/store';
@@ -12,7 +16,6 @@ const store = createCommonStore(reducer);
 const defaultProps = {
   benefitSummaryOptions: {
     benefitInfo: {
-      awardEffectiveDate: '1965-01-01T05:00:00.000+00:00',
       hasAdaptedHousing: true,
       hasChapter35Eligibility: false
     },
@@ -26,7 +29,7 @@ const defaultProps = {
     ]
   },
   optionsAvailable: true,
-  optionsToInclude: {
+  requestOptions: {
   }
 };
 
@@ -39,11 +42,39 @@ describe('<VeteranBenefitSummaryLetter>', () => {
 
   it('should show benefit info options', () => {
     const tree = SkinDeep.shallowRender(<VeteranBenefitSummaryLetter store={store} {...defaultProps}/>);
-    expect(tree.subTree('hasAdaptedHousing')).to.exist;
+    const rows = tree.dive(['div', '#benefitInfoTable', 'tbody']).everySubTree('tr');
+    expect(rows[0].dive(['th', 'input'])).not.to.be.empty;
+    expect(rows[0].dive(['td', '#hasAdaptedHousingLabel'])).not.to.be.empty;
+
+    expect(rows[1].dive(['th', 'input'])).not.to.be.empty;
+    expect(rows[1].dive(['td', '#hasChapter35EligibilityLabel'])).not.to.be.empty;
   });
 
   it('should show service info options', () => {
     const tree = SkinDeep.shallowRender(<VeteranBenefitSummaryLetter store={store} {...defaultProps}/>);
-    expect(tree.subTree('serviceInfoCheckboxId')).to.exist;
+    expect(tree.dive(['div', 'div', '#militaryService'])).not.to.be.empty;
+  });
+
+  it('should update request option when checked', () => {
+    const updateOption = sinon.spy();
+    const props = _.set('updateBenefitSummaryRequestOption', updateOption, defaultProps);
+    const component = ReactTestUtils.renderIntoDocument(
+      <VeteranBenefitSummaryLetter store={store} {...props}/>);
+    const formDOM = findDOMNode(component);
+    const inputs = formDOM.querySelectorAll('input');
+    expect(inputs.length).to.equal(3);
+
+    ReactTestUtils.Simulate.change(inputs[0], {
+      target: {
+        checked: false
+      }
+    });
+    ReactTestUtils.Simulate.change(inputs[1], {
+      target: {
+        checked: false
+      }
+    });
+
+    expect(updateOption.calledTwice).to.be.true;
   });
 });

--- a/test/letters/reducers/index.unit.spec.js
+++ b/test/letters/reducers/index.unit.spec.js
@@ -8,7 +8,27 @@ const initialState = {
   lettersAvailability: 'awaitingResponse',
   benefitInfo: {},
   serviceInfo: [],
-  optionsAvailable: false
+  optionsAvailable: false,
+  requestOptions: {}
+};
+
+const benefitSummaryOptionData = {
+  data: {
+    attributes: {
+      benefitInformation: {
+        awardEffectiveDate: '1965-01-01T05:00:00.000+00:00',
+        hasChapter35Eligibility: true
+      },
+      militaryService: [
+        {
+          branch: 'ARMY',
+          characterOfService: 'HONORABLE',
+          enteredDate: '1965-01-01T05:00:00.000+00:00',
+          releasedDate: '1972-10-01T04:00:00.000+00:00'
+        }
+      ]
+    }
+  }
 };
 
 describe('letters reducer', () => {
@@ -64,33 +84,29 @@ describe('letters reducer', () => {
     expect(state.optionsAvailable).to.be.false;
   });
 
-  it('should handle a successful request for letters', () => {
+  it('should handle a successful request for benefit summary options', () => {
     const state = lettersReducer.letters(
       initialState,
       {
         type: 'GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS',
-        data: {
-          data: {
-            attributes: {
-              benefitInformation: {
-                awardEffectiveDate: '1965-01-01T05:00:00.000+00:00',
-                hasChapter35Eligibility: true
-              },
-              militaryService: [
-                {
-                  branch: 'ARMY',
-                  characterOfService: 'HONORABLE',
-                  enteredDate: '1965-01-01T05:00:00.000+00:00',
-                  releasedDate: '1972-10-01T04:00:00.000+00:00'
-                }
-              ]
-            }
-          }
-        }
+        data: benefitSummaryOptionData
       }
     );
 
     expect(state.benefitInfo.hasChapter35Eligibility).to.be.true;
     expect(state.serviceInfo[0].branch).to.equal('ARMY');
+    expect(state.optionsAvailable).to.be.true;
+  });
+
+  it('should update benefit summary request options', () => {
+    const state = lettersReducer.letters(
+      initialState,
+      {
+        type: 'GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS',
+        data: benefitSummaryOptionData
+      }
+    );
+    expect(state.requestOptions.chapter35Eligibility).to.be.true;
+    expect(state.requestOptions.monthlyAward).to.be.true;
   });
 });

--- a/test/letters/utils/helpers.unit.spec.js
+++ b/test/letters/utils/helpers.unit.spec.js
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+// import sinon from 'sinon';
+import _ from 'lodash/fp';
+
+import {
+  getBenefitOptionText
+} from '../../../src/js/letters/utils/helpers';
+
+describe('Letters helpers: ', () => {
+  describe('getBenefitOptionText', () => {
+    it('should be defined for both veterans and dependents', () => {
+      _.forEach(option => {
+        expect(getBenefitOptionText(option, true, true)).not.to.be.undefined;
+        expect(getBenefitOptionText(option, true, false)).not.to.be.undefined;
+      }, ['hasChapter35Eligibility']);
+    });
+    it('should only be defined for veterans', () => {
+      _.forEach(option => {
+        expect(getBenefitOptionText(option, true, true)).not.to.be.undefined;
+        expect(getBenefitOptionText(option, true, false)).to.be.undefined;
+      }, ['hasNonServiceConnectedPension', 'hasServiceConnectedDisabilities', 'hasAdaptedHousing', 'hasIndividualUnemployabilityGranted', 'hasSpecialMonthlyCompensation']);
+    });
+    it('should only be defined for dependents', () => {
+      _.forEach(option => {
+        expect(getBenefitOptionText(option, true, true)).to.be.undefined;
+        expect(getBenefitOptionText(option, true, false)).not.to.be.undefined;
+      }, ['hasSurvivorsIndemnityCompensationAward', 'hasSurvivorsPensionAward', 'hasDeathResultOfDisability']);
+    });
+    it('should only be defined if value is true', () => {
+      _.forEach(option => {
+        expect(getBenefitOptionText(option, true, true)).not.to.be.undefined;
+        expect(getBenefitOptionText(option, false, true)).to.be.undefined;
+      }, ['hasNonServiceConnectedPension', 'hasAdaptedHousing', 'hasIndividualUnemployabilityGranted', 'hasSpecialMonthlyCompensation']);
+    });
+    it('should be defined whether value is true or false', () => {
+      // For both veterans and dependents
+      _.forEach(option => {
+        expect(getBenefitOptionText(option, true, true)).not.to.be.undefined;
+        expect(getBenefitOptionText(option, false, true)).not.to.be.undefined;
+        expect(getBenefitOptionText(option, true, false)).not.to.be.undefined;
+        expect(getBenefitOptionText(option, false, false)).not.to.be.undefined;
+      }, ['hasChapter35Eligibility']);
+      // For veterans only
+      _.forEach(option => {
+        expect(getBenefitOptionText(option, true, true)).not.to.be.undefined;
+        expect(getBenefitOptionText(option, false, true)).not.to.be.undefined;
+      }, ['hasServiceConnectedDisabilities']);
+      // For dependents only
+      _.forEach(option => {
+        expect(getBenefitOptionText(option, true, false)).not.to.be.undefined;
+        expect(getBenefitOptionText(option, false, false)).not.to.be.undefined;
+      }, ['hasSurvivorsIndemnityCompensationAward', 'hasSurvivorsPensionAward', 'hasDeathResultOfDisability']);
+    });
+    // Special cases for non-boolean options
+    it('should only be defined if date is valid', () => {
+      expect(getBenefitOptionText('awardEffectiveDate', '1965-01-01T05:00:00.000+00:00', true)).not.to.be.undefined;
+      expect(getBenefitOptionText('awardEffectiveDate', undefined, true)).to.be.undefined;
+    });
+    it('should only be defined if value is valid', () => {
+      _.forEach(option => {
+        expect(getBenefitOptionText(option, 20, true)).not.to.be.undefined;
+        expect(getBenefitOptionText(option, undefined, true)).to.be.undefined;
+        expect(getBenefitOptionText(option, 'unavailable', true)).to.be.undefined;
+      }, ['monthlyAwardAmount', 'serviceConnectedPercentage']);
+    });
+  });
+});
+


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3723
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3685

Tested this against CI, and the POST successfully downloads a customized BSL.
Now writing unit tests.

This also includes some refactoring, so here is a summary of the changes:
  - move pdf fetch into action creator so that success or failure actions are dispatched; currently we don't do much with these, but they should be handled with an appropriate error message (we may want to include this in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3780)
  - removed hard-coded military options for usability test
  - maps the BSL options returned by the initial request to the request body options for customizing the PDF
  - renames `optionsToInclude` to `requestOptions`
  - guts our `apiRequest` helper function so we can use `common/helpers/api/commonApiClient` (which should probably happen in a bunch of places throughout the codebase to reduce code duplication)
