### PR TITLE
Expand unit test command capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ very secret.
 | run the site so that devices on your local network can access it  | `npm run watch -- --host 0.0.0.0 --public 198.162.x.x:3001` Note that we use CORS to limit what hosts can access different APIs, so accessing with a `192.168.x.x` address may run into problems |
 | run all tests | `npm run test` |
 | run only unit tests | `npm run test:unit` |
-| run only unit tests for a subset of tests | `BABEL_ENV=test ./node_modules/.bin/mocha path/to/my/test.unit.spec.jsx` <br> or <br> `BABEL_ENV=test ./node_modules/.bin/mocha --recursive 'path/to/my/**/*.unit.spec.js?(x)'` |
+| run only unit tests for a subset of tests | `npm run test:unit -- path/to/my/test.unit.spec.jsx` <br> or <br> `npm run test:unit -- --recursive 'path/to/my/**/*.unit.spec.js?(x)'` |
 | run only e2e tests                       | `npm run test:e2e`                       |
 | run only e2e tests for a subset of tests | `npm run test:e2e -- test/edu-benefits/1995/*.e2e.spec.js` (provide file paths) |
 | run all linters                          | `npm run lint`                           |

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:sauce": "./script/run-nightwatch.sh --sauce",
     "test:sauce:desktop": "./script/run-nightwatch.sh --sauce -e chrome,firefox,ie,edge",
     "test:sauce:mobile": "./script/run-nightwatch.sh --sauce -e ios,android",
-    "test:unit": "BABEL_ENV=test mocha --recursive 'test/**/*.unit.spec.js?(x)' ",
+    "test:unit": "./script/run-unit-test.sh",
     "test:unit:edu": "BABEL_ENV=test mocha --recursive 'test/edu-benefits/**/*.unit.spec.js?(x)' ",
     "test:unit:hca": "BABEL_ENV=test mocha --recursive 'test/hca/**/*.unit.spec.js?(x)' ",
     "test:unit:msg": "BABEL_ENV=test mocha --recursive 'test/messaging/**/*.unit.spec.js?(x)' ",

--- a/script/run-unit-test.sh
+++ b/script/run-unit-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MOCHA=$SCRIPT_DIR/../node_modules/.bin/mocha
+
+if [ ! -f $MOCHA ]; then
+  echo "Mocha not found. Try \`yarn install\`"
+  exit 1
+fi
+
+# No test specified; run all of them
+if [ -z "$1" ]; then
+  BABEL_ENV=test $MOCHA --recursive '$SCRIPT_DIR/../test/**/*.unit.spec.js?(x)' 
+  exit 0
+fi
+
+BABEL_ENV=test $MOCHA $1
+


### PR DESCRIPTION
We can still run all unit tests with the old command:
```bash
npm run test:unit
```
It just now accepts another parameter like the e2e tests:
![image](https://user-images.githubusercontent.com/12970166/35704034-f4b99456-0752-11e8-88f5-c7d3f603b530.png)
