### PR TITLE
Use expiration date from backend for SiP

### DIFF
--- a/src/js/common/schemaform/SaveInProgressIntro.jsx
+++ b/src/js/common/schemaform/SaveInProgressIntro.jsx
@@ -19,7 +19,7 @@ export default class SaveInProgressIntro extends React.Component {
         const savedAt = this.props.lastSavedDate
           ? moment(this.props.lastSavedDate)
           : moment.unix(savedForm.last_updated);
-        const expirationDate = moment(savedAt).add(30, 'days');
+        const expirationDate = moment.unix(savedForm.metadata.expires_at);
 
         alert = (
           <div>
@@ -51,7 +51,9 @@ export default class SaveInProgressIntro extends React.Component {
 
   render() {
     const { profile } = this.props.user;
-    const savedForm = profile && profile.savedForms.find(f => f.form === this.props.formId);
+    const savedForm = profile && profile.savedForms
+      .filter(f => f.metadata.expires_at > f.metadata.last_updated)
+      .find(f => f.form === this.props.formId);
     const prefillAvailable = !!(profile && profile.prefillsAvailable.includes(this.props.formId));
 
     if (profile.loading) {

--- a/src/js/common/schemaform/SaveInProgressIntro.jsx
+++ b/src/js/common/schemaform/SaveInProgressIntro.jsx
@@ -52,7 +52,7 @@ export default class SaveInProgressIntro extends React.Component {
   render() {
     const { profile } = this.props.user;
     const savedForm = profile && profile.savedForms
-      .filter(f => f.metadata.expires_at > f.metadata.last_updated)
+      .filter(f => moment.unix(f.metadata.expires_at).isAfter())
       .find(f => f.form === this.props.formId);
     const prefillAvailable = !!(profile && profile.prefillsAvailable.includes(this.props.formId));
 

--- a/test/common/schemaform/SaveInProgressIntro.unit.spec.jsx
+++ b/test/common/schemaform/SaveInProgressIntro.unit.spec.jsx
@@ -15,7 +15,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     const user = {
       profile: {
         savedForms: [
-          { form: '1010ez' }
+          { form: '1010ez', metadata: { last_updated: 3000, expires_at: 4000 } } // eslint-disable-line camelcase
         ],
         prefillsAvailable: []
       },
@@ -41,7 +41,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     const user = {
       profile: {
         savedForms: [
-          { form: '1010ez' }
+          { form: '1010ez', metadata: { last_updated: 3000, expires_at: 4000 } } // eslint-disable-line camelcase
         ],
         prefillsAvailable: ['1010ez']
       },
@@ -63,7 +63,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     const user = {
       profile: {
         savedForms: [
-          { form: '1010ez' }
+          { form: '1010ez', metadata: { last_updated: 3000, expires_at: 4000 } } // eslint-disable-line camelcase
         ],
         prefillsAvailable: []
       },
@@ -109,7 +109,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     const user = {
       profile: {
         savedForms: [
-          { form: '1010ez' }
+          { form: '1010ez', metadata: { last_updated: 3000, expires_at: 4000 } } // eslint-disable-line camelcase
         ],
         prefillsAvailable: [],
         loading: true

--- a/test/common/schemaform/SaveInProgressIntro.unit.spec.jsx
+++ b/test/common/schemaform/SaveInProgressIntro.unit.spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import { expect } from 'chai';
 import SkinDeep from 'skin-deep';
 
@@ -15,7 +16,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     const user = {
       profile: {
         savedForms: [
-          { form: '1010ez', metadata: { last_updated: 3000, expires_at: 4000 } } // eslint-disable-line camelcase
+          { form: '1010ez', metadata: { last_updated: 3000, expires_at: moment().unix() + 2000 } } // eslint-disable-line camelcase
         ],
         prefillsAvailable: []
       },
@@ -41,7 +42,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     const user = {
       profile: {
         savedForms: [
-          { form: '1010ez', metadata: { last_updated: 3000, expires_at: 4000 } } // eslint-disable-line camelcase
+          { form: '1010ez', metadata: { last_updated: 3000, expires_at: moment().unix() + 2000 } } // eslint-disable-line camelcase
         ],
         prefillsAvailable: ['1010ez']
       },
@@ -63,7 +64,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     const user = {
       profile: {
         savedForms: [
-          { form: '1010ez', metadata: { last_updated: 3000, expires_at: 4000 } } // eslint-disable-line camelcase
+          { form: '1010ez', metadata: { last_updated: 3000, expires_at: moment().unix() + 2000 } } // eslint-disable-line camelcase
         ],
         prefillsAvailable: []
       },
@@ -109,7 +110,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     const user = {
       profile: {
         savedForms: [
-          { form: '1010ez', metadata: { last_updated: 3000, expires_at: 4000 } } // eslint-disable-line camelcase
+          { form: '1010ez', metadata: { last_updated: 3000, expires_at: moment().unix() + 2000 } } // eslint-disable-line camelcase
         ],
         prefillsAvailable: [],
         loading: true
@@ -128,5 +129,28 @@ describe('Schemaform <SaveInProgressIntro>', () => {
 
     expect(tree.subTree('LoadingIndicator')).not.to.be.false;
     expect(tree.subTree('withRouter(FormStartControls)')).to.be.false;
+  });
+  it('should render no message if signed in with an expired form', () => {
+    const user = {
+      profile: {
+        savedForms: [
+          { form: '1010ez', metadata: { last_updated: 3000, expires_at: moment().unix() - 1000 } } // eslint-disable-line camelcase
+        ],
+        prefillsAvailable: []
+      },
+      login: {
+        currentlyLoggedIn: true
+      }
+    };
+
+    const tree = SkinDeep.shallowRender(
+      <SaveInProgressIntro
+          pageList={pageList}
+          formId="1010ez"
+          user={user}/>
+    );
+
+    expect(tree.subTree('.usa-alert')).to.be.false;
+    expect(tree.subTree('withRouter(FormStartControls)')).not.to.be.false;
   });
 });


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4050

Uses the backend expiration date instead of one from the front end. Also filters out expired forms, while we figure out what the best way of handling that is.