### PR TITLE
Performance updates for photo cropper

### DIFF
--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -36,6 +36,7 @@ const MIN_RATIO = 0.2;
 const MAX_RATIO = 1.7;
 const WARN_RATIO = 1.3;
 const LARGE_SCREEN = 1201;
+const MAX_DIMENSION = 1024;
 
 function isSmallScreen(width) {
   return  width < LARGE_SCREEN;
@@ -45,11 +46,17 @@ function isValidFileType(fileName) {
   return FILE_TYPES.some(type => fileName.toLowerCase().endsWith(type));
 }
 
+// data urls start with data:image/jpg; and we need to pull out the
+// image/jpg part so canvas doesn't change the file type
 function getMimeType(dataUrl) {
+  // limit to 2 so we don't try to split a giant data url string
   const prefix = dataUrl.split(';', 2)[0];
   return prefix.replace('data:', '');
 }
 
+// If any of the image dimensions are greater than the max specified, 
+// resize it down to that dimension while keeping the aspect ratio
+// intact
 function resizeToMaxDimension(img, mimeType, maxDimension) {
   const oc = document.createElement('canvas');
   const octx = oc.getContext('2d');
@@ -73,7 +80,6 @@ function resizeToMaxDimension(img, mimeType, maxDimension) {
   }
 
   return img.src;
-
 }
 
 function isValidImageSize(img) {
@@ -166,7 +172,7 @@ export default class PhotoField extends React.Component {
                 });
               } else {
                 this.setState({
-                  src: resizeToMaxDimension(img, getMimeType(reader.result), 1024),
+                  src: resizeToMaxDimension(img, getMimeType(reader.result), MAX_DIMENSION),
                   done: false,
                   cropResult: null,
                   errorMessage: null
@@ -178,7 +184,7 @@ export default class PhotoField extends React.Component {
                 src: null,
                 done: false,
                 cropResult: null,
-                errorMessage: 'Sorry, we weren\'t able to load the image you selected'
+                errorMessage: 'Sorry, we weren’t able to load the image you selected'
               });
             });
         };

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -49,7 +49,7 @@ function isValidFileType(fileName) {
 // If any of the image dimensions are greater than the max specified, 
 // resize it down to that dimension while keeping the aspect ratio
 // intact
-function resizeToMaxDimension(img, mimeType, maxDimension) {
+function resizeIfAboveMaxDimension(img, mimeType, maxDimension) {
   const oc = document.createElement('canvas');
   const octx = oc.getContext('2d');
   let height = img.height;
@@ -166,7 +166,7 @@ export default class PhotoField extends React.Component {
                 });
               } else {
                 this.setState({
-                  src: resizeToMaxDimension(img, file.type, MAX_DIMENSION),
+                  src: resizeIfAboveMaxDimension(img, file.type, MAX_DIMENSION),
                   fileType: file.type,
                   done: false,
                   cropResult: null,

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -45,29 +45,51 @@ function isValidFileType(fileName) {
   return FILE_TYPES.some(type => fileName.toLowerCase().endsWith(type));
 }
 
-function isValidImageSize(result) {
+function getMimeType(dataUrl) {
+  const prefix = dataUrl.split(';', 2)[0];
+  return prefix.replace('data:', '');
+}
+
+function resizeToMaxDimension(img, mimeType, maxDimension) {
+  const oc = document.createElement('canvas');
+  const octx = oc.getContext('2d');
+  let height = img.height;
+  let width = img.width;
+
+  if (Math.max(img.width, img.height) > maxDimension) {
+    if (img.width > img.height) {
+      height = (height / width) * maxDimension;
+      width = maxDimension;
+    } else {
+      width = (width / height) * maxDimension;
+      height = maxDimension;
+    }
+
+    oc.width = width;
+    oc.height = height;
+    octx.drawImage(img, 0, 0, oc.width, oc.height);
+
+    return oc.toDataURL(mimeType);
+  }
+
+  return img.src;
+
+}
+
+function isValidImageSize(img) {
+  return img.width >= MIN_SIZE && img.height >= MIN_SIZE;
+}
+
+function loadImage(dataUrl) {
   return new Promise((resolve, reject) => {
     const img = new Image();
-    img.src = result;
+    img.src = dataUrl;
     img.onerror = (e) => reject(e);
     img.onload = () => {
-      const isValidSize = img.width >= MIN_SIZE && img.height >= MIN_SIZE;
-      resolve(isValidSize);
+      resolve(img);
     };
   });
 }
-
-function isValidImage(result, fileName) {
-  return new Promise((resolve, reject) => {
-    isValidImageSize(result)
-      .then(isValidSize => {
-        const isValidType = isValidFileType(fileName);
-        resolve(isValidSize && isValidType);
-      })
-      .catch((e) => reject(e));
-  });
-}
-
 
 export default class PhotoField extends React.Component {
   constructor(props) {
@@ -106,60 +128,62 @@ export default class PhotoField extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    const newView = this.state.src && (prevState.src !== this.state.src || (prevState.done && !this.state.done));
-    const cropper = this.refs.cropper;
-    if (cropper && newView) {
-      this.setCropBox();
-    }
-  }
-
   onEdit = () => {
     this.setState({ done: false, warningMessage: null });
   }
 
   onDone = () => {
-    this.setState({ done: true, warningMessage: null });
+    const cropResult = this.refs.cropper.getCroppedCanvas().toDataURL();
+    this.setState({ cropResult, done: true, warningMessage: null });
   }
 
   onChange = (files) => {
     if (files && files[0]) {
       const file = files[0];
-      const reader = new FileReader();
-      reader.readAsDataURL(file);
-      reader.onload = () => {
-        const fileName = file.name;
-        isValidImage(reader.result, fileName)
-          .then((isValid) => {
-            if (isValid) {
-              this.setState({
-                src: reader.result,
-                done: false,
-                cropResult: null,
-                errorMessage: null
-              });
-            } else if (!isValidFileType(file.name)) {
+      if (file.preview) {
+        // dropzone recommendation
+        window.URL.revokeObjectURL(file.preview);
+      }
+      if (!isValidFileType(file.name)) {
+        this.setState({
+          src: null,
+          done: false,
+          cropResult: null,
+          errorMessage: 'Please choose a file from one of the accepted types.'
+        });
+      } else {
+        const reader = new FileReader();
+        reader.readAsDataURL(file);
+        reader.onload = () => {
+          loadImage(reader.result)
+            .then((img) => {
+              if (!isValidImageSize(img)) {
+                this.setState({
+                  src: null,
+                  done: false,
+                  cropResult: null,
+                  errorMessage: 'The file you selected is smaller than the 350px minimum file width or height and could not be added.'
+                });
+              } else {
+                this.setState({
+                  src: resizeToMaxDimension(img, getMimeType(reader.result), 1024),
+                  done: false,
+                  cropResult: null,
+                  errorMessage: null
+                });
+              }
+            })
+            .catch(() => {
               this.setState({
                 src: null,
                 done: false,
                 cropResult: null,
-                errorMessage: 'Please choose a file from one of the accepted types.'
+                errorMessage: 'Sorry, we weren\'t able to load the image you selected'
               });
-            } else if (isValidFileType(file.name)) {
-              this.setState({
-                src: null,
-                done: false,
-                cropResult: null,
-                errorMessage: 'The file you selected is smaller than the 350px minimum file width or height and could not be added.'
-              });
-            }
-          });
-      };
+            });
+        };
+      }
     }
-  }
-
-  onDrop = (files) => {
-    this.setState({ src: files[0].preview });
   }
 
   onZoom = (e) => {
@@ -177,22 +201,20 @@ export default class PhotoField extends React.Component {
   setCropBox = () => {
     const cropper = this.refs.cropper;
     const slider = this.refs.slider;
-    setTimeout(() => {
-      const { width, naturalWidth } = this.refs.cropper.getImageData();
-      slider.value = width / naturalWidth;
-      const containerData = cropper.getContainerData();
-      const containerWidth = containerData.width;
-      const smallScreen = isSmallScreen(this.state.windowWidth);
-      const cropBoxSize = smallScreen ? 240 : 300;
-      const cropBoxLeftOffset = (containerWidth - cropBoxSize) / 2;
-      const cropBoxData = {
-        left: cropBoxLeftOffset,
-        top: 0,
-        width: cropBoxSize,
-        height: cropBoxSize
-      };
-      cropper.setCropBoxData(cropBoxData);
-    }, 0);
+    const { width, naturalWidth } = this.refs.cropper.getImageData();
+    slider.value = width / naturalWidth;
+    const containerData = cropper.getContainerData();
+    const containerWidth = containerData.width;
+    const smallScreen = isSmallScreen(this.state.windowWidth);
+    const cropBoxSize = smallScreen ? 240 : 300;
+    const cropBoxLeftOffset = (containerWidth - cropBoxSize) / 2;
+    const cropBoxData = {
+      left: cropBoxLeftOffset,
+      top: 0,
+      width: cropBoxSize,
+      height: cropBoxSize
+    };
+    cropper.setCropBoxData(cropBoxData);
   }
 
   getErrorMessage = () => {
@@ -246,11 +268,6 @@ export default class PhotoField extends React.Component {
     }
   }
 
-  cropImage = () => {
-    const cropResult = this.refs.cropper.getCroppedCanvas().toDataURL();
-    this.setState({ cropResult });
-  }
-
   render() {
     const smallScreen = isSmallScreen(this.state.windowWidth);
     const moveControlClass = classNames('cropper-control', 'cropper-control-label-container', 'va-button-link');
@@ -296,16 +313,16 @@ export default class PhotoField extends React.Component {
           {!this.state.done && this.state.src && <div className="cropper-container-outer">
             <Cropper
               ref="cropper"
+              ready={this.setCropBox}
               responsive
               src={this.state.src}
-              aspectRatio={1 / 1}
+              aspectRatio={1}
               cropBoxMovable={false}
               toggleDragModeOnDblclick={false}
               dragMode="move"
               guides={false}
               viewMode={1}
-              zoom={this.onZoom}
-              crop={this.cropImage}/>
+              zoom={this.onZoom}/>
             <div className="cropper-zoom-container">
               {smallScreen && <button className="cropper-control cropper-control-zoom cropper-control-zoom-out va-button va-button-link" type="button" onClick={this.zoomOut}><i className="fa fa-search-minus"></i></button>}
               {!smallScreen && <button className="cropper-control cropper-control-zoom cropper-control-zoom-out va-button va-button-link" type="button" onClick={this.zoomOut}>

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -46,14 +46,6 @@ function isValidFileType(fileName) {
   return FILE_TYPES.some(type => fileName.toLowerCase().endsWith(type));
 }
 
-// data urls start with data:image/jpg; and we need to pull out the
-// image/jpg part so canvas doesn't change the file type
-function getMimeType(dataUrl) {
-  // limit to 2 so we don't try to split a giant data url string
-  const prefix = dataUrl.split(';', 2)[0];
-  return prefix.replace('data:', '');
-}
-
 // If any of the image dimensions are greater than the max specified, 
 // resize it down to that dimension while keeping the aspect ratio
 // intact
@@ -139,7 +131,7 @@ export default class PhotoField extends React.Component {
   }
 
   onDone = () => {
-    const cropResult = this.refs.cropper.getCroppedCanvas().toDataURL();
+    const cropResult = this.refs.cropper.getCroppedCanvas().toDataURL(this.state.fileType);
     this.setState({ cropResult, done: true, warningMessage: null });
   }
 
@@ -153,6 +145,7 @@ export default class PhotoField extends React.Component {
       if (!isValidFileType(file.name)) {
         this.setState({
           src: null,
+          fileType: null,
           done: false,
           cropResult: null,
           errorMessage: 'Please choose a file from one of the accepted types.'
@@ -166,13 +159,15 @@ export default class PhotoField extends React.Component {
               if (!isValidImageSize(img)) {
                 this.setState({
                   src: null,
+                  fileType: null,
                   done: false,
                   cropResult: null,
                   errorMessage: 'The file you selected is smaller than the 350px minimum file width or height and could not be added.'
                 });
               } else {
                 this.setState({
-                  src: resizeToMaxDimension(img, getMimeType(reader.result), MAX_DIMENSION),
+                  src: resizeToMaxDimension(img, file.type, MAX_DIMENSION),
+                  fileType: file.type,
                   done: false,
                   cropResult: null,
                   errorMessage: null
@@ -182,6 +177,7 @@ export default class PhotoField extends React.Component {
             .catch(() => {
               this.setState({
                 src: null,
+                fileType: null,
                 done: false,
                 cropResult: null,
                 errorMessage: 'Sorry, we weren’t able to load the image you selected'


### PR DESCRIPTION
I found that moving the photo around on my Android phones (a Pixel and an old Moto G) was really slow. This ended up being two things:

1. The camera images are very large and can be resized (this is the guidance from the cropperjs readme)
2. We were generating a dataUrl on every crop event. This takes like 400ms on a slow phone and crop events are fired on every movement or zoom of the image. I changed the code to generate the data url only on when "I'm done" is clicked.
3. Dropzone says you should revoke preview urls, so I also made that change, but I didn't see any performance issues because of it.

The change for 1 also revealed an issue with the `setTimeout` call. When I loaded a dataUrl that was resized, I believe because the browser hadn't loaded and cached it already like with an image that has been read with a FileReader, it took longer for the cropper component to load the image and caused the crop box to be the wrong size. I changed the code to set the crop box on the `ready` event, which is fired when the cropper tool is done loading the image.
