### PR TITLE
Render trackedItem's displayName or "Document Request"

### DIFF
--- a/src/js/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/js/claims-status/containers/DocumentRequestPage.jsx
@@ -97,7 +97,7 @@ class DocumentRequestPage extends React.Component {
                     <Element name="uploadError"/>
                     <Notification title={message.title} body={message.body} type={message.type}/>
                   </div>}
-                <h1 className="claims-header">{trackedItem.displayName || 'Document Request'}</h1>
+                <h1 className="claims-header">{trackedItem ? trackedItem.displayName : 'Document Request'}</h1>
                 {trackedItem.type.endsWith('you_list') ? <DueDate date={trackedItem.suspenseDate}/> : null}
                 {trackedItem.type.endsWith('others_list')
                   ? <div className="optional-upload">

--- a/src/js/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/js/claims-status/containers/DocumentRequestPage.jsx
@@ -98,13 +98,13 @@ class DocumentRequestPage extends React.Component {
                     <Notification title={message.title} body={message.body} type={message.type}/>
                   </div>}
                 <h1 className="claims-header">{trackedItem ? trackedItem.displayName : 'Document Request'}</h1>
-                {trackedItem.type.endsWith('you_list') ? <DueDate date={trackedItem.suspenseDate}/> : null}
-                {trackedItem.type.endsWith('others_list')
+                {trackedItem && trackedItem.type.endsWith('you_list') ? <DueDate date={trackedItem.suspenseDate}/> : null}
+                {trackedItem && trackedItem.type.endsWith('others_list')
                   ? <div className="optional-upload">
                     <p><strong>Optional</strong> - We’ve asked others to send this to us, but you may upload it if you have it.</p>
                   </div>
                   : null}
-                <p>{trackedItem.description}</p>
+                {trackedItem && <p>{trackedItem.description}</p>}
                 <AddFilesForm
                   field={this.props.uploadField}
                   progress={this.props.progress}

--- a/src/js/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/js/claims-status/containers/DocumentRequestPage.jsx
@@ -34,7 +34,11 @@ const Element = Scroll.Element;
 class DocumentRequestPage extends React.Component {
   componentDidMount() {
     this.props.resetUploads();
-    document.title = `Request for ${this.props.trackedItem.displayName}`;
+    if (this.props.trackedItem) {
+      document.title = `Request for ${this.props.trackedItem.displayName}`;
+    } else {
+      document.title = 'Document Request';
+    }
     if (!this.props.loading) {
       setUpPage();
     } else {
@@ -43,7 +47,7 @@ class DocumentRequestPage extends React.Component {
   }
   componentWillReceiveProps(props) {
     if (props.loading && !!props.trackedItem) {
-      this.props.router.push(`/your-claims/${this.props.params.id}/status`);
+      this.props.router.replace(`/your-claims/${this.props.params.id}/status`);
     }
     if (props.uploadComplete) {
       this.goToFilesPage();

--- a/src/js/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/js/claims-status/containers/DocumentRequestPage.jsx
@@ -97,7 +97,7 @@ class DocumentRequestPage extends React.Component {
                     <Element name="uploadError"/>
                     <Notification title={message.title} body={message.body} type={message.type}/>
                   </div>}
-                <h1 className="claims-header">{trackedItem.displayName || "Document Request"}</h1>
+                <h1 className="claims-header">{trackedItem.displayName || 'Document Request'}</h1>
                 {trackedItem.type.endsWith('you_list') ? <DueDate date={trackedItem.suspenseDate}/> : null}
                 {trackedItem.type.endsWith('others_list')
                   ? <div className="optional-upload">

--- a/src/js/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/js/claims-status/containers/DocumentRequestPage.jsx
@@ -34,11 +34,7 @@ const Element = Scroll.Element;
 class DocumentRequestPage extends React.Component {
   componentDidMount() {
     this.props.resetUploads();
-    if (this.props.trackedItem) {
-      document.title = `Request for ${this.props.trackedItem.displayName}`;
-    } else {
-      this.props.router.push(`/your-claims/${this.props.params.id}/status`);
-    }
+    document.title = `Request for ${this.props.trackedItem.displayName}`;
     if (!this.props.loading) {
       setUpPage();
     } else {
@@ -46,6 +42,9 @@ class DocumentRequestPage extends React.Component {
     }
   }
   componentWillReceiveProps(props) {
+    if (props.loading && !!props.trackedItem) {
+      this.props.router.push(`/your-claims/${this.props.params.id}/status`);
+    }
     if (props.uploadComplete) {
       this.goToFilesPage();
     }

--- a/src/js/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/js/claims-status/containers/DocumentRequestPage.jsx
@@ -46,7 +46,7 @@ class DocumentRequestPage extends React.Component {
     }
   }
   componentWillReceiveProps(props) {
-    if (props.loading && !!props.trackedItem) {
+    if (!props.loading && !props.trackedItem) {
       this.props.router.replace(`/your-claims/${this.props.params.id}/status`);
     }
     if (props.uploadComplete) {

--- a/src/js/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/js/claims-status/containers/DocumentRequestPage.jsx
@@ -97,7 +97,7 @@ class DocumentRequestPage extends React.Component {
                     <Element name="uploadError"/>
                     <Notification title={message.title} body={message.body} type={message.type}/>
                   </div>}
-                <h1 className="claims-header">{trackedItem.displayName}</h1>
+                <h1 className="claims-header">{trackedItem.displayName || "Document Request"}</h1>
                 {trackedItem.type.endsWith('you_list') ? <DueDate date={trackedItem.suspenseDate}/> : null}
                 {trackedItem.type.endsWith('others_list')
                   ? <div className="optional-upload">

--- a/src/js/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/js/claims-status/containers/DocumentRequestPage.jsx
@@ -97,14 +97,14 @@ class DocumentRequestPage extends React.Component {
                     <Element name="uploadError"/>
                     <Notification title={message.title} body={message.body} type={message.type}/>
                   </div>}
-                <h1 className="claims-header">{trackedItem ? trackedItem.displayName : 'Document Request'}</h1>
-                {trackedItem && trackedItem.type.endsWith('you_list') ? <DueDate date={trackedItem.suspenseDate}/> : null}
-                {trackedItem && trackedItem.type.endsWith('others_list')
+                <h1 className="claims-header">{trackedItem.displayName}</h1>
+                {trackedItem.type.endsWith('you_list') ? <DueDate date={trackedItem.suspenseDate}/> : null}
+                {trackedItem.type.endsWith('others_list')
                   ? <div className="optional-upload">
                     <p><strong>Optional</strong> - We’ve asked others to send this to us, but you may upload it if you have it.</p>
                   </div>
                   : null}
-                {trackedItem && <p>{trackedItem.description}</p>}
+                <p>{trackedItem.description}</p>
                 <AddFilesForm
                   field={this.props.uploadField}
                   progress={this.props.progress}

--- a/src/js/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/js/claims-status/containers/DocumentRequestPage.jsx
@@ -37,7 +37,7 @@ class DocumentRequestPage extends React.Component {
     if (this.props.trackedItem) {
       document.title = `Request for ${this.props.trackedItem.displayName}`;
     } else {
-      document.title = 'Document Request';
+      this.props.router.push(`/your-claims/${this.props.params.id}/status`);
     }
     if (!this.props.loading) {
       setUpPage();

--- a/test/claims-status/components/DocumentRequestPage.unit.spec.jsx
+++ b/test/claims-status/components/DocumentRequestPage.unit.spec.jsx
@@ -179,7 +179,7 @@ describe('<DocumentRequestPage>', () => {
       replace: sinon.spy()
     };
     const params = {
-      id: 3456
+      id: 339
     };
     const getClaimDetail = sinon.spy();
     const resetUploads = sinon.spy();

--- a/test/claims-status/components/DocumentRequestPage.unit.spec.jsx
+++ b/test/claims-status/components/DocumentRequestPage.unit.spec.jsx
@@ -175,7 +175,11 @@ describe('<DocumentRequestPage>', () => {
       attributes: {}
     };
     const router = {
-      push: sinon.spy()
+      push: sinon.spy(),
+      replace: sinon.spy()
+    };
+    const params = {
+      id: 3456
     };
     const getClaimDetail = sinon.spy();
     const resetUploads = sinon.spy();
@@ -188,6 +192,7 @@ describe('<DocumentRequestPage>', () => {
         uploadField={{ value: null, dirty: false }}
         trackedItem={trackedItem}
         router={router}
+        params={params}
         getClaimDetail={getClaimDetail}
         resetUploads={resetUploads}/>
     );

--- a/test/claims-status/components/DocumentRequestPage.unit.spec.jsx
+++ b/test/claims-status/components/DocumentRequestPage.unit.spec.jsx
@@ -105,22 +105,6 @@ describe('<DocumentRequestPage>', () => {
     expect(tree.subTree('DueDate')).not.to.be.false;
     expect(tree.subTree('DueDate').props.date).to.eql(trackedItem.suspenseDate);
   });
-  it('should render Document Request if displayName property is missing', () => {
-    const trackedItem = {
-      type: 'still_need_from_others_list',
-      suspenseDate: '2010-05-10'
-    };
-    const claim = {
-      id: 1,
-      attributes: {}
-    };
-    const tree = SkinDeep.shallowRender(
-      <DocumentRequestPage
-        claim={claim}
-        trackedItem={trackedItem}/>
-    );
-    expect(tree.subTree('.claims-header')).not.to.be.false;
-  });
   it('should render optional upload alert', () => {
     const trackedItem = {
       type: 'still_need_from_others_list',

--- a/test/claims-status/components/DocumentRequestPage.unit.spec.jsx
+++ b/test/claims-status/components/DocumentRequestPage.unit.spec.jsx
@@ -105,6 +105,22 @@ describe('<DocumentRequestPage>', () => {
     expect(tree.subTree('DueDate')).not.to.be.false;
     expect(tree.subTree('DueDate').props.date).to.eql(trackedItem.suspenseDate);
   });
+  it('should render Document Request if displayName property is missing', () => {
+    const trackedItem = {
+      type: 'still_need_from_others_list',
+      suspenseDate: '2010-05-10'
+    };
+    const claim = {
+      id: 1,
+      attributes: {}
+    };
+    const tree = SkinDeep.shallowRender(
+      <DocumentRequestPage
+        claim={claim}
+        trackedItem={trackedItem}/>
+    );
+    expect(tree.subTree('.claims-header')).not.to.be.false;
+  });
   it('should render optional upload alert', () => {
     const trackedItem = {
       type: 'still_need_from_others_list',


### PR DESCRIPTION
If trackedItem's displayName property (often something like "Request 10") is missing, "Document Request" will be rendered instead. This is based on how the `document.title` is conditionally determined on [lines 37-41](https://github.com/department-of-veterans-affairs/vets-website/blob/bbd97694d8e6e926da2eff212fef217543c233b2/src/js/claims-status/containers/DocumentRequestPage.jsx#L39) of the same file (`src/js/claims-status/containers/DocumentRequestPage.jsx`):
```
    if (this.props.trackedItem) {
      document.title = `Request for ${this.props.trackedItem.displayName}`;
    } else {
      document.title = 'Document Request';
    }
```

![localhost-3001-track-claims-your-claims-339-document-request-211443](https://user-images.githubusercontent.com/16051172/31648391-47b0523e-b2c2-11e7-8c1b-a3b1003a70df.png)
