### PR TITLE
Fix for claims/appeals error msg

### DIFF
--- a/src/js/disability-benefits/containers/YourClaimsPage.jsx
+++ b/src/js/disability-benefits/containers/YourClaimsPage.jsx
@@ -88,7 +88,11 @@ class YourClaimsPage extends React.Component {
   }
 
   renderErrorMessages() {
-    const { appealsAvailable, canAccessAppeals, canAccessClaims, claimsAvailable, claimsAuthorized } = this.props;
+    const { loading, appealsAvailable, canAccessAppeals, canAccessClaims, claimsAvailable, claimsAuthorized } = this.props;
+
+    if (loading) {
+      return null;
+    }
 
     if (canAccessAppeals && canAccessClaims) {
       if (!claimsAvailable && !appealsAvailable) {


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4346
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4358

Adds explicit check to ensure that error messages do not show if app is in a loading state.