### PR TITLE
Actions unit tests mg

### DIFF
--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -75,9 +75,8 @@ export function getMailingAddress() {
       null,
       // on fetch success
       (response) => {
-        const { address } = response.data.attributes;
         const responseCopy = Object.assign({}, response);
-        const addressCopy = Object.assign({}, address);
+        const addressCopy = Object.assign({}, response.data.attributes.address);
         // Translate military-only fields into generic ones; we'll translate
         // them back later if necessary
         if (addressCopy.type === ADDRESS_TYPES.military) {

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -166,7 +166,7 @@ export function getLetterPdf(letterType, letterName, letterOptions) {
           }
         });
         window.URL.revokeObjectURL(downloadUrl);
-        dispatch({ type: GET_LETTER_PDF_SUCCESS, data: letterType });
+        return dispatch({ type: GET_LETTER_PDF_SUCCESS, data: letterType });
       },
       () => dispatch({ type: GET_LETTER_PDF_FAILURE, data: letterType })
     );
@@ -228,7 +228,7 @@ export function saveAddress(address) {
 
 export function getAddressCountries() {
   return (dispatch) => {
-    apiRequest(
+    return apiRequest(
       '/v0/address/countries',
       null,
       response => dispatch({
@@ -242,7 +242,7 @@ export function getAddressCountries() {
 
 export function getAddressStates() {
   return (dispatch) => {
-    apiRequest(
+    return apiRequest(
       '/v0/address/states',
       null,
       response => dispatch({

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -73,34 +73,29 @@ export function getMailingAddress() {
     apiRequest(
       '/v0/address',
       null,
+      // on fetch success
       (response) => {
-        try {
-          const { address } = response.data.attributes;
-          const responseCopy = Object.assign({}, response);
-          const addressCopy = Object.assign({}, address);
-          // Translate military-only fields into generic ones; we'll translate
-          // them back later if necessary
-          if (addressCopy.type === ADDRESS_TYPES.military) {
-            addressCopy.city = addressCopy.militaryPostOfficeTypeCode;
-            addressCopy.stateCode = addressCopy.militaryStateCode;
-            addressCopy.countryName = 'USA';
-            delete addressCopy.militaryPostOfficeTypeCode;
-            delete addressCopy.militaryStateCode;
-          }
-          responseCopy.data.attributes.address = addressCopy;
-          return dispatch({
-            type: GET_ADDRESS_SUCCESS,
-            data: responseCopy
-          });
-        } catch (error) {
-          return Promise.reject(new Error(`vets_letters_error_get: ${error}`));
+        const { address } = response.data.attributes;
+        const responseCopy = Object.assign({}, response);
+        const addressCopy = Object.assign({}, address);
+        // Translate military-only fields into generic ones; we'll translate
+        // them back later if necessary
+        if (addressCopy.type === ADDRESS_TYPES.military) {
+          addressCopy.city = addressCopy.militaryPostOfficeTypeCode;
+          addressCopy.stateCode = addressCopy.militaryStateCode;
+          addressCopy.countryName = 'USA';
+          delete addressCopy.militaryPostOfficeTypeCode;
+          delete addressCopy.militaryStateCode;
         }
+        responseCopy.data.attributes.address = addressCopy;
+        return dispatch({
+          type: GET_ADDRESS_SUCCESS,
+          data: responseCopy
+        });
       },
+      // on fetch error
       () => dispatch({ type: GET_ADDRESS_FAILURE })
-    ).catch((error) => {
-      Raven.captureException(error);
-      return dispatch({ type: GET_ADDRESS_FAILURE });
-    });
+    );
   };
 }
 

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -93,7 +93,7 @@ export function getMailingAddress() {
           data: responseCopy
         });
       },
-      // on fetch error
+      // catch errors in fetch or success handler
       () => dispatch({ type: GET_ADDRESS_FAILURE })
     );
   };

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -100,7 +100,7 @@ export function getMailingAddress() {
 
 export function getBenefitSummaryOptions() {
   return (dispatch) => {
-    apiRequest(
+    return apiRequest(
       '/v0/letters/beneficiary',
       null,
       response => dispatch({
@@ -142,7 +142,7 @@ export function getLetterPdf(letterType, letterName, letterOptions) {
   let downloadUrl;
   return (dispatch) => {
     dispatch({ type: GET_LETTER_PDF_DOWNLOADING, data: letterType });
-    apiRequest(
+    return apiRequest(
       `/v0/letters/${letterType}`,
       settings,
       response => {

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -28,7 +28,7 @@ import {
 
 export function getLetterList() {
   return (dispatch) => {
-    apiRequest(
+    return apiRequest(
       '/v0/letters',
       null,
       response => dispatch({
@@ -75,7 +75,7 @@ export function getAddressFailure() {
 
 export function getMailingAddress() {
   return (dispatch) => {
-    apiRequest(
+    return apiRequest(
       '/v0/address',
       null,
       // on fetch success
@@ -225,7 +225,7 @@ export function saveAddress(address) {
     // TODO: Show a spinner or some kind of indication we're waiting on this to return
     dispatch(saveAddressPending());
 
-    apiRequest(
+    return apiRequest(
       '/v0/address',
       settings,
       () => dispatch(saveAddressSuccess(address)),

--- a/test/letters/actions/letters.unit.spec.js
+++ b/test/letters/actions/letters.unit.spec.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import _ from 'lodash';
 
 import {
   ADDRESS_TYPES,
@@ -343,66 +342,3 @@ describe.only('getMailingAddress', () => {
     thunk(dispatch, getState);
   });
 });
-
-// Skipping these for now because we're having trouble with making a global way to "mock"
-//  apiRequest(). The answer to this might just be more copy pasta right here to setup
-//  like we've done elsewhere (schemaform save-load-actions, if I recall correctly).
-describe.skip('getMailingAddress', () => {
-  after(() => {
-    resetFetch();
-  });
-
-  it('should transform military address fields to generic ones', (done) => {
-    mockApiRequest(backendAddress);
-
-    // Had to do the expect()s inside the spy's function because it's asynchronous
-    const dispatchSpy = sinon.spy((action) => {
-      const address = action.data;
-      try {
-        expect(address.city).to.equal(backendAddress.militaryPostOfficeTypeCode);
-        expect(address.state).to.equal(backendAddress.militaryStateCode);
-        expect(address.militaryPostOfficeTypeCode).to.be.undefined;
-        expect(address.militaryStateCode).to.be.undefined;
-
-        done();
-      } catch (error) {
-        done(error);
-      }
-    });
-    const thunk = getMailingAddress();
-
-    thunk(dispatchSpy);
-  });
-});
-
-describe.skip('saveAddress', () => {
-  after(() => {
-    resetFetch();
-  });
-
-  it('should transform generic address fields to military ones', (done) => {
-    mockApiRequest({}); // We don't really need it to return anything, just resolve the promise
-    const thunk = saveAddress(frontEndAddress);
-
-    // Only test on the call to save the address, not to set the pending state
-    // If the function isn't called with the success action, it'll fail because done() isn't called
-    const dispatchSpy = sinon.spy((action) => {
-      if (action.type === SAVE_ADDRESS_SUCCESS) {
-        const address = action.address;
-
-        try {
-          expect(address.militaryPostOfficeTypeCode).to.equal(frontEndAddress.city);
-          expect(address.militaryStateCode).to.equal(frontEndAddress.state);
-          expect(address.city).to.be.undefined;
-          expect(address.state).to.be.undefined;
-
-          done();
-        } catch (error) {
-          done(error);
-        }
-      }
-    });
-    thunk(dispatchSpy);
-  });
-});
-

--- a/test/letters/actions/letters.unit.spec.js
+++ b/test/letters/actions/letters.unit.spec.js
@@ -16,7 +16,7 @@ import {
   GET_LETTERS_SUCCESS,
   GET_LETTERS_FAILURE,
   LETTER_ELIGIBILITY_ERROR,
-  LETTER_TYPES,
+  // LETTER_TYPES,
   SAVE_ADDRESS_PENDING,
   SAVE_ADDRESS_FAILURE,
   SAVE_ADDRESS_SUCCESS,
@@ -363,60 +363,45 @@ describe.skip('getLetterPdf', () => {
   beforeEach(setup);
   afterEach(teardown);
 
-  const civilSLetter = {
-    letterName: 'Civil Service Preference Letter',
-    letterType: LETTER_TYPES.civilService,
-    letterOptions: {
-      // Opts only relevant for BSL but ATM required in every download link
-      militaryService: true,
-      monthlyAward: true,
-      serviceConnectedEvaluation: true,
-      chapter35Eligibility: true,
-      serviceConnectedDisabilities: true
-    }
-  };
+  // const civilSLetter = {
+  //   letterName: 'Civil Service Preference Letter',
+  //   letterType: LETTER_TYPES.civilService,
+  //   letterOptions: {
+  //     // Opts only relevant for BSL but ATM required in every download link
+  //     militaryService: true,
+  //     monthlyAward: true,
+  //     serviceConnectedEvaluation: true,
+  //     chapter35Eligibility: true,
+  //     serviceConnectedDisabilities: true
+  //   }
+  // };
 
-  const benefitSLetter = {
-    letterName: 'Benefit Summary Letter',
-    letterType: LETTER_TYPES.benefitSummary,
-    letterOptions: {
-      // Opts only relevant for BSL but ATM required in every download link
-      militaryService: true,
-      monthlyAward: true,
-      serviceConnectedEvaluation: true,
-      chapter35Eligibility: true,
-      serviceConnectedDisabilities: true
-    }
-  };
+  // const benefitSLetter = {
+  //   letterName: 'Benefit Summary Letter',
+  //   letterType: LETTER_TYPES.benefitSummary,
+  //   letterOptions: {
+  //     // Opts only relevant for BSL but ATM required in every download link
+  //     militaryService: true,
+  //     monthlyAward: true,
+  //     serviceConnectedEvaluation: true,
+  //     chapter35Eligibility: true,
+  //     serviceConnectedDisabilities: true
+  //   }
+  // };
 
-  it('sets up fetch for benefit summary letter', (done) => {
+  it('sets up fetch for benefit summary letter', () => {});
 
-  });
+  it('sets up fetch for non-benefit-summary letters', () => {});
 
-  it('sets up fetch for non-benefit-summary letters', (done) => {
+  it('dispatches PENDING action when download initiated', () => {});
 
-  });
+  it('handles ie10 stuff', () => {});
 
-  it('dispatches PENDING action when download initiated', (done) => {
+  it('downloads stuff conditionally', () => {});
 
-  });
+  it('dispatches DOWNLOAD_SUCCESS once download succeeds', () => {});
 
-  it('handles ie10 stuff', (done) => {
-    // Skip these tests for now because this functionality is about to change
-  });
-
-  it('downloads stuff conditionally', (done) => {
-    // Skip this bucket as well because this functionality is up in the air
-  });
-
-  it('dispatches DOWNLOAD_SUCCESS once download succeeds', (done) => {
-
-  });
-
-  it('dispatches DOWNLOAD_FAILED if download or fetch fails', (done) => {
-
-  });
-
+  it('dispatches DOWNLOAD_FAILED if download or fetch fails', () => {});
 });
 
 describe('getAddressCountries', () => {

--- a/test/letters/actions/letters.unit.spec.js
+++ b/test/letters/actions/letters.unit.spec.js
@@ -1,8 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { mockApiRequest, resetFetch } from '../../util/unit-helpers';
-
 import {
   ADDRESS_TYPES,
   SAVE_ADDRESS_SUCCESS,
@@ -34,6 +32,7 @@ const frontEndAddress = {
   state: 'secret'
 };
 
+// TO-DO: Determine if this is needed
 const addressResponse = {
   data: {
     attributes: {
@@ -76,15 +75,19 @@ const setup = () => {
     userToken: '123abc'
   };
   global.fetch = sinon.stub();
-  global.fetch.returns(Promise.resolve({ ok: true }));
+  global.fetch.returns(Promise.resolve({
+    headers: { get: () => 'application/json' },
+    ok: true,
+    json: () => Promise.resolve({})
+  }));
 };
 const teardown = () => {
   global.fetch = oldFetch;
   global.sessionStorage = oldSessionStorage;
 };
-
 const getState = () => ({});
 
+// without redux mock store - these tests pass
 describe.only('saveAddress', () => {
   beforeEach(setup);
   afterEach(teardown);
@@ -110,14 +113,6 @@ describe.only('saveAddress', () => {
 
   it('dispatches SAVE_ADDRESS_SUCCESS on update success', (done) => {
     const thunk = saveAddress(frontEndAddress);
-    global.fetch.returns(Promise.resolve({
-      headers: {
-        get: () => 'application/json'
-      },
-      ok: true,
-      json: () => Promise.resolve({})
-    }));
-
     const dispatch = sinon.spy((action) => {
       const { type, address } = action;
       if (type === SAVE_ADDRESS_SUCCESS) {

--- a/test/letters/actions/letters.unit.spec.js
+++ b/test/letters/actions/letters.unit.spec.js
@@ -89,7 +89,26 @@ describe.only('saveAddress', () => {
   beforeEach(setup);
   afterEach(teardown);
 
-  it('dispatches SAVE_ADDRESS_PENDING', (done) => {
+  it('dispatches SAVE_ADDRESS_PENDING first', (done) => {
+    let callCount = 0;
+    const thunk = saveAddress(frontEndAddress);
+    const dispatch = sinon.spy((action) => {
+      callCount += 1;
+      const { type } = action;
+      if (callCount === 1) {
+        try {
+          expect(type).to.equal(SAVE_ADDRESS_PENDING);
+          done();
+        } catch (error) {
+          done(error);
+        }
+      }
+    });
+
+    thunk(dispatch, getState);
+  });
+
+  it('dispatches SAVE_ADDRESS_SUCCESS on update success', (done) => {
     const thunk = saveAddress(frontEndAddress);
     global.fetch.returns(Promise.resolve({
       headers: {
@@ -105,6 +124,26 @@ describe.only('saveAddress', () => {
         try {
           expect(type).to.equal(SAVE_ADDRESS_SUCCESS);
           expect(address).to.eql(frontEndAddress);
+          done();
+        } catch (error) {
+          done(error);
+        }
+      }
+    });
+
+    thunk(dispatch, getState);
+  });
+
+  it('dispatches SAVE_ADDRESS_FAILURE on update failure', (done) => {
+    let callCount = 0;
+    const thunk = saveAddress(frontEndAddress);
+    global.fetch.returns(Promise.reject(new Error('Oops, something went wrong')));
+    const dispatch = sinon.spy((action) => {
+      const { type } = action;
+      callCount += 1;
+      if (callCount === 2) {
+        try {
+          expect(type).to.equal(SAVE_ADDRESS_FAILURE);
           done();
         } catch (error) {
           done(error);

--- a/test/letters/actions/letters.unit.spec.js
+++ b/test/letters/actions/letters.unit.spec.js
@@ -5,6 +5,10 @@ import {
   ADDRESS_TYPES,
   BACKEND_SERVICE_ERROR,
   BACKEND_AUTHENTICATION_ERROR,
+  GET_ADDRESS_COUNTRIES_SUCCESS,
+  GET_ADDRESS_COUNTRIES_FAILURE,
+  GET_ADDRESS_STATES_SUCCESS,
+  GET_ADDRESS_STATES_FAILURE,
   GET_ADDRESS_SUCCESS,
   GET_ADDRESS_FAILURE,
   GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS,
@@ -12,6 +16,7 @@ import {
   GET_LETTERS_SUCCESS,
   GET_LETTERS_FAILURE,
   LETTER_ELIGIBILITY_ERROR,
+  LETTER_TYPES,
   SAVE_ADDRESS_PENDING,
   SAVE_ADDRESS_FAILURE,
   SAVE_ADDRESS_SUCCESS,
@@ -52,7 +57,7 @@ const teardown = () => {
 };
 const getState = () => ({});
 
-describe.skip('saveAddress', () => {
+describe('saveAddress', () => {
   const frontEndAddress = {
     type: ADDRESS_TYPES.military,
     city: 'apo',
@@ -121,7 +126,7 @@ describe.skip('saveAddress', () => {
   });
 });
 
-describe.skip('getLettersList', () => {
+describe('getLettersList', () => {
   beforeEach(setup);
   afterEach(teardown);
 
@@ -188,7 +193,7 @@ describe.skip('getLettersList', () => {
   });
 });
 
-describe.skip('getMailingAddress', () => {
+describe('getMailingAddress', () => {
   const addressResponse = {
     data: {
       attributes: {
@@ -339,7 +344,7 @@ describe.skip('getMailingAddress', () => {
   });
 });
 
-describe.skip('getBenefitSummaryOptions', () => {
+describe('getBenefitSummaryOptions', () => {
   beforeEach(setup);
   afterEach(teardown);
 
@@ -380,9 +385,9 @@ describe.skip('getBenefitSummaryOptions', () => {
       ok: true,
       json: () => Promise.resolve(mockResponse)
     }));
-
     const thunk = getBenefitSummaryOptions();
     const dispatch = sinon.spy();
+
     thunk(dispatch, getState)
       .then(() => {
         const action = dispatch.args[0][0]; // first call, first arg
@@ -393,10 +398,9 @@ describe.skip('getBenefitSummaryOptions', () => {
 
   it('dispatches FAILURE action when GET fails', (done) => {
     global.fetch.returns(Promise.reject({}));
-
     const thunk = getBenefitSummaryOptions();
-
     const dispatch = sinon.spy();
+
     thunk(dispatch, getState)
       .then(() => {
         expect(dispatch.calledWith({ type: GET_BENEFIT_SUMMARY_OPTIONS_FAILURE })).to.be.true;
@@ -404,7 +408,152 @@ describe.skip('getBenefitSummaryOptions', () => {
   });
 });
 
-describe.only('getLetterPdf', () => {
+describe.skip('getLetterPdf', () => {
   beforeEach(setup);
   afterEach(teardown);
-})
+
+  const civilSLetter = {
+    letterName: 'Civil Service Preference Letter',
+    letterType: LETTER_TYPES.civilService,
+    letterOptions: {
+      // Opts only relevant for BSL but ATM required in every download link
+      militaryService: true,
+      monthlyAward: true,
+      serviceConnectedEvaluation: true,
+      chapter35Eligibility: true,
+      serviceConnectedDisabilities: true
+    }
+  };
+
+  const benefitSLetter = {
+    letterName: 'Benefit Summary Letter',
+    letterType: LETTER_TYPES.benefitSummary,
+    letterOptions: {
+      // Opts only relevant for BSL but ATM required in every download link
+      militaryService: true,
+      monthlyAward: true,
+      serviceConnectedEvaluation: true,
+      chapter35Eligibility: true,
+      serviceConnectedDisabilities: true
+    }
+  };
+
+  it('sets up fetch for benefit summary letter', (done) => {
+
+  });
+
+  it('sets up fetch for non-benefit-summary letters', (done) => {
+
+  });
+
+  it('dispatches PENDING action when download initiated', (done) => {
+
+  });
+
+  it('handles ie10 stuff', (done) => {
+    // Skip these tests for now because this functionality is about to change
+  });
+
+  it('downloads stuff conditionally', (done) => {
+    // Skip this bucket as well because this functionality is up in the air
+  });
+
+  it('dispatches DOWNLOAD_SUCCESS once download succeeds', (done) => {
+
+  });
+
+  it('dispatches DOWNLOAD_FAILED if download or fetch fails', (done) => {
+
+  });
+
+});
+
+describe('getAddressCountries', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  const countriesResponse = {
+    data: {
+      attributes: {
+        countries: [
+          { name: 'USA' },
+          { name: 'Afghanistan' }
+        ]
+      }
+    }
+  };
+
+  it('dispatches SUCCESS when GET succeeds', (done) => {
+    global.fetch.returns(Promise.resolve({
+      headers: { get: () => 'application/json' },
+      ok: true,
+      json: () => Promise.resolve(countriesResponse)
+    }));
+    const thunk = getAddressCountries();
+    const dispatch = sinon.spy();
+
+    thunk(dispatch, getState)
+      .then(() => {
+        const action = dispatch.args[0][0]; // first call, first arg
+        expect(action.type).to.equal(GET_ADDRESS_COUNTRIES_SUCCESS);
+        expect(action.countries).to.eql(countriesResponse);
+      }).then(done, done);
+  });
+
+  it('dispatches FAILURE when GET fails', (done) => {
+    global.fetch.returns(Promise.reject({}));
+    const thunk = getAddressCountries();
+    const dispatch = sinon.spy();
+
+    thunk(dispatch, getState)
+      .then(() => {
+        const action = dispatch.args[0][0]; // first call, first arg
+        expect(action.type).to.equal(GET_ADDRESS_COUNTRIES_FAILURE);
+      }).then(done, done);
+  });
+});
+
+describe('getAddressStates', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  const statesResponse = {
+    data: {
+      attributes: {
+        states: [
+          { name: 'CA' },
+          { name: 'AK' }
+        ]
+      }
+    }
+  };
+
+  it('dispatches SUCCESS when GET succeeds', (done) => {
+    global.fetch.returns(Promise.resolve({
+      headers: { get: () => 'application/json' },
+      ok: true,
+      json: () => Promise.resolve(statesResponse)
+    }));
+    const thunk = getAddressStates();
+    const dispatch = sinon.spy();
+
+    thunk(dispatch, getState)
+      .then(() => {
+        const action = dispatch.args[0][0]; // first call, first arg
+        expect(action.type).to.equal(GET_ADDRESS_STATES_SUCCESS);
+        expect(action.states).to.eql(statesResponse);
+      }).then(done, done);
+  });
+
+  it('dispatches FAILURE when GET fails', (done) => {
+    global.fetch.returns(Promise.reject({}));
+    const thunk = getAddressStates();
+    const dispatch = sinon.spy();
+
+    thunk(dispatch, getState)
+      .then(() => {
+        const action = dispatch.args[0][0]; // first call, first arg
+        expect(action.type).to.equal(GET_ADDRESS_STATES_FAILURE);
+      }).then(done, done);
+  });
+});


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5190
Also closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4961

This PR adds a bunch of unit tests for our async action creators. Also bundled in are a couple of bugfixes for the action creators themselves:
- Primarily, keeping promises alive by returning each `apiRequest` instead of just calling it
- Splitting out some predictable errors for better reporting

These tests are still missing anything for `getLetterPdf()` just because we're still testing some things with how that action creator works.