### PR TITLE
Update burial tests with recent changes, make them live

### DIFF
--- a/test/burials/00-all-fields.e2e.spec.js
+++ b/test/burials/00-all-fields.e2e.spec.js
@@ -96,6 +96,9 @@ const runTest = E2eHelpers.createE2eTest(
     E2eHelpers.expectNavigateAwayFrom(client, '/claimant-contact-information');
 
     // TODO: Test file upload
+    client.axeCheck('.main')
+      .click('.form-panel .usa-button-primary');
+    E2eHelpers.expectNavigateAwayFrom(client, '/documents');
 
     client.assert.cssClassPresent('.progress-bar-segmented div.progress-segment:nth-child(6)', 'progress-segment-complete');
 
@@ -120,6 +123,4 @@ const runTest = E2eHelpers.createE2eTest(
   }
 );
 
-if (process.env.BUILDTYPE !== 'production') {
-  module.exports = runTest;
-}
+module.exports = runTest;

--- a/test/burials/schema/maximal-test.json
+++ b/test/burials/schema/maximal-test.json
@@ -67,8 +67,7 @@
     "deathDate": "2017-06-25",
     "burialDate": "2017-06-26",
     "locationOfDeath": {
-      "location": "other",
-      "other": "Location of death"
+      "location": "vaMedicalCenter"
     },
     "veteranFullName": {
       "first": "Donald",


### PR DESCRIPTION
I forgot to remove the build type flag on the e2e tests when we went live behind a password, so we got out of sync with some recent changes to the form.