### PR TITLE
Adding an event for when an option is checked or unchecked in benefits letters

### DIFF
--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -17,7 +17,11 @@ export class VeteranBenefitSummaryLetter extends React.Component {
   }
 
   handleChange(domEvent) {
-    window.dataLayer.push({ event: `letter-benefit-${domEvent.target.id}-${domEvent.target.checked ? 'checked' : 'unchecked'}` });
+    window.dataLayer.push({
+      event: 'letter-benefit-option-clicked',
+      'letter-benefit-option': domEvent.target.id,
+      'letter-benefit-option-status': domEvent.target.checked ? 'checked' : 'unchecked'
+    });
     this.props.updateBenefitSummaryRequestOption(
       benefitOptionsMap[domEvent.target.id],
       domEvent.target.checked);

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -17,6 +17,7 @@ export class VeteranBenefitSummaryLetter extends React.Component {
   }
 
   handleChange(domEvent) {
+    window.dataLayer.push({ event: `letter-benefit-${domEvent.target.id}-${domEvent.target.checked ? 'checked' : 'unchecked'}` });
     this.props.updateBenefitSummaryRequestOption(
       benefitOptionsMap[domEvent.target.id],
       domEvent.target.checked);


### PR DESCRIPTION
Re: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3446

I think this would do the trick but maybe isn't the cleanest with so many string interpolations. Feel free to tweak it. Once this is merged I'll do the config on the tag manager side so the reporting will flow through.