### PR TITLE
Fixed bugs in Health Records reducer

### DIFF
--- a/src/js/health-records/actions/refresh.js
+++ b/src/js/health-records/actions/refresh.js
@@ -7,29 +7,19 @@ export function initialAppRefresh() {
     return apiRequest(
       '/health_records/refresh',
       null,
-      () => dispatch({
-        type: 'INITIAL_REFRESH_SUCCESS'
-      }),
-      (response) => {
-        dispatch({ type: 'INITIAL_REFRESH_FAILURE', errors: response.errors });
-      }
+      () => dispatch({ type: 'INITIAL_REFRESH_SUCCESS' }),
+      ({ errors }) => dispatch({ type: 'INITIAL_REFRESH_FAILURE', errors })
     );
   };
 }
 
 export function checkRefreshStatus() {
   return (dispatch) => {
-    return apiRequest('/health_records/refresh',
+    return apiRequest(
+      '/health_records/refresh',
       null,
-      (response) => {
-        return dispatch({
-          type: 'REFRESH_POLL_SUCCESS',
-          data: response.data,
-        });
-      },
-      () => dispatch({
-        type: 'REFRESH_POLL_FAILURE'
-      })
+      ({ data }) => dispatch({ type: 'REFRESH_POLL_SUCCESS', data }),
+      () => dispatch({ type: 'REFRESH_POLL_FAILURE' })
     );
   };
 }

--- a/src/js/health-records/reducers/refresh.js
+++ b/src/js/health-records/reducers/refresh.js
@@ -22,7 +22,7 @@ export default function refresh(state = initialState, action) {
     case 'REFRESH_POLL_SUCCESS': {
     // returns group in form {'succeeded': [], 'failed': []}
       const statuses = _.groupBy(action.data, (e) => {
-        const isCurrentDay = moment().isSame(e.attributes.last_updated, 'day');
+        const isCurrentDay = moment().isSame(e.attributes.lastUpdated, 'day');
         const isStatusOK = e.attributes.status === 'OK';
         if (!isCurrentDay) {
           return 'incomplete';

--- a/src/js/health-records/reducers/refresh.js
+++ b/src/js/health-records/reducers/refresh.js
@@ -31,9 +31,7 @@ export default function refresh(state = initialState, action) {
         }
         return 'failed';
       });
-      return {
-        statuses
-      };
+      return { ...state, statuses };
     }
     default:
       return state;


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#7923.

The modal stopped working because upon clicking the button to return to the Main component, it tried to map to props an undefined `errors` property from the refresh state object. At this point, refresh has already overwritten its state upon `REFRESH_POLL_SUCCESS`, clearing `errors`.

Also found that we were still using a snake_cased `last_updated` key, but we receive all keys in camelCase now, so I corrected it to `lastUpdated`. Probably was causing plenty of problems with error reporting we were unaware of.