### PR TITLE
WIP - Remove Foundation

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "file-loader": "^0.9.0",
     "fine-uploader": "^5.11.8",
     "font-awesome": "^4.6.3",
-    "foundation-sites": "^5.5.3",
     "get-env": "^0.4.0",
     "glob": "^7.0.5",
     "history": "3",

--- a/src/sass/base/_b-variables.scss
+++ b/src/sass/base/_b-variables.scss
@@ -75,3 +75,5 @@ $green-white: #eff0e6;
 $olso-gray:   #849097;
 
 
+// Foundation Polyfilling
+$column-gutter: rem-calc(30) !default;

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -6,9 +6,9 @@
 @import "~uswds/src/stylesheets/lib/neat";
 @import "~uswds/src/stylesheets/lib/normalize"; // Currently 3.0.3
 
-@import "~foundation-sites/scss/foundation/components/grid";
-@import "~foundation-sites/scss/foundation/components/block-grid";
-@import "~foundation-sites/scss/foundation/components/visibility";
+// @import "~foundation-sites/scss/foundation/components/grid";
+// @import "~foundation-sites/scss/foundation/components/block-grid";
+// @import "~foundation-sites/scss/foundation/components/visibility";
 
 // Font Awesome WOFF/WOFF2 fonts only
 @import "~font-awesome/scss/variables";


### PR DESCRIPTION
#### Part 1. Backfill Foundation
We are currently using two style frameworks, Foundation and USWDS. As part of completing our migration to USWDS, this PR is intended to remove Foundation as a dependency. Our approach is to either backfill the following Foundation features, or to refactor the markup that uses them:

- [ ]  [Visibility classes](https://foundation.zurb.com/sites/docs/v/5.5.3/components/visibility.html)
- [ ]  [Grid classes](https://foundation.zurb.com/sites/docs/v/5.5.3/components/grid.html)
- [ ]  [Block grid](https://foundation.zurb.com/sites/docs/v/5.5.3/components/block_grid.html)

#### Part 2. Upgrade USWDS
USWDS installs bourbon and neat at the top level of our node_modules directory. Not sure why that is exactly. But in our `webpack.config` we require those modules if they are installed in our `package.json`. This all works for our current version of USWDS because of its install behavior, but it is not the same as the latest version of USWDS, currently 1.4.1.

Conclusively, to upgrade USWDS, you need to also install `bourbon` and `bourbon-neat`, or remove their references in `webpack.config`. No strong feelings about either for me.

##### Relevant Issues, PR's
-  [Migrate from Foundation to USWDS](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/549)
- [Upgrade to USWDS 1.0.0](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1463)
