### PR TITLE
Letters accessibility fixes

### DIFF
--- a/src/js/letters/components/Address.jsx
+++ b/src/js/letters/components/Address.jsx
@@ -20,7 +20,7 @@ class Address extends React.Component {
   }
 
   componentDidMount() {
-    focusElement('select');
+    focusElement('h5');
   }
 
   getAdjustedStateNames = () => {

--- a/src/js/letters/components/Address.jsx
+++ b/src/js/letters/components/Address.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
+import { focusElement } from '../../common/utils/helpers';
+
 import ErrorableSelect from './ErrorableSelect';
 import ErrorableTextInput from './ErrorableTextInput';
 import { STATE_CODE_TO_NAME, MILITARY_CITIES } from '../utils/constants';
@@ -15,6 +17,10 @@ import { militaryStateNames } from '../utils/helpers';
 class Address extends React.Component {
   componentWillMount() {
     this.id = _.uniqueId('address-input-');
+  }
+
+  componentDidMount() {
+    focusElement('select');
   }
 
   getAdjustedStateNames = () => {

--- a/src/js/letters/components/AddressBlock.jsx
+++ b/src/js/letters/components/AddressBlock.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 
-const AddressBlock = ({ name, children }) => (
+const AddressBlock = ({ children }) => (
   <div>
     <div className="address-block">
-      <h5 className="letters-address">{name}</h5>
       {children}
     </div>
     <p>

--- a/src/js/letters/components/AddressContent.jsx
+++ b/src/js/letters/components/AddressContent.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import UpdateFailureAlert from './UpdateFailureAlert';
 import AddressBlock from './AddressBlock';
 
-const AddressContent = ({ saveError, addressObject, name, children }) => {
+const AddressContent = ({ saveError, addressObject, children }) => {
   return (
     <div className="step-content">
       <p>Downloaded documents will list your address as:</p>
       {saveError
         ? <UpdateFailureAlert addressObject={addressObject}/>
-        : <AddressBlock name={name}>
+        : <AddressBlock>
           {children}
         </AddressBlock>
       }

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -307,7 +307,7 @@ export class AddressSection extends React.Component {
       );
     }
 
-    return <div>{addressContent}</div>;
+    return <div aria-live="polite">{addressContent}</div>;
   }
 }
 

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import Scroll from 'react-scroll';
 
 import { scrollToFirstError } from '../../common/utils/helpers';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
@@ -25,6 +26,16 @@ import {
   countryValidations,
   cityValidations
 } from '../utils/validations';
+
+const Element = Scroll.Element;
+const scroller = Scroll.scroller;
+const scrollToTop = () => {
+  scroller.scrollTo('addressScrollElement', window.VetsGov.scroll || {
+    duration: 500,
+    delay: 0,
+    smooth: true
+  });
+};
 
 // The address is empty if every field except type is falsey.
 // NOTE: It "shouldn't" ever happen, but it did in testing, so...paranoid programming!
@@ -167,6 +178,7 @@ export class AddressSection extends React.Component {
   startEditing = () => {
     window.dataLayer.push({ event: 'letter-update-address-started' });
     this.setState({ isEditingAddress: true });
+    scrollToTop();
   }
 
   dirtyInput = (fieldName) => {
@@ -307,7 +319,14 @@ export class AddressSection extends React.Component {
       );
     }
 
-    return <div aria-live="polite">{addressContent}</div>;
+    return (
+      <div>
+        <Element name="addressScrollElement"/>
+        <div aria-live="polite">
+          {addressContent}
+        </div>
+      </div>
+    );
   }
 }
 

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -324,7 +324,7 @@ export class AddressSection extends React.Component {
     return (
       <div>
         <Element name="addressScrollElement"/>
-        <div aria-live="polite">
+        <div aria-live="polite" aria-relevant="additions">
           {addressContent}
         </div>
       </div>

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import { scrollToFirstError } from '../../common/utils/helpers';
+import { scrollToFirstError, focusElement } from '../../common/utils/helpers';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
 
 import {
@@ -64,6 +64,9 @@ export class AddressSection extends React.Component {
     }
   }
 
+  componentDidMount() {
+    focusElement('h1');
+  }
 
   /* editableAddress is initialized from redux store in the constructor
    * but the prop it initializes from is not available at time of mounting, which means users
@@ -163,6 +166,7 @@ export class AddressSection extends React.Component {
       errorMessages: {}
     });
     this.props.saveAddress(this.state.editableAddress);
+    scrollToTop();
   }
 
   handleCancel = () => {

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -173,6 +173,7 @@ export class AddressSection extends React.Component {
       fieldsToValidate: {},
       editableAddress: this.props.savedAddress
     });
+    scrollToTop();
   }
 
   startEditing = () => {

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import { scrollToFirstError, focusElement } from '../../common/utils/helpers';
+import { scrollToFirstError } from '../../common/utils/helpers';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
 
 import {
@@ -62,10 +62,6 @@ export class AddressSection extends React.Component {
       // If we start with an empty address, go straight to editing
       this.state.isEditingAddress = isAddressEmpty(this.state.editableAddress);
     }
-  }
-
-  componentDidMount() {
-    focusElement('h1');
   }
 
   /* editableAddress is initialized from redux store in the constructor
@@ -273,6 +269,7 @@ export class AddressSection extends React.Component {
     if (this.state.isEditingAddress) {
       addressFields = (
         <div>
+          <h5>Edit Address</h5>
           <Address
             onInput={this.handleChange}
             onBlur={this.dirtyInput}
@@ -294,6 +291,7 @@ export class AddressSection extends React.Component {
     } else {
       addressFields = (
         <div>
+          <h5 className="letters-address">{(this.props.recipientName || '').toLowerCase()}</h5>
           <div className="letters-address street">{streetAddress}</div>
           <div className="letters-address city-state">{cityStatePostal}</div>
           <div className="letters-address country">{country}</div>
@@ -317,7 +315,6 @@ export class AddressSection extends React.Component {
       addressContent = (
         <AddressContent
           saveError={this.props.saveAddressError}
-          name={(this.props.recipientName || '').toLowerCase()}
           addressObject={addressContentLines}>
           {addressFields}
         </AddressContent>

--- a/src/js/letters/containers/DownloadLetters.jsx
+++ b/src/js/letters/containers/DownloadLetters.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import findIndex from 'lodash/fp/findIndex';
+import Scroll from 'react-scroll';
 
 import FormTitle from '../../common/schemaform/FormTitle';
 import SegmentedProgressBar from '../../common/components/SegmentedProgressBar';
@@ -8,10 +9,24 @@ import SegmentedProgressBar from '../../common/components/SegmentedProgressBar';
 import StepHeader from '../components/StepHeader';
 import { chapters } from '../routes';
 
+const Element = Scroll.Element;
+const scroller = Scroll.scroller;
+const scrollToTop = () => {
+  scroller.scrollTo('topScrollElement', window.VetsGov.scroll || {
+    duration: 500,
+    delay: 0,
+    smooth: true
+  });
+};
+
 export class DownloadLetters extends React.Component {
   constructor() {
     super();
     this.navigateToLetterList = this.navigateToLetterList.bind(this);
+  }
+
+  componentDidUpdate() {
+    scrollToTop();
   }
 
   navigateToLetterList() {
@@ -32,6 +47,7 @@ export class DownloadLetters extends React.Component {
 
     return (
       <div className="usa-width-three-fourths letters">
+        <Element name="topScrollElement"/>
         <FormTitle title="VA Letters and Documents"/>
         <div className="va-introtext">
           <p>

--- a/src/js/letters/containers/DownloadLetters.jsx
+++ b/src/js/letters/containers/DownloadLetters.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import findIndex from 'lodash/fp/findIndex';
-import Scroll from 'react-scroll';
 
 import FormTitle from '../../common/schemaform/FormTitle';
 import SegmentedProgressBar from '../../common/components/SegmentedProgressBar';
@@ -9,24 +8,10 @@ import SegmentedProgressBar from '../../common/components/SegmentedProgressBar';
 import StepHeader from '../components/StepHeader';
 import { chapters } from '../routes';
 
-const Element = Scroll.Element;
-const scroller = Scroll.scroller;
-const scrollToTop = () => {
-  scroller.scrollTo('topScrollElement', window.VetsGov.scroll || {
-    duration: 500,
-    delay: 0,
-    smooth: true
-  });
-};
-
 export class DownloadLetters extends React.Component {
   constructor() {
     super();
     this.navigateToLetterList = this.navigateToLetterList.bind(this);
-  }
-
-  componentDidUpdate() {
-    scrollToTop();
   }
 
   navigateToLetterList() {
@@ -47,7 +32,6 @@ export class DownloadLetters extends React.Component {
 
     return (
       <div className="usa-width-three-fourths letters">
-        <Element name="topScrollElement"/>
         <FormTitle title="VA Letters and Documents"/>
         <div className="va-introtext">
           <p>

--- a/src/js/letters/containers/LetterList.jsx
+++ b/src/js/letters/containers/LetterList.jsx
@@ -6,10 +6,15 @@ import CollapsiblePanel from '../../common/components/CollapsiblePanel';
 import DownloadLetterLink from '../components/DownloadLetterLink';
 import VeteranBenefitSummaryLetter from './VeteranBenefitSummaryLetter';
 
+import { focusElement } from '../../common/utils/helpers';
 import { letterContent, bslHelpInstructions } from '../utils/helpers';
 import { AVAILABILITY_STATUSES, LETTER_TYPES } from '../utils/constants';
 
 export class LetterList extends React.Component {
+  componentDidMount() {
+    focusElement('.nav-header');
+  }
+
   render() {
     const downloadStatus = this.props.letterDownloadStatus;
     const letterItems = (this.props.letters || []).map((letter, index) => {

--- a/src/js/letters/containers/LetterList.jsx
+++ b/src/js/letters/containers/LetterList.jsx
@@ -71,7 +71,7 @@ export class LetterList extends React.Component {
     }
 
     return (
-      <div className="step-content">
+      <div className="step-content" aria-live="polite">
         <p>
           To see an explanation about each letter, click on the (+) to expand the box. After you expand the box, you’ll be given the option to download the letter.
         </p>

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -100,7 +100,7 @@ export class VeteranBenefitSummaryLetter extends React.Component {
     if (this.props.optionsAvailable) {
       benefitSummaryContent = (
         <div>
-          <h2>Choose the information you want to include.</h2>
+          <h4>Choose the information you want to include.</h4>
           <h2>Military service information</h2>
           <p>
             Our records show the 3 most recent service periods. There may be additional service periods not shown here.

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -36,6 +36,10 @@
     h5 {
       color: $color-primary-darker;
       padding: 0;
+
+      &:focus {
+        outline: none;
+      }
     }
 
     button {

--- a/test/letters/components/AddressBlock.unit.spec.jsx
+++ b/test/letters/components/AddressBlock.unit.spec.jsx
@@ -3,27 +3,17 @@ import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 import AddressBlock from '../../../src/js/letters/components/AddressBlock';
 
-const defaultProps = { name: 'Gary Todd' };
-
 describe('<AddressBlock/>', () => {
   it('should render', () => {
-    const tree = SkinDeep.shallowRender(<AddressBlock { ...defaultProps }/>);
+    const tree = SkinDeep.shallowRender(<AddressBlock/>);
     const helpText = tree.subTree('p').text();
 
     expect(helpText).to.contain('When you download a letter');
   });
 
-  it('should render name', () => {
-    const tree = SkinDeep.shallowRender(<AddressBlock { ...defaultProps }/>);
-    const helpText = tree.subTree('h5').text();
-
-    expect(helpText).to.contain(defaultProps.name);
-  });
-
   it('should render children', () => {
     const children = (<span>I am a child!</span>);
-    const props = Object.assign({}, defaultProps, { children });
-    const tree = SkinDeep.shallowRender(<AddressBlock { ...props }/>);
+    const tree = SkinDeep.shallowRender(<AddressBlock {...{ children }}/>);
     const helpText = tree.dive(['div', 'span']).text();
 
     expect(helpText).to.contain('I am a child!');


### PR DESCRIPTION
This PR does a couple of things:
1. Focuses on certain elements when the page loads; this helps with tabbing and with the screen reader starting to read from the right place
2. Adds some scrolling functionality to the address section (this does not help with accessibility, but just something I added to this PR quickly)
3. Added some aria attributes that will read sections when the content changes.

Would love if the person who reviews this can pull the branch down and test it themselves to make sure the scrolling and focus elements work as they would expect.