### PR TITLE
Letters error message update

### DIFF
--- a/src/js/letters/components/DownloadLetterLink.jsx
+++ b/src/js/letters/components/DownloadLetterLink.jsx
@@ -116,4 +116,3 @@ const mapDispatchToProps = {
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(DownloadLetterLink);
-

--- a/src/js/letters/components/LetterList.jsx
+++ b/src/js/letters/components/LetterList.jsx
@@ -12,34 +12,18 @@ class LetterList extends React.Component {
     const downloadStatus = this.props.letterDownloadStatus;
     const letterItems = (this.props.letters || []).map((letter, index) => {
       let content;
-
+      let bslHelpInstructions;
       if (letter.letterType === 'benefit_summary') {
-        content = (
-          <div>
-            <VeteranBenefitSummaryLetter/>
-            <DownloadLetterLink
-                letterType={letter.letterType}
-                letterName={letter.name}
-                downloadStatus={downloadStatus[letter.letterType]}
-                key={`download-link-${index}`}/>
-            <p>
-              If your service period or disability status information is incorrect, please send us
-              a message through VA’s <a target="_blank" href="https://iris.custhelp.com/app/ask">
-              Inquiry Routing & Information System (IRIS)</a>. VA will respond within 5 business days.
-            </p>
-          </div>
+        content = (<VeteranBenefitSummaryLetter/>);
+        bslHelpInstructions = (
+          <p>
+            If your service period or disability status information is incorrect, please send us
+            a message through VA’s <a target="_blank" href="https://iris.custhelp.com/app/ask">
+            Inquiry Routing & Information System (IRIS)</a>. VA will respond within 5 business days.
+          </p>
         );
       } else {
-        content = (
-          <div>
-            <div>{letterContent[letter.letterType] || ''}</div>
-            <DownloadLetterLink
-                letterType={letter.letterType}
-                letterName={letter.name}
-                downloadStatus={downloadStatus[letter.letterType]}
-                key={`download-link-${index}`}/>
-          </div>
-        );
+        content = letterContent[letter.letterType] || '';
       }
 
       return (
@@ -47,6 +31,12 @@ class LetterList extends React.Component {
           panelName={letter.name}
           key={`collapsiblePanel-${index}`}>
           <div>{content}</div>
+          <DownloadLetterLink
+            letterType={letter.letterType}
+            letterName={letter.name}
+            downloadStatus={downloadStatus[letter.letterType]}
+            key={`download-link-${index}`}/>
+          <div>{bslHelpInstructions}</div>
         </CollapsiblePanel>
       );
     });

--- a/src/js/letters/components/LetterList.jsx
+++ b/src/js/letters/components/LetterList.jsx
@@ -16,7 +16,16 @@ class LetterList extends React.Component {
       if (letter.letterType === 'benefit_summary') {
         content = (<VeteranBenefitSummaryLetter/>);
       } else {
-        content = letterContent[letter.letterType] || '';
+        content = (
+          <div>
+            <div>{letterContent[letter.letterType] || ''}</div>
+            <DownloadLetterLink
+                letterType={letter.letterType}
+                letterName={letter.name}
+                downloadStatus={downloadStatus[letter.letterType]}
+                key={`download-link-${index}`}/>
+          </div>
+        );
       }
 
       return (
@@ -24,11 +33,6 @@ class LetterList extends React.Component {
           panelName={letter.name}
           key={`collapsiblePanel-${index}`}>
           <div>{content}</div>
-          <DownloadLetterLink
-            letterType={letter.letterType}
-            letterName={letter.name}
-            downloadStatus={downloadStatus[letter.letterType]}
-            key={`download-link-${index}`}/>
         </CollapsiblePanel>
       );
     });
@@ -38,11 +42,10 @@ class LetterList extends React.Component {
       eligibilityMessage = (
         <div className="usa-alert usa-alert-warning">
           <div className="usa-alert-body">
-            <h2 className="usa-alert-heading">Letters may be unavailable</h2>
+            <h2 className="usa-alert-heading">Some letters may not be available</h2>
             <p className="usa-alert-text">
-              Our system is temporarily down. If you believe you're missing
-              a letter or document from this list, please try again later,
-              or call:
+              One of our systems appears to be down. If you believe you are missing a
+              letter or document from the list above, please try again later.
             </p>
             <ul>
               <li><a href="tel:888-888-8888">888-888-8888</a> for health-related documents</li>

--- a/src/js/letters/components/LetterList.jsx
+++ b/src/js/letters/components/LetterList.jsx
@@ -14,7 +14,21 @@ class LetterList extends React.Component {
       let content;
 
       if (letter.letterType === 'benefit_summary') {
-        content = (<VeteranBenefitSummaryLetter/>);
+        content = (
+          <div>
+            <VeteranBenefitSummaryLetter/>
+            <DownloadLetterLink
+                letterType={letter.letterType}
+                letterName={letter.name}
+                downloadStatus={downloadStatus[letter.letterType]}
+                key={`download-link-${index}`}/>
+            <p>
+              If your service period or disability status information is incorrect, please send us
+              a message through VA’s <a target="_blank" href="https://iris.custhelp.com/app/ask">
+              Inquiry Routing & Information System (IRIS)</a>. VA will respond within 5 business days.
+            </p>
+          </div>
+        );
       } else {
         content = (
           <div>

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import DownloadLetterLink from '../components/DownloadLetterLink';
+
 import { updateBenefitSummaryRequestOption } from '../actions/letters';
 import {
   benefitOptionsMap,
@@ -149,10 +151,16 @@ export class VeteranBenefitSummaryLetter extends React.Component {
           Please choose what information you want to include in your letter.
         </p>
         {vaBenefitInformation}
+        <DownloadLetterLink
+            letterType="benefit_summary"
+            letterName="Benefit Summary Letter"
+            downloadStatus={this.props.letterDownloadStatus.benefit_summary}
+            key="download-link-bsl"/>
         <p>
-          If your service period or disability status information is incorrect, please send us a message through VA’s <a target="_blank" href="https://iris.custhelp.com/app/ask">Inquiry Routing & Information System (IRIS)</a>. VA will respond within 5 business days.
+          If your service period or disability status information is incorrect, please send us
+          a message through VA’s <a target="_blank" href="https://iris.custhelp.com/app/ask">
+          Inquiry Routing & Information System (IRIS)</a>. VA will respond within 5 business days.
         </p>
-
       </div>
     );
   }
@@ -166,7 +174,8 @@ function mapStateToProps(state) {
       serviceInfo: letterState.serviceInfo
     },
     optionsAvailable: letterState.optionsAvailable,
-    requestOptions: letterState.requestOptions
+    requestOptions: letterState.requestOptions,
+    letterDownloadStatus: letterState.letterDownloadStatus
   };
 }
 

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -2,8 +2,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import DownloadLetterLink from '../components/DownloadLetterLink';
-
 import { updateBenefitSummaryRequestOption } from '../actions/letters';
 import {
   benefitOptionsMap,
@@ -151,16 +149,6 @@ export class VeteranBenefitSummaryLetter extends React.Component {
           Please choose what information you want to include in your letter.
         </p>
         {vaBenefitInformation}
-        <DownloadLetterLink
-            letterType="benefit_summary"
-            letterName="Benefit Summary Letter"
-            downloadStatus={this.props.letterDownloadStatus.benefit_summary}
-            key="download-link-bsl"/>
-        <p>
-          If your service period or disability status information is incorrect, please send us
-          a message through VA’s <a target="_blank" href="https://iris.custhelp.com/app/ask">
-          Inquiry Routing & Information System (IRIS)</a>. VA will respond within 5 business days.
-        </p>
       </div>
     );
   }
@@ -174,8 +162,7 @@ function mapStateToProps(state) {
       serviceInfo: letterState.serviceInfo
     },
     optionsAvailable: letterState.optionsAvailable,
-    requestOptions: letterState.requestOptions,
-    letterDownloadStatus: letterState.letterDownloadStatus
+    requestOptions: letterState.requestOptions
   };
 }
 

--- a/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
+++ b/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
@@ -7,6 +7,7 @@ import { expect } from 'chai';
 import _ from 'lodash/fp';
 
 import { VeteranBenefitSummaryLetter } from '../../../src/js/letters/containers/VeteranBenefitSummaryLetter';
+import { DownloadLetterLink } from '../../../src/js/letters/components/DownloadLetterLink';
 
 import reducer from '../../../src/js/letters/reducers/index.js';
 import createCommonStore from '../../../src/js/common/store';
@@ -55,11 +56,19 @@ describe('<VeteranBenefitSummaryLetter>', () => {
     expect(tree.dive(['div', 'div', '#militaryService'])).not.to.be.empty;
   });
 
-  it('should update request option when checked', () => {
+  it.only('should update request option when checked', () => {
     const updateOption = sinon.spy();
     const props = _.set('updateBenefitSummaryRequestOption', updateOption, defaultProps);
     const component = ReactTestUtils.renderIntoDocument(
-      <VeteranBenefitSummaryLetter store={store} {...props}/>);
+      <VeteranBenefitSummaryLetter store={store} {...props}>
+        <DownloadLetterLink
+            letterType="benefit_summary"
+            letterName="Benefit Summary Letter"
+            downloadStatus="pending"
+            store={store}/>
+      </VeteranBenefitSummaryLetter>
+    );
+
     const formDOM = findDOMNode(component);
     const inputs = formDOM.querySelectorAll('input');
     expect(inputs.length).to.equal(3);

--- a/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
+++ b/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
@@ -7,7 +7,6 @@ import { expect } from 'chai';
 import _ from 'lodash/fp';
 
 import { VeteranBenefitSummaryLetter } from '../../../src/js/letters/containers/VeteranBenefitSummaryLetter';
-import { DownloadLetterLink } from '../../../src/js/letters/components/DownloadLetterLink';
 
 import reducer from '../../../src/js/letters/reducers/index.js';
 import createCommonStore from '../../../src/js/common/store';
@@ -30,8 +29,7 @@ const defaultProps = {
     ]
   },
   optionsAvailable: true,
-  requestOptions: {},
-  letterDownloadStatus: {}
+  requestOptions: {}
 };
 
 describe('<VeteranBenefitSummaryLetter>', () => {
@@ -56,17 +54,11 @@ describe('<VeteranBenefitSummaryLetter>', () => {
     expect(tree.dive(['div', 'div', '#militaryService'])).not.to.be.empty;
   });
 
-  it.only('should update request option when checked', () => {
+  it('should update request option when checked', () => {
     const updateOption = sinon.spy();
     const props = _.set('updateBenefitSummaryRequestOption', updateOption, defaultProps);
     const component = ReactTestUtils.renderIntoDocument(
-      <VeteranBenefitSummaryLetter store={store} {...props}>
-        <DownloadLetterLink
-            letterType="benefit_summary"
-            letterName="Benefit Summary Letter"
-            downloadStatus="pending"
-            store={store}/>
-      </VeteranBenefitSummaryLetter>
+      <VeteranBenefitSummaryLetter store={store} {...props}/>
     );
 
     const formDOM = findDOMNode(component);

--- a/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
+++ b/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
@@ -29,8 +29,8 @@ const defaultProps = {
     ]
   },
   optionsAvailable: true,
-  requestOptions: {
-  }
+  requestOptions: {},
+  letterDownloadStatus: {}
 };
 
 describe('<VeteranBenefitSummaryLetter>', () => {


### PR DESCRIPTION
Connects  to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4430
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4433

Decided to tackle 2 tickets in this PR because they both seemed small. Moving the IRIS content below the download letter button for the benefit summary letter (4433) turned out to be more complicated than I initially realized. The code in BSL had the download letter button always at the very end of the content, which means if I wanted to render it any other way I would have to refactor this.

There were 2 ways to handle this:
1. Importing `DownloadLetterLink` in `VeteranBenefitSummaryLetter`, so that I could place it in the middle of the content. This created an issue with one of the unit tests failing (something with the fact that `DownloadLetterLink` is a connected component and needs access to the store. When trying to render the whole component tree for the `VeteranBenefitSummaryLetter` unit test, since `DownloadLetterLink` is one of its children, it would fail saying `DownloadLetterLink` didn't have access to the store, even when I explicitly passed the store to it. This was the failure message I got: `Invariant Violation: Could not find "store" in either the context or props of "Connect(DownloadLetterLink)". Either wrap the root component in a <Provider>, or explicitly pass "store" as a prop to "Connect(DownloadLetterLink)"`. I couldn't figure out how to fix it, after trying several things).

So instead I did something hacky where I have the preliminary content for `VeteranBenefitSummaryLetter` in that component, then in `LetterList` I do the following:
```
<VeteranBenefitSummaryLetter/>
<DownloadLetterLink/>
<p>IRIS message content</p>
```

Not great because what this means is that all the content that's needed for the `VeteranBenefitSummaryLetter` is no longer contained within it, but it was the best way I could figure out without breaking tests.

Would love feedback on this, either on the solution or how to get that unit test to pass.

This is what is looked like before:
<img width="794" alt="screen shot 2017-08-21 at 5 18 47 pm" src="https://user-images.githubusercontent.com/25183456/29573686-a5812c00-872d-11e7-8224-cfd8c20ed221.png">

This is what it looked like after:
<img width="857" alt="screen shot 2017-08-21 at 4 54 18 pm" src="https://user-images.githubusercontent.com/25183456/29573704-af793266-872d-11e7-835e-6cff1d2e9202.png">
