### PR TITLE
Further common styles cleanup

### DIFF
--- a/src/js/user-profile/user-profile-entry.jsx
+++ b/src/js/user-profile/user-profile-entry.jsx
@@ -11,27 +11,12 @@ import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 
 require('../common');  // Bring in the common javascript.
-require('../../sass/rx/rx.scss');
 require('../../sass/user-profile.scss');
 
 const commonStore = createCommonStore();
 createLoginWidget(commonStore);
 
 function init() {
-  /*
-   * Invoked when the URL changes. A way to handle query
-   * string data.
-   *
-   * Plan is to make this trigger a sort when the query
-   * parameter is `sortby`.
-   */
-  const handleChangedURL = (event) => {
-    // Here so eslint doesn't tell us about an unused variable.
-    return event;
-  };
-  browserHistory.listen(handleChangedURL);
-  // End URL listening
-
   ReactDOM.render((
     <Provider store={commonStore}>
       <Router history={browserHistory} routes={routes}/>

--- a/src/sass/gi/gi.scss
+++ b/src/sass/gi/gi.scss
@@ -1,4 +1,4 @@
-@import "../style";
+@import "../shared-variables";
 @import "../modules/m-modal";
 @import "../modules/m-loading-indicator";
 

--- a/src/sass/health-records/health-records.scss
+++ b/src/sass/health-records/health-records.scss
@@ -1,4 +1,4 @@
-@import "../style";
+@import "../shared-variables";
 @import "../modules/m-modal";
 @import "../modules/m-progress-bar";
 @import "partials/bb-breadcrumbs";

--- a/src/sass/messaging/messaging.scss
+++ b/src/sass/messaging/messaging.scss
@@ -1,4 +1,4 @@
-@import "../style";
+@import "../shared-variables";
 @import "../modules/m-modal";
 @import "../modules/va-tabs";
 @import "~react-datepicker/dist/react-datepicker.css";

--- a/src/sass/rx/rx.scss
+++ b/src/sass/rx/rx.scss
@@ -1,4 +1,4 @@
-@import "../style";
+@import "../shared-variables";
 @import "../modules/m-modal";
 @import "../modules/m-alert";
 @import "../modules/va-pagination";


### PR DESCRIPTION
Connected to #5721.

Removes remaining imports of `style.scss` due to common styles now imported on every page of Vets.gov.

Looks the original set of changes missed the .scss files that were nested in directories.