### PR TITLE
Change menu item to CareerScope

### DIFF
--- a/src/js/gi/components/content/AdditionalResources.jsx
+++ b/src/js/gi/components/content/AdditionalResources.jsx
@@ -4,7 +4,7 @@ export const AdditionalResourcesLinks = () => (
   <div>
     <p>
       <a href="/education/tools-programs/careerscope" target="_blank">
-        Explore your career
+        Get started with CareerScope
       </a>
     </p>
     <p>


### PR DESCRIPTION
Per Beth:

> Change the language for one of the links in the right-side call-out, under the header "What's your plan?" where the video is. "Explore your career" needs to say: "Get started with CareerScope." This is a SME request.