### PR TITLE
Remove <ul> with phone numbers

### DIFF
--- a/src/js/letters/containers/LetterList.jsx
+++ b/src/js/letters/containers/LetterList.jsx
@@ -51,10 +51,6 @@ export class LetterList extends React.Component {
               One of our systems appears to be down. If you believe you are missing a
               letter or document from the list above, please try again later.
             </p>
-            <ul>
-              <li><a href="tel:888-888-8888">1-888-888-8888</a> for health-related documents</li>
-              <li><a href="tel:888-888-8888">1-888-888-8888</a> for benefits-related documents</li>
-            </ul>
           </div>
         </div>
       );


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4760

Remove fake support phone numbers when letters aren't available to line up the messaging defined in the error message mapping for [letterGeneration.letterEligibilityError](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/9ca72229004fc4c8ef951d111e44e41b7661b0df/Products/EVSS%20Integration/Letters%20and%20GIBS%20error%20messages%20mapping.md).