### PR TITLE
Don't error out when a form page isn't active

### DIFF
--- a/src/js/common/schemaform/FormNav.jsx
+++ b/src/js/common/schemaform/FormNav.jsx
@@ -25,12 +25,24 @@ export default class FormNav extends React.Component {
       .map(p => p.chapterKey)
       .filter(key => !!key)
     );
-    const page = expandedPageList.filter(p => p.path === currentPath)[0];
-    const current = chapters.indexOf(page.chapterKey) + 1;
-    // The review page is always part of our forms, but isn't listed in chapter list
-    const chapterName = page.chapterKey === 'review'
-      ? 'Review Application'
-      : formConfig.chapters[page.chapterKey].title;
+
+    let page = expandedPageList.filter(p => p.path === currentPath)[0];
+    // If the page isn't active, it won't be in the expandedPageList
+    // This is a fallback to still find the chapter name if you open the page directly
+    // (the chapter index will probably be wrong, but this isn't a scenario that happens in normal use)
+    if (!page) {
+      page = formPages.find(p => `${formConfig.urlPrefix}${p.path}` === currentPath);
+    }
+
+    let current;
+    let chapterName;
+    if (page) {
+      current = chapters.indexOf(page.chapterKey) + 1;
+      // The review page is always part of our forms, but isn't listed in chapter list
+      chapterName = page.chapterKey === 'review'
+        ? 'Review Application'
+        : formConfig.chapters[page.chapterKey].title;
+    }
 
     return (
       <div>


### PR DESCRIPTION
Sentry errors: http://sentry.vetsgov-internal/vets-gov/website-production/?query=is%3Aunresolved+chapterKey

If you open a page that has a `depends` property that isn't true by default, FormNav is erroring out. We should display the page, even if the nav info might be slightly off.

You can see this by going to https://www.vets.gov/health-care/apply/application/household-information/annual-income