### PR TITLE
Show expiration date for SiP forms

### DIFF
--- a/src/js/common/schemaform/SaveInProgressIntro.jsx
+++ b/src/js/common/schemaform/SaveInProgressIntro.jsx
@@ -8,6 +8,7 @@ import { fetchInProgressForm, removeInProgressForm } from './save-load-actions';
 import SignInLink from '../components/SignInLink';
 import LoadingIndicator from '../components/LoadingIndicator';
 import FormStartControls from './FormStartControls';
+import { dateDiffDesc } from '../utils/helpers';
 
 export default class SaveInProgressIntro extends React.Component {
   getAlert(savedForm) {
@@ -18,13 +19,14 @@ export default class SaveInProgressIntro extends React.Component {
         const savedAt = this.props.lastSavedDate
           ? moment(this.props.lastSavedDate)
           : moment.unix(savedForm.last_updated);
+        const expirationDate = moment(savedAt).add(30, 'days');
 
         alert = (
           <div>
             <div className="usa-alert usa-alert-info no-background-image schemaform-sip-alert">
               <div style={{ paddingBottom: '8px' }}>Application status: <strong>In progress</strong></div>
               <br/>
-              <div>Last saved on {savedAt.format('MM/DD/YYYY [at] h:mma')}</div>
+              <div>Last saved on {savedAt.format('MM/DD/YYYY [at] h:mma')}. <span className="schemaform-sip-expires">Expires in {dateDiffDesc(expirationDate)}</span>.</div>
               <div>{this.props.children}</div>
             </div>
             <br/>

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -162,3 +162,41 @@ export function displayFileSize(size) {
   const mbSize = kbSize / 1024;
   return `${Math.round(mbSize)}MB`;
 }
+
+function formatDiff(diff, desc) {
+  return `${diff} ${desc}${diff === 1 ? '' : 's'}`;
+}
+
+/**
+ * dateDiffDesc returns the number of days, hours, or minutes until
+ * the provided date occurs. It's meant to be less fuzzy than moment's
+ * dateDiffDesc so it can be used for expiration dates
+ *
+ * @param date {Moment Date} The future date to check against
+ * @param userFromDate {Moment Date} The earlier date in the range. Defaults to today.
+ * @returns {string} The string description of how long until date occurs
+ */
+export function dateDiffDesc(date, userFromDate = null) {
+  // Not using defaulting because we want today to be when this function
+  // is called, not when the file is parsed and run
+  const fromDate = userFromDate || moment();
+  const dayDiff = date.diff(fromDate, 'days');
+
+  if (dayDiff >= 1) {
+    return formatDiff(dayDiff, 'day');
+  }
+
+  const hourDiff = date.diff(fromDate, 'hours');
+
+  if (hourDiff >= 1) {
+    return formatDiff(hourDiff, 'hour');
+  }
+
+  const minuteDiff = date.diff(fromDate, 'minutes');
+
+  if (minuteDiff >= 1) {
+    return formatDiff(minuteDiff, 'minute');
+  }
+
+  return 'less than a minute';
+}

--- a/src/sass/modules/_m-schemaform.scss
+++ b/src/sass/modules/_m-schemaform.scss
@@ -439,3 +439,7 @@ label {
     padding-left: 3rem;
   }
 }
+
+.schemaform-sip-expires {
+  color: $color-secondary-dark;
+}

--- a/test/common/schemaform/SaveInProgressIntro.unit.spec.jsx
+++ b/test/common/schemaform/SaveInProgressIntro.unit.spec.jsx
@@ -32,6 +32,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     );
 
     expect(tree.subTree('.usa-alert').text()).to.contain('In progress');
+    expect(tree.subTree('.usa-alert').text()).to.contain('Expires in');
     expect(tree.subTree('withRouter(FormStartControls)')).not.to.be.false;
     expect(tree.subTree('withRouter(FormStartControls)').props.prefillAvailable).to.be.false;
     expect(tree.subTree('withRouter(FormStartControls)').props.startPage).to.equal('testing');

--- a/test/common/utils/helpers.unit.spec.js
+++ b/test/common/utils/helpers.unit.spec.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import moment from 'moment';
 
-import { isActivePage, dateToMoment } from '../../../src/js/common/utils/helpers.js';
+import { isActivePage, dateToMoment, dateDiffDesc } from '../../../src/js/common/utils/helpers.js';
 
 describe('Helpers unit tests', () => {
   describe('isActivePage', () => {
@@ -92,6 +93,21 @@ describe('Helpers unit tests', () => {
       expect(date.year()).to.equal(1901);
       expect(date.month()).to.equal(1);
       expect(date.date()).to.equal(1);
+    });
+  });
+  describe('dateDiffDesc', () => {
+    const today = moment();
+    it('should display time in days', () => {
+      expect(dateDiffDesc(moment(today).add(30, 'days'), today)).to.equal('30 days');
+    });
+    it('should display time in hours', () => {
+      expect(dateDiffDesc(moment(today).add(23, 'hours'), today)).to.equal('23 hours');
+    });
+    it('should display time in minutes', () => {
+      expect(dateDiffDesc(moment(today).add(59, 'minutes'), today)).to.equal('59 minutes');
+    });
+    it('should display time as less than a minute', () => {
+      expect(dateDiffDesc(moment(today).add(59, 'seconds'), today)).to.equal('less than a minute');
     });
   });
 });


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3590

The time formatting is what I thought was reasonable, but open to suggestions. Moment's calculations are fuzzy and that felt wrong for an expiration time that someone might look at more carefully.

![screen shot 2017-07-25 at 10 32 26 am](https://user-images.githubusercontent.com/634932/28579133-c31f310e-7129-11e7-95c7-922e8b92aaa9.png)
