### PR TITLE
Appeals Status V2 -- Need help sidebar

### DIFF
--- a/src/js/claims-status/components/AskVAQuestions.jsx
+++ b/src/js/claims-status/components/AskVAQuestions.jsx
@@ -5,11 +5,11 @@ class AskVAQuestions extends React.Component {
     return (
       <div>
         <h2 className="help-heading">Need help?</h2>
-        <p className="help-talk">Call Veterans Affairs Benefits and Services:</p>
+        <p>Call Veterans Affairs Benefits and Services:</p>
         <p className="help-phone-number">
-          <a className="help-phone-number-link" href="tel:+1-800-827-1000">1-800-827-1000</a><br/>
-          Monday &#8211; Friday, 8:00 a.m. &#8211; 9:00 p.m. (ET)
+          <a className="help-phone-number-link" href="tel:+1-800-827-1000">1-800-827-1000</a>
         </p>
+        <p>Monday &#8211; Friday, 8:00 a.m. &#8211; 9:00 p.m. (ET)</p>
         <p><a href="https://iris.custhelp.com/">Submit a question to VA</a></p>
       </div>
     );

--- a/src/js/claims-status/components/ClaimDetailLayout.jsx
+++ b/src/js/claims-status/components/ClaimDetailLayout.jsx
@@ -71,7 +71,7 @@ export default class ClaimDetailLayout extends React.Component {
                 ))}
               </div>
             </div>
-            <div className="small-12 usa-width-one-third medium-4 columns">
+            <div className="small-12 usa-width-one-third medium-4 columns help-sidebar">
               <AskVAQuestions/>
             </div>
           </div>

--- a/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
@@ -36,7 +36,8 @@ const boardVersion = (
  */
 export default function AppealHelpSidebar({ location, aoj }) {
   if (location === 'aoj') {
-    // If the location is 'aoj', we have to check which agency it came from
+    // If the location is 'aoj', we have to check which agency it came from to show
+    //  the appropriate information.
     switch (aoj) {
       case 'vba': return vbaVersion;
       case 'vha': return null; // vha version (coming soon to a sidebar near you!)

--- a/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Raven from 'raven-js';
 
 const vbaVersion = (
   <div>
@@ -44,12 +45,12 @@ export default function AppealHelpSidebar({ location, aoj }) {
     } else if (aoj === 'other') {
       return boardVersion;
     } else {
-      // Ah, bugger. Better log it.
+      Raven.captureMessage(`appeal-status-unexpected-aoj: ${aoj}`);
     }
   } else if (location === 'bva') {
     return boardVersion;
   } else {
-    // Well that's not good; log it!
+    Raven.captureMessage(`appeal-status-unexpected-location: ${location}`);
   }
 
   return null;

--- a/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
@@ -6,6 +6,7 @@ const vbaVersion = (
     <p className="help-talk">Call the Veterans Affairs Benefits and Services</p>
     <p className="help-phone-number">
       <a className="help-phone-number-link" href="tel:1-800-827-1000">1-800-827-1000</a>
+      <br/>
       Monday - Friday, 8:00am - 9:00pm (ET)
     </p>
   </div>
@@ -14,13 +15,15 @@ const vbaVersion = (
 const boardVersion = (
   <div>
     <h2 className="help-heading">Need help?</h2>
-    <p className="help-talk">Call the Board of Veterans' Appeals</p>
+    <p className="help-talk">Call the Board of Veterans’ Appeals</p>
     <p className="help-phone-number">
       <a className="help-phone-number-link" href="tel:1-800-923-8387">1-800-923-8387</a>
+      <br/>
       Monday - Friday, 9:00am - 4:30pm (ET)
     </p>
   </div>
 );
+
 
 /**
  * Displays the "Need help?" sidebar content based on the appeal's location.

--- a/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
@@ -36,16 +36,14 @@ const boardVersion = (
  */
 export default function AppealHelpSidebar({ location, aoj }) {
   if (location === 'aoj') {
-    if (aoj === 'vba') {
-      return vbaVersion;
-    } else if (aoj === 'vha') {
-      // vha version (coming soon to a sidebar near you!)
-    } else if (aoj === 'nca') {
-      // nca version (coming soon to a sidebar near you!)
-    } else if (aoj === 'other') {
-      return boardVersion;
-    } else {
-      Raven.captureMessage(`appeal-status-unexpected-aoj: ${aoj}`);
+    // If the location is 'aoj', we have to check which agency it came from
+    switch (aoj) {
+      case 'vba': return vbaVersion;
+      case 'vha': return null; // vha version (coming soon to a sidebar near you!)
+      case 'nca': return null; // nca version (coming soon to a sidebar near you!)
+      case 'other': return boardVersion;
+      default:
+        Raven.captureMessage(`appeal-status-unexpected-aoj: ${aoj}`);
     }
   } else if (location === 'bva') {
     return boardVersion;

--- a/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
@@ -3,24 +3,22 @@ import React from 'react';
 const vbaVersion = (
   <div>
     <h2 className="help-heading">Need help?</h2>
-    <p className="help-talk">Call the Veterans Affairs Benefits and Services</p>
+    <p>Call the Veterans Affairs Benefits and Services</p>
     <p className="help-phone-number">
       <a className="help-phone-number-link" href="tel:1-800-827-1000">1-800-827-1000</a>
-      <br/>
-      Monday - Friday, 8:00am - 9:00pm (ET)
     </p>
+    <p>Monday - Friday, 8:00am - 9:00pm (ET)</p>
   </div>
 );
 
 const boardVersion = (
   <div>
     <h2 className="help-heading">Need help?</h2>
-    <p className="help-talk">Call the Board of Veterans’ Appeals</p>
+    <p>Call the Board of Veterans’ Appeals</p>
     <p className="help-phone-number">
       <a className="help-phone-number-link" href="tel:1-800-923-8387">1-800-923-8387</a>
-      <br/>
-      Monday - Friday, 9:00am - 4:30pm (ET)
     </p>
+    <p>Monday - Friday, 9:00am - 4:30pm (ET)</p>
   </div>
 );
 

--- a/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
@@ -32,7 +32,7 @@ const boardVersion = (
  *                            Possible options:
  *                            ['vba', 'vha', 'nca', 'other']
  */
-export function AppealHelpSidebar({ location, aoj }) {
+export default function AppealHelpSidebar({ location, aoj }) {
   if (location === 'aoj') {
     if (aoj === 'vba') {
       return vbaVersion;

--- a/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+const vbaVersion = (
+  <div>
+    <h2 className="help-heading">Need help?</h2>
+    <p className="help-talk">Call the Veterans Affairs Benefits and Services</p>
+    <p className="help-phone-number">
+      <a className="help-phone-number-link" href="tel:1-800-827-1000">1-800-827-1000</a>
+      Monday - Friday, 8:00am - 9:00pm (ET)
+    </p>
+  </div>
+);
+
+const boardVersion = (
+  <div>
+    <h2 className="help-heading">Need help?</h2>
+    <p className="help-talk">Call the Board of Veterans' Appeals</p>
+    <p className="help-phone-number">
+      <a className="help-phone-number-link" href="tel:1-800-923-8387">1-800-923-8387</a>
+      Monday - Friday, 9:00am - 4:30pm (ET)
+    </p>
+  </div>
+);
+
+/**
+ * Displays the "Need help?" sidebar content based on the appeal's location.
+ *
+ * @param {String} location  The location of the appeal. Possible options:
+ *                            ['aoj', 'bva']
+ * @param {String} aoj       The Agency of Original Jurisdiction.
+ *                            Used if the location is 'aoj'
+ *                            Possible options:
+ *                            ['vba', 'vha', 'nca', 'other']
+ */
+export function AppealHelpSidebar({ location, aoj }) {
+  if (location === 'aoj') {
+    if (aoj === 'vba') {
+      return vbaVersion;
+    } else if (aoj === 'vha') {
+      // vha version (coming soon to a sidebar near you!)
+    } else if (aoj === 'nca') {
+      // nca version (coming soon to a sidebar near you!)
+    } else if (aoj === 'other') {
+      return boardVersion;
+    } else {
+      // Ah, bugger. Better log it.
+    }
+  } else if (location === 'bva') {
+    return boardVersion;
+  } else {
+    // Well that's not good; log it!
+  }
+
+  return null;
+}
+

--- a/src/js/claims-status/containers/AdditionalEvidencePage.jsx
+++ b/src/js/claims-status/containers/AdditionalEvidencePage.jsx
@@ -114,7 +114,7 @@ class AdditionalEvidencePage extends React.Component {
                   onDirtyFields={this.props.setFieldsDirty}/>
               </div>
             </div>
-            <div className="small-12 usa-width-one-third medium-4 columns">
+            <div className="small-12 usa-width-one-third medium-4 columns help-sidebar">
               <AskVAQuestions/>
             </div>
           </div>

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -50,7 +50,7 @@ export function AppealInfo({ params, appeal, children }) {
             {React.Children.map(children, child => React.cloneElement(child, { appeal }))}
           </div>
         </div>
-        <div className="medium-4 columns">
+        <div className="medium-4 columns help-sidebar">
           {appeal && <AppealHelpSidebar location={appeal.attributes.location} aoj={appeal.attributes.aoj}/>}
         </div>
       </div>

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -7,7 +7,7 @@ import moment from 'moment';
 
 import Breadcrumbs from '../components/Breadcrumbs';
 import AppealsV2TabNav from '../components/appeals-v2/AppealsV2TabNav';
-// import AppealHelpSidebar from '../components/appeals-v2/AppealHelpSidebar';
+import AppealHelpSidebar from '../components/appeals-v2/AppealHelpSidebar';
 
 import { EVENT_TYPES } from '../utils/appeals-v2-helpers';
 
@@ -51,7 +51,7 @@ export function AppealInfo({ params, appeal, children }) {
           </div>
         </div>
         <div className="medium-4 columns">
-          {/* <AppealHelpSidebar location={appeal.location} aoj={appeal.aoj}/> */}
+          <AppealHelpSidebar location={appeal.attributes.location} aoj={appeal.attributes.aoj}/>
         </div>
       </div>
     </div>

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -7,7 +7,7 @@ import moment from 'moment';
 
 import Breadcrumbs from '../components/Breadcrumbs';
 import AppealsV2TabNav from '../components/appeals-v2/AppealsV2TabNav';
-import AppealHelpSidebar from '../components/appeals-v2/AppealHelpSidebar';
+// import AppealHelpSidebar from '../components/appeals-v2/AppealHelpSidebar';
 
 import { EVENT_TYPES } from '../utils/appeals-v2-helpers';
 

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -7,6 +7,7 @@ import moment from 'moment';
 
 import Breadcrumbs from '../components/Breadcrumbs';
 import AppealsV2TabNav from '../components/appeals-v2/AppealsV2TabNav';
+import AppealHelpSidebar from '../components/appeals-v2/AppealHelpSidebar';
 
 import { EVENT_TYPES } from '../utils/appeals-v2-helpers';
 
@@ -49,7 +50,9 @@ export function AppealInfo({ params, appeal, children }) {
             {React.Children.map(children, child => React.cloneElement(child, { appeal }))}
           </div>
         </div>
-        {/* This assumes the Need Help sidebar doesn't change for either page */}
+        <div className="medium-4 columns">
+          {/* <AppealHelpSidebar location={appeal.location} aoj={appeal.aoj}/> */}
+        </div>
       </div>
     </div>
   );

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -51,7 +51,7 @@ export function AppealInfo({ params, appeal, children }) {
           </div>
         </div>
         <div className="medium-4 columns">
-          <AppealHelpSidebar location={appeal.attributes.location} aoj={appeal.attributes.aoj}/>
+          {appeal && <AppealHelpSidebar location={appeal.attributes.location} aoj={appeal.attributes.aoj}/>}
         </div>
       </div>
     </div>
@@ -70,3 +70,4 @@ function mapStateToProps(state, ownProps) {
 }
 
 export default connect(mapStateToProps)(AppealInfo);
+

--- a/src/js/claims-status/containers/AppealStatusPage.jsx
+++ b/src/js/claims-status/containers/AppealStatusPage.jsx
@@ -144,7 +144,7 @@ class AppealStatusPage extends React.Component {
               </div>
             </div>
           </div>
-          <div className="small-12 usa-width-one-third medium-4 columns">
+          <div className="small-12 usa-width-one-third medium-4 columns help-sidebar">
             <AskVAQuestions/>
           </div>
         </div>

--- a/src/js/claims-status/containers/AskVAPage.jsx
+++ b/src/js/claims-status/containers/AskVAPage.jsx
@@ -82,7 +82,7 @@ class AskVAPage extends React.Component {
                 : null}
             </div>
           </div>
-          <div className="small-12 usa-width-one-third medium-4 columns">
+          <div className="small-12 usa-width-one-third medium-4 columns help-sidebar">
             <AskVAQuestions/>
           </div>
         </div>

--- a/src/js/claims-status/containers/ClaimEstimationPage.jsx
+++ b/src/js/claims-status/containers/ClaimEstimationPage.jsx
@@ -51,7 +51,7 @@ class ClaimEstimationPage extends React.Component {
             <p>You can help speed up the process by promptly and electronically uploading the documents requested by VA.</p>
             <p>If you have questions, call VA at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY: <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).</p>
           </div>
-          <div className="small-12 usa-width-one-third medium-4 columns">
+          <div className="small-12 usa-width-one-third medium-4 columns help-sidebar">
             <AskVAQuestions/>
           </div>
         </div>

--- a/src/js/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/js/claims-status/containers/DocumentRequestPage.jsx
@@ -128,7 +128,7 @@ class DocumentRequestPage extends React.Component {
                   onDirtyFields={this.props.setFieldsDirty}/>
               </div>
             </div>
-            <div className="small-12 usa-width-one-third medium-4 columns">
+            <div className="small-12 usa-width-one-third medium-4 columns help-sidebar">
               <AskVAQuestions/>
             </div>
           </div>

--- a/src/js/claims-status/containers/YourClaimsPage.jsx
+++ b/src/js/claims-status/containers/YourClaimsPage.jsx
@@ -234,7 +234,7 @@ class YourClaimsPage extends React.Component {
               id="consolidated-claims"
               contents={<ConsolidatedClaims onClose={() => this.props.showConsolidatedMessage(false)}/>}/>
           </div>
-          <div className="small-12 usa-width-one-third medium-4 columns">
+          <div className="small-12 usa-width-one-third medium-4 columns help-sidebar">
             <FeaturesWarning/>
             <AskVAQuestions/>
           </div>

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -11,10 +11,37 @@
 
 .claim-file-border, .help-heading {
   border-bottom: 3px solid $color-primary;
-  margin: 0 0 0.3em;
+  margin: 10px 0 10px;
+  padding-bottom: 9px;
   font-size: 1.35em;
   line-height: 1.5;
   font-weight: bold;
+  max-width: 22.5rem;
+}
+
+.claims-status-content  {
+  .help-sidebar {
+    // Line up the bottom border under "Need help?" with the tab list bottom border
+    margin-top: calc(3rem - 16px);
+    margin-bottom: 50px;
+  }
+
+  // The claims container has a sizeable padding; don't make the whitespace bigger
+  .claims-container .help-sidebar {
+    margin-bottom: 0px;
+  }
+}
+
+.help-sidebar {
+  p {
+    margin: 0 0 4px;
+  }
+}
+
+@media (max-width: $medium-screen) {
+  .claims-status-content .help-sidebar {
+    margin-top: 0px;
+  }
 }
 
 .submit-additional-evidence {
@@ -231,11 +258,6 @@
 .event-description {
   margin-bottom: 1.5rem;
   margin-left: 3.25rem;
-}
-
-.help-talk {
-  margin: 0.5em 0;
-  padding: 0;
 }
 
 .help-phone-number {
@@ -861,3 +883,4 @@ h1:focus {
     font-weight: bold;
   }
 }
+

--- a/test/claims-status/components/appeals-v2/AppealHelpSidebar.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/AppealHelpSidebar.unit.spec.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import AppealHelpSidebar from '../../../../src/js/claims-status/components/appeals-v2/AppealHelpSidebar';
+
+describe('<AppealHelpSidebar>', () => {
+  it('should render', () => {
+    const props = { location: 'bva', aoj: 'other' };
+    const wrapper = shallow(<AppealHelpSidebar {...props}/>);
+
+    expect(wrapper.type()).to.equal('div');
+  });
+
+  const boardVersionText = 'Call the Board of Veterans’ Appeals';
+  it('should render the board version if location is bva', () => {
+    const props = { location: 'bva', aoj: 'other' };
+    const wrapper = shallow(<AppealHelpSidebar {...props}/>);
+
+    expect(wrapper.find('p').first().text()).to.equal(boardVersionText);
+  });
+
+  it('should render the board version if location is "aoj" and aoj is "other"', () => {
+    const props = { location: 'aoj', aoj: 'other' };
+    const wrapper = shallow(<AppealHelpSidebar {...props}/>);
+
+    expect(wrapper.find('p').first().text()).to.equal(boardVersionText);
+  });
+
+  it('should render the vba version', () => {
+    const props = { location: 'aoj', aoj: 'vba' };
+    const wrapper = shallow(<AppealHelpSidebar {...props}/>);
+
+    expect(wrapper.find('p').first().text()).to.equal('Call the Veterans Affairs Benefits and Services');
+  });
+
+  it.skip('should render the vha version', () => {
+    const props = { location: 'aoj', aoj: 'vha' };
+    const wrapper = shallow(<AppealHelpSidebar {...props}/>);
+
+    expect(wrapper.find('p').first().text()).to.equal();
+  });
+
+  it.skip('should render the nca version', () => {
+    const props = { location: 'aoj', aoj: 'nca' };
+    const wrapper = shallow(<AppealHelpSidebar {...props}/>);
+
+    expect(wrapper.find('p').first().text()).to.equal();
+  });
+});
+


### PR DESCRIPTION
Seems a little high on the wide-screen version, but I'll let @gnakm decide if we want to bring it down or not.

Also, I didn't follow the design exactly; I used the styling from the claims list page. If you want more what you had in the mockup, @gnakm, let me know and I can make it happen.

## Appeals status
**Widescreen**
![image](https://user-images.githubusercontent.com/12970166/34747142-c8424b98-f54b-11e7-82c9-f4bb7955214b.png)

**Small screen**
![image](https://user-images.githubusercontent.com/12970166/34747144-cdcd9cde-f54b-11e7-838f-d060cef658f7.png)

## Claims and appeals index
The changes also affected the sidebar on this page, so I fiddled around with it to make it work well in both places.

**Widescreen**
![image](https://user-images.githubusercontent.com/12970166/34747184-f89b62d4-f54b-11e7-9382-33dd5fa7bdd1.png)

**Small screen**
![image](https://user-images.githubusercontent.com/12970166/34747194-01462eb4-f54c-11e7-9fc6-cd31896c4443.png)
