### PR TITLE
Download letters properly in Safari <= 10

### DIFF
--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -133,21 +133,31 @@ export function getLetterPdf(letterType, letterName, letterOptions) {
 
   return (dispatch) => {
     dispatch({ type: GET_LETTER_PDF_DOWNLOADING, data: letterType });
+
+    // We handle IE10 separately but assume all other vets.gov-supported
+    // browsers have blob URL support.
+    // TODO: possibly want to explicitly check for blob URL support with something like
+    // const blobSupported = !!(/^blob:/.exec(downloadUrl));
+    const isIE = !!window.navigator.msSaveOrOpenBlob;
+    const save = document.createElement('a');
+    const downloadSupported = typeof save.download !== 'undefined';
+    let downloadWindow;
+
+    if (!downloadSupported) {
+      // Instead of giving the file a readable name and downloading
+      // it directly, open it in a new window with an ugly hash URL
+      // NOTE: We're opening the window here because Safari won't open
+      //  it as a result of an AJAX call--it has to be traced back to
+      //  a user interaction.
+      downloadWindow = window.open();
+    }
     return apiRequest(
       `/v0/letters/${letterType}`,
       settings,
       response => {
         let downloadUrl;
         response.blob().then(blob => {
-          // We handle IE10 separately but assume all other vets.gov-supported
-          // browsers have blob URL support.
-          // TODO: possibly want to explicitly check for blob URL support with something like
-          // const blobSupported = !!(/^blob:/.exec(downloadUrl));
-          const ie10 = !!window.navigator.msSaveOrOpenBlob;
-          const save = document.createElement('a');
-          const downloadSupported = typeof save.download !== 'undefined';
-
-          if (ie10) {
+          if (isIE) {
             window.navigator.msSaveOrOpenBlob(blob, `${letterName}.pdf`);
           } else {
             window.URL = window.URL || window.webkitURL;
@@ -161,9 +171,6 @@ export function getLetterPdf(letterType, letterName, letterOptions) {
               save.click();
               document.body.removeChild(save);
             } else {
-              // Instead of giving the file a readable name and downloading
-              // it directly, open it in a new window with an ugly hash URL
-              const downloadWindow = window.open();
               downloadWindow.location.href = downloadUrl;
             }
           }

--- a/src/js/letters/containers/LettersApp.jsx
+++ b/src/js/letters/containers/LettersApp.jsx
@@ -5,7 +5,7 @@ import RequiredLoginView from '../../common/components/RequiredLoginView';
 
 // This needs to be a React component for RequiredLoginView to pass down
 // the isDataAvailable prop, which is only passed on failure.
-function AppContent({ children, isDataAvailable }) {
+export function AppContent({ children, isDataAvailable }) {
   const unregistered = isDataAvailable === false;
   let view;
 
@@ -27,7 +27,7 @@ function AppContent({ children, isDataAvailable }) {
   );
 }
 
-class LettersApp extends React.Component {
+export class LettersApp extends React.Component {
   render() {
     return (
       <RequiredLoginView


### PR DESCRIPTION
Fun fact: Safari won't let you `window.open()` unless it's a direct result of a user interaction. This means we need to open the new window _before_ the API callback for it to work.

I'm guessing that's why you had that pulled out before, @raquelromano-gov.