### PR TITLE
Log review page validation errors to Sentry

### DIFF
--- a/src/js/common/schemaform/review/ReviewPage.jsx
+++ b/src/js/common/schemaform/review/ReviewPage.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import Raven from 'raven-js';
 import React from 'react';
 import Scroll from 'react-scroll';
 import _ from 'lodash/fp';
@@ -95,7 +96,8 @@ class ReviewPage extends React.Component {
 
   handleSubmit() {
     const formConfig = this.props.route.formConfig;
-    if (isValidForm(this.props.form, this.pagesByChapter)) {
+    const { isValid, errors } = isValidForm(this.props.form, this.pagesByChapter);
+    if (isValid) {
       this.props.submitForm(formConfig, this.props.form);
     } else {
       // validation errors in this situation are not visible, so we'd
@@ -103,6 +105,12 @@ class ReviewPage extends React.Component {
       if (this.props.form.data.privacyAgreementAccepted) {
         window.dataLayer.push({
           event: `${formConfig.trackingPrefix}-validation-failed`,
+        });
+        Raven.captureMessage('Validation issue not displayed', {
+          extra: {
+            errors,
+            prefix: formConfig.trackingPrefix
+          }
         });
       }
       this.props.setSubmission('hasAttemptedSubmit', true);

--- a/test/common/schemaform/validation.unit.spec.js
+++ b/test/common/schemaform/validation.unit.spec.js
@@ -409,7 +409,7 @@ describe('Schemaform validations', () => {
         }]
       };
 
-      expect(isValidForm(form, pageListByChapters)).to.be.false;
+      expect(isValidForm(form, pageListByChapters).isValid).to.be.false;
     });
     it('should validate only filtered items for pagePerItem schema', () => {
       const form = {
@@ -444,7 +444,7 @@ describe('Schemaform validations', () => {
         }]
       };
 
-      expect(isValidForm(form, pageListByChapters)).to.be.true;
+      expect(isValidForm(form, pageListByChapters).isValid).to.be.true;
     });
     it('should not validate pages where depends is false', () => {
       const form = {
@@ -491,7 +491,7 @@ describe('Schemaform validations', () => {
         }]
       };
 
-      expect(isValidForm(form, pageListByChapters)).to.be.true;
+      expect(isValidForm(form, pageListByChapters).isValid).to.be.true;
       expect(pageListByChapters.testChapter[1].depends.calledWith(form.data)).to.be.true;
     });
   });


### PR DESCRIPTION
We're seeing enough validation errors on the review page for the edu rjsf forms that we want to log what they are in Sentry. This creates a Sentry error when this happens and adds the errors to the extra info. The `instance` property is filtered out so we don't send PII.