### PR TITLE
Don't change returnUrl when prefilling

### DIFF
--- a/src/js/hca/config/migrations.js
+++ b/src/js/hca/config/migrations.js
@@ -111,7 +111,9 @@ export default [
     // because we don't know for sure what they meant to pick
     return {
       formData: newFormData,
-      metadata: _.set('returnUrl', '/va-benefits/basic-information', metadata)
+      metadata: metadata.prefill
+        ? metadata
+        : _.set('returnUrl', '/va-benefits/basic-information', metadata)
     };
   }
 ];

--- a/test/hca/config/migrations.unit.spec.js
+++ b/test/hca/config/migrations.unit.spec.js
@@ -229,5 +229,21 @@ describe('HCA migrations', () => {
       expect(formData.receivesVaPension).to.be.undefined;
       expect(formData.isVaServiceConnected).to.be.undefined;
     });
+    it('should not set url if prefill', () => {
+      const data = {
+        formData: {
+          compensableVaServiceConnected: true,
+          receivesVaPension: true,
+          isVaServiceConnected: false
+        },
+        metadata: {
+          prefill: true,
+          returnUrl: '/household-information/spouse-information'
+        }
+      };
+
+      const { metadata } = migration(data);
+      expect(metadata.returnUrl).to.equal('/household-information/spouse-information');
+    });
   });
 });


### PR DESCRIPTION
Pretty much what it says. We don't want to do this on prefill, since a user hasn't made it to that page yet.

This will probably become irrelevant if the backend updates the prefill mapping to use the new compensation field only.