### PR TITLE
Create currency definition and widget

### DIFF
--- a/src/js/common/schemaform/definitions/currency.js
+++ b/src/js/common/schemaform/definitions/currency.js
@@ -7,7 +7,7 @@ export default function uiSchema(title) {
     'ui:reviewWidget': CurrencyReviewWidget,
     'ui:title': title,
     'ui:options': {
-      widgetClassNames: 'schemaform-currency-input'
+      classNames: 'schemaform-currency-input'
     },
     'ui:errorMessages': {
       type: 'Please enter a valid dollar amount'

--- a/src/js/common/schemaform/definitions/currency.js
+++ b/src/js/common/schemaform/definitions/currency.js
@@ -1,0 +1,16 @@
+import CurrencyWidget from '../widgets/CurrencyWidget';
+import CurrencyReviewWidget from '../review/CurrencyWidget';
+
+export default function uiSchema(title) {
+  return {
+    'ui:widget': CurrencyWidget,
+    'ui:reviewWidget': CurrencyReviewWidget,
+    'ui:title': title,
+    'ui:options': {
+      widgetClassNames: 'schemaform-currency-input'
+    },
+    'ui:errorMessages': {
+      type: 'Please enter a valid dollar amount'
+    }
+  };
+}

--- a/src/js/common/schemaform/review/CurrencyWidget.jsx
+++ b/src/js/common/schemaform/review/CurrencyWidget.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function CurrencyWidget({ value }) {
+  if (value && typeof value === 'number') {
+    return <span>${value.toFixed(2)}</span>;
+  }
+
+  return <span>{value}</span>;
+}

--- a/src/js/common/schemaform/widgets/CurrencyWidget.jsx
+++ b/src/js/common/schemaform/widgets/CurrencyWidget.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export default class CurrencyWidget extends React.Component {
+  onBlur = () => {
+    this.props.onBlur(this.props.id);
+  }
+
+  handleChange = (event) => {
+    const val = event.target.value;
+    if (val === '') {
+      this.props.onChange();
+    } else {
+      // Sometimes we get a string back (e.g. when you enter 10.00)
+      // so we need to parse it to be sure
+      const parsed = parseFloat(val);
+      if (!isNaN(parsed)) {
+        this.props.onChange(parsed);
+      } else {
+        this.props.onChange(val);
+      }
+    }
+  }
+
+  render() {
+    let val = this.props.value;
+    if (typeof val === 'number') {
+      val = val.toFixed(2);
+    }
+
+    return (
+      <input type="number"
+          step=".01"
+          id={this.props.id}
+          name={this.props.id}
+          disabled={this.props.disabled}
+          autoComplete={this.props.options.autocomplete || false}
+          className={this.props.options.widgetClassNames}
+          value={typeof val === 'undefined' ? '' : val}
+          onBlur={this.onBlur}
+          onChange={this.handleChange}/>
+    );
+  }
+}

--- a/src/js/common/schemaform/widgets/CurrencyWidget.jsx
+++ b/src/js/common/schemaform/widgets/CurrencyWidget.jsx
@@ -29,7 +29,6 @@ export default class CurrencyWidget extends React.Component {
 
     return (
       <input type="number"
-          step=".01"
           id={this.props.id}
           name={this.props.id}
           disabled={this.props.disabled}

--- a/src/js/hca/config/form.js
+++ b/src/js/hca/config/form.js
@@ -39,6 +39,7 @@ import { schema as addressSchema, uiSchema as addressUI } from '../../common/sch
 import { createChildSchema, uiSchema as childUI, createChildIncomeSchema, childIncomeUiSchema } from '../definitions/child';
 import currentOrPastDateUI from '../../common/schemaform/definitions/currentOrPastDate';
 import ssnUI from '../../common/schemaform/definitions/ssn';
+import currencyUI from '../../common/schemaform/definitions/currency';
 
 import { validateServiceDates, validateMarriageDate } from '../validation';
 
@@ -617,33 +618,24 @@ const formConfig = {
           uiSchema: {
             'ui:title': 'Annual income',
             'ui:description': incomeDescription,
-            veteranGrossIncome: {
-              'ui:title': 'Veteran gross annual income from employment'
-            },
-            veteranNetIncome: {
-              'ui:title': 'Veteran net income from your farm, ranch, property or business'
-            },
-            veteranOtherIncome: {
-              'ui:title': 'Veteran other income amount'
-            },
+            veteranGrossIncome: currencyUI('Veteran gross annual income from employment'),
+            veteranNetIncome: currencyUI('Veteran net income from your farm, ranch, property or business'),
+            veteranOtherIncome: currencyUI('Veteran other income amount'),
             'view:spouseIncome': {
               'ui:title': 'Spouse income',
               'ui:options': {
                 hideIf: (formData) => !formData.maritalStatus ||
                   (formData.maritalStatus.toLowerCase() !== 'married' && formData.maritalStatus.toLowerCase() !== 'separated')
               },
-              spouseGrossIncome: {
-                'ui:title': 'Spouse gross annual income from employment',
+              spouseGrossIncome: _.merge(currencyUI('Spouse gross annual income from employment'), {
                 'ui:required': (formData) => formData.maritalStatus && (formData.maritalStatus.toLowerCase() === 'married' || formData.maritalStatus.toLowerCase() === 'separated')
-              },
-              spouseNetIncome: {
-                'ui:title': 'Spouse net income from your farm, ranch, property or business',
+              }),
+              spouseNetIncome: _.merge(currencyUI('Spouse net income from your farm, ranch, property or business'), {
                 'ui:required': (formData) => formData.maritalStatus && (formData.maritalStatus.toLowerCase() === 'married' || formData.maritalStatus.toLowerCase() === 'separated')
-              },
-              spouseOtherIncome: {
-                'ui:title': 'Spouse other income amount',
+              }),
+              spouseOtherIncome: _.merge(currencyUI('Spouse other income amount'), {
                 'ui:required': (formData) => formData.maritalStatus && (formData.maritalStatus.toLowerCase() === 'married' || formData.maritalStatus.toLowerCase() === 'separated')
-              }
+              })
             },
             children: {
               // 'ui:title': 'Child income',
@@ -686,15 +678,9 @@ const formConfig = {
           uiSchema: {
             'ui:title': 'Previous Calendar Year’s Deductible Expenses',
             'ui:description': 'Tell us a bit about your expenses this past calendar year. Enter information for any expenses that apply to you.',
-            deductibleMedicalExpenses: {
-              'ui:title': 'Amount you or your spouse paid in non-reimbursable medical expenses this past year.'
-            },
-            deductibleFuneralExpenses: {
-              'ui:title': 'Amount you paid in funeral or burial expenses for a deceased spouse or child this past year.'
-            },
-            deductibleEducationExpenses: {
-              'ui:title': 'Amount you paid for anything related to your own education (college or vocational) this past year. Do not list your dependents’ educational expenses.'
-            }
+            deductibleMedicalExpenses: currencyUI('Amount you or your spouse paid in non-reimbursable medical expenses this past year.'),
+            deductibleFuneralExpenses: currencyUI('Amount you paid in funeral or burial expenses for a deceased spouse or child this past year.'),
+            deductibleEducationExpenses: currencyUI('Amount you paid for anything related to your own education (college or vocational) this past year. Do not list your dependents’ educational expenses.')
           },
           schema: {
             type: 'object',

--- a/src/js/hca/definitions/child.js
+++ b/src/js/hca/definitions/child.js
@@ -83,7 +83,7 @@ export const uiSchema = {
     'ui:title': 'If child is between 18 and 23 years of age, did child attend school during the last calendar year?',
     'ui:widget': 'yesNo'
   },
-  childEducationExpenses: currencyUI('Expenses paid by your dependent child for college, vocational rehabilitation, or training (e.g., tuition, books, materials)?'),
+  childEducationExpenses: currencyUI('Expenses paid by your dependent child for college, vocational rehabilitation, or training (e.g., tuition, books, materials)'),
   childCohabitedLastYear: {
     'ui:title': 'Did your child live with you last year?',
     'ui:widget': 'yesNo'

--- a/src/js/hca/definitions/child.js
+++ b/src/js/hca/definitions/child.js
@@ -2,6 +2,7 @@ import _ from 'lodash/fp';
 import fullNameUI from '../../common/schemaform/definitions/fullName';
 import currentOrPastDateUI from '../../common/schemaform/definitions/currentOrPastDate';
 import ssnUI from '../../common/schemaform/definitions/ssn';
+import currencyUI from '../../common/schemaform/definitions/currency';
 import { validateDependentDate } from '../validation';
 
 const incomeFields = [
@@ -82,9 +83,7 @@ export const uiSchema = {
     'ui:title': 'If child is between 18 and 23 years of age, did child attend school during the last calendar year?',
     'ui:widget': 'yesNo'
   },
-  childEducationExpenses: {
-    'ui:title': 'Expenses paid by your dependent child for college, vocational rehabilitation, or training (e.g., tuition, books, materials)?'
-  },
+  childEducationExpenses: currencyUI('Expenses paid by your dependent child for college, vocational rehabilitation, or training (e.g., tuition, books, materials)?'),
   childCohabitedLastYear: {
     'ui:title': 'Did your child live with you last year?',
     'ui:widget': 'yesNo'
@@ -107,15 +106,9 @@ export const uiSchema = {
 };
 
 export const childIncomeUiSchema = {
-  grossIncome: {
-    'ui:title': 'Gross annual income from employment'
-  },
-  netIncome: {
-    'ui:title': 'Net income from farm, ranch, property or business'
-  },
-  otherIncome: {
-    'ui:title': 'Other income amount'
-  },
+  grossIncome: currencyUI('Gross annual income from employment'),
+  netIncome: currencyUI('Net income from farm, ranch, property or business'),
+  otherIncome: currencyUI('Other income amount'),
   'ui:options': {
     updateSchema: (formData, schema, ui, index) => {
       const name = _.get(`children.[${index}].childFullName`, formData);

--- a/test/common/schemaform/review/CurrencyWidget.unit.spec.jsx
+++ b/test/common/schemaform/review/CurrencyWidget.unit.spec.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { expect } from 'chai';
+import SkinDeep from 'skin-deep';
+
+import CurrencyWidget from '../../../../src/js/common/schemaform/review/CurrencyWidget';
+
+describe('Schemaform review <CurrencyWidget>', () => {
+  it('should format ssn', () => {
+    const tree = SkinDeep.shallowRender(
+      <CurrencyWidget value={10}/>
+    );
+
+    expect(tree.text()).to.equal('$10.00');
+  });
+  it('should render empty value', () => {
+    const tree = SkinDeep.shallowRender(
+      <CurrencyWidget/>
+    );
+
+    expect(tree.text()).to.equal('');
+  });
+});

--- a/test/common/schemaform/review/CurrencyWidget.unit.spec.jsx
+++ b/test/common/schemaform/review/CurrencyWidget.unit.spec.jsx
@@ -5,7 +5,7 @@ import SkinDeep from 'skin-deep';
 import CurrencyWidget from '../../../../src/js/common/schemaform/review/CurrencyWidget';
 
 describe('Schemaform review <CurrencyWidget>', () => {
-  it('should format ssn', () => {
+  it('should format currency', () => {
     const tree = SkinDeep.shallowRender(
       <CurrencyWidget value={10}/>
     );

--- a/test/common/schemaform/widgets/CurrencyWidget.unit.spec.jsx
+++ b/test/common/schemaform/widgets/CurrencyWidget.unit.spec.jsx
@@ -12,9 +12,9 @@ describe('Schemaform <CurrencyWidget>', () => {
           options={{}}
           value={178}/>
     );
-    expect(tree.subTree('input').props.value).to.equal('178.00');
-    expect(tree.subTree('input').props.type).to.equal('number');
-    expect(tree.subTree('input').props.step).to.equal('.01');
+    const input = tree.subTree('input');
+    expect(input.props.value).to.equal('178.00');
+    expect(input.props.type).to.equal('number');
   });
   it('should call onChange with parsed number when 0 filled', () => {
     const onChange = sinon.spy();

--- a/test/common/schemaform/widgets/CurrencyWidget.unit.spec.jsx
+++ b/test/common/schemaform/widgets/CurrencyWidget.unit.spec.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { expect } from 'chai';
+import SkinDeep from 'skin-deep';
+import sinon from 'sinon';
+
+import CurrencyWidget from '../../../../src/js/common/schemaform/widgets/CurrencyWidget';
+
+describe('Schemaform <CurrencyWidget>', () => {
+  it('should render', () => {
+    const tree = SkinDeep.shallowRender(
+      <CurrencyWidget
+          options={{}}
+          value={178}/>
+    );
+    expect(tree.subTree('input').props.value).to.equal('178.00');
+    expect(tree.subTree('input').props.type).to.equal('number');
+    expect(tree.subTree('input').props.step).to.equal('.01');
+  });
+  it('should call onChange with parsed number when 0 filled', () => {
+    const onChange = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <CurrencyWidget
+          options={{}}
+          onChange={onChange}/>
+    );
+    tree.subTree('input').props.onChange({
+      target: {
+        value: '10.00'
+      }
+    });
+    expect(onChange.calledWith(10)).to.be.true;
+  });
+  it('should call onChange with undefined if the value is blank', () => {
+    const onChange = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <CurrencyWidget
+          options={{}}
+          onChange={onChange}/>
+    );
+    tree.subTree('input').props.onChange({
+      target: {
+        value: ''
+      }
+    });
+    expect(onChange.calledWith()).to.be.true;
+  });
+});


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4116

It turns out that number inputs in some browsers in React will return a parsed value in some cases but not others. If you enter "10", you'll get the number 10, but if you enter "10.0" you'll get a string. That's annoying, so I created a currency input that always parses the numbers (and also adds some other currency configuration).

I've only updated HCA, but we need to do this on all forms.

![screen shot 2017-08-01 at 10 50 01 am](https://user-images.githubusercontent.com/634932/28832382-43c0b6e0-76aa-11e7-9a28-eae44dcb507b.png)
![screen shot 2017-08-01 at 10 49 54 am](https://user-images.githubusercontent.com/634932/28832381-43b8979e-76aa-11e7-97d4-ec4568c758ab.png)
