### PR TITLE
Appealsv2 api integration mg

### DIFF
--- a/src/js/claims-status/actions/index.jsx
+++ b/src/js/claims-status/actions/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import environment from '../../common/helpers/environment';
+import { apiRequest } from '../../common/helpers/api';
 import { makeAuthRequest, mockData } from '../utils/helpers';
 
 export const SET_CLAIMS = 'SET_CLAIMS';
@@ -85,16 +86,26 @@ export function fetchAppealsSuccess(response) {
 }
 
 // To test this functionality, go to http://localhost:3001/track-claims/appeals-v2/7387389/status
-export function getAppealsV2() {
-  return (dispatch) => {
-    dispatch({ type: FETCH_APPEALS_PENDING });
+// export function getAppealsV2() {
+//   return (dispatch) => {
+//     dispatch({ type: FETCH_APPEALS_PENDING });
 
-    // Fake the fetch by just returning a resolved promice with the object shape we expect
-    //  to get from the api.
-    return setTimeout(() => Promise.resolve(mockData)
-      .then((response) => dispatch(fetchAppealsSuccess(response)))
-      .catch(() => dispatch({ type: SET_APPEALS_UNAVAILABLE })), 4000);
-  };
+//     // Fake the fetch by just returning a resolved promice with the object shape we expect
+//     //  to get from the api.
+//     return setTimeout(() => Promise.resolve(mockData)
+//       .then((response) => dispatch(fetchAppealsSuccess(response)))
+//       .catch(() => dispatch({ type: SET_APPEALS_UNAVAILABLE })), 4000);
+//   };
+// }
+
+export function getAppealsV2(dispatch) {
+  dispatch({ type: FETCH_APPEALS_PENDING });
+  return apiRequest(
+    '/v2/appeals',
+    null,
+    (appeals) => dispatch(fetchAppealsSuccess(appeals)),
+    () => dispatch({ type: SET_APPEALS_UNAVAILABLE })
+  );
 }
 
 export function filterClaims(filter) {

--- a/src/js/claims-status/actions/index.jsx
+++ b/src/js/claims-status/actions/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Raven from 'raven-js';
 import environment from '../../common/helpers/environment';
 import { apiRequest } from '../../common/helpers/api';
-import { makeAuthRequest, mockData } from '../utils/helpers';
+import { makeAuthRequest } from '../utils/helpers';
 
 export const SET_CLAIMS = 'SET_CLAIMS';
 export const SET_APPEALS = 'SET_APPEALS';
@@ -103,7 +103,7 @@ export function getAppealsV2() {
   return (dispatch) => {
     dispatch({ type: FETCH_APPEALS_PENDING });
     return apiRequest(
-      '/v2/appeals',
+      '/appeals_v2',
       null,
       (appeals) => dispatch(fetchAppealsSuccess(appeals)),
       (error) => {

--- a/src/js/claims-status/actions/index.jsx
+++ b/src/js/claims-status/actions/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Raven from 'raven-js';
 import environment from '../../common/helpers/environment';
 import { apiRequest } from '../../common/helpers/api';
 import { makeAuthRequest, mockData } from '../utils/helpers';
@@ -98,14 +99,19 @@ export function fetchAppealsSuccess(response) {
 //   };
 // }
 
-export function getAppealsV2(dispatch) {
-  dispatch({ type: FETCH_APPEALS_PENDING });
-  return apiRequest(
-    '/v2/appeals',
-    null,
-    (appeals) => dispatch(fetchAppealsSuccess(appeals)),
-    () => dispatch({ type: SET_APPEALS_UNAVAILABLE })
-  );
+export function getAppealsV2() {
+  return (dispatch) => {
+    dispatch({ type: FETCH_APPEALS_PENDING });
+    return apiRequest(
+      '/v2/appeals',
+      null,
+      (appeals) => dispatch(fetchAppealsSuccess(appeals)),
+      (error) => {
+        Raven.captureException(`vets_appeals_v2_err_get_appeals ${error.message}`);
+        return dispatch({ type: SET_APPEALS_UNAVAILABLE });
+      }
+    );
+  };
 }
 
 export function filterClaims(filter) {

--- a/src/js/claims-status/actions/index.jsx
+++ b/src/js/claims-status/actions/index.jsx
@@ -94,7 +94,7 @@ export function getAppealsV2() {
       null,
       (appeals) => dispatch(fetchAppealsSuccess(appeals)),
       (error) => {
-        Raven.captureException(`vets_appeals_v2_err_get_appeals ${error.message}`);
+        Raven.captureMessage(`vets_appeals_v2_err_get_appeals ${error.message}`);
         return dispatch({ type: SET_APPEALS_UNAVAILABLE });
       }
     );

--- a/src/js/claims-status/actions/index.jsx
+++ b/src/js/claims-status/actions/index.jsx
@@ -86,19 +86,6 @@ export function fetchAppealsSuccess(response) {
   };
 }
 
-// To test this functionality, go to http://localhost:3001/track-claims/appeals-v2/7387389/status
-// export function getAppealsV2() {
-//   return (dispatch) => {
-//     dispatch({ type: FETCH_APPEALS_PENDING });
-
-//     // Fake the fetch by just returning a resolved promice with the object shape we expect
-//     //  to get from the api.
-//     return setTimeout(() => Promise.resolve(mockData)
-//       .then((response) => dispatch(fetchAppealsSuccess(response)))
-//       .catch(() => dispatch({ type: SET_APPEALS_UNAVAILABLE })), 4000);
-//   };
-// }
-
 export function getAppealsV2() {
   return (dispatch) => {
     dispatch({ type: FETCH_APPEALS_PENDING });

--- a/test/claims-status/utils/appealsV2Actions.unit.spec.js
+++ b/test/claims-status/utils/appealsV2Actions.unit.spec.js
@@ -32,8 +32,9 @@ describe.only('getAppealsV2', () => {
   afterEach(teardown);
 
   it('dispatches FETCH_APPEALS_PENDING', (done) => {
+    const thunk = getAppealsV2();
     const dispatch = sinon.spy();
-    getAppealsV2(dispatch)
+    thunk(dispatch)
       .then(() => {
         const action = dispatch.firstCall.args[0];
         expect(action.type).to.equal(FETCH_APPEALS_PENDING);
@@ -47,8 +48,9 @@ describe.only('getAppealsV2', () => {
       json: () => Promise.resolve({})
     }));
 
+    const thunk = getAppealsV2();
     const dispatch = sinon.spy();
-    getAppealsV2(dispatch)
+    thunk(dispatch)
       .then(() => {
         const action = dispatch.secondCall.args[0];
         expect(action.type).to.equal(FETCH_APPEALS_SUCCESS);
@@ -57,8 +59,9 @@ describe.only('getAppealsV2', () => {
 
   it('dispatches FETCH_APPEALS_UNAVAILABLE', (done) => {
     global.fetch.returns(Promise.reject());
+    const thunk = getAppealsV2();
     const dispatch = sinon.spy();
-    getAppealsV2(dispatch)
+    thunk(dispatch)
       .then(() => {
         const action = dispatch.secondCall.args[0];
         expect(action.type).to.equal(SET_APPEALS_UNAVAILABLE);

--- a/test/claims-status/utils/appealsV2Actions.unit.spec.js
+++ b/test/claims-status/utils/appealsV2Actions.unit.spec.js
@@ -27,7 +27,7 @@ const teardown = () => {
   global.sessionStorage = oldSessionStorage;
 };
 
-describe.only('getAppealsV2', () => {
+describe('getAppealsV2', () => {
   beforeEach(setup);
   afterEach(teardown);
 

--- a/test/claims-status/utils/appealsV2Actions.unit.spec.js
+++ b/test/claims-status/utils/appealsV2Actions.unit.spec.js
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  getAppealsV2,
+  FETCH_APPEALS_PENDING,
+  FETCH_APPEALS_SUCCESS,
+  SET_APPEALS_UNAVAILABLE
+} from '../../../src/js/claims-status/actions';
+
+let oldFetch;
+let oldSessionStorage;
+
+const setup = () => {
+  oldSessionStorage = global.sessionStorage;
+  oldFetch = global.fetch;
+  global.sessionStorage = { userToken: '123' };
+  global.fetch = sinon.stub();
+  global.fetch.returns(Promise.resolve({
+    headers: { get: () => 'application/json' },
+    ok: true,
+    json: () => Promise.resolve({})
+  }));
+};
+
+const teardown = () => {
+  global.fetch = oldFetch;
+  global.sessionStorage = oldSessionStorage;
+};
+
+describe.only('getAppealsV2', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('dispatches FETCH_APPEALS_PENDING', (done) => {
+    const dispatch = sinon.spy();
+    getAppealsV2(dispatch)
+      .then(() => {
+        const action = dispatch.firstCall.args[0];
+        expect(action.type).to.equal(FETCH_APPEALS_PENDING);
+      }).then(done, done);
+  });
+
+  it('dispatches FETCH_APPEALS_SUCCESS', (done) => {
+    global.fetch.returns(Promise.resolve({
+      headers: { get: () => 'application/json' },
+      ok: true,
+      json: () => Promise.resolve({})
+    }));
+
+    const dispatch = sinon.spy();
+    getAppealsV2(dispatch)
+      .then(() => {
+        const action = dispatch.secondCall.args[0];
+        expect(action.type).to.equal(FETCH_APPEALS_SUCCESS);
+      }).then(done, done);
+  });
+
+  it('dispatches FETCH_APPEALS_UNAVAILABLE', (done) => {
+    global.fetch.returns(Promise.reject());
+    const dispatch = sinon.spy();
+    getAppealsV2(dispatch)
+      .then(() => {
+        const action = dispatch.secondCall.args[0];
+        expect(action.type).to.equal(SET_APPEALS_UNAVAILABLE);
+      }).then(done, done);
+  });
+
+});


### PR DESCRIPTION
- Replace hard coded mock data return with actually querying the `appeals_v2` endpoint for appeals data.
- Add unit tests.