### PR TITLE
Style fixes for acceptance line of MHV terms and conditions.

### DIFF
--- a/src/sass/login.scss
+++ b/src/sass/login.scss
@@ -73,6 +73,7 @@
       }
 
       label {
+        display: inline-block;
         max-width: none;
       }
     }

--- a/src/sass/login.scss
+++ b/src/sass/login.scss
@@ -62,6 +62,16 @@
         color: $color-gray-light;
       }
 
+      input {
+        margin-left: -9999rem;
+
+        &[disabled] {
+          & + label {
+            cursor: default;
+          }
+        }
+      }
+
       label {
         max-width: none;
       }

--- a/src/sass/login.scss
+++ b/src/sass/login.scss
@@ -61,6 +61,10 @@
       &.disabled {
         color: $color-gray-light;
       }
+
+      label {
+        max-width: none;
+      }
     }
   }
 }


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#3962.

Moved the yes content to one line.

Ensured a consistent cursor when hovering around the label (default when disabled and pointer when enabled). @altangel: Let me know if that's the desired behavior. Also whether the cursor should be a pointer (hand) when hovering over the text or the line in general (as in the white space next to the text).

<img width="693" alt="screen shot 2017-07-27 at 9 44 30 pm" src="https://user-images.githubusercontent.com/1067024/28698966-ba61d700-7314-11e7-9549-b91d04d29627.png">