### PR TITLE
Docket logic

### DIFF
--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -14,7 +14,7 @@ import { APPEAL_TYPES } from '../../utils/appeals-v2-helpers';
  * @param {Bool}   aod - Whether the appeal is Advanced on Docket
  * @param {Bool}   frontOfDocket - Whether the appeal is at the front of the docket
  */
-function Docket({ ahead, total, form9Date, docketMonth, appealType, aod, frontOfDocket }) {
+function Docket({ ahead, total, form9Date, docketMonth, appealType, aod, front: frontOfDocket }) {
   // TODO: Assess how accessible this is
 
   const form9DateFormatted = moment(form9Date, 'YYYY-MM-DD').format('MMMM YYYY');
@@ -25,7 +25,7 @@ function Docket({ ahead, total, form9Date, docketMonth, appealType, aod, frontOf
   if (frontOfDocket) {
     yourPlaceText = <p>The Board is currently working on appeals from {docketMonthFormatted} or older. Your appeal is eligible to be assigned to a judge when it is ready for their review.</p>;
   } else {
-    yourPlaceText = <p>There are {total} appeals on the docket, not including Advanced on Docket and Court Remand appeals. Some of these appeals are not ready to be assigned to a judge. A judge will begin work on your appeal when it is among the oldest appeals that are ready for their review. The Board is currently working on appeals from {docketMonthFormatted} or older.</p>;
+    yourPlaceText = <p>There are {total.toLocaleString()} appeals on the docket, not including Advanced on Docket and Court Remand appeals. Some of these appeals are not ready to be assigned to a judge. A judge will begin work on your appeal when it is among the oldest appeals that are ready for their review. The Board is currently working on appeals from {docketMonthFormatted} or older.</p>;
   }
 
   // Start with the basic content...

--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -2,52 +2,63 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
-// TODO: Depending on when this gets rendered, we may want to return null if either
-//  `ahead` or `total` don't exist (or if `total` === 0 because of the divide by 0  error)
-function Docket({ ahead, total, form9Date }) {
-  const completedWidth = { width: `${((total - ahead) / total) * 100}%` };
+import DocketCard from './DocketCard';
+import { APPEAL_TYPES } from '../../utils/appeals-v2-helpers';
+
+/**
+ * @param {Number} ahead - The number of appeals ahead of this one
+ * @param {Number} total - The total number of appeals in the docket line
+ * @param {String} form9Date - The date the form 9 was sent in (or something)
+ * @param {String} docketMonth- The month that the board is looking at (or older)
+ * @param {String} appealType - The type of appeal
+ * @param {Bool}   aod - Whether the appeal is Advanced on Docket
+ * @param {Bool}   frontOfDocket - Whether the appeal is at the front of the docket
+ */
+function Docket({ ahead, total, form9Date, docketMonth, appealType, aod, frontOfDocket }) {
+  // TODO: Assess how accessible this is
+
   const date = moment(form9Date, 'YYYY-MM-DD').format('MMMM YYYY');
 
-  // TODO: Assess how accessible this is
+  // This is the only part that's different between the two "normal" contents
+  let yourPlaceText;
+  if (frontOfDocket) {
+    yourPlaceText = <p>The Board is currently working on appeals from {docketMonth} or older. Your appeal is eligible to be assigned to a judge when it is ready for their review.</p>;
+  } else {
+    yourPlaceText = <p>There are {total} appeals on the docket, not including Advanced on Docket and Court Remand appeals. Some of these appeals are not ready to be assigned to a judge. A judge will begin work on your appeal when it is among the oldest appeals that are ready for their review. The Board is currently working on appeals from {docketMonth} or older.</p>;
+  }
+
+  // Start with the basic content...
+  let content = (
+    <React.fragment>
+      <p>The Board of Veterans’ Appeals hears cases in the order they are received. When you completed a Form 9 in {date}, your appeal was added to the Board’s docket, securing your spot in line.</p>
+      {yourPlaceText}
+      <DocketCard total={total} ahead={ahead}/>
+      <h2>Is there a way for my appeal to be decided more quickly?</h2>
+      <p>If you are suffering a serious illness or are in financial distress, or for other sufficient cause, you can apply to have your appeal <strong>Advanced on Docket</strong>. If you are older than 75, your appeal will have this status automatically. Advanced on Docket appeals are prioritized so that they are always at the front of the line.</p>
+      <p><a target="_blank" href="">Learn more about requesting Advanced on Docket status.</a></p>
+    </React.fragment>
+  );
+
+  // ...and override it if necessary
+
+  if (aod) {
+    content = (
+      <React.fragment>
+        <p>Your appeal is Advanced on Docket. This could be because you or your representative requested this status, or because you are older than 75.</p>
+        <p>Advanced on Docket appeals are prioritized so that they are always at the front of the line. Your appeal will be assigned to a judge as soon as it is ready for their review.</p>
+      </React.fragment>
+    );
+  }
+
+  // This should override the aod section
+  if (appealType === APPEAL_TYPES.postCavcRemand) {
+    content = <p>Your appeal was remanded by the Court of Appeals for Veterans’ Claims. Court Remand appeals are prioritized so that they are always at the front of the line. Your appeal will be assigned to a judge as soon as it is ready for their review.</p>;
+  }
+
   return (
     <div>
       <h2>How long until a judge is ready to write your decision?</h2>
-      <p>The Board of Veterans’ Appeals hears cases in the order they are received. When you completed a Form 9 in {date}, you secured your spot in line. Your appeal is near the front of the line.</p>
-      <div className="docket-container">
-        <p className="appeals-ahead">{ahead.toLocaleString()}</p>
-        <p>Appeals ahead of you</p>
-
-        <div className="marker-container">
-          <div>
-            <div className="marker-text-spacer" style={completedWidth}/>
-            <span className="marker-text">You are here</span>
-          </div>
-          <div>
-            <div className="spacer" style={completedWidth}/>
-            <div className="marker">
-              <img src="/img/Docket-line-pin.svg" alt=""/>
-            </div>
-          </div>
-        </div>
-
-        <div>
-          <div className="docket-bar">
-            <div className="completed" style={completedWidth}/>
-          </div>
-          <div className="end-of-docket"/>
-        </div>
-
-        <div className="front-of-docket-text"><p>Front of docket line</p></div>
-        <p><strong>{total.toLocaleString()}</strong> total appeals on the docket</p>
-      </div>
-      <h2>Is there a way for my appeal to be decided more quickly?</h2>
-      <p>The Board can move your appeal to the front of the docket line if you:</p>
-      <ul>
-        <li>Are 75 years or older</li>
-        <li>Have a terminal illness</li>
-        <li>Are in financial distress</li>
-      </ul>
-      <p>These appeals are called Advanced on Docket (AOD). When you turn 75, your appeal automatically becomes AOD. If you have a terminal illness or are in financial distress, ask your VSO or representative to file a motion with the Board for AOD status.</p>
+      {content}
     </div>
   );
 }

--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -12,7 +12,7 @@ import { APPEAL_TYPES } from '../../utils/appeals-v2-helpers';
  * @param {String} docketMonth- The month that the board is looking at (or older)
  * @param {String} appealType - The type of appeal
  * @param {Bool}   aod - Whether the appeal is Advanced on Docket
- * @param {Bool}   frontOfDocket - Whether the appeal is at the front of the docket
+ * @param {Bool}   front - Whether the appeal is at the front of the docket
  */
 function Docket({ ahead, total, form9Date, docketMonth, appealType, aod, front: frontOfDocket }) {
   // TODO: Assess how accessible this is
@@ -70,8 +70,8 @@ Docket.propTypes = {
   form9Date: PropTypes.string.isRequired,
   docketMonth: PropTypes.string,
   appealType: PropTypes.string,
-  aos: PropTypes.bool,
-  frontOfDocket: PropTypes.bool,
+  aod: PropTypes.bool,
+  front: PropTypes.bool,
 };
 
 export default Docket;

--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -17,36 +17,37 @@ import { APPEAL_TYPES } from '../../utils/appeals-v2-helpers';
 function Docket({ ahead, total, form9Date, docketMonth, appealType, aod, frontOfDocket }) {
   // TODO: Assess how accessible this is
 
-  const date = moment(form9Date, 'YYYY-MM-DD').format('MMMM YYYY');
+  const form9DateFormatted = moment(form9Date, 'YYYY-MM-DD').format('MMMM YYYY');
+  const docketMonthFormatted = moment(docketMonth, 'YYYY-MM-DD').format('MMMM YYYY');
 
   // This is the only part that's different between the two "normal" contents
   let yourPlaceText;
   if (frontOfDocket) {
-    yourPlaceText = <p>The Board is currently working on appeals from {docketMonth} or older. Your appeal is eligible to be assigned to a judge when it is ready for their review.</p>;
+    yourPlaceText = <p>The Board is currently working on appeals from {docketMonthFormatted} or older. Your appeal is eligible to be assigned to a judge when it is ready for their review.</p>;
   } else {
-    yourPlaceText = <p>There are {total} appeals on the docket, not including Advanced on Docket and Court Remand appeals. Some of these appeals are not ready to be assigned to a judge. A judge will begin work on your appeal when it is among the oldest appeals that are ready for their review. The Board is currently working on appeals from {docketMonth} or older.</p>;
+    yourPlaceText = <p>There are {total} appeals on the docket, not including Advanced on Docket and Court Remand appeals. Some of these appeals are not ready to be assigned to a judge. A judge will begin work on your appeal when it is among the oldest appeals that are ready for their review. The Board is currently working on appeals from {docketMonthFormatted} or older.</p>;
   }
 
   // Start with the basic content...
   let content = (
-    <React.fragment>
-      <p>The Board of Veterans’ Appeals hears cases in the order they are received. When you completed a Form 9 in {date}, your appeal was added to the Board’s docket, securing your spot in line.</p>
+    <div>
+      <p>The Board of Veterans’ Appeals hears cases in the order they are received. When you completed a Form 9 in {form9DateFormatted}, your appeal was added to the Board’s docket, securing your spot in line.</p>
       {yourPlaceText}
       <DocketCard total={total} ahead={ahead}/>
       <h2>Is there a way for my appeal to be decided more quickly?</h2>
       <p>If you are suffering a serious illness or are in financial distress, or for other sufficient cause, you can apply to have your appeal <strong>Advanced on Docket</strong>. If you are older than 75, your appeal will have this status automatically. Advanced on Docket appeals are prioritized so that they are always at the front of the line.</p>
       <p><a target="_blank" href="">Learn more about requesting Advanced on Docket status.</a></p>
-    </React.fragment>
+    </div>
   );
 
   // ...and override it if necessary
 
   if (aod) {
     content = (
-      <React.fragment>
+      <div>
         <p>Your appeal is Advanced on Docket. This could be because you or your representative requested this status, or because you are older than 75.</p>
         <p>Advanced on Docket appeals are prioritized so that they are always at the front of the line. Your appeal will be assigned to a judge as soon as it is ready for their review.</p>
-      </React.fragment>
+      </div>
     );
   }
 
@@ -62,11 +63,24 @@ function Docket({ ahead, total, form9Date, docketMonth, appealType, aod, frontOf
     </div>
   );
 }
+/**
+ * @param {Number} ahead - The number of appeals ahead of this one
+ * @param {Number} total - The total number of appeals in the docket line
+ * @param {String} form9Date - The date the form 9 was sent in (or something)
+ * @param {String} docketMonth- The month that the board is looking at (or older)
+ * @param {String} appealType - The type of appeal
+ * @param {Bool}   aod - Whether the appeal is Advanced on Docket
+ * @param {Bool}   frontOfDocket - Whether the appeal is at the front of the docket
+ */
 
 Docket.propTypes = {
   ahead: PropTypes.number.isRequired,
   total: PropTypes.number.isRequired,
-  form9Date: PropTypes.string.isRequired
+  form9Date: PropTypes.string.isRequired,
+  docketMonth: PropTypes.string,
+  appealType: PropTypes.string,
+  aos: PropTypes.bool,
+  frontOfDocket: PropTypes.bool,
 };
 
 export default Docket;

--- a/src/js/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/js/claims-status/components/appeals-v2/Docket.jsx
@@ -63,15 +63,6 @@ function Docket({ ahead, total, form9Date, docketMonth, appealType, aod, frontOf
     </div>
   );
 }
-/**
- * @param {Number} ahead - The number of appeals ahead of this one
- * @param {Number} total - The total number of appeals in the docket line
- * @param {String} form9Date - The date the form 9 was sent in (or something)
- * @param {String} docketMonth- The month that the board is looking at (or older)
- * @param {String} appealType - The type of appeal
- * @param {Bool}   aod - Whether the appeal is Advanced on Docket
- * @param {Bool}   frontOfDocket - Whether the appeal is at the front of the docket
- */
 
 Docket.propTypes = {
   ahead: PropTypes.number.isRequired,

--- a/src/js/claims-status/components/appeals-v2/DocketCard.jsx
+++ b/src/js/claims-status/components/appeals-v2/DocketCard.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const DocketCard = ({ total, ahead }) => {
+  const completedWidth = { width: `${((total - ahead) / total) * 100}%` };
+
+  return (
+    <div className="docket-container">
+      <p className="appeals-ahead">{ahead.toLocaleString()}</p>
+      <p>Appeals ahead of you</p>
+
+      <div className="marker-container">
+        <div>
+          <div className="marker-text-spacer" style={completedWidth}/>
+          <span className="marker-text">You are here</span>
+        </div>
+        <div>
+          <div className="spacer" style={completedWidth}/>
+          <div className="marker">
+            <img src="/img/Docket-line-pin.svg" alt=""/>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div className="docket-bar">
+          <div className="completed" style={completedWidth}/>
+        </div>
+        <div className="end-of-docket"/>
+      </div>
+
+      <div className="front-of-docket-text"><p>Front of docket line</p></div>
+      <p><strong>{total.toLocaleString()}</strong> total appeals on the docket</p>
+    </div>
+  );
+};
+
+DocketCard.propTypes = {
+  ahead: PropTypes.number.isRequired,
+  total: PropTypes.number.isRequired
+};
+
+export default DocketCard;

--- a/src/js/claims-status/components/appeals-v2/DocketCard.jsx
+++ b/src/js/claims-status/components/appeals-v2/DocketCard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const DocketCard = ({ total, ahead }) => {
+function DocketCard({ total, ahead }) {
   const completedWidth = { width: `${((total - ahead) / total) * 100}%` };
 
   return (
@@ -33,7 +33,7 @@ const DocketCard = ({ total, ahead }) => {
       <p><strong>{total.toLocaleString()}</strong> total appeals on the docket</p>
     </div>
   );
-};
+}
 
 DocketCard.propTypes = {
   ahead: PropTypes.number.isRequired,

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -14,7 +14,7 @@ import Docket from '../components/appeals-v2/Docket';
  */
 const AppealsV2StatusPage = ({ appeal }) => {
   const {
-    events, alerts, status, docket, incompleteHistory,
+    events, alerts, status, docket, incompleteHistory, aod,
     active: appealIsActive,
     type: appealType
   } = appeal.attributes;
@@ -54,7 +54,7 @@ const AppealsV2StatusPage = ({ appeal }) => {
         isClosed={!appealIsActive}/>
       <AlertsList alerts={alerts}/>
       {appealIsActive && <WhatsNext nextEvents={nextEvents}/>}
-      {shouldShowDocket && <Docket {...docket} form9Date={form9Date} appealType={appeal.type}/>}
+      {shouldShowDocket && <Docket {...docket} aod={aod} form9Date={form9Date} appealType={appeal.type}/>}
       {!appealIsActive && <div className="closed-appeal-notice">This appeal is now closed</div>}
     </div>
   );

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getStatusContents, getNextEvents, EVENT_TYPES, CLOSED_STATUSES } from '../utils/appeals-v2-helpers';
+import { getStatusContents, getNextEvents, APPEAL_TYPES, EVENT_TYPES, STATUS_TYPES } from '../utils/appeals-v2-helpers';
 
 import Timeline from '../components/appeals-v2/Timeline';
 import CurrentStatus from '../components/appeals-v2/CurrentStatus';
@@ -14,11 +14,10 @@ import Docket from '../components/appeals-v2/Docket';
  */
 const AppealsV2StatusPage = ({ appeal }) => {
   const { events, alerts, status, docket, incompleteHistory } = appeal.attributes;
-  const { type, details } = status;
-  const currentStatus = getStatusContents(type, details);
+  const currentStatus = getStatusContents(status.type, status.details);
 
   // NB: 'details' doesn't do anything in getNextEvents for the time being
-  const nextEvents = getNextEvents(type, details);
+  const nextEvents = getNextEvents(status.type, status.details);
 
   // TODO: This will change. We'll be getting the date from the docket object in the api.
   const form9Event = events.find(e => e.type === EVENT_TYPES.form9, null);
@@ -28,7 +27,20 @@ const AppealsV2StatusPage = ({ appeal }) => {
   const form9Date = form9Event && form9Event.date;
 
   // Gates the What's Next and Docket chunks
-  const appealIsClosed = CLOSED_STATUSES.includes(type);
+  const appealIsClosed = !appeal.active;
+  const hideDocketStatusTypes = [
+    STATUS_TYPES.pendingSoc,
+    STATUS_TYPES.pendingForm9,
+    STATUS_TYPES.decisionInProgress,
+    STATUS_TYPES.bvaDevelopment
+  ];
+  const hideDocketAppealTypes = [
+    APPEAL_TYPES.reconsideration,
+    APPEAL_TYPES.cue
+  ];
+  const shouldShowDocket = !appealIsClosed &&
+    !hideDocketStatusTypes.includes(status.type) &&
+    !hideDocketAppealTypes.includes(appeal.type);
 
   return (
     <div>
@@ -39,7 +51,7 @@ const AppealsV2StatusPage = ({ appeal }) => {
         isClosed={appealIsClosed}/>
       <AlertsList alerts={alerts}/>
       {!appealIsClosed && <WhatsNext nextEvents={nextEvents}/>}
-      {!appealIsClosed && <Docket {...docket} form9Date={form9Date}/>}
+      {shouldShowDocket && <Docket {...docket} form9Date={form9Date}/>}
       {appealIsClosed && <div className="closed-appeal-notice">This appeal is now closed</div>}
     </div>
   );

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -51,7 +51,7 @@ const AppealsV2StatusPage = ({ appeal }) => {
         isClosed={appealIsClosed}/>
       <AlertsList alerts={alerts}/>
       {!appealIsClosed && <WhatsNext nextEvents={nextEvents}/>}
-      {shouldShowDocket && <Docket {...docket} form9Date={form9Date}/>}
+      {shouldShowDocket && <Docket {...docket} form9Date={form9Date} appealType={appeal.type}/>}
       {appealIsClosed && <div className="closed-appeal-notice">This appeal is now closed</div>}
     </div>
   );

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -13,7 +13,7 @@ import Docket from '../components/appeals-v2/Docket';
  * AppealsV2StatusPage is in charge of the layout of the status page
  */
 const AppealsV2StatusPage = ({ appeal }) => {
-  const { events, alerts, status, docket, incompleteHistory } = appeal.attributes;
+  const { events, alerts, status, docket, incompleteHistory, active: appealIsActive } = appeal.attributes;
   const currentStatus = getStatusContents(status.type, status.details);
 
   // NB: 'details' doesn't do anything in getNextEvents for the time being
@@ -27,7 +27,6 @@ const AppealsV2StatusPage = ({ appeal }) => {
   const form9Date = form9Event && form9Event.date;
 
   // Gates the What's Next and Docket chunks
-  const appealIsClosed = !appeal.active;
   const hideDocketStatusTypes = [
     STATUS_TYPES.pendingSoc,
     STATUS_TYPES.pendingForm9,
@@ -38,7 +37,7 @@ const AppealsV2StatusPage = ({ appeal }) => {
     APPEAL_TYPES.reconsideration,
     APPEAL_TYPES.cue
   ];
-  const shouldShowDocket = !appealIsClosed &&
+  const shouldShowDocket = appealIsActive &&
     !hideDocketStatusTypes.includes(status.type) &&
     !hideDocketAppealTypes.includes(appeal.type);
 
@@ -48,11 +47,11 @@ const AppealsV2StatusPage = ({ appeal }) => {
       <CurrentStatus
         title={currentStatus.title}
         description={currentStatus.description}
-        isClosed={appealIsClosed}/>
+        isClosed={appealIsActive}/>
       <AlertsList alerts={alerts}/>
-      {!appealIsClosed && <WhatsNext nextEvents={nextEvents}/>}
+      {appealIsActive && <WhatsNext nextEvents={nextEvents}/>}
       {shouldShowDocket && <Docket {...docket} form9Date={form9Date} appealType={appeal.type}/>}
-      {appealIsClosed && <div className="closed-appeal-notice">This appeal is now closed</div>}
+      {!appealIsActive && <div className="closed-appeal-notice">This appeal is now closed</div>}
     </div>
   );
 };

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -54,7 +54,7 @@ const AppealsV2StatusPage = ({ appeal }) => {
         isClosed={!appealIsActive}/>
       <AlertsList alerts={alerts}/>
       {appealIsActive && <WhatsNext nextEvents={nextEvents}/>}
-      {shouldShowDocket && <Docket {...docket} aod={aod} form9Date={form9Date} appealType={appeal.type}/>}
+      {shouldShowDocket && <Docket {...docket} aod={aod} form9Date={form9Date} appealType={appealType}/>}
       {!appealIsActive && <div className="closed-appeal-notice">This appeal is now closed</div>}
     </div>
   );

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -51,7 +51,7 @@ const AppealsV2StatusPage = ({ appeal }) => {
       <CurrentStatus
         title={currentStatus.title}
         description={currentStatus.description}
-        isClosed={appealIsActive}/>
+        isClosed={!appealIsActive}/>
       <AlertsList alerts={alerts}/>
       {appealIsActive && <WhatsNext nextEvents={nextEvents}/>}
       {shouldShowDocket && <Docket {...docket} form9Date={form9Date} appealType={appeal.type}/>}

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -13,7 +13,11 @@ import Docket from '../components/appeals-v2/Docket';
  * AppealsV2StatusPage is in charge of the layout of the status page
  */
 const AppealsV2StatusPage = ({ appeal }) => {
-  const { events, alerts, status, docket, incompleteHistory, active: appealIsActive } = appeal.attributes;
+  const {
+    events, alerts, status, docket, incompleteHistory,
+    active: appealIsActive,
+    type: appealType
+  } = appeal.attributes;
   const currentStatus = getStatusContents(status.type, status.details);
 
   // NB: 'details' doesn't do anything in getNextEvents for the time being
@@ -39,7 +43,7 @@ const AppealsV2StatusPage = ({ appeal }) => {
   ];
   const shouldShowDocket = appealIsActive &&
     !hideDocketStatusTypes.includes(status.type) &&
-    !hideDocketAppealTypes.includes(appeal.type);
+    !hideDocketAppealTypes.includes(appealType);
 
   return (
     <div>

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -3,6 +3,14 @@ import moment from 'moment';
 import _ from 'lodash';
 import Raven from 'raven-js';
 
+export const APPEAL_TYPES = {
+  original: 'original',
+  postRemand: 'post_remand',
+  postCavcRemand: 'post_cavc_remand',
+  reconsideration: 'reconsideration',
+  cue: 'cue'
+};
+
 // TO DO: Replace made up properties and content with real versions once finalized.
 export const STATUS_TYPES = {
   // Open Statuses:
@@ -38,17 +46,6 @@ export const ISSUE_STATUS = {
   remand: 'remand',
   cavcRemand: 'cavc_remand',
 };
-
-export const CLOSED_STATUSES = [
-  STATUS_TYPES.bvaDecision,
-  STATUS_TYPES.fieldGrant,
-  STATUS_TYPES.withdrawn,
-  STATUS_TYPES.ftr,
-  STATUS_TYPES.ramp,
-  STATUS_TYPES.reconsideration,
-  STATUS_TYPES.death,
-  STATUS_TYPES.otherClose
-];
 
 export const ALERT_TYPES = {
   form9Needed: 'form9_needed',

--- a/test/claims-status/components/appeals-v2/AppealsV2StatusPage.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/AppealsV2StatusPage.unit.spec.jsx
@@ -5,6 +5,8 @@ import { shallow } from 'enzyme';
 import { mockData } from '../../../../src/js/claims-status/utils/helpers';
 import AppealsV2StatusPage from '../../../../src/js/claims-status/containers/AppealsV2StatusPage';
 
+// TODO: Test the conditional logic for showing the docket
+
 describe('<AppealsV2StatusPage/>', () => {
   const defaultProps = { appeal: mockData.data[0] };
 

--- a/test/claims-status/components/appeals-v2/AppealsV2StatusPage.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/AppealsV2StatusPage.unit.spec.jsx
@@ -6,8 +6,6 @@ import { mockData } from '../../../../src/js/claims-status/utils/helpers';
 import { APPEAL_TYPES } from '../../../../src/js/claims-status/utils/appeals-v2-helpers';
 import AppealsV2StatusPage from '../../../../src/js/claims-status/containers/AppealsV2StatusPage';
 
-// TODO: Test the conditional logic for showing the docket
-
 describe('<AppealsV2StatusPage/>', () => {
   const defaultProps = { appeal: mockData.data[0] };
   const onDocketProps = { appeal: mockData.data[1] };

--- a/test/claims-status/components/appeals-v2/AppealsV2StatusPage.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/AppealsV2StatusPage.unit.spec.jsx
@@ -70,7 +70,13 @@ describe('<AppealsV2StatusPage/>', () => {
 
   it('should not render a <Docket/> when appeal type is a forbidden type', () => {
     // The appeal in defaultProps has a status of pending_soc, so the docket shouldn't be shown
-    const props = { ...defaultProps, type: APPEAL_TYPES.cue };
+    const props = {
+      ...defaultProps,
+      attributes: {
+        ...defaultProps.attributes,
+        type: APPEAL_TYPES.cue
+      }
+    };
     const wrapper = shallow(<AppealsV2StatusPage {...props}/>);
     expect(wrapper.find('Docket').length).to.equal(0);
   });

--- a/test/claims-status/components/appeals-v2/AppealsV2StatusPage.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/AppealsV2StatusPage.unit.spec.jsx
@@ -3,12 +3,14 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
 import { mockData } from '../../../../src/js/claims-status/utils/helpers';
+import { APPEAL_TYPES } from '../../../../src/js/claims-status/utils/appeals-v2-helpers';
 import AppealsV2StatusPage from '../../../../src/js/claims-status/containers/AppealsV2StatusPage';
 
 // TODO: Test the conditional logic for showing the docket
 
 describe('<AppealsV2StatusPage/>', () => {
   const defaultProps = { appeal: mockData.data[0] };
+  const onDocketProps = { appeal: mockData.data[1] };
 
   it('should render', () => {
     const wrapper = shallow(<AppealsV2StatusPage {...defaultProps}/>);
@@ -48,7 +50,7 @@ describe('<AppealsV2StatusPage/>', () => {
   });
 
   it('should render a <WhatsNext/> with nextEvents', () => {
-    const wrapper = shallow(<AppealsV2StatusPage {...defaultProps}/>);
+    const wrapper = shallow(<AppealsV2StatusPage {...onDocketProps}/>);
     const whatsNext = wrapper.find('WhatsNext');
     const whatsNextProps = whatsNext.props();
     expect(whatsNext.length).to.equal(1);
@@ -57,7 +59,31 @@ describe('<AppealsV2StatusPage/>', () => {
     expect(whatsNextProps.nextEvents).to.exist;
   });
 
-  it('should render a <Docket/>', () => {
-    // There's currently no docket, leave as placeholder
+  it('should render a <Docket/> when applicable', () => {
+    const wrapper = shallow(<AppealsV2StatusPage {...onDocketProps}/>);
+    expect(wrapper.find('Docket').length).to.equal(1);
+  });
+
+  it('should not render a <Docket/> when appeal status is a forbidden type', () => {
+    // The appeal in defaultProps has a status of pending_soc, so the docket shouldn't be shown
+    const wrapper = shallow(<AppealsV2StatusPage {...defaultProps}/>);
+    expect(wrapper.find('Docket').length).to.equal(0);
+  });
+
+  it('should not render a <Docket/> when appeal type is a forbidden type', () => {
+    // The appeal in defaultProps has a status of pending_soc, so the docket shouldn't be shown
+    const props = { ...defaultProps, type: APPEAL_TYPES.cue };
+    const wrapper = shallow(<AppealsV2StatusPage {...props}/>);
+    expect(wrapper.find('Docket').length).to.equal(0);
+  });
+
+  it('should not render a <Docket/> when appeal is closed', () => {
+    // The appeal in defaultProps has a status of pending_soc, so the docket shouldn't be shown
+    const props = {
+      ...defaultProps,
+      attributes: { ...defaultProps, active: false }
+    };
+    const wrapper = shallow(<AppealsV2StatusPage {...props}/>);
+    expect(wrapper.find('Docket').length).to.equal(0);
   });
 });

--- a/test/claims-status/components/appeals-v2/Docket.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Docket.unit.spec.jsx
@@ -2,33 +2,63 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
-import Docket from '../../../../src/js/claims-status/components/appeals-v2/Docket.jsx';
+import Docket from '../../../../src/js/claims-status/components/appeals-v2/Docket';
+import { APPEAL_TYPES } from '../../../../src/js/claims-status/utils/appeals-v2-helpers';
 
-const defaultProps = {
-  ahead: 109238,
-  total: 283941
-};
 
 describe('Appeals V2 Docket', () => {
+  const defaultProps = {
+    total: 123456,
+    ahead: 23456,
+    form9Date: '2006-10-24',
+    docketMonth: '2004-04-15',
+    appealType: APPEAL_TYPES.original,
+    aod: false,
+    frontOfDocket: false
+  };
+
   it('should render', () => {
     const wrapper = shallow(<Docket {...defaultProps}/>);
     expect(wrapper.type()).to.equal('div');
   });
 
-  it('should show the number of appeals ahead of the appellant', () => {
-    const wrapper = shallow(<Docket {...defaultProps}/>);
-    expect(wrapper.find('.appeals-ahead').text()).to.equal('109,238');
+  it('should display frontOfDocket text', () => {
+    const props = { ...defaultProps, frontOfDocket: true };
+    const wrapper = shallow(<Docket {...props}/>);
+    expect(wrapper.text()).to.contain('The Board is currently working on appeals from');
   });
 
-  it('should show the total number of appeals on the docket', () => {
+  it('should display non-frontOfDocket text', () => {
     const wrapper = shallow(<Docket {...defaultProps}/>);
-    expect(wrapper.find('.front-of-docket-text + p strong').first().text()).to.equal('283,941');
+    expect(wrapper.text()).to.contain('appeals on the docket, not including Advanced on Docket');
   });
 
-  it('should show a visual representaton of where the appellant is in the line', () => {
+  it('should render DocketCard', () => {
     const wrapper = shallow(<Docket {...defaultProps}/>);
-    const { ahead, total } = defaultProps;
-    const computedWidth = ((total - ahead) / total) * 100;
-    expect(wrapper.find('.spacer').first().prop('style').width).to.equal(`${computedWidth}%`);
+    expect(wrapper.find('DocketCard').length).to.equal(1);
+  });
+
+  it('should not render DocketCard for aod', () => {
+    const props = { ...defaultProps, aod: true };
+    const wrapper = shallow(<Docket {...props}/>);
+    expect(wrapper.find('DocketCard').length).to.equal(0);
+  });
+
+  it('should not render DocketCard for postCavcRemand', () => {
+    const props = { ...defaultProps, appealType: APPEAL_TYPES.postCavcRemand };
+    const wrapper = shallow(<Docket {...props}/>);
+    expect(wrapper.find('DocketCard').length).to.equal(0);
+  });
+
+  it('should display aod text', () => {
+    const props = { ...defaultProps, aod: true };
+    const wrapper = shallow(<Docket {...props}/>);
+    expect(wrapper.text()).to.contain('Your appeal is Advanced on Docket.');
+  });
+
+  it('should display postCavcRemand text', () => {
+    const props = { ...defaultProps, appealType: APPEAL_TYPES.postCavcRemand };
+    const wrapper = shallow(<Docket {...props}/>);
+    expect(wrapper.text()).to.contain('Your appeal was remanded by the Court of Appeals for Veterans’ Claims.');
   });
 });

--- a/test/claims-status/components/appeals-v2/DocketCard.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/DocketCard.unit.spec.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import DocketCard from '../../../../src/js/claims-status/components/appeals-v2/DocketCard';
+
+describe('Appeals V2 DocketCard', () => {
+  const defaultProps = {
+    ahead: 109238,
+    total: 283941
+  };
+
+  it('should render', () => {
+    const wrapper = shallow(<DocketCard {...defaultProps}/>);
+    expect(wrapper.type()).to.equal('div');
+  });
+
+  it('should show the number of appeals ahead of the appellant', () => {
+    const wrapper = shallow(<DocketCard {...defaultProps}/>);
+    expect(wrapper.find('.appeals-ahead').text()).to.equal('109,238');
+  });
+
+  it('should show the total number of appeals on the docket', () => {
+    const wrapper = shallow(<DocketCard {...defaultProps}/>);
+    expect(wrapper.find('.front-of-docket-text + p strong').first().text()).to.equal('283,941');
+  });
+
+  it('should show a visual representaton of where the appellant is in the line', () => {
+    const wrapper = shallow(<DocketCard {...defaultProps}/>);
+    const { ahead, total } = defaultProps;
+    const computedWidth = ((total - ahead) / total) * 100;
+    expect(wrapper.find('.spacer').first().prop('style').width).to.equal(`${computedWidth}%`);
+  });
+});


### PR DESCRIPTION
# Docket-Hiding Logic
An appeal object is kind of a hairy beast, so to be clear, this is where I'm pulling the information to describe the screenshots below:

**Appeal type:** `appeal.attributes.type`
**Status:** `appeal.attributes.status.type`
**Active:** `appeal.attributes.active`

I don't know if any of these appeals would happen in the wild, but to demonstrate what this PR does, I've messed around with the mock data to show the different scenarios.

**Appeal type:** original
**Status:** pending_soc
**Active:** true
![image](https://user-images.githubusercontent.com/12970166/35881745-ad7e3d0c-0b36-11e8-858e-48300e440852.png)
No docket because the status is a "forbidden" type.
"What's next" still shows because the appeal is still active.

**Appeal type:** cue
**Status:** bva_decision
**Active:** true
![image](https://user-images.githubusercontent.com/12970166/35882411-f75dff82-0b38-11e8-97d1-4264424f5092.png)
No docket because of the appeal type.
"What's next" still shows because the appeal is active.
Note: It looks the same as above, but I _did_ change the mock data and test.

**Appeal type:** original
**Status:** bva_decision
**Active:** false
![image](https://user-images.githubusercontent.com/12970166/35882893-6d183214-0b3a-11e8-9208-0d2d5a112b6c.png)
No docket and no "What's next" because active is false.

# Docket Content Logic

**Front of Docket:** false
**Advanced on Docket:** false
**Appeal type:** original
![image](https://user-images.githubusercontent.com/12970166/35884244-e8777e02-0b3e-11e8-8c84-7d348b7acb80.png)

**Front of Docket:** true
**Advanced on Docket:** false
**Appeal type:** original
![image](https://user-images.githubusercontent.com/12970166/35884380-6179cac6-0b3f-11e8-86b3-ce8e4dc9a530.png)

**Front of Docket:** false
**Advanced on Docket:** true
**Appeal type:** original
![image](https://user-images.githubusercontent.com/12970166/35885658-66cb53ba-0b43-11e8-9b2a-500b45e20649.png)

**Front of Docket:** false
**Advanced on Docket:** false
**Appeal type:** post_cavc_remand
![image](https://user-images.githubusercontent.com/12970166/35885799-e53fe76a-0b43-11e8-92c7-44a867c6f2b9.png)

---

**To do:**
- [ ] Get the link for the "learn more" link