### PR TITLE
Post911 print sr mg

### DIFF
--- a/src/js/post-911-gib-status/containers/PrintPage.jsx
+++ b/src/js/post-911-gib-status/containers/PrintPage.jsx
@@ -18,6 +18,9 @@ class PrintPage extends React.Component {
     document.querySelector('nav').classList.remove('no-print-no-sr');
   }
 
+  backToStatement = () => this.props.router.push('/');
+  printWindow = () => window.print();
+
   render() {
     const enrollmentData = this.props.enrollmentData || {};
 
@@ -29,8 +32,18 @@ class PrintPage extends React.Component {
           <div className="print-screen">
             <img src="/img/design/logo/va-logo.png" alt="VA logo" width="300"/>
             <h1 className="section-header">Post-9/11 GI Bill<sup>&reg;</sup> Statement of Benefits</h1>
-            <p>The information in this letter is the Post-9/11 GI Bill Statement of Benefits for the beneficiary listed below as of {todayFormatted}. Any pending or recent changes to enrollment may affect remaining entitlement.</p>
+            <button
+              className="usa-button-primary"
+              onClick={this.printWindow}>Print This Page</button>
+            <p>
+              The information in this letter is the Post-9/11 GI Bill Statement of Benefits for
+              the beneficiary listed below as of {todayFormatted}. Any pending or recent changes to
+              enrollment may affect remaining entitlement.
+            </p>
             <UserInfoSection enrollmentData={enrollmentData}/>
+            <button
+              className="usa-button-secondary"
+              onClick={this.backToStatement}>Back to Statement Page</button>
           </div>
         </div>
       </div>

--- a/src/js/post-911-gib-status/containers/PrintPage.jsx
+++ b/src/js/post-911-gib-status/containers/PrintPage.jsx
@@ -3,10 +3,11 @@ import { connect } from 'react-redux';
 
 import UserInfoSection from '../components/UserInfoSection';
 
-import { formatDateLong } from '../../common/utils/helpers';
+import { formatDateLong, focusElement } from '../../common/utils/helpers';
 
 class PrintPage extends React.Component {
   componentDidMount() {
+    focusElement('usa-button-primary');
     document.querySelector('header').classList.add('no-print-no-sr');
     document.querySelector('footer').classList.add('no-print-no-sr');
     document.querySelector('.va-nav-breadcrumbs').classList.add('no-print-no-sr');

--- a/src/js/post-911-gib-status/containers/PrintPage.jsx
+++ b/src/js/post-911-gib-status/containers/PrintPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { unmountComponentAtNode } from 'react-dom';
 import { connect } from 'react-redux';
 
 import UserInfoSection from '../components/UserInfoSection';
@@ -16,7 +17,7 @@ export class PrintPage extends React.Component {
   componentWillUnmount() {
     document.querySelector('header').classList.remove('no-print-no-sr');
     document.querySelector('footer').classList.remove('no-print-no-sr');
-    document.querySelector('nav').classList.remove('no-print-no-sr');
+    document.querySelector('.va-nav-breadcrumbs').classList.remove('no-print-no-sr');
   }
 
   backToStatement = () => this.props.router.push('/');

--- a/src/js/post-911-gib-status/containers/PrintPage.jsx
+++ b/src/js/post-911-gib-status/containers/PrintPage.jsx
@@ -7,7 +7,7 @@ import { formatDateLong, focusElement } from '../../common/utils/helpers';
 
 class PrintPage extends React.Component {
   componentDidMount() {
-    focusElement('usa-button-primary');
+    focusElement('.print-screen');
     document.querySelector('header').classList.add('no-print-no-sr');
     document.querySelector('footer').classList.add('no-print-no-sr');
     document.querySelector('.va-nav-breadcrumbs').classList.add('no-print-no-sr');

--- a/src/js/post-911-gib-status/containers/PrintPage.jsx
+++ b/src/js/post-911-gib-status/containers/PrintPage.jsx
@@ -5,7 +5,7 @@ import UserInfoSection from '../components/UserInfoSection';
 
 import { formatDateLong, focusElement } from '../../common/utils/helpers';
 
-class PrintPage extends React.Component {
+export class PrintPage extends React.Component {
   componentDidMount() {
     focusElement('.print-screen');
     document.querySelector('header').classList.add('no-print-no-sr');

--- a/src/js/post-911-gib-status/containers/PrintPage.jsx
+++ b/src/js/post-911-gib-status/containers/PrintPage.jsx
@@ -6,6 +6,18 @@ import UserInfoSection from '../components/UserInfoSection';
 import { formatDateLong } from '../../common/utils/helpers';
 
 class PrintPage extends React.Component {
+  componentDidMount() {
+    document.querySelector('header').classList.add('no-print-no-sr');
+    document.querySelector('footer').classList.add('no-print-no-sr');
+    document.querySelector('.va-nav-breadcrumbs').classList.add('no-print-no-sr');
+  }
+
+  componentWillUnmount() {
+    document.querySelector('header').classList.remove('no-print-no-sr');
+    document.querySelector('footer').classList.remove('no-print-no-sr');
+    document.querySelector('nav').classList.remove('no-print-no-sr');
+  }
+
   render() {
     const enrollmentData = this.props.enrollmentData || {};
 

--- a/src/js/post-911-gib-status/containers/PrintPage.jsx
+++ b/src/js/post-911-gib-status/containers/PrintPage.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { unmountComponentAtNode } from 'react-dom';
 import { connect } from 'react-redux';
 
 import UserInfoSection from '../components/UserInfoSection';

--- a/src/js/post-911-gib-status/containers/StatusPage.jsx
+++ b/src/js/post-911-gib-status/containers/StatusPage.jsx
@@ -9,7 +9,7 @@ import UserInfoSection from '../components/UserInfoSection';
 
 class StatusPage extends React.Component {
   componentDidMount() {
-    focusElement('.show-on-focus');
+    focusElement('.va-nav-breadcrumbs-list');
   }
 
   navigateToPrint = () => {

--- a/src/js/post-911-gib-status/containers/StatusPage.jsx
+++ b/src/js/post-911-gib-status/containers/StatusPage.jsx
@@ -11,6 +11,7 @@ class StatusPage extends React.Component {
   componentDidMount() {
     focusElement('.show-on-focus');
   }
+
   navigateToPrint = () => {
     this.props.router.push('/print');
   }

--- a/src/js/post-911-gib-status/containers/StatusPage.jsx
+++ b/src/js/post-911-gib-status/containers/StatusPage.jsx
@@ -31,7 +31,7 @@ class StatusPage extends React.Component {
       printButton = (
         <div className="section">
           <button onClick={this.navigateToPrint} className="usa-button-primary" id="print-button">
-            Print Statement of Benefits
+            Get Printable Statement of Benefits
           </button>
         </div>
       );

--- a/src/js/post-911-gib-status/containers/StatusPage.jsx
+++ b/src/js/post-911-gib-status/containers/StatusPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { focusElement } from '../../common/utils/helpers';
 
 import FormTitle from '../../common/schemaform/components/FormTitle';
 
@@ -7,6 +8,9 @@ import EnrollmentHistory from '../components/EnrollmentHistory';
 import UserInfoSection from '../components/UserInfoSection';
 
 class StatusPage extends React.Component {
+  componentDidMount() {
+    focusElement('.show-on-focus');
+  }
   navigateToPrint = () => {
     this.props.router.push('/print');
   }

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -51,6 +51,11 @@ body .row.full {
   float: left;
 }
 
+// Remove from print view, incidentally removes from screen readers as well
+.no-print-no-sr {
+  display: none !important;
+}
+
 // Abbr
 
 abbr {

--- a/src/sass/post-911-gib-status.scss
+++ b/src/sass/post-911-gib-status.scss
@@ -82,7 +82,19 @@
     }
 
     @media print {
+      font: $font-serif;
+      color: $color-gray-dark;
       padding: 0;
+      a {
+        text-decoration: none;
+        &:after {
+          content:" (https://vets.gov" attr(href) ")";
+        }
+      }
+
+      button {
+        display: none;
+      }
     }
   }
 }

--- a/src/sass/post-911-gib-status.scss
+++ b/src/sass/post-911-gib-status.scss
@@ -99,10 +99,6 @@
   }
 }
 
-.no-print-no-sr {
-    display: none !important;
-}
-
 #noChapter33Benefits {
   h2 {
     margin-top: 2em;

--- a/src/sass/post-911-gib-status.scss
+++ b/src/sass/post-911-gib-status.scss
@@ -82,6 +82,14 @@
     }
 
     @media print {
+      body {
+        display: none;
+      }
+
+      div.print-status {
+        display: block;
+      }
+
       padding: 0;
     }
   }

--- a/src/sass/post-911-gib-status.scss
+++ b/src/sass/post-911-gib-status.scss
@@ -82,17 +82,13 @@
     }
 
     @media print {
-      body {
-        display: none;
-      }
-
-      div.print-status {
-        display: block;
-      }
-
       padding: 0;
     }
   }
+}
+
+.no-print-no-sr {
+    display: none !important;
 }
 
 #noChapter33Benefits {

--- a/test/post-911-gib-status/components/PrintPage.unit.spec.jsx
+++ b/test/post-911-gib-status/components/PrintPage.unit.spec.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
+
 import { PrintPage } from '../../../src/js/post-911-gib-status/containers/PrintPage';
 
-describe.only('<PrintPage/>', () => {
+describe('<PrintPage/>', () => {
   const pushSpy = sinon.spy();
   const defaultProps = {
     router: { push: pushSpy },
+    enrollmentData: {}
   };
 
   it('should render', () => {
@@ -33,13 +35,15 @@ describe.only('<PrintPage/>', () => {
   });
 
   it('should fire a print request when print button clicked', () => {
-    const printSpy = sinon.spy(global.window, 'print');
+    const oldWindow = global.window;
+    const printSpy = sinon.spy();
+    global.window.print = printSpy;
     const wrapper = shallow(<PrintPage {...defaultProps}/>, { disableLifecycleMethods: true });
     const printButton = wrapper.find('.usa-button-primary');
     expect(printSpy.notCalled).to.be.true;
     printButton.simulate('click');
     expect(printSpy.calledOnce).to.be.true;
-    printSpy.restore();
+    global.window = oldWindow;
   });
 
   it('should navigate to statement when back to statement button clicked', () => {

--- a/test/post-911-gib-status/components/PrintPage.unit.spec.jsx
+++ b/test/post-911-gib-status/components/PrintPage.unit.spec.jsx
@@ -35,7 +35,7 @@ describe('<PrintPage/>', () => {
   });
 
   it('should fire a print request when print button clicked', () => {
-    const oldWindow = global.window;
+    const oldPrint = global.window.print;
     const printSpy = sinon.spy();
     global.window.print = printSpy;
     const wrapper = shallow(<PrintPage {...defaultProps}/>, { disableLifecycleMethods: true });
@@ -43,7 +43,7 @@ describe('<PrintPage/>', () => {
     expect(printSpy.notCalled).to.be.true;
     printButton.simulate('click');
     expect(printSpy.calledOnce).to.be.true;
-    global.window = oldWindow;
+    global.window.print = oldPrint;
   });
 
   it('should navigate to statement when back to statement button clicked', () => {

--- a/test/post-911-gib-status/components/PrintPage.unit.spec.jsx
+++ b/test/post-911-gib-status/components/PrintPage.unit.spec.jsx
@@ -12,6 +12,8 @@ describe('<PrintPage/>', () => {
     enrollmentData: {}
   };
 
+  afterEach(() => pushSpy.reset());
+
   it('should render', () => {
     const wrapper = shallow(<PrintPage {...defaultProps}/>, { disableLifecycleMethods: true });
     expect(wrapper.type()).to.equal('div');

--- a/test/post-911-gib-status/components/PrintPage.unit.spec.jsx
+++ b/test/post-911-gib-status/components/PrintPage.unit.spec.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import { PrintPage } from '../../../src/js/post-911-gib-status/containers/PrintPage';
+
+describe.only('<PrintPage/>', () => {
+  const pushSpy = sinon.spy();
+  const defaultProps = {
+    router: { push: pushSpy },
+  };
+
+  it('should render', () => {
+    const wrapper = shallow(<PrintPage {...defaultProps}/>, { disableLifecycleMethods: true });
+    expect(wrapper.type()).to.equal('div');
+  });
+
+  it('renders a UserInfoSection child', () => {
+    const wrapper = shallow(<PrintPage {...defaultProps}/>, { disableLifecycleMethods: true });
+    expect(wrapper.find('UserInfoSection').length).to.equal(1);
+  });
+
+  it('should render a print button', () => {
+    const wrapper = shallow(<PrintPage {...defaultProps}/>, { disableLifecycleMethods: true });
+    const printButton = wrapper.find('.usa-button-primary');
+    expect(printButton.length).to.equal(1);
+  });
+
+  it('should render a back to statement button', () => {
+    const wrapper = shallow(<PrintPage {...defaultProps}/>, { disableLifecycleMethods: true });
+    const backButton = wrapper.find('.usa-button-secondary');
+    expect(backButton.length).to.equal(1);
+  });
+
+  it('should fire a print request when print button clicked', () => {
+    const printSpy = sinon.spy(global.window, 'print');
+    const wrapper = shallow(<PrintPage {...defaultProps}/>, { disableLifecycleMethods: true });
+    const printButton = wrapper.find('.usa-button-primary');
+    expect(printSpy.notCalled).to.be.true;
+    printButton.simulate('click');
+    expect(printSpy.calledOnce).to.be.true;
+    printSpy.restore();
+  });
+
+  it('should navigate to statement when back to statement button clicked', () => {
+    const wrapper = shallow(<PrintPage {...defaultProps}/>, { disableLifecycleMethods: true });
+    const backButton = wrapper.find('.usa-button-secondary');
+    expect(pushSpy.notCalled).to.be.true;
+    backButton.simulate('click');
+    expect(pushSpy.calledOnce).to.be.true;
+  });
+});

--- a/test/post-911-gib-status/containers/StatusPage.unit.spec.jsx
+++ b/test/post-911-gib-status/containers/StatusPage.unit.spec.jsx
@@ -34,7 +34,7 @@ describe('<StatusPage>', () => {
     expect(node.querySelector('.schemaform-title').textContent)
       .to.contain('Post-9/11 GI Bill Statement of Benefits');
     expect(node.querySelector('.usa-button-primary').textContent)
-      .to.contain('Print Statement of Benefits');
+      .to.contain('Get Printable Statement of Benefits');
   });
 
   it('should not show intro and print button if veteran is not eligible', () => {


### PR DESCRIPTION
- Ensures screen readers don't read background behind print modal
- Adds print and back buttons to printable statement (these don't display once print button is clicked)
- Adds some print-specific styling
- Adds a few other small accessibility tweaks for print and status pages (focus elements once components are rendered)
- Accompanying tests
