### PR TITLE
Use currency definition on pension form

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,6 @@
   "dependencies": {
     "camelcase-keys-recursive": "^0.8.2",
     "reselect": "^2.5.4",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#75dc05646af4c553c54d70e9aab1a9639fb28ce7"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0e5db3eaa46d9a666ce96fe35ee7d6b71ff77b8b"
   }
 }

--- a/src/js/common/schemaform/widgets/CurrencyWidget.jsx
+++ b/src/js/common/schemaform/widgets/CurrencyWidget.jsx
@@ -22,7 +22,7 @@ export default class CurrencyWidget extends React.Component {
       this.props.onChange();
     } else {
       // Needs to look like a currency
-      if (!val.test(/^\${0,1}[0-9,]*(\.\d{1,2})?$/)) {
+      if (!/^\${0,1}[0-9,]*(\.\d{1,2})?$/.test(val)) {
         this.props.onChange(val);
       } else {
         // Needs to parse as a number

--- a/src/js/common/schemaform/widgets/CurrencyWidget.jsx
+++ b/src/js/common/schemaform/widgets/CurrencyWidget.jsx
@@ -22,7 +22,7 @@ export default class CurrencyWidget extends React.Component {
       this.props.onChange();
     } else {
       // Needs to look like a currency
-      if (!val.match(/^\${0,1}[0-9,]*(\.\d{1,2})?$/)) {
+      if (!val.test(/^\${0,1}[0-9,]*(\.\d{1,2})?$/)) {
         this.props.onChange(val);
       } else {
         // Needs to parse as a number

--- a/src/js/pensions/components/AdditionalSourcesField.jsx
+++ b/src/js/pensions/components/AdditionalSourcesField.jsx
@@ -4,6 +4,7 @@ import _ from 'lodash/fp';
 import Scroll from 'react-scroll';
 import { scrollToFirstError, focusElement } from '../../common/utils/helpers';
 import { setItemTouched } from '../../common/schemaform/helpers';
+import currencyUI from '../../common/schemaform/definitions/currency';
 
 import {
   toIdSchema,
@@ -187,12 +188,7 @@ export default class AdditionalSourcesField extends React.Component {
                 <SchemaField
                     name="amount"
                     schema={itemSchema.properties.amount}
-                    uiSchema={{
-                      'ui:title': itemData.name,
-                      'ui:options': {
-                        classNames: 'schemaform-currency-input'
-                      }
-                    }}
+                    uiSchema={currencyUI(itemData.name)}
                     errorSchema={_.get([index, 'amount'], errorSchema) || {}}
                     idSchema={itemIdSchema.amount}
                     formData={itemData.amount}

--- a/src/js/pensions/config/form.js
+++ b/src/js/pensions/config/form.js
@@ -57,6 +57,7 @@ import ssnUI from '../../common/schemaform/definitions/ssn';
 import fileUploadUI from '../../common/schemaform/definitions/file';
 import createNonRequiredFullName from '../../common/schemaform/definitions/nonRequiredFullName';
 import otherExpensesUI from '../definitions/otherExpenses';
+import currencyUI from '../../common/schemaform/definitions/currency';
 import GetFormHelp from '../../common/schemaform/GetPensionOrBurialFormHelp';
 
 const {
@@ -432,12 +433,7 @@ const formConfig = {
               'ui:options': {
                 expandUnder: 'view:receivedSeverancePay'
               },
-              amount: {
-                'ui:title': 'Amount',
-                'ui:options': {
-                  classNames: 'schemaform-currency-input'
-                }
-              },
+              amount: currencyUI('Amount'),
               type: {
                 'ui:title': 'Pay Type',
                 'ui:widget': 'radio',
@@ -563,12 +559,7 @@ const formConfig = {
                   daysMissed: {
                     'ui:title': 'How many days lost to disability'
                   },
-                  annualEarnings: {
-                    'ui:title': 'Total annual earnings',
-                    'ui:options': {
-                      classNames: 'schemaform-currency-input'
-                    }
-                  }
+                  annualEarnings: currencyUI('Total annual earnings')
                 }
               }
             }
@@ -803,15 +794,13 @@ const formConfig = {
                 expandUnderCondition: false
               }
             },
-            monthlySpousePayment: {
-              'ui:title': spouseContribution,
+            monthlySpousePayment: _.merge(currencyUI(spouseContribution), {
               'ui:required': form => form.liveWithSpouse === false,
               'ui:options': {
-                classNames: 'schemaform-currency-input',
                 expandUnder: 'liveWithSpouse',
                 expandUnderCondition: false
               }
-            },
+            }),
             spouseMarriages: {
               'ui:title': 'How many times has your spouse been married (including current marriage)?',
               'ui:widget': ArrayCountWidget,
@@ -1161,15 +1150,13 @@ const formConfig = {
                     }
                   }
                 ),
-                monthlyPayment: {
-                  'ui:title': 'How much do you contribute per month to their support?',
+                monthlyPayment: _.merge(currencyUI('How much do you contribute per month to their support?'), {
                   'ui:required': (form, index) => !_.get(['dependents', index, 'childInHousehold'], form),
                   'ui:options': {
-                    classNames: 'schemaform-currency-input',
                     expandUnder: 'childInHousehold',
                     expandUnderCondition: false
                   }
-                }
+                })
               }
             }
           }

--- a/src/js/pensions/definitions/additionalSources.js
+++ b/src/js/pensions/definitions/additionalSources.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp';
 
 import AdditionalSourcesField from '../components/AdditionalSourcesField';
+import currencyUI from '../../common/schemaform/definitions/currency';
 
 export function additionalSourcesSchema(schema) {
   return _.set('items.required', ['name', 'amount'], schema.definitions.additionalSources);
@@ -15,11 +16,6 @@ export const additionalSourcesUI = {
     name: {
       'ui:title': 'Source'
     },
-    amount: {
-      'ui:title': 'Amount',
-      'ui:options': {
-        classNames: 'schemaform-currency-input'
-      }
-    }
+    amount: currencyUI('Amount')
   }
 };

--- a/src/js/pensions/definitions/expectedIncome.js
+++ b/src/js/pensions/definitions/expectedIncome.js
@@ -1,4 +1,5 @@
 import { additionalSourcesUI } from './additionalSources';
+import currencyUI from '../../common/schemaform/definitions/currency';
 
 export default {
   'ui:order': [
@@ -6,17 +7,7 @@ export default {
     'interest',
     'additionalSources'
   ],
-  salary: {
-    'ui:title': 'Gross wages and salary',
-    'ui:options': {
-      classNames: 'schemaform-currency-input'
-    }
-  },
-  interest: {
-    'ui:title': 'Total dividends and interest',
-    'ui:options': {
-      classNames: 'schemaform-currency-input'
-    }
-  },
+  salary: currencyUI('Gross wages and salary'),
+  interest: currencyUI('Total dividends and interest'),
   additionalSources: additionalSourcesUI
 };

--- a/src/js/pensions/definitions/monthlyIncome.js
+++ b/src/js/pensions/definitions/monthlyIncome.js
@@ -1,4 +1,5 @@
 import { additionalSourcesUI } from './additionalSources';
+import currencyUI from '../../common/schemaform/definitions/currency';
 
 export default {
   'ui:order': [
@@ -10,41 +11,11 @@ export default {
     'ssi',
     'additionalSources'
   ],
-  socialSecurity: {
-    'ui:title': 'Social Security',
-    'ui:options': {
-      classNames: 'schemaform-currency-input'
-    }
-  },
-  civilService: {
-    'ui:title': 'US Civil Service',
-    'ui:options': {
-      classNames: 'schemaform-currency-input'
-    }
-  },
-  railroad: {
-    'ui:title': 'US Railroad Retirement',
-    'ui:options': {
-      classNames: 'schemaform-currency-input'
-    }
-  },
-  blackLung: {
-    'ui:title': 'Black Lung Benefits',
-    'ui:options': {
-      classNames: 'schemaform-currency-input'
-    }
-  },
-  serviceRetirement: {
-    'ui:title': 'Service Retirement',
-    'ui:options': {
-      classNames: 'schemaform-currency-input'
-    }
-  },
-  ssi: {
-    'ui:title': 'Supplemental Security Income (SSI) or Public Assistance',
-    'ui:options': {
-      classNames: 'schemaform-currency-input'
-    }
-  },
+  socialSecurity: currencyUI('Social Security'),
+  civilService: currencyUI('US Civil Service'),
+  railroad: currencyUI('US Railroad Retirement'),
+  blackLung: currencyUI('Black Lung Benefits'),
+  serviceRetirement: currencyUI('Service Retirement'),
+  ssi: currencyUI('Supplemental Security Income (SSI) or Public Assistance'),
   additionalSources: additionalSourcesUI
 };

--- a/src/js/pensions/definitions/netWorth.js
+++ b/src/js/pensions/definitions/netWorth.js
@@ -1,4 +1,5 @@
 import { additionalSourcesUI } from './additionalSources';
+import currencyUI from '../../common/schemaform/definitions/currency';
 
 export default {
   'ui:order': [
@@ -9,35 +10,10 @@ export default {
     'realProperty',
     'additionalSources'
   ],
-  bank: {
-    'ui:title': 'Cash/Non-interest bearing accounts',
-    'ui:options': {
-      classNames: 'schemaform-currency-input'
-    }
-  },
-  interestBank: {
-    'ui:title': 'Interest bearing accounts',
-    'ui:options': {
-      classNames: 'schemaform-currency-input'
-    }
-  },
-  ira: {
-    'ui:title': 'IRAs, KEOGH Plans, etc.',
-    'ui:options': {
-      classNames: 'schemaform-currency-input'
-    }
-  },
-  stocks: {
-    'ui:title': 'Stocks, bonds, mutual funds, etc',
-    'ui:options': {
-      classNames: 'schemaform-currency-input'
-    }
-  },
-  realProperty: {
-    'ui:title': 'Real Property (not your home, vehicle, furniture, or clothing)',
-    'ui:options': {
-      classNames: 'schemaform-currency-input'
-    }
-  },
+  bank: currencyUI('Cash/Non-interest bearing accounts'),
+  interestBank: currencyUI('Interest bearing accounts'),
+  ira: currencyUI('IRAs, KEOGH Plans, etc.'),
+  stocks: currencyUI('Stocks, bonds, mutual funds, etc'),
+  realProperty: currencyUI('Real Property (not your home, vehicle, furniture, or clothing)'),
   additionalSources: additionalSourcesUI
 };

--- a/src/js/pensions/definitions/otherExpenses.js
+++ b/src/js/pensions/definitions/otherExpenses.js
@@ -1,5 +1,6 @@
 import currentOrPastDateUI from '../../common/schemaform/definitions/currentOrPastDate';
 import ExpenseField from '../components/ExpenseField';
+import currencyUI from '../../common/schemaform/definitions/currency';
 
 export default {
   'ui:options': {
@@ -14,12 +15,7 @@ export default {
       'date',
       'paidTo'
     ],
-    amount: {
-      'ui:title': 'Amount paid',
-      'ui:options': {
-        classNames: 'schemaform-currency-input'
-      }
-    },
+    amount: currencyUI('Amount paid'),
     purpose: {
       'ui:title': 'Purpose (doctor fee, hospital charge, attorney fee, tuition, etc.)',
     },

--- a/test/pensions/config/otherExpenses.unit.spec.jsx
+++ b/test/pensions/config/otherExpenses.unit.spec.jsx
@@ -109,7 +109,7 @@ describe('Pensions', () => {
 
       formDOM.fillData(`#root_view\\:${namePath.startsWith('spouse') ? 'spouseHas' : 'has'}OtherExpensesYes`, 'Y');
 
-      formDOM.fillData(`#root_${namePath.startsWith('spouse') ? 'spouseOtherExpenses' : 'otherExpenses'}_0_amount`, 12);
+      formDOM.fillData(`#root_${namePath.startsWith('spouse') ? 'spouseOtherExpenses' : 'otherExpenses'}_0_amount`, '12');
       formDOM.fillData(`#root_${namePath.startsWith('spouse') ? 'spouseOtherExpenses' : 'otherExpenses'}_0_purpose`, 'procedure');
       formDOM.fillDate(`root_${namePath.startsWith('spouse') ? 'spouseOtherExpenses' : 'otherExpenses'}_0_date`, '12-11-2001');
       formDOM.fillData(`#root_${namePath.startsWith('spouse') ? 'spouseOtherExpenses' : 'otherExpenses'}_0_paidTo`, 'doctor');

--- a/yarn.lock
+++ b/yarn.lock
@@ -8315,9 +8315,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#75dc05646af4c553c54d70e9aab1a9639fb28ce7":
-  version "3.0.30"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#75dc05646af4c553c54d70e9aab1a9639fb28ce7"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#0e5db3eaa46d9a666ce96fe35ee7d6b71ff77b8b":
+  version "3.0.31"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0e5db3eaa46d9a666ce96fe35ee7d6b71ff77b8b"
 
 vinyl-assign@^1.0.1:
   version "1.2.1"


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4206

Updates pension form to use currency definition. Also changes currency widget to use the right regex method.

Only notable visual change (0 is now 0.00):

![screen shot 2017-08-07 at 1 07 56 pm](https://user-images.githubusercontent.com/634932/29037613-54e38796-7b72-11e7-823d-53fe70aab0ee.png)
