### PR TITLE
Validate against special characters

### DIFF
--- a/src/js/letters/utils/validations.js
+++ b/src/js/letters/utils/validations.js
@@ -15,6 +15,14 @@ const requiredValidator = (input, fullAddress, message = requiredMessage) => {
   return true;
 };
 
+const specialCharacterValidator = (input) => {
+  if (/[^A-Za-z0-9 #%&'()+,./:@]/.test(input)) {
+    return "Please only use letters, numbers, and the special characters #%&'()+,./:@";
+  }
+
+  return true;
+};
+
 
 /**
  * The signature of all validation functions is always the following
@@ -27,7 +35,8 @@ const requiredValidator = (input, fullAddress, message = requiredMessage) => {
  *                               if an error message is returned)
  */
 export const addressOneValidations = [
-  (input, fullAddress) => requiredValidator(input, fullAddress, 'Please enter a street address')
+  (input, fullAddress) => requiredValidator(input, fullAddress, 'Please enter a street address'),
+  specialCharacterValidator
 ];
 
 export const postalCodeValidations = [


### PR DESCRIPTION
This just runs a specific validation against `addressOne` to filter out certain special characters. Okay, technically, it just whitelists certain characters, but that's probably splitting hairs.

Things I'm uncertain of:
- Does this validation match what's in production?
  - The swagger docs are unclear, saying only that "Address must specify a valid address one"
- Should we run this against _only_ `addressOne`?
- Should it really disallow `-`?
  - The error message didn't include that in the list of accepted special characters, but it seems like that's pretty likely to show up in an actual (valid) address

@kreek can you answer any of those questions or point me in the right direction?