### PR TITLE
Appeals v2 timeline style tweaks

### DIFF
--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -27,7 +27,7 @@ class Timeline extends React.Component {
       return (
         <li key={index} role="presentation" className={`process-step ${liClass}`}>
           <h3>{title || 'Title here'}</h3>
-          <span className="appeal-event-date">on {formatDate(event.date)}</span>
+          <div className="appeal-event-date">on {formatDate(event.date)}</div>
           <p>{description}</p>
           <div className="separator"/>
         </li>
@@ -52,7 +52,6 @@ class Timeline extends React.Component {
           <h4 style={{ color: 'inherit' }}>{this.state.expanded ? 'Hide past events' : 'See past events'}</h4>
         </button>
         <div className="appeal-event-date">{dateRange}</div>
-        <br/>
         <div className="separator"/>
       </li>
     );

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -59,8 +59,10 @@ class Timeline extends React.Component {
     eventList.push(<CurrentStatus key={eventList.length} title={title} description={description}/>);
 
     return (
-      // May not want this as an ol...
-      <ol className="process form-process appeal-timeline">{eventList}</ol>
+      <div>
+        <ol className="process form-process appeal-timeline">{eventList}</ol>
+        <div className="down-arrow"/>
+      </div>
     );
   }
 }

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -29,6 +29,7 @@ class Timeline extends React.Component {
           <h3>{title || 'Title here'}</h3>
           <span className="appeal-event-date">on {formatDate(event.date)}</span>
           <p>{description}</p>
+          <div className="separator"/>
         </li>
       );
     });
@@ -51,6 +52,8 @@ class Timeline extends React.Component {
           <h4 style={{ color: 'inherit' }}>{this.state.expanded ? 'Hide past events' : 'See past events'}</h4>
         </button>
         <div className="appeal-event-date">{dateRange}</div>
+        <br/>
+        <div className="separator"/>
       </li>
     );
 

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -685,14 +685,14 @@ h1:focus {
     width: 0px;
     border-left: 0.6em solid transparent;
     border-right: 0.6em solid transparent;
-    border-top: 1.2em solid #d6d7d9;
+    border-top: 1.2em solid $color-gray-lighter;
     margin-top: -32px;
     margin-left: 0.8em;
   }
 
   .separator {
     margin: 0.8em 2em 0 -0.7em;
-    border-top: 1px solid #d6d7d9;
+    border-top: 1px solid $color-gray-lighter;
   }
 }
 

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -688,6 +688,11 @@ h1:focus {
     margin-top: -32px;
     margin-left: 0.8em;
   }
+
+  .separator {
+    margin: 0 2em 0 -0.7em;
+    border-top: 1px solid #d6d7d9;
+  }
 }
 
 .claim-timeline-icon {

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -678,7 +678,7 @@ h1:focus {
   }
 
   .appeal-event-date {
-    color: $color-gray-light;
+    color: $color-gray-medium;
   }
 
   & + .down-arrow {

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -649,6 +649,9 @@ h1:focus {
     // Align the bullet horizontally
     padding-left: calc(2em + 2px);
 
+    // Make sure the arrowhead lines up better
+    padding-bottom: 0px;
+
     h3 {
       // Pull the whole content up so the bullet border starts to cover the previous li's
       //  left border
@@ -669,6 +672,15 @@ h1:focus {
 
   .appeal-event-date {
     color: $color-gray-light;
+  }
+
+  & + .down-arrow {
+    width: 0px;
+    border-left: 0.6em solid transparent;
+    border-right: 0.6em solid transparent;
+    border-top: 1.2em solid #d6d7d9;
+    margin-top: -32px;
+    margin-left: 0.8em;
   }
 }
 

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -629,6 +629,7 @@ h1:focus {
   .process-step {
     border-left: 5px solid #d6d7d9; // Should probably make this a variable...
     margin-left: -2.65em;
+    padding-bottom: 1em;
 
     &:before {
       margin-left: -2.65em;
@@ -690,7 +691,7 @@ h1:focus {
   }
 
   .separator {
-    margin: 0 2em 0 -0.7em;
+    margin: 0.8em 2em 0 -0.7em;
     border-top: 1px solid #d6d7d9;
   }
 }

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -608,6 +608,12 @@ h1:focus {
   padding-top: 0;
 
   li {
+    // Pull the first bullet point up just a hair to cover the top of the line
+    //  for when the viewport is small.
+    &:first-child:before {
+      margin-top: 4px;
+    }
+
     &:before {
       background: $color-green;
       border-radius: 50%;

--- a/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
@@ -28,7 +28,7 @@ const defaultProps = {
 describe('<Timeline/>', () => {
   it('should render', () => {
     const wrapper = shallow(<Timeline {...defaultProps}/>);
-    expect(wrapper.type()).to.equal('ol');
+    expect(wrapper.type()).to.equal('div');
   });
 
   it('should expand and collapse past history events', () => {


### PR DESCRIPTION
The original design can be found [here](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5637).

![image](https://user-images.githubusercontent.com/12970166/32852928-6b0eac88-c9ee-11e7-9761-80834810069f.png)

**Note:** There's still some work left to do concerning the text spilling out past the divider lines, but that's an easy fix after we get the tabs PR merged in. Should just be able to take away the `right-margin` from the `.separator` and call it good. :crossed_fingers: 