### PR TITLE
Fix logic issue on RX tracking page

### DIFF
--- a/src/js/rx/containers/TrackPackage.jsx
+++ b/src/js/rx/containers/TrackPackage.jsx
@@ -5,7 +5,6 @@ import moment from 'moment';
 
 import SortableTable from '../../common/components/SortableTable';
 import TrackPackageLink from '../components/TrackPackageLink';
-import { rxStatuses } from '../config';
 import { formatDate } from '../utils/helpers';
 
 export class TrackPackage extends React.Component {
@@ -130,14 +129,13 @@ export class TrackPackage extends React.Component {
 
 const mapStateToProps = (state) => {
   const rxState = state.health.rx;
-  const { submitted, refillinprocess } = rxStatuses;
   const {
     rx: { attributes: { refillStatus } },
     trackings
   } = rxState.prescriptions.currentItem;
 
   return {
-    isPending: [submitted, refillinprocess].includes(refillStatus),
+    isPending: ['submitted', 'refillinprocess'].includes(refillStatus),
     items: trackings
   };
 };


### PR DESCRIPTION
resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4650

The change is that the `isPending` attribute is comparing keys of the form `refillinprocess` with keys of the form `In Process` which will always return false