### PR TITLE
Letters address accessibility mg

### DIFF
--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import { scrollToFirstError } from '../../common/utils/helpers';
+import { scrollToFirstError, focusElement } from '../../common/utils/helpers';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
 import Modal from '../../common/components/Modal';
 
@@ -65,6 +65,12 @@ export class AddressSection extends React.Component {
       // If we start with an empty address, go straight to editing
       this.state.isEditingAddress = (isAddressEmpty(this.state.editableAddress) && this.props.canUpdate);
     }
+  }
+
+  componentDidMount() {
+    // focusElement('.schemaform-title h1');
+    // focusElement('#content');
+    focusElement('.va-introtext');
   }
 
   /* editableAddress is initialized from redux store in the constructor

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -68,7 +68,7 @@ export class AddressSection extends React.Component {
   }
 
   componentDidMount() {
-    focusElement('.va-introtext');
+    focusElement('#content');
   }
 
   /* editableAddress is initialized from redux store in the constructor

--- a/src/js/letters/containers/AddressSection.jsx
+++ b/src/js/letters/containers/AddressSection.jsx
@@ -68,8 +68,6 @@ export class AddressSection extends React.Component {
   }
 
   componentDidMount() {
-    // focusElement('.schemaform-title h1');
-    // focusElement('#content');
     focusElement('.va-introtext');
   }
 

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -55,7 +55,6 @@
         padding: 0;
         text-decoration: underline;
         background-color: transparent;
-        outline: none;
         color: $color-primary-darker;
         font-weight: normal;
         text-align: left;


### PR DESCRIPTION
Intentionally sets focus on page content so it gets read on page load. This also has the intended side-effect of fixing the skipping of the links in the page contents on tab through (previously, hitting tab once would throw a user into the footer's links, where they would have to shift-tab to access the actual content links). Now everything seems to work as it should for keyboard-based users.
  