### PR TITLE
Edit VIC Error messages about military service history

### DIFF
--- a/src/js/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/js/veteran-id-card/components/RequiredVeteranView.jsx
@@ -10,11 +10,11 @@ class RequiredVeteranView extends React.Component {
 
     if (this.props.userProfile.veteranStatus === 'SERVER_ERROR') {
       // If eMIS status is null, show a system down message.
-      view = <SystemDownView messageLine1="We’re sorry. We can’t proceed with your request for a Veteran ID card because we can't confirm your military history right now. Please try again in a few minutes." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
+      view = <SystemDownView messageLine1="We're sorry. We can't process your request for a Veteran ID Card right now because we can't access your records at the moment. Please try again in a few minutes." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
     } else if (this.props.userProfile.veteranStatus === 'NOT_FOUND') {
       // If eMIS status is "not found", show message that we cannot find the user
       // in our system.
-      view = <SystemDownView messageLine1="We’re sorry. We can’t proceed with your request for a Veteran ID card because we can't confirm your military history right now. Please try again in a few minutes." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
+      view = <SystemDownView messageLine1="We’re sorry, but we need more information to process your Veteran ID Card request." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
     } else if (this.props.userProfile.veteranStatus === 'OK') {
       if (!serviceAvailable) {
         // If all above conditions are true and service is still not present in user profile, then user

--- a/src/js/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/js/veteran-id-card/components/RequiredVeteranView.jsx
@@ -10,7 +10,7 @@ class RequiredVeteranView extends React.Component {
 
     if (this.props.userProfile.veteranStatus === 'SERVER_ERROR') {
       // If eMIS status is null, show a system down message.
-      view = <SystemDownView messageLine1="We're sorry. We can't process your request for a Veteran ID Card right now because we can't access your records at the moment. Please try again in a few minutes." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
+      view = <SystemDownView messageLine1="We’re sorry. We can’t process your request for a Veteran ID Card right now because we can't access your records at the moment. Please try again in a few minutes." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
     } else if (this.props.userProfile.veteranStatus === 'NOT_FOUND') {
       // If eMIS status is "not found", show message that we cannot find the user
       // in our system.

--- a/src/js/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/js/veteran-id-card/components/RequiredVeteranView.jsx
@@ -14,7 +14,7 @@ class RequiredVeteranView extends React.Component {
     } else if (this.props.userProfile.veteranStatus === 'NOT_FOUND') {
       // If eMIS status is "not found", show message that we cannot find the user
       // in our system.
-      view = <SystemDownView messageLine1="We’re sorry, but we need more information to process your Veteran ID Card request." messageLine2="If it still doesn’t work, please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
+      view = <SystemDownView messageLine1="We’re sorry, but we need more information to process your Veteran ID Card request." messageLine2="Please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."/>;
     } else if (this.props.userProfile.veteranStatus === 'OK') {
       if (!serviceAvailable) {
         // If all above conditions are true and service is still not present in user profile, then user


### PR DESCRIPTION
Previously the same error message was being returned when both eMIS was down and a user was not in eMIS. This makes it so more specific error messages are shown, matching the text approved in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/6673#issuecomment-352493969.  

Closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/6673

