### PR TITLE
Use case number instead of case id

### DIFF
--- a/src/js/vic-v2/containers/ConfirmationPage.jsx
+++ b/src/js/vic-v2/containers/ConfirmationPage.jsx
@@ -70,7 +70,7 @@ class ConfirmationPage extends React.Component {
           <ul className="claim-list">
             <li>
               <strong>Confirmation number</strong><br/>
-              <span>{response.caseId}</span>
+              <span>{response.caseNumber}</span>
             </li>
             <li>
               <strong>Date received</strong><br/>

--- a/test/e2e/vic-helpers.js
+++ b/test/e2e/vic-helpers.js
@@ -44,7 +44,7 @@ function initApplicationPollMock() {
         attributes: {
           state: 'success',
           response: {
-            case_id: '123fake-submission-id-567' // eslint-disable-line camelcase
+            caseNumber: '123fake-submission-id-567' // eslint-disable-line camelcase
           }
         }
       }


### PR DESCRIPTION
I can't test this locally so I don't have a screenshot, but we're going to display the case number instead of the case id for requests.