### PR TITLE
Fix infinite verify URL loop and broken verify link in user profile.

### DIFF
--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -20,6 +20,21 @@ export function handleMultifactor(multifactorUrl) {
   }
 }
 
+export function getVerifyUrl(onUpdateVerifyUrl) {
+  const verifyUrlRequest = fetch(`${environment.API_URL}/v0/sessions/identity_proof`, {
+    method: 'GET',
+    headers: new Headers({
+      Authorization: `Token token=${sessionStorage.userToken}`
+    })
+  }).then(response => {
+    return response.json();
+  }).then(json => {
+    onUpdateVerifyUrl(json.identity_proof_url);
+  });
+
+  return verifyUrlRequest;
+}
+
 export function getMultifactorUrl(onUpdateMultifactorUrl) {
   const getMultifactorUrlRequest = fetch(`${environment.API_URL}/v0/sessions/multifactor`, {
     method: 'GET',

--- a/src/js/signin/containers/Main.jsx
+++ b/src/js/signin/containers/Main.jsx
@@ -35,8 +35,15 @@ class Main extends React.Component {
     window.onload = this.checkTokenStatus();
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.getVerifyUrl(!this.props.login.currentlyLoggedIn && nextProps.login.currentlyLoggedIn);
+  componentDidUpdate(prevProps) {
+    const shouldGetVerifyUrl =
+      !prevProps.login.currentlyLoggedIn &&
+      this.props.login.currentlyLoggedIn &&
+      !this.props.login.verifyUrl;
+
+    if (shouldGetVerifyUrl) {
+      this.getVerifyUrl();
+    }
   }
 
   componentWillUnmount() {
@@ -49,8 +56,9 @@ class Main extends React.Component {
     this.loginUrlRequest = getLoginUrls(this.props.onUpdateLoginUrls);
   }
 
-  getVerifyUrl(forceRequest) {
-    if (!forceRequest && !this.props.login.currentlyLoggedIn) return;
+  getVerifyUrl() {
+    const { currentlyLoggedIn, verifyUrl } = this.props.login;
+    if (!currentlyLoggedIn || verifyUrl) return;
 
     this.verifyUrlRequest = fetch(`${environment.API_URL}/v0/sessions/identity_proof`, {
       method: 'GET',

--- a/src/js/signin/containers/Main.jsx
+++ b/src/js/signin/containers/Main.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import moment from 'moment';
 
 import environment from '../../common/helpers/environment.js';
-import { getUserData, addEvent, handleLogin, getLoginUrls } from '../../common/helpers/login-helpers';
+import { getUserData, addEvent, handleLogin, getLoginUrls, getVerifyUrl } from '../../common/helpers/login-helpers';
 
 import { updateLoggedInStatus, updateVerifyUrl, updateLogoutUrl, updateLogInUrls } from '../../login/actions';
 import Signin from '../components/Signin';
@@ -58,18 +58,9 @@ class Main extends React.Component {
 
   getVerifyUrl() {
     const { currentlyLoggedIn, verifyUrl } = this.props.login;
-    if (!currentlyLoggedIn || verifyUrl) return;
-
-    this.verifyUrlRequest = fetch(`${environment.API_URL}/v0/sessions/identity_proof`, {
-      method: 'GET',
-      headers: new Headers({
-        Authorization: `Token token=${sessionStorage.userToken}`
-      })
-    }).then(response => {
-      return response.json();
-    }).then(json => {
-      this.props.onUpdateVerifyUrl(json.identity_proof_url);
-    });
+    if (currentlyLoggedIn && !verifyUrl) {
+      this.verifyUrlRequest = getVerifyUrl(this.props.onUpdateVerifyUrl);
+    }
   }
 
   setMyToken(event) {

--- a/src/js/user-profile/containers/UserProfileApp.jsx
+++ b/src/js/user-profile/containers/UserProfileApp.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
 
-import { removeSavedForm } from '../actions/index';
+import { getVerifyUrl } from '../../common/helpers/login-helpers.js';
+import { updateVerifyUrl } from '../../login/actions';
+import { removeSavedForm } from '../actions';
 import UserDataSection from '../components/UserDataSection';
 import AuthApplicationSection from '../components/AuthApplicationSection';
 import FormList from '../components/FormList';
@@ -18,9 +20,13 @@ moment.updateLocale('en', {
 });
 
 class UserProfileApp extends React.Component {
+  componentDidMount() {
+    if (!this.props.verifyUrl) {
+      getVerifyUrl(this.props.updateVerifyUrl);
+    }
+  }
 
   render() {
-
     const view = (
       <div className="row user-profile-row">
         <div className="usa-width-two-thirds medium-8 small-12 columns">
@@ -65,7 +71,8 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = {
-  removeSavedForm
+  removeSavedForm,
+  updateVerifyUrl
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserProfileApp);


### PR DESCRIPTION
### Infinite `identity_proof` fetches

Going to the verify page when logged in would infinitely fetch the identity proof URL. When the user was `currentlyLoggedIn` in `getVerifyUrl` in `Verify.jsx`, it would never return before the fetch. And each time it finished fetching, it would update the store and trigger `componentWillReceiveProps`.

I changed it to stop once it set the `verifyUrl`. I also changed it to use the `componentDidUpdate` lifecycle method instead so that it would deal with the current props if it had to call `getVerifyUrl`. With `componentWillReceiveProps`, the comparison for `forceRequest` was between the current props and what they would change to, but then `getVerifyUrl` would look at the current props, not what they were changing to, which is why you had to pass in the force flag. It felt a little confusing for me to think about.

### Broken verify URL in user profile

The "You need to verify your account" link wasn't working because `this.props.login.verifyUrl` wasn't populated, so I changed it to make the container fetch the URL if it wasn't available. Since these two instances did the same thing, I pulled the promise chain into its own helper function like the other identity URL helpers.