### PR TITLE
Fix for button border inside an accordion

### DIFF
--- a/src/sass/modules/_m-button.scss
+++ b/src/sass/modules/_m-button.scss
@@ -25,8 +25,9 @@ button,
   }
 }
 
-.usa-button-outline {
-  .usa-accordion &:focus {
+// @todo Remove this once the USWDS upgrade is complete.
+.usa-accordion {
+  .usa-button-outline:focus {
     box-shadow: inset 0 0 0 2px $color-primary-darkest, 0 0 3px $color-focus, 0 0 7px $color-focus;
   }
 }

--- a/src/sass/modules/_m-button.scss
+++ b/src/sass/modules/_m-button.scss
@@ -25,6 +25,12 @@ button,
   }
 }
 
+.usa-button-outline {
+  .usa-accordion &:focus {
+    box-shadow: inset 0 0 0 2px $color-primary-darkest, 0 0 3px $color-focus, 0 0 7px $color-focus;
+  }
+}
+
 .usa-button-outline-exit {
   &::after {
     background-image: url(/img/icons/exit-icon-primary.png);


### PR DESCRIPTION
Currently, there is a style applied to all buttons inside an accordion that changes the `box-shadow` property when the button is in the `focus` state:

```
.usa-accordion button:focus, .usa-accordion-bordered button:focus {
    box-shadow: 0 0 3px #3e94cf, 0 0 7px #3e94cf;
}
```

This isn't desirable for the outline-style buttons. This problem is really in the USWDS repo and has since been [fixed](https://github.com/18F/web-design-standards/commit/d77ee35e26a21d805367c3dddb9e2bb3168b9c37), but our version is frozen in our [package.json](https://github.com/department-of-veterans-affairs/vets-website/blob/master/package.json#L182), probably for good reason, so we need an override in our own style.

Connects to department-of-veterans-affairs/vets.gov-team/issues/4662.

