### PR TITLE
Prevent scrolling from changing number inputs

### DIFF
--- a/src/js/common/index.js
+++ b/src/js/common/index.js
@@ -9,3 +9,13 @@ require('./utils/sticky-action-box.js');
 
 // New navigation menu
 require('../legacy/mega-menu.js');
+
+// Disable scrolling on input[type="number"] because it was changing the value unexpectedly
+// NOTE: This also just stops the user from scrolling when hovering over a number
+//  input that has focus. This isn't ideal, but until a solution is found to that,
+//  this is what we've got.
+document.addEventListener('mousewheel', (event) => {
+  if (event.target.type === 'number' && document.activeElement === event.target) {
+    event.preventDefault();
+  }
+});

--- a/src/js/common/polyfills.js
+++ b/src/js/common/polyfills.js
@@ -24,3 +24,13 @@ if (!Modernizr.fetch) {
 
 // This polyfill has its own test logic so no need to conditionally require.
 require('polyfill-function-prototype-bind');
+
+// Disable scrolling on input[type="number"] because it was changing the value unexpectedly
+// NOTE: This also just stops the user from scrolling when hovering over a number
+//  input that has focus. This isn't ideal, but until a solution is found to that,
+//  this is what we've got.
+document.addEventListener('mousewheel', (event) => {
+  if (event.target.type === 'number' && document.activeElement === event.target) {
+    event.preventDefault();
+  }
+});

--- a/src/js/common/polyfills.js
+++ b/src/js/common/polyfills.js
@@ -24,13 +24,3 @@ if (!Modernizr.fetch) {
 
 // This polyfill has its own test logic so no need to conditionally require.
 require('polyfill-function-prototype-bind');
-
-// Disable scrolling on input[type="number"] because it was changing the value unexpectedly
-// NOTE: This also just stops the user from scrolling when hovering over a number
-//  input that has focus. This isn't ideal, but until a solution is found to that,
-//  this is what we've got.
-document.addEventListener('mousewheel', (event) => {
-  if (event.target.type === 'number' && document.activeElement === event.target) {
-    event.preventDefault();
-  }
-});


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets-website/issues/4061

I couldn't find a better solution, so this works. It also stops scrolling when hovering over the number input in focus, but...I couldn't find a better solution.