### PR TITLE
Fix file input validation error on claim status

### DIFF
--- a/src/js/common/components/form-elements/ErrorableFileInput.jsx
+++ b/src/js/common/components/form-elements/ErrorableFileInput.jsx
@@ -14,7 +14,12 @@ class ErrorableFileInput extends React.Component {
   }
 
   handleChange(domEvent) {
-    this.props.onChange(domEvent.target.files);
+    const files = domEvent.target.files;
+    // occasionally it seems like this event is triggering with an
+    // empty array, which is not helpful
+    if (files.length) {
+      this.props.onChange(files);
+    }
   }
 
   render() {

--- a/src/js/common/components/form-elements/ErrorableFileInput.jsx
+++ b/src/js/common/components/form-elements/ErrorableFileInput.jsx
@@ -14,12 +14,11 @@ class ErrorableFileInput extends React.Component {
   }
 
   handleChange(domEvent) {
-    const files = domEvent.target.files;
-    // occasionally it seems like this event is triggering with an
-    // empty array, which is not helpful
-    if (files.length) {
-      this.props.onChange(files);
-    }
+    this.props.onChange(domEvent.target.files);
+    // clear the original input, otherwise events will be triggered
+    // with empty file arrays and sometimes uploading a file twice will
+    // not work
+    domEvent.target.value = null; // eslint-disable-line no-param-reassign
   }
 
   render() {

--- a/test/common/components/form-elements/ErrorableFileInput.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableFileInput.unit.spec.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import ErrorableFileInput from '../../../../src/js/common/components/form-elements/ErrorableFileInput';
+
+describe('<ErrorableFileInput>', () => {
+  it('no error styles when errorMessage undefined', () => {
+    const tree = SkinDeep.shallowRender(
+      <ErrorableFileInput buttonText="my label" onChange={(_update) => {}}/>
+    );
+
+    // No error classes.
+    expect(tree.everySubTree('.usa-input-error')).to.have.lengthOf(0);
+    expect(tree.everySubTree('.usa-input-error-label')).to.have.lengthOf(0);
+    expect(tree.everySubTree('.usa-input-error-message')).to.have.lengthOf(0);
+  });
+
+  it('has error styles when errorMessage is set', () => {
+    const tree = SkinDeep.shallowRender(
+      <ErrorableFileInput buttonText="my label" errorMessage="error message" onChange={(_update) => {}}/>
+    );
+
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('error message');
+  });
+
+  it('onChange fires when input changes with file', () => {
+    const onChange = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <ErrorableFileInput buttonText="my label" onChange={onChange}/>
+    );
+
+    tree.getMountedInstance().handleChange({
+      target: {
+        files: [{}]
+      }
+    });
+
+    expect(onChange.called).to.be.true;
+  });
+  it('onChange does not fire if array is empty', () => {
+    const onChange = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <ErrorableFileInput buttonText="my label" onChange={onChange}/>
+    );
+
+    tree.getMountedInstance().handleChange({
+      target: {
+        files: []
+      }
+    });
+
+    expect(onChange.called).to.be.false;
+  });
+});

--- a/test/common/components/form-elements/ErrorableFileInput.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableFileInput.unit.spec.jsx
@@ -25,32 +25,22 @@ describe('<ErrorableFileInput>', () => {
     expect(tree.subTree('.usa-input-error-message').text()).to.equal('error message');
   });
 
-  it('onChange fires when input changes with file', () => {
+  it('onChange fires and clears input', () => {
     const onChange = sinon.spy();
     const tree = SkinDeep.shallowRender(
       <ErrorableFileInput buttonText="my label" onChange={onChange}/>
     );
 
-    tree.getMountedInstance().handleChange({
+    const event = {
       target: {
-        files: [{}]
+        files: [{}],
+        value: 'asdfasdf'
       }
-    });
+    };
+
+    tree.getMountedInstance().handleChange(event);
 
     expect(onChange.called).to.be.true;
-  });
-  it('onChange does not fire if array is empty', () => {
-    const onChange = sinon.spy();
-    const tree = SkinDeep.shallowRender(
-      <ErrorableFileInput buttonText="my label" onChange={onChange}/>
-    );
-
-    tree.getMountedInstance().handleChange({
-      target: {
-        files: []
-      }
-    });
-
-    expect(onChange.called).to.be.false;
+    expect(event.target.value).to.be.null;
   });
 });


### PR DESCRIPTION
The steps for reproducing this are:

1. Add a file here: http://localhost:3001/track-claims/your-claims/344/additional-evidence
2. Remove the file
3. Click Add File, then click cancel in the file dialog

This is happening because the file input still has the old file after you pick one and this has some weird effects when we add more files using the same input.