### PR TITLE
Raise the search bar above the nav menu

### DIFF
--- a/src/sass/modules/_m-vet-nav.scss
+++ b/src/sass/modules/_m-vet-nav.scss
@@ -361,7 +361,7 @@ body.va-pos-fixed {
     flex: 0 1 32.5rem;
     margin-left: 0;
     margin-right: 0;
-    z-index: 2;
+    z-index: 3;
   }
 
   p {


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3967

![image](https://user-images.githubusercontent.com/12970166/28545419-c7b31ee6-707b-11e7-81bb-51a2d10a7130.png)

![image](https://user-images.githubusercontent.com/12970166/28545424-ca527034-707b-11e7-914b-05d66ca164d6.png)

I also tested to make sure it was under a modal, and that was fine.

@goldenmeanie mentioned possibly expanding the banner vertically when the search bar is shown, but this is significantly more complicated. If that's still the route we want to go, we can figure out how to make it happen, but for the sake of shipping a fix, I wanted to get this out sooner rather than later.