### PR TITLE
Remove vestigial mega-menu code

### DIFF
--- a/src/js/common/index.js
+++ b/src/js/common/index.js
@@ -5,7 +5,7 @@ import '../legacy/menu';  // Used in the footer.
 import './usa-banner-toggle';
 import addMenuListeners from '../common/utils/accessible-menus';
 
-addMenuListeners(document.querySelector('#vetnav-menu'));
+addMenuListeners(document.querySelector('#vetnav-menu'), true);
 
 // New navigation menu
 if (document.querySelector('#vetnav')) {

--- a/src/js/common/utils/accessible-menus.js
+++ b/src/js/common/utils/accessible-menus.js
@@ -362,8 +362,7 @@ export default function addMenuListeners(menuElement, closeOnResize = false) {
   });
 
   // Close when the screen is resized
-  // Useful for when the menu might be hidden on smaller screens
-  // TODO: Actually use this
+  // Useful for when the menu might be hidden on smaller screens (nav menubar)
   if (closeOnResize) {
     window.addEventListener('resize', () => closeAll(menuElement));
   }
@@ -380,8 +379,6 @@ export default function addMenuListeners(menuElement, closeOnResize = false) {
     } else if (inMenu) {
       openMenu(targetLi);
     }
-
-    // TODO: Handle open and close menu button for small windows
   });
 
   // Handle clicking away from the menu
@@ -389,8 +386,6 @@ export default function addMenuListeners(menuElement, closeOnResize = false) {
     const target = event.target;
     if (!menuElement.contains(target)) {
       closeAll(menuElement);
-      // TODO: Handle the open / close menu button for small windows
-      // this.resetMenu();
     }
   });
 }

--- a/src/js/common/utils/accessible-menus.js
+++ b/src/js/common/utils/accessible-menus.js
@@ -150,9 +150,9 @@ function getMenuStructure(menuLi) {
  *
  * @param {HTMLLIElement} menuLI  The <li> containing the menubutton and menu
  */
-function closeMenu(menuLi) {
-  // If we're not dealing with a menu structure, abort
-  const struct = getMenuStructure(menuLi);
+function closeMenu(menuLiOrStruct) {
+  // Make sure we've got a menu
+  const struct = menuLiOrStruct.menuButton ? menuLiOrStruct : getMenuStructure(menuLiOrStruct);
   if (!struct) {
     return;
   }
@@ -173,9 +173,9 @@ function closeMenu(menuLi) {
  *                                 second-level menu in a wide screen, we want the third-level opened as well
  * @param {bool} stealFocus       Whether or not to focus on the first item in the opened menu
  */
-function openMenu(menuLi, openSubMenu = false, stealFocus = true) {
+function openMenu(menuLi, menuStructure = null, openSubMenu = false, stealFocus = true) {
   // If we're not dealing with a menu structure, abort
-  const struct = getMenuStructure(menuLi);
+  const struct = menuStructure || getMenuStructure(menuLi);
   if (!struct) {
     return;
   }
@@ -200,7 +200,28 @@ function openMenu(menuLi, openSubMenu = false, stealFocus = true) {
 
   // If we're wide-screen (for example), open the first submenu
   if (openSubMenu) {
-    openMenu(menu.firstElementChild, false, false);
+    openMenu(menu.firstElementChild, null, false, false);
+  }
+}
+
+
+/**
+ * Opens a menu if it's closed, closes a menu if it's open.
+ *
+ * @param {HTMLLIElement} menuLi  The <li> containing the menubutton and menu
+ */
+function toggleMenu(menuLi) {
+  // If we're not dealing with a menu structure, abort
+  const struct = getMenuStructure(menuLi);
+  if (!struct) {
+    return;
+  }
+
+  // Check if it's open
+  if (struct.menuButton.getAttribute('aria-expanded') === 'true') {
+    closeMenu(struct);
+  } else {
+    openMenu(menuLi, struct, isWideScreen());
   }
 }
 
@@ -235,7 +256,7 @@ function closeAll(menuElement) {
  * @param {HTMLElement} mobileOpenButton   Optional - The "Menu" button on mobile
  * @param {HTMLElement} mobileCloseButton  Optional - The "Close" button on mobile
  */
-export default function addMenuListeners(menuElement) {
+export default function addMenuListeners(menuElement, closeOnResize = false) {
   const menuRole = menuElement.getAttribute('role');
   if (!['menubar', 'menu'].includes(menuRole)) {
     // If we don't have a menubar or menu, don't continue
@@ -295,7 +316,7 @@ export default function addMenuListeners(menuElement) {
             //  doing it the hard way
             const menuItems = targetLi.querySelector('[role="menu"]').children;
             const lastSubmenu = menuItems[menuItems.length - 1];
-            openMenu(lastSubmenu, false, false);
+            openMenu(lastSubmenu, null, false, false);
             lastSubmenu.firstElementChild.focus();
           }
         } else if (inMenu) {
@@ -322,7 +343,7 @@ export default function addMenuListeners(menuElement) {
         const isMB = isMenuButton(e.target);
         if (inMenubar && isMB) {
           e.preventDefault();
-          openMenu(targetLi, isWideScreen());
+          openMenu(targetLi, null, isWideScreen());
         } else if (inMenu) {
           e.preventDefault();
           moveFocus(targetLi, 'next');
@@ -340,10 +361,37 @@ export default function addMenuListeners(menuElement) {
     }
   });
 
-  // TODO: Implement this and get rid of MegaMenu usage
-  // menuElement.addEventListener('click', (e) => {
-  //   // Handle opening menus
-  //   // Handle closing menus when clicked away
-  // });
+  // Close when the screen is resized
+  // Useful for when the menu might be hidden on smaller screens
+  // TODO: Actually use this
+  if (closeOnResize) {
+    window.addEventListener('resize', () => closeAll(menuElement));
+  }
+
+  menuElement.addEventListener('click', e => {
+    const targetLi = e.target.parentElement;
+    // Target's grandparent because the parent is a <li>
+    const inMenubar = targetLi.parentElement.getAttribute('role').toLowerCase() === 'menubar';
+    const inMenu = targetLi.parentElement.getAttribute('role').toLowerCase() === 'menu';
+
+    // Handle opening (and closing) menus
+    if (inMenubar) {
+      toggleMenu(targetLi);
+    } else if (inMenu) {
+      openMenu(targetLi);
+    }
+
+    // TODO: Handle open and close menu button for small windows
+  });
+
+  // Handle clicking away from the menu
+  document.addEventListener('click', event => {
+    const target = event.target;
+    if (!menuElement.contains(target)) {
+      closeAll(menuElement);
+      // TODO: Handle the open / close menu button for small windows
+      // this.resetMenu();
+    }
+  });
 }
 

--- a/src/js/legacy/mega-menu.js
+++ b/src/js/legacy/mega-menu.js
@@ -31,7 +31,6 @@ class MegaMenu {
   }
 
   showMegaMenu() {
-    console.log('menu shown');
     this.openControl.setAttribute('hidden', 'hidden');
     this.menu.removeAttribute('hidden');
     this.closeControl.removeAttribute('hidden');

--- a/src/js/legacy/mega-menu.js
+++ b/src/js/legacy/mega-menu.js
@@ -1,168 +1,40 @@
+function isWideScreen() {
+  return matchMedia('(min-width: 768px)').matches;
+}
+
 class MegaMenu {
   constructor(menuElement, openMenuElement, closeMenuElement) {
     this.menu = menuElement;
-    this.closeAll = this.closeAll.bind(this);
     this.closeControl = closeMenuElement;
-    this.closeMenu = this.closeMenu.bind(this);
-    this.addListeners = this.addListeners.bind(this);
-    this.getMenu = this.getMenu.bind(this);
-    this.hideMenu = this.hideMenu.bind(this);
-    this.isWideScreen = this.isWideScreen.bind(this);
     this.openControl = openMenuElement;
-    this.openMenu = this.openMenu.bind(this);
+    this.addListeners = this.addListeners.bind(this);
     this.resetMenu = this.resetMenu.bind(this);
-    this.showMenu = this.showMenu.bind(this);
-    this.toggleMenu = this.toggleMenu.bind(this);
-    this.toggleSubMenu = this.toggleSubMenu.bind(this);
-    this.handleDocumentClick = this.handleDocumentClick.bind(this);
+    this.showMegaMenu = this.showMegaMenu.bind(this);
+    this.hideMegaMenu = this.hideMegaMenu.bind(this);
 
     this.addListeners();
   }
 
   addListeners() {
-    const menus = Array.from(this.menu.querySelectorAll('.vetnav-level1'));
-    const submenus = Array.from(this.menu.querySelectorAll('.vetnav-level2'));
-    const backs = Array.from(this.menu.querySelectorAll('.vetnav-back'));
-
-    menus.forEach((menu) => {
-      // If it has an associated menu, add the event listener
-      if (menu.getAttribute('aria-controls')) {
-        menu.addEventListener('click', this.toggleMenu);
-      }
-    });
-
-    submenus.forEach((submenu) => {
-      submenu.addEventListener('click', this.toggleSubMenu);
-    });
-
-    backs.forEach((back) => {
-      back.addEventListener('click', this.closeMenu);
-    });
-
-    this.openControl.addEventListener('click', this.showMenu);
-    this.closeControl.addEventListener('click', this.hideMenu);
-    this.menu.addEventListener('click', (event) => event.stopPropagation());
-
-    document.addEventListener('click', this.handleDocumentClick);
     window.addEventListener('resize', this.resetMenu);
   }
 
-  handleDocumentClick(event) {
-    const target = event.target;
-    if (!this.menu.contains(target)){
-      this.closeAll();
-      this.resetMenu();
-    }
-  }
-
-  closeAll() {
-    const menus = this.menu.querySelectorAll('[aria-expanded=true]');
-    Array.from(menus).forEach((m) => {
-      const whichMenu = this.getMenu(m.getAttribute('aria-controls'));
-      whichMenu.setAttribute('hidden', 'hidden');
-      m.setAttribute('aria-expanded', false);
-    });
-  }
-
-  closeMenu(event) {
-    const target = event.target;
-    const dropdown = this.getMenu(target.getAttribute('aria-controls'));
-
-    event.stopPropagation();
-    target.setAttribute('aria-expanded', false);
-    dropdown.setAttribute('hidden', 'hidden');
-
-    this.menu.classList.remove('vetnav--submenu-expanded');
-  }
-
-  getMenu(idName) {
-    const selector = `#${idName}`;
-    return this.menu.querySelector(selector);
-  }
-
-  isWideScreen() {
-    return matchMedia('(min-width: 768px)').matches;
-  }
-
-  openMenu(event) {
-    const target = event.target;
-    const menu = target.getAttribute('aria-controls');
-
-    target.setAttribute('aria-expanded', true);
-    this.getMenu(menu).removeAttribute('hidden', 'hidden');
-  }
-
-  toggleMenu(event) {
-    const eTarget = event.target;
-
-    if (eTarget.getAttribute('aria-expanded') === 'true') {
-      this.closeMenu(event);
-
-    } else {
-      this.closeAll();
-      this.openMenu(event);
-
-      /*
-      Open the first sub-menu and expand first trigger
-      when the breakpoint > 768
-      */
-      const whichMenu = this.getMenu(eTarget.getAttribute('aria-controls'));
-      if (this.isWideScreen() && whichMenu.querySelector('.vetnav-panel--submenu')) {
-        whichMenu.querySelector('.vetnav-trigger').setAttribute('aria-expanded', true);
-        whichMenu.querySelector('.vetnav-panel--submenu').removeAttribute('hidden');
-      }
-    }
-  }
-
-  toggleSubMenu(event) {
-    const submenus = Array.from(this.menu.querySelectorAll('.vetnav-panel--submenu'));
-    const triggers = Array.from(this.menu.querySelectorAll('.vetnav-level2'));
-
-    event.stopPropagation();
-
-    submenus.forEach((sm) => {
-      sm.setAttribute('hidden', 'hidden');
-    });
-
-    triggers.forEach((sm) => {
-      sm.setAttribute('aria-expanded', false);
-    });
-
-    const showCurrent = submenus.find((sm) => {
-      return sm.id == event.target.getAttribute('aria-controls');
-    });
-
-    showCurrent.removeAttribute('hidden');
-    event.target.setAttribute('aria-expanded', true);
-
-    this.menu.classList.add('vetnav--submenu-expanded');
-  }
-
   resetMenu() {
-    if (this.isWideScreen()) {
-      this.closeAll();
-      this.showMenu();
+    if (isWideScreen()) {
+      // this.closeAll();
+      this.showMegaMenu();
     } else {
-      this.hideMenu();
+      this.hideMegaMenu();
     }
-    document.body.classList.remove('va-pos-fixed');
   }
 
-  showMenu(event) {
-    // If this function is programatically called like in resetMenu, there won't be an event.
-    // But we need to call it otherwise, because we need to prevent the document click event from
-    // firing and automatically closing the menu.
-    if (event) {
-      event.stopPropagation();
-    }
-    document.body.classList.add('va-pos-fixed');
+  showMegaMenu() {
     this.openControl.setAttribute('hidden', 'hidden');
     this.menu.removeAttribute('hidden');
     this.closeControl.removeAttribute('hidden');
   }
 
-  hideMenu() {
-    document.body.classList.remove('va-pos-fixed');
+  hideMegaMenu() {
     this.closeControl.setAttribute('hidden', 'hidden');
     this.menu.setAttribute('hidden', 'hidden');
     this.openControl.removeAttribute('hidden');
@@ -172,7 +44,7 @@ class MegaMenu {
 
 export default MegaMenu;
 
-function reInitMenu() {
+function initNavMenu() {
   const menuElement = document.querySelector('#vetnav');
   const openMenuElement = document.querySelector('.vetnav-controller-open');
   const closeMenuElement = document.querySelector('.vetnav-controller-close');
@@ -181,4 +53,4 @@ function reInitMenu() {
   mm.resetMenu();
 }
 
-document.addEventListener('DOMContentLoaded', reInitMenu);
+document.addEventListener('DOMContentLoaded', initNavMenu);

--- a/src/js/legacy/mega-menu.js
+++ b/src/js/legacy/mega-menu.js
@@ -16,6 +16,8 @@ class MegaMenu {
   }
 
   addListeners() {
+    this.closeControl.addEventListener('click', this.hideMegaMenu);
+    this.openControl.addEventListener('click', this.showMegaMenu);
     window.addEventListener('resize', this.resetMenu);
   }
 
@@ -29,6 +31,7 @@ class MegaMenu {
   }
 
   showMegaMenu() {
+    console.log('menu shown');
     this.openControl.setAttribute('hidden', 'hidden');
     this.menu.removeAttribute('hidden');
     this.closeControl.removeAttribute('hidden');

--- a/src/js/no-react-entry.js
+++ b/src/js/no-react-entry.js
@@ -15,9 +15,6 @@ import './common';
 // Used in the footer.
 import './legacy/menu.js';
 
-// New navigation menu
-import './legacy/mega-menu.js';
-
 // New sidebar menu
 import './legacy/sidebar-navigation.js';
 


### PR DESCRIPTION
So mega-menu.js isn't removed since it still has some nav-specific functionality--the nav menu behaves a little differently then "normal" menus when in a small window.

Specifically, it's still needed for:
- Hiding and revealing the nav menu on small windows
- Determining whether to show the menu / close button or the whole nav menu when the screen is resized

Since this is a pretty integral part of the site, we need to make sure this is tested thoroughly to make sure I didn't break anything. Please please please try to break it!

**Known weird functionality**
- When opening a menu by clicking on it, the focus goes to the first item in the newly-opened menu instead of staying on the menu button just clicked
  - If this is undesired, we can fix it pretty easily; it's just a bit of a code smell
- When a first-level menu is opened (Explore benefits, for example), hitting the up arrow when the focus is on "Explore benefits" opens the last sub-menu
  - This is fine and expected when the menu isn't already opened, and the up arrow is pressed, but maybe a bit awkward when the menu is already opened
- Cycling through the menu options in a first-level menu with the down arrow does _not_ focus on the opening menu button ("Explore benefits"), but cycling through with the up arrow _does_
  - Again, we can make this happen, but it's just a bit awkward

Find anything else? Make a comment!
  