### PR TITLE
Update tests to work with pagePerItem pages

### DIFF
--- a/test/pensions/config/childrenAddress.unit.spec.jsx
+++ b/test/pensions/config/childrenAddress.unit.spec.jsx
@@ -7,8 +7,7 @@ import { DefinitionTester, getFormDOM } from '../../util/schemaform-utils.jsx';
 import formConfig from '../../../src/js/pensions/config/form.js';
 
 describe('Child address page', () => {
-  const schema = formConfig.chapters.householdInformation.pages.childrenAddress.schema.properties.dependents.items;
-  const uiSchema = formConfig.chapters.householdInformation.pages.childrenAddress.uiSchema.dependents.items;
+  const { schema, uiSchema, arrayPath } = formConfig.chapters.householdInformation.pages.childrenAddress;
   let nameData = {
     'view:hasDependents': true,
     dependents: [
@@ -24,6 +23,8 @@ describe('Child address page', () => {
   it('should render', () => {
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
           definitions={formConfig.defaultDefinitions}
           schema={schema}
           data={nameData}
@@ -34,11 +35,30 @@ describe('Child address page', () => {
     expect(formDOM.querySelectorAll('input, select, textarea').length).to.equal(2);
   });
 
+  it('should render address fields', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
+          definitions={formConfig.defaultDefinitions}
+          schema={schema}
+          data={nameData}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = getFormDOM(form);
+    formDOM.selectRadio('root_childInHouseholdNo', 'N');
+
+    expect(formDOM.querySelectorAll('input, select, textarea').length).to.equal(13);
+  });
+
   it('should show errors when required fields are empty', () => {
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
           definitions={formConfig.defaultDefinitions}
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
           schema={schema}
           onSubmit={onSubmit}
           data={nameData}
@@ -54,6 +74,8 @@ describe('Child address page', () => {
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
           definitions={formConfig.defaultDefinitions}
           schema={schema}
           data={nameData}
@@ -66,6 +88,6 @@ describe('Child address page', () => {
     formDOM.fillData('#root_childInHouseholdYes', 'Y');
 
     formDOM.submitForm(form);
-    // expect(onSubmit.called).to.be.true;
+    expect(onSubmit.called).to.be.true;
   });
 });

--- a/test/pensions/config/childrenInformation.unit.spec.jsx
+++ b/test/pensions/config/childrenInformation.unit.spec.jsx
@@ -8,8 +8,7 @@ import { DefinitionTester, getFormDOM } from '../../util/schemaform-utils.jsx';
 import formConfig from '../../../src/js/pensions/config/form.js';
 
 describe('Child information page', () => {
-  const schema = formConfig.chapters.householdInformation.pages.childrenInformation.schema.properties.dependents.items;
-  const uiSchema = formConfig.chapters.householdInformation.pages.childrenInformation.uiSchema.dependents.items;
+  const { schema, uiSchema, arrayPath } = formConfig.chapters.householdInformation.pages.childrenInformation;
   let dependentData = {
     'view:hasDependents': true,
     dependents: [
@@ -25,6 +24,8 @@ describe('Child information page', () => {
   it('should render', () => {
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
           definitions={formConfig.defaultDefinitions}
           schema={schema}
           data={dependentData}
@@ -39,6 +40,8 @@ describe('Child information page', () => {
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
           definitions={formConfig.defaultDefinitions}
           schema={schema}
           onSubmit={onSubmit}
@@ -51,16 +54,16 @@ describe('Child information page', () => {
     expect(onSubmit.called).not.to.be.true;
   });
 
-  // Skipped because it's an array page with a ui:required
-  it.skip('should not require ssn if noSSN is checked', () => {
+  it('should not require ssn if noSSN is checked', () => {
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
           definitions={formConfig.defaultDefinitions}
           schema={schema}
           onSubmit={onSubmit}
           data={dependentData}
-          pagePerItemIndex={0}
           uiSchema={uiSchema}/>
     );
     const formDOM = getFormDOM(form);
@@ -78,6 +81,8 @@ describe('Child information page', () => {
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
           definitions={formConfig.defaultDefinitions}
           schema={schema}
           data={dependentData}
@@ -96,14 +101,15 @@ describe('Child information page', () => {
     expect(onSubmit.called).to.be.true;
   });
 
-  // Skipping these until we DefinitionTester deals with showPagePerItem pages
-  it.skip('should ask if the child is in school', () => {
+  it('should ask if the child is in school', () => {
     const data = Object.assign({}, dependentData);
     data.dependents[0].childDateOfBirth = moment().subtract(19, 'years').toString();
 
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
           definitions={formConfig.defaultDefinitions}
           schema={schema}
           data={data}
@@ -115,14 +121,15 @@ describe('Child information page', () => {
     expect(formDOM.querySelector('#root_attendingCollegeYes')).to.not.be.null;
   });
 
-  // Could be in the above test...
-  it.skip('should ask if the child is disabled', () => {
+  it('should ask if the child is disabled', () => {
     const data = Object.assign({}, dependentData);
     data.dependents[0].childDateOfBirth = moment().subtract(19, 'years').toString();
 
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
           definitions={formConfig.defaultDefinitions}
           schema={schema}
           data={data}

--- a/test/util/schemaform-utils.jsx
+++ b/test/util/schemaform-utils.jsx
@@ -43,13 +43,21 @@ export class DefinitionTester extends React.Component {
   handleChange = (data) => {
     const {
       schema,
-      uiSchema
+      uiSchema,
+      formData
     } = this.state;
+    const { pagePerItemIndex, arrayPath } = this.props;
+
+    let fullData = data;
+
+    if (arrayPath) {
+      fullData = _.set([arrayPath, pagePerItemIndex], data, formData);
+    }
 
     const {
       data: newData,
       schema: newSchema
-    } = updateSchemaAndData(schema, uiSchema, data);
+    } = updateSchemaAndData(schema, uiSchema, fullData);
 
     this.setState({
       formData: newData,
@@ -58,7 +66,14 @@ export class DefinitionTester extends React.Component {
     });
   }
   render() {
-    const { schema, uiSchema, formData } = this.state;
+    let { schema, uiSchema, formData } = this.state;
+    const { pagePerItemIndex, arrayPath } = this.props;
+
+    if (arrayPath) {
+      schema = schema.properties[arrayPath].items[pagePerItemIndex];
+      uiSchema = uiSchema[arrayPath].items;
+      formData = formData ? formData[arrayPath][pagePerItemIndex] : formData;
+    }
 
     return (
       <SchemaForm


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3690
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3473

Updates our `DefinitionTester` component to do the same logic as `FormPage` when you pass in an `arrayPath` prop.