### PR TITLE
Update message for address errors to general system down error message

### DIFF
--- a/src/js/letters/containers/Main.jsx
+++ b/src/js/letters/containers/Main.jsx
@@ -5,7 +5,6 @@ import LoadingIndicator from '../../common/components/LoadingIndicator';
 import { systemDownMessage, unableToFindRecordWarning } from '../../common/utils/error-messages';
 
 import { getBenefitSummaryOptions, getLetterList } from '../actions/letters';
-import { invalidAddressProperty } from '../utils/helpers.jsx';
 
 export class Main extends React.Component {
   componentDidMount() {

--- a/src/js/letters/containers/Main.jsx
+++ b/src/js/letters/containers/Main.jsx
@@ -31,7 +31,7 @@ export class Main extends React.Component {
         break;
       // Need a permanent UI for this
       case 'invalidAddressProperty':
-        appContent = invalidAddressProperty;
+        appContent = systemDownMessage;
         break;
       case 'letterEligibilityError':
         appContent = this.props.children;

--- a/test/letters/containers/Main.unit.spec.jsx
+++ b/test/letters/containers/Main.unit.spec.jsx
@@ -41,10 +41,10 @@ describe('<Main>', () => {
     expect(tree.subTree('#recordNotFound')).to.be.ok;
   });
 
-  it('should show invalid address error', () => {
+  it('should show system down message for invalid address error', () => {
     const props = _.merge({}, defaultProps, { lettersAvailability: 'invalidAddressProperty' });
     const tree = SkinDeep.shallowRender(<Main {...props}/>);
-    expect(tree.subTree('#invalidAddress')).to.be.ok;
+    expect(tree.subTree('#systemDownMessage')).to.be.ok;
   });
 
   it('should show letters unavailable message when service is unavailable', () => {


### PR DESCRIPTION
connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4135

Update to current messaging for `letterDestination.*.invalid` noted here:
https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/EVSS%20Integration/Letters%20and%20GIBS%20error%20messages%20mapping.md

Also update the associated unit test.

**Before**:
![screen shot 2017-09-01 at 8 57 51 pm](https://user-images.githubusercontent.com/24251447/29992217-e4a1e79a-8f5b-11e7-8383-6bb1d4d643ee.png)

**After**:
![screen shot 2017-09-01 at 9 07 50 pm](https://user-images.githubusercontent.com/24251447/29992226-0b8021d8-8f5c-11e7-8c16-90da685c4042.png)

