### PR TITLE
UpdateFailureAlert unit tests

### DIFF
--- a/test/letters/components/UpdateFailureAlert.unit.spec.jsx
+++ b/test/letters/components/UpdateFailureAlert.unit.spec.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import ReactTestUtils from 'react-dom/test-utils';
+import { expect } from 'chai';
+
+import { getFormDOM } from '../../util/schemaform-utils';
+
+import UpdateFailureAlert from '../../../src/js/letters/components/UpdateFailureAlert';
+
+const defaultProps = {
+  addressObject: {
+    addressOne: '123 Main St N',
+    city: 'Bigtowne',
+    stateCode: 'BS',
+    countryName: 'Elsweyre'
+  }
+};
+
+describe('<UpdateFailureAlert>', () => {
+  it('should render address and warning', () => {
+    // Have to wrap the stateless (function) component in <div></div> so renderIntoDocument() is happy
+    const tree = ReactTestUtils.renderIntoDocument(<div><UpdateFailureAlert {...defaultProps}/></div>);
+    const component = getFormDOM(tree);
+
+    const addressBlock = component.getElement('#warning-address-block').textContent;
+    Object.keys(defaultProps.addressObject).forEach((key) => {
+      expect(addressBlock).to.contain(defaultProps.addressObject[key]);
+    });
+  });
+});
+

--- a/test/util/schemaform-utils.jsx
+++ b/test/util/schemaform-utils.jsx
@@ -138,6 +138,10 @@ function printTree(node, level = 0, isLastChild = true, padding = '') {
 export function getFormDOM(form) {
   const formDOM = findDOMNode(form);
 
+  if (formDOM === null) {
+    throw new Error('Could not find DOM node. Please make sure to pass a component returned from ReactTestUtils.renderIntoDocument(). If you are testing a stateless (function) component, be sure to wrap it in a <div>.');
+  }
+
   /**
    * Returns the element or throws a nicer error.
    *


### PR DESCRIPTION
I almost got really into the weeds in getting a functional component to render using ReactTestUtils, but wrapping it in a `<div>` did the trick, fortunately.

Also, because it wasn't rendering for me without the `<div>` and I didn't know what was going on, I added a (more) helpful error message to `getFormDOM` for when `findDOMNode()` isn't passed something it can use...like when `ReactTestUtils.renderIntoDocument()` just returns null.