### PR TITLE
Ensure prebuild script runs on Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "node script/build.js",
     "prebuild": "node script/prebuild.js",
     "heroku-serve": "http-server",
-    "heroku-postbuild": "node script/build.js --entry no-react,style",
+    "heroku-postbuild": "npm run build --  --entry no-react,style",
     "lint": "npm run lint:js && npm run lint:sass",
     "lint:changed": "npm run lint:js:changed && npm run lint:sass",
     "lint:js": "eslint --quiet --ext .js --ext .jsx .",

--- a/script/prebuild.js
+++ b/script/prebuild.js
@@ -3,8 +3,6 @@ const fs = require('fs');
 const path = require('path');
 const minimumNodeVersion = '6.11.1';
 
-console.log("In Prebuild")
-
 if (!(process.env.INSTALL_HOOKS === 'no')) {
   // Make sure git pre-commit hooks are installed
   ['pre-commit'].forEach(hook => {

--- a/script/prebuild.js
+++ b/script/prebuild.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const minimumNodeVersion = '6.11.1';
 
+console.log("In Prebuild")
+
 if (!(process.env.INSTALL_HOOKS === 'no')) {
   // Make sure git pre-commit hooks are installed
   ['pre-commit'].forEach(hook => {


### PR DESCRIPTION
Heroku builds currently invoke the build.js script directly, which I believe bypasses the NPM pre- and post- script hooks.

Items currently in `prebuild.js` are not needed for Heroku builds so they're working fine. But if that changes, will want to be sure it gets picked up.

- [X] confirm current setup is skipping `prebuild.js` on Heroku
- [X] Confirm the fix runs prebuild