### PR TITLE
Handles Incomplete RJSF Forms Better

### DIFF
--- a/src/js/common/schemaform/FormApp.jsx
+++ b/src/js/common/schemaform/FormApp.jsx
@@ -42,12 +42,13 @@ class FormApp extends React.Component {
     }
 
     // If we start in the middle of a form, redirect to the beginning
-    const currentPath = this.props.location.pathname;
+    const currentPath = this.props.currentLocation.pathname;
     const firstPagePath = this.props.routes[this.props.routes.length - 1].pageList[0].path;
     // If we're in production, we'll redirect if we start in the middle of a form
     // In development, we won't redirect unless we append the URL with `?redirect` ()
-    const devRedirect = __BUILDTYPE__ !== 'development' || this.props.location.search.includes('redirect');
+    const devRedirect = __BUILDTYPE__ !== 'development' || this.props.currentLocation.search.includes('redirect');
     if (currentPath !== firstPagePath && devRedirect) {
+      // If the first page is not the intro and uses `depends`, this will probably break
       this.props.router.push(firstPagePath);
     }
   }

--- a/src/js/common/schemaform/FormApp.jsx
+++ b/src/js/common/schemaform/FormApp.jsx
@@ -40,6 +40,16 @@ class FormApp extends React.Component {
     if (window.History) {
       window.History.scrollRestoration = 'manual';
     }
+
+    // If we start in the middle of a form, redirect to the beginning
+    const currentPath = this.props.location.pathname;
+    const firstPagePath = this.props.routes[this.props.routes.length - 1].pageList[0].path;
+    // If we're in production, we'll redirect if we start in the middle of a form
+    // In development, we won't redirect unless we append the URL with `?redirect` ()
+    const devRedirect = __BUILDTYPE__ !== 'development' || this.props.location.search.includes('redirect');
+    if (currentPath !== firstPagePath && devRedirect) {
+      this.props.router.push(firstPagePath);
+    }
   }
 
   componentWillReceiveProps(newProps) {

--- a/src/js/common/schemaform/review/ReviewPage.jsx
+++ b/src/js/common/schemaform/review/ReviewPage.jsx
@@ -37,7 +37,8 @@ class ReviewPage extends React.Component {
       // to be slower than shallow cloning objects
       viewedPages: new Set(
         getPageKeys(props.route.pageList, props.form.data)
-      )
+      ),
+      showValidationWarning: false
     };
   }
 
@@ -99,6 +100,7 @@ class ReviewPage extends React.Component {
     const { isValid, errors } = isValidForm(this.props.form, this.pagesByChapter);
     if (isValid) {
       this.props.submitForm(formConfig, this.props.form);
+      this.setState({ showValidationWarning: false });
     } else {
       // validation errors in this situation are not visible, so we'd
       // like to know if they're common
@@ -112,6 +114,7 @@ class ReviewPage extends React.Component {
             prefix: formConfig.trackingPrefix
           }
         });
+        this.setState({ showValidationWarning: true });
       }
       this.props.setSubmission('hasAttemptedSubmit', true);
     }
@@ -150,6 +153,14 @@ class ReviewPage extends React.Component {
             ))}
           </div>
         </div>
+        {this.state.showValidationWarning && <div className="usa-error-alert">
+          <div className="usa-alert usa-alert-error" role="alert">
+            <div className="usa-alert-body">
+              <p><strong>We’re sorry. Some information in your application is missing or not valid.</strong></p>
+              <p>Please check each section of your application to make sure you’ve filled out all the information that is required.</p>
+            </div>
+          </div>
+        </div>}
         <p><strong>Note:</strong> According to federal law, there are criminal penalties, including a fine and/or imprisonment for up to 5 years, for withholding information or for providing incorrect information. (See 18 U.S.C. 1001)</p>
         <PrivacyAgreement required
             onChange={this.props.setPrivacyAgreement}

--- a/src/js/common/schemaform/review/ReviewPage.jsx
+++ b/src/js/common/schemaform/review/ReviewPage.jsx
@@ -37,8 +37,7 @@ class ReviewPage extends React.Component {
       // to be slower than shallow cloning objects
       viewedPages: new Set(
         getPageKeys(props.route.pageList, props.form.data)
-      ),
-      showValidationWarning: false
+      )
     };
   }
 
@@ -100,7 +99,6 @@ class ReviewPage extends React.Component {
     const { isValid, errors } = isValidForm(this.props.form, this.pagesByChapter);
     if (isValid) {
       this.props.submitForm(formConfig, this.props.form);
-      this.setState({ showValidationWarning: false });
     } else {
       // validation errors in this situation are not visible, so we'd
       // like to know if they're common
@@ -114,7 +112,7 @@ class ReviewPage extends React.Component {
             prefix: formConfig.trackingPrefix
           }
         });
-        this.setState({ showValidationWarning: true });
+        this.props.setSubmission('status', 'validationError');
       }
       this.props.setSubmission('hasAttemptedSubmit', true);
     }
@@ -163,14 +161,6 @@ class ReviewPage extends React.Component {
             onBack={this.goBack}
             onSubmit={this.handleSubmit}
             submission={form.submission}/>
-        {this.state.showValidationWarning && <div className="usa-error-alert">
-          <div className="usa-alert usa-alert-error" role="alert">
-            <div className="usa-alert-body">
-              <p><strong>We’re sorry. Some information in your application is missing or not valid.</strong></p>
-              <p>Please check each section of your application to make sure you’ve filled out all the information that is required.</p>
-            </div>
-          </div>
-        </div>}
       </div>
     );
   }

--- a/src/js/common/schemaform/review/ReviewPage.jsx
+++ b/src/js/common/schemaform/review/ReviewPage.jsx
@@ -153,14 +153,6 @@ class ReviewPage extends React.Component {
             ))}
           </div>
         </div>
-        {this.state.showValidationWarning && <div className="usa-error-alert">
-          <div className="usa-alert usa-alert-error" role="alert">
-            <div className="usa-alert-body">
-              <p><strong>We’re sorry. Some information in your application is missing or not valid.</strong></p>
-              <p>Please check each section of your application to make sure you’ve filled out all the information that is required.</p>
-            </div>
-          </div>
-        </div>}
         <p><strong>Note:</strong> According to federal law, there are criminal penalties, including a fine and/or imprisonment for up to 5 years, for withholding information or for providing incorrect information. (See 18 U.S.C. 1001)</p>
         <PrivacyAgreement required
             onChange={this.props.setPrivacyAgreement}
@@ -171,6 +163,14 @@ class ReviewPage extends React.Component {
             onBack={this.goBack}
             onSubmit={this.handleSubmit}
             submission={form.submission}/>
+        {this.state.showValidationWarning && <div className="usa-error-alert">
+          <div className="usa-alert usa-alert-error" role="alert">
+            <div className="usa-alert-body">
+              <p><strong>We’re sorry. Some information in your application is missing or not valid.</strong></p>
+              <p>Please check each section of your application to make sure you’ve filled out all the information that is required.</p>
+            </div>
+          </div>
+        </div>}
       </div>
     );
   }

--- a/src/js/common/schemaform/review/SubmitButtons.jsx
+++ b/src/js/common/schemaform/review/SubmitButtons.jsx
@@ -44,6 +44,21 @@ export default function SubmitButtons({ submission, onSubmit, onBack, errorMessa
         </div>
       </div>
     );
+  } else if (submission.status === 'validationError') {
+    submitButton = (
+      <ProgressButton
+          onButtonClick={onSubmit}
+          buttonText="Submit Application"
+          buttonClass="usa-button-primary"/>
+    );
+    submitMessage = (
+      <div className="usa-alert usa-alert-error schemaform-failure-alert">
+        <div className="usa-alert-body">
+          <p className="schemaform-warning-header"><strong>We’re sorry. Some information in your application is missing or not valid.</strong></p>
+          <p>Please check each section of your application to make sure you’ve filled out all the information that is required.</p>
+        </div>
+      </div>
+    );
   } else {
     submitMessage = errorMessage
       ? <Message/>

--- a/test/common/schemaform/FormApp.unit.spec.jsx
+++ b/test/common/schemaform/FormApp.unit.spec.jsx
@@ -104,7 +104,7 @@ describe('Schemaform <FormApp>', () => {
 
     expect(tree.everySubTree('LoadingIndicator')).not.to.be.empty;
   });
-  it.only('should route when prefill unfilled', () => {
+  it('should route when prefill unfilled', () => {
     const formConfig = {
       title: 'Testing'
     };
@@ -215,5 +215,43 @@ describe('Schemaform <FormApp>', () => {
     });
 
     expect(router.push.calledWith('/error')).to.be.true;
+  });
+  it('should route to the first page if started in the middle', () => {
+    const formConfig = {
+      title: 'Testing'
+    };
+    const currentLocation = {
+      pathname: 'test',
+      search: ''
+    };
+    const routes = [{
+      pageList: [
+        { path: '/introduction' },
+        { path: currentLocation.pathname }, // You are here
+        { path: '/lastPage' }
+      ]
+    }];
+    const router = {
+      push: sinon.spy()
+    };
+
+    // Only redirects in production or if ?redirect is in the URL
+    const buildType = __BUILDTYPE__;
+    __BUILDTYPE__ = 'production';
+    SkinDeep.shallowRender(
+      <FormApp
+          formConfig={formConfig}
+          routes={routes}
+          router={router}
+          currentLocation={currentLocation}
+          loadedStatus={LOAD_STATUSES.pending}
+          isLoggedIn
+          updateLogInUrl={() => {}}>
+        <div className="child"/>
+      </FormApp>
+    );
+    __BUILDTYPE__ = buildType;
+
+    expect(router.push.calledWith('/introduction')).to.be.true;
   });
 });

--- a/test/common/schemaform/FormApp.unit.spec.jsx
+++ b/test/common/schemaform/FormApp.unit.spec.jsx
@@ -244,9 +244,7 @@ describe('Schemaform <FormApp>', () => {
           routes={routes}
           router={router}
           currentLocation={currentLocation}
-          loadedStatus={LOAD_STATUSES.pending}
-          isLoggedIn
-          updateLogInUrl={() => {}}>
+          loadedStatus={LOAD_STATUSES.pending}>
         <div className="child"/>
       </FormApp>
     );

--- a/test/common/schemaform/FormApp.unit.spec.jsx
+++ b/test/common/schemaform/FormApp.unit.spec.jsx
@@ -10,12 +10,17 @@ describe('Schemaform <FormApp>', () => {
   it('should render children', () => {
     const formConfig = {};
     const currentLocation = {
-      pathname: 'introduction'
+      pathname: 'introduction',
+      search: ''
     };
+    const routes = [{
+      pageList: [{ path: currentLocation.pathname }]
+    }];
 
     const tree = SkinDeep.shallowRender(
       <FormApp
           formConfig={formConfig}
+          routes={routes}
           currentLocation={currentLocation}
           loadedStatus={LOAD_STATUSES.notAttempted}>
         <div className="child"/>
@@ -29,12 +34,17 @@ describe('Schemaform <FormApp>', () => {
   it('should render nav and children', () => {
     const formConfig = {};
     const currentLocation = {
-      pathname: 'test'
+      pathname: 'test',
+      search: ''
     };
+    const routes = [{
+      pageList: [{ path: currentLocation.pathname }]
+    }];
 
     const tree = SkinDeep.shallowRender(
       <FormApp
           formConfig={formConfig}
+          routes={routes}
           currentLocation={currentLocation}
           loadedStatus={LOAD_STATUSES.notAttempted}>
         <div className="child"/>
@@ -49,12 +59,17 @@ describe('Schemaform <FormApp>', () => {
       title: 'Testing'
     };
     const currentLocation = {
-      pathname: 'test'
+      pathname: 'test',
+      search: ''
     };
+    const routes = [{
+      pageList: [{ path: currentLocation.pathname }]
+    }];
 
     const tree = SkinDeep.shallowRender(
       <FormApp
           formConfig={formConfig}
+          routes={routes}
           currentLocation={currentLocation}
           loadedStatus={LOAD_STATUSES.notAttempted}>
         <div className="child"/>
@@ -68,12 +83,17 @@ describe('Schemaform <FormApp>', () => {
       title: 'Testing'
     };
     const currentLocation = {
-      pathname: 'test'
+      pathname: 'test',
+      search: ''
     };
+    const routes = [{
+      pageList: [{ path: currentLocation.pathname }]
+    }];
 
     const tree = SkinDeep.shallowRender(
       <FormApp
           formConfig={formConfig}
+          routes={routes}
           currentLocation={currentLocation}
           loadedStatus={LOAD_STATUSES.pending}
           isLoggedIn
@@ -84,12 +104,13 @@ describe('Schemaform <FormApp>', () => {
 
     expect(tree.everySubTree('LoadingIndicator')).not.to.be.empty;
   });
-  it('should route when prefill unfilled', () => {
+  it.only('should route when prefill unfilled', () => {
     const formConfig = {
       title: 'Testing'
     };
     const currentLocation = {
-      pathname: 'test'
+      pathname: 'test',
+      search: ''
     };
     const routes = [{
       pageList: [{}, {
@@ -103,6 +124,7 @@ describe('Schemaform <FormApp>', () => {
     const tree = SkinDeep.shallowRender(
       <FormApp
           formConfig={formConfig}
+          routes={routes}
           currentLocation={currentLocation}
           loadedStatus={LOAD_STATUSES.pending}
           prefillStatus={PREFILL_STATUSES.pending}
@@ -125,8 +147,12 @@ describe('Schemaform <FormApp>', () => {
       title: 'Testing'
     };
     const currentLocation = {
-      pathname: 'test'
+      pathname: 'test',
+      search: ''
     };
+    const routes = [{
+      pageList: [{ path: currentLocation.pathname }]
+    }];
     const router = {
       push: sinon.spy()
     };
@@ -136,6 +162,7 @@ describe('Schemaform <FormApp>', () => {
     const tree = SkinDeep.shallowRender(
       <FormApp
           formConfig={formConfig}
+          routes={routes}
           currentLocation={currentLocation}
           loadedStatus={LOAD_STATUSES.pending}
           isLoggedIn
@@ -159,8 +186,12 @@ describe('Schemaform <FormApp>', () => {
       title: 'Testing'
     };
     const currentLocation = {
-      pathname: 'test'
+      pathname: 'test',
+      search: ''
     };
+    const routes = [{
+      pageList: [{ path: currentLocation.pathname }]
+    }];
     const router = {
       push: sinon.spy()
     };
@@ -168,6 +199,7 @@ describe('Schemaform <FormApp>', () => {
     const tree = SkinDeep.shallowRender(
       <FormApp
           formConfig={formConfig}
+          routes={routes}
           currentLocation={currentLocation}
           loadedStatus={LOAD_STATUSES.pending}
           isLoggedIn

--- a/test/common/schemaform/review/SubmitButtons.unit.spec.jsx
+++ b/test/common/schemaform/review/SubmitButtons.unit.spec.jsx
@@ -53,6 +53,19 @@ describe('Schemaform review: <SubmitButtons>', () => {
     expect(tree.everySubTree('.usa-alert-error')).not.to.be.empty;
     expect(tree.everySubTree('a').length).to.equal(2);
   });
+  it('should render validation error', () => {
+    const submission = {
+      status: 'validationError'
+    };
+    const tree = SkinDeep.shallowRender(
+      <SubmitButtons
+          submission={submission}/>
+    );
+
+    // Make sure it displays an error--and the right one
+    expect(tree.everySubTree('.usa-alert-error')[0].text()).to.contain('Some information in your application is missing or not valid');
+    expect(tree.everySubTree('ProgressButton').length).to.equal(2);
+  });
   it('should render error in prod mode', () => {
     const submission = {
       status: 'error'


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4286

When we enter a page in the middle of a form, it redirects us back to the introduction page (technically, the first page, but that's the intro, so :man_shrugging:). It doesn't redirect us back if we're in development, but we can recreate the functionality for testing purposes by appending the URL with `?redirect`.

![image](https://user-images.githubusercontent.com/12970166/29420720-a6ebcf3c-8327-11e7-940f-67930513b12e.png)
