### PR TITLE
Add "Download health records" into navigation

### DIFF
--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -49,6 +49,7 @@
                 <li><a href="/health-care/health-conditions">Health needs and conditions</a></li>
                 <li><a class="login-required" href="/health-care/prescriptions">Refill prescriptions</a></li>
                 <li><a class="login-required" href="/health-care/messaging">Message your health care team</a></li>
+                <li><a href="/health-care/health-records/">Get your VA health records</a></li>
                 <li> <a href="/health-care/apply/application/" class="usa-button va-button-primary">Apply now</a></li>
               </ul>
             </li>

--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -169,7 +169,7 @@
                 <li><a href="/burials-and-memorials/">Burials &amp; memorials overview</a></li>
                 <li><a href="/burials-and-memorials/eligibility/">Eligibility</a></li>
                 <li><a href="/burials-and-memorials/burial-planning/">Plan a burial</a></li>
-                <li><a href="/burials-and-memorials/survivor-and-dependent-benefits/">Survivor benefits</a> </li>
+                <li><a href="/burials-and-memorials/survivor-and-dependent-benefits/">Survivor benefits</a></li>
                 <li><a href="/burials-and-memorials/find-a-cemetery/">Find a cemetery</a></li>
                </ul>
             </li>

--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -48,7 +48,7 @@
                 <li><a href="/health-care/apply/">Application process</a></li>
                 <li><a href="/health-care/health-conditions">Health needs and conditions</a></li>
                 <li><a class="login-required" href="/health-care/prescriptions">Refill prescriptions</a></li>
-                <li><a class="login-required" href="/health-care/messaging">Secure message your health care team</a></li>
+                <li><a class="login-required" href="/health-care/messaging">Message your health care team</a></li>
                 <li><a href="/health-care/health-records/">Get your VA health records</a></li>
                 <li> <a href="/health-care/apply/application/" class="usa-button va-button-primary">Apply now</a></li>
               </ul>

--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -49,7 +49,7 @@
                 <li><a href="/health-care/health-conditions">Health needs and conditions</a></li>
                 <li><a class="login-required" href="/health-care/prescriptions">Refill prescriptions</a></li>
                 <li><a class="login-required" href="/health-care/messaging">Secure message your health care team</a></li>
-                <li><a href="/health-care/health-records/">Download health records</a></li>
+                <li><a href="/health-care/health-records/">Get your VA health records</a></li>
                 <li> <a href="/health-care/apply/application/" class="usa-button va-button-primary">Apply now</a></li>
               </ul>
             </li>

--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -48,7 +48,7 @@
                 <li><a href="/health-care/apply/">Application process</a></li>
                 <li><a href="/health-care/health-conditions">Health needs and conditions</a></li>
                 <li><a class="login-required" href="/health-care/prescriptions">Refill prescriptions</a></li>
-                <li><a class="login-required" href="/health-care/messaging">Message your health care team</a></li>
+                <li><a class="login-required" href="/health-care/messaging">Secure message your health care team</a></li>
                 <li><a href="/health-care/health-records/">Download health records</a></li>
                 <li> <a href="/health-care/apply/application/" class="usa-button va-button-primary">Apply now</a></li>
               </ul>

--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -169,7 +169,7 @@
                 <li><a href="/burials-and-memorials/">Burials &amp; memorials overview</a></li>
                 <li><a href="/burials-and-memorials/eligibility/">Eligibility</a></li>
                 <li><a href="/burials-and-memorials/burial-planning/">Plan a burial</a></li>
-                <li><a href="/burials-and-memorials/survivor-and-dependent-benefits/">Survivor benefits</a></li>
+                <li><a href="/burials-and-memorials/survivor-and-dependent-benefits/">Survivor benefits</a> </li>
                 <li><a href="/burials-and-memorials/find-a-cemetery/">Find a cemetery</a></li>
                </ul>
             </li>

--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -49,6 +49,7 @@
                 <li><a href="/health-care/health-conditions">Health needs and conditions</a></li>
                 <li><a class="login-required" href="/health-care/prescriptions">Refill prescriptions</a></li>
                 <li><a class="login-required" href="/health-care/messaging">Message your health care team</a></li>
+                <li><a href="/health-care/health-records/">Download health records</a></li>
                 <li> <a href="/health-care/apply/application/" class="usa-button va-button-primary">Apply now</a></li>
               </ul>
             </li>

--- a/content/pages/health-care/health-records/index.md
+++ b/content/pages/health-care/health-records/index.md
@@ -1,7 +1,9 @@
 ---
-title: Get your VA health records
+title: Get Your VA Health Records
 layout: page-react.html
 entryname: health-records
+collection: healthCare
+order: 8
 ---
 
 <div id="main">

--- a/content/pages/health-care/health-records/index.md
+++ b/content/pages/health-care/health-records/index.md
@@ -1,6 +1,5 @@
 ---
-title: Get your VA health records
-display_title: Download Health Records
+title: Get Your VA Health Records
 layout: page-react.html
 entryname: health-records
 collection: healthCare

--- a/content/pages/health-care/health-records/index.md
+++ b/content/pages/health-care/health-records/index.md
@@ -3,7 +3,7 @@ title: Get Your VA Health Records
 layout: page-react.html
 entryname: health-records
 collection: healthCare
-order: 7
+order: 8
 ---
 
 <div id="main">

--- a/content/pages/health-care/health-records/index.md
+++ b/content/pages/health-care/health-records/index.md
@@ -4,7 +4,7 @@ display_title: Download Health Records
 layout: page-react.html
 entryname: health-records
 collection: healthCare
-order: 8
+order: 7
 ---
 
 <div id="main">

--- a/content/pages/health-care/health-records/index.md
+++ b/content/pages/health-care/health-records/index.md
@@ -1,6 +1,6 @@
 ---
 title: Get your VA health records
-display_title: Download health records
+display_title: Download Health Records
 layout: page-react.html
 entryname: health-records
 collection: healthCare

--- a/content/pages/health-care/health-records/index.md
+++ b/content/pages/health-care/health-records/index.md
@@ -1,7 +1,10 @@
 ---
 title: Get your VA health records
+display_title: Download health records
 layout: page-react.html
 entryname: health-records
+collection: healthCare
+order: 8
 ---
 
 <div id="main">

--- a/content/pages/health-care/index.md
+++ b/content/pages/health-care/index.md
@@ -19,15 +19,18 @@ majorlinks:
     - url: /health-care/health-conditions
       title: Health Needs and Conditions
       description: Find out how to access VA services for mental health, women’s health, and other specific needs.
+    - url: /health-care/health-conditions/conditions-related-to-service-era/
+      title: Conditions Related to When and Where You Served
+      description: Find out which service-connected health concerns you should be aware of, based on when and where you served.
     - url: /health-care/prescriptions/
       title: Refill Prescriptions
       description: Refill prescriptions online, and track the status of your refills.
     - url: /health-care/messaging/
       title: Send a Secure Message to Your Health Care Team
       description: Send a secure, private note to your primary care provider or other members of your VA health care team.
-    - url: /health-care/health-conditions/conditions-related-to-service-era/
-      title: Conditions Related to When and Where You Served
-      description: Find out which service-connected health concerns you should be aware of, based on when and where you served.
+    - url: /health-care/health-records/
+      title: Get Your VA Health Records
+      description: View, download, and print your VA health records.
 ---
 
 <div class="va-introtext">

--- a/content/pages/health-care/index.md
+++ b/content/pages/health-care/index.md
@@ -24,7 +24,7 @@ majorlinks:
       description: Refill prescriptions online, and track the status of your refills.
     - url: /health-care/health-records/
       title: Get Your VA Health Records
-      description: View, print, and download your VA health records.
+      description: View, download, and print your VA health records.
     - url: /health-care/messaging/
       title: Send a Secure Message to Your Health Care Team
       description: Send a secure, private note to your primary care provider or other members of your VA health care team.

--- a/content/pages/health-care/index.md
+++ b/content/pages/health-care/index.md
@@ -19,18 +19,18 @@ majorlinks:
     - url: /health-care/health-conditions
       title: Health Needs and Conditions
       description: Find out how to access VA services for mental health, women’s health, and other specific needs.
-    - url: /health-care/prescriptions/
-      title: Refill Prescriptions
-      description: Refill prescriptions online, and track the status of your refills.
-    - url: /health-care/health-records/
-      title: Get Your VA Health Records
-      description: View, download, and print your VA health records.
-    - url: /health-care/messaging/
-      title: Send a Secure Message to Your Health Care Team
-      description: Send a secure, private note to your primary care provider or other members of your VA health care team.
     - url: /health-care/health-conditions/conditions-related-to-service-era/
       title: Conditions Related to When and Where You Served
       description: Find out which service-connected health concerns you should be aware of, based on when and where you served.
+    - url: /health-care/prescriptions/
+      title: Refill Prescriptions
+      description: Refill prescriptions online, and track the status of your refills.
+    - url: /health-care/messaging/
+      title: Send a Secure Message to Your Health Care Team
+      description: Send a secure, private note to your primary care provider or other members of your VA health care team.
+    - url: /health-care/health-records/
+      title: Get Your VA Health Records
+      description: View, download, and print your VA health records.
 ---
 
 <div class="va-introtext">

--- a/content/pages/health-care/index.md
+++ b/content/pages/health-care/index.md
@@ -28,6 +28,9 @@ majorlinks:
     - url: /health-care/health-conditions/conditions-related-to-service-era/
       title: Conditions Related to When and Where You Served
       description: Find out which service-connected health concerns you should be aware of, based on when and where you served.
+    - url: /health-care/health-records/
+      title: Get Your VA Health Records
+      description: View, print, and download your VA health records.
 ---
 
 <div class="va-introtext">

--- a/content/pages/health-care/index.md
+++ b/content/pages/health-care/index.md
@@ -22,15 +22,15 @@ majorlinks:
     - url: /health-care/prescriptions/
       title: Refill Prescriptions
       description: Refill prescriptions online, and track the status of your refills.
+    - url: /health-care/health-records/
+      title: Get Your VA Health Records
+      description: View, print, and download your VA health records.
     - url: /health-care/messaging/
       title: Send a Secure Message to Your Health Care Team
       description: Send a secure, private note to your primary care provider or other members of your VA health care team.
     - url: /health-care/health-conditions/conditions-related-to-service-era/
       title: Conditions Related to When and Where You Served
       description: Find out which service-connected health concerns you should be aware of, based on when and where you served.
-    - url: /health-care/health-records/
-      title: Get Your VA Health Records
-      description: View, print, and download your VA health records.
 ---
 
 <div class="va-introtext">

--- a/content/pages/health-care/messaging/index.md
+++ b/content/pages/health-care/messaging/index.md
@@ -1,5 +1,5 @@
 ---
-title: Send a Secure Message to Your Health Care Team
+title: Message Your Health Care Team
 layout: page-react.html
 entryname: messaging
 gatePage: true

--- a/content/pages/health-care/messaging/index.md
+++ b/content/pages/health-care/messaging/index.md
@@ -1,5 +1,5 @@
 ---
-title: Send a Secure Message to Your Health Care Team
+title: Secure Message Health Care Team
 layout: page-react.html
 entryname: messaging
 gatePage: true

--- a/content/pages/health-care/messaging/index.md
+++ b/content/pages/health-care/messaging/index.md
@@ -4,7 +4,7 @@ layout: page-react.html
 entryname: messaging
 gatePage: true
 collection: healthCare
-order: 7
+order: 8
 includeBreadcrumbs: true
 ---
 

--- a/content/pages/health-care/messaging/index.md
+++ b/content/pages/health-care/messaging/index.md
@@ -4,7 +4,7 @@ layout: page-react.html
 entryname: messaging
 gatePage: true
 collection: healthCare
-order: 8
+order: 7
 includeBreadcrumbs: true
 ---
 

--- a/content/pages/health-care/messaging/index.md
+++ b/content/pages/health-care/messaging/index.md
@@ -1,5 +1,5 @@
 ---
-title: Secure Message Your Health Care Team
+title: Message Your Health Care Team
 layout: page-react.html
 entryname: messaging
 gatePage: true

--- a/content/pages/health-care/messaging/index.md
+++ b/content/pages/health-care/messaging/index.md
@@ -1,5 +1,5 @@
 ---
-title: Secure Message Health Care Team
+title: Secure Message Your Health Care Team
 layout: page-react.html
 entryname: messaging
 gatePage: true

--- a/content/pages/health-care/prescriptions/index.md
+++ b/content/pages/health-care/prescriptions/index.md
@@ -1,5 +1,5 @@
 ---
-title: Refill Your Prescriptions
+title: Refill Prescriptions
 layout: page-react.html
 entryname: rx
 collection: healthCare

--- a/src/sass/modules/_m-vet-nav.scss
+++ b/src/sass/modules/_m-vet-nav.scss
@@ -361,7 +361,7 @@ body.va-pos-fixed {
 
 @include media($medium-large-screen) {
   #vetnav-explore {
-    height: 310px;
+    height: 350px;
     padding-top: .8rem;
     width: 540px;
   }

--- a/test/messaging/00-required.e2e.spec.js
+++ b/test/messaging/00-required.e2e.spec.js
@@ -17,7 +17,7 @@ module.exports = E2eHelpers.createE2eTest(
     // Ensure main page (inbox) renders.
     LoginHelpers.logIn(token, client, '/health-care/messaging', 3)
       .waitForElementVisible('body', Timeouts.normal)
-      .assert.title('Send a Secure Message to Your Health Care Team: Vets.gov')
+      .assert.title('Message Your Health Care Team: Vets.gov')
       .waitForElementVisible('#messaging-app', Timeouts.slow);
 
     client

--- a/test/messaging/01-required-desktop.e2e.spec.js
+++ b/test/messaging/01-required-desktop.e2e.spec.js
@@ -19,7 +19,7 @@ module.exports = E2eHelpers.createE2eTest(
     client
       .url(`${E2eHelpers.baseUrl}/health-care/messaging`)
       .waitForElementVisible('body', Timeouts.normal)
-      .assert.title('Send a Secure Message to Your Health Care Team: Vets.gov')
+      .assert.title('Message Your Health Care Team: Vets.gov')
       .waitForElementVisible('#messaging-app', Timeouts.slow);
 
     // Inbox/Folder view

--- a/test/rx/00-required.e2e.spec.js
+++ b/test/rx/00-required.e2e.spec.js
@@ -16,7 +16,7 @@ module.exports = E2eHelpers.createE2eTest(
 
     // Ensure active page renders
     LoginHelpers.logIn(token, client, '/health-care/prescriptions', 3)
-      .assert.title('Refill Your Prescriptions: Vets.gov')
+      .assert.title('Refill Prescriptions: Vets.gov')
       .waitForElementVisible('#rx-active', Timeouts.normal)
       .axeCheck('.main');
 


### PR DESCRIPTION
This adds the "Download health records" link into the following locations:

- Navigation -> Explore benefits -> Health care
- Health Care index page major links (3rd from bottom)
- Health Care sidebar (second from bottom, pages other than index page)

This also shortens the title of "Refill your prescriptions" to "Refill prescriptions" and "Send a message to your provider" to "Secure message health care team" in the sidebar.

Resolves department-of-veterans-affairs/vets.gov-team/issues/3529