### PR TITLE
reorganize markup and tweak flexbox styling

### DIFF
--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -347,25 +347,27 @@ export default class PhotoField extends React.Component {
               </button>}
             </div>
             <div className="cropper-control-container">
-              <div className="cropper-control-column">
+              <div className="cropper-control-row">
                 {smallScreen && <button className="cropper-control cropper-control-label-container va-button va-button-link" type="button" onClick={this.zoomOut}>
                   <span className="cropper-control-label">Make smaller</span>
                 </button>}
+                {smallScreen && <button className="cropper-control cropper-control-label-container va-button va-button-link" type="button" onClick={this.zoomIn}>
+                  <span className="cropper-control-label">Make larger</span>
+                </button>}
+              </div>
+              <div className="cropper-control-row">
                 <button className={moveControlClass} type="button" onClick={this.moveUp}>
                   <span className="cropper-control-label">Move up<i className="fa fa-arrow-up"></i></span>
 
                 </button>
-                <button className={moveControlClass} type="button" onClick={this.moveLeft}>
-                  <span className="cropper-control-label">Move left<i className="fa fa-arrow-left"></i></span>
+                <button className={moveControlClass} type="button" onClick={this.moveDown}>
+                  <span className="cropper-control-label">Move down<i className="fa fa-arrow-down"></i></span>
 
                 </button>
               </div>
-              <div className="cropper-control-column">
-                {smallScreen && <button className="cropper-control cropper-control-label-container va-button va-button-link" type="button" onClick={this.zoomIn}>
-                  <span className="cropper-control-label">Make larger</span>
-                </button>}
-                <button className={moveControlClass} type="button" onClick={this.moveDown}>
-                  <span className="cropper-control-label">Move down<i className="fa fa-arrow-down"></i></span>
+              <div className="cropper-control-row">
+                <button className={moveControlClass} type="button" onClick={this.moveLeft}>
+                  <span className="cropper-control-label">Move left<i className="fa fa-arrow-left"></i></span>
 
                 </button>
                 <button className={moveControlClass} type="button" onClick={this.moveRight}>

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -46,7 +46,7 @@ function isValidFileType(fileName) {
   return FILE_TYPES.some(type => fileName.toLowerCase().endsWith(type));
 }
 
-// If any of the image dimensions are greater than the max specified, 
+// If any of the image dimensions are greater than the max specified,
 // resize it down to that dimension while keeping the aspect ratio
 // intact
 function resizeIfAboveMaxDimension(img, mimeType, maxDimension) {
@@ -355,25 +355,34 @@ export default class PhotoField extends React.Component {
                   <span className="cropper-control-label">Make larger</span>
                 </button>}
               </div>
-              <div className="cropper-control-row">
-                <button className={moveControlClass} type="button" onClick={this.moveUp}>
-                  <span className="cropper-control-label">Move up<i className="fa fa-arrow-up"></i></span>
-
-                </button>
-                <button className={moveControlClass} type="button" onClick={this.moveDown}>
-                  <span className="cropper-control-label">Move down<i className="fa fa-arrow-down"></i></span>
-
-                </button>
-              </div>
-              <div className="cropper-control-row">
-                <button className={moveControlClass} type="button" onClick={this.moveLeft}>
-                  <span className="cropper-control-label">Move left<i className="fa fa-arrow-left"></i></span>
-
-                </button>
-                <button className={moveControlClass} type="button" onClick={this.moveRight}>
-                  <span className="cropper-control-label">Move right<i className="fa fa-arrow-right"></i></span>
-                </button>
-              </div>
+              {[
+                [{
+                  labelText: 'Move up',
+                  className: 'fa fa-arrow-up',
+                  onClick: this.moveUp
+                }, {
+                  labelText: 'Move down',
+                  className: 'fa fa-arrow-down',
+                  onClick: this.moveDown
+                }],
+                [{
+                  labelText: 'Move left',
+                  className: 'fa fa-arrow-left',
+                  onClick: this.moveLeft
+                }, {
+                  labelText: 'Move right',
+                  className: 'fa fa-arrow-right',
+                  onClick: this.moveright
+                }]
+              ].map((row, index) => (
+                <div className="cropper-control-row" key={index}>
+                  {row.map((button) => (
+                    <button className={moveControlClass} type="button" onClick={button.onClick} key={button.className}>
+                      <span className="cropper-control-label">{button.labelText}<i className={button.className}></i></span>
+                    </button>))
+                  }
+                </div>))
+              }
             </div>
             <div className="crop-button-container">
               <button type="button" className="usa-button-primary" onClick={this.onDone}>

--- a/src/sass/vic-v2.scss
+++ b/src/sass/vic-v2.scss
@@ -181,21 +181,26 @@ input[type=range] {
 
 .cropper-control-container {
   display: flex;
-  flex-direction: row;
   justify-content: space-around;
+  flex-flow: row wrap;
   margin-bottom: 30px;
+  @media (min-width: $large-screen) {
+    flex-flow: unset;
+  }
 }
 
-.cropper-control-column {
+.cropper-control-row {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  justify-content: space-around;
   @media (min-width: $large-screen) {
-    flex-direction: row;
+    width: unset;
   }
 }
 
 .cropper-control-label-container {
   margin: 10px;
+  min-width: 96px;
 }
 
 .cropper-control-zoom {

--- a/src/sass/vic-v2.scss
+++ b/src/sass/vic-v2.scss
@@ -185,7 +185,7 @@ input[type=range] {
   flex-flow: row wrap;
   margin-bottom: 30px;
   @media (min-width: $large-screen) {
-    flex-flow: unset;
+    flex-flow: inherit;
   }
 }
 
@@ -194,7 +194,7 @@ input[type=range] {
   width: 100%;
   justify-content: space-around;
   @media (min-width: $large-screen) {
-    width: unset;
+    width: inherit;
   }
 }
 


### PR DESCRIPTION
PR addresses: reorganize the move controls so that when the button sequence is Up Down Left Right on large screens as indicated in the design, rather than the current organization of Up Left Down Right.

LMK is this is this correct @cehsu 

<img width="812" alt="screen shot 2018-02-01 at 08 54 28" src="https://user-images.githubusercontent.com/4998130/35685389-32c6ae06-072f-11e8-801a-811563315da1.png">
<img width="689" alt="screen shot 2018-02-01 at 08 54 19" src="https://user-images.githubusercontent.com/4998130/35685394-34ebe408-072f-11e8-9743-165b5a90a38e.png">
