### PR TITLE
Only go up to 80% on file upload progress

### DIFF
--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -236,7 +236,9 @@ export function uploadFile(file, filePath, uiOptions, progressCallback) {
 
       req.upload.addEventListener('progress', (evt) => {
         if (evt.lengthComputable && progressCallback) {
-          progressCallback((evt.loaded / evt.total) * 100);
+          // setting this at 80, because there's some time after we get to 100%
+          // where the backend is uploading to s3
+          progressCallback((evt.loaded / evt.total) * 80);
         }
       });
 


### PR DESCRIPTION
This addresses an issue where you upload a file, the bar goes to 100%, and you sit there waiting for a few more seconds. That wait is because the backend is uploading the file to s3, and the progress bar is just for upload progress for sending the file to our backend. 

This isn't a great fix, but it will at least indicate that there is still more to go with uploading. We could fake the rest of the way, but I'm not sure that's worth the extra code.