### PR TITLE
Remove the hurricane banner

### DIFF
--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -3,7 +3,7 @@ layout: home.html
 body_class: home
 title: Home
 plainlanguage: 11-1-16 Ready for Beth review
-enablewarning: true
+enablewarning: false
 description: Apply for and manage the VA benefits and services you’ve earned as a Veteran, Servicemember, or family member—like health care, disability, education, and more.
 majorlinks:
   - heading:


### PR DESCRIPTION
See the issue below for the full discussion:
> can we take down the banner. Both the va.gov and mhv.gov sites have removed the emergency banners and have "hurrican updates" as lower leverl links on their sites

Resolves department-of-veterans-affairs/vets.gov-team/issues/4920