### PR TITLE
Letters fix checkbox styling when focused

### DIFF
--- a/src/sass/base/_b-variables.scss
+++ b/src/sass/base/_b-variables.scss
@@ -34,6 +34,7 @@ $color-primary-darkest:      #112e51;
 $color-secondary-darkest:    #981b1e;
 $color-focus:                #3e94cf;
 $color-gray-light:           #aeb0b5;
+$color-gray-medium:			 #757575;
 $color-gray-dark:            #323a45;
 $color-primary-alt-light:    #9bdaf1;
 $color-white:                #fff;

--- a/src/sass/base/_b-variables.scss
+++ b/src/sass/base/_b-variables.scss
@@ -34,7 +34,7 @@ $color-primary-darkest:      #112e51;
 $color-secondary-darkest:    #981b1e;
 $color-focus:                #3e94cf;
 $color-gray-light:           #aeb0b5;
-$color-gray-medium:			 #757575;
+$color-gray-medium:          #757575;
 $color-gray-dark:            #323a45;
 $color-primary-alt-light:    #9bdaf1;
 $color-white:                #fff;

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -1466,7 +1466,7 @@ p.info-message {
 }
 .vertical-list-group .list-group-item::before {
   border-radius: 50%;
-  background-color: #757575;
+  background-color: $color-gray-medium;
   content: "";
   display: inline-block;
   float: left;

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -41,6 +41,10 @@
       opacity: inherit;
       position: inherit;
       width: 50%;
+
+      &:focus {
+        box-shadow: none;
+      }
     }
 
     label {


### PR DESCRIPTION
I noticed on letters when you clicked on a checkbox it would add a blue box shadow around the outside of the checkbox. 

<img width="698" alt="screen shot 2017-07-13 at 5 04 43 pm" src="https://user-images.githubusercontent.com/25183456/28187645-6817809e-67ed-11e7-93c1-08329e74c68d.png">

This was really bothering me, so just submitting a small css change to stop that box shadow from being added on `:focus` state of the checkbox.

Also fixed the lint warning we started getting a week ago with a css change. I just took the color value and put it in a variable so there are no more lint warnings! @bshyong I think this affects appeals status so wanted to make sure you take a look at this before merging.