### PR TITLE
Catch loading errors and log data to Sentry

### DIFF
--- a/src/js/common/schemaform/FormApp.jsx
+++ b/src/js/common/schemaform/FormApp.jsx
@@ -107,7 +107,11 @@ class FormApp extends React.Component {
       && status !== this.props.loadedStatus
       && !window.location.pathname.endsWith('/error')
     ) {
-      newProps.router.push(`${newProps.formConfig.urlPrefix || ''}error`);
+      let action = 'push';
+      if (window.location.pathname.endsWith('resume')) {
+        action = 'replace';
+      }
+      newProps.router[action](`${newProps.formConfig.urlPrefix || ''}error`);
     } else if (newProps.savedStatus !== this.props.savedStatus &&
       newProps.savedStatus === SAVE_STATUSES.success) {
       newProps.router.push(`${newProps.formConfig.urlPrefix || ''}form-saved`);


### PR DESCRIPTION
We're getting some Sentry errors in the formState logic when loading a form, this PR changes the error handling to sanitize and send the saved form data to Sentry so we can do further debugging.