### PR TITLE
Fix for session timeout dialog not showing up

### DIFF
--- a/src/js/auth/containers/AuthApp.jsx
+++ b/src/js/auth/containers/AuthApp.jsx
@@ -39,7 +39,7 @@ class AuthApp extends React.Component {
     parent.sessionStorage.removeItem('userToken');
     parent.sessionStorage.setItem('userToken', token);
     parent.sessionStorage.removeItem('entryTime');
-    parent.sessionStorage.setItem('entryTime', new Date);
+    parent.sessionStorage.setItem('entryTime', new Date());
     parent.postMessage(token, environment.BASE_URL);
 
     // This will trigger a browser reload if the user is using IE or Edge.

--- a/src/js/auth/containers/AuthApp.jsx
+++ b/src/js/auth/containers/AuthApp.jsx
@@ -38,6 +38,8 @@ class AuthApp extends React.Component {
     const parent = window.opener;
     parent.sessionStorage.removeItem('userToken');
     parent.sessionStorage.setItem('userToken', token);
+    parent.sessionStorage.removeItem('entryTime');
+    parent.sessionStorage.setItem('entryTime', new Date);
     parent.postMessage(token, environment.BASE_URL);
 
     // This will trigger a browser reload if the user is using IE or Edge.


### PR DESCRIPTION
The `entryTime` property, which is used as a timestamp after a user token is retrieved, was not being set on the session storage after retrieving a new user token, which caused the session timeout confirmation box to never appear. This initializes that property after retrieving a new user token.

Resolves department-of-veterans-affairs/vets.gov-team/issues/3337