### PR TITLE
Adding event for clicking through on closed alert in appeals status

### DIFF
--- a/src/js/disability-benefits/components/ClosedClaimMessage.jsx
+++ b/src/js/disability-benefits/components/ClosedClaimMessage.jsx
@@ -46,7 +46,7 @@ export default function ClosedClaimMessage({ claims, onClose }) {
         <h5 className="usa-alert-heading">Recently closed:</h5>
         {closedClaims.map(claim => (
           <p className="usa-alert-text claims-closed-text" key={claim.id}>
-            <Link to={claim.type === 'appeals_status_models_appeals' ? `appeals/${claim.id}/status` : `your-claims/${claim.id}/status`} onClick={() => { window.dataLayer.push({ event: "claims-closed-alert-clicked" }); }}>Your {claim.type === 'appeals_status_models_appeals' ? 'Compensation Appeal' : getClaimType(claim)} – Received {moment(claim.attributes.dateFiled).format('MMMM D, YYYY')}</Link> has been closed as of {moment(claim.attributes.phaseChangeDate).format('MMMM D, YYYY')}
+            <Link to={claim.type === 'appeals_status_models_appeals' ? `appeals/${claim.id}/status` : `your-claims/${claim.id}/status`} onClick={() => { window.dataLayer.push({ event: 'claims-closed-alert-clicked' }); }}>Your {claim.type === 'appeals_status_models_appeals' ? 'Compensation Appeal' : getClaimType(claim)} – Received {moment(claim.attributes.dateFiled).format('MMMM D, YYYY')}</Link> has been closed as of {moment(claim.attributes.phaseChangeDate).format('MMMM D, YYYY')}
           </p>
         ))}
       </div>

--- a/src/js/disability-benefits/components/ClosedClaimMessage.jsx
+++ b/src/js/disability-benefits/components/ClosedClaimMessage.jsx
@@ -46,7 +46,7 @@ export default function ClosedClaimMessage({ claims, onClose }) {
         <h5 className="usa-alert-heading">Recently closed:</h5>
         {closedClaims.map(claim => (
           <p className="usa-alert-text claims-closed-text" key={claim.id}>
-            <Link to={claim.type === 'appeals_status_models_appeals' ? `appeals/${claim.id}/status` : `your-claims/${claim.id}/status`} onClick={() => { window.dataLayer.push({ event: claims-closed-alert-clicked }); }}>Your {claim.type === 'appeals_status_models_appeals' ? 'Compensation Appeal' : getClaimType(claim)} – Received {moment(claim.attributes.dateFiled).format('MMMM D, YYYY')}</Link> has been closed as of {moment(claim.attributes.phaseChangeDate).format('MMMM D, YYYY')}
+            <Link to={claim.type === 'appeals_status_models_appeals' ? `appeals/${claim.id}/status` : `your-claims/${claim.id}/status`} onClick={() => { window.dataLayer.push({ event: "claims-closed-alert-clicked" }); }}>Your {claim.type === 'appeals_status_models_appeals' ? 'Compensation Appeal' : getClaimType(claim)} – Received {moment(claim.attributes.dateFiled).format('MMMM D, YYYY')}</Link> has been closed as of {moment(claim.attributes.phaseChangeDate).format('MMMM D, YYYY')}
           </p>
         ))}
       </div>

--- a/src/js/disability-benefits/components/ClosedClaimMessage.jsx
+++ b/src/js/disability-benefits/components/ClosedClaimMessage.jsx
@@ -46,7 +46,7 @@ export default function ClosedClaimMessage({ claims, onClose }) {
         <h5 className="usa-alert-heading">Recently closed:</h5>
         {closedClaims.map(claim => (
           <p className="usa-alert-text claims-closed-text" key={claim.id}>
-            <Link to={claim.type === 'appeals_status_models_appeals' ? `appeals/${claim.id}/status` : `your-claims/${claim.id}/status`}>Your {claim.type === 'appeals_status_models_appeals' ? 'Compensation Appeal' : getClaimType(claim)} – Received {moment(claim.attributes.dateFiled).format('MMMM D, YYYY')}</Link> has been closed as of {moment(claim.attributes.phaseChangeDate).format('MMMM D, YYYY')}
+            <Link to={claim.type === 'appeals_status_models_appeals' ? `appeals/${claim.id}/status` : `your-claims/${claim.id}/status`} onClick={() => { window.dataLayer.push({ event: claims-closed-alert-clicked }); }}>Your {claim.type === 'appeals_status_models_appeals' ? 'Compensation Appeal' : getClaimType(claim)} – Received {moment(claim.attributes.dateFiled).format('MMMM D, YYYY')}</Link> has been closed as of {moment(claim.attributes.phaseChangeDate).format('MMMM D, YYYY')}
           </p>
         ))}
       </div>


### PR DESCRIPTION
Part of https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2288

Adds an event so that we know the specific link clicked by the user to track usage of that alert.