### PR TITLE
Appeals V2 -- Docket

### DIFF
--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+// TODO: Depending on when this gets rendered, we may want to return null if either
+//  `ahead` or `total` don't exist (or if `total` === 0 because of the divide by 0  error)
 function Docket({ ahead, total }) {
   const completedWidth = { width: `${((total - ahead) / total) * 100}%` };
 
   // TODO: Assess how accessible this is
   return (
     <div className="docket-container">
-      <span className="appeals-ahead">{ahead.toLocaleString()}</span>
+      <p className="appeals-ahead">{ahead.toLocaleString()}</p>
       <p>Appeals ahead of you</p>
 
       <div className="marker-container">

--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 class Docket extends React.Component {
   render() {
-    const { ahead, ready } = this.props;
+    const { ahead, total } = this.props;
 
     // TODO: Assess how accessible this is
     return (
@@ -10,7 +10,7 @@ class Docket extends React.Component {
         <span className="appeals-ahead">{ahead.toLocaleString()}</span>
         <p>Appeals ahead of you</p>
         <div className="docket-bar">
-          <div className="completed" style={{ width: `${ahead / ready}%` }}/>
+          <div className="completed" style={{ width: `${(ahead / total) * 100}%` }}/>
         </div>
       </div>
     );

--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -1,42 +1,39 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class Docket extends React.Component {
-  render() {
-    const { ahead, total } = this.props;
-    const completedWidth = { width: `${((total - ahead) / total) * 100}%` };
+function Docket({ ahead, total }) {
+  const completedWidth = { width: `${((total - ahead) / total) * 100}%` };
 
-    // TODO: Assess how accessible this is
-    return (
-      <div className="docket-container">
-        <span className="appeals-ahead">{ahead.toLocaleString()}</span>
-        <p>Appeals ahead of you</p>
+  // TODO: Assess how accessible this is
+  return (
+    <div className="docket-container">
+      <span className="appeals-ahead">{ahead.toLocaleString()}</span>
+      <p>Appeals ahead of you</p>
 
-        <div className="marker-container">
-          <div>
-            <div className="marker-text-spacer" style={completedWidth}/>
-            <span className="marker-text">You are here</span>
-          </div>
-          <div>
-            <div className="spacer" style={completedWidth}/>
-            <div className="marker">
-              <img src="/img/Docket-line-pin.svg" alt=""/>
-            </div>
-          </div>
-        </div>
-
+      <div className="marker-container">
         <div>
-          <div className="docket-bar">
-            <div className="completed" style={completedWidth}/>
-          </div>
-          <div className="end-of-docket"/>
+          <div className="marker-text-spacer" style={completedWidth}/>
+          <span className="marker-text">You are here</span>
         </div>
-
-        <div className="front-of-docket-text"><p>Front of docket line</p></div>
-        <p><strong>{total.toLocaleString()}</strong> total appeals on the docket</p>
+        <div>
+          <div className="spacer" style={completedWidth}/>
+          <div className="marker">
+            <img src="/img/Docket-line-pin.svg" alt=""/>
+          </div>
+        </div>
       </div>
-    );
-  }
+
+      <div>
+        <div className="docket-bar">
+          <div className="completed" style={completedWidth}/>
+        </div>
+        <div className="end-of-docket"/>
+      </div>
+
+      <div className="front-of-docket-text"><p>Front of docket line</p></div>
+      <p><strong>{total.toLocaleString()}</strong> total appeals on the docket</p>
+    </div>
+  );
 }
 
 Docket.propTypes = {

--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 class Docket extends React.Component {
   render() {
     const { ahead, total } = this.props;
-    // const { ahead, total } = { ahead: 0, total: 100 };
     const completedWidth = { width: `${((total - ahead) / total) * 100}%` };
 
     // TODO: Assess how accessible this is
@@ -11,19 +10,27 @@ class Docket extends React.Component {
       <div className="docket-container">
         <span className="appeals-ahead">{ahead.toLocaleString()}</span>
         <p>Appeals ahead of you</p>
+
         <div className="marker-container">
-          <div className="marker-spacer" style={completedWidth}/>
-          <div className="marker">
-            <p>You are here</p>
-            <img src="/img/Docket-line-pin.svg" alt=""/>
+          <div>
+            <div className="marker-text-spacer" style={completedWidth}/>
+            <span className="marker-text">You are here</span>
+          </div>
+          <div>
+            <div className="spacer" style={completedWidth}/>
+            <div className="marker">
+              <img src="/img/Docket-line-pin.svg" alt=""/>
+            </div>
           </div>
         </div>
+
         <div>
           <div className="docket-bar">
             <div className="completed" style={completedWidth}/>
           </div>
           <div className="end-of-docket"/>
         </div>
+
         <div className="front-of-docket-text"><p>Front of docket line</p></div>
         <p><strong>{total.toLocaleString()}</strong> total appeals on the docket</p>
       </div>

--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class Docket extends React.Component {
   render() {
@@ -37,6 +38,11 @@ class Docket extends React.Component {
     );
   }
 }
+
+Docket.propTypes = {
+  ahead: PropTypes.number.isRequired,
+  total: PropTypes.number.isRequired
+};
 
 export default Docket;
 

--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -9,9 +9,14 @@ class Docket extends React.Component {
       <div className="docket-container">
         <span className="appeals-ahead">{ahead.toLocaleString()}</span>
         <p>Appeals ahead of you</p>
-        <div className="docket-bar">
-          <div className="completed" style={{ width: `${(ahead / total) * 100}%` }}/>
+        <div>
+          <div className="docket-bar">
+            <div className="completed" style={{ width: `${(ahead / total) * 100}%` }}/>
+          </div>
+          <div className="end-of-docket"/>
         </div>
+        <div className="front-of-docket-text"><p>Front of docket line</p></div>
+        <p><strong>{total.toLocaleString()}</strong> total appeals on the docket</p>
       </div>
     );
   }

--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -3,15 +3,24 @@ import React from 'react';
 class Docket extends React.Component {
   render() {
     const { ahead, total } = this.props;
+    // const { ahead, total } = { ahead: 0, total: 100 };
+    const completedWidth = { width: `${((total - ahead) / total) * 100}%` };
 
     // TODO: Assess how accessible this is
     return (
       <div className="docket-container">
         <span className="appeals-ahead">{ahead.toLocaleString()}</span>
         <p>Appeals ahead of you</p>
+        <div className="marker-container">
+          <div className="marker-spacer" style={completedWidth}/>
+          <div className="marker">
+            <p>You are here</p>
+            <img src="/img/Docket-line-pin.svg" alt=""/>
+          </div>
+        </div>
         <div>
           <div className="docket-bar">
-            <div className="completed" style={{ width: `${(ahead / total) * 100}%` }}/>
+            <div className="completed" style={completedWidth}/>
           </div>
           <div className="end-of-docket"/>
         </div>

--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -2,7 +2,18 @@ import React from 'react';
 
 class Docket extends React.Component {
   render() {
-    return (null);
+    const { ahead, ready } = this.props;
+
+    // TODO: Assess how accessible this is
+    return (
+      <div className="docket-container">
+        <span className="appeals-ahead">{ahead.toLocaleString()}</span>
+        <p>Appeals ahead of you</p>
+        <div className="docket-bar">
+          <div className="completed" style={{ width: `${ahead / ready}%` }}/>
+        </div>
+      </div>
+    );
   }
 }
 

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -13,7 +13,7 @@ import Docket from '../components/appeals-v2/Docket';
  * AppealsV2StatusPage is in charge of the layout of the status page
  */
 const AppealsV2StatusPage = ({ appeal }) => {
-  const { events, alerts, status } = appeal.attributes;
+  const { events, alerts, status, docket } = appeal.attributes;
   const { type, details } = status;
   const currentStatus = getStatusContents(type, details);
   const nextEvents = getNextEvents(type);
@@ -25,7 +25,7 @@ const AppealsV2StatusPage = ({ appeal }) => {
         description={currentStatus.description}/>
       <Alerts alerts={alerts}/>
       <WhatsNext nextEvents={nextEvents}/>
-      <Docket/>
+      <Docket {...docket}/>
     </div>
   );
 };

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -951,6 +951,8 @@ h1:focus {
 
 $end-of-docket-width: 4px;
 $docket-bar-width: calc(100% - #{$end-of-docket-width});
+$marker-width: 3rem;
+$marker-text-width: 9rem;
 
 .docket-container {
   // This is slightly darker than the cards above it
@@ -984,21 +986,27 @@ $docket-bar-width: calc(100% - #{$end-of-docket-width});
     width: $docket-bar-width;
     margin-bottom: -16px;
 
-    .marker-spacer {
+    .marker-text-spacer {
+      display: inline-block;
+      min-width: $marker-text-width / 2;
+      max-width: calc(100% - #{$marker-text-width} / 2);
+    }
+
+    .spacer {
       display: inline-block;
     }
 
     .marker {
-      display: inline-flex;
-      flex-direction: column;
-      align-items: center;
-      width: 9rem;
-      margin-left: -4.5rem;
+      display: inline-block;
+      width: $marker-width;
+      margin: 0px $marker-width / -2;
+    }
 
-      p {
-        font-weight: bold;
-        color: $color-primary;
-      }
+    span.marker-text {
+      font-weight: bold;
+      color: $color-primary;
+      width: $marker-text-width;
+      margin: 0px $marker-text-width / -2;
     }
   }
 

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -948,10 +948,15 @@ h1:focus {
   }
 }
 
+
+$end-of-docket-width: 4px;
+$docket-bar-width: calc(100% - #{$end-of-docket-width});
+
 .docket-container {
   // This is slightly darker than the cards above it
   background-color: $color-gray-light-alt;
   padding: 16px;
+  margin: 3em 0px;
 
   p {
     margin: 0px;
@@ -973,10 +978,34 @@ h1:focus {
     }
   }
 
+  .marker-container {
+    // Same width as .docket-bar so we can more easily line the marker
+    //  up with .docket-bar .completed
+    width: $docket-bar-width;
+    margin-bottom: -16px;
+
+    .marker-spacer {
+      display: inline-block;
+    }
+
+    .marker {
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      width: 9rem;
+      margin-left: -4.5rem;
+
+      p {
+        font-weight: bold;
+        color: $color-primary;
+      }
+    }
+  }
+
   .docket-bar {
     display: inline-block;
     // 100% - width of .end-of-docket
-    width: calc(100% - 4px);
+    width: $docket-bar-width;
     height: 40px;
     border: 1px solid $color-gray-light;
     // abuts the .end-of-docket
@@ -993,7 +1022,7 @@ h1:focus {
     display: inline-block;
     background-color: $color-gold;
     height: 64px;
-    width: 4px;
+    width: $end-of-docket-width;
   }
 
   .front-of-docket-text {

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -953,6 +953,10 @@ h1:focus {
   background-color: $color-gray-light-alt;
   padding: 16px;
 
+  p {
+    margin: 0px;
+  }
+
   span.appeals-ahead {
     display: block;
     font-family: Source Sans Pro, sans serif;
@@ -970,13 +974,35 @@ h1:focus {
   }
 
   .docket-bar {
+    display: inline-block;
+    // 100% - width of .end-of-docket
+    width: calc(100% - 4px);
     height: 40px;
     border: 1px solid $color-gray-light;
+    // abuts the .end-of-docket
+    border-right: 0px;
     background-color: $color-white;
 
     .completed {
       background-color: $color-primary-darker;
       height: 100%;
+    }
+  }
+
+  .end-of-docket {
+    display: inline-block;
+    background-color: $color-gold;
+    height: 64px;
+    width: 4px;
+  }
+
+  .front-of-docket-text {
+    display: flex;
+    flex-direction: row-reverse;
+
+    p {
+      width: 8rem;
+      text-align: right;
     }
   }
 }

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -964,8 +964,7 @@ $marker-text-width: 9rem;
     margin: 0px;
   }
 
-  span.appeals-ahead {
-    display: block;
+  .appeals-ahead {
     font-family: Source Sans Pro, sans serif;
     font-size: 26px;
     font-weight: bold;

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -948,3 +948,34 @@ h1:focus {
   }
 }
 
+.docket-container {
+  // This is slightly darker than the cards above it
+  background-color: $color-gray-light-alt;
+  padding: 16px;
+
+  span.appeals-ahead {
+    display: block;
+    font-family: Source Sans Pro, sans serif;
+    font-size: 26px;
+    font-weight: bold;
+    line-height: 1;
+    padding-bottom: 12px;
+    border-bottom: 1px solid $color-gray-light;
+    width: 80%;
+    max-width: 24rem;
+
+    & + p {
+      margin-top: 6px;
+    }
+  }
+
+  .docket-bar {
+    height: 40px;
+    border: 1px solid $color-gray-light;
+    background-color: $color-white;
+
+    .completed {
+      color: $color-primary-darker;
+    }
+  }
+}

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -975,7 +975,8 @@ h1:focus {
     background-color: $color-white;
 
     .completed {
-      color: $color-primary-darker;
+      background-color: $color-primary-darker;
+      height: 100%;
     }
   }
 }

--- a/test/claims-status/components/appeals-v2/Docket.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Docket.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('Appeals V2 Docket', () => {
 
   it('should show the number of appeals ahead of the appellant', () => {
     const wrapper = shallow(<Docket {...defaultProps}/>);
-    expect(wrapper.find('span.appeals-ahead').text()).to.equal('109,238');
+    expect(wrapper.find('.appeals-ahead').text()).to.equal('109,238');
   });
 
   it('should show the total number of appeals on the docket', () => {

--- a/test/claims-status/components/appeals-v2/Docket.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Docket.unit.spec.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import Docket from '../../../../src/js/claims-status/components/appeals-v2/Docket.jsx';
+
+const defaultProps = {
+  ahead: 109238,
+  total: 283941
+};
+
+describe('Appeals V2 Docket', () => {
+  it('should render', () => {
+    const wrapper = shallow(<Docket {...defaultProps}/>);
+    expect(wrapper.type()).to.equal('div');
+  });
+
+  it('should show the number of appeals ahead of the appellant', () => {
+    const wrapper = shallow(<Docket {...defaultProps}/>);
+    expect(wrapper.find('span.appeals-ahead').text()).to.equal('109,238');
+  });
+
+  it('should show the total number of appeals on the docket', () => {
+    const wrapper = shallow(<Docket {...defaultProps}/>);
+    expect(wrapper.find('.front-of-docket-text + p strong').first().text()).to.equal('283,941');
+  });
+
+  it('should show a visual representaton of where the appellant is in the line', () => {
+    const wrapper = shallow(<Docket {...defaultProps}/>);
+    const { ahead, total } = defaultProps;
+    const computedWidth = ((total - ahead) / total) * 100;
+    expect(wrapper.find('.spacer').first().prop('style').width).to.equal(`${computedWidth}%`);
+  });
+});


### PR DESCRIPTION
It was a little awkward to get the "You are here" text to not run off the screen but keep it aligned with the marker when it's in the middle of the bar, but other than that, it really wasn't bad. I feel like I leveled up my CSS skillz with this one.

**Note:** This does not address the accessibility concerns on this component. As it stands, this will be kind of an awkward reading for a screen reader, I think. We should address that in a separate ticket.

## Once upon a time
![image](https://user-images.githubusercontent.com/12970166/35070167-49e08340-fb91-11e7-8e26-9a4be90c6081.png)
The marker starts out uncomfortably far to the left, dipping into the left gutter. I'm not a huge fan of that, but the alternatives aren't great.

## Then we move along a bit
![image](https://user-images.githubusercontent.com/12970166/35070208-64f48172-fb91-11e7-9d76-5196090aa847.png)
Notice how the text stays to the left, aligned with the text above.

## Middle of the pack
![image](https://user-images.githubusercontent.com/12970166/35070325-c15ab1e8-fb91-11e7-9d62-9a39d24331c3.png)
The text is centered on the marker.

## The end is near!
![image](https://user-images.githubusercontent.com/12970166/35070367-eadc7254-fb91-11e7-9b02-15689ca085d8.png)
That's as far to the right as the text will go--don't want no cliff jumpers here!

## End of the line
![image](https://user-images.githubusercontent.com/12970166/35070026-e0554c80-fb90-11e7-8cfd-a21362c43538.png)
According to @cmgiven, :point_up: should never happen, so I'm not going to worry about the gold line overlapping the marker...Unless I should, then it's a simple `z-index: 1`.