### PR TITLE
Fix messaging date display issue on iOS

### DIFF
--- a/src/sass/messaging/partials/_messaging-folder.scss
+++ b/src/sass/messaging/partials/_messaging-folder.scss
@@ -109,7 +109,7 @@
       &:nth-child(3) {
         font-weight: normal;
         position: absolute;
-        right: 20%;
+        right: 26%;
         text-align: center;
         top: 0;
         width: 5%;
@@ -126,7 +126,7 @@
         right: 0;
         text-align: right;
         top: 0;
-        width: 20%;
+        width: 25%;
 
         a {
           padding: 2.25rem 2rem 2.25rem 0;


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4282

Prevents date from being cut off on iOS when it is a full date with a message attachment

![screen shot 2017-08-30 at 6 36 15 pm](https://user-images.githubusercontent.com/303289/29902340-6aee7ea4-8db2-11e7-9784-22abbb2fdf77.png)
