### PR TITLE
Make radio buttons more accessible

### DIFF
--- a/src/js/common/schemaform/widgets/RadioWidget.jsx
+++ b/src/js/common/schemaform/widgets/RadioWidget.jsx
@@ -28,7 +28,7 @@ export default function RadioWidget({
               autoComplete="false"
               checked={checked}
               id={`${id}_${i}`}
-              name={`${id}_${i}`}
+              name={`${id}`}
               value={option.value}
               disabled={disabled}
               onChange={_ => onChange(option.value)}/>

--- a/test/e2e/edu-helpers.js
+++ b/test/e2e/edu-helpers.js
@@ -84,11 +84,11 @@ function completeApplicantInformation(client, data, prefix = 'relative') {
 
   if (typeof data.relationship !== 'undefined') {
     client
-      .click('input[name="root_relationship_0"]');
+      .click('input#root_relationship_0');
   }
 
   if (data.gender) {
-    client.click(data.gender === 'M' ? 'input[name=root_gender_0]' : 'input[name=root_gender_1]');
+    client.click(data.gender === 'M' ? 'input#root_gender_0' : 'input#root_gender_1');
   }
 }
 
@@ -203,7 +203,7 @@ function completeContactInformation(client, data, isRelative = false) {
     .setValue('input[name="root_view:otherContactInfo_view:confirmEmail"]', data['view:otherContactInfo']['view:confirmEmail']);
 
   client
-    .click('input[name="root_preferredContactMethod_2"]')
+    .click('input#root_preferredContactMethod_2')
     .clearValue('input[name="root_view:otherContactInfo_homePhone"]')
     .setValue('input[name="root_view:otherContactInfo_homePhone"]', data['view:otherContactInfo'].homePhone)
     .clearValue('input[name="root_view:otherContactInfo_mobilePhone"]')
@@ -212,12 +212,12 @@ function completeContactInformation(client, data, isRelative = false) {
 
 function completePaymentChange(client) {
   client
-    .click('input[name="root_bankAccountChange_1"]');
+    .click('input#root_bankAccountChange_1');
 }
 
 function completeDirectDeposit(client, data) {
   client
-    .click('input[name="root_bankAccount_accountType_1"]')
+    .click('input#root_bankAccount_accountType_1')
     .setValue('input[name="root_bankAccount_accountNumber"]', data.bankAccount.accountNumber)
     .setValue('input[name="root_bankAccount_routingNumber"]', data.bankAccount.routingNumber);
 }


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4609

So there were a couple problems here. First, when we hit tab, it would cycle through all the radio options instead of the navigating to / from the whole `<fieldset>`. Second, the arrow keys wouldn't cycle through the options in the `<fieldset>`.

All of this is because the radio buttons had different names. With this PR, radio buttons inside the same `<fieldset>` all share the same name.

For more information, see [this WebAIM article](http://webaim.org/techniques/keyboard/) (search for "Keyboard Testing") and for an example, see [this WebAIM example](http://webaim.org/techniques/forms/controls) (search for "Radio Buttons").