### PR TITLE
Limit VIC render to 10% of requests

### DIFF
--- a/src/js/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/js/veteran-id-card/components/RequiredVeteranView.jsx
@@ -8,7 +8,7 @@ class RequiredVeteranView extends React.Component {
   render() {
     let view;
     const serviceAvailable = this.props.userProfile.services.indexOf('id-card') !== -1;
-    const serviceRateLimited = Math.random() > 0.75;
+    const serviceRateLimited = Math.random() > 0.9;
 
     if (this.props.userProfile.veteranStatus === 'SERVER_ERROR') {
       // If eMIS status is null, show a system down message.

--- a/src/js/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/js/veteran-id-card/components/RequiredVeteranView.jsx
@@ -8,6 +8,8 @@ class RequiredVeteranView extends React.Component {
   render() {
     let view;
     const serviceAvailable = this.props.userProfile.services.indexOf('id-card') !== -1;
+    const serviceRateLimited = Math.random() > 0.75;
+
     if (this.props.userProfile.veteranStatus === 'SERVER_ERROR') {
       // If eMIS status is null, show a system down message.
       view = <SystemDownView messageLine1="We’re sorry. We can’t proceed with your request for a Veteran ID card because we can't confirm your military history right now. Please try again in a few minutes." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
@@ -16,7 +18,9 @@ class RequiredVeteranView extends React.Component {
       // in our system.
       view = <SystemDownView messageLine1="We’re sorry. We can’t proceed with your request for a Veteran ID card because we can't confirm your military history right now. Please try again in a few minutes." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
     } else if (this.props.userProfile.veteranStatus === 'OK') {
-      if (!serviceAvailable) {
+      if (serviceRateLimited) {
+        view = <SystemDownView messageLine1="We can't proceed with your request for a Veteran ID Card." messageLine2="We're sorry, this service is currently under heavy load. We're actively addressing the issues, please try again later."/>;
+      } else if (!serviceAvailable) {
         // If all above conditions are true and service is still not present in user profile, then user
         // is either not enrolled in beta, or is not eligible on other grounds
         // such as discharge status.

--- a/src/js/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/js/veteran-id-card/components/RequiredVeteranView.jsx
@@ -19,7 +19,7 @@ class RequiredVeteranView extends React.Component {
       view = <SystemDownView messageLine1="We’re sorry. We can’t proceed with your request for a Veteran ID card because we can't confirm your military history right now. Please try again in a few minutes." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
     } else if (this.props.userProfile.veteranStatus === 'OK') {
       if (serviceRateLimited) {
-        view = <SystemDownView messageLine1="We can't proceed with your request for a Veteran ID Card." messageLine2="We're sorry, Veteran ID Card application is currently experiencing very high traffic. We're actively addressing the issues, please try again later."/>;
+        view = <SystemDownView messageLine1="We can't proceed with your request for a Veteran ID Card." messageLine2="The Veteran Identification Card application is currently experiencing very high traffic. If you're unable to send your application, please try again after 24 hours. We apologize and please know we're working to update it as soon as possible."/>;
       } else if (!serviceAvailable) {
         // If all above conditions are true and service is still not present in user profile, then user
         // is either not enrolled in beta, or is not eligible on other grounds

--- a/src/js/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/js/veteran-id-card/components/RequiredVeteranView.jsx
@@ -19,7 +19,7 @@ class RequiredVeteranView extends React.Component {
       view = <SystemDownView messageLine1="We’re sorry. We can’t proceed with your request for a Veteran ID card because we can't confirm your military history right now. Please try again in a few minutes." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
     } else if (this.props.userProfile.veteranStatus === 'OK') {
       if (serviceRateLimited) {
-        view = <SystemDownView messageLine1="We can't proceed with your request for a Veteran ID Card." messageLine2="We're sorry, this service is currently under heavy load. We're actively addressing the issues, please try again later."/>;
+        view = <SystemDownView messageLine1="We can't proceed with your request for a Veteran ID Card." messageLine2="We're sorry, Veteran ID Card application is currently experiencing very high traffic. We're actively addressing the issues, please try again later."/>;
       } else if (!serviceAvailable) {
         // If all above conditions are true and service is still not present in user profile, then user
         // is either not enrolled in beta, or is not eligible on other grounds


### PR DESCRIPTION
VIC services are currently struggling to accomodate the increased load. This limits the number of Veterans who will be making a request by limiting the interface to 10% of requests.

While folks may refresh and try again, this should ease the burden somewhat. We can tie into beta registrations if we need to enable this on a per-user basis, but I'd prefer being able to simply revert this change when the service is better able to handle the traffic.