### PR TITLE
Don't stop scrolling on number inputs

### DIFF
--- a/src/js/common/index.js
+++ b/src/js/common/index.js
@@ -10,7 +10,8 @@ require('./utils/sticky-action-box.js');
 // New navigation menu
 require('../legacy/mega-menu.js');
 
-// Disable scrolling on input[type="number"] because it was changing the value unexpectedly
+// Prevent some browsers from changing the value when scrolling while hovering
+//  over an input[type="number"] with focus.
 document.addEventListener('wheel', (event) => {
   if (event.target.type === 'number' && document.activeElement === event.target) {
     event.preventDefault();

--- a/src/js/common/index.js
+++ b/src/js/common/index.js
@@ -11,11 +11,9 @@ require('./utils/sticky-action-box.js');
 require('../legacy/mega-menu.js');
 
 // Disable scrolling on input[type="number"] because it was changing the value unexpectedly
-// NOTE: This also just stops the user from scrolling when hovering over a number
-//  input that has focus. This isn't ideal, but until a solution is found to that,
-//  this is what we've got.
-document.addEventListener('mousewheel', (event) => {
+document.addEventListener('wheel', (event) => {
   if (event.target.type === 'number' && document.activeElement === event.target) {
     event.preventDefault();
+    document.body.scrollTop += event.deltaY;
   }
 });

--- a/src/js/common/index.js
+++ b/src/js/common/index.js
@@ -15,6 +15,7 @@ require('../legacy/mega-menu.js');
 document.addEventListener('wheel', (event) => {
   if (event.target.type === 'number' && document.activeElement === event.target) {
     event.preventDefault();
-    document.body.scrollTop += event.deltaY;
+    document.body.scrollTop += event.deltaY; // Chrome, Safari, et al
+    document.documentElement.scrollTop += event.deltaY; // Firefox, IE, maybe more
   }
 });


### PR DESCRIPTION
Connect to https://github.com/department-of-veterans-affairs/vets-website/issues/4061

Turns out this _was_ really easy to do after all. Basically all the credit goes to @cehsu on this one! Thanks, Claire!

My previous fix made stopped scrolling when the cursor collided with the active number input. This keeps scrolling naturally.

I did a performance profile to see what would happen and...came up with nothing. Could be I don't know what I'm doing (true), or it could be that the performance impact is super minimal (probably true). I'd like to do some cross-platform testing, though, to make sure this will work as expected.