### PR TITLE
Letters change loading indicator condition

### DIFF
--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -27,6 +27,7 @@ import {
   countryValidations,
   cityValidations
 } from '../utils/validations';
+import { AVAILABILITY_STATUSES } from '../utils/constants';
 
 export class AddressSection extends React.Component {
   constructor(props) {
@@ -291,6 +292,7 @@ function mapStateToProps(state) {
   const {
     fullName,
     address,
+    addressAvailability,
     canUpdate,
     countries,
     countriesAvailable,

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -253,8 +253,9 @@ export class AddressSection extends React.Component {
 
     let addressContent;
     // If countries and states are not available when they try to update their address,
+    // or if the fetch for address failed,
     // they will see this warning message instead of the address fields.
-    if (isEmpty(address)) {
+    if (isEmpty(address) || this.props.addressAvailability === AVAILABILITY_STATUSES.unavailable) {
       addressContent = invalidAddressProperty;
     } else if (this.state.isEditingAddress && (!this.props.countriesAvailable || !this.props.statesAvailable)) {
       addressContent = (
@@ -303,6 +304,7 @@ function mapStateToProps(state) {
     recipientName: fullName,
     canUpdate,
     savedAddress: address,
+    addressAvailability,
     saveAddressError,
     savePending,
     countries,

--- a/src/js/letters/containers/Main.jsx
+++ b/src/js/letters/containers/Main.jsx
@@ -96,7 +96,7 @@ function mapStateToProps(state) {
   return {
     letters: letterState.letters,
     lettersAvailability: letterState.lettersAvailability,
-    destination: letterState.destination,
+    address: letterState.address,
     addressAvailability: letterState.addressAvailability,
     benefitSummaryOptions: {
       benefitInfo: letterState.benefitInfo,

--- a/src/js/letters/containers/Main.jsx
+++ b/src/js/letters/containers/Main.jsx
@@ -31,11 +31,6 @@ export class Main extends React.Component {
     // If letters are available, but address is still awaiting response, consider the entire app to still be awaiting response
     if (lettersAvailability === AVAILABILITY_STATUSES.awaitingResponse || addressAvailability === AVAILABILITY_STATUSES.awaitingResponse) {
       return AVAILABILITY_STATUSES.awaitingResponse;
-    // If letters have an eligibility error, the regular app content is still rendered,
-    // but address may still be awaiting response. In this case, consider the entire app
-    // to be awaiting response.
-    } else if (lettersAvailability === AVAILABILITY_STATUSES.letterEligibilityError && addressAvailability === AVAILABILITY_STATUSES.awaitingResponse) {
-      return AVAILABILITY_STATUSES.awaitingResponse;
     }
 
     return lettersAvailability;

--- a/src/js/letters/containers/Main.jsx
+++ b/src/js/letters/containers/Main.jsx
@@ -15,6 +15,16 @@ import {
   getAddressStates
 } from '../actions/letters';
 
+const {
+  awaitingResponse,
+  available,
+  backendServiceError,
+  backendAuthenticationError,
+  invalidAddressProperty,
+  unavailable,
+  letterEligibilityError
+} = AVAILABILITY_STATUSES;
+
 export class Main extends React.Component {
   componentDidMount() {
     this.props.getLetterList();
@@ -29,8 +39,8 @@ export class Main extends React.Component {
 
   appAvailability(lettersAvailability, addressAvailability) {
     // If letters are available, but address is still awaiting response, consider the entire app to still be awaiting response
-    if (lettersAvailability === AVAILABILITY_STATUSES.awaitingResponse || addressAvailability === AVAILABILITY_STATUSES.awaitingResponse) {
-      return AVAILABILITY_STATUSES.awaitingResponse;
+    if (lettersAvailability === awaitingResponse || addressAvailability === awaitingResponse) {
+      return awaitingResponse;
     }
 
     return lettersAvailability;
@@ -40,25 +50,25 @@ export class Main extends React.Component {
     let appContent;
 
     switch (this.appAvailability(this.props.lettersAvailability, this.props.addressAvailability)) {
-      case AVAILABILITY_STATUSES.available:
+      case available:
         appContent = this.props.children;
         break;
-      case AVAILABILITY_STATUSES.awaitingResponse:
+      case awaitingResponse:
         appContent = <LoadingIndicator message="Loading your letters..."/>;
         break;
-      case AVAILABILITY_STATUSES.backendServiceError:
+      case backendServiceError:
         appContent = systemDownMessage;
         break;
-      case AVAILABILITY_STATUSES.backendAuthenticationError:
+      case backendAuthenticationError:
         appContent = unableToFindRecordWarning;
         break;
-      case AVAILABILITY_STATUSES.invalidAddressProperty:
+      case invalidAddressProperty:
         appContent = systemDownMessage;
         break;
-      case AVAILABILITY_STATUSES.letterEligibilityError:
+      case letterEligibilityError:
         appContent = this.props.children;
         break;
-      case AVAILABILITY_STATUSES.unavailable:
+      case unavailable:
         appContent = (
           <div id="lettersUnavailable">
             <div className="usa-alert usa-alert-error" role="alert">

--- a/src/js/letters/containers/Main.jsx
+++ b/src/js/letters/containers/Main.jsx
@@ -29,7 +29,7 @@ export class Main extends React.Component {
   render() {
     let appContent;
 
-    switch (this.props.lettersAvailability) {
+    switch (this.props.addressAvailability) {
       case AVAILABILITY_STATUSES.available:
         appContent = this.props.children;
         break;
@@ -81,7 +81,7 @@ function mapStateToProps(state) {
   return {
     letters: letterState.letters,
     destination: letterState.destination,
-    lettersAvailability: letterState.lettersAvailability,
+    addressAvailability: letterState.addressAvailability,
     benefitSummaryOptions: {
       benefitInfo: letterState.benefitInfo,
       serviceInfo: letterState.serviceInfo

--- a/src/js/letters/containers/Main.jsx
+++ b/src/js/letters/containers/Main.jsx
@@ -26,10 +26,25 @@ export class Main extends React.Component {
     this.props.getAddressStates();
   }
 
+
+  appAvailability(lettersAvailability, addressAvailability) {
+    // If letters are available, but address is still awaiting response, consider the entire app to still be awaiting response
+    if (lettersAvailability === AVAILABILITY_STATUSES.awaitingResponse || addressAvailability === AVAILABILITY_STATUSES.awaitingResponse) {
+      return AVAILABILITY_STATUSES.awaitingResponse;
+    // If letters have an eligibility error, the regular app content is still rendered,
+    // but address may still be awaiting response. In this case, consider the entire app
+    // to be awaiting response.
+    } else if (lettersAvailability === AVAILABILITY_STATUSES.letterEligibilityError && addressAvailability === AVAILABILITY_STATUSES.awaitingResponse) {
+      return AVAILABILITY_STATUSES.awaitingResponse;
+    }
+
+    return lettersAvailability;
+  }
+
   render() {
     let appContent;
 
-    switch (this.props.addressAvailability) {
+    switch (this.appAvailability(this.props.lettersAvailability, this.props.addressAvailability)) {
       case AVAILABILITY_STATUSES.available:
         appContent = this.props.children;
         break;
@@ -80,6 +95,7 @@ function mapStateToProps(state) {
   const letterState = state.letters;
   return {
     letters: letterState.letters,
+    lettersAvailability: letterState.lettersAvailability,
     destination: letterState.destination,
     addressAvailability: letterState.addressAvailability,
     benefitSummaryOptions: {

--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -42,6 +42,7 @@ const initialState = {
   letterDownloadStatus: {},
   fullName: {},
   address: {},
+  addressAvailability: AVAILABILITY_STATUSES.awaitingResponse,
   optionsAvailable: false,
   requestOptions: {},
   serviceInfo: [],
@@ -81,11 +82,11 @@ function letters(state = initialState, action) {
         ...state,
         address: attributes.address,
         canUpdate: attributes.controlInformation.canUpdate,
-        addressAvailable: true
+        addressAvailability: AVAILABILITY_STATUSES.available
       };
     }
     case GET_ADDRESS_FAILURE:
-      return _.set('addressAvailable', false, state);
+      return _.set('addressAvailability', AVAILABILITY_STATUSES.unavailable, state);
     case GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS: {
     // Gather all possible displayed options that the user may toggle on/off.
       const benefitInfo = action.data.data.attributes.benefitInformation;

--- a/test/letters/containers/Main.unit.spec.jsx
+++ b/test/letters/containers/Main.unit.spec.jsx
@@ -56,14 +56,27 @@ describe('<Main>', () => {
     expect(tree.subTree('LoadingIndicator')).to.not.be.false;
   });
 
-  it('shows a loading spinner when letters is available but address is awaiting response', () => {
+  it('shows a loading spinner when letters is available, but address is awaiting response', () => {
     const props = _.merge({}, defaultProps, { lettersAvailability: available });
+    const tree = SkinDeep.shallowRender(<Main {...props}/>);
+    expect(tree.subTree('LoadingIndicator')).to.not.be.false;
+  });
+
+  it('shows a loading spinner when letters is awaiting response, but address is available', () => {
+    const props = _.merge({}, defaultProps, { addressAvailability: available });
     const tree = SkinDeep.shallowRender(<Main {...props}/>);
     expect(tree.subTree('LoadingIndicator')).to.not.be.false;
   });
 
   it('renders its children when letters and address are available', () => {
     const props = _.merge({}, defaultProps, { lettersAvailability: available, addressAvailability: available });
+    const tree = SkinDeep.shallowRender(<Main {...props}/>);
+    const childText = tree.subTree('span').text();
+    expect(childText).to.equal(testText);
+  });
+
+  it('renders its children when letters is available but address is unavailable', () => {
+    const props = _.merge({}, defaultProps, { lettersAvailability: available, addressAvailability: unavailable });
     const tree = SkinDeep.shallowRender(<Main {...props}/>);
     const childText = tree.subTree('span').text();
     expect(childText).to.equal(testText);

--- a/test/letters/containers/Main.unit.spec.jsx
+++ b/test/letters/containers/Main.unit.spec.jsx
@@ -29,7 +29,8 @@ const {
 const defaultProps = {
   letters: { },
   destination: { },
-  lettersAvailability: available,
+  addressAvailability: awaitingResponse,
+  lettersAvailability: awaitingResponse,
   benefitSummaryOptions: {
     benefitInfo: '',
     serviceInfo: '',
@@ -50,16 +51,22 @@ describe('<Main>', () => {
     expect(vdom).to.not.be.undefined;
   });
 
-  it('renders its children when letters are available', () => {
+  it('shows a loading spinner when awaiting response', () => {
     const tree = SkinDeep.shallowRender(<Main {...defaultProps}/>);
-    const childText = tree.subTree('span').text();
-    expect(childText).to.equal(testText);
+    expect(tree.subTree('LoadingIndicator')).to.not.be.false;
   });
 
-  it('shows a loading spinner when awaiting response', () => {
-    const props = _.merge({}, defaultProps, { lettersAvailability: awaitingResponse });
+  it('shows a loading spinner when letters is available but address is awaiting response', () => {
+    const props = _.merge({}, defaultProps, { lettersAvailability: available });
     const tree = SkinDeep.shallowRender(<Main {...props}/>);
     expect(tree.subTree('LoadingIndicator')).to.not.be.false;
+  });
+
+  it('renders its children when letters and address are available', () => {
+    const props = _.merge({}, defaultProps, { lettersAvailability: available, addressAvailability: available });
+    const tree = SkinDeep.shallowRender(<Main {...props}/>);
+    const childText = tree.subTree('span').text();
+    expect(childText).to.equal(testText);
   });
 
   it('shows a system down message for backend service error', () => {

--- a/test/letters/containers/Main.unit.spec.jsx
+++ b/test/letters/containers/Main.unit.spec.jsx
@@ -70,38 +70,38 @@ describe('<Main>', () => {
   });
 
   it('shows a system down message for backend service error', () => {
-    const props = _.merge({}, defaultProps, { lettersAvailability: backendServiceError });
+    const props = _.merge({}, defaultProps, { lettersAvailability: backendServiceError, addressAvailability: available });
     const tree = SkinDeep.shallowRender(<Main {...props}/>);
     expect(tree.subTree('#systemDownMessage')).to.not.be.false;
   });
 
   it('should show backend authentication error', () => {
-    const props = _.merge({}, defaultProps, { lettersAvailability: backendAuthenticationError });
+    const props = _.merge({}, defaultProps, { lettersAvailability: backendAuthenticationError, addressAvailability: available });
     const tree = SkinDeep.shallowRender(<Main {...props}/>);
     expect(tree.subTree('#recordNotFound')).to.not.be.false;
   });
 
   it('should show system down message for invalid address error', () => {
-    const props = _.merge({}, defaultProps, { lettersAvailability: invalidAddressProperty });
+    const props = _.merge({}, defaultProps, { lettersAvailability: invalidAddressProperty, addressAvailability: available });
     const tree = SkinDeep.shallowRender(<Main {...props}/>);
     expect(tree.subTree('#systemDownMessage')).to.not.be.false;
   });
 
   it('renders children for letter eligibility errors', () => {
-    const props = _.merge({}, defaultProps, { lettersAvailability: letterEligibilityError });
+    const props = _.merge({}, defaultProps, { lettersAvailability: letterEligibilityError, addressAvailability: available });
     const tree = SkinDeep.shallowRender(<Main {...props}/>);
     const childText = tree.subTree('span').text();
     expect(childText).to.equal(testText);
   });
 
   it('should show letters unavailable message when service is unavailable', () => {
-    const props = _.merge({}, defaultProps, { lettersAvailability: unavailable });
+    const props = _.merge({}, defaultProps, { lettersAvailability: unavailable, addressAvailability: available });
     const tree = SkinDeep.shallowRender(<Main {...props}/>);
     expect(tree.subTree('#lettersUnavailable')).to.not.be.false;
   });
 
   it('renders system down message for all unspecified errors', () => {
-    const props = _.merge({}, defaultProps, { lettersAvailability: 'bogusError' });
+    const props = _.merge({}, defaultProps, { lettersAvailability: 'bogusError', addressAvailability: available });
     const tree = SkinDeep.shallowRender(<Main {...props}/>);
     expect(tree.subTree('#systemDownMessage')).to.not.be.false;
   });


### PR DESCRIPTION
This PR maintains the loading indicator as long as letters or address is still being fetched. We heard from EVSS that the address for PCIU is fetched from a different source than the address for the letters, so we're going to still load the app if address is unavailable, but just display a message in the address box instead.