### PR TITLE
Disallow address update

### DIFF
--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -56,7 +56,7 @@ export class AddressSection extends React.Component {
         <div>
           <Address
             value={address}
-            onUserInput={(addr) => {this.props.updateAddress(addr);}}
+            onUserInput={(addr) => { this.props.updateAddress(addr); }}
             required/>
           <button className="usa-button-primary" onClick={this.handleUpdate}>Update</button>
           <button className="usa-button-outline" onClick={() => this.setState({ isEditingAddress: false })}>Cancel</button>
@@ -68,9 +68,8 @@ export class AddressSection extends React.Component {
           <div className="letters-address">{streetAddress}</div>
           <div className="letters-address">{cityStatePostal}</div>
           <div className="letters-address">{country}</div>
-          { this.props.canUpdateAddress
-            ? <button className="usa-button-outline" onClick={() => this.setState({ isEditingAddress: true })}>Edit</button>
-            : <div>Here goes helper text when a vet isn't allowed to edit his or her address</div>
+          {this.props.canUpdateAddress &&
+            <button className="usa-button-outline" onClick={() => this.setState({ isEditingAddress: true })}>Edit</button>
           }
         </div>
       );
@@ -107,7 +106,7 @@ export class AddressSection extends React.Component {
 }
 
 function mapStateToProps(state) {
-  const {fullName, address, canUpdateAddress} = state.letters;
+  const { fullName, address, canUpdateAddress } = state.letters;
   return {
     recipientName: fullName,
     address,

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -68,7 +68,10 @@ export class AddressSection extends React.Component {
           <div className="letters-address">{streetAddress}</div>
           <div className="letters-address">{cityStatePostal}</div>
           <div className="letters-address">{country}</div>
-          <button className="usa-button-outline" onClick={() => this.setState({ isEditingAddress: true })}>Edit</button>
+          { this.props.canUpdateAddress
+            ? <button className="usa-button-outline" onClick={() => this.setState({ isEditingAddress: true })}>Edit</button>
+            : <div>Here goes helper text when a vet isn't allowed to edit his or her address</div>
+          }
         </div>
       );
     }
@@ -104,10 +107,11 @@ export class AddressSection extends React.Component {
 }
 
 function mapStateToProps(state) {
-  const letterState = state.letters;
+  const {fullName, address, canUpdateAddress} = state.letters;
   return {
-    recipientName: letterState.fullName,
-    address: letterState.address
+    recipientName: fullName,
+    address,
+    canUpdateAddress,
   };
 }
 

--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -65,12 +65,15 @@ function letters(state = initialState, action) {
       return _.set('lettersAvailability', AVAILABILITY_STATUSES.unavailable, state);
     case LETTER_ELIGIBILITY_ERROR:
       return _.set('lettersAvailability', AVAILABILITY_STATUSES.letterEligibilityError, state);
-    case GET_ADDRESS_SUCCESS:
+    case GET_ADDRESS_SUCCESS: {
+      const { attributes } = action.data.data;
       return {
         ...state,
-        address: action.data.data.attributes.address,
+        address: attributes.address,
+        canUpdateAddress: attributes.controlInformation.canUpdateAddress,
         addressAvailable: true
       };
+    }
     case GET_ADDRESS_FAILURE:
       return _.set('addressAvailable', false, state);
     case GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS: {

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -18,7 +18,8 @@ const defaultProps = {
     state: 'VA',
     zipCode: '12345'
   },
-  saveAddress: saveSpy
+  canUpdateAddress: true,
+  saveAddress: saveSpy,
 };
 
 describe('<AddressSection>', () => {
@@ -48,6 +49,18 @@ describe('<AddressSection>', () => {
     });
     const tree = SkinDeep.shallowRender(<AddressSection {...props}/>);
     expect(tree.subTree('.step-content').text()).to.contain('2476 main street, ste #12 west');
+  });
+
+  it('should not render an edit button if user not allowed to edit address', () => {
+    const cannotEditProps = { ...defaultProps, canUpdateAddress: false };
+    const component = ReactTestUtils.renderIntoDocument(<AddressSection {...cannotEditProps}/>);
+    expect(() => ReactTestUtils.findRenderedDOMComponentWithTag(component, 'button')).to.throw();
+  });
+
+  it('should render an edit button if user is allowed to edit address', () => {
+    const component = ReactTestUtils.renderIntoDocument(<AddressSection {...defaultProps}/>);
+    const editButton = ReactTestUtils.findRenderedDOMComponentWithTag(component, 'button');
+    expect(editButton).to.not.be.empty;
   });
 
   it('should expand address fields when Edit button is clicked', () => {

--- a/test/letters/reducers/index.unit.spec.js
+++ b/test/letters/reducers/index.unit.spec.js
@@ -144,6 +144,9 @@ describe('letters reducer', () => {
             attributes: {
               address: {
                 addressOne: '2746 Main St'
+              },
+              controlInformation: {
+                canUpdateAddress: true,
               }
             }
           }


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4113

This adds conditional logic to edit address button so that it only shows for vets that can update their address per the vets-api.

Still needs tests.

Also, not sure I'm happy with how complex this component has gotten. Would like to refactor at some point and break out into smaller components that just do One Thing.