### PR TITLE
Fixes for verify page.

### DIFF
--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -178,7 +178,7 @@ class Main extends React.Component {
         );
       }
       case 'verifyPage':
-        return (this.props.profile.loading || !this.props.login.verifyUrl) ?
+        return this.props.profile.loading ?
           (<LoadingIndicator message="Loading the application..."/>) :
           (<Verify
             shouldRedirect={this.props.shouldRedirect}

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -4,12 +4,13 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import appendQuery from 'append-query';
 
-import environment from '../../common/helpers/environment.js';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
+import Modal from '../../common/components/Modal';
+import environment from '../../common/helpers/environment';
 import { getUserData, addEvent, getLoginUrls, getVerifyUrl, handleLogin } from '../../common/helpers/login-helpers';
 
 import { updateLoggedInStatus, updateLogoutUrl, updateLogInUrls, updateVerifyUrl, toggleLoginModal } from '../actions';
 import SearchHelpSignIn from '../components/SearchHelpSignIn';
-import Modal from '../../common/components/Modal';
 import Signin from '../components/Signin';
 import Verify from '../components/Verify';
 
@@ -158,26 +159,31 @@ class Main extends React.Component {
     const currentlyLoggedIn = this.props.login.currentlyLoggedIn;
 
     switch (this.props.renderType) {
-      case 'navComponent':
+      case 'navComponent': {
+        const modalContent = !this.props.login.loginUrls ?
+          (<LoadingIndicator message="Loading the application..."/>) :
+          (<Signin
+            onLoggedIn={() => this.props.toggleLoginModal(false)}
+            currentlyLoggedIn={currentlyLoggedIn}
+            handleSignup={this.handleSignup}
+            handleLogin={this.handleLogin}/>);
+
         return (
           <div>
             <SearchHelpSignIn onUserLogout={this.handleLogout}/>
             <Modal cssClass="va-modal-large" visible={this.props.login.showModal} onClose={this.handleCloseModal} id="signin-signup-modal" title="Sign in to Vets.gov">
-              <Signin
-                onLoggedIn={() => this.props.toggleLoginModal(false)}
-                currentlyLoggedIn={currentlyLoggedIn}
-                handleSignup={this.handleSignup}
-                handleLogin={this.handleLogin}/>
+              {modalContent}
             </Modal>
           </div>
         );
+      }
       case 'verifyPage':
-        return (
-          <Verify
+        return (this.props.profile.loading || !this.props.login.verifyUrl) ?
+          (<LoadingIndicator message="Loading the application..."/>) :
+          (<Verify
             shouldRedirect={this.props.shouldRedirect}
             profile={this.props.profile}
-            verifyUrl={this.props.login.verifyUrl}/>
-        );
+            verifyUrl={this.props.login.verifyUrl}/>);
       default:
         return null;
     }

--- a/src/js/login/reducers/login.js
+++ b/src/js/login/reducers/login.js
@@ -14,7 +14,7 @@ import {
 
 const initialState = {
   currentlyLoggedIn: false,
-  loginUrls: {},
+  loginUrls: null,
   logoutUrl: null,
   multifactorUrl: null,
   showModal: false,

--- a/src/sass/login.scss
+++ b/src/sass/login.scss
@@ -38,6 +38,8 @@ span.sidelines {
   }
 
   .va-modal-body {
+    // Overwrite white header color.
+    color: $color-gray-dark;
     padding-top: 0;
   }
 

--- a/src/sass/login.scss
+++ b/src/sass/login.scss
@@ -1,4 +1,5 @@
 @import "shared-variables";
+@import "modules/m-modal";
 
 span.sidelines {
   position: relative;


### PR DESCRIPTION
The other half of the conditional would keep the user on the verify page when not logged in, so I removed it.

Also, the styles for modals would be missing, since the verify page isn't a `no-react` page, so it doesn't include it by default. There's a short flash of the modal while it's redirecting, which can look really messed up without it. I think it's worth splitting the Verify page out of Main later when refactoring, but for now, let's include the styles.