### PR TITLE
Appealsv2 status overhaul mg

### DIFF
--- a/src/js/claims-status/components/appeals-v2/Alert.jsx
+++ b/src/js/claims-status/components/appeals-v2/Alert.jsx
@@ -8,7 +8,7 @@ const Alert = ({ alert }) => {
     <li>
       <div className={`usa-alert ${cssClass}`}>
         <div className="usa-alert-body">
-          <h3 className="usa-alert-heading">{title}</h3>
+          <h4 className="usa-alert-heading">{title}</h4>
           <p className="usa-alert-text">{description}</p>
         </div>
       </div>

--- a/src/js/claims-status/components/appeals-v2/AppealsV2TabNav.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealsV2TabNav.jsx
@@ -3,10 +3,9 @@ import PropTypes from 'prop-types';
 
 import TabItem from '../TabItem';
 
-const AppealsV2TabNav = ({ appealId, claimHeading }) => {
+const AppealsV2TabNav = ({ appealId }) => {
   return (
     <div>
-      <h1>{claimHeading}</h1>
       <ul className="va-tabs claims-status-tabs small-12 medium-10" role="tablist">
         <TabItem shortcut={1} className="appeals-tabs-item" id="v2status" tabpath={`appeals-v2/${appealId}/status`} title="Status"/>
         <TabItem shortcut={2} className="appeals-tabs-item" id="v2detail" tabpath={`appeals-v2/${appealId}/detail`} title="Detail"/>

--- a/src/js/claims-status/components/appeals-v2/AppealsV2TabNav.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealsV2TabNav.jsx
@@ -3,12 +3,15 @@ import PropTypes from 'prop-types';
 
 import TabItem from '../TabItem';
 
-const AppealsV2TabNav = ({ appealId }) => {
+const AppealsV2TabNav = ({ appealId, claimHeading }) => {
   return (
-    <ul className="va-tabs claims-status-tabs small-12 medium-10" role="tablist">
-      <TabItem shortcut={1} className="appeals-tabs-item" id="v2status" tabpath={`appeals-v2/${appealId}/status`} title="Status"/>
-      <TabItem shortcut={2} className="appeals-tabs-item" id="v2detail" tabpath={`appeals-v2/${appealId}/detail`} title="Detail"/>
-    </ul>
+    <div>
+      <h1>{claimHeading}</h1>
+      <ul className="va-tabs claims-status-tabs small-12 medium-10" role="tablist">
+        <TabItem shortcut={1} className="appeals-tabs-item" id="v2status" tabpath={`appeals-v2/${appealId}/status`} title="Status"/>
+        <TabItem shortcut={2} className="appeals-tabs-item" id="v2detail" tabpath={`appeals-v2/${appealId}/detail`} title="Detail"/>
+      </ul>
+    </div>
   );
 };
 

--- a/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
+++ b/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
@@ -4,8 +4,11 @@ import PropTypes from 'prop-types';
 const CurrentStatus = ({ title, description }) => (
   <div className="current-status">
     <h2>Current Status</h2>
-    <h3 className="section-current">{title}</h3>
-    <p>{description}</p>
+    <div className="current-status-content">
+      <h3>{title}</h3>
+      <p>{description}</p>
+    </div>
+    <div className="down-arrow"/>
   </div>
 );
 

--- a/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
+++ b/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
@@ -13,9 +13,11 @@ const CurrentStatus = ({ title, description }) => (
 );
 
 CurrentStatus.PropTypes = {
-  key: PropTypes.number,
   title: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
+  description: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ]).isRequired
 };
 
 export default CurrentStatus;

--- a/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
+++ b/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CurrentStatus = ({ title, description }) => (
-  <li className="process-step section-current">
+  <div>
     <h2>Current Status</h2>
-    <h4>{title}</h4>
-    <div>{description}</div>
-  </li>
+    <h3>{title}</h3>
+    <p>{description}</p>
+  </div>
 );
 
 CurrentStatus.PropTypes = {

--- a/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
+++ b/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
@@ -6,7 +6,7 @@ const CurrentStatus = ({ title, description }) => (
     <h2>Current Status</h2>
     <div className="current-status-content">
       <h3>{title}</h3>
-      <p>{description}</p>
+      <div>{description}</div>
     </div>
     <div className="down-arrow"/>
   </div>
@@ -14,10 +14,7 @@ const CurrentStatus = ({ title, description }) => (
 
 CurrentStatus.PropTypes = {
   title: PropTypes.string.isRequired,
-  description: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.element
-  ]).isRequired
+  description: PropTypes.element.isRequired
 };
 
 export default CurrentStatus;

--- a/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
+++ b/src/js/claims-status/components/appeals-v2/CurrentStatus.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const CurrentStatus = ({ title, description }) => (
-  <div>
+  <div className="current-status">
     <h2>Current Status</h2>
-    <h3>{title}</h3>
+    <h3 className="section-current">{title}</h3>
     <p>{description}</p>
   </div>
 );

--- a/src/js/claims-status/components/appeals-v2/Expander.jsx
+++ b/src/js/claims-status/components/appeals-v2/Expander.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Expander = ({ title, dateRange, onToggle, cssClass }) => {
+const Expander = ({ title, dateRange, onToggle, cssClass, hideSeparator }) => {
+  const separator = (hideSeparator === true)
+    ? null
+    : <div className="separator"/>;
+
   return (
     <li className={`process-step ${cssClass}`}>
       {/* Giving this a margin top to help center the text to the li bullet */}
@@ -9,7 +13,7 @@ const Expander = ({ title, dateRange, onToggle, cssClass }) => {
         <h3 style={{ color: 'inherit' }}>{title}</h3>
       </button>
       <div className="appeal-event-date">{dateRange}</div>
-      <div className="separator"/>
+      {separator}
     </li>
   );
 };

--- a/src/js/claims-status/components/appeals-v2/Expander.jsx
+++ b/src/js/claims-status/components/appeals-v2/Expander.jsx
@@ -6,7 +6,7 @@ const Expander = ({ title, dateRange, onToggle, cssClass }) => {
     <li className={`process-step ${cssClass}`}>
       {/* Giving this a margin top to help center the text to the li bullet */}
       <button onClick={onToggle} className="va-button-link">
-        <h4 style={{ color: 'inherit' }}>{title}</h4>
+        <h3 style={{ color: 'inherit' }}>{title}</h3>
       </button>
       <div className="appeal-event-date">{dateRange}</div>
       <div className="separator"/>

--- a/src/js/claims-status/components/appeals-v2/NextEvent.jsx
+++ b/src/js/claims-status/components/appeals-v2/NextEvent.jsx
@@ -10,7 +10,7 @@ const NextEvent = ({ title, description, durationText, cardDescription, showSepa
         <span className="number">{durationText}</span>
         <span className="description">{cardDescription}</span>
       </div>
-      { showSeparator && <span className="sidelines">OR</span>}
+      { showSeparator && <span className="sidelines">or</span>}
     </li>
   );
 };

--- a/src/js/claims-status/components/appeals-v2/PastEvent.jsx
+++ b/src/js/claims-status/components/appeals-v2/PastEvent.jsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const PastEvent = ({ title, description, liClass, date }) => {
+const PastEvent = ({ title, date, description, liClass, hideSeparator }) => {
+  const separator = (hideSeparator === true)
+    ? null
+    : <div className="separator"/>;
+
   return (
     <li role="presentation" className={`process-step ${liClass}`}>
       <h3>{title}</h3>
       <div className="appeal-event-date">on {date}</div>
       <p>{description}</p>
-      <div className="separator"/>
+      {separator}
     </li>
   );
 };
@@ -17,6 +21,7 @@ PastEvent.propTypes = {
   date: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   liClass: PropTypes.string.isRequired,
+  hideSeparator: PropTypes.bool,
 };
 
 export default PastEvent;

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getEventContent, formatDate } from '../../utils/appeals-v2-helpers';
-import CurrentStatus from './CurrentStatus';
 import Expander from './Expander';
 import PastEvent from './PastEvent';
 
@@ -47,14 +46,17 @@ class Timeline extends React.Component {
     let expanderTitle = '';
     let expanderCssClass = '';
     let displayedEvents = [];
+    let downArrow;
     if (this.state.expanded) {
       expanderTitle = 'Hide past events';
       expanderCssClass = 'section-expanded';
       displayedEvents = pastEventsList;
+      downArrow = <div className="down-arrow"/>;
     } else {
       expanderTitle = 'See past events';
       expanderCssClass = 'section-unexpanded';
       displayedEvents = [];
+      downArrow = null;
     }
 
     return (
@@ -67,12 +69,8 @@ class Timeline extends React.Component {
             onToggle={this.toggleExpanded}
             cssClass={expanderCssClass}/>
           {displayedEvents}
-          {/* <CurrentStatus
-            key={'current-event'}
-            title={this.props.currentStatus.title}
-            description={this.props.currentStatus.description}/> */}
         </ol>
-        <div className="down-arrow"/>
+        {downArrow}
       </div>
     );
   }

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -67,10 +67,10 @@ class Timeline extends React.Component {
             onToggle={this.toggleExpanded}
             cssClass={expanderCssClass}/>
           {displayedEvents}
-          <CurrentStatus
+          {/* <CurrentStatus
             key={'current-event'}
             title={this.props.currentStatus.title}
-            description={this.props.currentStatus.description}/>
+            description={this.props.currentStatus.description}/> */}
         </ol>
         <div className="down-arrow"/>
       </div>

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -5,7 +5,7 @@ import Expander from './Expander';
 import PastEvent from './PastEvent';
 
 /**
- * Timeline is in charge of the past events and current status.
+ * Timeline is in charge of the past events.
  */
 class Timeline extends React.Component {
   constructor(props) {
@@ -88,13 +88,6 @@ Timeline.propTypes = {
     date: PropTypes.string.isRequired,
     details: PropTypes.object
   })).isRequired,
-  currentStatus: PropTypes.shape({
-    title: PropTypes.string.isRequired,
-    description: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.element
-    ]).isRequired,
-  }).isRequired
 };
 
 export default Timeline;

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -32,29 +32,34 @@ class Timeline extends React.Component {
       pastEventsList = events.map((event, index) => {
         const { title, description, liClass } = getEventContent(event);
         const date = formatDate(event.date);
+        const hideSeparator = (index === events.length - 1);
         return (
           <PastEvent
             key={`past-event-${index}`}
             title={title}
             date={date}
             description={description}
-            liClass={liClass}/>
+            liClass={liClass}
+            hideSeparator={hideSeparator}/>
         );
       });
     }
 
     let expanderTitle = '';
     let expanderCssClass = '';
+    let hideSeparator = false;
     let displayedEvents = [];
     let downArrow;
     if (this.state.expanded) {
       expanderTitle = 'Hide past events';
       expanderCssClass = 'section-expanded';
+      hideSeparator = false;
       displayedEvents = pastEventsList;
       downArrow = <div className="down-arrow"/>;
     } else {
       expanderTitle = 'See past events';
       expanderCssClass = 'section-unexpanded';
+      hideSeparator = true;
       displayedEvents = [];
       downArrow = null;
     }
@@ -67,7 +72,8 @@ class Timeline extends React.Component {
             title={expanderTitle}
             dateRange={this.formatDateRange()}
             onToggle={this.toggleExpanded}
-            cssClass={expanderCssClass}/>
+            cssClass={expanderCssClass}
+            hideSeparator={hideSeparator}/>
           {displayedEvents}
         </ol>
         {downArrow}

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -45,10 +45,12 @@ export function AppealInfo({ params, appeal, children }) {
         </Breadcrumbs>
       </div>
       <div className="row">
+        <h1>{claimHeading}</h1>
+      </div>
+      <div className="row">
         <div className="medium-8 columns">
           <AppealsV2TabNav
-            appealId={appealId}
-            claimHeading={claimHeading}/>
+            appealId={appealId}/>
           <div className="va-tab-content va-appeals-content">
             {React.Children.map(children, child => React.cloneElement(child, { appeal }))}
           </div>

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -34,18 +34,21 @@ export function AppealInfo({ params, appeal, children }) {
   const appealId = params.id;
   const firstClaim = appeal ? appeal.attributes.events.find(a => a.type === EVENT_TYPES.claim) : null;
   const appealDate = firstClaim ? moment(firstClaim.date, 'YYYY-MM-DD').format(' MMMM YYYY') : '';
+  // Space is part of appealDate to ensure we don't have a trailing space if there is no firstClaim
+  const claimHeading = `Appeal of Claim Decision${appealDate}`;
   return (
     <div>
       <div className="row">
         <Breadcrumbs>
           <li><Link to="your-claims">Your Claims and Appeals</Link></li>
-          {/* Note: The space before the date is in appealDate to ensure we don't have a trailing space if there is no firstClaim */}
-          <li><strong>Appeal of Claim Decision{appealDate}</strong></li>
+          <li><strong>{claimHeading}</strong></li>
         </Breadcrumbs>
       </div>
       <div className="row">
         <div className="medium-8 columns">
-          <AppealsV2TabNav appealId={appealId}/>
+          <AppealsV2TabNav
+            appealId={appealId}
+            claimHeading={claimHeading}/>
           <div className="va-tab-content va-appeals-content">
             {React.Children.map(children, child => React.cloneElement(child, { appeal }))}
           </div>

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -35,7 +35,7 @@ class AppealsV2StatusPage extends React.Component {
     const nextEvents = getNextEvents(type);
     return (
       <div>
-        <Timeline events={events} currentStatus={currentStatus}/>
+        <Timeline events={events}/>
         <CurrentStatus
           title={currentStatus.title}
           description={currentStatus.description}/>

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -7,6 +7,7 @@ import { getStatusContents, getNextEvents } from '../utils/appeals-v2-helpers';
 
 import LoadingIndicator from '../../common/components/LoadingIndicator';
 import Timeline from '../components/appeals-v2/Timeline';
+import CurrentStatus from '../components/appeals-v2/CurrentStatus';
 import Alerts from '../components/appeals-v2/Alerts';
 import WhatsNext from '../components/appeals-v2/WhatsNext';
 import Docket from '../components/appeals-v2/Docket';
@@ -35,6 +36,9 @@ class AppealsV2StatusPage extends React.Component {
     return (
       <div>
         <Timeline events={events} currentStatus={currentStatus}/>
+        <CurrentStatus
+          title={currentStatus.title}
+          description={currentStatus.description}/>
         <Alerts alerts={alerts}/>
         <WhatsNext nextEvents={nextEvents}/>
         <Docket/>

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -27,7 +27,7 @@ export function formatDate(date) {
  * Grabs the matching title and dynamically-generated description for a given current status type
  * @typedef {Object} Contents
  * @property {string} title a current status type's title
- * @property {element} description details about the current status, can be any element
+ * @property {HTMLElement} description details about the current status, can be any element
  * ----------------------------------------------------------------------------------------------
  * @param {string} statusType the status type of a claim appeal as returned by the api
  * @param {Object} details optional, properties vary depending on the status type

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -27,7 +27,7 @@ export function formatDate(date) {
  * Grabs the matching title and dynamically-generated description for a given current status type
  * @typedef {Object} Contents
  * @property {string} title a current status type's title
- * @property {string} description a short paragraph describing the current status
+ * @property {element} description details about the current status, can be any element
  * ----------------------------------------------------------------------------------------------
  * @param {string} statusType the status type of a claim appeal as returned by the api
  * @param {Object} details optional, properties vary depending on the status type
@@ -39,17 +39,21 @@ export function getStatusContents(type, details) {
   if (type === nod) {
     const office = details.regionalOffice || 'Regional Office';
     contents.title = `The ${office} is reviewing your appeal`;
-    contents.description = `The ${office} received your Notice of Disagreement and is revewing 
-      your appeal. This means they review all of the evidence related to your appeal, including 
-      any new evidence you submit. They may contact you to request additional evidence or 
-      medical examinations, as needed. When they have completed their review, they will 
-      determine whether or not they can grant your appeal.`;
+    contents.description = (
+      <p>The ${office} received your Notice of Disagreement and is revewing
+      your appeal. This means they review all of the evidence related to your appeal, including
+      any new evidence you submit. They may contact you to request additional evidence or
+      medical examinations, as needed. When they have completed their review, they will
+      determine whether or not they can grant your appeal.</p>
+    );
   } else if (type === awaitingHearingDate) {
     const hearingType = details.hearingType || 'hearing';
     const currenltyHearing = details.currentlyHearing || 'an earlier month';
     contents.title = 'You are waiting for your hearing date';
-    contents.description = `You have selected to have a ${hearingType} in your form 9. 
-      Currently the Board is having hearings for appeals of ${currenltyHearing}`;
+    contents.description = (
+      <p>You have selected to have a ${hearingType} in your form 9.
+      Currently the Board is having hearings for appeals of ${currenltyHearing}</p>
+    );
   } else if (type === bvaDecision) {
     const { decisionIssues } = details;
     const allowedIssues = decisionIssues
@@ -136,13 +140,14 @@ export function getStatusContents(type, details) {
     );
   } else if (type === onDocket) {
     contents.title = 'Waiting to be assigned to a judge';
-    contents.description = `Your appeal is at the Board of Veterans’ Appeals waiting to be
+    contents.description = (
+      <p>Your appeal is at the Board of Veterans’ Appeals waiting to be
       assigned to a Veterans Law Judge. Staff at the Board are making sure that your case is
       complete, accurate, and ready to be decided by a judge. If you have evidence that isn’t
-      already included in your case, now is a good time to send it to the Board.`;
+      already included in your case, now is a good time to send it to the Board.</p>);
   } else {
     contents.title = 'Current Status Unknown';
-    contents.description = 'Your current appeal status is unknown at this time';
+    contents.description = <p>Your current appeal status is unknown at this time</p>;
   }
 
   return contents;

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -40,7 +40,7 @@ export function getStatusContents(type, details) {
     const office = details.regionalOffice || 'Regional Office';
     contents.title = `The ${office} is reviewing your appeal`;
     contents.description = (
-      <p>The ${office} received your Notice of Disagreement and is revewing
+      <p>The {office} received your Notice of Disagreement and is revewing
       your appeal. This means they review all of the evidence related to your appeal, including
       any new evidence you submit. They may contact you to request additional evidence or
       medical examinations, as needed. When they have completed their review, they will
@@ -51,8 +51,8 @@ export function getStatusContents(type, details) {
     const currenltyHearing = details.currentlyHearing || 'an earlier month';
     contents.title = 'You are waiting for your hearing date';
     contents.description = (
-      <p>You have selected to have a ${hearingType} in your form 9.
-      Currently the Board is having hearings for appeals of ${currenltyHearing}</p>
+      <p>You have selected to have a {hearingType} in your form 9.
+      Currently the Board is having hearings for appeals of {currenltyHearing}</p>
     );
   } else if (type === bvaDecision) {
     const { decisionIssues } = details;

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -663,28 +663,50 @@ h1:focus {
 }
 
 .current-status {
-  h2 {
-    margin-top: 1em;
-  }
 
-  .section-current {
-    // Align the bullet horizontally
-    padding-left: 4em;
+  .current-status-content {
+    border-left: 5px solid $color-gray-lighter;
+    margin-left: 20px;
+    padding-left: 2em;
 
-    // Make sure the arrowhead lines up better
-    padding-bottom: 0px;
+    h2 {
+      margin-top: 1em;
+    }
 
-    &:before {
-      // \2022 = unicode code point for bullet, then just color it green like the background
-      //  to make it "disappear"
-      content: "\2022";
+    h3 {
+      clear: none;
+      padding-bottom: 0;
+      position: relative;
+      top: -.2em;
+    }
+
+    + .down-arrow {
+      border-left: .6em solid transparent;
+      border-right: .6em solid transparent;
+      border-top: 1.2em solid $color-gray-lighter;
+      margin-left: .8em;
+      margin-top: -1em; // overlap flat part of arrowhead with bottom of gray line
+      width: 0;
+    }
+
+    &::before {
+      background: $color-green;
+      border: 4px solid $color-white;
+      border-radius: 50%;
       color: $color-green;
-      font-size: 0.8em;
+      content: '\2022';
+      display: block;
+      float: left;
+      font-size: .8em;
       line-height: 1.4em;
-      margin-left: -3.85em;
-      margin-top: 11px; // Pull the bullet down to align it better
+      margin-left: -3.64em;
+      position: relative;
+      top: -.2em;
+      width: 2em;
+
     }
   }
+
 }
 
 .va-appeals-content {

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -664,14 +664,14 @@ h1:focus {
 
 .current-status {
 
+  h2 {
+    margin-top: 1em;
+  }
+
   .current-status-content {
     border-left: 5px solid $color-gray-lighter;
     margin-left: 20px;
     padding-left: 2em;
-
-    h2 {
-      margin-top: 1em;
-    }
 
     h3 {
       clear: none;

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -589,35 +589,53 @@ h1:focus {
 
   // Child <li>s are expected to have .process-step as well as a .section-*
   .process-step {
-    border-left: 5px solid $color-gray-lighter;
-    margin-left: -2.65em;
     padding-bottom: 1em;
 
-    &:before {
-      margin-left: -2.65em;
+    &:last-child {
+      padding-left: 2em;
+    }
+
+    .va-button-link {
+      &h3 {
+        padding-top: 0;
+      }
     }
   }
 
-  .section-complete:before {
-    font-family: FontAwesome;
-    content: "\f00c";
-    margin-top: 5px; // Aligns the check bullets to their headers better
+  .section-complete {
+    border-left: 5px solid $color-gray-lighter;
+    &::before {
+      font-family: FontAwesome;
+      content: "\f00c";
+      margin-top: 5px; // Aligns the check bullets to their headers better
+    }
   }
 
-  .section-unexpanded:before {
-    font-family: FontAwesome;
-    content: "\f067";
-    color: $color-primary;
-    background-color: $color-white;
-    border-color: $color-primary;
+  .section-unexpanded {
+
+    // offset left border with padding so element doesn't move while toggling expander
+    &.process-step {
+      padding-left: calc(2em + 5px);
+    }
+
+    &::before {
+      font-family: FontAwesome;
+      content: "\f067";
+      color: $color-primary;
+      background-color: $color-white;
+      border-color: $color-primary;
+    }
   }
 
-  .section-expanded:before {
-    font-family: FontAwesome;
-    content: "\f068";
-    color: $color-primary;
-    background-color: $color-white;
-    border-color: $color-primary;
+  .section-expanded {
+    border-left: 5px solid $color-gray-lighter;
+    &::before {
+      font-family: FontAwesome;
+      content: "\f068";
+      color: $color-primary;
+      background-color: $color-white;
+      border-color: $color-primary;
+    }
   }
 
   .section-current {

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -596,7 +596,7 @@ h1:focus {
     }
 
     .va-button-link {
-      &h3 {
+      h3 {
         padding-top: 0;
       }
     }

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -905,7 +905,9 @@ h1:focus {
     }
 
     .sidelines {
-    // line up the horizontal divider with the li::before 'bullets'
+      // line up the horizontal divider with the li::before 'bullets'
+      font-family: $font-serif;
+      font-size: 3rem; // match h2 size
       margin-left: -.6em;
       width: 102%;
     }

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -918,6 +918,17 @@ h1:focus {
   li {
     margin-left: -.4em;
   }
+
+  .usa-alert {
+    // Shift alert icon and text over so that triangle lines
+    // up with CurrentStatus's title & description content
+    background-position: 2.5rem 2.8rem;
+    padding-left: 2.5em;
+
+    .usa-alert-text {
+      margin-top: 1em;
+    }
+  }
 }
 
 .decision-items {

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -553,6 +553,11 @@ h1:focus {
   padding-top: 0;
   padding-left: 0;
 
+  &.form-process {
+    margin-top: 1em;
+    margin-bottom: 0;
+  }
+
   // To get all the li's to flow together, remove the top margin of the titles
   h2, h3, h4, h5 {
     margin-top: 0px;
@@ -638,25 +643,6 @@ h1:focus {
     }
   }
 
-  .section-current {
-    // Align the bullet horizontally
-    padding-left: calc(2em + 2px);
-
-    // Make sure the arrowhead lines up better
-    padding-bottom: 0px;
-
-    &:before {
-      // \2022 = unicode code point for bullet, then just color it green like the background
-      //  to make it "disappear"
-      content: "\2022";
-      color: $color-green;
-      font-size: 0.8em;
-      line-height: 1.4em;
-      margin-left: -3.85em;
-      margin-top: 11px; // Pull the bullet down to align it better
-    }
-  }
-
   .appeal-event-date {
     color: $color-gray-medium;
   }
@@ -673,6 +659,31 @@ h1:focus {
   .separator {
     margin: 0.8em 0 0 -0.7em;
     border-top: 1px solid $color-gray-lighter;
+  }
+}
+
+.current-status {
+  h2 {
+    margin-top: 1em;
+  }
+
+  .section-current {
+    // Align the bullet horizontally
+    padding-left: 4em;
+
+    // Make sure the arrowhead lines up better
+    padding-bottom: 0px;
+
+    &:before {
+      // \2022 = unicode code point for bullet, then just color it green like the background
+      //  to make it "disappear"
+      content: "\2022";
+      color: $color-green;
+      font-size: 0.8em;
+      line-height: 1.4em;
+      margin-left: -3.85em;
+      margin-top: 11px; // Pull the bullet down to align it better
+    }
   }
 }
 

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -662,11 +662,11 @@ h1:focus {
   }
 
   & + .down-arrow {
-    width: 0px;
+    width: 0;
     border-left: 0.6em solid transparent;
     border-right: 0.6em solid transparent;
     border-top: 1.2em solid $color-gray-lighter;
-    margin-top: -1em;
+    margin-top: -.9em;
     margin-left: 0.8em;
   }
 

--- a/test/claims-status/components/appeals-v2/AppealsV2TabNav.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/AppealsV2TabNav.unit.spec.jsx
@@ -10,7 +10,7 @@ const defaultProps = {
 describe('<AppealsV2TabNav/>', () => {
   it('should render', () => {
     const wrapper = shallow(<AppealsV2TabNav {...defaultProps}/>);
-    expect(wrapper.type()).to.equal('ul');
+    expect(wrapper.type()).to.equal('div');
   });
 
   it('should render 2 tabs: Status and Detail', () => {

--- a/test/claims-status/components/appeals-v2/CurrentStatus.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/CurrentStatus.unit.spec.jsx
@@ -9,7 +9,7 @@ const defaultProps = {
   description: null,
 };
 
-describe.only('<CurrentStatus/>', () => {
+describe('<CurrentStatus/>', () => {
   it('should render', () => {
     const wrapper = shallow(<CurrentStatus {...defaultProps}/>);
     expect(wrapper.type()).to.equal('div');

--- a/test/claims-status/components/appeals-v2/CurrentStatus.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/CurrentStatus.unit.spec.jsx
@@ -6,10 +6,10 @@ import CurrentStatus from '../../../../src/js/claims-status/components/appeals-v
 
 const defaultProps = {
   title: '',
-  description: ''
+  description: null,
 };
 
-describe('<CurrentStatus/>', () => {
+describe.only('<CurrentStatus/>', () => {
   it('should render', () => {
     const wrapper = shallow(<CurrentStatus {...defaultProps}/>);
     expect(wrapper.type()).to.equal('div');
@@ -18,16 +18,18 @@ describe('<CurrentStatus/>', () => {
   it('should render title and description from passed in props', () => {
     const props = {
       title: 'The Chicago Regional Office is reviewing your appeal',
-      description: `The Chicago Regional Office received your Notice of Disagreement and is 
-      revewing your appeal. This means they review all of the evidence related to your appeal, 
-      including any new evidence you submit. They may contact you to request additional evidence 
-      or medical examinations, as needed. When they have completed their review, they will 
-      determine whether or not they can grant your appeal.`
+      description: (
+        <p>The Chicago Regional Office received your Notice of Disagreement and is
+        revewing your appeal. This means they review all of the evidence related to your appeal,
+        including any new evidence you submit. They may contact you to request additional evidence
+        or medical examinations, as needed. When they have completed their review, they will
+        determine whether or not they can grant your appeal.</p>
+      )
     };
     const wrapper = render(<CurrentStatus {...props}/>);
     const statusTitle = wrapper.find('h3').text();
     const statusDescription = wrapper.find('p').text();
     expect(statusTitle).to.equal(props.title);
-    expect(statusDescription).to.equal(props.description);
+    expect(statusDescription).to.equal(props.description.props.children);
   });
 });

--- a/test/claims-status/components/appeals-v2/CurrentStatus.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/CurrentStatus.unit.spec.jsx
@@ -12,7 +12,7 @@ const defaultProps = {
 describe('<CurrentStatus/>', () => {
   it('should render', () => {
     const wrapper = shallow(<CurrentStatus {...defaultProps}/>);
-    expect(wrapper.type()).to.equal('li');
+    expect(wrapper.type()).to.equal('div');
   });
 
   it('should render title and description from passed in props', () => {
@@ -25,8 +25,8 @@ describe('<CurrentStatus/>', () => {
       determine whether or not they can grant your appeal.`
     };
     const wrapper = render(<CurrentStatus {...props}/>);
-    const statusTitle = wrapper.find('h4').text();
-    const statusDescription = wrapper.find('div').text();
+    const statusTitle = wrapper.find('h3').text();
+    const statusDescription = wrapper.find('p').text();
     expect(statusTitle).to.equal(props.title);
     expect(statusDescription).to.equal(props.description);
   });

--- a/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
@@ -20,10 +20,6 @@ describe('<Timeline/>', () => {
         details: {}
       }
     ],
-    currentStatus: {
-      title: 'Current Status Title',
-      description: 'Status description here'
-    }
   };
 
   const formattedDateRange = 'May 30, 2016 - June 10, 2016';
@@ -71,13 +67,6 @@ describe('<Timeline/>', () => {
     expect(wrapper.find('PastEvent').length).to.equal(0);
   });
 
-
-  it('should render one CurrentStatus component', () => {
-    const wrapper = shallow(<Timeline {...defaultProps}/>);
-    const currentStatus = wrapper.find('CurrentStatus');
-    expect(currentStatus.length).to.equal(1);
-  });
-
   it('should pass formatted date range to the Expander', () => {
     const wrapper = shallow(<Timeline {...defaultProps}/>);
     const expander = wrapper.find('Expander');
@@ -120,13 +109,5 @@ describe('<Timeline/>', () => {
     const expanderProps = wrapper.find('Expander').props();
     expect(expanderProps.title).to.equal('Hide past events');
     expect(expanderProps.cssClass).to.equal('section-expanded');
-  });
-
-  it('should pass along its currentStatus props to CurrentStatus', () => {
-    const wrapper = shallow(<Timeline {...defaultProps}/>);
-    const { title, description } = defaultProps.currentStatus;
-    const currentStatusProps = wrapper.find('CurrentStatus').props();
-    expect(currentStatusProps.title).to.equal(title);
-    expect(currentStatusProps.description).to.equal(description);
   });
 });

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -468,7 +468,7 @@ describe('Disability benefits helpers: ', () => {
       const type = 123;
       const contents = getStatusContents(type);
       expect(contents.title).to.equal('Current Status Unknown');
-      expect(contents.description).to.equal('Your current appeal status is unknown at this time');
+      expect(contents.description.props.children).to.equal('Your current appeal status is unknown at this time');
     });
   });
 


### PR DESCRIPTION
- Adds a header to the status page
- Split up CurrentStatus and Timeline components (changed html structure, render `CurrentStatus` in `AppealInfo` instead of in `Timeline`
- Match `CurrentStatus` and `Timeline` styling to mocks in linked issue
- Update tests and some proptypes / prop passing in components.

**New Screenshots:**
![screen shot 2018-01-09 at 4 05 23 pm](https://user-images.githubusercontent.com/24251447/34745697-fb171bf6-f556-11e7-9f08-61a06f19ce8b.png)

![screen shot 2018-01-09 at 4 05 13 pm](https://user-images.githubusercontent.com/24251447/34745698-fb27fec6-f556-11e7-8cfd-fcaad6786e4e.png)

![screen shot 2018-01-09 at 4 04 18 pm](https://user-images.githubusercontent.com/24251447/34745699-fb3a216e-f556-11e7-84d7-ae8607d9c7a0.png)

![screen shot 2018-01-09 at 4 04 04 pm](https://user-images.githubusercontent.com/24251447/34745700-fb4c04ba-f556-11e7-886f-340df39ba759.png)
