### PR TITLE
Appeals timestamp mg

### DIFF
--- a/src/js/claims-status/components/appeals-v2/AppealHeader.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealHeader.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+
+const AppealHeader = ({ heading, lastUpdated }) => {
+  moment.updateLocale('en', {
+    meridiem: (hour) => {
+      if (hour < 12) {
+        return 'a.m.';
+      }
+      return 'p.m.';
+    },
+  });
+
+  const formattedDateTime = moment(lastUpdated).format('MMMM DD, YYYY, [at] h:mm a [(ET)]');
+  const description = `Up to date as of ${formattedDateTime}`;
+
+  return (
+    <div className="appeal-header">
+      <h1>{heading}</h1>
+      <p>{description}</p>
+    </div>
+  );
+};
+
+AppealHeader.propTypes = {
+  heading: PropTypes.string.isRequired,
+  lastUpdated: PropTypes.string.isRequired,
+};
+
+export default AppealHeader;

--- a/src/js/claims-status/components/appeals-v2/AppealHeader.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealHeader.jsx
@@ -12,7 +12,10 @@ const AppealHeader = ({ heading, lastUpdated }) => {
     },
   });
 
-  const formattedDateTime = moment(lastUpdated).format('MMMM DD, YYYY, [at] h:mm a [(ET)]');
+  const formattedDateTime = moment(lastUpdated)
+    .utc() // ignore user's own UTC offset (timezone)
+    .utcOffset(lastUpdated) // display lastUpdated's own timezone to everyone
+    .format('MMMM DD, YYYY, [at] h:mm a [(ET)]');
   const description = `Up to date as of ${formattedDateTime}`;
 
   return (

--- a/src/js/claims-status/components/appeals-v2/AppealNotFound.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealNotFound.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+const AppealNotFound = () => {
+  return (
+    <div className="row">
+      <h1>Sorry, we couldn't find that appeal.</h1>
+      <Link to="your-claims">Go back to your claims and appeals</Link>
+    </div>
+  );
+};
+
+export default AppealNotFound;

--- a/src/js/claims-status/components/appeals-v2/AppealNotFound.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealNotFound.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 const AppealNotFound = () => {
   return (
     <div className="row">
-      <h1>Sorry, we couldn't find that appeal.</h1>
+      <h1>Sorry, we couldn’t find that appeal.</h1>
       <Link to="your-claims">Go back to your claims and appeals</Link>
     </div>
   );

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -6,73 +6,96 @@ import { Link } from 'react-router';
 import moment from 'moment';
 
 import Breadcrumbs from '../components/Breadcrumbs';
+import LoadingIndicator from '../../common/components/LoadingIndicator';
+import AppealNotFound from '../components/appeals-v2/AppealNotFound';
+import { getAppealsV2 } from '../actions/index.jsx';
+import AppealHeader from '../components/appeals-v2/AppealHeader';
 import AppealsV2TabNav from '../components/appeals-v2/AppealsV2TabNav';
 import AppealHelpSidebar from '../components/appeals-v2/AppealHelpSidebar';
 
-import { EVENT_TYPES } from '../utils/appeals-v2-helpers';
+import { EVENT_TYPES, isolateAppeal } from '../utils/appeals-v2-helpers';
 
-function isolateAppeal(state, id) {
-  const claimsState = state.disability.status;
-  const { appeals } = claimsState.claims;
-  const appeal = appeals.find(a => a.id === id);
-
-  // append starting event for post-remand and post-cavc remand appeals
-  // NOTE: This is business logic pulled from v1 that we don't fully understand yet.
-  //  Also, having this logic in mapStateToProps is less than ideal; we want to
-  //  move it out when we know where it should live. Maybe just a helper.
-  if (appeal && appeal.attributes.type !== 'original' && appeal.attributes.prior_decision_date) {
-    appeal.attributes.events.unshift({
-      type: appeal.attributes.type === 'post_cavc_remand' ? 'cavc_decision' : 'bva_remand',
-      date: appeal.attributes.prior_decision_date,
-    });
+export class AppealInfo extends React.Component {
+  componentDidMount() {
+    if (!this.props.appeal) {
+      this.props.getAppealsV2();
+    }
   }
 
-  return appeal;
-}
-
-export function AppealInfo({ params, appeal, children }) {
-  const appealId = params.id;
-  const firstClaim = appeal ? appeal.attributes.events.find(a => a.type === EVENT_TYPES.claim) : null;
-  const appealDate = firstClaim ? moment(firstClaim.date, 'YYYY-MM-DD').format(' MMMM YYYY') : '';
-  // Space is part of appealDate to ensure we don't have a trailing space if there is no firstClaim
-  const claimHeading = `Appeal of Claim Decision${appealDate}`;
-  return (
-    <div>
-      <div className="row">
-        <Breadcrumbs>
-          <li><Link to="your-claims">Your Claims and Appeals</Link></li>
-          <li><strong>{claimHeading}</strong></li>
-        </Breadcrumbs>
-      </div>
-      <div className="row">
-        <h1>{claimHeading}</h1>
-      </div>
-      <div className="row">
-        <div className="medium-8 columns">
-          <AppealsV2TabNav
-            appealId={appealId}/>
-          <div className="va-tab-content va-appeals-content">
-            {React.Children.map(children, child => React.cloneElement(child, { appeal }))}
+  render() {
+    const { params, appeal, appealsLoading, children } = this.props;
+    let appealContent;
+    if (appeal) {
+      const appealId = params.id;
+      const firstClaim = appeal.attributes.events.find(a => a.type === EVENT_TYPES.claim);
+      const appealDate = firstClaim ? moment(firstClaim.date, 'YYYY-MM-DD').format(' MMMM YYYY') : '';
+      // Space is part of appealDate to ensure we don't have a trailing space if there is no firstClaim
+      const claimHeading = `Appeal of Claim Decision${appealDate}`;
+      appealContent = (
+        <div>
+          <div className="row">
+            <Breadcrumbs>
+              <li><Link to="your-claims">Your Claims and Appeals</Link></li>
+              <li><strong>{claimHeading}</strong></li>
+            </Breadcrumbs>
+          </div>
+          <div className="row">
+            <AppealHeader
+              heading={claimHeading}
+              lastUpdated={appeal.attributes.updated}/>
+          </div>
+          <div className="row">
+            <div className="medium-8 columns">
+              <AppealsV2TabNav
+                appealId={appealId}/>
+              <div className="va-tab-content va-appeals-content">
+                {React.Children.map(children, child => React.cloneElement(child, { appeal }))}
+              </div>
+            </div>
+            <div className="medium-4 columns help-sidebar">
+              {appeal && <AppealHelpSidebar location={appeal.attributes.location} aoj={appeal.attributes.aoj}/>}
+            </div>
           </div>
         </div>
-        <div className="medium-4 columns help-sidebar">
-          {appeal && <AppealHelpSidebar location={appeal.attributes.location} aoj={appeal.attributes.aoj}/>}
-        </div>
-      </div>
-    </div>
-  );
+      );
+    } else if (appealsLoading) {
+      appealContent = <LoadingIndicator message="Please wait while we load your appeal..."/>;
+    } else {
+      // Appeals finished loading but appeal not found, so the ID passed in the params
+      // doesn't match any appeals in Redux appeals array (at least not for this user)
+      // TO-DO: Get input from content team
+      appealContent = <AppealNotFound/>;
+    }
+
+    return (appealContent);
+  }
 }
 
 AppealInfo.propTypes = {
   params: PropTypes.shape({ id: PropTypes.string.isRequired }).isRequired,
-  children: PropTypes.object.isRequired
+  children: PropTypes.node.isRequired,
+  appealsLoading: PropTypes.bool.isRequired,
+  appeal: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    attributes: PropTypes.object.isRequired,
+  })
 };
 
 function mapStateToProps(state, ownProps) {
+  const { appealsLoading } = state.disability.status.appeals;
+  // appealsLoading is not initialized in Redux, it's added once fetch starts. We
+  // need it to be available immediately to know whether to show the loading spinner
+  const computedLoading = (typeof appealsLoading === 'undefined')
+    ? true
+    : appealsLoading;
   return {
-    appeal: isolateAppeal(state, ownProps.params.id)
+    appeal: isolateAppeal(state, ownProps.params.id),
+    appealsLoading: computedLoading,
   };
 }
 
-export default connect(mapStateToProps)(AppealInfo);
+const mapDispatchToProps = { getAppealsV2 };
+
+export default connect(mapStateToProps, mapDispatchToProps)(AppealInfo);
 

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -98,4 +98,3 @@ function mapStateToProps(state, ownProps) {
 const mapDispatchToProps = { getAppealsV2 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(AppealInfo);
-

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -22,15 +22,21 @@ export class AppealInfo extends React.Component {
     }
   }
 
+  createHeading = () => {
+    const firstClaim = this.props.appeal.attributes.events.find(a => a.type === EVENT_TYPES.claim);
+    const appealDate = firstClaim ? moment(firstClaim.date, 'YYYY-MM-DD').format(' MMMM YYYY') : '';
+    return `Appeal of Claim Decision${appealDate}`;
+  }
+
   render() {
     const { params, appeal, appealsLoading, children } = this.props;
     let appealContent;
     if (appeal) {
-      const appealId = params.id;
-      const firstClaim = appeal.attributes.events.find(a => a.type === EVENT_TYPES.claim);
-      const appealDate = firstClaim ? moment(firstClaim.date, 'YYYY-MM-DD').format(' MMMM YYYY') : '';
-      // Space is part of appealDate to ensure we don't have a trailing space if there is no firstClaim
-      const claimHeading = `Appeal of Claim Decision${appealDate}`;
+      // const firstClaim = appeal.attributes.events.find(a => a.type === EVENT_TYPES.claim);
+      // const appealDate = firstClaim ? moment(firstClaim.date, 'YYYY-MM-DD').format(' MMMM YYYY') : '';
+      // // Space is part of appealDate to ensure we don't have a trailing space if there is no firstClaim
+      // const claimHeading = `Appeal of Claim Decision${appealDate}`;
+      const claimHeading = this.createHeading();
       appealContent = (
         <div>
           <div className="row">
@@ -47,7 +53,7 @@ export class AppealInfo extends React.Component {
           <div className="row">
             <div className="medium-8 columns">
               <AppealsV2TabNav
-                appealId={appealId}/>
+                appealId={params.id}/>
               <div className="va-tab-content va-appeals-content">
                 {React.Children.map(children, child => React.cloneElement(child, { appeal }))}
               </div>

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -32,10 +32,6 @@ export class AppealInfo extends React.Component {
     const { params, appeal, appealsLoading, children } = this.props;
     let appealContent;
     if (appeal) {
-      // const firstClaim = appeal.attributes.events.find(a => a.type === EVENT_TYPES.claim);
-      // const appealDate = firstClaim ? moment(firstClaim.date, 'YYYY-MM-DD').format(' MMMM YYYY') : '';
-      // // Space is part of appealDate to ensure we don't have a trailing space if there is no firstClaim
-      // const claimHeading = `Appeal of Claim Decision${appealDate}`;
       const claimHeading = this.createHeading();
       appealContent = (
         <div>

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 
-import { getAppealsV2 } from '../actions/index.jsx';
 import { getStatusContents, getNextEvents } from '../utils/appeals-v2-helpers';
 
-import LoadingIndicator from '../../common/components/LoadingIndicator';
 import Timeline from '../components/appeals-v2/Timeline';
 import CurrentStatus from '../components/appeals-v2/CurrentStatus';
 import Alerts from '../components/appeals-v2/Alerts';
@@ -13,74 +10,39 @@ import WhatsNext from '../components/appeals-v2/WhatsNext';
 import Docket from '../components/appeals-v2/Docket';
 
 /**
- * AppealsV2StatusPage is in charge of the layout of the status page and is the source of truth
- * for the redux state. All child components shouldn't need to be connected to the store.
+ * AppealsV2StatusPage is in charge of the layout of the status page
  */
-class AppealsV2StatusPage extends React.Component {
-  componentDidMount() {
-    // Make sure we grab the appeals if we don't have them already
-    // Useful if the user goes directly to the appeal status without going to the list first
-    if (this.props.appeal === AppealsV2StatusPage.defaultProps.appeal) {
-      this.props.getAppealsV2();
-    }
-  }
-
-  render() {
-    if (this.props.appealsLoading) {
-      return <LoadingIndicator message="Please wait while we load your appeal..."/>;
-    }
-    const { events, alerts, status } = this.props.appeal.attributes;
-    const { type, details } = status;
-    const currentStatus = getStatusContents(type, details);
-    const nextEvents = getNextEvents(type);
-    return (
-      <div>
-        <Timeline events={events}/>
-        <CurrentStatus
-          title={currentStatus.title}
-          description={currentStatus.description}/>
-        <Alerts alerts={alerts}/>
-        <WhatsNext nextEvents={nextEvents}/>
-        <Docket/>
-      </div>
-    );
-  }
-}
-
-AppealsV2StatusPage.defaultProps = {
-  appeal: {
-    id: '',
-    type: '',
-    attributes: {
-      events: [],
-      alerts: [],
-      status: {
-        type: '',
-        details: {}
-      }
-    }
-  }
+const AppealsV2StatusPage = ({ appeal }) => {
+  const { events, alerts, status } = appeal.attributes;
+  const { type, details } = status;
+  const currentStatus = getStatusContents(type, details);
+  const nextEvents = getNextEvents(type);
+  return (
+    <div>
+      <Timeline events={events}/>
+      <CurrentStatus
+        title={currentStatus.title}
+        description={currentStatus.description}/>
+      <Alerts alerts={alerts}/>
+      <WhatsNext nextEvents={nextEvents}/>
+      <Docket/>
+    </div>
+  );
 };
 
 AppealsV2StatusPage.propTypes = {
-  params: PropTypes.shape({ id: PropTypes.string.isRequired }).isRequired,
   appeal: PropTypes.shape({
     id: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
-    attributes: PropTypes.object.isRequired, // Can flesh this out later
+    attributes: PropTypes.shape({
+      events: PropTypes.array,
+      alerts: PropTypes.array,
+      status: PropTypes.shape({
+        type: PropTypes.string,
+        details: PropTypes.object,
+      }).isRequired
+    }).isRequired,
   })
 };
 
-
-function mapStateToProps(state) {
-  return {
-    appealsLoading: state.disability.status.appeals.appealsLoading,
-  };
-}
-
-const mapDispatchToProps = {
-  getAppealsV2
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(AppealsV2StatusPage);
-
+export default AppealsV2StatusPage;

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import _ from 'lodash';
 
 // TO DO: Replace made up properties and content with real versions once finalized.
 export const STATUS_TYPES = {
@@ -17,6 +18,16 @@ export const ALERT_TYPES = {
   hearingScheduled: 'hearing_scheduled',
   bvaDecisionPending: 'bva_decision_pending'
 };
+
+/**
+ * Finds an appeal from the Redux store with ID matching arg ID
+ * @param {object} state Full redux store state tree
+ * @param {string} id Appeal ID of the appeal to find
+ * @returns {object} One appeal object or undefined if not found in the array
+ */
+export function isolateAppeal(state, id) {
+  return _.find(state.disability.status.claims.appeals, (a) => a.id === id);
+}
 
 export function formatDate(date) {
   return moment(date, 'YYYY-MM-DD').format('MMMM DD, YYYY');

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -252,6 +252,7 @@ export const mockData = {
       id: '7387389',
       type: 'appealSeries',
       attributes: {
+        updated: '2018-01-03T09:30:15-05:00',
         active: true,
         incompleteHistory: false,
         aoj: 'vba',
@@ -318,6 +319,7 @@ export const mockData = {
       id: '7387390',
       type: 'appealSeries',
       attributes: {
+        updated: '2018-01-03T09:30:15-05:00',
         active: true,
         incompleteHistory: false,
         aoj: 'vba',
@@ -394,6 +396,7 @@ export const mockData = {
       id: '7387391',
       type: 'appealSeries',
       attributes: {
+        updated: '2018-01-03T09:30:15-05:00',
         active: true,
         incompleteHistory: false,
         aoj: 'vba',

--- a/test/claims-status/components/appeals-v2/AppealHeader.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/AppealHeader.unit.spec.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import AppealHeader from '../../../../src/js/claims-status/components/appeals-v2/AppealHeader';
+
+describe('<AppealHeader/>', () => {
+  const defaultProps = {
+    heading: 'Some heading text',
+    lastUpdated: '2018-01-03T09:30:15-05:00',
+  };
+
+  const formattedUpdateTime = 'Up to date as of January 03, 2018, at 8:30 a.m. (ET)';
+
+  it('renders', () => {
+    const wrapper = shallow(<AppealHeader {...defaultProps}/>);
+    expect(wrapper.type()).to.equal('div');
+  });
+
+  it('renders the heading text passed in as a prop', () => {
+    const wrapper = shallow(<AppealHeader {...defaultProps}/>);
+    expect(wrapper.find('h1').text()).to.equal(defaultProps.heading);
+  });
+
+  it('renders a last updated <p/> with a formatted date and time', () => {
+    const wrapper = shallow(<AppealHeader {...defaultProps}/>);
+    expect(wrapper.find('p').text()).to.equal(formattedUpdateTime);
+  });
+});

--- a/test/claims-status/components/appeals-v2/AppealHeader.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/AppealHeader.unit.spec.jsx
@@ -9,7 +9,7 @@ describe('<AppealHeader/>', () => {
     lastUpdated: '2018-01-03T09:30:15-05:00',
   };
 
-  const formattedUpdateTime = 'Up to date as of January 03, 2018, at 8:30 a.m. (ET)';
+  const formattedDate = 'Up to date as of January 03, 2018, at 9:30 a.m. (ET)';
 
   it('renders', () => {
     const wrapper = shallow(<AppealHeader {...defaultProps}/>);
@@ -23,6 +23,6 @@ describe('<AppealHeader/>', () => {
 
   it('renders a last updated <p/> with a formatted date and time', () => {
     const wrapper = shallow(<AppealHeader {...defaultProps}/>);
-    expect(wrapper.find('p').text()).to.equal(formattedUpdateTime);
+    expect(wrapper.find('p').text()).to.equal(formattedDate);
   });
 });

--- a/test/claims-status/components/appeals-v2/AppealInfo.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/AppealInfo.unit.spec.jsx
@@ -9,7 +9,8 @@ const appealIdParam = mockData.data[0].id;
 
 const defaultProps = {
   params: { id: appealIdParam },
-  appeal: mockData.data[0]
+  appeal: mockData.data[0],
+  appealsLoading: false,
 };
 
 describe('<AppealInfo/>', () => {
@@ -18,13 +19,26 @@ describe('<AppealInfo/>', () => {
     expect(wrapper.type()).to.equal('div');
   });
 
+  it('should render LoadingIndicator when appeals loading', () => {
+    const props = { params: { id: appealIdParam }, appealsLoading: true };
+    const wrapper = shallow(<AppealInfo {...props}/>, { disableLifecycleMethods: true });
+    const loadingIndicator = wrapper.find('LoadingIndicator');
+    expect(loadingIndicator.length).to.equal(1);
+  });
+
   it('should render the breadcrumbs', () => {
     const wrapper = shallow(<AppealInfo {...defaultProps}/>);
     const breadcrumbs = wrapper.find('Breadcrumbs');
     expect(breadcrumbs.length).to.equal(1);
   });
 
-  it('should display a tabbed navigator', () => {
+  it('should render a header', () => {
+    const wrapper = shallow(<AppealInfo {...defaultProps}/>);
+    const header = wrapper.find('AppealHeader');
+    expect(header.length).to.equal(1);
+  });
+
+  it('should render a tabbed navigator', () => {
     const wrapper = shallow(<AppealInfo {...defaultProps}/>);
     const tabNavs = wrapper.find('AppealsV2TabNav');
     expect(tabNavs.length).to.equal(1);

--- a/test/claims-status/components/appeals-v2/AppealNotFound.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/AppealNotFound.unit.spec.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import AppealNotFound from '../../../../src/js/claims-status/components/appeals-v2/AppealNotFound';
+
+describe('<AppealNotFound/>', () => {
+  it('renders', () => {
+    const wrapper = shallow(<AppealNotFound/>);
+    expect(wrapper.type()).to.equal('div');
+  });
+
+  it('renders a heading', () => {
+    const wrapper = shallow(<AppealNotFound/>);
+    expect(wrapper.find('h1').length).to.equal(1);
+  });
+
+  it('renders a React Router link back to claims page', () => {
+    const wrapper = shallow(<AppealNotFound/>);
+    expect(wrapper.find('Link').length).to.equal(1);
+  });
+});


### PR DESCRIPTION
- Adds appeal last updated timestamp under the appeal heading
- Updated associated tests

Unfortunately, to accomplish this, several much larger changes got pushed into this PR:
- Consolidates loading indicators - there's just one now, and it's in `AppealsInfo`
- v2Status page was disconnected
- New render logic for `AppealInfo`, which will now display an error if the appeal in the params isn't found in the store

Screengrab:
<img width="1284" alt="screen shot 2018-01-12 at 4 36 14 pm" src="https://user-images.githubusercontent.com/24251447/34898069-bfdfbd10-f7b6-11e7-8977-d2d6ce704773.png">

