### PR TITLE
Update spinner to show when claims or appeals are loading

### DIFF
--- a/src/js/claims-status/reducers/claims-list.js
+++ b/src/js/claims-status/reducers/claims-list.js
@@ -17,7 +17,8 @@ const initialState = {
   sortProperty: 'phaseChangeDate',
   consolidatedModal: false,
   show30DayNotice: true,
-  loading: false,
+  claimsLoading: false,
+  appealsLoading: false
 };
 
 // We want to sort claims without dates below claims with dates
@@ -100,7 +101,7 @@ export default function claimsReducer(state = initialState, action) {
         visibleList,
         visibleRows: getVisibleRows(visibleList, state.page),
         pages: getTotalPages(visibleList),
-        loading: false,
+        claimsLoading: false,
       });
     }
     case SET_APPEALS: {
@@ -111,7 +112,7 @@ export default function claimsReducer(state = initialState, action) {
         visibleList,
         visibleRows: getVisibleRows(visibleList, state.page),
         pages: getTotalPages(visibleList),
-        loading: false,
+        appealsLoading: false,
       });
     }
     case FILTER_CLAIMS: {
@@ -146,15 +147,15 @@ export default function claimsReducer(state = initialState, action) {
       return _.set('show30DayNotice', false, state);
     }
     case FETCH_APPEALS: {
-      return _.set('loading', true, state);
+      return _.set('appealsLoading', true, state);
     }
     case FETCH_CLAIMS: {
-      return _.set('loading', true, state);
+      return _.set('claimsLoading', true, state);
     }
     case SET_CLAIMS_UNAVAILABLE:
-      return _.set('loading', false, state);
+      return _.set('claimsLoading', false, state);
     case SET_APPEALS_UNAVAILABLE:
-      return _.set('loading', false, state);
+      return _.set('appealsLoading', false, state);
     default:
       return state;
   }

--- a/test/claims-status/components/YourClaimsPage.unit.spec.jsx
+++ b/test/claims-status/components/YourClaimsPage.unit.spec.jsx
@@ -40,13 +40,52 @@ describe('<YourClaimsPage>', () => {
 
     const tree = SkinDeep.shallowRender(
       <YourClaimsPage
-        loading
+        claimsLoading
+        appealsLoading
         claims={claims}
         page={page}
         pages={pages}
         getClaims={getClaims}
         changePage={changePage}/>
     );
+    expect(tree.everySubTree('LoadingIndicator').length).to.equal(1);
+  });
+  it('should render loading div if one is loading and no appeals', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        claimsLoading
+        claims={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        changePage={changePage}/>
+    );
+    expect(tree.everySubTree('LoadingIndicator').length).to.equal(1);
+  });
+  it('should render claims list and loading indicator if claims is still loading', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [{}, {}];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        claimsLoading
+        list={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        route={{ showClosedClaims: false }}
+        changePage={changePage}/>
+    );
+    expect(tree.everySubTree('ClaimsListItem').length).to.equal(2);
     expect(tree.everySubTree('LoadingIndicator').length).to.equal(1);
   });
   it('should render sync warning', () => {


### PR DESCRIPTION
These changes make it so that the loading spinner shows up when at least one of claims or appeals are still loading, but doesn't hide any of the claims/appeals that have been loaded.

![screen shot 2017-10-05 at 5 19 58 pm](https://user-images.githubusercontent.com/634932/31253953-bb9ea172-a9f4-11e7-9db9-6e7881298459.png)
