### PR TITLE
Consistent checkbox size

### DIFF
--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -76,7 +76,7 @@ export class VeteranBenefitSummaryLetter extends React.Component {
                 name={key}
                 type="checkbox"
                 onChange={this.handleChange}/>
-              <label/>
+              <label />
             </th>
             <td><label id={`${key}Label`} htmlFor={key}>{optionText}</label></td>
           </tr>

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -76,7 +76,7 @@ export class VeteranBenefitSummaryLetter extends React.Component {
                 name={key}
                 type="checkbox"
                 onChange={this.handleChange}/>
-              <label />
+              <label/>
             </th>
             <td><label id={`${key}Label`} htmlFor={key}>{optionText}</label></td>
           </tr>

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -76,6 +76,7 @@ export class VeteranBenefitSummaryLetter extends React.Component {
                 name={key}
                 type="checkbox"
                 onChange={this.handleChange}/>
+              <label/>
             </th>
             <td><label id={`${key}Label`} htmlFor={key}>{optionText}</label></td>
           </tr>

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -70,34 +70,18 @@
     text-transform: capitalize;
   }
 
-  table > tbody > tr > td {
-    label {
-      margin: 0;
-      cursor: pointer;
-    }
-  }
-
-  #benefitInfoTable > tbody > tr > th > label {
-    vertical-align: middle;
+table > tbody > tr {
+  vertical-align: middle;
+  
+  td > label {
     margin: 0;
+    z-index: 100;
   }
-  // table {
-  //   input[type="checkbox"] {
-  //     height: inherit;
-  //     margin: auto;
-  //     opacity: inherit;
-  //     position: inherit;
-  //     width: 50%;
 
-  //     &:focus {
-  //       box-shadow: none;
-  //     }
-  //   }
-
-  //   label {
-  //     margin: 0;
-  //   }
-  // }
+  th > input, label {
+    margin: 0 !important;
+  }
+}
 
   th[scope="row"] {
     padding-top: 0;

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -70,23 +70,34 @@
     text-transform: capitalize;
   }
 
-  table {
-    input[type="checkbox"] {
-      height: inherit;
-      margin: auto;
-      opacity: inherit;
-      position: inherit;
-      width: 50%;
-
-      &:focus {
-        box-shadow: none;
-      }
-    }
-
+  table > tbody > tr > td {
     label {
       margin: 0;
+      cursor: pointer;
     }
   }
+
+  #benefitInfoTable > tbody > tr > th > label {
+    vertical-align: middle;
+    margin: 0;
+  }
+  // table {
+  //   input[type="checkbox"] {
+  //     height: inherit;
+  //     margin: auto;
+  //     opacity: inherit;
+  //     position: inherit;
+  //     width: 50%;
+
+  //     &:focus {
+  //       box-shadow: none;
+  //     }
+  //   }
+
+  //   label {
+  //     margin: 0;
+  //   }
+  // }
 
   th[scope="row"] {
     padding-top: 0;

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -75,11 +75,15 @@ table > tbody > tr {
   
   td > label {
     margin: 0;
-    z-index: 100;
+    cursor: pointer;
   }
 
+  // The USWDS label controlling the checkbox enforces an 8px margin-bottom
+  // We are adding an equivalent top margin so that vertical-align works
+  // correctly without using !important to over-ride margin-bottom
   th > input, label {
-    margin: 0 !important;
+    margin-top: 8px;
+    cursor: pointer;
   }
 }
 

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -78,12 +78,18 @@ table > tbody > tr {
     cursor: pointer;
   }
 
-  // The USWDS label controlling the checkbox enforces an 8px margin-bottom
-  // We are adding an equivalent top margin so that vertical-align works
-  // correctly without using !important to over-ride margin-bottom
-  th > input, label {
-    margin-top: 8px;
-    cursor: pointer;
+  th {
+    input, label {
+      cursor: pointer;  
+    }
+    
+    label {
+      // The USWDS label controlling the checkbox enforces an 8px margin-bottom
+      // We are adding an equivalent top margin so that vertical-align works
+      // correctly without using !important to over-ride margin-bottom
+      margin-top: 8px;
+      text-align: center;
+    }
   }
 }
 

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -72,12 +72,12 @@
 
 table > tbody > tr {
   vertical-align: middle;
-  
+
   th {
     input, label {
-      cursor: pointer;  
+      cursor: pointer;
     }
-    
+
     label {
       // The USWDS label controlling the checkbox enforces an 8px margin-bottom
       // We are adding an equivalent top margin so that vertical-align works
@@ -86,7 +86,7 @@ table > tbody > tr {
       text-align: center;
     }
   }
-  
+
   td > label {
     margin: 0;
     cursor: pointer;

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -73,11 +73,6 @@
 table > tbody > tr {
   vertical-align: middle;
   
-  td > label {
-    margin: 0;
-    cursor: pointer;
-  }
-
   th {
     input, label {
       cursor: pointer;  
@@ -90,6 +85,11 @@ table > tbody > tr {
       margin-top: 8px;
       text-align: center;
     }
+  }
+  
+  td > label {
+    margin: 0;
+    cursor: pointer;
   }
 }
 


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4360

Affects the Benefit Summary Letter checkable options

Goals were to 1.) increase size of all checkboxes to make them a bigger hit target 2.) improve consistency between these checkboxes and the standard USWDS checkboxes that are used elsewhere (including in the same component).

Due to the fact that the USWDS checkbox styling and behavior are heavily dependent on a sibling label, there were several potential ways to accomplish these goals while keeping the options rendered in a table (vs. a list). In the end, this approach seemed least disruptive.

Basically:
1. Introduce an empty `<label />` sibling after the `<input />` element to enable USWDS default styling / behavior on the input
2. Introduce slight style tweaks to the benefit options table to switch to a pointer cursor on the clickable area of the pre-existing label (and generally clean up the alignment of everything)


**Before:**
<img width="847" alt="screen shot 2017-09-06 at 11 07 51 pm" src="https://user-images.githubusercontent.com/24251447/30191971-0e4b6e42-940a-11e7-93f0-3b7a2e12e165.png">

**After:**
![screen shot 2017-09-07 at 8 22 48 pm](https://user-images.githubusercontent.com/24251447/30192022-5a72d238-940a-11e7-8a1f-37d2e48240af.png)
