### PR TITLE
Move sanitize so we don't import the world into every bundle

### DIFF
--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -542,17 +542,3 @@ export function getActiveChapters(formConfig, formData) {
   return _.uniq(expandedPageList.map(p => p.chapterKey).filter(key => !!key && key !== 'review'));
 }
 
-export function sanitizeForm(formData) {
-  try {
-    const suffixes = ['vaFileNumber', 'first', 'last', 'accountNumber', 'socialSecurityNumber', 'dateOfBirth'];
-    return JSON.stringify(formData, (key, value) => {
-      if (value && suffixes.some(suffix => key.toLowerCase().endsWith(suffix.toLowerCase()))) {
-        return 'removed';
-      }
-
-      return value;
-    });
-  } catch (e) {
-    return null;
-  }
-}

--- a/src/js/common/schemaform/save-in-progress/actions.js
+++ b/src/js/common/schemaform/save-in-progress/actions.js
@@ -4,7 +4,7 @@ import 'isomorphic-fetch';
 import { logOut } from '../../../login/actions';
 
 import { removeFormApi, saveFormApi } from './api';
-import { sanitizeForm } from '../helpers';
+import { sanitizeForm } from '../../utils/helpers';
 
 export const SET_SAVE_FORM_STATUS = 'SET_SAVE_FORM_STATUS';
 export const SET_AUTO_SAVE_FORM_STATUS = 'SET_AUTO_SAVE_FORM_STATUS';

--- a/src/js/common/schemaform/save-in-progress/api.js
+++ b/src/js/common/schemaform/save-in-progress/api.js
@@ -1,6 +1,6 @@
 import Raven from 'raven-js';
 import environment from '../../helpers/environment';
-import { sanitizeForm } from '../helpers';
+import { sanitizeForm } from '../../utils/helpers';
 
 export function removeFormApi(formId) {
   const userToken = sessionStorage.userToken;

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -267,3 +267,18 @@ export function sortListByFuzzyMatch(value, list, prop = 'label') {
     })
     .map(sorted => sorted.original);
 }
+
+export function sanitizeForm(formData) {
+  try {
+    const suffixes = ['vaFileNumber', 'first', 'last', 'accountNumber', 'socialSecurityNumber', 'dateOfBirth'];
+    return JSON.stringify(formData, (key, value) => {
+      if (value && suffixes.some(suffix => key.toLowerCase().endsWith(suffix.toLowerCase()))) {
+        return 'removed';
+      }
+
+      return value;
+    });
+  } catch (e) {
+    return null;
+  }
+}


### PR DESCRIPTION
The user profile code imports a `santizeForm` function from a helper file that imports all the schemaform code, which meant that the schemaform code was getting into every bundle.

Moving this function knocks 40kb (gzipped) off of non-form app bundles, which is around a 30% reduction, depending on the app.