### PR TITLE
Appeals housekeeping

### DIFF
--- a/src/js/claims-status/containers/YourClaimsPage.jsx
+++ b/src/js/claims-status/containers/YourClaimsPage.jsx
@@ -51,7 +51,7 @@ class YourClaimsPage extends React.Component {
     }
 
     if (this.props.canAccessAppeals) {
-      if (__BUILDTYPE__ !== 'production') {
+      if (__BUILDTYPE__ === 'development') {
         // Fetch against the new endpoint
         this.props.getAppealsV2();
       } else {

--- a/src/js/claims-status/reducers/appeals.js
+++ b/src/js/claims-status/reducers/appeals.js
@@ -19,11 +19,11 @@ export default function appealsReducer(state = initialState, action) {
       return _.merge(state, {
         appealsLoading: false,
         available: true,
-        appeals: action.appeals
       });
     case SET_APPEALS:
       return _.set('available', true, state);
     case SET_APPEALS_UNAVAILABLE:
+      // Maybe should set appealsLoading to false here too
       return _.set('available', false, state);
     default:
       return state;

--- a/src/js/claims-status/reducers/claims-list.js
+++ b/src/js/claims-status/reducers/claims-list.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp';
 import moment from 'moment';
 
 import { SET_CLAIMS, SET_APPEALS, FILTER_CLAIMS, SORT_CLAIMS, CHANGE_CLAIMS_PAGE, SHOW_CONSOLIDATED_MODAL, HIDE_30_DAY_NOTICE,
-  FETCH_APPEALS, FETCH_CLAIMS, SET_CLAIMS_UNAVAILABLE, SET_APPEALS_UNAVAILABLE } from '../actions/index.jsx';
+  FETCH_APPEALS, FETCH_APPEALS_SUCCESS, FETCH_CLAIMS, SET_CLAIMS_UNAVAILABLE, SET_APPEALS_UNAVAILABLE } from '../actions/index.jsx';
 import { getClaimType } from '../utils/helpers';
 
 const ROWS_PER_PAGE = 10;
@@ -104,6 +104,8 @@ export default function claimsReducer(state = initialState, action) {
         claimsLoading: false,
       });
     }
+    case FETCH_APPEALS_SUCCESS:
+      return _.set('appeals', action.appeals, state);
     case SET_APPEALS: {
       const visibleAppeals = sortList(filterList(action.appeals, action.filter), state.sortProperty);
       const visibleList = sortList(filterList(state.claims, action.filter).concat(visibleAppeals), state.sortProperty);


### PR DESCRIPTION
1. Makes the appeals v2 api requests in development only
2. Puts the appeals from :point_up: in the `claims` store (franchise?)