### PR TITLE
Force all users to be considered as veterans, update test

### DIFF
--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -162,16 +162,15 @@ export class VeteranBenefitSummaryLetter extends React.Component {
 
 function mapStateToProps(state) {
   const letterState = state.letters;
-  const { profile } = state.user;
 
   return {
     benefitSummaryOptions: {
       benefitInfo: letterState.benefitInfo,
       serviceInfo: letterState.serviceInfo
     },
-    // default isVeteran to true if service for determining this is down
-    // this decision may need to be revisited.
-    isVeteran: (profile.veteranStatus === 'OK' ? profile.isVeteran : true),
+    // default isVeteran to true for now - please see vets.gov-team issue #6250
+    // isVeteran: (state.user.profile.veteranStatus === 'OK' ? state.user.profile.isVeteran : true),
+    isVeteran: true,
     optionsAvailable: letterState.optionsAvailable,
     requestOptions: letterState.requestOptions
   };

--- a/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
+++ b/test/letters/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
@@ -131,12 +131,13 @@ describe('<VeteranBenefitSummaryLetter>', () => {
     });
   });
 
-  it('Does not render veteran options for dependents', () => {
-    const props = _.set('isVeteran', false, defaultProps);
-    const tree = SkinDeep.shallowRender(<VeteranBenefitSummaryLetter {...props}/>);
-    const benefitInfoRows = tree.dive(['div', '#benefitInfoTable', 'tbody']).everySubTree('tr');
-    benefitInfoRows.forEach((row) => {
-      expect(() => row.dive(['td', '#hasServiceConnectedDisabilities'])).to.throw();
-    });
-  });
+  // All users considered veterans for now - please see vets.gov-team issue #6250
+  // it('Does not render veteran options for dependents', () => {
+  //   const props = _.set('isVeteran', false, defaultProps);
+  //   const tree = SkinDeep.shallowRender(<VeteranBenefitSummaryLetter {...props}/>);
+  //   const benefitInfoRows = tree.dive(['div', '#benefitInfoTable', 'tbody']).everySubTree('tr');
+  //   benefitInfoRows.forEach((row) => {
+  //     expect(() => row.dive(['td', '#hasServiceConnectedDisabilities'])).to.throw();
+  //   });
+  // });
 });


### PR DESCRIPTION
Makes all users veterans, left some stuff in comments to make this easy to revert once we want to split out dependents and veterans again.