### PR TITLE
Add unit tests for DownloadLetters component

### DIFF
--- a/src/js/letters/containers/DownloadLetters.jsx
+++ b/src/js/letters/containers/DownloadLetters.jsx
@@ -8,7 +8,7 @@ import SegmentedProgressBar from '../../common/components/SegmentedProgressBar';
 import StepHeader from '../components/StepHeader';
 import { chapters } from '../routes';
 
-class DownloadLetters extends React.Component {
+export class DownloadLetters extends React.Component {
   constructor() {
     super();
     this.navigateToLetterList = this.navigateToLetterList.bind(this);

--- a/test/letters/containers/DownloadLetters.unit.spec.jsx
+++ b/test/letters/containers/DownloadLetters.unit.spec.jsx
@@ -1,19 +1,40 @@
 import React from 'react';
+import ReactTestUtils from 'react-dom/test-utils';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
-import DownloadLetters from '../../../src/js/letters/containers/DownloadLetters';
+import { DownloadLetters } from '../../../src/js/letters/containers/DownloadLetters';
 
-import reducer from '../../../src/js/letters/reducers/index.js';
-import createCommonStore from '../../../src/js/common/store';
-
-const store = createCommonStore(reducer);
+const defaultProps = {
+  location: {
+    pathname: '/confirm-address'
+  },
+  router: {
+    push: sinon.spy()
+  }
+};
 
 describe('<DownloadLetters>', () => {
   it('should render', () => {
-    const tree = SkinDeep.shallowRender(<DownloadLetters store={store}/>);
+    const tree = SkinDeep.shallowRender(<DownloadLetters {...defaultProps}/>);
     const vdom = tree.getRenderOutput();
     expect(vdom).to.exist;
+  });
+
+  it('should render button when at /confirm-address', () => {
+    const tree = SkinDeep.shallowRender(<DownloadLetters {...defaultProps}/>);
+    const stepHeader = tree.dive(['StepHeader']);
+    const button = stepHeader.subTree('button');
+    expect(button).to.exist;
+  });
+
+  it('should navigate to /letter-list when button is clicked', () => {
+    const component = ReactTestUtils.renderIntoDocument(<DownloadLetters {...defaultProps}/>);
+    const button = ReactTestUtils.findRenderedDOMComponentWithClass(component, 'view-letters-button');
+    ReactTestUtils.Simulate.click(button);
+
+    expect(defaultProps.router.push.calledWith('/letter-list')).to.be.true;
   });
 });
 


### PR DESCRIPTION
Not too much to test in this component, added tests for:
1. That the button is rendered when on '/confirm-address'
2. That `this.props.router.push` is called when the button is clicked