### PR TITLE
Use max-width to allow slider to shrink on VIC cropper

### DIFF
--- a/src/sass/vic-v2.scss
+++ b/src/sass/vic-v2.scss
@@ -233,10 +233,10 @@ input[type=range] {
 
 .cropper-zoom-slider {
   display: inline-block;
-  width: 240px !important;
+  max-width: 240px;
   @media (min-width: $large-screen) {
-    height: unset;
-    width: 340px !important;
+    height: inherit;
+    max-width: 340px;
     padding: 0 5px 5px 5px;
   }
 }


### PR DESCRIPTION
The slider width was keeping the cropper from shrinking to fit into the review page box on smaller phones.

![localhost_3001_veteran-id-card_apply_review-and-submit iphone 7](https://user-images.githubusercontent.com/634932/36102055-12e82a08-0fd9-11e8-882c-e552db219c79.png)
