### PR TITLE
Patch for login links disappearing while the request for user info is pending

### DIFF
--- a/src/js/common/components/DropDown.jsx
+++ b/src/js/common/components/DropDown.jsx
@@ -42,6 +42,7 @@ class DropDown extends React.Component {
         <button className={buttonClasses}
           aria-controls={this.props.id}
           aria-expanded={this.props.isOpen}
+          disabled={this.props.disabled}
           onClick={this.toggleDropDown}>
           <span>
             {this.props.icon}
@@ -72,11 +73,13 @@ DropDown.propTypes = {
   contents: PropTypes.node.isRequired,
   icon: PropTypes.node, /* Should be SVG markup */
   id: PropTypes.string,
-  isOpen: PropTypes.bool.isRequired
+  isOpen: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool
 };
 
 DropDown.defaultProps = {
-  container: window.document
+  container: window.document,
+  disabled: false
 };
 
 export default DropDown;

--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -64,38 +64,34 @@ export function getUserData(dispatch) {
     error.status = response.status;
     throw error;
   }).then(json => {
-    if (json.data) {
-      const userData = json.data.attributes.profile;
-      // sessionStorage coerces everything into String. this if-statement
-      // is to prevent the firstname being set to the string 'Null'
-      if (userData.first_name) {
-        sessionStorage.setItem('userFirstName', userData.first_name);
-      }
-      dispatch(updateProfileFields({
-        savedForms: json.data.attributes.in_progress_forms,
-        prefillsAvailable: json.data.attributes.prefills_available,
-        accountType: userData.loa.current,
-        email: userData.email,
-        userFullName: {
-          first: userData.first_name,
-          middle: userData.middle_name,
-          last: userData.last_name,
-        },
-        authnContext: userData.authn_context,
-        loa: userData.loa,
-        multifactor: userData.multifactor,
-        gender: userData.gender,
-        dob: userData.birth_date,
-        status: json.data.attributes.va_profile.status,
-        veteranStatus: json.data.attributes.veteran_status.status,
-        isVeteran: json.data.attributes.veteran_status.is_veteran,
-        services: json.data.attributes.services,
-        healthTermsCurrent: json.data.attributes.health_terms_current,
-      }));
-      dispatch(updateLoggedInStatus(true));
-    } else {
-      dispatch(profileLoadingFinished());
+    const userData = json.data.attributes.profile;
+    // sessionStorage coerces everything into String. this if-statement
+    // is to prevent the firstname being set to the string 'Null'
+    if (userData.first_name) {
+      sessionStorage.setItem('userFirstName', userData.first_name);
     }
+    dispatch(updateProfileFields({
+      savedForms: json.data.attributes.in_progress_forms,
+      prefillsAvailable: json.data.attributes.prefills_available,
+      accountType: userData.loa.current,
+      email: userData.email,
+      userFullName: {
+        first: userData.first_name,
+        middle: userData.middle_name,
+        last: userData.last_name,
+      },
+      authnContext: userData.authn_context,
+      loa: userData.loa,
+      multifactor: userData.multifactor,
+      gender: userData.gender,
+      dob: userData.birth_date,
+      status: json.data.attributes.va_profile.status,
+      veteranStatus: json.data.attributes.veteran_status.status,
+      isVeteran: json.data.attributes.veteran_status.is_veteran,
+      services: json.data.attributes.services,
+      healthTermsCurrent: json.data.attributes.health_terms_current,
+    }));
+    dispatch(updateLoggedInStatus(true));
   }).catch(error => {
     if (error.status === 401) {
       for (const key of ['entryTime', 'userToken', 'userFirstName']) {

--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -59,7 +59,10 @@ export function getUserData(dispatch) {
       Authorization: `Token token=${sessionStorage.userToken}`
     })
   }).then(response => {
-    return response.json();
+    if (response.ok) return response.json();
+    const error = new Error(response.statusText);
+    error.status = response.status;
+    throw error;
   }).then(json => {
     if (json.data) {
       const userData = json.data.attributes.profile;
@@ -93,6 +96,13 @@ export function getUserData(dispatch) {
     } else {
       dispatch(profileLoadingFinished());
     }
+  }).catch(error => {
+    if (error.status === 401) {
+      for (const key of ['entryTime', 'userToken', 'userFirstName']) {
+        sessionStorage.removeItem(key);
+      }
+    }
+    dispatch(profileLoadingFinished());
   });
 }
 

--- a/src/js/login/components/SearchHelpSignIn.jsx
+++ b/src/js/login/components/SearchHelpSignIn.jsx
@@ -25,7 +25,8 @@ class SearchHelpSignIn extends React.Component {
   }
 
   hasSession() {
-    return !!window.sessionStorage.getItem('userFirstName');
+    // Includes a safety check because sessionStorage is not defined during e2e testing
+    return !!(window.sessionStorage && window.sessionStorage.getItem('userFirstName'));
   }
 
   render() {

--- a/src/js/login/components/SearchHelpSignIn.jsx
+++ b/src/js/login/components/SearchHelpSignIn.jsx
@@ -53,8 +53,9 @@ class SearchHelpSignIn extends React.Component {
         isOpen={login.utilitiesMenuIsOpen.account}
         onUserLogout={this.props.onUserLogout}/>);
     } else {
+      const classes = classNames({ disabled: isLoading });
       content = (<div>
-        <a href="#" className={classNames({ disabled: isLoading })} onClick={this.handleSigninSignup}><span>Sign in</span><span className="signin-spacer">|</span><span>Sign up</span></a>
+        <a href="#" className={classes} onClick={this.handleSigninSignup}><span>Sign in</span><span className="signin-spacer">|</span><span>Sign up</span></a>
       </div>
       );
     }

--- a/src/js/login/components/SearchHelpSignIn.jsx
+++ b/src/js/login/components/SearchHelpSignIn.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 import URLSearchParams from 'url-search-params';
+import classNames from 'classnames';
 
 import HelpMenu from '../../common/components/HelpMenu';
 import SearchMenu from '../../common/components/SearchMenu';
@@ -52,12 +53,8 @@ class SearchHelpSignIn extends React.Component {
         isOpen={login.utilitiesMenuIsOpen.account}
         onUserLogout={this.props.onUserLogout}/>);
     } else {
-      const classList = [
-        isLoading ? 'disabled' : ''
-      ].join(' ');
-
       content = (<div>
-        <a href="#" className={classList} onClick={this.handleSigninSignup}><span>Sign in</span><span className="signin-spacer">|</span><span>Sign up</span></a>
+        <a href="#" className={classNames({ disabled: isLoading })} onClick={this.handleSigninSignup}><span>Sign in</span><span className="signin-spacer">|</span><span>Sign up</span></a>
       </div>
       );
     }

--- a/src/js/login/components/SearchHelpSignIn.jsx
+++ b/src/js/login/components/SearchHelpSignIn.jsx
@@ -24,28 +24,39 @@ class SearchHelpSignIn extends React.Component {
     this.props.toggleLoginModal(true);
   }
 
+  hasSession() {
+    return !!window.sessionStorage.getItem('userFirstName');
+  }
+
   render() {
     let content;
     const login = this.props.login;
+    const isLoading = this.props.profile.loading;
+    const hasSession = this.hasSession();
 
-    if (login.currentlyLoggedIn) {
+    // If we're done loading, and the user is logged in, or loading is in progress,
+    // and we have information is session storage, we can go ahead and render.
+    if ((!isLoading && login.currentlyLoggedIn) || (isLoading && hasSession)) {
       const firstName = _.startCase(_.toLower(
         this.props.profile.userFullName.first || sessionStorage.userFirstName
       ));
       const greeting = firstName || this.props.profile.email;
 
       content = (<SignInProfileMenu
+        disabled={isLoading}
         clickHandler={() => {
           this.props.toggleSearchHelpUserMenu('account', !login.utilitiesMenuIsOpen.account);
         }}
         greeting={greeting}
         isOpen={login.utilitiesMenuIsOpen.account}
         onUserLogout={this.props.onUserLogout}/>);
-    } else if (this.props.profile.loading) {
-      content = null;
     } else {
+      const classList = [
+        isLoading ? 'disabled' : ''
+      ].join(' ');
+
       content = (<div>
-        <a href="#" onClick={this.handleSigninSignup}><span>Sign in</span><span className="signin-spacer">|</span><span>Sign up</span></a>
+        <a href="#" className={classList} onClick={this.handleSigninSignup}><span>Sign in</span><span className="signin-spacer">|</span><span>Sign up</span></a>
       </div>
       );
     }

--- a/src/js/login/components/SignInProfileMenu.jsx
+++ b/src/js/login/components/SignInProfileMenu.jsx
@@ -21,7 +21,8 @@ class SignInProfileMenu extends React.Component {
         contents={dropDownContents}
         id="accountMenu"
         icon={icon}
-        isOpen={this.props.isOpen}/>
+        isOpen={this.props.isOpen}
+        disabled={this.props.disabled}/>
     );
   }
 }
@@ -31,7 +32,8 @@ SignInProfileMenu.propTypes = {
   cssClass: PropTypes.string,
   greeting: PropTypes.node,
   isOpen: PropTypes.bool.isRequired,
-  onUserLogout: PropTypes.func.isRequired
+  onUserLogout: PropTypes.func.isRequired,
+  disabled: PropTypes.bool
 };
 
 export default SignInProfileMenu;

--- a/src/sass/login.scss
+++ b/src/sass/login.scss
@@ -238,12 +238,24 @@ span.sidelines {
 .sign-in-link {
   color: $color-white;
 
+  button {
+    &:disabled {
+      background-color: inherit;
+      opacity: 0.7;
+    }
+  }
+
   a {
     color: inherit;
     text-decoration: none;
 
     &:visited {
       color: inherit;
+    }
+
+    &.disabled {
+      opacity: 0.7;
+      pointer-events: none;
     }
 
     span {


### PR DESCRIPTION
Currently, there are no login links (Sign in or the user's name) visible when the page loads. This is because certain information is needed before displaying that information. This PR changes that so that those links are visible immediately, but faded out to show that they are disabled. It think this is an improvement over hiding the links altogether. 

Resolves department-of-veterans-affairs/vets.gov-team/issues/6077