### PR TITLE
Don't redirect to login if API requests fail in auth flow.

### DIFF
--- a/src/js/common/helpers/api.js
+++ b/src/js/common/helpers/api.js
@@ -41,10 +41,15 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
         : Promise.resolve(response);
 
       if (!response.ok) {
-        if (response.status === 401) {
+        const { pathname } = window.location;
+        const shouldRedirectToLogin =
+          response.status === 401 &&
+          !pathname.includes('auth/login/callback');
+
+        if (shouldRedirectToLogin) {
           window.location.href = appendQuery(
             environment.BASE_URL,
-            { next: window.location.pathname }
+            { next: pathname }
           );
         }
 

--- a/src/js/common/helpers/api.js
+++ b/src/js/common/helpers/api.js
@@ -47,10 +47,8 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
           !pathname.includes('auth/login/callback');
 
         if (shouldRedirectToLogin) {
-          window.location.href = appendQuery(
-            environment.BASE_URL,
-            { next: pathname }
-          );
+          const loginUrl = appendQuery(environment.BASE_URL, { next: pathname });
+          window.location.href = loginUrl;
         }
 
         return data.then(Promise.reject.bind(Promise));

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -40,7 +40,7 @@ class Main extends React.Component {
     });
     this.bindNavbarLinks();
 
-    // In some cases this component is mounted on a url that is part of the login process and doesn't need to make another 
+    // In some cases this component is mounted on a url that is part of the login process and doesn't need to make another
     // request, because that data will be passed to the parent window and done there instead.
     if (!window.location.pathname.includes('auth/login/callback')) {
       window.onload = () => {


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#6600.

This solves an edge case where logging in might result in invalid data in the SAML callback (perhaps a wrong token) and consequently unauthorized requests to the API.