### PR TITLE
jenkinsfile bail on nextbuild

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,6 +124,9 @@ node('vetsgov-general-purpose') {
   // Perform a build for each build type
 
   stage('Build') {
+    if (currentBuild.nextBuild) {
+      return // bail early if a newer build is going in this branch
+    }
     try {
       def builds = [:]
 
@@ -153,6 +156,9 @@ node('vetsgov-general-purpose') {
   // Run E2E and accessibility tests
 
   stage('Integration') {
+    if (currentBuild.nextBuild) {
+      return // bail early if a newer build is going in this branch
+    }
     try {
       parallel (
         e2e: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ def isDeployable = {
   (env.BRANCH_NAME == devBranch ||
    env.BRANCH_NAME == stagingBranch) &&
     !env.CHANGE_TARGET &&
-    !currentBuild.nextBuild   // if there's a later build on this job (branch), don't deploy
+    !currentBuild.nextBuild // if there's a later build on this job (branch), don't deploy
 }
 
 def shouldBail = {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,10 +124,8 @@ node('vetsgov-general-purpose') {
   // Perform a build for each build type
 
   stage('Build') {
-    if (currentBuild.nextBuild) {
-      currentBuild.result = 'ABORTED'
-      return // bail early if a newer build is going in this branch
-    }
+    if (currentBuild.nextBuild) { return } // bail early if a newer build is going in this branch
+
     try {
       def builds = [:]
 
@@ -156,9 +154,8 @@ node('vetsgov-general-purpose') {
 
   // Run E2E and accessibility tests
   stage('Integration') {
-    if (currentBuild.nextBuild) {
-      return // bail early if a newer build is going in this branch
-    }
+    if (currentBuild.nextBuild) { return } // bail early if a newer build is going in this branch
+
     try {
       parallel (
         e2e: {
@@ -182,9 +179,8 @@ node('vetsgov-general-purpose') {
   }
 
   stage('Archive') {
-    if (currentBuild.nextBuild) {
-      return // bail early if a newer build is going in this branch
-    }
+    if (currentBuild.nextBuild) { return } // bail early if a newer build is going in this branch
+
     try {
       def builds = [ 'development', 'staging', 'production' ]
 
@@ -205,8 +201,10 @@ node('vetsgov-general-purpose') {
 
   stage('Review') {
     if (currentBuild.nextBuild) {
-      return //  bail early if a newer build is going in this branch
+      currentBuild.result = 'ABORTED'
+      return // bail early if a newer build is going in this branch
     }
+
     try {
       if (!isReviewable()) {
         return

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,7 @@ node('vetsgov-general-purpose') {
       parallel (
         e2e: {
           dockerImage.inside(args + " -e BUILDTYPE=production") {
-            sh "Xvfb :99 & cd /application && DISPLAY=:99 CONCURRENCY=20 npm --no-color run test:e2e"
+            sh "Xvfb :99 & cd /application && DISPLAY=:99 npm --no-color run test:e2e"
           }
         },
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,6 +181,9 @@ node('vetsgov-general-purpose') {
   }
 
   stage('Archive') {
+    if (currentBuild.nextBuild) {
+      return // bail early if a newer build is going in this branch
+    }
     try {
       def builds = [ 'development', 'staging', 'production' ]
 
@@ -200,6 +203,9 @@ node('vetsgov-general-purpose') {
   }
 
   stage('Review') {
+    if (currentBuild.nextBuild) {
+      return // bail early if a newer build is going in this branch
+    }
     try {
       if (!isReviewable()) {
         return

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,7 @@ node('vetsgov-general-purpose') {
       parallel (
         e2e: {
           dockerImage.inside(args + " -e BUILDTYPE=production") {
-            sh "Xvfb :99 & cd /application && DISPLAY=:99 CONCURRENCY=5 npm --no-color run test:e2e"
+            sh "Xvfb :99 & cd /application && DISPLAY=:99 CONCURRENCY=20 npm --no-color run test:e2e"
           }
         },
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,7 +204,7 @@ node('vetsgov-general-purpose') {
 
   stage('Review') {
     if (currentBuild.nextBuild) {
-      return // bail early if a newer build is going in this branch
+      return //  bail early if a newer build is going in this branch
     }
     try {
       if (!isReviewable()) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,6 +125,7 @@ node('vetsgov-general-purpose') {
 
   stage('Build') {
     if (currentBuild.nextBuild) {
+      currentBuild.result = 'ABORTED'
       return // bail early if a newer build is going in this branch
     }
     try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,7 +154,6 @@ node('vetsgov-general-purpose') {
   }
 
   // Run E2E and accessibility tests
-
   stage('Integration') {
     if (currentBuild.nextBuild) {
       return // bail early if a newer build is going in this branch

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,7 +163,7 @@ node('vetsgov-general-purpose') {
       parallel (
         e2e: {
           dockerImage.inside(args + " -e BUILDTYPE=production") {
-            sh "Xvfb :99 & cd /application && DISPLAY=:99 npm --no-color run test:e2e"
+            sh "Xvfb :99 & cd /application && DISPLAY=:99 CONCURRENCY=5 npm --no-color run test:e2e"
           }
         },
 


### PR DESCRIPTION
Have Jenkins abort a job if it detects a new build on the same branch that came after the current one. The evaluation only happens at the beginning of a stage, so it won't interrupt any of the longer-running tasks in the middle, but will bail as soon as it can cleanly to avoid extra work.

I specifically excluded master because the deploys have a timing-related condition where we could attempt to tag a build that didn't actually get built. I think it's worthwhile to continue to the end for each master commit.

ref: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/8407