### PR TITLE
Moved up facility type line in info.

### DIFF
--- a/src/js/facility-locator/components/search-results/FacilityInfoBlock.jsx
+++ b/src/js/facility-locator/components/search-results/FacilityInfoBlock.jsx
@@ -35,12 +35,12 @@ class FacilityInfoBlock extends Component {
           <h5>{name}</h5>
         </Link>
         <p>
+          <span><strong>Facility type:</strong> {facilityTypes[facilityType]}</span>
+        </p>
+        <p>
           <FacilityAddress facility={facility}/>
         </p>
         {this.renderDistance()}
-        <p>
-          <span><strong>Facility type:</strong> {facilityTypes[facilityType]}</span>
-        </p>
       </div>
     );
   }

--- a/src/js/facility-locator/containers/FacilityDetail.jsx
+++ b/src/js/facility-locator/containers/FacilityDetail.jsx
@@ -44,10 +44,10 @@ class FacilityDetail extends Component {
       <div>
         <h1>{name}</h1>
         <div className="p1">
-          <FacilityAddress facility={facility}/>
           <p>
             <span><strong>Facility type:</strong> {facilityTypes[facilityType]}</span>
           </p>
+          <FacilityAddress facility={facility}/>
         </div>
         <div>
           <FacilityPhoneLink facility={facility}/>


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#1075.

@altangel: Note that I also moved it up in the facility's detail page. Figured the ordering of lines should be analogous to its search result block. Let me know if I should revert it for the detail page.

#### Search result
> <img width="257" alt="screen shot 2017-07-25 at 1 47 13 am" src="https://user-images.githubusercontent.com/1067024/28557713-0b94b6aa-70dc-11e7-99ea-ed03c7cba7a1.png">

#### Detail page
> <img width="555" alt="screen shot 2017-07-25 at 1 47 46 am" src="https://user-images.githubusercontent.com/1067024/28557715-0cf6c07e-70dc-11e7-8580-95653b5d63b9.png">
