### PR TITLE
Block SM if there is an error related to account creation.

### DIFF
--- a/src/js/health-records/components/ErrorView.jsx
+++ b/src/js/health-records/components/ErrorView.jsx
@@ -16,7 +16,7 @@ class ErrorView extends React.Component {
     let detail;
     let alert;
 
-    if (some(errors, errorCodeIncludes(errorCodes.accountcreation))) {
+    if (some(errors, errorCodeIncludes(errorCodes.accountCreation))) {
       alert = true;
       title = 'We couldn’t access your health tools';
       detail = (
@@ -54,7 +54,7 @@ class ErrorView extends React.Component {
   render() {
     const { errors } = this.props;
     const blockingErrors = concat(
-      errorCodes.accountcreation,
+      errorCodes.accountCreation,
     );
 
     // don’t block application if no errors, or errors not in the list above

--- a/src/js/health-records/config.js
+++ b/src/js/health-records/config.js
@@ -203,7 +203,7 @@ module.exports = {
   },
 
   errorCodes: {
-    accountcreation: [
+    accountCreation: [
       'MHVAC1',
     ]
   }

--- a/src/js/messaging/components/ErrorView.jsx
+++ b/src/js/messaging/components/ErrorView.jsx
@@ -22,7 +22,7 @@ class ErrorView extends React.Component {
 
     if (some(errors, errorCodeIncludes(errorCodes.access))) {
       content = mhvAccessError;
-    } else if (some(errors, errorCodeIncludes(errorCodes.accountcreation))) {
+    } else if (some(errors, errorCodeIncludes(errorCodes.accountCreation))) {
       alert = true;
       title = 'We couldn’t access your health tools';
       detail = (
@@ -61,6 +61,7 @@ class ErrorView extends React.Component {
     const { errors } = this.props;
     const blockingErrors = concat(
       errorCodes.access,
+      errorCodes.accountCreation
     );
 
     // don’t block application if no errors, or errors not in the list above

--- a/src/js/messaging/config.js
+++ b/src/js/messaging/config.js
@@ -85,7 +85,7 @@ module.exports = {
     access: [
       'SM105'
     ],
-    accountcreation: [
+    accountCreation: [
       'MHVAC1',
     ]
   }

--- a/src/js/rx/components/ErrorView.jsx
+++ b/src/js/rx/components/ErrorView.jsx
@@ -38,7 +38,7 @@ class ErrorView extends React.Component {
           Please <a onClick={() => { window.location.reload(true); }}>refresh this page</a> or try again later. If this problem persists, please call the Vets.gov Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY: <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).
         </p>
       );
-    } else if (some(errors, errorCodeIncludes(errorCodes.accountcreation))) {
+    } else if (some(errors, errorCodeIncludes(errorCodes.accountCreation))) {
       alert = true;
       title = 'We couldn’t access your health tools';
       detail = (
@@ -79,7 +79,7 @@ class ErrorView extends React.Component {
       errorCodes.access,
       errorCodes.registration,
       errorCodes.prescriptions,
-      errorCodes.accountcreation,
+      errorCodes.accountCreation,
     );
 
     // don’t block application if no errors, or errors not in the list above

--- a/src/js/rx/config.js
+++ b/src/js/rx/config.js
@@ -57,7 +57,7 @@ module.exports = {
       'RX99',
       'VA900',
     ],
-    accountcreation: [
+    accountCreation: [
       'MHVAC1',
     ],
   },


### PR DESCRIPTION
Rx and BB were blocking access when getting the error `MHVAC1` and showing the ErrorView, but SM was not. Just fixing that inconsistency.