### PR TITLE
Fix for mobile menu resetting when non-link is clicked

### DIFF
--- a/src/js/legacy/mega-menu.js
+++ b/src/js/legacy/mega-menu.js
@@ -26,12 +26,6 @@ class MegaMenu {
 
     menus.forEach((menu) => {
       menu.addEventListener('click', this.toggleMenu);
-
-      const dropdown = this.getMenu(menu.getAttribute('aria-controls'));
-
-      if (dropdown) {
-        dropdown.addEventListener('click', (event) => event.stopPropagation());
-      }
     });
 
     submenus.forEach((submenu) => {
@@ -44,7 +38,8 @@ class MegaMenu {
 
     this.openControl.addEventListener('click', this.showMenu);
     this.closeControl.addEventListener('click', this.hideMenu);
-
+    this.menu.addEventListener('click', (event) => event.stopPropagation());
+    
     document.addEventListener('click', this.handleDocumentClick);
     window.addEventListener('resize', this.resetMenu);
   }


### PR DESCRIPTION
I was reviewing the functionality for the navigation on both desktop and mobile when I found that on the mobile menu on desktop, if you navigate within the menu, then click the bottom section, the menu will reset. This is because the document's click event is firing while the menu is open. This doesn't occur on the mobile devices I tested because the document's click event does not fire on mobile but I still think it should be fixed just in case there are some mobile devices that do fire the document's click event. 

This is a fix so that anywhere within the whole menu will prevent the document's click event from firing.