### PR TITLE
Handle schema validation errors for non-veteran filled out pre-needs forms

### DIFF
--- a/src/js/pre-need/utils/helpers.js
+++ b/src/js/pre-need/utils/helpers.js
@@ -6,6 +6,7 @@ import fullNameUI from '../../common/schemaform/definitions/fullName';
 import ssnUI from '../../common/schemaform/definitions/ssn';
 import TextWidget from '../../common/schemaform/widgets/TextWidget';
 import ServicePeriodView from '../../common/schemaform/ServicePeriodView';
+import { stringifyFormReplacer, filterViewFields } from '../../common/schemaform/helpers';
 
 export function isVeteran(item) {
   return get('application.claimant.relationshipToVet', item) === '1';
@@ -57,19 +58,30 @@ export function transform(formConfig, form) {
           applicantPhoneNumber: application.claimant.phoneNumber,
           mailingAddress: application.claimant.address,
           name: application.claimant.name
-        }
+        },
       }) : application;
+  };
+
+  // Copy over veteran data if a sponsor is filling out the form
+  const populateVeteranData = (application) => {
+    return merge(application, {
+      veteran: {
+        serviceName: application.veteran.serviceName || application.veteran.currentName
+      }
+    });
   };
 
   const application = [
     populateSponsorData,
     populatePreparerData,
+    populateVeteranData,
+    filterViewFields
   ].reduce((result, func) => func(result), form.data.application);
 
   // const formCopy = set('application', application, Object.assign({}, form));
   // const formData = transformForSubmit(formConfig, formCopy);
 
-  return JSON.stringify({ application });
+  return JSON.stringify({ application }, stringifyFormReplacer);
 
   /* Transformation for multiple applicants.
    *

--- a/src/js/pre-need/utils/helpers.js
+++ b/src/js/pre-need/utils/helpers.js
@@ -58,7 +58,7 @@ export function transform(formConfig, form) {
           applicantPhoneNumber: application.claimant.phoneNumber,
           mailingAddress: application.claimant.address,
           name: application.claimant.name
-        },
+        }
       }) : application;
   };
 

--- a/test/pre-needs/utils/helpers.unit.spec.js
+++ b/test/pre-needs/utils/helpers.unit.spec.js
@@ -1,0 +1,54 @@
+import { transform } from '../../../src/js/pre-need/utils/helpers';
+import { expect } from 'chai';
+
+describe('Preneed helpers', () => {
+  describe('transform', () => {
+    it('should remove view fields', () => {
+      const data = JSON.parse(transform({}, {
+        data: {
+          application: {
+            claimant: {},
+            veteran: {},
+            'view:testing': 'asdfadf'
+          }
+        }
+      }));
+
+      expect(data.application['view:testing']).to.be.undefined;
+    });
+
+    it('should populate service name', () => {
+      const data = JSON.parse(transform({}, {
+        data: {
+          application: {
+            claimant: {},
+            veteran: {
+              currentName: 'testing'
+            },
+            'view:testing': 'asdfadf'
+          }
+        }
+      }));
+
+      expect(data.application.veteran.serviceName).to.equal(data.application.veteran.currentName);
+    });
+
+    it('should remove partial addresses', () => {
+      const data = JSON.parse(transform({}, {
+        data: {
+          application: {
+            claimant: {
+              address: {
+                country: 'USA',
+                city: 'test'
+              }
+            },
+            veteran: {},
+          }
+        }
+      }));
+
+      expect(data.application.claimant.address).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
This fixes the following validation errors I saw when submitting the pre-needs form as a non-veteran applicant:

- `view:` fields were sometimes included
- `serviceName` was not set to `currentName` for the veteran
- Partial addresses were being sent through to the backend