### PR TITLE
Removed LOA check and manual redirect for identity proofing in auth flow.

### DIFF
--- a/src/js/auth/containers/AuthApp.jsx
+++ b/src/js/auth/containers/AuthApp.jsx
@@ -9,11 +9,6 @@ import { updateLoggedInStatus } from '../../login/actions';
 class AuthApp extends React.Component {
   constructor(props) {
     super(props);
-    this.checkUserLevel = this.checkUserLevel.bind(this);
-    this.handleAuthSuccess = this.handleAuthSuccess.bind(this);
-    this.setError = this.setError.bind(this);
-    this.setToken = this.setToken.bind(this);
-
     const { token } = props.location.query;
     this.state = { error: !token };
     this.authSettings = {
@@ -24,10 +19,10 @@ class AuthApp extends React.Component {
   }
 
   componentDidMount() {
-    if (!this.state.error) { this.checkUserLevel(); }
+    if (!this.state.error) { this.validateToken(); }
   }
 
-  setToken() {
+  setToken = () => {
     // Internet Explorer 6-11
     const isIE = /*@cc_on!@*/false || !!document.documentMode; // eslint-disable-line spaced-comment
     // Edge 20+
@@ -46,16 +41,16 @@ class AuthApp extends React.Component {
     window.close();
   }
 
-  setError() {
+  setError = () => {
     this.setState({ error: true });
   }
 
-  checkUserLevel() {
-    // Fetch the user to get the login policy and validate the token against the API.
+  // Fetch the user to get the login policy and validate the token against the API.
+  validateToken = () => {
     apiRequest('/user', this.authSettings, this.handleAuthSuccess, this.setError);
   }
 
-  handleAuthSuccess({ data }) {
+  handleAuthSuccess = ({ data }) => {
     // Upon successful authentication, push analytics event and store the token.
     const userData = data.attributes.profile;
     const loginPolicy = userData.authnContext || 'idme';

--- a/src/js/auth/containers/AuthApp.jsx
+++ b/src/js/auth/containers/AuthApp.jsx
@@ -40,13 +40,8 @@ export class AuthApp extends React.Component {
     window.close();
   }
 
-  setError = () => {
+  handleAuthError = () => {
     this.setState({ error: true });
-  }
-
-  // Fetch the user to get the login policy and validate the token against the API.
-  validateToken = () => {
-    apiRequest('/user', this.authSettings, this.handleAuthSuccess, this.setError);
   }
 
   handleAuthSuccess = ({ data }) => {
@@ -55,6 +50,11 @@ export class AuthApp extends React.Component {
     const loginPolicy = userData.authnContext || 'idme';
     window.dataLayer.push({ event: `login-success-${loginPolicy}` });
     this.setToken();
+  }
+
+  // Fetch the user to get the login policy and validate the token against the API.
+  validateToken = () => {
+    apiRequest('/user', this.authSettings, this.handleAuthSuccess, this.handleAuthError);
   }
 
   render() {

--- a/src/js/auth/containers/AuthApp.jsx
+++ b/src/js/auth/containers/AuthApp.jsx
@@ -4,9 +4,8 @@ import { connect } from 'react-redux';
 import LoadingIndicator from '../../common/components/LoadingIndicator';
 import { apiRequest } from '../../common/helpers/api';
 import environment from '../../common/helpers/environment';
-import { updateLoggedInStatus } from '../../login/actions';
 
-class AuthApp extends React.Component {
+export class AuthApp extends React.Component {
   constructor(props) {
     super(props);
     const { token } = props.location.query;
@@ -90,13 +89,4 @@ const mapStateToProps = (state) => {
   return { login, profile };
 };
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    onUpdateLoggedInStatus: (update) => {
-      dispatch(updateLoggedInStatus(update));
-    }
-  };
-};
-
-export default connect(mapStateToProps, mapDispatchToProps, undefined, { pure: false })(AuthApp);
-export { AuthApp };
+export default connect(mapStateToProps)(AuthApp);


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#8886.
Depends on department-of-veterans-affairs/vets-api#1708.

@omgitsbillryan: I tagged you since we're going to end up removing the `clientId` query param on a lot of these auth URLs since the redirects will be coming from the backend. I dug around to find out why we needed this and found this old issue (department-of-veterans-affairs/vets.gov-team#3440).

In order to maintain the query param, perhaps we can send up the GA `clientId` as part of the request header, and the API could append it to any ID.me URLs it ends up redirecting to?