### PR TITLE
Fixed missing submit and fill dates on active subscriptions

### DIFF
--- a/src/js/rx/components/PrescriptionTable.jsx
+++ b/src/js/rx/components/PrescriptionTable.jsx
@@ -49,8 +49,8 @@ class PrescriptionTable extends React.Component {
             <span>Prescription #: {item.id}</span>
           </div>
         ),
-        lastSubmitDate: formatDate(attrs.refillSubmitDate),
-        lastFillDate: formatDate(attrs.refillDate),
+        refillSubmitDate: formatDate(attrs.refillSubmitDate),
+        refillDate: formatDate(attrs.refillDate),
         facilityName: attrs.facilityName,
         refillsLeft: attrs.refillRemaining,
         refillStatus: <RefillStatus {...item} glossaryModalHandler={this.props.glossaryModalHandler} refillModalHandler={this.props.refillModalHandler}/>,

--- a/src/sass/rx/partials/_rx-history.scss
+++ b/src/sass/rx/partials/_rx-history.scss
@@ -5,14 +5,6 @@
 }
 
 #rx-history table {
-  tr {
-    &:last-child {
-      td {
-        border-bottom: none;
-      }
-    }
-  }
-
   td {
     &:nth-child(3) {
       a {


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#8578.

Also fixes the missing bottom border of the table on the history page:
> <img width="1002" alt="screen shot 2018-02-06 at 8 10 01 pm" src="https://user-images.githubusercontent.com/1067024/35893155-b46b9a08-0b7a-11e8-8c99-b385b0518a3b.png">
