### PR TITLE
Add banner to GIBS info page

### DIFF
--- a/content/includes/gibs-down.html
+++ b/content/includes/gibs-down.html
@@ -1,0 +1,7 @@
+<div id="top-of-page-alert-container">
+  <div id="top-of-page-alert" class="usa-alert usa-alert-warning">
+    <div class="usa-alert-body">
+      <p class="usa-alert-text">We’re sorry. Something’s not working quite right with the GI Bill benefits tool. We’re working to fix the problem. If you encounter any errors, please try again later.</p>
+    </div>
+  </div>
+</div>

--- a/content/includes/homepage-warning.html
+++ b/content/includes/homepage-warning.html
@@ -1,5 +1,5 @@
-<div id="hurricane-warning-container">
-  <div id="hurricane-warning" class="usa-alert usa-alert-warning">
+<div id="top-of-page-alert-container">
+  <div id="top-of-page-alert" class="usa-alert usa-alert-warning">
       <div class="usa-alert-body">
           <h4 class="usa-alert-heading">Some Vets.gov tools may not be working</h4>
           <p class="usa-alert-text">

--- a/content/layouts/page-breadcrumbs.html
+++ b/content/layouts/page-breadcrumbs.html
@@ -1,5 +1,9 @@
 {% include "content/includes/header.html" %}
 
+{% if gibsAlert %}
+  {% include "content/includes/gibs-down.html" %}
+{% endif %}
+
 {% include "content/includes/breadcrumbs.html" %}
 
 <div id="content" class="interior {{ id }}">

--- a/content/pages/education/gi-bill/post-9-11.md
+++ b/content/pages/education/gi-bill/post-9-11.md
@@ -4,6 +4,7 @@ template: detail-page
 title: Post-9/11 GI Bill
 plainlanguage: 12-01-16 certified in compliance with the Plain Writing Act now
 concurrence: complete
+gibsAlert: true
 order: 3
 ---
 

--- a/src/sass/_shame.scss
+++ b/src/sass/_shame.scss
@@ -245,14 +245,14 @@ form {
 
 // .usa-alert shame moved to _m_alert.scss
 
-#hurricane-warning-container {
+#top-of-page-alert-container {
 
   width: 100%;
   background-color: $color-gibill-accent;
 
 }
 
-#hurricane-warning {
+#top-of-page-alert {
 
   max-width: 62.5em;
   margin: 0 auto;


### PR DESCRIPTION
This adds a banner to `/education/gi-bill/post-9-11/` to indicate that we're having some problems. I wanted to reuse the same styling we've used for the homepage banner, but it had the id `#hurricane-warning`, so I just renamed that. Included below is the screenshot of the homepage warning banner to show it didn't get messed up.

When we go to remove that banner, we shouldn't just revert this. I think it makes sense to keep the `#hurricane-warning` --> `#top-of-page-alert` rename (even if it isn't the best name).

**Note:** This banner only shows up on the one page--it's not inside `/education/gi-bill/post-9-11/ch-33-benefit`. They'll just get the system down error message if it's not working for them.

## Post-9/11 GI bill warning banner
![image](https://user-images.githubusercontent.com/12970166/34801912-cd8671b8-f61f-11e7-84ff-b64f9762e292.png)


## Other pages don't have it
![image](https://user-images.githubusercontent.com/12970166/34801928-e1b1c4bc-f61f-11e7-8a53-adc26aac92d3.png)


## Homepage warning banner is unaffected
![image](https://user-images.githubusercontent.com/12970166/34801937-f244d774-f61f-11e7-871d-7d7534474778.png)
