### PR TITLE
Disable shutdown notification banner

### DIFF
--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -3,7 +3,7 @@ layout: home.html
 body_class: home
 title: Home
 plainlanguage: 11-1-16 Ready for Beth review
-enablewarning: true
+enablewarning: false
 description: Apply for and manage the VA benefits and services you’ve earned as a Veteran, Servicemember, or family member—like health care, disability, education, and more.
 majorlinks:
   - heading:


### PR DESCRIPTION
This will disable the warning banner once the shutdown ends.

Should stay on hold until the VA is fully back to work and VA.gov removes their banner.