### PR TITLE
Set lettersAvailability to unavailable when address fetch fails

### DIFF
--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -85,7 +85,11 @@ function letters(state = initialState, action) {
       };
     }
     case GET_ADDRESS_FAILURE:
-      return _.set('addressAvailable', false, state);
+      return {
+        ...state,
+        addressAvailable: false,
+        lettersAvailability: AVAILABILITY_STATUSES.invalidAddressProperty
+      };
     case GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS: {
     // Gather all possible displayed options that the user may toggle on/off.
       const benefitInfo = action.data.data.attributes.benefitInformation;


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5106

Updates reducer for `GET_ADDRESS_FAILURE` action types to also set the `lettersAvailability` store property to `invalidAddressProperty`.

This change results in the Letters app displaying the general system down error message when we get an error while trying to fetch the user's address, instead of showing an address block-level error message about the address not being available.