### PR TITLE
Restore alert on no messaging recipients

### DIFF
--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -113,7 +113,7 @@ export class Main extends React.Component {
             <ButtonClose
                 className="messaging-folder-nav-close"
                 onClick={this.props.toggleFolderNav}/>
-            <ComposeButton/>
+            <ComposeButton disabled={_.isEmpty(this.props.recipients)}/>
             <FolderNav
                 currentFolderId={this.props.currentFolderId}
                 folders={this.props.folders}

--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -113,7 +113,7 @@ export class Main extends React.Component {
             <ButtonClose
                 className="messaging-folder-nav-close"
                 onClick={this.props.toggleFolderNav}/>
-            <ComposeButton disabled={_.isEmpty(this.props.recipients)}/>
+            <ComposeButton/>
             <FolderNav
                 currentFolderId={this.props.currentFolderId}
                 folders={this.props.folders}

--- a/src/js/messaging/containers/MessagingApp.jsx
+++ b/src/js/messaging/containers/MessagingApp.jsx
@@ -38,9 +38,9 @@ class MessagingApp extends React.Component {
         <div>
           <h4>Currently not assigned to a health care team</h4>
           <p>
-            We’re sorry. It looks like you don’t have a VA health care team linked to your account in our system.
+            We're sorry. It looks like you don't have a VA health care team linked to your account in our system.
             To begin sending secure messages, please contact your health care team, and ask them to add you into the system.
-            If you need more help, please call the Vets.gov Help Desk at 855-574-7286 (TTY: 800-829-4833). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. (ET).
+            If you need more help, please call the Vets.gov Help Desk at 855-574-7286 (TTY: 800-829-4833). We're here Monday–Friday, 8:00 a.m.–8:00 p.m. (ET).
           </p>
         </div>
       );

--- a/src/js/messaging/containers/MessagingApp.jsx
+++ b/src/js/messaging/containers/MessagingApp.jsx
@@ -33,12 +33,14 @@ function AppContent({ children, isDataAvailable }) {
 class MessagingApp extends React.Component {
   // this warning is rendered if the user has no triage teams
   renderWarningBanner() {
-    if (this.props.folders && this.props.folders.length && isEmpty(this.props.recipients) && !this.props.loading.recipients) {
+    if (this.props.recipients && isEmpty(this.props.recipients) && !this.props.loading.recipients) {
       const alertContent = (
         <div>
           <h4>Currently not assigned to a health care team</h4>
           <p>
-            You can't send secure messages because you're not assigned to a VA health care team right now. Please call the Vets.gov Help Desk at 1-855-574-7286, Monday - Friday, 8:00 a.m. - 8:00 p.m. (ET).
+            We’re sorry. It looks like you don’t have a VA health care team linked to your account in our system.
+            To begin sending secure messages, please contact your health care team, and ask them to add you into the system.
+            If you need more help, please call the Vets.gov Help Desk at 855-574-7286 (TTY: 800-829-4833). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. (ET).
           </p>
         </div>
       );


### PR DESCRIPTION
Addresses the SM part of https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3657

Commit history looks like first there was an attempt to show this alert if no recipients, then there was a change to prevent loading the entire app if loading folders or recipients failed, but they kind of conflicted. User should still be able to load app if they have an empty recipients list (versus loading recipients list failed). 

This restores that functionality and also goes back to disabling the compose button. If the user somehow navigates directly to the `/compose` screen, they still get the alert there as well. 

<img width="981" alt="screen shot 2017-07-11 at 1 02 09 pm" src="https://user-images.githubusercontent.com/20694532/28088319-2ca7b5b0-663a-11e7-9107-45afa66843eb.png">
<img width="975" alt="screen shot 2017-07-11 at 1 02 23 pm" src="https://user-images.githubusercontent.com/20694532/28088318-2ca6dc80-663a-11e7-8a17-ae28a6f121a6.png">
