### PR TITLE
Add GA events for VIC submission, success, failure

### DIFF
--- a/src/js/veteran-id-card/actions/index.js
+++ b/src/js/veteran-id-card/actions/index.js
@@ -6,25 +6,27 @@ export const ATTRS_FAILURE = 'ATTRS_FAILURE';
 export const REDIRECT_TIMED_OUT = 'REDIRECT_TIMED_OUT';
 
 export function initiateIdRequest() {
-  window.dataLayer.push({ event: "vic-submit-started" });
+  window.dataLayer.push({ event: 'vic-submit-started' });
   return dispatch => {
     dispatch({ type: ATTRS_FETCHING });
 
     apiRequest('/id_card/attributes',
       {},
       (response) => {
-        window.dataLayer.push({ event: "vic-submit-success" });
+        window.dataLayer.push({ event: 'vic-submit-success' });
         dispatch({
           type: ATTRS_SUCCESS,
           vicUrl: response.url,
           traits: response.traits
-      })},
+        })
+      },
       (response) => {
-        window.dataLayer.push({ event: "vic-submit-failure" });
+        window.dataLayer.push({ event: 'vic-submit-failure' });
         dispatch({
           type: ATTRS_FAILURE,
           errors: response.errors
-      })}
+        })
+      }
     );
   };
 }

--- a/src/js/veteran-id-card/actions/index.js
+++ b/src/js/veteran-id-card/actions/index.js
@@ -18,14 +18,14 @@ export function initiateIdRequest() {
           type: ATTRS_SUCCESS,
           vicUrl: response.url,
           traits: response.traits
-        })
+        });
       },
       (response) => {
         window.dataLayer.push({ event: 'vic-submit-failure' });
         dispatch({
           type: ATTRS_FAILURE,
           errors: response.errors
-        })
+        });
       }
     );
   };

--- a/src/js/veteran-id-card/actions/index.js
+++ b/src/js/veteran-id-card/actions/index.js
@@ -6,20 +6,25 @@ export const ATTRS_FAILURE = 'ATTRS_FAILURE';
 export const REDIRECT_TIMED_OUT = 'REDIRECT_TIMED_OUT';
 
 export function initiateIdRequest() {
+  window.dataLayer.push({ event: "vic-submit-started" });
   return dispatch => {
     dispatch({ type: ATTRS_FETCHING });
 
     apiRequest('/id_card/attributes',
       {},
-      (response) => dispatch({
-        type: ATTRS_SUCCESS,
-        vicUrl: response.url,
-        traits: response.traits
-      }),
-      (response) => dispatch({
-        type: ATTRS_FAILURE,
-        errors: response.errors
-      })
+      (response) => {
+        window.dataLayer.push({ event: "vic-submit-success" });
+        dispatch({
+          type: ATTRS_SUCCESS,
+          vicUrl: response.url,
+          traits: response.traits
+      })},
+      (response) => {
+        window.dataLayer.push({ event: "vic-submit-failure" });
+        dispatch({
+          type: ATTRS_FAILURE,
+          errors: response.errors
+      })}
     );
   };
 }


### PR DESCRIPTION
Adds three events to track how many submissions total and how many succeed and fail through GA.

I don't try to track the exact error codes. That can be added if needed, but the assumption is those will be picked up by one of the backend monitoring systems already for service improvements.