### PR TITLE
Prevent deployment when new build on branch pending

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,8 @@ env.CONCURRENCY = 10
 def isDeployable = {
   (env.BRANCH_NAME == 'master' ||
     env.BRANCH_NAME == 'production') &&
-    !env.CHANGE_TARGET
+    !env.CHANGE_TARGET &&
+    !currentBuild.nextBuild   // if there's a later build on this job (branch), don't deploy
 }
 
 def buildDetails = { vars ->


### PR DESCRIPTION
When two commits followed closely on the same branch there was a possibility that the earlier commit's associated build would run slower than the later. This resulted in the deploy stage for the earlier build running after the later.

This prevents the deploy stage from running on a build when another is already in progress.

Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2878