### PR TITLE
Fix infinite spinner on new tab issue

### DIFF
--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -40,9 +40,9 @@ class Main extends React.Component {
     });
     this.bindNavbarLinks();
 
-    // If there is a window.opener, then this window was spawned by another instance of the website as the auth app.
-    // In this case, we don't need to actually login, because that data will be passed to the parent window and done there instead.
-    if (!window.opener) {
+    // In some cases this component is mounted on a url that is part of the login process and doesn't need to make another 
+    // request, because that data will be passed to the parent window and done there instead.
+    if (!window.location.pathname.includes('auth/login/callback')) {
       window.onload = () => {
         this.loginUrlRequest.then(this.checkTokenStatus);
       };


### PR DESCRIPTION
When vets.gov is opened in a new tab, window.opener is set and login requests are not made. This results in infinite spinners in many places. I've changed the logic to look for the auth callback page instead, because I believe that's the only case where we wouldn't want to make the login request.