### PR TITLE
Appealsv2 alerts bugfix mg

### DIFF
--- a/src/js/claims-status/components/appeals-v2/Alert.jsx
+++ b/src/js/claims-status/components/appeals-v2/Alert.jsx
@@ -19,7 +19,6 @@ const Alert = ({ alert }) => {
 Alert.propTypes = {
   alert: PropTypes.shape({
     type: PropTypes.string.isRequired,
-    date: PropTypes.string,
     details: PropTypes.object
   })
 };

--- a/src/js/claims-status/components/appeals-v2/Alert.jsx
+++ b/src/js/claims-status/components/appeals-v2/Alert.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { getAlertContent } from '../../utils/appeals-v2-helpers';
 
-const Alert = ({ alert, key }) => {
+const Alert = ({ alert }) => {
   const { title, description, cssClass } = getAlertContent(alert);
   return (
-    <li key={key}>
+    <li>
       <div className={`usa-alert ${cssClass}`}>
         <div className="usa-alert-body">
           <h3 className="usa-alert-heading">{title}</h3>
@@ -17,7 +17,6 @@ const Alert = ({ alert, key }) => {
 };
 
 Alert.propTypes = {
-  key: PropTypes.string.isRequired,
   alert: PropTypes.shape({
     type: PropTypes.string.isRequired,
     date: PropTypes.string,

--- a/src/js/claims-status/components/appeals-v2/Alert.jsx
+++ b/src/js/claims-status/components/appeals-v2/Alert.jsx
@@ -21,7 +21,7 @@ Alert.propTypes = {
   alert: PropTypes.shape({
     type: PropTypes.string.isRequired,
     date: PropTypes.string,
-    details: PropTypes.string
+    details: PropTypes.object
   })
 };
 

--- a/src/js/claims-status/components/appeals-v2/Alerts.jsx
+++ b/src/js/claims-status/components/appeals-v2/Alerts.jsx
@@ -22,7 +22,6 @@ const Alerts = (props) => {
 Alerts.propTypes = {
   alerts: PropTypes.arrayOf(PropTypes.shape({
     type: PropTypes.string.isRequired,
-    date: PropTypes.string,
     details: PropTypes.object
   }))
 };

--- a/src/js/claims-status/components/appeals-v2/Alerts.jsx
+++ b/src/js/claims-status/components/appeals-v2/Alerts.jsx
@@ -23,7 +23,7 @@ Alerts.propTypes = {
   alerts: PropTypes.arrayOf(PropTypes.shape({
     type: PropTypes.string.isRequired,
     date: PropTypes.string,
-    details: PropTypes.string
+    details: PropTypes.object
   }))
 };
 

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -52,7 +52,7 @@ AppealsV2StatusPage.defaultProps = {
       alerts: [],
       status: {
         type: '',
-        details: {},
+        details: {}
       }
     }
   }

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -6,12 +6,7 @@ export const STATUS_TYPES = {
   bvaDecision: 'bva_decision',
 };
 
-export const ALERT_STYLE_TYPES = {
-  warning: 'warning',
-  information: 'information'
-};
-
-export const ALERT_CONTENT_TYPES = {
+export const ALERT_TYPES = {
   waitingOnAction: 'waiting_on_action',
   hearingScheduled: 'hearing_scheduled',
   bvaDecisionPending: 'bva_decision_pending'
@@ -265,8 +260,8 @@ export function getNextEvents(currentStatus) {
  */
 export function getAlertContent(alert) {
   const { type, date, details } = alert;
-  switch (details.type) {
-    case ALERT_CONTENT_TYPES.waitingOnAction:
+  switch (type) {
+    case ALERT_TYPES.waitingOnAction:
       return {
         title: 'Your appeal is waiting on action by your representative',
         description: `Your appeal is near the front of the line, but it is not
@@ -278,7 +273,7 @@ export function getAlertContent(alert) {
         type,
         date
       };
-    case ALERT_CONTENT_TYPES.hearingScheduled:
+    case ALERT_TYPES.hearingScheduled:
       return {
         title: `Your hearing has been scheduled for ${details.date}`,
         description: '',
@@ -286,7 +281,7 @@ export function getAlertContent(alert) {
         type,
         date
       };
-    case ALERT_CONTENT_TYPES.bvaDecisionPending:
+    case ALERT_TYPES.bvaDecisionPending:
       return {
         title: 'You will soon receive your Board decision',
         description: (

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -259,7 +259,7 @@ export function getNextEvents(currentStatus) {
  * @returns {object} containing dynamically-generated title & description properties
  */
 export function getAlertContent(alert) {
-  const { type, date, details } = alert;
+  const { type, details } = alert;
   switch (type) {
     case ALERT_TYPES.waitingOnAction:
       return {
@@ -270,8 +270,7 @@ export function getAlertContent(alert) {
           informal hearing presentation (IHP). Please contact your
           representative for more information.`,
         cssClass: 'usa-alert-warning',
-        type,
-        date
+        type
       };
     case ALERT_TYPES.hearingScheduled:
       return {
@@ -279,7 +278,6 @@ export function getAlertContent(alert) {
         description: '',
         cssClass: 'usa-alert-info',
         type,
-        date
       };
     case ALERT_TYPES.bvaDecisionPending:
       return {
@@ -299,7 +297,6 @@ export function getAlertContent(alert) {
         ),
         cssClass: 'usa-alert-info',
         type,
-        date
       };
     default:
       return {
@@ -307,7 +304,6 @@ export function getAlertContent(alert) {
         description: '',
         cssClass: '',
         type,
-        date
       };
   }
 }

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -284,19 +284,16 @@ export const mockData = {
         alerts: [
           {
             type: 'waiting_on_action',
-            date: '09-21-2017',
             details: {
               representative: 'Mr. Spock'
             }
           }, {
             type: 'hearing_scheduled',
-            date: '09-21-2017',
             details: {
               date: 'March 5th, 2018'
             }
           }, {
             type: 'bva_decision_pending',
-            date: '09-30-2020',
             details: {}
           }
         ],

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -283,18 +283,21 @@ export const mockData = {
         ],
         alerts: [
           {
-            type: 'warning',
+            type: 'waiting_on_action',
             date: '09-21-2017',
             details: {
-              type: 'waiting_on_action'
+              representative: 'Mr. Spock'
             }
           }, {
-            type: 'warning',
+            type: 'hearing_scheduled',
             date: '09-21-2017',
             details: {
-              type: 'hearing_scheduled',
               date: 'March 5th, 2018'
             }
+          }, {
+            type: 'bva_decision_pending',
+            date: '09-30-2020',
+            details: {}
           }
         ],
         events: [

--- a/test/claims-status/components/appeals-v2/Alert.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Alert.unit.spec.jsx
@@ -6,7 +6,6 @@ import Alert from '../../../../src/js/claims-status/components/appeals-v2/Alert'
 const defaultProps = {
   alert: {
     type: 'hearing-scheduled',
-    date: '09-21-2017',
     details: {
       date: 'March th, 2018'
     }

--- a/test/claims-status/components/appeals-v2/Alert.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Alert.unit.spec.jsx
@@ -4,12 +4,10 @@ import { expect } from 'chai';
 import Alert from '../../../../src/js/claims-status/components/appeals-v2/Alert';
 
 const defaultProps = {
-  key: 'hearing-scheduled-0',
   alert: {
-    type: 'warning',
+    type: 'hearing-scheduled',
     date: '09-21-2017',
     details: {
-      type: 'hearing-scheduled',
       date: 'March th, 2018'
     }
   }

--- a/test/claims-status/components/appeals-v2/Alerts.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Alerts.unit.spec.jsx
@@ -6,16 +6,15 @@ import Alerts from '../../../../src/js/claims-status/components/appeals-v2/Alert
 const defaultProps = {
   alerts: [
     {
-      type: 'warning',
+      type: 'waiting_on_action',
       date: '09-21-2017',
       details: {
-        type: 'waiting_on_action'
+        representative: 'Mr. Spock'
       }
     }, {
-      type: 'warning',
+      type: 'hearing_scheduled',
       date: '09-21-2017',
       details: {
-        type: 'hearing_scheduled',
         date: 'March 5th, 2018'
       }
     }

--- a/test/claims-status/components/appeals-v2/Alerts.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Alerts.unit.spec.jsx
@@ -7,13 +7,11 @@ const defaultProps = {
   alerts: [
     {
       type: 'waiting_on_action',
-      date: '09-21-2017',
       details: {
         representative: 'Mr. Spock'
       }
     }, {
       type: 'hearing_scheduled',
-      date: '09-21-2017',
       details: {
         date: 'March 5th, 2018'
       }

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -490,7 +490,6 @@ describe('Disability benefits helpers: ', () => {
     it('returns an object with title, desc, type, and date', () => {
       const alert = {
         type: 'waiting_on_action',
-        date: '09-21-2017',
         details: {
           representative: 'Mr. Spock'
         }

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -489,10 +489,10 @@ describe('Disability benefits helpers: ', () => {
   describe('getAlertContent', () => {
     it('returns an object with title, desc, type, and date', () => {
       const alert = {
-        type: 'warning',
+        type: 'waiting_on_action',
         date: '09-21-2017',
         details: {
-          type: 'waiting_on_action'
+          representative: 'Mr. Spock'
         }
       };
 

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -498,8 +498,8 @@ describe('Disability benefits helpers: ', () => {
       const alertContent = getAlertContent(alert);
       expect(alertContent.title).to.exist;
       expect(alertContent.description).to.exist;
+      expect(alertContent.cssClass).to.exist;
       expect(alertContent.type).to.exist;
-      expect(alertContent.date).to.exist;
     });
   });
 });


### PR DESCRIPTION
Addresses a few small issues from the original Alerts component PR, namely:
- Shape of the Alert object didn't make sense and wasn't likely to match the eventual API. Needed to update some helpers, as well as mock data and unit tests.
- Some linting
- Deleted unnecessary ref to own key in `Alert` component. Not only do React components not receive their own `key` prop, but they also don't need it in this case since the key was given to the subcomponent in the `Alerts` component's `render` function. Oops.