### PR TITLE
Copy claims & appeals index page

### DIFF
--- a/src/js/claims-status/containers/YourClaimsPage.jsx
+++ b/src/js/claims-status/containers/YourClaimsPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import Modal from '../../common/components/Modal';
-import { getAppeals, getAppealsV2, getClaims, filterClaims, sortClaims, changePage, showConsolidatedMessage, hide30DayNotice } from '../actions/index.jsx';
+import { getAppeals, getClaims, filterClaims, sortClaims, changePage, showConsolidatedMessage, hide30DayNotice } from '../actions/index.jsx';
 import ErrorableSelect from '../../common/components/form-elements/ErrorableSelect';
 import ClaimsUnauthorized from '../components/ClaimsUnauthorized';
 import ClaimsUnavailable from '../components/ClaimsUnavailable';
@@ -268,7 +268,6 @@ function mapStateToProps(state) {
 
 const mapDispatchToProps = {
   getAppeals,
-  getAppealsV2,
   getClaims,
   filterClaims,
   changePage,

--- a/src/js/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/js/claims-status/containers/YourClaimsPageV2.jsx
@@ -37,7 +37,7 @@ const sortOptions = [
   }
 ];
 
-class YourClaimsPage extends React.Component {
+class YourClaimsPageV2 extends React.Component {
   constructor(props) {
     super(props);
     this.changePage = this.changePage.bind(this);
@@ -51,7 +51,7 @@ class YourClaimsPage extends React.Component {
     }
 
     if (this.props.canAccessAppeals) {
-      this.props.getAppeals(this.getFilter(this.props));
+      this.props.getAppealsV2();
     }
 
     if (this.props.claimsLoading && this.props.appealsLoading) {
@@ -277,6 +277,6 @@ const mapDispatchToProps = {
   hide30DayNotice
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(YourClaimsPage);
+export default connect(mapStateToProps, mapDispatchToProps)(YourClaimsPageV2);
 
-export { YourClaimsPage };
+export { YourClaimsPageV2 };

--- a/src/js/claims-status/routes.jsx
+++ b/src/js/claims-status/routes.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Route, IndexRedirect, Redirect } from 'react-router';
 
 import YourClaimsPage from './containers/YourClaimsPage';
+import YourClaimsPageV2 from './containers/YourClaimsPageV2';
 import ClaimPage from './containers/ClaimPage';
 import ClaimStatusPage from './containers/ClaimStatusPage';
 import AppealStatusPage from './containers/AppealStatusPage';
@@ -21,6 +22,10 @@ const routes = [
     key="/track-claims/your-claims"
     from="/disability-benefits/track-claims*"
     to="/your-claims"/>,
+  <Route
+    component={YourClaimsPageV2}
+    key="/your-claims-v2"
+    path="/your-claims-v2"/>,
   <Route
     component={YourClaimsPage}
     key="/your-claims"

--- a/test/claims-status/components/YourClaimsPageV2.unit.spec.jsx
+++ b/test/claims-status/components/YourClaimsPageV2.unit.spec.jsx
@@ -1,0 +1,312 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { YourClaimsPage } from '../../../src/js/claims-status/containers/YourClaimsPageV2';
+
+describe('<YourClaimsPage>', () => {
+  it('should render tabs', () => {
+    const claims = [];
+    const routeParams = {
+      showClosedClaims: true
+    };
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        route={routeParams}
+        list={claims}/>
+    );
+    expect(tree.everySubTree('MainTabNav').length).to.equal(1);
+  });
+  it('should render sort select ', () => {
+    const claims = [];
+    const routeParams = {
+      showClosedClaims: true
+    };
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        route={routeParams}
+        list={claims}/>
+    );
+    const sortDiv = tree.subTree('claims-list-sort');
+    expect(sortDiv).to.exist;
+  });
+  it('should render loading div', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        claimsLoading
+        appealsLoading
+        claims={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        changePage={changePage}/>
+    );
+    expect(tree.everySubTree('LoadingIndicator').length).to.equal(1);
+  });
+  it('should render loading div if one is loading and no appeals', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        claimsLoading
+        claims={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        changePage={changePage}/>
+    );
+    expect(tree.everySubTree('LoadingIndicator').length).to.equal(1);
+  });
+  it('should render claims list and loading indicator if claims is still loading', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [{}, {}];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        claimsLoading
+        list={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        route={{ showClosedClaims: false }}
+        changePage={changePage}/>
+    );
+    expect(tree.everySubTree('ClaimsListItem').length).to.equal(2);
+    expect(tree.everySubTree('LoadingIndicator').length).to.equal(1);
+  });
+  it('should render sync warning', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        list={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        route={{ showClosedClaims: false }}
+        synced={false}
+        changePage={changePage}/>
+    );
+    expect(tree.everySubTree('ClaimSyncWarning')).not.to.be.empty;
+  });
+  it('should not render error message when loading', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        loading
+        list={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        route={{ showClosedClaims: false }}
+        synced={false}
+        changePage={changePage}/>
+    );
+
+    expect(tree.everySubTree('ClaimsAppealsUnavailable')).to.be.empty;
+    expect(tree.everySubTree('ClaimsUnavailable')).to.be.empty;
+    expect(tree.everySubTree('ClaimsUnauthorized')).to.be.empty;
+    expect(tree.everySubTree('AppealsUnavailable')).to.be.empty;
+  });
+
+  it('should render error message when claims & appeals are unavailable', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        canAccessAppeals
+        canAccessClaims
+        appealsAvailable={false}
+        claimsAvailable={false}
+        list={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        route={{ showClosedClaims: false }}
+        synced={false}
+        changePage={changePage}/>
+    );
+
+    expect(tree.everySubTree('ClaimsAppealsUnavailable')).not.to.be.empty;
+    expect(tree.everySubTree('ClaimsUnavailable')).to.be.empty;
+    expect(tree.everySubTree('ClaimsUnauthorized')).to.be.empty;
+    expect(tree.everySubTree('AppealsUnavailable')).to.be.empty;
+  });
+
+  it('should render error message when only claims are unavailable', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        canAccessClaims
+        claimsAvailable={false}
+        list={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        route={{ showClosedClaims: false }}
+        synced={false}
+        changePage={changePage}/>
+    );
+
+    expect(tree.everySubTree('ClaimsAppealsUnavailable')).to.be.empty;
+    expect(tree.everySubTree('ClaimsUnavailable')).not.to.be.empty;
+    expect(tree.everySubTree('ClaimsUnauthorized')).to.be.empty;
+    expect(tree.everySubTree('AppealsUnavailable')).to.be.empty;
+  });
+
+  it('should render error message when claims are unauthorized', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        canAccessClaims
+        claimsAvailable
+        claimsAuthorized={false}
+        list={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        route={{ showClosedClaims: false }}
+        synced={false}
+        changePage={changePage}/>
+    );
+
+    expect(tree.everySubTree('ClaimsAppealsUnavailable')).to.be.empty;
+    expect(tree.everySubTree('ClaimsUnavailable')).to.be.empty;
+    expect(tree.everySubTree('ClaimsUnauthorized')).not.to.be.empty;
+    expect(tree.everySubTree('AppealsUnavailable')).to.be.empty;
+  });
+
+  it('should render no claims message', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        list={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        route={{ showClosedClaims: false }}
+        changePage={changePage}/>
+    );
+    expect(tree.everySubTree('NoClaims').length).to.equal(1);
+  });
+
+  it('should render claims list and pagination', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [{}, {}];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        list={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        route={{ showClosedClaims: false }}
+        changePage={changePage}/>
+    );
+    expect(tree.everySubTree('ClaimsListItem').length).to.equal(2);
+    expect(tree.subTree('Pagination').props.page).to.equal(page);
+    expect(tree.subTree('Pagination').props.pages).to.equal(pages);
+  });
+  it('should render 30 day notice', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [{}, {}];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        unfilteredClaims={claims}
+        unfilteredAppeals={claims}
+        list={claims}
+        page={page}
+        pages={pages}
+        show30DayNotice
+        getClaims={getClaims}
+        route={{}}
+        changePage={changePage}/>
+    );
+    expect(tree.everySubTree('ClosedClaimMessage')).not.to.be.empty;
+  });
+  it('should not render 30 day notice', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [{}, {}];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        list={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        route={{}}
+        changePage={changePage}/>
+    );
+    expect(tree.everySubTree('ClosedClaimMessage')).to.be.empty;
+  });
+  it('should not render 30 day notice if on closed tab', () => {
+    const changePage = sinon.spy();
+    const getClaims = sinon.spy();
+    const page = 1;
+    const pages = 2;
+    const claims = [{}, {}];
+
+    const tree = SkinDeep.shallowRender(
+      <YourClaimsPage
+        list={claims}
+        page={page}
+        pages={pages}
+        getClaims={getClaims}
+        route={{ showClosedClaims: true }}
+        changePage={changePage}/>
+    );
+    expect(tree.everySubTree('ClosedClaimMessage')).to.be.empty;
+  });
+});

--- a/test/claims-status/components/YourClaimsPageV2.unit.spec.jsx
+++ b/test/claims-status/components/YourClaimsPageV2.unit.spec.jsx
@@ -3,16 +3,16 @@ import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { YourClaimsPage } from '../../../src/js/claims-status/containers/YourClaimsPageV2';
+import { YourClaimsPageV2 } from '../../../src/js/claims-status/containers/YourClaimsPageV2';
 
-describe('<YourClaimsPage>', () => {
+describe('<YourClaimsPageV2>', () => {
   it('should render tabs', () => {
     const claims = [];
     const routeParams = {
       showClosedClaims: true
     };
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         route={routeParams}
         list={claims}/>
     );
@@ -24,7 +24,7 @@ describe('<YourClaimsPage>', () => {
       showClosedClaims: true
     };
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         route={routeParams}
         list={claims}/>
     );
@@ -39,7 +39,7 @@ describe('<YourClaimsPage>', () => {
     const claims = [];
 
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         claimsLoading
         appealsLoading
         claims={claims}
@@ -58,7 +58,7 @@ describe('<YourClaimsPage>', () => {
     const claims = [];
 
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         claimsLoading
         claims={claims}
         page={page}
@@ -76,7 +76,7 @@ describe('<YourClaimsPage>', () => {
     const claims = [{}, {}];
 
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         claimsLoading
         list={claims}
         page={page}
@@ -96,7 +96,7 @@ describe('<YourClaimsPage>', () => {
     const claims = [];
 
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         list={claims}
         page={page}
         pages={pages}
@@ -115,7 +115,7 @@ describe('<YourClaimsPage>', () => {
     const claims = [];
 
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         loading
         list={claims}
         page={page}
@@ -140,7 +140,7 @@ describe('<YourClaimsPage>', () => {
     const claims = [];
 
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         canAccessAppeals
         canAccessClaims
         appealsAvailable={false}
@@ -168,7 +168,7 @@ describe('<YourClaimsPage>', () => {
     const claims = [];
 
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         canAccessClaims
         claimsAvailable={false}
         list={claims}
@@ -194,7 +194,7 @@ describe('<YourClaimsPage>', () => {
     const claims = [];
 
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         canAccessClaims
         claimsAvailable
         claimsAuthorized={false}
@@ -221,7 +221,7 @@ describe('<YourClaimsPage>', () => {
     const claims = [];
 
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         list={claims}
         page={page}
         pages={pages}
@@ -240,7 +240,7 @@ describe('<YourClaimsPage>', () => {
     const claims = [{}, {}];
 
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         list={claims}
         page={page}
         pages={pages}
@@ -260,7 +260,7 @@ describe('<YourClaimsPage>', () => {
     const claims = [{}, {}];
 
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         unfilteredClaims={claims}
         unfilteredAppeals={claims}
         list={claims}
@@ -281,7 +281,7 @@ describe('<YourClaimsPage>', () => {
     const claims = [{}, {}];
 
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         list={claims}
         page={page}
         pages={pages}
@@ -299,7 +299,7 @@ describe('<YourClaimsPage>', () => {
     const claims = [{}, {}];
 
     const tree = SkinDeep.shallowRender(
-      <YourClaimsPage
+      <YourClaimsPageV2
         list={claims}
         page={page}
         pages={pages}


### PR DESCRIPTION
Nothing fancy here. Only thing of note was I got rid of the buildtype conditional and always query for v1 appeals on the original page and v2 on the v2 page.