### PR TITLE
Remove cssClass proptype, reorder remaining proptypes

### DIFF
--- a/src/js/claims-status/components/appeals-v2/Expander.jsx
+++ b/src/js/claims-status/components/appeals-v2/Expander.jsx
@@ -31,10 +31,9 @@ const Expander = ({ expanded, dateRange, onToggle, missingEvents }) => {
 
 Expander.propTypes = {
   expanded: PropTypes.bool.isRequired,
-  missingEvents: PropTypes.bool.isRequired,
   dateRange: PropTypes.string.isRequired,
   onToggle: PropTypes.func.isRequired,
-  cssClass: PropTypes.string.isRequired,
+  missingEvents: PropTypes.bool.isRequired,
 };
 
 export default Expander;


### PR DESCRIPTION
Removed cssClass, and moved missingEvents around to line up with the order in which the props are destructured in the component's functional definition.