### PR TITLE
Added transformForSubmit to pre-need.

### DIFF
--- a/src/js/pre-need/config/form.js
+++ b/src/js/pre-need/config/form.js
@@ -24,6 +24,7 @@ import {
   formatName,
   isVeteran,
   requiresSponsorInfo,
+  transform,
   veteranUISchema
 } from '../utils/helpers';
 
@@ -51,6 +52,7 @@ const formConfig = {
   urlPrefix: '/',
   submitUrl: '/v0/preneed',
   trackingPrefix: 'preneed-',
+  transformForSubmit: transform,
   formId: '40-10007',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,

--- a/src/js/pre-need/utils/helpers.js
+++ b/src/js/pre-need/utils/helpers.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import set from 'lodash/fp/set';
 
 import { validateBooleanGroup } from '../../common/schemaform/validation';
+import { transformForSubmit } from '../../common/schemaform/helpers';
 
 export function isVeteran(item) {
   return item.claimant.relationshipToVet.type === 1;
@@ -21,6 +23,48 @@ export function claimantHeader({ formData }) {
   return (
     <h4 className="highlight">{name}</h4>
   );
+}
+
+
+export function transform(formConfig, form) {
+  const matchClaimant = name => a => formatName(a.claimant.name) === name;
+  const formCopy = Object.assign({}, form);
+
+  // Fill in veteran info in each application
+  // where the sponsor is another claimant.
+  formCopy.applications = formCopy.applications.map(application => {
+    const sponsorName = application['view:sponsor'];
+    if (sponsorName !== 'Other') {
+      const veteranApplication = form.applications.find(matchClaimant(sponsorName));
+      return set('veteran', veteranApplication.veteran, application);
+    }
+
+    return application;
+  });
+
+  // Fill in applicant info in each application
+  // if the applicant is another claimant.
+  const applicantName = form['view:preparer'];
+  if (applicantName !== 'Other') {
+    const applicantApplication = form.applications.find(matchClaimant(applicantName));
+    const { address, email, name, phoneNumber } = applicantApplication.claimant;
+    formCopy.applications = formCopy.applications.map(application => set('applicant',  {
+      applicantEmail: email,
+      applicantPhoneNumber: phoneNumber,
+      applicantRelationshipToClaimant: application.claimant.ssn === applicantApplication.claimant.ssn ? 'Self' : 'Authorized Agent/Rep',
+      completingReason: '',
+      mailingAddress: address,
+      name
+    }, application));
+  }
+
+  const formData = transformForSubmit(formConfig, formCopy);
+
+  return JSON.stringify({
+    preNeedClaim: {
+      form: formData
+    },
+  });
 }
 
 export const veteranUISchema = {


### PR DESCRIPTION
There can be multiple claimants (persons checking for their eligibility) in a pre-need form, and each one can designate another claimant as their sponsor (a veteran) and/or as their preparer (applicant, or the person filling out the form on all claimants' behalves).

In the schema that's received by the API, each application has a claimant, veteran, and applicant. But in the actual form that's being displayed, there can be multiple claimants (called "applicants" in the form), and each claimant chooses a sponsor by name (`view:sponsor`) and there is one preparer (`view:preparer`) for the whole form. So this transform function does the work of copying over the appropriate data for the API to receive.