### PR TITLE
Add events to track errors around Veteran profile lookup

### DIFF
--- a/src/js/veteran-id-card/containers/VeteranIDCard.jsx
+++ b/src/js/veteran-id-card/containers/VeteranIDCard.jsx
@@ -27,6 +27,15 @@ class VeteranIDCard extends React.Component {
         window.dataLayer.push({ event: 'vic-unauthenticated' });
       }
     }
+
+    if (this.renderEmailCapture === true ){
+      // Report if they will see an error message around eMIS status
+      if (this.props.profile.veteranStatus === 'NOT_FOUND') {
+        window.dataLayer.push({ events: 'vic-emis-lookup-failed' });
+      } else if (this.props.profile.veteranStatus === 'SERVER_ERROR' ) {
+        window.dataLayer.push({ events: 'vic-emis-error' });
+      }
+    }
   }
 
   render() {

--- a/src/js/veteran-id-card/containers/VeteranIDCard.jsx
+++ b/src/js/veteran-id-card/containers/VeteranIDCard.jsx
@@ -28,11 +28,11 @@ class VeteranIDCard extends React.Component {
       }
     }
 
-    if (this.renderEmailCapture === true ){
+    if (this.renderEmailCapture === true) {
       // Report if they will see an error message around eMIS status
       if (this.props.profile.veteranStatus === 'NOT_FOUND') {
         window.dataLayer.push({ events: 'vic-emis-lookup-failed' });
-      } else if (this.props.profile.veteranStatus === 'SERVER_ERROR' ) {
+      } else if (this.props.profile.veteranStatus === 'SERVER_ERROR') {
         window.dataLayer.push({ events: 'vic-emis-error' });
       }
     }


### PR DESCRIPTION
Take it or leave it. Figured it may be good to track how many accesses that we're getting that fail out on the eMIS steps. That is, get passed through the rate limits but never get a chance to go through to the VIC app attribute lookup