### PR TITLE
Update introduction page content

### DIFF
--- a/src/js/common/schemaform/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/js/common/schemaform/save-in-progress/SaveInProgressIntro.jsx
@@ -65,7 +65,11 @@ export default class SaveInProgressIntro extends React.Component {
         <div>
           <div className="usa-alert usa-alert-info schemaform-sip-alert">
             <div className="usa-alert-body">
-              <strong>Note:</strong> If you’re signed in to your account, we can prefill part of your application based on your account details. You can also save your form in progress, and come back later to finish filling it out. You have 60 days from the date you start or update your application to submit the form. After 60 days, the form won’t be saved and you’ll need to start over.<br/>
+              If you’re signed in to your account, your application process can go more smoothly. Here’s why:<br/>
+              <ul>
+                <li>We can prefill part of your application based on your account details.</li>
+                <li>You can save your form in progress, and come back later to finish filling it out. You have 60 days from the date you start or update your application to submit the form. After 60 days, the form won’t be saved, and you’ll need to start over.</li>
+              </ul><br/>
               <button className="va-button-link" onClick={() => this.props.toggleLoginModal(true)}>Sign in to your account.</button>
             </div>
           </div>

--- a/src/js/vre/chapter36/components/IntroductionPage.jsx
+++ b/src/js/vre/chapter36/components/IntroductionPage.jsx
@@ -16,7 +16,7 @@ class IntroductionPage extends React.Component {
   }
   goForward = () => {
     this.props.router.push(this.props.route.pageList[1].path);
-  };
+  }
   render() {
     return (
       <div className="schemaform-intro">

--- a/src/js/vre/chapter36/components/IntroductionPage.jsx
+++ b/src/js/vre/chapter36/components/IntroductionPage.jsx
@@ -71,14 +71,6 @@ class IntroductionPage extends React.Component {
                   Get help filing your claim
                 </a>.
               </p>
-              <p>
-                <strong>Learn about other VR&E benefits</strong>
-                <br/>
-                <a href="/employment/vocational-rehab-and-employment/family-members/">
-                  See what other VR&E benefits you may be eligible for as a
-                  dependent
-                </a>.
-              </p>
             </li>
             <li className="process-step list-two">
               <div>

--- a/src/js/vre/chapter36/components/IntroductionPage.jsx
+++ b/src/js/vre/chapter36/components/IntroductionPage.jsx
@@ -5,7 +5,10 @@ import { connect } from 'react-redux';
 import { focusElement } from '../../../common/utils/helpers';
 import OMBInfo from '../../../common/components/OMBInfo';
 import FormTitle from '../../../common/schemaform/components/FormTitle';
-import SaveInProgressIntro, { introActions, introSelector } from '../../../common/schemaform/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro, {
+  introActions,
+  introSelector
+} from '../../../common/schemaform/save-in-progress/SaveInProgressIntro';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -13,64 +16,108 @@ class IntroductionPage extends React.Component {
   }
   goForward = () => {
     this.props.router.push(this.props.route.pageList[1].path);
-  }
+  };
   render() {
     return (
       <div className="schemaform-intro">
-        <FormTitle title="Apply for VR&E"/>
-        <p>Equal to form chapter 36</p>
+        <FormTitle title="Apply for educational and vocational counseling"/>
+        <p>
+          Equal to VA Form 28-8832 (Educational/Vocational Counseling
+          Application).
+        </p>
         <SaveInProgressIntro
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
           pageList={this.props.route.pageList}
-          startText="Start the Chapter 36 application"
+          startText="Start the VR&E Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}>
           Please complete the Chapter 36 form to apply for benefits
         </SaveInProgressIntro>
         <div className="process schemaform-process schemaform-process-sip">
-          <h4>Follow the steps below to apply for VR&E benefits.</h4>
+          <h4>
+            Follow the steps below to apply for educational and vocational
+            counseling.
+          </h4>
           <ol>
             <li className="process-step list-one">
-              <div><h5>Prepare</h5></div>
-              <div><h6>To fill out this application, you’ll need information about the deceased Veteran, including their:</h6></div>
+              <div>
+                <h5>Prepare</h5>
+              </div>
+              <div>
+                <h6>
+                  To fill out this application, you’ll need your or your
+                  sponsor’s:
+                </h6>
+              </div>
               <ul>
                 <li>Social Security number or VA file number (required)</li>
-                <li>Date and place of birth (required)</li>
-                <li>Date and place of death (required)</li>
-                <li>Military status and history</li>
+                <li>Date of birth</li>
+                <li>Military status and service history</li>
               </ul>
-              <div><h6>You may need to upload:</h6></div>
+              <div>
+                <h6>
+                  If you’re not on active duty, you may also need a copy of
+                  your:
+                </h6>
+              </div>
               <ul>
-                <li>A copy of the deceased Veteran’s DD214 or other separation documents</li>
-                <li>A copy of the Veteran’s death certificate</li>
-                <li>Documentation for transportation costs (if you’re claiming costs for the transportation of the Veteran’s remains)</li>
+                <li>Discharge papers (DD214 or other separation documents)</li>
               </ul>
-              <p><strong>What if I need help filling out my application?</strong> An accredited representative with a Veterans Service Organization (VSO) can help you fill out your claim. <a href="/disability-benefits/apply/help/index.html">Find an accredited representative</a>.</p>
+              <p>
+                <strong>What if I need help filling out my application?</strong>{' '}
+                An accredited representative with a Veterans Service
+                Organization (VSO) can help you fill out your claim.{' '}
+                <a href="/disability-benefits/apply/help/index.html">
+                  Get help filing your claim
+                </a>.
+              </p>
+              <p>
+                <strong>Learn about other VR&E benefits</strong>
+                <br/>
+                <a href="/employment/vocational-rehab-and-employment/family-members/">
+                  See what other VR&E benefits you may be eligible for as a
+                  dependent
+                </a>.
+              </p>
             </li>
             <li className="process-step list-two">
-              <div><h5>Apply</h5></div>
-              <p>Complete this form.</p>
-              <p>After submitting the form, you’ll get a confirmation message. You can print this for your records.</p>
+              <div>
+                <h5>Apply</h5>
+              </div>
+              <p>Complete this educational and vocational counseling form.</p>
+              <p>
+                After submitting the form, you’ll get a confirmation message.
+                You can print this for your records.
+              </p>
             </li>
             <li className="process-step list-three">
-              <div><h5>VA Review</h5></div>
+              <div>
+                <h5>VA Review</h5>
+              </div>
               <p>We process claims in the order we receive them.</p>
               <p>We’ll let you know by mail if we need more information.</p>
             </li>
             <li className="process-step list-four">
-              <div><h5>Decision</h5></div>
-              <p>After we process your claim, you’ll get a notice in the mail about the decision.</p>
+              <div>
+                <h5>Decision</h5>
+              </div>
+              <p>
+                If you’re eligible for educational and vocational counseling
+                benefits, we’ll invite you to meet with a Vocational
+                Rehabilitation Counselor (VRC). Your VRC will work with you to
+                map out a career path.
+              </p>
             </li>
           </ol>
         </div>
         <SaveInProgressIntro
           buttonOnly
           pageList={this.props.route.pageList}
-          startText="Start the Chapter 36 application"
+          startText="Start the VR&E Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}/>
         <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
-          <OMBInfo resBurden={15} ombNumber="2900-0003" expDate="04/30/2020"/>
+          <OMBInfo resBurden={15} ombNumber="2900-0154" expDate="12/31/2019"/>
         </div>
       </div>
     );

--- a/test/common/schemaform/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/test/common/schemaform/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -130,7 +130,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         toggleLoginModal={toggleLoginModal}/>
     );
 
-    expect(tree.subTree('.usa-alert').text()).to.contain('Note: If you’re signed in to your account, we can prefill part of your application based on your account details. You can also save your form in progress, and come back later to finish filling it out.');
+    expect(tree.subTree('.usa-alert').text()).to.contain('If you’re signed in to your account, your application process can go more smoothly. Here’s why:We can prefill part of your application based on your account details.You can save your form in progress, and come back later to finish filling it out. You have 60 days from the date you start or update your application to submit the form. After 60 days, the form won’t be saved, and you’ll need to start over.Sign in to your account.');
     expect(tree.subTree('.va-button-link')).not.to.be.false;
     expect(tree.subTree('withRouter(FormStartControls)')).not.to.be.false;
   });


### PR DESCRIPTION
These changes update the chapter 36 introduction page ([design](https://adhoc.invisionapp.com/share/G9F1A8U7K#/screens)).
One departure from the design is the sign in message. The message used here is the default message used for forms with prefill enabled. If the message in the design should be used instead, that can be updated.

![localhost_3001_employment_vocational-rehab-and-employment_application_chapter36_introduction](https://user-images.githubusercontent.com/16051172/36571706-fc7fedfc-17ec-11e8-856b-7ecd40ff3d37.png)

