### PR TITLE
Change baseline VIC rate limit

### DIFF
--- a/config/create-settings.js
+++ b/config/create-settings.js
@@ -12,7 +12,7 @@ function createSettings(options) {
     },
     vic: {
       rateLimitAuthed: 1,
-      rateLimitUnauthed: 0.5
+      rateLimitUnauthed: 1
     }
   };
 }


### PR DESCRIPTION
VIC has been doing better, so removing the rate limit (0% of users will now see the email capture page). 