### PR TITLE
Increase z index so it overrides nav

### DIFF
--- a/src/sass/post-911-gib-status.scss
+++ b/src/sass/post-911-gib-status.scss
@@ -63,7 +63,7 @@
     width: 100%;
     height: 100%;
     overflow-y: scroll;
-    z-index: 10;
+    z-index: 2000;
 
     h1 {
       margin-top: 1em;


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4907

The z-index of one of the nav elements was recently changed to 1011, which was causing it to show up on the print page. This PR increase the z-index of the print page to 2000 to override that.

Before:
<img width="973" alt="screen shot 2017-09-19 at 12 34 58 pm" src="https://user-images.githubusercontent.com/25183456/30603895-f951f426-9d36-11e7-9800-ec71790fc13c.png">


After:
<img width="1078" alt="screen shot 2017-09-19 at 12 34 30 pm" src="https://user-images.githubusercontent.com/25183456/30603872-ee72e7f4-9d36-11e7-84e1-e25c8973fb3b.png">
