### PR TITLE
Add progress bar and file type check to file upload field

### DIFF
--- a/src/js/common/schemaform/FileField.jsx
+++ b/src/js/common/schemaform/FileField.jsx
@@ -54,12 +54,11 @@ export default class FileField extends React.Component {
         filePath,
         this.props.uiSchema['ui:options'],
         this.updateProgress
-      )
-        .then(() => {
-          // rather not use the promise here, but seems better than trying to pass
-          // a blur function
-          this.props.onBlur(this.props.idSchema.$id);
-        });
+      ).then(() => {
+        // rather not use the promise here, but seems better than trying to pass
+        // a blur function
+        this.props.onBlur(this.props.idSchema.$id);
+      });
     }
   }
 

--- a/src/js/common/schemaform/FileField.jsx
+++ b/src/js/common/schemaform/FileField.jsx
@@ -11,7 +11,6 @@ export default class FileField extends React.Component {
     const files = this.props.formData || [];
     this.state = {
       editing: files.map(() => false),
-      isUploading: false,
       progress: 0
     };
   }
@@ -36,8 +35,9 @@ export default class FileField extends React.Component {
     }
 
     const isUploading = newFiles.some(file => file.uploading);
-    if (isUploading !== this.state.isUploading) {
-      this.setState({ isUploading });
+    const wasUploading = files.some(file => file.uploading);
+    if (isUploading && !wasUploading) {
+      this.setState({ progress: 0 });
     }
   }
 
@@ -55,7 +55,7 @@ export default class FileField extends React.Component {
         this.props.uiSchema['ui:options'],
         this.updateProgress
       )
-        .catch(() => {
+        .then(() => {
           // rather not use the promise here, but seems better than trying to pass
           // a blur function
           this.props.onBlur(this.props.idSchema.$id);

--- a/src/js/common/schemaform/FileField.jsx
+++ b/src/js/common/schemaform/FileField.jsx
@@ -3,13 +3,16 @@ import React from 'react';
 import _ from 'lodash/fp';
 import classNames from 'classnames';
 import { focusElement } from '../utils/helpers';
+import ProgressBar from '../components/ProgressBar';
 
 export default class FileField extends React.Component {
   constructor(props) {
     super(props);
     const files = this.props.formData || [];
     this.state = {
-      editing: files.map(() => false)
+      editing: files.map(() => false),
+      isUploading: false,
+      progress: 0
     };
   }
 
@@ -31,6 +34,11 @@ export default class FileField extends React.Component {
       });
       this.setState({ editing });
     }
+
+    const isUploading = newFiles.some(file => file.uploading);
+    if (isUploading !== this.state.isUploading) {
+      this.setState({ isUploading });
+    }
   }
 
   onAddFile = (event, index = null) => {
@@ -41,13 +49,22 @@ export default class FileField extends React.Component {
         idx = files.length === 0 ? 0 : files.length;
       }
       const filePath = this.props.idSchema.$id.split('_').slice(1).concat(idx);
-      this.props.formContext.uploadFile(event.target.files[0], filePath, this.props.uiSchema['ui:options'])
+      this.props.formContext.uploadFile(
+        event.target.files[0],
+        filePath,
+        this.props.uiSchema['ui:options'],
+        this.updateProgress
+      )
         .catch(() => {
           // rather not use the promise here, but seems better than trying to pass
           // a blur function
           this.props.onBlur(this.props.idSchema.$id);
         });
     }
+  }
+
+  updateProgress = (progress) => {
+    this.setState({ progress });
   }
 
   editFile = (index, isEditing = true) => {
@@ -94,7 +111,12 @@ export default class FileField extends React.Component {
 
               return (
                 <li key={index} id={`${idSchema.$id}_file_${index}`} className={itemClasses}>
-                  {file.uploading && 'Uploading file...'}
+                  {file.uploading &&
+                    <div className="schemaform-file-uploading">
+                      <span>{file.name}</span><br/>
+                      <ProgressBar percent={this.state.progress}/>
+                    </div>
+                  }
                   {file.confirmationCode && <span>{file.name}</span>}
                   {!file.uploading && !!errors.length && <span>{errors[0]}</span>}
                   {!file.uploading && !editingOrErrors &&

--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -102,7 +102,7 @@ export function submitForm(formConfig, form) {
   };
 }
 
-export function uploadFile(file, filePath, uiOptions = {}) {
+export function uploadFile(file, filePath, uiOptions, progressCallback) {
   return (dispatch, getState) => {
     if (file.size > uiOptions.maxSize) {
       dispatch(
@@ -137,40 +137,73 @@ export function uploadFile(file, filePath, uiOptions = {}) {
     }
 
     dispatch(
-      setData(_.set(filePath, { uploading: true }, getState().form.data))
+      setData(_.set(filePath, { name: file.name, uploading: true }, getState().form.data))
     );
 
     const payload = new FormData();
     payload.append('file', file);
     payload.append('form_id', getState().form.formId);
 
-    return fetch(`${environment.API_URL}${uiOptions.endpoint}`, {
-      method: 'POST',
-      headers: {
-        'X-Key-Inflection': 'camel'
-      },
-      body: payload
-    }).then(resp => {
-      if (resp.ok) {
-        return resp.json();
-      }
+    return new Promise((resolve, reject) => {
+      const req = new XMLHttpRequest();
 
-      return Promise.reject(new Error(`vets_upload_error: ${resp.statusText}`));
-    }).then(fileInfo => {
-      dispatch(
-        setData(_.set(filePath, {
-          name: fileInfo.data.attributes.name,
-          size: fileInfo.data.attributes.size,
-          confirmationCode: fileInfo.data.attributes.confirmationCode
-        }, getState().form.data))
-      );
-    }).catch(error => {
-      dispatch(
-        setData(_.set(filePath, {
-          errorMessage: error.message.replace('vets_upload_error: ', '')
-        }, getState().form.data))
-      );
-      Raven.captureException(error);
+      req.open('POST', `${environment.API_URL}${uiOptions.endpoint}`);
+      req.addEventListener('load', () => {
+        if (req.status >= 200 && req.status < 300) {
+          const body = 'response' in req ? req.response : req.responseText;
+          const fileInfo = JSON.parse(body);
+          dispatch(
+            setData(_.set(filePath, {
+              name: fileInfo.data.attributes.name,
+              size: fileInfo.data.attributes.size,
+              confirmationCode: fileInfo.data.attributes.confirmationCode
+            }, getState().form.data))
+          );
+          resolve(fileInfo);
+        } else {
+          dispatch(
+            setData(_.set(filePath, {
+              errorMessage: req.statusText
+            }, getState().form.data))
+          );
+          Raven.captureMessage(`vets_upload_error: ${req.statusText}`);
+          reject(req.statusText);
+        }
+      });
+
+      req.addEventListener('error', () => {
+        const errorMessage = 'Network request failed';
+        dispatch(
+          setData(_.set(filePath, {
+            errorMessage
+          }, getState().form.data))
+        );
+        Raven.captureMessage(`vets_upload_error: ${errorMessage}`, {
+          extra: {
+            statusText: req.statusText
+          }
+        });
+        reject(errorMessage);
+      });
+
+      req.addEventListener('abort', () => {
+        dispatch(
+          setData(_.set(filePath, {
+            errorMessage: 'Upload aborted'
+          }, getState().form.data))
+        );
+        Raven.captureMessage('vets_upload_error: Upload aborted');
+        reject();
+      });
+
+      req.upload.addEventListener('progress', (evt) => {
+        if (evt.lengthComputable && progressCallback) {
+          progressCallback((evt.loaded / evt.total) * 100);
+        }
+      });
+
+      req.setRequestHeader('X-Key-Inflection', 'camel');
+      req.send(payload);
     });
   };
 }

--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -124,6 +124,18 @@ export function uploadFile(file, filePath, uiOptions = {}) {
       return Promise.reject();
     }
 
+    // we limit file types, but it's not respected on mobile and desktop
+    // users can bypass it without much effort
+    if (!uiOptions.fileTypes.some(fileType => file.name.endsWith(fileType))) {
+      dispatch(
+        setData(_.set(filePath, {
+          errorMessage: 'File is not one of the allowed types'
+        }, getState().form.data))
+      );
+
+      return Promise.reject();
+    }
+
     dispatch(
       setData(_.set(filePath, { uploading: true }, getState().form.data))
     );

--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -144,7 +144,7 @@ export function uploadFile(file, filePath, uiOptions, progressCallback) {
     payload.append('file', file);
     payload.append('form_id', getState().form.formId);
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       const req = new XMLHttpRequest();
 
       req.open('POST', `${environment.API_URL}${uiOptions.endpoint}`);
@@ -167,7 +167,7 @@ export function uploadFile(file, filePath, uiOptions, progressCallback) {
             }, getState().form.data))
           );
           Raven.captureMessage(`vets_upload_error: ${req.statusText}`);
-          reject(req.statusText);
+          resolve();
         }
       });
 
@@ -183,7 +183,7 @@ export function uploadFile(file, filePath, uiOptions, progressCallback) {
             statusText: req.statusText
           }
         });
-        reject(errorMessage);
+        resolve();
       });
 
       req.addEventListener('abort', () => {
@@ -193,7 +193,7 @@ export function uploadFile(file, filePath, uiOptions, progressCallback) {
           }, getState().form.data))
         );
         Raven.captureMessage('vets_upload_error: Upload aborted');
-        reject();
+        resolve();
       });
 
       req.upload.addEventListener('progress', (evt) => {

--- a/src/sass/modules/_m-schemaform.scss
+++ b/src/sass/modules/_m-schemaform.scss
@@ -284,7 +284,7 @@ label {
   }
   > .schemaform-file-item-edit {
     flex-direction: column;
-    align-items: left;
+    align-items: flex-start;
   }
 }
 

--- a/src/sass/modules/_m-schemaform.scss
+++ b/src/sass/modules/_m-schemaform.scss
@@ -347,3 +347,7 @@ label {
     margin-top: 1rem;
   }
 }
+
+.schemaform-file-uploading {
+  width: 100%;
+}

--- a/test/common/schemaform/FileField.unit.spec.jsx
+++ b/test/common/schemaform/FileField.unit.spec.jsx
@@ -82,10 +82,38 @@ describe('Schemaform <FileField>', () => {
           requiredSchema={requiredSchema}/>
     );
 
-    expect(tree.subTree('.va-growable-background').text()).to.contain('Uploading file...');
+    expect(tree.everySubTree('ProgressBar')).not.to.be.empty;
     expect(tree.everySubTree('button')).to.be.empty;
   });
 
+  it('should update progress', () => {
+    const idSchema = {
+      $id: 'field'
+    };
+    const schema = {};
+    const uiSchema = fileUploadUI('Files');
+    const formData = [
+      {
+        uploading: true
+      }
+    ];
+    const tree = SkinDeep.shallowRender(
+      <FileField
+          schema={schema}
+          uiSchema={uiSchema}
+          idSchema={idSchema}
+          formData={formData}
+          formContext={formContext}
+          onChange={f => f}
+          requiredSchema={requiredSchema}/>
+    );
+
+    expect(tree.subTree('ProgressBar').props.percent).to.equal(0);
+
+    tree.getMountedInstance().updateProgress(20);
+
+    expect(tree.subTree('ProgressBar').props.percent).to.equal(20);
+  });
   it('should render error', () => {
     const idSchema = {
       $id: 'field'
@@ -235,10 +263,9 @@ describe('Schemaform <FileField>', () => {
 
     formDOM.files('input[type=file]', [{}]);
 
-    expect(uploadFile.firstCall.args).to.eql([
-      {},
-      ['fileField', 0],
-      uiSchema['ui:options']
-    ]);
+    expect(uploadFile.firstCall.args[0]).to.eql({});
+    expect(uploadFile.firstCall.args[1]).to.eql(['fileField', 0]);
+    expect(uploadFile.firstCall.args[2]).to.eql(uiSchema['ui:options']);
+    expect(uploadFile.firstCall.args[3]).to.be.a('function');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7792,7 +7792,7 @@ supports-color@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-1.2.0.tgz#ff1ed1e61169d06b3cf2d588e188b18d8847e17e"
 
-supports-color@3.1.2, supports-color@^3.1.0, supports-color@^3.1.1:
+supports-color@3.1.2, supports-color@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -7806,7 +7806,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.2, supports-color@^3.2.3:
+supports-color@^3.1.1, supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:


### PR DESCRIPTION
This addresses a few things I noticed in testing:

- The occasional slowness of staging makes it clear that putting up "Uploading files..." is not a good solution to telling the user to wait while files upload. So, this adds a progress bar. However, to get progress events, you can't use fetch, you have to use xhr. So that's most of the changes here.
- The `accepts` property on file inputs is really just a guideline, not a rule, so we need to actual prevent files that aren't the right type on the front end.
- IE11 was centering some of the buttons, because I used `left` instead of `flex-start`. The former is incorrect, but Chrome looked correct with it.

![screen shot 2017-07-07 at 4 50 25 pm](https://user-images.githubusercontent.com/634932/27976646-74d5bc54-6335-11e7-955e-a6d41f107492.png)
