### PR TITLE
Fix HCA demographic default data

### DIFF
--- a/src/js/hca/config/form.js
+++ b/src/js/hca/config/form.js
@@ -25,6 +25,8 @@ import {
   resumeMessage
 } from '../helpers';
 
+import migrations from './migrations';
+
 import SIPIntroductionPage from '../components/SIPIntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import ErrorMessage from '../components/ErrorMessage';
@@ -118,7 +120,8 @@ const formConfig = {
   submitUrl: '/v0/health_care_applications',
   trackingPrefix: 'hca-',
   formId: '1010ez',
-  version: 0,
+  version: 1,
+  migrations,
   savedFormMessages: {
     notFound: 'Please start over to apply for health care.',
     noAuth: 'Please sign in again to resume your application for health care.',

--- a/src/js/hca/config/form.js
+++ b/src/js/hca/config/form.js
@@ -215,7 +215,9 @@ const formConfig = {
           path: 'veteran-information/demographic-information',
           title: 'Veteran information',
           initialData: {
-            isSpanishHispanicLatino: false
+            'view:demographicCategories': {
+              isSpanishHispanicLatino: false
+            }
           },
           uiSchema: {
             gender: {

--- a/src/js/hca/config/migrations.js
+++ b/src/js/hca/config/migrations.js
@@ -1,0 +1,15 @@
+import _ from 'lodash/fp';
+
+export default [
+  // 0 -> 1, we had a bug where isSpanishHispanicLatino was defaulted in the wrong place
+  // and this removes it and defaults it in the right spot if necessary
+  (savedData) => {
+    const newData = _.unset('isSpanishHispanicLatino', savedData);
+
+    if (typeof _.get('view:demographicCategories.isSpanishHispanicLatino', newData) === 'undefined') {
+      return _.set('view:demographicCategories.isSpanishHispanicLatino', false, newData);
+    }
+
+    return newData;
+  }
+];

--- a/test/hca/config/migrations.unit.spec.js
+++ b/test/hca/config/migrations.unit.spec.js
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+
+import formConfig from '../../../src/js/hca/config/form';
+
+const migrations = formConfig.migrations;
+
+describe('HCA migrations', () => {
+  describe('first migration', () => {
+    it('should remove hispanic property and add in view: object', () => {
+      const data = {
+        isSpanishHispanicLatino: false
+      };
+
+      expect(migrations[0](data)).to.eql({
+        'view:demographicCategories': {
+          isSpanishHispanicLatino: false
+        }
+      });
+    });
+    it('should not remove existing hispanic choice', () => {
+      const data = {
+        isSpanishHispanicLatino: false,
+        'view:demographicCategories': {
+          isSpanishHispanicLatino: true
+        }
+      };
+
+      expect(migrations[0](data)).to.eql({
+        'view:demographicCategories': {
+          isSpanishHispanicLatino: true
+        }
+      });
+    });
+  });
+});

--- a/test/hca/schema/maximal-test.json
+++ b/test/hca/schema/maximal-test.json
@@ -131,7 +131,6 @@
       "suffix": "Jr."
     },
     "mothersMaidenName": "Smith",
-    "privacyAgreementAccepted": true,
-    "isSpanishHispanicLatino": false
+    "privacyAgreementAccepted": true
   }
 }

--- a/test/hca/schema/minimal-test.json
+++ b/test/hca/schema/minimal-test.json
@@ -34,7 +34,9 @@
       "last": "Doe"
     },
     "privacyAgreementAccepted": true,
-    "isSpanishHispanicLatino": false,
+    "view:demographicCategories": {
+      "isSpanishHispanicLatino": false
+    }
     "spouseFullName": {}
   }
 }

--- a/test/hca/schema/minimal-test.json
+++ b/test/hca/schema/minimal-test.json
@@ -36,7 +36,7 @@
     "privacyAgreementAccepted": true,
     "view:demographicCategories": {
       "isSpanishHispanicLatino": false
-    }
+    },
     "spouseFullName": {}
   }
 }


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4517

We have to default `isSpanishHispanicLatino` because of the backend schema, but the default was set incorrectly and always overrode the user's choice. This fixes that.