### PR TITLE
Letters create 2 pages

### DIFF
--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import isEmpty from 'lodash/isEmpty';
 
 import { invalidAddressProperty } from '../utils/helpers.jsx';
 
-class AddressSection extends React.Component {
+export class AddressSection extends React.Component {
   render() {
     const destination = this.props.destination || {};
     const addressLines = [
@@ -43,8 +43,11 @@ class AddressSection extends React.Component {
   }
 }
 
-AddressSection.propTypes = {
-  destination: PropTypes.object
-};
+function mapStateToProps(state) {
+  const letterState = state.letters;
+  return {
+    destination: letterState.destination,
+  };
+}
 
-export default AddressSection;
+export default connect(mapStateToProps)(AddressSection);

--- a/src/js/letters/containers/DownloadLetters.jsx
+++ b/src/js/letters/containers/DownloadLetters.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import findIndex from 'lodash/findIndex';
+import findIndex from 'lodash/fp/findIndex';
 
 import FormTitle from '../../common/schemaform/FormTitle';
 import SegmentedProgressBar from '../../common/components/SegmentedProgressBar';
@@ -20,7 +20,7 @@ class DownloadLetters extends React.Component {
 
   render() {
     const { children, location } = this.props;
-    const currentPageIndex = findIndex(chapters, ['path', location.pathname]);
+    const currentPageIndex = findIndex(['path', location.pathname], chapters);
     const currentStep = currentPageIndex + 1;
 
     let viewLettersButton;

--- a/src/js/letters/containers/DownloadLetters.jsx
+++ b/src/js/letters/containers/DownloadLetters.jsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import findIndex from 'lodash/findIndex';
 
 import FormTitle from '../../common/schemaform/FormTitle';
-// import AddressSection from '../components/AddressSection';
-// import LetterList from '../components/LetterList';
-// import StepHeader from '../components/StepHeader';
+import SegmentedProgressBar from '../../common/components/SegmentedProgressBar';
+
+import StepHeader from '../components/StepHeader';
+import { chapters } from '../routes';
 
 class DownloadLetters extends React.Component {
   render() {
+    const { children, location } = this.props;
+    const currentPageIndex = findIndex(chapters, ['path', location.pathname]);
+    const currentStep = currentPageIndex + 1;
+
     return (
       <div className="usa-width-three-fourths letters">
         <FormTitle title="VA Letters and Documents"/>
@@ -16,7 +22,14 @@ class DownloadLetters extends React.Component {
             To receive some benefits, Veterans and their surviving spouse or family members need a letter proving their Veteran or survivor status. You can download these benefit letters and documents online.
           </p>
         </div>
-        {this.props.children}
+
+        <div className="letters-progress-bar">
+          <SegmentedProgressBar total={chapters.length} current={currentStep}/>
+        </div>
+        <StepHeader name={chapters[currentPageIndex].name} current={currentStep} steps="2">
+          {children}
+        </StepHeader>
+
         <br/>
         <h4>Can’t find what you’re looking for?</h4>
         <p>
@@ -60,14 +73,3 @@ function mapStateToProps(state) {
 }
 
 export default connect(mapStateToProps)(DownloadLetters);
-
-// <StepHeader name="Review your address" current="1" steps="2">
-//           <AddressSection destination={this.props.destination}/>
-//         </StepHeader>
-//         <StepHeader name="Select and download" current="2" steps="2">
-//           <LetterList
-//             letters={this.props.letters}
-//             lettersAvailability={this.props.lettersAvailability}
-//             letterDownloadStatus={this.props.letterDownloadStatus}
-//             benefitSummaryOptions={this.props.benefitSummaryOptions}/>
-//         </StepHeader>

--- a/src/js/letters/containers/DownloadLetters.jsx
+++ b/src/js/letters/containers/DownloadLetters.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import FormTitle from '../../common/schemaform/FormTitle';
-import AddressSection from '../components/AddressSection';
-import LetterList from '../components/LetterList';
-import StepHeader from '../components/StepHeader';
+// import AddressSection from '../components/AddressSection';
+// import LetterList from '../components/LetterList';
+// import StepHeader from '../components/StepHeader';
 
 class DownloadLetters extends React.Component {
   render() {
@@ -16,16 +16,7 @@ class DownloadLetters extends React.Component {
             To receive some benefits, Veterans and their surviving spouse or family members need a letter proving their Veteran or survivor status. You can download these benefit letters and documents online.
           </p>
         </div>
-        <StepHeader name="Review your address" current="1" steps="2">
-          <AddressSection destination={this.props.destination}/>
-        </StepHeader>
-        <StepHeader name="Select and download" current="2" steps="2">
-          <LetterList
-            letters={this.props.letters}
-            lettersAvailability={this.props.lettersAvailability}
-            letterDownloadStatus={this.props.letterDownloadStatus}
-            benefitSummaryOptions={this.props.benefitSummaryOptions}/>
-        </StepHeader>
+        {this.props.children}
         <br/>
         <h4>Can’t find what you’re looking for?</h4>
         <p>
@@ -69,3 +60,14 @@ function mapStateToProps(state) {
 }
 
 export default connect(mapStateToProps)(DownloadLetters);
+
+// <StepHeader name="Review your address" current="1" steps="2">
+//           <AddressSection destination={this.props.destination}/>
+//         </StepHeader>
+//         <StepHeader name="Select and download" current="2" steps="2">
+//           <LetterList
+//             letters={this.props.letters}
+//             lettersAvailability={this.props.lettersAvailability}
+//             letterDownloadStatus={this.props.letterDownloadStatus}
+//             benefitSummaryOptions={this.props.benefitSummaryOptions}/>
+//         </StepHeader>

--- a/src/js/letters/containers/DownloadLetters.jsx
+++ b/src/js/letters/containers/DownloadLetters.jsx
@@ -9,10 +9,26 @@ import StepHeader from '../components/StepHeader';
 import { chapters } from '../routes';
 
 class DownloadLetters extends React.Component {
+  constructor() {
+    super();
+    this.navigateToLetterList = this.navigateToLetterList.bind(this);
+  }
+
+  navigateToLetterList() {
+    this.props.router.push('/letter-list');
+  }
+
   render() {
     const { children, location } = this.props;
     const currentPageIndex = findIndex(chapters, ['path', location.pathname]);
     const currentStep = currentPageIndex + 1;
+
+    let viewLettersButton;
+    if (location.pathname === '/confirm-address') {
+      viewLettersButton = (
+        <button onClick={this.navigateToLetterList} className="usa-button-primary view-letters-button">View letters</button>
+      );
+    }
 
     return (
       <div className="usa-width-three-fourths letters">
@@ -28,28 +44,8 @@ class DownloadLetters extends React.Component {
         </div>
         <StepHeader name={chapters[currentPageIndex].name} current={currentStep} steps="2">
           {children}
+          {viewLettersButton}
         </StepHeader>
-
-        <br/>
-        <h4>Can’t find what you’re looking for?</h4>
-        <p>
-          This system doesn’t include every VA letter. Learn more about how to access other VA letters and documents you might need.
-        </p>
-        <ul>
-          <li><a href="/education/gi-bill/post-9-11/ch-33-benefit" target="_blank"><strong>View and print your Post-9/11 GI Bill benefits summary and eligibility.</strong></a></li>
-          <li><a href="https://gibill.custhelp.com/app/ask" target="_blank"><strong>Request a Certificate of Eligibility (COE) for your Post-9/11 GI Bill benefits.</strong></a></li>
-          <li><a href="https://eauth.va.gov/ebenefits/coe" target="_blank"><strong>Request a Certificate of Eligibility (COE) for your home loan benefits.</strong></a></li>
-          <li><a href="https://eauth.va.gov/ebenefits/DPRIS" target="_blank"><strong>Request a copy of your discharge or separation papers (DD214).</strong></a></li>
-        </ul>
-        <p>
-          Please visit <a href="https://www.ebenefits.va.gov/" target="_blank">eBenefits</a> for any document or letter not listed here.
-        </p>
-        <div className="feature help-desk">
-          <h2>Need help?</h2>
-          <div>If you have any questions, please call the Vets.gov Help Desk:</div>
-          <div>855-574-7286</div>
-          <div>Monday - Friday, 8 a.m. - 8 p.m. (ET)</div>
-        </div>
       </div>
     );
   }

--- a/src/js/letters/containers/LetterList.jsx
+++ b/src/js/letters/containers/LetterList.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import CollapsiblePanel from '../../common/components/CollapsiblePanel';
-import DownloadLetterLink from './DownloadLetterLink';
-import VeteranBenefitSummaryLetter from '../containers/VeteranBenefitSummaryLetter';
+import DownloadLetterLink from '../components/DownloadLetterLink';
+import VeteranBenefitSummaryLetter from './VeteranBenefitSummaryLetter';
 
 import { letterContent } from '../utils/helpers.jsx';
 
-class LetterList extends React.Component {
+export class LetterList extends React.Component {
   render() {
     const downloadStatus = this.props.letterDownloadStatus;
     const letterItems = (this.props.letters || []).map((letter, index) => {
@@ -75,11 +75,17 @@ class LetterList extends React.Component {
   }
 }
 
-LetterList.PropTypes = {
-  letters: PropTypes.array,
-  lettersAvailability: PropTypes.string,
-  benefitSummaryOptions: PropTypes.object,
-  letterDownloadStatus: PropTypes.object
-};
+function mapStateToProps(state) {
+  const letterState = state.letters;
+  return {
+    benefitSummaryOptions: {
+      benefitInfo: letterState.benefitInfo,
+      serviceInfo: letterState.serviceInfo
+    },
+    letters: letterState.letters,
+    lettersAvailability: letterState.lettersAvailability,
+    letterDownloadStatus: letterState.letterDownloadStatus
+  };
+}
 
-export default LetterList;
+export default connect(mapStateToProps)(LetterList);

--- a/src/js/letters/containers/LetterList.jsx
+++ b/src/js/letters/containers/LetterList.jsx
@@ -70,6 +70,27 @@ export class LetterList extends React.Component {
         </p>
         {letterItems}
         {eligibilityMessage}
+
+        <br/>
+        <h4>Can’t find what you’re looking for?</h4>
+        <p>
+          This system doesn’t include every VA letter. Learn more about how to access other VA letters and documents you might need.
+        </p>
+        <ul>
+          <li><a href="/education/gi-bill/post-9-11/ch-33-benefit" target="_blank"><strong>View and print your Post-9/11 GI Bill benefits summary and eligibility.</strong></a></li>
+          <li><a href="https://gibill.custhelp.com/app/ask" target="_blank"><strong>Request a Certificate of Eligibility (COE) for your Post-9/11 GI Bill benefits.</strong></a></li>
+          <li><a href="https://eauth.va.gov/ebenefits/coe" target="_blank"><strong>Request a Certificate of Eligibility (COE) for your home loan benefits.</strong></a></li>
+          <li><a href="https://eauth.va.gov/ebenefits/DPRIS" target="_blank"><strong>Request a copy of your discharge or separation papers (DD214).</strong></a></li>
+        </ul>
+        <p>
+          Please visit <a href="https://www.ebenefits.va.gov/" target="_blank">eBenefits</a> for any document or letter not listed here.
+        </p>
+        <div className="feature help-desk">
+          <h2>Need help?</h2>
+          <div>If you have any questions, please call the Vets.gov Help Desk:</div>
+          <div>855-574-7286</div>
+          <div>Monday - Friday, 8 a.m. - 8 p.m. (ET)</div>
+        </div>
       </div>
     );
   }

--- a/src/js/letters/routes.jsx
+++ b/src/js/letters/routes.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route } from 'react-router';
+import { Route, IndexRedirect } from 'react-router';
 
 import DownloadLetters from './containers/DownloadLetters.jsx';
 import AddressSection from './containers/AddressSection.jsx';
@@ -14,6 +14,7 @@ const routes = [
       component={DownloadLetters}
       name="Download Letters"
       key="download-letters">
+      <IndexRedirect to="confirm-address"/>,
       <Route
         component={AddressSection}
         name="Review your address"

--- a/src/js/letters/routes.jsx
+++ b/src/js/letters/routes.jsx
@@ -16,12 +16,12 @@ const routes = [
       key="download-letters">
       <Route
         component={AddressSection}
-        name="Address Section"
-        key="address-section"
-        path="address-section"/>,
+        name="Review your address"
+        key="confirm-address"
+        path="confirm-address"/>,
       <Route
         component={LetterList}
-        name="Letter List"
+        name="Select and download"
         key="letter-list"
         path="letter-list"/>
     </Route>
@@ -29,3 +29,8 @@ const routes = [
 ];
 
 export default routes;
+
+export const chapters = [
+  { name: 'Review your address', path: '/confirm-address' },
+  { name: 'Select and download', path: '/letter-list' }
+];

--- a/src/js/letters/routes.jsx
+++ b/src/js/letters/routes.jsx
@@ -1,17 +1,30 @@
 import React from 'react';
-import { Route, IndexRoute } from 'react-router';
+import { Route } from 'react-router';
 
 import DownloadLetters from './containers/DownloadLetters.jsx';
+import AddressSection from './containers/AddressSection.jsx';
+import LetterList from './containers/LetterList.jsx';
 import Main from './containers/Main.jsx';
 
 const routes = [
   <Route
     component={Main}
     key="main">
-    <IndexRoute
+    <Route
       component={DownloadLetters}
       name="Download Letters"
-      key="download-letters"/>
+      key="download-letters">
+      <Route
+        component={AddressSection}
+        name="Address Section"
+        key="address-section"
+        path="address-section"/>,
+      <Route
+        component={LetterList}
+        name="Letter List"
+        key="letter-list"
+        path="letter-list"/>
+    </Route>
   </Route>
 ];
 

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -25,6 +25,10 @@
     margin-left: 2em;
   }
 
+  .letters-progress-bar {
+    width: 6em;
+  }
+
   .letters-address {
     text-transform: capitalize;
   }

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -33,6 +33,10 @@
     text-transform: capitalize;
   }
 
+  .view-letters-button {
+    margin: 2em;
+  }
+
   .accordion-header > button {
     min-height: 6rem;
     padding-top: 1.5rem;

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -3,14 +3,9 @@ import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 import _ from 'lodash';
 
-import AddressSection from '../../../src/js/letters/containers/AddressSection.jsx';
+import { AddressSection } from '../../../src/js/letters/containers/AddressSection.jsx';
 
-import reducer from '../../../src/js/letters/reducers/index.js';
-import createCommonStore from '../../../src/js/common/store';
-
-const store = createCommonStore(reducer);
-const defaultProps = store.getState();
-defaultProps.letters = {
+const defaultProps = {
   destination: {
     addressLine1: '2476 Main Street',
     city: 'Reston',
@@ -24,19 +19,19 @@ defaultProps.letters = {
 
 describe('<AddressSection>', () => {
   it('should render', () => {
-    const tree = SkinDeep.shallowRender(<AddressSection store={store} {...defaultProps}/>);
+    const tree = SkinDeep.shallowRender(<AddressSection {...defaultProps}/>);
     const vdom = tree.getRenderOutput();
     expect(vdom).to.exist;
   });
 
   it('should format 1 address line', () => {
-    const tree = SkinDeep.shallowRender(<AddressSection store={store} {...defaultProps}/>);
+    const tree = SkinDeep.shallowRender(<AddressSection {...defaultProps}/>);
     expect(tree.subTree('.step-content').text()).to.contain('2476 main street');
   });
 
   it('should format address 2 address lines', () => {
     const props = _.merge({}, defaultProps, { destination: { addressLine2: 'ste #12' } });
-    const tree = SkinDeep.shallowRender(<AddressSection store={store} {...props}/>);
+    const tree = SkinDeep.shallowRender(<AddressSection {...props}/>);
     expect(tree.subTree('.step-content').text()).to.contain('2476 main street, ste #12');
   });
 
@@ -47,7 +42,7 @@ describe('<AddressSection>', () => {
         addressLine3: 'west'
       }
     });
-    const tree = SkinDeep.shallowRender(<AddressSection store={store} {...props}/>);
+    const tree = SkinDeep.shallowRender(<AddressSection {...props}/>);
     expect(tree.subTree('.step-content').text()).to.contain('2476 main street, ste #12 west');
   });
 });

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -9,8 +9,8 @@ import reducer from '../../../src/js/letters/reducers/index.js';
 import createCommonStore from '../../../src/js/common/store';
 
 const store = createCommonStore(reducer);
-
-const defaultProps = {
+const defaultProps = store.getState();
+defaultProps.letters = {
   destination: {
     addressLine1: '2476 Main Street',
     city: 'Reston',
@@ -34,7 +34,7 @@ describe('<AddressSection>', () => {
     expect(tree.subTree('.step-content').text()).to.contain('2476 main street');
   });
 
-  it('should format address 2 address lines', () => {
+  it.only('should format address 2 address lines', () => {
     const props = _.merge({}, defaultProps, { destination: { addressLine2: 'ste #12' } });
     const tree = SkinDeep.shallowRender(<AddressSection store={store} {...props}/>);
     expect(tree.subTree('.step-content').text()).to.contain('2476 main street, ste #12');

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -34,7 +34,7 @@ describe('<AddressSection>', () => {
     expect(tree.subTree('.step-content').text()).to.contain('2476 main street');
   });
 
-  it.only('should format address 2 address lines', () => {
+  it('should format address 2 address lines', () => {
     const props = _.merge({}, defaultProps, { destination: { addressLine2: 'ste #12' } });
     const tree = SkinDeep.shallowRender(<AddressSection store={store} {...props}/>);
     expect(tree.subTree('.step-content').text()).to.contain('2476 main street, ste #12');

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -3,7 +3,12 @@ import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 import _ from 'lodash';
 
-import AddressSection from '../../../src/js/letters/components/AddressSection.jsx';
+import AddressSection from '../../../src/js/letters/containers/AddressSection.jsx';
+
+import reducer from '../../../src/js/letters/reducers/index.js';
+import createCommonStore from '../../../src/js/common/store';
+
+const store = createCommonStore(reducer);
 
 const defaultProps = {
   destination: {
@@ -19,19 +24,19 @@ const defaultProps = {
 
 describe('<AddressSection>', () => {
   it('should render', () => {
-    const tree = SkinDeep.shallowRender(<AddressSection {...defaultProps}/>);
+    const tree = SkinDeep.shallowRender(<AddressSection store={store} {...defaultProps}/>);
     const vdom = tree.getRenderOutput();
     expect(vdom).to.exist;
   });
 
   it('should format 1 address line', () => {
-    const tree = SkinDeep.shallowRender(<AddressSection {...defaultProps}/>);
+    const tree = SkinDeep.shallowRender(<AddressSection store={store} {...defaultProps}/>);
     expect(tree.subTree('.step-content').text()).to.contain('2476 main street');
   });
 
   it('should format address 2 address lines', () => {
     const props = _.merge({}, defaultProps, { destination: { addressLine2: 'ste #12' } });
-    const tree = SkinDeep.shallowRender(<AddressSection {...props}/>);
+    const tree = SkinDeep.shallowRender(<AddressSection store={store} {...props}/>);
     expect(tree.subTree('.step-content').text()).to.contain('2476 main street, ste #12');
   });
 
@@ -42,7 +47,7 @@ describe('<AddressSection>', () => {
         addressLine3: 'west'
       }
     });
-    const tree = SkinDeep.shallowRender(<AddressSection {...props}/>);
+    const tree = SkinDeep.shallowRender(<AddressSection store={store} {...props}/>);
     expect(tree.subTree('.step-content').text()).to.contain('2476 main street, ste #12 west');
   });
 });

--- a/test/letters/containers/LetterList.unit.spec.jsx
+++ b/test/letters/containers/LetterList.unit.spec.jsx
@@ -2,9 +2,14 @@ import React from 'react';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 
-import LetterList from '../../../src/js/letters/components/LetterList.jsx';
+import LetterList from '../../../src/js/letters/containers/LetterList.jsx';
 
-const defaultProps = {
+import reducer from '../../../src/js/letters/reducers/index.js';
+import createCommonStore from '../../../src/js/common/store';
+
+const store = createCommonStore(reducer);
+const defaultProps = store.getState();
+defaultProps.letters = {
   letters: [
     {
       name: 'Commissary Letter',
@@ -24,13 +29,13 @@ const defaultProps = {
 
 describe('<LetterList>', () => {
   it('should render', () => {
-    const tree = SkinDeep.shallowRender(<LetterList {...defaultProps}/>);
+    const tree = SkinDeep.shallowRender(<LetterList store={store} {...defaultProps}/>);
     const vdom = tree.getRenderOutput();
     expect(vdom).to.exist;
   });
 
   it('should show collapsible panels for all letters', () => {
-    const tree = SkinDeep.shallowRender(<LetterList {...defaultProps}/>);
+    const tree = SkinDeep.shallowRender(<LetterList store={store} {...defaultProps}/>);
     const collapsibles = tree.everySubTree('CollapsiblePanel');
     expect(collapsibles.length).to.equal(3);
   });

--- a/test/letters/containers/LetterList.unit.spec.jsx
+++ b/test/letters/containers/LetterList.unit.spec.jsx
@@ -2,14 +2,9 @@ import React from 'react';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 
-import LetterList from '../../../src/js/letters/containers/LetterList.jsx';
+import { LetterList } from '../../../src/js/letters/containers/LetterList.jsx';
 
-import reducer from '../../../src/js/letters/reducers/index.js';
-import createCommonStore from '../../../src/js/common/store';
-
-const store = createCommonStore(reducer);
-const defaultProps = store.getState();
-defaultProps.letters = {
+const defaultProps = {
   letters: [
     {
       name: 'Commissary Letter',
@@ -29,13 +24,13 @@ defaultProps.letters = {
 
 describe('<LetterList>', () => {
   it('should render', () => {
-    const tree = SkinDeep.shallowRender(<LetterList store={store} {...defaultProps}/>);
+    const tree = SkinDeep.shallowRender(<LetterList {...defaultProps}/>);
     const vdom = tree.getRenderOutput();
     expect(vdom).to.exist;
   });
 
   it('should show collapsible panels for all letters', () => {
-    const tree = SkinDeep.shallowRender(<LetterList store={store} {...defaultProps}/>);
+    const tree = SkinDeep.shallowRender(<LetterList {...defaultProps}/>);
     const collapsibles = tree.everySubTree('CollapsiblePanel');
     expect(collapsibles.length).to.equal(3);
   });


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4458

Moves the letters content to 2 pages. The steps I had to take to achieve this:
1. Make `AddressSection` and `LetterList` connected containers instead of regular components so that they could have the info they needed from props. Since we were no longer rendering them explicitly, and instead just as `{this.props.children}`, we wouldn't pass the props directly, so they had to instead connect to the store to get the information they needed.
2. Added `AddressSection` and `LetterList` to `routes.jsx`, and added a redirect so that going to `/letters` takes you automatically to the first page, which is `/letters/confirm-address`.
3. Add some logic to `StepHeader` and `SegmentedProgressBar` so that those 2 things are calculated automatically based on the path. This led to some hacky code in `routes.jsx` to manually create the `chapters` variable. Not super happy with it, but couldn't copy what the education apps used with `groupPagesIntoChapters` because there aren't pages in the same way.
4. Added a button to navigate
5. Moved content in `DownloadLetters` to `LetterList` based on the mockups.

There are unit tests that are still failing. I'm stumped as to why they're failing, but I'll keep digging in (something to do with the fact that these components are now connected and the store is handled differently, I think).