### PR TITLE
Appeals v2 breadcrumbs

### DIFF
--- a/src/js/claims-status/actions/index.jsx
+++ b/src/js/claims-status/actions/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import environment from '../../common/helpers/environment';
-import { makeAuthRequest } from '../utils/helpers';
+import { makeAuthRequest, mockData } from '../utils/helpers';
 
 export const SET_CLAIMS = 'SET_CLAIMS';
 export const SET_APPEALS = 'SET_APPEALS';
@@ -91,71 +91,7 @@ export function getAppealsV2() {
 
     // Fake the fetch by just returning a resolved promice with the object shape we expect
     //  to get from the api.
-    // NOTE: This shape may change once we know what the api will be returning for sure. This
-    //  is just an example of what evss(?) is returning to the api.
-    return Promise.resolve({
-      data: [
-        {
-          id: '7387389', // Apparently this is a string...
-          type: 'appealSeries',
-          attributes: {
-            active: true,
-            incompleteHistory: false,
-            aoj: 'vba',
-            programArea: 'compensation',
-            description: 'Service connection for tinnitus, hearing loss, and two more',
-            type: 'original',
-            aod: false,
-            location: 'aoj',
-            status: {
-              type: 'nod', // This may or may not be a real status type
-              details: { // Don't actually know what's in here
-                regionalOffice: 'Chicago Regional Office'
-              }
-            },
-            docket: {
-              front: false,
-              total: 206900,
-              ahead: 109203,
-              ready: 22109,
-              eta: '2019-08-31'
-            },
-            issues: [
-              {
-                active: true,
-                description: 'Service connection for tinnitus',
-                lastAction: 'field_grant',
-                date: '2016-05-30'
-              }
-            ],
-            alerts: [
-              {
-                type: 'tbd', // Need to get a real status type
-                details: {}
-              }
-            ],
-            events: [
-              {
-                type: 'claim',
-                date: '2016-05-30',
-                details: {}
-              },
-              {
-                type: 'nod',
-                date: '2016-06-10',
-                details: {}
-              }
-            ],
-            evidence: [
-              {
-                description: 'Service treatment records',
-                date: '2017-09-30'
-              }
-            ]
-          }
-        }
-      ]
-    })
+    return Promise.resolve(mockData)
       .then((response) => dispatch(fetchAppealsSuccess(response)))
       .catch(() => dispatch({ type: SET_APPEALS_UNAVAILABLE }));
   };

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -29,33 +29,30 @@ function isolateAppeal(state, id) {
   return appeal;
 }
 
-export class AppealInfo extends React.Component {
-  render() {
-    const { params, children } = this.props;
-    const appealId = params.id;
-    const firstClaim = this.props.appeal ? this.props.appeal.attributes.events.find(a => a.type === EVENT_TYPES.claim) : null;
-    const appealDate = firstClaim ? moment(firstClaim.date, 'YYYY-MM-DD').format(' MMMM YYYY') : '';
-    return (
-      <div>
-        <div className="row">
-          <Breadcrumbs>
-            <li><Link to="your-claims">Your Claims and Appeals</Link></li>
-            {/* Note: The space before the date is in appealDate to ensure we don't have a trailing space if there is no firstClaim */}
-            <li><strong>Appeal of Claim Decision{appealDate}</strong></li>
-          </Breadcrumbs>
-        </div>
-        <div className="row">
-          <div className="medium-8 columns">
-            <AppealsV2TabNav appealId={appealId}/>
-            <div className="va-tab-content va-appeals-content">
-              {React.Children.map(children, child => React.cloneElement(child, { appeal: this.props.appeal }))}
-            </div>
-          </div>
-          {/* This assumes the Need Help sidebar doesn't change for either page */}
-        </div>
+export function AppealInfo({ params, appeal, children }) {
+  const appealId = params.id;
+  const firstClaim = appeal ? appeal.attributes.events.find(a => a.type === EVENT_TYPES.claim) : null;
+  const appealDate = firstClaim ? moment(firstClaim.date, 'YYYY-MM-DD').format(' MMMM YYYY') : '';
+  return (
+    <div>
+      <div className="row">
+        <Breadcrumbs>
+          <li><Link to="your-claims">Your Claims and Appeals</Link></li>
+          {/* Note: The space before the date is in appealDate to ensure we don't have a trailing space if there is no firstClaim */}
+          <li><strong>Appeal of Claim Decision{appealDate}</strong></li>
+        </Breadcrumbs>
       </div>
-    );
-  }
+      <div className="row">
+        <div className="medium-8 columns">
+          <AppealsV2TabNav appealId={appealId}/>
+          <div className="va-tab-content va-appeals-content">
+            {React.Children.map(children, child => React.cloneElement(child, { appeal }))}
+          </div>
+        </div>
+        {/* This assumes the Need Help sidebar doesn't change for either page */}
+      </div>
+    </div>
+  );
 }
 
 AppealInfo.propTypes = {

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -27,7 +27,7 @@ function isolateAppeal(state, id) {
   return appeal;
 }
 
-class AppealInfo extends React.Component {
+export class AppealInfo extends React.Component {
   render() {
     const { params, children } = this.props;
     const appealId = params.id;

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 
+import moment from 'moment';
+
 import Breadcrumbs from '../components/Breadcrumbs';
 import AppealsV2TabNav from '../components/appeals-v2/AppealsV2TabNav';
 
@@ -29,11 +31,14 @@ class AppealInfo extends React.Component {
   render() {
     const { params, children } = this.props;
     const appealId = params.id;
+    // TODO: Make sure this is where we should get the date from
+    const appealDate = this.props.appeal ? moment(this.props.appeal.attributes.events[0].date, 'YYYY-MM-DD').format('MMMM YYYY') : '';
     return (
       <div>
         <div className="row">
           <Breadcrumbs>
             <li><Link to="your-claims">Your Claims and Appeals</Link></li>
+            <li><strong>Appeal of {appealDate} Claim Decision</strong></li>
           </Breadcrumbs>
         </div>
         <div className="row">

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -8,6 +8,8 @@ import moment from 'moment';
 import Breadcrumbs from '../components/Breadcrumbs';
 import AppealsV2TabNav from '../components/appeals-v2/AppealsV2TabNav';
 
+import { EVENT_TYPES } from '../utils/appeals-v2-helpers';
+
 function isolateAppeal(state, id) {
   const claimsState = state.disability.status;
   const { appeals } = claimsState.claims;
@@ -31,14 +33,15 @@ export class AppealInfo extends React.Component {
   render() {
     const { params, children } = this.props;
     const appealId = params.id;
-    // TODO: Make sure this is where we should get the date from
-    const appealDate = this.props.appeal ? moment(this.props.appeal.attributes.events[0].date, 'YYYY-MM-DD').format('MMMM YYYY') : '';
+    const firstClaim = this.props.appeal ? this.props.appeal.attributes.events.find(a => a.type === EVENT_TYPES.claim) : null;
+    const appealDate = firstClaim ? moment(firstClaim.date, 'YYYY-MM-DD').format(' MMMM YYYY') : '';
     return (
       <div>
         <div className="row">
           <Breadcrumbs>
             <li><Link to="your-claims">Your Claims and Appeals</Link></li>
-            <li><strong>Appeal of {appealDate} Claim Decision</strong></li>
+            {/* Note: The space before the date is in appealDate to ensure we don't have a trailing space if there is no firstClaim */}
+            <li><strong>Appeal of Claim Decision{appealDate}</strong></li>
           </Breadcrumbs>
         </div>
         <div className="row">

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -1,20 +1,64 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Link } from 'react-router';
+
+import Breadcrumbs from '../components/Breadcrumbs';
 import AppealsV2TabNav from '../components/appeals-v2/AppealsV2TabNav';
 
-const AppealInfo = ({ params, children }) => {
-  const appealId = params.id;
-  return (
-    <div>
-      <AppealsV2TabNav appealId={appealId}/>
-      {children}
-    </div>
-  );
-};
+function isolateAppeal(state, id) {
+  const claimsState = state.disability.status;
+  const { appeals } = claimsState.claims;
+  const appeal = appeals.find(a => a.id === id);
+
+  // append starting event for post-remand and post-cavc remand appeals
+  // NOTE: This is business logic pulled from v1 that we don't fully understand yet.
+  //  Also, having this logic in mapStateToProps is less than ideal; we want to
+  //  move it out when we know where it should live. Maybe just a helper.
+  if (appeal && appeal.attributes.type !== 'original' && appeal.attributes.prior_decision_date) {
+    appeal.attributes.events.unshift({
+      type: appeal.attributes.type === 'post_cavc_remand' ? 'cavc_decision' : 'bva_remand',
+      date: appeal.attributes.prior_decision_date,
+    });
+  }
+
+  return appeal;
+}
+
+class AppealInfo extends React.Component {
+  render() {
+    const { params, children } = this.props;
+    const appealId = params.id;
+    return (
+      <div>
+        <div className="row">
+          <Breadcrumbs>
+            <li><Link to="your-claims">Your Claims and Appeals</Link></li>
+          </Breadcrumbs>
+        </div>
+        <div className="row">
+          <div className="medium-8 columns">
+            <AppealsV2TabNav appealId={appealId}/>
+            <div className="va-tab-content va-appeals-content">
+              {React.Children.map(children, child => React.cloneElement(child, { appeal: this.props.appeal }))}
+            </div>
+          </div>
+          {/* This assumes the Need Help sidebar doesn't change for either page */}
+        </div>
+      </div>
+    );
+  }
+}
 
 AppealInfo.propTypes = {
   params: PropTypes.shape({ id: PropTypes.string.isRequired }).isRequired,
   children: PropTypes.object.isRequired
 };
 
-export default AppealInfo;
+function mapStateToProps(state, ownProps) {
+  return {
+    appeal: isolateAppeal(state, ownProps.params.id)
+  };
+}
+
+export default connect(mapStateToProps)(AppealInfo);

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -61,28 +61,9 @@ AppealsV2StatusPage.propTypes = {
   })
 };
 
-function isolateAppeal(state, id) {
-  const claimsState = state.disability.status;
-  const { appeals } = claimsState.claims;
-  const appeal = appeals.find(a => a.id === id);
 
-  // append starting event for post-remand and post-cavc remand appeals
-  // NOTE: This is business logic pulled from v1 that we don't fully understand yet.
-  //  Also, having this logic in mapStateToProps is less than ideal; we want to
-  //  move it out when we know where it should live. Maybe just a helper.
-  if (appeal && appeal.attributes.type !== 'original' && appeal.attributes.prior_decision_date) {
-    appeal.attributes.events.unshift({
-      type: appeal.attributes.type === 'post_cavc_remand' ? 'cavc_decision' : 'bva_remand',
-      date: appeal.attributes.prior_decision_date,
-    });
-  }
-
-  return appeal;
-}
-
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
   return {
-    appeal: isolateAppeal(state, ownProps.params.id),
     loading: state.loading
   };
 }

--- a/src/js/claims-status/routes.jsx
+++ b/src/js/claims-status/routes.jsx
@@ -40,24 +40,19 @@ const routes = [
       path=":id/status"/>,
   </Route>,
   <Route
-    component={AppealLayout}
-    key="/appeals-v2"
-    path="/appeals-v2">
+    component={AppealInfo}
+    key="/appeals-v2/:id"
+    path="/appeals-v2/:id">
+    <IndexRedirect
+      to="status"/>
     <Route
-      component={AppealInfo}
-      key=":id"
-      path=":id">
-      <IndexRedirect
-        to="status"/>
-      <Route
-        component={AppealsV2StatusPage}
-        key="status"
-        path="status"/>
-      <Route
-        component={AppealsV2DetailPage}
-        key="detail"
-        path="detail"/>
-    </Route>
+      component={AppealsV2StatusPage}
+      key="status"
+      path="status"/>
+    <Route
+      component={AppealsV2DetailPage}
+      key="detail"
+      path="detail"/>
   </Route>,
   <Route
     component={ClaimPage}

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -244,3 +244,68 @@ export function getClaimType(claim) {
   return claim.attributes.claimType || 'Disability Compensation';
 }
 
+// NOTE: This shape may change once we know what the api will be returning for sure. This
+//  is just an example of what evss(?) is returning to the api.
+export const mockData = {
+  data: [
+    {
+      id: '7387389', // Apparently this is a string...
+      type: 'appealSeries',
+      attributes: {
+        active: true,
+        incompleteHistory: false,
+        aoj: 'vba',
+        programArea: 'compensation',
+        description: 'Service connection for tinnitus, hearing loss, and two more',
+        type: 'original',
+        aod: false,
+        location: 'aoj',
+        status: {
+          type: 'nod', // This may or may not be a real status type
+          details: { // Don't actually know what's in here
+            regionalOffice: 'Chicago Regional Office'
+          }
+        },
+        docket: {
+          front: false,
+          total: 206900,
+          ahead: 109203,
+          ready: 22109,
+          eta: '2019-08-31'
+        },
+        issues: [
+          {
+            active: true,
+            description: 'Service connection for tinnitus',
+            lastAction: 'field_grant',
+            date: '2016-05-30'
+          }
+        ],
+        alerts: [
+          {
+            type: 'tbd', // Need to get a real status type
+            details: {}
+          }
+        ],
+        events: [
+          {
+            type: 'claim',
+            date: '2016-05-30',
+            details: {}
+          },
+          {
+            type: 'nod',
+            date: '2016-06-10',
+            details: {}
+          }
+        ],
+        evidence: [
+          {
+            description: 'Service treatment records',
+            date: '2017-09-30'
+          }
+        ]
+      }
+    }
+  ]
+};

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -289,7 +289,7 @@ export const mockData = {
         ],
         events: [
           {
-            type: 'nod',
+            type: 'claim',
             date: '2016-05-30',
             details: {}
           },

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -289,7 +289,7 @@ export const mockData = {
         ],
         events: [
           {
-            type: 'claim',
+            type: 'nod',
             date: '2016-05-30',
             details: {}
           },

--- a/test/claims-status/components/appeals-v2/AppealInfo.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/AppealInfo.unit.spec.jsx
@@ -2,18 +2,26 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 import { merge } from 'lodash';
-import AppealInfo from '../../../../src/js/claims-status/containers/AppealInfo';
+import { AppealInfo } from '../../../../src/js/claims-status/containers/AppealInfo';
+import { mockData } from '../../../../src/js/claims-status/utils/helpers';
 
-const appealIdParam = '7387389';
+const appealIdParam = mockData.data[0].id;
 
 const defaultProps = {
   params: { id: appealIdParam },
+  appeal: mockData.data[0]
 };
 
 describe('<AppealInfo/>', () => {
   it('should render', () => {
     const wrapper = shallow(<AppealInfo {...defaultProps}/>);
     expect(wrapper.type()).to.equal('div');
+  });
+
+  it('should render the breadcrumbs', () => {
+    const wrapper = shallow(<AppealInfo {...defaultProps}/>);
+    const breadcrumbs = wrapper.find('Breadcrumbs');
+    expect(breadcrumbs.length).to.equal(1);
   });
 
   it('should display a tabbed navigator', () => {
@@ -29,9 +37,17 @@ describe('<AppealInfo/>', () => {
     expect(wrapper.find('span.test').length).to.equal(1);
   });
 
+  it('should pass appeal as a prop to its children', () => {
+    const children = (<span className="test">Child Goes Here</span>);
+    const props = merge({}, { children }, defaultProps);
+    const wrapper = shallow(<AppealInfo {...props}/>);
+    expect(wrapper.find('span.test').prop('appeal')).to.eql(defaultProps.appeal);
+  });
+
   it('should have access to the appeal id in route params', () => {
     const wrapper = shallow(<AppealInfo {...defaultProps}/>);
     const appealId = wrapper.instance().props.params.id;
     expect(appealId).to.equal(appealIdParam);
   });
 });
+


### PR DESCRIPTION
Our component hierarchy wasn't really great for the breadcrumbs as they were, so I pondered it over with @cehsu and decided to nix the `AppealLayout`, moving the breadcrumb logic into `AppealInfo`. I then pulled the appeals redux state grabbing logic out of `AppealsV2StatusPage` and put it in `AppealInfo`, which I had wanted to do already for when we start building the details page.

**Note:** This doesn't test the `isolateAppeal()` functionality, but I'm not sure if 1) we want to or 2) the best way to do that if we do want to.

![image](https://user-images.githubusercontent.com/12970166/32960989-be82ee36-cb7b-11e7-9dd4-0035f3d64d27.png)

![image](https://user-images.githubusercontent.com/12970166/32961003-cd18c01a-cb7b-11e7-9205-d6400925e3fd.png)
