### PR TITLE
Alerts component for Appeals v2.

### DIFF
--- a/src/js/claims-status/components/appeals-v2/Alert.jsx
+++ b/src/js/claims-status/components/appeals-v2/Alert.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { getAlertContent } from '../../utils/appeals-v2-helpers';
+
+const Alert = ({ alert, key }) => {
+  const { title, description, cssClass } = getAlertContent(alert);
+  return (
+    <li key={key}>
+      <div className={`usa-alert ${cssClass}`}>
+        <div className="usa-alert-body">
+          <h3 className="usa-alert-heading">{title}</h3>
+          <p className="usa-alert-text">{description}</p>
+        </div>
+      </div>
+    </li>
+  );
+};
+
+Alert.propTypes = {
+  key: PropTypes.string.isRequired,
+  alert: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    date: PropTypes.string,
+    details: PropTypes.string
+  })
+};
+
+export default Alert;

--- a/src/js/claims-status/components/appeals-v2/Alerts.jsx
+++ b/src/js/claims-status/components/appeals-v2/Alerts.jsx
@@ -1,21 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getAlertContent } from '../../utils/appeals-v2-helpers';
+import Alert from './Alert';
 
 const Alerts = (props) => {
+  if (typeof props.alerts === 'undefined' || props.alerts.length === 0) {
+    return null;
+  }
+
   const alertsList = props.alerts.map((alert, index) => {
     const key = `${alert.type}-${index}`;
-    const { title, description, cssClass } = getAlertContent(alert);
-    return (
-      <li key={key}>
-        <div className={`usa-alert ${cssClass}`}>
-          <div className="usa-alert-body">
-            <h3 className="usa-alert-heading">{title}</h3>
-            <p className="usa-alert-text">{description}</p>
-          </div>
-        </div>
-      </li>
-    );
+    return (<Alert key={key} alert={alert}/>);
   });
 
   return (
@@ -30,7 +24,7 @@ Alerts.propTypes = {
     type: PropTypes.string.isRequired,
     date: PropTypes.string,
     details: PropTypes.string
-  })).isRequired
+  }))
 };
 
 export default Alerts;

--- a/src/js/claims-status/components/appeals-v2/Alerts.jsx
+++ b/src/js/claims-status/components/appeals-v2/Alerts.jsx
@@ -1,12 +1,34 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-class Alerts extends React.Component {
-  render() {
+const Alerts = ({ alerts }) => {
+  const alertsList = alerts.map((alert, index) => {
+    const { type, date, details } = alert;
+    const key = `${type}-${index}`;
     return (
-      <div>Alerts</div>
+      <div key={key} className="usa-alert usa-alert-warning">
+        <div className="usa-alert-body">
+          <h3 className="usa-alert-heading">{details.title}</h3>
+          <p className="usa-alert-text">{date} - {details.description}</p>
+        </div>
+      </div>
     );
-  }
-}
+  });
+
+  return (
+    <div>
+
+    </div>
+  );
+};
+
+Alerts.propTypes = {
+  alerts: PropTypes.arrayOf(PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    date: PropTypes.string.isRequired,
+    details: PropTypes.string
+  })).isRequired
+};
 
 export default Alerts;
 

--- a/src/js/claims-status/components/appeals-v2/Alerts.jsx
+++ b/src/js/claims-status/components/appeals-v2/Alerts.jsx
@@ -1,31 +1,34 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { getAlertContent } from '../../utils/appeals-v2-helpers';
 
-const Alerts = ({ alerts }) => {
-  const alertsList = alerts.map((alert, index) => {
-    const { type, date, details } = alert;
-    const key = `${type}-${index}`;
+const Alerts = (props) => {
+  const alertsList = props.alerts.map((alert, index) => {
+    const key = `${alert.type}-${index}`;
+    const { title, description, cssClass } = getAlertContent(alert);
     return (
-      <div key={key} className="usa-alert usa-alert-warning">
-        <div className="usa-alert-body">
-          <h3 className="usa-alert-heading">{details.title}</h3>
-          <p className="usa-alert-text">{date} - {details.description}</p>
+      <li key={key}>
+        <div className={`usa-alert ${cssClass}`}>
+          <div className="usa-alert-body">
+            <h3 className="usa-alert-heading">{title}</h3>
+            <p className="usa-alert-text">{description}</p>
+          </div>
         </div>
-      </div>
+      </li>
     );
   });
 
   return (
-    <div>
-
-    </div>
+    <ul className="alerts-list">
+      {alertsList}
+    </ul>
   );
 };
 
 Alerts.propTypes = {
   alerts: PropTypes.arrayOf(PropTypes.shape({
     type: PropTypes.string.isRequired,
-    date: PropTypes.string.isRequired,
+    date: PropTypes.string,
     details: PropTypes.string
   })).isRequired
 };

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -28,14 +28,14 @@ class AppealsV2StatusPage extends React.Component {
     if (this.props.appealsLoading) {
       return <LoadingIndicator message="Please wait while we load your appeal..."/>;
     }
-    const { events, status } = this.props.appeal.attributes;
+    const { events, alerts, status } = this.props.appeal.attributes;
     const { type, details } = status;
     const currentStatus = getStatusContents(type, details);
     const nextEvents = getNextEvents(type);
     return (
       <div>
         <Timeline events={events} currentStatus={currentStatus}/>
-        <Alerts/>
+        <Alerts alerts={alerts}/>
         <WhatsNext nextEvents={nextEvents}/>
         <Docket/>
       </div>
@@ -49,9 +49,10 @@ AppealsV2StatusPage.defaultProps = {
     type: '',
     attributes: {
       events: [],
+      alerts: [],
       status: {
         type: '',
-        details: {}
+        details: {},
       }
     }
   }

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -1,8 +1,20 @@
+import React from 'react';
 // TO DO: Replace made up properties and content with real versions once finalized.
 export const STATUS_TYPES = {
   nod: 'nod',
   awaitingHearingDate: 'awaiting_hearing_date',
   bvaDecision: 'bva_decision',
+};
+
+export const ALERT_STYLE_TYPES = {
+  warning: 'warning',
+  information: 'information'
+};
+
+export const ALERT_CONTENT_TYPES = {
+  waitingOnAction: 'waiting_on_action',
+  hearingScheduled: 'hearing_scheduled',
+  bvaDecisionPending: 'bva_decision_pending'
 };
 
 // TO DO: Replace made up properties and content with real versions once finalized.
@@ -246,3 +258,57 @@ export function getNextEvents(currentStatus) {
   }
 }
 
+/**
+ * 
+ * @param {string} type each alert can have one of two types as defined by ALERT_TYPES
+ * @returns {object} containing dynamically-generated title & description properties
+ */
+export function getAlertContent(alert) {
+  const { type, date, details } = alert;
+  switch (details.type) {
+    case ALERT_CONTENT_TYPES.waitingOnAction:
+      return {
+        title: 'Your appeal is waiting on action by your representative',
+        description: `Your appeal is near the front of the line, but it is not
+          ready to go to a judge. It is currently waiting on your
+          representative, the ${details.representative}, to complete an
+          informal hearing presentation (IHP). Please contact your
+          representative for more information.`,
+        type,
+        date
+      };
+    case ALERT_CONTENT_TYPES.hearingScheduled:
+      return {
+        title: `Your hearing has been scheduled for ${details.date}`,
+        description: '',
+        type,
+        date
+      };
+    case ALERT_CONTENT_TYPES.bvaDecisionPending:
+      return {
+        title: 'You will soon receive your Board decision',
+        description: (
+          <ul>
+            <li>
+              While a judge is reviewing your case, please do not send any
+              additional evidence. This may delay your decision and increase
+              your wait time.
+            </li>
+            <li>
+              Please call your representative or Regional Office to make
+              sure we have the correct address to mail your decision letter.
+            </li>
+          </ul>
+        ),
+        type,
+        date
+      };
+    default:
+      return {
+        title: '',
+        description: '',
+        type,
+        date
+      };
+  }
+}

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -310,6 +310,7 @@ export function getAlertContent(alert) {
       return {
         title: '',
         description: '',
+        cssClass: '',
         type,
         date
       };

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -274,6 +274,7 @@ export function getAlertContent(alert) {
           representative, the ${details.representative}, to complete an
           informal hearing presentation (IHP). Please contact your
           representative for more information.`,
+        cssClass: 'usa-alert-warning',
         type,
         date
       };
@@ -281,6 +282,7 @@ export function getAlertContent(alert) {
       return {
         title: `Your hearing has been scheduled for ${details.date}`,
         description: '',
+        cssClass: 'usa-alert-info',
         type,
         date
       };
@@ -300,6 +302,7 @@ export function getAlertContent(alert) {
             </li>
           </ul>
         ),
+        cssClass: 'usa-alert-info',
         type,
         date
       };

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -283,8 +283,18 @@ export const mockData = {
         ],
         alerts: [
           {
-            type: 'tbd', // Need to get a real status type
-            details: {}
+            type: 'warning',
+            date: '09-21-2017',
+            details: {
+              type: 'waiting_on_action'
+            }
+          }, {
+            type: 'warning',
+            date: '09-21-2017',
+            details: {
+              type: 'hearing_scheduled',
+              date: 'March 5th, 2018'
+            }
           }
         ],
         events: [

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -905,3 +905,7 @@ h1:focus {
     }
   }
 }
+
+.alerts-list {
+  list-style: none;
+}

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -908,4 +908,8 @@ h1:focus {
 
 .alerts-list {
   list-style: none;
+
+  li {
+    margin-left: -.4em;
+  }
 }

--- a/test/claims-status/components/appeals-v2/Alert.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Alert.unit.spec.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import Alert from '../../../../src/js/claims-status/components/appeals-v2/Alert';
+
+describe('<Alert/>', () => {
+  it('should render', () => {
+    const wrapper = shallow(<Alert/>);
+    expect(wrapper.type()).to.equal('li');
+  });
+});

--- a/test/claims-status/components/appeals-v2/Alert.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Alert.unit.spec.jsx
@@ -3,9 +3,21 @@ import { shallow } from 'enzyme';
 import { expect } from 'chai';
 import Alert from '../../../../src/js/claims-status/components/appeals-v2/Alert';
 
+const defaultProps = {
+  key: 'hearing-scheduled-0',
+  alert: {
+    type: 'warning',
+    date: '09-21-2017',
+    details: {
+      type: 'hearing-scheduled',
+      date: 'March th, 2018'
+    }
+  }
+};
+
 describe('<Alert/>', () => {
   it('should render', () => {
-    const wrapper = shallow(<Alert/>);
+    const wrapper = shallow(<Alert {...defaultProps}/>);
     expect(wrapper.type()).to.equal('li');
   });
 });

--- a/test/claims-status/components/appeals-v2/Alerts.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Alerts.unit.spec.jsx
@@ -28,9 +28,20 @@ describe.only('<Alerts/>', () => {
     expect(wrapper.type()).to.equal('ul');
   });
 
-  it('renders all alerts', () => {
+  it('should render all alerts', () => {
     const wrapper = shallow(<Alerts {...defaultProps}/>);
-    const alertsList = wrapper.find('li');
+    const alertsList = wrapper.find('Alert');
     expect(alertsList.length).to.equal(defaultProps.alerts.length);
+  });
+
+  it('should return null if alerts prop missing', () => {
+    const wrapper = shallow(<Alerts/>);
+    expect(wrapper.type()).to.equal(null);
+  });
+
+  it('should return null if alerts array empty', () => {
+    const props = { alerts: [] };
+    const wrapper = shallow(<Alerts {...props}/>);
+    expect(wrapper.type()).to.equal(null);
   });
 });

--- a/test/claims-status/components/appeals-v2/Alerts.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Alerts.unit.spec.jsx
@@ -22,7 +22,7 @@ const defaultProps = {
   ]
 };
 
-describe.only('<Alerts/>', () => {
+describe('<Alerts/>', () => {
   it('renders', () => {
     const wrapper = shallow(<Alerts {...defaultProps}/>);
     expect(wrapper.type()).to.equal('ul');

--- a/test/claims-status/components/appeals-v2/Alerts.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Alerts.unit.spec.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import Alerts from '../../../../src/js/claims-status/components/appeals-v2/Alerts';
+
+const defaultProps = {};
+
+describe('<Alerts/>', () => {
+  it('renders', () => {
+    const wrapper = shallow(<Alerts/>);
+    expect(wrapper.type).to.equal('div');
+  });
+
+  it('renders all alerts', () => {
+    const wrapper = shallow(<Alerts {...defaultProps}/>);
+  });
+});

--- a/test/claims-status/components/appeals-v2/Alerts.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Alerts.unit.spec.jsx
@@ -3,15 +3,34 @@ import { shallow } from 'enzyme';
 import { expect } from 'chai';
 import Alerts from '../../../../src/js/claims-status/components/appeals-v2/Alerts';
 
-const defaultProps = {};
+const defaultProps = {
+  alerts: [
+    {
+      type: 'warning',
+      date: '09-21-2017',
+      details: {
+        type: 'waiting_on_action'
+      }
+    }, {
+      type: 'warning',
+      date: '09-21-2017',
+      details: {
+        type: 'hearing_scheduled',
+        date: 'March 5th, 2018'
+      }
+    }
+  ]
+};
 
-describe('<Alerts/>', () => {
+describe.only('<Alerts/>', () => {
   it('renders', () => {
-    const wrapper = shallow(<Alerts/>);
-    expect(wrapper.type).to.equal('div');
+    const wrapper = shallow(<Alerts {...defaultProps}/>);
+    expect(wrapper.type()).to.equal('ul');
   });
 
   it('renders all alerts', () => {
     const wrapper = shallow(<Alerts {...defaultProps}/>);
+    const alertsList = wrapper.find('li');
+    expect(alertsList.length).to.equal(defaultProps.alerts.length);
   });
 });

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -486,7 +486,7 @@ describe('Disability benefits helpers: ', () => {
     });
   });
 
-  describe.only('getAlertContent', () => {
+  describe('getAlertContent', () => {
     it('returns an object with title, desc, type, and date', () => {
       const alert = {
         type: 'warning',

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -19,6 +19,7 @@ import {
 } from '../../../src/js/claims-status/utils/helpers';
 
 import {
+  getAlertContent,
   getStatusContents,
   getNextEvents,
   STATUS_TYPES
@@ -482,6 +483,24 @@ describe('Disability benefits helpers: ', () => {
       // each of the 2 'nod' nextEvents has 4 properties
       expect(Object.keys(firstEvent).length).to.equal(4);
       expect(Object.keys(secondEvent).length).to.equal(4);
+    });
+  });
+
+  describe.only('getAlertContent', () => {
+    it('returns an object with title, desc, type, and date', () => {
+      const alert = {
+        type: 'warning',
+        date: '09-21-2017',
+        details: {
+          type: 'waiting_on_action'
+        }
+      };
+
+      const alertContent = getAlertContent(alert);
+      expect(alertContent.title).to.exist;
+      expect(alertContent.description).to.exist;
+      expect(alertContent.type).to.exist;
+      expect(alertContent.date).to.exist;
     });
   });
 });


### PR DESCRIPTION
Components that together render a list of alerts - one for each object in the `appeal.attributes.alerts` array. Also introduces a helper function into `helpers-v2` that maps content to each alert type.

To-Do:
[x] - Wire up Alerts and Alert to each other, Status page
[x] - Finish logic for both components (prop passing, conditional styling based on alert type)
[x] - Make sure everything looks right at different viewport sizes
[x] - Everything accompanied by unit tests

**Full**
<img width="750" alt="screen shot 2017-11-27 at 12 11 57 pm" src="https://user-images.githubusercontent.com/24251447/33282379-168f143e-d36e-11e7-98a5-3b6e015900cc.png">


**Mobile**
<img width="403" alt="screen shot 2017-11-27 at 12 11 43 pm" src="https://user-images.githubusercontent.com/24251447/33282387-1d2ce38e-d36e-11e7-8264-e0bad8b53189.png">




