### PR TITLE
Override scrolling in discharge wizard e2e test

### DIFF
--- a/src/js/discharge-wizard/components/FormQuestions.jsx
+++ b/src/js/discharge-wizard/components/FormQuestions.jsx
@@ -22,7 +22,7 @@ class FormQuestions extends React.Component {
     this.props.updateField(name, value);
     this.forceUpdate();
     setTimeout(() => {
-      scroller.scrollTo(this.props.formValues.questions.slice(-1)[0], {
+      scroller.scrollTo(this.props.formValues.questions.slice(-1)[0], window.VetsGov.scroll || {
         duration: 1000,
         smooth: true,
         offset: -150,
@@ -35,7 +35,7 @@ class FormQuestions extends React.Component {
 
     window.dataLayer.push({ event: 'discharge-upgrade-review-edit' });
 
-    scroller.scrollTo(e.target.name, {
+    scroller.scrollTo(e.target.name, window.VetsGov.scroll || {
       duration: 1000,
       smooth: true,
     });


### PR DESCRIPTION
Hopefully this will help with the failing test.

When running the discharge wizard test locally, I couldn't reproduce the error, but I did notice that the scrolling _should_ have been overridden, but it didn't seem to be completely. For all the questions, it would jump to the appropriate question, but I don't know if that's because the `.click()` call just brought it into focus while it was in the middle of scrolling or if it was actually being overridden. I tent to think the former.

Anyhow, I _did_ see that it was scrolling to the bottom results section. My hypothesis is that the scrolling on that part was taking too long (with resource sharing in Jenkins), and it'd timeout because of that. I'm not 100% on _why_ that happens, but I know it's been a problem in the past.