### PR TITLE
Fix signed in user mapping for VIC confirmation page

### DIFF
--- a/src/js/vic-v2/containers/ConfirmationPage.jsx
+++ b/src/js/vic-v2/containers/ConfirmationPage.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import _ from 'lodash/fp';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 import moment from 'moment';
@@ -34,8 +33,7 @@ class ConfirmationPage extends React.Component {
   }
 
   render() {
-    const form = this.props.form;
-    const userSignedIn = this.props.userSignedIn;
+    const { form, userSignedIn } = this.props;
     // If someone refreshes this page after submitting a form and it loads
     // without an empty response object, we don't want to throw errors
     const response = form.submission.response || {};
@@ -97,10 +95,9 @@ class ConfirmationPage extends React.Component {
 }
 
 function mapStateToProps(state) {
-  const userSignedIn = _.get(state, 'user.login.currentlyLoggedIn', false);
   return {
     form: state.form,
-    userSignedIn
+    userSignedIn: state.user.login.currentlyLoggedIn
   };
 }
 


### PR DESCRIPTION
We were using `_.get` with the arguments out of order, I removed that and pulled the object directly, since it always exists.