### PR TITLE
Move "other ways to apply" options into list

### DIFF
--- a/content/pages/burials-and-memorials/survivor-and-dependent-benefits/burial-costs.md
+++ b/content/pages/burials-and-memorials/survivor-and-dependent-benefits/burial-costs.md
@@ -64,6 +64,9 @@ You may need a copy of:
 
 #### Other ways to apply
 
+<ul>
+<li>
+
 ##### By mail
 
 Apply by mail using the Application for Burial Benefits (VA Form 21P-530). [Download VA Form 21P-530](http://www.vba.va.gov/pubs/forms/VBA-21P-530-ARE.pdf).
@@ -71,6 +74,9 @@ Apply by mail using the Application for Burial Benefits (VA Form 21P-530). [Down
 Mail the application and other paperwork to your local regional benefits office. [Find your local regional benefits office](/facilities).
 
 If you have questions, call <a href="tel:+18008271000">800-827-1000</a> (our TDD number for the hearing-impaired is 711) or call your regional benefits office.
+
+</li>
+</ul>
 
 #### What are the burial allowance amounts for a service-connected death?
 

--- a/content/pages/disability-benefits/apply.md
+++ b/content/pages/disability-benefits/apply.md
@@ -62,13 +62,22 @@ For all disability claims, please provide:
 
 ### Other ways to apply
 
-#### Work with a trained professional
+<ul>
+<li>
+
+<strong>Work with a trained professional</strong>
 
 You can work with a trained professional who can help you file a claim.  [Find an accredited representative](/disability-benefits/apply/help/index.html).
 
-#### Apply in person
+</li>
+<li>
+
+<strong>Apply in person</strong>
 
 [Go to a Regional Benefits Office](http://www.benefits.va.gov/benefits/offices.asp).
+
+</li>
+</ul>
 
 ### What happens after I apply?
 

--- a/content/pages/education/apply.md
+++ b/content/pages/education/apply.md
@@ -41,12 +41,23 @@ If you’re a Servicemember, Veteran, or family member interested in education a
 
 ### Other ways to apply
 
-#### In person
+<ul>
+<li>
+
+<strong>In person</strong>
+
 - Go to a VA regional office and have a VA employee help you. [Find a regional office near you](/facilities).
 - Work with your school’s certifying official. This person is usually in the Registrar or Financial Aid office at the school.
 
-#### By mail
+</li>
+<li>
+
+<strong>By mail</strong>
+
 - Call <a href="tel:+18884424551">888-442-4551</a> (888-GI-BILL-1) from 8:00 a.m. to 7:00 p.m. (ET), Monday through Friday, to request that we send the application to you. Fill it out and mail it to the VA regional claims processing office that’s in the same location as your school. [See a list of regional claims processing offices](http://www.benefits.va.gov/gibill/regional_processing.asp).
+
+</li>
+</ul>
 
 ### What happens after I apply?
 

--- a/content/pages/health-care/apply.md
+++ b/content/pages/health-care/apply.md
@@ -94,27 +94,41 @@ You may qualify for VA health care and other benefits. View the Application for 
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
 <div itemprop="text">
 
-##### By phone
+<ul>
+<li>
+
+**By phone**
 
 Call the Vets.gov Help Desk at <a href="tel:+1-855-574-7286">855-574-7286</a>, Monday through Friday, 8:00 a.m. to 8:00 p.m. (ET) to get help with your application.
+</li>
 
-##### By mail
+<li>
+
+**By mail**
 
 [Download an Application for Health Benefits (VA Form 10-10EZ)](http://www.va.gov/vaforms/medical/pdf/1010EZ-fillable.pdf).
 
 Print the form, fill it out, and send it to this address:
+
 
 <p class="va-address-block">
 Health Eligibility Center<br>
 2957 Clairmont Rd., Suite 200<br>
 Atlanta, GA 30329<br>
 </p>
+</li>
 
-##### In person
+<li>
+
+**In person**
 
 Go to your nearest VA medical center or clinic. Bring an Application for Health Benefits (VA Form 10-10EZ) with you.<br />
 [Find a VA medical center or clinic near you](/facilities/).<br />
 [Download VA Form 10-10EZ](http://www.va.gov/vaforms/medical/pdf/1010EZ-fillable.pdf)
+
+</li>
+
+</ul>
 
 </div>
 </div>

--- a/content/pages/pension/apply.md
+++ b/content/pages/pension/apply.md
@@ -37,22 +37,35 @@ You can apply online, in person, or by mail for a Veterans pension. Follow these
 
 ### Other ways to apply
 
-**By mail**
+<ul>
+<li>
+
+<strong>By mail</strong>
 
 Apply by mail using an Application for Pension (VA Form 21P-527EZ). [Download VA Form 21P-527EZ](https://www.vba.va.gov/pubs/forms/VBA-21P-527EZ-ARE.pdf).
 
 Mail the application to the Pension Management Center (PMC) for your state. [Find your PMC](/pension/pension-management-center/).
 
-**In person**
+</li>
+<li>
+
+<strong>In person</strong>
 
 Bring your application to a regional benefits office near you. [Find a regional benefits office](/facilities/).
 
-**With the help of a trained professional**
+</li>
+<li>
+
+<strong>With the help of a trained professional</strong>
 
 You can work with a trained professional called an accredited representative to get help applying for VA pension benefits. [Find an accredited representative](/disability-benefits/apply/help/).
 
-
 [Find out how to apply for the Survivors Pension program](/pension/survivors-pension/).
+
+</li>
+</ul>
+
+
 
 ### How long does it take VA to make a decision?
 


### PR DESCRIPTION
Instead of just using headings, the options under the "Other ways to apply" have been moved into a standard bulleted list for clarity purposes.

Connects to department-of-veterans-affairs/vets.gov-team/issues/4767.