### PR TITLE
Fix prefill message on forms

### DIFF
--- a/src/js/common/schemaform/ObjectField.jsx
+++ b/src/js/common/schemaform/ObjectField.jsx
@@ -147,7 +147,6 @@ class ObjectField extends React.Component {
       ? this.props.formData
       : getDefaultFormState(schema, {}, definitions);
     const uiOptions = uiSchema['ui:options'] || {};
-    const hasApplicantPrefillInfo = !_.values(formData).some(x => x !== undefined);
 
     // description and title setup
     const showFieldLabel = uiOptions.showFieldLabel;
@@ -211,7 +210,7 @@ class ObjectField extends React.Component {
             {DescriptionField && <DescriptionField formData={formData} formContext={formContext} options={uiSchema['ui:options']}/>}
             {!textDescription && !DescriptionField && description}
           </div>}
-          {uiOptions.showPrefillMessage && formContext.prefilled && hasApplicantPrefillInfo && <PrefillMessage/>}
+          {uiOptions.showPrefillMessage && formContext.prefilled && <PrefillMessage/>}
           {this.orderedProperties.map((objectFields, index) => {
             if (objectFields.length > 1) {
               const [first, ...rest] = objectFields;

--- a/src/js/common/schemaform/reducers/index.js
+++ b/src/js/common/schemaform/reducers/index.js
@@ -214,7 +214,7 @@ export default function createSchemaFormReducer(formConfig) {
           if (Object.keys(action.data.formData).length > 0) {
             newState.prefillStatus = PREFILL_STATUSES.success;
           } else {
-            newState.prefillStatus = PREFILL_STATUSES.notAttempted;
+            newState.prefillStatus = PREFILL_STATUSES.unfilled;
           }
         } else {
           newState = _.set('loadedData', action.data, state);

--- a/src/js/common/schemaform/reducers/index.js
+++ b/src/js/common/schemaform/reducers/index.js
@@ -208,7 +208,14 @@ export default function createSchemaFormReducer(formConfig) {
           const formData = _.merge(state.data, action.data.formData);
           const loadedData = _.set('formData', formData, action.data);
           newState = _.set('loadedData', loadedData, state);
-          newState.prefillStatus = PREFILL_STATUSES.success;
+
+          // We get an empty object back when we attempt to prefill and there's
+          // no information
+          if (Object.keys(action.data.formData).length > 0) {
+            newState.prefillStatus = PREFILL_STATUSES.success;
+          } else {
+            newState.prefillStatus = PREFILL_STATUSES.notAttempted;
+          }
         } else {
           newState = _.set('loadedData', action.data, state);
           newState.prefillStatus = PREFILL_STATUSES.notAttempted;

--- a/test/common/schemaform/reducers/index.unit.spec.js
+++ b/test/common/schemaform/reducers/index.unit.spec.js
@@ -1,3 +1,4 @@
+import _ from 'lodash/fp';
 import { expect } from 'chai';
 
 import { SET_DATA,
@@ -254,6 +255,19 @@ describe('schemaform createSchemaFormReducer', () => {
 
       expect(state.data.existingProp).to.be.true;
       expect(state.data.field).to.equal('foo');
+      expect(state.prefillStatus).to.equal(PREFILL_STATUSES.success);
+    });
+    it('should not mark prefill successful when data is empty', () => {
+      const state = reducer({
+        data: {},
+        prefillStatus: PREFILL_STATUSES.pending,
+        pages: {}
+      }, {
+        type: SET_IN_PROGRESS_FORM,
+        data: _.set('formData', {}, data)
+      });
+
+      expect(state.prefillStatus).to.equal(PREFILL_STATUSES.unfilled);
     });
     it('should set fetch form pending', () => {
       const state = reducer({


### PR DESCRIPTION
The prefill message was no longer showing up. I removed the previous check and added another one in the reducer, which should catch the usual cases where we try to prefill data and it is empty.

![screen shot 2017-10-10 at 3 35 53 pm](https://user-images.githubusercontent.com/634932/31407547-42f5581e-add3-11e7-8701-a13889a5ab74.png)
