### PR TITLE
Error message button fix

### DIFF
--- a/src/js/common/utils/error-messages.jsx
+++ b/src/js/common/utils/error-messages.jsx
@@ -6,7 +6,7 @@ export const systemDownMessage = (
     <div className="small-12 columns">
       <div className="react-container">
         <h3>Sorry, our system is temporarily down while we fix a few things. Please try again later.</h3>
-        <a href="/"><button>Go Back to Vets.gov</button></a>
+        <a href="/" className="usa-button-primary">Go Back to Vets.gov</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4679

This affects the generic error-messages.jsx, so I'm requesting the review of all of you!

Also, I can't log in to reproduce the error (this is an ongoing issue), so could one of you guys try it out? I think if you go to `localhost:3001/letters` while logged in, it should get you to that error page.