### PR TITLE
Update message, use correct image src

### DIFF
--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -254,8 +254,8 @@ export function stringifyFormReplacer(key, value) {
     }
 
     // Exclude file data
-    if (value.confirmationCode && (value.serverPath || value.file)) {
-      return _.omit(['serverPath', 'serverName', 'file'], value);
+    if (value.confirmationCode && value.file) {
+      return _.omit('file', value);
     }
   }
 

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -3,7 +3,6 @@ import Cropper from 'react-cropper';
 import Dropzone from 'react-dropzone';
 import classNames from 'classnames';
 
-import environment from '../../common/helpers/environment';
 import ErrorableFileInput from '../../common/components/form-elements/ErrorableFileInput';
 import ProgressBar from '../../common/components/ProgressBar';
 import { scrollAndFocus } from '../../common/utils/helpers';
@@ -175,14 +174,6 @@ function isSquareImage(img) {
   return img.width === img.height;
 }
 
-function getImageUrl({ serverPath, serverName } = {}) {
-  if (serverName) {
-    return `${environment.API_URL}/content/vic/${serverPath}/${serverName}`;
-  }
-
-  return null;
-}
-
 export default class PhotoField extends React.Component {
   constructor(props) {
     super(props);
@@ -268,7 +259,7 @@ export default class PhotoField extends React.Component {
     this.setState({
       isCropping: true,
       fileName: this.props.formData.name,
-      src: this.state.previewSrc || getImageUrl(this.props.formData),
+      src: this.state.previewSrc,
       warningMessage: null
     });
   }

--- a/src/js/vic-v2/components/PhotoPreview.jsx
+++ b/src/js/vic-v2/components/PhotoPreview.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import environment from '../../common/helpers/environment';
+import { fetchPreview } from '../helpers';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
 
 export default class PhotoPreview extends React.Component {
@@ -8,22 +8,8 @@ export default class PhotoPreview extends React.Component {
     super(props);
 
     if (props.isLoggedIn && props.id && !props.src) {
-      const userToken = window.sessionStorage.userToken;
-      const headers = {
-        'X-Key-Inflection': 'camel',
-        Authorization: `Token token=${userToken}`
-      };
-
-      fetch(`${environment.API_URL}/v0/vic/profile_photo_attachments/${props.id}`, {
-        headers
-      }).then(resp => {
-        if (resp.ok) {
-          return resp.blob();
-        }
-
-        return new Error(resp.responseText);
-      }).then(blob => {
-        this.props.onUpdatePreview(window.URL.createObjectURL(blob));
+      fetchPreview(props.id).then(src => {
+        this.props.onUpdatePreview(src);
       }).catch(err => {
         this.props.onError(err);
       });
@@ -37,15 +23,15 @@ export default class PhotoPreview extends React.Component {
       return (
         <div className="usa-alert usa-alert-warning vic-processing-warning">
           <div className="usa-alert-body">
-            <h4 className="usa-alert-title">We're still processing your preview photo</h4>
-            This does not affect your application. You can continue down the form while we process your photo in the meantime.
+            <h4 className="usa-alert-title">We’re still loading your photo</h4>
+            You can continue working on the application while we finish loading your photo.
           </div>
         </div>
       );
     }
 
     if (!src && id && isLoggedIn) {
-      return <LoadingIndicator message="Loading your profile photo..."/>;
+      return <LoadingIndicator message="We’re loading your photo..."/>;
     }
 
     if (!src && !id) {

--- a/src/js/vic-v2/config/form.js
+++ b/src/js/vic-v2/config/form.js
@@ -193,9 +193,7 @@ const formConfig = {
               parseResponse: (response, file) => {
                 return {
                   name: file.name,
-                  confirmationCode: response.data.attributes.guid,
-                  serverName: response.data.attributes.filename,
-                  serverPath: response.data.attributes.path
+                  confirmationCode: response.data.attributes.guid
                 };
               }
             }), {
@@ -239,9 +237,7 @@ const formConfig = {
               parseResponse: (response, file) => {
                 return {
                   name: file.name,
-                  confirmationCode: response.data.attributes.guid,
-                  serverPath: response.data.attributes.path,
-                  serverName: response.data.attributes.filename
+                  confirmationCode: response.data.attributes.guid
                 };
               }
             })

--- a/src/js/vic-v2/containers/ConfirmationPage.jsx
+++ b/src/js/vic-v2/containers/ConfirmationPage.jsx
@@ -2,39 +2,48 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 import moment from 'moment';
-import environment from '../../common/helpers/environment';
+import _ from 'lodash/fp';
 
 import { focusElement } from '../../common/utils/helpers';
 
 import VeteranIDCard from '../components/VeteranIDCard';
 
+import { fetchPreview } from '../helpers';
+
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
-  scroller.scrollTo('topScrollElement', {
+  scroller.scrollTo('topScrollElement', window.VetsGov.scroll || {
     duration: 500,
     delay: 0,
     smooth: true,
   });
 };
 
-function getImageUrl({ serverPath, serverName } = {}) {
-  return `${environment.API_URL}/content/vic/${serverPath}/${serverName}`;
-}
-
 class ConfirmationPage extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { isExpanded: false };
+
+    let photoSrc;
+    const file = _.get('form.data.photo.file', props);
+    if (file instanceof Blob) {
+      photoSrc = window.URL.createObjectURL(file);
+    }
+
+    this.state = {
+      photoSrc
+    };
+
+    if (!photoSrc && props.userSignedIn) {
+      fetchPreview(_.get('form.data.photo.confirmationCode', props))
+        .then(src => {
+          this.setState({ photoSrc: src });
+        });
+    }
   }
 
   componentDidMount() {
     focusElement('.confirmation-page-title');
     scrollToTop();
-  }
-
-  toggleExpanded = (e) => {
-    e.preventDefault();
-    this.setState({ isExpanded: !this.state.isExpanded });
   }
 
   render() {
@@ -49,8 +58,6 @@ class ConfirmationPage extends React.Component {
     } = form.data.veteranFullName;
 
     const { serviceBranch, verified } = form.data;
-
-    const photoUrl = getImageUrl(form.data.photo);
 
     const response = form.submission.response || {};
     const submittedAt = moment();
@@ -69,11 +76,11 @@ class ConfirmationPage extends React.Component {
           <p>We’ll send you emails updating you on the status of your application. You can also print this page for your records. You should receive your Veteran ID Card by mail in about 60 days.<br/>
             In the meantime, you can print a temporary digital Veteran ID Card.</p>
           <div className="id-card-preview">
-            <VeteranIDCard
+            {!!this.state.photoSrc && <VeteranIDCard
               veteranFullName={veteranFullNameStr}
               veteranBranchCode={serviceBranch}
               caseId={response.caseId}
-              veteranPhotoUrl={photoUrl}/>
+              veteranPhotoUrl={this.state.photoSrc}/>}
           </div>
           <button type="button" className="va-button-link" onClick={() => window.print()}>Print your temporary Veteran ID Card.</button>
         </div>}

--- a/src/js/vic-v2/helpers.jsx
+++ b/src/js/vic-v2/helpers.jsx
@@ -121,3 +121,23 @@ export function submit(form, formConfig) {
     }).catch(reject);
   });
 }
+
+export function fetchPreview(id) {
+  const userToken = window.sessionStorage.userToken;
+  const headers = {
+    'X-Key-Inflection': 'camel',
+    Authorization: `Token token=${userToken}`
+  };
+
+  return fetch(`${environment.API_URL}/v0/vic/profile_photo_attachments/${id}`, {
+    headers
+  }).then(resp => {
+    if (resp.ok) {
+      return resp.blob();
+    }
+
+    return new Error(resp.responseText);
+  }).then(blob => {
+    return window.URL.createObjectURL(blob);
+  });
+}

--- a/test/vic-v2/components/PhotoPreview.unit.spec.jsx
+++ b/test/vic-v2/components/PhotoPreview.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
+import 'isomorphic-fetch';
 
 import { mockFetch, resetFetch } from '../../util/unit-helpers.js';
 

--- a/test/vic-v2/containers/ConfirmationPage.unit.spec.jsx
+++ b/test/vic-v2/containers/ConfirmationPage.unit.spec.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import _ from 'lodash/fp';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 
+import { mockFetch, resetFetch } from '../../util/unit-helpers.js';
 import { ConfirmationPage } from '../../../src/js/vic-v2/containers/ConfirmationPage';
 
 const form = {
@@ -21,7 +23,17 @@ const form = {
   }
 };
 
+function setFetchResponse(stub, data) {
+  const response = new Response();
+  response.ok = true;
+  response.blob = () => Promise.resolve(data);
+  stub.resolves(response);
+}
+
 describe('<ConfirmationPage>', () => {
+  beforeEach(() => {
+    mockFetch();
+  });
   it('should render unverified', () => {
     const tree = shallow(
       <ConfirmationPage form={form} userSignedIn/>
@@ -40,13 +52,28 @@ describe('<ConfirmationPage>', () => {
     expect(tree.text()).to.contain('We process applications and print cards in the order we receive them.');
     expect(tree.text()).to.contain('We’ll send you emails updating you on the status of your application. You can also print this page for your records.');
   });
-  it('should render verified and signed in', () => {
+  it('should render verified and signed in', (done) => {
+    const response = new Blob();
+    setFetchResponse(global.fetch.onFirstCall(), response);
+
+    window.URL = {
+      createObjectURL: sinon.stub().returns('imagesrc')
+    };
+
     const tree = shallow(
       <ConfirmationPage form={_.set('data.verified', true, form)} userSignedIn/>
     );
 
-    expect(tree.text()).not.to.contain('We’ll review your application to verify your eligibility.');
-    expect(tree.text()).to.contain('In the meantime, you can print a temporary digital Veteran ID Card.');
-    expect(tree.find('VeteranIDCard').exists()).to.be.true;
+    setTimeout(() => {
+      tree.update();
+      expect(tree.text()).not.to.contain('We’ll review your application to verify your eligibility.');
+      expect(tree.text()).to.contain('In the meantime, you can print a temporary digital Veteran ID Card.');
+      expect(tree.find('VeteranIDCard').props().veteranPhotoUrl).to.equal('imagesrc');
+      done();
+    });
+  });
+  afterEach(() => {
+    resetFetch();
+    delete window.URL;
   });
 });


### PR DESCRIPTION
Also addresses https://github.com/department-of-veterans-affairs/vets.gov-team/issues/8876

I can't really test the confirmation page fully locally, so some of that will have to wait until staging.

This cleans up the use of serverName and serverPath in favor of the authenticated url approach.

![screen shot 2018-02-21 at 2 18 24 pm](https://user-images.githubusercontent.com/634932/36500431-4523b79a-1712-11e8-9482-a58f93466562.png)
