### PR TITLE
Letters use new address mg

### DIFF
--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -237,7 +237,7 @@ export function saveAddress(address) {
         const responseAddress = militaryToGeneric(response.data.attributes.address);
         if (!isEqual(stripEmpties(address), stripEmpties(responseAddress))) {
           const mismatchError = new Error('letters-address-update addresses don\'t match');
-          Raven.captureException(mismatchError, { submitted: address, returned: responseAddress });
+          Raven.captureException(mismatchError);
         }
         return dispatch(saveAddressSuccess(responseAddress));
       },

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -83,17 +83,8 @@ export function getMailingAddress() {
       // on fetch success
       (response) => {
         const responseCopy = Object.assign({}, response);
-        // Translate military-only fields into generic ones; we'll translate
-        // them back later if necessary
+        // translate military address properties to generic properties for use in front end
         responseCopy.data.attributes.address = militaryToGeneric(response.data.attributes.address);
-        // if (addressCopy.type === ADDRESS_TYPES.military) {
-        //   addressCopy.city = addressCopy.militaryPostOfficeTypeCode;
-        //   addressCopy.stateCode = addressCopy.militaryStateCode;
-        //   addressCopy.countryName = 'USA';
-        //   delete addressCopy.militaryPostOfficeTypeCode;
-        //   delete addressCopy.militaryStateCode;
-        // }
-        // responseCopy.data.attributes.address = addressCopy;
         return dispatch({
           type: GET_ADDRESS_SUCCESS,
           data: responseCopy
@@ -242,16 +233,8 @@ export function saveAddress(address) {
       '/v0/address',
       settings,
       (response) => {
-        // translate military addresses back to front end address
+        // translate military address properties back to front end address
         const responseAddress = militaryToGeneric(response.data.attributes.address);
-        // const responseAddress = Object.assign({}, response.data.attributes.address);
-        // if (transformedAddress.type === ADDRESS_TYPES.military) {
-        //   responseAddress.city = responseAddress.militaryPostOfficeTypeCode;
-        //   responseAddress.stateCode = responseAddress.militaryStateCode;
-        //   responseAddress.countryName = 'USA';
-        //   delete responseAddress.militaryPostOfficeTypeCode;
-        //   delete responseAddress.militaryStateCode;
-        // }
         if (!isEqual(stripEmpties(address), stripEmpties(responseAddress))) {
           const mismatchError = new Error('letters-address-update addresses don\'t match');
           Raven.captureException(mismatchError, { submitted: address, returned: responseAddress });

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -1,7 +1,7 @@
 import Raven from 'raven-js';
 import { isEqual } from 'lodash';
 
-import { apiRequest, stripEmpties } from '../utils/helpers.jsx';
+import { apiRequest, stripEmpties, militaryToGeneric } from '../utils/helpers.jsx';
 import {
   ADDRESS_TYPES,
   BACKEND_AUTHENTICATION_ERROR,
@@ -83,17 +83,17 @@ export function getMailingAddress() {
       // on fetch success
       (response) => {
         const responseCopy = Object.assign({}, response);
-        const addressCopy = Object.assign({}, response.data.attributes.address);
         // Translate military-only fields into generic ones; we'll translate
         // them back later if necessary
-        if (addressCopy.type === ADDRESS_TYPES.military) {
-          addressCopy.city = addressCopy.militaryPostOfficeTypeCode;
-          addressCopy.stateCode = addressCopy.militaryStateCode;
-          addressCopy.countryName = 'USA';
-          delete addressCopy.militaryPostOfficeTypeCode;
-          delete addressCopy.militaryStateCode;
-        }
-        responseCopy.data.attributes.address = addressCopy;
+        responseCopy.data.attributes.address = militaryToGeneric(response.data.attributes.address);
+        // if (addressCopy.type === ADDRESS_TYPES.military) {
+        //   addressCopy.city = addressCopy.militaryPostOfficeTypeCode;
+        //   addressCopy.stateCode = addressCopy.militaryStateCode;
+        //   addressCopy.countryName = 'USA';
+        //   delete addressCopy.militaryPostOfficeTypeCode;
+        //   delete addressCopy.militaryStateCode;
+        // }
+        // responseCopy.data.attributes.address = addressCopy;
         return dispatch({
           type: GET_ADDRESS_SUCCESS,
           data: responseCopy
@@ -243,14 +243,15 @@ export function saveAddress(address) {
       settings,
       (response) => {
         // translate military addresses back to front end address
-        const responseAddress = Object.assign({}, response.data.attributes.address);
-        if (transformedAddress.type === ADDRESS_TYPES.military) {
-          responseAddress.city = responseAddress.militaryPostOfficeTypeCode;
-          responseAddress.stateCode = responseAddress.militaryStateCode;
-          responseAddress.countryName = 'USA';
-          delete responseAddress.militaryPostOfficeTypeCode;
-          delete responseAddress.militaryStateCode;
-        }
+        const responseAddress = militaryToGeneric(response.data.attributes.address);
+        // const responseAddress = Object.assign({}, response.data.attributes.address);
+        // if (transformedAddress.type === ADDRESS_TYPES.military) {
+        //   responseAddress.city = responseAddress.militaryPostOfficeTypeCode;
+        //   responseAddress.stateCode = responseAddress.militaryStateCode;
+        //   responseAddress.countryName = 'USA';
+        //   delete responseAddress.militaryPostOfficeTypeCode;
+        //   delete responseAddress.militaryStateCode;
+        // }
         if (!isEqual(stripEmpties(address), stripEmpties(responseAddress))) {
           const mismatchError = new Error('letters-address-update addresses don\'t match');
           Raven.captureException(mismatchError, { submitted: address, returned: responseAddress });

--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -346,13 +346,11 @@ export function resetDisallowedAddressFields(address) {
  * @returns a cloned object with no empty properties
  */
 export const stripEmpties = (input) => {
-  const newObject = {};
-  const pushToNewObject = (key) => {
-    newObject[key] = input[key];
-  };
-  const notEmpty = (key) => (input[key].length > 0);
+  const newObject = { ...input };
+  const deleteProperty = (key) => (delete newObject[key]);
+  const isEmpty = (key) => (input[key].length === 0);
   Object.keys(input)
-    .filter(notEmpty)
-    .forEach(pushToNewObject);
+    .filter(isEmpty)
+    .forEach(deleteProperty);
   return newObject;
 };

--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -354,3 +354,22 @@ export const stripEmpties = (input) => {
     .forEach(deleteProperty);
   return newObject;
 };
+
+/**
+ * Takes an address object as returned from vets-api and translates its properties to
+ * generic properties that are consumed by the front end
+ * @param {Object} address an address object as formatted by vets-api
+ * @returns {Object} shallow clone of address with military properties swapped for generics
+ */
+export const militaryToGeneric = (address) => {
+  if (address.type !== ADDRESS_TYPES.military) {
+    return { ...address };
+  }
+  const genericAddress = { ...address };
+  genericAddress.city = genericAddress.militaryPostOfficeTypeCode;
+  genericAddress.stateCode = genericAddress.militaryStateCode;
+  genericAddress.countryName = 'USA';
+  delete genericAddress.militaryPostOfficeTypeCode;
+  delete genericAddress.militaryStateCode;
+  return genericAddress;
+};

--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -339,3 +339,20 @@ export function resetDisallowedAddressFields(address) {
 
   return newAddress;
 }
+
+/**
+ * Traverses a single-level object and removes its zero-length own-enumerable properties
+ * @param {Object} input an object with no nested properties
+ * @returns a cloned object with no empty properties
+ */
+export const stripEmpties = (input) => {
+  const newObject = {};
+  const pushToNewObject = (key) => {
+    newObject[key] = input[key];
+  };
+  const notEmpty = (key) => (input[key].length > 0);
+  Object.keys(input)
+    .filter(notEmpty)
+    .forEach(pushToNewObject);
+  return newObject;
+};

--- a/test/e2e/letters-helpers.js
+++ b/test/e2e/letters-helpers.js
@@ -74,18 +74,46 @@ const address = {
     }
   }
 };
-
 const newAddress = {
-  addressEffectiveDate: '2012-04-03T04:00:00.000+00:00',
-  addressOne: '57 COLUMBUS STRASSA',
-  addressThree: '',
-  addressTwo: 'BEN FRANKLIN VILLAGE',
-  city: 'Chicago',
-  state: 'IL',
-  type: 'DOMESTIC',
-  zipCode: '60602',
-  zipSuffix: ''
+  data: {
+    attributes: {
+      address: {
+        addressEffectiveDate: '2012-04-03T04:00:00.000+00:00',
+        addressOne: '57 COLUMBUS STRASSA',
+        addressThree: '',
+        addressTwo: 'BEN FRANKLIN VILLAGE',
+        city: 'Chicago',
+        state: 'IL',
+        type: 'DOMESTIC',
+        zipCode: '60602',
+        zipSuffix: ''
+      },
+      controlInformation: {
+        canUpdate: true,
+        corpAvailIndicator: true,
+        corpRecFoundIndicator: true,
+        hasNoBdnPaymentsIndicator: true,
+        indentityIndicator: true,
+        indexIndicator: true,
+        isCompetentIndicator: true,
+        noFiduciaryAssignedIndicator: true,
+        notDeceasedIndicator: true
+      }
+    }
+  }
 };
+
+// const newAddress = {
+//   addressEffectiveDate: '2012-04-03T04:00:00.000+00:00',
+//   addressOne: '57 COLUMBUS STRASSA',
+//   addressThree: '',
+//   addressTwo: 'BEN FRANKLIN VILLAGE',
+//   city: 'Chicago',
+//   state: 'IL',
+//   type: 'DOMESTIC',
+//   zipCode: '60602',
+//   zipSuffix: ''
+// };
 
 const countries = {
   data: {

--- a/test/e2e/letters-helpers.js
+++ b/test/e2e/letters-helpers.js
@@ -103,18 +103,6 @@ const newAddress = {
   }
 };
 
-// const newAddress = {
-//   addressEffectiveDate: '2012-04-03T04:00:00.000+00:00',
-//   addressOne: '57 COLUMBUS STRASSA',
-//   addressThree: '',
-//   addressTwo: 'BEN FRANKLIN VILLAGE',
-//   city: 'Chicago',
-//   state: 'IL',
-//   type: 'DOMESTIC',
-//   zipCode: '60602',
-//   zipSuffix: ''
-// };
-
 const countries = {
   data: {
     attributes: {

--- a/test/e2e/letters-helpers.js
+++ b/test/e2e/letters-helpers.js
@@ -83,7 +83,7 @@ const newAddress = {
         addressThree: '',
         addressTwo: 'BEN FRANKLIN VILLAGE',
         city: 'Chicago',
-        state: 'IL',
+        stateCode: 'IL',
         type: 'DOMESTIC',
         zipCode: '60602',
         zipSuffix: ''

--- a/test/letters/01-authed.e2e.spec.js
+++ b/test/letters/01-authed.e2e.spec.js
@@ -5,6 +5,7 @@ const Timeouts = require('../e2e/timeouts.js');
 const LettersHelpers = require('../e2e/letters-helpers.js');
 const LoginHelpers = require('../e2e/login-helpers');
 
+const newAddress = LettersHelpers.newAddress.data.attributes.address;
 const oldAddress = LettersHelpers.address.data.attributes.address;
 const oldAddressOne = startCase(oldAddress.addressOne.toLowerCase());
 const oldAddressTwo = oldAddress.addressTwo ? `, ${startCase(oldAddress.addressTwo.toLowerCase())}` : '';
@@ -54,11 +55,10 @@ module.exports = E2eHelpers.createE2eTest(
 
     client
       .clearValue('input[name="city"]')
-      .fill('input[name="city"]', LettersHelpers.newAddress.city)
-      .setValue('select[name="state"]', LettersHelpers.newAddress.state)
+      .fill('input[name="city"]', newAddress.city)
+      .setValue('select[name="state"]', newAddress.stateCode)
       .clearValue('input[name="postalCode"]')
-      .fill('input[name="postalCode"]', LettersHelpers.newAddress.zipCode)
-      .pause(10000)
+      .fill('input[name="postalCode"]', newAddress.zipCode)
       .click('.usa-button-primary') // submits new data
       .waitForElementVisible('.city-state', Timeouts.normal)
       .expect.element('.city-state').text.to.contain('Chicago, Illinois 60602');

--- a/test/letters/01-authed.e2e.spec.js
+++ b/test/letters/01-authed.e2e.spec.js
@@ -59,9 +59,8 @@ module.exports = E2eHelpers.createE2eTest(
       .clearValue('input[name="postalCode"]')
       .fill('input[name="postalCode"]', LettersHelpers.newAddress.zipCode)
       .click('.usa-button-primary')
-      .waitForElementVisible('.city-state', Timeouts.normal)
+      .waitForElementVisible('.city-state', Timeouts.slow) // loading spinner shows until success
       .expect.element('.city-state').text.to.contain('Chicago, Illinois 60602');
-
 
     client
       .click('.view-letters-button')

--- a/test/letters/01-authed.e2e.spec.js
+++ b/test/letters/01-authed.e2e.spec.js
@@ -58,8 +58,9 @@ module.exports = E2eHelpers.createE2eTest(
       .setValue('select[name="state"]', LettersHelpers.newAddress.state)
       .clearValue('input[name="postalCode"]')
       .fill('input[name="postalCode"]', LettersHelpers.newAddress.zipCode)
-      .click('.usa-button-primary')
-      .waitForElementVisible('.city-state', Timeouts.slow) // loading spinner shows until success
+      .pause(10000)
+      .click('.usa-button-primary') // submits new data
+      .waitForElementVisible('.city-state', Timeouts.normal)
       .expect.element('.city-state').text.to.contain('Chicago, Illinois 60602');
 
     client

--- a/test/letters/actions/letters.unit.spec.js
+++ b/test/letters/actions/letters.unit.spec.js
@@ -64,6 +64,14 @@ describe('saveAddress', () => {
     state: 'secret'
   };
 
+  const successResponse = {
+    data: {
+      attributes: {
+        address: { ...frontEndAddress }
+      }
+    }
+  };
+
   beforeEach(setup);
   afterEach(teardown);
 
@@ -77,7 +85,22 @@ describe('saveAddress', () => {
       }).then(done, done);
   });
 
+  it('dispatches SAVE_ADDRESS_FAILURE when addresses do not match', (done) => {
+    const thunk = saveAddress(frontEndAddress);
+    const dispatch = sinon.spy();
+    thunk(dispatch, getState)
+      .then(() => {
+        const action = dispatch.secondCall.args[0];
+        expect(action.type).to.equal(SAVE_ADDRESS_FAILURE);
+      }).then(done, done);
+  });
+
   it('dispatches SAVE_ADDRESS_SUCCESS on update success', (done) => {
+    global.fetch.returns(Promise.resolve({
+      headers: { get: () => 'application/json' },
+      ok: true,
+      json: () => Promise.resolve(successResponse)
+    }));
     const thunk = saveAddress(frontEndAddress);
     const dispatch = sinon.spy();
     thunk(dispatch, getState)

--- a/test/letters/actions/letters.unit.spec.js
+++ b/test/letters/actions/letters.unit.spec.js
@@ -60,14 +60,19 @@ const getState = () => ({});
 describe('saveAddress', () => {
   const frontEndAddress = {
     type: ADDRESS_TYPES.military,
-    city: 'apo',
-    state: 'secret'
+    city: 'APO',
+    stateCode: 'AE',
+    countryName: 'USA'
   };
 
   const successResponse = {
     data: {
       attributes: {
-        address: { ...frontEndAddress }
+        address: {
+          type: frontEndAddress.type,
+          militaryPostOfficeTypeCode: frontEndAddress.city,
+          militaryStateCode: frontEndAddress.stateCode,
+        }
       }
     }
   };

--- a/test/letters/utils/helpers.unit.spec.jsx
+++ b/test/letters/utils/helpers.unit.spec.jsx
@@ -166,7 +166,7 @@ describe('Letters helpers: ', () => {
     });
   });
 
-  describe.only('military to generic', () => {
+  describe('military to generic', () => {
     const militaryAddress = {
       addressEffectiveDate: '2012-04-03T04:00:00.000+00:00',
       addressOne: '57 COLUMBUS STRASSA',

--- a/test/letters/utils/helpers.unit.spec.jsx
+++ b/test/letters/utils/helpers.unit.spec.jsx
@@ -7,7 +7,9 @@ import { ADDRESS_TYPES, MILITARY_STATES } from '../../../src/js/letters/utils/co
 import {
   getBenefitOptionText,
   inferAddressType,
-  resetDisallowedAddressFields
+  resetDisallowedAddressFields,
+  stripEmpties,
+  militaryToGeneric
 } from '../../../src/js/letters/utils/helpers';
 
 const address = {
@@ -133,6 +135,91 @@ describe('Letters helpers: ', () => {
 
       expect(resetAddress.state).to.equal('');
       expect(resetAddress.zipCode).to.equal('');
+    });
+  });
+
+  describe('stripEmpties', () => {
+    const inputAddress = {
+      addressEffectiveDate: '2012-04-03T04:00:00.000+00:00',
+      addressOne: '57 COLUMBUS STRASSA',
+      addressThree: '',
+      addressTwo: '',
+      militaryPostOfficeTypeCode: 'APO',
+      militaryStateCode: 'AE',
+      type: 'MILITARY',
+      zipCode: '09028',
+      zipSuffix: ''
+    };
+
+    const expectedAddress = {
+      addressEffectiveDate: '2012-04-03T04:00:00.000+00:00',
+      addressOne: '57 COLUMBUS STRASSA',
+      militaryPostOfficeTypeCode: 'APO',
+      militaryStateCode: 'AE',
+      type: 'MILITARY',
+      zipCode: '09028',
+    };
+
+    it('should only remove all zero-length properties from an object', () => {
+      const actualAddress = stripEmpties(inputAddress);
+      expect(actualAddress).to.eql(expectedAddress);
+    });
+  });
+
+  describe.only('military to generic', () => {
+    const militaryAddress = {
+      addressEffectiveDate: '2012-04-03T04:00:00.000+00:00',
+      addressOne: '57 COLUMBUS STRASSA',
+      addressThree: '',
+      addressTwo: '',
+      militaryPostOfficeTypeCode: 'APO',
+      militaryStateCode: 'AE',
+      type: 'MILITARY',
+      zipCode: '09028',
+      zipSuffix: ''
+    };
+
+    const domesticAddress = {
+      addressEffectiveDate: '2012-04-03T04:00:00.000+00:00',
+      addressOne: '57 COLUMBUS STRASSA',
+      addressThree: '',
+      addressTwo: '',
+      city: 'Chicago',
+      stateCode: 'IL',
+      countryName: 'USA',
+      type: 'DOMESTIC',
+      zipCode: '06628',
+      zipSuffix: ''
+    };
+
+    const genericAddress = {
+      addressEffectiveDate: '2012-04-03T04:00:00.000+00:00',
+      addressOne: '57 COLUMBUS STRASSA',
+      addressThree: '',
+      addressTwo: '',
+      city: 'APO',
+      stateCode: 'AE',
+      countryName: 'USA',
+      type: 'MILITARY',
+      zipCode: '09028',
+      zipSuffix: ''
+    };
+
+    it('translates military addresses to generic', () => {
+      const actualAddress = militaryToGeneric(militaryAddress);
+      expect(actualAddress).to.eql(genericAddress);
+    });
+
+    it('lets non-military address types pass through unmodified', () => {
+      const actualAddress = militaryToGeneric(domesticAddress);
+      expect(actualAddress).to.eql(domesticAddress);
+    });
+
+    it('returns a clone for all cases', () => {
+      const militaryTest = militaryToGeneric(militaryAddress);
+      const nonMilitaryTest = militaryToGeneric(domesticAddress);
+      expect(militaryTest).to.not.equal(militaryAddress);
+      expect(nonMilitaryTest).to.not.equal(domesticAddress);
     });
   });
 });


### PR DESCRIPTION
- Switch to using address returned from API in the UI after a successful address update (involved some transforming of the response back into the shape required by the front end)
- Log any mismatches between PUT and response addresses to Sentry
- Update related tests

Also successfully tested all update permutations manually against CI (M -> D; M -> I; M -> M; etc...)
