### PR TITLE
Post 9/11 print page fix

### DIFF
--- a/src/js/post-911-gib-status/containers/StatusPage.jsx
+++ b/src/js/post-911-gib-status/containers/StatusPage.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 
 import FormTitle from '../../common/schemaform/FormTitle';
@@ -66,4 +65,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default withRouter(connect(mapStateToProps)(StatusPage));
+export default connect(mapStateToProps)(StatusPage);

--- a/src/js/post-911-gib-status/containers/StatusPage.jsx
+++ b/src/js/post-911-gib-status/containers/StatusPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 
 import FormTitle from '../../common/schemaform/FormTitle';
@@ -7,13 +8,8 @@ import EnrollmentHistory from '../components/EnrollmentHistory';
 import UserInfoSection from '../components/UserInfoSection';
 
 class StatusPage extends React.Component {
-  constructor() {
-    super();
-    this.navigateToPrint = this.navigateToPrint.bind(this);
-  }
-
-  navigateToPrint() {
-    window.open('/education/gi-bill/post-9-11/ch-33-benefit/print', '_blank');
+  navigateToPrint = () => {
+    this.props.router.push('/print');
   }
 
   render() {
@@ -70,4 +66,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(StatusPage);
+export default withRouter(connect(mapStateToProps)(StatusPage));


### PR DESCRIPTION
Because of the session issue, we'll just keep it in the same window for now.

@rroueche I can make a "Go back" button and have it not show up on the print page if that'll help. I'm guessing the reason behind opening in a new tab is so the veteran doesn't get confused about needing to go back.