### PR TITLE
Change zoom warning trigger for cropper

### DIFF
--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -10,7 +10,6 @@ import { PhotoReviewDescription } from '../helpers.jsx';
 const MIN_SIZE = 350;
 const SMALL_CROP_BOX_SIZE = 240;
 const LARGE_CROP_BOX_SIZE = 300;
-const WARN_RATIO = 1.3;
 const LARGE_SCREEN = 1201;
 
 function getCanvasDataForMove({ canvasData, cropBoxData, moveX, moveY }) {
@@ -361,7 +360,8 @@ export default class PhotoField extends React.Component {
     // zoom value is good- update the state / messaging
     this.setState({ zoomValue });
 
-    const zoomWarn = zoomValue >= WARN_RATIO;
+    const currentWidth = this.refs.cropper.getData().width;
+    const zoomWarn = currentWidth < MIN_SIZE;
     // at this point, the onZoom event has not resized the canvas-
     // this forces the canvas back into move bounds if the zoom pulls a canvas edge into the cropBox
     //   after the canvas has rendered with new width values

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -10,6 +10,7 @@ import { PhotoReviewDescription } from '../helpers.jsx';
 const MIN_SIZE = 350;
 const SMALL_CROP_BOX_SIZE = 240;
 const LARGE_CROP_BOX_SIZE = 300;
+const WARN_RATIO = 1.3;
 const LARGE_SCREEN = 1201;
 
 function getCanvasDataForMove({ canvasData, cropBoxData, moveX, moveY }) {
@@ -363,7 +364,7 @@ export default class PhotoField extends React.Component {
     // at this point, the onZoom event has not resized the canvas-
     // this forces the canvas back into move bounds if the zoom pulls a canvas edge into the cropBox
     //   after the canvas has rendered with new width values
-    window.requestAnimationFrame(() => this.maybeMoveCanvasWithinBounds({}));
+    window.requestAnimationFrame(() => this.maybeMoveCanvasWithinBounds({}, zoomValue));
   }
 
   setCropBox = () => {
@@ -421,16 +422,19 @@ export default class PhotoField extends React.Component {
     });
   }
 
-  maybeMoveCanvasWithinBounds = (moveData) => {
+  maybeMoveCanvasWithinBounds = (moveData, zoomValue = null) => {
     const newCanvasData = getCanvasDataForMove({
       canvasData: this.refs.cropper.getCanvasData(),
       cropBoxData: this.refs.cropper.getCropBoxData(),
       ...moveData
     });
 
+    const currentZoomValue = zoomValue || this.state.zoomValue;
+
     this.refs.cropper.setCanvasData(newCanvasData);
 
-    const zoomWarn = this.refs.cropper.getData().width < MIN_SIZE;
+    const zoomWarn = this.refs.cropper.getData().width < MIN_SIZE
+      || currentZoomValue > WARN_RATIO;
     this.updateBoundaryWarningAndButtonStates(newCanvasData, zoomWarn);
   }
 

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -360,12 +360,10 @@ export default class PhotoField extends React.Component {
     // zoom value is good- update the state / messaging
     this.setState({ zoomValue });
 
-    const currentWidth = this.refs.cropper.getData().width;
-    const zoomWarn = currentWidth < MIN_SIZE;
     // at this point, the onZoom event has not resized the canvas-
     // this forces the canvas back into move bounds if the zoom pulls a canvas edge into the cropBox
     //   after the canvas has rendered with new width values
-    window.requestAnimationFrame(() => this.maybeMoveCanvasWithinBounds({}, zoomWarn));
+    window.requestAnimationFrame(() => this.maybeMoveCanvasWithinBounds({}));
   }
 
   setCropBox = () => {
@@ -423,7 +421,7 @@ export default class PhotoField extends React.Component {
     });
   }
 
-  maybeMoveCanvasWithinBounds = (moveData, zoomWarn = false) => {
+  maybeMoveCanvasWithinBounds = (moveData) => {
     const newCanvasData = getCanvasDataForMove({
       canvasData: this.refs.cropper.getCanvasData(),
       cropBoxData: this.refs.cropper.getCropBoxData(),
@@ -432,6 +430,7 @@ export default class PhotoField extends React.Component {
 
     this.refs.cropper.setCanvasData(newCanvasData);
 
+    const zoomWarn = this.refs.cropper.getData().width < MIN_SIZE;
     this.updateBoundaryWarningAndButtonStates(newCanvasData, zoomWarn);
   }
 


### PR DESCRIPTION
I was noticing that I wasn't seeing zoom warnings when I uploaded relatively small images and zoomed in a lot. The threshold for a fuzzy image should probably be different depending on the size of image, since large images can be zoomed in a lot, but small images can only be zoomed in a little before getting a cropped image under 350px.

So, this changes the threshold to be a pixel size for the cropped image, rather than just a zoom ratio.

I could be missing some of the background of this warning, so please correct me if this something we've talked about and didn't want to do.