### PR TITLE
Leave margins and padding for 'ul li p' by default.

### DIFF
--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -1170,14 +1170,6 @@ li {
   }
 }
 
-// List overrides
-
-ul li p {
-  margin: 0;
-  padding: 0;
-}
-
-
 // vets.gov branded apps
 .vets-app {
   border-left: 3px solid $color-gold;


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#3964.

Removing a rule that causes problem for some content. `p` elements would otherwise have some default margins, and I think it should be up to individual use cases to remove them within `ul` elements. Additionally, it seems like it would be overkill if I wanted to add back margins using a specific class. Also strange that this wasn't applied to paragraphs within `ol` elements.