### PR TITLE
Standardize loading message design

### DIFF
--- a/content/pages/auth/login/callback/index.md
+++ b/content/pages/auth/login/callback/index.md
@@ -8,8 +8,9 @@ entryname: auth
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we log you in.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="lease wait while we log you in." tabIndex="0"></div> Please wait while we log you in.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/burials-and-memorials/application/530.md
+++ b/content/pages/burials-and-memorials/application/530.md
@@ -15,8 +15,9 @@ layout: page-react.html
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/burials-and-memorials/burial-planning/application.md
+++ b/content/pages/burials-and-memorials/burial-planning/application.md
@@ -15,8 +15,9 @@ layout: page-react.html
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/disability-benefits/track-claims/index.md
+++ b/content/pages/disability-benefits/track-claims/index.md
@@ -13,8 +13,9 @@ includeBreadcrumbs: true
     <div id="react-root">
       <div class="loading-message">
         <h1>Working</h1>
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/education/apply-for-education-benefits/application/1990.md
+++ b/content/pages/education/apply-for-education-benefits/application/1990.md
@@ -15,8 +15,9 @@ description: Use your VA education benefits to pay for college or training progr
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/education/apply-for-education-benefits/application/1990E.md
+++ b/content/pages/education/apply-for-education-benefits/application/1990E.md
@@ -15,8 +15,9 @@ description: Use your VA education benefits to pay for college or training progr
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/education/apply-for-education-benefits/application/1990N.md
+++ b/content/pages/education/apply-for-education-benefits/application/1990N.md
@@ -15,8 +15,9 @@ description: Use your VA education benefits to pay for college or training progr
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/education/apply-for-education-benefits/application/1995.md
+++ b/content/pages/education/apply-for-education-benefits/application/1995.md
@@ -15,8 +15,9 @@ description: Use your VA education benefits to pay for college or training progr
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/education/apply-for-education-benefits/application/5490.md
+++ b/content/pages/education/apply-for-education-benefits/application/5490.md
@@ -15,8 +15,9 @@ description: Use your VA education benefits to pay for college or training progr
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/education/apply-for-education-benefits/application/5495.md
+++ b/content/pages/education/apply-for-education-benefits/application/5495.md
@@ -15,8 +15,9 @@ description: Use your VA education benefits to pay for college or training progr
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/education/gi-bill/post-9-11/ch-33-benefit.md
+++ b/content/pages/education/gi-bill/post-9-11/ch-33-benefit.md
@@ -11,8 +11,9 @@ maintenance_line2: In the meantime, please try the search box above or one of th
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/facilities/index.md
+++ b/content/pages/facilities/index.md
@@ -7,8 +7,9 @@ entryname: facilities
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/gi-bill-comparison-tool/index.md
+++ b/content/pages/gi-bill-comparison-tool/index.md
@@ -11,8 +11,9 @@ order: 4
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/health-beta/index.md
+++ b/content/pages/health-beta/index.md
@@ -13,8 +13,9 @@ entryname: health-beta
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/health-care/apply/application.md
+++ b/content/pages/health-care/apply/application.md
@@ -20,8 +20,9 @@ maintenance_line2: In the meantime, you can still call 1-877-222-VETS(8387) and 
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/health-care/health-records/index.md
+++ b/content/pages/health-care/health-records/index.md
@@ -10,8 +10,9 @@ order: 8
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/health-care/messaging/index.md
+++ b/content/pages/health-care/messaging/index.md
@@ -12,8 +12,9 @@ includeBreadcrumbs: true
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/health-care/prescriptions/index.md
+++ b/content/pages/health-care/prescriptions/index.md
@@ -10,8 +10,9 @@ order: 6
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/letters/index.md
+++ b/content/pages/letters/index.md
@@ -12,8 +12,9 @@ maintenance_line2: In the meantime, please try the search box above or one of th
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/pension/application/527EZ.md
+++ b/content/pages/pension/application/527EZ.md
@@ -15,8 +15,9 @@ layout: page-react.html
     <div id="react-root">
       <div class="loading-message">
         <h1>Working</h1>
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/profile/index.md
+++ b/content/pages/profile/index.md
@@ -13,8 +13,9 @@ entryname: user-profile
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/signin.md
+++ b/content/pages/signin.md
@@ -9,8 +9,9 @@ noHeader: true
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/track-claims/index.md
+++ b/content/pages/track-claims/index.md
@@ -9,8 +9,9 @@ description: Log in to your Vets.gov account to track the status of your VA clai
     <div id="react-root">
       <div class="loading-message">
         <h1>Working</h1>
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/verify.md
+++ b/content/pages/verify.md
@@ -8,8 +8,9 @@ layout: page-react.html
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/content/pages/veteran-id-card/index.md
+++ b/content/pages/veteran-id-card/index.md
@@ -13,8 +13,9 @@ entryname: veteran-id-card
   <div class="section">
     <div id="react-root">
       <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
       </div>
     </div>
   </div>

--- a/src/js/auth/containers/AuthApp.jsx
+++ b/src/js/auth/containers/AuthApp.jsx
@@ -6,6 +6,7 @@ import { apiRequest } from '../../common/helpers/api';
 import environment from '../../common/helpers/environment';
 import { gaClientId } from '../../common/utils/helpers';
 import { updateLoggedInStatus } from '../../login/actions';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
 
 class AuthApp extends React.Component {
   constructor(props) {
@@ -92,13 +93,7 @@ class AuthApp extends React.Component {
         </div>
       );
     } else {
-      view = (
-        <div className="overlay">
-          <div className="overlay-content">
-            <h3>Signing in to Vets.gov...</h3>
-          </div>
-        </div>
-      );
+      view = <LoadingIndicator message="Signing in to Vets.gov..."/>;
     }
 
     return (

--- a/src/js/messaging/components/compose/MessageSend.jsx
+++ b/src/js/messaging/components/compose/MessageSend.jsx
@@ -62,7 +62,7 @@ class MessageSend extends React.Component {
 
   render() {
     const isDisabled = this.props.disabled;
-    const spinnerIcon = this.props.sendingMessage && <span className="fa fa-spinner fa-spin"/>;
+    const spinnerIcon = this.props.sendingMessage && <i className="fa fa-spinner fa-spin"/>;
 
     return (
       <div className="msg-send-group">

--- a/src/js/messaging/components/compose/MessageSend.jsx
+++ b/src/js/messaging/components/compose/MessageSend.jsx
@@ -62,6 +62,7 @@ class MessageSend extends React.Component {
 
   render() {
     const isDisabled = this.props.disabled;
+    const spinnerIcon = this.props.loading.sendingMessage ? <span className="fa fa-spinner fa-spin"/> : null;
 
     return (
       <div className="msg-send-group">
@@ -69,7 +70,7 @@ class MessageSend extends React.Component {
           <button
             disabled={isDisabled}
             type="button"
-            onClick={this.props.onSend}>Send</button>
+            onClick={this.props.onSend}>{spinnerIcon} Send</button>
           <button
             disabled={isDisabled}
             className="usa-button-outline msg-btn-save"

--- a/src/js/messaging/components/compose/MessageSend.jsx
+++ b/src/js/messaging/components/compose/MessageSend.jsx
@@ -62,7 +62,7 @@ class MessageSend extends React.Component {
 
   render() {
     const isDisabled = this.props.disabled;
-    const spinnerIcon = this.props.loading.sendingMessage ? <span className="fa fa-spinner fa-spin"/> : null;
+    const spinnerIcon = this.props.sendingMessage && <span className="fa fa-spinner fa-spin"/>;
 
     return (
       <div className="msg-send-group">

--- a/src/js/messaging/components/compose/MessageSend.jsx
+++ b/src/js/messaging/components/compose/MessageSend.jsx
@@ -95,6 +95,7 @@ MessageSend.propTypes = {
   onSave: PropTypes.func.isRequired,
   onSend: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
+  sendingMessage: PropTypes.bool
 };
 
 export default MessageSend;

--- a/src/js/messaging/components/compose/MessageWriteGroup.jsx
+++ b/src/js/messaging/components/compose/MessageWriteGroup.jsx
@@ -27,10 +27,9 @@ class MessageWriteGroup extends React.Component {
           files={this.props.files}
           onClose={this.props.onAttachmentsClose}/>
         <MessageSend
-          disabled={!this.props.messageText.value.length || this.props.loading || this.props.disabled}
+          disabled={!this.props.messageText.value.length || this.props.sendingMessage || this.props.disabled}
           allowedMimeTypes={this.props.allowedMimeTypes}
           attachedFiles={this.props.files}
-          loading={this.props.loading}
           maxFiles={this.props.maxFiles}
           maxFileSize={this.props.maxFileSize}
           maxTotalFileSize={this.props.maxTotalFileSize}
@@ -38,7 +37,8 @@ class MessageWriteGroup extends React.Component {
           onAttachmentsError={this.props.onAttachmentsError}
           onSave={this.props.onSave}
           onSend={this.props.onSend}
-          onDelete={this.props.onDelete}/>
+          onDelete={this.props.onDelete}
+          sendingMessage={this.props.sendingMessage}/>
       </div>
     );
   }

--- a/src/js/messaging/components/compose/MessageWriteGroup.jsx
+++ b/src/js/messaging/components/compose/MessageWriteGroup.jsx
@@ -64,6 +64,7 @@ MessageWriteGroup.propTypes = {
   onSend: PropTypes.func,
   onTextChange: PropTypes.func,
   placeholder: PropTypes.string,
+  sendingMessage: PropTypes.bool
 };
 
 export default MessageWriteGroup;

--- a/src/js/messaging/components/compose/MessageWriteGroup.jsx
+++ b/src/js/messaging/components/compose/MessageWriteGroup.jsx
@@ -27,9 +27,10 @@ class MessageWriteGroup extends React.Component {
           files={this.props.files}
           onClose={this.props.onAttachmentsClose}/>
         <MessageSend
-          disabled={!this.props.messageText.value.length || this.props.disabled}
+          disabled={!this.props.messageText.value.length || this.props.loading || this.props.disabled}
           allowedMimeTypes={this.props.allowedMimeTypes}
           attachedFiles={this.props.files}
+          loading={this.props.loading}
           maxFiles={this.props.maxFiles}
           maxFileSize={this.props.maxFileSize}
           maxTotalFileSize={this.props.maxTotalFileSize}

--- a/src/js/messaging/components/forms/NewMessageForm.jsx
+++ b/src/js/messaging/components/forms/NewMessageForm.jsx
@@ -126,6 +126,7 @@ NewMessageForm.propTypes = {
   onSaveMessage: PropTypes.func.isRequired,
   onSendMessage: PropTypes.func.isRequired,
   onSubjectChange: PropTypes.func,
+  sendingMessage: PropTypes.bool,
   toggleConfirmDelete: PropTypes.func.isRequired,
 };
 

--- a/src/js/messaging/components/forms/NewMessageForm.jsx
+++ b/src/js/messaging/components/forms/NewMessageForm.jsx
@@ -65,6 +65,7 @@ export class NewMessageForm extends React.Component {
           allowedMimeTypes={allowedMimeTypes}
           errorMessage={validations.isValidMessageBody(message.body) ? undefined : composeMessage.errors.message}
           files={this.props.message.attachments}
+          loading={this.props.loading}
           maxFiles={composeMessage.attachments.maxNum}
           maxFileSize={composeMessage.attachments.maxSingleFile}
           maxTotalFileSize={composeMessage.attachments.maxTotalFiles}

--- a/src/js/messaging/components/forms/NewMessageForm.jsx
+++ b/src/js/messaging/components/forms/NewMessageForm.jsx
@@ -65,7 +65,6 @@ export class NewMessageForm extends React.Component {
           allowedMimeTypes={allowedMimeTypes}
           errorMessage={validations.isValidMessageBody(message.body) ? undefined : composeMessage.errors.message}
           files={this.props.message.attachments}
-          loading={this.props.loading}
           maxFiles={composeMessage.attachments.maxNum}
           maxFileSize={composeMessage.attachments.maxSingleFile}
           maxTotalFileSize={composeMessage.attachments.maxTotalFiles}

--- a/src/js/messaging/components/forms/NewMessageForm.jsx
+++ b/src/js/messaging/components/forms/NewMessageForm.jsx
@@ -77,7 +77,8 @@ export class NewMessageForm extends React.Component {
           onSave={this.props.onSaveMessage}
           onSend={this.props.onSendMessage}
           messageText={message.body}
-          placeholder={composeMessage.placeholders.message}/>
+          placeholder={composeMessage.placeholders.message}
+          sendingMessage={this.props.sendingMessage}/>
       </form>
     );
   }

--- a/src/js/messaging/containers/Compose.jsx
+++ b/src/js/messaging/containers/Compose.jsx
@@ -141,7 +141,6 @@ export class Compose extends React.Component {
           </button>
         </div>
         <NewMessageForm
-          loading={this.props.loading}
           message={this.props.message}
           recipients={this.props.recipients}
           onAttachmentsClose={this.props.deleteComposeAttachment}
@@ -154,6 +153,7 @@ export class Compose extends React.Component {
           onSaveMessage={this.saveDraftIfNoAttachments}
           onSendMessage={this.sendMessage}
           onSubjectChange={this.props.setMessageField.bind(null, 'message.subject')}
+          sendingMessage={this.props.loading.sendingMessage}
           toggleConfirmDelete={this.props.toggleConfirmDelete}/>
         <NoticeBox/>
         <ModalConfirmDelete

--- a/src/js/messaging/containers/Compose.jsx
+++ b/src/js/messaging/containers/Compose.jsx
@@ -141,6 +141,7 @@ export class Compose extends React.Component {
           </button>
         </div>
         <NewMessageForm
+          loading={this.props.loading}
           message={this.props.message}
           recipients={this.props.recipients}
           onAttachmentsClose={this.props.deleteComposeAttachment}

--- a/src/js/messaging/containers/Main.jsx
+++ b/src/js/messaging/containers/Main.jsx
@@ -98,10 +98,6 @@ export class Main extends React.Component {
       return <LoadingIndicator message="Saving your message..."/>;
     }
 
-    if (loading.sendingMessage) {
-      return <LoadingIndicator message="Sending your message..."/>;
-    }
-
     const navClass = classNames({
       opened: this.props.nav.visible
     });

--- a/src/js/rx/components/ConfirmRefillModal.jsx
+++ b/src/js/rx/components/ConfirmRefillModal.jsx
@@ -26,7 +26,7 @@ class ConfirmRefillModal extends React.Component {
 
     if (this.props.prescription) {
       const prescription = this.props.prescription;
-      const spinnerIcon = this.props.isLoading && <span className="fa fa-spin fa-spinner"/>;
+      const spinnerIcon = this.props.isLoading && <i className="fa fa-spin fa-spinner"/>;
 
       innerElement = (
         <form onSubmit={this.handleConfirmRefill}>

--- a/src/js/rx/components/ConfirmRefillModal.jsx
+++ b/src/js/rx/components/ConfirmRefillModal.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from '../../common/components/Modal';
-import LoadingIndicator from '../../common/components/LoadingIndicator';
 import { formatDate } from '../utils/helpers';
 
 class ConfirmRefillModal extends React.Component {
@@ -25,13 +24,10 @@ class ConfirmRefillModal extends React.Component {
     // Initialize to prevent console errors
     let innerElement = '';
 
-    if (this.props.isLoading) {
-      innerElement = (
-        <LoadingIndicator
-          message="Submitting your refill request..."/>
-      );
-    } else if (this.props.prescription) {
+    if (this.props.prescription) {
       const prescription = this.props.prescription;
+      const spinnerIcon = this.props.isLoading && <span className="fa fa-spin fa-spinner"/>;
+
       innerElement = (
         <form onSubmit={this.handleConfirmRefill}>
           <div className="rx-modal-refillinfo">
@@ -49,7 +45,7 @@ class ConfirmRefillModal extends React.Component {
               <strong>Last submit date:</strong> {formatDate(prescription.refillSubmitDate)}
             </div>
             <div className="va-modal-button-group cf">
-              <button type="submit">Order refill</button>
+              <button type="submit" disabled={this.props.isLoading}>{spinnerIcon} Order refill</button>
               <button type="button" className="usa-button-outline"
                 onClick={this.handleCloseModal}>Cancel</button>
             </div>


### PR DESCRIPTION
- [x] Messaging - While a message is sending, switch to an inline loader instead of full-screen.
- [x] RX - Same as above but for sending prescriptions instead.
- [x] Auth, landing pages - Switch from miscellaneous loaders to the standards Vets.gov circle loader

Resolves department-of-veterans-affairs/vets.gov-team/issues/4449