### PR TITLE
Check if veteran or dependent

### DIFF
--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -31,6 +31,7 @@ export function getUserData(dispatch) {
         savedForms: json.data.attributes.in_progress_forms,
         prefillsAvailable: json.data.attributes.prefills_available,
         accountType: userData.loa.current,
+        veteranStatus: json.data.attributes.veteran_status.status,
         email: userData.email,
         userFullName: {
           first: userData.first_name,

--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -31,7 +31,6 @@ export function getUserData(dispatch) {
         savedForms: json.data.attributes.in_progress_forms,
         prefillsAvailable: json.data.attributes.prefills_available,
         accountType: userData.loa.current,
-        veteranStatus: json.data.attributes.veteran_status.status,
         email: userData.email,
         userFullName: {
           first: userData.first_name,
@@ -41,6 +40,8 @@ export function getUserData(dispatch) {
         gender: userData.gender,
         dob: userData.birth_date,
         status: json.data.attributes.va_profile.status,
+        veteranStatus: json.data.attributes.veteran_status.status,
+        isVeteran: json.data.attributes.veteran_status.is_veteran,
         services: json.data.attributes.services,
         healthTermsCurrent: json.data.attributes.health_terms_current,
       }));

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -163,9 +163,7 @@ function mapStateToProps(state) {
       serviceInfo: letterState.serviceInfo
     },
     // default isVeteran to true if service for determining this is down
-    // this decision may need to be revisited if we expect more than a 
-    // small percentage of dependents to use the system, or we infer status
-    // from the actual available letters returned from vets-api.
+    // this decision may need to be revisited.
     isVeteran: (profile.veteranStatus === "OK" ? profile.isVeteran : true),
     optionsAvailable: letterState.optionsAvailable,
     requestOptions: letterState.requestOptions

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -60,7 +60,8 @@ export class VeteranBenefitSummaryLetter extends React.Component {
       // customization checkbox is always displayed.
       const value = benefitInfo[key];
       const displayOption = optionsToAlwaysDisplay.includes(key) || value !== false;
-      const optionText = getBenefitOptionText(key, value, true, benefitInfo.awardEffectiveDate);
+      const { isVeteran } = this.props;
+      const optionText = getBenefitOptionText(key, value, isVeteran, benefitInfo.awardEffectiveDate);
       if (optionText && displayOption) {
         vaBenefitInfoRows.push(
           <tr key={`option${key}`}>

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -42,7 +42,7 @@ export class VeteranBenefitSummaryLetter extends React.Component {
         </tr>
       );
     });
-
+    
     const benefitInfo = this.props.benefitSummaryOptions.benefitInfo;
     const requestOptions = this.props.requestOptions;
     let vaBenefitInformation;
@@ -60,9 +60,6 @@ export class VeteranBenefitSummaryLetter extends React.Component {
       // customization checkbox is always displayed.
       const value = benefitInfo[key];
       const displayOption = optionsToAlwaysDisplay.includes(key) || value !== false;
-      // TODO: find out if there is anything in the profile or from EVSS that can tell
-      // us whether the user is a veteran or a user. For now we just pass in
-      // true for the isVeteran parameter
       const optionText = getBenefitOptionText(key, value, true, benefitInfo.awardEffectiveDate);
       if (optionText && displayOption) {
         vaBenefitInfoRows.push(
@@ -157,11 +154,15 @@ export class VeteranBenefitSummaryLetter extends React.Component {
 
 function mapStateToProps(state) {
   const letterState = state.letters;
+  const { veteranStatus, isVeteran } = state.user.profile;
+
   return {
     benefitSummaryOptions: {
       benefitInfo: letterState.benefitInfo,
       serviceInfo: letterState.serviceInfo
     },
+    // default isVeteran to true if backing service for determining this is down
+    isVeteran: (veteranStatus === "OK" ? isVeteran : true),
     optionsAvailable: letterState.optionsAvailable,
     requestOptions: letterState.requestOptions
   };

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -163,6 +163,9 @@ function mapStateToProps(state) {
       serviceInfo: letterState.serviceInfo
     },
     // default isVeteran to true if service for determining this is down
+    // this decision may need to be revisited if we expect more than a 
+    // small percentage of dependents to use the system, or we infer status
+    // from the actual available letters returned from vets-api.
     isVeteran: (profile.veteranStatus === "OK" ? profile.isVeteran : true),
     optionsAvailable: letterState.optionsAvailable,
     requestOptions: letterState.requestOptions

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -42,7 +42,7 @@ export class VeteranBenefitSummaryLetter extends React.Component {
         </tr>
       );
     });
-    
+
     const benefitInfo = this.props.benefitSummaryOptions.benefitInfo;
     const requestOptions = this.props.requestOptions;
     let vaBenefitInformation;
@@ -164,7 +164,7 @@ function mapStateToProps(state) {
     },
     // default isVeteran to true if service for determining this is down
     // this decision may need to be revisited.
-    isVeteran: (profile.veteranStatus === "OK" ? profile.isVeteran : true),
+    isVeteran: (profile.veteranStatus === 'OK' ? profile.isVeteran : true),
     optionsAvailable: letterState.optionsAvailable,
     requestOptions: letterState.requestOptions
   };

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -155,15 +155,15 @@ export class VeteranBenefitSummaryLetter extends React.Component {
 
 function mapStateToProps(state) {
   const letterState = state.letters;
-  const { veteranStatus, isVeteran } = state.user.profile;
+  const { profile } = state.user;
 
   return {
     benefitSummaryOptions: {
       benefitInfo: letterState.benefitInfo,
       serviceInfo: letterState.serviceInfo
     },
-    // default isVeteran to true if backing service for determining this is down
-    isVeteran: (veteranStatus === "OK" ? isVeteran : true),
+    // default isVeteran to true if service for determining this is down
+    isVeteran: (profile.veteranStatus === "OK"? profile.isVeteran : true),
     optionsAvailable: letterState.optionsAvailable,
     requestOptions: letterState.requestOptions
   };

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -163,7 +163,7 @@ function mapStateToProps(state) {
       serviceInfo: letterState.serviceInfo
     },
     // default isVeteran to true if service for determining this is down
-    isVeteran: (profile.veteranStatus === "OK"? profile.isVeteran : true),
+    isVeteran: (profile.veteranStatus === "OK" ? profile.isVeteran : true),
     optionsAvailable: letterState.optionsAvailable,
     requestOptions: letterState.requestOptions
   };

--- a/test/e2e/hca-helpers.js
+++ b/test/e2e/hca-helpers.js
@@ -236,6 +236,10 @@ function initSaveInProgressMock(url, client) {
             gender: 'F',
             birth_date: '1985-01-01',
           },
+          veteran_status: {
+            is_veteran: true,
+            status: 'OK',
+          },
           in_progress_forms: [{
             form: '1010ez',
             last_updated: 1501608808,

--- a/test/e2e/login-helpers.js
+++ b/test/e2e/login-helpers.js
@@ -39,6 +39,10 @@ function initUserMock(token, level) {
             gender: 'F',
             birth_date: '1985-01-01'
           },
+          veteran_status: {
+            status: "OK",
+            is_veteran: true,
+          },
           in_progress_forms: [],
           prefills_available: [],
           services: ['facilities', 'hca', 'edu-benefits', 'evss-claims', 'user-profile', 'rx', 'messaging'],

--- a/test/e2e/login-helpers.js
+++ b/test/e2e/login-helpers.js
@@ -40,7 +40,7 @@ function initUserMock(token, level) {
             birth_date: '1985-01-01'
           },
           veteran_status: {
-            status: "OK",
+            status: 'OK',
             is_veteran: true,
           },
           in_progress_forms: [],

--- a/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
+++ b/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
@@ -28,6 +28,7 @@ const defaultProps = {
       }
     ]
   },
+  isVeteran: true,
   optionsAvailable: true,
   requestOptions: {}
 };
@@ -77,5 +78,22 @@ describe('<VeteranBenefitSummaryLetter>', () => {
     });
 
     expect(updateOption.calledTwice).to.be.true;
+  });
+
+  it('Does not render dependent options for veterans', () => {
+    const tree = SkinDeep.shallowRender(<VeteranBenefitSummaryLetter store={store} {...defaultProps}/>);
+    const benefitInfoRows = tree.dive(['div', '#benefitInfoTable', 'tbody']).everySubTree('tr');
+    benefitInfoRows.forEach((row) => {
+      expect(() => row.dive(['td', '#hasDeathResultOfDisability'])).to.throw();
+    });
+  });
+
+  it('Does not render veteran options for dependents', () => {
+    const dependentProps = {isVeteran: false, ...defaultProps};
+    const tree = SkinDeep.shallowRender(<VeteranBenefitSummaryLetter store={store} {...dependentProps}/>);
+    const benefitInfoRows = tree.dive(['div', '#benefitInfoTable', 'tbody']).everySubTree('tr');
+    benefitInfoRows.forEach((row) => {
+      expect(() => row.dive(['td', '#hasServiceConnectedDisabilities'])).to.throw();
+    });
   });
 });

--- a/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
+++ b/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
@@ -89,7 +89,7 @@ describe('<VeteranBenefitSummaryLetter>', () => {
   });
 
   it('Does not render veteran options for dependents', () => {
-    const dependentProps = {isVeteran: false, ...defaultProps};
+    const dependentProps = { isVeteran: false, ...defaultProps };
     const tree = SkinDeep.shallowRender(<VeteranBenefitSummaryLetter store={store} {...dependentProps}/>);
     const benefitInfoRows = tree.dive(['div', '#benefitInfoTable', 'tbody']).everySubTree('tr');
     benefitInfoRows.forEach((row) => {


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3890

This PR simply adds isVeteran and veteranStatus returns from vets-api to store, connects it to the BSL component, and removes the hard-coded veteran status in this component's rendering.

This allows us to conditionally render BSL options / text based on whether the logged-in user is a veteran or a dependent.

Also includes some related tests.