### PR TITLE
Wait for page to load before checking url

### DIFF
--- a/test/save-in-progress/01-sip-finish-later.e2e.spec.js
+++ b/test/save-in-progress/01-sip-finish-later.e2e.spec.js
@@ -17,12 +17,13 @@ module.exports = E2eHelpers.createE2eTest(
 
     client.axeCheck('.main');
 
+    E2eHelpers.overrideVetsGovApi(client);
+    E2eHelpers.overrideSmoothScrolling(client);
+
     // load an in progress form
     client
       .click('.usa-button-primary');
 
-    E2eHelpers.overrideVetsGovApi(client);
-    E2eHelpers.overrideSmoothScrolling(client);
     E2eHelpers.expectNavigateAwayFrom(client, '/introduction');
     client.assert.urlContains('/veteran-information/birth-information');
 

--- a/test/save-in-progress/01-sip-finish-later.e2e.spec.js
+++ b/test/save-in-progress/01-sip-finish-later.e2e.spec.js
@@ -79,7 +79,7 @@ module.exports = E2eHelpers.createE2eTest(
       .click('.schemaform-sip-save-link');
     /* eslint-enable camelcase */
 
-    client.waitForElementVisible('.saved-form-metadata-container', Timeouts.normal);
+    client.waitForElementVisible('.saved-form-metadata-container', Timeouts.slow);
     client.assert.urlContains('form-saved');
 
     // test start over, but all it really does is fetch the form again

--- a/test/save-in-progress/01-sip-finish-later.e2e.spec.js
+++ b/test/save-in-progress/01-sip-finish-later.e2e.spec.js
@@ -53,6 +53,8 @@ module.exports = E2eHelpers.createE2eTest(
       }, token)
       .click('.schemaform-sip-save-link');
 
+    client.waitForElementVisible('.usa-alert-error', Timeouts.slow);
+
     client.assert.urlContains('birth-information');
 
     client

--- a/test/save-in-progress/01-sip-finish-later.e2e.spec.js
+++ b/test/save-in-progress/01-sip-finish-later.e2e.spec.js
@@ -79,13 +79,15 @@ module.exports = E2eHelpers.createE2eTest(
       .click('.schemaform-sip-save-link');
     /* eslint-enable camelcase */
 
+    client.waitForElementVisible('.saved-form-metadata-container', Timeouts.normal);
     client.assert.urlContains('form-saved');
 
     // test start over, but all it really does is fetch the form again
     client
       .click('.usa-button-secondary')
       .waitForElementVisible('.va-modal', Timeouts.normal)
-      .click('.va-modal .usa-button-primary');
+      .click('.va-modal .usa-button-primary')
+      .waitForElementVisible('.schemaform-chapter-progress', Timeouts.normal);
 
     E2eHelpers.expectNavigateAwayFrom(client, 'form-saved');
     client.assert.urlContains('/veteran-information/birth-information');


### PR DESCRIPTION
I think this test is sometimes running the url assertion before the page actually changes. This changes makes it so we wait for an element on the next page to be visible before doing the assertion.