### PR TITLE
Fix application status spinner

### DIFF
--- a/content/pages/burials-and-memorials/index.md
+++ b/content/pages/burials-and-memorials/index.md
@@ -47,4 +47,4 @@ We can help Servicemembers, Veterans, and family members plan a burial or memori
 
 </div>
 
-<div id="react-applicationStatus" data-hide-apply-button></div>
+<div id="react-applicationStatus" data-hide-apply-button class="static-page-widget"></div>

--- a/content/pages/burials-and-memorials/survivor-and-dependent-benefits.md
+++ b/content/pages/burials-and-memorials/survivor-and-dependent-benefits.md
@@ -35,7 +35,7 @@ We give the surviving spouse, children, and parents of deceased Servicemembers a
 
 </div>
 
-<div id="react-applicationStatus" data-hide-apply-button>
+<div id="react-applicationStatus" data-hide-apply-button class="static-page-widget">
   <a class="usa-button-primary va-button-primary" href="/burials-and-memorials/application/530/">Apply for Burial Benefits</a>
 </div>
 

--- a/content/pages/burials-and-memorials/survivor-and-dependent-benefits/burial-costs.md
+++ b/content/pages/burials-and-memorials/survivor-and-dependent-benefits/burial-costs.md
@@ -62,7 +62,7 @@ You may need a copy of:
 
 </div>
 
-<div id="react-applicationStatus">
+<div id="react-applicationStatus" class="static-page-widget">
   <a class="usa-button-primary va-button-primary" href="/burials-and-memorials/application/530/">Apply for Burial Benefits</a>
 </div>
 

--- a/content/pages/education/apply.md
+++ b/content/pages/education/apply.md
@@ -50,7 +50,7 @@ If you’re a Servicemember, Veteran, or family member interested in education a
 </div>
 </div>
 </div>
-<div id="react-applicationStatus"></div>
+<div id="react-applicationStatus" class="static-page-widget"></div>
 
 <div itemprop="steps" itemscope itemtype ="http://schema.org/HowToSection">
 

--- a/content/pages/education/eligibility.md
+++ b/content/pages/education/eligibility.md
@@ -96,7 +96,7 @@ If you have a service-connected disability that limits your ability to work or p
 </div>
 </div>
 </div>
-<div id="react-applicationStatus"></div>
+<div id="react-applicationStatus" class="static-page-widget"></div>
 
 [Learn about the application process](/education/apply/).
 

--- a/content/pages/education/index.md
+++ b/content/pages/education/index.md
@@ -53,4 +53,4 @@ majorlinks:
 We offer Veterans, Servicemembers, and their families education benefits like help paying tuition, help finding the right school or training program, and career counseling. Explore your benefit options.   
 
 </div>
-<div id="react-applicationStatus" data-hide-apply-button></div>
+<div id="react-applicationStatus" data-hide-apply-button class="static-page-widget"></div>

--- a/content/pages/health-care/apply.md
+++ b/content/pages/health-care/apply.md
@@ -59,7 +59,7 @@ Or, [find your state’s Veterans agency](https://www.va.gov/statedva.htm).
 </div>
 </div>
 
-<div id="react-applicationStatus">
+<div id="react-applicationStatus" class="static-page-widget">
   <a class="usa-button-primary va-button-primary" href="/health-care/apply/application/">Apply for Health Care Benefits</a>
 </div>
 

--- a/content/pages/health-care/eligibility.md
+++ b/content/pages/health-care/eligibility.md
@@ -70,7 +70,7 @@ If none of the above apply to you, you may still qualify for care based on your 
 
 <div markdown="0"><br></div>
 
-<div id="react-applicationStatus">
+<div id="react-applicationStatus" class="static-page-widget">
   <a class="usa-button-primary va-button-primary" href="/health-care/apply/application/">Apply for Health Care Benefits</a>
 </div>
 

--- a/content/pages/health-care/index.md
+++ b/content/pages/health-care/index.md
@@ -47,7 +47,7 @@ With VA health care, you’re covered for regular checkups with your primary car
 
 </div>
 
-<div id="react-applicationStatus" data-hide-apply-button></div>
+<div id="react-applicationStatus" data-hide-apply-button class="static-page-widget"></div>
 
 <div class="va-alert usa-alert usa-alert-warning">
   <div class="usa-alert-body">

--- a/content/pages/pension/apply.md
+++ b/content/pages/pension/apply.md
@@ -36,7 +36,7 @@ You can apply online, in person, or by mail for a Veterans pension. Follow these
 
 </div>
 
-<div id="react-applicationStatus">
+<div id="react-applicationStatus" class="static-page-widget">
   <a class="usa-button-primary va-button-primary" href="/pension/application/527EZ">Apply for a Veterans Pension</a>
 </div>
 

--- a/content/pages/pension/eligibility.md
+++ b/content/pages/pension/eligibility.md
@@ -47,7 +47,7 @@ If you’re a surviving spouse or a child of a deceased Veteran with wartime ser
 
 </div>
 
-<div id="react-applicationStatus">
+<div id="react-applicationStatus" class="static-page-widget">
   <a class="usa-button-primary va-button-primary" href="/pension/application/527EZ">Apply for a Veterans Pension</a>
 </div>
 

--- a/content/pages/pension/index.md
+++ b/content/pages/pension/index.md
@@ -37,4 +37,4 @@ If you’re a wartime Veteran who meets certain age or disability requirements, 
 
 </div>
 
-<div id="react-applicationStatus" data-hide-apply-button></div>
+<div id="react-applicationStatus" data-hide-apply-button class="static-page-widget"></div>

--- a/src/js/common/utils/static-page-widgets.js
+++ b/src/js/common/utils/static-page-widgets.js
@@ -34,6 +34,8 @@ function mountWidgets(widgets) {
           }
         }, timeout);
       }
+
+      root.classList.remove('static-page-widget');
   });
 }
 

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -40,9 +40,9 @@ class Main extends React.Component {
     });
     this.bindNavbarLinks();
 
-    // If there is a window.opener, then this window was spawned by another instance of the website as the auth app.
-    // In this case, we don't need to actually login, because that data will be passed to the parent window and done there instead.
-    if (!window.opener) {
+    // In some cases this component is mounted on a url that is part of the login process and doesn't need to make another 
+    // request, because that data will be passed to the parent window and done there instead.
+    if (!window.location.pathname.includes('auth/login/callback')) {
       window.onload = () => {
         this.loginUrlRequest.then(this.checkTokenStatus);
       };

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -40,9 +40,9 @@ class Main extends React.Component {
     });
     this.bindNavbarLinks();
 
-    // In some cases this component is mounted on a url that is part of the login process and doesn't need to make another 
-    // request, because that data will be passed to the parent window and done there instead.
-    if (!window.location.pathname.includes('auth/login/callback')) {
+    // If there is a window.opener, then this window was spawned by another instance of the website as the auth app.
+    // In this case, we don't need to actually login, because that data will be passed to the parent window and done there instead.
+    if (!window.opener) {
       window.onload = () => {
         this.loginUrlRequest.then(this.checkTokenStatus);
       };

--- a/src/js/user-profile/reducers/profile.js
+++ b/src/js/user-profile/reducers/profile.js
@@ -10,7 +10,7 @@ import {
   ACCEPTING_LATEST_MHV_TERMS_SUCCESS,
   ACCEPTING_LATEST_MHV_TERMS_FAILURE,
 } from '../actions';
-import { UPDATE_LOGGEDIN_STATUS } from '../../login/actions';
+import { UPDATE_LOGGEDIN_STATUS, FETCH_LOGIN_URLS_FAILED } from '../../login/actions';
 
 // TODO(crew): Romove before this goes to production.
 const initialState = {
@@ -39,6 +39,9 @@ function profileInformation(state = initialState, action) {
       return _.assign(state, action.newState);
     }
     case PROFILE_LOADING_FINISHED: {
+      return _.set('loading', false, state);
+    }
+    case FETCH_LOGIN_URLS_FAILED: {
       return _.set('loading', false, state);
     }
     case UPDATE_LOGGEDIN_STATUS: {

--- a/src/sass/no-react.scss
+++ b/src/sass/no-react.scss
@@ -40,3 +40,7 @@
     }
   }
 }
+
+.static-page-widget {
+  display: none;
+}

--- a/test/e2e/login-helpers.js
+++ b/test/e2e/login-helpers.js
@@ -96,6 +96,7 @@ function getUserToken() {
 function logIn(token, client, url, level) {
   initUserMock(token, level);
   initLogoutMock(token);
+  initLoginUrlsMock(token);
 
   client
     .url(`${E2eHelpers.baseUrl}${url}`)


### PR DESCRIPTION
There are two issues here:

1. The apply now button flashes before showing the spinner, even when logged out. This seems to happen because the page renders with the button (because it's in the markup), then JS takes over and replaces the button with a spinner. Now the button is hidden by default, and JS has to remove a class to show anything.
2. When there's an error fetching the login urls (like a connection issue), the loading state for the profile is never changed and so we have the spinner show indefinitely. I'm not sure this is all of the problems from the call center, but it's probably some of them. There are regular client-side failures of the login api calls.