### PR TITLE
Create employment history page for 1990

### DIFF
--- a/src/js/common/schemaform/definitions/nonMilitaryJobs.js
+++ b/src/js/common/schemaform/definitions/nonMilitaryJobs.js
@@ -2,6 +2,17 @@ import EmploymentPeriodView from '../../../edu-benefits/components/EmploymentPer
 
 const uiSchema = {
   items: {
+    postMilitaryJob: {
+      'ui:title': 'When did you do this work?',
+      'ui:widget': 'yesNo',
+      'ui:options': {
+        labels: {
+          Y: 'Before military service',
+          N: 'After military service'
+        },
+        yesNoReverse: true
+      }
+    },
     name: {
       'ui:title': 'Main job'
     },

--- a/src/js/edu-benefits/1990-rjsf/config/form.js
+++ b/src/js/edu-benefits/1990-rjsf/config/form.js
@@ -4,12 +4,12 @@ import moment from 'moment';
 import fullSchema1990 from 'vets-json-schema/dist/22-1990-schema.json';
 
 import applicantInformation from '../../../common/schemaform/pages/applicantInformation';
+import employmentHistoryPage from '../../pages/employmentHistory';
 
 import postHighSchoolTrainingsUI from '../../definitions/postHighSchoolTrainings';
 import currentOrPastDateUI from '../../../common/schemaform/definitions/currentOrPastDate';
 import yearUI from '../../../common/schemaform/definitions/year';
 import * as toursOfDuty from '../../definitions/toursOfDuty';
-
 
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
@@ -275,19 +275,9 @@ const formConfig = {
     employmentHistory: {
       title: 'Employment History',
       pages: {
-        employmentHistory: {
-          title: 'Employment history',
-          // There's only one page in this chapter (right?), so this url seems a
-          //  bit heavy-handed.
-          path: 'employment-history/employment-information',
-          uiSchema: {
-          },
-          schema: {
-            type: 'object',
-            properties: {
-            }
-          }
-        }
+        employmentHistory: _.merge(employmentHistoryPage(fullSchema1990), {
+          path: 'employment-history/employment-information'
+        })
       }
     },
     schoolSelection: {

--- a/src/js/edu-benefits/1990e/config/form.js
+++ b/src/js/edu-benefits/1990e/config/form.js
@@ -8,11 +8,11 @@ import GetFormHelp from '../../components/GetFormHelp';
 import createContactInformationPage from '../../pages/contactInformation';
 import createSchoolSelectionPage, { schoolSelectionOptionsFor } from '../../pages/schoolSelection';
 import createDirectDepositPage from '../../pages/directDeposit';
+import employmentHistoryPage from '../../pages/employmentHistory';
 
 import * as address from '../../../common/schemaform/definitions/address';
 import fullNameUISchema from '../../../common/schemaform/definitions/fullName';
 import dateUi from '../../../common/schemaform/definitions/date';
-import nonMilitaryJobsUi from '../../../common/schemaform/definitions/nonMilitaryJobs';
 import postHighSchoolTrainingsUi from '../../definitions/postHighSchoolTrainings';
 import * as personId from '../../../common/schemaform/definitions/personId';
 
@@ -36,7 +36,6 @@ const {
   dateRange,
   educationType,
   fullName,
-  nonMilitaryJobs,
   postHighSchoolTrainings
 } = fullSchema1990e.definitions;
 
@@ -171,26 +170,7 @@ const formConfig = {
     employmentHistory: {
       title: 'Employment History',
       pages: {
-        employmentHistory: {
-          title: 'Employment history',
-          path: 'employment/history',
-          uiSchema: {
-            'view:hasNonMilitaryJobs': {
-              'ui:title': 'Have you ever held a license of journeyman rating (for example, as a contractor or plumber) to practice a profession?',
-              'ui:widget': 'yesNo'
-            },
-            nonMilitaryJobs: _.set(['ui:options', 'expandUnder'], 'view:hasNonMilitaryJobs', nonMilitaryJobsUi)
-          },
-          schema: {
-            type: 'object',
-            properties: {
-              'view:hasNonMilitaryJobs': {
-                type: 'boolean'
-              },
-              nonMilitaryJobs: _.unset('items.properties.postMilitaryJob', nonMilitaryJobs)
-            }
-          }
-        }
+        employmentHistory: employmentHistoryPage(fullSchema1990e, false)
       }
     },
     schoolSelection: {

--- a/src/js/edu-benefits/5490/config/form.js
+++ b/src/js/edu-benefits/5490/config/form.js
@@ -31,7 +31,6 @@ import * as personId from '../../../common/schemaform/definitions/personId';
 
 import dateRangeUi from '../../../common/schemaform/definitions/dateRange';
 import fullNameUi from '../../../common/schemaform/definitions/fullName';
-import nonMilitaryJobsUi from '../../../common/schemaform/definitions/nonMilitaryJobs';
 import GetFormHelp from '../../components/GetFormHelp';
 import postHighSchoolTrainingsUi from '../../definitions/postHighSchoolTrainings';
 
@@ -41,6 +40,7 @@ import applicantInformationPage from '../../../common/schemaform/pages/applicant
 import applicantServicePage from '../../pages/applicantService';
 import createSchoolSelectionPage, { schoolSelectionOptionsFor } from '../../pages/schoolSelection';
 import additionalBenefitsPage from '../../pages/additionalBenefits';
+import employmentHistoryPage from '../../pages/employmentHistory';
 
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
@@ -61,7 +61,6 @@ const {
 } = fullSchema5490.properties;
 
 const {
-  nonMilitaryJobs,
   secondaryContact,
   date,
   dateRange,
@@ -562,26 +561,7 @@ const formConfig = {
     employmentHistory: {
       title: 'Employment History',
       pages: {
-        employmentHistory: {
-          title: 'Employment history',
-          path: 'employment/history',
-          uiSchema: {
-            'view:hasNonMilitaryJobs': {
-              'ui:title': 'Have you ever held a license of journeyman rating (for example, as a contractor or plumber) to practice a profession?',
-              'ui:widget': 'yesNo'
-            },
-            nonMilitaryJobs: _.set(['ui:options', 'expandUnder'], 'view:hasNonMilitaryJobs', nonMilitaryJobsUi)
-          },
-          schema: {
-            type: 'object',
-            properties: {
-              'view:hasNonMilitaryJobs': {
-                type: 'boolean'
-              },
-              nonMilitaryJobs: _.unset('items.properties.postMilitaryJob', nonMilitaryJobs)
-            }
-          }
-        }
+        employmentHistory: employmentHistoryPage(fullSchema5490, false)
       }
     },
     schoolSelection: {

--- a/src/js/edu-benefits/pages/employmentHistory.js
+++ b/src/js/edu-benefits/pages/employmentHistory.js
@@ -1,0 +1,39 @@
+import _ from 'lodash/fp';
+import nonMilitaryJobsUi from '../../common/schemaform/definitions/nonMilitaryJobs';
+
+export default function employmentHistoryPage(schema, usePostMilitaryJob = true) {
+  let nonMilitaryJobs = schema.definitions.nonMilitaryJobs;
+  let jobUISchema = _.set(['ui:options', 'expandUnder'], 'view:hasNonMilitaryJobs', nonMilitaryJobsUi);
+
+  if (!usePostMilitaryJob) {
+    nonMilitaryJobs = _.unset('items.properties.postMilitaryJob', nonMilitaryJobs);
+  } else {
+    jobUISchema = _.set('items.ui:order', [
+      'postMilitaryJob',
+      'name',
+      'months',
+      'licenseOrRating'
+    ], jobUISchema);
+  }
+
+  return {
+    title: 'Employment history',
+    path: 'employment/history',
+    uiSchema: {
+      'view:hasNonMilitaryJobs': {
+        'ui:title': 'Have you ever held a license of journeyman rating (for example, as a contractor or plumber) to practice a profession?',
+        'ui:widget': 'yesNo'
+      },
+      nonMilitaryJobs: jobUISchema
+    },
+    schema: {
+      type: 'object',
+      properties: {
+        'view:hasNonMilitaryJobs': {
+          type: 'boolean'
+        },
+        nonMilitaryJobs
+      }
+    }
+  };
+}

--- a/test/common/schemaform/definitions/nonMilitaryJobs.unit.spec.jsx
+++ b/test/common/schemaform/definitions/nonMilitaryJobs.unit.spec.jsx
@@ -19,7 +19,7 @@ describe('Schemaform definition nonMilitaryJobs', () => {
 
     const inputs = formDOM.querySelectorAll('input');
 
-    expect(inputs.length).to.equal(4);
+    expect(inputs.length).to.equal(5);
   });
 
   it('should add another', () => {

--- a/test/edu-benefits/1990-rjsf/config/employmentHistory.unit.spec.jsx
+++ b/test/edu-benefits/1990-rjsf/config/employmentHistory.unit.spec.jsx
@@ -5,7 +5,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import { DefinitionTester, getFormDOM } from '../../../util/schemaform-utils.jsx';
 import formConfig from '../../../../src/js/edu-benefits/1990e/config/form';
 
-describe('Edu 1990e employmentHistory', () => {
+describe('Edu 1990 employmentHistory', () => {
   const { schema, uiSchema } = formConfig.chapters.employmentHistory.pages.employmentHistory;
   const definitions = formConfig.defaultDefinitions;
   it('should render', () => {

--- a/test/edu-benefits/1990-rjsf/config/employmentHistory.unit.spec.jsx
+++ b/test/edu-benefits/1990-rjsf/config/employmentHistory.unit.spec.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { expect } from 'chai';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import { DefinitionTester } from '../../../util/schemaform-utils.jsx';
+import formConfig from '../../../../src/js/edu-benefits/1990e/config/form';
+
+describe('Edu 1990e employmentHistory', () => {
+  const { schema, uiSchema } = formConfig.chapters.employmentHistory.pages.employmentHistory;
+  const definitions = formConfig.defaultDefinitions;
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}
+          definitions={definitions}/>
+    );
+
+    const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input');
+
+    expect(inputs.length).to.equal(2);
+  });
+});

--- a/test/edu-benefits/1990-rjsf/config/employmentHistory.unit.spec.jsx
+++ b/test/edu-benefits/1990-rjsf/config/employmentHistory.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import { DefinitionTester } from '../../../util/schemaform-utils.jsx';
+import { DefinitionTester, getFormDOM } from '../../../util/schemaform-utils.jsx';
 import formConfig from '../../../../src/js/edu-benefits/1990e/config/form';
 
 describe('Edu 1990e employmentHistory', () => {
@@ -17,8 +17,23 @@ describe('Edu 1990e employmentHistory', () => {
           definitions={definitions}/>
     );
 
-    const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input');
+    const formDOM = getFormDOM(form);
 
-    expect(inputs.length).to.equal(2);
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(2);
+  });
+  it('should show history fields', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}
+          definitions={definitions}/>
+    );
+
+    const formDOM = getFormDOM(form);
+
+    formDOM.setYesNo('#root_view\\:hasNonMilitaryJobsYes', 'Y');
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(5);
   });
 });

--- a/test/edu-benefits/1990e/config/employmentHistory.unit.spec.jsx
+++ b/test/edu-benefits/1990e/config/employmentHistory.unit.spec.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { expect } from 'chai';
 import ReactTestUtils from 'react-dom/test-utils';
 
-import { DefinitionTester } from '../../../util/schemaform-utils.jsx';
-import formConfig from '../../../../src/js/edu-benefits/1990e/config/form';
+import { DefinitionTester, getFormDOM } from '../../../util/schemaform-utils.jsx';
+import formConfig from '../../../../src/js/edu-benefits/1990-rjsf/config/form';
 
-describe('Edu 1990e employmentHistory', () => {
+describe('Edu 1990 employmentHistory', () => {
   const { schema, uiSchema } = formConfig.chapters.employmentHistory.pages.employmentHistory;
   const definitions = formConfig.defaultDefinitions;
   it('should render', () => {
@@ -17,8 +17,23 @@ describe('Edu 1990e employmentHistory', () => {
           definitions={definitions}/>
     );
 
-    const inputs = ReactTestUtils.scryRenderedDOMComponentsWithTag(form, 'input');
+    const formDOM = getFormDOM(form);
 
-    expect(inputs.length).to.equal(2);
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(2);
+  });
+  it('should show history fields', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}
+          definitions={definitions}/>
+    );
+
+    const formDOM = getFormDOM(form);
+
+    formDOM.setYesNo('#root_view\\:hasNonMilitaryJobsYes', 'Y');
+
+    expect(formDOM.querySelectorAll('input,select').length).to.equal(7);
   });
 });


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2818

I also changed the 1990e and 5490 to use the common page I created for this.

The only difference from the current 1990 is an "Employment" header when you expand the jobs list, but since that's not shown on the other two instances of this page, I think it's ok to leave it off.

Old:
![screen shot 2017-08-16 at 11 16 10 am](https://user-images.githubusercontent.com/634932/29371108-7630efa6-8275-11e7-899f-b37816bdb136.png)

New:
![screen shot 2017-08-16 at 11 12 07 am](https://user-images.githubusercontent.com/634932/29370628-f37dd53e-8273-11e7-9d44-314fe97700bb.png)
