### PR TITLE
removed apostrophe that makes survivors' possessive

### DIFF
--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -147,7 +147,7 @@
                 <li><a href="/pension/">Pension benefits overview</a></li>
                 <li><a href="/pension/eligibility/">Eligibility</a></li>
                 <li><a href="/pension/apply/">Application process</a></li>
-                <li><a href="/pension/survivors-pension/">Survivors' pension</a></li>
+                <li><a href="/pension/survivors-pension/">Survivors pension</a></li>
                 <li><a href="/pension/application/527EZ/" class="usa-button va-button-primary">Apply now</a></li>
               </ul>
             </li>


### PR DESCRIPTION
per peggy it should _not_ be possessive, but can't rollback the merge automagically. Thus, new PR. 