### PR TITLE
Switch mobile navigation menu to use a calculated height

### DIFF
--- a/src/sass/modules/_m-vet-nav.scss
+++ b/src/sass/modules/_m-vet-nav.scss
@@ -1,3 +1,6 @@
+// The distance from the top of the sceen that the mobile navigation menu should appear
+$height-offset: 111.16px;
+
 body.va-pos-fixed {
   width: 100%;
   height: 100%;
@@ -5,7 +8,8 @@ body.va-pos-fixed {
 
 #vetnav {
   background-color: $color-primary-darkest;
-  height: 100%;
+  height: calc(100% - #{$height-offset});
+  top: $height-offset;
   left: 0;
   overflow-y: scroll;
   position: absolute;
@@ -19,6 +23,8 @@ body.va-pos-fixed {
     overflow-y: visible;
     position: relative;
     width: auto;
+    top: 0;
+    height: 100%;
   }
 
   .va-wip-message {
@@ -28,7 +34,7 @@ body.va-pos-fixed {
 }
 
 #vetnav-menu {
-  height: 62rem;
+  height: auto;
   list-style: none;
   margin: 1rem 0;
   overflow-y: auto;

--- a/src/sass/modules/_m-vet-nav.scss
+++ b/src/sass/modules/_m-vet-nav.scss
@@ -9,6 +9,10 @@ body.va-pos-fixed {
 #vetnav {
   background-color: $color-primary-darkest;
   height: calc(100% - #{$height-offset});
+  
+  // This value should be equal to the default y-position of the menu so that removing it 
+  // shouldn't affect anything. However, it's here to show how the height is offset by the
+  // vertical positioning.
   top: $height-offset;
   left: 0;
   overflow-y: scroll;


### PR DESCRIPTION
Currently, the height of the navigation menu's container (on mobile) is set at `100%` and the actual contents at `62rem`. This causes some weird behavior, because the container is then offscreen by the distance from the navigation to the top of the window. This causes the content to get cut off in some instances, specifically if you have the "Explore benefits" menu expanded.

To fix this, these changes include using the CSS `calc()` function to set the container's height to `100%` of the screen minus the distance from the navigation bar to the top of the window. That second value I determined to be `111.16px` by inspecting each element - there wasn't really a clear way to do this otherwise without involving JavaScript. It then applies that value to the `top` value to offset it from the top of the menu and allows the navigation menu's contents to increase the height according to the length of the content.

Connects to department-of-veterans-affairs/vets.gov-team/issues/4619.