### PR TITLE
Chunk manifest compatibility for CSP

### DIFF
--- a/content/includes/header.html
+++ b/content/includes/header.html
@@ -67,11 +67,7 @@
 <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
 <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA" id="_fed_an_ua_tag"></script>
 
-<script>
-//<![CDATA[
-window.webpackManifest = 'CHUNK_MANIFEST_PLACEHOLDER';
-//]]>
-</script>
+<script src="/generated/chunk-manifest.js"/></script>
 
 <script src="/generated/vendor.js"></script>
 {% if entryname %}

--- a/script/build.js
+++ b/script/build.js
@@ -645,14 +645,11 @@ if (options.buildtype !== 'development') {
     });
     const chunkManifest = files[chunkManifestKey].contents.toString();
 
-    Object.keys(files).forEach((filename) => {
-      if (filename.match(/\.html$/) !== null) {
-        const file = files[filename];
-        const contents = file.contents.toString();
-        const regex = new RegExp("'CHUNK_MANIFEST_PLACEHOLDER'", 'g');
-        file.contents = new Buffer(contents.replace(regex, chunkManifest));
-      }
-    });
+    // Write chunk manifest to a js file we can include. Inlining cause issues with CSP headers
+    files['generated/chunk-manifest.js'] = {
+      contents: new Buffer(`window.webpackManifest='${chunkManifest}';`)
+    };
+
     done();
   });
 }

--- a/script/build.js
+++ b/script/build.js
@@ -645,7 +645,7 @@ if (options.buildtype !== 'development') {
     });
     const chunkManifest = files[chunkManifestKey].contents.toString();
 
-    // Write chunk manifest to a js file we can include. Inlining cause issues with CSP headers
+    // Write chunk manifest to a js file we can include. Inlining causes issues with CSP headers
     files['generated/chunk-manifest.js'] = {
       contents: new Buffer(`window.webpackManifest=${chunkManifest};`)
     };

--- a/script/build.js
+++ b/script/build.js
@@ -647,7 +647,7 @@ if (options.buildtype !== 'development') {
 
     // Write chunk manifest to a js file we can include. Inlining cause issues with CSP headers
     files['generated/chunk-manifest.js'] = {
-      contents: new Buffer(`window.webpackManifest='${chunkManifest}';`)
+      contents: new Buffer(`window.webpackManifest=${chunkManifest};`)
     };
 
     done();


### PR DESCRIPTION
CSP script-src currently requires unsafe-inline, which is considered overly permissive. This change removes the inline chunk manifest declaration and instead writes the manifest to a js file later included with a script tag.