### PR TITLE
Add message when profile is slow

### DIFF
--- a/src/js/common/schemaform/ApplicationStatus.jsx
+++ b/src/js/common/schemaform/ApplicationStatus.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { connect } from 'react-redux';
+import Raven from 'raven-js';
 
 import { formLinks, formTitles } from '../../user-profile/helpers';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
@@ -14,7 +15,8 @@ export class ApplicationStatus extends React.Component {
     super(props);
     this.state = {
       modalOpen: false,
-      loading: false
+      loading: false,
+      timedOut: false
     };
 
     moment.updateLocale('en', {
@@ -39,6 +41,20 @@ export class ApplicationStatus extends React.Component {
         'Dec.'
       ]
     });
+  }
+
+  componentDidMount() {
+    if (this.props.profile.loading) {
+      this.timeout = setTimeout(() => {
+        Raven.captureMessage('vets_application_status_slow');
+      }, 5000);
+    }
+  }
+
+  componentDidUpdate(oldProps) {
+    if (oldProps.profile.loading && !this.props.profile.loading) {
+      clearTimeout(this.timeout);
+    }
   }
 
   removeForm = (formId) => {

--- a/src/js/common/schemaform/ApplicationStatus.jsx
+++ b/src/js/common/schemaform/ApplicationStatus.jsx
@@ -15,8 +15,7 @@ export class ApplicationStatus extends React.Component {
     super(props);
     this.state = {
       modalOpen: false,
-      loading: false,
-      timedOut: false
+      loading: false
     };
 
     moment.updateLocale('en', {


### PR DESCRIPTION
This adds a Sentry message when loading the user profile is slow. There's no UI change, I want to get some more info before making changes there.