### PR TITLE
Fix for address appearing as a separate column

### DIFF
--- a/content/pages/pension/pension-management-center.md
+++ b/content/pages/pension/pension-management-center.md
@@ -16,6 +16,8 @@ We have 3 regional pension management centers. Look at the lists below to find t
 
 This office serves:
 
+<div class="usa-grid-full">
+
 <div class="small-12 medium-6 usa-width-five-twelfths columns">
 <ul>
 <li>Connecticut</li>
@@ -45,6 +47,8 @@ This office serves:
 </ul>
 </div>
 
+</div>
+
 To submit a pension application to this office, mail it to:
 
 <p class="va-address-block">
@@ -65,6 +69,7 @@ Or, fax it to 1-844-655-1604.
 
 This office serves:
 
+<div class="usa-grid-full">
 <div class="small-12 medium-6 usa-width-five-twelfths columns">
 <ul>
 <li>Alabama</li>
@@ -85,6 +90,8 @@ This office serves:
 <li>Tennessee</li>
 <li>Wisconsin</li>
 </ul>
+</div>
+
 </div>
 
 To submit a pension application to this office, mail it to:


### PR DESCRIPTION
The wrapper class for grids was missing on the Pension Management Center (/pension/pension-management-center/), causing the address content to show up as a column:

![image](https://user-images.githubusercontent.com/1915775/32966592-42f164be-cba8-11e7-8548-30525c8adcec.png)

Not sure when this started or what it caused it, but this PR fixes it.

Resolves department-of-veterans-affairs/vets.gov-team/issues/6089#event-1347778714