### PR TITLE
Test against WCAG 2.0 AA

### DIFF
--- a/config/nightwatch.js
+++ b/config/nightwatch.js
@@ -62,7 +62,7 @@ module.exports = {
     },
     wcag2a: {
       globals: {
-        rules: ['section508', 'wcag2aa']
+        rules: ['section508', 'wcag2a', 'wcag2aa']
       }
     }
   }

--- a/config/nightwatch.js
+++ b/config/nightwatch.js
@@ -62,7 +62,10 @@ module.exports = {
     },
     wcag2a: {
       globals: {
-        rules: ['section508', 'wcag2a', 'wcag2aa']
+        runOnly: {
+          type: 'tag',
+          values: ['section508', 'wcag2a', 'wcag2aa']
+        }
       }
     }
   }

--- a/config/nightwatch.js
+++ b/config/nightwatch.js
@@ -62,7 +62,7 @@ module.exports = {
     },
     wcag2a: {
       globals: {
-        rules: ['section508', 'wcag2a']
+        rules: ['section508', 'wcag2aa']
       }
     }
   }

--- a/config/nightwatch.js
+++ b/config/nightwatch.js
@@ -60,12 +60,9 @@ module.exports = {
     accessibility: {
       filter: './test/accessibility/*.spec.js'
     },
-    wcag2a: {
+    bestpractice: {
       globals: {
-        runOnly: {
-          type: 'tag',
-          values: ['section508', 'wcag2a', 'wcag2aa']
-        }
+        rules: ['section508', 'wcag2a', 'wcag2aa', 'best-practice']
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:e2e:docker": "docker-compose -p e2e up -d && docker-compose -p e2e run --user=node --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=production vets-website --no-color run nightwatch:docker && docker-compose -p e2e stop",
     "test:accessibility": "./script/run-nightwatch.sh --env accessibility",
     "test:accessibility:docker": "docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=production vets-website --no-color run nightwatch:docker -- --env=accessibility && docker-compose -p accessibility stop",
-    "test:wcag2a": "./script/run-nightwatch.sh --env wcag2a",
+    "test:bestpractice": "./script/run-nightwatch.sh --env best-practice",
     "test:coverage": "NODE_ENV=test nyc --all --reporter=lcov --reporter=text --reporter=html mocha --no-color --recursive 'test/**/*.unit.spec.js?(x)' test/helper.js",
     "test:sauce": "./script/run-nightwatch.sh --sauce",
     "test:sauce:desktop": "./script/run-nightwatch.sh --sauce -e chrome,firefox,ie,edge",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:e2e:docker": "docker-compose -p e2e up -d && docker-compose -p e2e run --user=node --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=production vets-website --no-color run nightwatch:docker && docker-compose -p e2e stop",
     "test:accessibility": "./script/run-nightwatch.sh --env accessibility",
     "test:accessibility:docker": "docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=production vets-website --no-color run nightwatch:docker -- --env=accessibility && docker-compose -p accessibility stop",
-    "test:bestpractice": "./script/run-nightwatch.sh --env best-practice",
+    "test:best-practice": "./script/run-nightwatch.sh --env bestpractice",
     "test:coverage": "NODE_ENV=test nyc --all --reporter=lcov --reporter=text --reporter=html mocha --no-color --recursive 'test/**/*.unit.spec.js?(x)' test/helper.js",
     "test:sauce": "./script/run-nightwatch.sh --sauce",
     "test:sauce:desktop": "./script/run-nightwatch.sh --sauce -e chrome,firefox,ie,edge",

--- a/test/util/nightwatch-commands/axeCheck.js
+++ b/test/util/nightwatch-commands/axeCheck.js
@@ -28,7 +28,7 @@ export function command(context, config, _callback) {
     }, (err, results) => {
       done({ err, results });
     });
-  }, [context, (config || {}).rules || this.globals.rules || ['section508', 'wcag2a']], response => {
+  }, [context, (config || {}).rules || this.globals.rules || ['section508', 'wcag2aa']], response => {
     const { err, results } = response.value;
 
     if (err) {

--- a/test/util/nightwatch-commands/axeCheck.js
+++ b/test/util/nightwatch-commands/axeCheck.js
@@ -28,7 +28,7 @@ export function command(context, config, _callback) {
     }, (err, results) => {
       done({ err, results });
     });
-  }, [context, (config || {}).rules || this.globals.rules || ['section508', 'wcag2aa']], response => {
+  }, [context, (config || {}).rules || this.globals.rules || ['section508', 'wcag2a', 'wcag2aa']], response => {
     const { err, results } = response.value;
 
     if (err) {


### PR DESCRIPTION
- update default rule set to include `wcag2aa`
- add a nightwatch command for testing against the `best-practice` ruleset, for future accessibility improvements: `npm run:best-practice`