### PR TITLE
WIP - Session Timeout Modal

### DIFF
--- a/src/js/login/actions/index.js
+++ b/src/js/login/actions/index.js
@@ -3,6 +3,7 @@ import { gaClientId } from '../../common/utils/helpers';
 export const LOG_OUT = 'LOG_OUT';
 export const TOGGLE_LOGIN_MODAL = 'TOGGLE_LOGIN_MODAL';
 export const UPDATE_LOGGEDIN_STATUS = 'UPDATE_LOGGEDIN_STATUS';
+export const UPDATE_SESSION_EXPIRES_SOON = 'UPDATE_SESSION_EXPIRES_SOON';
 export const UPDATE_LOGIN_URLS = 'UPDATE_LOGIN_URLS';
 export const UPDATE_LOGOUT_URL = 'UPDATE_LOGOUT_URL';
 export const UPDATE_MULTIFACTOR_URL = 'UPDATE_MULTIFACTOR_URL';
@@ -13,6 +14,13 @@ export const FETCH_LOGIN_URLS_FAILED = 'FETCH_LOGIN_URLS_FAILED';
 export function updateLoggedInStatus(value) {
   return {
     type: UPDATE_LOGGEDIN_STATUS,
+    value
+  };
+}
+
+export function updateSessionExpiresSoon(value) {
+  return {
+    type: UPDATE_SESSION_EXPIRES_SOON,
     value
   };
 }

--- a/src/js/login/components/SessionRefreshModal.jsx
+++ b/src/js/login/components/SessionRefreshModal.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import moment from 'moment';
+import Modal from '../../common/components/Modal';
+
+function SessionRefreshModal({ sessionExpiresAfterMinutes, visible, login, logout }) {
+  const now = moment();
+  const isExpired =  now.isAfter(moment(window.sessionStorage.entryTime).add(sessionExpiresAfterMinutes, 'm'));
+  let title = null;
+  let content = null;
+
+  if (isExpired) {
+    title = 'Your Vets.gov session has expired';
+    content = (
+      <div>
+        <p>To protect your privacy and security, your session has expired after an hour of inactivity.</p>
+        <button type="button" className="usa-button-primary" onClick={() => document.location.reload()}>Return to Vets.gov</button>
+      </div>
+    );
+  } else {
+    title = 'Your Vets.gov session is expiring';
+    content = (
+      <div>
+        <p>To protect your privacy and security, your session is expiring and you will be automatically signed out within 10 minutes. Would you like to stay signed in?</p>
+        <button type="button"
+          className="usa-button-primary"
+          onClick={(event) => {
+            event.preventDefault();
+            return login();
+          }}>Stay signed in</button>
+        <button type="button"
+          className="usa-button-secondary"
+          onClick={(event) => {
+            event.preventDefault();
+            return logout();
+          }}>Sign out now</button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Modal
+        id="session-refresh-modal"
+        hideCloseButton
+        onClose={() => {}}
+        visible={visible}
+        focusSelector="button"
+        title={title}>
+        {content}
+      </Modal>
+    </div>
+  );
+}
+
+export default SessionRefreshModal;

--- a/src/js/login/components/SessionRefreshModal.jsx
+++ b/src/js/login/components/SessionRefreshModal.jsx
@@ -2,54 +2,80 @@ import React from 'react';
 import moment from 'moment';
 import Modal from '../../common/components/Modal';
 
-function SessionRefreshModal({ sessionExpiresAfterMinutes, visible, login, logout }) {
-  const now = moment();
-  const isExpired =  now.isAfter(moment(window.sessionStorage.entryTime).add(sessionExpiresAfterMinutes, 'm'));
-  let title = null;
-  let content = null;
+class SessionRefreshModal extends React.Component {
 
-  if (isExpired) {
-    title = 'Your Vets.gov session has expired';
-    content = (
+  componentDidMount() {
+    this.interval = window.setInterval(this.checkTokenExpiration, this.props.sessionExpirationIntervalSeconds * 1000);
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(this.interval);
+  }
+
+  checkTokenExpiration = () => {
+    if (this.props.profile.loading ||
+      !this.props.login.currentlyLoggedIn ||
+      this.props.login.showSessionRefreshModal) return;
+
+    const now = moment();
+    const entryTime = sessionStorage.entryTime;
+    const expiresSoon = now.isAfter(moment(entryTime).add(this.props.sessionExpiresAfterMinutes - 10, 'm'));
+    if (!expiresSoon) return;
+
+    this.props.updateSessionExpiresSoon(true);
+  }
+
+  render() {
+    const { sessionExpiresAfterMinutes, visible, handleLogin, handleLogout } = this.props;
+    const now = moment();
+    const isExpired =  now.isAfter(moment(window.sessionStorage.entryTime).add(sessionExpiresAfterMinutes, 'm'));
+    let title = null;
+    let content = null;
+
+    if (isExpired) {
+      title = 'Your Vets.gov session has expired';
+      content = (
+        <div>
+          <p>To protect your privacy and security, your session has expired after an hour of inactivity.</p>
+          <button type="button" className="usa-button-primary" onClick={() => document.location.reload()}>Return to Vets.gov</button>
+        </div>
+      );
+    } else {
+      title = 'Your Vets.gov session is expiring';
+      content = (
+        <div>
+          <p>To protect your privacy and security, your session is expiring and you will be automatically signed out within 10 minutes. Would you like to stay signed in?</p>
+          <button type="button"
+            className="usa-button-primary"
+            onClick={(event) => {
+              event.preventDefault();
+              return handleLogin();
+            }}>Stay signed in</button>
+          <button type="button"
+            className="usa-button-secondary"
+            onClick={(event) => {
+              event.preventDefault();
+              return handleLogout();
+            }}>Sign out now</button>
+        </div>
+      );
+    }
+
+    return (
       <div>
-        <p>To protect your privacy and security, your session has expired after an hour of inactivity.</p>
-        <button type="button" className="usa-button-primary" onClick={() => document.location.reload()}>Return to Vets.gov</button>
-      </div>
-    );
-  } else {
-    title = 'Your Vets.gov session is expiring';
-    content = (
-      <div>
-        <p>To protect your privacy and security, your session is expiring and you will be automatically signed out within 10 minutes. Would you like to stay signed in?</p>
-        <button type="button"
-          className="usa-button-primary"
-          onClick={(event) => {
-            event.preventDefault();
-            return login();
-          }}>Stay signed in</button>
-        <button type="button"
-          className="usa-button-secondary"
-          onClick={(event) => {
-            event.preventDefault();
-            return logout();
-          }}>Sign out now</button>
+        <Modal
+          id="session-refresh-modal"
+          hideCloseButton
+          onClose={() => {}}
+          visible={visible}
+          focusSelector="button"
+          title={title}>
+          {content}
+        </Modal>
       </div>
     );
   }
 
-  return (
-    <div>
-      <Modal
-        id="session-refresh-modal"
-        hideCloseButton
-        onClose={() => {}}
-        visible={visible}
-        focusSelector="button"
-        title={title}>
-        {content}
-      </Modal>
-    </div>
-  );
 }
 
 export default SessionRefreshModal;

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -153,9 +153,11 @@ class Main extends React.Component {
   }
 
   checkTokenExpiration = () => {
-    const isLoading = this.props.profile.loading;
-    const isLoggedIn = this.props.profile.accountType;
-    if (isLoading || !isLoggedIn) return;
+    // If the profile request is pending; the user is not logged-in; or the session refresh modal is already shown,
+    // we can exit this function right away.
+    if (this.props.profile.loading ||
+      !this.props.login.currentlyLoggedIn ||
+      this.props.login.showSessionRefreshModal) return;
 
     const entryTime = moment(sessionStorage.entryTime);
     const expiresSoon = moment() > entryTime.add(this.props.sessionRefreshIntervalMinutes, 'm');

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import moment from 'moment';
 import PropTypes from 'prop-types';
 import appendQuery from 'append-query';
+import moment from 'moment';
 
 import LoadingIndicator from '../../common/components/LoadingIndicator';
 import Modal from '../../common/components/Modal';
@@ -13,56 +13,7 @@ import { updateLoggedInStatus, updateSessionExpiresSoon, updateLogoutUrl, update
 import SearchHelpSignIn from '../components/SearchHelpSignIn';
 import Signin from '../components/Signin';
 import Verify from '../components/Verify';
-
-function SessionRefreshModal({ sessionExpiresAfterMinutes, visible, login, logout }) {
-  const now = moment();
-  const isExpired =  now.isAfter(moment(window.sessionStorage.entryTime).add(sessionExpiresAfterMinutes, 'm'));
-  let title = null;
-  let content = null;
-
-  if (isExpired) {
-    title = 'Your Vets.gov session has expired';
-    content = (
-      <div>
-        <p>To protect your privacy and security, your session has expired after an hour of inactivity.</p>
-        <button type="button" className="usa-button-primary" onClick={() => document.location.reload()}>Return to Vets.gov</button>
-      </div>
-    );
-  } else {
-    title = 'Your Vets.gov session is expiring';
-    content = (
-      <div>
-        <p>To protect your privacy and security, your session is expiring and you will be automatically signed out within 10 minutes. Would you like to stay signed in?</p>
-        <button type="button"
-          className="usa-button-primary"
-          onClick={(event) => {
-            event.preventDefault();
-            return login();
-          }}>Stay signed in</button>
-        <button type="button"
-          className="usa-button-secondary"
-          onClick={(event) => {
-            event.preventDefault();
-            return logout();
-          }}>Sign out now</button>
-      </div>
-    );
-  }
-
-  return (
-    <div>
-      <Modal
-        id="session-refresh-modal"
-        hideCloseButton
-        onClose={() => {}}
-        visible={visible}
-        focusSelector="button"
-        title={title}>
-        {content}
-      </Modal>
-    </div>
-  );
-}
+import SessionRefreshModal from '../components/SessionRefreshModal';
 
 class Main extends React.Component {
 

--- a/src/js/login/containers/Main.jsx
+++ b/src/js/login/containers/Main.jsx
@@ -35,17 +35,6 @@ function SessionRefreshModal({ visible, isLoading, login, logout }) {
 }
 
 class Main extends React.Component {
-  constructor(props) {
-    super(props);
-    this.checkTokenStatus = this.checkTokenStatus.bind(this);
-    this.getLoginUrls = this.getLoginUrls.bind(this);
-    this.getLogoutUrl = this.getLogoutUrl.bind(this);
-    this.getVerifyUrl = this.getVerifyUrl.bind(this);
-    this.handleLogin = this.handleLogin.bind(this);
-    this.handleLogout = this.handleLogout.bind(this);
-    this.handleSignup = this.handleSignup.bind(this);
-    this.setMyToken = this.setMyToken.bind(this);
-  }
 
   componentDidMount() {
     if (sessionStorage.userToken) {
@@ -89,25 +78,25 @@ class Main extends React.Component {
     this.unbindNavbarLinks();
   }
 
-  getVerifyUrl() {
+  getVerifyUrl = () => {
     const { currentlyLoggedIn, verifyUrl } = this.props.login;
     if (currentlyLoggedIn && !verifyUrl) {
       this.verifyUrlRequest = getVerifyUrl(this.props.updateVerifyUrl);
     }
   }
 
-  setMyToken(event) {
+  setMyToken = (event) => {
     if (event.data === sessionStorage.userToken) {
       this.props.getUserData();
       this.getLogoutUrl();
     }
   }
 
-  getLoginUrls() {
+  getLoginUrls = () => {
     this.loginUrlRequest = this.props.getLoginUrls();
   }
 
-  getLogoutUrl() {
+  getLogoutUrl = () => {
     this.logoutUrlRequest = fetch(`${environment.API_URL}/v0/sessions`, {
       method: 'DELETE',
       headers: new Headers({
@@ -140,7 +129,7 @@ class Main extends React.Component {
     });
   }
 
-  handleLogout() {
+  handleLogout = () => {
     window.dataLayer.push({ event: 'logout-link-clicked' });
     const myLogoutUrl = this.props.login.logoutUrl;
     if (myLogoutUrl) {
@@ -150,7 +139,7 @@ class Main extends React.Component {
     }
   }
 
-  handleSignup() {
+  handleSignup = () => {
     window.dataLayer.push({ event: 'register-link-clicked' });
     const myLoginUrl = this.props.login.loginUrls.idme;
     if (myLoginUrl) {
@@ -160,11 +149,11 @@ class Main extends React.Component {
     }
   }
 
-  handleLogin(loginUrl = 'idme') {
+  handleLogin = (loginUrl = 'idme') => {
     this.loginUrlRequest = handleLogin(this.props.login.loginUrls[loginUrl], this.props.updateLogInUrls);
   }
 
-  checkTokenStatus() {
+  checkTokenStatus = () => {
     if (sessionStorage.userToken) {
       if (this.props.getUserData()) this.props.updateLoggedInStatus(true);
     } else {

--- a/src/js/login/reducers/login.js
+++ b/src/js/login/reducers/login.js
@@ -40,8 +40,10 @@ function closeAllMenus(menuState) {
 
 function loginStuff(state = initialState, action) {
   switch (action.type) {
-    case UPDATE_LOGGEDIN_STATUS:
-      return _.set('currentlyLoggedIn', action.value, state);
+    case UPDATE_LOGGEDIN_STATUS: {
+      const result = _.set('currentlyLoggedIn', action.value, state);
+      return _.set('showSessionRefreshModal', false, result);
+    }
     case FETCH_LOGIN_URLS_FAILED:
       return _.set('loginUrlsError', true, state);
     case UPDATE_LOGIN_URLS:

--- a/src/js/login/reducers/login.js
+++ b/src/js/login/reducers/login.js
@@ -5,6 +5,7 @@ import {
   LOG_OUT,
   TOGGLE_LOGIN_MODAL,
   UPDATE_LOGGEDIN_STATUS,
+  UPDATE_SESSION_EXPIRES_SOON,
   UPDATE_LOGIN_URLS,
   UPDATE_LOGOUT_URL,
   UPDATE_MULTIFACTOR_URL,
@@ -20,6 +21,7 @@ const initialState = {
   logoutUrl: null,
   multifactorUrl: null,
   showModal: false,
+  showSessionRefreshModal: false,
   verifyUrl: null,
   utilitiesMenuIsOpen: {
     search: false,
@@ -64,6 +66,9 @@ function loginStuff(state = initialState, action) {
 
     case TOGGLE_LOGIN_MODAL:
       return _.set('showModal', action.isOpen, state);
+
+    case UPDATE_SESSION_EXPIRES_SOON:
+      return _.set('showSessionRefreshModal', action.value, state);
 
     case LOG_OUT:
       return _.set('currentlyLoggedIn', false, state);

--- a/src/sass/modules/_m-modal.scss
+++ b/src/sass/modules/_m-modal.scss
@@ -158,6 +158,21 @@
   white-space: nowrap;
 }
 
+#session-refresh-modal {
+  .va-modal-title {
+    display: block;
+    color: $color-gray-dark;
+  }
+  .va-modal-inner {
+    max-width: 55rem;
+    width: 55vw;
+    .va-modal-body {
+      max-height: 55vh;
+      overflow-y: auto;
+    }
+  }
+}
+
 button.va-modal-close {
   background-color: inherit;
   color: $color-va-modal-close;

--- a/src/sass/modules/_m-modal.scss
+++ b/src/sass/modules/_m-modal.scss
@@ -166,6 +166,7 @@
   .va-modal-inner {
     max-width: 55rem;
     width: 55vw;
+    padding-top: 2rem;
     .va-modal-body {
       max-height: 55vh;
       overflow-y: auto;


### PR DESCRIPTION
### How do we know when the session is going to timeout?
The token expires one hour after issued, but that is expiration is increased by one hour per each API request for a maximum of 12 hours. So, if the user is refreshing the token all day at the end of each hour, it can be used for 12 hours and 59 minutes before it becomes invalid.
    
### Pure UI Ideas
- Centralize API access:
        - Override window.fetch (bad idea)
        - Switch all API access methods to use the API helper in the common directory (probably the best)
- Create a custom middleware that checks for network access via promises (probably the easiest)
- A big long reducer that expands the session expiration when certain actions are dispatched (a very controlled way but would be some work to maintain)

### API Ideas
- Include a header in API responses about when the authorization expires
    - This at least seems more reliable than having the front-end do all of the calculation for session expiry.
- API Route for getting session expiry
    - This is a little tricky because the UI still has to determine when to hit that route, but this is way seems like the most reliable way to do it. The UI can probably check every 45 minutes, or if it detects that the website was left idle for an undetermined amount of time.

Resolves department-of-veterans-affairs/vets.gov-team/issues/6582
  
On hold until API is implemented and Frontend's API access is centralized -
department-of-veterans-affairs/vets.gov-team/issues/7053
department-of-veterans-affairs/vets.gov-team/issues/7102