### PR TITLE
Don't call onBlur if list is open

### DIFF
--- a/src/js/common/schemaform/fields/AutosuggestField.jsx
+++ b/src/js/common/schemaform/fields/AutosuggestField.jsx
@@ -155,6 +155,7 @@ export default class AutosuggestField extends React.Component {
         onInputValueChange={this.handleInputValueChange}
         inputValue={this.state.input}
         selectedItem={this.state.input}
+        onOuterClick={this.handleBlur}
         itemToString={item => {
           if (typeof item === 'string') {
             return item;
@@ -170,7 +171,12 @@ export default class AutosuggestField extends React.Component {
           highlightedIndex
         }) => (
           <div className="autosuggest-container">
-            <input {...getInputProps({ id, name: id, onKeyDown: this.handleKeyDown, onBlur: this.handleBlur })}/>
+            <input {...getInputProps({
+              id,
+              name: id,
+              onBlur: isOpen ? undefined : this.handleBlur,
+              onKeyDown: this.handleKeyDown
+            })}/>
             {isOpen && (
               <div className="autosuggest-list" role="listbox">
                 {this.state.suggestions

--- a/test/common/schemaform/fields/AutosuggestField.unit.spec.jsx
+++ b/test/common/schemaform/fields/AutosuggestField.unit.spec.jsx
@@ -139,6 +139,46 @@ describe('<AutosuggestField>', () => {
     });
     expect(onChange.lastCall.args.length).to.equal(0);
   });
+  it('should trigger onBlur', (done) => {
+    const uiSchema = {
+      'ui:options': {
+        getOptions: () => Promise.resolve([
+          {
+            id: '1',
+            label: 'first'
+          },
+          {
+            id: '2',
+            label: 'second'
+          }
+        ])
+      }
+    };
+    const formContext = {
+      reviewMode: false
+    };
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+
+    const tree = mount(
+      <AutosuggestField
+        formData={{ widget: 'autosuggest', id: '1', label: 'first' }}
+        formContext={formContext}
+        onChange={onChange}
+        onBlur={onBlur}
+        idSchema={{ $id: 'id' }}
+        uiSchema={uiSchema}/>
+    );
+
+    const input = tree.find('input');
+    input.simulate('focus');
+
+    setTimeout(() => {
+      input.simulate('blur');
+      expect(onBlur.called).to.be.true;
+      done();
+    });
+  });
   it('should leave data on blur if partially filled in', (done) => {
     const uiSchema = {
       'ui:options': {
@@ -183,9 +223,8 @@ describe('<AutosuggestField>', () => {
       expect(onChange.called).to.be.true;
       input.simulate('blur');
       expect(input.getDOMNode().value).to.equal('fir');
-      expect(onBlur.called).to.be.true;
       done();
-    }, 0);
+    });
   });
   it('should use options from enum to get first item', (done) => {
     const uiSchema = {


### PR DESCRIPTION
We were calling blur if you clicked on an option, which moved the list down and made your click not register. This uses Downshift's onOuterClick to handle blur if the list is open, and uses the input blur event otherwise.