### PR TITLE
update zoom and move logic / repair layout issues

### DIFF
--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -335,7 +335,7 @@ export default class PhotoField extends React.Component {
     // at this point, the onZoom event has not resized the canvas-
     // this forces the canvas back into move bounds if the zoom pulls a canvas edge into the cropBox
     //   after the canvas has rendered with new width values
-    window.requestAnimationFrame(this.maybeMoveCanvasWithinBounds.bind(this, {}, zoomWarn));
+    window.requestAnimationFrame(() => this.maybeMoveCanvasWithinBounds({}, zoomWarn));
   }
 
   setCropBox = () => {

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -411,8 +411,6 @@ export default class PhotoField extends React.Component {
   }
 
   updateBoundaryWarningAndButtonStates = (moveBoundariesMet, zoomWarn = false) => {
-    // const moveBoundariesMet = getMoveBoundariesMet(this.refs.cropper.getCanvasData(), this.refs.cropper.getCropBoxData());
-
     this.setState({
       warningMessage: makeCropBoundaryWarningMessage({ zoomWarn, ...moveBoundariesMet }),
       ...makeMoveButtonsEnabledStates(moveBoundariesMet)

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -350,7 +350,7 @@ export default class PhotoField extends React.Component {
       width: smallScreen ? 240 : 300
     });
 
-    // use the cropbox dimensions to force the into default position
+    // use the cropbox dimensions to force canvas into default position
     const { height: cropBoxHeight, width: cropBoxWidth, left: cropBoxLeft } = this.refs.cropper.getCropBoxData();
     const { width: oldCanvasWidth, height: oldCanvasHeight, naturalHeight, naturalWidth } = this.refs.cropper.getCanvasData();
     // tall images take the full width of the cropBox

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -66,10 +66,10 @@ function makeMovedCanvasData({ canvasData, cropBoxData, moveX, moveY }) {
     newCanvasData.rightBoundaryMet = true;
   } else if (newCanvasData.left > boundaries.leftMax) {
     newCanvasData.left = boundaries.leftMax;
-    newCanvasData.rightBoundaryMet = true;
+    newCanvasData.leftBoundaryMet = true;
   } else if (newCanvasData.left < boundaries.leftMin) {
     newCanvasData.left = boundaries.leftMin;
-    newCanvasData.leftBoundaryMet = true;
+    newCanvasData.rightBoundaryMet = true;
   }
 
   return newCanvasData;
@@ -340,7 +340,7 @@ export default class PhotoField extends React.Component {
 
   setCropBox = () => {
     // center the cropbox using container width
-    const containerWidth = this.refs.container.offsetWidth;
+    const containerWidth = this.refs.cropper.getContainerData().width;
     const smallScreen = isSmallScreen(this.state.windowWidth);
     const left = smallScreen ? (containerWidth / 2) - 120 : (containerWidth / 2) - 150;
     this.refs.cropper.setCropBoxData({
@@ -510,24 +510,22 @@ export default class PhotoField extends React.Component {
             <ProgressBar percent={this.state.progress}/>
           </div>}
           {!isDone && this.state.src && <div className="cropper-container-outer">
-            <div ref="container">
-              <Cropper
-                ref="cropper"
-                key={smallScreen ? 'smallScreen' : 'largeScreen'}
-                ready={this.setCropBox}
-                responsive
-                src={this.state.src}
-                aspectRatio={1}
-                cropBoxMovable={false}
-                cropend={this.handleCropend}
-                cropmove={this.handleCropMove}
-                minContainerHeight={smallScreen ? 240 : 300}
-                toggleDragModeOnDblclick={false}
-                dragMode="move"
-                guides={false}
-                viewMode={0}
-                zoom={this.onZoom}/>
-            </div>
+            <Cropper
+              ref="cropper"
+              key={smallScreen ? 'smallScreen' : 'largeScreen'}
+              ready={this.setCropBox}
+              responsive
+              src={this.state.src}
+              aspectRatio={1}
+              cropBoxMovable={false}
+              cropend={this.handleCropend}
+              cropmove={this.handleCropMove}
+              minContainerHeight={smallScreen ? 240 : 300}
+              toggleDragModeOnDblclick={false}
+              dragMode="move"
+              guides={false}
+              viewMode={0}
+              zoom={this.onZoom}/>
             <div className="cropper-zoom-container">
               {smallScreen && <button className="cropper-control cropper-control-zoom cropper-control-zoom-out va-button va-button-link" type="button" onClick={() => this.handleZoomButtonClick('OUT')}><i className="fa fa-search-minus"></i></button>}
               {!smallScreen && <button className="cropper-control cropper-control-zoom cropper-control-zoom-out va-button va-button-link" type="button" onClick={() => this.handleZoomButtonClick('OUT')}>

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -421,6 +421,15 @@ export default class PhotoField extends React.Component {
     this.maybeMoveCanvasWithinBounds();
   }
 
+  handleCropstart = (e) => {
+    const action = e.detail.action;
+    const allowedActions = ['crop', 'move', 'zoom', 'all'];
+
+    if (!allowedActions.includes(action)) {
+      e.preventDefault();
+    }
+  }
+
   handleMove = (direction) => {
     let moveData;
     switch (direction) {
@@ -509,7 +518,6 @@ export default class PhotoField extends React.Component {
           </div>}
           {!isDone && this.state.src && <div className="cropper-container-outer">
             <Cropper
-              cropBoxResizable={false}
               ref="cropper"
               key={smallScreen ? 'smallScreen' : 'largeScreen'}
               ready={this.setCropBox}
@@ -517,6 +525,7 @@ export default class PhotoField extends React.Component {
               src={this.state.src}
               aspectRatio={1}
               cropBoxMovable={false}
+              cropstart={this.handleCropstart}
               cropend={this.handleCropend}
               cropmove={this.handleCropMove}
               minContainerHeight={smallScreen ? 240 : 300}

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -509,6 +509,7 @@ export default class PhotoField extends React.Component {
           </div>}
           {!isDone && this.state.src && <div className="cropper-container-outer">
             <Cropper
+              cropBoxResizable={false}
               ref="cropper"
               key={smallScreen ? 'smallScreen' : 'largeScreen'}
               ready={this.setCropBox}

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -513,6 +513,7 @@ export default class PhotoField extends React.Component {
             <div ref="container">
               <Cropper
                 ref="cropper"
+                key={smallScreen ? 'smallScreen' : 'largeScreen'}
                 ready={this.setCropBox}
                 responsive
                 src={this.state.src}

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -359,7 +359,8 @@ export default class PhotoField extends React.Component {
       if (naturalHeight > naturalWidth) {
         this.refs.cropper.setCanvasData({
           width: cropBoxWidth,
-          left: cropBoxLeft
+          left: cropBoxLeft,
+          top: 0
         });
         // wide images take the full height of the cropBox
         // to center, uses the ratio of cropBoxHeight / cavasHeight
@@ -381,6 +382,14 @@ export default class PhotoField extends React.Component {
         zoomValue: minRatio,
         minRatio
       });
+
+      // update warning messages
+      const newCanvasData = makeMovedCanvasData({
+        canvasData: this.refs.cropper.getCanvasData(),
+        cropBoxData: this.refs.cropper.getCropBoxData(),
+      });
+
+      this.updateBoundaryWarningAndButtonStates(newCanvasData);
     });
   }
 

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -24,6 +24,8 @@ const PhotoDescription = (
   </div>);
 
 const MIN_SIZE = 350;
+const SMALL_CROP_BOX_SIZE = 240;
+const LARGE_CROP_BOX_SIZE = 300;
 const WARN_RATIO = 1.3;
 const LARGE_SCREEN = 1201;
 const MAX_DIMENSION = 1024;
@@ -348,8 +350,8 @@ export default class PhotoField extends React.Component {
       this.refs.cropper.setCropBoxData({
         top: 0,
         left,
-        height: smallScreen ? 240 : 300,
-        width: smallScreen ? 240 : 300
+        height: smallScreen ? SMALL_CROP_BOX_SIZE : LARGE_CROP_BOX_SIZE,
+        width: smallScreen ? SMALL_CROP_BOX_SIZE : LARGE_CROP_BOX_SIZE
       });
 
       // use the cropbox dimensions to force canvas into default position
@@ -540,7 +542,7 @@ export default class PhotoField extends React.Component {
               cropstart={this.handleCropstart}
               cropend={this.handleCropend}
               cropmove={this.handleCropMove}
-              minContainerHeight={smallScreen ? 240 : 300}
+              minContainerHeight={smallScreen ? SMALL_CROP_BOX_SIZE : LARGE_CROP_BOX_SIZE}
               toggleDragModeOnDblclick={false}
               dragMode="move"
               guides={false}

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -339,45 +339,48 @@ export default class PhotoField extends React.Component {
   }
 
   setCropBox = () => {
-    // center the cropbox using container width
-    const containerWidth = this.refs.cropper.getContainerData().width;
-    const smallScreen = isSmallScreen(this.state.windowWidth);
-    const left = smallScreen ? (containerWidth / 2) - 120 : (containerWidth / 2) - 150;
-    this.refs.cropper.setCropBoxData({
-      top: 0,
-      left,
-      height: smallScreen ? 240 : 300,
-      width: smallScreen ? 240 : 300
-    });
-
-    // use the cropbox dimensions to force canvas into default position
-    const { height: cropBoxHeight, width: cropBoxWidth, left: cropBoxLeft } = this.refs.cropper.getCropBoxData();
-    const { width: oldCanvasWidth, height: oldCanvasHeight, naturalHeight, naturalWidth } = this.refs.cropper.getCanvasData();
-    // tall images take the full width of the cropBox
-    if (naturalHeight > naturalWidth) {
-      this.refs.cropper.setCanvasData({
-        width: cropBoxWidth,
-        left: cropBoxLeft
-      });
-      // wide images take the full height of the cropBox
-      // to center, uses the ratio of cropBoxHeight / cavasHeight
-    } else {
-      this.refs.cropper.setCanvasData({
-        height: cropBoxHeight,
+    window.requestAnimationFrame(() => {
+      // center the cropbox using container width
+      const containerWidth = this.refs.cropper.getContainerData().width;
+      // const containerWidth = this.refs.container.offsetWidth;
+      const smallScreen = isSmallScreen(this.state.windowWidth);
+      const left = smallScreen ? (containerWidth / 2) - 120 : (containerWidth / 2) - 150;
+      this.refs.cropper.setCropBoxData({
         top: 0,
-        left: (containerWidth - (cropBoxHeight / oldCanvasHeight * oldCanvasWidth)) / 2
+        left,
+        height: smallScreen ? 240 : 300,
+        width: smallScreen ? 240 : 300
       });
-    }
 
-    // with the canvas resized, use its dimensions to determine the min zoom ratio
-    const { width: newCanvasWidth } = this.refs.cropper.getCanvasData();
-    const minRatio = newCanvasWidth / naturalWidth;
-    const slider = this.refs.slider;
-    slider.value = minRatio;
+      // use the cropbox dimensions to force canvas into default position
+      const { height: cropBoxHeight, width: cropBoxWidth, left: cropBoxLeft } = this.refs.cropper.getCropBoxData();
+      const { width: oldCanvasWidth, height: oldCanvasHeight, naturalHeight, naturalWidth } = this.refs.cropper.getCanvasData();
+      // tall images take the full width of the cropBox
+      if (naturalHeight > naturalWidth) {
+        this.refs.cropper.setCanvasData({
+          width: cropBoxWidth,
+          left: cropBoxLeft
+        });
+        // wide images take the full height of the cropBox
+        // to center, uses the ratio of cropBoxHeight / cavasHeight
+      } else {
+        this.refs.cropper.setCanvasData({
+          height: cropBoxHeight,
+          top: 0,
+          left: (containerWidth - (cropBoxHeight / oldCanvasHeight * oldCanvasWidth)) / 2
+        });
+      }
 
-    this.setState({
-      zoomValue: minRatio,
-      minRatio
+      // with the canvas resized, use its dimensions to determine the min zoom ratio
+      const { width: newCanvasWidth } = this.refs.cropper.getCanvasData();
+      const minRatio = newCanvasWidth / naturalWidth;
+      const slider = this.refs.slider;
+      slider.value = minRatio;
+
+      this.setState({
+        zoomValue: minRatio,
+        minRatio
+      });
     });
   }
 

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -369,7 +369,7 @@ export default class PhotoField extends React.Component {
       });
     }
 
-    // with the canvas resized, use it's dimensions to determine the min zoom ratio
+    // with the canvas resized, use its dimensions to determine the min zoom ratio
     const { width: newCanvasWidth } = this.refs.cropper.getCanvasData();
     const minRatio = newCanvasWidth / naturalWidth;
     const slider = this.refs.slider;

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -28,7 +28,7 @@ const WARN_RATIO = 1.3;
 const LARGE_SCREEN = 1201;
 const MAX_DIMENSION = 1024;
 
-function makeMovedCanvasData({ canvasData, cropBoxData, moveX, moveY }) {
+function getCanvasDataForMove({ canvasData, cropBoxData, moveX, moveY }) {
   const { left: canvasLeft, top: canvasTop, width: canvasWidth, height: canvasHeight } =  canvasData;
   const { left: cropBoxLeft, top: cropBoxTop, width: cropBoxWidth, height: cropBoxHeight } =  cropBoxData;
 
@@ -384,7 +384,7 @@ export default class PhotoField extends React.Component {
       });
 
       // update warning messages
-      const newCanvasData = makeMovedCanvasData({
+      const newCanvasData = getCanvasDataForMove({
         canvasData: this.refs.cropper.getCanvasData(),
         cropBoxData: this.refs.cropper.getCropBoxData(),
       });
@@ -394,7 +394,7 @@ export default class PhotoField extends React.Component {
   }
 
   maybeMoveCanvasWithinBounds = (moveData, zoomWarn = false) => {
-    const newCanvasData = makeMovedCanvasData({
+    const newCanvasData = getCanvasDataForMove({
       canvasData: this.refs.cropper.getCanvasData(),
       cropBoxData: this.refs.cropper.getCropBoxData(),
       ...moveData

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -54,10 +54,10 @@ function makeMovedCanvasData({ canvasData, cropBoxData, moveX, moveY }) {
     newCanvasData.bottomBoundaryMet = true;
   } else if (newCanvasData.top > boundaries.topMax) {
     newCanvasData.top = boundaries.topMax;
-    newCanvasData.bottomBoundaryMet = true;
+    newCanvasData.topBoundaryMet = true;
   } else if (newCanvasData.top  < boundaries.topMin) {
     newCanvasData.top = boundaries.topMin;
-    newCanvasData.topBoundaryMet = true;
+    newCanvasData.bottomBoundaryMet = true;
   }
 
   if (boundaries.leftMin === boundaries.leftMax) {

--- a/src/sass/vic-v2.scss
+++ b/src/sass/vic-v2.scss
@@ -131,6 +131,10 @@ input[type=range] {
   }
 }
 
+span.cropper-line {
+  display: inline !important;
+}
+
 .cropper-container {
   height: 240px !important;
   width: 100% !important;

--- a/src/sass/vic-v2.scss
+++ b/src/sass/vic-v2.scss
@@ -131,10 +131,6 @@ input[type=range] {
   }
 }
 
-span.cropper-line {
-  display: inline !important;
-}
-
 .cropper-container {
   height: 240px !important;
   width: 100% !important;


### PR DESCRIPTION
This is a PR to repair the following issues: 

- cropbox shrinks when wide image is used; see [this](https://github.com/department-of-veterans-affairs/vets-website/pull/7229#pullrequestreview-94587190) and [this](https://github.com/department-of-veterans-affairs/vets-website/pull/7229#discussion_r166514321).
- cropbox is not centered after changing the window size
- zoom slider does not allow end to end adjustment 

<img width="588" alt="screen shot 2018-02-06 at 20 38 51" src="https://user-images.githubusercontent.com/4998130/35895660-0957efaa-0b7e-11e8-8009-e173ad881b69.png">
<img width="571" alt="screen shot 2018-02-06 at 20 38 21" src="https://user-images.githubusercontent.com/4998130/35895662-0d4c0772-0b7e-11e8-9622-8c7a02c0657f.png">
<img width="612" alt="screen shot 2018-02-06 at 20 37 27" src="https://user-images.githubusercontent.com/4998130/35895663-0f301f56-0b7e-11e8-9ccd-f733726b1eef.png">

A couple of factors played into these issues:
- changing the container height after cropper is mounted is not supported by cropperjs
- the default behavior is to display the entire image when it is initially displayed- this behavior ignores values set for the cropper size 

Final result:
![wide image demo](https://user-images.githubusercontent.com/4998130/35897945-4f9fdf94-0b89-11e8-9dfd-ef63a207a795.gif)
![narrow image demo](https://user-images.githubusercontent.com/4998130/35897953-52bd9a68-0b89-11e8-8c2d-2473a5a6fa28.gif)

