### PR TITLE
Track form data for client failures

### DIFF
--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -536,7 +536,7 @@ export function getActiveChapters(formConfig, formData) {
 
 export function sanitizeForm(formData) {
   try {
-    const suffixes = ['first', 'last', 'accountNumber', 'socialSecurityNumber', 'dateOfBirth'];
+    const suffixes = ['vaFileNumber', 'first', 'last', 'accountNumber', 'socialSecurityNumber', 'dateOfBirth'];
     return JSON.stringify(formData, (key, value) => {
       if (value && suffixes.some(suffix => key.toLowerCase().endsWith(suffix.toLowerCase()))) {
         return 'removed';

--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -536,12 +536,9 @@ export function getActiveChapters(formConfig, formData) {
 
 export function sanitizeForm(formData) {
   try {
-    const keys = new Set(['first', 'last', 'accountNumber']);
-    const suffixes = ['socialSecurityNumber', 'dateOfBirth'];
+    const suffixes = ['first', 'last', 'accountNumber', 'socialSecurityNumber', 'dateOfBirth'];
     return JSON.stringify(formData, (key, value) => {
-      if (value && keys.has(key)) {
-        return 'removed';
-      } else if (value && suffixes.some(suffix => key.toLowerCase().endsWith(suffix.toLowerCase()))) {
+      if (value && suffixes.some(suffix => key.toLowerCase().endsWith(suffix.toLowerCase()))) {
         return 'removed';
       }
 

--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -533,3 +533,21 @@ export function getActiveChapters(formConfig, formData) {
 
   return _.uniq(expandedPageList.map(p => p.chapterKey).filter(key => !!key && key !== 'review'));
 }
+
+export function sanitizeForm(formData) {
+  try {
+    const keys = new Set(['first', 'last', 'accountNumber']);
+    const suffixes = ['socialSecurityNumber', 'dateOfBirth'];
+    return JSON.stringify(formData, (key, value) => {
+      if (value && keys.has(key)) {
+        return 'removed';
+      } else if (value && suffixes.some(suffix => key.toLowerCase().endsWith(suffix.toLowerCase()))) {
+        return 'removed';
+      }
+
+      return value;
+    });
+  } catch (e) {
+    return null;
+  }
+}

--- a/src/js/common/schemaform/save-load-actions.js
+++ b/src/js/common/schemaform/save-load-actions.js
@@ -4,6 +4,7 @@ import 'isomorphic-fetch';
 import { logOut } from '../../login/actions';
 
 import { removeFormApi } from './sip-api';
+import { sanitizeForm } from './helpers';
 
 export const SET_SAVE_FORM_STATUS = 'SET_SAVE_FORM_STATUS';
 export const SET_FETCH_FORM_STATUS = 'SET_FETCH_FORM_STATUS';
@@ -208,7 +209,11 @@ export function saveInProgressForm(formId, version, returnUrl, formData, auto = 
         } else {
           dispatch(setSaveFormStatus(SAVE_STATUSES.clientFailure));
           Raven.captureException(resOrError);
-          Raven.captureMessage('vets_sip_error_save');
+          Raven.captureMessage('vets_sip_error_save', {
+            extra: {
+              form: sanitizeForm(formData)
+            }
+          });
           window.dataLayer.push({
             event: `${trackingPrefix}sip-form-save-failed-client`
           });


### PR DESCRIPTION
This adds the form data to the extra info sent to Sentry for client errors, to see if that will help us track down the cause of some TypeErrors. I'm filtering out the obvious PII in them, which is pretty consistent across forms.