### PR TITLE
fix empty education card bug

### DIFF
--- a/src/js/common/components/form-elements/GrowableTable.jsx
+++ b/src/js/common/components/form-elements/GrowableTable.jsx
@@ -124,11 +124,12 @@ class GrowableTable extends React.Component {
     return _.findKey(this.state, v => v === 'incomplete');
   }
 
-  handleAdd() {
+  handleAdd(allFields) {
     // Save existing
     const success = this.handleSave();
 
-    if (success) {
+    if (success && allFields) {
+      this.submitEducation = false;
       const key = this.createNewElement();
       this.scrollToRow(key);
     }
@@ -177,6 +178,16 @@ class GrowableTable extends React.Component {
   // TODO: change this to not use reaactKey, and instead perhaps add
   // `this.rows = []` in the constructor and update on changes
   render() {
+    this.submitEducation = false;
+    if (this.props.data && this.props.data.postHighSchoolTrainings.length) {
+      const currentHSTData = this.props.data.postHighSchoolTrainings[this.props.data.postHighSchoolTrainings.length - 1];
+      const keys = Object.keys(currentHSTData);
+      keys.forEach(key => {
+        if (currentHSTData[key].value) {
+          this.submitEducation = true;
+        }
+      });
+    }
     let reactKey = 0;
     let rowContent;
     const state = this.state;
@@ -255,7 +266,7 @@ class GrowableTable extends React.Component {
       <div className="va-growable">
         <Element name={`topOfTable${this.tableId}`}/>
         {rowElements}
-        {this.props.showAddAnotherButton && <button className="usa-button-outline va-growable-add-btn" onClick={this.handleAdd}>{this.props.addNewMessage || 'Add Another'}</button>}
+        {this.props.showAddAnotherButton && <button className="usa-button-outline va-growable-add-btn" onClick={() => this.handleAdd(this.submitEducation)}>{this.props.addNewMessage || 'Add Another'}</button>}
       </div>
     );
   }


### PR DESCRIPTION
This PR is our first attempt to contribute to an open source project.  Apologies ahead of time for any first-timer mistakes.

Issue#3434, we were able to update the growableTables.jsx component to prevent users from submitting a card with no input fields filled out.  In doing so, we found an additional bug.  If a user submits a valid card, then attempts to submit an invalid card with no fields filled out, the input fields are hidden.  We believe this bug to be caused by functionality that causes the inputs to actually be hidden every time.  Successful card submissions actually create two cards, one that is collapsed and one that is open and ready for the user to “add another” card.  This PR resolves the issue 3434, however we feel that a new issue may need to be opened addressing the duplicate card creation.  

This resolution does affect the test ‘Add Button adds new row w/o disturbing existing entries’ - line 64 of GrowableTable.unit.spec.js  
sinon.calledOnce evaluates false due to the fact that if the user does not enter any values, sinon is correctly not called because a card is not created.  We tried for sometime to ascertain how to correctly simulate the user updating the inputs on the dom, but were unfortunately unsuccessful.

![gif of changes](http://g.recordit.co/PnwpUfW3xA.gif)