### PR TITLE
Fix USWDS upgrade issue

### DIFF
--- a/src/js/common/components/CollapsiblePanel.jsx
+++ b/src/js/common/components/CollapsiblePanel.jsx
@@ -50,7 +50,7 @@ export default class CollapsiblePanel extends React.Component {
         <Element name={`collapsible-panel-${this.id}-scroll-element`}/>
         <div className="accordion-header clearfix">
           <button
-            className="usa-accordion-button"
+            className="usa-accordion-button usa-button-unstyled"
             aria-expanded={this.state.open ? 'true' : 'false'}
             aria-controls={`collapsible-${this.id}`}
             onClick={this.toggleChapter}>

--- a/src/js/letters/containers/DownloadLetters.jsx
+++ b/src/js/letters/containers/DownloadLetters.jsx
@@ -26,7 +26,9 @@ export class DownloadLetters extends React.Component {
     let viewLettersButton;
     if (location.pathname === '/confirm-address') {
       viewLettersButton = (
-        <button onClick={this.navigateToLetterList} className="usa-button-primary view-letters-button">View Letters</button>
+        <div className="step-content">
+          <button onClick={this.navigateToLetterList} className="usa-button-primary view-letters-button">View Letters</button>
+        </div>
       );
     }
 

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -36,6 +36,10 @@
     h5 {
       color: $color-primary-darker;
       padding: 0;
+
+      &:focus {
+        outline: none;
+      }
     }
 
     button {

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -51,10 +51,6 @@
     text-transform: capitalize;
   }
 
-  .view-letters-button {
-    margin: 2em;
-  }
-
   .accordion-header > button {
     min-height: 6rem;
     padding-top: 1.5rem;

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -36,10 +36,6 @@
     h5 {
       color: $color-primary-darker;
       padding: 0;
-
-      &:focus {
-        outline: none;
-      }
     }
 
     button {
@@ -49,6 +45,10 @@
 
   .letters-address {
     text-transform: capitalize;
+  }
+
+  .view-letters-button {
+    margin: 2em 0;
   }
 
   .accordion-header > button {


### PR DESCRIPTION
There are 2 issues this PR fixes:

1. `CollapsiblePanel` styles were broken on the letters app. The fix is to add a class of `.usa-button-unstyled` to the `button` in `CollapsiblePanel` common component (currently, this component is only being used by the letters app). This is what the `ReviewCollapsibleChapter` component does, which is used by the rjsf forms on the review page. This basically prevents the offending styles from being applied, which were coming from styles in `/sass/modules/_m-form-process.scss`: `.form-review-panel button:not(.usa-button-styled)`.

In general I don't have a good sense of why these `_m-form-process` styles exist, and if they will continue to create issues, but we can address that in a separate PR. The only class that should be needed on the `button` is `.usa-accordion-button` (according to https://standards.usa.gov/components/accordions/), and shouldn't need to be overridden with the addition of `.usa-button-unstyled`, so something in our codebase is breaking that and I'd like to understand why.

#### Before
<img width="853" alt="screen shot 2017-11-01 at 4 11 38 pm" src="https://user-images.githubusercontent.com/25183456/32295340-5f221f74-bf1f-11e7-954e-970e02611230.png">

#### After
<img width="891" alt="screen shot 2017-11-01 at 4 06 14 pm" src="https://user-images.githubusercontent.com/25183456/32295344-65043b20-bf1f-11e7-8f78-541f392f0f23.png">

2. Noticed a slightly borked style on mobile with the buttons (existed before the USWDS upgrade) and just wanted to fix quickly.

#### Before
<img width="429" alt="screen shot 2017-11-01 at 4 32 55 pm" src="https://user-images.githubusercontent.com/25183456/32296341-5bbfc14e-bf22-11e7-9748-f54193bc9544.png">

#### After
<img width="432" alt="screen shot 2017-11-01 at 4 31 40 pm" src="https://user-images.githubusercontent.com/25183456/32296319-49438140-bf22-11e7-9813-112656430c6e.png">
