### PR TITLE
Add events to support login custom dimension

### DIFF
--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -70,7 +70,7 @@ export function getUserData(dispatch) {
     if (userData.first_name) {
       sessionStorage.setItem('userFirstName', userData.first_name);
     }
-    //Report out the current level of assurance for the user
+    // Report out the current level of assurance for the user
     window.dataLayer.push({ event: `login-loa-current-${userData.loa.current}` });
     dispatch(updateProfileFields({
       savedForms: json.data.attributes.in_progress_forms,

--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -70,6 +70,8 @@ export function getUserData(dispatch) {
     if (userData.first_name) {
       sessionStorage.setItem('userFirstName', userData.first_name);
     }
+    //Report out the current level of assurance for the user
+    window.dataLayer.push({ event: `login-current-loa-${userData.loa.current}`});
     dispatch(updateProfileFields({
       savedForms: json.data.attributes.in_progress_forms,
       prefillsAvailable: json.data.attributes.prefills_available,

--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -71,7 +71,7 @@ export function getUserData(dispatch) {
       sessionStorage.setItem('userFirstName', userData.first_name);
     }
     //Report out the current level of assurance for the user
-    window.dataLayer.push({ event: `login-current-loa-${userData.loa.current}`});
+    window.dataLayer.push({ event: `login-loa-current-${userData.loa.current}` });
     dispatch(updateProfileFields({
       savedForms: json.data.attributes.in_progress_forms,
       prefillsAvailable: json.data.attributes.prefills_available,

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -40,7 +40,7 @@ class Main extends React.Component {
     });
     this.bindNavbarLinks();
 
-    // In some cases this component is mounted on a url that is part of the login process and doesn't need to make another 
+    // In some cases this component is mounted on a url that is part of the login process and doesn't need to make another
     // request, because that data will be passed to the parent window and done there instead.
     if (!window.location.pathname.includes('auth/login/callback')) {
       window.onload = () => {
@@ -160,6 +160,7 @@ class Main extends React.Component {
 
       // @todo after doing the above, remove this code.
       if (this.props.getUserData()) {
+        window.dataLayer.push({ event: 'login-user-logged-in' });
         this.props.updateLoggedInStatus(true);
       }
     } else {


### PR DESCRIPTION
This adds two events to the login flow to help us track user logins.

One should fire whenever we set the user attribute of `loggedIn` to true. When picked up, we'll mark the whole session as logged in from that point forward.

The other fires events to show if the LOA level is 1 or 3. We'll track this for the session as well.

Combined these events will allow us to create custom dimensions to help answer questions about usage patterns while logged in.

Nick touched this most recently. I tagged jeff and ben more as a "cc" since they seem to have done some heavy lifting on this in the past.

Closes: department-of-veterans-affairs/vets.gov-team#4539