### PR TITLE
Remove schemaform style dependency from letters

### DIFF
--- a/src/js/letters/components/StepHeader.jsx
+++ b/src/js/letters/components/StepHeader.jsx
@@ -5,14 +5,14 @@ class StepHeader extends React.Component {
   render() {
     const { current, steps, name } = this.props;
     return (
-      <div className="schemaform-chapter-progress">
+      <div className="section-content">
         <div
           role="progressbar"
           aria-valuenow={this.props.current}
           aria-valuemin="1"
           aria-valuetext={`Step ${current} of ${steps}: ${name}`}
           aria-valuemax={steps}
-          className="nav-header nav-header-schemaform">
+          className="nav-header">
           <h4>
             <span className="form-process-step current">{current}</span>
             <span className="form-process-total">of {steps}</span>

--- a/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/js/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -114,7 +114,6 @@ export class VeteranBenefitSummaryLetter extends React.Component {
               type="checkbox"
               onChange={this.handleChange}/>
             <label
-              className="schemaform-label"
               name="militaryService-label"
               htmlFor="militaryService">
               Include military service information

--- a/src/sass/letters.scss
+++ b/src/sass/letters.scss
@@ -1,7 +1,7 @@
 @import "shared-variables";
 @import "modules/m-form-process";
 @import "modules/m-progress-bar";
-@import "modules/m-schemaform";
+
 @mixin schemaform-padding {
   // query borrowed from _m-schemaform.scss
   @media(max-width: 40.063em) {
@@ -164,3 +164,36 @@
     white-space: nowrap;
   }
 }
+
+// --- Copied from _m-schemaform.css --- //
+
+// This probably belongs somewhere else
+
+.usa-alert, .usa-input-error, .nav-header > h4, .nav-header {
+  &:focus {
+    outline: none;
+  }
+}
+
+label + div {
+  select, input:not([type="radio"]) {
+    margin-top: 0.5em;
+  }
+}
+
+// Copied from .schemaform-chapter-progress
+.section-content {
+  padding-left: 2rem;
+  padding-right: 2rem;
+  margin-bottom: 1.5em;
+  @media (max-width: 40.063em) {
+    padding-left: 2rem - .9375rem;
+    padding-right: 2rem - .9375rem;
+  }
+  > h4 {
+    padding-bottom: 0 !important;
+  }
+}
+
+// --- End copy from _m-schemaform.css --- //
+

--- a/test/letters/components/StepHeader.unit.spec.jsx
+++ b/test/letters/components/StepHeader.unit.spec.jsx
@@ -21,7 +21,7 @@ describe('<StepHeader>', () => {
     const tree = SkinDeep.shallowRender(<StepHeader {...defaultProps}/>);
     expect(tree.subTree('.form-process-step').text()).to.equal('3');
     expect(tree.subTree('.form-process-total').text()).to.equal('of 6');
-    expect(tree.subTree('.schemaform-chapter-progress').text()).to.contain('First step of the process');
+    expect(tree.subTree('.section-content').text()).to.contain('First step of the process');
   });
 });
 


### PR DESCRIPTION
The generated `letters.css` when from 1551 lines to 984, meaning 567 lines were removed. I'm not sure what the actual file size change is since neither my local dev environment nor staging has the stylesheets minified, but I think we can estimate about a 30% reduction in minified file size.

There's only one small visual change: There's a slightly smaller space between the title and subtitle content:
![image](https://user-images.githubusercontent.com/12970166/35249201-f81c35ba-ff85-11e7-8693-15be0a4dd806.png)

I could have fixed that, but it seemed small enough of a change, I didn't worry about it. If there needs to be that extra little bit of space, let me know, @goldenmeanie.
