### PR TITLE
Fix VIC image type mismatch and update messages

### DIFF
--- a/src/js/vic-v2/components/DD214Description.jsx
+++ b/src/js/vic-v2/components/DD214Description.jsx
@@ -7,7 +7,7 @@ export default function DD214Description() {
       <p>If you have more than one discharge document, please upload the one with the highest character of discharge.</p>
       <p>If you don’t have a digital copy of your discharge document, you can scan or take a photo of it and then upload it to your computer or phone. The digital file could be a .pdf file or other photo file format, like a .jpeg or .png.</p>
 
-      <div>File types you can upload: .pdf, .jpeg, or .png</div>
+      <div>File types you can upload: .pdf, .jpeg, .gif, .tif, or .png</div>
       <div>Maximum file size: 25 MB</div>
     </div>
   );

--- a/src/js/vic-v2/components/DD214Description.jsx
+++ b/src/js/vic-v2/components/DD214Description.jsx
@@ -7,7 +7,7 @@ export default function DD214Description() {
       <p>If you have more than one discharge document, please upload the one with the highest character of discharge.</p>
       <p>If you don’t have a digital copy of your discharge document, you can scan or take a photo of it and then upload it to your computer or phone. The digital file could be a .pdf file or other photo file format, like a .jpeg or .png.</p>
 
-      <div>File types you can upload: .pdf, .jpeg, .gif, .tif, or .png</div>
+      <div>File types you can upload: .pdf, .jpeg, .gif, .tiff, or .png</div>
       <div>Maximum file size: 25 MB</div>
     </div>
   );

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -306,7 +306,7 @@ export default class PhotoField extends React.Component {
     const fileTypes = this.props.uiSchema['ui:options'].fileTypes;
     if (!isValidFileType(file.name, fileTypes)) {
       this.props.onChange({
-        errorMessage: 'We weren’t able to upload your file. Please make sure the file you’re uploading is a gif, jpeg, .png, or .tiff file and try again.'
+        errorMessage: 'We weren’t able to upload your file. Please make sure the file you’re uploading is a jpeg, tiff, .gif, or .png file and try again.'
       });
     } else {
       const reader = new FileReader();
@@ -354,7 +354,7 @@ export default class PhotoField extends React.Component {
       }
       if (!isValidFileType(fileName, fileTypes)) {
         this.props.onChange({
-          errorMessage: 'We weren’t able to upload your file. Please make sure the file you’re uploading is a gif, jpeg, .png, .tiff, or .bmp file and try again.'
+          errorMessage: 'We weren’t able to upload your file. Please make sure the file you’re uploading is a jpeg, tiff, .gif, .png, or .bmp file and try again.'
         });
       } else {
         const reader = new FileReader();

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -306,7 +306,7 @@ export default class PhotoField extends React.Component {
     const fileTypes = this.props.uiSchema['ui:options'].fileTypes;
     if (!isValidFileType(file.name, fileTypes)) {
       this.props.onChange({
-        errorMessage: 'We weren’t able to upload your file. Please make sure the file you’re uploading is a jpeg, .png, or .tiff file and try again.'
+        errorMessage: 'We weren’t able to upload your file. Please make sure the file you’re uploading is a gif, jpeg, .png, or .tiff file and try again.'
       });
     } else {
       const reader = new FileReader();
@@ -354,7 +354,7 @@ export default class PhotoField extends React.Component {
       }
       if (!isValidFileType(fileName, fileTypes)) {
         this.props.onChange({
-          errorMessage: 'We weren’t able to upload your file. Please make sure the file you’re uploading is a jpeg, .png, .tiff, or .bmp file and try again.'
+          errorMessage: 'We weren’t able to upload your file. Please make sure the file you’re uploading is a gif, jpeg, .png, .tiff, or .bmp file and try again.'
         });
       } else {
         const reader = new FileReader();
@@ -830,7 +830,7 @@ export default class PhotoField extends React.Component {
               onDragEnter={() => this.handleDrag({ dragActive: true })}
               onDragLeave={() => this.handleDrag({ dragActive: false })}
               onDrop={this.onChange}
-              accept="image/jpeg, image/jpg, image/png, image/tiff, image/tif, image/bmp">
+              accept="image/jpeg, image/gif, image/jpg, image/png, image/tiff, image/tif, image/bmp">
               {this.state.dragActive ?
                 <div className="drag-active-text"><span>DROP PHOTO</span></div> :
                 <img alt="placeholder" src="/img/photo-placeholder.png"/>}

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -276,7 +276,7 @@ export default class PhotoField extends React.Component {
     this.refs.cropper.getCroppedCanvas(croppedCanvasOptions).toBlob(blob => {
       const file = blob;
       file.lastModifiedDate = new Date();
-      file.name = this.state.fileName;
+      file.name = 'profile_photo.png';
       this.props.formContext.uploadFile(
         file,
         (formData) => {
@@ -306,7 +306,7 @@ export default class PhotoField extends React.Component {
     const fileTypes = this.props.uiSchema['ui:options'].fileTypes;
     if (!isValidFileType(file.name, fileTypes)) {
       this.props.onChange({
-        errorMessage: 'We weren’t able to upload your file. Please make sure the file you’re uploading is a jpeg, .png, .tiff,  or .bmp file and try again.'
+        errorMessage: 'We weren’t able to upload your file. Please make sure the file you’re uploading is a jpeg, .png, or .tiff file and try again.'
       });
     } else {
       const reader = new FileReader();
@@ -344,7 +344,7 @@ export default class PhotoField extends React.Component {
     this.screenReaderPath = false;
     this.setState({ dragActive: false });
 
-    const fileTypes = this.props.uiSchema['ui:options'].fileTypes;
+    const fileTypes = this.props.uiSchema['ui:options'].fileTypes.concat('bmp');
     if (files && files[0]) {
       const file = files[0];
       const fileName = file.name;
@@ -354,7 +354,7 @@ export default class PhotoField extends React.Component {
       }
       if (!isValidFileType(fileName, fileTypes)) {
         this.props.onChange({
-          errorMessage: 'We weren’t able to upload your file. Please make sure the file you’re uploading is a jpeg, .png, .tiff,  or .bmp file and try again.'
+          errorMessage: 'We weren’t able to upload your file. Please make sure the file you’re uploading is a jpeg, .png, .tiff, or .bmp file and try again.'
         });
       } else {
         const reader = new FileReader();
@@ -642,6 +642,7 @@ export default class PhotoField extends React.Component {
     const smallScreen = isSmallScreen(this.state.windowWidth) || onReviewPage(this.props.formContext.pageTitle);
     const moveControlClass = ['cropper-control', 'cropper-control-label-container', 'va-button-link'];
     const fileTypes = this.props.uiSchema['ui:options'].fileTypes;
+    const cropperTypes = fileTypes.concat('bmp');
     const progressBarContainerClass = classNames('schemaform-file-uploading', 'progress-bar-container');
 
     let fieldView;
@@ -850,7 +851,7 @@ export default class PhotoField extends React.Component {
               Edit your photo
             </button>}
             {(fieldView === 'initial' || fieldView === 'cropper') && <ErrorableFileInput
-              accept={fileTypes.map(type => `.${type}`).join(',')}
+              accept={cropperTypes.map(type => `.${type}`).join(',')}
               onChange={this.onChange}
               buttonText={uploadMessage}
               aria-describedby="croppingToolDescription"

--- a/src/js/vic-v2/config/form.js
+++ b/src/js/vic-v2/config/form.js
@@ -38,6 +38,7 @@ const {
 } = fullSchemaVIC.definitions;
 
 const TWENTY_FIVE_MB = 26214400;
+const TEN_MB = 10485760;
 
 const formConfig = {
   urlPrefix: '/',
@@ -182,7 +183,7 @@ const formConfig = {
                 'jpeg',
                 'jpg'
               ],
-              maxSize: TWENTY_FIVE_MB,
+              maxSize: TEN_MB,
               showFieldLabel: false,
               createPayload: (file) => {
                 const payload = new FormData();

--- a/src/js/vic-v2/config/form.js
+++ b/src/js/vic-v2/config/form.js
@@ -178,9 +178,9 @@ const formConfig = {
                 'png',
                 'tiff',
                 'tif',
+                'gif',
                 'jpeg',
-                'jpg',
-                'bmp'
+                'jpg'
               ],
               maxSize: TWENTY_FIVE_MB,
               showFieldLabel: false,
@@ -226,6 +226,9 @@ const formConfig = {
                 'png',
                 'jpeg',
                 'jpg',
+                'gif',
+                'tif',
+                'tiff'
               ],
               maxSize: TWENTY_FIVE_MB,
               buttonText: 'Upload Your Discharge Document',

--- a/test/vic-v2/components/PhotoField.unit.spec.jsx
+++ b/test/vic-v2/components/PhotoField.unit.spec.jsx
@@ -182,7 +182,7 @@ describe('<PhotoField>', () => {
       }]);
 
       setTimeout(() => {
-        expect(onChange.firstCall.args[0].errorMessage).to.contain('make sure the file you’re uploading is a gif, jpeg');
+        expect(onChange.firstCall.args[0].errorMessage).to.contain('make sure the file you’re uploading is a jpeg');
         done();
       });
     });

--- a/test/vic-v2/components/PhotoField.unit.spec.jsx
+++ b/test/vic-v2/components/PhotoField.unit.spec.jsx
@@ -182,7 +182,7 @@ describe('<PhotoField>', () => {
       }]);
 
       setTimeout(() => {
-        expect(onChange.firstCall.args[0].errorMessage).to.contain('make sure the file you’re uploading is a jpeg');
+        expect(onChange.firstCall.args[0].errorMessage).to.contain('make sure the file you’re uploading is a gif, jpeg');
         done();
       });
     });


### PR DESCRIPTION
A few changes:

1. Overwrite the image file name when cropping. The output is always image/png and the file name doesn't really matter, so setting it to a static name.
2. Remove bmp from allowed types, but allow them into the cropper tool. The cropper tool will convert it to png, so no reason to restrict it there.
3. Add gif to allowed types. This was allowed on the backend, but not the front.
4. Update messages.