### PR TITLE
WIP: Rate limit both authenticated and unauthenticated users

### DIFF
--- a/config/create-settings.js
+++ b/config/create-settings.js
@@ -12,7 +12,7 @@ function createSettings(options) {
     },
     vic: {
       rateLimitAuthed: 1,
-      rateLimitUnauthed: 1
+      rateLimitUnauthed: 0.05
     }
   };
 }

--- a/config/create-settings.js
+++ b/config/create-settings.js
@@ -11,7 +11,8 @@ function createSettings(options) {
       BASE_URL: process.env.BASE_URL
     },
     vic: {
-      rateLimit: options.buildtype === 'development' ? 1 : 0.1
+      rateLimitAuthed: 1,
+      rateLimitUnauthed: 1
     }
   };
 }

--- a/src/js/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/js/veteran-id-card/components/RequiredVeteranView.jsx
@@ -2,24 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import SystemDownView from '../../common/components/SystemDownView';
-import EmailCapture from '../containers/EmailCapture';
-
-const rateLimit = window.settings.vic.rateLimit;
 
 class RequiredVeteranView extends React.Component {
-
-  componentDidMount() {
-    if (this.props.serviceRateLimited) {
-      window.dataLayer.push({ event: 'vic-ratelimited' });
-    }
-  }
-
   render() {
-    // redirect logged-in users to email form based on serviceRateLimited prop
-    if (this.props.serviceRateLimited) {
-      return <EmailCapture/>;
-    }
-
     let view;
     const serviceAvailable = this.props.userProfile.services.indexOf('id-card') !== -1;
 
@@ -50,11 +35,6 @@ class RequiredVeteranView extends React.Component {
 
 RequiredVeteranView.propTypes = {
   userProfile: PropTypes.object.isRequired,
-  serviceRateLimited: PropTypes.bool
-};
-
-RequiredVeteranView.defaultProps = {
-  serviceRateLimited: Math.random() > rateLimit
 };
 
 export default RequiredVeteranView;

--- a/src/js/veteran-id-card/containers/VeteranIDCard.jsx
+++ b/src/js/veteran-id-card/containers/VeteranIDCard.jsx
@@ -27,6 +27,15 @@ class VeteranIDCard extends React.Component {
         window.dataLayer.push({ event: 'vic-unauthenticated' });
       }
     }
+
+    if (this.renderEmailCapture === true ){
+      // Report if they will see an error message around eMIS status
+      if (this.props.profile.veteranStatus === 'NOT_FOUND') {
+        window.dataLayer.push({ events: 'vic-emis-lookup-failed' });
+      } else if (this.props.profile.veteranStatus === 'SERVER_ERROR' ) {
+        window.dataLayer.push({ events: 'vic-emis-error' });
+      }
+    }
   }
 
   render() {

--- a/src/js/veteran-id-card/containers/VeteranIDCard.jsx
+++ b/src/js/veteran-id-card/containers/VeteranIDCard.jsx
@@ -28,11 +28,11 @@ class VeteranIDCard extends React.Component {
       }
     }
 
-    if (this.renderEmailCapture === true ){
+    if (this.renderEmailCapture === true) {
       // Report if they will see an error message around eMIS status
       if (this.props.profile.veteranStatus === 'NOT_FOUND') {
         window.dataLayer.push({ events: 'vic-emis-lookup-failed' });
-      } else if (this.props.profile.veteranStatus === 'SERVER_ERROR' ) {
+      } else if (this.props.profile.veteranStatus === 'SERVER_ERROR') {
         window.dataLayer.push({ events: 'vic-emis-error' });
       }
     }

--- a/src/js/veteran-id-card/containers/VeteranIDCard.jsx
+++ b/src/js/veteran-id-card/containers/VeteranIDCard.jsx
@@ -5,17 +5,32 @@ import RequiredLoginView from '../../common/components/RequiredLoginView';
 import RequiredVeteranView from '../components/RequiredVeteranView';
 import EmailCapture from './EmailCapture';
 
+const rateLimitAuthed = window.settings.vic.rateLimitAuthed;
+const rateLimitUnauthed = window.settings.vic.rateLimitUnauthed;
+
 class VeteranIDCard extends React.Component {
 
   componentDidMount() {
-    if (!this.props.profile.accountType) {
-      window.dataLayer.push({ event: 'vic-unauthenticated' });
+    // Redirect users to email form based on rate limits for unauthed or authed users
+    if (this.props.profile.accountType) {
+      if (this.props.serviceRateLimitedAuthed) {
+        window.dataLayer.push({ event: 'vic-authenticated-ratelimited' });
+        this.renderEmailCapture = true;
+      } else {
+        window.dataLayer.push({ event: 'vic-authenticated' });
+      }
+    } else {
+      if (this.props.serviceRateLimitedUnauthed) {
+        window.dataLayer.push({ event: 'vic-unauthenticated-ratelimited' });
+        this.renderEmailCapture = true;
+      } else {
+        window.dataLayer.push({ event: 'vic-unauthenticated' });
+      }
     }
   }
 
   render() {
-    // direct all unauthenticated users to email form
-    if (!this.props.profile.accountType) {
+    if (this.renderEmailCapture) {
       return <EmailCapture/>;
     }
 
@@ -42,6 +57,8 @@ const mapStateToProps = (state) => {
     profile: userState.profile,
     loginUrl: userState.login.loginUrl,
     verifyUrl: userState.login.verifyUrl,
+    serviceRateLimitedAuthed: Math.random() > rateLimitAuthed,
+    serviceRateLimitedUnauthed: Math.random() > rateLimitUnauthed
   };
 };
 


### PR DESCRIPTION
This moves all rate-limiting logic and analytics events into VeteranIDCard.jsx and out of RequiredVeteranView.jsx, and adds a second variable so we can independently adjust the rate limit for authenticated and unauthenticated users.

This is WIP, so have yet to get a demo up to test behavior, but in the meantime @bshyong @ncksllvn  can you review? We'll probably want to deploy this manually tomorrow morning so we can begin sending a fraction of unauthenticated users to the VIC page

@robertfairhead can you review the changes analytics events? This renames events to more clearly reflect the conditions, but am also open to preserving the existing naming conventions instead, and settling for event names that are a bit harder to interpret