### PR TITLE
changed 'survivors pension' to the possessive 'survivor's pension'

### DIFF
--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -147,7 +147,7 @@
                 <li><a href="/pension/">Pension benefits overview</a></li>
                 <li><a href="/pension/eligibility/">Eligibility</a></li>
                 <li><a href="/pension/apply/">Application process</a></li>
-                <li><a href="/pension/survivors-pension/">Survivors pension</a></li>
+                <li><a href="/pension/survivors-pension/">Survivors' pension</a></li>
                 <li><a href="/pension/application/527EZ/" class="usa-button va-button-primary">Apply now</a></li>
               </ul>
             </li>


### PR DESCRIPTION
See [#4616](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4616)