### PR TITLE
Fixes the sentry error

### DIFF
--- a/src/js/common/schemaform/FormApp.jsx
+++ b/src/js/common/schemaform/FormApp.jsx
@@ -61,7 +61,7 @@ class FormApp extends React.Component {
       newProps.setFetchFormStatus(LOAD_STATUSES.notAttempted);
     } else if (newProps.prefillStatus !== this.props.prefillStatus
       && newProps.prefillStatus === PREFILL_STATUSES.unfilled) {
-      newProps.router.push(newProps.routes[newProps.routes.length - 1].pageList[1].path);
+      newProps.router.push(newProps.routes[0].childRoutes[0].pageList[0].path);
     } else if (status !== LOAD_STATUSES.notAttempted
       && status !== LOAD_STATUSES.pending
       && status !== this.props.loadedStatus

--- a/src/js/common/schemaform/FormApp.jsx
+++ b/src/js/common/schemaform/FormApp.jsx
@@ -43,7 +43,7 @@ class FormApp extends React.Component {
 
     // If we start in the middle of a form, redirect to the beginning
     const currentPath = this.props.currentLocation.pathname;
-    const firstPagePath = this.props.routes[this.props.routes.length - 1].pageList[0].path;
+    const firstPagePath = this.props.routes[0].childRoutes[0].pageList[0].path;
     // If we're in production, we'll redirect if we start in the middle of a form
     // In development, we won't redirect unless we append the URL with `?redirect` ()
     const devRedirect = __BUILDTYPE__ !== 'development' || this.props.currentLocation.search.includes('redirect');

--- a/src/js/common/schemaform/FormApp.jsx
+++ b/src/js/common/schemaform/FormApp.jsx
@@ -42,12 +42,11 @@ class FormApp extends React.Component {
     }
 
     // If we start in the middle of a form, redirect to the beginning
-    const currentPath = this.props.currentLocation.pathname;
-    const firstPagePath = this.props.routes[0].childRoutes[0].pageList[0].path;
     // If we're in production, we'll redirect if we start in the middle of a form
     // In development, we won't redirect unless we append the URL with `?redirect` ()
     const devRedirect = __BUILDTYPE__ !== 'development' || this.props.currentLocation.search.includes('redirect');
-    if (currentPath !== firstPagePath && devRedirect) {
+    if (isInProgress(this.props.currentLocation.pathname) && devRedirect) {
+      const firstPagePath = this.props.routes[this.props.routes.length - 1].pageList[0].path;
       // If the first page is not the intro and uses `depends`, this will probably break
       this.props.router.push(firstPagePath);
     }
@@ -61,7 +60,7 @@ class FormApp extends React.Component {
       newProps.setFetchFormStatus(LOAD_STATUSES.notAttempted);
     } else if (newProps.prefillStatus !== this.props.prefillStatus
       && newProps.prefillStatus === PREFILL_STATUSES.unfilled) {
-      newProps.router.push(newProps.routes[0].childRoutes[0].pageList[0].path);
+      newProps.router.push(newProps.routes[this.props.routes.length - 1].pageList[0].path);
     } else if (status !== LOAD_STATUSES.notAttempted
       && status !== LOAD_STATUSES.pending
       && status !== this.props.loadedStatus

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -42,7 +42,8 @@ export function groupPagesIntoChapters(routes, prefix = '') {
   });
 }
 
-export function isInProgress(trimmedPathname) {
+export function isInProgress(pathName) {
+  const trimmedPathname = pathName.replace(/\/$/, '');
   return !(
     trimmedPathname.endsWith('introduction')
     || trimmedPathname.endsWith('confirmation')

--- a/test/common/schemaform/FormApp.unit.spec.jsx
+++ b/test/common/schemaform/FormApp.unit.spec.jsx
@@ -14,7 +14,9 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      pageList: [{ path: currentLocation.pathname }]
+      childRoutes: [{
+        pageList: [{ path: currentLocation.pathname }]
+      }]
     }];
 
     const tree = SkinDeep.shallowRender(
@@ -38,7 +40,9 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      pageList: [{ path: currentLocation.pathname }]
+      childRoutes: [{
+        pageList: [{ path: currentLocation.pathname }]
+      }]
     }];
 
     const tree = SkinDeep.shallowRender(
@@ -63,7 +67,9 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      pageList: [{ path: currentLocation.pathname }]
+      childRoutes: [{
+        pageList: [{ path: currentLocation.pathname }]
+      }]
     }];
 
     const tree = SkinDeep.shallowRender(
@@ -87,7 +93,9 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      pageList: [{ path: currentLocation.pathname }]
+      childRoutes: [{
+        pageList: [{ path: currentLocation.pathname }]
+      }]
     }];
 
     const tree = SkinDeep.shallowRender(
@@ -113,8 +121,10 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      pageList: [{}, {
-        path: 'test-path'
+      childRoutes: [{
+        pageList: [{
+          path: 'test-path'
+        }]
       }]
     }];
     const router = {
@@ -151,7 +161,9 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      pageList: [{ path: currentLocation.pathname }]
+      childRoutes: [{
+        pageList: [{ path: currentLocation.pathname }]
+      }]
     }];
     const router = {
       push: sinon.spy()
@@ -190,7 +202,9 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      pageList: [{ path: currentLocation.pathname }]
+      childRoutes: [{
+        pageList: [{ path: currentLocation.pathname }]
+      }]
     }];
     const router = {
       push: sinon.spy()
@@ -225,11 +239,13 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      pageList: [
-        { path: '/introduction' },
-        { path: currentLocation.pathname }, // You are here
-        { path: '/lastPage' }
-      ]
+      childRoutes: [{
+        pageList: [
+          { path: '/introduction' },
+          { path: currentLocation.pathname }, // You are here
+          { path: '/lastPage' }
+        ]
+      }]
     }];
     const router = {
       push: sinon.spy()

--- a/test/common/schemaform/FormApp.unit.spec.jsx
+++ b/test/common/schemaform/FormApp.unit.spec.jsx
@@ -14,9 +14,7 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      childRoutes: [{
-        pageList: [{ path: currentLocation.pathname }]
-      }]
+      pageList: [{ path: currentLocation.pathname }]
     }];
 
     const tree = SkinDeep.shallowRender(
@@ -40,9 +38,7 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      childRoutes: [{
-        pageList: [{ path: currentLocation.pathname }]
-      }]
+      pageList: [{ path: currentLocation.pathname }]
     }];
 
     const tree = SkinDeep.shallowRender(
@@ -67,9 +63,7 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      childRoutes: [{
-        pageList: [{ path: currentLocation.pathname }]
-      }]
+      pageList: [{ path: currentLocation.pathname }]
     }];
 
     const tree = SkinDeep.shallowRender(
@@ -93,9 +87,7 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      childRoutes: [{
-        pageList: [{ path: currentLocation.pathname }]
-      }]
+      pageList: [{ path: currentLocation.pathname }]
     }];
 
     const tree = SkinDeep.shallowRender(
@@ -121,10 +113,8 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      childRoutes: [{
-        pageList: [{
-          path: 'test-path'
-        }]
+      pageList: [{
+        path: 'test-path'
       }]
     }];
     const router = {
@@ -161,9 +151,7 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      childRoutes: [{
-        pageList: [{ path: currentLocation.pathname }]
-      }]
+      pageList: [{ path: currentLocation.pathname }]
     }];
     const router = {
       push: sinon.spy()
@@ -202,9 +190,7 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      childRoutes: [{
-        pageList: [{ path: currentLocation.pathname }]
-      }]
+      pageList: [{ path: currentLocation.pathname }]
     }];
     const router = {
       push: sinon.spy()
@@ -239,13 +225,11 @@ describe('Schemaform <FormApp>', () => {
       search: ''
     };
     const routes = [{
-      childRoutes: [{
-        pageList: [
-          { path: '/introduction' },
-          { path: currentLocation.pathname }, // You are here
-          { path: '/lastPage' }
-        ]
-      }]
+      pageList: [
+        { path: '/introduction' },
+        { path: currentLocation.pathname }, // You are here
+        { path: '/lastPage' }
+      ]
     }];
     const router = {
       push: sinon.spy()


### PR DESCRIPTION
There was a problem with refreshing on the confirmation page. We were getting a lot of `Cannot read property '0' of undefined` because the confirmation page wasn't passed `pageList`. This references the first page's `childRoutes` to get the path. It's a bit convoluted, but should be okay.