### PR TITLE
Add GIBS alert banner to eligibility and gi-bill education pages

### DIFF
--- a/content/pages/education/eligibility.md
+++ b/content/pages/education/eligibility.md
@@ -12,6 +12,7 @@ widgets:
     loadingMessage: Checking your application status.
     errorMessage: <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br/>Please try refreshing your browser in a few minutes.
 description: Get help paying for college or other training. Find out if you qualify for VA education benefits through the GI Bill and other educational assistance programs.
+gibsAlert: true
 ---
 <div itemscope itemtype="http://schema.org/FAQPage">
 <div class="va-introtext" itemprop="description" >

--- a/content/pages/education/gi-bill.md
+++ b/content/pages/education/gi-bill.md
@@ -7,6 +7,7 @@ plainlanguage: 11-29-16 certified in compliance with the Plain Writing Act
 collection: education
 children: educationGIBill
 order: 4
+gibsAlert: true
 majorlinks:
   - heading: Post-9/11 GI Bill Benefits
     links:


### PR DESCRIPTION
Adds GIBS warning banner to two more content pages (which should now cover all the pages where there is a link to the GIBS app). See https://github.com/department-of-veterans-affairs/vets-website/pull/7080 for initial PR and https://github.com/department-of-veterans-affairs/vets.gov-team/issues/7677 for the initial issue. 

Screenshots:
<img width="1654" alt="screen shot 2018-01-11 at 10 17 43 am" src="https://user-images.githubusercontent.com/24251447/34835385-43e8e594-f6ba-11e7-840e-e4b4ade3aa6f.png">

<img width="1651" alt="screen shot 2018-01-11 at 10 17 53 am" src="https://user-images.githubusercontent.com/24251447/34835384-43a8d256-f6ba-11e7-8092-4ebcc8fb7246.png">
