### PR TITLE
Jenkins build performance - parallel lint, security, unit jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,19 +92,6 @@ node('vetsgov-general-purpose') {
     }
   }
 
-  // Check package.json for known vulnerabilities
-
-  stage('Security') {
-    try {
-      dockerImage.inside(args) {
-        sh "cd /application && nsp check"
-      }
-    } catch (error) {
-      notify("vets-website ${env.BRANCH_NAME} branch CI failed in security stage!", 'danger')
-      throw error
-    }
-  }
-
   stage('pre-build (lint, security, unit)') {
     try {
       parallel (

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,13 +113,13 @@ node('vetsgov-general-purpose') {
             sh "cd /application && npm --no-color run test:coverage"
             sh "cd /application && CODECLIMATE_REPO_TOKEN=fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24 codeclimate-test-reporter < ./coverage/lcov.info"
           }
-        }
+        },
 
         lint: {
           dockerImage.inside(args) {
             sh "cd /application && npm --no-color run lint"
           }
-        }
+        },
 
         // Check package.json for known vulnerabilities
         security: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,16 +92,9 @@ node('vetsgov-general-purpose') {
     }
   }
 
-  stage('Coverage|Lint|Security') {
+  stage('Lint|Security|Unit') {
     try {
       parallel (
-        coverage: {
-          dockerImage.inside(args) {
-            sh "cd /application && npm --no-color run test:coverage"
-            sh "cd /application && CODECLIMATE_REPO_TOKEN=fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24 codeclimate-test-reporter < ./coverage/lcov.info"
-          }
-        },
-
         lint: {
           dockerImage.inside(args) {
             sh "cd /application && npm --no-color run lint"
@@ -112,6 +105,13 @@ node('vetsgov-general-purpose') {
         security: {
           dockerImage.inside(args) {
             sh "cd /application && nsp check"
+          }
+        },
+
+        unit: {
+          dockerImage.inside(args) {
+            sh "cd /application && npm --no-color run test:coverage"
+            sh "cd /application && CODECLIMATE_REPO_TOKEN=fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24 codeclimate-test-reporter < ./coverage/lcov.info"
           }
         }
       )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ node('vetsgov-general-purpose') {
 
   stage('pre-build (lint, security, unit)') {
     try {
-      parallel {
+      parallel (
         dockerImage.inside(args) {
           sh "cd /application && npm --no-color run test:coverage"
           sh "cd /application && CODECLIMATE_REPO_TOKEN=fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24 codeclimate-test-reporter < ./coverage/lcov.info"
@@ -121,7 +121,7 @@ node('vetsgov-general-purpose') {
         dockerImage.inside(args) {
           sh "cd /application && nsp check"
         }
-      }
+      )
     } catch (error) {
       notify("vets-website ${env.BRANCH_NAME} branch CI failed in pre-build stage!", 'danger')
       throw error

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,18 +108,24 @@ node('vetsgov-general-purpose') {
   stage('pre-build (lint, security, unit)') {
     try {
       parallel (
-        dockerImage.inside(args) {
-          sh "cd /application && npm --no-color run test:coverage"
-          sh "cd /application && CODECLIMATE_REPO_TOKEN=fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24 codeclimate-test-reporter < ./coverage/lcov.info"
+        coverage: {
+          dockerImage.inside(args) {
+            sh "cd /application && npm --no-color run test:coverage"
+            sh "cd /application && CODECLIMATE_REPO_TOKEN=fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24 codeclimate-test-reporter < ./coverage/lcov.info"
+          }
         }
 
-        dockerImage.inside(args) {
-          sh "cd /application && npm --no-color run lint"
+        lint: {
+          dockerImage.inside(args) {
+            sh "cd /application && npm --no-color run lint"
+          }
         }
 
         // Check package.json for known vulnerabilities
-        dockerImage.inside(args) {
-          sh "cd /application && nsp check"
+        security: {
+          dockerImage.inside(args) {
+            sh "cd /application && nsp check"
+          }
         }
       )
     } catch (error) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ node('vetsgov-general-purpose') {
     }
   }
 
-  stage('pre-build (lint, security, unit)') {
+  stage('Coverage|Lint|Security') {
     try {
       parallel (
         coverage: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,7 +116,7 @@ node('vetsgov-general-purpose') {
         }
       )
     } catch (error) {
-      notify("vets-website ${env.BRANCH_NAME} branch CI failed in pre-build stage!", 'danger')
+      notify("vets-website ${env.BRANCH_NAME} branch CI failed in lint|security|unit stage!", 'danger')
       throw error
     }
   }

--- a/config/create-settings.js
+++ b/config/create-settings.js
@@ -15,6 +15,6 @@ function createSettings(options) {
       rateLimitUnauthed: 1
     }
   };
-}
+}  
 
 module.exports = createSettings;

--- a/config/create-settings.js
+++ b/config/create-settings.js
@@ -15,6 +15,6 @@ function createSettings(options) {
       rateLimitUnauthed: 1
     }
   };
-}  
+}
 
 module.exports = createSettings;


### PR DESCRIPTION
This cuts an additional minute+ off the job time by running lint and unit tests in parallel (security is only a few seconds, but may as well combine it while we're at it).

Ref: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/8407