### PR TITLE
Initial analytics opt-out page for internal users

### DIFF
--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,4 +1,5 @@
 User-Agent: *
 Disallow: /scorecard
+Disallow: /analytics-opt-out.html
 
 Sitemap: https://www.vets.gov/sitemap.xml

--- a/content/pages/analytics-opt-out.md
+++ b/content/pages/analytics-opt-out.md
@@ -16,7 +16,7 @@ private: true
         <h4>Click the below button to opt out of the vets.gov Google Analytics collection.</h4>
         <p>This opt-out is durable for this computer/browser combination. It is stored in cookie. To re-enable vets.gov Google Analytics collection, you will need to clear your cookies.</p>
         <p>The intended use case of this opt-out is for vets.gov team members performing testing or validation in the production environment. Other uses are not recommended.</p>
-        <button class="usa-button-primary" onClick="window.dataLayer.push({'internal_user': 'true'});">Opt-out</button>
+        <button class="usa-button-primary" onClick="window.dataLayer.push({'internal-user': 'true'});">Opt-out</button>
         </div>
       </div>
     </div>

--- a/content/pages/analytics-opt-out.md
+++ b/content/pages/analytics-opt-out.md
@@ -14,8 +14,8 @@ private: true
         <div style="padding: 2em 0;">
         <h3>Analytics Opt-out</h3>
         <h4>Click the below button to opt out of the vets.gov Google Analytics collection.</h4>
-        <p>This opt-out is durable for this computer/browser combination. It is stored in cookie. To re-enable vets.gov Google Analytics collection, you will need to clear your cookies.</p>
-        <p>The intended use case of this opt-out is for vets.gov team members performing testing or validation in the production environment. Other uses are not recommended.</p>
+        <p>This opt-out is durable for this computer/browser combination. It is stored in a secure cookie. To re-enable vets.gov Google Analytics collection, you will need to clear your cookies.</p>
+        <p>The intended use case of this opt-out is for Vets.gov team members performing testing or validation in the production environment. Other uses are not recommended.</p>
         <button class="usa-button-primary" onClick="window.dataLayer.push({'internal-user': 'true'});">Opt-out</button>
         </div>
       </div>

--- a/content/pages/analytics-opt-out.md
+++ b/content/pages/analytics-opt-out.md
@@ -1,0 +1,27 @@
+---
+layout: page.html
+title: Analytics Opt-Out
+permalink: false
+private: true
+---
+
+<!-- Maintenance Page Start -->
+
+<div class="main home" role="main">
+  <div class="section main-menu">
+    <div class="row">
+      <div class="small-12 columns">
+        <div style="padding: 2em 0;">
+        <h3>Analytics Opt-out</h3>
+        <h4>Click the below button to opt out of the vets.gov Google Analytics collection.</h4>
+        <p>This opt-out is durable for this computer/browser combination. It is stored in cookie. To re-enable vets.gov Google Analytics collection, you will need to clear your cookies.</p>
+        <p>The intended use case of this opt-out is for vets.gov team members performing testing or validation in the production environment. Other uses are not recommended.</p>
+        <button class="usa-button-primary">Opt-out</button>
+        </div>
+      </div>
+    </div>
+  </div>
+   {% include content/includes/common-and-popular.html %}
+</div>
+
+<!-- Maintenance Page End -->

--- a/content/pages/analytics-opt-out.md
+++ b/content/pages/analytics-opt-out.md
@@ -16,12 +16,11 @@ private: true
         <h4>Click the below button to opt out of the vets.gov Google Analytics collection.</h4>
         <p>This opt-out is durable for this computer/browser combination. It is stored in cookie. To re-enable vets.gov Google Analytics collection, you will need to clear your cookies.</p>
         <p>The intended use case of this opt-out is for vets.gov team members performing testing or validation in the production environment. Other uses are not recommended.</p>
-        <button class="usa-button-primary">Opt-out</button>
+        <button class="usa-button-primary" onClick="window.dataLayer.push({'internal_user': 'true'});">Opt-out</button>
         </div>
       </div>
     </div>
   </div>
-   {% include content/includes/common-and-popular.html %}
 </div>
 
 <!-- Maintenance Page End -->


### PR DESCRIPTION
Related to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3624

Will set a user-scoped custom dimension in Google Analytics that we can add a filter for to drop our internal user traffic in production. This is an opt-in filter and will need to be set for each computer/browser combination but should endure across sessions.