### PR TITLE
Switch to display savedAddress in address block

### DIFF
--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -188,7 +188,7 @@ export class AddressSection extends React.Component {
 
 
   render() {
-    const address = this.state.editableAddress || {};
+    const address = this.props.savedAddress || {};
     // Street address: first line of address
     const streetAddressLines = [
       address.addressOne,


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5099, https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5116

Quick fix that just swaps the address used for display from `this.state.editableAddress` to `this.props.savedAddress`