### PR TITLE
Address the Moment.js deprecation warning

### DIFF
--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -2,6 +2,8 @@ import _ from 'lodash';
 import moment from 'moment';
 import Scroll from 'react-scroll';
 
+export const DATE_FORMAT = 'YYYY-MM-DD';
+
 export function getPageList(routes, prefix = '') {
   return routes.map(route => {
     const obj = {

--- a/test/pensions/config/childrenInformation.unit.spec.jsx
+++ b/test/pensions/config/childrenInformation.unit.spec.jsx
@@ -4,8 +4,14 @@ import sinon from 'sinon';
 import ReactTestUtils from 'react-dom/test-utils';
 import moment from 'moment';
 
+import { DATE_FORMAT } from '../../../src/js/common/utils/helpers';
+
 import { DefinitionTester, getFormDOM } from '../../util/schemaform-utils.jsx';
 import formConfig from '../../../src/js/pensions/config/form.js';
+import submittedForm from '../schema/maximal-test.json';
+
+const formData = submittedForm.data;
+
 
 describe('Child information page', () => {
   const { schema, uiSchema, arrayPath } = formConfig.chapters.householdInformation.pages.childrenInformation;
@@ -13,11 +19,8 @@ describe('Child information page', () => {
     'view:hasDependents': true,
     dependents: [
       {
-        fullName: {
-          first: 'Jane',
-          last: 'Doe'
-        },
-        dependentRelationship: 'child',
+        fullName: formData.dependents[0].fullName,
+        childRelationship: formData.dependents[0].childRelationship
       }
     ]
   };
@@ -50,7 +53,8 @@ describe('Child information page', () => {
     );
     const formDOM = getFormDOM(form);
     formDOM.submitForm(form);
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(4);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(3);
     expect(onSubmit.called).not.to.be.true;
   });
 
@@ -68,12 +72,13 @@ describe('Child information page', () => {
     );
     const formDOM = getFormDOM(form);
     formDOM.setCheckbox('#root_view\\:noSSN', true);
+
     formDOM.submitForm(form);
     const errors = formDOM.querySelectorAll('.usa-input-error-label');
 
-    errors.forEach(e => console.log(e.getAttribute('for'))); // eslint-disable-line no-console
+    // errors.forEach(e => console.log(e.getAttribute('for')));
 
-    expect(errors.length).to.equal(3);
+    expect(errors.length).to.equal(2);
     expect(onSubmit.called).not.to.be.true;
   });
 
@@ -103,7 +108,7 @@ describe('Child information page', () => {
 
   it('should ask if the child is in school', () => {
     const data = Object.assign({}, dependentData);
-    data.dependents[0].childDateOfBirth = moment().subtract(19, 'years').toString();
+    data.dependents[0].childDateOfBirth = moment().subtract(19, 'years').format(DATE_FORMAT);
 
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
@@ -123,7 +128,7 @@ describe('Child information page', () => {
 
   it('should ask if the child is disabled', () => {
     const data = Object.assign({}, dependentData);
-    data.dependents[0].childDateOfBirth = moment().subtract(19, 'years').toString();
+    data.dependents[0].childDateOfBirth = moment().subtract(19, 'years').format(DATE_FORMAT);
 
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4045

I added a `DATE_FORMAT` in `src/js/common/utils/helpers.js` to address the depreciation warning moment was giving us. If we run into more of these warnings, we just have to track down where we're calling `moment(dateString)` without specifying the format and give it the `DATE_FORMAT` (unless it's not a `YYYY-MM-DD` string, of course).