### PR TITLE
Appealsv2 wait time mg

### DIFF
--- a/src/js/claims-status/components/appeals-v2/DurationCard.jsx
+++ b/src/js/claims-status/components/appeals-v2/DurationCard.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const DurationCard = ({ durationText, cardDescription }) => {
+  // Card's not very helpful without any actual duration information
+  if (!durationText) {
+    return null;
+  }
+
+  return (
+    <div className="card information">
+      <span className="number">{durationText}</span>
+      <span className="description">{cardDescription}</span>
+    </div>
+  );
+};
+
+DurationCard.propTypes = {
+  durationText: PropTypes.string.isRequired,
+  cardDescription: PropTypes.string
+};
+
+export default DurationCard;

--- a/src/js/claims-status/components/appeals-v2/NextEvent.jsx
+++ b/src/js/claims-status/components/appeals-v2/NextEvent.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import DurationCard from './DurationCard';
 
 const NextEvent = ({ title, description, durationText, cardDescription, showSeparator }) => {
   return (
     <li className="next-event">
       <h3>{title}</h3>
       <div>{description}</div>
-      <div className="card information">
-        <span className="number">{durationText}</span>
-        <span className="description">{cardDescription}</span>
-      </div>
+      <DurationCard
+        durationText={durationText}
+        cardDescription={cardDescription}/>
       { showSeparator && <span className="sidelines">or</span>}
     </li>
   );

--- a/src/js/claims-status/components/appeals-v2/WhatsNext.jsx
+++ b/src/js/claims-status/components/appeals-v2/WhatsNext.jsx
@@ -49,6 +49,10 @@ const WhatsNext = ({ nextEvents }) => {
 WhatsNext.propTypes = {
   nextEvents: PropTypes.shape({
     header: PropTypes.string.isRequired,
+    headerCard: PropTypes.shape({
+      durationText: PropTypes.string.isRequired,
+      cardDescription: PropTypes.string.isRequired,
+    }),
     events: PropTypes.arrayOf(PropTypes.shape({
       title: PropTypes.string.isRequired,
       description: PropTypes.element.isRequired,

--- a/src/js/claims-status/components/appeals-v2/WhatsNext.jsx
+++ b/src/js/claims-status/components/appeals-v2/WhatsNext.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import NextEvent from './NextEvent';
+import DurationCard from './DurationCard';
 
 const WhatsNext = ({ nextEvents }) => {
   const { header, events } = nextEvents;
@@ -17,10 +18,27 @@ const WhatsNext = ({ nextEvents }) => {
     );
   });
 
+  // Some current status types (really, just pendingSoc) have multiple
+  // NextEvents that each have the same duration. In these cases, we want to
+  // show one duration card, above the NextEvent list, instead of one card for
+  // each NextEvent item. getNextEvents() will only return a headerCard
+  // property if the corresponding current status type should be treated in
+  // this way
+  let headerDurationCard = null;
+  if (nextEvents.headerCard) {
+    const { durationText, cardDescription } = nextEvents.headerCard;
+    headerDurationCard = (
+      <DurationCard
+        durationText={durationText}
+        cardDescription={cardDescription}/>
+    );
+  }
+
   return (
     <div>
       <h2>What happens next?</h2>
       <p>{header}</p>
+      {headerDurationCard}
       <ul className="appeals-next-list">
         {eventsList}
       </ul>

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -568,30 +568,42 @@ const DECISION_REVIEW_CONTENT = (
 
 /**
  * Translates an array of two ints into a string that conveys a duration estimate
+ * @typedef {Object} durationText contains strings to fill in time snippets in NextEvents
+ * @property {string} header formatted time string to be used in the duration card header
+ * @property {string} description formatted time string to be used in the duration card description
  * @param {number[]} timeliness two integers that represent the low and high time durations
  * (in months) of a given thing
- * @returns {string} formatted to convey the estimated duration range, in months
+ * @returns {durationText} formatted to convey the estimated duration range, in months
  */
 const makeDurationHeader = (timeliness) => {
+  const durationText = {
+    header: 'unknown',
+    description: 'unknown',
+  };
+
   if (!timeliness || !Array.isArray(timeliness) || timeliness.length !== 2) {
     const durationError = new Error(
       'vets_appeals_v2_helpers_makeDurationHeader_bad_timeliness_input'
     );
     Raven.captureException(durationError);
-    return 'No estimated duration for this step';
+    return durationText;
   }
 
   const lowEst = timeliness[0];
   const highEst = timeliness[1];
   const estIsExact = (lowEst === highEst);
 
-  if (estIsExact) {
-    return (lowEst === 1)
-      ? '1 Month'
-      : `${lowEst} Months`;
+  if (estIsExact && lowEst === 1) {
+    durationText.header = '1 month';
+    durationText.description = 'about 1 month';
+  } else if (estIsExact) {
+    durationText.header = `${lowEst} months`;
+    durationText.description = `about ${lowEst} months`;
+  } else {
+    durationText.header = `${lowEst}–${highEst} months`;
+    durationText.description = `between ${lowEst}–${highEst} months`;
   }
-
-  return `${lowEst}-${highEst} Months`;
+  return durationText;
 };
 
 /**
@@ -624,8 +636,8 @@ export function getNextEvents(currentStatus, details) {
         header: `What happens next depends on whether the Decision Review Officer has enough 
           evidence to decide in your favor.`,
         headerCard: {
-          durationText: socDuration,
-          cardDescription: `The Veterans Benefits Administration typically takes ${socDuration} months to review new appeals.`,
+          durationText: socDuration.header,
+          cardDescription: `The Veterans Benefits Administration typically takes ${socDuration.description} to review new appeals.`,
         },
         events: [
           {
@@ -657,7 +669,7 @@ export function getNextEvents(currentStatus, details) {
       };
     }
     case STATUS_TYPES.pendingForm9: {
-      const certificationDuration = makeDurationHeader(details.certificationTimeliness);
+      const certDuration = makeDurationHeader(details.certificationTimeliness);
       const ssocDuration = makeDurationHeader(details.ssocTimeliness);
       return {
         header: `If you return a Form 9 within 60 days, what happens next depends on whether you 
@@ -672,8 +684,8 @@ export function getNextEvents(currentStatus, details) {
                 Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: certificationDuration,
-            cardDescription: `The Veterans Benefits Administration typically takes ${certificationDuration} months to transfer cases to the Board.`
+            durationText: certDuration.header,
+            cardDescription: `The Veterans Benefits Administration typically takes ${certDuration.description} to transfer cases to the Board.`
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
@@ -685,14 +697,14 @@ export function getNextEvents(currentStatus, details) {
                 by the Veterans Benefits Administration.
               </p>
             ),
-            durationText: ssocDuration,
-            cardDescription: `The Veterans Benefits Administration typically takes ${ssocDuration} months to write additional Statements of the Case.`
+            durationText: ssocDuration.header,
+            cardDescription: `The Veterans Benefits Administration typically takes ${ssocDuration.description} to write additional Statements of the Case.`
           },
         ]
       };
     }
     case STATUS_TYPES.pendingCertification: {
-      const certificationDuration = makeDurationHeader(details.certificationTimeliness);
+      const certDuration = makeDurationHeader(details.certificationTimeliness);
       const ssocDuration = makeDurationHeader(details.ssocTimeliness);
       return {
         header: 'What happens next depends on whether you send in new evidence.',
@@ -706,8 +718,8 @@ export function getNextEvents(currentStatus, details) {
                 Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: certificationDuration,
-            cardDescription: `The Veterans Benefits Administration typically takes ${certificationDuration} months to transfer cases to the Board.`
+            durationText: certDuration.header,
+            cardDescription: `The Veterans Benefits Administration typically takes ${certDuration.description} to transfer cases to the Board.`
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
@@ -719,14 +731,14 @@ export function getNextEvents(currentStatus, details) {
                 by the Veterans Benefits Administration.
               </p>
             ),
-            durationText: ssocDuration,
-            cardDescription: `The Veterans Benefits Administration typically takes ${ssocDuration} months to write additional Statements of the Case.`
+            durationText: ssocDuration.header,
+            cardDescription: `The Veterans Benefits Administration typically takes ${ssocDuration.description} to write additional Statements of the Case.`
           }
         ]
       };
     }
     case STATUS_TYPES.pendingCertificationSsoc: {
-      const certificationDuration = makeDurationHeader(details.certificationTimeliness);
+      const certDuration = makeDurationHeader(details.certificationTimeliness);
       const ssocDuration = makeDurationHeader(details.ssocTimeliness);
       return  {
         header: 'What happens next depends on whether you send in new evidence.',
@@ -740,8 +752,8 @@ export function getNextEvents(currentStatus, details) {
                 Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: certificationDuration,
-            cardDescription: `The Veterans Benefits Administration typically takes ${certificationDuration} months to transfer cases to the Board.`
+            durationText: certDuration.header,
+            cardDescription: `The Veterans Benefits Administration typically takes ${certDuration.description} to transfer cases to the Board.`
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
@@ -753,8 +765,8 @@ export function getNextEvents(currentStatus, details) {
                 by the Veterans Benefits Administration.
               </p>
             ),
-            durationText: ssocDuration,
-            cardDescription: `The Veterans Benefits Administration typically takes ${ssocDuration} months to write additional Statements of the Case.`
+            durationText: ssocDuration.header,
+            cardDescription: `The Veterans Benefits Administration typically takes ${ssocDuration.description} to write additional Statements of the Case.`
           }
         ]
       };
@@ -774,8 +786,8 @@ export function getNextEvents(currentStatus, details) {
                 your case to the Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: returnSsocDuration,
-            cardDescription: `The Veterans Benefits Administration typically takes ${returnSsocDuration} to return cases to the Board.`,
+            durationText: returnSsocDuration.header,
+            cardDescription: `The Veterans Benefits Administration typically takes ${returnSsocDuration.description} to return cases to the Board.`,
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
@@ -785,8 +797,8 @@ export function getNextEvents(currentStatus, details) {
                 before returning your case to the Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: remandSsocDuration,
-            cardDescription: `The Veterans Benefits Administration typically takes ${remandSsocDuration} to write additional Statements of the Case.`,
+            durationText: remandSsocDuration.header,
+            cardDescription: `The Veterans Benefits Administration typically takes ${remandSsocDuration.description} to write additional Statements of the Case.`,
           }
         ]
       };
@@ -864,8 +876,8 @@ export function getNextEvents(currentStatus, details) {
           {
             title: 'The Board will make a decision',
             description: DECISION_REVIEW_CONTENT,
-            durationText: decisionDuration,
-            cardDescription: `The Board of Veterans’ Appeals typically takes ${decisionDuration} to decide appeals once a judge starts their review.`,
+            durationText: decisionDuration.header,
+            cardDescription: `The Board of Veterans’ Appeals typically takes ${decisionDuration.description} to decide appeals once a judge starts their review.`,
           }
         ]
       };
@@ -909,8 +921,8 @@ export function getNextEvents(currentStatus, details) {
                 Veterans’ Appeals for a new decision.
               </p>
             ),
-            durationText: remandDuration,
-            cardDescription: `The Veterans Benefits Administration typically takes ${remandDuration} to complete remand instructions.`
+            durationText: remandDuration.header,
+            cardDescription: `The Veterans Benefits Administration typically takes ${remandDuration.description} to complete remand instructions.`
           }
         ]
       };

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -838,8 +838,8 @@ export function getNextEvents(currentStatus, details) {
           {
             title: 'The Board will make a decision',
             description: DECISION_REVIEW_CONTENT,
-            durationText: '10 months',
-            cardDescription: 'A Veterans Law Judge typically takes 10 months to write a decision.'
+            durationText: '',
+            cardDescription: ''
           }
         ]
       };

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -575,7 +575,7 @@ const DECISION_REVIEW_CONTENT = (
  * (in months) of a given thing
  * @returns {durationText} formatted to convey the estimated duration range, in months
  */
-const makeDurationText = (timeliness) => {
+export const makeDurationText = (timeliness) => {
   const durationText = {
     header: 'unknown',
     description: 'unknown',

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -602,8 +602,13 @@ const makeDurationHeader = (timeliness) => {
  * @property {string} durationText descriptor of how long this NextEvent usually takes
  * @property {string} cardDescription info about why this NextEvent takes as long as it does
  * ----------------------------------------------------------------------------------------------
+ * @typedef {Object} headerCard some NextEvent sections have one card displayed above the event list
+ * @property {string} durationText descriptor of how long these NextEvents usually take
+ * @property {string} cardDescription info about why these NextEvents take as long as they does
+ * ----------------------------------------------------------------------------------------------
  * @typedef {Object} allNextEvents
  * @property {string} header a short description to introduce all of the nextEvents
+ * @property {headerCard} [headerCard] containing info for top-level duration cards
  * @property {nextEvent[]} events each contain text content for a NextEvent component
  * ----------------------------------------------------------------------------------------------
  * @param {string} currentStatus an appeal's current status, one of STATUS_TYPES
@@ -613,10 +618,15 @@ const makeDurationHeader = (timeliness) => {
  */
 export function getNextEvents(currentStatus, details) {
   switch (currentStatus) {
-    case STATUS_TYPES.pendingSoc:
+    case STATUS_TYPES.pendingSoc: {
+      const socDuration = makeDurationHeader(details.ssocTimeliness);
       return {
         header: `What happens next depends on whether the Decision Review Officer has enough 
           evidence to decide in your favor.`,
+        headerCard: {
+          durationText: socDuration,
+          cardDescription: `The Veterans Benefits Administration typically takes ${socDuration} months to review new appeals.`,
+        },
         events: [
           {
             title: 'The Veterans Benefits Administration will grant some or all of your appeal',
@@ -628,7 +638,7 @@ export function getNextEvents(currentStatus, details) {
                 expect this change to be made in 1 to 2 months.
               </p>
             ),
-            durationText: makeDurationHeader(details.socTimeliness),
+            durationText: '',
             cardDescription: '',
           }, {
             title: 'The Veterans Benefits Administration will send you a Statement of the Case',
@@ -645,7 +655,10 @@ export function getNextEvents(currentStatus, details) {
           },
         ]
       };
-    case STATUS_TYPES.pendingForm9:
+    }
+    case STATUS_TYPES.pendingForm9: {
+      const certificationDuration = makeDurationHeader(details.certificationTimeliness);
+      const ssocDuration = makeDurationHeader(details.ssocTimeliness);
       return {
         header: `If you return a Form 9 within 60 days, what happens next depends on whether you 
           also send in new evidence.`,
@@ -659,8 +672,8 @@ export function getNextEvents(currentStatus, details) {
                 Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: makeDurationHeader(details.certificationTimeliness),
-            cardDescription: ''
+            durationText: certificationDuration,
+            cardDescription: `The Veterans Benefits Administration typically takes ${certificationDuration} months to transfer cases to the Board.`
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
@@ -672,12 +685,15 @@ export function getNextEvents(currentStatus, details) {
                 by the Veterans Benefits Administration.
               </p>
             ),
-            durationText: makeDurationHeader(details.ssocTimeliness),
-            cardDescription: ''
+            durationText: ssocDuration,
+            cardDescription: `The Veterans Benefits Administration typically takes ${ssocDuration} months to write additional Statements of the Case.`
           },
         ]
       };
-    case STATUS_TYPES.pendingCertification:
+    }
+    case STATUS_TYPES.pendingCertification: {
+      const certificationDuration = makeDurationHeader(details.certificationTimeliness);
+      const ssocDuration = makeDurationHeader(details.ssocTimeliness);
       return {
         header: 'What happens next depends on whether you send in new evidence.',
         events: [
@@ -690,8 +706,8 @@ export function getNextEvents(currentStatus, details) {
                 Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: makeDurationHeader(details.certificationTimeliness),
-            cardDescription: '',
+            durationText: certificationDuration,
+            cardDescription: `The Veterans Benefits Administration typically takes ${certificationDuration} months to transfer cases to the Board.`
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
@@ -703,12 +719,15 @@ export function getNextEvents(currentStatus, details) {
                 by the Veterans Benefits Administration.
               </p>
             ),
-            durationText: makeDurationHeader(details.ssocTimeliness),
-            cardDescription: '',
+            durationText: ssocDuration,
+            cardDescription: `The Veterans Benefits Administration typically takes ${ssocDuration} months to write additional Statements of the Case.`
           }
         ]
       };
-    case STATUS_TYPES.pendingCertificationSsoc:
+    }
+    case STATUS_TYPES.pendingCertificationSsoc: {
+      const certificationDuration = makeDurationHeader(details.certificationTimeliness);
+      const ssocDuration = makeDurationHeader(details.ssocTimeliness);
       return  {
         header: 'What happens next depends on whether you send in new evidence.',
         events: [
@@ -721,8 +740,8 @@ export function getNextEvents(currentStatus, details) {
                 Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: makeDurationHeader(details.certificationTimeliness),
-            cardDescription: '',
+            durationText: certificationDuration,
+            cardDescription: `The Veterans Benefits Administration typically takes ${certificationDuration} months to transfer cases to the Board.`
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
@@ -734,12 +753,15 @@ export function getNextEvents(currentStatus, details) {
                 by the Veterans Benefits Administration.
               </p>
             ),
-            durationText: makeDurationHeader(details.ssocTimeliness),
-            cardDescription: '',
+            durationText: ssocDuration,
+            cardDescription: `The Veterans Benefits Administration typically takes ${ssocDuration} months to write additional Statements of the Case.`
           }
         ]
       };
-    case STATUS_TYPES.remandSsoc:
+    }
+    case STATUS_TYPES.remandSsoc: {
+      const returnSsocDuration = makeDurationHeader(details.returnTimeliness);
+      const remandSsocDuration = makeDurationHeader(details.remandSsocTimeliness);
       return {
         header: 'What happens next depends on whether you send in new evidence.',
         events: [
@@ -752,8 +774,8 @@ export function getNextEvents(currentStatus, details) {
                 your case to the Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: makeDurationHeader(details.returnTimeliness),
-            cardDescription: '',
+            durationText: returnSsocDuration,
+            cardDescription: `The Veterans Benefits Administration typically takes ${returnSsocDuration} to return cases to the Board.`,
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
@@ -763,11 +785,12 @@ export function getNextEvents(currentStatus, details) {
                 before returning your case to the Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: makeDurationHeader(details.remandSsocTimeliness),
-            cardDescription: '',
+            durationText: remandSsocDuration,
+            cardDescription: `The Veterans Benefits Administration typically takes ${remandSsocDuration} to write additional Statements of the Case.`,
           }
         ]
       };
+    }
     case STATUS_TYPES.pendingHearingScheduling:
       return {
         header: '', // intentionally empty
@@ -833,18 +856,20 @@ export function getNextEvents(currentStatus, details) {
           }
         ]
       };
-    case STATUS_TYPES.decisionInProgress:
+    case STATUS_TYPES.decisionInProgress: {
+      const decisionDuration = makeDurationHeader(details.decisionTimeliness);
       return {
         header: '', // intentionally empty
         events: [
           {
             title: 'The Board will make a decision',
             description: DECISION_REVIEW_CONTENT,
-            durationText: '',
-            cardDescription: '',
+            durationText: decisionDuration,
+            cardDescription: `The Board of Veterans’ Appeals typically takes ${decisionDuration} to decide appeals once a judge starts their review.`,
           }
         ]
       };
+    }
     case STATUS_TYPES.bvaDevelopment:
       return {
         header: '', // intentionally empty
@@ -869,7 +894,8 @@ export function getNextEvents(currentStatus, details) {
           }
         ]
       };
-    case STATUS_TYPES.remand:
+    case STATUS_TYPES.remand: {
+      const remandDuration = makeDurationHeader(details.remandTimeliness);
       return {
         header: '', // intentionally empty
         events: [
@@ -883,11 +909,12 @@ export function getNextEvents(currentStatus, details) {
                 Veterans’ Appeals for a new decision.
               </p>
             ),
-            durationText: makeDurationHeader(details.remandTimeliness),
-            cardDescription: 'VBA takes about 11 months to produce a Statement of the Case (SOC)'
+            durationText: remandDuration,
+            cardDescription: `The Veterans Benefits Administration typically takes ${remandDuration} to complete remand instructions.`
           }
         ]
       };
+    }
     default:
       return {
         header: '', // intentionally empty

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -601,7 +601,7 @@ export const makeDurationText = (timeliness) => {
     durationText.description = `about ${lowEst} months`;
   } else {
     durationText.header = `${lowEst}–${highEst} months`;
-    durationText.description = `between ${lowEst}–${highEst} months`;
+    durationText.description = `between ${lowEst} and ${highEst} months`;
   }
   return durationText;
 };

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -575,7 +575,7 @@ const DECISION_REVIEW_CONTENT = (
  * (in months) of a given thing
  * @returns {durationText} formatted to convey the estimated duration range, in months
  */
-const makeDurationHeader = (timeliness) => {
+const makeDurationText = (timeliness) => {
   const durationText = {
     header: 'unknown',
     description: 'unknown',
@@ -583,7 +583,7 @@ const makeDurationHeader = (timeliness) => {
 
   if (!timeliness || !Array.isArray(timeliness) || timeliness.length !== 2) {
     const durationError = new Error(
-      'vets_appeals_v2_helpers_makeDurationHeader_bad_timeliness_input'
+      'vets_appeals_v2_helpers_makeDurationText_bad_timeliness_input'
     );
     Raven.captureException(durationError);
     return durationText;
@@ -631,7 +631,7 @@ const makeDurationHeader = (timeliness) => {
 export function getNextEvents(currentStatus, details) {
   switch (currentStatus) {
     case STATUS_TYPES.pendingSoc: {
-      const socDuration = makeDurationHeader(details.ssocTimeliness);
+      const socDuration = makeDurationText(details.ssocTimeliness);
       return {
         header: `What happens next depends on whether the Decision Review Officer has enough 
           evidence to decide in your favor.`,
@@ -669,8 +669,8 @@ export function getNextEvents(currentStatus, details) {
       };
     }
     case STATUS_TYPES.pendingForm9: {
-      const certDuration = makeDurationHeader(details.certificationTimeliness);
-      const ssocDuration = makeDurationHeader(details.ssocTimeliness);
+      const certDuration = makeDurationText(details.certificationTimeliness);
+      const ssocDuration = makeDurationText(details.ssocTimeliness);
       return {
         header: `If you return a Form 9 within 60 days, what happens next depends on whether you 
           also send in new evidence.`,
@@ -704,8 +704,8 @@ export function getNextEvents(currentStatus, details) {
       };
     }
     case STATUS_TYPES.pendingCertification: {
-      const certDuration = makeDurationHeader(details.certificationTimeliness);
-      const ssocDuration = makeDurationHeader(details.ssocTimeliness);
+      const certDuration = makeDurationText(details.certificationTimeliness);
+      const ssocDuration = makeDurationText(details.ssocTimeliness);
       return {
         header: 'What happens next depends on whether you send in new evidence.',
         events: [
@@ -738,8 +738,8 @@ export function getNextEvents(currentStatus, details) {
       };
     }
     case STATUS_TYPES.pendingCertificationSsoc: {
-      const certDuration = makeDurationHeader(details.certificationTimeliness);
-      const ssocDuration = makeDurationHeader(details.ssocTimeliness);
+      const certDuration = makeDurationText(details.certificationTimeliness);
+      const ssocDuration = makeDurationText(details.ssocTimeliness);
       return  {
         header: 'What happens next depends on whether you send in new evidence.',
         events: [
@@ -772,8 +772,8 @@ export function getNextEvents(currentStatus, details) {
       };
     }
     case STATUS_TYPES.remandSsoc: {
-      const returnSsocDuration = makeDurationHeader(details.returnTimeliness);
-      const remandSsocDuration = makeDurationHeader(details.remandSsocTimeliness);
+      const returnSsocDuration = makeDurationText(details.returnTimeliness);
+      const remandSsocDuration = makeDurationText(details.remandSsocTimeliness);
       return {
         header: 'What happens next depends on whether you send in new evidence.',
         events: [
@@ -869,7 +869,7 @@ export function getNextEvents(currentStatus, details) {
         ]
       };
     case STATUS_TYPES.decisionInProgress: {
-      const decisionDuration = makeDurationHeader(details.decisionTimeliness);
+      const decisionDuration = makeDurationText(details.decisionTimeliness);
       return {
         header: '', // intentionally empty
         events: [
@@ -907,7 +907,7 @@ export function getNextEvents(currentStatus, details) {
         ]
       };
     case STATUS_TYPES.remand: {
-      const remandDuration = makeDurationHeader(details.remandTimeliness);
+      const remandDuration = makeDurationText(details.remandTimeliness);
       return {
         header: '', // intentionally empty
         events: [

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import _ from 'lodash';
+import Raven from 'raven-js';
 
 // TO DO: Replace made up properties and content with real versions once finalized.
 export const STATUS_TYPES = {
@@ -566,6 +567,34 @@ const DECISION_REVIEW_CONTENT = (
 );
 
 /**
+ * Translates an array of two ints into a string that conveys a duration estimate
+ * @param {number[]} timeliness two integers that represent the low and high time durations
+ * (in months) of a given thing
+ * @returns {string} formatted to convey the estimated duration range, in months
+ */
+const makeDurationHeader = (timeliness) => {
+  if (!timeliness || !Array.isArray(timeliness) || timeliness.length !== 2) {
+    const durationError = new Error(
+      'vets_appeals_v2_helpers_makeDurationHeader_bad_timeliness_input'
+    );
+    Raven.captureException(durationError);
+    return 'No estimated duration for this step';
+  }
+
+  const lowEst = timeliness[0];
+  const highEst = timeliness[1];
+  const estIsExact = (lowEst === highEst);
+
+  if (estIsExact) {
+    return (lowEst === 1)
+      ? '1 Month'
+      : `${lowEst} Months`;
+  }
+
+  return `${lowEst}-${highEst} Months`;
+};
+
+/**
  * Gets 'what's next' content for a given current status type
  * @typedef {Object} nextEvent
  * @property {string} title header for each NextEvent
@@ -582,8 +611,7 @@ const DECISION_REVIEW_CONTENT = (
  * @returns {allNextEvents} a section description and array containing all next event possibilities
  *                          for a given current status
  */
-// TO-DO: Add 'details' to args list once they're complete in the API
-export function getNextEvents(currentStatus) {
+export function getNextEvents(currentStatus, details) {
   switch (currentStatus) {
     case STATUS_TYPES.pendingSoc:
       return {
@@ -600,7 +628,7 @@ export function getNextEvents(currentStatus) {
                 expect this change to be made in 1 to 2 months.
               </p>
             ),
-            durationText: '',
+            durationText: makeDurationHeader(details.socTimeliness),
             cardDescription: '',
           }, {
             title: 'The Veterans Benefits Administration will send you a Statement of the Case',
@@ -631,7 +659,7 @@ export function getNextEvents(currentStatus) {
                 Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: '',
+            durationText: makeDurationHeader(details.certificationTimeliness),
             cardDescription: ''
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
@@ -644,7 +672,7 @@ export function getNextEvents(currentStatus) {
                 by the Veterans Benefits Administration.
               </p>
             ),
-            durationText: '',
+            durationText: makeDurationHeader(details.ssocTimeliness),
             cardDescription: ''
           },
         ]
@@ -662,7 +690,7 @@ export function getNextEvents(currentStatus) {
                 Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: '',
+            durationText: makeDurationHeader(details.certificationTimeliness),
             cardDescription: '',
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
@@ -675,7 +703,7 @@ export function getNextEvents(currentStatus) {
                 by the Veterans Benefits Administration.
               </p>
             ),
-            durationText: '',
+            durationText: makeDurationHeader(details.ssocTimeliness),
             cardDescription: '',
           }
         ]
@@ -693,7 +721,7 @@ export function getNextEvents(currentStatus) {
                 Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: '',
+            durationText: makeDurationHeader(details.certificationTimeliness),
             cardDescription: '',
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
@@ -706,7 +734,7 @@ export function getNextEvents(currentStatus) {
                 by the Veterans Benefits Administration.
               </p>
             ),
-            durationText: '',
+            durationText: makeDurationHeader(details.ssocTimeliness),
             cardDescription: '',
           }
         ]
@@ -724,7 +752,7 @@ export function getNextEvents(currentStatus) {
                 your case to the Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: '',
+            durationText: makeDurationHeader(details.returnTimeliness),
             cardDescription: '',
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
@@ -735,7 +763,7 @@ export function getNextEvents(currentStatus) {
                 before returning your case to the Board of Veterans’ Appeals.
               </p>
             ),
-            durationText: '',
+            durationText: makeDurationHeader(details.remandSsocTimeliness),
             cardDescription: '',
           }
         ]
@@ -855,7 +883,7 @@ export function getNextEvents(currentStatus) {
                 Veterans’ Appeals for a new decision.
               </p>
             ),
-            durationText: '11 months',
+            durationText: makeDurationHeader(details.remandTimeliness),
             cardDescription: 'VBA takes about 11 months to produce a Statement of the Case (SOC)'
           }
         ]

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -264,7 +264,9 @@ export const mockData = {
         status: {
           type: 'pending_form9',
           details: {
-            regionalOffice: 'Chicago Regional Office'
+            lastSocDate: '2015-09-12',
+            certificationTimeliness: [1, 4],
+            ssocTimeliness: [2, 16],
           }
         },
         docket: {

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -262,7 +262,7 @@ export const mockData = {
         aod: false,
         location: 'aoj',
         status: {
-          type: 'pending_form9',
+          type: 'pending_soc',
           details: {
             lastSocDate: '2015-09-12',
             certificationTimeliness: [1, 4],

--- a/test/claims-status/components/appeals-v2/Duration.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Duration.unit.spec.jsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import { expect } from 'chai';
 import DurationCard from '../../../../src/js/claims-status/components/appeals-v2/DurationCard';
 
-describe.only('<DurationCard/>', () => {
+describe('<DurationCard/>', () => {
   const defaultProps = {
     durationText: '1-2 Months',
     cardDescription: 'Hey There, this is some text',

--- a/test/claims-status/components/appeals-v2/Duration.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Duration.unit.spec.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import DurationCard from '../../../../src/js/claims-status/components/appeals-v2/DurationCard';
+
+describe.only('<DurationCard/>', () => {
+  const defaultProps = {
+    durationText: '1-2 Months',
+    cardDescription: 'Hey There, this is some text',
+  };
+
+  it('should render', () => {
+    const wrapper = shallow(<DurationCard {...defaultProps}/>);
+    expect(wrapper.type()).to.equal('div');
+  });
+
+  it('should not render if no duration text passed in', () => {
+    const wrapper = shallow(<DurationCard/>);
+    expect(wrapper.type()).to.equal(null);
+  });
+
+  it('should render a passed in durationText string', () => {
+    const wrapper = shallow(<DurationCard {...defaultProps}/>);
+    const renderedDuration = wrapper.find('.number').render().text();
+    expect(renderedDuration).to.equal(defaultProps.durationText);
+  });
+
+  it('should render a passed in cardDescription string', () => {
+    const wrapper = shallow(<DurationCard {...defaultProps}/>);
+    const renderedDescription = wrapper.find('.description').render().text();
+    expect(renderedDescription).to.contain(defaultProps.cardDescription);
+  });
+});

--- a/test/claims-status/components/appeals-v2/WhatsNext.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/WhatsNext.unit.spec.jsx
@@ -45,6 +45,27 @@ describe('<WhatsNext/>', () => {
     expect(headerText).to.equal(testHeaderText);
   });
 
+  it('renders a header DurationCard if headerCard property exists', () => {
+    const props = {
+      nextEvents: {
+        header: '',
+        headerCard: {
+          durationText: 'Some duration text goes here',
+          cardDescription: 'Not sure how long this takes',
+        },
+        events: [],
+      },
+    };
+
+    const wrapper = shallow(<WhatsNext {...props}/>);
+    expect(wrapper.find('DurationCard').length).to.equal(1);
+  });
+
+  it('does not render a header DurationCard if no headerCard property exists', () => {
+    const wrapper = shallow(<WhatsNext {...defaultProps}/>);
+    expect(wrapper.find('DurationCard').length).to.equal(0);
+  });
+
   it('renders a list of all next events for a given currentStatus', () => {
     const props = {
       ...defaultProps,

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -522,14 +522,22 @@ describe('Disability benefits helpers: ', () => {
   describe('getNextEvents', () => {
     it('returns an object with a header property', () => {
       const type = STATUS_TYPES.pendingCertificationSsoc;
-      const nextEvents = getNextEvents(type);
+      const details = {
+        certificationTimeliness: [1, 2],
+        ssocTimeliness: [1, 1],
+      };
+      const nextEvents = getNextEvents(type, details);
       expect(nextEvents.header).to.equal('What happens next depends on whether you send in new evidence.');
     });
 
     it('returns an object with an events array property', () => {
       const type = STATUS_TYPES.remandSsoc;
       // 'remandSsoc' status has 2 nextEvents in the array
-      const nextEvents = getNextEvents(type);
+      const details = {
+        returnTimeliness: [1, 2],
+        remandSsocTimeliness: [1, 1],
+      };
+      const nextEvents = getNextEvents(type, details);
       const { events } = nextEvents;
       expect(events.length).to.equal(2);
       const firstEvent = events[0];

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -564,7 +564,7 @@ describe('Disability benefits helpers: ', () => {
     it('should format range time estimates', () => {
       const testText = makeDurationText(inputs.range);
       expect(testText.header).to.equal('1–8 months');
-      expect(testText.description).to.equal('between 1–8 months');
+      expect(testText.description).to.equal('between 1 and 8 months');
     });
   });
 

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -24,6 +24,7 @@ import {
   getAlertContent,
   getStatusContents,
   getNextEvents,
+  makeDurationText,
   STATUS_TYPES
 } from '../../../src/js/claims-status/utils/appeals-v2-helpers';
 
@@ -516,6 +517,54 @@ describe('Disability benefits helpers: ', () => {
 
       expect(allowedList.find('li').length).to.equal(allowedDisposition.length);
       expect(deniedList.find('li').length).to.equal(deniedDisposition.length);
+    });
+  });
+
+  describe('makeDurationText', () => {
+    const inputs = {
+      exactSingular: [1, 1],
+      exactPlural: [2, 2],
+      range: [1, 8],
+      empty: [],
+      nonsense: 'danger, danger',
+    };
+
+    it('should return an object with header and description properties', () => {
+      const testText = makeDurationText(inputs.exactSingular);
+      expect(!!testText.header && !!testText.description).to.be.true;
+    });
+
+    it('should return an object with header and description properties with nonsense input', () => {
+      const testText = makeDurationText(inputs.nonsense);
+      expect(!!testText.header && !!testText.description).to.be.true;
+    });
+
+    it('should return an object with header and description properties with empty array input', () => {
+      const testText = makeDurationText(inputs.empty);
+      expect(!!testText.header && !!testText.description).to.be.true;
+    });
+
+    it('should return an object with header and description properties with no input', () => {
+      const testText = makeDurationText();
+      expect(!!testText.header && !!testText.description).to.be.true;
+    });
+
+    it('should format exact singular time estimates', () => {
+      const testText = makeDurationText(inputs.exactSingular);
+      expect(testText.header).to.equal('1 month');
+      expect(testText.description).to.equal('about 1 month');
+    });
+
+    it('should format exact plural time estimates', () => {
+      const testText = makeDurationText(inputs.exactPlural);
+      expect(testText.header).to.equal('2 months');
+      expect(testText.description).to.equal('about 2 months');
+    });
+
+    it('should format range time estimates', () => {
+      const testText = makeDurationText(inputs.range);
+      expect(testText.header).to.equal('1–8 months');
+      expect(testText.description).to.equal('between 1–8 months');
     });
   });
 


### PR DESCRIPTION
- Adds new content to cards that show duration of the Next Event(s) in the appeal
- Adds logic to conditionally render these cards based on content
- Adds logic to display a top-level card above the NextEvents list when desired
- Adds ability to not show a duration card at all for a given NextEvent
- Refactors the DurationCards that show this info into their own component
- Adds tests for all the above

Top-Level duration card:
<img width="832" alt="screen shot 2018-02-02 at 12 30 58 pm" src="https://user-images.githubusercontent.com/24251447/35750317-2f57f54a-081a-11e8-9798-da03cb3131b0.png">

Duration cards for each sub-event:
<img width="786" alt="screen shot 2018-02-02 at 12 33 16 pm" src="https://user-images.githubusercontent.com/24251447/35750333-3c4f7f7a-081a-11e8-99e3-25b904e31ec7.png">


When date range is exact, singular & plural months:
<img width="759" alt="screen shot 2018-02-02 at 12 34 02 pm" src="https://user-images.githubusercontent.com/24251447/35750340-445f0d34-081a-11e8-82cd-f0622e14fc69.png">
