### PR TITLE
Prevent validation from running twice

### DIFF
--- a/src/js/common/schemaform/FormPage.jsx
+++ b/src/js/common/schemaform/FormPage.jsx
@@ -62,16 +62,18 @@ class FormPage extends React.Component {
   }
 
   onChange(formData) {
-    let newData = formData;
-    if (this.props.route.pageConfig.showPagePerItem) {
+    if (event && event.type !== 'message') {
+      let newData = formData;
+      if (this.props.route.pageConfig.showPagePerItem) {
       // If this is a per item page, the formData object will have data for a particular
       // row in an array, so we need to update the full form data object and then call setData
-      newData = _.set([this.props.route.pageConfig.arrayPath, this.props.params.index], formData, this.props.form.data);
+        newData = _.set([this.props.route.pageConfig.arrayPath, this.props.params.index], formData, this.props.form.data);
+      }
+      this.props.setData(newData);
     }
-    this.props.setData(newData);
   }
 
-  onSubmit({ formData }) {
+  onSubmit({formData}) {
     const { route, params, form } = this.props;
 
     // This makes sure defaulted data on a page with no changes is saved

--- a/src/js/common/schemaform/FormPage.jsx
+++ b/src/js/common/schemaform/FormPage.jsx
@@ -60,20 +60,18 @@ class FormPage extends React.Component {
       focusForm();
     }
   }
-
+  
   onChange(formData) {
-    if (event && event.type !== 'message') {
-      let newData = formData;
-      if (this.props.route.pageConfig.showPagePerItem) {
+    let newData = formData;
+    if (this.props.route.pageConfig.showPagePerItem) {
       // If this is a per item page, the formData object will have data for a particular
       // row in an array, so we need to update the full form data object and then call setData
-        newData = _.set([this.props.route.pageConfig.arrayPath, this.props.params.index], formData, this.props.form.data);
-      }
-      this.props.setData(newData);
+      newData = _.set([this.props.route.pageConfig.arrayPath, this.props.params.index], formData, this.props.form.data);
     }
+    this.props.setData(newData);
   }
 
-  onSubmit({formData}) {
+  onSubmit({ formData }) {
     const { route, params, form } = this.props;
 
     // This makes sure defaulted data on a page with no changes is saved
@@ -142,7 +140,7 @@ class FormPage extends React.Component {
           pagePerItemIndex={params ? params.index : undefined}
           uploadFile={this.props.uploadFile}
           prefilled={this.props.form.prefillStatus === PREFILL_STATUSES.success}
-          onChange={this.onChange}
+          onChange={_.once(this.onChange)} // Wrapped in _.once to prevent message events from retriggering validation
           onSubmit={this.onSubmit}>
           <div className="row form-progress-buttons schemaform-buttons">
             <div className="small-6 usa-width-five-twelfths medium-5 columns">

--- a/src/js/common/schemaform/FormPage.jsx
+++ b/src/js/common/schemaform/FormPage.jsx
@@ -60,7 +60,7 @@ class FormPage extends React.Component {
       focusForm();
     }
   }
-  
+
   onChange(formData) {
     let newData = formData;
     if (this.props.route.pageConfig.showPagePerItem) {

--- a/src/js/common/schemaform/FormPage.jsx
+++ b/src/js/common/schemaform/FormPage.jsx
@@ -140,7 +140,7 @@ class FormPage extends React.Component {
           pagePerItemIndex={params ? params.index : undefined}
           uploadFile={this.props.uploadFile}
           prefilled={this.props.form.prefillStatus === PREFILL_STATUSES.success}
-          onChange={_.once(this.onChange)} // Wrapped in _.once to prevent message events from retriggering validation
+          onChange={this.onChange}
           onSubmit={this.onSubmit}>
           <div className="row form-progress-buttons schemaform-buttons">
             <div className="small-6 usa-width-five-twelfths medium-5 columns">

--- a/src/js/common/schemaform/SchemaForm.jsx
+++ b/src/js/common/schemaform/SchemaForm.jsx
@@ -164,7 +164,7 @@ class SchemaForm extends React.Component {
           onSubmit={onSubmit}
           schema={schema}
           uiSchema={uiSchema}
-          validate={this.validate}
+          validate={_.once(this.validate)}
           showErrorList={false}
           formData={data}
           widgets={useReviewMode ? reviewWidgets : widgets}

--- a/src/js/common/schemaform/SchemaForm.jsx
+++ b/src/js/common/schemaform/SchemaForm.jsx
@@ -160,7 +160,7 @@ class SchemaForm extends React.Component {
           noHtml5Validate
           onError={this.onError}
           onBlur={this.onBlur}
-          onChange={({ formData }) => onChange(formData)}
+          onChange={({formData}) => onChange(formData)}
           onSubmit={onSubmit}
           schema={schema}
           uiSchema={uiSchema}

--- a/src/js/common/schemaform/SchemaForm.jsx
+++ b/src/js/common/schemaform/SchemaForm.jsx
@@ -160,7 +160,7 @@ class SchemaForm extends React.Component {
           noHtml5Validate
           onError={this.onError}
           onBlur={this.onBlur}
-          onChange={({formData}) => onChange(formData)}
+          onChange={({ formData }) => onChange(formData)}
           onSubmit={onSubmit}
           schema={schema}
           uiSchema={uiSchema}


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4284

@jbalboni explained the issue thus:

The double validation thing was happening because of this sequence:
1. User makes a change
2. rjsf calls validation in its onChange method
3. rjsf calls our onChange, we run our updates in Redux
4. New data is sent to rjsf, it calls validation again in its componentWillReceiveProps method

This change stops step 4. That means that we’re running validation against data with the immediate change from the user, but not with any changes from custom updateSchema or required functions in the config. Theoretically, that could cause problems, but I have not been able to find an example of it doing so. I think rjsf is still running the basic JSON Schema validation twice, just not our custom validation.

This change is fine, since our custom validation is unlikely to change based on custom updates in the config. It would be more efficient if rjsf didn’t run the json schema validation twice, but that would require a change to rjsf itself.