### PR TITLE
Fix ArrayField Sentry Error

### DIFF
--- a/src/js/common/schemaform/review/ArrayField.jsx
+++ b/src/js/common/schemaform/review/ArrayField.jsx
@@ -175,7 +175,9 @@ class ArrayField extends React.Component {
 
     // TODO: Make this better; it’s super hacky for now.
     const itemCountLocked = this.isLocked();
-    const items = itemCountLocked ? this.props.arrayData : this.state.items;
+    // Make sure we default to an empty array if the item count is locked and no
+    //  arrayData is passed (mysteriously)
+    const items = itemCountLocked ? (this.props.arrayData || []) : this.state.items;
     const itemsNeeded = (schema.minItems || 0) > 0 && items.length === 0;
 
     return (

--- a/test/common/schemaform/review/ArrayField.unit.spec.jsx
+++ b/test/common/schemaform/review/ArrayField.unit.spec.jsx
@@ -150,6 +150,66 @@ describe('Schemaform review <ArrayField>', () => {
 
     expect(tree.everySubTree('h5')[1].text()).to.equal('New Item name');
   });
+  it('should render array warning', () => {
+    // If it's a BasicArrayField with a set minItems, make sure it doesn't break
+    //  if no items are found; it should render a validation warning instead.
+    const idSchema = {};
+    const schema = {
+      type: 'array',
+      minItems: 1,
+      items: [{
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string'
+          }
+        }
+      }, {
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string'
+          }
+        }
+      }],
+      additionalItems: {
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string'
+          }
+        }
+      }
+    };
+    const uiSchema = {
+      'ui:title': 'List of things',
+      'ui:field': 'BasicArrayField',
+      items: {
+      },
+      'ui:options': {
+        viewField: f => f,
+        itemName: 'Item name'
+      }
+    };
+    const arrayData = undefined;
+    const tree = SkinDeep.shallowRender(
+      <ArrayField
+        pageKey="page1"
+        arrayData={arrayData}
+        path={['thingList']}
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={idSchema}
+        registry={registry}
+        formContext={formContext}
+        pageTitle=""
+        requiredSchema={requiredSchema}/>
+    );
+
+    tree.getMountedInstance().handleAdd();
+
+    expect(tree.everySubTree('.schemaform-review-array-warning')).to.not.be.empty;
+  });
   describe('should handle', () => {
     let tree;
     let setData;


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4688

This was only happening in HCA because that's the only place we had an array field with a locked item count (I'm pretty sure). I'm not sure how this was possible, but I'm thinking maybe they reported that they didn't have any children? Seems odd that there were so few errors if that were the case.

At any rate, this just defaults to an empty array if the item count is locked and no `arrayData` is passed, so it'll generate the validation error, but the application won't die ignominiously.