### PR TITLE
Removed overly fancy terms events naming scheme

### DIFF
--- a/src/js/common/components/RequiredTermsAcceptanceView.jsx
+++ b/src/js/common/components/RequiredTermsAcceptanceView.jsx
@@ -16,8 +16,7 @@ export class RequiredTermsAcceptanceView extends React.Component {
       this.props.fetchLatestTerms(this.props.termsName);
       window.scrollTo(0, 0);
     }
-    const app = window.location.pathname.split('/').pop();
-    window.dataLayer.push({ event: `terms-shown-${app}` });
+    window.dataLayer.push({ event: `terms-shown` });
   }
 
   componentDidUpdate(prevProps) {

--- a/src/js/common/components/RequiredTermsAcceptanceView.jsx
+++ b/src/js/common/components/RequiredTermsAcceptanceView.jsx
@@ -16,7 +16,7 @@ export class RequiredTermsAcceptanceView extends React.Component {
       this.props.fetchLatestTerms(this.props.termsName);
       window.scrollTo(0, 0);
     }
-    window.dataLayer.push({ event: `terms-shown` });
+    window.dataLayer.push({ event: 'terms-shown' });
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
Follow-up on https://github.com/department-of-veterans-affairs/vets-website/pull/5941

Looking at it in practice @patrickvinograd was right and folks are coming in at sub-URLs so the fancy naming scheme isn't actually all that useful.

![screen shot 2017-07-14 at 3 19 07 pm](https://user-images.githubusercontent.com/6646098/28229319-da6ef694-68a7-11e7-8433-14fea2a16c66.png)

Worth a shot, I guess.

Reverting to a simpler naming scheme before too much data piles up. We can use the pages view of events (as shown above) to determine what page caused the terms to be shown so there's real data loss from dropping it from the event name.
