### PR TITLE
Fix bug with HCA array items

### DIFF
--- a/src/js/common/schemaform/review/ArrayField.jsx
+++ b/src/js/common/schemaform/review/ArrayField.jsx
@@ -39,6 +39,20 @@ class ArrayField extends React.Component {
     this.isLocked = this.isLocked.bind(this);
   }
 
+  componentWillReceiveProps(newProps) {
+    if (newProps.arrayData !== this.props.arrayData) {
+      const arrayData = Array.isArray(newProps.arrayData) ? newProps.arrayData : [];
+      const newState = {
+        items: arrayData
+      };
+      if (arrayData.length !== this.state.items.length) {
+        newState.editing = arrayData.map(() => false);
+      }
+
+      this.setState(newState);
+    }
+  }
+
   getItemSchema(index) {
     const schema = this.props.schema;
     if (schema.items.length > index) {

--- a/src/js/hca/definitions/child.js
+++ b/src/js/hca/definitions/child.js
@@ -100,7 +100,7 @@ export const uiSchema = {
     'ui:options': {
       // Not being invoked until the data is changed...which means this is open
       //  by default
-      hideIf: (formData, index) => formData.children[index].childCohabitedLastYear !== false
+      hideIf: (formData, index) => _.get(`formData.children[${index}].childCohabitedLastYear`) !== false
     }
   },
 };

--- a/src/js/hca/definitions/child.js
+++ b/src/js/hca/definitions/child.js
@@ -100,7 +100,7 @@ export const uiSchema = {
     'ui:options': {
       // Not being invoked until the data is changed...which means this is open
       //  by default
-      hideIf: (formData, index) => _.get(`formData.children[${index}].childCohabitedLastYear`) !== false
+      hideIf: (formData, index) => _.get(`children[${index}].childCohabitedLastYear`, formData) !== false
     }
   },
 };

--- a/test/common/schemaform/review/ArrayField.unit.spec.jsx
+++ b/test/common/schemaform/review/ArrayField.unit.spec.jsx
@@ -1,3 +1,4 @@
+import _ from 'lodash/fp';
 import React from 'react';
 import { expect } from 'chai';
 import SkinDeep from 'skin-deep';
@@ -229,5 +230,54 @@ describe('Schemaform review <ArrayField>', () => {
       tree.subTree('SchemaForm').props.onChange({ test: 1 });
       expect(setData.calledWith({ thingList: [{ test: 1 }] })).to.be.true;
     });
+  });
+  it('should update state when props change', () => {
+    const idSchema = {};
+    const schema = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string'
+          }
+        }
+      }
+    };
+    const uiSchema = {
+      'ui:title': 'List of things',
+      items: {
+      },
+      'ui:options': {
+        viewField: f => f
+      }
+    };
+    const arrayData = [{
+      testing: 1
+    }];
+    const tree = SkinDeep.shallowRender(
+      <ArrayField
+          pageKey="page1"
+          arrayData={arrayData}
+          path={['thingList']}
+          schema={schema}
+          uiSchema={uiSchema}
+          idSchema={idSchema}
+          registry={registry}
+          formContext={formContext}
+          pageTitle=""
+          requiredSchema={requiredSchema}/>
+    );
+
+    const instance = tree.getMountedInstance();
+
+    const newProps = _.assign(instance.props, {
+      arrayData: []
+    });
+
+    instance.componentWillReceiveProps(newProps);
+
+    expect(instance.state.items).to.eql(newProps.arrayData);
+    expect(instance.state.editing).to.eql([]);
   });
 });


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4410

I can't reproduce the above error directly, but I think it's due to the fact that the review version of `ArrayField` doesn't account for array data changing outside of itself, which is a possibility. You can see that cause problems by changing the number of children on the HCA review page, then trying to edit their financial info. It jumps back to the old version that's in `ArrayField`'s state.

In addition, I made the `hideIf` function that's erroring to use `_.get`, so it won't throw an error now anyway.