### PR TITLE
Handle Edge 14 fetch errors and add more tracking

### DIFF
--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -1,4 +1,6 @@
 import _ from 'lodash/fp';
+import Raven from 'raven-js';
+
 import environment from '../../common/helpers/environment';
 import { SET_UNAUTHORIZED } from '../actions';
 
@@ -196,6 +198,15 @@ export function makeAuthRequest(url, userOptions, dispatch, onSuccess, onError) 
   }, userOptions);
 
   fetch(`${environment.API_URL}${url}`, options)
+    .catch(err => {
+      Raven.captureMessage(`vets_client_error: ${err.message}`, {
+        extra: {
+          error: err
+        }
+      });
+
+      return Promise.reject(err);
+    })
     .then((resp) => {
       if (resp.ok) {
         if (options.responseType) {

--- a/src/js/common/helpers/api.js
+++ b/src/js/common/helpers/api.js
@@ -1,4 +1,5 @@
 import merge from 'lodash/fp/merge';
+import Raven from 'raven-js';
 
 import environment from './environment';
 
@@ -24,6 +25,15 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
   const settings = merge(defaultSettings, optionalSettings);
 
   return fetch(url, settings)
+    .catch(err => {
+      Raven.captureMessage(`vets_client_error: ${err.message}`, {
+        extra: {
+          error: err
+        }
+      });
+
+      return Promise.reject(err);
+    })
     .then((response) => {
       const data = isJson(response)
         ? response.json()

--- a/src/js/common/polyfills.js
+++ b/src/js/common/polyfills.js
@@ -19,9 +19,16 @@ if (!Modernizr.classlist) {
 if (!Modernizr.dataset) {
   require('dataset');  // dataSet accessor support.
 }
-if (!Modernizr.fetch) {
-  require('whatwg-fetch');  // dataSet accessor support.
+
+// Edge 14's fetch implementation throws TypeMismatchErrors seemingly without
+// reason. This is fixed in fetch 15, but we should use the (xhr based) polyfill
+// for 14.
+// https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/8546263/
+if (navigator.userAgent.includes('Edge/14')) {
+  window.fetch = undefined;
 }
+
+require('whatwg-fetch');
 
 // This polyfill has its own test logic so no need to conditionally require.
 require('polyfill-function-prototype-bind');

--- a/src/js/health-records/utils/helpers.js
+++ b/src/js/health-records/utils/helpers.js
@@ -1,5 +1,6 @@
 import environment from '../../common/helpers/environment';
 import merge from 'lodash/fp/merge';
+import Raven from 'raven-js';
 
 function isJson(response) {
   const contentType = response.headers.get('content-type');
@@ -20,6 +21,15 @@ export function apiRequest(url, optionalSettings = {}, success, error) {
   const settings = merge(defaultSettings, optionalSettings);
 
   return fetch(requestUrl, settings)
+    .catch(err => {
+      Raven.captureMessage(`vets_client_error: ${err.message}`, {
+        extra: {
+          error: err
+        }
+      });
+
+      return Promise.reject(err);
+    })
     .then((response) => {
       if (!response.ok) {
         // Refresh to show login view when requests are unauthorized.

--- a/test/claims-status/actions.unit.spec.js
+++ b/test/claims-status/actions.unit.spec.js
@@ -205,7 +205,7 @@ describe('Actions', () => {
     it('should fetch claims', (done) => {
       const appeals = [];
       fetchMock.returns({
-        then: (fn) => fn({ ok: true, json: () => Promise.resolve(appeals) })
+        'catch': () => ({ then: (fn) => fn({ ok: true, json: () => Promise.resolve(appeals) }) }),
       });
       const thunk = getAppeals();
       const dispatchSpy = sinon.spy();
@@ -223,7 +223,7 @@ describe('Actions', () => {
     it('should fail on error', (done) => {
       const appeals = [];
       fetchMock.returns({
-        then: (fn) => fn({ ok: false, status: 500, json: () => Promise.resolve(appeals) })
+        'catch': () => ({ then: (fn) => fn({ ok: false, status: 500, json: () => Promise.resolve(appeals) }) }),
       });
       const thunk = getAppeals();
       const dispatchSpy = sinon.spy();
@@ -245,7 +245,7 @@ describe('Actions', () => {
     it('should fetch claims', (done) => {
       const claims = [];
       fetchMock.returns({
-        then: (fn) => fn({ ok: true, json: () => Promise.resolve(claims) })
+        'catch': () => ({ then: (fn) => fn({ ok: true, json: () => Promise.resolve(claims) }) }),
       });
       const thunk = getClaims();
       const dispatchSpy = sinon.spy();
@@ -263,7 +263,7 @@ describe('Actions', () => {
     it('should fail on error', (done) => {
       const claims = [];
       fetchMock.returns({
-        then: (fn) => fn({ ok: false, status: 500, json: () => Promise.resolve(claims) })
+        'catch': () => ({ then: (fn) => fn({ ok: false, status: 500, json: () => Promise.resolve(claims) }) }),
       });
       const thunk = getClaims();
       const dispatchSpy = sinon.spy();
@@ -285,7 +285,7 @@ describe('Actions', () => {
     it('should fetch claim', (done) => {
       const claim = { data: {}, meta: {} };
       fetchMock.returns({
-        then: (fn) => fn({ ok: true, json: () => Promise.resolve(claim) })
+        'catch': () => ({ then: (fn) => fn({ ok: true, json: () => Promise.resolve(claim) }) }),
       });
       const thunk = getClaimDetail();
       const dispatchSpy = sinon.spy();
@@ -309,7 +309,7 @@ describe('Actions', () => {
     it('should fail on 500 error', (done) => {
       const claim = { data: {}, meta: {} };
       fetchMock.returns({
-        then: (fn) => fn({ ok: false, status: 500, json: () => Promise.resolve(claim) })
+        'catch': () => ({ then: (fn) => fn({ ok: false, status: 500, json: () => Promise.resolve(claim) }) }),
       });
       const thunk = getClaimDetail();
       const dispatchSpy = sinon.spy();
@@ -331,7 +331,7 @@ describe('Actions', () => {
     it('should redirect on 404 error', (done) => {
       const claim = { data: {}, meta: {} };
       fetchMock.returns({
-        then: (fn) => fn({ ok: false, status: 404, json: () => Promise.resolve(claim) })
+        'catch': () => ({ then: (fn) => fn({ ok: false, status: 404, json: () => Promise.resolve(claim) }) }),
       });
       const dispatchSpy = sinon.spy();
       const routerSpy = (path) => {
@@ -351,7 +351,7 @@ describe('Actions', () => {
     beforeEach(mockFetch);
     it('should submit request', (done) => {
       fetchMock.returns({
-        then: (fn) => fn({ ok: true, json: () => Promise.resolve() })
+        'catch': () => ({ then: (fn) => fn({ ok: true, json: () => Promise.resolve() }) }),
       });
       const thunk = submitRequest(5);
       const dispatchSpy = sinon.spy();
@@ -375,7 +375,7 @@ describe('Actions', () => {
     });
     it('should fail on error', (done) => {
       fetchMock.returns({
-        then: (fn) => fn({ ok: false, status: 500, json: () => Promise.resolve() })
+        'catch': () => ({ then: (fn) => fn({ ok: false, status: 500, json: () => Promise.resolve() }) }),
       });
       const thunk = submitRequest(5);
       const dispatchSpy = sinon.spy();

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -404,7 +404,7 @@ describe('Disability benefits helpers: ', () => {
     it('should make a fetch request', (done) => {
       global.sessionStorage = { userToken: '1234' };
       fetchMock.returns({
-        then: (fn) => fn({ ok: true, json: () => Promise.resolve() })
+        'catch': () => ({ then: (fn) => fn({ ok: true, json: () => Promise.resolve() }) })
       });
 
       const onSuccess = () => done();
@@ -417,7 +417,7 @@ describe('Disability benefits helpers: ', () => {
     it('should reject promise when there is an error', (done) => {
       global.sessionStorage = { userToken: '1234' };
       fetchMock.returns({
-        then: (fn) => fn({ ok: false, status: 500, json: () => Promise.resolve() })
+        'catch': () => ({ then: (fn) => fn({ ok: false, status: 500, json: () => Promise.resolve() }) })
       });
 
       const onError = (resp) => {
@@ -433,7 +433,7 @@ describe('Disability benefits helpers: ', () => {
     it('should dispatch auth error', (done) => {
       global.sessionStorage = { userToken: '1234' };
       fetchMock.returns({
-        then: (fn) => fn({ ok: false, status: 401, json: () => Promise.resolve() })
+        'catch': () => ({ then: (fn) => fn({ ok: false, status: 401, json: () => Promise.resolve() }) })
       });
 
       const onError = sinon.spy();


### PR DESCRIPTION
We see lots of TypeMismatchErrors when making fetch calls on Edge 14 (http://sentry.vetsgov-internal/vets-gov/website-production/issues/7140/). This appears to be specific to that browser's fetch implementation. This adds some code to force the fetch polyfill on that browser.

The other changes in here are to add some error tracking for client-side errors in our different api functions. These errors are swallowed currently, but they're common enough on Rainbows apps to generate call center tickets, so I would like to see if they're common on other features.