### PR TITLE
Add preparer tests, fix required name on pre-need

### DIFF
--- a/src/js/pre-need/config/form.jsx
+++ b/src/js/pre-need/config/form.jsx
@@ -698,9 +698,12 @@ const formConfig = {
                   'ui:widget': 'radio',
                   'ui:options': {
                     updateSchema: (formData) => {
-                      const applicantName = formatName(formData.application.claimant.name);
+                      const nameData = _.get('application.claimant.name', formData);
+                      const applicantName = nameData
+                        ? formatName(nameData)
+                        : null;
+
                       return {
-                        'enum': ['Self', 'Authorized Agent/Rep'],
                         enumNames: [applicantName || 'Myself', 'Someone else']
                       };
                     },
@@ -715,7 +718,9 @@ const formConfig = {
                     expandUnderCondition: 'Authorized Agent/Rep'
                   },
                   name: _.merge(nonRequiredFullNameUI, {
-                    'ui:title': 'Preparer information'
+                    'ui:title': 'Preparer information',
+                    first: { 'ui:required': isAuthorizedAgent },
+                    last: { 'ui:required': isAuthorizedAgent },
                   }),
                   mailingAddress: _.merge(address.uiSchema('Mailing address'), {
                     country: { 'ui:required': isAuthorizedAgent },

--- a/test/pre-need/config/preparer.unit.spec.jsx
+++ b/test/pre-need/config/preparer.unit.spec.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+
+import { DefinitionTester, fillData, selectRadio } from '../../util/schemaform-utils.jsx';
+import formConfig from '../../../src/js/pre-need/config/form';
+
+describe('Pre-need preparer info', () => {
+  const { schema, uiSchema } = formConfig.chapters.contactInformation.pages.preparer;
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        definitions={formConfig.defaultDefinitions}
+        uiSchema={uiSchema}/>
+    );
+
+    expect(form.find('input').length).to.equal(2);
+  });
+
+  it('should not submit empty form', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+        uiSchema={uiSchema}/>
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should submit with required fields filled in', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+        uiSchema={uiSchema}/>
+    );
+
+    selectRadio(form, 'root_application_applicant_applicantRelationshipToClaimant', 'Self');
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+
+  it('should reveal name fields', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+        uiSchema={uiSchema}/>
+    );
+
+    selectRadio(form, 'root_application_applicant_applicantRelationshipToClaimant', 'Authorized Agent/Rep');
+
+    expect(form.find('input').length).to.equal(10);
+    expect(form.find('select').length).to.equal(3);
+  });
+
+  it('should not submit without required agent fields', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+        uiSchema={uiSchema}/>
+    );
+
+    selectRadio(form, 'root_application_applicant_applicantRelationshipToClaimant', 'Authorized Agent/Rep');
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(7);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should submit with all required info filled in', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+        uiSchema={uiSchema}/>
+    );
+
+    selectRadio(form, 'root_application_applicant_applicantRelationshipToClaimant', 'Authorized Agent/Rep');
+    fillData(form, 'input[name="root_application_applicant_view:applicantInfo_name_first"]', 'Jane');
+    fillData(form, 'input[name="root_application_applicant_view:applicantInfo_name_last"]', 'Smith');
+    fillData(form, 'input[name="root_application_applicant_view:applicantInfo_mailingAddress_street"]', '101 big sky st');
+    fillData(form, 'input[name="root_application_applicant_view:applicantInfo_mailingAddress_city"]', 'Bozeman');
+    fillData(form, 'select[name="root_application_applicant_view:applicantInfo_mailingAddress_state"]', 'MT');
+    fillData(form, 'input[name="root_application_applicant_view:applicantInfo_mailingAddress_postalCode"]', '01060');
+    fillData(form, 'input[name="root_application_applicant_view:applicantInfo_view:contactInfo_applicantPhoneNumber"]', '2344445555');
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+});


### PR DESCRIPTION
Adds tests for preparer page. I also made the name required, since that's how it is in the Marvel prototype and doesn't really make sense as an optional field.

![screen shot 2017-12-04 at 10 41 11 am](https://user-images.githubusercontent.com/634932/33561059-90840274-d8df-11e7-97a4-c72579826cbd.png)
