### PR TITLE
Fix case when no primary care wait time but yes other wait time data

### DIFF
--- a/src/js/facility-locator/components/AppointmentInfo.jsx
+++ b/src/js/facility-locator/components/AppointmentInfo.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { some, pull, startCase } from 'lodash';
+import { get, some, pull, startCase } from 'lodash';
 import classNames from 'classnames';
 import moment from 'moment';
 
@@ -23,8 +23,7 @@ export default class AppointmentInfo extends Component {
   }
 
   hasPrimaryCare(accessAttrs, category) {
-    return (typeof accessAttrs.primaryCare !== 'undefined' &&
-        accessAttrs.primaryCare[category] !== null);
+    return get(accessAttrs, ['primaryCare', category]);
   }
 
   render() {

--- a/src/js/facility-locator/components/AppointmentInfo.jsx
+++ b/src/js/facility-locator/components/AppointmentInfo.jsx
@@ -22,6 +22,11 @@ export default class AppointmentInfo extends Component {
         );
   }
 
+  hasPrimaryCare(accessAttrs, category) {
+    return (typeof accessAttrs.primaryCare !== 'undefined' &&
+        accessAttrs.primaryCare[category] !== null);
+  }
+
   render() {
     const { facility } = this.props;
 
@@ -113,7 +118,7 @@ export default class AppointmentInfo extends Component {
           <h4>New patient wait times</h4>
           <p>The average number of days a Veteran who hasn't been to this location has to wait for a non-urgent appointment</p>
           <ul>
-            {renderStat('Primary Care', healthAccessAttrs.primaryCare.new)}
+            {this.hasPrimaryCare(healthAccessAttrs, 'new') && renderStat('Primary Care', healthAccessAttrs.primaryCare.new)}
             {renderSpecialtyTimes()}
           </ul>
         </div>}
@@ -121,7 +126,7 @@ export default class AppointmentInfo extends Component {
           <h4>Existing patient wait times</h4>
           <p>The average number of days a patient who has already been to this location has to wait for a non-urgent appointment.</p>
           <ul>
-            {renderStat('Primary Care', healthAccessAttrs.primaryCare.established)}
+            {this.hasPrimaryCare(healthAccessAttrs, 'established') && renderStat('Primary Care', healthAccessAttrs.primaryCare.established)}
             {renderSpecialtyTimes(true)}
           </ul>
         </div>}


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4112

Only affected a small number of facilities - those that were reporting wait times for some specialty categories but not for primary care. Avoids assuming that the primary care element will be present.