### PR TITLE
Set to lower case before comparing file types in rjsf

### DIFF
--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -126,7 +126,7 @@ export function uploadFile(file, filePath, uiOptions, progressCallback) {
 
     // we limit file types, but it's not respected on mobile and desktop
     // users can bypass it without much effort
-    if (!uiOptions.fileTypes.some(fileType => file.name.endsWith(fileType))) {
+    if (!uiOptions.fileTypes.some(fileType => file.name.toLowerCase().endsWith(fileType.toLowerCase()))) {
       dispatch(
         setData(_.set(filePath, {
           errorMessage: 'File is not one of the allowed types'

--- a/test/common/schemaform/actions.unit.spec.js
+++ b/test/common/schemaform/actions.unit.spec.js
@@ -288,6 +288,40 @@ describe('Schemaform actions:', () => {
       });
     });
 
+    it('should reject if file is wrong type', () => {
+      const thunk = uploadFile(
+        {
+          name: 'jpg',
+          size: 5
+        },
+        ['fileField', 0],
+        {
+          fileTypes: ['jpeg'],
+          maxSize: 5
+        }
+      );
+      const dispatch = sinon.spy();
+      const getState = sinon.stub().returns({
+        form: {
+          data: {}
+        }
+      });
+
+      return thunk(dispatch, getState).then(() => {
+        throw new Error('Should have failed on non-allowed file type');
+      }).catch(() => {
+        expect(dispatch.firstCall.args[0]).to.eql({
+          type: SET_DATA,
+          data: {
+            fileField: [
+              {
+                errorMessage: 'File is not one of the allowed types'
+              }
+            ]
+          }
+        });
+      });
+    });
     it('should call set data on success', () => {
       const thunk = uploadFile(
         {
@@ -297,7 +331,7 @@ describe('Schemaform actions:', () => {
         ['fileField', 0],
         {
           endpoint: '/v0/endpoint',
-          fileTypes: ['jpg'],
+          fileTypes: ['JPG'],
           maxSize: 5
         }
       );


### PR DESCRIPTION
Sometimes files are upper case and that was causing problems when checking their extensions.