### PR TITLE
Switch from "require" syntax to "import" where possible

### DIFF
--- a/src/js/auth/auth-entry.jsx
+++ b/src/js/auth/auth-entry.jsx
@@ -1,4 +1,7 @@
 import 'core-js';
+import '../common';
+import '../../sass/auth.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -9,9 +12,6 @@ import initReact from '../common/init-react';
 import routes from './routes';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
-
-import '../common'; // Bring in the common javascript.
-import '../../sass/auth.scss';
 
 const store = createCommonStore();
 createLoginWidget(store);

--- a/src/js/auth/auth-entry.jsx
+++ b/src/js/auth/auth-entry.jsx
@@ -10,8 +10,8 @@ import routes from './routes';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 
-require('../common');  // Bring in the common javascript.
-require('../../sass/auth.scss');
+import '../common'; // Bring in the common javascript.
+import '../../sass/auth.scss';
 
 const store = createCommonStore();
 createLoginWidget(store);

--- a/src/js/burials/burials-entry.jsx
+++ b/src/js/burials/burials-entry.jsx
@@ -1,3 +1,6 @@
+import '../common';
+import '../../sass/burials.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -9,9 +12,6 @@ import route from './routes';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 import reducer from './reducer';
-
-import '../common';
-import '../../sass/burials.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/burials/burials-entry.jsx
+++ b/src/js/burials/burials-entry.jsx
@@ -10,8 +10,8 @@ import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 import reducer from './reducer';
 
-require('../common');
-require('../../sass/burials.scss');
+import '../common';
+import '../../sass/burials.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/claims-status/claims-status-entry.jsx
+++ b/src/js/claims-status/claims-status-entry.jsx
@@ -1,4 +1,7 @@
 import 'core-js';
+import '../common';
+import '../../sass/claims-status.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -13,9 +16,6 @@ import { setLastPage } from './actions/index.jsx';
 import { basename } from './utils/page';
 import reducer from './reducers';
 import createLoginWidget from '../login/login-entry';
-
-import '../common';
-import '../../sass/claims-status.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/claims-status/claims-status-entry.jsx
+++ b/src/js/claims-status/claims-status-entry.jsx
@@ -14,8 +14,8 @@ import { basename } from './utils/page';
 import reducer from './reducers';
 import createLoginWidget from '../login/login-entry';
 
-require('../common');  // Bring in the common javascript.
-require('../../sass/claims-status.scss');
+import '../common';
+import '../../sass/claims-status.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/common/index.js
+++ b/src/js/common/index.js
@@ -1,10 +1,7 @@
 // polyfills are loaded in vendor chunk
 import './polyfills';
-
 import './sentry.js';
-
-// Used in the footer.
-import '../legacy/menu';
+import '../legacy/menu';  // Used in the footer.
 
 // New navigation menu
 if (document.querySelector('#vetnav')) {

--- a/src/js/common/index.js
+++ b/src/js/common/index.js
@@ -1,10 +1,10 @@
 // polyfills are loaded in vendor chunk
-require('./polyfills');
+import './polyfills';
 
-require('./sentry.js');
+import './sentry.js';
 
 // Used in the footer.
-require('../legacy/menu.js');
+import '../legacy/menu';
 
 // New navigation menu
 if (document.querySelector('#vetnav')) {

--- a/src/js/common/polyfills.js
+++ b/src/js/common/polyfills.js
@@ -5,13 +5,13 @@
 // other such libraries in here. Most of the site does not use these legacy
 // frameworks and it belongs in a lower-level module.
 
-require('babel-polyfill');
+import 'babel-polyfill';
 
 // Basic polyfills.
 // TODO(awong): These do NOT correctly conditionally load the polyfill.
 // The polyfill is always loaded. require.ensure() should be used instead but
 // then load ordering needs to be worked out. Fix later.
-const Modernizr = require('modernizr');
+import Modernizr from 'modernizr';
 
 if (!Modernizr.classlist) {
   require('classlist-polyfill'); // DOM element classList support.
@@ -28,7 +28,7 @@ if (navigator.userAgent.includes('Edge/14')) {
   window.fetch = undefined;
 }
 
-require('whatwg-fetch');
+import 'whatwg-fetch';
 
 // This polyfill has its own test logic so no need to conditionally require.
-require('polyfill-function-prototype-bind');
+import 'polyfill-function-prototype-bind';

--- a/src/js/edu-benefits/1990/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1990/edu-benefits-entry.jsx
@@ -1,4 +1,6 @@
 import 'core-js';
+import '../../../sass/edu-benefits.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -10,8 +12,6 @@ import routes from './routes';
 import reducer from './reducer';
 import createLoginWidget from '../../login/login-entry';
 import createCommonStore from '../../common/store';
-
-import '../../../sass/edu-benefits.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/edu-benefits/1990/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1990/edu-benefits-entry.jsx
@@ -11,7 +11,7 @@ import reducer from './reducer';
 import createLoginWidget from '../../login/login-entry';
 import createCommonStore from '../../common/store';
 
-require('../../../sass/edu-benefits.scss');
+import '../../../sass/edu-benefits.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/edu-benefits/1990e/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1990e/edu-benefits-entry.jsx
@@ -1,4 +1,6 @@
 import 'core-js';
+import '../../../sass/edu-benefits.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -10,8 +12,6 @@ import routes from './routes';
 import reducer from './reducer';
 import createLoginWidget from '../../login/login-entry';
 import createCommonStore from '../../common/store';
-
-import '../../../sass/edu-benefits.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/edu-benefits/1990e/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1990e/edu-benefits-entry.jsx
@@ -11,7 +11,7 @@ import reducer from './reducer';
 import createLoginWidget from '../../login/login-entry';
 import createCommonStore from '../../common/store';
 
-require('../../../sass/edu-benefits.scss');
+import '../../../sass/edu-benefits.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/edu-benefits/1990n/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1990n/edu-benefits-entry.jsx
@@ -1,4 +1,6 @@
 import 'core-js';
+import '../../../sass/edu-benefits.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -10,8 +12,6 @@ import routes from './routes';
 import reducer from './reducer';
 import createLoginWidget from '../../login/login-entry';
 import createCommonStore from '../../common/store';
-
-import '../../../sass/edu-benefits.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/edu-benefits/1990n/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1990n/edu-benefits-entry.jsx
@@ -11,7 +11,7 @@ import reducer from './reducer';
 import createLoginWidget from '../../login/login-entry';
 import createCommonStore from '../../common/store';
 
-require('../../../sass/edu-benefits.scss');
+import '../../../sass/edu-benefits.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/edu-benefits/1995/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1995/edu-benefits-entry.jsx
@@ -1,4 +1,6 @@
 import 'core-js';
+import '../../../sass/edu-benefits.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -10,8 +12,6 @@ import routes from './routes';
 import reducer from './reducer';
 import createLoginWidget from '../../login/login-entry';
 import createCommonStore from '../../common/store';
-
-import '../../../sass/edu-benefits.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/edu-benefits/1995/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1995/edu-benefits-entry.jsx
@@ -11,7 +11,7 @@ import reducer from './reducer';
 import createLoginWidget from '../../login/login-entry';
 import createCommonStore from '../../common/store';
 
-require('../../../sass/edu-benefits.scss');
+import '../../../sass/edu-benefits.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/edu-benefits/5490/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/5490/edu-benefits-entry.jsx
@@ -1,4 +1,6 @@
 import 'core-js';
+import '../../../sass/edu-benefits.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -10,8 +12,6 @@ import routes from './routes';
 import reducer from './reducer';
 import createLoginWidget from '../../login/login-entry';
 import createCommonStore from '../../common/store';
-
-import '../../../sass/edu-benefits.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/edu-benefits/5490/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/5490/edu-benefits-entry.jsx
@@ -11,7 +11,7 @@ import reducer from './reducer';
 import createLoginWidget from '../../login/login-entry';
 import createCommonStore from '../../common/store';
 
-require('../../../sass/edu-benefits.scss');
+import '../../../sass/edu-benefits.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/edu-benefits/5495/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/5495/edu-benefits-entry.jsx
@@ -1,4 +1,6 @@
 import 'core-js';
+import '../../../sass/edu-benefits.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -10,8 +12,6 @@ import routes from './routes';
 import reducer from './reducer';
 import createLoginWidget from '../../login/login-entry';
 import createCommonStore from '../../common/store';
-
-import '../../../sass/edu-benefits.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/edu-benefits/5495/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/5495/edu-benefits-entry.jsx
@@ -11,7 +11,7 @@ import reducer from './reducer';
 import createLoginWidget from '../../login/login-entry';
 import createCommonStore from '../../common/store';
 
-require('../../../sass/edu-benefits.scss');
+import '../../../sass/edu-benefits.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/facility-locator/facility-locator-entry.jsx
+++ b/src/js/facility-locator/facility-locator-entry.jsx
@@ -1,4 +1,6 @@
 import 'core-js';
+import '../../sass/facility-locator.scss';
+
 import { createHistory } from 'history';
 import { Provider } from 'react-redux';
 import { Router, useRouterHistory } from 'react-router';
@@ -8,8 +10,6 @@ import ReactDOM from 'react-dom';
 import routes from './routes';
 import { store } from './store';
 import createLoginWidget from '../login/login-entry';
-
-import '../../sass/facility-locator.scss';
 
 createLoginWidget(store);
 

--- a/src/js/facility-locator/facility-locator-entry.jsx
+++ b/src/js/facility-locator/facility-locator-entry.jsx
@@ -9,7 +9,7 @@ import routes from './routes';
 import { store } from './store';
 import createLoginWidget from '../login/login-entry';
 
-require('../../sass/facility-locator.scss');
+import '../../sass/facility-locator.scss';
 
 createLoginWidget(store);
 

--- a/src/js/gi/gi-entry.jsx
+++ b/src/js/gi/gi-entry.jsx
@@ -1,4 +1,5 @@
-import '../common';  // common javascript.
+import '../common';
+import '../../sass/gi/gi.scss';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -11,8 +12,6 @@ import routes from './routes';
 import { store } from './store';
 import { updateRoute } from './actions';
 import createLoginWidget from '../login/login-entry';
-
-import '../../sass/gi/gi.scss';
 
 createLoginWidget(store);
 

--- a/src/js/gi/gi-entry.jsx
+++ b/src/js/gi/gi-entry.jsx
@@ -1,4 +1,4 @@
-require('../common');  // common javascript.
+import '../common';  // common javascript.
 
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -12,7 +12,7 @@ import { store } from './store';
 import { updateRoute } from './actions';
 import createLoginWidget from '../login/login-entry';
 
-require('../../sass/gi/gi.scss');
+import '../../sass/gi/gi.scss';
 
 createLoginWidget(store);
 

--- a/src/js/hca/hca-entry.jsx
+++ b/src/js/hca/hca-entry.jsx
@@ -10,8 +10,8 @@ import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 import reducer from './reducer';
 
-require('../common');
-require('../../sass/hca.scss');
+import '../common';
+import '../../sass/hca.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/hca/hca-entry.jsx
+++ b/src/js/hca/hca-entry.jsx
@@ -1,3 +1,6 @@
+import '../common';
+import '../../sass/hca.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -9,9 +12,6 @@ import route from './routes';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 import reducer from './reducer';
-
-import '../common';
-import '../../sass/hca.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/health-beta/health-beta-entry.jsx
+++ b/src/js/health-beta/health-beta-entry.jsx
@@ -11,9 +11,9 @@ import reducer from './reducers';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 
-require('../common');  // Bring in the common javascript.
-require('../../sass/rx/rx.scss');
-require('../../sass/user-profile.scss');
+import '../common';  // Bring in the common javascript.
+import '../../sass/rx/rx.scss';
+import '../../sass/user-profile.scss';
 
 const commonStore = createCommonStore(reducer);
 createLoginWidget(commonStore);

--- a/src/js/health-beta/health-beta-entry.jsx
+++ b/src/js/health-beta/health-beta-entry.jsx
@@ -1,4 +1,8 @@
 import 'core-js';
+import '../common';
+import '../../sass/rx/rx.scss';
+import '../../sass/user-profile.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -10,10 +14,6 @@ import routes from './routes';
 import reducer from './reducers';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
-
-import '../common';  // Bring in the common javascript.
-import '../../sass/rx/rx.scss';
-import '../../sass/user-profile.scss';
 
 const commonStore = createCommonStore(reducer);
 createLoginWidget(commonStore);

--- a/src/js/health-records/health-records-entry.jsx
+++ b/src/js/health-records/health-records-entry.jsx
@@ -10,8 +10,8 @@ import reducer from './reducers';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 
-require('../common');  // common javascript.
-require('../../sass/health-records/health-records.scss');
+import '../common';  // common javascript.
+import '../../sass/health-records/health-records.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/health-records/health-records-entry.jsx
+++ b/src/js/health-records/health-records-entry.jsx
@@ -1,3 +1,6 @@
+import '../common';
+import '../../sass/health-records/health-records.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, useRouterHistory } from 'react-router';
@@ -9,9 +12,6 @@ import routes from './routes';
 import reducer from './reducers';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
-
-import '../common';  // common javascript.
-import '../../sass/health-records/health-records.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/id-card-beta/id-card-beta-entry.jsx
+++ b/src/js/id-card-beta/id-card-beta-entry.jsx
@@ -1,4 +1,7 @@
 import 'core-js';
+import '../common';
+import '../../sass/user-profile.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -10,9 +13,6 @@ import routes from './routes';
 import reducer from './reducers';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
-
-import '../common';  // Bring in the common javascript.
-import '../../sass/user-profile.scss';
 
 const commonStore = createCommonStore(reducer);
 createLoginWidget(commonStore);

--- a/src/js/id-card-beta/id-card-beta-entry.jsx
+++ b/src/js/id-card-beta/id-card-beta-entry.jsx
@@ -11,8 +11,8 @@ import reducer from './reducers';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 
-require('../common');  // Bring in the common javascript.
-require('../../sass/user-profile.scss');
+import '../common';  // Bring in the common javascript.
+import '../../sass/user-profile.scss';
 
 const commonStore = createCommonStore(reducer);
 createLoginWidget(commonStore);

--- a/src/js/letters/letters-entry.jsx
+++ b/src/js/letters/letters-entry.jsx
@@ -12,8 +12,8 @@ import reducer from './reducers';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 
-require('../common');
-require('../../sass/letters.scss');
+import '../common';
+import '../../sass/letters.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/letters/letters-entry.jsx
+++ b/src/js/letters/letters-entry.jsx
@@ -1,4 +1,7 @@
 import 'core-js';
+import '../common';
+import '../../sass/letters.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -11,9 +14,6 @@ import routes from './routes.jsx';
 import reducer from './reducers';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
-
-import '../common';
-import '../../sass/letters.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/login/login-entry.jsx
+++ b/src/js/login/login-entry.jsx
@@ -1,3 +1,6 @@
+import '../common';
+import '../../sass/login.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -6,9 +9,6 @@ import { Provider } from 'react-redux';
 import initReact from '../common/init-react';
 
 import Main from './containers/Main';
-
-import '../common';  // Bring in the common javascript.
-import '../../sass/login.scss';
 
 export default function createLoginWidget(store) {
   function init() {

--- a/src/js/login/login-entry.jsx
+++ b/src/js/login/login-entry.jsx
@@ -7,8 +7,8 @@ import initReact from '../common/init-react';
 
 import Main from './containers/Main';
 
-require('../common');  // Bring in the common javascript.
-require('../../sass/login.scss');
+import '../common';  // Bring in the common javascript.
+import '../../sass/login.scss';
 
 export default function createLoginWidget(store) {
   function init() {

--- a/src/js/login/verify-entry.jsx
+++ b/src/js/login/verify-entry.jsx
@@ -1,3 +1,6 @@
+import '../common';
+import '../../sass/login.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -9,9 +12,6 @@ import initReact from '../common/init-react';
 import createLoginWidget from './login-entry';
 import reducer from './reducers/login';
 import Main from './containers/Main';
-
-import '../common';  // Bring in the common javascript.
-import '../../sass/login.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/login/verify-entry.jsx
+++ b/src/js/login/verify-entry.jsx
@@ -10,8 +10,8 @@ import createLoginWidget from './login-entry';
 import reducer from './reducers/login';
 import Main from './containers/Main';
 
-require('../common');  // Bring in the common javascript.
-require('../../sass/login.scss');
+import '../common';  // Bring in the common javascript.
+import '../../sass/login.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/messaging/messaging-entry.jsx
+++ b/src/js/messaging/messaging-entry.jsx
@@ -2,6 +2,9 @@
 // be included with babel-polyfill but only this import allowed
 // them to be recognized in phantomjs/e2e tests
 import 'core-js';
+import '../../sass/messaging/messaging.scss';
+import '../common';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, useRouterHistory } from 'react-router';
@@ -14,9 +17,6 @@ import reducer from './reducers';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 import { updateRoute } from './actions';
-
-import '../../sass/messaging/messaging.scss';
-import '../common';  // Bring in the common javascript.
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/messaging/messaging-entry.jsx
+++ b/src/js/messaging/messaging-entry.jsx
@@ -15,8 +15,8 @@ import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 import { updateRoute } from './actions';
 
-require('../../sass/messaging/messaging.scss');
-require('../common');  // Bring in the common javascript.
+import '../../sass/messaging/messaging.scss';
+import '../common';  // Bring in the common javascript.
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/no-react-entry.js
+++ b/src/js/no-react-entry.js
@@ -6,18 +6,18 @@ const wizardPages = new Set(['/education/apply/', '/education/eligibility/']);
 const pensionPages = new Set(['/pension/', '/pension/apply/', '/pension/eligibility/']);
 const healthcarePages = new Set(['/health-care/', '/health-care/apply/', '/health-care/eligibility/']);
 // No-react styles.
-require('../sass/no-react.scss');
+import '../sass/no-react.scss';
 
-require('./common');
+import './common';
 
 // Used in the footer.
-require('./legacy/menu.js');
+import './legacy/menu.js';
 
 // New navigation menu
-require('./legacy/mega-menu.js');
+import './legacy/mega-menu.js';
 
 // New sidebar menu
-require('./legacy/sidebar-navigation.js');
+import './legacy/sidebar-navigation.js';
 
 if (wizardPages.has(location.pathname)) {
   require('./edu-benefits/education-wizard.js');

--- a/src/js/pensions/pensions-entry.jsx
+++ b/src/js/pensions/pensions-entry.jsx
@@ -10,8 +10,8 @@ import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 import reducer from './reducer';
 
-require('../common');
-require('../../sass/pensions.scss');
+import '../common';
+import '../../sass/pensions.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/pensions/pensions-entry.jsx
+++ b/src/js/pensions/pensions-entry.jsx
@@ -1,3 +1,6 @@
+import '../common';
+import '../../sass/pensions.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -9,9 +12,6 @@ import route from './routes';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 import reducer from './reducer';
-
-import '../common';
-import '../../sass/pensions.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/post-911-gib-status/post-911-gib-status-entry.jsx
+++ b/src/js/post-911-gib-status/post-911-gib-status-entry.jsx
@@ -13,8 +13,8 @@ import createLoginWidget from '../login/login-entry';
 
 import Post911GIBStatusApp from './containers/Post911GIBStatusApp';
 
-require('../common');
-require('../../sass/post-911-gib-status.scss');
+import '../common';
+import '../../sass/post-911-gib-status.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/post-911-gib-status/post-911-gib-status-entry.jsx
+++ b/src/js/post-911-gib-status/post-911-gib-status-entry.jsx
@@ -1,4 +1,7 @@
 import 'core-js';
+import '../common';
+import '../../sass/post-911-gib-status.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -12,9 +15,6 @@ import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 
 import Post911GIBStatusApp from './containers/Post911GIBStatusApp';
-
-import '../common';
-import '../../sass/post-911-gib-status.scss';
 
 const store = createCommonStore(reducer);
 

--- a/src/js/pre-need/pre-need-entry.jsx
+++ b/src/js/pre-need/pre-need-entry.jsx
@@ -1,3 +1,6 @@
+import '../common';
+import '../../sass/pre-need.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -9,9 +12,6 @@ import route from './routes';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 import reducer from './reducer';
-
-import '../common';
-import '../../sass/pre-need.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/pre-need/pre-need-entry.jsx
+++ b/src/js/pre-need/pre-need-entry.jsx
@@ -10,8 +10,8 @@ import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 import reducer from './reducer';
 
-require('../common');
-require('../../sass/pre-need.scss');
+import '../common';
+import '../../sass/pre-need.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/rx/rx-entry.jsx
+++ b/src/js/rx/rx-entry.jsx
@@ -1,3 +1,6 @@
+import '../common';
+import '../../sass/rx/rx.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createHistory } from 'history';
@@ -9,9 +12,6 @@ import routes from './routes';
 import reducer from './reducers';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
-
-import '../common';  // Bring in the common javascript.
-import '../../sass/rx/rx.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/rx/rx-entry.jsx
+++ b/src/js/rx/rx-entry.jsx
@@ -10,8 +10,8 @@ import reducer from './reducers';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 
-require('../common');  // Bring in the common javascript.
-require('../../sass/rx/rx.scss');
+import '../common';  // Bring in the common javascript.
+import '../../sass/rx/rx.scss';
 
 const store = createCommonStore(reducer);
 createLoginWidget(store);

--- a/src/js/user-profile/user-profile-entry.jsx
+++ b/src/js/user-profile/user-profile-entry.jsx
@@ -1,4 +1,7 @@
 import 'core-js';
+import '../common';
+import '../../sass/user-profile.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -9,9 +12,6 @@ import initReact from '../common/init-react';
 import routes from './routes';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
-
-import '../common';  // Bring in the common javascript.
-import '../../sass/user-profile.scss';
 
 const commonStore = createCommonStore();
 createLoginWidget(commonStore);

--- a/src/js/user-profile/user-profile-entry.jsx
+++ b/src/js/user-profile/user-profile-entry.jsx
@@ -10,8 +10,8 @@ import routes from './routes';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 
-require('../common');  // Bring in the common javascript.
-require('../../sass/user-profile.scss');
+import '../common';  // Bring in the common javascript.
+import '../../sass/user-profile.scss';
 
 const commonStore = createCommonStore();
 createLoginWidget(commonStore);

--- a/src/js/veteran-id-card/veteran-id-card-entry.jsx
+++ b/src/js/veteran-id-card/veteran-id-card-entry.jsx
@@ -11,8 +11,8 @@ import reducer from './reducers';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
 
-require('../common');  // Bring in the common javascript.
-require('../../sass/veteran-id-card.scss');
+import '../common';  // Bring in the common javascript.
+import '../../sass/veteran-id-card.scss';
 
 const commonStore = createCommonStore(reducer);
 createLoginWidget(commonStore);

--- a/src/js/veteran-id-card/veteran-id-card-entry.jsx
+++ b/src/js/veteran-id-card/veteran-id-card-entry.jsx
@@ -1,4 +1,7 @@
 import 'core-js';
+import '../common';
+import '../../sass/veteran-id-card.scss';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -10,9 +13,6 @@ import routes from './routes';
 import reducer from './reducers';
 import createCommonStore from '../common/store';
 import createLoginWidget from '../login/login-entry';
-
-import '../common';  // Bring in the common javascript.
-import '../../sass/veteran-id-card.scss';
 
 const commonStore = createCommonStore(reducer);
 createLoginWidget(commonStore);


### PR DESCRIPTION
This PR switches from `require()` to `import` where possible. Exceptions include conditional-requires, because I don't believe that's possible yet with `import`. For consistency I also moved imports that do not contain an export to the top of each file.

Resolves department-of-veterans-affairs/vets.gov-team/issues/2944