### PR TITLE
Fetch BSL options after letter list

### DIFF
--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -27,48 +27,71 @@ import {
   SAVE_ADDRESS_SUCCESS
 } from '../utils/constants';
 
-export function getLetterList() {
+export function getLetterList(dispatch) {
+  return apiRequest(
+    '/v0/letters',
+    null,
+    response => dispatch({
+      type: GET_LETTERS_SUCCESS,
+      data: response,
+    }),
+    (response) => {
+      window.dataLayer.push({ event: 'letter-list-failure' });
+      if (typeof response.errors === 'undefined' || response.errors.length === 0) {
+        return Promise.reject(new Error('vets_letters_error_server_get: undefined error'));
+      }
+      const error = response.errors[0];
+      switch (error.status) {
+        case '503': // Handled same as 504
+        case '504':
+          // Either EVSS or a partner service is down or EVSS times out
+          return dispatch({ type: BACKEND_SERVICE_ERROR });
+        case '403':
+          // Backend authentication problem
+          return dispatch({ type: BACKEND_AUTHENTICATION_ERROR });
+        case '502':
+          // Some of the partner services are down, so we cannot verify the
+          // eligibility of some letters
+          return dispatch({ type: LETTER_ELIGIBILITY_ERROR });
+        default:
+          return Promise.reject(
+            new Error(`vets_letters_error_server_get: ${error.status || 'unknown'}`)
+          );
+      }
+    }
+  ).catch((error) => {
+    if (error.message.match('vets_letters_error_server_get')) {
+      Raven.captureException(error);
+      return dispatch({ type: GET_LETTERS_FAILURE });
+    }
+    throw error;
+  });
+}
+
+
+export function getBenefitSummaryOptions(dispatch) {
+  return apiRequest(
+    '/v0/letters/beneficiary',
+    null,
+    response => dispatch({
+      type: GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS,
+      data: response,
+    }),
+    () => dispatch({ type: GET_BENEFIT_SUMMARY_OPTIONS_FAILURE })
+  );
+}
+
+
+// Call getLetterList then getBenefitSummaryOptions
+export function getLetterListAndBSLOptions() {
   return (dispatch) => {
-    return apiRequest(
-      '/v0/letters',
-      null,
-      response => dispatch({
-        type: GET_LETTERS_SUCCESS,
-        data: response,
-      }),
-      (response) => {
-        window.dataLayer.push({ event: 'letter-list-failure' });
-        if (typeof response.errors === 'undefined' || response.errors.length === 0) {
-          return Promise.reject(new Error('vets_letters_error_server_get: undefined error'));
-        }
-        const error = response.errors[0];
-        switch (error.status) {
-          case '503': // Handled same as 504
-          case '504':
-            // Either EVSS or a partner service is down or EVSS times out
-            return dispatch({ type: BACKEND_SERVICE_ERROR });
-          case '403':
-            // Backend authentication problem
-            return dispatch({ type: BACKEND_AUTHENTICATION_ERROR });
-          case '502':
-            // Some of the partner services are down, so we cannot verify the
-            // eligibility of some letters
-            return dispatch({ type: LETTER_ELIGIBILITY_ERROR });
-          default:
-            return Promise.reject(
-              new Error(`vets_letters_error_server_get: ${error.status || 'unknown'}`)
-            );
-        }
-      }
-    ).catch((error) => {
-      if (error.message.match('vets_letters_error_server_get')) {
-        Raven.captureException(error);
-        return dispatch({ type: GET_LETTERS_FAILURE });
-      }
-      throw error;
-    });
+    return getLetterList(dispatch)
+      // Maybe shouldn't try to get BSO options if we get an error or we don't get a BSL...
+      .then(() => getBenefitSummaryOptions(dispatch))
+      .catch(rejectedPromise => rejectedPromise); // getLetterList should return a rejected promise if it fails
   };
 }
+
 
 export function getAddressFailure() {
   window.dataLayer.push({ event: 'letter-update-address-notfound' });
@@ -92,20 +115,6 @@ export function getMailingAddress() {
       },
       // catch errors in fetch or success handler
       () => dispatch(getAddressFailure())
-    );
-  };
-}
-
-export function getBenefitSummaryOptions() {
-  return (dispatch) => {
-    return apiRequest(
-      '/v0/letters/beneficiary',
-      null,
-      response => dispatch({
-        type: GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS,
-        data: response,
-      }),
-      () => dispatch({ type: GET_BENEFIT_SUMMARY_OPTIONS_FAILURE })
     );
   };
 }

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -61,8 +61,7 @@ export function getLetterList(dispatch) {
     }
   ).catch((error) => {
     if (error.message.match('vets_letters_error_server_get')) {
-      Raven.captureException(error);
-      return dispatch({ type: GET_LETTERS_FAILURE });
+      dispatch({ type: GET_LETTERS_FAILURE });
     }
     throw error;
   });
@@ -77,7 +76,11 @@ export function getBenefitSummaryOptions(dispatch) {
       type: GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS,
       data: response,
     }),
-    () => dispatch({ type: GET_BENEFIT_SUMMARY_OPTIONS_FAILURE })
+    () => {
+      dispatch({ type: GET_BENEFIT_SUMMARY_OPTIONS_FAILURE });
+      // Is there a prize for the longest error name?
+      throw new Error('vets_letters_get_benefit_summary_options_failure');
+    }
   );
 }
 
@@ -88,7 +91,9 @@ export function getLetterListAndBSLOptions() {
     return getLetterList(dispatch)
       // Maybe shouldn't try to get BSO options if we get an error or we don't get a BSL...
       .then(() => getBenefitSummaryOptions(dispatch))
-      .catch(rejectedPromise => rejectedPromise); // getLetterList should return a rejected promise if it fails
+      .catch(error => {
+        Raven.captureException(error);
+      });
   };
 }
 

--- a/src/js/letters/containers/Main.jsx
+++ b/src/js/letters/containers/Main.jsx
@@ -7,8 +7,7 @@ import { AVAILABILITY_STATUSES } from '../utils/constants';
 import { recordsNotFound } from '../utils/helpers';
 
 import {
-  getBenefitSummaryOptions,
-  getLetterList,
+  getLetterListAndBSLOptions,
   getMailingAddress,
   getAddressCountries,
   getAddressStates
@@ -26,9 +25,8 @@ const {
 
 export class Main extends React.Component {
   componentDidMount() {
-    this.props.getLetterList();
+    this.props.getLetterListAndBSLOptions();
     this.props.getMailingAddress();
-    this.props.getBenefitSummaryOptions();
     this.props.getAddressCountries();
     this.props.getAddressStates();
   }
@@ -114,8 +112,9 @@ function mapStateToProps(state) {
 }
 
 const mapDispatchToProps = {
-  getBenefitSummaryOptions,
-  getLetterList,
+  // getBenefitSummaryOptions,
+  // getLetterList,
+  getLetterListAndBSLOptions,
   getMailingAddress,
   getAddressCountries,
   getAddressStates,

--- a/test/letters/actions/letters.unit.spec.js
+++ b/test/letters/actions/letters.unit.spec.js
@@ -117,6 +117,8 @@ describe('saveAddress', () => {
     const dispatch = sinon.spy();
     thunk(dispatch, getState)
       .then(() => {
+        throw new Error('Should not resolve the promise when GET fails');
+      }).catch(() => {
         const action = dispatch.secondCall.args[0];
         expect(action.type).to.equal(SAVE_ADDRESS_FAILURE);
       }).then(done, done);
@@ -144,6 +146,8 @@ describe('saveAddress', () => {
     const dispatch = sinon.spy();
     thunk(dispatch, getState)
       .then(() => {
+        throw new Error('Should not resolve the promise when GET fails');
+      }).catch(() => {
         const action = dispatch.secondCall.args[0];
         expect(action.type).to.equal(SAVE_ADDRESS_FAILURE);
       }).then(done, done);
@@ -188,6 +192,8 @@ describe('getLettersList', () => {
     const dispatch = sinon.spy();
     getLetterList(dispatch)
       .then(() => {
+        throw new Error('Should not resolve the promise when GET fails');
+      }).catch(() => {
         const action = dispatch.firstCall.args[0];
         expect(action.type).to.equal(GET_LETTERS_FAILURE);
       }).then(done, done);
@@ -209,6 +215,9 @@ describe('getLettersList', () => {
 
       const dispatch = sinon.spy();
       getLetterList(dispatch)
+        // Just get to the test already!
+        // Note: This could swallow unexpected errors
+        .catch(() => Promise.resolve())
         .then(() => {
           const action = dispatch.firstCall.args[0];
           expect(action.type).to.equal(lettersErrors[code]);
@@ -399,6 +408,8 @@ describe('getBenefitSummaryOptions', () => {
 
     getBenefitSummaryOptions(dispatch, getState)
       .then(() => {
+        throw new Error('Should not resolve the promise when the GET fails');
+      }).catch(() => {
         expect(dispatch.calledWith({ type: GET_BENEFIT_SUMMARY_OPTIONS_FAILURE })).to.be.true;
       }).then(done, done);
   });

--- a/test/letters/actions/letters.unit.spec.js
+++ b/test/letters/actions/letters.unit.spec.js
@@ -27,6 +27,7 @@ import {
 
 import {
   getLetterList,
+  getLetterListAndBSLOptions,
   getMailingAddress,
   getBenefitSummaryOptions,
   getLetterPdf,
@@ -222,6 +223,34 @@ describe('getLettersList', () => {
           const action = dispatch.firstCall.args[0];
           expect(action.type).to.equal(lettersErrors[code]);
         }).then(done, done);
+    });
+  });
+});
+
+describe('getLetterListAndBSLOptions', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('should make the call to get the BSL options after the letter list call is complete', (done) => {
+    const thunk = getLetterListAndBSLOptions();
+    const dispatch = () => {};
+
+    thunk(dispatch).then(() => {
+      expect(global.fetch.callCount).to.equal(2);
+      expect(global.fetch.firstCall.args[0].endsWith('/v0/letters')).to.be.true;
+      expect(global.fetch.secondCall.args[0].endsWith('/v0/letters/beneficiary')).to.be.true;
+      done();
+    });
+  });
+
+  it('should not make the call to get the BSL options if the letter list call fails', (done) => {
+    global.fetch.returns(Promise.reject());
+    const thunk = getLetterListAndBSLOptions();
+    const dispatch = () => {};
+
+    thunk(dispatch).then(() => {
+      expect(global.fetch.callCount).to.equal(1);
+      done();
     });
   });
 });

--- a/test/letters/actions/letters.unit.spec.js
+++ b/test/letters/actions/letters.unit.spec.js
@@ -174,9 +174,8 @@ describe('getLettersList', () => {
       ok: true,
       json: () => Promise.resolve(lettersResponse)
     }));
-    const thunk = getLetterList();
     const dispatch = sinon.spy();
-    thunk(dispatch, getState)
+    getLetterList(dispatch)
       .then(() => {
         const action = dispatch.firstCall.args[0];
         expect(action.type).to.equal(GET_LETTERS_SUCCESS);
@@ -186,9 +185,8 @@ describe('getLettersList', () => {
 
   it('dispatches GET_LETTERS_FAILURE when GET fails with generic error', (done) => {
     global.fetch.returns(Promise.reject(new Error('something went wrong')));
-    const thunk = getLetterList();
     const dispatch = sinon.spy();
-    thunk(dispatch, getState)
+    getLetterList(dispatch)
       .then(() => {
         const action = dispatch.firstCall.args[0];
         expect(action.type).to.equal(GET_LETTERS_FAILURE);
@@ -209,9 +207,8 @@ describe('getLettersList', () => {
         errors: [{ status: `${code}` }]
       }));
 
-      const thunk = getLetterList();
       const dispatch = sinon.spy();
-      thunk(dispatch, getState)
+      getLetterList(dispatch)
         .then(() => {
           const action = dispatch.firstCall.args[0];
           expect(action.type).to.equal(lettersErrors[code]);
@@ -386,10 +383,9 @@ describe('getBenefitSummaryOptions', () => {
       ok: true,
       json: () => Promise.resolve(mockResponse)
     }));
-    const thunk = getBenefitSummaryOptions();
     const dispatch = sinon.spy();
 
-    thunk(dispatch, getState)
+    getBenefitSummaryOptions(dispatch, getState)
       .then(() => {
         const action = dispatch.args[0][0]; // first call, first arg
         expect(action.type).to.equal(GET_BENEFIT_SUMMARY_OPTIONS_SUCCESS);
@@ -399,10 +395,9 @@ describe('getBenefitSummaryOptions', () => {
 
   it('dispatches FAILURE action when GET fails', (done) => {
     global.fetch.returns(Promise.reject({}));
-    const thunk = getBenefitSummaryOptions();
     const dispatch = sinon.spy();
 
-    thunk(dispatch, getState)
+    getBenefitSummaryOptions(dispatch, getState)
       .then(() => {
         expect(dispatch.calledWith({ type: GET_BENEFIT_SUMMARY_OPTIONS_FAILURE })).to.be.true;
       }).then(done, done);

--- a/test/letters/actions/letters.unit.spec.js
+++ b/test/letters/actions/letters.unit.spec.js
@@ -118,11 +118,10 @@ describe('saveAddress', () => {
     const dispatch = sinon.spy();
     thunk(dispatch, getState)
       .then(() => {
-        throw new Error('Should not resolve the promise when GET fails');
-      }).catch(() => {
         const action = dispatch.secondCall.args[0];
         expect(action.type).to.equal(SAVE_ADDRESS_FAILURE);
-      }).then(done, done);
+        done();
+      });
   });
 
   it('dispatches SAVE_ADDRESS_SUCCESS on update success', (done) => {
@@ -147,11 +146,10 @@ describe('saveAddress', () => {
     const dispatch = sinon.spy();
     thunk(dispatch, getState)
       .then(() => {
-        throw new Error('Should not resolve the promise when GET fails');
-      }).catch(() => {
         const action = dispatch.secondCall.args[0];
         expect(action.type).to.equal(SAVE_ADDRESS_FAILURE);
-      }).then(done, done);
+        done();
+      });
   });
 });
 
@@ -193,11 +191,12 @@ describe('getLettersList', () => {
     const dispatch = sinon.spy();
     getLetterList(dispatch)
       .then(() => {
-        throw new Error('Should not resolve the promise when GET fails');
+        done(new Error('Should not resolve the promise when GET fails'));
       }).catch(() => {
         const action = dispatch.firstCall.args[0];
         expect(action.type).to.equal(GET_LETTERS_FAILURE);
-      }).then(done, done);
+        done();
+      });
   });
 
   const lettersErrors = {
@@ -437,10 +436,11 @@ describe('getBenefitSummaryOptions', () => {
 
     getBenefitSummaryOptions(dispatch, getState)
       .then(() => {
-        throw new Error('Should not resolve the promise when the GET fails');
+        done(new Error('Should not resolve the promise when the GET fails'));
       }).catch(() => {
         expect(dispatch.calledWith({ type: GET_BENEFIT_SUMMARY_OPTIONS_FAILURE })).to.be.true;
-      }).then(done, done);
+        done();
+      });
   });
 });
 

--- a/test/letters/containers/Main.unit.spec.jsx
+++ b/test/letters/containers/Main.unit.spec.jsx
@@ -36,9 +36,8 @@ const defaultProps = {
     serviceInfo: '',
   },
   optionsAvailable: {},
-  getLetterList: () => {},
   getMailingAddress: () => {},
-  getBenefitSummaryOptions: () => {},
+  getLetterListAndBSLOptions: () => {},
   getAddressCountries: () => {},
   getAddressStates: () => {},
   children: childElement,
@@ -120,9 +119,8 @@ describe('<Main>', () => {
 
   it('fetches all necessary data after mounting', () => {
     const spies = {
-      getLetterList: sinon.spy(),
       getMailingAddress: sinon.spy(),
-      getBenefitSummaryOptions: sinon.spy(),
+      getLetterListAndBSLOptions: sinon.spy(),
       getAddressCountries: sinon.spy(),
       getAddressStates: sinon.spy(),
     };
@@ -132,9 +130,7 @@ describe('<Main>', () => {
     const instance = tree.getMountedInstance();
     // mounted instance doesn't call lifecycle methods automatically so...
     instance.componentDidMount();
-    expect(props.getLetterList.callCount).to.equal(1);
-    expect(props.getMailingAddress.callCount).to.equal(1);
-    expect(props.getBenefitSummaryOptions.callCount).to.equal(1);
+    expect(props.getLetterListAndBSLOptions.callCount).to.equal(1);
     expect(props.getAddressCountries.callCount).to.equal(1);
     expect(props.getAddressStates.callCount).to.equal(1);
   });


### PR DESCRIPTION
Calls the fetch to get the BSL options after the fetch to get the available letters list so the response from the letters list fetch can be cached for the BSL options request in an EVSS partner services...to my understanding.