### PR TITLE
Fix focusElement bug

### DIFF
--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -125,7 +125,6 @@ export function focusElement(selectorOrElement, options) {
     : selectorOrElement;
 
   if (el) {
-    el.setAttribute('tabindex', '-1');
     el.focus(options);
   }
 }

--- a/src/js/common/utils/helpers.js
+++ b/src/js/common/utils/helpers.js
@@ -125,6 +125,7 @@ export function focusElement(selectorOrElement, options) {
     : selectorOrElement;
 
   if (el) {
+    if (el.tabIndex === -1) el.setAttribute('tabindex', '-1');
     el.focus(options);
   }
 }


### PR DESCRIPTION
These changes update focusElement to make the tabIndex setting logic conditional, and apply only to non-focusable elements.