### PR TITLE
Remove address fetch error warning

### DIFF
--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -11,7 +11,6 @@ import {
   isMilitaryAddress,
   isInternationalAddress,
   addressUpdateUnavailable,
-  invalidAddressProperty,
   inferAddressType,
   resetDisallowedAddressFields
 } from '../utils/helpers';
@@ -26,7 +25,6 @@ import {
   countryValidations,
   cityValidations
 } from '../utils/validations';
-import { AVAILABILITY_STATUSES } from '../utils/constants';
 
 // The address is empty if every field except type is falsey.
 // NOTE: It "shouldn't" ever happen, but it did in testing, so...paranoid programming!
@@ -291,11 +289,8 @@ export class AddressSection extends React.Component {
 
     let addressContent;
     // If countries and states are not available when they try to update their address,
-    // or if the fetch for address failed,
     // they will see this warning message instead of the address fields.
-    if (this.props.addressAvailability === AVAILABILITY_STATUSES.unavailable) {
-      addressContent = invalidAddressProperty;
-    } else if (this.state.isEditingAddress && (!this.props.countriesAvailable || !this.props.statesAvailable)) {
+    if (this.state.isEditingAddress && (!this.props.countriesAvailable || !this.props.statesAvailable)) {
       addressContent = (
         <div className="step-content">
           {addressUpdateUnavailable}

--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -22,19 +22,6 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
   return commonApiClient(requestUrl, optionalSettings, success, error);
 }
 
-export const invalidAddressProperty = (
-  <div id="invalidAddress">
-    <div className="usa-alert usa-alert-error">
-      <div className="usa-alert-body">
-        <h2 className="usa-alert-heading">Address unavailable</h2>
-        <p className="usa-alert-text">
-          We’re encountering an error with your address information. This is not required for your letters, but if you’d like to see the address we have on file, or to update it, please visit <a href="/" target="_blank">this link</a>.
-        </p>
-      </div>
-    </div>
-  </div>
-);
-
 export const addressUpdateUnavailable = (
   <div>
     <div className="usa-alert usa-alert-warning">


### PR DESCRIPTION
The final decision was to just remove the warning entirely since https://github.com/department-of-veterans-affairs/vets-website/pull/6683 makes it impossible to get to such a state anyhow.

This has no visual changes, it's just a bit of cleanup.