### PR TITLE
Comment out session refresh code

### DIFF
--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -145,12 +145,14 @@ class Main extends React.Component {
   checkTokenStatus() {
     if (sessionStorage.userToken) {
       if (moment() > moment(sessionStorage.entryTime).add(SESSION_REFRESH_INTERVAL_MINUTES, 'm')) {
-        // TODO(crew): make more customized prompt.
-        if (confirm('For security, you’ll be automatically signed out in 2 minutes. To stay signed in, click OK.')) {
-          this.handleLogin();
-        } else {
-          this.handleLogout();
-        }
+
+        // @todo once we have time to replace the confirm dialog with an actual modal we should uncomment this code.
+        // if (confirm('For security, you’ll be automatically signed out in 2 minutes. To stay signed in, click OK.')) {
+        //   this.handleLogin();
+        // } else {
+        //   this.handleLogout();
+        // }
+
       } else {
         if (this.props.getUserData()) {
           this.props.updateLoggedInStatus(true);

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -144,18 +144,21 @@ class Main extends React.Component {
 
   checkTokenStatus() {
     if (sessionStorage.userToken) {
+
+      // @todo once we have time to replace the confirm dialog with an actual modal we should uncomment this code.
       // if (moment() > moment(sessionStorage.entryTime).add(SESSION_REFRESH_INTERVAL_MINUTES, 'm')) {
-
-      //   // @todo once we have time to replace the confirm dialog with an actual modal we should uncomment this code.
-      //   // if (confirm('For security, you’ll be automatically signed out in 2 minutes. To stay signed in, click OK.')) {
-      //   //   this.handleLogin();
-      //   // } else {
-      //   //   this.handleLogout();
-      //   // }
-
+      //   if (confirm('For security, you’ll be automatically signed out in 2 minutes. To stay signed in, click OK.')) {
+      //     this.handleLogin();
+      //   } else {
+      //     this.handleLogout();
+      //   }
       // } else {
-
+      //   if (this.props.getUserData()) {
+      //     this.props.updateLoggedInStatus(true);
+      //   }
       // }
+
+      // @todo after doing the above, remove this code.
       if (this.props.getUserData()) {
         this.props.updateLoggedInStatus(true);
       }

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import moment from 'moment';
+// import moment from 'moment';
 import PropTypes from 'prop-types';
 import appendQuery from 'append-query';
 
@@ -14,7 +14,7 @@ import SearchHelpSignIn from '../components/SearchHelpSignIn';
 import Signin from '../components/Signin';
 import Verify from '../components/Verify';
 
-const SESSION_REFRESH_INTERVAL_MINUTES = 45;
+// const SESSION_REFRESH_INTERVAL_MINUTES = 45;
 
 class Main extends React.Component {
   constructor(props) {

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -144,19 +144,20 @@ class Main extends React.Component {
 
   checkTokenStatus() {
     if (sessionStorage.userToken) {
-      if (moment() > moment(sessionStorage.entryTime).add(SESSION_REFRESH_INTERVAL_MINUTES, 'm')) {
+      // if (moment() > moment(sessionStorage.entryTime).add(SESSION_REFRESH_INTERVAL_MINUTES, 'm')) {
 
-        // @todo once we have time to replace the confirm dialog with an actual modal we should uncomment this code.
-        // if (confirm('For security, you’ll be automatically signed out in 2 minutes. To stay signed in, click OK.')) {
-        //   this.handleLogin();
-        // } else {
-        //   this.handleLogout();
-        // }
+      //   // @todo once we have time to replace the confirm dialog with an actual modal we should uncomment this code.
+      //   // if (confirm('For security, you’ll be automatically signed out in 2 minutes. To stay signed in, click OK.')) {
+      //   //   this.handleLogin();
+      //   // } else {
+      //   //   this.handleLogout();
+      //   // }
 
-      } else {
-        if (this.props.getUserData()) {
-          this.props.updateLoggedInStatus(true);
-        }
+      // } else {
+
+      // }
+      if (this.props.getUserData()) {
+        this.props.updateLoggedInStatus(true);
       }
     } else {
       this.props.updateLoggedInStatus(false);


### PR DESCRIPTION
This disables the confirm dialog from popping up on page load after the user's session has reached 45 minutes. `window.open` can only be used after some sort of user interaction through an event listener, otherwise the browser's popup blocker will block it from opening. So, in most cases this was probably just a random dialog that popped up and didn't do anything.

Soon, we should definitely add an actual modal that refreshes the session to alleviate this issues.