### PR TITLE
Appeals v2 CurrentStatus component & helpers

### DIFF
--- a/src/js/claims-status/actions/index.jsx
+++ b/src/js/claims-status/actions/index.jsx
@@ -107,8 +107,10 @@ export function getAppealsV2() {
             aod: false,
             location: 'aoj',
             status: {
-              type: 'tbd', // Need to get a real status type
-              details: {}
+              type: 'nod', // This may or may not be a real status type
+              details: { // Don't actually know what's in here
+                regionalOffice: 'Chicago Regional Office'
+              }
             },
             docket: {
               front: false,

--- a/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
+++ b/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
@@ -1,12 +1,17 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-class CurrentStatus extends React.Component {
-  render() {
-    return (
-      <div>CurrentStatus</div>
-    );
-  }
-}
+const CurrentStatus = ({ title, description }) => (
+  <div>
+    <h3>Current Status</h3>
+    <h4>{title}</h4>
+    <p>{description}</p>
+  </div>
+);
+
+CurrentStatus.PropTypes = {
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+};
 
 export default CurrentStatus;
-

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -245,7 +245,7 @@ export function getClaimType(claim) {
 }
 
 // TO DO: Replace made up properties and content with real versions once finalized.
-export const STATUS_CONTENT = {
+export const STATUS_TYPES = {
   nod: 'nod',
   awaitingHearingDate: 'awaiting_hearing_date',
   bvaDecision: 'bva_decision',
@@ -263,7 +263,7 @@ export const STATUS_CONTENT = {
  * @returns {Contents}
  */
 export function getStatusContents(type, details) {
-  const { nod, awaitingHearingDate, bvaDecision } = STATUS_CONTENT;
+  const { nod, awaitingHearingDate, bvaDecision } = STATUS_TYPES;
 
   const contents = {};
   if (type === nod) {

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -243,3 +243,97 @@ export function getCompletedDate(claim) {
 export function getClaimType(claim) {
   return claim.attributes.claimType || 'Disability Compensation';
 }
+
+// TO DO: Replace made up properties and content with real versions once finalized.
+export const STATUS_CONTENT = {
+  nod: 'nod',
+  awaitingHearingDate: 'awaiting_hearing_date',
+  bvaDecision: 'bva_decision',
+};
+
+// TO DO: Replace made up properties and content with real versions once finalized.
+/**
+ * Grabs the matching title and dynamically-generated description for a given current status type
+ * @typedef {Object} Contents
+ * @property {string} title a current status type's title
+ * @property {string} description a short paragraph describing the current status
+ * ----------------------------------------------------------------------------------------------
+ * @param {string} statusType the status type of a claim appeal as returned by the api
+ * @param {Object} details optional, properties vary depending on the status type
+ * @returns {Contents}
+ */
+export function getStatusContents(type, details) {
+  const { nod, awaitingHearingDate, bvaDecision } = STATUS_CONTENT;
+
+  const contents = {};
+  if (type === nod) {
+    const office = details.regionalOffice || 'Regional Office';
+    contents.title = `The ${office} is reviewing your appeal`;
+    contents.description = `The ${office} received your Notice of Disagreement and is revewing 
+      your appeal. This means they review all of the evidence related to your appeal, including 
+      any new evidence you submit. They may contact you to request additional evidence or 
+      medical examinations, as needed. When they have completed their review, they will 
+      determine whether or not they can grant your appeal.`;
+  } else if (type === awaitingHearingDate) {
+    const hearingType = details.hearingType || 'hearing';
+    const currenltyHearing = details.currentlyHearing || 'an earlier month';
+    contents.title = 'You are waiting for your hearing date';
+    contents.description = `You have selected to have a ${hearingType} in your form 9. 
+      Currently the Board is having hearings for appeals of ${currenltyHearing}`;
+  } else if (type === bvaDecision) {
+    const decisionType = details.decisionType || 'Unknown (please wait for your letter)';
+    contents.title = 'The Board has made a decision on your appeal';
+    contents.description = `The Board of Veterans’ Appeals has made a decision on your appeal. 
+    You will receive your decision letter in the mail in 7 business days. Your appeal  
+    decision is: ${decisionType}`;
+  } else {
+    contents.title = 'Current Status Unknown';
+    contents.description = 'Your current appeal status is unknown at this time';
+  }
+
+  return contents;
+}
+
+// Alternative implementation
+// export function getStatusContents(type, details) {
+//   // Define content for each status type
+//   const makeNodContents = (info) => {
+//     const office = info.regionalOffice || 'Regional Office';
+//     const title = `The ${office} is reviewing your appeal`;
+//     const description = `The ${office} received your Notice of Disagreement and is revewing 
+//       your appeal. This means they review all of the evidence related to your appeal, including 
+//       any new evidence you submit. They may contact you to request additional evidence or 
+//       medical examinations, as needed. When they have completed their review, they will 
+//       determine whether or not they can grant your appeal.`;
+//     return { title, description };
+//   };
+
+//   const makeAwaitingHearingDateContents = (info) => {
+//     const hearingType = info.hearingType || 'hearing';
+//     const currenltyHearing = info.currentlyHearing || 'an earlier month';
+//     const title = 'You are waiting for your hearing date';
+//     const description = `You have selected to have a ${hearingType} in your form 9. 
+//       Currently the Board is having hearings for appeals of ${currenltyHearing}`;
+//     return { title, description };
+//   };
+
+//   const makeBvaDecisionContents = (info) => {
+//     const decisionType = info.decisionType || 'Unknown (please wait for your letter)';
+//     const title = 'The Board has made a decision on your appeal';
+//     const description = `The Board of Veterans’ Appeals has made a decision on your appeal. 
+//     You will receive your decision letter in the mail in 7 business days. Your appeal  
+//     decision is: ${decisionType}`;
+//     return { title, description };
+//   };
+
+//   // map content to known 'current status' types
+//   // TO DO: what happens if we get a bad type from the api?
+//   const makeContent = {
+//     nod: makeNodContents,
+//     awaitingHearingDate: makeAwaitingHearingDateContents,
+//     bvaDecision: makeBvaDecisionContents
+//   };
+
+//   // Return a new content object with title and description
+//   return makeContent[type](details);
+// }

--- a/test/claims-status/components/appeals-v2/CurrentStatus.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/CurrentStatus.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import SD from 'skin-deep';
+import { shallow, render } from 'enzyme';
 import { expect } from 'chai';
 
 import CurrentStatus from '../../../../src/js/claims-status/components/appeals-v2/CurrentStatus';
@@ -11,7 +11,23 @@ const defaultProps = {
 
 describe('<CurrentStatus/>', () => {
   it('should render', () => {
-    const tree = SD.shallowRender(<CurrentStatus {...defaultProps}/>);
-    expect(tree.type).to.equal('div');
+    const wrapper = shallow(<CurrentStatus {...defaultProps}/>);
+    expect(wrapper.type()).to.equal('div');
+  });
+
+  it('should render title and description from passed in props', () => {
+    const props = {
+      title: 'The Chicago Regional Office is reviewing your appeal',
+      description: `The Chicago Regional Office received your Notice of Disagreement and is 
+      revewing your appeal. This means they review all of the evidence related to your appeal, 
+      including any new evidence you submit. They may contact you to request additional evidence 
+      or medical examinations, as needed. When they have completed their review, they will 
+      determine whether or not they can grant your appeal.`
+    };
+    const wrapper = render(<CurrentStatus {...props}/>);
+    const statusTitle = wrapper.find('h4').text();
+    const statusDescription = wrapper.find('p').text();
+    expect(statusTitle).to.equal(props.title);
+    expect(statusDescription).to.equal(props.description);
   });
 });

--- a/test/claims-status/components/appeals-v2/CurrentStatus.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/CurrentStatus.unit.spec.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import SD from 'skin-deep';
+import { expect } from 'chai';
+
+import CurrentStatus from '../../../../src/js/claims-status/components/appeals-v2/CurrentStatus';
+
+const defaultProps = {
+  title: '',
+  description: ''
+};
+
+describe('<CurrentStatus/>', () => {
+  it('should render', () => {
+    const tree = SD.shallowRender(<CurrentStatus {...defaultProps}/>);
+    expect(tree.type).to.equal('div');
+  });
+});

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -17,7 +17,7 @@ import {
   makeAuthRequest,
   getClaimType,
   getStatusContents,
-  STATUS_CONTENT,
+  STATUS_TYPES,
 } from '../../../src/js/claims-status/utils/helpers';
 
 describe('Disability benefits helpers: ', () => {
@@ -451,9 +451,9 @@ describe('Disability benefits helpers: ', () => {
     });
   });
 
-  describe('getStatusContents', () => {
+  describe.only('getStatusContents', () => {
     it('returns an object with correct title & description', () => {
-      const type = STATUS_CONTENT.nod;
+      const type = STATUS_TYPES.nod;
       const details = { regionalOffice: 'Chicago Regional Office' };
       const contents = getStatusContents(type, details);
       expect(contents.title).to.equal('The Chicago Regional Office is reviewing your appeal');

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -451,7 +451,7 @@ describe('Disability benefits helpers: ', () => {
     });
   });
 
-  describe.only('getStatusContents', () => {
+  describe('getStatusContents', () => {
     it('returns an object with correct title & description', () => {
       const type = STATUS_TYPES.nod;
       const details = { regionalOffice: 'Chicago Regional Office' };

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -15,7 +15,9 @@ import {
   isClaimComplete,
   itemsNeedingAttentionFromVet,
   makeAuthRequest,
-  getClaimType
+  getClaimType,
+  getStatusContents,
+  STATUS_CONTENT,
 } from '../../../src/js/claims-status/utils/helpers';
 
 describe('Disability benefits helpers: ', () => {
@@ -446,6 +448,22 @@ describe('Disability benefits helpers: ', () => {
       };
 
       makeAuthRequest('/testing', null, dispatch, onSuccess, onError);
+    });
+  });
+
+  describe('getStatusContents', () => {
+    it('returns an object with correct title & description', () => {
+      const type = STATUS_CONTENT.nod;
+      const details = { regionalOffice: 'Chicago Regional Office' };
+      const contents = getStatusContents(type, details);
+      expect(contents.title).to.equal('The Chicago Regional Office is reviewing your appeal');
+    });
+
+    it('returns sane object when given unknown type', () => {
+      const type = 123;
+      const contents = getStatusContents(type);
+      expect(contents.title).to.equal('Current Status Unknown');
+      expect(contents.description).to.equal('Your current appeal status is unknown at this time');
     });
   });
 });


### PR DESCRIPTION
Adds a component that displays the current status for an appeal, as well as a helper that retrieves the right content based on the status type.

Lots of fake content in here as it's still being finalized. Also need to get some feedback on implementation (the content list will grow by more than 3x so the current approach may get messy).