### PR TITLE
Dynamically show Health Records options and error messages

### DIFF
--- a/src/js/health-records/actions/form.js
+++ b/src/js/health-records/actions/form.js
@@ -1,4 +1,4 @@
-import { apiRequest } from '../../common/helpers/api';
+import { apiRequest } from '../utils/helpers';
 import moment from 'moment';
 
 function getDataClasses(formData) {
@@ -64,6 +64,25 @@ export function resetForm() {
   };
 }
 
+export function getEligibleClasses() {
+  return (dispatch) => {
+    dispatch({ type: 'FETCHING_ELIGIBLE_CLASSES' });
+
+    apiRequest(
+      '/eligible_data_classes',
+      null,
+      (response) => dispatch({
+        type: 'FETCH_ELIGIBLE_CLASSES_SUCCESS',
+        classes: response.data.attributes.dataClasses
+      }),
+      (response) => dispatch({
+        type: 'FETCH_ELIGIBLE_CLASSES_FAILURE',
+        errors: response.errors
+      })
+    );
+  };
+}
+
 export function submitForm(formData) {
   return (dispatch) => {
     window.dataLayer.push({
@@ -72,24 +91,21 @@ export function submitForm(formData) {
 
     dispatch({ type: 'FORM_SUBMITTING' });
 
-    apiRequest('/health_records',
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        method: 'POST',
-        body: JSON.stringify({
-          dataClasses: getDataClasses(formData),
-          fromDate: getFromDate(formData),
-          toDate: getToDate(formData)
-        })
-      },
-      () => dispatch({
-        type: 'FORM_SUCCESS'
-      }),
-      () => dispatch({
-        type: 'FORM_FAILURE'
+    const settings = {
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+      body: JSON.stringify({
+        dataClasses: getDataClasses(formData),
+        fromDate: getFromDate(formData),
+        toDate: getToDate(formData)
       })
+    };
+
+    apiRequest(
+      '/',
+      settings,
+      () => dispatch({ type: 'FORM_SUCCESS' }),
+      () => dispatch({ type: 'FORM_FAILURE' })
     );
   };
 }

--- a/src/js/health-records/actions/form.js
+++ b/src/js/health-records/actions/form.js
@@ -68,7 +68,7 @@ export function getEligibleClasses() {
   return (dispatch) => {
     dispatch({ type: 'FETCHING_ELIGIBLE_CLASSES' });
 
-    apiRequest(
+    return apiRequest(
       '/eligible_data_classes',
       null,
       (response) => dispatch({
@@ -101,7 +101,7 @@ export function submitForm(formData) {
       })
     };
 
-    apiRequest(
+    return apiRequest(
       '/',
       settings,
       () => dispatch({ type: 'FORM_SUCCESS' }),

--- a/src/js/health-records/actions/index.js
+++ b/src/js/health-records/actions/index.js
@@ -1,0 +1,17 @@
+export * from './form';
+export * from './modal';
+export * from './refresh';
+
+import { getEligibleClasses } from './form';
+import { initialAppRefresh } from './refresh';
+
+// TODO: Remove this hack to avoid parallel requests
+// due to account creation race condition when MHVAC APIs are no longer invoked
+// automatically on all actions.
+export function initializeResources() {
+  return dispatch => {
+    return dispatch(getEligibleClasses()).then(() => {
+      return dispatch(initialAppRefresh());
+    });
+  };
+}

--- a/src/js/health-records/actions/refresh.js
+++ b/src/js/health-records/actions/refresh.js
@@ -4,7 +4,7 @@ export function initialAppRefresh() {
   return (dispatch) => {
     dispatch({ type: 'INITIAL_LOADING' });
 
-    apiRequest(
+    return apiRequest(
       '/health_records/refresh',
       null,
       () => dispatch({
@@ -19,7 +19,7 @@ export function initialAppRefresh() {
 
 export function checkRefreshStatus() {
   return (dispatch) => {
-    apiRequest('/health_records/refresh',
+    return apiRequest('/health_records/refresh',
       null,
       (response) => {
         return dispatch({

--- a/src/js/health-records/containers/Main.jsx
+++ b/src/js/health-records/containers/Main.jsx
@@ -291,6 +291,17 @@ export class Main extends React.Component {
       return <LoadingIndicator message="Loading your application..."/>;
     }
 
+    if (!Object.keys(selections).length) {
+      return (
+        <ErrorView errors={this.props.errors}>
+          <p>
+            The application failed to load your available health record types.
+            Click <a onClick={this.props.getEligibleClasses}>here</a> to try again.
+          </p>
+        </ErrorView>
+      );
+    }
+
     return (
       <ErrorView errors={this.props.errors}>
         <div>

--- a/src/js/health-records/containers/Main.jsx
+++ b/src/js/health-records/containers/Main.jsx
@@ -14,13 +14,13 @@ import { reportTypes as reportTypesConfig } from '../config';
 import {
   changeDateOption,
   getEligibleClasses,
+  initializeResources,
+  openModal,
   resetForm,
   setDate,
   toggleAllReports,
   toggleReportType
-} from '../actions/form';
-import { openModal } from '../actions/modal';
-import { initialAppRefresh } from '../actions/refresh';
+} from '../actions';
 import { isValidDateRange } from '../utils/validations';
 
 export class Main extends React.Component {
@@ -41,13 +41,7 @@ export class Main extends React.Component {
 
   componentDidMount() {
     this.props.resetForm();
-    // kick off initial PHR refresh process
-    if (!this.props.refreshing) {
-      this.props.initialAppRefresh();
-    }
-    if (!this.props.loading) {
-      this.props.getEligibleClasses();
-    }
+    this.props.initializeResources();
   }
 
   handleStartDateChange(startDate) {
@@ -351,7 +345,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = {
   changeDateOption,
   getEligibleClasses,
-  initialAppRefresh,
+  initializeResources,
   openModal,
   resetForm,
   setDate,

--- a/src/js/health-records/reducers/form.js
+++ b/src/js/health-records/reducers/form.js
@@ -8,6 +8,7 @@ const initialState = {
     start: null,
     end: moment(),
   },
+  errors: [],
   loading: false,
   reportTypes: {},
   ready: false,
@@ -24,7 +25,7 @@ const initializeReportTypes = (eligibleClasses) => {
 export default function form(state = initialState, action) {
   switch (action.type) {
     case 'FETCHING_ELIGIBLE_CLASSES':
-      return { ...state, loading: true };
+      return { ...state, loading: true, errors: [] };
     case 'FETCH_ELIGIBLE_CLASSES_FAILURE':
       return { ...state, loading: false, errors: action.errors };
     case 'FETCH_ELIGIBLE_CLASSES_SUCCESS':

--- a/src/js/health-records/reducers/form.js
+++ b/src/js/health-records/reducers/form.js
@@ -1,6 +1,5 @@
 import set from 'lodash/fp/set';
 import { mapValues } from 'lodash';
-import { reportTypes } from '../config';
 import moment from 'moment';
 
 const initialState = {
@@ -9,21 +8,31 @@ const initialState = {
     start: null,
     end: moment(),
   },
+  loading: false,
   reportTypes: {},
   ready: false,
   requestDate: null,
-  inProgress: false,
+  inProgress: false
 };
 
-// map of all reportTypes in form { reportTypeValue: boolean }
-Object.keys(reportTypes).forEach(section => {
-  reportTypes[section].children.forEach(child => {
-    initialState.reportTypes[child.value] = false;
-  });
-});
+const initializeReportTypes = (eligibleClasses) => {
+  const reportTypes = {};
+  eligibleClasses.forEach((type) => { reportTypes[type] = false; });
+  return reportTypes;
+};
 
 export default function form(state = initialState, action) {
   switch (action.type) {
+    case 'FETCHING_ELIGIBLE_CLASSES':
+      return { ...state, loading: true };
+    case 'FETCH_ELIGIBLE_CLASSES_FAILURE':
+      return { ...state, loading: false, errors: action.errors };
+    case 'FETCH_ELIGIBLE_CLASSES_SUCCESS':
+      return {
+        ...state,
+        loading: false,
+        reportTypes: initializeReportTypes(action.classes)
+      };
     case 'START_DATE_CHANGED':
       return set('dateRange.start', action.date, state);
     case 'END_DATE_CHANGED':

--- a/src/js/health-records/utils/helpers.js
+++ b/src/js/health-records/utils/helpers.js
@@ -1,44 +1,11 @@
+import { apiRequest as commonApiClient } from '../../common/helpers/api';
 import environment from '../../common/helpers/environment';
-import merge from 'lodash/fp/merge';
-import Raven from 'raven-js';
 
-function isJson(response) {
-  const contentType = response.headers.get('content-type');
-  return contentType && contentType.indexOf('application/json') !== -1;
-}
+export function apiRequest(resource, optionalSettings = {}, success, error) {
+  const baseUrl = `${environment.API_URL}/v0/health_records`;
+  const url = resource[0] === '/'
+    ? [baseUrl, resource].join('')
+    : resource;
 
-export function apiRequest(url, optionalSettings = {}, success, error) {
-  const requestUrl = `${environment.API_URL}${url}`;
-
-  const defaultSettings = {
-    method: 'GET',
-    headers: {
-      Authorization: `Token token=${sessionStorage.userToken}`,
-      'X-Key-Inflection': 'camel',
-    }
-  };
-
-  const settings = merge(defaultSettings, optionalSettings);
-
-  return fetch(requestUrl, settings)
-    .catch(err => {
-      Raven.captureMessage(`vets_client_error: ${err.message}`, {
-        extra: {
-          error: err
-        }
-      });
-
-      return Promise.reject(err);
-    })
-    .then((response) => {
-      if (!response.ok) {
-        // Refresh to show login view when requests are unauthorized.
-        if (response.status === 401) { return window.location.reload(); }
-        return Promise.reject(response);
-      } else if (isJson(response)) {
-        return response.json();
-      }
-      return Promise.resolve(response);
-    })
-    .then(success, error);
+  return commonApiClient(url, optionalSettings, success, error);
 }


### PR DESCRIPTION
This is to enable more clarity around errors users may encounter in Health Records. Get eligible classes and show the corresponding options, or if the request failed, show an error that allows retrying. This up-front check will immediately return errors if anything is terribly wrong rather than letting the user get errors only after filling out the form.

Since the MHVAC race condition still exists, made sure to not make the initial refresh in parallel and instead made the requests in series.