### PR TITLE
Appealsv2 fix status mg

### DIFF
--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -525,7 +525,7 @@ export function getEventContent(event) {
       };
     case EVENT_TYPES.hearingHeld:
       return {
-        title: `Your hearing was held at the ${event.details.regionalOffice} Regional Office`,
+        title: 'Your hearing was held at the regional office',
         description: '',
       };
     case EVENT_TYPES.hearingCancelled:
@@ -616,8 +616,8 @@ const DECISION_REVIEW_CONTENT = (
  */
 export const makeDurationText = (timeliness) => {
   const durationText = {
-    header: 'unknown',
-    description: 'unknown',
+    header: '',
+    description: '',
   };
 
   if (!timeliness || !Array.isArray(timeliness) || timeliness.length !== 2) {
@@ -973,8 +973,8 @@ export function getNextEvents(currentStatus, details) {
           {
             title: 'Unknown event',
             description: (<p>We could not find the next event in your appeal</p>),
-            durationText: 'Unknown',
-            cardDescription: 'No description found'
+            durationText: '',
+            cardDescription: ''
           }
         ]
       };

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -537,17 +537,20 @@ describe('Disability benefits helpers: ', () => {
 
     it('should return an object with header and description properties with nonsense input', () => {
       const testText = makeDurationText(inputs.nonsense);
-      expect(!!testText.header && !!testText.description).to.be.true;
+      expect(testText.header).to.equal('');
+      expect(testText.description).to.equal('');
     });
 
     it('should return an object with header and description properties with empty array input', () => {
       const testText = makeDurationText(inputs.empty);
-      expect(!!testText.header && !!testText.description).to.be.true;
+      expect(testText.header).to.equal('');
+      expect(testText.description).to.equal('');
     });
 
     it('should return an object with header and description properties with no input', () => {
       const testText = makeDurationText();
-      expect(!!testText.header && !!testText.description).to.be.true;
+      expect(testText.header).to.equal('');
+      expect(testText.description).to.equal('');
     });
 
     it('should format exact singular time estimates', () => {


### PR DESCRIPTION
- Change default return of `makeDurationText` to an object with empty strings. This enables us to conditionally render the time duration cards for `NextEvent`s only when we have a duration to give.
- Remove property reference from past event text description of `hearingHeld` events. The property getting referenced in this text snippet doesn't exist in the api, and there's no clear spec for what it will be called, so just changed text to something generic. Will open another issue to ensure our event mapping & content are complete and final in a broader sense.
- Fixes some tests that were asserting against the default return values of the `makeDurationText` function.