### PR TITLE
Letters letter download loading

### DIFF
--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -99,6 +99,7 @@ export function getLetterPdf(letterType, letterName, letterOptions) {
   }
   let downloadUrl;
   return (dispatch) => {
+    dispatch({ type: 'GET_LETTER_PDF_DOWNLOADING', data: letterType });
     apiRequest(
       `/v0/letters/${letterType}`,
       settings,
@@ -123,7 +124,7 @@ export function getLetterPdf(letterType, letterName, letterOptions) {
           }
         });
         window.URL.revokeObjectURL(downloadUrl); // make sure this doesn't cause problems
-        dispatch({ type: GET_LETTER_PDF_SUCCESS });
+        dispatch({ type: GET_LETTER_PDF_SUCCESS, data: letterType });
       },
       () => dispatch({ type: GET_LETTER_PDF_FAILURE, data: letterType })
     );

--- a/src/js/letters/components/DownloadLetterLink.jsx
+++ b/src/js/letters/components/DownloadLetterLink.jsx
@@ -27,7 +27,7 @@ export class DownloadLetterLink extends React.Component {
     let buttonClasses;
     let buttonText;
     let buttonDisabled;
-    let unavailableMessage;
+    let message;
     switch (this.props.downloadStatus) {
       case 'downloading':
         buttonClasses = 'usa-button-disabled';
@@ -36,14 +36,24 @@ export class DownloadLetterLink extends React.Component {
         break;
       case 'success':
         buttonClasses = 'usa-button-primary va-button-primary';
-        buttonText = 'Download Again';
+        buttonText = 'Download Letter';
         buttonDisabled = false;
+        message = (
+          <div className="usa-alert usa-alert-success" role="alert">
+            <div className="usa-alert-body">
+              <h2 className="usa-alert-heading">Your letter has successfully downloaded.</h2>
+              <p className="usa-alert-text">
+                If you want to download your letter again, please press the button below.
+              </p>
+            </div>
+          </div>
+        );
         break;
       case 'failure':
         buttonClasses = 'usa-button-primary va-button-primary';
         buttonText = 'Retry Download';
         buttonDisabled = false;
-        unavailableMessage = (
+        message = (
           <div className="usa-alert usa-alert-error" role="alert">
             <div className="usa-alert-body">
               <h2 className="usa-alert-heading">Your letter didn't download.</h2>
@@ -71,7 +81,7 @@ export class DownloadLetterLink extends React.Component {
               transitionAppearTimeout={700}
               transitionEnterTimeout={700}
               transitionLeave={false}>
-            {unavailableMessage}
+            {message}
           </ReactCSSTransitionGroup>
         </div>
         <div className="download-button">

--- a/src/js/letters/components/DownloadLetterLink.jsx
+++ b/src/js/letters/components/DownloadLetterLink.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
 
 import { getLetterPdf } from '../actions/letters';
 
@@ -24,11 +23,39 @@ export class DownloadLetterLink extends React.Component {
   }
 
   render() {
+    let buttonClasses;
+    let buttonText;
+    let buttonDisabled;
+    switch (this.props.downloadStatus) {
+      case 'downloading':
+        buttonClasses = 'usa-button-disabled';
+        buttonText = 'Downloading...';
+        buttonDisabled = true;
+        break;
+      case 'success':
+        buttonClasses = 'usa-button-primary va-button-primary';
+        buttonText = 'Downloaded';
+        buttonDisabled = false;
+        break;
+      case 'failure':
+        buttonClasses = 'usa-button-disabled';
+        buttonText = 'Failed to download';
+        buttonDisabled = true;
+        break;
+      default:
+        buttonClasses = 'usa-button-primary va-button-primary';
+        buttonText = 'Download Letter';
+        buttonDisabled = false;
+    }
+
     return (
-      <Link onClick={this.downloadLetter} to="/" target="_blank"
-          className="usa-button-primary va-button-primary">
-        Download Letter
-      </Link>
+      <div className="download-button">
+        <button onClick={this.downloadLetter}
+            disabled={buttonDisabled}
+            className={buttonClasses}>
+          {buttonText}
+        </button>
+      </div>
     );
   }
 }

--- a/src/js/letters/components/DownloadLetterLink.jsx
+++ b/src/js/letters/components/DownloadLetterLink.jsx
@@ -46,11 +46,11 @@ export class DownloadLetterLink extends React.Component {
         unavailableMessage = (
           <div className="usa-alert usa-alert-error" role="alert">
             <div className="usa-alert-body">
-              <h2 className="usa-alert-heading">Your letter failed to download</h2>
+              <h2 className="usa-alert-heading">Your letter didn't download.</h2>
               <p className="usa-alert-text">
-                Your letter may be unavailable at this time. If you would like
-                assistance downloading your letter, please call <a href="tel: 855-574-7286">
-                855-574-7286</a> between Monday-Friday 8:00 a.m. - 8:00 p.m. (ET).
+                Your letter isn't available at this time. If you need help with
+                accessing your letter, please call <a href="tel: 855-574-7286">
+                855-574-7286</a>, Monday-Friday, 8 a.m. - 8 p.m. (ET).
               </p>
             </div>
           </div>

--- a/src/js/letters/components/DownloadLetterLink.jsx
+++ b/src/js/letters/components/DownloadLetterLink.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 import { getLetterPdf } from '../actions/letters';
 
@@ -26,6 +27,7 @@ export class DownloadLetterLink extends React.Component {
     let buttonClasses;
     let buttonText;
     let buttonDisabled;
+    let unavailableMessage;
     switch (this.props.downloadStatus) {
       case 'downloading':
         buttonClasses = 'usa-button-disabled';
@@ -34,13 +36,25 @@ export class DownloadLetterLink extends React.Component {
         break;
       case 'success':
         buttonClasses = 'usa-button-primary va-button-primary';
-        buttonText = 'Downloaded';
+        buttonText = 'Download Again';
         buttonDisabled = false;
         break;
       case 'failure':
-        buttonClasses = 'usa-button-disabled';
-        buttonText = 'Failed to download';
-        buttonDisabled = true;
+        buttonClasses = 'usa-button-primary va-button-primary';
+        buttonText = 'Retry Download';
+        buttonDisabled = false;
+        unavailableMessage = (
+          <div className="usa-alert usa-alert-error" role="alert">
+            <div className="usa-alert-body">
+              <h2 className="usa-alert-heading">Your letter failed to download</h2>
+              <p className="usa-alert-text">
+                Your letter may be unavailable at this time. If you would like
+                assistance downloading your letter, please call <a href="tel: 855-574-7286">
+                855-574-7286</a> between Monday-Friday 8:00 a.m. - 8:00 p.m. (ET).
+              </p>
+            </div>
+          </div>
+        );
         break;
       default:
         buttonClasses = 'usa-button-primary va-button-primary';
@@ -49,12 +63,24 @@ export class DownloadLetterLink extends React.Component {
     }
 
     return (
-      <div className="download-button">
-        <button onClick={this.downloadLetter}
-            disabled={buttonDisabled}
-            className={buttonClasses}>
-          {buttonText}
-        </button>
+      <div>
+        <div className="form-expanding-group form-expanding-group-open">
+          <ReactCSSTransitionGroup
+              transitionName="form-expanding-group-inner"
+              transitionAppear
+              transitionAppearTimeout={700}
+              transitionEnterTimeout={700}
+              transitionLeave={false}>
+            {unavailableMessage}
+          </ReactCSSTransitionGroup>
+        </div>
+        <div className="download-button">
+          <button onClick={this.downloadLetter}
+              disabled={buttonDisabled}
+              className={buttonClasses}>
+            {buttonText}
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/js/letters/components/DownloadLetterLink.jsx
+++ b/src/js/letters/components/DownloadLetterLink.jsx
@@ -37,13 +37,15 @@ function mapStateToProps(state, ownProps) {
   return {
     letterType: ownProps.letterType,
     letterName: ownProps.letterName,
+    downloadStatus: ownProps.downloadStatus,
     letterOptions: state.letters.requestOptions
   };
 }
 
 DownloadLetterLink.PropTypes = {
   letterType: PropTypes.string.required,
-  letterName: PropTypes.string.required
+  letterName: PropTypes.string.required,
+  downloadStatus: PropTypes.string
 };
 
 const mapDispatchToProps = {

--- a/src/js/letters/components/LetterList.jsx
+++ b/src/js/letters/components/LetterList.jsx
@@ -9,6 +9,7 @@ import { letterContent } from '../utils/helpers.jsx';
 
 class LetterList extends React.Component {
   render() {
+    const downloadStatus = this.props.letterDownloadStatus;
     const letterItems = (this.props.letters || []).map((letter, index) => {
       let content;
 
@@ -26,6 +27,7 @@ class LetterList extends React.Component {
           <DownloadLetterLink
               letterType={letter.letterType}
               letterName={letter.name}
+              downloadStatus={downloadStatus[letter.letterType]}
               key={`download-link-${index}`}/>
         </CollapsiblePanel>
       );
@@ -67,7 +69,8 @@ class LetterList extends React.Component {
 LetterList.PropTypes = {
   letters: PropTypes.array,
   lettersAvailability: PropTypes.string,
-  benefitSummaryOptions: PropTypes.object
+  benefitSummaryOptions: PropTypes.object,
+  letterDownloadStatus: PropTypes.object
 };
 
 export default LetterList;

--- a/src/js/letters/containers/DownloadLetters.jsx
+++ b/src/js/letters/containers/DownloadLetters.jsx
@@ -58,12 +58,8 @@ function mapStateToProps(state) {
     profile: userState.profile,
     letters: letterState.letters,
     destination: letterState.destination,
-<<<<<<< HEAD
     lettersAvailability: letterState.lettersAvailability,
-=======
-    lettersAvailable: letterState.lettersAvailable,
     letterDownloadStatus: letterState.letterDownloadStatus,
->>>>>>> 43a611b... passing props working
     benefitSummaryOptions: {
       benefitInfo: letterState.benefitInfo,
       serviceInfo: letterState.serviceInfo

--- a/src/js/letters/containers/DownloadLetters.jsx
+++ b/src/js/letters/containers/DownloadLetters.jsx
@@ -23,6 +23,7 @@ class DownloadLetters extends React.Component {
           <LetterList
               letters={this.props.letters}
               lettersAvailability={this.props.lettersAvailability}
+              letterDownloadStatus={this.props.letterDownloadStatus}
               benefitSummaryOptions={this.props.benefitSummaryOptions}/>
         </StepHeader>
         <br/>
@@ -57,7 +58,12 @@ function mapStateToProps(state) {
     profile: userState.profile,
     letters: letterState.letters,
     destination: letterState.destination,
+<<<<<<< HEAD
     lettersAvailability: letterState.lettersAvailability,
+=======
+    lettersAvailable: letterState.lettersAvailable,
+    letterDownloadStatus: letterState.letterDownloadStatus,
+>>>>>>> 43a611b... passing props working
     benefitSummaryOptions: {
       benefitInfo: letterState.benefitInfo,
       serviceInfo: letterState.serviceInfo

--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -16,23 +16,30 @@ import {
 } from '../utils/constants';
 
 const initialState = {
-  letters: [],
-  destination: {},
-  lettersAvailability: 'awaitingResponse',
   benefitInfo: {},
-  serviceInfo: [],
+  destination: {},
+  letters: [],
+  lettersAvailability: 'awaitingResponse',
+  letterDownloadStatus: {},
   optionsAvailable: false,
-  requestOptions: {}
+  requestOptions: {},
+  serviceInfo: []
 };
 
 function letters(state = initialState, action) {
   switch (action.type) {
     case GET_LETTERS_SUCCESS: {
+      const letterDownloadStatus = {};
+      _.forEach((letter) => {
+        letterDownloadStatus[letter.letterType] = 'pending';
+      }, action.data.data.attributes.letters);
+
       return {
         ...state,
         letters: action.data.data.attributes.letters,
         destination: action.data.data.attributes.address,
-        lettersAvailability: 'available'
+        lettersAvailability: 'available',
+        letterDownloadStatus
       };
     }
     case BACKEND_SERVICE_ERROR:
@@ -77,6 +84,12 @@ function letters(state = initialState, action) {
       return _.set('optionsAvailable', false, state);
     case UPDATE_BENFIT_SUMMARY_REQUEST_OPTION:
       return _.set(['requestOptions', action.propertyPath], action.value, state);
+    case 'GET_LETTER_PDF_DOWNLOADING':
+      return _.set(['letterDownloadStatus', action.data], 'downloading', state);
+    case 'GET_LETTER_PDF_SUCCESS':
+      return _.set(['letterDownloadStatus', action.data], 'success', state);
+    case 'GET_LETTER_PDF_FAILURE':
+      return _.set(['letterDownloadStatus', action.data], 'failure', state);
     default:
       return state;
   }

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -3,6 +3,8 @@
 @import "modules/m-progress-bar";
 @import "modules/m-schemaform";
 
+$color-gray-lighter: #d6d7d9;
+
 .letters {
   h5 {
     padding-top: 1.5em;
@@ -33,6 +35,15 @@
     min-height: 6rem;
     padding-top: 1.5rem;
     padding-bottom: 1.5rem;
+  }
+
+  .download-button {
+    margin: 1.5em 0 1em;
+
+    button:disabled {
+      background-color: $color-gray-lighter;
+      color: $color-black;
+    }
   }
 
   .service-info {

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -3,8 +3,6 @@
 @import "modules/m-progress-bar";
 @import "modules/m-schemaform";
 
-$color-gray-lighter: #d6d7d9;
-
 .letters {
   h5 {
     padding-top: 1.5em;
@@ -40,7 +38,7 @@ $color-gray-lighter: #d6d7d9;
   .download-button {
     margin: 1.5em 0 1em;
 
-    button:disabled {
+    > button:disabled {
       background-color: $color-gray-lighter;
       color: $color-black;
     }
@@ -71,6 +69,10 @@ $color-gray-lighter: #d6d7d9;
   th[scope="row"] {
     padding-top: 0;
     padding-bottom: 0;
+  }
+
+  .form-expanding-group {
+    margin-top: 1.5em;
   }
 }
 

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -72,7 +72,13 @@
   }
 
   .form-expanding-group {
+    margin-left: initial;
     margin-top: 1.5em;
+  }
+
+  .form-expanding-group-open {
+    border-left: 0;
+    padding-left: initial;
   }
 }
 

--- a/test/letters/components/DownloadLetterLink.unit.spec.jsx
+++ b/test/letters/components/DownloadLetterLink.unit.spec.jsx
@@ -19,11 +19,6 @@ describe('<DownloadLetterLink>', () => {
     expect(vdom).to.exist;
   });
 
-  it('should render Link component', () => {
-    const tree = SkinDeep.shallowRender(<DownloadLetterLink {...defaultProps}/>);
-    expect(tree.subTree('Link')).to.exist;
-  });
-
   it('should show download button', () => {
     const tree = SkinDeep.shallowRender(<DownloadLetterLink {...defaultProps}/>);
     expect(tree.dive(['.usa-button-primary']).text()).to.equal('Download Letter');
@@ -37,7 +32,7 @@ describe('<DownloadLetterLink>', () => {
     const getLetterPdf = sinon.spy();
     const props = _.set('getLetterPdf', getLetterPdf, defaultProps);
     const component = (ReactTestUtils.renderIntoDocument(<DownloadLetterLink {...props}/>));
-    const link = ReactTestUtils.findRenderedDOMComponentWithTag(component, 'a');
+    const link = ReactTestUtils.findRenderedDOMComponentWithTag(component, 'button');
     ReactTestUtils.Simulate.click(link);
     expect(getLetterPdf.calledOnce).to.be.true;
     expect(global.window.dataLayer).not.to.be.empty;

--- a/test/letters/components/LetterList.unit.spec.jsx
+++ b/test/letters/components/LetterList.unit.spec.jsx
@@ -18,7 +18,8 @@ const defaultProps = {
       name: 'Benefit Verification Letter',
       letterType: 'benefit_verification'
     }
-  ]
+  ],
+  letterDownloadStatus: {}
 };
 
 describe('<LetterList>', () => {


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3724

This PR adds logic around changing the content of the "Download Letter" button depending on the state of the download. The 4 possible states are:
1. `pending`: not yet attempted to be downloaded (what the state is initialized at)
<img width="546" alt="screen shot 2017-08-04 at 4 02 36 pm" src="https://user-images.githubusercontent.com/25183456/28985253-aaa28230-792f-11e7-8efe-72d204b11d1d.png">

2. `downloading`: button has been clicked and downloading has started
<img width="557" alt="screen shot 2017-08-04 at 4 01 47 pm" src="https://user-images.githubusercontent.com/25183456/28985257-af729afc-792f-11e7-95af-e80760566186.png">

3. `success`: letter has been successfully downloaded
<img width="543" alt="screen shot 2017-08-04 at 3 57 39 pm" src="https://user-images.githubusercontent.com/25183456/28985267-b5e411d6-792f-11e7-8e9d-aa8c2c3c3357.png">

4. `failed`: letter has failed to download
<img width="533" alt="screen shot 2017-08-04 at 3 57 47 pm" src="https://user-images.githubusercontent.com/25183456/28985271-bc1a647e-792f-11e7-8ab7-57c9d6931f59.png">

This PR may need some design/content/product review. While I was passing this design pattern off of what we do for form submit buttons, there is a difference between how these buttons behave. While we don't want to enable multiple attempts to submit a form, do we want to enable multiple attempts to download a letter? The questions I think need answering are:
1. During which states should the button be disabled? If it fails to download should you be allowed to try again? If it successfully downloads should you be allowed to try again?
2. What should the content and look of the button be during each state?

