### PR TITLE
Address edit letters mg

### DIFF
--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -60,7 +60,7 @@ export class AddressSection extends React.Component {
     if (Object.keys(this.state.editableAddress).length > 0) {
       this.state.hasLoadedAddress = true;
       // If we start with an empty address, go straight to editing
-      this.state.isEditingAddress = isAddressEmpty(this.state.editableAddress);
+      this.state.isEditingAddress = (isAddressEmpty(this.state.editableAddress) && this.props.canUpdate);
     }
   }
 

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -261,7 +261,7 @@ describe('<AddressSection>', () => {
   // Not sure how to test this bit yet...
   // it('should scroll to first error', () => {});
 
-  it('should start in the editing state if address is empty', () => {
+  it('should start in the editing state if address is empty and user canUpdate', () => {
     const props = cloneDeep(defaultProps);
     props.savedAddress = {
       addressOne: '',
@@ -277,6 +277,25 @@ describe('<AddressSection>', () => {
     const instance = tree.getMountedInstance();
     expect(instance.state.isEditingAddress).to.be.true;
   });
+
+  it('should not start editing if address is empty but user !canUpdate', () => {
+    const props = cloneDeep(defaultProps);
+    props.savedAddress = {
+      addressOne: '',
+      addressTwo: '',
+      addressThree: '',
+      city: '',
+      countryName: '',
+      stateCode: '',
+      type: ADDRESS_TYPES.domestic
+    };
+    props.canUpdate = false;
+
+    const tree = SkinDeep.shallowRender(<AddressSection {...props}/>);
+    const instance = tree.getMountedInstance();
+    expect(instance.state.isEditingAddress).to.be.false;
+  });
+
 
   describe('validation', () => {
     // Spy on all the validation functions!


### PR DESCRIPTION
Gates address update functionality for users with blank address to ensure only users who `canUpdate` are presented with the edit form by default.

Note - blank addresses shouldn't be possible to get back from EVSS, so this state shouldn't be possible in Prod. We're seeing it in Staging, probably because of bad test data, so this change is purely precautionary.