### PR TITLE
Add search console verification for shared analytics user

### DIFF
--- a/content/pages/google80ca4a6fba8ea245.html
+++ b/content/pages/google80ca4a6fba8ea245.html
@@ -1,0 +1,5 @@
+---
+permalink: false
+private: true
+---
+google-site-verification: google80ca4a6fba8ea245.html


### PR DESCRIPTION
Part of: department-of-veterans-affairs/vets.gov-team#6219

Currently our search console "root of trust" if my `bob@adhocteam.us` account. This provides a second google verification for the `vetsdotgovanalytics@gmail.com` shared account so that if, for some reason, my account is no longer active on vets.gov there will not be any gaps in our search console ownership.

The PR just adds the plain text file that google requires on your domain.

The YAML front matter prevents the CMS from stripping the `.html` extension and removes it from the sitemap so it's not crawled.