### PR TITLE
Reset h2 top margin to match other alerts

### DIFF
--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -18,6 +18,10 @@
 
     &.help-desk {
       margin-top: 2em;
+
+      h2 {
+        margin-top: .5em;
+      }
     }
   }
 


### PR DESCRIPTION
- Reduces top margin for the alert header

**Before:**
<img width="1055" alt="screen shot 2018-01-02 at 1 14 01 pm" src="https://user-images.githubusercontent.com/24251447/34496367-f098bcfe-efbe-11e7-99f0-b518ad8daf3c.png">


**After:**
<img width="848" alt="screen shot 2018-01-02 at 1 11 49 pm" src="https://user-images.githubusercontent.com/24251447/34496310-a416a83c-efbe-11e7-8688-ef9ec2779351.png">
