### PR TITLE
Fix search submission corner cases from landing page

### DIFF
--- a/src/js/gi/containers/LandingPage.jsx
+++ b/src/js/gi/containers/LandingPage.jsx
@@ -28,18 +28,20 @@ export class LandingPage extends React.Component {
 
   handleSubmit(event) {
     event.preventDefault();
-    this.search();
+    this.handleFilterChange('name', this.props.autocomplete.searchTerm);
   }
 
-  handleFilterChange() {
+  handleFilterChange(field, value) {
     // Only search upon blur, keyUp, suggestion selection
     // if the search term is not empty.
-    if (this.props.autocomplete.searchTerm) { this.search(); }
+    if (value) {
+      this.search(value);
+    }
   }
 
-  search() {
+  search(value) {
     const query = {
-      name: this.props.autocomplete.searchTerm,
+      name: value,
       version: this.props.location.query.version
     };
 

--- a/test/gibct/containers/LandingPage.unit.spec.js
+++ b/test/gibct/containers/LandingPage.unit.spec.js
@@ -20,7 +20,8 @@ describe('<LandingPage>', () => {
     const props = {
       ...defaultProps,
       router: { push: sinon.spy() },
-      location: { query: {} }
+      location: { query: {} },
+      autocomplete: { searchTerm: 'foo' }
     };
 
     const tree = SkinDeep.shallowRender(<LandingPage {...props}/>);


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3697

Selection of autocomplete suggestion via mouse was not passing params to `handleFilterChange` so it was using the `autocomplete.searchTerm` prop instead (i.e. whatever was in the input box).

Changing the above broke the scenario of typing a string and hitting enter (i.e. not involving autocomplete at all). That case uses the form-level `handleSubmit`, so that too changed to pass the searchTerm to `handleFilterChange`. 