### PR TITLE
Read/write filter parameters to URL query parameters.

### DIFF
--- a/src/js/facility-locator/components/SearchControls.jsx
+++ b/src/js/facility-locator/components/SearchControls.jsx
@@ -85,17 +85,19 @@ class SearchControls extends Component {
     }
   }
 
-  handleFacilityFilterSelect(facilityType) {
-    if (['benefits', 'vet_center'].includes(facilityType)) {
+  handleFacilityFilterSelect(newFacilityType) {
+    const { currentQuery: { facilityType } } = this.props;
+    if (['benefits', 'vet_center'].includes(newFacilityType) &&
+        newFacilityType === facilityType) {
       return () => {
         this.props.updateSearchQuery({
-          facilityType,
+          facilityType: newFacilityType,
         });
       };
     }
     return () => {
       this.props.updateSearchQuery({
-        facilityType,
+        facilityType: newFacilityType,
         serviceType: null,
       });
     };

--- a/src/js/facility-locator/containers/VAMap.jsx
+++ b/src/js/facility-locator/containers/VAMap.jsx
@@ -43,6 +43,10 @@ class VAMap extends Component {
       return;
     }
 
+    this.props.updateSearchQuery({
+      facilityType: location.query.facilityType,
+      serviceType: location.query.serviceType,
+    });
     if (location.query.address) {
       this.props.updateSearchQuery({
         searchString: location.query.address,
@@ -144,12 +148,13 @@ class VAMap extends Component {
   // TODO (bshyong): try out existing query-string npm library
   updateUrlParams = (params) => {
     const { location, currentQuery } = this.props;
-
     const queryParams = compact(map({
       ...location.query,
       zoomLevel: currentQuery.zoomLevel,
       page: currentQuery.currentPage,
       address: currentQuery.searchString,
+      facilityType: currentQuery.facilityType,
+      serviceType: currentQuery.serviceType,
       ...params,
     }, (v, k) => {
       if (v) { return `${k}=${v}`; }


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3989

With this you can use a URL like: `http://localhost:3001/facilities/?facilityType=vet_center` and it will load with the facility-type pre-selected. Other behavior (whether it geolocates or defaults to Washington DC) remains the same.

Also fixed a latent bug I observed where if you toggled between the two facility types that have service filters (benefits and vet centers), it would not reset the service type, leading to the possibility of submitting a search for vet centers with a benefits-appropriate service filter (or vice versa) which would result in an API error. 