### PR TITLE
Add padding around unregistered message for better formatting

### DIFF
--- a/src/js/post-911-gib-status/containers/Post911GIBStatusApp.jsx
+++ b/src/js/post-911-gib-status/containers/Post911GIBStatusApp.jsx
@@ -11,14 +11,20 @@ function AppContent({ children, isDataAvailable }) {
 
   if (unregistered) {
     view = (
-      <h4>
-        We weren't able to find information about your Post-9/11 GI Bill Benefit Status.
-        If you think you should be able to access this information, please call the Vets.gov Help Desk at 855-574-7286 (TTY: 800-829-4833). We're here Monday–Friday, 8:00 a.m.–8:00 p.m. (ET).
-      </h4>
+      <div className="row">
+        <div className="small-12 columns">
+          <h4>
+            We weren't able to find information about your Post-9/11 GI Bill Benefit Status.
+            If you think you should be able to access this information, please call the Vets.gov Help Desk at 855-574-7286 (TTY: 800-829-4833). We're here Monday–Friday, 8:00 a.m.–8:00 p.m. (ET).
+          </h4>
+          <br/>
+        </div>
+      </div>
     );
   } else {
     view = children;
   }
+
   return (
     <div>
       {view}


### PR DESCRIPTION
Adding a little padding around the unregistered message that appears for users who are not veterans. Will address longer-term styles of this message as a broader conversation on global styles across Vets.gov. For now at least this is a bit cleaned up.

<img width="1284" alt="screen shot 2017-07-20 at 9 13 24 am" src="https://user-images.githubusercontent.com/25183456/28419099-07c177c4-6d2c-11e7-9342-08290761d6ac.png">
