### PR TITLE
Improve messaging when user is removed from a health care team

### DIFF
--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { intersection } from 'lodash';
 
 import LoadingIndicator from '../../common/components/LoadingIndicator';
+import AlertBox from '../../common/components/AlertBox';
 
 import {
   addDraftAttachments,
@@ -304,12 +305,15 @@ export class Thread extends React.Component {
   renderHealthCareTeamNotice(shouldShow) {
     if (shouldShow) {
       return (
-        <div>
-          <h4>Health care team has changed</h4>
-          <p>
-            You are no longer associated with this health care team and cannot reply to this message. Please contact the help desk at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY: <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET) if you have any questions.
-          </p>
-        </div>
+        <AlertBox
+          content={<div>
+            <h4 className="usa-alert-heading">Health care team has changed</h4>
+            <p>
+              You are no longer associated with this health care team and cannot reply to this message. Please contact the help desk at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY: <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET) if you have any questions.
+            </p>
+          </div>}
+          isVisible
+          status="warning"/>
       );
     }
     return null;

--- a/src/js/messaging/containers/Thread.jsx
+++ b/src/js/messaging/containers/Thread.jsx
@@ -301,8 +301,8 @@ export class Thread extends React.Component {
     return form;
   }
 
-  renderNotice(disabled = false) {
-    if (disabled) {
+  renderHealthCareTeamNotice(shouldShow) {
+    if (shouldShow) {
       return (
         <div>
           <h4>Health care team has changed</h4>
@@ -312,8 +312,7 @@ export class Thread extends React.Component {
         </div>
       );
     }
-
-    return <NoticeBox/>;
+    return null;
   }
 
   render() {
@@ -400,9 +399,10 @@ export class Thread extends React.Component {
               Send
             </button>
           </div>
+          {this.renderHealthCareTeamNotice(disabled)}
           {form}
         </div>
-        {this.renderNotice(disabled)}
+        {!disabled && <NoticeBox/>}
         <ModalConfirmDelete
           cssClass="messaging-modal"
           onClose={this.props.toggleConfirmDelete}


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/5723

Separates out notice box from health care team warning.
Adds use of AlertBox for better visibility when health care team is changed.