### PR TITLE
Upgrade node-sass version to meet USWDS requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "morgan": "^1.7.0",
     "nightwatch": "^0.9.16",
     "node-fetch": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.5.3.tgz",
-    "node-sass": "^3.10.1",
+    "node-sass": "3.4.2",
     "null-loader": "^0.1.1",
     "nyc": "^11.1.0",
     "polyfill-function-prototype-bind": "0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5866,7 +5866,25 @@ node-pre-gyp@^0.6.29, node-pre-gyp@~0.6.32:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-sass@^3.10.1, node-sass@^3.4:
+node-sass@3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-3.4.2.tgz#ef61069927f1578ae51408ed60298449c4cdd294"
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^2.0.0"
+    gaze "^0.5.1"
+    get-stdin "^4.0.1"
+    glob "^5.0.14"
+    meow "^3.3.0"
+    mkdirp "^0.5.1"
+    nan "^2.0.8"
+    node-gyp "^3.0.1"
+    npmconf "^2.1.2"
+    request "^2.61.0"
+    sass-graph "^2.0.1"
+
+node-sass@^3.4:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-3.13.1.tgz#7240fbbff2396304b4223527ed3020589c004fc2"
   dependencies:


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1463

No errors encountered when upgrading.