### PR TITLE
Fix mistake about fingerprint property location

### DIFF
--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -55,10 +55,10 @@ export function submitForm(formConfig, form) {
 
   const captureError = (error, clientError) => {
     Raven.captureException(error, {
+      fingerprint: [formConfig.trackingPrefix, error.message],
       extra: {
         clientError,
-        statusText: error.statusText,
-        fingerprint: [formConfig.trackingPrefix, error.message]
+        statusText: error.statusText
       }
     });
     window.dataLayer.push({

--- a/src/js/edu-benefits/1990/actions/index.js
+++ b/src/js/edu-benefits/1990/actions/index.js
@@ -101,10 +101,10 @@ export function submitForm(data) {
 
   const captureError = (error, clientError) => {
     Raven.captureException(error, {
+      fingerprint: ['edu-', error.message],
       extra: {
         clientError,
-        statusText: error.statusText,
-        fingerprint: ['edu-', error.message]
+        statusText: error.statusText
       }
     });
     window.dataLayer.push({


### PR DESCRIPTION
The `fingerprint` property is in the wrong place, so it's not picked up by Sentry.