### PR TITLE
Hide top-level menu on iOS Safari

### DIFF
--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -3,7 +3,7 @@
     <nav id="vetnav" role="navigation" hidden>
       <ul id="vetnav-menu" role="menubar">
         <li><a href="/" class="vetnav-level1" role="menuitem">Home</a></li>
-        <li role="none">
+        <li>
           <button
             aria-controls="vetnav-explore"
             role="button"

--- a/src/js/common/utils/accessible-menus.js
+++ b/src/js/common/utils/accessible-menus.js
@@ -200,9 +200,6 @@ function openMenu(menuLi, menuStructure = null, openSubMenu = false, stealFocus 
   const parentMenu = findNearestAncestor(menuButton, el => el.getAttribute('role') === 'menu');
   if (parentMenu) {
     parentMenu.classList.add('child-menu-opened');
-    console.log('parentMenu found:', parentMenu);
-  } else {
-    console.log('parentMenu not found');
   }
 
   if (stealFocus) {

--- a/src/js/common/utils/accessible-menus.js
+++ b/src/js/common/utils/accessible-menus.js
@@ -156,6 +156,13 @@ function closeMenu(menuLiOrStruct) {
 
   const { menuButton, menu } = struct;
 
+  // Tell the parent menu (if any) that this one is open
+  // This is so longer parent menus on mobile don't show up underneath shorter child menus
+  const parentMenu = findNearestAncestor(menuButton, el => el.getAttribute('role') === 'menu');
+  if (parentMenu) {
+    parentMenu.classList.remove('child-menu-opened');
+  }
+
   // Close the menu
   menuButton.removeAttribute('aria-expanded');
   menu.setAttribute('hidden', 'hidden');
@@ -187,6 +194,16 @@ function openMenu(menuLi, menuStructure = null, openSubMenu = false, stealFocus 
   // Open the menu
   menuButton.setAttribute('aria-expanded', true);
   menu.removeAttribute('hidden');
+
+  // Tell the parent menu (if any) that this one is open
+  // This is so longer parent menus on mobile don't show up underneath shorter child menus
+  const parentMenu = findNearestAncestor(menuButton, el => el.getAttribute('role') === 'menu');
+  if (parentMenu) {
+    parentMenu.classList.add('child-menu-opened');
+    console.log('parentMenu found:', parentMenu);
+  } else {
+    console.log('parentMenu not found');
+  }
 
   if (stealFocus) {
     const menuRole = (menu.getAttribute('role') || '').toLowerCase();

--- a/src/sass/modules/_m-vet-nav.scss
+++ b/src/sass/modules/_m-vet-nav.scss
@@ -10,10 +10,10 @@ body.va-pos-fixed {
 #vetnav, [role="menu"] [role="menu"] {
   // The main menu takes up the whole screen under the Menu button for xsmall & small screens
   // Sub menus also take up the whole screen to cover the main menu
-  height: calc(100vh - #{$height-offset-xsmall});
+  min-height: calc(100vh - #{$height-offset-xsmall});
 
   @include media($small-screen){
-    height: calc(100vh - #{$height-offset-small});
+    min-height: calc(100vh - #{$height-offset-small});
   }
 
   // For medium and large screens, they're just as big as they need to be

--- a/src/sass/modules/_m-vet-nav.scss
+++ b/src/sass/modules/_m-vet-nav.scss
@@ -18,7 +18,7 @@ body.va-pos-fixed {
 
   // For medium and large screens, they're just as big as they need to be
   @include media($medium-large-screen) {
-    height: 100%;
+    min-height: 100%;
   }
 }
 

--- a/src/sass/modules/_m-vet-nav.scss
+++ b/src/sass/modules/_m-vet-nav.scss
@@ -451,3 +451,14 @@ body.va-pos-fixed {
     align-items: center;
   }
 }
+
+.child-menu-opened {
+  height: 0;
+  overflow: hidden;
+}
+
+@include media($medium-screen) {
+  .child-menu-opened {
+    height: initial;
+  }
+}

--- a/src/sass/modules/_m-vet-nav.scss
+++ b/src/sass/modules/_m-vet-nav.scss
@@ -10,10 +10,10 @@ body.va-pos-fixed {
 #vetnav, [role="menu"] [role="menu"] {
   // The main menu takes up the whole screen under the Menu button for xsmall & small screens
   // Sub menus also take up the whole screen to cover the main menu
-  height: calc(100% - #{$height-offset-xsmall});
+  height: calc(100vh - #{$height-offset-xsmall});
 
   @include media($small-screen){
-    height: calc(100% - #{$height-offset-small});
+    height: calc(100vh - #{$height-offset-small});
   }
 
   // For medium and large screens, they're just as big as they need to be


### PR DESCRIPTION
@markgreenburg and I tested on macOS Safari and this bug wasn't present, but it is on iOS Safari. I was able to reproduce locally.

While testing, I noticed the sub-menu didn't cover everything underneath it, so I made a little tweak to use `100vh` instead of `100%`, and that somehow managed to fix what I thought was a transparency problem.

To be honest, I don't know _why_ this works, but my theory goes like this: In all other (sane) browsers, the `<ul>` has a height of the sum of its parts, but in iOS Safari, it doesn't. This means that the background color (applied to the `<ul>`) isn't covering up the menu underneath it.

This PR isn't a complete fix to everything, but it does fix the problem in the connected issue.

If the viewport height < first-level menu height, the first-level menu will show up below the second-level menu. This is because the second-level menu has a `min-height` of `100vh`, not `100%` of the `<ul>` above it in the DOM (great-grandparent). Changing this programmatically is painful because the breakpoints aren't on the javascript side (intentionally) and it behaves completely different on small screens vs large screens.

Too many words! More screenshots, please!
Okay, okay, I'll just show you!
![image](https://user-images.githubusercontent.com/12970166/35545144-7f9f4864-0522-11e8-84e2-89ead9dc61d2.png)
