### PR TITLE
Letters state to state code

### DIFF
--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -81,7 +81,7 @@ export function getMailingAddress() {
         if (address.type === ADDRESS_TYPES.military) {
           address.city = address.militaryPostOfficeTypeCode;
           address.stateCode = address.militaryStateCode;
-          address.country = 'USA';
+          address.countryName = 'USA';
           delete address.militaryPostOfficeTypeCode;
           delete address.militaryStateCode;
         }
@@ -229,7 +229,7 @@ export function saveAddress(address) {
     transformedAddress.militaryStateCode = transformedAddress.stateCode;
     delete transformedAddress.city;
     delete transformedAddress.stateCode;
-    delete transformedAddress.country;
+    delete transformedAddress.countryName;
   }
 
   const settings = {

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -80,7 +80,7 @@ export function getMailingAddress() {
         // Translate military-only fields into generic ones; we'll translate them back later if necessary
         if (address.type === ADDRESS_TYPES.military) {
           address.city = address.militaryPostOfficeTypeCode;
-          address.state = address.militaryStateCode;
+          address.stateCode = address.militaryStateCode;
           address.country = 'USA';
           delete address.militaryPostOfficeTypeCode;
           delete address.militaryStateCode;
@@ -226,9 +226,9 @@ export function saveAddress(address) {
   const transformedAddress = Object.assign({}, address);
   if (transformedAddress.type === ADDRESS_TYPES.military) {
     transformedAddress.militaryPostOfficeTypeCode = transformedAddress.city;
-    transformedAddress.militaryStateCode = transformedAddress.state;
+    transformedAddress.militaryStateCode = transformedAddress.stateCode;
     delete transformedAddress.city;
-    delete transformedAddress.state;
+    delete transformedAddress.stateCode;
     delete transformedAddress.country;
   }
 

--- a/src/js/letters/components/Address.jsx
+++ b/src/js/letters/components/Address.jsx
@@ -66,12 +66,12 @@ class Address extends React.Component {
     // This will be changed once we pull the real country list from the
     // address endpoint.
     let selectedCountry;
-    if (this.props.address.country === undefined && this.props.address.type === ADDRESS_TYPES.military) {
+    if (this.props.address.countryName === undefined && this.props.address.type === ADDRESS_TYPES.military) {
       selectedCountry = 'USA';
-    } else if (this.props.address.country === 'US') {
+    } else if (this.props.address.countryName === 'US') {
       selectedCountry = 'USA';
     } else {
-      selectedCountry = this.props.address.country;
+      selectedCountry = this.props.address.countryName;
     }
 
     const isUSA = selectedCountry === 'USA';
@@ -80,14 +80,14 @@ class Address extends React.Component {
 
     return (
       <div>
-        <ErrorableSelect errorMessage={errorMessages.country}
+        <ErrorableSelect errorMessage={errorMessages.countryName}
           label="Country"
           name="country"
           autocomplete="country"
           options={this.props.countries}
           value={selectedCountry}
           required={this.props.required}
-          onValueChange={(update) => this.props.onInput('country', update)}/>
+          onValueChange={(update) => this.props.onInput('countryName', update)}/>
         <ErrorableTextInput errorMessage={errorMessages.addressOne}
           label="Street address"
           name="address"
@@ -148,7 +148,7 @@ const addressShape = PropTypes.shape({
   addressThree: PropTypes.string,
   city: PropTypes.string,
   stateCode: PropTypes.string,
-  country: PropTypes.string,
+  countryName: PropTypes.string,
   zipCode: PropTypes.string
 });
 

--- a/src/js/letters/components/Address.jsx
+++ b/src/js/letters/components/Address.jsx
@@ -119,14 +119,14 @@ class Address extends React.Component {
           required={this.props.required}
           onValueChange={(update) => this.props.onInput('city', update)}/>
         {/* Hide the state for addresses that aren't in the US */}
-        {isUSA && <ErrorableSelect errorMessage={errorMessages.state}
+        {isUSA && <ErrorableSelect errorMessage={errorMessages.stateCode}
           label="State"
           name="state"
           autocomplete="address-level1"
           options={adjustedStateNames}
-          value={this.props.address.state}
+          value={this.props.address.stateCode}
           required={this.props.required}
-          onValueChange={(update) => this.props.onInput('state', update)}/>}
+          onValueChange={(update) => this.props.onInput('stateCode', update)}/>}
 
         {/* Hide the zip code for addresseses that aren't in the US */}
         {isUSA && <ErrorableTextInput errorMessage={errorMessages.zipCode}
@@ -147,7 +147,7 @@ const addressShape = PropTypes.shape({
   addressTwo: PropTypes.string,
   addressThree: PropTypes.string,
   city: PropTypes.string,
-  state: PropTypes.string,
+  stateCode: PropTypes.string,
   country: PropTypes.string,
   zipCode: PropTypes.string
 });

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -28,7 +28,7 @@ const fieldValidations = {
   addressOne: addressOneValidations,
   zipCode: postalCodeValidations,
   stateCode: stateValidations,
-  country: countryValidations,
+  countryName: countryValidations,
   city: cityValidations
 };
 
@@ -142,7 +142,7 @@ export class AddressSection extends React.Component {
    */
   inferAddressType = (address) => {
     let type = ADDRESS_TYPES.domestic;
-    if (!['USA', 'US'].includes(address.country)) {
+    if (!['USA', 'US'].includes(address.countryName)) {
       type = ADDRESS_TYPES.international;
     } else if (['AE', 'AA', 'AP'].includes(address.stateCode)) {
       // Are these ^^ constants anywhere?
@@ -168,7 +168,7 @@ export class AddressSection extends React.Component {
 
     let address = Object.assign({}, this.state.editableAddress, { [fieldName]: update });
     // if country is changing we should clear the state
-    if (fieldName === 'country') {
+    if (fieldName === 'countryName') {
       address.stateCode = '';
     }
 

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -27,7 +27,7 @@ import { ADDRESS_TYPES } from '../utils/constants';
 const fieldValidations = {
   addressOne: addressOneValidations,
   zipCode: postalCodeValidations,
-  state: stateValidations,
+  stateCode: stateValidations,
   country: countryValidations,
   city: cityValidations
 };
@@ -144,7 +144,7 @@ export class AddressSection extends React.Component {
     let type = ADDRESS_TYPES.domestic;
     if (!['USA', 'US'].includes(address.country)) {
       type = ADDRESS_TYPES.international;
-    } else if (['AE', 'AA', 'AP'].includes(address.state)) {
+    } else if (['AE', 'AA', 'AP'].includes(address.stateCode)) {
       // Are these ^^ constants anywhere?
       type = ADDRESS_TYPES.military;
     }
@@ -169,7 +169,7 @@ export class AddressSection extends React.Component {
     let address = Object.assign({}, this.state.editableAddress, { [fieldName]: update });
     // if country is changing we should clear the state
     if (fieldName === 'country') {
-      address.state = '';
+      address.stateCode = '';
     }
 
     // Make sure we've got the right address type (domestic, military, international)
@@ -200,11 +200,11 @@ export class AddressSection extends React.Component {
     let cityStatePostal;
     if (isDomesticAddress(address)) {
       const city = (address.city || '').toLowerCase();
-      const state = getStateName(address.state);
+      const state = getStateName(address.stateCode);
       cityStatePostal = `${city}, ${state} ${zipCode}`;
     } else if (isMilitaryAddress(address)) {
       const city = address.city || '';
-      const militaryStateCode = address.state || '';
+      const militaryStateCode = address.stateCode || '';
       cityStatePostal = `${city}, ${militaryStateCode} ${zipCode}`;
     }
     const country = isInternationalAddress(address) ? address.countryName : '';

--- a/test/letters/components/Address.unit.spec.jsx
+++ b/test/letters/components/Address.unit.spec.jsx
@@ -13,7 +13,7 @@ const defaultProps = {
     addressOne: '2746 Main St',
     addressTwo: 'Apt 2',
     city: 'Town',
-    state: 'MA',
+    stateCode: 'MA',
     country: 'US',
     zipCode: '02138'
   },
@@ -31,7 +31,7 @@ describe('<Address>', () => {
     const militaryFields = {
       type: 'MILITARY',
       city: 'APO',
-      state: 'AE'
+      stateCode: 'AE'
     };
     const props = {
       ...defaultProps,

--- a/test/letters/components/Address.unit.spec.jsx
+++ b/test/letters/components/Address.unit.spec.jsx
@@ -14,7 +14,7 @@ const defaultProps = {
     addressTwo: 'Apt 2',
     city: 'Town',
     stateCode: 'MA',
-    country: 'US',
+    countryName: 'US',
     zipCode: '02138'
   },
   errorMessages: {},

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -15,7 +15,7 @@ const defaultProps = {
     type: ADDRESS_TYPES.domestic,
     addressOne: '2476 Main Street',
     city: 'Reston',
-    country: 'US',
+    countryName: 'US',
     stateCode: 'VA',
     zipCode: '12345'
   },

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -16,7 +16,7 @@ const defaultProps = {
     addressOne: '2476 Main Street',
     city: 'Reston',
     country: 'US',
-    state: 'VA',
+    stateCode: 'VA',
     zipCode: '12345'
   },
   canUpdate: true,


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5074

Change field names that were stored on the front-end incorrectly:
`state` --> `stateCode`
`country` --> `countryName`

Fixes failed posts to `v0/address`