### PR TITLE
Fix lint warnings

### DIFF
--- a/src/sass/base/_b-utils.scss
+++ b/src/sass/base/_b-utils.scss
@@ -56,7 +56,7 @@
     background: $color-link-default-hover;
   }
   &:focus {
-		outline: 2px dotted #aeb0b5;
+		outline: 2px dotted $color-gray-light;
 		outline-offset: 3px;
   }
 }

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -694,7 +694,7 @@ h1:focus {
       border: 4px solid $color-white;
       border-radius: 50%;
       color: $color-green;
-      content: '\2022';
+      content: "\2022";
       display: block;
       float: left;
       font-size: .8em;

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -1,7 +1,7 @@
-@import 'shared-variables';
-@import 'modules/m-form-process';
-@import 'modules/m-progress-bar';
-@import 'modules/m-schemaform';
+@import "shared-variables";
+@import "modules/m-form-process";
+@import "modules/m-progress-bar";
+@import "modules/m-schemaform";
 @mixin schemaform-padding {
   // query borrowed from _m-schemaform.scss
   @media(max-width: 40.063em) {
@@ -132,7 +132,7 @@
   }
 
   th {
-    [scope='row'] {
+    [scope="row"] {
       padding-bottom: 0;
       padding-top: 0;
     }

--- a/src/sass/modules/_m-alert.scss
+++ b/src/sass/modules/_m-alert.scss
@@ -34,7 +34,7 @@
   padding-bottom: 1.2em;
 
   .usa-alert-body {
-    display:table-cell;
+    display: table-cell;
     vertical-align: middle;
   //  border:1px solid pink;
   }
@@ -54,7 +54,7 @@
     }
 
     ul {
-      padding-left:2rem;
+      padding-left: 2rem;
     }
   }
 }
@@ -65,20 +65,20 @@
 
 // on post-9/11 GI Bill
 p.usa-alert-heading {
-  margin-top:0;
+  margin-top: 0;
 }
 
 .usa-alert-body, .usa-alert-header {
   > h3:first-child, > h4:first-child, > h5:first-child {
     margin-top: .5rem;
-    padding-top:0;
+    padding-top: 0;
   }
   padding-left: 2.2rem;
 
   h3, h4, h5 {
-    font-size:1.7rem;
-    margin-top:.5rem;
-    padding-top:0;
+    font-size: 1.7rem;
+    margin-top: .5rem;
+    padding-top: 0;
   }
 }
 

--- a/src/sass/post-911-gib-status.scss
+++ b/src/sass/post-911-gib-status.scss
@@ -88,7 +88,7 @@
       a {
         text-decoration: none;
         &:after {
-          content:" (https://vets.gov" attr(href) ")";
+          content: " (https://vets.gov" attr(href) ")";
         }
       }
 


### PR DESCRIPTION
Does what it says on the tin - adds missing whitespaces, changes single to double quotes, and swaps a color literal for a variable.