### PR TITLE
Letters error logging mg

### DIFF
--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -60,7 +60,6 @@ export function getLetterList(dispatch) {
   );
 }
 
-
 export function getBenefitSummaryOptions(dispatch) {
   return apiRequest(
     '/v0/letters/beneficiary',
@@ -77,7 +76,6 @@ export function getBenefitSummaryOptions(dispatch) {
   );
 }
 
-
 // Call getLetterList then getBenefitSummaryOptions
 export function getLetterListAndBSLOptions() {
   return (dispatch) => {
@@ -86,7 +84,6 @@ export function getLetterListAndBSLOptions() {
       .catch((error) => Raven.captureException(error));
   };
 }
-
 
 export function getAddressFailure() {
   window.dataLayer.push({ event: 'letter-update-address-notfound' });

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -106,7 +106,6 @@ export function getMailingAddress() {
     return apiRequest(
       '/v0/address',
       null,
-      // on fetch success
       (response) => {
         const responseCopy = Object.assign({}, response);
         // translate military address properties to generic properties for use in front end
@@ -116,8 +115,13 @@ export function getMailingAddress() {
           data: responseCopy
         });
       },
-      // catch errors in fetch or success handler
-      () => dispatch(getAddressFailure())
+      (response) => {
+        const status = (response.errors && response.errors.length)
+          ? response.errors[0].status
+          : 'unknown';
+        Raven.captureException(new Error(`vets_letters_error_getMailingAddress: ${status}`));
+        return dispatch(getAddressFailure());
+      }
     );
   };
 }

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -257,7 +257,13 @@ export function saveAddress(address) {
         }
         return dispatch(saveAddressSuccess(responseAddress));
       },
-      () => dispatch(saveAddressFailure())
+      (response) => {
+        const status = (response.errors && response.errors.length)
+          ? response.errors[0].status
+          : 'unknown';
+        Raven.captureException(new Error(`vets_letters_error_saveAddress: ${status}`));
+        return dispatch(saveAddressFailure());
+      }
     );
   };
 }

--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -267,11 +267,17 @@ export function getAddressCountries() {
     return apiRequest(
       '/v0/address/countries',
       null,
-      response => dispatch({
+      (response) => dispatch({
         type: GET_ADDRESS_COUNTRIES_SUCCESS,
         countries: response,
       }),
-      () => dispatch({ type: GET_ADDRESS_COUNTRIES_FAILURE })
+      (response) => {
+        const status = (response.errors && response.errors.length)
+          ? response.errors[0].status
+          : 'unknown';
+        Raven.captureException(new Error(`vets_letters_error_getAddressCountries: ${status}`));
+        return dispatch({ type: GET_ADDRESS_COUNTRIES_FAILURE });
+      }
     );
   };
 }
@@ -281,11 +287,17 @@ export function getAddressStates() {
     return apiRequest(
       '/v0/address/states',
       null,
-      response => dispatch({
+      (response) => dispatch({
         type: GET_ADDRESS_STATES_SUCCESS,
         states: response,
       }),
-      () => dispatch({ type: GET_ADDRESS_STATES_FAILURE })
+      (response) => {
+        const status = (response.errors && response.errors.length)
+          ? response.errors[0].status
+          : 'unknown';
+        Raven.captureException(new Error(`vets_letters_error_getAddressStates: ${status}`));
+        return dispatch({ type: GET_ADDRESS_STATES_FAILURE });
+      }
     );
   };
 }

--- a/src/js/letters/containers/LettersApp.jsx
+++ b/src/js/letters/containers/LettersApp.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import RequiredLoginView from '../../common/components/RequiredLoginView';
 
-const logDataError = () => Raven.captureException(new Error('vets_letters_user_unregistered'));
+const UNREGISTERED_ERROR = 'vets_letters_user_unregistered';
 
 // This needs to be a React component for RequiredLoginView to pass down
 // the isDataAvailable prop, which is only passed on failure.
@@ -12,7 +12,7 @@ export class AppContent extends React.Component {
   constructor(props) {
     super(props);
     if (props.isDataAvailable === false) {
-      logDataError();
+      Raven.captureException(new Error(UNREGISTERED_ERROR));
       this.state = { errorLogged: true };
     } else {
       this.state = { errorLogged: false };
@@ -22,7 +22,7 @@ export class AppContent extends React.Component {
   componentWillReceiveProps(nextProps) {
     // only log isDataAvailable error if one isn't already logged
     if (nextProps.isDataAvailable === false && !this.state.errorLogged) {
-      logDataError();
+      Raven.captureException(new Error(UNREGISTERED_ERROR));
       this.setState({ errorLogged: true });
     }
   }

--- a/src/js/letters/containers/LettersApp.jsx
+++ b/src/js/letters/containers/LettersApp.jsx
@@ -4,29 +4,50 @@ import { connect } from 'react-redux';
 
 import RequiredLoginView from '../../common/components/RequiredLoginView';
 
+const logDataError = () => Raven.captureException(new Error('vets_letters_user_unregistered'));
+
 // This needs to be a React component for RequiredLoginView to pass down
 // the isDataAvailable prop, which is only passed on failure.
-export function AppContent({ children, isDataAvailable }) {
-  const unregistered = isDataAvailable === false;
-  let view;
-
-  if (unregistered) {
-    view = (
-      <h4>
-        We weren’t able to find information about your VA letters.
-        If you think you should be able to access this information, please call the Vets.gov Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY: <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).
-      </h4>
-    );
-    Raven.captureException(new Error('vets_letters_user_unregistered'));
-  } else {
-    view = children;
+export class AppContent extends React.Component {
+  constructor(props) {
+    super(props);
+    if (props.isDataAvailable === false) {
+      logDataError();
+      this.state = { errorLogged: true };
+    } else {
+      this.state = { errorLogged: false };
+    }
   }
 
-  return (
-    <div className="usa-grid">
-      {view}
-    </div>
-  );
+  componentWillReceiveProps(nextProps) {
+    // only log isDataAvailable error if one isn't already logged
+    if (nextProps.isDataAvailable === false && !this.state.errorLogged) {
+      logDataError();
+      this.setState({ errorLogged: true });
+    }
+  }
+
+  render() {
+    const unregistered = this.props.isDataAvailable === false;
+    let view;
+
+    if (unregistered) {
+      view = (
+        <h4>
+          We weren’t able to find information about your VA letters.
+          If you think you should be able to access this information, please call the Vets.gov Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY: <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).
+        </h4>
+      );
+    } else {
+      view = this.props.children;
+    }
+
+    return (
+      <div className="usa-grid">
+        {view}
+      </div>
+    );
+  }
 }
 
 export class LettersApp extends React.Component {

--- a/src/js/letters/containers/LettersApp.jsx
+++ b/src/js/letters/containers/LettersApp.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Raven from 'raven-js';
 import { connect } from 'react-redux';
 
 import RequiredLoginView from '../../common/components/RequiredLoginView';
@@ -16,6 +17,7 @@ export function AppContent({ children, isDataAvailable }) {
         If you think you should be able to access this information, please call the Vets.gov Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY: <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).
       </h4>
     );
+    Raven.captureException(new Error('vets_letters_user_unregistered'));
   } else {
     view = children;
   }

--- a/src/js/letters/containers/Main.jsx
+++ b/src/js/letters/containers/Main.jsx
@@ -56,36 +56,18 @@ export class Main extends React.Component {
       case awaitingResponse:
         appContent = <LoadingIndicator message="Loading your letters..."/>;
         break;
-      case backendServiceError:
-        appContent = systemDownMessage;
-        break;
       case backendAuthenticationError:
         appContent = recordsNotFound;
-        break;
-      case invalidAddressProperty:
-        appContent = systemDownMessage;
         break;
       case letterEligibilityError:
         appContent = this.props.children;
         break;
-      case unavailable:
-        appContent = (
-          <div id="lettersUnavailable">
-            <div className="usa-alert usa-alert-error" role="alert">
-              <div className="usa-alert-body">
-                <h4 className="usa-alert-heading">Letters Unavailable</h4>
-                <p className="usa-alert-text">
-                  We weren’t able to retrieve your VA letters. Please call <a href="tel:855-574-7286">1-855-574-7286</a>,
-                  TTY: <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).
-                </p>
-              </div>
-            </div>
-            <br/>
-          </div>
-        );
-        break;
+      case unavailable: // fall-through to default
+      case backendServiceError: // fall-through to default
+      case invalidAddressProperty: // fall-through to default
       default:
         appContent = systemDownMessage;
+        break;
     }
 
     return (

--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -399,6 +399,12 @@ export const toGenericAddress = (address) => {
   return genericAddress;
 };
 
+/**
+ * Tests an http error response for an errors array and status property for the
+ * first error in the array. Returns the status code or 'unknown'
+ * @param {Object} response error response object from vets-api
+ * @returns {string} status code or 'unknown'
+ */
 export const getStatus = (response) => {
   return (response.errors && response.errors.length)
     ? response.errors[0].status

--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -398,3 +398,9 @@ export const toGenericAddress = (address) => {
   delete genericAddress.militaryStateCode;
   return genericAddress;
 };
+
+export const getStatus = (response) => {
+  return (response.errors && response.errors.length)
+    ? response.errors[0].status
+    : 'unknown';
+};

--- a/test/letters/actions/letters.unit.spec.js
+++ b/test/letters/actions/letters.unit.spec.js
@@ -191,7 +191,7 @@ describe('getLettersList', () => {
     const dispatch = sinon.spy();
     getLetterList(dispatch)
       .then(() => {
-        done(new Error('Should not resolve the promise when GET fails'));
+        done(new Error('getLetterList should have rejected but resolved instead'));
       }).catch(() => {
         const action = dispatch.firstCall.args[0];
         expect(action.type).to.equal(GET_LETTERS_FAILURE);
@@ -436,7 +436,7 @@ describe('getBenefitSummaryOptions', () => {
 
     getBenefitSummaryOptions(dispatch, getState)
       .then(() => {
-        done(new Error('Should not resolve the promise when the GET fails'));
+        done(new Error('getBenefitSummaryOptions should have rejected but resolved instead'));
       }).catch(() => {
         expect(dispatch.calledWith({ type: GET_BENEFIT_SUMMARY_OPTIONS_FAILURE })).to.be.true;
         done();

--- a/test/letters/containers/Main.unit.spec.jsx
+++ b/test/letters/containers/Main.unit.spec.jsx
@@ -105,10 +105,10 @@ describe('<Main>', () => {
     expect(childText).to.equal(testText);
   });
 
-  it('should show letters unavailable message when service is unavailable', () => {
+  it('should show system down message when service is unavailable', () => {
     const props = _.merge({}, defaultProps, { lettersAvailability: unavailable, addressAvailability: available });
     const tree = SkinDeep.shallowRender(<Main {...props}/>);
-    expect(tree.subTree('#lettersUnavailable')).to.not.be.false;
+    expect(tree.subTree('#systemDownMessage')).to.not.be.false;
   });
 
   it('renders system down message for all unspecified errors', () => {


### PR DESCRIPTION
- Adds `Raven.captureException` logging events for failed actions across the app
- Adds `Raven.captureException` log event to `LettersApp` component if it receives a false `isDataAvailable` prop from the `RequiredLoginView` wrapper. Not sure this is ideal since we may be hitting multiple renders and thus logging redundantly.
- Simplifies some view logic in `Main` component based on conversations with Content team
- Adds action for `INVALID_ADDRESS_PROPERTY` which has its own state in the reducer as well as its own view, but wasn't getting triggered anywhere in the app.

These logs should cover all instances of the UI showing an error message. Each captured error message should be specific enough to allow us to see where things went wrong but also general enough that we're not capturing any PII at all.