### PR TITLE
Add event so variable will transmit

### DIFF
--- a/content/pages/analytics-opt-out.md
+++ b/content/pages/analytics-opt-out.md
@@ -16,7 +16,7 @@ private: true
         <h4>Click the below button to opt out of the vets.gov Google Analytics collection.</h4>
         <p>This opt-out is durable for this computer/browser combination. It is stored in a secure cookie. To re-enable vets.gov Google Analytics collection, you will need to clear your cookies.</p>
         <p>The intended use case of this opt-out is for Vets.gov team members performing testing or validation in the production environment. Other uses are not recommended.</p>
-        <button class="usa-button-primary" onClick="window.dataLayer.push({'internal-user': 'true'});">Opt-out</button>
+        <button class="usa-button-primary" onClick="window.dataLayer.push({ event: 'analytics-opt-out', 'internal-user': 'true' });">Opt-out</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
When adding the variable I forgot the event so nothing actually gets sent to GA to mark the user as opted out. Adding the event to the dataLayer push makes it get sent.