### PR TITLE
If address is unavailable, show system unavailable message

### DIFF
--- a/src/js/letters/containers/Main.jsx
+++ b/src/js/letters/containers/Main.jsx
@@ -30,8 +30,6 @@ export class Main extends React.Component {
     this.props.getLetterList();
     this.props.getMailingAddress();
     this.props.getBenefitSummaryOptions();
-    // FOR TESTING PURPOSES ONLY; DO NOT LET THIS INTO PRODUCTION
-    // this.props.getAddressSuccessAction();
     this.props.getAddressCountries();
     this.props.getAddressStates();
   }
@@ -41,6 +39,11 @@ export class Main extends React.Component {
     // If letters are available, but address is still awaiting response, consider the entire app to still be awaiting response
     if (lettersAvailability === awaitingResponse || addressAvailability === awaitingResponse) {
       return awaitingResponse;
+    }
+
+    // If address isn't available, take the whole system down
+    if (addressAvailability === unavailable) {
+      return backendServiceError;
     }
 
     return lettersAvailability;
@@ -117,8 +120,6 @@ const mapDispatchToProps = {
   getMailingAddress,
   getAddressCountries,
   getAddressStates,
-  // FOR TESTING PURPOSES ONLY; DO NOT LET THIS INTO PRODUCTION
-  // getAddressSuccessAction
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Main);

--- a/test/letters/containers/Main.unit.spec.jsx
+++ b/test/letters/containers/Main.unit.spec.jsx
@@ -75,11 +75,10 @@ describe('<Main>', () => {
     expect(childText).to.equal(testText);
   });
 
-  it('renders its children when letters is available but address is unavailable', () => {
+  it('renders a system down message when letters is available but address is unavailable', () => {
     const props = _.merge({}, defaultProps, { lettersAvailability: available, addressAvailability: unavailable });
     const tree = SkinDeep.shallowRender(<Main {...props}/>);
-    const childText = tree.subTree('span').text();
-    expect(childText).to.equal(testText);
+    expect(tree.subTree('#systemDownMessage')).to.not.be.false;
   });
 
   it('shows a system down message for backend service error', () => {


### PR DESCRIPTION
The unavailability of the address doesn't actually affect the veteran's ability to download their letters, but it may be confusing for that bit to not work but for them to _still_ be able to download their letters.

Before merging this, I want to be 100% certain this is the right thing to do since it will affect how we serve our Veterans.

**Update:** I confirmed with @kreek that this _is_ what we want to do.