### PR TITLE
Revert dev to deploy master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@ def envNames = ['development', 'staging', 'production']
 
 def isReviewable = {
   env.BRANCH_NAME != 'production' &&
-    env.BRANCH_NAME != 'user_feedback_footer_form-I3445' &&
     env.BRANCH_NAME != 'master'
 }
 
@@ -12,7 +11,6 @@ env.CONCURRENCY = 10
 
 def isDeployable = {
   (env.BRANCH_NAME == 'master' ||
-    env.BRANCH_NAME == 'user_feedback_footer_form-I3445' ||
     env.BRANCH_NAME == 'production') &&
     !env.CHANGE_TARGET &&
     !currentBuild.nextBuild   // if there's a later build on this job (branch), don't deploy
@@ -32,7 +30,6 @@ def buildDetails = { vars ->
 
 def notify = { message, color='good' ->
     if (env.BRANCH_NAME == 'master' ||
-        env.BRANCH_NAME == 'user_feedback_footer_form-I3445' ||
         env.BRANCH_NAME == 'production') {
         slackSend message: message,
                   color: color,
@@ -228,8 +225,7 @@ node('vetsgov-general-purpose') {
       }
 
       def targets = [
-        'master': [ 'staging' ],
-        'user_feedback_footer_form-I3445': [ 'dev' ],
+        'master': [ 'dev', 'staging' ],
         'production': [ 'prod' ],
       ][env.BRANCH_NAME]
 


### PR DESCRIPTION
Per Slack convo, removing dev being pinned to `user_feedback_footer_form-I3445` because it's no longer needed.