### PR TITLE
Fix setAttribute error on claim status

### DIFF
--- a/src/js/claims-status/utils/page.js
+++ b/src/js/claims-status/utils/page.js
@@ -11,8 +11,10 @@ export function scrollToTop() {
 
 export function setFocus(selector) {
   const el = typeof selector === 'string' ? document.querySelector(selector) : selector;
-  el.setAttribute('tabIndex', -1);
-  el.focus();
+  if (el) {
+    el.setAttribute('tabIndex', -1);
+    el.focus();
+  }
 }
 
 export function setPageFocus(selector = '.va-nav-breadcrumbs') {


### PR DESCRIPTION
Error: Cannot read property 'setAttribute' of null
Proposed fix: only reach this logic if `el` exists