### PR TITLE
Don't show name twice while upload file

### DIFF
--- a/src/js/common/schemaform/FileField.jsx
+++ b/src/js/common/schemaform/FileField.jsx
@@ -114,7 +114,7 @@ export default class FileField extends React.Component {
                       <ProgressBar percent={this.state.progress}/>
                     </div>
                   }
-                  <span>{file.name}</span>
+                  {!file.uploading && <span>{file.name}</span>}
                   {!hasErrors && itemSchema.properties.attachmentId &&
                     <div className="schemaform-file-attachment">
                       <SchemaField

--- a/src/js/pre-need/config/form.jsx
+++ b/src/js/pre-need/config/form.jsx
@@ -73,7 +73,7 @@ const formConfig = {
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   disableSave: true,
-  title: 'Apply online for pre-need determination of eligibility in a VA national cemetery',
+  title: 'Apply for pre-need eligibility determination',
   subTitle: 'Form 40-10007',
   getHelp: GetFormHelp,
   defaultDefinitions: {


### PR DESCRIPTION
Was doing this:

![screen shot 2017-11-21 at 1 56 58 pm](https://user-images.githubusercontent.com/634932/33091053-04f10e8e-cec4-11e7-96a1-7e995d17fd38.png)


Now it's not (screen disappears very quickly, so I haven't taken a shot of it)

Also fixed the title.