### PR TITLE
Add role to validation errors

### DIFF
--- a/src/js/common/components/form-elements/ErrorableCheckbox.jsx
+++ b/src/js/common/components/form-elements/ErrorableCheckbox.jsx
@@ -40,7 +40,11 @@ class ErrorableCheckbox extends React.Component {
     let errorSpanId = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+          <span className="sr-only">Error</span> {this.props.errorMessage}
+        </span>
+      );
     }
 
     // Addes ToolTip if text is provided.

--- a/src/js/common/components/form-elements/ErrorableCheckbox.jsx
+++ b/src/js/common/components/form-elements/ErrorableCheckbox.jsx
@@ -41,7 +41,7 @@ class ErrorableCheckbox extends React.Component {
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
-        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
           <span className="sr-only">Error</span> {this.props.errorMessage}
         </span>
       );

--- a/src/js/common/components/form-elements/ErrorableDate.jsx
+++ b/src/js/common/components/form-elements/ErrorableDate.jsx
@@ -78,7 +78,7 @@ class ErrorableDate extends React.Component {
     if (!isValid) {
       errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
-        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
           <span className="sr-only">Error</span> {errorMessage}
         </span>
       );

--- a/src/js/common/components/form-elements/ErrorableDate.jsx
+++ b/src/js/common/components/form-elements/ErrorableDate.jsx
@@ -77,7 +77,11 @@ class ErrorableDate extends React.Component {
     let errorSpan = '';
     if (!isValid) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{errorMessage}</span>;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+          <span className="sr-only">Error</span> {errorMessage}
+        </span>
+      );
     }
 
     // Adds ToolTip if text is provided.

--- a/src/js/common/components/form-elements/ErrorableFileInput.jsx
+++ b/src/js/common/components/form-elements/ErrorableFileInput.jsx
@@ -29,7 +29,11 @@ class ErrorableFileInput extends React.Component {
 
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className={`usa-input-error-message ${this.props.additionalErrorClass}`} id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
+      errorSpan = (
+        <span className={`usa-input-error-message ${this.props.additionalErrorClass}`} role="alert" id={`${errorSpanId}`}>
+          <span className="sr-only">Error</span> {this.props.errorMessage}
+        </span>
+      );
       inputErrorClass = 'usa-input-error';
       labelErrorClass = 'usa-input-error-label';
     }

--- a/src/js/common/components/form-elements/ErrorableFileInput.jsx
+++ b/src/js/common/components/form-elements/ErrorableFileInput.jsx
@@ -30,7 +30,7 @@ class ErrorableFileInput extends React.Component {
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
-        <span className={`usa-input-error-message ${this.props.additionalErrorClass}`} role="alert" id={`${errorSpanId}`}>
+        <span className={`usa-input-error-message ${this.props.additionalErrorClass}`} role="alert" id={errorSpanId}>
           <span className="sr-only">Error</span> {this.props.errorMessage}
         </span>
       );

--- a/src/js/common/components/form-elements/ErrorableGroup.jsx
+++ b/src/js/common/components/form-elements/ErrorableGroup.jsx
@@ -23,7 +23,11 @@ class ErrorableGroup extends React.Component {
     let errorSpanId = undefined;
     if (hasError) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+          <span className="sr-only">Error</span> {this.props.errorMessage}
+        </span>
+      );
     }
 
     // Calculate required.

--- a/src/js/common/components/form-elements/ErrorableGroup.jsx
+++ b/src/js/common/components/form-elements/ErrorableGroup.jsx
@@ -24,7 +24,7 @@ class ErrorableGroup extends React.Component {
     if (hasError) {
       errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
-        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
           <span className="sr-only">Error</span> {this.props.errorMessage}
         </span>
       );

--- a/src/js/common/components/form-elements/ErrorableMonthYear.jsx
+++ b/src/js/common/components/form-elements/ErrorableMonthYear.jsx
@@ -69,7 +69,11 @@ class ErrorableMonthYear extends React.Component {
     let errorSpan = '';
     if (!isValid) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{errorMessage}</span>;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+          <span className="sr-only">Error</span> {errorMessage}
+        </span>
+      );
     }
 
     // Adds ToolTip if text is provided.

--- a/src/js/common/components/form-elements/ErrorableMonthYear.jsx
+++ b/src/js/common/components/form-elements/ErrorableMonthYear.jsx
@@ -70,7 +70,7 @@ class ErrorableMonthYear extends React.Component {
     if (!isValid) {
       errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
-        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
           <span className="sr-only">Error</span> {errorMessage}
         </span>
       );

--- a/src/js/common/components/form-elements/ErrorableNumberInput.jsx
+++ b/src/js/common/components/form-elements/ErrorableNumberInput.jsx
@@ -50,7 +50,7 @@ class ErrorableNumberInput extends React.Component {
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
-        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
           <span className="sr-only">Error</span> {this.props.errorMessage}
         </span>
       );

--- a/src/js/common/components/form-elements/ErrorableNumberInput.jsx
+++ b/src/js/common/components/form-elements/ErrorableNumberInput.jsx
@@ -49,7 +49,11 @@ class ErrorableNumberInput extends React.Component {
     // is not clear right now
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+          <span className="sr-only">Error</span> {this.props.errorMessage}
+        </span>
+      );
     }
 
     // Calculate required.

--- a/src/js/common/components/form-elements/ErrorableRadioButtons.jsx
+++ b/src/js/common/components/form-elements/ErrorableRadioButtons.jsx
@@ -54,7 +54,7 @@ class ErrorableRadioButtons extends React.Component {
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
-        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
           <span className="sr-only">Error</span> {this.props.errorMessage}
         </span>
       );

--- a/src/js/common/components/form-elements/ErrorableRadioButtons.jsx
+++ b/src/js/common/components/form-elements/ErrorableRadioButtons.jsx
@@ -53,7 +53,11 @@ class ErrorableRadioButtons extends React.Component {
     let errorSpanId = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+          <span className="sr-only">Error</span> {this.props.errorMessage}
+        </span>
+      );
     }
 
     // Addes ToolTip if text is provided.

--- a/src/js/common/components/form-elements/ErrorableSelect.jsx
+++ b/src/js/common/components/form-elements/ErrorableSelect.jsx
@@ -46,7 +46,11 @@ class ErrorableSelect extends React.Component {
     let errorSpanId = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.selectId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={errorSpanId} role="alert">{this.props.errorMessage}</span>;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
+          <span className="sr-only">Error</span> {this.props.errorMessage}
+        </span>
+      );
     }
 
     // Addes ToolTip if text is provided.

--- a/src/js/common/components/form-elements/ErrorableSelect.jsx
+++ b/src/js/common/components/form-elements/ErrorableSelect.jsx
@@ -46,7 +46,7 @@ class ErrorableSelect extends React.Component {
     let errorSpanId = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.selectId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`} role="alert">{this.props.errorMessage}</span>;
+      errorSpan = <span className="usa-input-error-message" id={errorSpanId} role="alert">{this.props.errorMessage}</span>;
     }
 
     // Addes ToolTip if text is provided.

--- a/src/js/common/components/form-elements/ErrorableTextInput.jsx
+++ b/src/js/common/components/form-elements/ErrorableTextInput.jsx
@@ -53,7 +53,7 @@ class ErrorableTextInput extends React.Component {
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
-        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
           <span className="sr-only">Error</span> {this.props.errorMessage}
         </span>
       );

--- a/src/js/common/components/form-elements/ErrorableTextInput.jsx
+++ b/src/js/common/components/form-elements/ErrorableTextInput.jsx
@@ -52,7 +52,11 @@ class ErrorableTextInput extends React.Component {
     let labelErrorClass = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+          <span className="sr-only">Error</span> {this.props.errorMessage}
+        </span>
+      );
       inputErrorClass = 'usa-input-error';
       labelErrorClass = 'usa-input-error-label';
     }

--- a/src/js/common/components/form-elements/ErrorableTextarea.jsx
+++ b/src/js/common/components/form-elements/ErrorableTextarea.jsx
@@ -56,7 +56,11 @@ class ErrorableTextarea extends React.Component {
     let labelErrorClass = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={errorSpanId}>{this.props.errorMessage}</span>;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
+          <span className="sr-only">Error</span> {this.props.errorMessage}
+        </span>
+      );
       inputErrorClass = 'usa-input-error';
       labelErrorClass = 'usa-input-error-label';
     }

--- a/src/js/common/components/form-elements/ErrorableTextarea.jsx
+++ b/src/js/common/components/form-elements/ErrorableTextarea.jsx
@@ -56,7 +56,7 @@ class ErrorableTextarea extends React.Component {
     let labelErrorClass = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
+      errorSpan = <span className="usa-input-error-message" id={errorSpanId}>{this.props.errorMessage}</span>;
       inputErrorClass = 'usa-input-error';
       labelErrorClass = 'usa-input-error-label';
     }

--- a/src/js/common/schemaform/components/FieldTemplate.jsx
+++ b/src/js/common/schemaform/components/FieldTemplate.jsx
@@ -44,7 +44,11 @@ export default function FieldTemplate(props) {
   if (hasErrors) {
     errorClass = isDateField ? 'input-error-date' : 'usa-input-error';
     errorSpanId = `${id}-error-message`;
-    errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{rawErrors[0]}</span>;
+    errorSpan = (
+      <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+        <span className="sr-only">Error</span> {rawErrors[0]}
+      </span>
+    );
   }
 
   const containerClassNames = classNames(

--- a/src/js/common/schemaform/components/FieldTemplate.jsx
+++ b/src/js/common/schemaform/components/FieldTemplate.jsx
@@ -45,7 +45,7 @@ export default function FieldTemplate(props) {
     errorClass = isDateField ? 'input-error-date' : 'usa-input-error';
     errorSpanId = `${id}-error-message`;
     errorSpan = (
-      <span className="usa-input-error-message" role="alert" id={`${errorSpanId}`}>
+      <span className="usa-input-error-message" role="alert" id={errorSpanId}>
         <span className="sr-only">Error</span> {rawErrors[0]}
       </span>
     );

--- a/src/js/gi/components/Checkbox.jsx
+++ b/src/js/gi/components/Checkbox.jsx
@@ -40,7 +40,11 @@ class Checkbox extends React.Component {
     let errorSpanId = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={errorSpanId}>{this.props.errorMessage}</span>;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
+          <span className="sr-only">Error</span> {this.props.errorMessage}
+        </span>
+      );
     }
 
     // Addes ToolTip if text is provided.

--- a/src/js/gi/components/Checkbox.jsx
+++ b/src/js/gi/components/Checkbox.jsx
@@ -40,7 +40,7 @@ class Checkbox extends React.Component {
     let errorSpanId = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
+      errorSpan = <span className="usa-input-error-message" id={errorSpanId}>{this.props.errorMessage}</span>;
     }
 
     // Addes ToolTip if text is provided.

--- a/src/js/gi/components/RadioButtons.jsx
+++ b/src/js/gi/components/RadioButtons.jsx
@@ -38,7 +38,11 @@ class RadioButtons extends React.Component {
     let errorSpanId = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={errorSpanId}>{this.props.errorMessage}</span>;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
+          <span className="sr-only">Error</span> {this.props.errorMessage}
+        </span>
+      );
     }
 
     // Addes ToolTip if text is provided.

--- a/src/js/gi/components/RadioButtons.jsx
+++ b/src/js/gi/components/RadioButtons.jsx
@@ -38,7 +38,7 @@ class RadioButtons extends React.Component {
     let errorSpanId = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
+      errorSpan = <span className="usa-input-error-message" id={errorSpanId}>{this.props.errorMessage}</span>;
     }
 
     // Addes ToolTip if text is provided.

--- a/src/js/letters/components/ErrorableSelect.jsx
+++ b/src/js/letters/components/ErrorableSelect.jsx
@@ -36,7 +36,11 @@ class ErrorableSelect extends React.Component {
     let errorSpanId = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.selectId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={errorSpanId} role="alert">{this.props.errorMessage}</span>;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
+          <span className="sr-only">Error</span> {this.props.errorMessage}
+        </span>
+      );
     }
 
     // Calculate required.

--- a/src/js/letters/components/ErrorableTextInput.jsx
+++ b/src/js/letters/components/ErrorableTextInput.jsx
@@ -37,7 +37,7 @@ class ErrorableTextInput extends React.Component {
     let labelErrorClass = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={`${errorSpanId}`}>{this.props.errorMessage}</span>;
+      errorSpan = <span className="usa-input-error-message" id={errorSpanId}>{this.props.errorMessage}</span>;
       inputErrorClass = 'usa-input-error';
       labelErrorClass = 'usa-input-error-label';
     }

--- a/src/js/letters/components/ErrorableTextInput.jsx
+++ b/src/js/letters/components/ErrorableTextInput.jsx
@@ -37,7 +37,11 @@ class ErrorableTextInput extends React.Component {
     let labelErrorClass = undefined;
     if (this.props.errorMessage) {
       errorSpanId = `${this.inputId}-error-message`;
-      errorSpan = <span className="usa-input-error-message" id={errorSpanId}>{this.props.errorMessage}</span>;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
+          <span className="sr-only">Error</span> {this.props.errorMessage}
+        </span>
+      );
       inputErrorClass = 'usa-input-error';
       labelErrorClass = 'usa-input-error-label';
     }

--- a/test/common/components/form-elements/ErrorableCheckbox.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableCheckbox.unit.spec.jsx
@@ -55,7 +55,7 @@ describe('<ErrorableCheckbox>', () => {
 
     const errorMessages = tree.everySubTree('.usa-input-error-message');
     expect(errorMessages).to.have.lengthOf(1);
-    expect(errorMessages[0].text()).to.equal('error message');
+    expect(errorMessages[0].text()).to.equal('Error error message');
 
     // No error means no aria-describedby to not confuse screen readers.
     const inputs = tree.everySubTree('input');

--- a/test/common/components/form-elements/ErrorableDate.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableDate.unit.spec.jsx
@@ -31,7 +31,7 @@ describe('<ErrorableDate>', () => {
       <ErrorableDate required date={date} onValueChange={(_update) => {}}/>);
 
     expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
-    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Please provide a response');
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Error Please provide a response');
   });
   it('displays invalid message', () => {
     const date = {
@@ -47,7 +47,7 @@ describe('<ErrorableDate>', () => {
       <ErrorableDate date={date} onValueChange={(_update) => {}}/>);
 
     expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
-    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Please provide a valid date');
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Error Please provide a valid date');
   });
   it('does not show invalid message for month year date', () => {
     const date = {
@@ -78,7 +78,7 @@ describe('<ErrorableDate>', () => {
       <ErrorableDate date={date} validation={{ valid: false, message: 'Test' }} onValueChange={(_update) => {}}/>);
 
     expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
-    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Test');
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Error Test');
   });
   it('displays custom message from array', () => {
     const date = {
@@ -101,7 +101,7 @@ describe('<ErrorableDate>', () => {
     );
 
     expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
-    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Test');
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Error Test');
   });
 });
 

--- a/test/common/components/form-elements/ErrorableFileInput.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableFileInput.unit.spec.jsx
@@ -22,7 +22,7 @@ describe('<ErrorableFileInput>', () => {
       <ErrorableFileInput buttonText="my label" errorMessage="error message" onChange={(_update) => {}}/>
     );
 
-    expect(tree.subTree('.usa-input-error-message').text()).to.equal('error message');
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Error error message');
   });
 
   it('onChange fires and clears input', () => {

--- a/test/common/components/form-elements/ErrorableMonthYear.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableMonthYear.unit.spec.jsx
@@ -28,7 +28,7 @@ describe('<ErrorableMonthYear>', () => {
       <ErrorableMonthYear required date={date} onValueChange={(_update) => {}}/>);
 
     expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
-    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Please provide a response');
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Error Please provide a response');
   });
   it('displays invalid message', () => {
     const date = {
@@ -42,7 +42,7 @@ describe('<ErrorableMonthYear>', () => {
       <ErrorableMonthYear date={date} onValueChange={(_update) => {}}/>);
 
     expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
-    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Please provide a valid month and/or year');
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Error Please provide a valid month and/or year');
   });
   it('does not show invalid message for partial date', () => {
     const date = {
@@ -69,7 +69,7 @@ describe('<ErrorableMonthYear>', () => {
       <ErrorableMonthYear date={date} validation={{ valid: false, message: 'Test' }} onValueChange={(_update) => {}}/>);
 
     expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
-    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Test');
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Error Test');
   });
   it('displays custom message from array', () => {
     const date = {
@@ -90,7 +90,7 @@ describe('<ErrorableMonthYear>', () => {
     );
 
     expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
-    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Test');
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Error Test');
   });
 });
 

--- a/test/common/components/form-elements/ErrorableNumberInput.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableNumberInput.unit.spec.jsx
@@ -76,7 +76,7 @@ describe('<ErrorableNumberInput>', () => {
 
     const errorMessages = tree.everySubTree('.usa-input-error-message');
     expect(errorMessages).to.have.lengthOf(1);
-    expect(errorMessages[0].text()).to.equal('error message');
+    expect(errorMessages[0].text()).to.equal('Error error message');
 
     // No error means no aria-describedby to not confuse screen readers.
     const inputs = tree.everySubTree('input');

--- a/test/common/components/form-elements/ErrorableSelect.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableSelect.unit.spec.jsx
@@ -62,7 +62,7 @@ describe('<ErrorableSelect>', () => {
 
     const errorMessages = tree.everySubTree('.usa-input-error-message');
     expect(errorMessages).to.have.lengthOf(1);
-    expect(errorMessages[0].text()).to.equal('error message');
+    expect(errorMessages[0].text()).to.equal('Error error message');
 
     // No error means no aria-describedby to not confuse screen readers.
     const selects = tree.everySubTree('select');

--- a/test/common/components/form-elements/ErrorableTextInput.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableTextInput.unit.spec.jsx
@@ -74,7 +74,7 @@ describe('<ErrorableTextInput>', () => {
 
     const errorMessages = tree.everySubTree('.usa-input-error-message');
     expect(errorMessages).to.have.lengthOf(1);
-    expect(errorMessages[0].text()).to.equal('error message');
+    expect(errorMessages[0].text()).to.equal('Error error message');
 
     // No error means no aria-describedby to not confuse screen readers.
     const inputs = tree.everySubTree('input');

--- a/test/common/components/form-elements/ErrorableTextarea.unit.spec.jsx
+++ b/test/common/components/form-elements/ErrorableTextarea.unit.spec.jsx
@@ -91,7 +91,7 @@ describe('<ErrorableTextarea>', () => {
 
     const errorMessages = tree.everySubTree('.usa-input-error-message');
     expect(errorMessages).to.have.lengthOf(1);
-    expect(errorMessages[0].text()).to.equal('error message');
+    expect(errorMessages[0].text()).to.equal('Error error message');
 
     const textareas = tree.everySubTree('textarea');
     expect(textareas).to.have.lengthOf(1);

--- a/test/common/schemaform/components/FieldTemplate.unit.spec.jsx
+++ b/test/common/schemaform/components/FieldTemplate.unit.spec.jsx
@@ -100,7 +100,7 @@ describe('Schemaform <FieldTemplate>', () => {
       </FieldTemplate>
     );
 
-    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Some error');
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Error Some error');
     expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
   });
   it('should render error when submitted', () => {
@@ -126,7 +126,7 @@ describe('Schemaform <FieldTemplate>', () => {
       </FieldTemplate>
     );
 
-    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Some error');
+    expect(tree.subTree('.usa-input-error-message').text()).to.equal('Error Some error');
     expect(tree.everySubTree('.usa-input-error')).not.to.be.empty;
   });
   it('should render description', () => {

--- a/test/common/schemaform/definitions/bankAccount.unit.spec.jsx
+++ b/test/common/schemaform/definitions/bankAccount.unit.spec.jsx
@@ -45,6 +45,6 @@ describe('Schemaform definition bankAccount', () => {
     ReactTestUtils.findRenderedComponentWithType(form, Form).onSubmit({
       preventDefault: f => f
     });
-    expect(find('.usa-input-error-message').textContent).to.equal(uiSchema.routingNumber['ui:errorMessages'].pattern);
+    expect(find('.usa-input-error-message').textContent).to.equal(`Error ${uiSchema.routingNumber['ui:errorMessages'].pattern}`);
   });
 });

--- a/test/common/schemaform/definitions/date.unit.spec.jsx
+++ b/test/common/schemaform/definitions/date.unit.spec.jsx
@@ -42,7 +42,7 @@ describe('Schemaform definition date', () => {
       preventDefault: f => f
     });
 
-    expect(find('.usa-input-error-message').textContent).to.equal(dateUISchema['ui:errorMessages'].pattern);
+    expect(find('.usa-input-error-message').textContent).to.equal(`Error ${dateUISchema['ui:errorMessages'].pattern}`);
   });
   it('should render date title', () => {
     const form = ReactTestUtils.renderIntoDocument(

--- a/test/common/schemaform/definitions/dateRange.unit.spec.jsx
+++ b/test/common/schemaform/definitions/dateRange.unit.spec.jsx
@@ -59,7 +59,7 @@ describe('Schemaform definition dateRange', () => {
       preventDefault: f => f
     });
 
-    expect(find('.usa-input-error-message').textContent).to.equal(dateRangeUISchema['ui:errorMessages'].pattern);
+    expect(find('.usa-input-error-message').textContent).to.equal(`Error ${dateRangeUISchema['ui:errorMessages'].pattern}`);
   });
   it('should render dateRange title and messages', () => {
     const form = ReactTestUtils.renderIntoDocument(

--- a/test/common/schemaform/definitions/ssn.unit.spec.jsx
+++ b/test/common/schemaform/definitions/ssn.unit.spec.jsx
@@ -28,7 +28,7 @@ describe('Schemaform definition ssn', () => {
     ReactTestUtils.Simulate.blur(node);
 
     expect(formDOM.querySelector('.usa-input-error-message').textContent)
-      .to.equal(uiSchema['ui:errorMessages'].pattern);
+      .to.equal(`Error ${uiSchema['ui:errorMessages'].pattern}`);
   });
   it('should render formatted ssn for review', () => {
     const form = ReactTestUtils.renderIntoDocument(

--- a/test/letters/components/Address.unit.spec.jsx
+++ b/test/letters/components/Address.unit.spec.jsx
@@ -139,7 +139,7 @@ describe('<Address>', () => {
 
     // Make sure every error message is rendered
     Object.values(errorMessages).forEach(message => {
-      expect(errors).to.contain(message);
+      expect(errors).to.contain(`Error ${message}`);
     });
   });
 

--- a/test/letters/components/ErrorableSelect.unit.spec.jsx
+++ b/test/letters/components/ErrorableSelect.unit.spec.jsx
@@ -61,7 +61,7 @@ describe('<ErrorableSelect>', () => {
 
     const errorMessages = tree.everySubTree('.usa-input-error-message');
     expect(errorMessages).to.have.lengthOf(1);
-    expect(errorMessages[0].text()).to.equal('error message');
+    expect(errorMessages[0].text()).to.equal('Error error message');
 
     // If there's an error, we should have a describedby for screen readers
     const selects = tree.everySubTree('select');

--- a/test/letters/components/ErrorableTextInput.unit.spec.jsx
+++ b/test/letters/components/ErrorableTextInput.unit.spec.jsx
@@ -66,7 +66,7 @@ describe('<ErrorableTextInput>', () => {
 
     const errorMessages = tree.everySubTree('.usa-input-error-message');
     expect(errorMessages).to.have.lengthOf(1);
-    expect(errorMessages[0].text()).to.equal('error message');
+    expect(errorMessages[0].text()).to.equal('Error error message');
 
     // No error means no aria-describedby to not confuse screen readers.
     const inputs = tree.everySubTree('input');


### PR DESCRIPTION
This adds `role="alert"` to error messages so that they're read aloud. It also adds an "Error" prefix for screen readers to help with context.