### PR TITLE
Refactor claim status styles for status and detail tabs

### DIFF
--- a/src/js/claims-status/components/AddingDetails.jsx
+++ b/src/js/claims-status/components/AddingDetails.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 class AddingDetails extends React.Component {
   render() {
     return (
-      <div className="usa-alert usa-alert-info claims-no-icon claims-alert-status">
-        <h4>We’re adding your details</h4>
+      <div className="usa-alert usa-alert-info no-background-image claims-alert-status">
+        <h4 className="claims-alert-header">We’re adding your details</h4>
         We’ve received your claim and are still adding some of your information. Check back soon to see the complete details of your claim.
       </div>
     );

--- a/src/js/claims-status/components/AppealsUnavailable.jsx
+++ b/src/js/claims-status/components/AppealsUnavailable.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 class ClaimsAppealsUnavailable extends React.Component {
   render() {
     return (
-      <div className="usa-alert usa-alert-warning claims-no-icon claims-unavailable">
-        <h4 className="warning-title">
+      <div className="usa-alert usa-alert-warning no-background-image claims-unavailable">
+        <h4 className="claims-alert-header">
           <i className="fa fa-exclamation-triangle"></i>&nbsp;Appeal status is unavailable
         </h4>
         Vets.gov is having trouble loading appeals information at this time. Please check back again in a hour.

--- a/src/js/claims-status/components/AskVAToDecide.jsx
+++ b/src/js/claims-status/components/AskVAToDecide.jsx
@@ -5,9 +5,9 @@ import { Link } from 'react-router';
 export default class AskVAToDecide extends React.Component {
   render() {
     return (
-      <div className="usa-alert usa-alert-info claims-no-icon claims-alert-status ask-va-alert">
+      <div className="usa-alert usa-alert-info no-background-image claims-alert-status ask-va-alert">
         <div className="item-title-container">
-          <h4>Ask for your Claim Decision</h4>
+          <h4 className="claims-alert-header">Ask for your Claim Decision</h4>
         </div>
         <Link
           aria-label="View details about asking VA for a claim decision"

--- a/src/js/claims-status/components/ClaimComplete.jsx
+++ b/src/js/claims-status/components/ClaimComplete.jsx
@@ -6,8 +6,8 @@ class ClaimComplete extends React.Component {
   render() {
     const completedDate = this.props.completedDate;
     return (
-      <div className="claim-decision-is-ready usa-alert usa-alert-info claims-no-icon claims-alert-status">
-        <h4>Your claim was closed {completedDate ? `on ${moment(completedDate).format('MMM D, YYYY')}` : null}</h4>
+      <div className="claim-decision-is-ready usa-alert usa-alert-info no-background-image claims-alert-status">
+        <h4 className="claims-alert-header">Your claim was closed {completedDate ? `on ${moment(completedDate).format('MMM D, YYYY')}` : null}</h4>
       </div>
     );
   }

--- a/src/js/claims-status/components/ClaimDetailLayout.jsx
+++ b/src/js/claims-status/components/ClaimDetailLayout.jsx
@@ -44,12 +44,12 @@ export default class ClaimDetailLayout extends React.Component {
             <div className="usa-width-two-thirds medium-8 columns">
               <div className="claim-container">
                 <div className="claim-contentions">
-                  <h6>What you’ve claimed:</h6>
-                  <p className="list">
+                  <h6 className="claim-contentions-header">What you’ve claimed:</h6>
+                  <span>
                     {claim.attributes.contentionList && claim.attributes.contentionList.length
                       ? claim.attributes.contentionList.slice(0, MAX_CONTENTIONS).map(cond => cond.trim()).join(', ')
                       : 'Not available'}
-                  </p>
+                  </span>
                   {claim.attributes.contentionList && claim.attributes.contentionList.length > MAX_CONTENTIONS
                     ? <span><br/><Link to={`your-claims/${claim.id}/details`}>See all your claimed contentions</Link>.</span>
                     : null}
@@ -62,7 +62,7 @@ export default class ClaimDetailLayout extends React.Component {
                     id={`tabPanel${tab}`}
                     aria-labelledby={`tab${tab}`}>
                     {currentTab === tab &&
-                      <div className="va-tab-content db-tab-content">
+                      <div className="va-tab-content claim-tab-content">
                         {isPopulatedClaim(claim) || !claim.attributes.open ? null : <AddingDetails/>}
                         {this.props.children}
                       </div>

--- a/src/js/claims-status/components/ClaimEstimate.jsx
+++ b/src/js/claims-status/components/ClaimEstimate.jsx
@@ -9,7 +9,7 @@ export default function ClaimEstimate({ maxDate, id }) {
 
   if (maxDate === undefined || !estimatedDate.isValid() || estimatedDate.isAfter(moment(today).add(2, 'years'))) {
     return (
-      <div className="claim-completion-estimation">
+      <div>
         <p>Estimate not available</p>
       </div>
     );
@@ -21,7 +21,7 @@ export default function ClaimEstimate({ maxDate, id }) {
       {estimatedDate.isBefore(today)
         ? <span>We estimated your claim would be completed by now but we need more time.</span>
         : <span>We base this on claims similar to yours. It isn’t an exact date.</span>}<br/>
-      <span><Link to={`your-claims/${id}/claim-estimate`}>Learn about this estimate</Link>.</span>
+      <span><Link className="claim-estimate-link" to={`your-claims/${id}/claim-estimate`}>Learn about this estimate</Link>.</span>
     </p>
   );
 }

--- a/src/js/claims-status/components/ClaimEstimate.jsx
+++ b/src/js/claims-status/components/ClaimEstimate.jsx
@@ -16,13 +16,13 @@ export default function ClaimEstimate({ maxDate, id }) {
   }
 
   return (
-    <div className="claim-completion-estimation">
-      <p className="date-estimation">Estimated date: {estimatedDate.format('MMM D, YYYY')}</p>
+    <p>
+      <span className="claim-completion-estimation">Estimated date: {estimatedDate.format('MMM D, YYYY')}</span><br/>
       {estimatedDate.isBefore(today)
-        ? <p>We estimated your claim would be completed by now but we need more time.</p>
-        : <p>We base this on claims similar to yours. It isn’t an exact date.</p>}
-      <p><Link to={`your-claims/${id}/claim-estimate`}>Learn about this estimate</Link>.</p>
-    </div>
+        ? <span>We estimated your claim would be completed by now but we need more time.</span>
+        : <span>We base this on claims similar to yours. It isn’t an exact date.</span>}<br/>
+      <span><Link to={`your-claims/${id}/claim-estimate`}>Learn about this estimate</Link>.</span>
+    </p>
   );
 }
 

--- a/src/js/claims-status/components/ClaimEstimate.jsx
+++ b/src/js/claims-status/components/ClaimEstimate.jsx
@@ -9,7 +9,7 @@ export default function ClaimEstimate({ maxDate, id }) {
 
   if (maxDate === undefined || !estimatedDate.isValid() || estimatedDate.isAfter(moment(today).add(2, 'years'))) {
     return (
-      <div>
+      <div className="claim-completion-desc">
         <p>Estimate not available</p>
       </div>
     );
@@ -19,8 +19,8 @@ export default function ClaimEstimate({ maxDate, id }) {
     <p>
       <span className="claim-completion-estimation">Estimated date: {estimatedDate.format('MMM D, YYYY')}</span><br/>
       {estimatedDate.isBefore(today)
-        ? <span>We estimated your claim would be completed by now but we need more time.</span>
-        : <span>We base this on claims similar to yours. It isn’t an exact date.</span>}<br/>
+        ? <span className="claim-completion-desc">We estimated your claim would be completed by now but we need more time.</span>
+        : <span className="claim-completion-desc">We base this on claims similar to yours. It isn’t an exact date.</span>}<br/>
       <span><Link className="claim-estimate-link" to={`your-claims/${id}/claim-estimate`}>Learn about this estimate</Link>.</span>
     </p>
   );

--- a/src/js/claims-status/components/ClaimPhase.jsx
+++ b/src/js/claims-status/components/ClaimPhase.jsx
@@ -44,28 +44,28 @@ export default class ClaimPhase extends React.Component {
     switch (event.type) {
       case 'phase_entered':
         return (
-          <div className="claims-evidence-item columns usa-width-three-fourths medium-9">
+          <div className="claims-evidence-item">
             Your claim moved to {getUserPhaseDescription(this.props.phase)}
           </div>
         );
 
       case 'filed':
-        return <div className="claims-evidence-item columns usa-width-three-fourths medium-9">Thank you. VA received your claim</div>;
+        return <div className="claims-evidence-item">Thank you. VA received your claim</div>;
 
       case 'completed':
-        return <div className="claims-evidence-item columns usa-width-three-fourths medium-9">Your claim is closed</div>;
+        return <div className="claims-evidence-item">Your claim is closed</div>;
 
       case 'still_need_from_you_list':
       case 'still_need_from_others_list':
         if (event.uploaded || event.status === 'SUBMITTED_AWAITING_REVIEW') {
           return (
-            <div className="claims-evidence-item columns usa-width-three-fourths medium-9">
+            <div className="claims-evidence-item">
               You or others submitted {event.displayName}. We will notify you when we have reviewed it.
             </div>
           );
         }
         return (
-          <div className="claims-evidence-item columns usa-width-three-fourths medium-9">
+          <div className="claims-evidence-item">
             We added a notice for: <Link to={filesPath}>{event.displayName}</Link>
           </div>
         );
@@ -74,27 +74,27 @@ export default class ClaimPhase extends React.Component {
       case 'received_from_others_list':
         if (event.status === 'SUBMITTED_AWAITING_REVIEW') {
           return (
-            <div className="claims-evidence-item columns usa-width-three-fourths medium-9">
+            <div className="claims-evidence-item">
               You or others submitted {event.displayName}. We will notify you when we have reviewed it.
             </div>
           );
         }
         return (
-          <div className="claims-evidence-item columns usa-width-three-fourths medium-9">
+          <div className="claims-evidence-item">
             We have reviewed your submitted evidence for {event.displayName}. We will notify you if we need additional information.
           </div>
         );
       case 'never_received_from_you_list':
       case 'never_received_from_others_list':
         return (
-          <div className="claims-evidence-item columns usa-width-three-fourths medium-9">
+          <div className="claims-evidence-item">
             We closed the notice for {event.displayName}
           </div>
         );
 
       case 'other_documents_list':
         return (
-          <div className="claims-evidence-item columns usa-width-three-fourths medium-9">
+          <div className="claims-evidence-item">
             You or others submitted {event.fileType}. We will notify you when we’ve reviewed it.
           </div>
         );
@@ -112,8 +112,8 @@ export default class ClaimPhase extends React.Component {
         : _.take(INITIAL_ACTIVITY_ROWS, activityList);
 
       const activityListContent = limitedList.map((activity, index) => (
-        <div key={index} className="claims-evidence row small-collapse">
-          <div className="claims-evidence-date columns usa-width-one-fourth medium-3">{moment(activity.date).format('MMM D, YYYY')}</div>
+        <div key={index} className="claims-evidence">
+          <div className="claims-evidence-date">{moment(activity.date).format('MMM D, YYYY')}</div>
           {this.getEventDescription(activity)}
         </div>));
 
@@ -123,7 +123,7 @@ export default class ClaimPhase extends React.Component {
             {activityListContent}
           </div>
           <button
-            className="older-updates usa-button-outline"
+            className="claim-older-updates usa-button-outline"
             onClick={this.showAllActivity}>
             See older updates&nbsp;<i className="fa fa-chevron-down"></i>
           </button>
@@ -156,7 +156,7 @@ export default class ClaimPhase extends React.Component {
     return (
       <li onClick={() => this.expandCollapse()} role="presentation" className={`${getClasses(phase, current)}`}>
         {expandCollapseIcon}
-        <h5>{getUserPhaseDescription(phase)}</h5>
+        <h5 className="section-header">{getUserPhaseDescription(phase)}</h5>
         {this.state.open || phase === COMPLETE_PHASE
           ? <div>
             {children}

--- a/src/js/claims-status/components/ClaimsAppealsUnavailable.jsx
+++ b/src/js/claims-status/components/ClaimsAppealsUnavailable.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 class ClaimsAppealsUnavailable extends React.Component {
   render() {
     return (
-      <div className="usa-alert usa-alert-warning claims-no-icon claims-unavailable">
-        <h4 className="warning-title">
+      <div className="usa-alert usa-alert-warning no-background-image claims-unavailable">
+        <h4 className="claims-alert-header">
           <i className="fa fa-exclamation-triangle"></i>&nbsp;Claim and Appeal status is unavailable
         </h4>
         Vets.gov is having trouble loading claims and appeals information at this time. Please check back again in a hour.

--- a/src/js/claims-status/components/ClaimsDecision.jsx
+++ b/src/js/claims-status/components/ClaimsDecision.jsx
@@ -6,11 +6,11 @@ class ClaimsDecision extends React.Component {
   render() {
     const completedDate = this.props.completedDate;
     return (
-      <div className="claim-decision-is-ready usa-alert usa-alert-info claims-no-icon claims-alert-status">
-        <h4>Your claim decision is ready</h4>
+      <div className="claim-decision-is-ready usa-alert usa-alert-info claims-alert-status no-background-image">
+        <h4 className="claims-alert-header">Your claim decision is ready</h4>
         <p>{completedDate ? `We finished reviewing your claim on ${moment(completedDate).format('MMM D, YYYY')}. ` : null}
           We sent you a packet by U.S. mail that includes details of the decision on your claim. Please allow 7 to 10 business days for your packet to arrive before contacting a VA call center. If you haven’t received the packet with the full details of your claim decision yet, you can see your rating by going to your disability page in eBenefits. <a href="https://www.ebenefits.va.gov" target="_blank">Check your disability page in eBenefits for your rating</a>.</p>
-        <h5 className="estimation-header">Next steps</h5>
+        <h5 className="claims-paragraph-header">Next steps</h5>
         <p>If you agree with your rating, you don’t need to do anything else.</p>
         <p>If we decided that an issue you claimed wasn’t service connected, and you have new evidence that you haven’t submitted yet, you can ask VA to reopen your claim. <a href="/disability-benefits/apply/claim-types/reopened-claim/" target="_blank">Find out how to reopen your claim</a>.</p>
         <p>Has your condition gotten worse since you filed your claim? You can file a new claim for an increase in disability compensation. <a href="/disability-benefits/apply/claim-types/new-claim/" target="_blank">Find out how to file a new claim</a>.</p>

--- a/src/js/claims-status/components/ClaimsTimeline.jsx
+++ b/src/js/claims-status/components/ClaimsTimeline.jsx
@@ -14,7 +14,7 @@ export default class ClaimsTimeline extends React.Component {
     const activityByPhase = groupTimelineActivity(events);
 
     return (
-      <ol className="process form-process disability-benefits-timeline">
+      <ol className="process form-process claim-timeline">
         <ClaimPhase phase={1} current={userPhase} activity={activityByPhase} id={id}/>
         <ClaimPhase phase={2} current={userPhase} activity={activityByPhase} id={id}>
           <p>Your claim has been assigned to a reviewer who is determining if additional information is needed.</p>

--- a/src/js/claims-status/components/ClaimsUnauthorized.jsx
+++ b/src/js/claims-status/components/ClaimsUnauthorized.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 class ClaimsUnauthorized extends React.Component {
   render() {
     return (
-      <div className="usa-alert usa-alert-warning claims-no-icon claims-unavailable">
-        <h4 className="warning-title">
+      <div className="usa-alert usa-alert-warning no-background-image claims-unavailable">
+        <h4 className="claims-alert-header">
           <i className="fa fa-exclamation-triangle"></i>&nbsp;Sorry, your session has expired
         </h4>
         You may need to refresh the page and sign in again.

--- a/src/js/claims-status/components/ClaimsUnavailable.jsx
+++ b/src/js/claims-status/components/ClaimsUnavailable.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 class ClaimsUnavailable extends React.Component {
   render() {
     return (
-      <div className="usa-alert usa-alert-warning claims-no-icon claims-unavailable">
-        <h4 className="warning-title">
+      <div className="usa-alert usa-alert-warning no-background-image claims-unavailable">
+        <h4 className="claims-alert-header">
           <i className="fa fa-exclamation-triangle"></i>&nbsp;Claim status is unavailable
         </h4>
         Vets.gov is having trouble loading claims information at this time. Please check back again in a hour.

--- a/src/js/claims-status/components/MviRecordsUnavailable.jsx
+++ b/src/js/claims-status/components/MviRecordsUnavailable.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 class MviRecordsUnavailable extends React.Component {
   render() {
     return (
-      <div className="usa-alert usa-alert-warning claims-no-icon claims-unavailable">
-        <h4 className="warning-title">
+      <div className="usa-alert usa-alert-warning no-background-image claims-unavailable">
+        <h4 className="claims-alert-header">
           <i className="fa fa-exclamation-triangle"></i>&nbsp;We weren’t able to find your records
         </h4>
           Please call 1-855-574-7286 between Monday - Friday, 8:00 a.m. - 8:00 p.m. ET.

--- a/src/js/claims-status/components/NoClaims.jsx
+++ b/src/js/claims-status/components/NoClaims.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 export default function NoClaims() {
   return (
-    <div className="usa-alert usa-alert-info claims-alert claims-no-icon claims-alert-status">
-      <h4>You do not have any submitted claims</h4>
+    <div className="usa-alert usa-alert-info claims-alert no-background-image claims-alert-status">
+      <h4 className="claims-alert-header">You do not have any submitted claims</h4>
       <p>This page shows only completed claim applications. If you started a claim but haven’t finished it yet, go to <a href="https://www.ebenefits.va.gov/">eBenefits</a> to work on it.</p>
     </div>
   );

--- a/src/js/claims-status/components/RequestedFilesInfo.jsx
+++ b/src/js/claims-status/components/RequestedFilesInfo.jsx
@@ -19,7 +19,7 @@ export default class RequestedFilesInfo extends React.Component {
             : null}
 
           {filesNeeded.map(item => (
-            <div className="file-request-list-item usa-alert usa-alert-warning claims-no-icon" key={item.trackedItemId}>
+            <div className="file-request-list-item usa-alert usa-alert-warning no-background-image" key={item.trackedItemId}>
               <div className="item-container">
                 <h5 className="file-request-title">{item.displayName}</h5>
                 <p>{truncateDescription(item.description)}</p>
@@ -31,7 +31,7 @@ export default class RequestedFilesInfo extends React.Component {
           ))}
 
           {optionalFiles.map(item => (
-            <div className="file-request-list-item usa-alert file-request-list-item-optional claims-no-icon" key={item.trackedItemId}>
+            <div className="file-request-list-item usa-alert file-request-list-item-optional no-background-image" key={item.trackedItemId}>
               <div className="item-container">
                 <h5 className="file-request-title">{item.displayName}</h5>
                 <p>{truncateDescription(item.description)}</p>

--- a/src/js/claims-status/containers/AskVAPage.jsx
+++ b/src/js/claims-status/containers/AskVAPage.jsx
@@ -63,7 +63,7 @@ class AskVAPage extends React.Component {
                 <li>Whether you get our help to gather evidence to support your claim</li>
                 <li>The date benefits will begin if we approve your claim</li>
               </ul>
-              <div className="usa-alert usa-alert-info claims-no-icon claims-alert">
+              <div className="usa-alert usa-alert-info no-background-image claims-alert">
                 <ErrorableCheckbox
                   className="claims-alert-checkbox"
                   checked={this.state.submittedDocs}

--- a/src/js/claims-status/containers/ClaimEstimationPage.jsx
+++ b/src/js/claims-status/containers/ClaimEstimationPage.jsx
@@ -28,7 +28,7 @@ class ClaimEstimationPage extends React.Component {
             <div>
               <h1>How We Come Up with Your Estimated Decision Date</h1>
               <p className="first-of-type">We look at every claim carefully before making a decision. Sometimes we can decide quickly, but more complex claims take longer to review.</p>
-              <h2 className="estimation-header">We base your estimated decision date on:</h2>
+              <h2 className="claims-paragraph-header">We base your estimated decision date on:</h2>
               <ul>
                 <li>The type of claim you submitted</li>
                 <li>The number of claims you submitted</li>
@@ -36,16 +36,16 @@ class ClaimEstimationPage extends React.Component {
                 <li>How long it took us to decide other claims like yours</li>
                 <li>How long it takes us to get supporting documents</li>
               </ul>
-              <h2 className="estimation-header">Estimated dates may change when:</h2>
+              <h2 className="claims-paragraph-header">Estimated dates may change when:</h2>
               <ul>
                 <li>You upload optional evidence that we need to process</li>
                 <li>You filed a second claim that we combined with an existing claim</li>
                 <li>We decide we need more evidence that supports your claim</li>
                 <li>We have a high volume of claims that we weren’t expecting</li>
               </ul>
-              <h2 className="estimation-header">When we don’t meet the estimated decision date:</h2>
+              <h2 className="claims-paragraph-header">When we don’t meet the estimated decision date:</h2>
               <p>The above reasons sometimes result in your claim needing additional time that exceeds the estimated completion date. We are working to process your claim as quickly as possible.</p>
-              <h2 className="estimation-header">When we don’t give you an estimated decision date:</h2>
+              <h2 className="claims-paragraph-header">When we don’t give you an estimated decision date:</h2>
               <p>Sometimes we can’t estimate the decision date because we don’t have enough information. We can give you an estimated decision date after we have gathered all the information we need.</p>
             </div>
             <p>You can help speed up the process by promptly and electronically uploading the documents requested by VA.</p>

--- a/src/js/claims-status/containers/DetailsPage.jsx
+++ b/src/js/claims-status/containers/DetailsPage.jsx
@@ -36,31 +36,31 @@ class DetailsPage extends React.Component {
     let content = null;
     if (!loading) {
       content = (
-        <div className="claim-details">
-          <div className="claim-types">
-            <h6>Claim Type</h6>
-            <p>{claim.attributes.claimType || 'Not Available'}</p>
+        <dl className="claim-details">
+          <div className="claim-detail-row">
+            <dt className="claim-detail-label">Claim Type</dt>
+            <dd>{claim.attributes.claimType || 'Not Available'}</dd>
           </div>
-          <div className="claim-contentions-list">
-            <h6>What you’ve claimed</h6>
-            {claim.attributes.contentionList && claim.attributes.contentionList.length
-              ? <ul>{
+          <div className="claim-detail-row">
+            <dt className="claim-detail-label">What you’ve claimed</dt>
+            <dd>{claim.attributes.contentionList && claim.attributes.contentionList.length
+              ? <ul className="claim-detail-list">{
                 claim.attributes.contentionList.map((contention, index) =>
-                  <li key={index}>{contention}</li>
+                  <li key={index} className="claim-detail-list-item">{contention}</li>
                 )}
               </ul>
               : 'Not Available'
-            }
+            }</dd>
           </div>
-          <div className="claim-date-recieved">
-            <h6>Date Received</h6>
-            <p>{moment(claim.attributes.dateFiled).format('MMM D, YYYY')}</p>
+          <div className="claim-detail-row">
+            <dt className="claim-detail-label">Date Received</dt>
+            <dd>{moment(claim.attributes.dateFiled).format('MMM D, YYYY')}</dd>
           </div>
-          <div className="claim-va-representative">
-            <h6>Your Representative for VA Claims</h6>
-            <p>{claim.attributes.vaRepresentative || 'Not Available'}</p>
+          <div className="claim-detail-row">
+            <dt className="claim-detail-label">Your Representative for VA Claims</dt>
+            <dd>{claim.attributes.vaRepresentative || 'Not Available'}</dd>
           </div>
-        </div>
+        </dl>
       );
     }
 

--- a/src/js/claims-status/containers/DetailsPage.jsx
+++ b/src/js/claims-status/containers/DetailsPage.jsx
@@ -37,29 +37,21 @@ class DetailsPage extends React.Component {
     if (!loading) {
       content = (
         <dl className="claim-details">
-          <div className="claim-detail-row">
-            <dt className="claim-detail-label">Claim Type</dt>
-            <dd>{claim.attributes.claimType || 'Not Available'}</dd>
-          </div>
-          <div className="claim-detail-row">
-            <dt className="claim-detail-label">What you’ve claimed</dt>
-            <dd>{claim.attributes.contentionList && claim.attributes.contentionList.length
-              ? <ul className="claim-detail-list">{
-                claim.attributes.contentionList.map((contention, index) =>
-                  <li key={index} className="claim-detail-list-item">{contention}</li>
-                )}
-              </ul>
-              : 'Not Available'
-            }</dd>
-          </div>
-          <div className="claim-detail-row">
-            <dt className="claim-detail-label">Date Received</dt>
-            <dd>{moment(claim.attributes.dateFiled).format('MMM D, YYYY')}</dd>
-          </div>
-          <div className="claim-detail-row">
-            <dt className="claim-detail-label">Your Representative for VA Claims</dt>
-            <dd>{claim.attributes.vaRepresentative || 'Not Available'}</dd>
-          </div>
+          <dt className="claim-detail-label">Claim Type</dt>
+          <dd>{claim.attributes.claimType || 'Not Available'}</dd>
+          <dt className="claim-detail-label">What you’ve claimed</dt>
+          <dd>{claim.attributes.contentionList && claim.attributes.contentionList.length
+            ? <ul className="claim-detail-list">{
+              claim.attributes.contentionList.map((contention, index) =>
+                <li key={index} className="claim-detail-list-item">{contention}</li>
+              )}
+            </ul>
+            : 'Not Available'
+          }</dd>
+          <dt className="claim-detail-label">Date Received</dt>
+          <dd>{moment(claim.attributes.dateFiled).format('MMM D, YYYY')}</dd>
+          <dt className="claim-detail-label">Your Representative for VA Claims</dt>
+          <dd>{claim.attributes.vaRepresentative || 'Not Available'}</dd>
         </dl>
       );
     }

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -803,9 +803,3 @@ h1:focus {
   font-weight: bold;
 }
 
-.claim-detail-row {
-  margin-bottom: 1.5em;
-  &:last-child {
-    margin-bottom: 2em;
-  }
-}

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -5,11 +5,6 @@
 @import "modules/m-progress-bar";
 @import "modules/va-tabs";
 
-.claim-alert-status {
-  margin-top: 0;
-  margin-bottom: 2em;
-}
-
 .claim-list {
   margin-bottom: 2em;
 }
@@ -138,77 +133,10 @@
   }
 }
 
-.claims-evidence {
-  border-bottom: 1px solid $color-gray-light;
-  padding: 1em 0;
-  &.row {
-    margin: 0 0;
-  }
-  .claims-evidence-date {
-    font-weight: bold;
-    padding-right: 10px;
-  }
-  &:last-child {
-    border: none;
-    padding-bottom: 0;
-  }
-}
-
-.completion-container {
-  margin-left: 8px;
-}
-
-.claim-completion-estimation {
-  p {
-    margin: 0;
-  }
-  .date-estimation {
-    display: inline-block;
-    font-weight: bold;
-    margin-right: 10px;
-  }
-
-}
-
-.claim-decision-is-ready,
 .you-have-no-claims {
   h4, p {
     margin: 0.5em 0;
     padding: 0;
-  }
-}
-
-.claims-no-icon,
-.usa-alert-info.claims-no-icon {
-  background-image: none;
-  h4 {
-    padding-bottom: 0 !important;
-  }
-}
-
-.form-process li.section-complete:before {
-  background: $color-green;
-  content: "\2713\fe0e";
-
-  @include media($medium-large-screen) {
-    content: "\2714\fe0e";
-  }
-}
-
-.form-process li.section-current {
-  h5 {
-    font-weight: bold;
-    color: $color-primary;
-  }
-  li {
-    display: list-item;
-    &.sub-section-current {
-      font-weight: bold;
-      color: $color-primary;
-    }
-  }
-  &:before {
-    background: $color-primary;
   }
 }
 
@@ -435,48 +363,6 @@ a.claim-list-item {
   }
 }
 
-.claim-title {
-  margin: 0;
-  display: inline-block;
-}
-
-.claim-contentions {
-  margin-top: 0.5em;
-  margin-bottom: 2em;
-  p {
-    margin: 0;
-  }
-  h6, p {
-    display: inline-block;
-  }
-  h6 {
-    margin-right: 6px !important;
-    padding-bottom: 0 !important;
-  }
-}
-
-.claim-details {
-  .claim-contentions-list,
-  .claim-date-recieved,
-  .claim-va-representative {
-    margin-top: 1.5em;
-  }
-  .claim-types {
-    h6 {
-      padding: 0;
-    }
-  }
-
-  .claim-va-representative {
-    margin-bottom: 2em;
-  }
-
-  h6, p, ul, li {
-    margin: 0;
-    padding: 0;
-    display: block;
-  }
-}
 
 .clearfix:after {
   content: " ";
@@ -512,26 +398,6 @@ a.claim-list-item {
   margin: 1.5em 0;
 }
 
-.disability-benefits-timeline {
-  padding-top: 0;
-  > li.step.section-current:not(.last), > li.step.section-complete:not(.last) {
-    cursor: pointer;
-  }
-  > li > h5 {
-    padding-right: 23px !important;
-  }
-}
-
-.claim-timeline-icon {
-  float: right;
-  margin-top: 6px;
-  font-size: 17px;
-}
-
-button.older-updates {
-  margin-top: 1em;
-  margin-bottom: 0;
-}
 
 .claims-alert-checkbox {
   > label {
@@ -644,17 +510,8 @@ p.first-of-type {
   background-position: 1rem 1.4rem;
 }
 
-.claims-alert-status {
-  margin-top: 0;
-  margin-bottom: 2em;
-}
-
 .claims-header {
   margin: 0;
-}
-
-.estimation-header {
-  padding: 0.5em 0 0 !important;
 }
 
 .claims-files-cancel {
@@ -769,10 +626,6 @@ h1:focus {
   align-items: center;
 }
 
-.db-tab-content {
-  padding-top: 2em;
-}
-
 .claims-list-sort {
   margin: 2em 0;
 
@@ -819,4 +672,140 @@ h1:focus {
 .claims-breadcrumbs {
   padding-left: 0.9375rem;
   padding-right: 0.9375rem;
+}
+
+// New styles
+.claim-tab-content {
+  padding-top: 2em;
+}
+
+.claims-paragraph-header {
+  padding: 0.5em 0 0 !important;
+}
+
+.claims-alert-status {
+  margin-top: 0;
+  margin-bottom: 2em;
+}
+
+.claims-alert-header {
+  padding-bottom: 0 !important;
+}
+
+.claim-title {
+  margin: 0;
+  display: inline-block;
+}
+
+// Claim status page
+
+.claim-contentions {
+  margin-top: 0.5em;
+  margin-bottom: 2em;
+}
+
+.claim-contentions-header {
+  display: inline-block;
+  margin-right: 6px;
+  padding-bottom: 0;
+}
+
+.claim-timeline {
+  padding-top: 0;
+
+  .section-current > .section-header {
+    color: $color-primary;
+  }
+
+  .section-header {
+    padding-right: 23px !important;
+  }
+
+  .section-current:before {
+    background: $color-primary;
+  }
+
+  .section-complete:before {
+    background: $color-green;
+    content: "\2713\fe0e";
+
+    @include media($medium-large-screen) {
+      content: "\2714\fe0e";
+    }
+  }
+
+  > .section-current:not(.last), > .section-complete:not(.last) {
+    cursor: pointer;
+  }
+}
+
+.claim-timeline-icon {
+  float: right;
+  margin-top: 6px;
+  font-size: 17px;
+}
+
+.claim-older-updates {
+  margin-top: 1em;
+  margin-bottom: 0;
+}
+
+.claims-evidence {
+  border-bottom: 1px solid $color-gray-light;
+  padding: 1em 0;
+  display: flex;
+  flex-direction: column;
+
+  @include media($medium-large-screen) {
+    flex-direction: row;
+  }
+
+  &:last-child {
+    border: none;
+    padding-bottom: 0;
+  }
+}
+
+.claims-evidence-date {
+  font-weight: bold;
+  padding-right: 10px;
+
+  @include media($medium-large-screen) {
+    width: 25%;
+    flex-shrink: 0;
+  }
+}
+
+.claim-completion-estimation {
+  display: inline-block;
+  font-weight: bold;
+  margin-right: 10px;
+}
+
+// Claim detail page
+
+.claim-details {
+  margin-top: 0;
+}
+
+.claim-detail-list {
+  margin: 0;
+  padding: 0;
+}
+
+.claim-detail-list-item {
+  display: block;
+}
+
+.claim-detail-label {
+  font-size: 0.9em;
+  line-height: 1.5;
+  font-weight: bold;
+}
+
+.claim-detail-row {
+  margin-bottom: 1.5em;
+  &:last-child {
+    margin-bottom: 2em;
+  }
 }

--- a/test/accessibility/disability-benefits-508.spec.js
+++ b/test/accessibility/disability-benefits-508.spec.js
@@ -44,7 +44,7 @@ module.exports = E2eHelpers.createE2eTest(
       .pause(500)
       .waitForElementPresent('.claim-completion-estimation', Timeouts.normal)
       .click('.claim-completion-estimation a')
-      .waitForElementVisible('.estimation-header', Timeouts.normal)
+      .waitForElementVisible('.claims-paragraph-header', Timeouts.normal)
       .axeCheck('.main');
 
     client

--- a/test/accessibility/disability-benefits-508.spec.js
+++ b/test/accessibility/disability-benefits-508.spec.js
@@ -43,7 +43,7 @@ module.exports = E2eHelpers.createE2eTest(
       .execute('window.scrollTo(0,8000)')
       .pause(500)
       .waitForElementPresent('.claim-completion-estimation', Timeouts.normal)
-      .click('.claim-completion-estimation a')
+      .click('.claim-estimate-link')
       .waitForElementVisible('.claims-paragraph-header', Timeouts.normal)
       .axeCheck('.main');
 
@@ -92,7 +92,7 @@ module.exports = E2eHelpers.createE2eTest(
     // details tab
     client
       .click('.va-tabs li:nth-child(3) > a')
-      .waitForElementVisible('.claim-types', Timeouts.normal)
+      .waitForElementVisible('.claim-details', Timeouts.normal)
       .axeCheck('.main');
 
     client.end();

--- a/test/claims-status/components/ClaimDetailLayout.unit.spec.jsx
+++ b/test/claims-status/components/ClaimDetailLayout.unit.spec.jsx
@@ -45,7 +45,7 @@ describe('<ClaimDetailLayout>', () => {
         claim={claim}/>
     );
 
-    expect(tree.subTree('.list').text()).to.contain('Condition 1, Condition 2');
+    expect(tree.subTree('.claim-contentions').text()).to.contain('Condition 1, Condition 2');
   });
   it('should render see all link if long contention list', () => {
     const claim = {
@@ -66,7 +66,7 @@ describe('<ClaimDetailLayout>', () => {
         claim={claim}/>
     );
 
-    expect(tree.subTree('.list').text()).to.contain('Condition 1, Condition 2, Condition 3');
+    expect(tree.subTree('.claim-contentions').text()).to.contain('Condition 1, Condition 2, Condition 3');
     expect(tree.subTree('.claim-contentions').subTree('Link').props.to).to.equal('your-claims/5/details');
   });
   it('should render not available if no contention list', () => {
@@ -82,7 +82,7 @@ describe('<ClaimDetailLayout>', () => {
         claim={claim}/>
     );
 
-    expect(tree.subTree('.list').text()).to.contain('Not available');
+    expect(tree.subTree('.claim-contentions').text()).to.contain('Not available');
   });
   it('should render adding details info if open', () => {
     const claim = {

--- a/test/claims-status/components/ClaimEstimate.unit.spec.jsx
+++ b/test/claims-status/components/ClaimEstimate.unit.spec.jsx
@@ -12,8 +12,8 @@ describe('<ClaimEstimate>', () => {
       <ClaimEstimate
         maxDate={date.format('YYYY-MM-DD')}/>
     );
-    expect(tree.subTree('.date-estimation').text()).to.contain(`Estimated date: ${date.format('MMM D, YYYY')}`);
-    expect(tree.subTree('.claim-completion-estimation').text()).to.contain('We base this on claims similar to yours. It isn’t an exact date.');
+    expect(tree.text()).to.contain(`Estimated date: ${date.format('MMM D, YYYY')}`);
+    expect(tree.text()).to.contain('We base this on claims similar to yours. It isn’t an exact date.');
   });
   it('should render estimated date warning', () => {
     const date = moment().startOf('day').subtract(2, 'days');
@@ -21,14 +21,14 @@ describe('<ClaimEstimate>', () => {
       <ClaimEstimate
         maxDate={date.format('YYYY-MM-DD')}/>
     );
-    expect(tree.subTree('.claim-completion-estimation').text()).to.contain('We estimated your claim would be completed by now');
+    expect(tree.text()).to.contain('We estimated your claim would be completed by now');
   });
   it('should render no estimate warning', () => {
     const tree = SkinDeep.shallowRender(
       <ClaimEstimate
         maxDate=""/>
     );
-    expect(tree.subTree('.claim-completion-estimation').text()).to.contain('Estimate not available');
+    expect(tree.text()).to.contain('Estimate not available');
   });
   it('should render no estimate warning with far away date', () => {
     const date = moment().startOf('day').add(5, 'years');
@@ -36,6 +36,6 @@ describe('<ClaimEstimate>', () => {
       <ClaimEstimate
         maxDate={date.format('YYYY-MM-DD')}/>
     );
-    expect(tree.subTree('.claim-completion-estimation').text()).to.contain('Estimate not available');
+    expect(tree.text()).to.contain('Estimate not available');
   });
 });

--- a/test/claims-status/components/DetailsPage.unit.spec.jsx
+++ b/test/claims-status/components/DetailsPage.unit.spec.jsx
@@ -19,7 +19,7 @@ describe('<DetailsPage>', () => {
       <DetailsPage
         claim={claim}/>
     );
-    expect(tree.subTree('.claim-contentions-list').text()).to.contain('Condition 1Condition 2');
+    expect(tree.subTree('.claim-detail-list').text()).to.contain('Condition 1Condition 2');
   });
 
   it('should render not available with an empty contention list', () => {
@@ -33,6 +33,6 @@ describe('<DetailsPage>', () => {
       <DetailsPage
         claim={claim}/>
     );
-    expect(tree.subTree('.claim-contentions-list').text()).to.contain('Not Available');
+    expect(tree.subTree('.claim-details').text()).to.contain('Not Available');
   });
 });

--- a/test/claims-status/e2e/01.claim-status-est-current.e2e.spec.js
+++ b/test/claims-status/e2e/01.claim-status-est-current.e2e.spec.js
@@ -24,7 +24,7 @@ module.exports = E2eHelpers.createE2eTest(
     client.assert.urlContains('/your-claims/11/status');
 
     client
-      .expect.element('.claim-completion-estimation').text.to.contain('Estimate not available');
+      .expect.element('.claim-completion-desc').text.to.contain('Estimate not available');
 
     client.end();
   }

--- a/test/claims-status/e2e/01.claim-status-est-past.e2e.spec.js
+++ b/test/claims-status/e2e/01.claim-status-est-past.e2e.spec.js
@@ -24,7 +24,7 @@ module.exports = E2eHelpers.createE2eTest(
     client.assert.urlContains('/your-claims/11/status');
 
     client
-      .expect.element('.claim-completion-estimation').text.to.contain('We estimated your claim would be completed by now');
+      .expect.element('.claim-completion-desc').text.to.contain('We estimated your claim would be completed by now');
 
     client.end();
   }

--- a/test/claims-status/e2e/01.claim-status-est.e2e.spec.js
+++ b/test/claims-status/e2e/01.claim-status-est.e2e.spec.js
@@ -24,7 +24,7 @@ module.exports = E2eHelpers.createE2eTest(
     client.assert.urlContains('/your-claims/11/status');
 
     client
-      .expect.element('.claim-completion-estimation').text.to.contain('base this on claims similar to yours');
+      .expect.element('.claim-completion-desc').text.to.contain('base this on claims similar to yours');
 
     client.end();
   }

--- a/test/claims-status/e2e/01.claim-status.e2e.spec.js
+++ b/test/claims-status/e2e/01.claim-status.e2e.spec.js
@@ -28,7 +28,7 @@ module.exports = E2eHelpers.createE2eTest(
 
     // conditions list
     client
-      .expect.element('.claim-contentions .list').text.equals('Hearing Loss (New), skin condition (New), jungle rot (New)');
+      .expect.element('.claim-contentions > span').text.equals('Hearing Loss (New), skin condition (New), jungle rot (New)');
 
     // timeline
     client
@@ -49,7 +49,7 @@ module.exports = E2eHelpers.createE2eTest(
     client
       .expect.element('.claims-evidence:nth-child(3) .claims-evidence-item').text.equals('Your claim is closed');
     client
-      .expect.element('button.older-updates').to.be.present;
+      .expect.element('.claim-older-updates').to.be.present;
     client
       .click('li.list-one')
       .waitForElementNotPresent('li.list-one .claims-evidence', Timeouts.slow);

--- a/test/claims-status/e2e/03.claim-details.e2e.spec.js
+++ b/test/claims-status/e2e/03.claim-details.e2e.spec.js
@@ -20,20 +20,20 @@ module.exports = E2eHelpers.createE2eTest(
     // go to details tab
     client
       .click('.va-tabs li:nth-child(3) > a')
-      .waitForElementVisible('.claim-types', Timeouts.normal);
+      .waitForElementVisible('.claim-details', Timeouts.normal);
     client.assert.urlContains('/your-claims/11/details');
 
     client
       .expect.element('a.va-tab-trigger.va-tab-trigger--current').text.to.equal('Details');
 
     client
-      .expect.element('.claim-types h6').text.to.equal('Claim Type');
+      .expect.element('.claim-detail-label:nth-of-type(1)').text.to.equal('Claim Type');
     client
-      .expect.element('.claim-contentions-list h6').text.to.equal('What you’ve claimed');
+      .expect.element('.claim-detail-label:nth-of-type(2)').text.to.equal('What you’ve claimed');
     client
-      .expect.element('.claim-date-recieved h6').text.to.equal('Date Received');
+      .expect.element('.claim-detail-label:nth-of-type(3)').text.to.equal('Date Received');
     client
-      .expect.element('.claim-va-representative h6').text.to.equal('Your Representative for VA Claims');
+      .expect.element('.claim-detail-label:nth-of-type(4)').text.to.equal('Your Representative for VA Claims');
     client.end();
   }
 );

--- a/test/claims-status/e2e/06.claim-estimation.e2e.spec.js
+++ b/test/claims-status/e2e/06.claim-estimation.e2e.spec.js
@@ -18,7 +18,7 @@ module.exports = E2eHelpers.createE2eTest(
       .waitForElementVisible('body', Timeouts.normal)
       .waitForElementVisible('.claim-title', Timeouts.normal);
 
-    const selector = '.claim-completion-estimation a';
+    const selector = '.claim-estimate-link';
 
     client
       .pause(500) // Since the link is below the fold, we must wait for the full render to finish

--- a/test/claims-status/e2e/06.claim-estimation.e2e.spec.js
+++ b/test/claims-status/e2e/06.claim-estimation.e2e.spec.js
@@ -24,7 +24,7 @@ module.exports = E2eHelpers.createE2eTest(
       .pause(500) // Since the link is below the fold, we must wait for the full render to finish
       .waitForElementVisible(selector, Timeouts.normal)
       .click(selector)
-      .waitForElementVisible('.estimation-header', Timeouts.normal);
+      .waitForElementVisible('.claims-paragraph-header', Timeouts.normal);
 
     client
       .expect.element('.disability-benefits-content h1').text.to.equal('How We Come Up with Your Estimated Decision Date');


### PR DESCRIPTION
This updates the styles for the status and detail tab on the claim detail page. It also updates some app-wide styles when necessary.

![screen shot 2017-10-06 at 1 24 53 pm](https://user-images.githubusercontent.com/634932/31290304-fdfc1e46-aa99-11e7-980b-7d8ed9b14e32.png)
![screen shot 2017-10-06 at 1 25 03 pm](https://user-images.githubusercontent.com/634932/31290305-fdfeacba-aa99-11e7-8758-7b442987d43e.png)
