### PR TITLE
Add whitespace before anchor tag by breaking line on anchor tag inste…

### DIFF
--- a/src/js/letters/containers/Main.jsx
+++ b/src/js/letters/containers/Main.jsx
@@ -42,9 +42,8 @@ export class Main extends React.Component {
               <div className="usa-alert-body">
                 <h4 className="usa-alert-heading">Letters Unavailable</h4>
                 <p className="usa-alert-text">
-                  We weren't able to retrieve your VA letters. Please call
-                  <a href="tel:855-574-7286">1-855-574-7286</a> between Monday-Friday
-                  8:00 a.m. - 8:00 p.m. (ET).
+                  We weren't able to retrieve your VA letters. Please call <a href="tel:855-574-7286">
+                  1-855-574-7286</a> between Monday-Friday 8:00 a.m. - 8:00 p.m. (ET).
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4664

Introduces whitespace between text and beginning of inline anchor tag by moving the line break to be within anchor element instead of within text (which strips the EOL whitespace).