### PR TITLE
Hide invisible elements from tab order and keep focus on selection

### DIFF
--- a/src/js/edu-benefits/education-wizard.js
+++ b/src/js/edu-benefits/education-wizard.js
@@ -2,9 +2,11 @@ function toggleClass(element, className) {
   element.classList.toggle(className);
 }
 function openState(element) {
+  element.setAttribute('hidden', false);
   element.setAttribute('data-state', 'open');
 }
 function closeState(element) {
+  element.setAttribute('hidden', true);
   element.setAttribute('data-state', 'closed');
   const selectionElement = element.querySelector('input:checked');
   if (selectionElement) {
@@ -77,7 +79,6 @@ function reInitWidget() {
       const nextQuestion = radio.dataset.nextQuestion;
       const nextQuestionElement = container.querySelector(`[data-question=${nextQuestion}]`);
       openState(nextQuestionElement);
-      nextQuestionElement.querySelector('input').focus();
     }
   });
   button.addEventListener('click', () => {

--- a/src/sass/modules/_m-education-wizard.scss
+++ b/src/sass/modules/_m-education-wizard.scss
@@ -42,12 +42,9 @@
 
 // Handles the question toggling
 [data-state="closed"] {
-  left: -9999px;
-  opacity: 0;
-  position: absolute;
-  top: -9999px;
+  display: none;
 }
 
 [data-state="open"] {
-  transition: opacity 700ms ease-in-out;
+  display: block;
 }

--- a/test/edu-benefits/edu-apply-wizard.e2e.spec.js
+++ b/test/edu-benefits/edu-apply-wizard.e2e.spec.js
@@ -12,49 +12,49 @@ module.exports = E2eHelpers.createE2eTest(
       .waitForElementVisible('.wizard-container', Timeouts.normal)
       .click('.wizard-button')
       .waitForElementVisible('[data-question="create-or-update"]', Timeouts.normal)
-      .expect.element('[data-question="create-or-update"]').to.have.css('left').equals('auto');
+      .expect.element('[data-question="create-or-update"]').to.have.css('display').equals('block');
 
     // Create a new application
     client
       .click('#new-application')
       .waitForElementVisible('[data-question="create"]', Timeouts.normal)
-      .expect.element('[data-question="create"]').to.have.css('left').equals('auto');
+      .expect.element('[data-question="create"]').to.have.css('display').equals('block');
 
     // Select veteran
     client
       .click('#is-veteran')
       .waitForElementVisible('[data-question="national-call-to-service"]', Timeouts.normal)
-      .expect.element('[data-question="national-call-to-service"]').to.have.css('left').equals('auto');
+      .expect.element('[data-question="national-call-to-service"]').to.have.css('display').equals('block');
 
     // Select national call to service
     client
       .click('#is-ncts')
       .waitForElementVisible('#apply-now-button', Timeouts.normal)
-      .expect.element('#apply-now-button').to.have.css('left').equals('auto');
+      .expect.element('#apply-now-button').to.have.css('display').equals('block');
 
     client
       .expect.element('#apply-now-button').to.have.attribute('href').which.contains('/education/apply-for-education-benefits/application/1990n/introduction');
 
     client
-      .expect.element('#ncts-warning').to.have.css('left').equals('auto');
+      .expect.element('#ncts-warning').to.have.css('display').equals('block');
 
     // Select non-veteran
     client
       .click('#is-not-veteran')
-      .expect.element('#apply-now-button').to.have.css('left').equals('-9999px');
+      .expect.element('#apply-now-button').to.have.css('display').equals('none');
 
     client
-      .expect.element('#ncts-warning').to.have.css('left').equals('-9999px');
+      .expect.element('#ncts-warning').to.have.css('display').equals('none');
 
     client
       .waitForElementVisible('[data-question="create-dependent"]', Timeouts.normal)
-      .expect.element('[data-question="create-dependent"]').to.have.css('left').equals('auto');
+      .expect.element('[data-question="create-dependent"]').to.have.css('display').equals('block');
 
     // Select dependent
     client
       .click('#create-dependent')
       .waitForElementVisible('#apply-now-button', Timeouts.normal)
-      .expect.element('#apply-now-button').to.have.css('left').equals('auto');
+      .expect.element('#apply-now-button').to.have.css('display').equals('block');
 
     client
       .expect.element('#apply-now-button').to.have.attribute('href').which.contains('/education/apply-for-education-benefits/application/5490/introduction');
@@ -62,17 +62,17 @@ module.exports = E2eHelpers.createE2eTest(
     // Select non-dependent
     client
       .click('#create-non-dependent')
-      .expect.element('#apply-now-button').to.have.css('left').equals('-9999px');
+      .expect.element('#apply-now-button').to.have.css('display').equals('none');
 
     client
       .waitForElementVisible('[data-question="create-transfer"]', Timeouts.normal)
-      .expect.element('[data-question="create-transfer"]').to.have.css('left').equals('auto');
+      .expect.element('[data-question="create-transfer"]').to.have.css('display').equals('block');
 
     // Select transfer
     client
       .click('#create-transfer')
       .waitForElementVisible('#apply-now-button', Timeouts.normal)
-      .expect.element('#apply-now-button').to.have.css('left').equals('auto');
+      .expect.element('#apply-now-button').to.have.css('display').equals('block');
 
     client
       .expect.element('#apply-now-button').to.have.attribute('href').which.contains('/education/apply-for-education-benefits/application/1990e/introduction');
@@ -81,10 +81,10 @@ module.exports = E2eHelpers.createE2eTest(
     client
       .click('#create-non-transfer')
       .waitForElementVisible('a#apply-now-button', Timeouts.normal)
-      .expect.element('#apply-now-button').to.have.css('left').equals('auto');
+      .expect.element('#apply-now-button').to.have.css('display').equals('block');
 
     client
-      .expect.element('#transfer-warning').to.have.css('left').equals('auto');
+      .expect.element('#transfer-warning').to.have.css('display').equals('block');
 
     client
       .expect.element('#apply-now-button').to.have.attribute('href').which.contains('/education/apply-for-education-benefits/application/1990e/introduction');
@@ -92,20 +92,20 @@ module.exports = E2eHelpers.createE2eTest(
     // Update an existing application
     client
       .click('#existing-application')
-      .expect.element('#apply-now-button').to.have.css('left').equals('-9999px');
+      .expect.element('#apply-now-button').to.have.css('display').equals('none');
 
     client
       .waitForElementVisible('div[data-question="update"]', Timeouts.normal)
-      .expect.element('div[data-question="update"]').to.have.css('left').equals('auto');
+      .expect.element('div[data-question="update"]').to.have.css('display').equals('block');
 
     // Select dependent
     client
       .click('#update-dependent')
       .waitForElementVisible('#apply-now-button', Timeouts.normal)
-      .expect.element('#apply-now-button').to.have.css('left').equals('auto');
+      .expect.element('#apply-now-button').to.have.css('display').equals('block');
 
     client
-      .expect.element('#transfer-warning').to.have.css('left').equals('-9999px');
+      .expect.element('#transfer-warning').to.have.css('display').equals('none');
 
     client
       .expect.element('#apply-now-button').to.have.attribute('href').which.contains('/education/apply-for-education-benefits/application/5495/introduction');
@@ -114,7 +114,7 @@ module.exports = E2eHelpers.createE2eTest(
     client
       .click('#update-non-dependent')
       .waitForElementVisible('#apply-now-button', Timeouts.normal)
-      .expect.element('#apply-now-button').to.have.css('left').equals('auto');
+      .expect.element('#apply-now-button').to.have.css('display').equals('block');
 
     client
       .expect.element('#apply-now-button').to.have.attribute('href').which.contains('/education/apply-for-education-benefits/application/1995/introduction');


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4454

This enables keyboard navigation of the wizard. In researching [radio accessibility](http://webaim.org/techniques/keyboard/), I learned that arrow keys should enable toggling, which is not how the forms behave. Is this desirable? Or is it beyond the scope of our requirements?