### PR TITLE
Defer Validations

### DIFF
--- a/src/js/letters/components/Address.jsx
+++ b/src/js/letters/components/Address.jsx
@@ -71,7 +71,7 @@ class Address extends React.Component {
           options={this.props.countries}
           value={this.props.address.countryName}
           required={this.props.required}
-          onValueChange={(update) => this.props.onInput('countryName', update)}/>
+          onValueChange={(update) => this.props.onInput('countryName', update, true)}/>
         <ErrorableTextInput errorMessage={errorMessages.addressOne}
           label="Street address"
           name="address"
@@ -79,21 +79,24 @@ class Address extends React.Component {
           charMax={35}
           value={this.props.address.addressOne}
           required={this.props.required}
-          onValueChange={(update) => this.props.onInput('addressOne', update)}/>
+          onValueChange={(update) => this.props.onInput('addressOne', update)}
+          onBlur={() => this.props.onBlur('addressOne')}/>
         <ErrorableTextInput
           label="Street address (optional)"
           name="address"
           autocomplete="street-address"
           charMax={35}
           value={this.props.address.addressTwo}
-          onValueChange={(update) => this.props.onInput('addressTwo', update)}/>
+          onValueChange={(update) => this.props.onInput('addressTwo', update)}
+          onBlur={() => this.props.onBlur('addressTwo')}/>
         <ErrorableTextInput
           label="Street address (optional)"
           name="address"
           autocomplete="street-address"
           charMax={35}
           value={this.props.address.addressThree}
-          onValueChange={(update) => this.props.onInput('addressThree', update)}/>
+          onValueChange={(update) => this.props.onInput('addressThree', update)}
+          onBlur={() => this.props.onBlur('addressThree')}/>
         <ErrorableTextInput errorMessage={errorMessages.city}
           label={<span>City <em>(or APO/FPO/DPO)</em></span>}
           name="city"
@@ -101,7 +104,8 @@ class Address extends React.Component {
           charMax={30}
           value={this.props.address.city}
           required={this.props.required}
-          onValueChange={(update) => this.props.onInput('city', update)}/>
+          onValueChange={(update) => this.props.onInput('city', update)}
+          onBlur={() => this.props.onBlur('city')}/>
 
         {/* Hide the state for addresses that aren't in the US */}
         {isUSA && <ErrorableSelect errorMessage={errorMessages.stateCode}
@@ -111,7 +115,7 @@ class Address extends React.Component {
           options={adjustedStateNames}
           value={this.props.address.stateCode}
           required={this.props.required}
-          onValueChange={(update) => this.props.onInput('stateCode', update)}/>}
+          onValueChange={(update) => this.props.onInput('stateCode', update, true)}/>}
 
         {/* Hide the zip code for addresseses that aren't in the US */}
         {isUSA && <ErrorableTextInput errorMessage={errorMessages.zipCode}
@@ -121,7 +125,8 @@ class Address extends React.Component {
           autocomplete="postal-code"
           value={this.props.address.zipCode}
           required={this.props.required}
-          onValueChange={(update) => this.props.onInput('zipCode', update)}/>}
+          onValueChange={(update) => this.props.onInput('zipCode', update)}
+          onBlur={() => this.props.onBlur('zipCode')}/>}
       </div>
     );
   }

--- a/src/js/letters/components/ErrorableSelect.jsx
+++ b/src/js/letters/components/ErrorableSelect.jsx
@@ -20,16 +20,11 @@ import _ from 'lodash';
  * `onValueChange` - a function with this prototype: (newValue)
  */
 class ErrorableSelect extends React.Component {
-  constructor() {
-    super();
-    this.handleChange = this.handleChange.bind(this);
-  }
-
   componentWillMount() {
     this.selectId = _.uniqueId('errorable-select-');
   }
 
-  handleChange(domEvent) {
+  handleChange = (domEvent) => {
     this.props.onValueChange(domEvent.target.value);
   }
 

--- a/src/js/letters/components/ErrorableTextInput.jsx
+++ b/src/js/letters/components/ErrorableTextInput.jsx
@@ -20,22 +20,12 @@ import _ from 'lodash';
  * `onValueChange` - a function with this prototype: (newValue)
  */
 class ErrorableTextInput extends React.Component {
-  constructor() {
-    super();
-    this.handleChange = this.handleChange.bind(this);
-    this.handleBlur = this.handleBlur.bind(this);
-  }
-
   componentWillMount() {
     this.inputId = _.uniqueId('errorable-text-input-');
   }
 
-  handleChange(domEvent) {
+  handleChange = (domEvent) => {
     this.props.onValueChange(domEvent.target.value);
-  }
-
-  handleBlur() {
-    this.props.onValueChange(this.props.value);
   }
 
   render() {
@@ -86,7 +76,7 @@ class ErrorableTextInput extends React.Component {
           maxLength={this.props.charMax}
           value={this.props.value}
           onChange={this.handleChange}
-          onBlur={this.handleBlur}/>
+          onBlur={this.props.onBlur}/>
         {maxCharacters}
       </div>
     );

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -153,17 +153,31 @@ export class AddressSection extends React.Component {
     });
   }
 
-
-  handleChange = (fieldName, update) => {
+  dirtyInput = (fieldName) => {
     let fieldsToValidate = this.state.fieldsToValidate;
-    // When a field is changed, make sure we validate it
+    // When a field is blurred, add it to the fields we want to validate
     if (!fieldsToValidate[fieldName]) {
-      // If we set state here, the validation won't run when the field is modified the first time
-      // This is because the state won't be updated in time for validateAll to catch it
-      fieldsToValidate =  Object.assign({}, this.state.fieldsToValidate, { [fieldName]: true });
-    }
+      fieldsToValidate = Object.assign({}, this.state.fieldsToValidate, { [fieldName]: true });
 
+      // Make sure to _actually_ validate it
+      const errorMessages = this.validateAll(this.state.editableAddress, fieldsToValidate);
+      this.setState({
+        fieldsToValidate,
+        errorMessages
+      });
+    }
+  }
+
+  /**
+   * Handles changing input from the Address component.
+   * @param {String}  fieldName   The name of the field that's changing
+   * @param {String}  update      The new value of the field
+   * @param {Boolean} forceDirty  Whether to set the field as dirty immediately before validation.
+   *                              Useful for select fields which don't trigger the onBlur event.
+   */
+  handleChange = (fieldName, update, forceDirty = false) => {
     let address = Object.assign({}, this.state.editableAddress, { [fieldName]: update });
+    let fieldsToValidate = this.state.fieldsToValidate;
     // if country is changing we should clear the state
     if (fieldName === 'countryName') {
       address.stateCode = '';
@@ -178,13 +192,18 @@ export class AddressSection extends React.Component {
       address = resetDisallowedAddressFields(address);
     }
 
+    // Force the input to dirty if necessary
+    if (forceDirty && !fieldsToValidate[fieldName]) {
+      fieldsToValidate = Object.assign({}, this.state.fieldsToValidate, { [fieldName]: true });
+    }
+
     // Update the error messages
     // TODO: This might get super slow, so we can debounce the validation if necessary...probably
     const errorMessages = this.validateAll(address, fieldsToValidate);
     this.setState({
+      fieldsToValidate,
       editableAddress: address,
       errorMessages,
-      fieldsToValidate
     });
   }
 
@@ -223,6 +242,7 @@ export class AddressSection extends React.Component {
         <div>
           <Address
             onInput={this.handleChange}
+            onBlur={this.dirtyInput}
             address={this.state.editableAddress}
             errorMessages={this.state.errorMessages}
             countries={this.props.countries}

--- a/src/js/letters/utils/validations.js
+++ b/src/js/letters/utils/validations.js
@@ -53,7 +53,7 @@ export const stateValidations = [
   // Require a state for US addresses
   (state, fullAddress) => {
     if (fullAddress.countryName === 'USA' && !state) {
-      return 'Please enter a state';
+      return 'Please select a state';
     }
 
     return true;


### PR DESCRIPTION
When select elements are changed, they're marked as dirty immediately and validation is run against them. The text inputs are dirtied only after blurred, so validation isn't run on them until after the user is finished with editing the field for the first time.