### PR TITLE
Target name for production deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,7 +197,7 @@ node('vets-website-linting') {
 
       def targets = [
         'master': [ 'dev', 'staging' ],
-        'production': [ 'production' ],
+        'production': [ 'prod' ],
       ][env.BRANCH_NAME]
 
       // Deploy the build associated with this ref. To deploy from a release use 


### PR DESCRIPTION
Caused failure in today's production deployment (http://jenkins.vetsgov-internal/job/testing/job/vets-website/job/production/133/console -
 https://dsva.slack.com/archives/C37M86Y8G/p1503604758000586) since the name of the Jenkins job targets "prod" not "production".