### PR TITLE
Reset editableAddress when user clicks Cancel

### DIFF
--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -49,6 +49,13 @@ export class AddressSection extends React.Component {
     this.props.saveAddress(this.state.editableAddress);
   }
 
+  handleCancel = () => {
+    this.setState({
+      isEditingAddress: false,
+      editableAddress: this.props.savedAddress
+    });
+  }
+
   handleChange = (path, update) => {
     this.setState(({ editableAddress }) => {
       // reset state code when user updates country
@@ -109,7 +116,7 @@ export class AddressSection extends React.Component {
             states={this.props.states}
             required/>
           <button className="usa-button-primary" onClick={this.handleSave}>Update</button>
-          <button className="usa-button-outline" onClick={() => this.setState({ isEditingAddress: false })}>Cancel</button>
+          <button className="usa-button-outline" onClick={this.handleCancel}>Cancel</button>
         </div>
       );
     } else {

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -123,4 +123,20 @@ describe('<AddressSection>', () => {
     expect(ReactTestUtils.scryRenderedDOMComponentsWithTag(component, 'select')).to.be.empty;
     expect(saveSpy.calledWith(component.state.editableAddress)).to.be.true;
   });
+
+  it('should collapse address fields when Cancel button is clicked', () => {
+    const component = ReactTestUtils.renderIntoDocument(<AddressSection {...defaultProps}/>);
+    const tree = getFormDOM(component);
+
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithTag(component, 'select')).to.be.empty;
+
+    tree.click('button.usa-button-outline');
+
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithTag(component, 'select')).to.not.be.empty;
+
+    tree.click('button.usa-button-outline');
+
+    expect(ReactTestUtils.scryRenderedDOMComponentsWithTag(component, 'select')).to.be.empty;
+  });
+
 });


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5026

1.) Update Cancel button's `onClick` handler in `AddressSection` to also reset the `editableAddress` state back to the `savedAddress` prop (from Redux).