### PR TITLE
Appealsv2 expand accordion mg

### DIFF
--- a/src/js/claims-status/components/appeals-v2/Issues.jsx
+++ b/src/js/claims-status/components/appeals-v2/Issues.jsx
@@ -67,8 +67,9 @@ const Issues = ({ issues }) => {
 
   let activeItems = null;
   if (openListItems.length || remandListItems.length) {
+    // Active panel should always render as expanded by default (when items present)
     activeItems = (
-      <CollapsiblePanel panelName={'Currently on appeal'}>
+      <CollapsiblePanel panelName={'Currently on appeal'} startOpen>
         {openSection}
         {remandSection}
       </CollapsiblePanel>
@@ -77,8 +78,9 @@ const Issues = ({ issues }) => {
 
   let closedItems = null;
   if (grantedListItems.length || deniedListItems.length || withdrawnListItems.length) {
+    // Closed panel should render as expanded by default only if no active panel present
     closedItems = (
-      <CollapsiblePanel panelName={'Closed'}>
+      <CollapsiblePanel panelName={'Closed'} startOpen={!activeItems}>
         {grantedSection}
         {deniedSection}
         {withdrawnSection}

--- a/src/js/common/components/CollapsiblePanel.jsx
+++ b/src/js/common/components/CollapsiblePanel.jsx
@@ -7,10 +7,12 @@ const Element = Scroll.Element;
 const scroller = Scroll.scroller;
 
 export default class CollapsiblePanel extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
+    this.state = { open: !!(props.startOpen) };
+
     this.toggleChapter = this.toggleChapter.bind(this);
-    this.state = { open: false };
+    this.scrollToTop = this.scrollToTop.bind(this);
   }
 
   componentWillMount() {
@@ -27,7 +29,7 @@ export default class CollapsiblePanel extends React.Component {
 
   toggleChapter() {
     const isOpening = !this.state.open;
-    this.setState({ open: !this.state.open }, () => {
+    this.setState((prevState) => ({ open: !prevState.open }), () => {
       if (isOpening) {
         this.scrollToTop();
       }

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -1094,7 +1094,10 @@ $marker-text-width: 9rem;
     }
 
     .usa-accordion-content {
+      padding-top: 1.25em;
+
       h5 {
+        font-family: $font-sans;
         margin-top: 0;
       }
     }

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -1088,20 +1088,27 @@ $marker-text-width: 9rem;
   &>h2 {
     margin-top: 0;
   }
-
-  .usa-accordion-button {
-    font-size: 2rem; // match standard h3
-  }
-
-  .granted-section {
-    h5 {
-      color: $color-green;
+  .usa-accordion-bordered {
+    .usa-accordion-button {
+      font-size: 2rem; // match standard h3
     }
-  }
 
-  .denied-section {
-    h5 {
-      color: $color-secondary;
+    .usa-accordion-content {
+      h5 {
+        margin-top: 0;
+      }
+    }
+
+    .granted-section {
+      h5 {
+        color: $color-green;
+      }
+    }
+  
+    .denied-section {
+      h5 {
+        color: $color-secondary;
+      }
     }
   }
 }

--- a/test/claims-status/components/appeals-v2/Issues.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Issues.unit.spec.jsx
@@ -46,11 +46,9 @@ describe('<Issues/>', () => {
     const wrapper = mount(<Issues {...props }/>);
     const panelButton = wrapper.find('.usa-accordion-button');
     expect(panelButton.html()).to.contain('Currently on appeal');
-    // expand the collapsed accordion to reveal child HTML
-    panelButton.simulate('click');
-    const expandedPanel = wrapper.find('.usa-accordion-bordered');
+    // no need to click, panel should be auto-expanded
     // open items are in the first ul within the first accordion's content
-    const openContentList = expandedPanel.find('.usa-accordion-content > ul');
+    const openContentList = wrapper.find('.usa-accordion-content > ul');
     expect(openContentList.find('li').length).to.equal(props.issues.length);
   });
 
@@ -59,11 +57,37 @@ describe('<Issues/>', () => {
     const wrapper = mount(<Issues {...props }/>);
     const panelButton = wrapper.find('.usa-accordion-button');
     expect(panelButton.html()).to.contain('Closed');
-    // expand the collapsed accordion to reveal child HTML
-    panelButton.simulate('click');
-    const expandedPanel = wrapper.find('.usa-accordion-bordered');
+    // no need to click, panel should be auto-expanded
     // closed items are in accordion > div > ul > li
-    const remandDiv = expandedPanel.find('.usa-accordion-content > div');
+    const remandDiv = wrapper.find('.usa-accordion-content > div');
     expect(remandDiv.find('ul > li').length).to.equal(props.issues.length);
+  });
+
+  it('should pass auto-expand prop to active panel when both active and closed panels present', () => {
+    const wrapper = shallow(<Issues {...manyIssues}/>);
+    const activePanelProps = wrapper.find('CollapsiblePanel').first().props();
+    expect(activePanelProps.panelName).to.equal('Currently on appeal');
+    expect(activePanelProps.startOpen).to.be.true;
+  });
+
+  it('should pass auto-expand prop to active panel when only active panel present', () => {
+    const wrapper = shallow(<Issues {...oneOpenIssue}/>);
+    const activePanelProps = wrapper.find('CollapsiblePanel').props();
+    expect(activePanelProps.panelName).to.equal('Currently on appeal');
+    expect(activePanelProps.startOpen).to.be.true;
+  });
+
+  it('should pass auto-expand prop to closed panel when no active panel present', () => {
+    const wrapper = shallow(<Issues {...oneClosedIssue}/>);
+    const closedPanelProps = wrapper.find('CollapsiblePanel').first().props();
+    expect(closedPanelProps.panelName).to.equal('Closed');
+    expect(closedPanelProps.startOpen).to.be.true;
+  });
+
+  it('should not pass auto-expand prop to closed panel when active panel present', () => {
+    const wrapper = shallow(<Issues {...manyIssues}/>);
+    const closedPanelProps = wrapper.find('CollapsiblePanel').at(1).props();
+    expect(closedPanelProps.panelName).to.equal('Closed');
+    expect(closedPanelProps.startOpen).to.be.false;
   });
 });

--- a/test/common/components/CollapsiblePanel.unit.spec.jsx
+++ b/test/common/components/CollapsiblePanel.unit.spec.jsx
@@ -1,33 +1,53 @@
 import React from 'react';
-import SkinDeep from 'skin-deep';
+import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import CollapsiblePanel from '../../../src/js/common/components/CollapsiblePanel';
 
+
 describe('<CollapsiblePanel>', () => {
   it('should render the correct panel header', () => {
-    const tree = SkinDeep.shallowRender(
-      <CollapsiblePanel
-        panelName={'Test panel'}/>
-    );
-
-    expect(tree.subTree('.usa-accordion-button').text()).to.contain('Test panel');
+    const testHeaderText = 'Test panel';
+    const wrapper = shallow(<CollapsiblePanel panelName={testHeaderText}/>);
+    const renderedHeaderText = wrapper.find('.usa-accordion-button').render().text();
+    expect(renderedHeaderText).to.equal(testHeaderText);
   });
 
   it('should handle toggling chapter', () => {
-    const tree = SkinDeep.shallowRender(
-      <CollapsiblePanel
-        panelName={'Test panel'}/>
-    );
+    const wrapper = shallow(<CollapsiblePanel panelName={'Test panel'}/>);
 
-    expect(tree.everySubTree('.usa-accordion-content')).to.be.empty;
+    const toggleButton = wrapper.find('button');
+    expect(wrapper.find('.usa-accordion-content').length).to.equal(0);
 
-    tree.getMountedInstance().toggleChapter();
+    toggleButton.simulate('click');
+    expect(wrapper.find('.usa-accordion-content').length).to.equal(1);
 
-    expect(tree.everySubTree('.usa-accordion-content')).not.to.be.empty;
+    toggleButton.simulate('click');
+    expect(wrapper.find('.usa-accordion-content').length).to.equal(0);
+  });
 
-    tree.getMountedInstance().toggleChapter();
+  it('should default to open if startOpen prop is true', () => {
+    const wrapper = shallow(<CollapsiblePanel panelName={'Test'} startOpen/>);
+    const toggleButton = wrapper.find('button');
 
-    expect(tree.everySubTree('.usa-accordion-content')).to.be.empty;
+    expect(wrapper.find('.usa-accordion-content').length).to.equal(1);
+
+    toggleButton.simulate('click');
+    expect(wrapper.find('.usa-accordion-content').length).to.equal(0);
+
+    toggleButton.simulate('click');
+    expect(wrapper.find('.usa-accordion-content').length).to.equal(1);
+  });
+
+  it('should call scrollToTop on toggle open', () => {
+    const scrollSpy = sinon.spy();
+    CollapsiblePanel.prototype.scrollToTop = scrollSpy;
+    const wrapper = mount(<CollapsiblePanel panelName={'Test'}/>);
+    const button = wrapper.find('button');
+    expect(scrollSpy.called).to.be.false;
+
+    button.simulate('click');
+    expect(scrollSpy.calledOnce).to.be.true;
   });
 });

--- a/test/common/components/CollapsiblePanel.unit.spec.jsx
+++ b/test/common/components/CollapsiblePanel.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -43,7 +43,7 @@ describe('<CollapsiblePanel>', () => {
   it('should call scrollToTop on toggle open', () => {
     const scrollSpy = sinon.spy();
     CollapsiblePanel.prototype.scrollToTop = scrollSpy;
-    const wrapper = mount(<CollapsiblePanel panelName={'Test'}/>);
+    const wrapper = shallow(<CollapsiblePanel panelName={'Test'}/>);
     const button = wrapper.find('button');
     expect(scrollSpy.called).to.be.false;
 


### PR DESCRIPTION
- Updates common accordion (`CollapsiblePanel`) component to optionally take another prop, `startOpen`, which (predictably) determines whether the accordion will render as collapsed or expanded. Once rendered, functionality remains the same.
- This change should not affect the codebase that already uses the component.
- Adds more logic to the `Issues` component to take advantage of this new prop - the new logic should work such that the first instance of an accordion on the Issues tab will render as expanded (regardless of whether both 'Currently on appeals' and 'Closed' are rendered, or just one of them).
- Updates tests for both components.

One closed / granted issue only:
<img width="1113" alt="screen shot 2018-02-07 at 10 29 20 am" src="https://user-images.githubusercontent.com/24251447/35928075-e3d12610-0bf1-11e8-8435-17b64604c8ea.png">

One active issue only:
<img width="1170" alt="screen shot 2018-02-07 at 10 27 29 am" src="https://user-images.githubusercontent.com/24251447/35928076-e40e6494-0bf1-11e8-87c0-72a62b8adee4.png">

Both active and closed issues:
<img width="1234" alt="screen shot 2018-02-07 at 10 23 45 am" src="https://user-images.githubusercontent.com/24251447/35928079-e44cac36-0bf1-11e8-8c5e-e04be0d0bbe4.png">
