### PR TITLE
Fix formatting of today date

### DIFF
--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 
 import InfoPair from './InfoPair';
 
-import { formatDateWithoutTimeShort, formatDateWithoutTimeLong } from '../../common/utils/helpers';
+import { formatDateShort, formatDateWithoutTimeLong } from '../../common/utils/helpers';
 import {
   formatPercent,
   formatVAFileNumber,
@@ -18,8 +17,7 @@ class UserInfoSection extends React.Component {
     const enrollmentData = this.props.enrollmentData || {};
 
     // Get today's date to show information current as of
-    const today = new Date();
-    const todayFormatted = formatDateWithoutTimeShort(moment(today).format());
+    const todayFormatted = formatDateShort(new Date());
     const percentageBenefit = formatPercent(enrollmentData.percentageBenefit) || 'unavailable';
     const fullName = `${enrollmentData.firstName} ${enrollmentData.lastName}`;
 

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 
 import InfoPair from './InfoPair';
 
@@ -18,7 +19,7 @@ class UserInfoSection extends React.Component {
 
     // Get today's date to show information current as of
     const today = new Date();
-    const todayFormatted = formatDateWithoutTimeShort(today);
+    const todayFormatted = formatDateWithoutTimeShort(moment(today).format());
     const percentageBenefit = formatPercent(enrollmentData.percentageBenefit) || 'unavailable';
     const fullName = `${enrollmentData.firstName} ${enrollmentData.lastName}`;
 

--- a/src/js/post-911-gib-status/containers/PrintPage.jsx
+++ b/src/js/post-911-gib-status/containers/PrintPage.jsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import moment from 'moment';
 
 import UserInfoSection from '../components/UserInfoSection';
 
-import { formatDateWithoutTimeLong } from '../../common/utils/helpers';
+import { formatDateLong } from '../../common/utils/helpers';
 
 class PrintPage extends React.Component {
   render() {
     const enrollmentData = this.props.enrollmentData || {};
 
-    const today = new Date();
-    const todayFormatted = formatDateWithoutTimeLong(moment(today).format());
+    const todayFormatted = formatDateLong(new Date());
 
     return (
       <div className="usa-width-two-thirds medium-8 columns gib-info">


### PR DESCRIPTION
Missed a formatting fix for a `new Date()` in the previous PR (https://github.com/department-of-veterans-affairs/vets-website/pull/6184).