### PR TITLE
Add GA event to capture facility type in FL search

### DIFF
--- a/src/js/facility-locator/components/AppointmentInfo.jsx
+++ b/src/js/facility-locator/components/AppointmentInfo.jsx
@@ -69,6 +69,7 @@ export default class AppointmentInfo extends Component {
       }
 
       const onClick = () => {
+        window.dataLayer.push({ event: 'fl-show-waittimes' });
         this.setState({
           [showHideKey]: !this.state[showHideKey],
         });

--- a/src/js/facility-locator/components/SearchControls.jsx
+++ b/src/js/facility-locator/components/SearchControls.jsx
@@ -59,6 +59,13 @@ class SearchControls extends Component {
     const { onSearch } = this.props;
     e.preventDefault();
 
+    const { facilityType } = this.props.currentQuery;
+    // Report event here to only send analytics event when a user clicks on the button
+    window.dataLayer.push({
+      event: 'fl-search',
+      'fl-search-fac-type': facilityType
+    });
+
     onSearch();
   }
 


### PR DESCRIPTION
Per Slack convo with @NatalieEMoore this adds a GA event to capture which facility type was selected on a FL search.

Tagging @patrickvinograd for review per Natalie

I added the event push in the onClick handler b/c from looking through it seemed like multiple API calls may get triggered from a single user action so I didn't want to push this lower in the stack near the `fetch` call like I usually would. Definitely open to thoughts if a better place to capture this since I only spent an hour or two looking over FL so I may have missed an edge case or something.