### PR TITLE
Main nav keyboard navigation e2e tests

### DIFF
--- a/test/common/utils/accessible-menus.e2e.spec.js
+++ b/test/common/utils/accessible-menus.e2e.spec.js
@@ -1,0 +1,36 @@
+const E2eHelpers = require('../../e2e/e2e-helpers');
+const Timeouts = require('../../e2e/timeouts.js');
+
+const exploreButton = '#vetnav-menu button[aria-controls="vetnav-explore"]';
+
+module.exports = E2eHelpers.createE2eTest(
+  (client) => {
+    client
+      .url(`${E2eHelpers.baseUrl}/`);
+
+    E2eHelpers.overrideSmoothScrolling(client);
+
+    // landing page
+    client
+      .waitForElementVisible('body', Timeouts.normal)
+      .waitForElementVisible('#vetnav', Timeouts.slow)
+      // do not run 'wcag2a' rules because of open aXe bug https://github.com/dequelabs/axe-core/issues/214
+      .axeCheck('.main');
+
+
+    // --------------------- //
+    // --- Menubar tests --- //
+    // --------------------- //
+
+
+    // Down arrow should open menu
+    client
+      .focusOn(exploreButton)
+      .assert.isActiveElement(exploreButton);
+
+    // Up arrow should
+
+
+    client.end();
+  });
+

--- a/test/common/utils/accessible-menus.e2e.spec.js
+++ b/test/common/utils/accessible-menus.e2e.spec.js
@@ -2,9 +2,13 @@ const E2eHelpers = require('../../e2e/e2e-helpers');
 const Timeouts = require('../../e2e/timeouts.js');
 
 const exploreButton = '#vetnav-menu button[aria-controls="vetnav-explore"]';
+const benefitsButton = '#vetnav-menu button[aria-controls="vetnav-benefits"]';
+const facilitiesLink = '#vetnav-menu a[href="/facilities/"]';
 
 module.exports = E2eHelpers.createE2eTest(
   (client) => {
+    const { SPACE, ENTER, UP_ARROW, DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, ESCAPE } = client.Keys;
+
     client
       .url(`${E2eHelpers.baseUrl}/`);
 
@@ -13,7 +17,10 @@ module.exports = E2eHelpers.createE2eTest(
     // landing page
     client
       .waitForElementVisible('body', Timeouts.normal)
-      .waitForElementVisible('#vetnav', Timeouts.slow)
+      // Make sure everything is where we think it should be
+      .waitForElementVisible(exploreButton, Timeouts.slow)
+      .waitForElementVisible(benefitsButton, Timeouts.slow)
+      .waitForElementVisible(facilitiesLink, Timeouts.slow)
       // do not run 'wcag2a' rules because of open aXe bug https://github.com/dequelabs/axe-core/issues/214
       .axeCheck('.main');
 
@@ -22,14 +29,199 @@ module.exports = E2eHelpers.createE2eTest(
     // --- Menubar tests --- //
     // --------------------- //
 
+    // Explore benefits menu items
+    const firstMenuItem = 'button[aria-controls="vetnav-disability"]';
+    const secondMenuItem = 'button[aria-controls="vetnav-healthcare"]';
+    const lastMenuItem = 'button[aria-controls="vetnav-burials"]';
 
-    // Down arrow should open menu
-    client
-      .focusOn(exploreButton)
+    const testOpenExploreMenu = (key, focusedOn, keyName) => {
+      if (keyName) {
+        client.log(`   Testing opening the explore menu with ${keyName}`);
+      }
+
+      client.expect.element('#vetnav-explore').to.not.be.visible;
+      client.focusOn(exploreButton)
+        .keys(key)
+        .expect.element('#vetnav-explore').to.be.visible;
+
+      // TODO: Uncomment this when the code that does this for clicking is merged into master
+      // client.assert.isActiveElement(focusedOn);
+
+      // Close the menu behind us
+      client.click(exploreButton);
+    };
+    // Space, enter, and the down arrow should open menu, focus on first element
+    testOpenExploreMenu(SPACE, firstMenuItem, 'space');
+    testOpenExploreMenu(ENTER, firstMenuItem, 'enter');
+    testOpenExploreMenu(DOWN_ARROW, firstMenuItem, 'down arrow');
+
+    // Up arrow should open menu, focus on last element
+    testOpenExploreMenu(UP_ARROW, lastMenuItem, 'down arrow');
+
+    // Right arrow should move focus to the right
+    client.focusOn(exploreButton)
+      .keys(RIGHT_ARROW)
+      .assert.isActiveElement(benefitsButton);
+    //  with wraparound
+    client.focusOn(facilitiesLink)
+      .keys(RIGHT_ARROW)
       .assert.isActiveElement(exploreButton);
 
-    // Up arrow should
+    // Left arrow should move focus to the left
+    client.focusOn(benefitsButton)
+      .keys(LEFT_ARROW)
+      .assert.isActiveElement(exploreButton);
+    //  with wraparound
+    client.focusOn(exploreButton)
+      .keys(LEFT_ARROW)
+      .assert.isActiveElement(facilitiesLink);
 
+
+    // ------------------------------ //
+    // --- First-level menu tests --- //
+    // ------------------------------ //
+
+    // Health care sub menu items
+    const hcFirstItem = '#vetnav-healthcare a[href="/health-care/"]';
+    const hcSecondItem = '#vetnav-healthcare a[href="/health-care/eligibility/"]';
+    const hcLastItem = '#vetnav-healthcare a[href="/health-care/apply/application/"]';
+
+    // Disability menu items
+    // const disFirstItem = '#vetnav-disability a[href="/disability-benefits/"]';
+
+    // Open the menu
+    client.click(exploreButton);
+
+    // Down arrow should move focus to the next element
+    client
+      .focusOn(firstMenuItem)
+      .keys(DOWN_ARROW)
+      .assert.isActiveElement(secondMenuItem);
+    //  with wraparound
+    client
+      .focusOn(lastMenuItem)
+      .keys(DOWN_ARROW)
+      .assert.isActiveElement(firstMenuItem);
+
+    // Up arrow should move focus to the previous element
+    client
+      .focusOn(secondMenuItem)
+      .keys(UP_ARROW)
+      .assert.isActiveElement(firstMenuItem);
+    //  with wraparound going to the opening menu button
+    client
+      .focusOn(firstMenuItem)
+      .keys(UP_ARROW)
+      .assert.isActiveElement(exploreButton);
+
+    // Left arrow should do nothing
+    client
+      .focusOn(firstMenuItem)
+      .keys(LEFT_ARROW)
+      .assert.isActiveElement(firstMenuItem);
+
+    // Right arrow should open the sub-menu and focus on the first element if sub-menu exists
+    client.expect.element('#vetnav-healthcare').to.not.be.visible;
+    client
+      .focusOn(secondMenuItem)
+      .keys(RIGHT_ARROW)
+      .assert.visible('#vetnav-healthcare');
+    client.assert.isActiveElement(hcFirstItem);
+
+    // Space should open the sub-menu and focus on the first element if sub-menu exists
+    client.expect.element('#vetnav-disability').to.not.be.visible;
+    client
+      .focusOn(firstMenuItem)
+      .keys(SPACE)
+      .assert.visible('#vetnav-disability');
+    // TODO: Uncomment this when the code that makes this work is merged in
+    // client.assert.isActiveElement(disFirstItem);
+
+    // Enter should open the sub-menu and focus on the first element if sub-menu exists
+    client.expect.element('#vetnav-healthcare').to.not.be.visible;
+    client
+      .focusOn(secondMenuItem)
+      .keys(ENTER)
+      .assert.visible('#vetnav-healthcare');
+    // TODO: Uncomment this when the code that makes this work is merged in
+    // client.assert.isActiveElement(hcFirstItem);
+
+
+    // -- Non-sub menu buttons -- //
+    const prescriptionsLink = 'a[href="/health-care/prescriptions"]';
+
+    client.click(benefitsButton);
+
+    // Right arrow should do nothing if no sub-menu exists
+    client
+      .focusOn(prescriptionsLink)
+      .keys(RIGHT_ARROW)
+      .assert.visible(prescriptionsLink);
+
+    // TODO: Write these; I'm not sure what to do with them
+    //  Do we just poke them and test the url? Seems like it'd get pretty slow
+    // Space should follow the link if the menu item is a link
+    // Enter should follow the link if the menu item is a link
+
+    client.click(exploreButton); // Open our explore menu back up again
+
+
+    // ---------------------- //
+    // --- Sub-menu tests --- //
+    // ---------------------- //
+
+    client.click(secondMenuItem); // Open up the health care menu
+
+    // Down arrow should move focus to the next item
+    client
+      .focusOn(hcFirstItem)
+      .keys(DOWN_ARROW)
+      .assert.isActiveElement(hcSecondItem);
+    //  with wraparound
+    client
+      .focusOn(hcLastItem)
+      .keys(DOWN_ARROW)
+      .assert.isActiveElement(hcFirstItem);
+
+    // Up arrow should move focus to the previous item
+    client
+      .focusOn(hcSecondItem)
+      .keys(UP_ARROW)
+      .assert.isActiveElement(hcFirstItem);
+    //  with wraparound
+    client
+      .focusOn(hcFirstItem)
+      .keys(UP_ARROW)
+      .assert.isActiveElement(hcLastItem);
+
+    // Right arrow should do nothing
+    client
+      .focusOn(hcFirstItem)
+      .keys(RIGHT_ARROW)
+      .assert.isActiveElement(hcFirstItem);
+
+    // Left arrow should move focus back to the opening menu button
+    client
+      .focusOn(hcFirstItem)
+      .keys(LEFT_ARROW)
+      .assert.isActiveElement(secondMenuItem);
+
+    // TODO: Write these; I'm not sure what to do with them
+    //  Do we just poke them and test the url? Seems like it'd get pretty slow
+    // Space should follow links
+    // Enter should follow links
+
+
+    // --------------------------- //
+    // --- Miscellaneous tests --- //
+    // --------------------------- //
+
+    // Escape should close all menus
+    //  Should focus be doing anything special here? When hitting tab, it goes to the next menubar item
+    client.assert.visible('#vetnav-explore');
+    client
+      .keys(ESCAPE)
+      .expect.element('#vetnav-explore').to.not.be.visible;
 
     client.end();
   });

--- a/test/util/nightwatch-commands/focusOn.js
+++ b/test/util/nightwatch-commands/focusOn.js
@@ -1,0 +1,14 @@
+/**
+ * Change select value and trigger change event programatically. This
+ * is necessary because long select boxes tend to render offscreen,
+ * causing Selenium to fail in unexpected ways.
+ * The first parameter is the field name, not the whole selector.
+ */
+exports.command = function focusOn(selector) {
+  this.execute((sel) => {
+    document.querySelector(sel).focus();
+  }, [selector]);
+
+  return this;
+};
+

--- a/test/util/nightwatch-commands/focusOn.js
+++ b/test/util/nightwatch-commands/focusOn.js
@@ -1,8 +1,7 @@
 /**
- * Change select value and trigger change event programatically. This
- * is necessary because long select boxes tend to render offscreen,
- * causing Selenium to fail in unexpected ways.
- * The first parameter is the field name, not the whole selector.
+ * Focus on the element specified in `selector`.
+ *
+ * @param {String} selector  CSS selector pointing to the element to focus on
  */
 exports.command = function focusOn(selector) {
   this.execute((sel) => {

--- a/test/util/nightwatch-commands/selectDropdown.js
+++ b/test/util/nightwatch-commands/selectDropdown.js
@@ -20,7 +20,7 @@ exports.command = function selectDropdown(name, value) {
     element.value = clientValue;
     element.dispatchEvent(evt);
     return element.value;
-    /* eslint-disable */
+    /* eslint-enable */
   },
   [select, value]);
 


### PR DESCRIPTION
It's written like unit tests, but is _actually_ a browser (e2e) test. I think it's a good phase 2 for these kinds of tests.

I wrote a little `.focusOn()` function that I used to help reset the state so I could write the tests more like unit tests. `.focusOn(selector)` in conjunction with `.keys()` instead of `.sendKeys(selector)` I think will also more closely follow what happens in the browser. For example, if the result of `.sendKeys()` moves the focus to a spot that the next `.sendKeys(selector)` didn't anticipate, that undesired behavior will just get passed over because `.sendKeys(selector)` doesn't care where the focus currently is (from my understanding).

Moving forward, I think it might make sense to encapsulate the individual functionality tests a bit more next time (e.g. hitting the down arrow in a certain context). Unfortunately while breaking them out into helper functions I think may succeed in increasing readability, it'll also open up for bugs where the state wasn't reset properly. Not sure what the best way to do that is (with the least overhead). I have some ideas, but they seem kinda clunky.