### PR TITLE
Use 'school' for every non-OJT institution.

### DIFF
--- a/src/js/gi/components/profile/HeadingSummary.jsx
+++ b/src/js/gi/components/profile/HeadingSummary.jsx
@@ -65,8 +65,7 @@ class HeadingSummary extends React.Component {
                 On-the-job training
               </IconWithInfo>
               <IconWithInfo icon="institution" present={it.type && it.type !== 'ojt'}>
-                {_.capitalize(it.type)}&nbsp;
-                {it.type === 'for profit' ? 'school' : 'institution'}
+                {_.capitalize(it.type)} school
               </IconWithInfo>
               <IconWithInfo icon="map" present={it.localeType && it.type && it.type !== 'ojt'}>
                 {_.capitalize(it.localeType)} locale


### PR DESCRIPTION
Resolves #5726.