### PR TITLE
Update review tests to remove pauses

### DIFF
--- a/test/common/schemaform/review/00-complete-form.e2e.spec.js
+++ b/test/common/schemaform/review/00-complete-form.e2e.spec.js
@@ -43,7 +43,7 @@ module.exports = E2eHelpers.createE2eTest(
     // Close panel
     client.expect.element('.edit-btn').to.be.visible;
     client
-      .pause(1200)
+      .waitForElementVisible('button.usa-button-unstyled', Timeouts.normal)
       .click('button.usa-button-unstyled');
 
     client.expect.element('.edit-btn').to.not.be.present;
@@ -62,10 +62,7 @@ module.exports = E2eHelpers.createE2eTest(
 
     client
       .click('.usa-button-primary.null')
-      .pause(1000);
-
-    client
-      .expect.element('.usa-input-error').to.be.visible;
+      .waitForElementVisible('.usa-input-error', Timeouts.normal);
 
     // Fix validation errors and save successfully
     client

--- a/test/common/schemaform/review/01-blank-form.e2e.spec.js
+++ b/test/common/schemaform/review/01-blank-form.e2e.spec.js
@@ -21,12 +21,10 @@ module.exports = E2eHelpers.createE2eTest(
     client
       .waitForElementVisible('.usa-accordion-bordered', Timeouts.normal)
       .click('.usa-accordion-bordered .usa-button-unstyled')
-      .pause(1200);
-    client.expect.element('.edit-btn').to.be.visible;
+      .waitForElementVisible('.edit-btn', Timeouts.normal);
 
     // Try to save form with validation errors
     client
-      .waitForElementVisible('.edit-btn', Timeouts.normal)
       .click('.edit-btn');
     client.expect.element('input[name="root_veteranFullName_first"]').to.be.visible;
 


### PR DESCRIPTION
I think the pauses are causing some instability, so this should help. The other SiP tests have already been updated.