### PR TITLE
Added link in caution flag specific to Ashford University.

### DIFF
--- a/src/js/gi/components/profile/CautionaryInformation.jsx
+++ b/src/js/gi/components/profile/CautionaryInformation.jsx
@@ -39,9 +39,18 @@ export class CautionaryInformation extends React.Component {
     const it = this.props.institution;
     if (!it.complaints) { return null; }
 
+    // If Ashford, show specific link.
+    const schoolSpecificLink =
+      (it.facilityCode === '21007103' || it.website === 'http://www.ashford.edu') && (
+        <a href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#AshfordSAA" target="_blank">More information on Ashford University</a>
+      );
+
     const flagContent = (
       <div>
-        {it.cautionFlagReason}
+        <p>
+          {it.cautionFlagReason} {schoolSpecificLink}
+        </p>
+        <br/>
         <p>
           <a onClick={this.props.onShowModal.bind(this, 'cautionInfo')}>
             Learn more about these warnings

--- a/src/js/gi/containers/Modals.jsx
+++ b/src/js/gi/containers/Modals.jsx
@@ -272,7 +272,6 @@ export class Modals extends React.Component {
           <p><a href="http://www.justice.gov/opa/pr/profit-college-company-pay-955-million-settle-claims-illegal-recruiting-consumer-fraud-and" target="_blank">Settlement reached with the Federal Trade Commission (FTC)</a></p>
           <p><a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#caution" target="_blank">Suspended for 85/15 violation – Flight Program</a></p>
           <p><a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#caution" target="_blank">Denial of Recertification Application to Participate in the Federal Student Financial Assistance Programs</a></p>
-          <p><a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#ISAA" target="_blank">Iowa SAA approval ends 9/18/16 (Potential lapse in program approval and payment of GI Bill benefits.)</a></p>
           <p><a href="http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#ACICS" target="_blank">School operating under provisional accreditation (previously accredited by ACICS)</a></p>
           <p>
             To learn more, visit the "Caution Flag" section of the <a


### PR DESCRIPTION
Resolves department-of-veterans-affairs/gi-bill-comparison-tool#477.

> <img width="931" alt="screen shot 2017-11-24 at 4 30 26 pm" src="https://user-images.githubusercontent.com/1067024/33224220-10d9fc4c-d135-11e7-81ce-3a5bf1ebaac2.png">

The message before the link will have to be updated separately in GIDS. The Iowa link removed from the modal pertains to Ashford as well, and the relevant section is directly below the content that the "more information" link leads to.