### PR TITLE
Change up the exit statuses on run-unit-test.sh

### DIFF
--- a/script/run-unit-test.sh
+++ b/script/run-unit-test.sh
@@ -11,8 +11,12 @@ fi
 # No test specified; run all of them
 if [ -z "$1" ]; then
   BABEL_ENV=test $MOCHA --recursive '$SCRIPT_DIR/../test/**/*.unit.spec.js?(x)' 
-  exit 0
+  exit $?
 fi
 
 BABEL_ENV=test $MOCHA $1
+# Stop that bloody npm error messaging after failed tests
+# NOTE: This is only to cut down on the visual clutter when running a single test.
+#  This WILL be the wrong status if the test actually failed, so don't rely on it.
+exit 0
 


### PR DESCRIPTION
Previously, the exit status was always going to be 0 for `npm run test:unit`, so...that wasn't good. My bad.