### PR TITLE
Connect supporting documents upload to api

### DIFF
--- a/src/js/vic-v2/config/form.js
+++ b/src/js/vic-v2/config/form.js
@@ -193,7 +193,22 @@ const formConfig = {
           uiSchema: {
             'ui:description': DD214Description,
             dd214: fileUploadUI('Upload your discharge document', {
-              endpoint: '/v0/vic/vic_attachments'
+              endpoint: '/v0/vic/supporting_documentation_attachments',
+              fileTypes: ['pdf'],
+              maxSize: 15728640,
+              hideLabelText: true,
+              createPayload: (file) => {
+                const payload = new FormData();
+                payload.append('supporting_documentation_attachment[file_data]', file);
+
+                return payload;
+              },
+              parseResponse: (response, file) => {
+                return {
+                  name: file.name,
+                  confirmationCode: response.data.attributes.guid
+                };
+              }
             })
           },
           schema: {

--- a/src/js/vic-v2/config/form.js
+++ b/src/js/vic-v2/config/form.js
@@ -194,7 +194,15 @@ const formConfig = {
             'ui:description': DD214Description,
             dd214: fileUploadUI('Upload your discharge document', {
               endpoint: '/v0/vic/supporting_documentation_attachments',
-              fileTypes: ['pdf'],
+              fileTypes: [
+                'pdf',
+                'png',
+                'tiff',
+                'tif',
+                'jpeg',
+                'jpg',
+                'bmp'
+              ],
               maxSize: 15728640,
               hideLabelText: true,
               createPayload: (file) => {


### PR DESCRIPTION
These changes connect supporting documents upload to the API:
endpoint: /v0/vic/supporting_documentation_attachments
File field is: supporting_documentation_attachment[file_data]