### PR TITLE
Fixed folder names in dropdown menu

### DIFF
--- a/src/js/messaging/components/MoveTo.jsx
+++ b/src/js/messaging/components/MoveTo.jsx
@@ -43,8 +43,9 @@ class MoveTo extends React.Component {
       return (
         <li key={folder.folderId}>
           <MoveToOption
-            folderName={`${folder.name.replace(/\s+/g, '-')}-${this.props.messageId}`}
-            folderId={folder.folderId}/>
+            folderName={folder.name}
+            folderId={folder.folderId}
+            messageId={this.props.messageId}/>
         </li>
       );
     });

--- a/src/js/messaging/components/MoveToOption.jsx
+++ b/src/js/messaging/components/MoveToOption.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 
 class MoveToOption extends React.Component {
   render() {
-    const folderHtmlId = `msg-move-${this.props.messageId}-${this.props.folderId}`;
+    const { folderName, folderId, messageId } = this.props;
+    const folderHtmlId = `msg-move-${messageId}-${folderId}`;
 
     return (
       <div>
@@ -12,10 +13,10 @@ class MoveToOption extends React.Component {
           name="messagingMoveToFolder"
           type="radio"
           id={folderHtmlId}
-          value={this.props.folderId}/>
+          value={folderId}/>
         <label
           className="msg-move-to-label"
-          htmlFor={folderHtmlId}>{this.props.folderName}</label>
+          htmlFor={folderHtmlId}>{folderName}</label>
       </div>
     );
   }

--- a/src/js/messaging/components/MoveToOption.jsx
+++ b/src/js/messaging/components/MoveToOption.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 
 class MoveToOption extends React.Component {
   render() {
-    const folderHtmlId = `msg-move-to-${this.props.folderName}`;
+    const folderHtmlId = `msg-move-${this.props.messageId}-${this.props.folderId}`;
+
     return (
       <div>
         <input
@@ -22,7 +23,8 @@ class MoveToOption extends React.Component {
 
 MoveToOption.propTypes = {
   folderName: PropTypes.string,
-  folderId: PropTypes.number
+  folderId: PropTypes.number,
+  messageId: PropTypes.number
 };
 
 export default MoveToOption;

--- a/src/sass/messaging/partials/_messaging-moveto.scss
+++ b/src/sass/messaging/partials/_messaging-moveto.scss
@@ -58,7 +58,7 @@
 
   .msg-btn-newfolder[type="button"] {
     display: block;
-    padding: .5rem;
+    padding: 1rem;
     width: 100%;
   }
 }
@@ -72,7 +72,7 @@
   white-space: nowrap;
 }
 
-// Exception for button in message table. 
+// Exception for button in message table.
 .messaging-message-row {
   .msg-move-to {
     position: static;


### PR DESCRIPTION
Fixed a bug that resulted from #6212. It was changing the actual displayed folder name in the dropdown when the intent was just to change the HTML id on the label and input pair.

#### Before
> <img width="248" alt="screen shot 2017-08-23 at 5 07 19 pm" src="https://user-images.githubusercontent.com/1067024/29639669-8d02f6fc-8829-11e7-8c8e-b818903e5263.png">

#### After
> <img width="251" alt="screen shot 2017-08-23 at 5 10 50 pm" src="https://user-images.githubusercontent.com/1067024/29639681-933b4272-8829-11e7-8254-3d2d2b53890a.png">
