### PR TITLE
Add content for seeing payment info

### DIFF
--- a/src/js/post-911-gib-status/containers/StatusPage.jsx
+++ b/src/js/post-911-gib-status/containers/StatusPage.jsx
@@ -52,7 +52,7 @@ class StatusPage extends React.Component {
         <div>
           If you've received education benefit payments through this program, <a target="_blank"
             href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=payment-history">
-          you can see your payment history on eBenefits</a>
+          you can see your payment history on eBenefits</a>.
         </div>
         <EnrollmentHistory enrollmentData={enrollmentData}/>
         <div className="feature help-desk">

--- a/src/js/post-911-gib-status/containers/StatusPage.jsx
+++ b/src/js/post-911-gib-status/containers/StatusPage.jsx
@@ -48,6 +48,12 @@ class StatusPage extends React.Component {
         {introText}
         {printButton}
         <UserInfoSection enrollmentData={enrollmentData}/>
+        <h4>How can I see my Post-9/11 GI Bill benefit payments?</h4>
+        <div>
+          If you've received education benefit payments through this program, <a target="_blank"
+            href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=payment-history">
+          you can see your payment history on eBenefits</a>
+        </div>
         <EnrollmentHistory enrollmentData={enrollmentData}/>
         <div className="feature help-desk">
           <h2>Need help?</h2>


### PR DESCRIPTION
<img width="814" alt="screen shot 2017-10-26 at 11 31 26 am" src="https://user-images.githubusercontent.com/25183456/32062025-488ca226-ba41-11e7-901b-75304a6bb299.png">

It has not been added to the print page:
<img width="977" alt="screen shot 2017-10-26 at 11 20 39 am" src="https://user-images.githubusercontent.com/25183456/32061930-0a0c1dba-ba41-11e7-98aa-b5e652e3efbb.png">

