### PR TITLE
Gibs utc time

### DIFF
--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -101,16 +101,21 @@ export function dateToMoment(dateField) {
   });
 }
 
-export function formatDateLong(date) {
-  return moment(date).format('MMMM DD, YYYY');
-}
-
-export function formatDateWithoutTimeLong(date) {
+export function dropTimeAndTimezone(date) {
   let newDate = moment(date).format();
   const indexOfTime = newDate.indexOf('T');
   if (indexOfTime >= 0) {
     newDate = newDate.substring(0, indexOfTime);
   }
+  return newDate;
+}
+
+export function formatDateLong(date) {
+  return moment(date).format('MMMM DD, YYYY');
+}
+
+export function formatDateWithoutTimeLong(date) {
+  const newDate = dropTimeAndTimezone(date);
   return moment(newDate).format('MMMM DD, YYYY');
 }
 
@@ -119,11 +124,7 @@ export function formatDateShort(date) {
 }
 
 export function formatDateWithoutTimeShort(date) {
-  let newDate = moment(date).format();
-  const indexOfTime = newDate.indexOf('T');
-  if (indexOfTime >= 0) {
-    newDate = newDate.substring(0, indexOfTime);
-  }
+  const newDate = dropTimeAndTimezone(date);
   return moment(newDate).format('MM/DD/YYYY');
 }
 

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -105,8 +105,26 @@ export function formatDateLong(date) {
   return moment(date).format('MMMM DD, YYYY');
 }
 
+export function formatDateWithoutTimeLong(date) {
+  let newDate = moment(date).format();
+  const indexOfTime = newDate.indexOf('T');
+  if (indexOfTime >= 0) {
+    newDate = newDate.substring(0, indexOfTime);
+  }
+  return moment(newDate).format('MMMM DD, YYYY');
+}
+
 export function formatDateShort(date) {
   return moment(date).format('MM/DD/YYYY');
+}
+
+export function formatDateWithoutTimeShort(date) {
+  let newDate = moment(date).format();
+  const indexOfTime = newDate.indexOf('T');
+  if (indexOfTime >= 0) {
+    newDate = newDate.substring(0, indexOfTime);
+  }
+  return moment(newDate).format('MM/DD/YYYY');
 }
 
 export function focusElement(selectorOrElement) {

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -102,12 +102,12 @@ export function dateToMoment(dateField) {
 }
 
 export function dropTimeAndTimezone(date) {
-  let newDate = moment(date).format();
-  const indexOfTime = newDate.indexOf('T');
+  let formattedDate = moment(date).format();
+  const indexOfTime = formattedDate.indexOf('T');
   if (indexOfTime >= 0) {
-    newDate = newDate.substring(0, indexOfTime);
+    formattedDate = formattedDate.substring(0, indexOfTime);
   }
-  return newDate;
+  return formattedDate;
 }
 
 export function formatDateLong(date) {
@@ -115,8 +115,8 @@ export function formatDateLong(date) {
 }
 
 export function formatDateWithoutTimeLong(date) {
-  const newDate = dropTimeAndTimezone(date);
-  return moment(newDate).format('MMMM DD, YYYY');
+  const formattedDate = dropTimeAndTimezone(date);
+  return moment(formattedDate).format('MMMM DD, YYYY');
 }
 
 export function formatDateShort(date) {
@@ -124,8 +124,8 @@ export function formatDateShort(date) {
 }
 
 export function formatDateWithoutTimeShort(date) {
-  const newDate = dropTimeAndTimezone(date);
-  return moment(newDate).format('MM/DD/YYYY');
+  const formattedDate = dropTimeAndTimezone(date);
+  return moment(formattedDate).format('MM/DD/YYYY');
 }
 
 export function focusElement(selectorOrElement) {

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -102,7 +102,7 @@ export function dateToMoment(dateField) {
 }
 
 export function dropTimeAndTimezone(date) {
-  let formattedDate = moment(date).format();
+  let formattedDate = date.toString();
   const indexOfTime = formattedDate.indexOf('T');
   if (indexOfTime >= 0) {
     formattedDate = formattedDate.substring(0, indexOfTime);

--- a/src/js/post-911-gib-status/components/EnrollmentPeriod.jsx
+++ b/src/js/post-911-gib-status/components/EnrollmentPeriod.jsx
@@ -4,7 +4,7 @@ import Scroll from 'react-scroll';
 
 import InfoPair from './InfoPair';
 
-import { formatDateShort, getScrollOptions } from '../../common/utils/helpers';
+import { formatDateWithoutTimeShort, getScrollOptions } from '../../common/utils/helpers';
 
 const scroller = Scroll.scroller;
 
@@ -53,7 +53,7 @@ class EnrollmentPeriod extends React.Component {
               <InfoPair label="Type of Change" value={amendment.type}/>
               <InfoPair
                   label="Change Effective Date"
-                  value={formatDateShort(amendment.changeEffectiveDate)}/>
+                  value={formatDateWithoutTimeShort(amendment.changeEffectiveDate)}/>
             </div>
           );
         })}
@@ -83,7 +83,7 @@ class EnrollmentPeriod extends React.Component {
 
     return (
       <div id={id}>
-        <h4>{formatDateShort(enrollment.beginDate)} to {formatDateShort(enrollment.endDate)} at <span className="facility">{(enrollment.facilityName || '').toLowerCase()}</span> ({enrollment.facilityCode})</h4>
+        <h4>{formatDateWithoutTimeShort(enrollment.beginDate)} to {formatDateWithoutTimeShort(enrollment.endDate)} at <span className="facility">{(enrollment.facilityName || '').toLowerCase()}</span> ({enrollment.facilityCode})</h4>
         {yellowRibbonStatus}
         <InfoPair label="On-campus Hours" value={enrollment.onCampusHours}/>
         <InfoPair label="Online Hours" value={enrollment.onlineHours}/>

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -17,7 +17,8 @@ class UserInfoSection extends React.Component {
     const enrollmentData = this.props.enrollmentData || {};
 
     // Get today's date to show information current as of
-    const todayFormatted = formatDateWithoutTimeShort(new Date());
+    const today = new Date();
+    const todayFormatted = formatDateWithoutTimeShort(today);
     const percentageBenefit = formatPercent(enrollmentData.percentageBenefit) || 'unavailable';
     const fullName = `${enrollmentData.firstName} ${enrollmentData.lastName}`;
 

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import InfoPair from './InfoPair';
 
-import { formatDateShort, formatDateLong } from '../../common/utils/helpers';
+import { formatDateWithoutTimeShort, formatDateWithoutTimeLong } from '../../common/utils/helpers';
 import {
   formatPercent,
   formatVAFileNumber,
@@ -17,7 +17,7 @@ class UserInfoSection extends React.Component {
     const enrollmentData = this.props.enrollmentData || {};
 
     // Get today's date to show information current as of
-    const todayFormatted = formatDateShort(new Date());
+    const todayFormatted = formatDateWithoutTimeShort(new Date());
     const percentageBenefit = formatPercent(enrollmentData.percentageBenefit) || 'unavailable';
     const fullName = `${enrollmentData.firstName} ${enrollmentData.lastName}`;
 
@@ -79,7 +79,7 @@ class UserInfoSection extends React.Component {
           <InfoPair
               label="Date of birth"
               name="dateOfBirth"
-              value={formatDateLong(enrollmentData.dateOfBirth)}
+              value={formatDateWithoutTimeLong(enrollmentData.dateOfBirth)}
               additionalClass="section-line"/>
           <InfoPair
               label="VA file number"

--- a/src/js/post-911-gib-status/containers/PrintPage.jsx
+++ b/src/js/post-911-gib-status/containers/PrintPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import moment from 'moment';
 
 import UserInfoSection from '../components/UserInfoSection';
 
@@ -9,7 +10,8 @@ class PrintPage extends React.Component {
   render() {
     const enrollmentData = this.props.enrollmentData || {};
 
-    const todayFormatted = formatDateWithoutTimeLong(new Date());
+    const today = new Date();
+    const todayFormatted = formatDateWithoutTimeLong(moment(today).format());
 
     return (
       <div className="usa-width-two-thirds medium-8 columns gib-info">

--- a/src/js/post-911-gib-status/containers/PrintPage.jsx
+++ b/src/js/post-911-gib-status/containers/PrintPage.jsx
@@ -3,13 +3,13 @@ import { connect } from 'react-redux';
 
 import UserInfoSection from '../components/UserInfoSection';
 
-import { formatDateLong } from '../../common/utils/helpers';
+import { formatDateWithoutTimeLong } from '../../common/utils/helpers';
 
 class PrintPage extends React.Component {
   render() {
     const enrollmentData = this.props.enrollmentData || {};
 
-    const todayFormatted = formatDateLong(new Date());
+    const todayFormatted = formatDateWithoutTimeLong(new Date());
 
     return (
       <div className="usa-width-two-thirds medium-8 columns gib-info">

--- a/src/js/post-911-gib-status/utils/helpers.jsx
+++ b/src/js/post-911-gib-status/utils/helpers.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formatDateLong } from '../../common/utils/helpers';
+import { formatDateWithoutTimeLong } from '../../common/utils/helpers';
 
 export function formatPercent(percent) {
   let validPercent = undefined;
@@ -73,7 +73,7 @@ export function benefitEndDateExplanation(condition, delimitingDate) {
         <div className="section benefit-end-date">
           <h4>Benefit End Date</h4>
           <div>
-            You have until <strong>{formatDateLong(delimitingDate)}</strong> to use these benefits.
+            You have until <strong>{formatDateWithoutTimeLong(delimitingDate)}</strong> to use these benefits.
           </div>
         </div>
       );

--- a/test/post-911-gib-status/components/UserInfoSection.unit.spec.jsx
+++ b/test/post-911-gib-status/components/UserInfoSection.unit.spec.jsx
@@ -75,6 +75,7 @@ describe('<UserInfoSection>', () => {
       const newProps = {
         enrollmentData: {
           veteranIsEligible: false,
+          dateOfBirth: '1995-11-12T06:00:00.000+0000',
           originalEntitlement: {},
           usedEntitlement: {},
           remainingEntitlement: {},
@@ -112,6 +113,7 @@ describe('<UserInfoSection>', () => {
       const newProps = {
         enrollmentData: {
           veteranIsEligible: true,
+          dateOfBirth: '1995-11-12T06:00:00.000+0000',
           activeDuty: true,
           originalEntitlement: {},
           usedEntitlement: {},

--- a/test/post-911-gib-status/containers/StatusPage.unit.spec.jsx
+++ b/test/post-911-gib-status/containers/StatusPage.unit.spec.jsx
@@ -14,6 +14,7 @@ const defaultProps = store.getState();
 defaultProps.post911GIBStatus = {
   enrollmentData: {
     veteranIsEligible: true,
+    dateOfBirth: '1995-11-12T06:00:00.000+0000',
     remainingEntitlement: {},
     originalEntitlement: {},
     usedEntitlement: {}
@@ -40,6 +41,7 @@ describe('<StatusPage>', () => {
     const props = {
       enrollmentData: {
         veteranIsEligible: false,
+        dateOfBirth: '1995-11-12T06:00:00.000+0000',
         originalEntitlement: {},
         usedEntitlement: {},
         remainingEntitlement: {},


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4281

We heard of an issue where some users were seeing their DOB as being one day off. We suspect this is due to a timezone issue where the dates sent to us from EVSS are specifying UTC, and when we display these dates on the front-end it changes the day in their DOB depending on the timezone of their birth. This PR simply drops the time and timezone before reformatting the dates.