### PR TITLE
Set page focus on appeals detail page

### DIFF
--- a/src/js/disability-benefits/containers/AppealStatusPage.jsx
+++ b/src/js/disability-benefits/containers/AppealStatusPage.jsx
@@ -7,12 +7,14 @@ import _ from 'lodash';
 import { getAppeals } from '../actions';
 import AskVAQuestions from '../components/AskVAQuestions';
 import { appealStatusDescriptions, hearingDescriptions } from '../utils/appeal-helpers.jsx';
+import { setPageFocus } from '../utils/page';
 
 class AppealStatusPage extends React.Component {
   componentDidMount() {
     if (!this.props.appeal) {
       this.props.getAppeals();
     }
+    setPageFocus();
   }
 
   renderStatusNextAction(lastEvent, previousHistory) {


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3752

Sets page focus on Appeals detail page to help with tab ordering issues