### PR TITLE
Avoid dispatching some login actions when there's an error

### DIFF
--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -29,7 +29,9 @@ export function getVerifyUrl(onUpdateVerifyUrl) {
   }).then(response => {
     return response.json();
   }).then(json => {
-    onUpdateVerifyUrl(json.identity_proof_url);
+    if (json.identity_proof_url) {
+      onUpdateVerifyUrl(json.identity_proof_url);
+    }
   });
 
   return verifyUrlRequest;

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -85,7 +85,9 @@ class Main extends React.Component {
     }).then(response => {
       return response.json();
     }).then(json => {
-      this.props.updateLogoutUrl(json.logout_via_get);
+      if (json.logout_via_get) {
+        this.props.updateLogoutUrl(json.logout_via_get);
+      }
     });
   }
 


### PR DESCRIPTION
These errors are happening whenever users open a page with an expired session. See connected issue for an example Sentry error.

Note: I grabbed this because I initially thought it was related to some GA changes that I made, but that turned out not to be the case.