### PR TITLE
Stop opening a new window in IE

### DIFF
--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -144,7 +144,7 @@ export function getLetterPdf(letterType, letterName, letterOptions) {
     const downloadSupported = typeof save.download !== 'undefined';
     let downloadWindow;
 
-    if (!downloadSupported) {
+    if (!downloadSupported && !isIE) {
       // Instead of giving the file a readable name and downloading
       // it directly, open it in a new window with an ugly hash URL
       // NOTE: We're opening the window here because Safari won't open


### PR DESCRIPTION
The window to oblivion is back. This shuts that portal to never open it again!

The history is something like this: I fixed this by moving that `window.open()` chunk down in the callback, but to get it to work in Safari, we have to call `window.open()` _before_ the callback. Unfortunately, IE opens that window because it doesn't support `download`...and then it never uses it. To fix that, we just make sure we don't open that tab for IE. Problem solved.