### PR TITLE
Add selenium port option

### DIFF
--- a/config/nightwatch-sauce.js
+++ b/config/nightwatch-sauce.js
@@ -32,6 +32,9 @@ module.exports = {
         recordLogs: true,
         captureHtml: true,
         seleniumVersion: '3.4.0'
+      },
+      selenium: {
+        port: process.env.SELENIUM_PORT || 4444
       }
     },
     chrome: {


### PR DESCRIPTION
The sauce connect proxy was unable to start the selenium server on my machine for some reason, causing it to fail. To fix this, I had to specify another port to run selenium on and then tell our e2e tests to look for selenium on that port.

### Workflow

Open up the proxy (from the sauce connect directory):
```
$ ./bin/sc  --user [user] --api-key [key] --se-port [port number]
```

Run the sauce tests (from `vets-website`):
```
$ SAUCE_USERNAME=[username] SAUCE_ACCESS_KEY=[key] SELENIUM_PORT=[port number] npm run test:sauce:desktop
```