### PR TITLE
Letters blank address fix cv

### DIFF
--- a/src/js/letters/actions/letters.js
+++ b/src/js/letters/actions/letters.js
@@ -25,8 +25,18 @@ import {
   SAVE_ADDRESS_PENDING,
   SAVE_ADDRESS_FAILURE,
   SAVE_ADDRESS_SUCCESS,
-  INVALID_ADDRESS_PROPERTY
+  INVALID_ADDRESS_PROPERTY,
+  START_EDITING_ADDRESS,
+  CANCEL_EDITING_ADDRESS
 } from '../utils/constants';
+
+export function editAddress() {
+  return (dispatch) => dispatch({ type: START_EDITING_ADDRESS });
+}
+
+export function cancelEditingAddress() {
+  return (dispatch) => dispatch({ type: CANCEL_EDITING_ADDRESS });
+}
 
 export function getLetterList(dispatch) {
   return apiRequest(
@@ -316,3 +326,4 @@ export function getAddressStates() {
     );
   };
 }
+

--- a/src/js/letters/containers/DownloadLetters.jsx
+++ b/src/js/letters/containers/DownloadLetters.jsx
@@ -8,6 +8,8 @@ import SegmentedProgressBar from '../../common/components/SegmentedProgressBar';
 import StepHeader from '../components/StepHeader';
 import { chapters } from '../routes';
 
+import { isAddressEmpty } from '../utils/helpers';
+
 export class DownloadLetters extends React.Component {
   constructor() {
     super();
@@ -22,6 +24,7 @@ export class DownloadLetters extends React.Component {
     const { children, location } = this.props;
     const currentPageIndex = findIndex(['path', location.pathname], chapters);
     const currentStep = currentPageIndex + 1;
+    const emptyAddress = isAddressEmpty(this.props.address);
 
     let viewLettersButton;
     if (location.pathname === '/confirm-address') {
@@ -30,7 +33,7 @@ export class DownloadLetters extends React.Component {
           <button
             onClick={this.navigateToLetterList}
             className="usa-button-primary view-letters-button"
-            disabled={this.props.isEditingAddress}>
+            disabled={this.props.isEditingAddress || emptyAddress}>
             View Letters
           </button>
         </div>

--- a/src/js/letters/containers/DownloadLetters.jsx
+++ b/src/js/letters/containers/DownloadLetters.jsx
@@ -29,7 +29,8 @@ export class DownloadLetters extends React.Component {
         <div className="step-content">
           <button
             onClick={this.navigateToLetterList}
-            className="usa-button-primary view-letters-button">
+            className="usa-button-primary view-letters-button"
+            disabled={this.props.isEditingAddress}>
             View Letters
           </button>
         </div>
@@ -60,6 +61,7 @@ function mapStateToProps(state) {
     letters: letterState.letters,
     fullName: letterState.fullName,
     address: letterState.address,
+    isEditingAddress: letterState.isEditingAddress,
     lettersAvailability: letterState.lettersAvailability,
     letterDownloadStatus: letterState.letterDownloadStatus,
     benefitSummaryOptions: {

--- a/src/js/letters/reducers/index.js
+++ b/src/js/letters/reducers/index.js
@@ -30,6 +30,8 @@ import {
   SAVE_ADDRESS_SUCCESS,
   SAVE_ADDRESS_FAILURE,
   UPDATE_BENFIT_SUMMARY_REQUEST_OPTION,
+  START_EDITING_ADDRESS,
+  CANCEL_EDITING_ADDRESS
 } from '../utils/constants';
 
 export const initialState = {
@@ -43,6 +45,7 @@ export const initialState = {
   fullName: {},
   address: {},
   addressAvailability: AVAILABILITY_STATUSES.awaitingResponse,
+  isEditingAddress: false,
   optionsAvailable: false,
   requestOptions: {},
   serviceInfo: [],
@@ -131,8 +134,11 @@ function letters(state = initialState, action) {
       return _.set(['letterDownloadStatus', action.data], DOWNLOAD_STATUSES.success, state);
     case GET_LETTER_PDF_FAILURE:
       return _.set(['letterDownloadStatus', action.data], DOWNLOAD_STATUSES.failure, state);
-    case SAVE_ADDRESS_PENDING:
-      return _.set('savePending', true, state);
+    case SAVE_ADDRESS_PENDING: {
+      const newState = _.set('savePending', true, state);
+      newState.isEditingAddress = false;
+      return newState;
+    }
     case SAVE_ADDRESS_SUCCESS: {
       const newState = Object.assign({}, state, { savePending: false });
       return _.set('address', action.address, newState);
@@ -174,6 +180,10 @@ function letters(state = initialState, action) {
     }
     case GET_ADDRESS_STATES_FAILURE:
       return _.set('statesAvailable', false, state);
+    case START_EDITING_ADDRESS:
+      return _.set('isEditingAddress', true, state);
+    case CANCEL_EDITING_ADDRESS:
+      return _.set('isEditingAddress', false, state);
     default:
       return state;
   }

--- a/src/js/letters/utils/constants.js
+++ b/src/js/letters/utils/constants.js
@@ -36,6 +36,9 @@ export const GET_LETTER_PDF_SUCCESS = 'GET_LETTER_PDF_SUCCESS';
 // updateBenefitSummaryRequestOption() actions
 export const UPDATE_BENFIT_SUMMARY_REQUEST_OPTION = 'UPDATE_BENFIT_SUMMARY_REQUEST_OPTION';
 
+export const START_EDITING_ADDRESS = 'START_EDITING_ADDRESS';
+export const CANCEL_EDITING_ADDRESS = 'CANCEL_EDITING_ADDRESS';
+
 export const AVAILABILITY_STATUSES = Object.freeze({
   awaitingResponse: 'awaitingResponse',
   available: 'available',

--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -410,3 +410,13 @@ export const getStatus = (response) => {
     ? response.errors[0].status
     : 'unknown';
 };
+
+// NOTE: It "shouldn't" ever happen...but it did. In production.
+export function isAddressEmpty(address) {
+  // An address will always have:
+  //  type because it errors out on the api if it doesn't exist (pretty sure)
+  //  countryName because of toGenericAddress() adds it
+  const fieldsToIgnore = ['type', 'countryName'];
+  return Object.keys(address).reduce((emptySoFar, nextField) => emptySoFar && (fieldsToIgnore.includes(nextField) || !address[nextField]), true);
+}
+

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -23,6 +23,8 @@ const cleanUpSpies = () => {
 };
 
 const saveSpy = sinon.spy();
+const editSpy = sinon.spy();
+const cancelEditSpy = sinon.spy();
 
 const defaultProps = {
   savedAddress: {
@@ -36,6 +38,9 @@ const defaultProps = {
     zipCode: '12345'
   },
   canUpdate: true,
+  cancelEditingAddress: cancelEditSpy,
+  editAddress: editSpy,
+  isEditingAddress: false,
   saveAddress: saveSpy,
   savePending: false,
   countries: [],
@@ -44,10 +49,13 @@ const defaultProps = {
   statesAvailable: true
 };
 
-// For running ./node_modules/.bin/mocha directly on this file
-window.dataLayer = [];
 
 describe('<AddressSection>', () => {
+  beforeEach(() => {
+    saveSpy.reset();
+    editSpy.reset();
+  });
+
   // we expect a render with default props to show the AddressContent component
   it('should display an address if one is provided in props', () => {
     const tree = shallow(<AddressSection {...defaultProps}/>);
@@ -116,7 +124,7 @@ describe('<AddressSection>', () => {
     expect(component.find('usa-button-secondary')).to.have.lengthOf(0);
   });
 
-  it('should expand address fields when Edit button is clicked', () => {
+  it('should call editAddress() when Edit button is clicked', () => {
     const tree = mount(<AddressSection {...defaultProps}/>);
 
     // Make sure we're not editing yet
@@ -124,56 +132,45 @@ describe('<AddressSection>', () => {
 
     // Poke the edit button
     tree.find('button.usa-button-secondary').simulate('click');
-    expect(tree.find('select')).to.have.lengthOf(2);
+    expect(editSpy.called).to.be.true;
   });
 
-  it('should collapse address fields when Update button is clicked', () => {
-    saveSpy.reset();
+  it('should render edit fields when isEditingAddress is true', () => {});
 
-    const tree = mount(<AddressSection {...defaultProps}/>);
-
-    expect(tree.find('select')).to.have.lengthOf(0);
-
-    tree.find('button.usa-button-secondary').simulate('click');
-    // We could just check the internal state to see if we're editing, too
-    expect(tree.find('select')).to.have.lengthOf(2);
+  it('should call saveAddress() when Update button is clicked', () => {
+    const tree = mount(<AddressSection {...defaultProps} isEditingAddress/>);
 
     // Click the save button
     tree.find('button.usa-button-primary').simulate('click');
-    expect(tree.find('select')).to.have.lengthOf(0);
     expect(saveSpy.calledWith(tree.state('editableAddress'))).to.be.true;
   });
 
-  it('should collapse address fields when Cancel button is clicked', () => {
-    const tree = mount(<AddressSection {...defaultProps}/>);
-
-    expect(tree.find('select')).to.have.lengthOf(0);
-
-    tree.find('button.usa-button-secondary').simulate('click');
-    expect(tree.find('select')).to.have.lengthOf(2);
+  it('should call cancelEditingAddress when Cancel button is clicked', () => {
+    const tree = mount(<AddressSection {...defaultProps} isEditingAddress/>);
 
     // Click the cancel button
     tree.find('button.usa-button-secondary').simulate('click');
-    expect(tree.find('select')).to.have.lengthOf(0);
+    expect(cancelEditSpy.called).to.be.true;
   });
 
   // NOTE: This is a bit of a misnomer; it only tests if countries are unavailable, but that should be sufficient
   it('should show addressUpdateUnavailable if countries or states lists aren\'t available', () => {
     const props = Object.assign({}, defaultProps, { countriesAvailable: false });
-    const tree = mount(<AddressSection {...props}/>);
+    const tree = mount(<AddressSection {...props} isEditingAddress/>);
 
-    // Start editing
-    tree.find('button.usa-button-secondary').simulate('click');
     expect(tree.find('.usa-alert-heading').text()).to.contain('Address update unavailable');
   });
 
   it('should load address in new props after mounting', () => {
+    const tree = mount(<AddressSection {...defaultProps}/>);
+
+    expect(tree.state('editableAddress')).to.equal(defaultProps.savedAddress);
+  });
+
+  it('should update editableAddress when the input changes', () => {
     const props = cloneDeep(defaultProps);
     props.savedAddress = {};
-    const tree = mount(<AddressSection {...props}/>);
-
-    expect(tree.state('editableAddress')).to.equal(props.savedAddress);
-    tree.find('.usa-button-secondary').simulate('click');
+    const tree = mount(<AddressSection {...props} isEditingAddress/>);
 
     // Edit the street address
     const newAddress = '123 Main St';
@@ -183,10 +180,7 @@ describe('<AddressSection>', () => {
 
   it('should not call saveAddress when Cancel is clicked', () => {
     saveSpy.reset();
-    const tree = mount(<AddressSection {...defaultProps}/>);
-
-    // Start editing
-    tree.find('button.usa-button-secondary').simulate('click');
+    const tree = mount(<AddressSection {...defaultProps} isEditingAddress/>);
 
     // Try to save
     tree.find('button.usa-button-secondary').simulate('click');
@@ -195,10 +189,7 @@ describe('<AddressSection>', () => {
 
   it('should not call saveAddress when Update is clicked with invalid data', () => {
     saveSpy.reset();
-    const tree = mount(<AddressSection {...defaultProps}/>);
-
-    // Start editing
-    tree.find('button.usa-button-secondary').simulate('click');
+    const tree = mount(<AddressSection {...defaultProps} isEditingAddress/>);
 
     // Clear out country to get a validation error
     tree.find('select[name="country"]').simulate('change', { target: { value: '' } });
@@ -209,10 +200,7 @@ describe('<AddressSection>', () => {
   });
 
   it('should display error messages for validation failures', () => {
-    const tree = mount(<AddressSection {...defaultProps}/>);
-
-    // Start editing
-    tree.find('button.usa-button-secondary').simulate('click');
+    const tree = mount(<AddressSection {...defaultProps} isEditingAddress/>);
 
     // Clear out country to get a validation error
     tree.find('select[name="country"]').simulate('change', { target: { value: '' } });
@@ -220,10 +208,7 @@ describe('<AddressSection>', () => {
   });
 
   it('should infer new address type', () => {
-    const tree = mount(<AddressSection {...defaultProps}/>);
-
-    // Start editing
-    tree.find('button.usa-button-secondary').simulate('click');
+    const tree = mount(<AddressSection {...defaultProps} isEditingAddress/>);
 
     // Sanity check; make sure the type is what we expect before we change it
     // NOTE: We're checking that it's domestic specifically just so we make absolutely sure
@@ -241,10 +226,7 @@ describe('<AddressSection>', () => {
   });
 
   it('should reset disallowed address fields when type changes', () => {
-    const tree = mount(<AddressSection {...defaultProps}/>);
-
-    // Start editing
-    tree.find('button.usa-button-secondary').simulate('click');
+    const tree = mount(<AddressSection {...defaultProps} isEditingAddress/>);
 
     // Sanity check; make sure the type is what we expect before we change it
     expect(tree.state('editableAddress').stateCode).to.not.equal('');
@@ -257,7 +239,7 @@ describe('<AddressSection>', () => {
   // Not sure how to test this bit yet...
   // it('should scroll to first error', () => {});
 
-  it('should start in the editing state if address is empty and user canUpdate', () => {
+  it('should start in the editing state by calling editAddress() if address is empty and user canUpdate', () => {
     const props = cloneDeep(defaultProps);
     props.savedAddress = {
       addressOne: '',
@@ -268,12 +250,12 @@ describe('<AddressSection>', () => {
       stateCode: '',
       type: ADDRESS_TYPES.domestic
     };
-    const tree = shallow(<AddressSection {...props}/>);
+    const tree = shallow(<AddressSection {...props}/>); // eslint-disable-line
 
-    expect(tree.state('isEditingAddress')).to.be.true;
+    expect(editSpy.called).to.be.true;
   });
 
-  it('should not start editing if address is empty but user !canUpdate', () => {
+  it('should not start editing by calling editAddress() if address is empty but user !canUpdate', () => {
     const props = cloneDeep(defaultProps);
     props.savedAddress = {
       addressOne: '',
@@ -286,8 +268,8 @@ describe('<AddressSection>', () => {
     };
     props.canUpdate = false;
 
-    const component = shallow(<AddressSection {...props}/>);
-    expect(component.state('isEditingAddress')).to.be.false;
+    const component = shallow(<AddressSection {...props}/>); // eslint-disable-line
+    expect(editSpy.called).to.be.false;
   });
 
   it('should render an address help button', () => {
@@ -303,7 +285,7 @@ describe('<AddressSection>', () => {
     afterEach(cleanUpSpies);
 
     it('should run all validations against a field if the address is valid', () => {
-      const tree = mount(<AddressSection {...defaultProps}/>);
+      const tree = mount(<AddressSection {...defaultProps} isEditingAddress/>);
 
       // Start editing
       tree.find('button.usa-button-secondary').simulate('click');
@@ -316,7 +298,7 @@ describe('<AddressSection>', () => {
     });
 
     it('should return the first error message it finds', () => {
-      const tree = mount(<AddressSection {...defaultProps}/>);
+      const tree = mount(<AddressSection {...defaultProps} isEditingAddress/>);
 
       // Start editing
       tree.find('button.usa-button-secondary').simulate('click');
@@ -331,7 +313,7 @@ describe('<AddressSection>', () => {
     });
 
     it('should run validations on modified fields only', () => {
-      const tree = mount(<AddressSection {...defaultProps}/>);
+      const tree = mount(<AddressSection {...defaultProps} isEditingAddress/>);
 
       // Start editing
       tree.find('button.usa-button-secondary').simulate('click');
@@ -354,7 +336,7 @@ describe('<AddressSection>', () => {
     });
 
     it('should run validation against dropdowns immediately', () => {
-      const tree = mount(<AddressSection {...defaultProps}/>);
+      const tree = mount(<AddressSection {...defaultProps} isEditingAddress/>);
 
       // Start editing
       tree.find('.usa-button-secondary').simulate('click');
@@ -374,7 +356,7 @@ describe('<AddressSection>', () => {
     });
 
     it('should run validations on all fields before saving the address', () => {
-      const tree = shallow(<AddressSection {...defaultProps}/>);
+      const tree = shallow(<AddressSection {...defaultProps} isEditingAddress/>);
       tree.instance().saveAddress();
 
       Object.keys(AddressSection.fieldValidations).forEach((key) => {

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -135,7 +135,12 @@ describe('<AddressSection>', () => {
     expect(editSpy.called).to.be.true;
   });
 
-  it('should render edit fields when isEditingAddress is true', () => {});
+  it('should render edit fields when isEditingAddress is true', () => {
+    const tree = mount(<AddressSection {...defaultProps} isEditingAddress/>);
+
+    expect(tree.find('input')).to.have.lengthOf(5);
+    expect(tree.find('select')).to.have.lengthOf(2);
+  });
 
   it('should call saveAddress() when Update button is clicked', () => {
     const tree = mount(<AddressSection {...defaultProps} isEditingAddress/>);

--- a/test/letters/containers/AddressSection.unit.spec.jsx
+++ b/test/letters/containers/AddressSection.unit.spec.jsx
@@ -49,6 +49,16 @@ const defaultProps = {
   statesAvailable: true
 };
 
+const emptyAddress = {
+  addressOne: '',
+  addressTwo: '',
+  addressThree: '',
+  city: '',
+  countryName: '',
+  stateCode: '',
+  type: ADDRESS_TYPES.domestic
+};
+
 
 describe('<AddressSection>', () => {
   beforeEach(() => {
@@ -262,15 +272,7 @@ describe('<AddressSection>', () => {
 
   it('should not start editing by calling editAddress() if address is empty but user !canUpdate', () => {
     const props = cloneDeep(defaultProps);
-    props.savedAddress = {
-      addressOne: '',
-      addressTwo: '',
-      addressThree: '',
-      city: '',
-      countryName: '',
-      stateCode: '',
-      type: ADDRESS_TYPES.domestic
-    };
+    props.savedAddress = emptyAddress;
     props.canUpdate = false;
 
     const component = shallow(<AddressSection {...props}/>); // eslint-disable-line
@@ -280,6 +282,16 @@ describe('<AddressSection>', () => {
   it('should render an address help button', () => {
     const tree = mount(<AddressSection {...defaultProps}/>);
     expect(tree.find('.address-help-btn').exists()).to.be.true;
+  });
+
+  it('should render an empty address warning on the edit screen', () => {
+    const tree = mount(<AddressSection {...defaultProps} isEditingAddress savedAddress={emptyAddress}/>);
+    expect(tree.find('.usa-alert-heading').first().text()).to.equal('VA does not have a valid address on file for you');
+  });
+
+  it('should render an empty address warning on the view screen', () => {
+    const tree = mount(<AddressSection {...defaultProps} savedAddress={emptyAddress}/>);
+    expect(tree.find('.usa-alert-heading').first().text()).to.equal('VA does not have a valid address on file for you');
   });
 
   describe('validation', () => {

--- a/test/letters/containers/DownloadLetters.unit.spec.jsx
+++ b/test/letters/containers/DownloadLetters.unit.spec.jsx
@@ -12,6 +12,9 @@ const defaultProps = {
   },
   router: {
     push: sinon.spy()
+  },
+  address: {
+    address1: 'asdf' // Just something so this isn't seen as a blank address
   }
 };
 

--- a/test/letters/reducers/index.unit.spec.js
+++ b/test/letters/reducers/index.unit.spec.js
@@ -27,6 +27,8 @@ import {
   SAVE_ADDRESS_SUCCESS,
   SAVE_ADDRESS_FAILURE,
   UPDATE_BENFIT_SUMMARY_REQUEST_OPTION,
+  START_EDITING_ADDRESS,
+  CANCEL_EDITING_ADDRESS
 } from '../../../src/js/letters/utils/constants';
 
 function reduce(action, state = initialState) {
@@ -345,5 +347,15 @@ describe('letters reducer', () => {
 
     expect(state.savePending).to.be.false;
     expect(state.saveAddressError).to.be.true;
+  });
+
+  it('should handle editing and address', () => {
+    const state = reduce({ type: START_EDITING_ADDRESS });
+    expect(state.isEditingAddress).to.be.true;
+  });
+
+  it('should handle cancelling editing and address', () => {
+    const state = reduce({ type: CANCEL_EDITING_ADDRESS });
+    expect(state.isEditingAddress).to.be.false;
   });
 });


### PR DESCRIPTION
When we get a blank address from EVSS, the user starts at this screen:
![image](https://user-images.githubusercontent.com/12970166/36925901-ef97282e-1e29-11e8-8b51-35c54790003a.png)
Not featured in the above screenshot is the disabled "View letters" button below the edit content.

If they cancel out of that, they'll go to the view state, which looks like this:
![image](https://user-images.githubusercontent.com/12970166/36925929-10d83f78-1e2a-11e8-81f6-8751ab193bb1.png)

Valid addresses still show up as expected:
![image](https://user-images.githubusercontent.com/12970166/36925996-65239f46-1e2a-11e8-8d64-8f8b4b2d14de.png)
