### PR TITLE
Clean up Sentry error grouping for form submissions

### DIFF
--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -57,7 +57,8 @@ export function submitForm(formConfig, form) {
     Raven.captureException(error, {
       extra: {
         clientError,
-        statusText: error.statusText
+        statusText: error.statusText,
+        fingerprint: [formConfig.trackingPrefix, error]
       }
     });
     window.dataLayer.push({

--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -58,7 +58,7 @@ export function submitForm(formConfig, form) {
       extra: {
         clientError,
         statusText: error.statusText,
-        fingerprint: [formConfig.trackingPrefix, error]
+        fingerprint: [formConfig.trackingPrefix, error.message]
       }
     });
     window.dataLayer.push({

--- a/src/js/common/sentry.js
+++ b/src/js/common/sentry.js
@@ -15,7 +15,11 @@ if (trackErrors) {
   // it does not work locally with the webpack devtool setting we
   // use but does with the one we use in prod/staging
   window.addEventListener('unhandledrejection', (evt) => {
-    Raven.captureException(evt.reason);
+    Raven.captureException(evt.reason || 'Unhandled promise rejection', {
+      extra: {
+        evt
+      }
+    });
   });
 }
 

--- a/src/js/common/sentry.js
+++ b/src/js/common/sentry.js
@@ -15,11 +15,17 @@ if (trackErrors) {
   // it does not work locally with the webpack devtool setting we
   // use but does with the one we use in prod/staging
   window.addEventListener('unhandledrejection', (evt) => {
-    Raven.captureException(evt.reason || 'Unhandled promise rejection', {
+    const options = {
       extra: {
         evt
       }
-    });
+    };
+
+    if (evt && evt.reason) {
+      Raven.captureException(evt.reason, options);
+    } else {
+      Raven.captureMessage('Unhandled promise rejection', options);
+    }
   });
 }
 

--- a/src/js/edu-benefits/1990/actions/index.js
+++ b/src/js/edu-benefits/1990/actions/index.js
@@ -103,7 +103,8 @@ export function submitForm(data) {
     Raven.captureException(error, {
       extra: {
         clientError,
-        statusText: error.statusText
+        statusText: error.statusText,
+        fingerprint: ['edu-', error]
       }
     });
     window.dataLayer.push({

--- a/src/js/edu-benefits/1990/actions/index.js
+++ b/src/js/edu-benefits/1990/actions/index.js
@@ -104,7 +104,7 @@ export function submitForm(data) {
       extra: {
         clientError,
         statusText: error.statusText,
-        fingerprint: ['edu-', error]
+        fingerprint: ['edu-', error.message]
       }
     });
     window.dataLayer.push({


### PR DESCRIPTION
Related to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3168

The submission errors are not grouped well in Sentry because of the variety of stacktraces you can get, so this adds [fingerprinting](https://docs.sentry.io/learn/rollups/#customize-grouping-with-fingerprints) to group them more specifically (by form and error message).

I also found that we get a lot of `undefined` error messages in Sentry because not all unhandled promise rejections have a reason. So, this adds a default message and also sends the event as extra info so we can figure out if there are other properties we can use to organize the errors.