### PR TITLE
Mark JS assets as async and defer where appropriate

### DIFF
--- a/content/includes/footer.html
+++ b/content/includes/footer.html
@@ -92,7 +92,7 @@ visit <a href="https://www.veteranscrisisline.net/">VeteransCrisisLine.net</a> f
   {% include "content/includes/modal.html" %}
 {% endif %}
 
-<script src="/js/user-voice.js"></script>
+<script async src="/js/user-voice.js"></script>
 
 <!-- htmllint attr-bans="[]" -->
 {% if buildtype === 'development' %}

--- a/content/includes/header.html
+++ b/content/includes/header.html
@@ -68,21 +68,21 @@
 <link rel='stylesheet' href='/assets/css/ie.css'>
 <![endif]-->
 
-<!-- We participate in the US government’s analytics program. See the data at analytics.usa.gov. -->
-<script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA" id="_fed_an_ua_tag"></script>
-
 <script>
 //<![CDATA[
 window.webpackManifest = 'CHUNK_MANIFEST_PLACEHOLDER';
 //]]>
 </script>
 
-<script src="/generated/vendor.js"></script>
+<script defer src="/generated/vendor.js"></script>
 {% if entryname %}
-<script src="/generated/{{ entryname }}.entry.js"></script>
+<script defer src="/generated/{{ entryname }}.entry.js"></script>
 {% else %}
-<script src="/generated/no-react.entry.js"></script>
+<script defer src="/generated/no-react.entry.js"></script>
 {% endif %}
+
+<!-- We participate in the US government’s analytics program. See the data at analytics.usa.gov. -->
+<script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA" id="_fed_an_ua_tag"></script>
 
 </head>
 <body class="{{ body_class }}">
@@ -151,4 +151,4 @@ window.webpackManifest = 'CHUNK_MANIFEST_PLACEHOLDER';
 
 </header>
 
-<script src="/js/usa-search.js"></script>
+<script async src="/js/usa-search.js"></script>

--- a/src/js/legacy/mega-menu.js
+++ b/src/js/legacy/mega-menu.js
@@ -146,6 +146,7 @@ class MegaMenu {
 export default MegaMenu;
 
 function reInitMenu() {
+  console.log('menu');
   const menuElement = document.querySelector('#vetnav');
   const openMenuElement = document.querySelector('.vetnav-controller-open');
   const closeMenuElement = document.querySelector('.vetnav-controller-close');

--- a/src/js/legacy/mega-menu.js
+++ b/src/js/legacy/mega-menu.js
@@ -146,7 +146,6 @@ class MegaMenu {
 export default MegaMenu;
 
 function reInitMenu() {
-  console.log('menu');
   const menuElement = document.querySelector('#vetnav');
   const openMenuElement = document.querySelector('.vetnav-controller-open');
   const closeMenuElement = document.querySelector('.vetnav-controller-close');

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -196,9 +196,11 @@ hr {
   clear: both;
   margin: 0;
   padding: 0;
+  min-height: 147.19px;
 
   @include media($medium-screen) {
     position: relative;
+    min-height: 168.5px;
   }
 
 .login-container {


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2839

We have JS assets that can be marked as async and defer so that the static content pages load faster. It has a minor impact on the React app pages, since those pages are rendered with JS.

For the home page, throttled to Good 3G.

Before:
![screen shot 2017-08-25 at 10 07 13 am](https://user-images.githubusercontent.com/634932/29717512-6a726438-897d-11e7-92e9-466ee020e26a.png)
![screen shot 2017-08-25 at 9 37 48 am](https://user-images.githubusercontent.com/634932/29717508-6a6dc162-897d-11e7-84d5-5f59f77b208f.png)

We're not putting any content on the screen for around 5 seconds, just because we're waiting for JS that only renders the menus. 

After:
![screen shot 2017-08-25 at 10 07 20 am](https://user-images.githubusercontent.com/634932/29717507-6a6cc776-897d-11e7-8312-a659f31dca18.png)
![screen shot 2017-08-25 at 9 32 37 am](https://user-images.githubusercontent.com/634932/29717510-6a725ac4-897d-11e7-86b4-3102f083fe8e.png)

Deferring our JS assets means that the page doesn't stop rendering to wait for the scripts to load, so we're able to render most of the content. The effect of this is that users see a page with the content rendered, but the header is missing the menus, starting 3 seconds in. I think this is better, since people can start reading the page they're on sooner.

The next step after this would be to attempt to pare down style.css. It's pretty big and is now the main bottleneck for rendering on the static pages.

Note: I chose `async` for some scripts that are external and don't require a particular loading order. Our JS bundles can't use `async` because they need to run in a specific order, which `async` doesn't guarantee.