### PR TITLE
add chapter 31 introduction page content

### DIFF
--- a/src/js/vre/chapter31/components/IntroductionPage.jsx
+++ b/src/js/vre/chapter31/components/IntroductionPage.jsx
@@ -36,7 +36,7 @@ class IntroductionPage extends React.Component {
                 <li>Military status and service history</li>
                 <li>Disability rating</li>
               </ul>
-              <p><strong>What if I need help filling out my application?</strong><br/>An accredited representative with a Veterans Service Organization (VSO) can help you fill out your claim. <a href="/disability-benefits/apply/help/index.html">Get help filing your claim</a>.</p>
+              <p><strong>What if I need help filling out my application?</strong><br/>An accredited representative with a Veterans Service Organization (VSO) can help you fill out your claim. <a href="/disability-benefits/apply/help/">Get help filing your claim</a>.</p>
               <p><strong>What if I don’t yet have a service connected disability rating?</strong><br/>You don’t need to wait for a rating to apply for VR&E benefits. <a href="/employment/vocational-rehab-and-employment/apply-vre/">Learn how to apply for VR&E services if you haven’t yet received a service-connected disability rating</a>.</p>
             </li>
             <li className="process-step list-two">

--- a/src/js/vre/chapter31/components/IntroductionPage.jsx
+++ b/src/js/vre/chapter31/components/IntroductionPage.jsx
@@ -30,7 +30,7 @@ class IntroductionPage extends React.Component {
           <ol>
             <li className="process-step list-one">
               <div><h5>Prepare</h5></div>
-              <div><h6>To fill out this application, you’ll need your or your sponsor’s:</h6></div>
+              <div><h6>To fill out this application, you’ll need your:</h6></div>
               <ul>
                 <li>Social Security number or VA file number (required)</li>
                 <li>Military status and service history</li>

--- a/src/js/vre/chapter31/components/IntroductionPage.jsx
+++ b/src/js/vre/chapter31/components/IntroductionPage.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
+import { focusElement } from '../../../common/utils/helpers';
 import SaveInProgressIntro, { introActions, introSelector } from '../../../common/schemaform/save-in-progress/SaveInProgressIntro';
 import FormTitle from '../../../common/schemaform/components/FormTitle';
 import OMBInfo from '../../../common/components/OMBInfo';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
+    focusElement('.va-nav-breadcrumbs-list');
   }
   goForward = () => {
     this.props.router.push(this.props.route.pageList[1].path);
@@ -15,15 +17,53 @@ class IntroductionPage extends React.Component {
   render() {
     return (
       <div className="schemaform-intro">
-        <FormTitle title="Apply for VR&E"/>
+        <FormTitle title="Apply for vocational rehabilitation for service-disabled Veterans"/>
+        <p>Equal to VA Form 28-1900 (Disabled Veterans Application for Vocational Rehabilitation).</p>
         <SaveInProgressIntro
-          buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           pageList={this.props.route.pageList}
-          startText="Start the Chapter 31 application"
+          startText="Start the VR&E Application"
+          {...this.props.saveInProgressActions}
+          {...this.props.saveInProgress}/>
+        <div className="process schemaform-process schemaform-process-sip">
+          <h4>Follow the steps below to apply for vocational rehabilitiation benefits.</h4>
+          <ol>
+            <li className="process-step list-one">
+              <div><h5>Prepare</h5></div>
+              <div><h6>To fill out this application, you’ll need your or your sponsor’s:</h6></div>
+              <ul>
+                <li>Social Security number or VA file number (required)</li>
+                <li>Military status and service history</li>
+                <li>Disability rating</li>
+              </ul>
+              <p><strong>What if I need help filling out my application?</strong><br/>An accredited representative with a Veterans Service Organization (VSO) can help you fill out your claim. <a href="/disability-benefits/apply/help/index.html">Get help filing your claim</a>.</p>
+              <p><strong>What if I don’t yet have a service connected disability rating?</strong><br/>You don’t need to wait for a rating to apply for VR&E benefits. <a href="/TODO">Learn how to apply for VR&E services if you haven’t yet received a service-connected disability rating</a>.</p>
+            </li>
+            <li className="process-step list-two">
+              <div><h5>Apply</h5></div>
+
+              <p>Complete this vocational rehabilitation form.</p>
+              <p>After submitting the form, you’ll get a confirmation message. You can print this for your records.</p>
+            </li>
+            <li className="process-step list-three">
+              <div><h5>VA Review</h5></div>
+              <p>We process claims in the order we receive them.</p>
+              <p>We’ll let you know by mail if we need more information.</p>
+            </li>
+            <li className="process-step list-four">
+              <div><h5>Decision</h5></div>
+              <p>If you’re eligible for vocational rehabilitation benefits, we’ll invite you to an orientation session at your nearest VA regional office.</p>
+            </li>
+          </ol>
+        </div>
+        <SaveInProgressIntro
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
+          pageList={this.props.route.pageList}
+          startText="Start the VR&E Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}/>
         <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
-          <OMBInfo resBurden={15} ombNumber="2900-0003" expDate="04/30/2020"/>
+          <OMBInfo resBurden={15} ombNumber="2900-0154" expDate="12/31/2019"/>
         </div>
       </div>
     );

--- a/src/js/vre/chapter31/components/IntroductionPage.jsx
+++ b/src/js/vre/chapter31/components/IntroductionPage.jsx
@@ -37,11 +37,10 @@ class IntroductionPage extends React.Component {
                 <li>Disability rating</li>
               </ul>
               <p><strong>What if I need help filling out my application?</strong><br/>An accredited representative with a Veterans Service Organization (VSO) can help you fill out your claim. <a href="/disability-benefits/apply/help/index.html">Get help filing your claim</a>.</p>
-              <p><strong>What if I don’t yet have a service connected disability rating?</strong><br/>You don’t need to wait for a rating to apply for VR&E benefits. <a href="/TODO">Learn how to apply for VR&E services if you haven’t yet received a service-connected disability rating</a>.</p>
+              <p><strong>What if I don’t yet have a service connected disability rating?</strong><br/>You don’t need to wait for a rating to apply for VR&E benefits. <a href="/employment/vocational-rehab-and-employment/apply-vre/">Learn how to apply for VR&E services if you haven’t yet received a service-connected disability rating</a>.</p>
             </li>
             <li className="process-step list-two">
               <div><h5>Apply</h5></div>
-
               <p>Complete this vocational rehabilitation form.</p>
               <p>After submitting the form, you’ll get a confirmation message. You can print this for your records.</p>
             </li>


### PR DESCRIPTION
[Design](https://app.zenhub.com/workspace/o/department-of-veterans-affairs/vets.gov-team/issues/8819)
- Not sure how to get the breadcrumb to match the design- according to the design there should be a **Apply Online**
- Need a link to the learn how to apply without a service-connected disability rating
- Not sure if the `focusElement` piece is needed- it's on the chapter36 intro page 

![2018-02-20-14-54-localhost_3001](https://user-images.githubusercontent.com/4998130/36448702-03d74bb8-164e-11e8-92b2-f588037208a0.png)
