### PR TITLE
Add GA event to track 404s

### DIFF
--- a/content/includes/footer.html
+++ b/content/includes/footer.html
@@ -106,9 +106,9 @@ visit <a href="https://www.veteranscrisisline.net/">VeteransCrisisLine.net</a> f
 {% else %}
   <!-- Google Tag Manager -->
   <script>
-    dataLayer = [{
-      'environment': '{{ buildtype }}'
-    }];
+    // Always use push with GTM: https://www.simoahava.com/gtm-tips/datalayer-declaration-vs-push/
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({ environment: '{{ buildtype }}' });
     // We want to know if we are being iframed
     if ( self !== top ) {
       window.dataLayer.push({ event: 'iframed', embeddedIn: document.referrer});

--- a/content/pages/404.md
+++ b/content/pages/404.md
@@ -43,4 +43,7 @@ private: true
 {% include "content/includes/common-and-popular.html" %}
 
 <script src="/js/usa-search.js"></script>
-<script>window.dataLayer.push({ 'event': 'nav-404-error' });</script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({ event: 'nav-404-error' });
+</script>

--- a/content/pages/404.md
+++ b/content/pages/404.md
@@ -43,3 +43,4 @@ private: true
 {% include "content/includes/common-and-popular.html" %}
 
 <script src="/js/usa-search.js"></script>
+<script>window.dataLayer.push({ 'event': 'nav-404-error' });</script>


### PR DESCRIPTION
Part of: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5671

This PR adds a custom event fired on any page that renders in the `404.md` content. If the user goes to nonexistent page like `https://www.vets.gov/nothing-here.html` in GA we currently see that URL show up but do not know if it rendered actual content or the `404.md` content for being a missing page.

This adds an event so we can see which URLs are turning up the `404.md` content over time.

Also, there was a slight refactor of the `footer.html` code. It's a general best practice to not overwrite the `window.dataLayer` variable if it exists. That way regardless of the `404.md` or the `footer.html` executes first they'll both use the `push` function and not overwrite anything that may exist. I added a comment with a ref on that, but that can be axed if it's overkill.