### PR TITLE
Add SiP check to form title in FormApp

### DIFF
--- a/src/js/common/schemaform/FormApp.jsx
+++ b/src/js/common/schemaform/FormApp.jsx
@@ -207,7 +207,6 @@ class FormApp extends React.Component {
       );
     }
 
-
     return (
       <div>
         <div className="row">
@@ -216,7 +215,7 @@ class FormApp extends React.Component {
             {
               formConfig.title &&
               // If we’re on the introduction page, show the title if we’re actually on the loading screen
-              (!isIntroductionPage || this.props.loadedStatus !== LOAD_STATUSES.notAttempted) &&
+              (!isIntroductionPage || (!formConfig.disableSave && this.props.loadedStatus !== LOAD_STATUSES.notAttempted)) &&
                 <FormTitle title={formConfig.title} subTitle={formConfig.subTitle}/>
             }
             {content}


### PR DESCRIPTION
My previous SiP refactor removed the SiP state from forms with it disabled, and this one line didn't have a SiP check and was triggering the wrong condition.

The result was two titles on the pre-need intro page, on from IntroductionPage and the other from FormApp.