### PR TITLE
Appeals spacing tweaks

### DIFF
--- a/src/js/disability-benefits/containers/AppealStatusPage.jsx
+++ b/src/js/disability-benefits/containers/AppealStatusPage.jsx
@@ -79,11 +79,11 @@ class AppealStatusPage extends React.Component {
     }
 
     return (
-      <ul className="events-list">
+      <ol className="events-list">
         {previousHistory.map((e, i) => (
           <AppealEventItem key={i} event={e}/>
         ))}
-      </ul>
+      </ol>
     );
   }
 

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -351,7 +351,7 @@ a.claim-list-item {
   }
 
   .events-list {
-    margin-top: 0;
+    margin: 0;
     padding: 0;
   }
 
@@ -366,34 +366,29 @@ a.claim-list-item {
 
   .event-header {
     cursor: pointer;
+    display: flex;
+    align-items: center;
     padding: 1.5rem 0;
 
-    & > * {
-      display: inline-block;
-      vertical-align: middle;
-    }
-
     .date {
-      display: inline-block;
-      width: 12rem;
+      flex: 0 1 12rem;
     }
 
     i.fa {
       &:first-child {
         color: $color-gray;
-        width: 3.25rem;
+        flex: 0 1 3.25rem;
       }
 
       &:last-child {
-        float: right;
         font-size: 1.75rem;
-        line-height: 2.75rem;
+        margin-left: 2rem;
       }
     }
   }
 
   .event-title {
-    max-width: 45rem;
+    flex: 1 0 40rem;
   }
 
   .event-description {

--- a/src/sass/disability-benefits.scss
+++ b/src/sass/disability-benefits.scss
@@ -394,6 +394,12 @@ a.claim-list-item {
   .event-description {
     margin-bottom: 1.5rem;
     margin-left: 3.25rem;
+
+    p {
+      &:first-child {
+        margin-top: 0;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Addendum to #6087 to center the icons. Also semantic correction to define the list as an `ol`.

The latter also correctly styles the spacing of paragraphs in the description contents due to a rule for `ul li p` that removes margins and padding and is the cause of department-of-veterans-affairs/vets.gov-team#3964. That rule should be removed separately, but it's still more correct to declare this list as `ol` than `ul`.

<img width="635" alt="screen shot 2017-07-25 at 8 00 53 pm" src="https://user-images.githubusercontent.com/1067024/28598809-1f4387ce-7174-11e7-9baf-31817d91d72a.png">
