### PR TITLE
Make download button show for all letters

### DIFF
--- a/src/js/letters/containers/LetterList.jsx
+++ b/src/js/letters/containers/LetterList.jsx
@@ -15,9 +15,11 @@ export class LetterList extends React.Component {
     const letterItems = (this.props.letters || []).map((letter, index) => {
       let content;
       let letterTitle;
+      let helpText;
       if (letter.letterType === LETTER_TYPES.benefitSummary) {
         letterTitle = 'Benefit Summary and Service Verification Letter';
         content = (<VeteranBenefitSummaryLetter/>);
+        helpText = bslHelpInstructions;
       } else if (letter.letterType === LETTER_TYPES.proofOfService) {
         letterTitle = 'Proof of Service Card';
         content = letterContent[letter.letterType] || '';
@@ -26,19 +28,22 @@ export class LetterList extends React.Component {
         content = letterContent[letter.letterType] || '';
       }
 
+      let conditionalDownloadButton;
+      if (letter.letterType !== LETTER_TYPES.benefitSummary || this.props.optionsAvailable) {
+        conditionalDownloadButton = (<DownloadLetterLink
+          letterType={letter.letterType}
+          letterName={letter.name}
+          downloadStatus={downloadStatus[letter.letterType]}
+          key={`download-link-${index}`}/>);
+      }
+
       return (
         <CollapsiblePanel
           panelName={letterTitle}
           key={`collapsiblePanel-${index}`}>
           <div>{content}</div>
-          <DownloadLetterLink
-            letterType={letter.letterType}
-            letterName={letter.name}
-            downloadStatus={downloadStatus[letter.letterType]}
-            key={`download-link-${index}`}/>
-          { letter.letterType === LETTER_TYPES.benefitSummary &&
-            bslHelpInstructions
-          }
+          {conditionalDownloadButton}
+          {helpText}
         </CollapsiblePanel>
       );
     });

--- a/src/js/letters/containers/LetterList.jsx
+++ b/src/js/letters/containers/LetterList.jsx
@@ -35,7 +35,8 @@ export class LetterList extends React.Component {
             letterType={letter.letterType}
             letterName={letter.name}
             downloadStatus={downloadStatus[letter.letterType]}
-            key={`download-link-${index}`}/>);
+            key={`download-link-${index}`}/>
+        );
       }
 
       return (

--- a/src/js/letters/containers/LetterList.jsx
+++ b/src/js/letters/containers/LetterList.jsx
@@ -30,11 +30,12 @@ export class LetterList extends React.Component {
 
       let conditionalDownloadButton;
       if (letter.letterType !== LETTER_TYPES.benefitSummary || this.props.optionsAvailable) {
-        conditionalDownloadButton = (<DownloadLetterLink
-          letterType={letter.letterType}
-          letterName={letter.name}
-          downloadStatus={downloadStatus[letter.letterType]}
-          key={`download-link-${index}`}/>);
+        conditionalDownloadButton = (
+          <DownloadLetterLink
+            letterType={letter.letterType}
+            letterName={letter.name}
+            downloadStatus={downloadStatus[letter.letterType]}
+            key={`download-link-${index}`}/>);
       }
 
       return (

--- a/src/js/letters/containers/LetterList.jsx
+++ b/src/js/letters/containers/LetterList.jsx
@@ -6,7 +6,7 @@ import CollapsiblePanel from '../../common/components/CollapsiblePanel';
 import DownloadLetterLink from '../components/DownloadLetterLink';
 import VeteranBenefitSummaryLetter from './VeteranBenefitSummaryLetter';
 
-import { letterContent } from '../utils/helpers';
+import { letterContent, bslHelpInstructions } from '../utils/helpers';
 import { AVAILABILITY_STATUSES, LETTER_TYPES } from '../utils/constants';
 
 export class LetterList extends React.Component {
@@ -15,17 +15,9 @@ export class LetterList extends React.Component {
     const letterItems = (this.props.letters || []).map((letter, index) => {
       let content;
       let letterTitle;
-      let bslHelpInstructions;
       if (letter.letterType === LETTER_TYPES.benefitSummary) {
         letterTitle = 'Benefit Summary and Service Verification Letter';
         content = (<VeteranBenefitSummaryLetter/>);
-        bslHelpInstructions = (
-          <p>
-            If your service period or disability status information is incorrect, please send us
-            a message through VA’s <a target="_blank" href="https://iris.custhelp.com/app/ask">
-            Inquiry Routing & Information System (IRIS)</a>. VA will respond within 5 business days.
-          </p>
-        );
       } else if (letter.letterType === LETTER_TYPES.proofOfService) {
         letterTitle = 'Proof of Service Card';
         content = letterContent[letter.letterType] || '';
@@ -34,24 +26,19 @@ export class LetterList extends React.Component {
         content = letterContent[letter.letterType] || '';
       }
 
-      let downloadLetterLink;
-      if (this.props.optionsAvailable) {
-        downloadLetterLink = (
-          <DownloadLetterLink
-            letterType={letter.letterType}
-            letterName={letter.name}
-            downloadStatus={downloadStatus[letter.letterType]}
-            key={`download-link-${index}`}/>
-        );
-      }
-
       return (
         <CollapsiblePanel
           panelName={letterTitle}
           key={`collapsiblePanel-${index}`}>
           <div>{content}</div>
-          <div>{downloadLetterLink}</div>
-          <div>{bslHelpInstructions}</div>
+          <DownloadLetterLink
+            letterType={letter.letterType}
+            letterName={letter.name}
+            downloadStatus={downloadStatus[letter.letterType]}
+            key={`download-link-${index}`}/>
+          { letter.letterType === LETTER_TYPES.benefitSummary &&
+            bslHelpInstructions
+          }
         </CollapsiblePanel>
       );
     });

--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -92,6 +92,17 @@ const commissaryLetterContent = (
   </div>
 );
 
+// Benefit Summary Letter Help Instructions
+export const bslHelpInstructions = (
+  <div>
+    <p>
+      If your service period or disability status information is incorrect, please send us
+      a message through VA’s <a target="_blank" href="https://iris.custhelp.com/app/ask">
+      Inquiry Routing & Information System (IRIS)</a>. VA will respond within 5 business days.
+    </p>
+  </div>
+);
+
 // Map values returned by vets-api to display text.
 export const letterContent = {
   commissary: commissaryLetterContent,

--- a/test/letters/containers/LetterList.unit.spec.jsx
+++ b/test/letters/containers/LetterList.unit.spec.jsx
@@ -62,12 +62,43 @@ describe('<LetterList>', () => {
   });
 
   it('does not render DL button for BSL if !optionsAvailable', () => {
+    const assertButtonUndefined = (panel) => {
+      const renderedPanel = panel.getRenderOutput();
+      const downloadButton = renderedPanel.props.children[1]; // 0 content 1 DL link 2 BSL instrct
+      expect(downloadButton).to.be.undefined;
+    };
+
+    const isBSL = (panel) => (panel.props.panelName === defaultProps.letters[1].name);
     const props = { ...defaultProps, optionsAvailable: false };
     const component = SkinDeep.shallowRender(<LetterList {...props}/>);
+
+    component
+      .everySubTree('CollapsiblePanel')
+      .filter(isBSL)
+      .forEach(assertButtonUndefined);
     const bslPanel = component.everySubTree('CollapsiblePanel')[1]; // bsl is second in defaultProps array
     const renderedBsl = bslPanel.getRenderOutput();
     const downloadButton = renderedBsl.props.children[1]; // 0 content 1 DL link 2 BSL instrct
+
     expect(downloadButton).to.be.undefined;
+  });
+
+  it('renders DL button for non-benefit-summary letters if !optionsAvailable', () => {
+    const checkButtonInPanel = (panel) => {
+      const renderedPanel = panel.getRenderOutput();
+      const downloadButton = renderedPanel.props.children[1]; // 0 content 1 DL link 2 BSL instrct
+      expect(downloadButton.type.displayName).to.equal('Connect(DownloadLetterLink)');
+    };
+
+    const isNotBSL = (panel) => (panel.props.panelName !== defaultProps.letters[1].name);
+
+    const props = { ...defaultProps, optionsAvailable: false };
+    const component = SkinDeep.shallowRender(<LetterList {...props}/>);
+
+    component
+      .everySubTree('CollapsiblePanel')
+      .filter(isNotBSL)
+      .forEach(checkButtonInPanel);
   });
 
   it('renders eligibility error when letters not available', () => {

--- a/test/letters/containers/LetterList.unit.spec.jsx
+++ b/test/letters/containers/LetterList.unit.spec.jsx
@@ -76,11 +76,6 @@ describe('<LetterList>', () => {
       .everySubTree('CollapsiblePanel')
       .filter(isBSL)
       .forEach(assertButtonUndefined);
-    const bslPanel = component.everySubTree('CollapsiblePanel')[1]; // bsl is second in defaultProps array
-    const renderedBsl = bslPanel.getRenderOutput();
-    const downloadButton = renderedBsl.props.children[1]; // 0 content 1 DL link 2 BSL instrct
-
-    expect(downloadButton).to.be.undefined;
   });
 
   it('renders DL button for non-benefit-summary letters if !optionsAvailable', () => {

--- a/test/letters/containers/LetterList.unit.spec.jsx
+++ b/test/letters/containers/LetterList.unit.spec.jsx
@@ -25,7 +25,7 @@ const defaultProps = {
   optionsAvailable: true,
 };
 
-describe.only('<LetterList>', () => {
+describe('<LetterList>', () => {
   it('renders', () => {
     const tree = SkinDeep.shallowRender(<LetterList {...defaultProps}/>);
     expect(tree.type).to.equal('div');

--- a/test/letters/containers/LetterList.unit.spec.jsx
+++ b/test/letters/containers/LetterList.unit.spec.jsx
@@ -25,7 +25,7 @@ const defaultProps = {
   optionsAvailable: true,
 };
 
-describe('<LetterList>', () => {
+describe.only('<LetterList>', () => {
   it('renders', () => {
     const tree = SkinDeep.shallowRender(<LetterList {...defaultProps}/>);
     expect(tree.type).to.equal('div');
@@ -44,6 +44,21 @@ describe('<LetterList>', () => {
       const letterProps = panels[index].props;
       expect(letterProps.panelName).to.equal(defaultProps.letters[index].name);
     });
+  });
+
+  it('renders DL buttons for all letters in list', () => {
+    const component = SkinDeep.shallowRender(<LetterList {...defaultProps}/>);
+
+    const checkButtonInPanel = (panel) => {
+      const renderedPanel = panel.getRenderOutput();
+      const downloadButton = renderedPanel.props.children[1]; // 0 content 1 DL link 2 BSL instrct
+      expect(downloadButton.type.displayName).to.equal('Connect(DownloadLetterLink)');
+    };
+
+    component
+      .everySubTree('CollapsiblePanel')
+      .forEach(checkButtonInPanel);
+
   });
 
   it('renders eligibility error when letters not available', () => {

--- a/test/letters/containers/LetterList.unit.spec.jsx
+++ b/test/letters/containers/LetterList.unit.spec.jsx
@@ -61,6 +61,15 @@ describe.only('<LetterList>', () => {
 
   });
 
+  it('does not render DL button for BSL if !optionsAvailable', () => {
+    const props = { ...defaultProps, optionsAvailable: false };
+    const component = SkinDeep.shallowRender(<LetterList {...props}/>);
+    const bslPanel = component.everySubTree('CollapsiblePanel')[1]; // bsl is second in defaultProps array
+    const renderedBsl = bslPanel.getRenderOutput();
+    const downloadButton = renderedBsl.props.children[1]; // 0 content 1 DL link 2 BSL instrct
+    expect(downloadButton).to.be.undefined;
+  });
+
   it('renders eligibility error when letters not available', () => {
     const props = { ...defaultProps, lettersAvailability: AVAILABILITY_STATUSES.letterEligibilityError };
     const component = SkinDeep.shallowRender(<LetterList {...props}/>);


### PR DESCRIPTION
PR updates conditions under which a Download Letter link should render and adds associated test.

Basically, a download link should be included for all letters that are in the letters array, regardless of whether `optionsAvailable` for BSL is `true` or `false`.

Also took the opportunity to extract a snippet of static helper text to `helpers` module to tighten things up a bit.