### PR TITLE
Remove prop types, fix enzyme warnings

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -19,7 +19,10 @@
   "env": {
     "test": {
       "presets": ["env", "stage-2"],
-      "plugins": [ "istanbul" ]
+      "plugins": [ 
+        "istanbul",
+        "transform-react-remove-prop-types"
+      ]
     },
     "production": {
       "plugins": [

--- a/test/common/schemaform/fields/FileField.unit.spec.jsx
+++ b/test/common/schemaform/fields/FileField.unit.spec.jsx
@@ -156,8 +156,8 @@ describe('Schemaform <FileField>', () => {
         requiredSchema={requiredSchema}/>
     );
 
-    expect(tree.find('ProgressBar').isEmpty()).to.be.false;
-    expect(tree.find('button').isEmpty()).to.be.true;
+    expect(tree.find('ProgressBar').exists()).to.be.true;
+    expect(tree.find('button').exists()).to.be.false;
   });
 
   it('should update progress', () => {
@@ -279,7 +279,7 @@ describe('Schemaform <FileField>', () => {
         requiredSchema={requiredSchema}/>
     );
 
-    expect(tree.find('label').isEmpty()).to.be.true;
+    expect(tree.find('label').exists()).to.be.false;
   });
 
   it('should delete file', () => {

--- a/test/common/schemaform/save-in-progress/RoutedSavablePage.unit.spec.jsx
+++ b/test/common/schemaform/save-in-progress/RoutedSavablePage.unit.spec.jsx
@@ -48,8 +48,8 @@ describe('Schemaform <RoutedSavablePage>', () => {
       <RoutedSavablePage form={form} route={route} user={user} location={location}/>
     ).find('FormPage').dive();
 
-    expect(tree.find('SaveStatus').isEmpty()).not.to.be.true;
-    expect(tree.find('SaveFormLink').isEmpty()).not.to.be.true;
+    expect(tree.find('SaveStatus').exists()).to.be.true;
+    expect(tree.find('SaveFormLink').exists()).to.be.true;
   });
 
   it('should auto save on change', () => {


### PR DESCRIPTION
We've talked about this, but hadn't done it. This removes prop types when running in the test env.

Still a bunch of warnings, but it's better.