### PR TITLE
Server error copy change for VIC

### DIFF
--- a/src/js/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/js/veteran-id-card/components/RequiredVeteranView.jsx
@@ -25,7 +25,7 @@ class RequiredVeteranView extends React.Component {
 
     if (this.props.userProfile.veteranStatus === 'SERVER_ERROR') {
       // If eMIS status is null, show a system down message.
-      view = <SystemDownView messageLine1="We’re sorry. We can’t proceed with your request for a Veteran ID card because of a temporary system error. Please try again in a few minutes." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
+      view = <SystemDownView messageLine1="We’re sorry. We can’t process your request for a Veteran ID card right now because of a temporary system error. Please try again in a few minutes." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
     } else if (this.props.userProfile.veteranStatus === 'NOT_FOUND') {
       // If eMIS status is "not found", show message that we cannot find the user
       // in our system.

--- a/src/js/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/js/veteran-id-card/components/RequiredVeteranView.jsx
@@ -25,7 +25,7 @@ class RequiredVeteranView extends React.Component {
 
     if (this.props.userProfile.veteranStatus === 'SERVER_ERROR') {
       // If eMIS status is null, show a system down message.
-      view = <SystemDownView messageLine1="We’re sorry. We can’t proceed with your request for a Veteran ID card because we can't confirm your military history right now. Please try again in a few minutes." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
+      view = <SystemDownView messageLine1="We’re sorry. We can’t proceed with your request for a Veteran ID card because of a temporary system error. Please try again in a few minutes." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
     } else if (this.props.userProfile.veteranStatus === 'NOT_FOUND') {
       // If eMIS status is "not found", show message that we cannot find the user
       // in our system.


### PR DESCRIPTION
When a server error prevents determining Veteran status, use an error
message that points less to a records problem and more to a temporary
systems problem.