### PR TITLE
Jenkins build performance - Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,9 @@ RUN \
     echo "===> install Java"  && \
     echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections  && \
     echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections  && \
-    DEBIAN_FRONTEND=noninteractive  apt-get install -y --force-yes libnss3 libgconf-2-4 libxss1 libxtst6 libgtk2.0-0 libasound2 xvfb netcat oracle-java8-installer oracle-java8-set-default
-
-RUN mkdir -p /application && chown jenkins:jenkins /application
+    DEBIAN_FRONTEND=noninteractive  apt-get install -y --force-yes libnss3 libgconf-2-4 libxss1 libxtst6 libgtk2.0-0 libasound2 xvfb netcat oracle-java8-installer oracle-java8-set-default && \
+    \
+    \
+    mkdir -p /application && chown jenkins:jenkins /application
 
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN \
     echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections  && \
     DEBIAN_FRONTEND=noninteractive  apt-get install -y --force-yes libnss3 libgconf-2-4 libxss1 libxtst6 libgtk2.0-0 libasound2 xvfb netcat oracle-java8-installer oracle-java8-set-default
 
-RUN mkdir -p /application
+RUN mkdir -p /application && chown jenkins:jenkins /application
 
 WORKDIR /application
 
@@ -78,10 +78,4 @@ COPY .yarnrc .
 # skips all dev dependencies if NODE_ENV=production.. so..
 RUN yarn install --production=false
 
-# Copy application source to image
-
-COPY . .
-RUN chown -R jenkins:jenkins /application
-RUN chmod -R 777 /application
-RUN chmod -R 777 /home/jenkins
 USER jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,18 +64,4 @@ RUN \
 
 RUN mkdir -p /application && chown jenkins:jenkins /application
 
-WORKDIR /application
-
-# Create empty directory for selenium logs
-
-RUN mkdir -p logs/selenium
-
-# Install required npm dependencies
-
-COPY package.json .
-COPY yarn.lock .
-COPY .yarnrc .
-# skips all dev dependencies if NODE_ENV=production.. so..
-RUN yarn install --production=false
-
 USER jenkins

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,9 @@ node('vetsgov-general-purpose') {
 
       dockerImage = docker.build("vets-website:${imageTag}")
       args = "-v ${pwd()}:/application"
+      dockerImage.inside(args) {
+        sh "cd /application && yarn install --production=false"
+      }
     } catch (error) {
       notify("vets-website ${env.BRANCH_NAME} branch CI failed in setup stage!", 'danger')
       throw error

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,7 @@ node('vetsgov-general-purpose') {
       def imageTag = java.net.URLDecoder.decode(env.BUILD_TAG).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
 
       dockerImage = docker.build("vets-website:${imageTag}")
-      args = "-v ${pwd()}/build:/application/build -v ${pwd()}/logs:/application/logs -v ${pwd()}/coverage:/application/coverage"
+      args = "-v ${pwd()}:/application"
     } catch (error) {
       notify("vets-website ${env.BRANCH_NAME} branch CI failed in setup stage!", 'danger')
       throw error


### PR DESCRIPTION
We aren't benefitting from having vets-website directory synced into the running container since this app is not distributed via a Docker image, and the resulting I/O from the copy/chown/chmod is maxing out disks plus adding extra layers for unionfs to resolve. This modifies the behavior of Jenkins to use a volume for all of `/application` during the build/test phase, which reduces run time by roughly 4 minutes on average.

Ref: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/8407