### PR TITLE
Pass correct data to depends when submitting rjsf form

### DIFF
--- a/src/js/common/schemaform/validation.js
+++ b/src/js/common/schemaform/validation.js
@@ -172,7 +172,7 @@ export function errorSchemaIsValid(errorSchema) {
 export function isValidForm(form, pageListByChapters) {
   const pageConfigs = _.flatten(_.values(pageListByChapters));
   const validPages = Object.keys(form.pages)
-    .filter(pageKey => isActivePage(_.find({ pageKey }, pageConfigs), form));
+    .filter(pageKey => isActivePage(_.find({ pageKey }, pageConfigs), form.data));
 
   const v = new Validator();
 

--- a/test/common/schemaform/validation.unit.spec.js
+++ b/test/common/schemaform/validation.unit.spec.js
@@ -446,5 +446,53 @@ describe('Schemaform validations', () => {
 
       expect(isValidForm(form, pageListByChapters)).to.be.true;
     });
+    it('should not validate pages where depends is false', () => {
+      const form = {
+        data: {
+          privacyAgreementAccepted: true,
+          testArray: ['test']
+        },
+        pages: {
+          testPage2: {
+            schema: {
+              type: 'object',
+              properties: {
+                testArray: {
+                  type: 'string',
+                }
+              }
+            },
+            uiSchema: {},
+          },
+          testPage: {
+            schema: {
+              type: 'object',
+              properties: {
+                testArray: {
+                  type: 'array',
+                  items: {
+                    type: 'string'
+                  }
+                }
+              }
+            },
+            uiSchema: {},
+          }
+        }
+      };
+      const pageListByChapters = {
+        testChapter: [{
+          pageKey: 'testPage',
+          chapterKey: 'testChapter'
+        }, {
+          pageKey: 'testPage2',
+          chapterKey: 'testChapter',
+          depends: sinon.stub().returns(false)
+        }]
+      };
+
+      expect(isValidForm(form, pageListByChapters)).to.be.true;
+      expect(pageListByChapters.testChapter[1].depends.calledWith(form.data)).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
@U-DON noticed that we're passing the entire form state to `depends` functions when submitting, unlike when we're creating lists of active pages.

This has been in production for a little while, but since it results in depends always being false it means we're skipping validation, rather than enforcing it when we shouldn't, so we were likely not preventing anyone from submitting.