### PR TITLE
Handle null field error

### DIFF
--- a/src/js/common/schemaform/formState.js
+++ b/src/js/common/schemaform/formState.js
@@ -161,7 +161,9 @@ export function setHiddenFields(schema, uiSchema, formData, path = []) {
  * a user can’t see.
  */
 export function removeHiddenData(schema, data) {
-  if (isHiddenField(schema) || typeof data === 'undefined') {
+  // null is necessary here because Rails 4 will convert empty arrays to null
+  // In the forms, there's no difference between an empty array and null or undefined
+  if (isHiddenField(schema) || typeof data === 'undefined' || data === null) {
     return undefined;
   }
 


### PR DESCRIPTION
Treats nulls as undefined values in the form state updates. This is necessary because of how Rails 4 handles data set as parameters.