### PR TITLE
Fix development GTM JS snippet

### DIFF
--- a/assets/js/google-analytics-dev.js
+++ b/assets/js/google-analytics-dev.js
@@ -1,7 +1,7 @@
 <!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=N9BisSDKAwJENFQtQIEvXQ&gtm_preview=env-423&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-WFJWBD');</script>
+})(window,document,'script','dataLayer','GTM-WFJWBD');
 <!-- End Google Tag Manager -->


### PR DESCRIPTION
I forgot to remove the surrounding `<script>` tag when setting up the separate snippet for dev. This should fix things.

![doh](https://user-images.githubusercontent.com/6646098/35356258-7d997fb4-0115-11e8-86c8-f8f863c9596a.gif)
