### PR TITLE
Switch allowed to granted

### DIFF
--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -92,7 +92,7 @@ export function addStatusToIssues(issues) {
         status = 'withdrawn';
         break;
       case ISSUE_STATUS.allowed:
-        status = 'allowed';
+        status = 'granted';
         break;
       case ISSUE_STATUS.denied:
         status = 'denied';


### PR DESCRIPTION
Fixes issue where `Issues` component expects only 'granted' status types but was getting both 'granted' and 'allowed' status types