### PR TITLE
Claim status add files form ceh

### DIFF
--- a/src/js/claims-status/components/AddFilesForm.jsx
+++ b/src/js/claims-status/components/AddFilesForm.jsx
@@ -76,7 +76,7 @@ class AddFilesForm extends React.Component {
   }
   render() {
     return (
-      <div className="upload-files">
+      <div>
         <div>
           <p><a href onClick={(evt) => {
             evt.preventDefault();

--- a/src/js/claims-status/components/AddFilesForm.jsx
+++ b/src/js/claims-status/components/AddFilesForm.jsx
@@ -90,12 +90,12 @@ class AddFilesForm extends React.Component {
         <div>
           <ErrorableFileInput
             errorMessage={this.getErrorMessage()}
-            label={<h5>Select files to upload</h5>}
+            label={<h5 className="claims-upload-input-title">Select files to upload</h5>}
             accept={FILE_TYPES.map(type => `.${type}`).join(',')}
             onChange={this.add}
             buttonText="Add Files"
             name="fileUpload"
-            additionalClass="claims-upload-input"/>
+            additionalErrorClass="claims-upload-input-error-message"/>
         </div>
         <div className="file-requirements">
           <p className="file-requirement-header">Accepted file types:</p>
@@ -109,10 +109,10 @@ class AddFilesForm extends React.Component {
             <div className="document-title-size">
               <div className="document-title-row">
                 <div className="document-title-text-container">
-                  <div className="document-title-header">
-                    <h4 className="title">{file.name}</h4>
+                  <div>
+                    <h4 className="document-title">{file.name}</h4>
                   </div>
-                  <div className="document-size-text">
+                  <div>
                     {displayFileSize(file.size)}
                   </div>
                 </div>

--- a/src/js/claims-status/components/AddFilesForm.jsx
+++ b/src/js/claims-status/components/AddFilesForm.jsx
@@ -116,8 +116,8 @@ class AddFilesForm extends React.Component {
                     {displayFileSize(file.size)}
                   </div>
                 </div>
-                <div className="remove-document-button">
-                  <button className="usa-button-outline" onClick={() => this.props.onRemoveFile(index)}>Remove</button>
+                <div>
+                  <button className="remove-document-button usa-button-outline" onClick={() => this.props.onRemoveFile(index)}>Remove</button>
                 </div>
               </div>
               <div className="clearfix"></div>

--- a/src/js/claims-status/components/AddFilesForm.jsx
+++ b/src/js/claims-status/components/AddFilesForm.jsx
@@ -90,7 +90,7 @@ class AddFilesForm extends React.Component {
         <div>
           <ErrorableFileInput
             errorMessage={this.getErrorMessage()}
-            label={<h5 className="claims-upload-input-title">Select files to upload</h5>}
+            label={<span className="claims-upload-input-title">Select files to upload</span>}
             accept={FILE_TYPES.map(type => `.${type}`).join(',')}
             onChange={this.add}
             buttonText="Add Files"

--- a/src/js/claims-status/components/AddFilesForm.jsx
+++ b/src/js/claims-status/components/AddFilesForm.jsx
@@ -77,7 +77,7 @@ class AddFilesForm extends React.Component {
   render() {
     return (
       <div className="upload-files">
-        <div className="mail-or-fax-files">
+        <div>
           <p><a href onClick={(evt) => {
             evt.preventDefault();
             window.dataLayer.push({
@@ -133,7 +133,7 @@ class AddFilesForm extends React.Component {
             </div>
           </div>
         ))}
-        <div className="file-review">
+        <div>
           <button
             className="usa-button"
             onClick={this.submit}>

--- a/src/js/claims-status/components/AddFilesForm.jsx
+++ b/src/js/claims-status/components/AddFilesForm.jsx
@@ -110,7 +110,7 @@ class AddFilesForm extends React.Component {
               <div className="document-title-row">
                 <div className="document-title-text-container">
                   <div>
-                    <h4 className="document-title">{file.name}</h4>
+                    <span className="document-title">{file.name}</span>
                   </div>
                   <div>
                     {displayFileSize(file.size)}

--- a/src/js/common/components/form-elements/ErrorableFileInput.jsx
+++ b/src/js/common/components/form-elements/ErrorableFileInput.jsx
@@ -29,7 +29,7 @@ class ErrorableFileInput extends React.Component {
 
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
+      errorSpan = <span className={`usa-input-error-message ${this.props.additionalErrorClass}`} id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
       inputErrorClass = 'usa-input-error';
       labelErrorClass = 'usa-input-error-label';
     }
@@ -69,6 +69,7 @@ ErrorableFileInput.propTypes = {
   multiple: PropTypes.bool,
   buttonText: PropTypes.string,
   additionalClass: PropTypes.string,
+  additionalErrorClass: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   accept: PropTypes.string,
   name: PropTypes.string.isRequired,

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -288,15 +288,17 @@ p.first-of-type {
 
 .file-requirements {
   margin-bottom: 1.5em;
-  .file-requirement-header {
-    font-weight: bold;
-    margin-bottom: 0;
-  }
-  .file-requirement-text {
-    margin: 0;
-    &:last-child {
-      margin-bottom: 1em;
-    }
+}
+
+.file-requirement-header {
+  font-weight: bold;
+  margin-bottom: 0;
+}
+
+.file-requirement-text {
+  margin: 0;
+  &:last-child {
+    margin-bottom: 1em;
   }
 }
 
@@ -304,23 +306,20 @@ p.first-of-type {
   background-color: $color-gray-lightest;
   padding: 1em;
   margin-bottom: 1.5em;
-  .document-title-text-container {
-    padding-right: 1em;
-    word-break: break-all;
-    .document-size-text {
-      p {
-        margin: 0;
-      }
-    }
-  }
-  .remove-document-button {
-    > button {
-      margin: 0;
-      font-weight: bold;
-    }
-  }
   &:focus {
     outline: none;
+  }
+}
+
+.document-title-text-container {
+  padding-right: 1em;
+  word-break: break-all;
+}
+
+.remove-document-button {
+  > .usa-button-outline {
+    margin: 0;
+    font-weight: bold;
   }
 }
 
@@ -329,10 +328,8 @@ p.first-of-type {
   justify-content: space-between;
 }
 
-#content .section {
-  .document-title-header > .title {
-    padding: 0;
-  }
+.document-title {
+  padding: 0;
 }
 
 .disability-claims-warning {
@@ -346,13 +343,12 @@ p.first-of-type {
   margin-bottom: 1.5em;
 }
 
-.claims-upload-input {
-  h5 {
-    padding-bottom: 0 !important;
-  }
-  .usa-input-error-message {
-    margin-bottom: 1em;
-  }
+.claims-upload-input-error-message {
+  margin-bottom: 1em;
+}
+
+.claims-upload-input-title {
+  padding-bottom: 0 !important;
 }
 
 .claim-container {

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -332,6 +332,9 @@ p.first-of-type {
 }
 
 .document-title {
+  font-size: 1.35em;
+  line-height: 1.5;
+  font-weight: bold;
   padding: 0;
 }
 

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -320,10 +320,8 @@ p.first-of-type {
 }
 
 .remove-document-button {
-  > .usa-button-outline {
-    margin: 0;
-    font-weight: bold;
-  }
+  margin: 0;
+  font-weight: bold;
 }
 
 .document-title-row {

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -41,7 +41,6 @@
   }
 }
 
-
 .claim-list-item-container {
   background-color: $color-gray-lightest;
   padding: 2em 1em 1em;
@@ -62,7 +61,8 @@
   padding: 0;
 }
 
-.communications, .status {
+.communications,
+.status {
   margin: 0 0 0.5em;
 }
 
@@ -82,7 +82,9 @@
   display: block;
   color: inherit;
 
-  &:visited, &:hover, &:active {
+  &:visited,
+  &:hover,
+  &:active {
     color: inherit;
     text-decoration: none;
     background-color: inherit;
@@ -140,7 +142,8 @@
     background: $color-inset-bg;
   }
 
-  &.soc, &.ssoc {
+  &.soc,
+  &.ssoc {
     background: $color-gibill-accent;
     padding-left: 2.5em;
 
@@ -161,7 +164,8 @@
 }
 
 .claims-first-paragraph {
-  .event-description &, .last-status-header + & {
+  .event-description &,
+  .last-status-header + & {
     margin-top: 0;
   }
 }
@@ -255,14 +259,13 @@
   }
 }
 
-
 .clearfix:after {
   content: " ";
   visibility: hidden;
   display: block;
   height: 0;
   clear: both;
- }
+}
 
 .loading-message-center-spinner {
   > img {
@@ -348,6 +351,9 @@ p.first-of-type {
 }
 
 .claims-upload-input-title {
+  font-size: 1.15em;
+  line-height: 1.5;
+  font-weight: bold;
   padding-bottom: 0 !important;
 }
 
@@ -444,7 +450,7 @@ h1:focus {
 }
 
 .va-nav-breadcrumbs:focus {
-  outline: none
+  outline: none;
 }
 
 .notification-close {
@@ -594,7 +600,8 @@ h1:focus {
     }
   }
 
-  > .section-current:not(.last), > .section-complete:not(.last) {
+  > .section-current:not(.last),
+  > .section-complete:not(.last) {
     cursor: pointer;
   }
 }

--- a/test/claims-status/e2e/05.claim-additional-evidence.e2e.spec.js
+++ b/test/claims-status/e2e/05.claim-additional-evidence.e2e.spec.js
@@ -26,16 +26,16 @@ module.exports = E2eHelpers.createE2eTest(
     // go to additional evidence page
     client
       .click('.additional-evidence-alert .usa-button')
-      .waitForElementVisible('.upload-files', Timeouts.normal)
+      .waitForElementVisible('.file-requirements', Timeouts.normal)
       .axeCheck('.main');
 
     client.assert.urlContains('additional-evidence');
 
     client
-      .expect.element('.upload-files button.usa-button').text.to.equal('Submit Files for Review');
+      .expect.element('button.usa-button').text.to.equal('Submit Files for Review');
 
     client
-      .click('.upload-files button.usa-button')
+      .click('button.usa-button')
       .waitForElementPresent('.usa-input-error', Timeouts.normal);
 
     client

--- a/test/claims-status/e2e/05.claim-document-request.e2e.spec.js
+++ b/test/claims-status/e2e/05.claim-document-request.e2e.spec.js
@@ -27,14 +27,14 @@ module.exports = E2eHelpers.createE2eTest(
     // go to document request page
     client
       .click('.file-request-list-item .usa-button')
-      .waitForElementVisible('.upload-files', Timeouts.normal)
+      .waitForElementVisible('.file-requirements', Timeouts.normal)
       .axeCheck('.main');
 
     client
-      .expect.element('.upload-files button.usa-button').text.to.equal('Submit Files for Review');
+      .expect.element('button.usa-button').text.to.equal('Submit Files for Review');
 
     client
-      .click('.upload-files button.usa-button')
+      .click('button.usa-button')
       .waitForElementPresent('.usa-input-error', Timeouts.normal);
 
     client


### PR DESCRIPTION
- make markup semantic
   - [x] document-title
   - [x] claims-upload-input-title
- delete unnused styles
    - [x] file-review
    - [x] mail-or-fax-files
    - [x] document-size-text (nested p never used)
    - [x] upload-files
 - unnest nested styles
    - [X] document-item-container (.document-title-text-container (document-size-text (p)), remove-document-button (button), &:focus) 
    - [x] claims-upload-input (h5 and usa-input-error-message)
    - [x] file-requirements (file-requirement-header, file-requirement-text)
    - [x] file-requirement-header (noted above)
    - [x] file-requirement-text (noted above)
    - [x] document-title-text-container (noted above, and need to unnest (document-size-text (p)))
    - [x] removed document-title-header
    - [x] title, renamed to document-title
    - [x] remove-document-button (noted above and unnest button or >)
  - (don't see opportunities for consolidating classes)