### PR TITLE
Update VIC photo upload page content

### DIFF
--- a/src/js/vic-v2/components/PhotoDescription.jsx
+++ b/src/js/vic-v2/components/PhotoDescription.jsx
@@ -10,7 +10,8 @@ export default function PhotoDescription() {
           <li>Show a full front view of your face and neck, (with no hat, head covering, or headphones covering or casting shadows on your hairline or face), <strong>and</strong></li>
           <li>Be cropped from your shoulders up (much like a passport photo), <strong>and</strong></li>
           <li>Show you with your eyes open and a neutral expression, <strong>and</strong></li>
-          <li>Be a square size and have a white or plain-color background (with no scenery or other people in the photo)</li>
+          <li>Be a square size and have a white or plain-color background (with no scenery or other people in the photo), <strong>and</strong></li>
+          <li>Show what you look like now (a photo taken sometime in the last 10 years), <strong>and</strong></li>
           <li>Be uploaded as a .jpeg, .png, .bmp, or .tiff file</li>
         </ul>
         <h3>Examples of good ID photos</h3>

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -625,7 +625,7 @@ export default class PhotoField extends React.Component {
     if (fieldView === 'cropper') {
       description = <p>Move and resize your photo, so your head and shoulders fit in the square frame below. Click and drag, or use the arrow and magnifying buttons to help.</p>;
     } else if (fieldView === 'preview') {
-      description = <div>Success! This photo will be printed on your Veteran ID card.</div>;
+      description = <div>Success! This photo will be printed on your Veteran ID Card.</div>;
     } else if (fieldView === 'initial' && this.state.dragAndDropSupported) {
       description = <p>Drag and drop your image into the square or click the upload button.</p>;
     }
@@ -758,7 +758,7 @@ export default class PhotoField extends React.Component {
             </div>
             <div className="crop-button-container">
               <button type="button" className="usa-button-primary" onClick={this.onDone}>
-                I’m done
+                I’m Done
               </button>
             </div>
           </div>
@@ -798,7 +798,7 @@ export default class PhotoField extends React.Component {
             {fieldView === 'initial' && <ErrorableFileInput
               accept={fileTypes.map(type => `.${type}`).join(',')}
               onChange={this.onChangeScreenReader}
-              buttonText="Screen reader friendly photo upload tool"
+              buttonText="Use our screen reader-friendly photo upload tool."
               aria-describedby="screenReaderPathDescription"
               triggerClass="va-button-link"
               name="screenReaderFileUpload"/>}

--- a/src/sass/vic-v2.scss
+++ b/src/sass/vic-v2.scss
@@ -392,6 +392,11 @@ input[type=range] {
   }
 }
 
+.photo-preview-link {
+  margin-right: 10px;
+  font-weight: $font-normal;
+}
+
 .photo-edit-button {
   max-width: 150px;
 }
@@ -440,7 +445,7 @@ input[type=range] {
     }
     .photo-preview-link {
       margin-right: 10px;
-      font-weight: 400;
+      font-weight: $font-normal;
     }
   }
 }


### PR DESCRIPTION
These changes update the content for the photo upload page.

Please note that there is an question regarding the proposed change to the progress bar, which is being discussed on the linked issue.

We're missing the below bullet in the photo requirement list:
Show what you look like now (a photo taken sometime in the last 10 years), and
<img width="598" alt="screen shot 2018-02-14 at 11 26 51 am" src="https://user-images.githubusercontent.com/16051172/36223674-fee5a9f2-1179-11e8-9c4b-0c3afe220189.png">

Under “YOUR PHOTO GOES HERE,” there’s a button then a link. Change the wording of the link to say: “Use our screen reader-friendly photo upload tool.”
<img width="595" alt="screen shot 2018-02-14 at 11 12 37 am" src="https://user-images.githubusercontent.com/16051172/36223076-1c5c4e20-1178-11e8-8bda-a70d547dc304.png">

I'm done button. Capitalize: I'm Done
<img width="265" alt="screen shot 2018-02-14 at 11 12 57 am" src="https://user-images.githubusercontent.com/16051172/36223079-1f191378-1178-11e8-8685-89c8e9110b05.png">

Success! This photo will be printed on your Veteran ID Card. (cap Card)
<img width="578" alt="screen shot 2018-02-14 at 11 20 48 am" src="https://user-images.githubusercontent.com/16051172/36223482-672bf92c-1179-11e8-953c-0626c23cb2bb.png">

Bug fix to replace style moved into USWDS override
<img width="570" alt="screen shot 2018-02-14 at 11 17 03 am" src="https://user-images.githubusercontent.com/16051172/36223487-6c35727c-1179-11e8-90b3-9cfc5ba3d5c5.png">
