### PR TITLE
Letters address update fix mg

### DIFF
--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -1,7 +1,7 @@
 import Raven from 'raven-js';
 import { isEqual } from 'lodash';
 
-import { apiRequest, stripEmpties, militaryToGeneric } from '../utils/helpers.jsx';
+import { apiRequest, stripEmpties, toGenericAddress } from '../utils/helpers.jsx';
 import {
   ADDRESS_TYPES,
   BACKEND_AUTHENTICATION_ERROR,
@@ -84,7 +84,7 @@ export function getMailingAddress() {
       (response) => {
         const responseCopy = Object.assign({}, response);
         // translate military address properties to generic properties for use in front end
-        responseCopy.data.attributes.address = militaryToGeneric(response.data.attributes.address);
+        responseCopy.data.attributes.address = toGenericAddress(response.data.attributes.address);
         return dispatch({
           type: GET_ADDRESS_SUCCESS,
           data: responseCopy
@@ -234,7 +234,7 @@ export function saveAddress(address) {
       settings,
       (response) => {
         // translate military address properties back to front end address
-        const responseAddress = militaryToGeneric(response.data.attributes.address);
+        const responseAddress = toGenericAddress(response.data.attributes.address);
         if (!isEqual(stripEmpties(address), stripEmpties(responseAddress))) {
           const mismatchError = new Error('letters-address-update addresses don\'t match');
           Raven.captureException(mismatchError);

--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -348,11 +348,12 @@ export const stripEmpties = (input) => {
  * @param {Object} address an address object as formatted by vets-api
  * @returns {Object} shallow clone of address with military properties swapped for generics
  */
-export const militaryToGeneric = (address) => {
-  if (address.type !== ADDRESS_TYPES.military) {
-    return { ...address };
-  }
+export const toGenericAddress = (address) => {
   const genericAddress = { ...address };
+  delete genericAddress.addressEffectiveDate;
+  if (address.type !== ADDRESS_TYPES.military) {
+    return genericAddress;
+  }
   genericAddress.city = genericAddress.militaryPostOfficeTypeCode;
   genericAddress.stateCode = genericAddress.militaryStateCode;
   genericAddress.countryName = 'USA';

--- a/test/letters/actions/letters.unit.spec.js
+++ b/test/letters/actions/letters.unit.spec.js
@@ -59,19 +59,30 @@ const getState = () => ({});
 
 describe('saveAddress', () => {
   const frontEndAddress = {
-    type: ADDRESS_TYPES.military,
+    addressOne: '123 Any Street',
+    addressThree: '',
+    addressTwo: 'Apt 102',
     city: 'APO',
+    countryName: 'USA',
     stateCode: 'AE',
-    countryName: 'USA'
+    type: ADDRESS_TYPES.military,
+    zipCode: '12345',
+    zipSuffix: ''
   };
 
   const successResponse = {
     data: {
       attributes: {
         address: {
-          type: frontEndAddress.type,
+          addressEffectiveDate: null,
+          addressOne: frontEndAddress.addressOne,
+          addressThree: frontEndAddress.addressThree,
+          addressTwo: frontEndAddress.addressTwo,
           militaryPostOfficeTypeCode: frontEndAddress.city,
           militaryStateCode: frontEndAddress.stateCode,
+          type: frontEndAddress.type,
+          zipCode: frontEndAddress.zipCode,
+          zipSuffix: frontEndAddress.zipSuffix
         }
       }
     }
@@ -111,8 +122,8 @@ describe('saveAddress', () => {
     thunk(dispatch, getState)
       .then(() => {
         const action = dispatch.secondCall.args[0];
-        expect(action.type).to.equal(SAVE_ADDRESS_SUCCESS);
         expect(action.address).to.eql(frontEndAddress);
+        expect(action.type).to.equal(SAVE_ADDRESS_SUCCESS);
       }).then(done, done);
   });
 

--- a/test/letters/utils/helpers.unit.spec.jsx
+++ b/test/letters/utils/helpers.unit.spec.jsx
@@ -9,7 +9,7 @@ import {
   inferAddressType,
   resetDisallowedAddressFields,
   stripEmpties,
-  militaryToGeneric
+  toGenericAddress
 } from '../../../src/js/letters/utils/helpers';
 
 const address = {
@@ -166,7 +166,7 @@ describe('Letters helpers: ', () => {
     });
   });
 
-  describe('military to generic', () => {
+  describe('toGenericAddress', () => {
     const militaryAddress = {
       addressEffectiveDate: '2012-04-03T04:00:00.000+00:00',
       addressOne: '57 COLUMBUS STRASSA',
@@ -174,6 +174,18 @@ describe('Letters helpers: ', () => {
       addressTwo: '',
       militaryPostOfficeTypeCode: 'APO',
       militaryStateCode: 'AE',
+      type: 'MILITARY',
+      zipCode: '09028',
+      zipSuffix: ''
+    };
+
+    const genericFromMilitary = {
+      addressOne: '57 COLUMBUS STRASSA',
+      addressThree: '',
+      addressTwo: '',
+      city: 'APO',
+      stateCode: 'AE',
+      countryName: 'USA',
       type: 'MILITARY',
       zipCode: '09028',
       zipSuffix: ''
@@ -192,32 +204,31 @@ describe('Letters helpers: ', () => {
       zipSuffix: ''
     };
 
-    const genericAddress = {
-      addressEffectiveDate: '2012-04-03T04:00:00.000+00:00',
+    const genericFromDomestic = {
       addressOne: '57 COLUMBUS STRASSA',
       addressThree: '',
       addressTwo: '',
-      city: 'APO',
-      stateCode: 'AE',
+      city: 'Chicago',
+      stateCode: 'IL',
       countryName: 'USA',
-      type: 'MILITARY',
-      zipCode: '09028',
+      type: 'DOMESTIC',
+      zipCode: '06628',
       zipSuffix: ''
     };
 
     it('translates military addresses to generic', () => {
-      const actualAddress = militaryToGeneric(militaryAddress);
-      expect(actualAddress).to.eql(genericAddress);
+      const actualAddress = toGenericAddress(militaryAddress);
+      expect(actualAddress).to.eql(genericFromMilitary);
     });
 
-    it('lets non-military address types pass through unmodified', () => {
-      const actualAddress = militaryToGeneric(domesticAddress);
-      expect(actualAddress).to.eql(domesticAddress);
+    it('translates non-military address to generic', () => {
+      const actualAddress = toGenericAddress(domesticAddress);
+      expect(actualAddress).to.eql(genericFromDomestic);
     });
 
     it('returns a clone for all cases', () => {
-      const militaryTest = militaryToGeneric(militaryAddress);
-      const nonMilitaryTest = militaryToGeneric(domesticAddress);
+      const militaryTest = toGenericAddress(militaryAddress);
+      const nonMilitaryTest = toGenericAddress(domesticAddress);
       expect(militaryTest).to.not.equal(militaryAddress);
       expect(nonMilitaryTest).to.not.equal(domesticAddress);
     });


### PR DESCRIPTION
- Don't store `addressEffectiveDate` property of `address` in Redux store
- ^ means that `addressEffectiveDate` isn't submitted to `vets-api` when an updated address is PUT
- Strip out `addressEffectiveDate` property from PUT response so that we can compare the response against the PUT values accurately
- Update associated tests