### PR TITLE
Fix config for feature flag

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -186,7 +186,7 @@ const configGenerator = (options) => {
       new webpack.DefinePlugin({
         __BUILDTYPE__: JSON.stringify(options.buildtype),
         __SAMPLE_ENABLED__: (process.env.SAMPLE_ENABLED === 'true'),
-        __VIC_RATE_LIMIT_ENABLED__: (JSON.stringify(options.buildtype) === 'production' || process.env.VIC_RATE_LIMIT_ENABLED === 'true'),
+        __VIC_RATE_LIMIT_ENABLED__: (options.buildtype === 'production' || process.env.VIC_RATE_LIMIT_ENABLED === 'true'),
         'process.env': {
           NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development'),
           API_PORT: (process.env.API_PORT || 3000),


### PR DESCRIPTION
JSON.stringify is not necessary and causes problems when setting boolean values.

I scanned the history for examples before building the initial implementation. Caught 8650328b86398deac8817383081be47985a3001a, which was addressed in 113170e0bfcc5e7a9f52009f4086391689d300da. 