### PR TITLE
Add dependent messaging

### DIFF
--- a/src/js/post-911-gib-status/utils/helpers.jsx
+++ b/src/js/post-911-gib-status/utils/helpers.jsx
@@ -105,7 +105,7 @@ export function notQualifiedWarning() {
 
 export function noChapter33BenefitsWarning() {
   return (
-    <div className="record-not-found">
+    <div id="noChapter33Benefits">
       <header>
         <h1>We couldn’t find your Post-9/11 GI Bill information.</h1>
       </header>

--- a/src/js/post-911-gib-status/utils/helpers.jsx
+++ b/src/js/post-911-gib-status/utils/helpers.jsx
@@ -120,7 +120,8 @@ export function noChapter33BenefitsWarning() {
       <h2>Need GI Bill help?</h2>
       <hr className="divider"/>
       <p>If you have questions or need help looking up your GI Bill information, please call <a
-        className="gi-phone-help" href="tel:1-888-442-4551">1-888-442-4551</a> (1-888-GI-BILL-1) from 8:00 a.m. to 7:00 pm (ET).</p>
+        className="gi-phone-nowrap" href="tel:1-888-442-4551">1-888-442-4551</a> <span className="gi-phone-nowrap">
+          (1-888-GI-BILL-1)</span> from 8:00 a.m. to 7:00 pm (ET).</p>
     </div>
   );
 }

--- a/src/js/post-911-gib-status/utils/helpers.jsx
+++ b/src/js/post-911-gib-status/utils/helpers.jsx
@@ -104,25 +104,23 @@ export function notQualifiedWarning() {
 }
 
 export function noChapter33BenefitsWarning() {
-  // TODO: expand vertical spacing
   return (
-    <div className="feature" id="noChapter33Benefits">
-      <h4>You don’t currently have any Post-9/11 GI Bill Benefits</h4>
-      We may not have information about your Post-9/11 GI Bill benefit because
-      <ul>
-        <li>You haven’t applied for Post-9/11 GI Bill benefits, <strong>or</strong></li>
-        <li>Your application for Post-9/11 GI Bill benefits is still in process, <strong>or</strong></li>
-        <li>You have education benefits through a different benefit or chapter.</li>
-      </ul>
-      Need to apply?
-      <ul>
-        <li><a href="">Check to make sure you qualify for Post-9/11 GI Bill benefits</a></li>
-        <li><a href="">Apply for benefits</a></li>
-      </ul>
-      Not sure if you have benefits through another program?
-      <ul>
-        <li><a href="" target="_blank">Check your benefit status through our Web Automated Verification of Enrollment (W.A.V.E.) system</a></li>
-      </ul>
+    <div className="record-not-found">
+      <header>
+        <h1>We couldn’t find your Post-9/11 GI Bill information.</h1>
+      </header>
+      <div className="usa-alert usa-alert-warning">
+        <div className="usa-alert-body">
+          <p className="usa-alert-heading">
+            <a target="_blank" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=post-911-gi-bill-enrollment-status">
+            If you’re a dependent, please go to eBenefits to look up your GI Bill information.</a>
+          </p>
+        </div>
+      </div>
+      <h2>Need GI Bill help?</h2>
+      <hr className="divider"/>
+      <p>If you have questions or need help looking up your GI Bill information, please call <a
+        className="gi-phone-help" href="tel:1-888-442-4551">1-888-442-4551</a> (1-888-GI-BILL-1) from 8:00 a.m. to 7:00 pm (ET).</p>
     </div>
   );
 }

--- a/src/sass/post-911-gib-status.scss
+++ b/src/sass/post-911-gib-status.scss
@@ -95,7 +95,7 @@
   hr {
     margin-top: 0;
     margin-bottom: 0;
-    border-color: $color-primary-darker;
+    border-color: $color-primary;
   }
 
   .gi-phone-help {

--- a/src/sass/post-911-gib-status.scss
+++ b/src/sass/post-911-gib-status.scss
@@ -87,7 +87,7 @@
   }
 }
 
-.record-not-found {
+#noChapter33Benefits {
   h2 {
     margin-top: 2em;
   }

--- a/src/sass/post-911-gib-status.scss
+++ b/src/sass/post-911-gib-status.scss
@@ -86,3 +86,19 @@
     }
   }
 }
+
+.record-not-found {
+  h2 {
+    margin-top: 2em;
+  }
+
+  hr {
+    margin-top: 0;
+    margin-bottom: 0;
+    border-color: $color-primary-darker;
+  }
+
+  .gi-phone-help {
+    white-space: nowrap;
+  }
+}

--- a/src/sass/post-911-gib-status.scss
+++ b/src/sass/post-911-gib-status.scss
@@ -98,7 +98,7 @@
     border-color: $color-primary;
   }
 
-  .gi-phone-help {
+  .gi-phone-nowrap {
     white-space: nowrap;
   }
 }


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4592

Replaces the old 404 [post-9/11 GIBS message](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/EVSS%20Integration/Letters%20and%20GIBS%20error%20messages%20mapping.md) with a new one:

<img width="1204" alt="screen shot 2017-09-18 at 8 34 18 pm" src="https://user-images.githubusercontent.com/24251447/30572269-2ecd4d88-9cb2-11e7-847d-38b5710cbf17.png">

<img width="374" alt="screen shot 2017-09-18 at 8 40 15 pm" src="https://user-images.githubusercontent.com/24251447/30572272-31f9aaa6-9cb2-11e7-808e-06826a1958b3.png">

