### PR TITLE
Save defaulted form data on page change in rjsf forms

### DIFF
--- a/src/js/common/schemaform/FormPage.jsx
+++ b/src/js/common/schemaform/FormPage.jsx
@@ -72,7 +72,16 @@ class FormPage extends React.Component {
     this.props.setData(newData);
   }
 
-  onSubmit() {
+  onSubmit({ formData }) {
+    const { route, params, form } = this.props;
+
+    // This makes sure defaulted data on a page with no changes is saved
+    // Probably safe to do this for regular pages, too, but it hasn't been necessary
+    if (route.pageConfig.showPagePerItem) {
+      const newData = _.set([route.pageConfig.arrayPath, params.index], formData, form.data);
+      this.props.setData(newData);
+    }
+
     const { pages, pageIndex } = this.getEligiblePages();
     this.props.router.push(pages[pageIndex + 1].path);
   }

--- a/src/js/common/schemaform/review/ReviewCollapsibleChapter.jsx
+++ b/src/js/common/schemaform/review/ReviewCollapsibleChapter.jsx
@@ -54,6 +54,17 @@ export default class ReviewCollapsibleChapter extends React.Component {
     this.focusOnPage(`${key}${index === null ? '' : index}`);
   }
 
+  handleSubmit = (formData, key, path = null, index = null) => {
+    // This makes sure defaulted data on a page with no changes is saved
+    // Probably safe to do this for regular pages, too, but it hasn't been necessary
+    if (path) {
+      const newData = _.set([path, index], formData, this.props.form.data);
+      this.props.setData(newData);
+    }
+
+    this.handleEdit(key, false, index);
+  }
+
   scrollToTop() {
     scroller.scrollTo(`chapter${this.props.chapterKey}ScrollElement`, {
       duration: 500,
@@ -148,7 +159,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
                       hideTitle={expandedPages.length === 1}
                       pagePerItemIndex={page.index}
                       onEdit={() => this.handleEdit(page.pageKey, !editing, page.index)}
-                      onSubmit={() => this.handleEdit(page.pageKey, false, page.index)}
+                      onSubmit={({ formData }) => this.handleSubmit(formData, page.pageKey, page.arrayPath, page.index)}
                       onChange={(formData) => this.onChange(formData, page.arrayPath, page.index)}
                       uploadFile={this.props.uploadFile}
                       reviewMode={!editing}

--- a/test/common/schemaform/FormPage.unit.spec.jsx
+++ b/test/common/schemaform/FormPage.unit.spec.jsx
@@ -103,7 +103,7 @@ describe('Schemaform <FormPage>', () => {
       expect(setData.calledWith('testPage', newData));
     });
     it('submit', () => {
-      tree.getMountedInstance().onSubmit();
+      tree.getMountedInstance().onSubmit({});
 
       expect(router.push.calledWith('next-page'));
     });
@@ -318,5 +318,68 @@ describe('Schemaform <FormPage>', () => {
     const { pageIndex } = tree.getMountedInstance().getEligiblePages();
 
     expect(pageIndex).to.equal(1);
+  });
+  it('should update data when submitting on array page', () => {
+    const setData = sinon.spy();
+    const route = {
+      pageConfig: {
+        pageKey: 'testPage',
+        showPagePerItem: true,
+        arrayPath: 'arrayProp',
+        errorMessages: {},
+        title: ''
+      },
+      pageList: [
+        {
+          path: 'testing'
+        }
+      ]
+    };
+    const form = {
+      pages: {
+        testPage: {
+          schema: {
+            properties: {
+              arrayProp: {
+                items: [{}]
+              }
+            }
+          },
+          uiSchema: {
+            arrayProp: {
+              items: {}
+            }
+          }
+        }
+      },
+      data: {
+        arrayProp: [{}]
+      }
+    };
+    const router = {
+      push: sinon.spy()
+    };
+
+    const tree = SkinDeep.shallowRender(
+      <FormPage
+          setData={setData}
+          router={router}
+          form={form}
+          route={route}
+          location={{
+            pathname: '/testing/0'
+          }}
+          params={{ index: 0 }}/>
+    );
+
+    tree.getMountedInstance().onSubmit({ formData: { test: 2 } });
+
+    expect(setData.firstCall.args[0]).to.eql({
+      arrayProp: [
+        {
+          test: 2
+        }
+      ]
+    });
   });
 });

--- a/test/common/schemaform/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/test/common/schemaform/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -333,4 +333,50 @@ describe('<ReviewCollapsibleChapter>', () => {
     tree.getMountedInstance().toggleChapter();
     expect(setPagesViewed.firstCall.args[0]).to.eql(['test']);
   });
+  it('should handle submitting array page', () => {
+    const onEdit = sinon.spy();
+    const setData = sinon.spy();
+    const pages = [{
+      title: '',
+      pageKey: 'test'
+    }];
+    const chapterKey = 'test';
+    const chapter = {};
+    const form = {
+      pages: {
+        test: {
+          showPagePerItem: true,
+          arrayPath: 'testing',
+          title: '',
+          schema: {
+            properties: {}
+          },
+          editMode: [false],
+        }
+      },
+      data: {
+        testing: [{}]
+      }
+    };
+
+    const tree = SkinDeep.shallowRender(
+      <ReviewCollapsibleChapter
+          viewedPages={new Set()}
+          onEdit={onEdit}
+          setData={setData}
+          pages={pages}
+          chapterKey={chapterKey}
+          chapter={chapter}
+          form={form}/>
+    );
+
+    tree.getMountedInstance().handleSubmit({ test: 2 }, 'test', 'testing', 0);
+
+    expect(onEdit.calledWith('test', false, 0)).to.be.true;
+    expect(setData.firstCall.args[0]).to.eql({
+      testing: [{
+        test: 2
+      }]
+    });
+  });
 });


### PR DESCRIPTION
On the Pension form, if you have a dependent and you don't change their financial info, no financial information will be included in the array for each item, even though all fields are defaulted to 0. This happens because when create the object for each dependent, we're using a schema that doesn't have the financial fields.

This change makes it so that we always save the data rjsf sends back in the onSubmit callback (which has the defaults set) when we switch pages. I've limited this to just for page per item pages, but it could probably be used for all pages.