### PR TITLE
Increase sauce timeouts

### DIFF
--- a/test/e2e/timeouts.js
+++ b/test/e2e/timeouts.js
@@ -4,8 +4,8 @@ const timeouts = {
 };
 
 if (process.env.SAUCE_ACCESS_KEY) {
-  timeouts.normal = 60000;
-  timeouts.slow = 150000;
+  timeouts.normal = 240000;
+  timeouts.slow = 480000;
 }
 
 module.exports = timeouts;


### PR DESCRIPTION
Related to department-of-veterans-affairs/vets.gov-team#4167

We have specs randomly failing on Sauce due to timeouts because things take forever to render.