### PR TITLE
Remove login class from ch 33 benefits link

### DIFF
--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -247,7 +247,7 @@
               <li><a href="/health-care/schedule-an-appointment/" onClick="reportHeaderNav('Manage Health and Benefits');">Schedule a VA appointment</a></li>
               <li><a class="login-required" href="/health-care/health-records" onClick="reportHeaderNav('Manage Health and Benefits');">Get your VA health records</a></li>
               <li><a class="login-required" href="/track-claims" onClick="reportHeaderNav('Manage Health and Benefits');">Check claim and appeal status</a></li>
-              <li><a class="login-required" href="/education/gi-bill/post-9-11/ch-33-benefit" onClick="reportHeaderNav('Manage Health and Benefits');">Check Post-9/11 GI Bill benefits</a></li>
+              <li><a href="/education/gi-bill/post-9-11/ch-33-benefit" onClick="reportHeaderNav('Manage Health and Benefits');">Check Post-9/11 GI Bill benefits</a></li>
             </ul>
           </div>
         </li>


### PR DESCRIPTION
Removes the login required class from the menu link for ch. 33 benefits. This makes it so that a user doesn't have to login before seeing the maintenance message if they click on the ch 33 benefits link from the main nav.