### PR TITLE
Fix touched functionality for array field items

### DIFF
--- a/src/js/common/schemaform/ArrayField.jsx
+++ b/src/js/common/schemaform/ArrayField.jsx
@@ -4,7 +4,7 @@ import _ from 'lodash/fp';
 import classNames from 'classnames';
 import Scroll from 'react-scroll';
 import { scrollToFirstError } from '../utils/helpers';
-import { setItemTouched } from './helpers';
+import { setArrayRecordTouched } from './helpers';
 
 import {
   toIdSchema,
@@ -116,7 +116,7 @@ export default class ArrayField extends React.Component {
       });
     } else {
       // Set all the fields for this item as touched, so we show errors
-      const touched = setItemTouched(this.props.idSchema.$id, index, this.props.idSchema);
+      const touched = setArrayRecordTouched(this.props.idSchema.$id, index);
       this.props.formContext.setTouched(touched, () => {
         scrollToFirstError();
       });
@@ -145,7 +145,7 @@ export default class ArrayField extends React.Component {
         this.scrollToRow(`${this.props.idSchema.$id}_${lastIndex + 1}`);
       });
     } else {
-      const touched = setItemTouched(this.props.idSchema.$id, lastIndex, this.props.idSchema);
+      const touched = setArrayRecordTouched(this.props.idSchema.$id, lastIndex);
       this.props.formContext.setTouched(touched, () => {
         scrollToFirstError();
       });

--- a/src/js/common/schemaform/FieldTemplate.jsx
+++ b/src/js/common/schemaform/FieldTemplate.jsx
@@ -18,7 +18,9 @@ export default function FieldTemplate(props) {
     uiSchema
   } = props;
 
-  const hasErrors = (formContext.submitted || formContext.touched[id])
+  const isTouched = formContext.touched[id]
+    || Object.keys(formContext.touched).some(touched => id.startsWith(touched));
+  const hasErrors = (formContext.submitted || isTouched)
     && rawErrors && rawErrors.length;
   const requiredSpan = required
     ? <span className="schemaform-required-span">(*Required)</span>

--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -424,16 +424,8 @@ export function checkValidSchema(schema, errors = [], path = ['root']) {
   }
 }
 
-export function setItemTouched(prefix, index, idSchema) {
-  const fields = Object.keys(idSchema).filter(field => field !== '$id');
-  if (!fields.length) {
-    const id = idSchema.$id.replace(prefix, `${prefix}_${index}`);
-    return { [id]: true };
-  }
-
-  return fields.reduce((idObj, field) => {
-    return _.merge(idObj, setItemTouched(prefix, index, idSchema[field]));
-  }, {});
+export function setArrayRecordTouched(prefix, index) {
+  return { [`${prefix}_${index}`]: true };
 }
 
 export function createUSAStateLabels(states) {

--- a/src/js/pensions/components/AdditionalSourcesField.jsx
+++ b/src/js/pensions/components/AdditionalSourcesField.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import _ from 'lodash/fp';
 import Scroll from 'react-scroll';
 import { scrollToFirstError, focusElement } from '../../common/utils/helpers';
-import { setItemTouched } from '../../common/schemaform/helpers';
+import { setArrayRecordTouched } from '../../common/schemaform/helpers';
 import currencyUI from '../../common/schemaform/definitions/currency';
 
 import {
@@ -87,7 +87,7 @@ export default class AdditionalSourcesField extends React.Component {
       });
     } else {
       // Set all the fields for this item as touched, so we show errors
-      const touched = setItemTouched(this.props.idSchema.$id, index, this.props.idSchema);
+      const touched = setArrayRecordTouched(this.props.idSchema.$id);
       this.props.formContext.setTouched(touched, () => {
         scrollToFirstError();
       });

--- a/test/common/schemaform/helpers.unit.spec.js
+++ b/test/common/schemaform/helpers.unit.spec.js
@@ -7,7 +7,7 @@ import {
   hasFieldsOtherThanArray,
   transformForSubmit,
   getArrayFields,
-  setItemTouched,
+  setArrayRecordTouched,
   getNonArraySchema,
   checkValidSchema,
   formatReviewDate,
@@ -485,27 +485,13 @@ describe('Schemaform helpers:', () => {
       expect(output.emptyArray).to.be.undefined;
     });
   });
-  describe('setItemTouched', () => {
+  describe('setArrayRecordTouched', () => {
     /* eslint-disable camelcase */
     it('should set field as touched', () => {
-      const touched = setItemTouched('root', 0, {
-        $id: 'root_field'
-      });
+      const touched = setArrayRecordTouched('root', 0);
 
       expect(touched).to.eql({
-        root_0_field: true
-      });
-    });
-    it('should set nested field as touched', () => {
-      const touched = setItemTouched('root', 0, {
-        $id: 'root',
-        field: {
-          $id: 'root_field'
-        }
-      });
-
-      expect(touched).to.eql({
-        root_0_field: true
+        root_0: true
       });
     });
     /* eslint-enable camelcase */


### PR DESCRIPTION
This updates our array field and additional sources field to set the whole array item as touched and updates the field template to read that and act accordingly. This was the original intent, I'm not sure why we moved away from it.