### PR TITLE
Add school selection page to 1990

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,6 @@
   "dependencies": {
     "camelcase-keys-recursive": "^0.8.2",
     "reselect": "^2.5.4",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#91379d76189f605d53b9ec810da1171aa4975ea4"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#badd13aa3a754917901d131c6783e61794cbc9e7"
   }
 }

--- a/src/js/edu-benefits/1990-rjsf/config/form.js
+++ b/src/js/edu-benefits/1990-rjsf/config/form.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 import fullSchema1990 from 'vets-json-schema/dist/22-1990-schema.json';
 
 import applicantInformation from '../../../common/schemaform/pages/applicantInformation';
+import createSchoolSelectionPage from '../../pages/schoolSelection';
 
 import postHighSchoolTrainingsUI from '../../definitions/postHighSchoolTrainings';
 import currentOrPastDateUI from '../../../common/schemaform/definitions/currentOrPastDate';
@@ -293,19 +294,16 @@ const formConfig = {
     schoolSelection: {
       title: 'School Selection',
       pages: {
-        schoolSelection: {
-          title: 'School selection',
-          // There's only one page in this chapter (right?), so this url seems a
-          //  bit heavy-handed.
-          path: 'school-selection/school-information',
-          uiSchema: {
-          },
-          schema: {
-            type: 'object',
-            properties: {
-            }
-          }
-        }
+        schoolSelection: _.merge(createSchoolSelectionPage(fullSchema1990, {
+          fields: [
+            'educationProgram',
+            'educationObjective',
+            'educationStartDate'
+          ],
+          required: ['educationType']
+        }), {
+          path: 'school-selection/school-information'
+        })
       }
     },
     personalInformation: {

--- a/test/edu-benefits/1990-rjsf/config/schoolSelection.unit.spec.jsx
+++ b/test/edu-benefits/1990-rjsf/config/schoolSelection.unit.spec.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import { DefinitionTester, getFormDOM } from '../../../util/schemaform-utils.jsx';
+
+import formConfig1990 from '../../../../src/js/edu-benefits/1990-rjsf/config/form';
+
+describe('Edu 1990 schoolSelection', () => {
+  const { schema, uiSchema } = formConfig1990.chapters.schoolSelection.pages.schoolSelection;
+
+  // They should all render
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          data={{}}
+          definitions={formConfig1990.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+
+    const formDOM = getFormDOM(form);
+
+    const inputs = formDOM.querySelectorAll('input, select, textarea');
+
+    expect(inputs.length).to.equal(6);
+  });
+
+  it('should have 1 required input', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          onSubmit={onSubmit}
+          data={{}}
+          definitions={formConfig1990.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = getFormDOM(form);
+    formDOM.submitForm();
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.not.be.true;
+  });
+  it('should reveal address', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+          schema={schema}
+          onSubmit={onSubmit}
+          data={{}}
+          definitions={formConfig1990.defaultDefinitions}
+          uiSchema={uiSchema}/>
+    );
+    const formDOM = getFormDOM(form);
+    formDOM.fillData('#root_educationProgram_educationType', 'college');
+
+    expect(formDOM.querySelectorAll('input,select,textarea').length).to.equal(12);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8315,9 +8315,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#91379d76189f605d53b9ec810da1171aa4975ea4":
-  version "3.0.34"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#91379d76189f605d53b9ec810da1171aa4975ea4"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#badd13aa3a754917901d131c6783e61794cbc9e7":
+  version "3.1.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#badd13aa3a754917901d131c6783e61794cbc9e7"
 
 vinyl-assign@^1.0.1:
   version "1.2.1"


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2819

Adds school selection page. I am matching it to the existing RJSF form school selection page, which means it's slightly different than the 1990 one. There's an issue for Alex T to ask Shay about that. The major difference is that the school name field is conditionally hidden after the education type.

Old:
![screencapture-localhost-3001-education-apply-for-education-benefits-application-1990-school-selection-school-information-1502913582187](https://user-images.githubusercontent.com/634932/29382872-09b44824-829c-11e7-8a08-c240cb665327.png)

New:
![screencapture-localhost-3001-education-apply-for-education-benefits-application-1990-rjsf-school-selection-school-information-1502913557478](https://user-images.githubusercontent.com/634932/29382871-09b3cfb6-829c-11e7-9c93-d5cfeeffe9f2.png)
