### PR TITLE
Update Appeals v2 Status UI for Usability Testing

### DIFF
--- a/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
+++ b/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
@@ -5,7 +5,7 @@ const CurrentStatus = ({ title, description }) => (
   <li className="process-step section-current">
     <h3>Current Status</h3>
     <h4>{title}</h4>
-    <p>{description}</p>
+    <div>{description}</div>
   </li>
 );
 

--- a/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
+++ b/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const CurrentStatus = ({ title, description }) => (
   <li className="process-step section-current">
-    <h3>Current Status</h3>
+    <h2>Current Status</h2>
     <h4>{title}</h4>
     <div>{description}</div>
   </li>

--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -2,9 +2,7 @@ import React from 'react';
 
 class Docket extends React.Component {
   render() {
-    return (
-      <div>Docket</div>
-    );
+    return (null);
   }
 }
 

--- a/src/js/claims-status/components/appeals-v2/Expander.jsx
+++ b/src/js/claims-status/components/appeals-v2/Expander.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Expander = ({ title, dateRange, onToggle, cssClass }) => {
+  return (
+    <li className={`process-step ${cssClass}`}>
+      {/* Giving this a margin top to help center the text to the li bullet */}
+      <button onClick={onToggle} className="va-button-link">
+        <h4 style={{ color: 'inherit' }}>{title}</h4>
+      </button>
+      <div className="appeal-event-date">{dateRange}</div>
+      <div className="separator"/>
+    </li>
+  );
+};
+
+Expander.propTypes = {
+  title: PropTypes.string.isRequired,
+  dateRange: PropTypes.string.isRequired,
+  onToggle: PropTypes.func.isRequired,
+  cssClass: PropTypes.string.isRequired,
+};
+
+export default Expander;

--- a/src/js/claims-status/components/appeals-v2/NextEvent.jsx
+++ b/src/js/claims-status/components/appeals-v2/NextEvent.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const NextEvent = ({ title, description, durationText, cardDescription, showSeparator }) => {
   return (
-    <li>
+    <li className="next-event">
       <h3>{title}</h3>
       <p>{description}</p>
       <div className="card information">
@@ -17,7 +17,10 @@ const NextEvent = ({ title, description, durationText, cardDescription, showSepa
 
 NextEvent.propTypes = {
   title: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
+  description: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ]).isRequired,
   durationText: PropTypes.string.isRequired,
   cardDescription: PropTypes.string.isRequired,
   showSeparator: PropTypes.bool.isRequired

--- a/src/js/claims-status/components/appeals-v2/PastEvent.jsx
+++ b/src/js/claims-status/components/appeals-v2/PastEvent.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const PastEvent = ({ title, description, liClass, date }) => {
+  return (
+    <li role="presentation" className={`process-step ${liClass}`}>
+      <h3>{title}</h3>
+      <div className="appeal-event-date">on {date}</div>
+      <p>{description}</p>
+      <div className="separator"/>
+    </li>
+  );
+};
+
+PastEvent.propTypes = {
+  title: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  liClass: PropTypes.string.isRequired,
+};
+
+export default PastEvent;

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -16,7 +16,7 @@ class Timeline extends React.Component {
 
   formatDateRange = () => {
     const { events } = this.props;
-    if (!events[0]) {
+    if (!events.length) {
       return '';
     }
     const first = formatDate(events[0].date);
@@ -29,7 +29,7 @@ class Timeline extends React.Component {
   render() {
     const { events } = this.props;
     let pastEventsList = [];
-    if (events[0]) {
+    if (events.length) {
       pastEventsList = events.map((event, index) => {
         const { title, description, liClass } = getEventContent(event);
         const date = formatDate(event.date);

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -86,7 +86,10 @@ Timeline.propTypes = {
   })).isRequired,
   currentStatus: PropTypes.shape({
     title: PropTypes.string.isRequired,
-    description: PropTypes.string.isRequired
+    description: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element
+    ]).isRequired,
   }).isRequired
 };
 

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -14,12 +14,20 @@ class Timeline extends React.Component {
     this.state = { expanded: false };
   }
 
-  getPastEvents = () => {
+  formatDateRange = () => {
     const { events } = this.props;
     if (!events[0]) {
-      return [];
+      return '';
     }
-    return events.map((event, index) => {
+    const first = formatDate(events[0].date);
+    const last = formatDate(events[events.length - 1].date);
+    return `${first} - ${last}`;
+  };
+
+  toggleExpanded = () => this.setState((prevState) => ({ expanded: !prevState.expanded }));
+
+  render() {
+    const pastEventsList = this.props.events.map((event, index) => {
       const { title, description, liClass } = getEventContent(event);
       const date = formatDate(event.date);
       return (
@@ -31,60 +39,34 @@ class Timeline extends React.Component {
           liClass={liClass}/>
       );
     });
-  };
 
-  formatDateRange = () => {
-    const { events } = this.props;
-    if (events[0]) {
-      const first = formatDate(events[0].date);
-      const last = formatDate(events[events.length - 1].date);
-      return `${first} - ${last}`;
-    }
-    return '';
-  };
-
-  toggleExpanded = () => this.setState((prevState) => ({ expanded: !prevState.expanded }));
-
-  render() {
-    // Add the expander
-    let expanderTitle;
-    let expanderCssClass;
+    let expanderTitle = '';
+    let expanderCssClass = '';
+    let displayedEvents = [];
     if (this.state.expanded) {
       expanderTitle = 'Hide past events';
       expanderCssClass = 'section-expanded';
+      displayedEvents = pastEventsList;
     } else {
       expanderTitle = 'See past events';
       expanderCssClass = 'section-unexpanded';
+      displayedEvents = [];
     }
 
-    const expander = (
-      <Expander
-        key={'expander'}
-        title={expanderTitle}
-        dateRange={this.formatDateRange()}
-        onToggle={this.toggleExpanded}
-        cssClass={expanderCssClass}/>
-    );
-
-    // Add past events
-    const pastEvents = this.state.expanded ? this.getPastEvents() : [];
-
-    // Add the current status
-    const { title, description } = this.props.currentStatus;
-    const currentEvent = (
-      <CurrentStatus
-        key={'current-event'}
-        title={title}
-        description={description}/>
-    );
-
-    // Combine into unified timeline
     return (
       <div>
         <ol className="form-process appeal-timeline">
-          {expander}
-          {pastEvents}
-          {currentEvent}
+          <Expander
+            key={'expander'}
+            title={expanderTitle}
+            dateRange={this.formatDateRange()}
+            onToggle={this.toggleExpanded}
+            cssClass={expanderCssClass}/>
+          {displayedEvents}
+          <CurrentStatus
+            key={'current-event'}
+            title={this.props.currentStatus.title}
+            description={this.props.currentStatus.description}/>
         </ol>
         <div className="down-arrow"/>
       </div>
@@ -94,10 +76,10 @@ class Timeline extends React.Component {
 
 Timeline.propTypes = {
   events: PropTypes.arrayOf(PropTypes.shape({
-    type: PropTypes.string,
-    date: PropTypes.string,
+    type: PropTypes.string.isRequired,
+    date: PropTypes.string.isRequired,
     details: PropTypes.object
-  })),
+  })).isRequired,
   currentStatus: PropTypes.shape({
     title: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired
@@ -105,4 +87,3 @@ Timeline.propTypes = {
 };
 
 export default Timeline;
-

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -1,14 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import moment from 'moment';
-
-import { getEventContent } from '../../utils/appeals-v2-helpers';
+import { getEventContent, formatDate } from '../../utils/appeals-v2-helpers';
 import CurrentStatus from './CurrentStatus';
-
-function formatDate(date) {
-  return moment(date, 'YYYY-MM-DD').format('MMMM d, YYYY');
-}
+import Expander from './Expander';
+import PastEvent from './PastEvent';
 
 /**
  * Timeline is in charge of the past events and current status.
@@ -16,68 +11,81 @@ function formatDate(date) {
 class Timeline extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      expanded: false
-    };
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    // If we just expanded or unexpanded
-    if (prevState.expanded !== this.state.expanded) {
-      const x = (window.pageXOffset || document.documentElement.scrollLeft);
-      // I think this is too slow...should be happening after rendering, but it's like it's getting the previous button location
-      const topOfButton = document.querySelector('li button.va-button-link').getBoundingClientRect().top;
-      const y = (window.pageYOffset || document.documentElement.scrollTop);
-      // Put the expander button in the same position it was in before relative to the window
-      window.scrollTo(x, y + topOfButton - this.prevTopOfButton);
-    }
+    this.state = { expanded: false };
   }
 
   getPastEvents = () => {
-    return this.props.events.map((event, index) => {
+    const { events } = this.props;
+    if (!events[0]) {
+      return [];
+    }
+    return events.map((event, index) => {
       const { title, description, liClass } = getEventContent(event);
+      const date = formatDate(event.date);
       return (
-        <li key={index} role="presentation" className={`process-step ${liClass}`}>
-          <h3>{title || 'Title here'}</h3>
-          <div className="appeal-event-date">on {formatDate(event.date)}</div>
-          <p>{description}</p>
-          <div className="separator"/>
-        </li>
+        <PastEvent
+          key={`past-event-${index}`}
+          title={title}
+          date={date}
+          description={description}
+          liClass={liClass}/>
       );
     });
-  }
+  };
 
-  toggleExpanded = () => {
-    this.setState((prevState) => ({ expanded: !prevState.expanded }));
-    this.prevTopOfButton = document.querySelector('li button.va-button-link').getBoundingClientRect().top;
-  }
+  formatDateRange = () => {
+    const { events } = this.props;
+    if (events[0]) {
+      const first = formatDate(events[0].date);
+      const last = formatDate(events[events.length - 1].date);
+      return `${first} - ${last}`;
+    }
+    return '';
+  };
 
-  prevTopOfButton = 0
+  toggleExpanded = () => this.setState((prevState) => ({ expanded: !prevState.expanded }));
 
   render() {
-    const eventList = this.state.expanded ? this.getPastEvents() : [];
-    const dateRange = this.props.events[0] ? `${formatDate(this.props.events[0].date)} - ${formatDate(this.props.events[this.props.events.length - 1].date)}` : '';
-
     // Add the expander
-    const expanderClassName = this.state.expanded ? 'section-expanded' : 'section-unexpanded';
-    eventList.push(
-      <li key={eventList.length} className={`process-step ${expanderClassName}`}>
-        {/* Giving this a margin top to help center the text to the li bullet */}
-        <button onClick={this.toggleExpanded} className="va-button-link">
-          <h4 style={{ color: 'inherit' }}>{this.state.expanded ? 'Hide past events' : 'See past events'}</h4>
-        </button>
-        <div className="appeal-event-date">{dateRange}</div>
-        <div className="separator"/>
-      </li>
+    let expanderTitle;
+    let expanderCssClass;
+    if (this.state.expanded) {
+      expanderTitle = 'Hide past events';
+      expanderCssClass = 'section-expanded';
+    } else {
+      expanderTitle = 'See past events';
+      expanderCssClass = 'section-unexpanded';
+    }
+
+    const expander = (
+      <Expander
+        key={'expander'}
+        title={expanderTitle}
+        dateRange={this.formatDateRange()}
+        onToggle={this.toggleExpanded}
+        cssClass={expanderCssClass}/>
     );
+
+    // Add past events
+    const pastEvents = this.state.expanded ? this.getPastEvents() : [];
 
     // Add the current status
     const { title, description } = this.props.currentStatus;
-    eventList.push(<CurrentStatus key={eventList.length} title={title} description={description}/>);
+    const currentEvent = (
+      <CurrentStatus
+        key={'current-event'}
+        title={title}
+        description={description}/>
+    );
 
+    // Combine into unified timeline
     return (
       <div>
-        <ol className="form-process appeal-timeline">{eventList}</ol>
+        <ol className="form-process appeal-timeline">
+          {expander}
+          {pastEvents}
+          {currentEvent}
+        </ol>
         <div className="down-arrow"/>
       </div>
     );

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -27,18 +27,22 @@ class Timeline extends React.Component {
   toggleExpanded = () => this.setState((prevState) => ({ expanded: !prevState.expanded }));
 
   render() {
-    const pastEventsList = this.props.events.map((event, index) => {
-      const { title, description, liClass } = getEventContent(event);
-      const date = formatDate(event.date);
-      return (
-        <PastEvent
-          key={`past-event-${index}`}
-          title={title}
-          date={date}
-          description={description}
-          liClass={liClass}/>
-      );
-    });
+    const { events } = this.props;
+    let pastEventsList = [];
+    if (events[0]) {
+      pastEventsList = events.map((event, index) => {
+        const { title, description, liClass } = getEventContent(event);
+        const date = formatDate(event.date);
+        return (
+          <PastEvent
+            key={`past-event-${index}`}
+            title={title}
+            date={date}
+            description={description}
+            liClass={liClass}/>
+        );
+      });
+    }
 
     let expanderTitle = '';
     let expanderCssClass = '';

--- a/src/js/claims-status/components/appeals-v2/WhatsNext.jsx
+++ b/src/js/claims-status/components/appeals-v2/WhatsNext.jsx
@@ -32,7 +32,10 @@ class WhatsNext extends React.Component {
 WhatsNext.propTypes = {
   nextEvents: PropTypes.arrayOf(PropTypes.shape({
     title: PropTypes.string.isRequired,
-    description: PropTypes.string.isRequired,
+    description: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element
+    ]).isRequired,
     durationText: PropTypes.string.isRequired,
     cardDescription: PropTypes.string.isRequired
   })).isRequired

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import moment from 'moment';
+
 // TO DO: Replace made up properties and content with real versions once finalized.
 export const STATUS_TYPES = {
   nod: 'nod',
@@ -306,4 +308,8 @@ export function getAlertContent(alert) {
         type,
       };
   }
+}
+
+export function formatDate(date) {
+  return moment(date, 'YYYY-MM-DD').format('MMMM d, YYYY');
 }

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -4,12 +4,15 @@ import moment from 'moment';
 // TO DO: Replace made up properties and content with real versions once finalized.
 export const STATUS_TYPES = {
   nod: 'nod',
+  pendingForm9: 'pending_form9',
   awaitingHearingDate: 'awaiting_hearing_date',
+  onDocket: 'on_docket',
   bvaDecision: 'bva_decision',
 };
 
 export const ALERT_TYPES = {
   waitingOnAction: 'waiting_on_action',
+  form9Due: 'form9_due',
   hearingScheduled: 'hearing_scheduled',
   bvaDecisionPending: 'bva_decision_pending'
 };
@@ -26,7 +29,7 @@ export const ALERT_TYPES = {
  * @returns {Contents}
  */
 export function getStatusContents(type, details) {
-  const { nod, awaitingHearingDate, bvaDecision } = STATUS_TYPES;
+  const { nod, awaitingHearingDate, bvaDecision, pendingForm9, onDocket } = STATUS_TYPES;
 
   const contents = {};
   if (type === nod) {
@@ -49,6 +52,31 @@ export function getStatusContents(type, details) {
     contents.description = `The Board of Veterans’ Appeals has made a decision on your appeal. 
     You will receive your decision letter in the mail in 7 business days. Your appeal  
     decision is: ${decisionType}`;
+  } else if (type === pendingForm9) {
+    contents.title = 'Review your Statement of the Case';
+    contents.description = (
+      <div>
+        <p>
+          The Veterans Benefits Administration (VBA) sent you a Statement of the Case on November
+          28, 2017. The Statement of the Case document explains the reasons why the Regional Office
+          could not fully grant your appeal. If you don’t agree with the Statement of the Case, you
+          can bring your appeal to the Board of Veterans’ Appeals. To do this you must complete and
+          return a Form 9 within 60 days.
+        </p>
+        <p>
+          <em>Note:</em> If you send more evidence with the Form 9, it will be reviewed by the
+            Regional Office and will likely delay a decision on your appeal. If you have new
+            evidence, it’s best to send it when the Board of Veterans Appeals is reviewing your
+            case.
+        </p>
+      </div>
+    );
+  } else if (type === onDocket) {
+    contents.title = 'Waiting to be assigned to a judge';
+    contents.description = `Your appeal is at the Board of Veterans’ Appeals waiting to be
+      assigned to a Veterans Law Judge. Staff at the Board are making sure that your case is
+      complete, accurate, and ready to be decided by a judge. If you have evidence that isn’t
+      already included in your case, now is a good time to send it to the Board.`;
   } else {
     contents.title = 'Current Status Unknown';
     contents.description = 'Your current appeal status is unknown at this time';
@@ -65,6 +93,7 @@ export const EVENT_TYPES = {
   soc: 'soc',
   form9: 'form9',
   ssoc: 'ssoc',
+  appealReceived: 'appeal_received',
   certified: 'certified',
   hearingHeld: 'hearing_held',
   hearingCancelled: 'hearing_cancelled',
@@ -87,116 +116,122 @@ export function getEventContent(event) {
   switch (event.type) {
     case EVENT_TYPES.claim:
       return {
-        title: 'Claim Decision',
-        description: 'Your original claim decision was sent to you.',
+        title: 'VBA sent the original claim decision to you',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.nod:
       return {
-        title: 'Notice of Disagreement',
-        description: 'Notice of Disagreement received by your Regional Office.',
+        title: 'VBA received your Notice of Disagreement',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.droHearing:
       return {
         title: 'Dro Hearing',
-        description: 'You have a hearing at VBA with a Decision Review Officer prior to SOC.',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.fieldGrant:
       return {
         title: 'Field grant',
-        description: 'You have received a Field Grant.',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.soc:
       return {
-        title: 'Statement of the Case',
-        description: 'Statement of the Case (SOC) prepared by your Regional Office.',
+        title: 'VBA prepared a Statement of the Case (SOC)',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.form9:
       return {
         title: 'Form 9 Recieved',
-        description: 'Form 9 received by your Regional Office.',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.ssoc:
       return {
         title: 'Supplemental Statement of the Case',
-        description: 'Supplemental Statement of the Case (SOC) prepared by your Regional Office.',
+        description: '',
+        liClass: 'section-complete'
+      };
+    case EVENT_TYPES.appealReceived:
+      return {
+        title: 'The Board received your appeal',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.certified:
       return {
         title: 'Certification',
-        description: 'Your appeal was received by the Board.',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.hearingHeld:
       return {
-        title: 'Hearing Held',
-        description: `Your hearing was held at ${event.details.location}.`,
+        title: `Your hearing was held at the ${event.details.regionalOffice} Regional Office`,
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.hearingCancelled:
       return {
         title: 'Hearing Cancelled',
-        description: 'Your hearing was cancelled.',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.hearingNoShow:
       return {
         title: 'Hearing No Show',
-        description: 'You missed your hearing.',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.bvaDecision:
       return {
         title: 'Board Decision',
-        description: 'The Board has made a decision on your appeal.',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.bvaRemand:
       return {
         title: 'Board Remand',
-        description: 'BVA is collecting more evidence.',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.withdrawn:
       return {
         title: 'Withdrawn',
-        description: 'You have withdrawn your appeal.',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.merged:
       return {
         title: 'Merged',
-        description: 'Your appeals have been merged.',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.cavcDecision:
       return {
         title: 'CAVC Decision',
-        description: 'CAVC has made a decision.',
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.recordDesignation:
       return {
         title: 'Designation of Record',
-        description: `${event.details.name} has submitted a motion to continue this appeal.`,
+        description: '',
         liClass: 'section-complete'
       };
     case EVENT_TYPES.reconsideration:
       return {
         title: 'Reconsideration by Letter',
-        description: 'The Board has denied your motion for reconsideration.',
+        description: '',
         liClass: 'section-complete'
       };
     default:
       return {
         title: 'Unknown Event',
-        description: 'Not sure what happened here...weird.',
+        description: '',
         liClass: 'section-complete'
       };
   }
@@ -225,6 +260,29 @@ export function getNextEvents(currentStatus) {
           cardDescription: 'The Oakland regional office takes about 2 months to certify your appeal to the Board.'
         }
       ];
+    case STATUS_TYPES.pendingForm9:
+      return [
+        {
+          title: 'The Board receives your appeal',
+          description: `If you send the Form 9 without new evidence, the Veterans Benefits
+            Administration (VBA) will finish its review and transfer your case to the Board of
+            Veterans’ Appeals.`,
+          durationText: '2 months',
+          cardDescription: 'VBA takes about 2 months to certify appeals to the Board'
+        }, {
+          title: 'VBA prepares a Statement of the Case (SOC)',
+          description: `If you send the Form 9 with new evidence, the Veterans Benefits
+            Administration (VBA) will finish its review and transfer your case to the Board of
+            Veterans’ Appeals.`,
+          durationText: '11 months',
+          cardDescription: 'VBA takes about 11 months to produce a Statement of the Case (SOC)'
+        }, {
+          title: 'You withdraw your appeal',
+          description: 'If you do not send the Form 9 within 60 days, your appeal will be closed.',
+          durationText: '2 months',
+          cardDescription: 'You have 60 days to submit your appeal before it is closed'
+        }
+      ];
     case STATUS_TYPES.awaitingHearingDate:
       return [
         {
@@ -243,6 +301,38 @@ export function getNextEvents(currentStatus) {
           cardDescription: 'The Oakland regional office takes about 2 weeks to mail your decision.'
         }
       ];
+    case STATUS_TYPES.onDocket: {
+      const boldStyle = { fontWeight: 'bold' };
+      return [
+        {
+          title: 'Judge Decides Your Appeal',
+          description: (
+            <div>
+              <div>
+                A Veterans Law Judge, working with one of the Board attorneys, will review all of
+                the available evidence and write a decision. For each issue you are appealing, they
+                can decide to:
+              </div>
+              <ul>
+                <li>
+                  <span style={boldStyle}>Allow - </span>The judge overrules the Regional Office and makes a decision
+                  on your rating
+                </li>
+                <li><span style={boldStyle}>Deny - </span>The judge agrees with the Regional Office decision</li>
+                <li >
+                  <span style={boldStyle}>Remand - </span>The judge sends the issue to Veterans Benefits
+                    Administration (VBA) for more evidence or to fix a mistake before making a
+                    decision
+                </li>
+              </ul>
+              <p><span>Note:</span> About 60% of all cases have at least 1 issue remanded.</p>
+            </div>
+          ),
+          durationText: '10 months',
+          cardDescription: 'A Veterans Law Judge typically takes 10 months to write a decision.'
+        }
+      ];
+    }
     default:
       return [
         {
@@ -273,6 +363,25 @@ export function getAlertContent(alert) {
           representative for more information.`,
         cssClass: 'usa-alert-warning',
         type
+      };
+    case ALERT_TYPES.form9Due:
+      return {
+        title: `Return the Form 9 by ${details.date} in order to continue your appeal`,
+        description: (
+          <div>
+            <p>
+              A Form 9 was included with your Statement of the Case. By completing and returning
+              the form, you bring your appeal to the Board of Veterans’ Appeals. On this form,
+              you can request a hearing with a Veterans Law Judge, if you would like one.
+            </p>
+            <p>
+              If you need help with understanding your Statement of the Case or completing the Form
+              9, contact your VSO or representative.
+            </p>
+            <p><a href="#">Learn more about completing the Form 9</a>.</p>
+          </div>
+        ),
+        cssClass: 'usa-alert-warning'
       };
     case ALERT_TYPES.hearingScheduled:
       return {

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -67,12 +67,12 @@ export function getStatusContents(type, details) {
           of the decision:
         </div>
         <br/>
-        <div>
-          Allowed
+        <div className="decision-items">
+          <h5 className="allowed-items">Allowed</h5>
           <ul>{allowedIssues}</ul>
-          Denied
+          <h5 className="denied-items">Denied</h5>
           <ul>{deniedIssues}</ul>
-          Remanded
+          <h5 className="remand-items">Remand</h5>
           <ul>{remandIssues}</ul>
         </div>
         <div>

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -248,8 +248,158 @@ export function getClaimType(claim) {
 //  is just an example of what evss(?) is returning to the api.
 export const mockData = {
   data: [
-    {
-      id: '7387389', // Apparently this is a string...
+    { // Status: Review your statement of the case - pending_form9
+      id: '7387389',
+      type: 'appealSeries',
+      attributes: {
+        active: true,
+        incompleteHistory: false,
+        aoj: 'vba',
+        programArea: 'compensation',
+        description: 'Service connection for tinnitus, hearing loss, and two more',
+        type: 'original',
+        aod: false,
+        location: 'aoj',
+        status: {
+          type: 'pending_form9',
+          details: {
+            regionalOffice: 'Chicago Regional Office'
+          }
+        },
+        docket: {
+          front: false,
+          total: 206900,
+          ahead: 109203,
+          ready: 22109,
+          eta: '2019-08-31'
+        },
+        issues: [
+          {
+            active: true,
+            description: 'Service connection for tinnitus',
+            lastAction: 'field_grant',
+            date: '2016-05-30'
+          }
+        ],
+        alerts: [
+          {
+            type: 'form9_due',
+            details: {
+              date: 'January 28, 2018'
+            }
+          }
+        ],
+        events: [
+          {
+            type: 'claim',
+            date: '2016-05-30',
+            details: {}
+          },
+          {
+            type: 'nod',
+            date: '2016-06-10',
+            details: {}
+          },
+          {
+            type: 'soc',
+            date: '2016-09-12',
+            details: {}
+          }
+        ],
+        evidence: [
+          {
+            description: 'Service treatment records',
+            date: '2017-09-30'
+          }
+        ]
+      }
+    },
+    { // Status: Waiting to be assigned to a judge - on_docket
+      id: '7387390',
+      type: 'appealSeries',
+      attributes: {
+        active: true,
+        incompleteHistory: false,
+        aoj: 'vba',
+        programArea: 'compensation',
+        description: 'Service connection for tinnitus, hearing loss, and two more',
+        type: 'original',
+        aod: false,
+        location: 'aoj',
+        status: {
+          type: 'on_docket',
+          details: {
+            regionalOffice: 'Chicago Regional Office'
+          }
+        },
+        docket: {
+          front: false,
+          total: 206900,
+          ahead: 109203,
+          ready: 22109,
+          eta: '2019-08-31'
+        },
+        issues: [
+          {
+            active: true,
+            description: 'Service connection for tinnitus',
+            lastAction: 'field_grant',
+            date: '2016-05-30'
+          }
+        ],
+        alerts: [
+          {
+            type: 'waiting_on_action',
+            details: {
+              representative: 'Mr. Spock'
+            }
+          }, {
+            type: 'hearing_scheduled',
+            details: {
+              date: 'March 5th, 2018'
+            }
+          }, {
+            type: 'bva_decision_pending',
+            details: {}
+          }
+        ],
+        events: [
+          {
+            type: 'claim',
+            date: '2010-05-30',
+            details: {}
+          },
+          {
+            type: 'nod',
+            date: '2012-06-10',
+            details: {}
+          },
+          {
+            type: 'soc',
+            date: '2013-06-01',
+            details: {}
+          },
+          {
+            type: 'form9',
+            date: '2014-06-12',
+            details: {}
+          },
+          {
+            type: 'appeal_received',
+            date: '2014-09-21',
+            details: {}
+          }
+        ],
+        evidence: [
+          {
+            description: 'Service treatment records',
+            date: '2017-09-30'
+          }
+        ]
+      }
+    },
+    { // Status: The Board has made a decision on your appeal - bva_decision
+      id: '7387391',
       type: 'appealSeries',
       attributes: {
         active: true,

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -388,6 +388,13 @@ export const mockData = {
             type: 'appeal_received',
             date: '2014-09-21',
             details: {}
+          },
+          {
+            type: 'hearing_held',
+            date: '2015-05-06',
+            details: {
+              regionalOffice: 'Chicago'
+            }
           }
         ],
         evidence: [
@@ -411,9 +418,28 @@ export const mockData = {
         aod: false,
         location: 'aoj',
         status: {
-          type: 'nod', // This may or may not be a real status type
-          details: { // Don't actually know what's in here
-            regionalOffice: 'Chicago Regional Office'
+          type: 'remand',
+          details: {
+            regionalOffice: 'Chicago Regional Office',
+            decisionIssues: [
+              {
+                description: 'Heel, increased rating',
+                disposition: 'allowed',
+                date: '2016-05-30'
+              }, {
+                description: 'Knee, increased rating',
+                disposition: 'allowed',
+                date: '2016-05-30'
+              }, {
+                description: 'Leg, service connection',
+                disposition: 'denied',
+                date: '2016-05-30'
+              }, {
+                description: 'Diabetes, service connection',
+                disposition: 'remand',
+                date: '2016-05-30'
+              },
+            ]
           }
         },
         docket: {
@@ -426,38 +452,48 @@ export const mockData = {
         issues: [
           {
             active: true,
-            description: 'Service connection for tinnitus',
+            description: 'Tinnitus, service connection',
             lastAction: 'field_grant',
             date: '2016-05-30'
           }
         ],
-        alerts: [
-          {
-            type: 'waiting_on_action',
-            details: {
-              representative: 'Mr. Spock'
-            }
-          }, {
-            type: 'hearing_scheduled',
-            details: {
-              date: 'March 5th, 2018'
-            }
-          }, {
-            type: 'bva_decision_pending',
-            details: {}
-          }
-        ],
+        alerts: [],
         events: [
           {
             type: 'claim',
-            date: '2016-05-30',
+            date: '2010-05-30',
             details: {}
           },
           {
             type: 'nod',
+            date: '2011-06-10',
+            details: {}
+          },
+          {
+            type: 'soc',
+            date: '2012-06-10',
+            details: {}
+          },
+          {
+            type: 'form9',
+            date: '2013-06-10',
+            details: {}
+          },
+          {
+            type: 'certified',
+            date: '2014-06-10',
+            details: {}
+          },
+          {
+            type: 'hearing_held',
+            date: '2015-06-10',
+            details: {}
+          },
+          {
+            type: 'bva_decision',
             date: '2016-06-10',
             details: {}
-          }
+          },
         ],
         evidence: [
           {

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -347,22 +347,7 @@ export const mockData = {
             date: '2016-05-30'
           }
         ],
-        alerts: [
-          {
-            type: 'waiting_on_action',
-            details: {
-              representative: 'Mr. Spock'
-            }
-          }, {
-            type: 'hearing_scheduled',
-            details: {
-              date: 'March 5th, 2018'
-            }
-          }, {
-            type: 'bva_decision_pending',
-            details: {}
-          }
-        ],
+        alerts: [],
         events: [
           {
             type: 'claim',
@@ -385,7 +370,7 @@ export const mockData = {
             details: {}
           },
           {
-            type: 'appeal_received',
+            type: 'certified',
             date: '2014-09-21',
             details: {}
           },
@@ -487,7 +472,9 @@ export const mockData = {
           {
             type: 'hearing_held',
             date: '2015-06-10',
-            details: {}
+            details: {
+              regionalOffice: 'Chicago'
+            }
           },
           {
             type: 'bva_decision',

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -285,7 +285,7 @@ export const mockData = {
           {
             type: 'form9_due',
             details: {
-              date: 'January 28, 2018'
+              date: '2018-01-28'
             }
           }
         ],

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -870,7 +870,7 @@ h1:focus {
 .appeals-next-list {
   list-style-type: none;
 
-  li {
+  li.next-event {
     &:before { // styles the bullets to mimic bullets in Timeline
       display: inline-block;
       vertical-align: middle;
@@ -917,5 +917,20 @@ h1:focus {
 
   li {
     margin-left: -.4em;
+  }
+}
+
+.decision-items {
+  h5 {
+    &.allowed-items {
+      color: $color-green;
+    }
+    &.denied-items {
+      color: $color-red;
+    }
+    &.remand-items {
+      color: $color-primary;
+    }
+    font-weight: bold;
   }
 }

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -658,6 +658,9 @@ h1:focus {
   .section-unexpanded:before {
     font-family: FontAwesome;
     content: "\f067";
+    // new stuff
+    color: $color-primary;
+    background-color: transparent;
   }
 
   .section-expanded:before {

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -658,14 +658,17 @@ h1:focus {
   .section-unexpanded:before {
     font-family: FontAwesome;
     content: "\f067";
-    // new stuff
     color: $color-primary;
-    background-color: transparent;
+    background-color: $color-white;
+    border-color: $color-primary;
   }
 
   .section-expanded:before {
     font-family: FontAwesome;
     content: "\f068";
+    color: $color-primary;
+    background-color: $color-white;
+    border-color: $color-primary;
   }
 
   .section-current {

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -699,7 +699,7 @@ h1:focus {
     border-left: 0.6em solid transparent;
     border-right: 0.6em solid transparent;
     border-top: 1.2em solid $color-gray-lighter;
-    margin-top: -24px;
+    margin-top: -1em;
     margin-left: 0.8em;
   }
 

--- a/test/claims-status/components/appeals-v2/CurrentStatus.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/CurrentStatus.unit.spec.jsx
@@ -26,7 +26,7 @@ describe('<CurrentStatus/>', () => {
     };
     const wrapper = render(<CurrentStatus {...props}/>);
     const statusTitle = wrapper.find('h4').text();
-    const statusDescription = wrapper.find('p').text();
+    const statusDescription = wrapper.find('div').text();
     expect(statusTitle).to.equal(props.title);
     expect(statusDescription).to.equal(props.description);
   });

--- a/test/claims-status/components/appeals-v2/Expander.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Expander.unit.spec.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import Expander from '../../../../src/js/claims-status/components/appeals-v2/Expander';
+
+describe('<Expander/>', () => {
+  const defaultProps = {
+    dateRange: 'June 5, 1985 - July 29, 2017',
+    onToggle: () => {},
+    cssClass: 'section-unexpanded',
+    expanded: false
+  };
+
+  it('should render as an <li/>', () => {
+    const wrapper = shallow(<Expander {...defaultProps}/>);
+    expect(wrapper.type()).to.equal('li');
+  });
+
+  it('should render a button that calls onToggle prop when clicked', () => {
+    const toggleSpy = sinon.spy();
+    const props = {
+      ...defaultProps,
+      onToggle: toggleSpy
+    };
+    const wrapper = shallow(<Expander {...props}/>);
+    const toggleButton = wrapper.find('button');
+    toggleButton.simulate('click');
+    expect(toggleSpy.calledOnce).to.be.true;
+  });
+});

--- a/test/claims-status/components/appeals-v2/PastEvent.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/PastEvent.unit.spec.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import PastEvent from '../../../../src/js/claims-status/components/appeals-v2/PastEvent';
+
+describe('<PastEvent', () => {
+  const defaultProps = {
+    title: 'Test',
+    description: 'Some test event',
+    liClass: 'class-goes-here',
+    date: 'June 01, 2015'
+  };
+
+  it('should render an <li/>', () => {
+    const wrapper = shallow(<PastEvent {...defaultProps}/>);
+    expect(wrapper.type()).to.equal('li');
+  });
+});

--- a/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
@@ -6,73 +6,51 @@ import Timeline from '../../../../src/js/claims-status/components/appeals-v2/Tim
 
 import { getEventContent } from '../../../../src/js/claims-status/utils/appeals-v2-helpers';
 
-const defaultProps = {
-  events: [
-    {
-      type: 'claim',
-      date: '2016-05-30',
-      details: {}
-    },
-    {
-      type: 'nod',
-      date: '2016-06-10',
-      details: {}
-    }
-  ],
-  currentStatus: {
-    title: 'Current Status Title',
-    description: 'Status description here'
-  }
-};
-
 describe('<Timeline/>', () => {
-  // We get a warning to not attach the DOM directly to document.body, so create a wrapper element
-  // Note: Be sure to .detach() the DOM from the wrapper when the test is finished!
-  const wrapper = document.createElement('div');
-  document.body.appendChild(wrapper);
-
-  // window.scrollTo isn't implemented, so just stub it out to avoid the warning
-  const oldScrollTo = window.scrollTo;
-
-  before(() => {
-    window.scrollTo = () => {};
-  });
-
-  after(() => {
-    window.scrollTo = oldScrollTo;
-  });
-
-  // Use this if you have to attach the DOM to an element
-  let mountedWrapper;
-
-  afterEach(() => {
-    // If it's been used, cleanup the mess.
-    // This is out here in case a test fails and the .detach() call at the end of the test
-    //  doesn't get run.
-    if (typeof mountedWrapper !== 'undefined' && mountedWrapper.unmount) {
-      mountedWrapper.detach();
-      mountedWrapper.unmount();
+  const defaultProps = {
+    events: [
+      {
+        type: 'claim',
+        date: '2016-05-30',
+        details: {}
+      },
+      {
+        type: 'nod',
+        date: '2016-06-10',
+        details: {}
+      }
+    ],
+    currentStatus: {
+      title: 'Current Status Title',
+      description: 'Status description here'
     }
-  });
+  };
 
   it('should render', () => {
     const component = shallow(<Timeline {...defaultProps}/>);
     expect(component.type()).to.equal('div');
   });
 
-  it('should expand and collapse past history events', () => {
-    mountedWrapper = mount(<Timeline {...defaultProps}/>, { attachTo: wrapper });
-    const expander = mountedWrapper.find('.section-unexpanded button');
-    expect(expander.exists()).to.be.true;
+  it('should render an expander', () => {
+    const wrapper = shallow(<Timeline {...defaultProps}/>);
+    const expander = wrapper.find('Expander');
+    expect(expander.type()).to.equal('li');
+  });
 
-    expander.simulate('click');
+  it('should not render past events by default', () => {
 
-    const collapser = mountedWrapper.find('.section-expanded button');
-    expect(collapser.exists()).to.be.true;
+  });
 
-    collapser.simulate('click');
+  it('should render past events when state toggled', () => {
 
-    expect(mountedWrapper.find('.section-unexpanded button').exists()).to.be.true;
+  });
+
+  it('should hide past events when state is toggled', () => {
+
+  });
+
+  it('should always render the current event', () => {
+
   });
 
   it('should render CurrentStatus', () => {

--- a/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
@@ -26,7 +26,7 @@ describe('<Timeline/>', () => {
     }
   };
 
-  const formattedDateRange = 'May 1, 2016 - June 5, 2016';
+  const formattedDateRange = 'May 30, 2016 - June 10, 2016';
 
   it('should render', () => {
     const component = shallow(<Timeline {...defaultProps}/>);

--- a/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
@@ -57,6 +57,8 @@ describe('<Timeline/>', () => {
   it('should render past events when expanded state is true', () => {
     const wrapper = shallow(<Timeline {...defaultProps}/>);
     expect(wrapper.find('PastEvent').length).to.equal(0);
+    // wrapper's instance.toggleExpanded() method doesn't cause a re-render
+    // in enzyme, so need to setState directly (which explicitly does re-render)
     wrapper.setState({ expanded: true });
     expect(wrapper.find('PastEvent').length).to.equal(defaultProps.events.length);
   });

--- a/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
@@ -6,7 +6,7 @@ import Timeline from '../../../../src/js/claims-status/components/appeals-v2/Tim
 
 import { getEventContent, formatDate } from '../../../../src/js/claims-status/utils/appeals-v2-helpers';
 
-describe.only('<Timeline/>', () => {
+describe('<Timeline/>', () => {
   const defaultProps = {
     events: [
       {

--- a/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
@@ -33,7 +33,7 @@ describe.only('<Timeline/>', () => {
     expect(component.exists()).to.be.true;
   });
 
-  it('should render one expander item', () => {
+  it('should render one expander item if events present', () => {
     const wrapper = shallow(<Timeline {...defaultProps}/>);
     const expander = wrapper.find('Expander');
     expect(expander.length).to.equal(1);
@@ -60,6 +60,15 @@ describe.only('<Timeline/>', () => {
     wrapper.setState({ expanded: true });
     expect(wrapper.find('PastEvent').length).to.equal(defaultProps.events.length);
   });
+
+  it('should render nothing for past events if no events in list', () => {
+    const props = { ...defaultProps, events: [] };
+    const wrapper = shallow(<Timeline {...props}/>);
+    expect(wrapper.find('PastEvent').length).to.equal(0);
+    wrapper.setState({ expanded: true });
+    expect(wrapper.find('PastEvent').length).to.equal(0);
+  });
+
 
   it('should render one CurrentStatus component', () => {
     const wrapper = shallow(<Timeline {...defaultProps}/>);


### PR DESCRIPTION
**Update**
- Some of the screenshots below show the 'current status' out of alignment with the timeline arrow / bar. This only happens at <67% scaling in Chrome - scaling settings from 67% - 200% (at least) show everything in alignment. Similarly, mobile screens look fine, down to the smallest size I could test (iPhone 5, 320 x 568).
- Size of 'Current Status' header has been increased a bit, to h2 size.
- updated screenshots below.
Collapsed:
<img width="460" alt="screen shot 2017-12-08 at 1 59 47 pm" src="https://user-images.githubusercontent.com/24251447/33782908-227d3fa4-dc20-11e7-942f-7bf2e71c80b3.png">

Expanded:
<img width="475" alt="screen shot 2017-12-08 at 1 59 42 pm" src="https://user-images.githubusercontent.com/24251447/33782916-29c9d4e8-dc20-11e7-92b9-0db1e1587b8e.png">


This PR is a bit large, but a lot of it is content updates to our appeals v2 helpers as well as content / shape updates to our mock api data. Basically, the point here is to:
- Provide 3 different appeals for testing, each with specific and different content
- Conform the layout and content to what was specced out in the linked issue
- Make some logic and data source updates based on current knowledge of what the API will look like

Known issues, but don't think these are blockers for this PR:
- Some improper DOM nesting (e.g., p > div, p > ul) under certain conditions - this doesn't seem to affect the way things render for now, but top of list to fix.
- Accessibility wasn't fully considered in markup on this go-round, but should be looked at app-wide once content and the API are truly finalized.

We now have 3 appeals to test: 7387389, 7387390, 7387391 which can be accessed locally at http://localhost:3001/track-claims/appeals-v2/[number]/status. Recommend anyone testing this pull the branch down and give it a whirl. Alternatively, after these changes are merged, these three appeals should be accessible in Staging as well.

Screenshots:
**7387389 - pending_form9**
Collapsed:
<img width="448" alt="screen shot 2017-12-08 at 2 23 16 am" src="https://user-images.githubusercontent.com/24251447/33757241-e265836a-dbbe-11e7-92c8-87522e421372.png">
Expanded:
<img width="769" alt="screen shot 2017-12-08 at 2 23 38 am" src="https://user-images.githubusercontent.com/24251447/33757256-f1d07814-dbbe-11e7-9cbc-a7e0afca6502.png">

**7387390 - on_docket**
Collapsed:
<img width="545" alt="screen shot 2017-12-08 at 2 25 53 am" src="https://user-images.githubusercontent.com/24251447/33757316-3a1dfa24-dbbf-11e7-8b67-86075aff34bf.png">
Expanded:
<img width="464" alt="screen shot 2017-12-08 at 2 26 13 am" src="https://user-images.githubusercontent.com/24251447/33757322-438af1e8-dbbf-11e7-8570-66d1f0f79793.png">

**7387391 - bva_decision**
Collapsed:
<img width="556" alt="screen shot 2017-12-08 at 2 27 57 am" src="https://user-images.githubusercontent.com/24251447/33757394-888845ac-dbbf-11e7-9d19-60f5dfa1181a.png">
Expanded:
<img width="394" alt="screen shot 2017-12-08 at 2 28 30 am" src="https://user-images.githubusercontent.com/24251447/33757404-92f9c74a-dbbf-11e7-8184-e33ef0e3f439.png">



