### PR TITLE
Show city for international address types

### DIFF
--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -199,18 +199,17 @@ export class AddressSection extends React.Component {
 
     // City, state, postal code: second line of address
     const zipCode = getZipCode(address);
+    const city = address.city || '';
     let cityStatePostal;
     if (isDomesticAddress(address)) {
-      const city = (address.city || '').toLowerCase();
       const state = getStateName(address.stateCode);
       cityStatePostal = `${city}, ${state} ${zipCode}`;
     } else if (isMilitaryAddress(address)) {
-      const city = address.city || '';
       const militaryStateCode = address.stateCode || '';
       cityStatePostal = `${city}, ${militaryStateCode} ${zipCode}`;
     } else {
       // Must be an international address, only show a city
-      cityStatePostal = `${address.city || ''}`;
+      cityStatePostal = `${city}`;
     }
 
     const country = isInternationalAddress(address) ? address.countryName : '';

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -208,7 +208,11 @@ export class AddressSection extends React.Component {
       const city = address.city || '';
       const militaryStateCode = address.stateCode || '';
       cityStatePostal = `${city}, ${militaryStateCode} ${zipCode}`;
+    } else {
+      // Must be an international address, only show a city
+      cityStatePostal = `${address.city || ''}`;
     }
+
     const country = isInternationalAddress(address) ? address.countryName : '';
     const addressContentLines = { streetAddress, cityStatePostal, country };
 


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5116

Adds a simple check to ensure that `cityStatePostal` is defined for international address types - should be equal to address's city for these international addresses per comments here: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4110#issuecomment-328640426