### PR TITLE
Handle 0 indexed month test values

### DIFF
--- a/test/common/utils/validations.unit.spec.js
+++ b/test/common/utils/validations.unit.spec.js
@@ -437,7 +437,7 @@ describe('Validations unit tests', () => {
       expect(isValidPartialMonthYearInPast('2', '2001')).to.be.true;
     });
     it('should validate month and year that is current', () => {
-      expect(isValidPartialMonthYearInPast(moment().month().toString(),
+      expect(isValidPartialMonthYearInPast(moment().add(1, 'month').month().toString(),
         moment().year().toString())).to.be.true;
     });
     it('should not validate month and year that is in the future', () => {


### PR DESCRIPTION
This change fixes a bug in our unit tests for isValidPartialMonthYearInPast, which is due to a discrepancy between how months are indexed in MomentJS (0 indexed) and in our app (1 indexed).