### PR TITLE
Redirect after successfully verifying.

### DIFF
--- a/src/js/login/components/Verify.jsx
+++ b/src/js/login/components/Verify.jsx
@@ -7,7 +7,6 @@ import { handleVerify } from '../../common/helpers/login-helpers.js';
 class Verify extends React.Component {
   constructor(props) {
     super(props);
-
     this.handleLogin = this.handleLogin.bind(this);
     this.handleVerify = this.handleVerify.bind(this);
   }
@@ -19,10 +18,10 @@ class Verify extends React.Component {
     return window.dataLayer.push({ event: 'verify-prompt-displayed' });
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.login.currentlyLoggedIn && !this.props.login.currentlyLoggedIn) {
-      this.checkAccountAccess(nextProps.profile.accountType);
-    }
+  componentDidUpdate(prevProps) {
+    const { accountType } = this.props.profile;
+    const shouldCheckAccount = prevProps.profile.accountType !== accountType;
+    if (shouldCheckAccount) { this.checkAccountAccess(accountType); }
   }
 
   checkAccountAccess(accountType) {


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#5119.

When testing out verification from basic DS Logon to ID.me LOA 3, upon successful verification, the main tab would remain the on the verify page instead of redirecting. I don't think the user is actually logged out, so I'm not sure if the `currentlyLoggedIn` prop changes. The account type is sure to change, though, so the change is to condition on that instead.