### PR TITLE
Fix state path when canceling uploads on claim status

### DIFF
--- a/src/js/claims-status/actions/index.js
+++ b/src/js/claims-status/actions/index.js
@@ -303,7 +303,7 @@ export function showMailOrFaxModal(visible) {
 
 export function cancelUpload() {
   return (dispatch, getState) => {
-    const uploader = getState().uploads.uploader;
+    const uploader = getState().disability.status.uploads.uploader;
     window.dataLayer.push({
       event: 'claims-upload-cancel',
     });

--- a/test/claims-status/actions.unit.spec.js
+++ b/test/claims-status/actions.unit.spec.js
@@ -185,9 +185,13 @@ describe('Actions', () => {
       const dispatchSpy = sinon.spy();
       const getState = () => {
         return {
-          uploads: {
-            uploader: {
-              cancelAll: uploaderSpy
+          disability: {
+            status: {
+              uploads: {
+                uploader: {
+                  cancelAll: uploaderSpy
+                }
+              }
             }
           }
         };


### PR DESCRIPTION
The path being used to pull the uploader from the Redux state was wrong and was causing an error whenever someone tried to cancel uploads on claim status.