### PR TITLE
Fix address line autocomplete names

### DIFF
--- a/src/js/letters/components/Address.jsx
+++ b/src/js/letters/components/Address.jsx
@@ -74,8 +74,8 @@ class Address extends React.Component {
           onValueChange={(update) => this.props.onInput('countryName', update, true)}/>
         <ErrorableTextInput errorMessage={errorMessages.addressOne}
           label="Street address"
-          name="address"
-          autocomplete="street-address"
+          name="addressOne"
+          autocomplete="address-line1"
           charMax={35}
           value={this.props.address.addressOne}
           required={this.props.required}
@@ -83,16 +83,16 @@ class Address extends React.Component {
           onBlur={() => this.props.onBlur('addressOne')}/>
         <ErrorableTextInput
           label="Street address (optional)"
-          name="address"
-          autocomplete="street-address"
+          name="addressTwo"
+          autocomplete="address-line2"
           charMax={35}
           value={this.props.address.addressTwo}
           onValueChange={(update) => this.props.onInput('addressTwo', update)}
           onBlur={() => this.props.onBlur('addressTwo')}/>
         <ErrorableTextInput
           label="Street address (optional)"
-          name="address"
-          autocomplete="street-address"
+          name="addressThree"
+          autocomplete="address-line3"
           charMax={35}
           value={this.props.address.addressThree}
           onValueChange={(update) => this.props.onInput('addressThree', update)}

--- a/test/letters/components/Address.unit.spec.jsx
+++ b/test/letters/components/Address.unit.spec.jsx
@@ -61,7 +61,7 @@ describe('<Address>', () => {
 
     const addressLine1 = '321 Niam';
     // NOTE: All address lines are currently named "address", but querySelector just picks the first one
-    form.fillData('input[name="address"]', addressLine1);
+    form.fillData('input[name="addressOne"]', addressLine1);
     expect(onInputSpy.calledWith('addressOne', addressLine1)).to.be.true;
   });
 

--- a/test/letters/reducers/index.unit.spec.js
+++ b/test/letters/reducers/index.unit.spec.js
@@ -174,7 +174,7 @@ describe('letters reducer', () => {
     const state = reduce({ type: GET_ADDRESS_FAILURE });
 
     expect(state.address).to.be.empty;
-    expect(state.addressAvailable).to.be.false;
+    expect(state.addressAvailability).to.equal(AVAILABILITY_STATUSES.unavailable);
   });
 
   it('should handle successful request for the countries', () => {


### PR DESCRIPTION
Changed the `autocomplete` attributes values for the address lines to be in line with what Google and Mozilla recommend for multiple line addresses:
1. https://developers.google.com/web/updates/2015/06/checkout-faster-with-autofill
2. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

Also changed the `name` attributes, since those were also all the same, to correspond with the name of the field we get from the response.