### PR TITLE
Adding analytics tracking for main nav buttons

### DIFF
--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -5,7 +5,7 @@ title: Home
 plainlanguage: 11-1-16 Ready for Beth review
 majorlinks:
   - heading:
-    links: 
+    links:
     - url: /disability-benefits/
       title: Disability Benefits
       description: Apply for disability compensation and other benefits for conditions related to your military service.
@@ -33,7 +33,7 @@ majorlinks:
 ---
 <div class="homepage-hero">
   <div class="homepage-hero-image usa-grid">
-    <!-- Keep the white space here in order to force a line break. --> 
+    <!-- Keep the white space here in order to force a line break. -->
     <div class="homepage-hero-title">Get the VA services
 you’ve earned.</div>
   </div>
@@ -42,15 +42,15 @@ you’ve earned.</div>
 <div class="popular-container usa-grid-full">
 <h3>Get started with Vets.gov</h3>
 <div class="popular-container-links">
-  <a href="/health-care/apply/" class="usa-button usa-button-outline">
+  <a href="/health-care/apply/" class="usa-button usa-button-outline" onClick="window.dataLayer.push({ event: 'nav-main-healthcare' });">
     Apply for health care
   </a>
 
-  <a href="/facilities/" class="usa-button usa-button-outline">
+  <a href="/facilities/" class="usa-button usa-button-outline" onClick="window.dataLayer.push({ event: 'nav-main-facility' });">
     Find nearby VA locations
   </a>
 
-  <button data-show="#modal-crisisline" class="va-overlay-trigger usa-button usa-button-outline">
+  <button data-show="#modal-crisisline" class="va-overlay-trigger usa-button usa-button-outline" onClick="window.dataLayer.push({ event: 'nav-main-vcl' });">
     In crisis? Get help now
   </button>
 </div>


### PR DESCRIPTION
Per @suzchap on Slack (https://dsva.slack.com/archives/C1Q4294JJ/p1501592929465429) adding in some events to track clicks on the "buttons" beneath the photo headers (circled in red below).

![screen shot 2017-08-01 at 1 23 13 pm](https://user-images.githubusercontent.com/6646098/28840471-ae1081ee-76bc-11e7-9cde-29d768e09c9e.png)

Note, there will be a race condition between the onClick handler and the browser loading the next page because most browsers stop executing the "old" page's JS once it starts loading the "new" page. There's a `beacon` transport that newer browsers support that solves this issue. Overall, the data should be "okay" but just noting the caveat that this will undercount those clicks by some unknowable amount.

Tagging @phiden for review as an overall site/design issue