### PR TITLE
Adjust rate limit for VIC default to 100% allowed

### DIFF
--- a/config/create-settings.js
+++ b/config/create-settings.js
@@ -11,7 +11,7 @@ function createSettings(options) {
       BASE_URL: process.env.BASE_URL
     },
     vic: {
-      rateLimit: options.buildtype === 'development' ? 1 : 0.1
+      rateLimit: 1
     }
   };
 }


### PR DESCRIPTION
We had the settings overridden on our most recent deploy 😢 

This updates the defaults.