### PR TITLE
Don't show broken image on review page

### DIFF
--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -175,7 +175,11 @@ function isSquareImage(img) {
 }
 
 function getImageUrl({ serverPath, serverName } = {}) {
-  return `${environment.API_URL}/content/vic/${serverPath}/${serverName}`;
+  if (serverName) {
+    return `${environment.API_URL}/content/vic/${serverPath}/${serverName}`;
+  }
+
+  return null;
 }
 
 export default class PhotoField extends React.Component {

--- a/src/js/vic-v2/helpers.jsx
+++ b/src/js/vic-v2/helpers.jsx
@@ -37,7 +37,10 @@ export function prefillTransformer(pages, formData, metadata) {
 export function PhotoReviewDescription({ url }) {
   return (
     <div className="va-growable-background">
-      <img className="photo-review" src={url} alt="Photograph of you that will be displayed on the ID card"/>
+      {url
+        ? <img className="photo-review" src={url} alt="Photograph of you that will be displayed on the ID card"/>
+        : <span>No photo chosen</span>
+      }
     </div>);
 }
 


### PR DESCRIPTION
We're currently showing a broken image if you open the review page without having selected a photo. This shouldn't happen often (or at all), but we can handle it better:

![screen shot 2018-02-12 at 2 43 02 pm](https://user-images.githubusercontent.com/634932/36116102-2c62bbc2-1003-11e8-96ba-3801e933bf50.png)
