### PR TITLE
Gibs vet not found message mg

### DIFF
--- a/src/js/post-911-gib-status/containers/Main.jsx
+++ b/src/js/post-911-gib-status/containers/Main.jsx
@@ -5,7 +5,7 @@ import LoadingIndicator from '../../common/components/LoadingIndicator';
 import { systemDownMessage, unableToFindRecordWarning } from '../../common/utils/error-messages';
 
 import { getEnrollmentData } from '../actions/post-911-gib-status';
-import { noChapter33BenefitsWarning } from '../utils/helpers.jsx';
+// import { noChapter33BenefitsWarning } from '../utils/helpers.jsx';
 
 export class Main extends React.Component {
   componentDidMount() {
@@ -28,7 +28,12 @@ export class Main extends React.Component {
         appContent = unableToFindRecordWarning;
         break;
       case 'noChapter33Record':
-        appContent = noChapter33BenefitsWarning();
+        /*
+          Temporarily replace noChapter33BenefitsWarning() with systemDown.
+          See: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/7677
+        */
+        // appContent = noChapter33BenefitsWarning();
+        appContent = systemDownMessage;
         break;
       case 'unavailable':
       default:

--- a/test/post-911-gib-status/containers/Main.unit.spec.jsx
+++ b/test/post-911-gib-status/containers/Main.unit.spec.jsx
@@ -45,10 +45,20 @@ describe('Main', () => {
     expect(tree.subTree('#recordNotFound')).to.be.ok;
   });
 
-  it('should show record not found warning', () => {
+  /* 
+    Temporarily switch out record not found and replace with System Down
+    See: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/7677
+  */
+  // it('should show record not found warning', () => {
+  //   const props = _.merge({}, defaultProps, { availability: 'noChapter33Record' });
+  //   const tree = SkinDeep.shallowRender(<Main {...props}/>);
+  //   expect(tree.subTree('#noChapter33Benefits')).to.be.ok;
+  // });
+
+  it('should show System Down warning when record not found', () => {
     const props = _.merge({}, defaultProps, { availability: 'noChapter33Record' });
     const tree = SkinDeep.shallowRender(<Main {...props}/>);
-    expect(tree.subTree('#noChapter33Benefits')).to.be.ok;
+    expect(tree.subTree('#systemDownMessage')).to.be.ok;
   });
 
   it('should show system down message when service is unavailable', () => {


### PR DESCRIPTION
Replaces 'Record Not Found' error message in GIBS app (which happens when `vet_not_found` causes `vets-api` to return a 404 to the front end) with a 'System Down' error message.