### PR TITLE
Check request options against supported vets-api BSL customization op…

### DIFF
--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -6,29 +6,30 @@ import {
   optionsToAlwaysDisplay
 } from '../utils/helpers.jsx';
 import {
+  AVAILABILITY_STATUSES,
   BACKEND_AUTHENTICATION_ERROR,
   BACKEND_SERVICE_ERROR,
-  INVALID_ADDRESS_PROPERTY,
-  GET_LETTERS_FAILURE,
-  GET_LETTERS_SUCCESS,
+  DOWNLOAD_STATUSES,
   GET_ADDRESS_FAILURE,
   GET_ADDRESS_SUCCESS,
-  GET_BENEFIT_SUMMARY_OPTIONS_FAILURE,
-  GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS,
-  GET_LETTER_PDF_DOWNLOADING,
-  GET_LETTER_PDF_SUCCESS,
-  GET_LETTER_PDF_FAILURE,
-  LETTER_ELIGIBILITY_ERROR,
-  UPDATE_BENFIT_SUMMARY_REQUEST_OPTION,
-  AVAILABILITY_STATUSES,
-  DOWNLOAD_STATUSES,
-  SAVE_ADDRESS_PENDING,
-  SAVE_ADDRESS_SUCCESS,
-  SAVE_ADDRESS_FAILURE,
   GET_ADDRESS_COUNTRIES_SUCCESS,
   GET_ADDRESS_COUNTRIES_FAILURE,
   GET_ADDRESS_STATES_SUCCESS,
-  GET_ADDRESS_STATES_FAILURE
+  GET_ADDRESS_STATES_FAILURE,
+  GET_BENEFIT_SUMMARY_OPTIONS_FAILURE,
+  GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS,
+  GET_LETTERS_FAILURE,
+  GET_LETTERS_SUCCESS,
+  GET_LETTER_PDF_DOWNLOADING,
+  GET_LETTER_PDF_SUCCESS,
+  GET_LETTER_PDF_FAILURE,
+  INVALID_ADDRESS_PROPERTY,
+  LETTER_ELIGIBILITY_ERROR,
+  REQUEST_OPTIONS,
+  SAVE_ADDRESS_PENDING,
+  SAVE_ADDRESS_SUCCESS,
+  SAVE_ADDRESS_FAILURE,
+  UPDATE_BENFIT_SUMMARY_REQUEST_OPTION,
 } from '../utils/constants';
 
 const initialState = {
@@ -90,8 +91,14 @@ function letters(state = initialState, action) {
       const benefitInfo = action.data.data.attributes.benefitInformation;
       const possibleOptions = [];
       Object.keys(benefitInfo).forEach(key => {
-        if ((optionsToAlwaysDisplay.includes(key) || (benefitInfo[key] !== false)) &&
-            !possibleOptions.includes[key]) {
+        if (
+          // the option should always be displayed or vets-api says it is available
+          (optionsToAlwaysDisplay.includes(key) || (benefitInfo[key] !== false))
+          // and the option is not yet in the possibleOptions array
+          && !possibleOptions.includes[key]
+          // and the option is a customization option that vets-api supports
+          &&  REQUEST_OPTIONS[key]
+        ) {
           possibleOptions.push(key);
         }
       });

--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -97,7 +97,7 @@ function letters(state = initialState, action) {
           // and the option is not yet in the possibleOptions array
           && !possibleOptions.includes[key]
           // and the option is a customization option that vets-api supports
-          &&  REQUEST_OPTIONS[key]
+          && REQUEST_OPTIONS[key]
         ) {
           possibleOptions.push(key);
         }

--- a/src/js/letters/utils/constants.js
+++ b/src/js/letters/utils/constants.js
@@ -58,6 +58,7 @@ export const LETTER_TYPES = Object.freeze({
   benefitVerification: 'benefit_verification'
 });
 
+// Benefit options returned from vets-api, used in UI
 export const BENEFIT_OPTIONS = Object.freeze({
   awardEffectiveDate: 'awardEffectiveDate',
   monthlyAwardAmount: 'monthlyAwardAmount',
@@ -73,6 +74,21 @@ export const BENEFIT_OPTIONS = Object.freeze({
   hasIndividualUnemployabilityGranted: 'hasIndividualUnemployabilityGranted',
   hasSpecialMonthlyCompensation: 'hasSpecialMonthlyCompensation',
 });
+
+// Benefit Summary Letter request customization options, subset of BENEFIT_OPTIONS
+export const REQUEST_OPTIONS = {
+  monthlyAwardAmount: 'monthlyAwardAmount',
+  serviceConnectedPercentage: 'serviceConnectedPercentage',
+  hasNonServiceConnectedPension: 'hasNonServiceConnectedPension',
+  hasServiceConnectedDisabilities: 'hasServiceConnectedDisabilities',
+  hasSurvivorsIndemnityCompensationAward: 'hasSurvivorsIndemnityCompensationAward',
+  hasSurvivorsPensionAward: 'hasSurvivorsPensionAward',
+  hasAdaptedHousing: 'hasAdaptedHousing',
+  hasChapter35Eligibility: 'hasChapter35Eligibility',
+  hasDeathResultOfDisability: 'hasDeathResultOfDisability',
+  hasIndividualUnemployabilityGranted: 'hasIndividualUnemployabilityGranted',
+  hasSpecialMonthlyCompensation: 'hasSpecialMonthlyCompensation',
+};
 
 export const STATE_CODE_TO_NAME = {
   AL: 'Alabama',

--- a/src/js/letters/utils/constants.js
+++ b/src/js/letters/utils/constants.js
@@ -76,7 +76,8 @@ export const BENEFIT_OPTIONS = Object.freeze({
 });
 
 // Benefit Summary Letter request customization options, subset of BENEFIT_OPTIONS
-export const REQUEST_OPTIONS = {
+// Currently only key removed is awardEffectiveDate
+export const REQUEST_OPTIONS = Object.freeze({
   monthlyAwardAmount: 'monthlyAwardAmount',
   serviceConnectedPercentage: 'serviceConnectedPercentage',
   hasNonServiceConnectedPension: 'hasNonServiceConnectedPension',
@@ -88,7 +89,7 @@ export const REQUEST_OPTIONS = {
   hasDeathResultOfDisability: 'hasDeathResultOfDisability',
   hasIndividualUnemployabilityGranted: 'hasIndividualUnemployabilityGranted',
   hasSpecialMonthlyCompensation: 'hasSpecialMonthlyCompensation',
-};
+});
 
 export const STATE_CODE_TO_NAME = {
   AL: 'Alabama',


### PR DESCRIPTION
…tions

Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5111, https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3872

We should ensure that we're only passing valid options to vets-api when we specify how a user wants their BSL customized. The least "why is this happening" approach seemed to me to create a new constant that reflects which of the benefit options are actually able to be customized in our request to vets-api, and then ensure that our request options object only contains these recognized keys.

In the future, if the `BENEFIT_OPTIONS` we receive from `vets-api` continue to diverge from `REQUEST-OPTIONS` accepted by `vets-api`, we'll be able to just modify the `REQUEST-OPTIONS` constant further.