### PR TITLE
Change VCL link to desktop site

### DIFF
--- a/content/includes/footer.html
+++ b/content/includes/footer.html
@@ -74,7 +74,7 @@ Monday &#8211; Friday, 8:00 am &#8211; 8:00 pm (<abbr title="eastern time">ET</a
         <ul>
           <li><a href="tel:18002738255">Call <strong>1-800-273-8255 (Press 1)</strong></a></li>
           <li><a href="sms:838255">Text to <b>838255</b></a></li>
-          <li><a href="https://www.veteranscrisisline.net/mobile/ChatTermsOfService.aspx?account=Veterans%20Chat">Chat <b>confidentially now</b></a></li>
+          <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat">Chat <b>confidentially now</b></a></li>
         </ul>
 
         <p>If you are in crisis or having thoughts of suicide,


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3158

There are ~15 other places this link appears on vets.gov. Was thinking once VCL fixes the mobile site to be accessible, we could add breakpoint and provide either the mobile or the desktop link appropriately, but that's actually their job to do on page load.