### PR TITLE
Show loading spinner while savePending address updates

### DIFF
--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import isEmpty from 'lodash/isEmpty';
 
 import { scrollToFirstError } from '../../common/utils/helpers';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
 
 import {
   getStateName,
@@ -239,6 +240,12 @@ export class AddressSection extends React.Component {
           <button className="usa-button-outline" onClick={this.handleCancel}>Cancel</button>
         </div>
       );
+    } else if (this.props.savePending) {
+      addressFields = (
+        <div>
+          <LoadingIndicator message="Updating your address..."/>
+        </div>
+      );
     } else {
       addressFields = (
         <div>
@@ -279,12 +286,24 @@ export class AddressSection extends React.Component {
 }
 
 function mapStateToProps(state) {
-  const { fullName, address, canUpdate, countries, countriesAvailable, states, statesAvailable, saveAddressError } = state.letters;
+  const {
+    fullName,
+    address,
+    canUpdate,
+    countries,
+    countriesAvailable,
+    states,
+    statesAvailable,
+    saveAddressError,
+    savePending
+  } = state.letters;
+
   return {
     recipientName: fullName,
     canUpdate,
     savedAddress: address,
     saveAddressError,
+    savePending,
     countries,
     countriesAvailable,
     states,

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -21,6 +21,7 @@ const defaultProps = {
   },
   canUpdate: true,
   saveAddress: saveSpy,
+  savePending: false,
   countries: [],
   countriesAvailable: true,
   states: [],
@@ -43,6 +44,14 @@ describe('<AddressSection>', () => {
     const invalidAddress = tree.subTree('p').text();
 
     expect(invalidAddress).to.contain('We’re encountering an error with your');
+  });
+
+  it('should display a loading spinner if address save in progress', () => {
+    const newProps = { ...defaultProps, savePending: true };
+    const tree = SkinDeep.shallowRender(<AddressSection {...newProps}/>);
+    const spinner = tree.subTree('.address-block', '.loading-indicator-container', '.loading-indicator');
+    const spinnerText = spinner.text();
+    expect(spinnerText).to.contain('Updating your address...');
   });
 
   it('should format 1 address line', () => {

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -49,9 +49,8 @@ describe('<AddressSection>', () => {
   it('should display a loading spinner if address save in progress', () => {
     const newProps = { ...defaultProps, savePending: true };
     const tree = SkinDeep.shallowRender(<AddressSection {...newProps}/>);
-    const spinner = tree.subTree('.address-block', '.loading-indicator-container', '.loading-indicator');
-    const spinnerText = spinner.text();
-    expect(spinnerText).to.contain('Updating your address...');
+    const spinner = tree.dive(['AddressContent', 'AddressBlock', 'LoadingIndicator']);
+    expect(spinner.text()).to.contain('Updating your address...');
   });
 
   it('should format 1 address line', () => {


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5128 . 

Wires `savePending` state from redux store to `AddressSection`, then uses that to conditionally display the standard loading spinner in place of an address within `AddressSection` while the save is still pending.

**TO-DO:**
[x] Show loading spinner in place of old address while address update is in progress
[x] Add tests to ensure spinner shows when its supposed to and doesn't when it's not

Screenshot:
<img width="993" alt="screen shot 2017-10-09 at 5 48 15 pm" src="https://user-images.githubusercontent.com/24251447/31361860-35246486-ad1b-11e7-90f6-166df9f8405e.png">
