### PR TITLE
Reformat va file number to hide everything but last 4 digits

### DIFF
--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import InfoPair from './InfoPair';
 
 import { formatDateShort } from '../../common/utils/helpers';
-import { formatPercent, formatVAFilNumber } from '../utils/helpers';
+import { formatPercent, formatVAFileNumber } from '../utils/helpers';
 
 class UserInfoSection extends React.Component {
   render() {
@@ -78,7 +78,7 @@ class UserInfoSection extends React.Component {
           {/* TODO: find out whether this should be only partially displayed  xxxx1234 */}
           <InfoPair
               label="VA file number"
-              value={formatVAFilNumber(enrollmentData.vaFileNumber)}
+              value={formatVAFileNumber(enrollmentData.vaFileNumber)}
               spacingClass="section-line"/>
           <InfoPair
               label="Regional processing office"

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import InfoPair from './InfoPair';
 
 import { formatDateShort } from '../../common/utils/helpers';
-import { formatPercent } from '../utils/helpers';
+import { formatPercent, formatVAFilNumber } from '../utils/helpers';
 
 class UserInfoSection extends React.Component {
   render() {
@@ -78,7 +78,7 @@ class UserInfoSection extends React.Component {
           {/* TODO: find out whether this should be only partially displayed  xxxx1234 */}
           <InfoPair
               label="VA file number"
-              value={enrollmentData.vaFileNumber}
+              value={formatVAFilNumber(enrollmentData.vaFileNumber)}
               spacingClass="section-line"/>
           <InfoPair
               label="Regional processing office"

--- a/src/js/post-911-gib-status/utils/helpers.js
+++ b/src/js/post-911-gib-status/utils/helpers.js
@@ -12,6 +12,11 @@ export function formatPercent(percent) {
   return validPercent;
 }
 
+export function formatVAFilNumber(number) {
+  const lengthOfXString = number.length - 4;
+  return number.replace(number.substring(0, lengthOfXString), `${'x'.repeat(lengthOfXString)}-`);
+}
+
 function isJson(response) {
   const contentType = response.headers.get('content-type');
   return contentType && contentType.indexOf('application/json') !== -1;

--- a/src/js/post-911-gib-status/utils/helpers.js
+++ b/src/js/post-911-gib-status/utils/helpers.js
@@ -12,8 +12,10 @@ export function formatPercent(percent) {
   return validPercent;
 }
 
-export function formatVAFilNumber(number) {
-  const lengthOfXString = number.length - 4;
+export function formatVAFileNumber(n) {
+  const number = n || '';
+  const lengthOfXString = number.length > 4 ? number.length - 4 : 0;
+
   return number.replace(number.substring(0, lengthOfXString), `${'x'.repeat(lengthOfXString)}-`);
 }
 

--- a/test/post-911-gib-status/components/UserInfoSection.unit.spec.js
+++ b/test/post-911-gib-status/components/UserInfoSection.unit.spec.js
@@ -7,6 +7,7 @@ import UserInfoSection from '../../../src/js/post-911-gib-status/components/User
 
 const props = {
   enrollmentData: {
+    vaFileNumber: '12345678'
   }
 };
 const currentHeadingSelector = '#current-as-of';


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3744.

This replaces everything but the last 4 digits in the VA file number with x's. I couldn't make it look exactly like the mock-up, which includes 2 hyphens (e.g. `xxx-xx-6789`) because I won't know how many total digits the number is going to be. While VA file number is usually just going to be the user's ssn, sometimes it's not, and original file numbers can be a range of possible lengths. Therefore, what this will render is x's for each digit up until the last 4, a hyphen, and then the last 4 digits (e.g., `xxxx-5678`).