### PR TITLE
Update error message for ineligible VIC users

### DIFF
--- a/src/js/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/js/veteran-id-card/components/RequiredVeteranView.jsx
@@ -18,9 +18,8 @@ class RequiredVeteranView extends React.Component {
     } else if (this.props.userProfile.veteranStatus === 'OK') {
       if (!serviceAvailable) {
         // If all above conditions are true and service is still not present in user profile, then user
-        // is either not enrolled in beta, or is not eligible on other grounds
-        // such as discharge status.
-        view = <SystemDownView messageLine1="We can't proceed with your request for a Veteran ID Card." messageLine2="We’re working to expand the program to all eligible Veterans, so please check back again soon to see if you’re eligible."/>;
+        // is not eligible due to title 38 status indicator
+        view = <SystemDownView messageLine1="We're sorry. We can't proceed with your request for a Veteran ID card because we can't confirm your eligibility right now." messageLine2="Please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
       } else {
         view = this.props.children;
       }

--- a/src/js/veteran-id-card/config.js
+++ b/src/js/veteran-id-card/config.js
@@ -2,7 +2,7 @@ module.exports = {
 
   messages: {
     VIC002: "We can't proceed with your request for a Veteran ID card because we can't find your DoD ID number in our system. Please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).",
-    VIC003: "We can't proceed with your request for a Veteran ID card because our records don't confirm your status as a Veteran. If you think this is incorrect, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).",
+    VIC003: "We're sorry. We can't proceed with your request for a Veteran ID card because we can't confirm your eligibility right now. Please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).",
     VIC010: "We're sorry. We can't proceed with your request for a Veteran ID card because we can't confirm your military history right now. Please try again in a few minutes. If it still doesn't work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).",
     VIC011: "We're sorry. We can't proceed with your request for a Veteran ID card because we can't confirm your military history right now. Please try again in a few minutes. If it still doesn't work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).",
     'default': "We're sorry, but something went wrong. Please try again in a few moments."


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/6283

Duplication is probably something to be cleaned up, but guards against the id_card API returning an error status if somehow they get past the fact that they don't have the veteran_id_card in their list of available services. 