### PR TITLE
Add screen reader content to exit-icon mixin, over-ride in footer

### DIFF
--- a/src/sass/base/_b-mixins.scss
+++ b/src/sass/base/_b-mixins.scss
@@ -63,5 +63,19 @@
   background-size: 1em auto;
   padding-right: 1.2em;
   position: relative;
+
+  &:after {
+    // adds non-visible alt content for screen readers
+    position: absolute;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: clip;
+    padding: 0;
+    border: 0;
+    margin: -1px;
+    content: "opens in a new tab";
+  }
 }
 

--- a/src/sass/base/_b-mixins.scss
+++ b/src/sass/base/_b-mixins.scss
@@ -75,7 +75,7 @@
     padding: 0;
     border: 0;
     margin: -1px;
-    content: "opens in a new tab";
+    content: "this will open a new website";
   }
 }
 

--- a/src/sass/base/_b-mixins.scss
+++ b/src/sass/base/_b-mixins.scss
@@ -79,3 +79,12 @@
   }
 }
 
+// There are a few places where the exit-icon is explicitly hidden using prop / values
+// like 'background-image: none;'. In these cases, we want to hide the corresponding
+// content placed in the ::after pseudo-element
+@mixin no-sr-content {
+  &:after {
+    content: none;
+  }
+}
+

--- a/src/sass/modules/_m-button.scss
+++ b/src/sass/modules/_m-button.scss
@@ -23,6 +23,8 @@ button,
     background-image: none;
     // TODO: clean up #content .main.interior a then remove !important
     text-decoration: none !important;
+
+    @include no-sr-content;
   }
 }
 

--- a/src/sass/modules/_m-button.scss
+++ b/src/sass/modules/_m-button.scss
@@ -20,11 +20,12 @@ button,
     // background-color: $color-primary-darker;
   }
   &[href^=http] {
+    @include no-sr-content;
+
     background-image: none;
     // TODO: clean up #content .main.interior a then remove !important
     text-decoration: none !important;
 
-    @include no-sr-content;
   }
 }
 

--- a/src/sass/modules/_m-crisis-line.scss
+++ b/src/sass/modules/_m-crisis-line.scss
@@ -39,6 +39,8 @@
   a {
     padding: 0;
     background-image: none;
+
+    @include no-sr-content;
   }
 }
 

--- a/src/sass/modules/_m-crisis-line.scss
+++ b/src/sass/modules/_m-crisis-line.scss
@@ -37,10 +37,11 @@
   }
 
   a {
+    @include no-sr-content;
+
     padding: 0;
     background-image: none;
 
-    @include no-sr-content;
   }
 }
 

--- a/src/sass/modules/_m-footer.scss
+++ b/src/sass/modules/_m-footer.scss
@@ -55,6 +55,12 @@
     &:hover {
       color: $color-gold;
     }
+
+    &:after {
+      // don't add exit-icon screen reader alt content because exit-icon is
+      // itself hidden with background: none applied to the parent anchor tag
+      content: none;
+    }
   }
 }
 

--- a/src/sass/modules/_m-footer.scss
+++ b/src/sass/modules/_m-footer.scss
@@ -56,11 +56,7 @@
       color: $color-gold;
     }
 
-    &:after {
-      // don't add exit-icon screen reader alt content because exit-icon is
-      // itself hidden with background: none applied to the parent anchor tag
-      content: none;
-    }
+    @include no-sr-content;
   }
 }
 

--- a/src/sass/modules/_m-vet-nav.scss
+++ b/src/sass/modules/_m-vet-nav.scss
@@ -319,6 +319,8 @@ body.va-pos-fixed {
     padding: .8rem 1.6rem;
     text-decoration: none;
 
+    @include no-sr-content;
+
     @include media($medium-large-screen) {
       color: $color-link-default;
 

--- a/src/sass/modules/_m-vet-nav.scss
+++ b/src/sass/modules/_m-vet-nav.scss
@@ -313,13 +313,13 @@ body.va-pos-fixed {
 
 .vetnav-panel {
   a {
+    @include no-sr-content;
+
     background-image: none;
     color: $color-white;
     display: block;
     padding: .8rem 1.6rem;
     text-decoration: none;
-
-    @include no-sr-content;
 
     @include media($medium-large-screen) {
       color: $color-link-default;


### PR DESCRIPTION
Adds "opens in new tab" screen reader content to all instances where the `exit-icon` mixin is being actively applied. To check for side-effects, I looked at all refs in our css to `background: none;` as well as `background-image: none;`, and checked all of the instances where related classes are used. As far as I can tell, I've hidden the screenreader content from all cases where the icon was hidden as well.

As for functionality, I'm only able to test on VoiceOver. Even though this content is applied with an `:after` pseudo-element selector on the links themselves, VoiceOver announces the SR content first:
> `link, opens in a new tab, download Form 21P-527EZ`. . .

which is probably a good thing anyway.

Would really appreciate some IE testing