### PR TITLE
Claims list item v2 tests

### DIFF
--- a/src/js/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
+++ b/src/js/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import moment from 'moment';
 
-import { getPhaseDescription, isClaimComplete, getClaimType } from '../utils/helpers';
+import { getPhaseDescription, isClaimComplete, getClaimType } from '../../utils/helpers';
 
 function listPhase(phase) {
   return (phase === 8) ? 'Closed' : getPhaseDescription(phase);

--- a/src/js/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/js/claims-status/containers/YourClaimsPageV2.jsx
@@ -24,7 +24,7 @@ import AppealsUnavailable from '../components/AppealsUnavailable';
 import AskVAQuestions from '../components/AskVAQuestions';
 import ConsolidatedClaims from '../components/ConsolidatedClaims';
 import FeaturesWarning from '../components/FeaturesWarning';
-import ClaimsListItem from '../components/ClaimsListItemV2';
+import ClaimsListItem from '../components/appeals-v2/ClaimsListItemV2';
 import AppealListItem from '../components/AppealListItemV2';
 import NoClaims from '../components/NoClaims';
 import Pagination from '../../common/components/Pagination';

--- a/test/claims-status/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ClaimsListItemV2 from '../../../../src/js/claims-status/components/appeals-v2/ClaimsListItemV2';
+
+
+describe('<ClaimsListItemV2>', () => {
+  it('should not show any flags', () => {
+    const claim = {
+      id: 1,
+      attributes: {
+        phase: 2,
+        decisionLetterSent: false,
+        developmentLetterSent: false,
+        documentsNeeded: false
+      }
+    };
+    const tree = shallow(<ClaimsListItemV2 claim={claim}/>);
+    expect(tree.find('.communications').text()).to.equal('');
+  });
+
+  it('should show closed status', () => {
+    const claim = {
+      id: 1,
+      attributes: {
+        phase: 8
+      }
+    };
+    const tree = shallow(<ClaimsListItemV2 claim={claim}/>);
+    expect(tree.find('.status-circle + p').first().text()).to.equal('Status: Closed');
+  });
+
+  it('should show the status', () => {
+    const claim = {
+      id: 1,
+      attributes: {
+        phase: 2
+      }
+    };
+    const tree = shallow(<ClaimsListItemV2 claim={claim}/>);
+    expect(tree.find('.status-circle + p').first().text()).to.equal('Status: Initial review');
+  });
+
+  it('should show development letter flag', () => {
+    const claim = {
+      id: 1,
+      attributes: {
+        phase: 2,
+        decisionLetterSent: false,
+        developmentLetterSent: true,
+        documentsNeeded: false
+      }
+    };
+    const tree = shallow(<ClaimsListItemV2 claim={claim}/>);
+    expect(tree.find('.communications').text()).to.contain('We sent you a development letter');
+  });
+
+  it('should show decision letter flag', () => {
+    const claim = {
+      id: 1,
+      attributes: {
+        phase: 2,
+        decisionLetterSent: true,
+        developmentLetterSent: true,
+        documentsNeeded: false
+      }
+    };
+    const tree = shallow(<ClaimsListItemV2 claim={claim}/>);
+    expect(tree.find('.communications').text()).to.contain('We sent you a decision letter');
+  });
+
+  it('should show items needed flag', () => {
+    const claim = {
+      id: 1,
+      attributes: {
+        phase: 2,
+        decisionLetterSent: false,
+        developmentLetterSent: false,
+        documentsNeeded: true
+      }
+    };
+    const tree = shallow(<ClaimsListItemV2 claim={claim}/>);
+    expect(tree.find('.communications').text()).to.contain('Items need attention');
+  });
+
+  it('should hide flags when complete', () => {
+    const claim = {
+      id: 1,
+      attributes: {
+        phase: 8,
+        decisionLetterSent: false,
+        developmentLetterSent: true,
+        documentsNeeded: true
+      }
+    };
+    const tree = shallow(<ClaimsListItemV2 claim={claim}/>);
+    expect(tree.find('.communications').text()).to.equal('');
+  });
+
+  it('should render a status circle with the `open` class', () => {
+    const claim = {
+      id: 1,
+      attributes: {
+        phase: 2,
+        open: true
+      }
+    };
+    const tree = shallow(<ClaimsListItemV2 claim={claim}/>);
+    const circle = tree.find('.status-circle').first();
+    expect(circle.hasClass('open')).to.be.true;
+    expect(circle.hasClass('closed')).to.be.false;
+  });
+
+  it('should render a status circle with the `closed` class', () => {
+    const claim = {
+      id: 1,
+      attributes: {
+        phase: 8,
+        open: false
+      }
+    };
+    const tree = shallow(<ClaimsListItemV2 claim={claim}/>);
+    const circle = tree.find('.status-circle').first();
+    expect(circle.hasClass('open')).to.be.false;
+    expect(circle.hasClass('closed')).to.be.true;
+  });
+
+  it('should render a link to the claim status page', () => {
+    const claim = {
+      id: 1,
+      attributes: {
+        phase: 8,
+        open: false
+      }
+    };
+    const tree = shallow(<ClaimsListItemV2 claim={claim}/>);
+    expect(tree.find('Link').first().props().to).to.equal(`your-claims/${claim.id}/status`);
+  });
+});


### PR DESCRIPTION
I moved `ClaimsListItemV2` up into `components/appeals-v2/` because it's only used in the v2 index page and it made more sense in there.

The tests are basically just copied from the v2 component tests, then converted to use `enzyme`. The last two tests are new since that's the only major functionality change in the v2 list item.