### PR TITLE
Remove dark-blue color property for intro text

### DIFF
--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -364,7 +364,6 @@ h6 {
 }
 
 .va-introtext {
-  color: $color-primary-darker;
   letter-spacing: normal;
   font-size: 1.25em;
 }


### PR DESCRIPTION
Removes the intro text's color property so that it defaults to the color of the body text. Resolves [Issue 4498](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4498).

