### PR TITLE
Appealsv2 next content mg

### DIFF
--- a/src/js/claims-status/components/appeals-v2/NextEvent.jsx
+++ b/src/js/claims-status/components/appeals-v2/NextEvent.jsx
@@ -5,7 +5,7 @@ const NextEvent = ({ title, description, durationText, cardDescription, showSepa
   return (
     <li className="next-event">
       <h3>{title}</h3>
-      <p>{description}</p>
+      <div>{description}</div>
       <div className="card information">
         <span className="number">{durationText}</span>
         <span className="description">{cardDescription}</span>
@@ -17,10 +17,7 @@ const NextEvent = ({ title, description, durationText, cardDescription, showSepa
 
 NextEvent.propTypes = {
   title: PropTypes.string.isRequired,
-  description: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.element
-  ]).isRequired,
+  description: PropTypes.element.isRequired,
   durationText: PropTypes.string.isRequired,
   cardDescription: PropTypes.string.isRequired,
   showSeparator: PropTypes.bool.isRequired

--- a/src/js/claims-status/components/appeals-v2/WhatsNext.jsx
+++ b/src/js/claims-status/components/appeals-v2/WhatsNext.jsx
@@ -13,7 +13,7 @@ const WhatsNext = ({ nextEvents }) => {
         durationText={event.durationText}
         cardDescription={event.cardDescription}
         // show a separator after all events except the last one
-        showSeparator={(index !== eventsList.length - 1)}/>
+        showSeparator={(index !== events.length - 1)}/>
     );
   });
 

--- a/src/js/claims-status/components/appeals-v2/WhatsNext.jsx
+++ b/src/js/claims-status/components/appeals-v2/WhatsNext.jsx
@@ -2,43 +2,42 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import NextEvent from './NextEvent';
 
-class WhatsNext extends React.Component {
-  render() {
-    const { nextEvents } = this.props;
-    const eventsList = nextEvents.map((event, index) => {
-      return (
-        <NextEvent
-          key={event.title}
-          title={event.title}
-          description={event.description}
-          durationText={event.durationText}
-          cardDescription={event.cardDescription}
-          // show a separator after all events except the last one
-          showSeparator={(index !== nextEvents.length - 1)}/>
-      );
-    });
-
+const WhatsNext = ({ nextEvents }) => {
+  const { header, events } = nextEvents;
+  const eventsList = events.map((event, index) => {
     return (
-      <div>
-        <h2>What happens next?</h2>
-        <ul className="appeals-next-list">
-          {eventsList}
-        </ul>
-      </div>
+      <NextEvent
+        key={event.title}
+        title={event.title}
+        description={event.description}
+        durationText={event.durationText}
+        cardDescription={event.cardDescription}
+        // show a separator after all events except the last one
+        showSeparator={(index !== eventsList.length - 1)}/>
     );
-  }
-}
+  });
+
+  return (
+    <div>
+      <h2>What happens next?</h2>
+      <p>{header}</p>
+      <ul className="appeals-next-list">
+        {eventsList}
+      </ul>
+    </div>
+  );
+};
 
 WhatsNext.propTypes = {
-  nextEvents: PropTypes.arrayOf(PropTypes.shape({
-    title: PropTypes.string.isRequired,
-    description: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.element
-    ]).isRequired,
-    durationText: PropTypes.string.isRequired,
-    cardDescription: PropTypes.string.isRequired
-  })).isRequired
+  nextEvents: PropTypes.shape({
+    header: PropTypes.string.isRequired,
+    events: PropTypes.arrayOf(PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      description: PropTypes.element.isRequired,
+      durationText: PropTypes.string.isRequired,
+      cardDescription: PropTypes.string.isRequired
+    })).isRequired
+  }).isRequired,
 };
 
 export default WhatsNext;

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -16,7 +16,8 @@ const AppealsV2StatusPage = ({ appeal }) => {
   const { events, alerts, status, docket } = appeal.attributes;
   const { type, details } = status;
   const currentStatus = getStatusContents(type, details);
-  const nextEvents = getNextEvents(type);
+  // NB: 'details' doesn't do anything in getNextEvents for the time being
+  const nextEvents = getNextEvents(type, details);
   return (
     <div>
       <Timeline events={events}/>

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -615,7 +615,7 @@ export function getNextEvents(currentStatus) {
             title: 'Your appeal will be sent to the Board',
             description: (
               <p>
-                <strong>If you don’t send in new evidence after the Statement of the Case on [date]</strong>,
+                <strong>If you don’t send in new evidence after the Statement of the Case on [DATE]</strong>,
                 the Decision Review Officer will finish their review and transfer your case to the
                 Board of Veterans’ Appeals.
               </p>
@@ -646,7 +646,7 @@ export function getNextEvents(currentStatus) {
             title: 'Your appeal will be sent to the Board',
             description: (
               <p>
-                <strong>If you don’t send in new evidence after the Statement of the Case on [date]</strong>,
+                <strong>If you don’t send in new evidence after the Statement of the Case on [DATE]</strong>,
                 the Decision Review Officer will finish their review and transfer your case to the
                 Board of Veterans’ Appeals.
               </p>
@@ -657,7 +657,7 @@ export function getNextEvents(currentStatus) {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
               <p>
-                <strong>If you send in new evidence after the Statement of the Case on [date]</strong>, the
+                <strong>If you send in new evidence after the Statement of the Case on [DATE]</strong>, the
                 Decision Review Officer will need to write a new Statement of the Case before
                 transferring your case to the Board of Veterans’ Appeals. Once your appeal is
                 transferred, new evidence can be sent directly to the Board and will not be reviewed
@@ -677,7 +677,7 @@ export function getNextEvents(currentStatus) {
             title: 'Your appeal will be sent to the Board',
             description: (
               <p>
-                <strong>If you don’t send in new evidence after the Statement of the Case on [date]</strong>,
+                <strong>If you don’t send in new evidence after the Statement of the Case on [DATE]</strong>,
                 the Decision Review Officer will finish their review and transfer your case to the
                 Board of Veterans’ Appeals.
               </p>
@@ -688,7 +688,7 @@ export function getNextEvents(currentStatus) {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
               <p>
-                <strong>If you send new evidence after the Statement of the Case on [date]</strong>, the
+                <strong>If you send new evidence after the Statement of the Case on [DATE]</strong>, the
                 Decision Review Officer will need to write a new Statement of the Case before
                 transferring your case to the Board of Veterans’ Appeals. Once your appeal is
                 transferred, new evidence can be sent directly to the Board and will not be reviewed
@@ -708,7 +708,7 @@ export function getNextEvents(currentStatus) {
             title: 'Your appeal will be returned to the Board',
             description: (
               <p>
-                <strong>If you don’t send in new evidence after the Statement of the Case on [date]</strong>,
+                <strong>If you don’t send in new evidence after the Statement of the Case on [DATE]</strong>,
                 the Veterans Benefits Administration will finish their work on the remand and return
                 your case to the Board of Veterans’ Appeals.
               </p>
@@ -719,7 +719,7 @@ export function getNextEvents(currentStatus) {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
               <p>
-                <strong>If you send in new evidence after the Statement of the Case on [date]</strong>, the
+                <strong>If you send in new evidence after the Statement of the Case on [DATE]</strong>, the
                 Veterans Benefits Administration will need to write a new Statement of the Case
                 before returning your case to the Board of Veterans’ Appeals.
               </p>

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -583,8 +583,8 @@ export function getNextEvents(currentStatus) {
             title: 'The Veterans Benefits Administration will grant some or all of your appeal',
             description: (
               <p>
-                <em>If the Decision Review Officer determines that there is enough evidence to grant
-                one or more of the issues on your appeal</em>, they will make a new decision. If this
+                <strong>If the Decision Review Officer determines that there is enough evidence to grant
+                one or more of the issues on your appeal</strong>, they will make a new decision. If this
                 decision changes your disability rating or eligibility for VA benefits, you should
                 expect this change to be made in 1 to 2 months.
               </p>
@@ -595,8 +595,8 @@ export function getNextEvents(currentStatus) {
             title: 'The Veterans Benefits Administration will send you a Statement of the Case',
             description: (
               <p>
-                <em>If the Decision Review Officer determines that there is not enough evidence to
-                fully grant your appeal</em>, they will send you their findings in a document called
+                <strong>If the Decision Review Officer determines that there is not enough evidence to
+                fully grant your appeal</strong>, they will send you their findings in a document called
                 a Statement of the Case. You can then decide whether to continue your appeal to the
                 Board of Veterans’ Appeals.
               </p>
@@ -615,7 +615,7 @@ export function getNextEvents(currentStatus) {
             title: 'Your appeal will be sent to the Board',
             description: (
               <p>
-                <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
+                <strong>If you don’t send in new evidence after the Statement of the Case on [date]</strong>,
                 the Decision Review Officer will finish their review and transfer your case to the
                 Board of Veterans’ Appeals.
               </p>
@@ -626,7 +626,7 @@ export function getNextEvents(currentStatus) {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
               <p>
-                <em>If you send in new evidence after the Statement of the Case on [DATE]</em>, the
+                <strong>If you send in new evidence after the Statement of the Case on [DATE]</strong>, the
                 Decision Review Officer will need to write a new Statement of the Case before
                 transferring your case to the Board of Veterans’ Appeals. Once your appeal is
                 transferred, new evidence can be sent directly to the Board and will not be reviewed
@@ -646,7 +646,7 @@ export function getNextEvents(currentStatus) {
             title: 'Your appeal will be sent to the Board',
             description: (
               <p>
-                <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
+                <strong>If you don’t send in new evidence after the Statement of the Case on [date]</strong>,
                 the Decision Review Officer will finish their review and transfer your case to the
                 Board of Veterans’ Appeals.
               </p>
@@ -657,7 +657,7 @@ export function getNextEvents(currentStatus) {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
               <p>
-                <em>If you send in new evidence after the Statement of the Case on [date]</em>, the
+                <strong>If you send in new evidence after the Statement of the Case on [date]</strong>, the
                 Decision Review Officer will need to write a new Statement of the Case before
                 transferring your case to the Board of Veterans’ Appeals. Once your appeal is
                 transferred, new evidence can be sent directly to the Board and will not be reviewed
@@ -677,7 +677,7 @@ export function getNextEvents(currentStatus) {
             title: 'Your appeal will be sent to the Board',
             description: (
               <p>
-                <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
+                <strong>If you don’t send in new evidence after the Statement of the Case on [date]</strong>,
                 the Decision Review Officer will finish their review and transfer your case to the
                 Board of Veterans’ Appeals.
               </p>
@@ -688,7 +688,7 @@ export function getNextEvents(currentStatus) {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
               <p>
-                <em>If you send new evidence after the Statement of the Case on [date]</em>, the
+                <strong>If you send new evidence after the Statement of the Case on [date]</strong>, the
                 Decision Review Officer will need to write a new Statement of the Case before
                 transferring your case to the Board of Veterans’ Appeals. Once your appeal is
                 transferred, new evidence can be sent directly to the Board and will not be reviewed
@@ -708,7 +708,7 @@ export function getNextEvents(currentStatus) {
             title: 'Your appeal will be returned to the Board',
             description: (
               <p>
-                <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
+                <strong>If you don’t send in new evidence after the Statement of the Case on [date]</strong>,
                 the Veterans Benefits Administration will finish their work on the remand and return
                 your case to the Board of Veterans’ Appeals.
               </p>
@@ -719,7 +719,7 @@ export function getNextEvents(currentStatus) {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
               <p>
-                <em>If you send in new evidence after the Statement of the Case on [date]</em>, the
+                <strong>If you send in new evidence after the Statement of the Case on [date]</strong>, the
                 Veterans Benefits Administration will need to write a new Statement of the Case
                 before returning your case to the Board of Veterans’ Appeals.
               </p>

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -571,6 +571,7 @@ const DECISION_REVIEW_CONTENT = (
  * @returns {allNextEvents} a section description and array containing all next event possibilities
  *                          for a given current status
  */
+// TO-DO: Add 'details' to args list once they're complete in the API
 export function getNextEvents(currentStatus) {
   switch (currentStatus) {
     case STATUS_TYPES.pendingSoc:

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -855,7 +855,7 @@ export function getNextEvents(currentStatus) {
         events: [
           {
             title: 'Unknown event',
-            description: 'We could not find the next event in your appeal',
+            description: (<p>We could not find the next event in your appeal</p>),
             durationText: 'Unknown',
             cardDescription: 'No description found'
           }

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -556,261 +556,308 @@ const DECISION_REVIEW_CONTENT = (
 
 /**
  * Gets 'what's next' content for a given current status type
- * @typedef {Object} nextEventText
+ * @typedef {Object} nextEvent
  * @property {string} title header for each NextEvent
  * @property {HTMLElement} description formatted content for each NextEvent
  * @property {string} durationText descriptor of how long this NextEvent usually takes
  * @property {string} cardDescription info about why this NextEvent takes as long as it does
  * ----------------------------------------------------------------------------------------------
+ * @typedef {Object} allNextEvents
+ * @property {string} header a short description to introduce all of the nextEvents
+ * @property {nextEvent[]} events each contain text content for a NextEvent component
+ * ----------------------------------------------------------------------------------------------
  * @param {string} currentStatus an appeal's current status, one of STATUS_TYPES
  * @param {Object} details can contain dynamic info to fill in for certain NextEvent descriptions
- * @returns {nextEventText[]} each contain text content for a NextEvent component
+ * @returns {allNextEvents} a section description and array containing all next event possibilities
+ *                          for a given current status
  */
 export function getNextEvents(currentStatus) {
   switch (currentStatus) {
     case STATUS_TYPES.pendingSoc:
-      return [
-        {
-          title: 'The Veterans Benefits Administration will grant some or all of your appeal',
-          description: (
-            <p>
-              <em>If the Decision Review Officer determines that there is enough evidence to grant
-              one or more of the issues on your appeal</em>, they will make a new decision. If this
-              decision changes your disability rating or eligibility for VA benefits, you should
-              expect this change to be made in 1 to 2 months.
-            </p>
-          ),
-          durationText: '',
-          cardDescription: '',
-        }, {
-          title: 'The Veterans Benefits Administration will send you a Statement of the Case',
-          description: (
-            <p>
-              <em>If the Decision Review Officer determines that there is not enough evidence to
-              fully grant your appeal</em>, they will send you their findings in a document called
-              a Statement of the Case. You can then decide whether to continue your appeal to the
-              Board of Veterans’ Appeals.
-            </p>
-          ),
-          durationText: '',
-          cardDescription: '',
-        },
-      ];
+      return {
+        header: 'What happens next depends on whether the Decision Review Officer has enough evidence to decide in your favor.',
+        events: [
+          {
+            title: 'The Veterans Benefits Administration will grant some or all of your appeal',
+            description: (
+              <p>
+                <em>If the Decision Review Officer determines that there is enough evidence to grant
+                one or more of the issues on your appeal</em>, they will make a new decision. If this
+                decision changes your disability rating or eligibility for VA benefits, you should
+                expect this change to be made in 1 to 2 months.
+              </p>
+            ),
+            durationText: '',
+            cardDescription: '',
+          }, {
+            title: 'The Veterans Benefits Administration will send you a Statement of the Case',
+            description: (
+              <p>
+                <em>If the Decision Review Officer determines that there is not enough evidence to
+                fully grant your appeal</em>, they will send you their findings in a document called
+                a Statement of the Case. You can then decide whether to continue your appeal to the
+                Board of Veterans’ Appeals.
+              </p>
+            ),
+            durationText: '',
+            cardDescription: '',
+          },
+        ]
+      };
     case STATUS_TYPES.pendingForm9:
-      return [
-        {
-          title: 'Your appeal will be sent to the Board',
-          description: (
-            <p>
-              <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
-              the Decision Review Officer will finish their review and transfer your case to the
-              Board of Veterans’ Appeals.
-            </p>
-          ),
-          durationText: '',
-          cardDescription: ''
-        }, {
-          title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
-          description: (
-            <p>
-              <em>If you send in new evidence after the Statement of the Case on [DATE]</em>, the
-              Decision Review Officer will need to write a new Statement of the Case before
-              transferring your case to the Board of Veterans’ Appeals. Once your appeal is
-              transferred, new evidence can be sent directly to the Board and will not be reviewed
-              by the Veterans Benefits Administration.
-            </p>
-          ),
-          durationText: '',
-          cardDescription: ''
-        },
-      ];
+      return {
+        header: '',
+        events: [
+          {
+            title: 'Your appeal will be sent to the Board',
+            description: (
+              <p>
+                <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
+                the Decision Review Officer will finish their review and transfer your case to the
+                Board of Veterans’ Appeals.
+              </p>
+            ),
+            durationText: '',
+            cardDescription: ''
+          }, {
+            title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
+            description: (
+              <p>
+                <em>If you send in new evidence after the Statement of the Case on [DATE]</em>, the
+                Decision Review Officer will need to write a new Statement of the Case before
+                transferring your case to the Board of Veterans’ Appeals. Once your appeal is
+                transferred, new evidence can be sent directly to the Board and will not be reviewed
+                by the Veterans Benefits Administration.
+              </p>
+            ),
+            durationText: '',
+            cardDescription: ''
+          },
+        ]
+      };
     case STATUS_TYPES.pendingCertification:
-      return [
-        {
-          title: 'Your appeal will be sent to the Board',
-          description: (
-            <p>
-              <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
-              the Decision Review Officer will finish their review and transfer your case to the
-              Board of Veterans’ Appeals.
-            </p>
-          ),
-          durationText: '',
-          cardDescription: '',
-        }, {
-          title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
-          description: (
-            <p>
-              <em>If you send in new evidence after the Statement of the Case on [date]</em>, the
-              Decision Review Officer will need to write a new Statement of the Case before
-              transferring your case to the Board of Veterans’ Appeals. Once your appeal is
-              transferred, new evidence can be sent directly to the Board and will not be reviewed
-              by the Veterans Benefits Administration.
-            </p>
-          ),
-          durationText: '',
-          cardDescription: '',
-        }
-      ];
+      return {
+        header: '',
+        events: [
+          {
+            title: 'Your appeal will be sent to the Board',
+            description: (
+              <p>
+                <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
+                the Decision Review Officer will finish their review and transfer your case to the
+                Board of Veterans’ Appeals.
+              </p>
+            ),
+            durationText: '',
+            cardDescription: '',
+          }, {
+            title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
+            description: (
+              <p>
+                <em>If you send in new evidence after the Statement of the Case on [date]</em>, the
+                Decision Review Officer will need to write a new Statement of the Case before
+                transferring your case to the Board of Veterans’ Appeals. Once your appeal is
+                transferred, new evidence can be sent directly to the Board and will not be reviewed
+                by the Veterans Benefits Administration.
+              </p>
+            ),
+            durationText: '',
+            cardDescription: '',
+          }
+        ]
+      };
     case STATUS_TYPES.pendingCertificationSsoc:
-      return [
-        {
-          title: 'Your appeal will be sent to the Board',
-          description: (
-            <p>
-              <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
-              the Decision Review Officer will finish their review and transfer your case to the
-              Board of Veterans’ Appeals.
-            </p>
-          ),
-          durationText: '',
-          cardDescription: '',
-        }, {
-          title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
-          description: (
-            <p>
-              <em>If you send new evidence after the Statement of the Case on [date]</em>, the
-              Decision Review Officer will need to write a new Statement of the Case before
-              transferring your case to the Board of Veterans’ Appeals. Once your appeal is
-              transferred, new evidence can be sent directly to the Board and will not be reviewed
-              by the Veterans Benefits Administration.
-            </p>
-          ),
-          durationText: '',
-          cardDescription: '',
-        }
-      ];
+      return  {
+        header: '',
+        events: [
+          {
+            title: 'Your appeal will be sent to the Board',
+            description: (
+              <p>
+                <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
+                the Decision Review Officer will finish their review and transfer your case to the
+                Board of Veterans’ Appeals.
+              </p>
+            ),
+            durationText: '',
+            cardDescription: '',
+          }, {
+            title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
+            description: (
+              <p>
+                <em>If you send new evidence after the Statement of the Case on [date]</em>, the
+                Decision Review Officer will need to write a new Statement of the Case before
+                transferring your case to the Board of Veterans’ Appeals. Once your appeal is
+                transferred, new evidence can be sent directly to the Board and will not be reviewed
+                by the Veterans Benefits Administration.
+              </p>
+            ),
+            durationText: '',
+            cardDescription: '',
+          }
+        ]
+      };
     case STATUS_TYPES.remandSsoc:
-      return [
-        {
-          title: 'Your appeal will be returned to the Board',
-          description: (
-            <p>
-              <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
-              the Veterans Benefits Administration will finish their work on the remand and return
-              your case to the Board of Veterans’ Appeals.
-            </p>
-          ),
-          durationText: '',
-          cardDescription: '',
-        }, {
-          title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
-          description: (
-            <p>
-              <em>If you send in new evidence after the Statement of the Case on [date]</em>, the
-              Veterans Benefits Administration will need to write a new Statement of the Case
-              before returning your case to the Board of Veterans’ Appeals.
-            </p>
-          ),
-          durationText: '',
-          cardDescription: '',
-        }
-      ];
+      return {
+        header: '',
+        events: [
+          {
+            title: 'Your appeal will be returned to the Board',
+            description: (
+              <p>
+                <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
+                the Veterans Benefits Administration will finish their work on the remand and return
+                your case to the Board of Veterans’ Appeals.
+              </p>
+            ),
+            durationText: '',
+            cardDescription: '',
+          }, {
+            title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
+            description: (
+              <p>
+                <em>If you send in new evidence after the Statement of the Case on [date]</em>, the
+                Veterans Benefits Administration will need to write a new Statement of the Case
+                before returning your case to the Board of Veterans’ Appeals.
+              </p>
+            ),
+            durationText: '',
+            cardDescription: '',
+          }
+        ]
+      };
     case STATUS_TYPES.pendingHearingScheduling:
-      return [
-        {
-          title: 'You will have your [TYPE] hearing',
-          description: (
-            <p>
-              At your hearing, a Veterans Law Judge will ask you questions about your appeal. A
-              transcript of your hearing will be taken and added to your appeal file. The judge
-              will not make a decision about your appeal at the hearing. Learn more about hearings,
-              including how to request a different kind of hearing or withdraw your hearing
-              request.
-            </p>
-          ),
-          durationText: '',
-          cardDescription: '',
-        }
-      ];
+      return {
+        header: '',
+        events: [
+          {
+            title: 'You will have your [TYPE] hearing',
+            description: (
+              <p>
+                At your hearing, a Veterans Law Judge will ask you questions about your appeal. A
+                transcript of your hearing will be taken and added to your appeal file. The judge
+                will not make a decision about your appeal at the hearing. Learn more about hearings,
+                including how to request a different kind of hearing or withdraw your hearing
+                request.
+              </p>
+            ),
+            durationText: '',
+            cardDescription: '',
+          }
+        ]
+      };
     case STATUS_TYPES.scheduledHearing:
-      return [
-        {
-          title: 'You will have your [TYPE] hearing',
-          description: (
-            <p>
-              Your hearing is scheduled for [DATE] at [LOCATION]. At your hearing, a Veterans Law
-              Judge will ask you questions about your appeal. A transcript of your hearing will be
-              taken and added to your appeal file. The judge will not make a decision about your
-              appeal at the hearing. Learn more about hearings, including how to prepare for your
-              hearing.
-            </p>
-          ),
-          durationText: '',
-          cardDescription: '',
-        }
-      ];
+      return {
+        header: '',
+        events: [
+          {
+            title: 'You will have your [TYPE] hearing',
+            description: (
+              <p>
+                Your hearing is scheduled for [DATE] at [LOCATION]. At your hearing, a Veterans Law
+                Judge will ask you questions about your appeal. A transcript of your hearing will be
+                taken and added to your appeal file. The judge will not make a decision about your
+                appeal at the hearing. Learn more about hearings, including how to prepare for your
+                hearing.
+              </p>
+            ),
+            durationText: '',
+            cardDescription: '',
+          }
+        ]
+      };
     case STATUS_TYPES.onDocket: {
-      return [
-        {
-          title: 'The Board will make a decision',
-          description: DECISION_REVIEW_CONTENT,
-          durationText: '10 months',
-          cardDescription: 'A Veterans Law Judge typically takes 10 months to write a decision.'
-        }
-      ];
+      return {
+        header: '',
+        events: [
+          {
+            title: 'The Board will make a decision',
+            description: DECISION_REVIEW_CONTENT,
+            durationText: '10 months',
+            cardDescription: 'A Veterans Law Judge typically takes 10 months to write a decision.'
+          }
+        ]
+      };
     }
     case STATUS_TYPES.atVso:
-      return [
-        {
-          title: 'The Board will make a decision',
-          description: DECISION_REVIEW_CONTENT,
-          durationText: '',
-          cardDescription: '',
-        }
-      ];
+      return {
+        header: '',
+        events: [
+          {
+            title: 'The Board will make a decision',
+            description: DECISION_REVIEW_CONTENT,
+            durationText: '',
+            cardDescription: '',
+          }
+        ]
+      };
     case STATUS_TYPES.decisionInProgress:
-      return [
-        {
-          title: 'The Board will make a decision',
-          description: DECISION_REVIEW_CONTENT,
-          durationText: '',
-          cardDescription: '',
-        }
-      ];
+      return {
+        header: '',
+        events: [
+          {
+            title: 'The Board will make a decision',
+            description: DECISION_REVIEW_CONTENT,
+            durationText: '',
+            cardDescription: '',
+          }
+        ]
+      };
     case STATUS_TYPES.bvaDevelopment:
-      return [
-        {
-          title: 'The Board will make a decision',
-          description: DECISION_REVIEW_CONTENT,
-          durationText: '',
-          cardDescription: '',
-        }
-      ];
+      return {
+        header: '',
+        events: [
+          {
+            title: 'The Board will make a decision',
+            description: DECISION_REVIEW_CONTENT,
+            durationText: '',
+            cardDescription: '',
+          }
+        ]
+      };
     case STATUS_TYPES.stayed:
-      return [
-        {
-          title: 'The Board will make a decision',
-          description: DECISION_REVIEW_CONTENT,
-          durationText: '',
-          cardDescription: '',
-        }
-      ];
+      return {
+        header: '',
+        events: [
+          {
+            title: 'The Board will make a decision',
+            description: DECISION_REVIEW_CONTENT,
+            durationText: '',
+            cardDescription: '',
+          }
+        ]
+      };
     case STATUS_TYPES.remand:
-      return [
-        {
-          title: 'The Veterans Benefits Administration completes the remand instructions',
-          description: (
-            <p>
-              They may contact you to request additional evidence or medical examinations, as
-              needed. When they have completed the remand instructions, they will determine whether
-              or not they can grant your appeal. If not, your appeal will return to the Board of
-              Veterans’ Appeals for a new decision.
-            </p>
-          ),
-          durationText: '11 months',
-          cardDescription: 'VBA takes about 11 months to produce a Statement of the Case (SOC)'
-        }
-      ];
+      return {
+        header: '',
+        events: [
+          {
+            title: 'The Veterans Benefits Administration completes the remand instructions',
+            description: (
+              <p>
+                They may contact you to request additional evidence or medical examinations, as
+                needed. When they have completed the remand instructions, they will determine whether
+                or not they can grant your appeal. If not, your appeal will return to the Board of
+                Veterans’ Appeals for a new decision.
+              </p>
+            ),
+            durationText: '11 months',
+            cardDescription: 'VBA takes about 11 months to produce a Statement of the Case (SOC)'
+          }
+        ]
+      };
     default:
-      return [
-        {
-          title: 'Unknown event',
-          description: 'We could not find the next event in your appeal',
-          durationText: 'Unknown',
-          cardDescription: 'No description found'
-        }
-      ];
+      return {
+        header: '',
+        events: [
+          {
+            title: 'Unknown event',
+            description: 'We could not find the next event in your appeal',
+            durationText: 'Unknown',
+            cardDescription: 'No description found'
+          }
+        ]
+      };
   }
 }
 

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -575,7 +575,8 @@ export function getNextEvents(currentStatus) {
   switch (currentStatus) {
     case STATUS_TYPES.pendingSoc:
       return {
-        header: 'What happens next depends on whether the Decision Review Officer has enough evidence to decide in your favor.',
+        header: `What happens next depends on whether the Decision Review Officer has enough 
+          evidence to decide in your favor.`,
         events: [
           {
             title: 'The Veterans Benefits Administration will grant some or all of your appeal',
@@ -606,7 +607,8 @@ export function getNextEvents(currentStatus) {
       };
     case STATUS_TYPES.pendingForm9:
       return {
-        header: '',
+        header: `If you return a Form 9 within 60 days, what happens next depends on whether you 
+          also send in new evidence.`,
         events: [
           {
             title: 'Your appeal will be sent to the Board',
@@ -637,7 +639,7 @@ export function getNextEvents(currentStatus) {
       };
     case STATUS_TYPES.pendingCertification:
       return {
-        header: '',
+        header: 'What happens next depends on whether you send in new evidence.',
         events: [
           {
             title: 'Your appeal will be sent to the Board',
@@ -668,7 +670,7 @@ export function getNextEvents(currentStatus) {
       };
     case STATUS_TYPES.pendingCertificationSsoc:
       return  {
-        header: '',
+        header: 'What happens next depends on whether you send in new evidence.',
         events: [
           {
             title: 'Your appeal will be sent to the Board',
@@ -699,7 +701,7 @@ export function getNextEvents(currentStatus) {
       };
     case STATUS_TYPES.remandSsoc:
       return {
-        header: '',
+        header: 'What happens next depends on whether you send in new evidence.',
         events: [
           {
             title: 'Your appeal will be returned to the Board',
@@ -728,7 +730,7 @@ export function getNextEvents(currentStatus) {
       };
     case STATUS_TYPES.pendingHearingScheduling:
       return {
-        header: '',
+        header: '', // intentionally empty
         events: [
           {
             title: 'You will have your [TYPE] hearing',
@@ -748,7 +750,7 @@ export function getNextEvents(currentStatus) {
       };
     case STATUS_TYPES.scheduledHearing:
       return {
-        header: '',
+        header: '', // intentionally empty
         events: [
           {
             title: 'You will have your [TYPE] hearing',
@@ -768,7 +770,7 @@ export function getNextEvents(currentStatus) {
       };
     case STATUS_TYPES.onDocket: {
       return {
-        header: '',
+        header: '', // intentionally empty
         events: [
           {
             title: 'The Board will make a decision',
@@ -781,7 +783,7 @@ export function getNextEvents(currentStatus) {
     }
     case STATUS_TYPES.atVso:
       return {
-        header: '',
+        header: '', // intentionally empty
         events: [
           {
             title: 'The Board will make a decision',
@@ -793,7 +795,7 @@ export function getNextEvents(currentStatus) {
       };
     case STATUS_TYPES.decisionInProgress:
       return {
-        header: '',
+        header: '', // intentionally empty
         events: [
           {
             title: 'The Board will make a decision',
@@ -805,7 +807,7 @@ export function getNextEvents(currentStatus) {
       };
     case STATUS_TYPES.bvaDevelopment:
       return {
-        header: '',
+        header: '', // intentionally empty
         events: [
           {
             title: 'The Board will make a decision',
@@ -817,7 +819,7 @@ export function getNextEvents(currentStatus) {
       };
     case STATUS_TYPES.stayed:
       return {
-        header: '',
+        header: '', // intentionally empty
         events: [
           {
             title: 'The Board will make a decision',
@@ -829,7 +831,7 @@ export function getNextEvents(currentStatus) {
       };
     case STATUS_TYPES.remand:
       return {
-        header: '',
+        header: '', // intentionally empty
         events: [
           {
             title: 'The Veterans Benefits Administration completes the remand instructions',
@@ -848,7 +850,7 @@ export function getNextEvents(currentStatus) {
       };
     default:
       return {
-        header: '',
+        header: '', // intentionally empty
         events: [
           {
             title: 'Unknown event',

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -530,6 +530,30 @@ export function getEventContent(event) {
   }
 }
 
+// This static piece of content gets reused throughout getNextEvents()
+const DECISION_REVIEW_CONTENT = (
+  <div>
+    <p>
+      A Veterans Law Judge, working with their team of attorneys, will review all of the
+      available evidence and write a decision. For each issue you are appealing, they can
+      decide to:
+    </p>
+    <ul>
+      <li>
+        <strong>Allow:</strong> The judge overrules the original decision and decides in
+        your favor.
+      </li>
+      <li><strong>Deny:</strong> The judge upholds the original decision.</li>
+      <li>
+        <strong>Remand:</strong> The judge is sending the issue back to the Veterans
+        Benefits Administration to gather more evidence or to fix a mistake before
+        making a decision.
+      </li>
+    </ul>
+    <p><strong>Note:</strong> About 60% of all cases have at least 1 issue remanded.</p>
+  </div>
+);
+
 /**
  * Gets 'what's next' content for a given current status type
  * @typedef {Object} nextEventText
@@ -547,43 +571,82 @@ export function getNextEvents(currentStatus) {
     case STATUS_TYPES.pendingSoc:
       return [
         {
-          title: '',
+          title: 'The Veterans Benefits Administration will grant some or all of your appeal',
           description: (
-            <p></p>
+            <p>
+              <em>If the Decision Review Officer determines that there is enough evidence to grant
+              one or more of the issues on your appeal</em>, they will make a new decision. If this
+              decision changes your disability rating or eligibility for VA benefits, you should
+              expect this change to be made in 1 to 2 months.
+            </p>
           ),
           durationText: '',
           cardDescription: '',
-        }
+        }, {
+          title: 'The Veterans Benefits Administration will send you a Statement of the Case',
+          description: (
+            <p>
+              <em>If the Decision Review Officer determines that there is not enough evidence to
+              fully grant your appeal</em>, they will send you their findings in a document called
+              a Statement of the Case. You can then decide whether to continue your appeal to the
+              Board of Veterans’ Appeals.
+            </p>
+          ),
+          durationText: '',
+          cardDescription: '',
+        },
       ];
     case STATUS_TYPES.pendingForm9:
       return [
         {
-          title: 'The Board receives your appeal',
-          description: `If you send the Form 9 without new evidence, the Veterans Benefits
-            Administration (VBA) will finish its review and transfer your case to the Board of
-            Veterans’ Appeals.`,
-          durationText: '2 months',
-          cardDescription: 'VBA takes about 2 months to certify appeals to the Board'
+          title: 'Your appeal will be sent to the Board',
+          description: (
+            <p>
+              <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
+              the Decision Review Officer will finish their review and transfer your case to the
+              Board of Veterans’ Appeals.
+            </p>
+          ),
+          durationText: '',
+          cardDescription: ''
         }, {
-          title: 'VBA prepares a Statement of the Case (SOC)',
-          description: `If you send the Form 9 with new evidence, the Veterans Benefits
-            Administration (VBA) will finish its review and transfer your case to the Board of
-            Veterans’ Appeals.`,
-          durationText: '11 months',
-          cardDescription: 'VBA takes about 11 months to produce a Statement of the Case (SOC)'
-        }, {
-          title: 'You withdraw your appeal',
-          description: 'If you do not send the Form 9 within 60 days, your appeal will be closed.',
-          durationText: '2 months',
-          cardDescription: 'You have 60 days to submit your appeal before it is closed'
-        }
+          title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
+          description: (
+            <p>
+              <em>If you send in new evidence after the Statement of the Case on [DATE]</em>, the
+              Decision Review Officer will need to write a new Statement of the Case before
+              transferring your case to the Board of Veterans’ Appeals. Once your appeal is
+              transferred, new evidence can be sent directly to the Board and will not be reviewed
+              by the Veterans Benefits Administration.
+            </p>
+          ),
+          durationText: '',
+          cardDescription: ''
+        },
       ];
     case STATUS_TYPES.pendingCertification:
       return [
         {
-          title: '',
+          title: 'Your appeal will be sent to the Board',
           description: (
-            <p></p>
+            <p>
+              <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
+              the Decision Review Officer will finish their review and transfer your case to the
+              Board of Veterans’ Appeals.
+            </p>
+          ),
+          durationText: '',
+          cardDescription: '',
+        }, {
+          title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
+          description: (
+            <p>
+              <em>If you send in new evidence after the Statement of the Case on [date]</em>, the
+              Decision Review Officer will need to write a new Statement of the Case before
+              transferring your case to the Board of Veterans’ Appeals. Once your appeal is
+              transferred, new evidence can be sent directly to the Board and will not be reviewed
+              by the Veterans Benefits Administration.
+            </p>
           ),
           durationText: '',
           cardDescription: '',
@@ -592,9 +655,26 @@ export function getNextEvents(currentStatus) {
     case STATUS_TYPES.pendingCertificationSsoc:
       return [
         {
-          title: '',
+          title: 'Your appeal will be sent to the Board',
           description: (
-            <p></p>
+            <p>
+              <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
+              the Decision Review Officer will finish their review and transfer your case to the
+              Board of Veterans’ Appeals.
+            </p>
+          ),
+          durationText: '',
+          cardDescription: '',
+        }, {
+          title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
+          description: (
+            <p>
+              <em>If you send new evidence after the Statement of the Case on [date]</em>, the
+              Decision Review Officer will need to write a new Statement of the Case before
+              transferring your case to the Board of Veterans’ Appeals. Once your appeal is
+              transferred, new evidence can be sent directly to the Board and will not be reviewed
+              by the Veterans Benefits Administration.
+            </p>
           ),
           durationText: '',
           cardDescription: '',
@@ -603,9 +683,24 @@ export function getNextEvents(currentStatus) {
     case STATUS_TYPES.remandSsoc:
       return [
         {
-          title: '',
+          title: 'Your appeal will be returned to the Board',
           description: (
-            <p></p>
+            <p>
+              <em>If you don’t send in new evidence after the Statement of the Case on [date]</em>,
+              the Veterans Benefits Administration will finish their work on the remand and return
+              your case to the Board of Veterans’ Appeals.
+            </p>
+          ),
+          durationText: '',
+          cardDescription: '',
+        }, {
+          title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
+          description: (
+            <p>
+              <em>If you send in new evidence after the Statement of the Case on [date]</em>, the
+              Veterans Benefits Administration will need to write a new Statement of the Case
+              before returning your case to the Board of Veterans’ Appeals.
+            </p>
           ),
           durationText: '',
           cardDescription: '',
@@ -614,9 +709,15 @@ export function getNextEvents(currentStatus) {
     case STATUS_TYPES.pendingHearingScheduling:
       return [
         {
-          title: '',
+          title: 'You will have your [TYPE] hearing',
           description: (
-            <p></p>
+            <p>
+              At your hearing, a Veterans Law Judge will ask you questions about your appeal. A
+              transcript of your hearing will be taken and added to your appeal file. The judge
+              will not make a decision about your appeal at the hearing. Learn more about hearings,
+              including how to request a different kind of hearing or withdraw your hearing
+              request.
+            </p>
           ),
           durationText: '',
           cardDescription: '',
@@ -625,9 +726,15 @@ export function getNextEvents(currentStatus) {
     case STATUS_TYPES.scheduledHearing:
       return [
         {
-          title: '',
+          title: 'You will have your [TYPE] hearing',
           description: (
-            <p></p>
+            <p>
+              Your hearing is scheduled for [DATE] at [LOCATION]. At your hearing, a Veterans Law
+              Judge will ask you questions about your appeal. A transcript of your hearing will be
+              taken and added to your appeal file. The judge will not make a decision about your
+              appeal at the hearing. Learn more about hearings, including how to prepare for your
+              hearing.
+            </p>
           ),
           durationText: '',
           cardDescription: '',
@@ -636,29 +743,8 @@ export function getNextEvents(currentStatus) {
     case STATUS_TYPES.onDocket: {
       return [
         {
-          title: 'Judge Decides Your Appeal',
-          description: (
-            <div>
-              <div>
-                A Veterans Law Judge, working with one of the Board attorneys, will review all of
-                the available evidence and write a decision. For each issue you are appealing, they
-                can decide to:
-              </div>
-              <ul>
-                <li>
-                  <strong>Allow - </strong>The judge overrules the Regional Office and makes a decision
-                  on your rating
-                </li>
-                <li><strong>Deny - </strong>The judge agrees with the Regional Office decision</li>
-                <li>
-                  <strong>Remand - </strong>The judge sends the issue to Veterans Benefits
-                    Administration (VBA) for more evidence or to fix a mistake before making a
-                    decision
-                </li>
-              </ul>
-              <div><strong>Note:</strong> About 60% of all cases have at least 1 issue remanded.</div>
-            </div>
-          ),
+          title: 'The Board will make a decision',
+          description: DECISION_REVIEW_CONTENT,
           durationText: '10 months',
           cardDescription: 'A Veterans Law Judge typically takes 10 months to write a decision.'
         }
@@ -667,10 +753,8 @@ export function getNextEvents(currentStatus) {
     case STATUS_TYPES.atVso:
       return [
         {
-          title: '',
-          description: (
-            <p></p>
-          ),
+          title: 'The Board will make a decision',
+          description: DECISION_REVIEW_CONTENT,
           durationText: '',
           cardDescription: '',
         }
@@ -678,10 +762,8 @@ export function getNextEvents(currentStatus) {
     case STATUS_TYPES.decisionInProgress:
       return [
         {
-          title: '',
-          description: (
-            <p></p>
-          ),
+          title: 'The Board will make a decision',
+          description: DECISION_REVIEW_CONTENT,
           durationText: '',
           cardDescription: '',
         }
@@ -689,10 +771,8 @@ export function getNextEvents(currentStatus) {
     case STATUS_TYPES.bvaDevelopment:
       return [
         {
-          title: '',
-          description: (
-            <p></p>
-          ),
+          title: 'The Board will make a decision',
+          description: DECISION_REVIEW_CONTENT,
           durationText: '',
           cardDescription: '',
         }
@@ -700,10 +780,8 @@ export function getNextEvents(currentStatus) {
     case STATUS_TYPES.stayed:
       return [
         {
-          title: '',
-          description: (
-            <p></p>
-          ),
+          title: 'The Board will make a decision',
+          description: DECISION_REVIEW_CONTENT,
           durationText: '',
           cardDescription: '',
         }
@@ -711,30 +789,17 @@ export function getNextEvents(currentStatus) {
     case STATUS_TYPES.remand:
       return [
         {
-          title: 'VBA prepares a Statement of the Case (SOC)',
-          description: `If you send the Form 9 with new evidence, the Veterans Benefits
-            Administration (VBA) will finish its review and transfer your case to the Board of
-            Veterans’ Appeals.`,
+          title: 'The Veterans Benefits Administration completes the remand instructions',
+          description: (
+            <p>
+              They may contact you to request additional evidence or medical examinations, as
+              needed. When they have completed the remand instructions, they will determine whether
+              or not they can grant your appeal. If not, your appeal will return to the Board of
+              Veterans’ Appeals for a new decision.
+            </p>
+          ),
           durationText: '11 months',
           cardDescription: 'VBA takes about 11 months to produce a Statement of the Case (SOC)'
-        }
-      ];
-    case STATUS_TYPES.bvaDecision:
-      return [
-        {
-          title: 'Board decision reached',
-          description: 'Your appeal decision is being sent to your mailing address',
-          durationText: '2 weeks',
-          cardDescription: 'The Oakland regional office takes about 2 weeks to mail your decision.'
-        }
-      ];
-    case STATUS_TYPES.awaitingHearingDate:
-      return [
-        {
-          title: 'Awaiting hearing date',
-          description: 'VBA is in the process of scheduling your hearing date',
-          durationText: '2 months',
-          cardDescription: 'The Oakland regional office takes about 2 months to schedule a hearing date.'
         }
       ];
     default:

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -531,26 +531,28 @@ export function getEventContent(event) {
 }
 
 /**
+ * Gets 'what's next' content for a given current status type
+ * @typedef {Object} nextEventText
+ * @property {string} title header for each NextEvent
+ * @property {HTMLElement} description formatted content for each NextEvent
+ * @property {string} durationText descriptor of how long this NextEvent usually takes
+ * @property {string} cardDescription info about why this NextEvent takes as long as it does
+ * ----------------------------------------------------------------------------------------------
  * @param {string} currentStatus an appeal's current status, one of STATUS_TYPES
- * @returns {array} of objects that each contain text details of a next event
+ * @param {Object} details can contain dynamic info to fill in for certain NextEvent descriptions
+ * @returns {nextEventText[]} each contain text content for a NextEvent component
  */
 export function getNextEvents(currentStatus) {
   switch (currentStatus) {
-    case STATUS_TYPES.nod:
+    case STATUS_TYPES.pendingSoc:
       return [
         {
-          title: 'Additional evidence',
-          description: `VBA must reveiw any additional evidence you submit prios to certifying
-          your appeal to the Board of Veterans’ Appeals. This evidence could cause VBA
-          to grant your appeal, but if not, they will need to produce an additional
-          Statement of the Case.`,
-          durationText: '11 months',
-          cardDescription: 'The Oakland regional office takes about 11 months to produce additional Statements of the Case.'
-        }, {
-          title: 'Appeal certified to the Board',
-          description: 'Your appeal will be sent to the Board of Veterans’ Appeals in Washington, D.C.',
-          durationText: '2 months',
-          cardDescription: 'The Oakland regional office takes about 2 months to certify your appeal to the Board.'
+          title: '',
+          description: (
+            <p></p>
+          ),
+          durationText: '',
+          cardDescription: '',
         }
       ];
     case STATUS_TYPES.pendingForm9:
@@ -576,33 +578,59 @@ export function getNextEvents(currentStatus) {
           cardDescription: 'You have 60 days to submit your appeal before it is closed'
         }
       ];
-    case STATUS_TYPES.awaitingHearingDate:
+    case STATUS_TYPES.pendingCertification:
       return [
         {
-          title: 'Awaiting hearing date',
-          description: 'VBA is in the process of scheduling your hearing date',
-          durationText: '2 months',
-          cardDescription: 'The Oakland regional office takes about 2 months to schedule a hearing date.'
+          title: '',
+          description: (
+            <p></p>
+          ),
+          durationText: '',
+          cardDescription: '',
         }
       ];
-    case STATUS_TYPES.bvaDecision:
+    case STATUS_TYPES.pendingCertificationSsoc:
       return [
         {
-          title: 'Board decision reached',
-          description: 'Your appeal decision is being sent to your mailing address',
-          durationText: '2 weeks',
-          cardDescription: 'The Oakland regional office takes about 2 weeks to mail your decision.'
+          title: '',
+          description: (
+            <p></p>
+          ),
+          durationText: '',
+          cardDescription: '',
         }
       ];
-    case STATUS_TYPES.remand:
+    case STATUS_TYPES.remandSsoc:
       return [
         {
-          title: 'VBA prepares a Statement of the Case (SOC)',
-          description: `If you send the Form 9 with new evidence, the Veterans Benefits
-            Administration (VBA) will finish its review and transfer your case to the Board of
-            Veterans’ Appeals.`,
-          durationText: '11 months',
-          cardDescription: 'VBA takes about 11 months to produce a Statement of the Case (SOC)'
+          title: '',
+          description: (
+            <p></p>
+          ),
+          durationText: '',
+          cardDescription: '',
+        }
+      ];
+    case STATUS_TYPES.pendingHearingScheduling:
+      return [
+        {
+          title: '',
+          description: (
+            <p></p>
+          ),
+          durationText: '',
+          cardDescription: '',
+        }
+      ];
+    case STATUS_TYPES.scheduledHearing:
+      return [
+        {
+          title: '',
+          description: (
+            <p></p>
+          ),
+          durationText: '',
+          cardDescription: '',
         }
       ];
     case STATUS_TYPES.onDocket: {
@@ -636,6 +664,79 @@ export function getNextEvents(currentStatus) {
         }
       ];
     }
+    case STATUS_TYPES.atVso:
+      return [
+        {
+          title: '',
+          description: (
+            <p></p>
+          ),
+          durationText: '',
+          cardDescription: '',
+        }
+      ];
+    case STATUS_TYPES.decisionInProgress:
+      return [
+        {
+          title: '',
+          description: (
+            <p></p>
+          ),
+          durationText: '',
+          cardDescription: '',
+        }
+      ];
+    case STATUS_TYPES.bvaDevelopment:
+      return [
+        {
+          title: '',
+          description: (
+            <p></p>
+          ),
+          durationText: '',
+          cardDescription: '',
+        }
+      ];
+    case STATUS_TYPES.stayed:
+      return [
+        {
+          title: '',
+          description: (
+            <p></p>
+          ),
+          durationText: '',
+          cardDescription: '',
+        }
+      ];
+    case STATUS_TYPES.remand:
+      return [
+        {
+          title: 'VBA prepares a Statement of the Case (SOC)',
+          description: `If you send the Form 9 with new evidence, the Veterans Benefits
+            Administration (VBA) will finish its review and transfer your case to the Board of
+            Veterans’ Appeals.`,
+          durationText: '11 months',
+          cardDescription: 'VBA takes about 11 months to produce a Statement of the Case (SOC)'
+        }
+      ];
+    case STATUS_TYPES.bvaDecision:
+      return [
+        {
+          title: 'Board decision reached',
+          description: 'Your appeal decision is being sent to your mailing address',
+          durationText: '2 weeks',
+          cardDescription: 'The Oakland regional office takes about 2 weeks to mail your decision.'
+        }
+      ];
+    case STATUS_TYPES.awaitingHearingDate:
+      return [
+        {
+          title: 'Awaiting hearing date',
+          description: 'VBA is in the process of scheduling your hearing date',
+          durationText: '2 months',
+          cardDescription: 'The Oakland regional office takes about 2 months to schedule a hearing date.'
+        }
+      ];
     default:
       return [
         {

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -872,8 +872,9 @@ h1:focus {
 
   li.next-event {
     &:before { // styles the bullets to mimic bullets in Timeline
-      display: inline-block;
-      vertical-align: middle;
+      display: block;
+      float: left;
+      // vertical-align: middle;
       width: 1em;
       height: 1em;
       content: "";
@@ -881,12 +882,15 @@ h1:focus {
       border-radius: 50%;
       background: $color-gray-medium;
       margin-left: -.6em;
+      position: relative;
+      top: .33em;
     }
 
     h3 {
+      clear: none;
       margin-left: 1.5em;
-      display: inline;
-      vertical-align: middle;
+      margin-top: 0;
+      display: block;
     }
 
     p {

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -874,7 +874,6 @@ h1:focus {
     &:before { // styles the bullets to mimic bullets in Timeline
       display: block;
       float: left;
-      // vertical-align: middle;
       width: 1em;
       height: 1em;
       content: "";

--- a/test/claims-status/components/appeals-v2/WhatsNext.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/WhatsNext.unit.spec.jsx
@@ -4,34 +4,58 @@ import { expect } from 'chai';
 
 import WhatsNext from '../../../../src/js/claims-status/components/appeals-v2/WhatsNext';
 
-const defaultProps = {
-  nextEvents: [
+describe('<WhatsNext/>', () => {
+  const defaultProps = {
+    nextEvents: {
+      header: '',
+      events: [],
+    },
+  };
+
+  const eventsList = [
     {
       title: 'Additional evidence',
-      description: `VBA must reveiw any additional evidence you submit prios to certifying
-      your appeal to the Board of Veterans’ Appeals. This evidence could cause VBA
-      to grant your appeal, but if not, they will need to produce an additional
-      Statement of the Case.`,
+      description: <p>Some description goes here</p>,
       durationText: '11 months',
       cardDescription: 'Test description contents',
     }, {
       title: 'Appeal certified to the Board',
-      description: 'Your appeal will be sent to the Board of Veterans’ Appeals in Washington, D.C.',
+      description: <p>Another description goes here</p>,
       durationText: '2 months',
       cardDescription: 'Test description contents'
     }
-  ]
-};
+  ];
 
-describe('<WhatsNext/>', () => {
   it('renders', () => {
     const wrapper = shallow(<WhatsNext {...defaultProps}/>);
     expect(wrapper.type()).to.equal('div');
   });
 
+  it('renders a header title', () => {
+    const testHeaderText = 'Test Header';
+    const props = {
+      ...defaultProps,
+      nextEvents: {
+        ...defaultProps.nextEvents,
+        header: testHeaderText
+      },
+    };
+    const wrapper = shallow(<WhatsNext {...props}/>);
+    const headerText = wrapper.find('h2 + p').render().text();
+    expect(headerText).to.equal(testHeaderText);
+  });
+
   it('renders a list of all next events for a given currentStatus', () => {
-    const wrapper = shallow(<WhatsNext {...defaultProps}/>);
+    const props = {
+      ...defaultProps,
+      nextEvents: {
+        ...defaultProps.nextEvents,
+        events: eventsList
+      }
+    };
+
+    const wrapper = shallow(<WhatsNext {...props}/>);
     const nextEventList = wrapper.find('NextEvent');
-    expect(nextEventList.length).to.equal(defaultProps.nextEvents.length);
+    expect(nextEventList.length).to.equal(eventsList.length);
   });
 });

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -520,14 +520,21 @@ describe('Disability benefits helpers: ', () => {
   });
 
   describe('getNextEvents', () => {
-    it('returns an array of next event objects', () => {
-      const type = STATUS_TYPES.nod;
-      // 'nod' status has 2 nextEvents in the array
+    it('returns an object with a header property', () => {
+      const type = STATUS_TYPES.pendingCertificationSsoc;
       const nextEvents = getNextEvents(type);
-      expect(nextEvents.length).to.equal(2);
-      const firstEvent = nextEvents[0];
-      const secondEvent = nextEvents[1];
-      // each of the 2 'nod' nextEvents has 4 properties
+      expect(nextEvents.header).to.equal('What happens next depends on whether you send in new evidence.');
+    });
+
+    it('returns an object with an events array property', () => {
+      const type = STATUS_TYPES.remandSsoc;
+      // 'remandSsoc' status has 2 nextEvents in the array
+      const nextEvents = getNextEvents(type);
+      const { events } = nextEvents;
+      expect(events.length).to.equal(2);
+      const firstEvent = events[0];
+      const secondEvent = events[1];
+      // each of the 2 'remandSsoc' nextEvents has 4 properties
       expect(Object.keys(firstEvent).length).to.equal(4);
       expect(Object.keys(secondEvent).length).to.equal(4);
     });


### PR DESCRIPTION
Predominantly a content update, with some other tweaks to support the new content. The content for this update was pulled from https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Appeals%20Status/V2/Design%20files/Statuses.md#pending-soc

- Adds updated content for each current status type's 'What's Next'
- Updates styling a bit to more closely match current mocks in [8313](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/8313) (namely, second header line for each next event left-aligns with the first line instead of getting de-dented)
- Updates the `getNextEvents()` helper to return a `header` property in addition to the `events` array. This also involves updating some PropTypes, JSDoc, and most importantly support for the new format in the `WhatsNext` component. The header is a paragraph that's optionally used to summarize cases where there are multiple next events, and shows up just below the 'What Happens Next?' heading.
- Adds tests for the new `header` property in both `WhatsNext` and `helpers` tests.
- Updates `description` properties to elements from plain strings, which makes DOM nesting sane and also increases flexibility for formatting each WhatsNext event

What this PR doesn't do:
- Update content for the time cards below each NextEvent
- Some NextEvents have dynamic things like dates and locations. They API for these isn't quite finalized yet, so wherever these are needed there's just a [PLACEHOLDER].

One Fancy-Formatted Event:
![screen shot 2018-01-26 at 2 45 29 pm](https://user-images.githubusercontent.com/24251447/35460020-0115f136-02a8-11e8-80fc-be9a63d221b2.png)

Multiple Simple Events:
![screen shot 2018-01-26 at 2 44 27 pm](https://user-images.githubusercontent.com/24251447/35460021-0126ec16-02a8-11e8-8155-9800066912d5.png)
