### PR TITLE
Pass duplicate ID test for firefox

### DIFF
--- a/src/js/messaging/components/MoveTo.jsx
+++ b/src/js/messaging/components/MoveTo.jsx
@@ -43,7 +43,7 @@ class MoveTo extends React.Component {
       return (
         <li key={folder.folderId}>
           <MoveToOption
-              folderName={folder.name}
+              folderName={`${folder.name.replace(/\s+/g, '-')}-${this.props.messageId}`}
               folderId={folder.folderId}/>
         </li>
       );

--- a/test/messaging/00-required.e2e.spec.js
+++ b/test/messaging/00-required.e2e.spec.js
@@ -17,7 +17,6 @@ module.exports = E2eHelpers.createE2eTest(
     // Ensure main page (inbox) renders.
     LoginHelpers.logIn(token, client, '/health-care/messaging', 3)
       .waitForElementVisible('body', Timeouts.normal)
-      .axeCheck('.main')
       .assert.title('Send a Secure Message to Your Health Care Team: Vets.gov')
       .waitForElementVisible('#messaging-app', Timeouts.slow);
 
@@ -26,6 +25,7 @@ module.exports = E2eHelpers.createE2eTest(
       .waitForElementVisible('#messaging-content-header', Timeouts.slow)
       .waitForElementPresent('#messaging-folder-controls', Timeouts.normal)
       // Expect messages to show up.
+      .axeCheck('.main')
       .expect.element('.msg-table-list td:nth-of-type(1) a:nth-of-type(1)').text.to.equal('Clinician');
 
     client.click('.msg-table-list td:nth-of-type(1) a:nth-of-type(1)');


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4168

@aub this fix should pass all sauce tests successfully on firefox. I searched for the `dnsrsearch.com` issue in your test logs, and it seems like it may be related to an ISP or local web browser issue causing the test to fail