### PR TITLE
Move rjsf form submission to xhr for better error visibility

### DIFF
--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -111,7 +111,7 @@ export function submitForm(formConfig, form) {
       req.setRequestHeader('X-Key-Inflection', 'camel');
       req.setRequestHeader('Content-Type', 'application/json');
 
-      const userToken = window.sessionStorage.userToken;
+      const userToken = _.get('sessionStorage.userToken', window);
       if (userToken) {
         req.setRequestHeader('Authorization', `Token token=${userToken}`);
       }

--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -64,6 +64,10 @@ export function submitForm(formConfig, form) {
       req.open('POST', `${environment.API_URL}${formConfig.submitUrl}`);
       req.addEventListener('load', () => {
         if (req.status >= 200 && req.status < 300) {
+          window.dataLayer.push({
+            event: `${formConfig.trackingPrefix}-submission-successful`,
+          });
+          // got this from the fetch polyfill, keeping it to be safe
           const responseBody = 'response' in req ? req.response : req.responseText;
           const results = JSON.parse(responseBody);
           resolve(results);
@@ -71,6 +75,7 @@ export function submitForm(formConfig, form) {
           const error = new Error(`vets_server_error: ${req.statusText}`);
           Raven.captureException(error, {
             extra: {
+              clientError: false,
               statusText: req.statusText
             }
           });
@@ -82,6 +87,7 @@ export function submitForm(formConfig, form) {
         const error = new Error('vets_client_error: Network request failed');
         Raven.captureException(error, {
           extra: {
+            clientError: true,
             statusText: req.statusText
           }
         });
@@ -92,6 +98,7 @@ export function submitForm(formConfig, form) {
         const error = new Error('vets_client_error: Request aborted');
         Raven.captureException(error, {
           extra: {
+            clientError: true,
             statusText: req.statusText
           }
         });
@@ -102,6 +109,7 @@ export function submitForm(formConfig, form) {
         const error = new Error('vets_client_error: Request timed out');
         Raven.captureException(error, {
           extra: {
+            clientError: true,
             statusText: req.statusText
           }
         });


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3168
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3144

Using xhr instead of fetch gives us some more error visibility by being able to see timeout and abort errors. This may not help at all, but we'll at least be consistent across browsers. It should address the issue with fetch and Edge 14, too.