### PR TITLE
Restructure expected vets-api response, and remove hard-coded code

### DIFF
--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -17,26 +17,10 @@ const initialState = {
 function letters(state = initialState, action) {
   switch (action.type) {
     case 'GET_LETTERS_SUCCESS': {
-      // Hard-code a few extra letters for usability testing purposes. Revert after testing.
-      let letterList = action.data.data.attributes.letters;
-      if (_.findIndex({ letterType: 'medicare_partd' }, letterList) < 0) {
-        letterList = _.concat(letterList, [{
-          name: 'Proof of Creditable Prescription Drug Coverage Letter',
-          letterType: 'medicare_partd'
-        }]
-        );
-      }
-      if (_.findIndex({ letterType: 'minimum_essential_coverage' }, letterList) < 0) {
-        letterList = _.concat(letterList, [{
-          name: 'Proof of Minimum Essential Coverage Letter',
-          letterType: 'minimum_essential_coverage'
-        }]
-        );
-      }
       return {
         ...state,
-        letters: letterList,
-        destination: action.data.meta.address,
+        letters: action.data.data.attributes.letters,
+        destination: action.data.data.attributes.address,
         lettersAvailability: 'available'
       };
     }

--- a/test/letters/reducers/index.unit.spec.js
+++ b/test/letters/reducers/index.unit.spec.js
@@ -50,18 +50,16 @@ describe('letters reducer', () => {
         data: {
           data: {
             attributes: {
+              address: {
+                addressLine1: '2476 MAIN STREET',
+                fullName: 'MARK WEBB'
+              },
               letters: [
                 {
                   letterType: 'commissary',
                   name: 'Commissary Letter'
                 }
               ]
-            }
-          },
-          meta: {
-            address: {
-              addressLine1: '2476 MAIN STREET',
-              fullName: 'MARK WEBB'
             }
           }
         }


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3722

This PR does 2 things:
1. The structure of the response we get from vets-api has changed: instead of nesting the address info under `meta`, it's now under the regular `data: attributes` part of the response with everything else we get. Change the call for this address data to match the new response structure.
2. Remove some old hard-coded code that we put in place for a usability test.