### PR TITLE
Letters progress updates mg

### DIFF
--- a/src/js/letters/containers/DownloadLetters.jsx
+++ b/src/js/letters/containers/DownloadLetters.jsx
@@ -27,7 +27,11 @@ export class DownloadLetters extends React.Component {
     if (location.pathname === '/confirm-address') {
       viewLettersButton = (
         <div className="step-content">
-          <button onClick={this.navigateToLetterList} className="usa-button-primary view-letters-button">View Letters</button>
+          <button
+            onClick={this.navigateToLetterList}
+            className="usa-button-primary view-letters-button">
+            View Letters
+          </button>
         </div>
       );
     }
@@ -35,15 +39,10 @@ export class DownloadLetters extends React.Component {
     return (
       <div className="usa-width-three-fourths letters">
         <FormTitle title="VA Letters and Documents"/>
-        <div className="va-introtext">
-          <p>
-            To receive some benefits, Veterans need a letter proving their status. You can download some of these benefit letters and documents online.
-          </p>
-        </div>
-
-        <div className="letters-progress-bar">
-          <SegmentedProgressBar total={chapters.length} current={currentStep}/>
-        </div>
+        <p className="va-introtext">
+          To receive some benefits, Veterans need a letter proving their status. You can download some of these benefit letters and documents online.
+        </p>
+        <SegmentedProgressBar total={chapters.length} current={currentStep}/>
         <StepHeader name={chapters[currentPageIndex].name} current={currentStep} steps="2">
           {children}
           {viewLettersButton}

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -21,14 +21,6 @@
     }
   }
 
-  .step-content {
-    margin-left: 2em;
-  }
-
-  .letters-progress-bar {
-    width: 6em;
-  }
-
   .address-block {
     background-color: $color-gray-lightest;
     padding: 1em;

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -1,7 +1,7 @@
-@import "shared-variables";
-@import "modules/m-form-process";
-@import "modules/m-progress-bar";
-@import "modules/m-schemaform";
+@import 'shared-variables';
+@import 'modules/m-form-process';
+@import 'modules/m-progress-bar';
+@import 'modules/m-schemaform';
 @mixin schemaform-padding {
   // query borrowed from _m-schemaform.scss
   @media(max-width: 40.063em) {
@@ -19,8 +19,8 @@
   }
 
   .feature {
-      min-height: 0;
-      margin-top: 1em;
+    margin-top: 1em;
+    min-height: 0;
 
     &.help-desk {
       margin-top: 2em;
@@ -48,15 +48,15 @@
       }
 
       &.address-help-btn {
-        display: block;
-        margin: 1em 0;
-        padding: 0;
-        text-decoration: underline;
         background-color: transparent;
-        outline: none;
         color: $color-primary-darker;
+        display: block;
         font-weight: normal;
+        margin: 1em 0;
+        outline: none;
+        padding: 0;
         text-align: left;
+        text-decoration: underline;
       }
 
       &.edit-address {
@@ -70,8 +70,8 @@
   }
 
   .progress-bar-segmented {
-    padding-right: 2rem;
     @include schemaform-padding;
+    padding-right: 2rem;
   }
 
   .letters-address {
@@ -84,16 +84,18 @@
 
   .accordion-header > button {
     min-height: 6rem;
-    padding-top: 1.5rem;
     padding-bottom: 1.5rem;
+    padding-top: 1.5rem;
   }
 
   .download-button {
     margin: 1.5em 0 1em;
 
-    > button:disabled {
-      background-color: $color-gray-lighter;
-      color: $color-black;
+    > button {
+      &:disabled {
+        background-color: $color-gray-lighter;
+        color: $color-black;
+      }
     }
   }
 
@@ -101,32 +103,35 @@
     text-transform: capitalize;
   }
 
-table > tbody > tr {
-  vertical-align: middle;
+  table > tbody > tr {
+    vertical-align: middle;
+
+    th {
+      input,
+      label {
+        cursor: pointer;
+      }
+
+      label {
+        // The USWDS label controlling the checkbox enforces an 8px margin-bottom
+        // We are adding an equivalent top margin so that vertical-align works
+        // correctly without using !important to over-ride margin-bottom
+        margin-top: 8px;
+        text-align: center;
+      }
+    }
+
+    td > label {
+      cursor: pointer;
+      margin: 0;
+    }
+  }
 
   th {
-    input, label {
-      cursor: pointer;
+    [scope='row'] {
+      padding-bottom: 0;
+      padding-top: 0;
     }
-
-    label {
-      // The USWDS label controlling the checkbox enforces an 8px margin-bottom
-      // We are adding an equivalent top margin so that vertical-align works
-      // correctly without using !important to over-ride margin-bottom
-      margin-top: 8px;
-      text-align: center;
-    }
-  }
-
-  td > label {
-    margin: 0;
-    cursor: pointer;
-  }
-}
-
-  th[scope="row"] {
-    padding-top: 0;
-    padding-bottom: 0;
   }
 
   .form-expanding-group {
@@ -140,19 +145,15 @@ table > tbody > tr {
   }
 }
 
-#invalidAddress {
-  margin-bottom: 4em;
-}
-
 #records-not-found {
   h2 {
     margin-top: 2em;
   }
 
   hr {
-    margin-top: 0;
-    margin-bottom: 0;
     border-color: $color-primary;
+    margin-bottom: 0;
+    margin-top: 0;
   }
 
   .letters-phone-nowrap {

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -59,6 +59,10 @@
     }
   }
 
+  .progress-bar-segmented {
+    padding-right: 2rem;
+  }
+
   .letters-address {
     text-transform: capitalize;
   }

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -2,6 +2,12 @@
 @import "modules/m-form-process";
 @import "modules/m-progress-bar";
 @import "modules/m-schemaform";
+@mixin schemaform-padding {
+  // query borrowed from _m-schemaform.scss
+  @media(max-width: 40.063em) {
+    padding-right: 2rem - .9375rem;
+  }
+}
 
 .letters {
   h5 {
@@ -59,8 +65,13 @@
     }
   }
 
+  .va-introtext {
+    @include schemaform-padding;
+  }
+
   .progress-bar-segmented {
     padding-right: 2rem;
+    @include schemaform-padding;
   }
 
   .letters-address {


### PR DESCRIPTION
Tweaks a few bits of Letters styling:
- Aligns schemaform content with the `StepHeader` (progress bar description) on the left.
- Makes progress bar same width as content
- Standardizes right padding between progress bar, schemaform (address / letters list) content, and the intro text paragraph. This includes a media query for small screens
- Simplifies some of the markup by switching to semantic tags and removing unnecessary wrapping divs.

**Before:**
![34581376-c9ee1eda-f155-11e7-8c4c-66478b9b9a25](https://user-images.githubusercontent.com/24251447/34632136-6c86215e-f239-11e7-9f74-5ed9b4e53995.png)


**After:**
<img width="831" alt="34628572-689e3eb4-f22a-11e7-9476-83f7a0c82ca6" src="https://user-images.githubusercontent.com/24251447/34632140-70f7d5ac-f239-11e7-8062-92f1b62acf23.png">


