### PR TITLE
Implement helper function for rendering all site-wide components

### DIFF
--- a/src/js/burials/burials-entry.jsx
+++ b/src/js/burials/burials-entry.jsx
@@ -9,12 +9,11 @@ import { Provider } from 'react-redux';
 
 import initReact from '../common/init-react';
 import route from './routes';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 import reducer from './reducer';
 
 const store = createCommonStore(reducer);
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/burials-and-memorials/application/530'

--- a/src/js/burials/burials-entry.jsx
+++ b/src/js/burials/burials-entry.jsx
@@ -9,11 +9,10 @@ import { Provider } from 'react-redux';
 
 import initReact from '../common/init-react';
 import route from './routes';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 import reducer from './reducer';
 
-const store = createCommonStore(reducer);
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/burials-and-memorials/application/530'

--- a/src/js/claims-status/claims-status-entry.jsx
+++ b/src/js/claims-status/claims-status-entry.jsx
@@ -10,14 +10,13 @@ import { Provider } from 'react-redux';
 
 import ClaimsStatusApp from './containers/ClaimsStatusApp.jsx';
 import initReact from '../common/init-react';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 import routes from './routes.jsx';
 import { setLastPage } from './actions/index.jsx';
 import { basename } from './utils/page';
 import reducer from './reducers';
 
-const store = createCommonStore(reducer);
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const history = useRouterHistory(createHistory)({
   basename

--- a/src/js/claims-status/claims-status-entry.jsx
+++ b/src/js/claims-status/claims-status-entry.jsx
@@ -10,15 +10,14 @@ import { Provider } from 'react-redux';
 
 import ClaimsStatusApp from './containers/ClaimsStatusApp.jsx';
 import initReact from '../common/init-react';
-import createCommonStore from '../common/store';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 import routes from './routes.jsx';
 import { setLastPage } from './actions/index.jsx';
 import { basename } from './utils/page';
 import reducer from './reducers';
-import createLoginWidget from '../login/login-entry';
 
 const store = createCommonStore(reducer);
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const history = useRouterHistory(createHistory)({
   basename

--- a/src/js/common/init-common.js
+++ b/src/js/common/init-common.js
@@ -1,0 +1,11 @@
+import createCommonStore from './store'
+
+export function renderCommonComponents(commonStore) {
+  createLoginWidget(commonStore);
+}
+
+export default function initCommon(reducer) {
+  const commonStore = createCommonStore(reducer);
+  renderCommonComponents(commonStore);
+  return commonStore;
+}

--- a/src/js/common/init-common.js
+++ b/src/js/common/init-common.js
@@ -1,4 +1,5 @@
-import createCommonStore from './store'
+import createLoginWidget from '../login/login-entry';
+import createCommonStore from './store';
 
 export function renderCommonComponents(commonStore) {
   createLoginWidget(commonStore);

--- a/src/js/common/store/index.js
+++ b/src/js/common/store/index.js
@@ -12,10 +12,6 @@ export const commonReducer = {
   })
 };
 
-export function renderCommonComponents(commonStore) {
-  createLoginWidget(commonStore);
-}
-
 export default function createCommonStore(appReducer = {}) {
   const reducer = _.assign(appReducer, commonReducer);
   const useDevTools = __BUILDTYPE__ === 'development' && window.devToolsExtension;

--- a/src/js/common/store/index.js
+++ b/src/js/common/store/index.js
@@ -12,7 +12,7 @@ export const commonReducer = {
   })
 };
 
-export function renderCommonComponents(commonStore){
+export function renderCommonComponents(commonStore) {
   createLoginWidget(commonStore);
 }
 

--- a/src/js/common/store/index.js
+++ b/src/js/common/store/index.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp';
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
 import thunk from 'redux-thunk';
+import createLoginWidget from '../../login/login-entry';
 import login from '../../login/reducers/login';
 import profile from '../../user-profile/reducers/profile';
 
@@ -10,6 +11,10 @@ export const commonReducer = {
     profile
   })
 };
+
+export function renderCommonComponents(commonStore){
+  createLoginWidget(commonStore);
+}
 
 export default function createCommonStore(appReducer = {}) {
   const reducer = _.assign(appReducer, commonReducer);

--- a/src/js/common/store/index.js
+++ b/src/js/common/store/index.js
@@ -1,7 +1,6 @@
 import _ from 'lodash/fp';
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
 import thunk from 'redux-thunk';
-import createLoginWidget from '../../login/login-entry';
 import login from '../../login/reducers/login';
 import profile from '../../user-profile/reducers/profile';
 

--- a/src/js/discharge-wizard/discharge-wizard-entry.jsx
+++ b/src/js/discharge-wizard/discharge-wizard-entry.jsx
@@ -10,10 +10,9 @@ import { createHistory } from 'history';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 
-const store = createCommonStore(reducer);
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const history = useRouterHistory(createHistory)({
   basename: '/discharge-wizard'

--- a/src/js/discharge-wizard/discharge-wizard-entry.jsx
+++ b/src/js/discharge-wizard/discharge-wizard-entry.jsx
@@ -10,11 +10,10 @@ import { createHistory } from 'history';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 
 const store = createCommonStore(reducer);
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const history = useRouterHistory(createHistory)({
   basename: '/discharge-wizard'

--- a/src/js/edu-benefits/1990/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1990/edu-benefits-entry.jsx
@@ -10,11 +10,9 @@ import { Provider } from 'react-redux';
 import initReact from '../../common/init-react';
 import routes from './routes';
 import reducer from './reducer';
-import createCommonStore, { renderCommonComponents } from '../../common/store';
+import initCommon from '../../common/init-common';
 
-const store = createCommonStore(reducer);
-
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/education/apply-for-education-benefits/application/1990'

--- a/src/js/edu-benefits/1990/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1990/edu-benefits-entry.jsx
@@ -10,12 +10,11 @@ import { Provider } from 'react-redux';
 import initReact from '../../common/init-react';
 import routes from './routes';
 import reducer from './reducer';
-import createLoginWidget from '../../login/login-entry';
-import createCommonStore from '../../common/store';
+import createCommonStore, { renderCommonComponents } from '../../common/store';
 
 const store = createCommonStore(reducer);
 
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/education/apply-for-education-benefits/application/1990'

--- a/src/js/edu-benefits/1990e/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1990e/edu-benefits-entry.jsx
@@ -10,11 +10,9 @@ import { Provider } from 'react-redux';
 import initReact from '../../common/init-react';
 import routes from './routes';
 import reducer from './reducer';
-import createCommonStore, { renderCommonComponents } from '../../common/store';
+import initCommon from '../../common/init-common';
 
-const store = createCommonStore(reducer);
-
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/education/apply-for-education-benefits/application/1990E'

--- a/src/js/edu-benefits/1990e/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1990e/edu-benefits-entry.jsx
@@ -10,12 +10,11 @@ import { Provider } from 'react-redux';
 import initReact from '../../common/init-react';
 import routes from './routes';
 import reducer from './reducer';
-import createLoginWidget from '../../login/login-entry';
-import createCommonStore from '../../common/store';
+import createCommonStore, { renderCommonComponents } from '../../common/store';
 
 const store = createCommonStore(reducer);
 
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/education/apply-for-education-benefits/application/1990E'

--- a/src/js/edu-benefits/1990n/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1990n/edu-benefits-entry.jsx
@@ -10,11 +10,9 @@ import { Provider } from 'react-redux';
 import initReact from '../../common/init-react';
 import routes from './routes';
 import reducer from './reducer';
-import createCommonStore, { renderCommonComponents } from '../../common/store';
+import initCommon from '../../common/init-common';
 
-const store = createCommonStore(reducer);
-
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/education/apply-for-education-benefits/application/1990N'

--- a/src/js/edu-benefits/1990n/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1990n/edu-benefits-entry.jsx
@@ -10,12 +10,11 @@ import { Provider } from 'react-redux';
 import initReact from '../../common/init-react';
 import routes from './routes';
 import reducer from './reducer';
-import createLoginWidget from '../../login/login-entry';
-import createCommonStore from '../../common/store';
+import createCommonStore, { renderCommonComponents } from '../../common/store';
 
 const store = createCommonStore(reducer);
 
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/education/apply-for-education-benefits/application/1990N'

--- a/src/js/edu-benefits/1995/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1995/edu-benefits-entry.jsx
@@ -10,11 +10,9 @@ import { Provider } from 'react-redux';
 import initReact from '../../common/init-react';
 import routes from './routes';
 import reducer from './reducer';
-import createCommonStore,  { renderCommonComponents } from '../../common/store';
+import initCommon from '../../common/init-common';
 
-const store = createCommonStore(reducer);
-
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/education/apply-for-education-benefits/application/1995'

--- a/src/js/edu-benefits/1995/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/1995/edu-benefits-entry.jsx
@@ -10,12 +10,11 @@ import { Provider } from 'react-redux';
 import initReact from '../../common/init-react';
 import routes from './routes';
 import reducer from './reducer';
-import createLoginWidget from '../../login/login-entry';
-import createCommonStore from '../../common/store';
+import createCommonStore,  { renderCommonComponents } from '../../common/store';
 
 const store = createCommonStore(reducer);
 
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/education/apply-for-education-benefits/application/1995'

--- a/src/js/edu-benefits/5490/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/5490/edu-benefits-entry.jsx
@@ -10,11 +10,9 @@ import { Provider } from 'react-redux';
 import initReact from '../../common/init-react';
 import routes from './routes';
 import reducer from './reducer';
-import createCommonStore, { renderCommonComponents } from '../../common/store';
+import initCommon from '../../common/init-common';
 
-const store = createCommonStore(reducer);
-
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/education/apply-for-education-benefits/application/5490'

--- a/src/js/edu-benefits/5490/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/5490/edu-benefits-entry.jsx
@@ -10,12 +10,11 @@ import { Provider } from 'react-redux';
 import initReact from '../../common/init-react';
 import routes from './routes';
 import reducer from './reducer';
-import createLoginWidget from '../../login/login-entry';
-import createCommonStore from '../../common/store';
+import createCommonStore, { renderCommonComponents } from '../../common/store';
 
 const store = createCommonStore(reducer);
 
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/education/apply-for-education-benefits/application/5490'

--- a/src/js/edu-benefits/5495/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/5495/edu-benefits-entry.jsx
@@ -10,12 +10,11 @@ import { Provider } from 'react-redux';
 import initReact from '../../common/init-react';
 import routes from './routes';
 import reducer from './reducer';
-import createLoginWidget from '../../login/login-entry';
-import createCommonStore from '../../common/store';
+import createCommonStore, { renderCommonComponents } from '../../common/store';
 
 const store = createCommonStore(reducer);
 
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/education/apply-for-education-benefits/application/5495'

--- a/src/js/edu-benefits/5495/edu-benefits-entry.jsx
+++ b/src/js/edu-benefits/5495/edu-benefits-entry.jsx
@@ -10,11 +10,9 @@ import { Provider } from 'react-redux';
 import initReact from '../../common/init-react';
 import routes from './routes';
 import reducer from './reducer';
-import createCommonStore, { renderCommonComponents } from '../../common/store';
+import initCommon from '../../common/init-common';
 
-const store = createCommonStore(reducer);
-
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/education/apply-for-education-benefits/application/5495'

--- a/src/js/facility-locator/facility-locator-entry.jsx
+++ b/src/js/facility-locator/facility-locator-entry.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import routes from './routes';
 import { store } from './store';
-import { renderCommonComponents } from '../common/store';
+import { renderCommonComponents } from '../common/init-common';
 
 renderCommonComponents(store);
 

--- a/src/js/facility-locator/facility-locator-entry.jsx
+++ b/src/js/facility-locator/facility-locator-entry.jsx
@@ -9,9 +9,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import routes from './routes';
 import { store } from './store';
-import createLoginWidget from '../login/login-entry';
+import { renderCommonComponents } from '../common/store';
 
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const history = useRouterHistory(createHistory)({
   basename: '/facilities'

--- a/src/js/gi/gi-entry.jsx
+++ b/src/js/gi/gi-entry.jsx
@@ -12,7 +12,7 @@ import routes from './routes';
 import { store } from './store';
 import { updateRoute } from './actions';
 
-import { renderCommonComponents } from '../common/store';
+import { renderCommonComponents } from '../common/init-common';
 
 renderCommonComponents(store);
 

--- a/src/js/gi/gi-entry.jsx
+++ b/src/js/gi/gi-entry.jsx
@@ -11,9 +11,10 @@ import initReact from '../common/init-react';
 import routes from './routes';
 import { store } from './store';
 import { updateRoute } from './actions';
-import createLoginWidget from '../login/login-entry';
 
-createLoginWidget(store);
+import { renderCommonComponents } from '../common/store';
+
+renderCommonComponents(store);
 
 const history = useRouterHistory(createHistory)({
   basename: '/gi-bill-comparison-tool'

--- a/src/js/hca/hca-entry.jsx
+++ b/src/js/hca/hca-entry.jsx
@@ -9,11 +9,10 @@ import { Provider } from 'react-redux';
 
 import initReact from '../common/init-react';
 import route from './routes';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 import reducer from './reducer';
 
-const store = createCommonStore(reducer);
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const folderName = window.location.pathname.indexOf('health-care/') >= 0
   ? 'health-care'

--- a/src/js/hca/hca-entry.jsx
+++ b/src/js/hca/hca-entry.jsx
@@ -9,12 +9,11 @@ import { Provider } from 'react-redux';
 
 import initReact from '../common/init-react';
 import route from './routes';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 import reducer from './reducer';
 
 const store = createCommonStore(reducer);
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const folderName = window.location.pathname.indexOf('health-care/') >= 0
   ? 'health-care'

--- a/src/js/health-beta/health-beta-entry.jsx
+++ b/src/js/health-beta/health-beta-entry.jsx
@@ -12,10 +12,9 @@ import { Provider } from 'react-redux';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 
-const commonStore = createCommonStore(reducer);
-renderCommonComponents(commonStore);
+const commonStore = initCommon(reducer);
 
 function init() {
   ReactDOM.render((

--- a/src/js/health-beta/health-beta-entry.jsx
+++ b/src/js/health-beta/health-beta-entry.jsx
@@ -12,11 +12,10 @@ import { Provider } from 'react-redux';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 
 const commonStore = createCommonStore(reducer);
-createLoginWidget(commonStore);
+renderCommonComponents(commonStore);
 
 function init() {
   ReactDOM.render((

--- a/src/js/health-records/health-records-entry.jsx
+++ b/src/js/health-records/health-records-entry.jsx
@@ -10,11 +10,10 @@ import { createHistory } from 'history';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 
 const store = createCommonStore(reducer);
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const history = useRouterHistory(createHistory)({
   basename: '/health-care/health-records'

--- a/src/js/health-records/health-records-entry.jsx
+++ b/src/js/health-records/health-records-entry.jsx
@@ -10,10 +10,9 @@ import { createHistory } from 'history';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 
-const store = createCommonStore(reducer);
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const history = useRouterHistory(createHistory)({
   basename: '/health-care/health-records'

--- a/src/js/id-card-beta/id-card-beta-entry.jsx
+++ b/src/js/id-card-beta/id-card-beta-entry.jsx
@@ -11,10 +11,9 @@ import { Provider } from 'react-redux';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 
-const commonStore = createCommonStore(reducer);
-renderCommonComponents(commonStore);
+const commonStore = initCommon(reducer);
 
 function init() {
   ReactDOM.render((

--- a/src/js/id-card-beta/id-card-beta-entry.jsx
+++ b/src/js/id-card-beta/id-card-beta-entry.jsx
@@ -11,11 +11,10 @@ import { Provider } from 'react-redux';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 
 const commonStore = createCommonStore(reducer);
-createLoginWidget(commonStore);
+renderCommonComponents(commonStore);
 
 function init() {
   ReactDOM.render((

--- a/src/js/letters/letters-entry.jsx
+++ b/src/js/letters/letters-entry.jsx
@@ -12,11 +12,10 @@ import LettersApp from './containers/LettersApp.jsx';
 import initReact from '../common/init-react';
 import routes from './routes.jsx';
 import reducer from './reducers';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 
 const store = createCommonStore(reducer);
-createLoginWidget(store);
+renderCommonComponents(store);
 const history = useRouterHistory(createHistory)({
   basename: '/letters'
 });

--- a/src/js/letters/letters-entry.jsx
+++ b/src/js/letters/letters-entry.jsx
@@ -12,10 +12,9 @@ import LettersApp from './containers/LettersApp.jsx';
 import initReact from '../common/init-react';
 import routes from './routes.jsx';
 import reducer from './reducers';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 
-const store = createCommonStore(reducer);
-renderCommonComponents(store);
+const store = initCommon(reducer);
 const history = useRouterHistory(createHistory)({
   basename: '/letters'
 });

--- a/src/js/login/verify-entry.jsx
+++ b/src/js/login/verify-entry.jsx
@@ -6,15 +6,14 @@ import ReactDOM from 'react-dom';
 
 import { Provider } from 'react-redux';
 
-import createCommonStore from '../common/store';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 import initReact from '../common/init-react';
 
-import createLoginWidget from './login-entry';
 import reducer from './reducers/login';
 import Main from './containers/Main';
 
 const store = createCommonStore(reducer);
-createLoginWidget(store);
+renderCommonComponents(store);
 
 function init() {
   ReactDOM.render((

--- a/src/js/login/verify-entry.jsx
+++ b/src/js/login/verify-entry.jsx
@@ -6,14 +6,13 @@ import ReactDOM from 'react-dom';
 
 import { Provider } from 'react-redux';
 
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 import initReact from '../common/init-react';
 
 import reducer from './reducers/login';
 import Main from './containers/Main';
 
-const store = createCommonStore(reducer);
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 function init() {
   ReactDOM.render((

--- a/src/js/messaging/messaging-entry.jsx
+++ b/src/js/messaging/messaging-entry.jsx
@@ -14,12 +14,11 @@ import { createHistory } from 'history';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 import { updateRoute } from './actions';
 
 const store = createCommonStore(reducer);
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const history = useRouterHistory(createHistory)({
   basename: '/health-care/messaging'

--- a/src/js/messaging/messaging-entry.jsx
+++ b/src/js/messaging/messaging-entry.jsx
@@ -14,11 +14,10 @@ import { createHistory } from 'history';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 import { updateRoute } from './actions';
 
-const store = createCommonStore(reducer);
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const history = useRouterHistory(createHistory)({
   basename: '/health-care/messaging'

--- a/src/js/no-react-entry.js
+++ b/src/js/no-react-entry.js
@@ -1,5 +1,4 @@
-import createCommonStore from './common/store';
-import createLoginWidget from './login/login-entry';
+import createCommonStore, { renderCommonComponents } from './common/store';
 import createApplicationStatus from './common/components/createApplicationStatus';
 import createEducationApplicationStatus from './edu-benefits/components/createEducationApplicationStatus';
 
@@ -23,7 +22,7 @@ import './legacy/mega-menu.js';
 import './legacy/sidebar-navigation.js';
 
 const store = createCommonStore();
-createLoginWidget(store);
+renderCommonComponents(store);
 if (pensionPages.has(location.pathname)) {
   createApplicationStatus(store, {
     formId: '21P-527EZ',

--- a/src/js/no-react-entry.js
+++ b/src/js/no-react-entry.js
@@ -1,4 +1,4 @@
-import createCommonStore, { renderCommonComponents } from './common/store';
+import initCommon from './common/init-common';
 import createApplicationStatus from './common/components/createApplicationStatus';
 import createEducationApplicationStatus from './edu-benefits/components/createEducationApplicationStatus';
 
@@ -21,8 +21,8 @@ import './legacy/mega-menu.js';
 // New sidebar menu
 import './legacy/sidebar-navigation.js';
 
-const store = createCommonStore();
-renderCommonComponents(store);
+const store = initCommon();
+
 if (pensionPages.has(location.pathname)) {
   createApplicationStatus(store, {
     formId: '21P-527EZ',

--- a/src/js/pensions/pensions-entry.jsx
+++ b/src/js/pensions/pensions-entry.jsx
@@ -9,12 +9,11 @@ import { Provider } from 'react-redux';
 
 import initReact from '../common/init-react';
 import route from './routes';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 import reducer from './reducer';
 
 const store = createCommonStore(reducer);
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/pension/application/527EZ'

--- a/src/js/pensions/pensions-entry.jsx
+++ b/src/js/pensions/pensions-entry.jsx
@@ -9,11 +9,10 @@ import { Provider } from 'react-redux';
 
 import initReact from '../common/init-react';
 import route from './routes';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 import reducer from './reducer';
 
-const store = createCommonStore(reducer);
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/pension/application/527EZ'

--- a/src/js/post-911-gib-status/post-911-gib-status-entry.jsx
+++ b/src/js/post-911-gib-status/post-911-gib-status-entry.jsx
@@ -11,13 +11,11 @@ import { Provider } from 'react-redux';
 import initReact from '../common/init-react';
 import routes from './routes.jsx';
 import reducer from './reducers';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 
 import Post911GIBStatusApp from './containers/Post911GIBStatusApp';
 
-const store = createCommonStore(reducer);
-
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const history = useRouterHistory(createHistory)({
   basename: '/education/gi-bill/post-9-11/ch-33-benefit'

--- a/src/js/post-911-gib-status/post-911-gib-status-entry.jsx
+++ b/src/js/post-911-gib-status/post-911-gib-status-entry.jsx
@@ -11,14 +11,13 @@ import { Provider } from 'react-redux';
 import initReact from '../common/init-react';
 import routes from './routes.jsx';
 import reducer from './reducers';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 
 import Post911GIBStatusApp from './containers/Post911GIBStatusApp';
 
 const store = createCommonStore(reducer);
 
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const history = useRouterHistory(createHistory)({
   basename: '/education/gi-bill/post-9-11/ch-33-benefit'

--- a/src/js/pre-need/pre-need-entry.jsx
+++ b/src/js/pre-need/pre-need-entry.jsx
@@ -9,12 +9,11 @@ import { Provider } from 'react-redux';
 
 import initReact from '../common/init-react';
 import route from './routes';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 import reducer from './reducer';
 
 const store = createCommonStore(reducer);
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/burials-and-memorials/burial-planning/application'

--- a/src/js/pre-need/pre-need-entry.jsx
+++ b/src/js/pre-need/pre-need-entry.jsx
@@ -9,11 +9,10 @@ import { Provider } from 'react-redux';
 
 import initReact from '../common/init-react';
 import route from './routes';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 import reducer from './reducer';
 
-const store = createCommonStore(reducer);
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: '/burials-and-memorials/burial-planning/application'

--- a/src/js/rx/rx-entry.jsx
+++ b/src/js/rx/rx-entry.jsx
@@ -10,11 +10,10 @@ import { Provider } from 'react-redux';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 
 const store = createCommonStore(reducer);
-createLoginWidget(store);
+renderCommonComponents(store);
 
 const history = useRouterHistory(createHistory)({
   basename: '/health-care/prescriptions'

--- a/src/js/rx/rx-entry.jsx
+++ b/src/js/rx/rx-entry.jsx
@@ -10,10 +10,9 @@ import { Provider } from 'react-redux';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 
-const store = createCommonStore(reducer);
-renderCommonComponents(store);
+const store = initCommon(reducer);
 
 const history = useRouterHistory(createHistory)({
   basename: '/health-care/prescriptions'

--- a/src/js/user-profile/user-profile-entry.jsx
+++ b/src/js/user-profile/user-profile-entry.jsx
@@ -10,11 +10,10 @@ import { Provider } from 'react-redux';
 
 import initReact from '../common/init-react';
 import routes from './routes';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 
 const commonStore = createCommonStore();
-createLoginWidget(commonStore);
+renderCommonComponents(commonStore);
 
 function init() {
   ReactDOM.render((

--- a/src/js/user-profile/user-profile-entry.jsx
+++ b/src/js/user-profile/user-profile-entry.jsx
@@ -10,10 +10,9 @@ import { Provider } from 'react-redux';
 
 import initReact from '../common/init-react';
 import routes from './routes';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 
-const commonStore = createCommonStore();
-renderCommonComponents(commonStore);
+const commonStore = initCommon();
 
 function init() {
   ReactDOM.render((

--- a/src/js/veteran-id-card/veteran-id-card-entry.jsx
+++ b/src/js/veteran-id-card/veteran-id-card-entry.jsx
@@ -11,10 +11,9 @@ import { Provider } from 'react-redux';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore, { renderCommonComponents } from '../common/store';
+import initCommon from '../common/init-common';
 
-const commonStore = createCommonStore(reducer);
-renderCommonComponents(commonStore);
+const commonStore = initCommon(reducer);
 
 function init() {
   ReactDOM.render((

--- a/src/js/veteran-id-card/veteran-id-card-entry.jsx
+++ b/src/js/veteran-id-card/veteran-id-card-entry.jsx
@@ -11,11 +11,10 @@ import { Provider } from 'react-redux';
 import initReact from '../common/init-react';
 import routes from './routes';
 import reducer from './reducers';
-import createCommonStore from '../common/store';
-import createLoginWidget from '../login/login-entry';
+import createCommonStore, { renderCommonComponents } from '../common/store';
 
 const commonStore = createCommonStore(reducer);
-createLoginWidget(commonStore);
+renderCommonComponents(commonStore);
 
 function init() {
   ReactDOM.render((


### PR DESCRIPTION
Eventually we'll be adding a React-based footer and header, and since we already have a login component rendering on nearly all pages, it seems like a good idea to create a single helper function for rendering all site-wide/fixed components to avoid adding new code to all of the app entry points whenever we add a new one. This PR implements that function and replaces calls to create the single login component to use that instead.