### PR TITLE
Appeals refactor -- Use default liClass

### DIFF
--- a/src/js/claims-status/components/appeals-v2/PastEvent.jsx
+++ b/src/js/claims-status/components/appeals-v2/PastEvent.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const PastEvent = ({ title, date, description, liClass, hideSeparator }) => {
+const PastEvent = ({ title, date, description, hideSeparator }) => {
   const separator = (hideSeparator === true)
     ? null
     : <div className="separator"/>;
 
   return (
-    <li role="presentation" className={`process-step ${liClass}`}>
+    <li role="presentation" className={'process-step section-complete'}>
       <h3>{title}</h3>
       <div className="appeal-event-date">on {date}</div>
       <p>{description}</p>
@@ -20,7 +20,6 @@ PastEvent.propTypes = {
   title: PropTypes.string.isRequired,
   date: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
-  liClass: PropTypes.string.isRequired,
   hideSeparator: PropTypes.bool,
 };
 

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -39,7 +39,7 @@ class Timeline extends React.Component {
             title={title}
             date={date}
             description={description}
-            liClass={liClass || 'section-complete'}
+            liClass={liClass}
             hideSeparator={hideSeparator}/>
         );
       });

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -39,7 +39,7 @@ class Timeline extends React.Component {
             title={title}
             date={date}
             description={description}
-            liClass={liClass}
+            liClass={liClass || 'section-complete'}
             hideSeparator={hideSeparator}/>
         );
       });

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -486,115 +486,96 @@ export function getEventContent(event) {
       return {
         title: 'VBA sent the original claim decision to you',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.nod:
       return {
         title: 'VBA received your Notice of Disagreement',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.droHearing:
       return {
         title: 'Dro Hearing',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.fieldGrant:
       return {
         title: 'Field grant',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.soc:
       return {
         title: 'VBA prepared a Statement of the Case (SOC)',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.form9:
       return {
         title: 'Form 9 Recieved',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.ssoc:
       return {
         title: 'Supplemental Statement of the Case',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.certified:
       return {
         title: 'The Board received your appeal',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.hearingHeld:
       return {
         title: `Your hearing was held at the ${event.details.regionalOffice} Regional Office`,
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.hearingCancelled:
       return {
         title: 'Hearing Cancelled',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.hearingNoShow:
       return {
         title: 'Hearing No Show',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.bvaDecision:
       return {
         title: 'The Board made a decision on your appeal',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.bvaRemand:
       return {
         title: 'Board Remand',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.withdrawn:
       return {
         title: 'Withdrawn',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.merged:
       return {
         title: 'Merged',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.cavcDecision:
       return {
         title: 'CAVC Decision',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.recordDesignation:
       return {
         title: 'Designation of Record',
         description: '',
-        liClass: 'section-complete'
       };
     case EVENT_TYPES.reconsideration:
       return {
         title: 'Reconsideration by Letter',
         description: '',
-        liClass: 'section-complete'
       };
     default:
       return {
         title: 'Unknown Event',
         description: '',
-        liClass: 'section-complete'
       };
   }
 }


### PR DESCRIPTION
Just a simple refactor. No visual changes.

I was having trouble with https://github.com/department-of-veterans-affairs/vets-website/pull/7202, so I just closed that out and re-did it here.