### PR TITLE
Add "." after "vs" in GIBCT glossary modal headline

### DIFF
--- a/src/js/gi/containers/Modals.jsx
+++ b/src/js/gi/containers/Modals.jsx
@@ -214,7 +214,7 @@ export class Modals extends React.Component {
         </Modal>
 
         <Modal onClose={this.props.hideModal} visible={this.shouldDisplayModal('typeAccredited')}>
-          <h2>Accreditation types (Regional vs. National vs Hybrid)</h2>
+          <h2>Accreditation types (Regional vs. National vs. Hybrid)</h2>
           <p>Is the school regionally or nationally accredited at the institution level?</p>
           <p>Schools are accredited by private educational associations of regional or national scope. While the Department of Education does not say whether regional or national accreditation is better, a recent ED study revealed that, “Nearly 90 percent of all student credit transfer opportunities occurred between institutions that were regionally, rather than nationally, accredited.” <a href="http://nces.ed.gov/pubs2014/2014163.pdf" id="anch_386">http://nces.ed.gov/pubs2014/2014163.pdf</a></p>
           <p>To learn more about accreditation types, visit the <a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#accreditation_type" target="_blank"> about this tool</a> page. </p>


### PR DESCRIPTION
Adds a single period after "vs" in the modal headline.

Connects to department-of-veterans-affairs/vets.gov-team/issues/4635.