### PR TITLE
Gibs parse zone fix

### DIFF
--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -114,18 +114,8 @@ export function formatDateLong(date) {
   return moment.parseZone(date).format('MMMM DD, YYYY');
 }
 
-export function formatDateWithoutTimeLong(date) {
-  const formattedDate = dropTimeAndTimezone(date);
-  return moment(formattedDate).format('MMMM DD, YYYY');
-}
-
 export function formatDateShort(date) {
   return moment.parseZone(date).format('MM/DD/YYYY');
-}
-
-export function formatDateWithoutTimeShort(date) {
-  const formattedDate = dropTimeAndTimezone(date);
-  return moment(formattedDate).format('MM/DD/YYYY');
 }
 
 export function focusElement(selectorOrElement) {

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -111,10 +111,18 @@ export function dropTimeAndTimezone(date) {
 }
 
 export function formatDateLong(date) {
+  return moment(date).format('MMMM DD, YYYY');
+}
+
+export function formatDateParsedZoneLong(date) {
   return moment.parseZone(date).format('MMMM DD, YYYY');
 }
 
 export function formatDateShort(date) {
+  return moment(date).format('MM/DD/YYYY');
+}
+
+export function formatDateParsedZoneShort(date) {
   return moment.parseZone(date).format('MM/DD/YYYY');
 }
 

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -101,15 +101,6 @@ export function dateToMoment(dateField) {
   });
 }
 
-export function dropTimeAndTimezone(date) {
-  let formattedDate = date.toString();
-  const indexOfTime = formattedDate.indexOf('T');
-  if (indexOfTime >= 0) {
-    formattedDate = formattedDate.substring(0, indexOfTime);
-  }
-  return formattedDate;
-}
-
 export function formatDateLong(date) {
   return moment(date).format('MMMM DD, YYYY');
 }

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -111,7 +111,7 @@ export function dropTimeAndTimezone(date) {
 }
 
 export function formatDateLong(date) {
-  return moment(date).format('MMMM DD, YYYY');
+  return moment.parseZone(date).format('MMMM DD, YYYY');
 }
 
 export function formatDateWithoutTimeLong(date) {
@@ -120,7 +120,7 @@ export function formatDateWithoutTimeLong(date) {
 }
 
 export function formatDateShort(date) {
-  return moment(date).format('MM/DD/YYYY');
+  return moment.parseZone(date).format('MM/DD/YYYY');
 }
 
 export function formatDateWithoutTimeShort(date) {

--- a/src/js/post-911-gib-status/components/EnrollmentPeriod.jsx
+++ b/src/js/post-911-gib-status/components/EnrollmentPeriod.jsx
@@ -4,7 +4,7 @@ import Scroll from 'react-scroll';
 
 import InfoPair from './InfoPair';
 
-import { formatDateShort, getScrollOptions } from '../../common/utils/helpers';
+import { formatDateParsedZoneShort, getScrollOptions } from '../../common/utils/helpers';
 
 const scroller = Scroll.scroller;
 
@@ -53,7 +53,7 @@ class EnrollmentPeriod extends React.Component {
               <InfoPair label="Type of Change" value={amendment.type}/>
               <InfoPair
                   label="Change Effective Date"
-                  value={formatDateShort(amendment.changeEffectiveDate)}/>
+                  value={formatDateParsedZoneShort(amendment.changeEffectiveDate)}/>
             </div>
           );
         })}
@@ -83,7 +83,7 @@ class EnrollmentPeriod extends React.Component {
 
     return (
       <div id={id}>
-        <h4>{formatDateShort(enrollment.beginDate)} to {formatDateShort(enrollment.endDate)} at <span className="facility">{(enrollment.facilityName || '').toLowerCase()}</span> ({enrollment.facilityCode})</h4>
+        <h4>{formatDateParsedZoneShort(enrollment.beginDate)} to {formatDateParsedZoneShort(enrollment.endDate)} at <span className="facility">{(enrollment.facilityName || '').toLowerCase()}</span> ({enrollment.facilityCode})</h4>
         {yellowRibbonStatus}
         <InfoPair label="On-campus Hours" value={enrollment.onCampusHours}/>
         <InfoPair label="Online Hours" value={enrollment.onlineHours}/>

--- a/src/js/post-911-gib-status/components/EnrollmentPeriod.jsx
+++ b/src/js/post-911-gib-status/components/EnrollmentPeriod.jsx
@@ -4,7 +4,7 @@ import Scroll from 'react-scroll';
 
 import InfoPair from './InfoPair';
 
-import { formatDateWithoutTimeShort, getScrollOptions } from '../../common/utils/helpers';
+import { formatDateShort, getScrollOptions } from '../../common/utils/helpers';
 
 const scroller = Scroll.scroller;
 
@@ -53,7 +53,7 @@ class EnrollmentPeriod extends React.Component {
               <InfoPair label="Type of Change" value={amendment.type}/>
               <InfoPair
                   label="Change Effective Date"
-                  value={formatDateWithoutTimeShort(amendment.changeEffectiveDate)}/>
+                  value={formatDateShort(amendment.changeEffectiveDate)}/>
             </div>
           );
         })}
@@ -83,7 +83,7 @@ class EnrollmentPeriod extends React.Component {
 
     return (
       <div id={id}>
-        <h4>{formatDateWithoutTimeShort(enrollment.beginDate)} to {formatDateWithoutTimeShort(enrollment.endDate)} at <span className="facility">{(enrollment.facilityName || '').toLowerCase()}</span> ({enrollment.facilityCode})</h4>
+        <h4>{formatDateShort(enrollment.beginDate)} to {formatDateShort(enrollment.endDate)} at <span className="facility">{(enrollment.facilityName || '').toLowerCase()}</span> ({enrollment.facilityCode})</h4>
         {yellowRibbonStatus}
         <InfoPair label="On-campus Hours" value={enrollment.onCampusHours}/>
         <InfoPair label="Online Hours" value={enrollment.onlineHours}/>

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import InfoPair from './InfoPair';
 
-import { formatDateShort, formatDateLong } from '../../common/utils/helpers';
+import { formatDateShort, formatDateParsedZoneLong } from '../../common/utils/helpers';
 import {
   formatPercent,
   formatVAFileNumber,
@@ -79,7 +79,7 @@ class UserInfoSection extends React.Component {
           <InfoPair
               label="Date of birth"
               name="dateOfBirth"
-              value={formatDateLong(enrollmentData.dateOfBirth)}
+              value={formatDateParsedZoneLong(enrollmentData.dateOfBirth)}
               additionalClass="section-line"/>
           <InfoPair
               label="VA file number"

--- a/src/js/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/js/post-911-gib-status/components/UserInfoSection.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import InfoPair from './InfoPair';
 
-import { formatDateShort, formatDateWithoutTimeLong } from '../../common/utils/helpers';
+import { formatDateShort, formatDateLong } from '../../common/utils/helpers';
 import {
   formatPercent,
   formatVAFileNumber,
@@ -79,7 +79,7 @@ class UserInfoSection extends React.Component {
           <InfoPair
               label="Date of birth"
               name="dateOfBirth"
-              value={formatDateWithoutTimeLong(enrollmentData.dateOfBirth)}
+              value={formatDateLong(enrollmentData.dateOfBirth)}
               additionalClass="section-line"/>
           <InfoPair
               label="VA file number"

--- a/src/js/post-911-gib-status/utils/helpers.jsx
+++ b/src/js/post-911-gib-status/utils/helpers.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formatDateLong } from '../../common/utils/helpers';
+import { formatDateParsedZoneLong } from '../../common/utils/helpers';
 
 export function formatPercent(percent) {
   let validPercent = undefined;
@@ -73,7 +73,7 @@ export function benefitEndDateExplanation(condition, delimitingDate) {
         <div className="section benefit-end-date">
           <h4>Benefit End Date</h4>
           <div>
-            You have until <strong>{formatDateLong(delimitingDate)}</strong> to use these benefits.
+            You have until <strong>{formatDateParsedZoneLong(delimitingDate)}</strong> to use these benefits.
           </div>
         </div>
       );

--- a/src/js/post-911-gib-status/utils/helpers.jsx
+++ b/src/js/post-911-gib-status/utils/helpers.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formatDateWithoutTimeLong } from '../../common/utils/helpers';
+import { formatDateLong } from '../../common/utils/helpers';
 
 export function formatPercent(percent) {
   let validPercent = undefined;
@@ -73,7 +73,7 @@ export function benefitEndDateExplanation(condition, delimitingDate) {
         <div className="section benefit-end-date">
           <h4>Benefit End Date</h4>
           <div>
-            You have until <strong>{formatDateWithoutTimeLong(delimitingDate)}</strong> to use these benefits.
+            You have until <strong>{formatDateLong(delimitingDate)}</strong> to use these benefits.
           </div>
         </div>
       );

--- a/test/common/utils/helpers.unit.spec.js
+++ b/test/common/utils/helpers.unit.spec.js
@@ -2,7 +2,13 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import moment from 'moment';
 
-import { isActivePage, dateToMoment, dateDiffDesc } from '../../../src/js/common/utils/helpers.js';
+import {
+  isActivePage,
+  dateToMoment,
+  dateDiffDesc,
+  formatDateShort,
+  formatDateLong
+} from '../../../src/js/common/utils/helpers.js';
 
 describe('Helpers unit tests', () => {
   describe('isActivePage', () => {
@@ -108,6 +114,48 @@ describe('Helpers unit tests', () => {
     });
     it('should display time as less than a minute', () => {
       expect(dateDiffDesc(moment(today).add(59, 'seconds'), today)).to.equal('less than a minute');
+    });
+  });
+  describe('formatDateShort', () => {
+    const midnight = '1995-11-12T00:00:00.000+0000';
+    const midnightOffsetNegative1 = '1995-11-12T00:00:00.000-1000';
+    const sixAMOffset0 = '1995-11-12T06:00:00.000+0000';
+    const eightAMOffset0 = '1995-11-12T08:00:00.000+0000';
+    const almostMidnightOffset0 = '1995-11-12T23:59:59.999+0000';
+    const almostMidnightOffsetNegative1 = '1995-11-12T23:59:59.999-1000';
+
+    it('should display the date in the short format', () => {
+      expect(formatDateShort(midnight)).to.equal('11/12/1995');
+    });
+
+    it('should display the date string without regard to the timezone or offset', () => {
+      expect(formatDateShort(midnight)).to.equal('11/12/1995');
+      expect(formatDateShort(midnightOffsetNegative1)).to.equal('11/12/1995');
+      expect(formatDateShort(sixAMOffset0)).to.equal('11/12/1995');
+      expect(formatDateShort(eightAMOffset0)).to.equal('11/12/1995');
+      expect(formatDateShort(almostMidnightOffset0)).to.equal('11/12/1995');
+      expect(formatDateShort(almostMidnightOffsetNegative1)).to.equal('11/12/1995');
+    });
+  });
+  describe('formatDateLong', () => {
+    const midnight = '1995-11-12T00:00:00.000+0000';
+    const midnightOffsetNegative1 = '1995-11-12T00:00:00.000-1000';
+    const sixAMOffset0 = '1995-11-12T06:00:00.000+0000';
+    const eightAMOffset0 = '1995-11-12T08:00:00.000+0000';
+    const almostMidnightOffset0 = '1995-11-12T23:59:59.999+0000';
+    const almostMidnightOffsetNegative1 = '1995-11-12T23:59:59.999-1000';
+
+    it('should display the date in the short format', () => {
+      expect(formatDateLong(midnight)).to.equal('November 12, 1995');
+    });
+
+    it('should display the date string without regard to the timezone or offset', () => {
+      expect(formatDateLong(midnight)).to.equal('November 12, 1995');
+      expect(formatDateLong(midnightOffsetNegative1)).to.equal('November 12, 1995');
+      expect(formatDateLong(sixAMOffset0)).to.equal('November 12, 1995');
+      expect(formatDateLong(eightAMOffset0)).to.equal('November 12, 1995');
+      expect(formatDateLong(almostMidnightOffset0)).to.equal('November 12, 1995');
+      expect(formatDateLong(almostMidnightOffsetNegative1)).to.equal('November 12, 1995');
     });
   });
 });

--- a/test/common/utils/helpers.unit.spec.js
+++ b/test/common/utils/helpers.unit.spec.js
@@ -7,7 +7,9 @@ import {
   dateToMoment,
   dateDiffDesc,
   formatDateShort,
-  formatDateLong
+  formatDateParsedZoneShort,
+  formatDateLong,
+  formatDateParsedZoneLong
 } from '../../../src/js/common/utils/helpers.js';
 
 describe('Helpers unit tests', () => {
@@ -117,6 +119,13 @@ describe('Helpers unit tests', () => {
     });
   });
   describe('formatDateShort', () => {
+    const noon = '1995-11-12T12:00:00.000+0000';
+
+    it('should display the date in the short format', () => {
+      expect(formatDateShort(noon)).to.equal('11/12/1995');
+    });
+  });
+  describe('formatDateParsedZoneShort', () => {
     const midnight = '1995-11-12T00:00:00.000+0000';
     const midnightOffsetNegative1 = '1995-11-12T00:00:00.000-1000';
     const sixAMOffset0 = '1995-11-12T06:00:00.000+0000';
@@ -125,19 +134,26 @@ describe('Helpers unit tests', () => {
     const almostMidnightOffsetNegative1 = '1995-11-12T23:59:59.999-1000';
 
     it('should display the date in the short format', () => {
-      expect(formatDateShort(midnight)).to.equal('11/12/1995');
+      expect(formatDateParsedZoneShort(midnight)).to.equal('11/12/1995');
     });
 
     it('should display the date string without regard to the timezone or offset', () => {
-      expect(formatDateShort(midnight)).to.equal('11/12/1995');
-      expect(formatDateShort(midnightOffsetNegative1)).to.equal('11/12/1995');
-      expect(formatDateShort(sixAMOffset0)).to.equal('11/12/1995');
-      expect(formatDateShort(eightAMOffset0)).to.equal('11/12/1995');
-      expect(formatDateShort(almostMidnightOffset0)).to.equal('11/12/1995');
-      expect(formatDateShort(almostMidnightOffsetNegative1)).to.equal('11/12/1995');
+      expect(formatDateParsedZoneShort(midnight)).to.equal('11/12/1995');
+      expect(formatDateParsedZoneShort(midnightOffsetNegative1)).to.equal('11/12/1995');
+      expect(formatDateParsedZoneShort(sixAMOffset0)).to.equal('11/12/1995');
+      expect(formatDateParsedZoneShort(eightAMOffset0)).to.equal('11/12/1995');
+      expect(formatDateParsedZoneShort(almostMidnightOffset0)).to.equal('11/12/1995');
+      expect(formatDateParsedZoneShort(almostMidnightOffsetNegative1)).to.equal('11/12/1995');
     });
   });
   describe('formatDateLong', () => {
+    const noon = '1995-11-12T12:00:00.000+0000';
+
+    it('should display the date in the short format', () => {
+      expect(formatDateLong(noon)).to.equal('November 12, 1995');
+    });
+  });
+  describe('formatDateParsedZoneLong', () => {
     const midnight = '1995-11-12T00:00:00.000+0000';
     const midnightOffsetNegative1 = '1995-11-12T00:00:00.000-1000';
     const sixAMOffset0 = '1995-11-12T06:00:00.000+0000';
@@ -146,16 +162,16 @@ describe('Helpers unit tests', () => {
     const almostMidnightOffsetNegative1 = '1995-11-12T23:59:59.999-1000';
 
     it('should display the date in the short format', () => {
-      expect(formatDateLong(midnight)).to.equal('November 12, 1995');
+      expect(formatDateParsedZoneLong(midnight)).to.equal('November 12, 1995');
     });
 
     it('should display the date string without regard to the timezone or offset', () => {
-      expect(formatDateLong(midnight)).to.equal('November 12, 1995');
-      expect(formatDateLong(midnightOffsetNegative1)).to.equal('November 12, 1995');
-      expect(formatDateLong(sixAMOffset0)).to.equal('November 12, 1995');
-      expect(formatDateLong(eightAMOffset0)).to.equal('November 12, 1995');
-      expect(formatDateLong(almostMidnightOffset0)).to.equal('November 12, 1995');
-      expect(formatDateLong(almostMidnightOffsetNegative1)).to.equal('November 12, 1995');
+      expect(formatDateParsedZoneLong(midnight)).to.equal('November 12, 1995');
+      expect(formatDateParsedZoneLong(midnightOffsetNegative1)).to.equal('November 12, 1995');
+      expect(formatDateParsedZoneLong(sixAMOffset0)).to.equal('November 12, 1995');
+      expect(formatDateParsedZoneLong(eightAMOffset0)).to.equal('November 12, 1995');
+      expect(formatDateParsedZoneLong(almostMidnightOffset0)).to.equal('November 12, 1995');
+      expect(formatDateParsedZoneLong(almostMidnightOffsetNegative1)).to.equal('November 12, 1995');
     });
   });
 });


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4281

Better fix for the time/timezone problem with DOBs. `moment.parseZone()` goes a step beyond `moment.utc()` by fixing the date instead of converting the date to local or utc time (https://momentjs.com/docs/#/parsing/parse-zone/).

Also added some unit tests with various edge cases to ensure that the correct date is getting rendered every time.