### PR TITLE
Appealsv2 whats next alignment mg

### DIFF
--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -589,7 +589,7 @@ const DECISION_REVIEW_CONTENT = (
       available evidence and write a decision. For each issue you are appealing, they can
       decide to:
     </p>
-    <ul>
+    <ul className="decision-review-list">
       <li>
         <strong>Allow:</strong> The judge overrules the original decision and decides in
         your favor.

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -942,6 +942,12 @@ h1:focus {
       width: 102%;
     }
   }
+
+  .decision-review-list {
+    li {
+      padding-left: .5em;
+    }
+  }
 }
 
 .alerts-list-container {

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -945,7 +945,7 @@ h1:focus {
 
   .decision-review-list {
     li {
-      padding-left: .5em;
+      margin-left: .5em;
     }
   }
 }


### PR DESCRIPTION
Adds some margin to DECISION_REVIEW_CONTENT `<li/>`s to line them up with the intro paragraph. See linked issue for old screenshot.

<img width="829" alt="screen shot 2018-02-02 at 4 21 49 pm" src="https://user-images.githubusercontent.com/24251447/35757587-6337d5a4-0835-11e8-954f-d7055d20d652.png">
