### PR TITLE
WIP: appeals v2 alerts content edits

### DIFF
--- a/src/js/claims-status/components/appeals-v2/AlertsList.jsx
+++ b/src/js/claims-status/components/appeals-v2/AlertsList.jsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import Alert from './Alert';
 import { getAlertContent } from '../../utils/appeals-v2-helpers';
 
-const AlertsList = ({ alerts }) => {
+const AlertsList = ({ alerts, appealIsActive }) => {
   if (typeof alerts === 'undefined' || alerts.length === 0) {
     return null;
   }
 
-  const allAlertsContent = alerts.map((alert) => getAlertContent(alert));
+  const allAlertsContent = alerts.map((alert) => getAlertContent(alert, appealIsActive));
 
   const takeActionAlerts = allAlertsContent.filter((alert) => (alert.displayType === 'take_action'));
   const infoAlert = allAlertsContent.filter((alert) => (alert.displayType === 'info'));

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -50,7 +50,7 @@ const AppealsV2StatusPage = ({ appeal, fullName }) => {
         title={currentStatus.title}
         description={currentStatus.description}
         isClosed={!appealIsActive}/>
-      <AlertsList alerts={alerts}/>
+      <AlertsList alerts={alerts} appealIsActive/>
       {appealIsActive && <WhatsNext nextEvents={nextEvents}/>}
       {shouldShowDocket && <Docket {...docket} aod={aod} form9Date={form9Date} appealType={appealType}/>}
       {!appealIsActive && <div className="closed-appeal-notice">This appeal is now closed</div>}

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -371,7 +371,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       contents.description = (
         <div>
           <p>
-            The Board of Veterans’ Appeals made a decision on your appeal. Here's an overview of
+            The Board of Veterans’ Appeals made a decision on your appeal. Here’s an overview of
             the decision:
           </p>
           <div className="decision-items">

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -863,8 +863,8 @@ export function getNextEvents(currentStatus, details) {
                 on {formattedSocDate}</strong>, the Decision Review Officer will
                 need to write a new Statement of the Case before sending it
                 to the Board of Veterans’ Appeals. Once your appeal has
-                been sent, you'll need to submit any new evidence directly to the Board.
-                It won't be reviewed by the Veterans Benefits Administration.
+                been sent, you’ll need to submit any new evidence directly to the Board.
+                It won’t be reviewed by the Veterans Benefits Administration.
               </p>
             ),
             durationText: ssocDuration.header,
@@ -934,7 +934,7 @@ export function getNextEvents(currentStatus, details) {
         header: '', // intentionally empty
         events: [
           {
-            title: `You'll have your ${getHearingType(details.type)} hearing`,
+            title: `You’ll have your ${getHearingType(details.type)} hearing`,
             description: (
               <p>
                 Your hearing is scheduled for {formattedDate} at {details.location}. At your hearing,
@@ -1110,7 +1110,7 @@ export function getAlertContent(alert, appealIsActive) {
         title: `You missed your hearing on ${formattedDate}`,
         description: (
           <div>
-            <p>You were scheduled for a hearing on {formattedDate}, but VA records show that you didn’t attend. If you want to request a new hearing, you'll need to send the Board of Veterans’ Appeals a letter that explains why you didn't go to the hearing. You’ll need to send this letter by {formattedDueDate}.</p>
+            <p>You were scheduled for a hearing on {formattedDate}, but VA records show that you didn’t attend. If you want to request a new hearing, you’ll need to send the Board of Veterans’ Appeals a letter that explains why you didn’t go to the hearing. You’ll need to send this letter by {formattedDueDate}.</p>
             <p>Board of Veterans’ Appeals PO Box 27063 Washington, DC 20038</p>
             <p>Please contact your Veterans Service Organization or representative for more information.</p>
           </div>

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -261,7 +261,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
     case STATUS_TYPES.pendingHearingScheduling:
       contents.title = 'You’re waiting for your hearing to be scheduled';
       contents.description = (
-        <p>You requested a {getHearingType(details.type)} hearing on your Form 9. When the Board schedules your hearing, you’ll
+        <p>You requested a {getHearingType(details.type)} hearing on your Form 9. When your hearing is scheduled, you’ll
         get a notice in the mail at least 30 days before the hearing date.</p>
       );
       break;
@@ -269,7 +269,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       const formattedDate = moment(details.date, 'YYYY-MM-DD').format('MMMM Do, YYYY');
       contents.title = 'Your hearing has been scheduled';
       contents.description = (
-        <p>The Board scheduled your {getHearingType(details.type)} hearing for {formattedDate} at {details.location}. If you need to change this
+        <p>Your {getHearingType(details.type)} hearing is scheduled for {formattedDate} at {details.location}. If you need to change this
         date, please contact your Veterans Service Organization or representative as soon as
         possible.</p>
       );
@@ -494,7 +494,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       const nameString = `${first || ''} ${middle || ''} ${last || ''}`;
       contents.title = 'The appeal was closed';
       contents.description = (
-        <p>VA records indicate that {_.startCase(_.toLower(nameString))} is deceased, so the Board has closed this appeal. If
+        <p>VA records show that {_.startCase(_.toLower(nameString))} is deceased, so this appeal has been closed. If
         this information is incorrect, please contact your Veterans Service Organization or
         representative as soon as possible.</p>
       );
@@ -503,7 +503,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
     case STATUS_TYPES.otherClose:
       contents.title = 'Your appeal was closed';
       contents.description = (
-        <p>The Board dismissed or closed your appeal. Please contact your Veterans Service Organization or
+        <p>Your appeal was dismissed or closed. Please contact your Veterans Service Organization or
         representative for more information.</p>
       );
       break;

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -570,7 +570,7 @@ export function getEventContent(event) {
       };
     case EVENT_TYPES.form9:
       return {
-        title: 'Form 9 Recieved',
+        title: 'Form 9 Received',
         description: '',
       };
     case EVENT_TYPES.ssoc:

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -211,7 +211,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
           </p>
           <p>
             If you don’t agree with the Statement of the Case, you can bring your appeal to the Board
-            of Veterans’ Appeals. To do this, you must complete and return a Form 9 within 60 days.
+            of Veterans’ Appeals. To do this, you must complete and return a VA Form 9 within 60 days.
           </p>
         </div>
       );
@@ -220,7 +220,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
     case STATUS_TYPES.pendingCertification:
       contents.title = 'The Decision Review Officer is finishing the review of your appeal';
       contents.description = (
-        <p>The Veterans Benefits Administration received your Form 9 and will send your appeal
+        <p>The Veterans Benefits Administration received your VA Form 9 and will send your appeal
         to the Board of Veterans’ Appeals. But first, the Decision Review Officer must
         finish reviewing all the evidence related to your appeal.</p>
       );
@@ -301,8 +301,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
     case STATUS_TYPES.bvaDevelopment:
       contents.title = 'The judge is asking for more information before making a decision';
       contents.description = (
-        <p>The judge reviewing your case at the Board of Veterans’ Appeals is asking for more evidence or an outside opinion from a legal,
-        medical, or other professional in order to make a decision about your appeal.</p>
+        <p>The Board of Veterans’ Appeals is seeking evidence or an outside opinion from a legal, medical, or other professional necessary to make a decision about your appeal.</p>
       );
       break;
     case STATUS_TYPES.stayed:

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -743,9 +743,7 @@ export function getNextEvents(currentStatus, details) {
             description: (
               <p>
                 <strong>If the Decision Review Officer determines that there’s enough evidence to grant
-                one or more of the issues on your appeal</strong>, they’ll make a new decision. If this
-                decision changes your disability rating or eligibility for VA benefits, 
-                you should see this change made in 1 to 2 months.
+                one or more of the issues on your appeal</strong>, they’ll make a new decision. If this decision changes your disability rating or eligibility for VA benefits, you should see this change made in 1 to 2 months.
               </p>
             ),
             durationText: '',

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -259,7 +259,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       break;
     }
     case STATUS_TYPES.pendingHearingScheduling:
-      contents.title = 'You’re waiting for the Board to schedule your hearing';
+      contents.title = 'You’re waiting for your hearing to be scheduled';
       contents.description = (
         <p>You requested a {getHearingType(details.type)} hearing on your Form 9. When the Board schedules your hearing, you’ll
         get a notice in the mail at least 30 days before the hearing date.</p>
@@ -267,7 +267,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       break;
     case STATUS_TYPES.scheduledHearing: {
       const formattedDate = moment(details.date, 'YYYY-MM-DD').format('MMMM Do, YYYY');
-      contents.title = 'The Board has scheduled your hearing';
+      contents.title = 'Your hearing has been scheduled';
       contents.description = (
         <p>The Board scheduled your {getHearingType(details.type)} hearing for {formattedDate} at {details.location}. If you need to change this
         date, please contact your Veterans Service Organization or representative as soon as
@@ -284,7 +284,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       );
       break;
     case STATUS_TYPES.atVso:
-      contents.title = 'Your Veterans Service Organization is preparing your appeal';
+      contents.title = 'Your appeal is with your Veterans Service Organization';
       contents.description = (
         <p>{details.vsoName} is preparing a document in support of your appeal. For more information,
         please contact your Veterans Service Organization or representative.</p>
@@ -459,7 +459,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       );
       break;
     case STATUS_TYPES.ftr:
-      contents.title = 'We closed your appeal';
+      contents.title = 'Your appeal was closed';
       contents.description = (
         <p>You didn’t take action on something we requested that would have kept your appeal open. If this
         information is incorrect, or if you want to reopen your appeal, please contact your Veterans
@@ -483,7 +483,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       );
       break;
     case STATUS_TYPES.reconsideration:
-      contents.title = 'The Board denied your motion for reconsideration';
+      contents.title = 'Your motion for reconsideration was denied';
       contents.description = (
         <p>The Board of Veterans’ Appeals decided not to reopen your appeal. Please contact your
         Veterans Service Organization or representative for more information.</p>
@@ -492,7 +492,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
     case STATUS_TYPES.death: {
       const { first, middle, last } = name;
       const nameString = `${first || ''} ${middle || ''} ${last || ''}`;
-      contents.title = 'The Board closed this appeal';
+      contents.title = 'The appeal was closed';
       contents.description = (
         <p>VA records indicate that {_.startCase(_.toLower(nameString))} is deceased, so the Board has closed this appeal. If
         this information is incorrect, please contact your Veterans Service Organization or
@@ -501,7 +501,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       break;
     }
     case STATUS_TYPES.otherClose:
-      contents.title = 'The Board closed your appeal';
+      contents.title = 'Your appeal was closed';
       contents.description = (
         <p>The Board dismissed or closed your appeal. Please contact your Veterans Service Organization or
         representative for more information.</p>
@@ -776,7 +776,7 @@ export function getNextEvents(currentStatus, details) {
           also send in new evidence.`,
         events: [
           {
-            title: 'The Decision Review Officer will send your appeal to the Board',
+            title: 'Your appeal will be sent to the Board',
             description: (
               <p>
                 <strong>If you don’t send in new evidence after the Statement of the Case

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -339,7 +339,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
             <h5 className="allowed-items">Allowed</h5>
             <p>
               The judge overrules the original decision and finds {pluralize.allowed} in
-              your favor.
+              your favor
             </p>
             <ul>{allowedIssues}</ul>
           </div>
@@ -349,7 +349,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
         deniedBlock = (
           <div>
             <h5 className="denied-items">Denied</h5>
-            <p>The judge upholds the original decision for the following {pluralize.denied}.</p>
+            <p>The judge upholds the original decision for the following {pluralize.denied}</p>
             <ul>{deniedIssues}</ul>
           </div>
         );
@@ -408,7 +408,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
         allowedBlock = (
           <div>
             <h5 className="allowed-items">Allowed</h5>
-            <p>The judge overrules the original decision and finds {pluralize.allowed} in your favor.</p>
+            <p>The judge overrules the original decision and finds {pluralize.allowed} in your favor</p>
             <ul>{allowedIssues}</ul>
           </div>
         );
@@ -417,7 +417,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
         deniedBlock = (
           <div>
             <h5 className="denied-items">Denied</h5>
-            <p>The judge upholds the original decision for the following {pluralize.denied}.</p>
+            <p>The judge upholds the original decision for the following {pluralize.denied}</p>
             <ul>{deniedIssues}</ul>
           </div>
         );

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -624,7 +624,7 @@ export function getEventContent(event) {
       };
     case EVENT_TYPES.recordDesignation:
       return {
-        title: 'Designation of record',
+        title: 'Designation of Record',
         description: '',
       };
     case EVENT_TYPES.reconsideration:

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -1164,7 +1164,6 @@ export function getAlertContent(alert) {
     }
     case ALERT_TYPES.decisionSoon:
       return {
-        // TODO: confirm which of duplicate content is correct
         title: 'Decision soon',
         description: (
           <p>Your appeal will soon receive a Board decision. Sending in new evidence at this time could delay review of your appeal. If you’ve moved recently, please make sure that VA has your current mailing address.</p>
@@ -1175,7 +1174,6 @@ export function getAlertContent(alert) {
     case ALERT_TYPES.blockedByVso:
       return {
         title: 'A judge cannot review your appeal',
-        // TODO: confirm vsoName variable
         description: (
           <p>Your appeal is eligible to be assigned to a judge based on its place in line, but they are prevented from reviewing your appeal because your Veteran Service Organization, {details.vsoName}, is currently reviewing it. For more information, please contact your Veteran Service Organization or representative.</p>
         ),
@@ -1191,7 +1189,6 @@ export function getAlertContent(alert) {
       const formattedDueDate = formatDate(details.dueDate);
       return {
         title: 'What if I disagree with my decision?',
-        // TODO: confirm this link display format
         description: (
           <p>If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You will need to hire a VA-accredited attorney to represent you, or you may represent yourself. You will need to file your Court appeal by {formattedDueDate}. For more information, review the document “Your Rights to Appeal Our Decision” enclosed with the Board’s decision, visit the <a href="https://www.uscourts.cavc.gov/appeal.php">Court’s website</a>, or contact your Veteran Service Organization or representative.</p>
         ),

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -1193,7 +1193,7 @@ export function getAlertContent(alert) {
         title: 'What if I disagree with my decision?',
         // TODO: confirm this link display format
         description: (
-          <p>If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You will need to hire a VA-accredited attorney to represent you, or you may represent yourself. You will need to file your Court appeal by {formattedDueDate}. For more information, review the document “Your Rights to Appeal Our Decision” enclosed with the Board’s decision, visit the Court’s website (<a href="https://www.uscourts.cavc.gov/appeal.php">https://www.uscourts.cavc.gov/appeal.php</a>), or contact your Veteran Service Organization or representative.</p>
+          <p>If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You will need to hire a VA-accredited attorney to represent you, or you may represent yourself. You will need to file your Court appeal by {formattedDueDate}. For more information, review the document “Your Rights to Appeal Our Decision” enclosed with the Board’s decision, visit the <a href="https://www.uscourts.cavc.gov/appeal.php">Court’s website</a>, or contact your Veteran Service Organization or representative.</p>
         ),
         displayType: 'info',
         type,

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -1069,16 +1069,11 @@ export function getNextEvents(currentStatus, details) {
  * @returns {alertOutput} dynamically-generated title, description, and styling properties
  */
 export function getAlertContent(alert) {
-  const { type, details, date, dueDate } = alert;
-  // TODO: confirm new date/dueDate usages
-  const formattedDate = moment(date, 'YYYY-MM-DD').format('MMMM DD, YYYY');
-  const formattedDueDate = moment(dueDate, 'YYYY-MM-DD').format('MMMM DD, YYYY');
-  // TODO: confirm status logic and property
-  const statusDescription = details.status === 'open' ? 'is active at the Board of Veterans’ Appeals' : 'is closed'; // Used in ramp_ineligible alert
+  const { type, details } = alert;
 
   switch (type) {
     case ALERT_TYPES.form9Needed: {
-
+      const formattedDueDate = formatDate(details.dueDate);
       return {
         title: `Return the VA Form 9 by ${formattedDueDate} in order to continue your appeal`,
         description: (
@@ -1099,19 +1094,21 @@ export function getAlertContent(alert) {
       };
     }
     case ALERT_TYPES.scheduledHearing: {
+      const formattedDate = formatDate(details.date);
       return {
         title: (
           <span>A hearing has been scheduled. <a href="/disability-benefits/claims-appeal/hearings/">Learn more about hearings, including how to prepare for, reschedule, or cancel your hearing</a>.</span>
         ),
-        // TODO: determine whether details.type or type should be used here
         description: (
-          <p>Your {type} hearing is scheduled for {formattedDate} at {details.location}.</p>
+          <p>Your {getHearingType(details.type)} hearing is scheduled for {formattedDate} at {details.location}.</p>
         ),
         displayType: 'take_action',
         type
       };
     }
     case ALERT_TYPES.hearingNoShow: {
+      const formattedDate = formatDate(details.date);
+      const formattedDueDate = formatDate(details.dueDate);
       return {
         title: `You missed your hearing on ${formattedDate}`,
         description: (
@@ -1126,6 +1123,7 @@ export function getAlertContent(alert) {
       };
     }
     case ALERT_TYPES.heldForEvidence: {
+      const formattedDueDate = formatDate(details.dueDate);
       return {
         title: 'Your appeals case is being held open',
         description: (
@@ -1138,7 +1136,8 @@ export function getAlertContent(alert) {
         type
       };
     }
-    case ALERT_TYPES.rampEligible:
+    case ALERT_TYPES.rampEligible: {
+      const formattedDate = formatDate(details.date);
       return {
         title: 'This appeal is eligible for the Rapid Appeals Modernization Program',
         description: (
@@ -1150,7 +1149,10 @@ export function getAlertContent(alert) {
         displayType: 'info',
         type,
       };
-    case ALERT_TYPES.rampIneligible:
+    }
+    case ALERT_TYPES.rampIneligible: {
+      const statusDescription = details.appeal.attributes.active ? 'is active at the Board of Veterans’ Appeals' : 'is closed';
+      const formattedDate = formatDate(details.date);
       return {
         title: 'This appeal is not eligible for the Rapid Appeals Modernization Program',
         description: (
@@ -1159,6 +1161,7 @@ export function getAlertContent(alert) {
         displayType: 'info',
         type,
       };
+    }
     case ALERT_TYPES.decisionSoon:
       return {
         // TODO: confirm which of duplicate content is correct
@@ -1184,7 +1187,8 @@ export function getAlertContent(alert) {
       return {};
     case ALERT_TYPES.droHearingNoShow:
       return {};
-    case ALERT_TYPES.cavcOption:
+    case ALERT_TYPES.cavcOption: {
+      const formattedDueDate = formatDate(details.dueDate);
       return {
         title: 'What if I disagree with my decision?',
         // TODO: confirm this link display format
@@ -1194,6 +1198,7 @@ export function getAlertContent(alert) {
         displayType: 'info',
         type,
       };
+    }
     default:
       return {
         title: '',

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -194,9 +194,9 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       contents.title = 'A Decision Review Officer is reviewing your appeal';
       contents.description = (
         <p>The Veterans Benefits Administration received your Notice of Disagreement. A Decision
-        Review Officer will review all of the evidence related to your appeal, including any new
-        evidence you sent. The officer may contact you to request additional evidence or medical
-        examinations, as needed. When the officer has completed their review, they will determine
+        Review Officer will review all the evidence related to your appeal, including any new
+        evidence you sent. The officer may contact you to ask for more evidence or medical
+        exams as needed. When the officer has completed the review, they’ll determine
         whether or not they can grant your appeal.</p>
       );
       break;
@@ -207,22 +207,22 @@ export function getStatusContents(statusType, details = {}, name = {}) {
         <div>
           <p>
             The Veterans Benefits Administration sent you a Statement of the Case on {formattedSocDate}. The
-            Statement of the Case explains the reasons why they could not fully grant your appeal.
+            Statement of the Case explains why they couldn’t fully grant your appeal.
           </p>
           <p>
             If you don’t agree with the Statement of the Case, you can bring your appeal to the Board
-            of Veterans’ Appeals. To do this you must complete and return a Form 9 within 60 days.
+            of Veterans’ Appeals. To do this, you must complete and return a Form 9 within 60 days.
           </p>
         </div>
       );
       break;
     }
     case STATUS_TYPES.pendingCertification:
-      contents.title = 'The Decision Review Officer is finishing their review of your appeal';
+      contents.title = 'The Decision Review Officer is finishing the review of your appeal';
       contents.description = (
-        <p>The Veterans Benefits Administration received your Form 9 and will transfer your appeal
-        to the Board of Veterans’ Appeals. Before doing so, the Decision Review Officer must
-        certify that they have finished reviewing all of the evidence related to your appeal.</p>
+        <p>The Veterans Benefits Administration received your Form 9 and will send your appeal
+        to the Board of Veterans’ Appeals. But first, the Decision Review Officer must
+        finish reviewing all the evidence related to your appeal.</p>
       );
       break;
     case STATUS_TYPES.pendingCertificationSsoc: {
@@ -240,8 +240,8 @@ export function getStatusContents(statusType, details = {}, name = {}) {
               to your appeal, and/or
             </li>
             <li>
-              VA found it had further duty to assist you in developing your appeal, such as helping
-              you get treatment records or providing a physical exam if needed.
+              VA determined that we need to help you develop your appeal, such as helping
+              you get treatment records or giving you a physical exam if needed.
             </li>
           </ul>
         </div>
@@ -253,24 +253,24 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       contents.title = 'Please review your new Statement of the Case';
       contents.description = (
         <p>The Veterans Benefits Administration sent you a new Statement of the Case on {formattedSocDate}
-        because after completing the remand instructions from the Board, they couldn’t fully grant
+        because, after completing the remand instructions from the Board, they couldn’t fully grant
         your appeal.</p>
       );
       break;
     }
     case STATUS_TYPES.pendingHearingScheduling:
-      contents.title = 'You’re waiting for your hearing to be scheduled';
+      contents.title = 'You’re waiting for the Board to schedule your hearing';
       contents.description = (
-        <p>You requested a {getHearingType(details.type)} hearing on your Form 9. When your hearing is scheduled, you will
-        receive a notice in the mail at least 30 days before the hearing date.</p>
+        <p>You requested a {getHearingType(details.type)} hearing on your Form 9. When the Board schedules your hearing, you’ll
+        get a notice in the mail at least 30 days before the hearing date.</p>
       );
       break;
     case STATUS_TYPES.scheduledHearing: {
       const formattedDate = moment(details.date, 'YYYY-MM-DD').format('MMMM Do, YYYY');
-      contents.title = 'Your hearing has been scheduled';
+      contents.title = 'The Board has scheduled your hearing';
       contents.description = (
-        <p>Your {getHearingType(details.type)} hearing is scheduled for {formattedDate} at {details.location}. If you need to change this
-        date, please contact your Veteran Service Organization or representative as soon as
+        <p>The Board scheduled your {getHearingType(details.type)} hearing for {formattedDate} at {details.location}. If you need to change this
+        date, please contact your Veterans Service Organization or representative as soon as
         possible.</p>
       );
       break;
@@ -278,16 +278,16 @@ export function getStatusContents(statusType, details = {}, name = {}) {
     case STATUS_TYPES.onDocket:
       contents.title = 'Your appeal is waiting to be assigned to a judge';
       contents.description = (
-        <p>Your appeal is at the Board of Veterans’ Appeals waiting to be assigned to a Veterans
-        Law Judge. Staff at the Board will make sure that your case is complete, accurate, and
+        <p>Your appeal is at the Board of Veterans’ Appeals, waiting to be assigned to a Veterans
+        Law Judge. Staff at the Board will make sure your case is complete, accurate, and
         ready to be decided by a judge.</p>
       );
       break;
     case STATUS_TYPES.atVso:
-      contents.title = 'Your appeal is currently with your Veteran Service Organization';
+      contents.title = 'Your Veterans Service Organization is preparing your appeal';
       contents.description = (
-        <p>{details.vsoName} is currently preparing a document in support of your appeal. For more information,
-        please contact your Veteran Service Organization or representative.</p>
+        <p>{details.vsoName} is preparing a document in support of your appeal. For more information,
+        please contact your Veterans Service Organization or representative.</p>
       );
       break;
     case STATUS_TYPES.decisionInProgress:
@@ -295,22 +295,22 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       contents.description = (
         <p>Your appeal is at the Board of Veterans’ Appeals being reviewed by a Veterans Law Judge
         and their team of attorneys. If you submit evidence that isn’t already included in your
-        case, this may delay your appeal.</p>
+        case, it may delay your appeal.</p>
       );
       break;
     case STATUS_TYPES.bvaDevelopment:
-      contents.title = 'The judge is seeking additional information before making a decision';
+      contents.title = 'The judge is asking for more information before making a decision';
       contents.description = (
-        <p>The Board of Veterans’ Appeals is seeking evidence or an outside opinion from a legal,
-        medical, or other professional necessary to make decision about your appeal.</p>
+        <p>The judge reviewing your case at the Board of Veterans’ Appeals is asking for more evidence or an outside opinion from a legal,
+        medical, or other professional in order to make a decision about your appeal.</p>
       );
       break;
     case STATUS_TYPES.stayed:
       contents.title = 'The Board is waiting until a higher court makes a decision';
       contents.description = (
-        <p>A higher court has requested that a group of appeals currently before the Board of
-        Veterans’ Appeals be held open. This is because the decision the court makes on a different
-        appeal could impact your appeal.</p>
+        <p>A higher court has asked the Board of
+        Veterans’ Appeals to hold open a group of appeals awaiting review. Yours is one of the appeals held open. The higher court believes that a decision it will make on a different
+        appeal could affect yours.</p>
       );
       break;
     case STATUS_TYPES.remand: {
@@ -340,7 +340,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
             <h5 className="allowed-items">Allowed</h5>
             <p>
               The judge overrules the original decision and finds {pluralize.allowed} in
-              your favor
+              your favor.
             </p>
             <ul>{allowedIssues}</ul>
           </div>
@@ -350,7 +350,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
         deniedBlock = (
           <div>
             <h5 className="denied-items">Denied</h5>
-            <p>The judge upholds the original decision for the following {pluralize.denied}</p>
+            <p>The judge upholds the original decision for the following {pluralize.denied}.</p>
             <ul>{deniedIssues}</ul>
           </div>
         );
@@ -360,8 +360,8 @@ export function getStatusContents(statusType, details = {}, name = {}) {
           <div>
             <h5 className="remand-items">Remand</h5>
             <p>
-              The judge needs additional evidence to be collected or a procedural error to be
-              corrected for the following {pluralize.remand}
+              The judge needs more evidence to be collected or a error in procedure to be
+              corrected for the following {pluralize.remand}.
             </p>
             <ul>{remandIssues}</ul>
           </div>
@@ -372,7 +372,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       contents.description = (
         <div>
           <p>
-            The Board of Veterans’ Appeals made a decision on your appeal. Here is an overview of
+            The Board of Veterans’ Appeals made a decision on your appeal. Here's an overview of
             the decision:
           </p>
           <div className="decision-items">
@@ -382,7 +382,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
           </div>
           <p>
             If this decision changes your disability rating or your eligibility for VA benefits,
-            you should expect this adjustment to be made in 1 to 2 months.
+            you should see this change made in 1 to 2 months.
           </p>
         </div>
       );
@@ -409,7 +409,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
         allowedBlock = (
           <div>
             <h5 className="allowed-items">Allowed</h5>
-            <p>The judge overrules the original decision and finds {pluralize.allowed} in your favor</p>
+            <p>The judge overrules the original decision and finds {pluralize.allowed} in your favor.</p>
             <ul>{allowedIssues}</ul>
           </div>
         );
@@ -418,7 +418,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
         deniedBlock = (
           <div>
             <h5 className="denied-items">Denied</h5>
-            <p>The judge upholds the original decision for the following {pluralize.denied}</p>
+            <p>The judge upholds the original decision for the following {pluralize.denied}.</p>
             <ul>{deniedIssues}</ul>
           </div>
         );
@@ -428,7 +428,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       contents.description = (
         <div>
           <p>
-            The Board of Veterans’ Appeals made a decision on your appeal. Here is an overview of
+            The Board of Veterans’ Appeals made a decision on your appeal. Here’s an overview of
             the decision:
           </p>
           <div className="decision-items">
@@ -437,7 +437,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
           </div>
           <p>
             If this decision changes your disability rating or your eligibility for VA benefits,
-            you should expect this adjustment to be made in 1 to 2 months.
+            you should see this change made in 1 to 2 months.
           </p>
         </div>
       );
@@ -448,68 +448,68 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       contents.description = (
         <p>The Veterans Benefits Administration agreed with you and decided to overturn the
         original decision. If this decision changes your disability rating or eligibility for VA
-        benefits, you should expect this adjustment to be made in 1 to 2 months.</p>
+        benefits, you should see this change made in 1 to 2 months.</p>
       );
       break;
     case STATUS_TYPES.withdrawn:
       contents.title = 'You withdrew your appeal';
       contents.description = (
-        <p>You have opted to not continue your appeal. If this information is incorrect, please
-        contact your Veteran Service Organization or representative for more information.</p>
+        <p>You have decided not to continue your appeal. If this information is incorrect, please
+        contact your Veterans Service Organization or representative for more information.</p>
       );
       break;
     case STATUS_TYPES.ftr:
-      contents.title = 'Your appeal was closed';
+      contents.title = 'We closed your appeal';
       contents.description = (
-        <p>You did not take an action VA requested in order to continue your appeal. If this
-        information is incorrect, or if you want to reopen your appeal, please contact your Veteran
+        <p>You didn’t take action on something we requested that would have kept your appeal open. If this
+        information is incorrect, or if you want to reopen your appeal, please contact your Veterans
         Service Organization or representative for more information.</p>
       );
       break;
     case STATUS_TYPES.ramp:
-      contents.title = 'You opted in to the Rapid Appeals Modernization Program (RAMP)';
+      contents.title = 'You chose to take part in the Rapid Appeals Modernization Program (RAMP)';
       contents.description = (
         <div>
           <p>
             You chose to participate in the new supplemental claim or higher-level review lanes.
-            This does not mean that your appeal has been closed. If this information is incorrect,
-            please contact your Veteran Service Organization or representative as soon as possible.
+            This doesn’t mean that we’ve closed your appeal. If this information is incorrect,
+            please contact your Veterans Service Organization or representative as soon as possible.
           </p>
           <p>
-            At this time, Vets.gov is not able to provide information about appeals that are part
+            At this time, Vets.gov isn’t able to provide information about appeals that are part
             of RAMP.
           </p>
         </div>
       );
       break;
     case STATUS_TYPES.reconsideration:
-      contents.title = 'Your motion for reconsideration was denied';
+      contents.title = 'The Board denied your motion for reconsideration';
       contents.description = (
-        <p>The Board of Veterans’ Appeals declined to reopen your appeal. Please contact your
-        Veteran Service Organization or representative for more information.</p>
+        <p>The Board of Veterans’ Appeals decided not to reopen your appeal. Please contact your
+        Veterans Service Organization or representative for more information.</p>
       );
       break;
     case STATUS_TYPES.death: {
       const { first, middle, last } = name;
       const nameString = `${first || ''} ${middle || ''} ${last || ''}`;
-      contents.title = 'The appeal was closed';
+      contents.title = 'The Board closed this appeal';
       contents.description = (
-        <p>VA records indicate that {_.startCase(_.toLower(nameString))} is deceased, so this appeal has been closed. If
-        this information is incorrect, please contact your Veteran Service Organization or
+        <p>VA records indicate that {_.startCase(_.toLower(nameString))} is deceased, so the Board has closed this appeal. If
+        this information is incorrect, please contact your Veterans Service Organization or
         representative as soon as possible.</p>
       );
       break;
     }
     case STATUS_TYPES.otherClose:
-      contents.title = 'Your appeal was closed';
+      contents.title = 'The Board closed your appeal';
       contents.description = (
-        <p>Your appeal was dismissed or closed. Please contact your Veteran Service Organization or
+        <p>The Board dismissed or closed your appeal. Please contact your Veterans Service Organization or
         representative for more information.</p>
       );
       break;
     default:
-      contents.title = 'Current Appeal Status Unknown';
-      contents.description = <p>Your current appeal status is unknown at this time</p>;
+      contents.title = 'We don’t know your appeal status';
+      contents.description = <p>Your appeal status is unknown at this time</p>;
   }
 
   return contents;
@@ -555,7 +555,7 @@ export function getEventContent(event) {
       };
     case EVENT_TYPES.droHearing:
       return {
-        title: 'Dro Hearing',
+        title: 'DRO Hearing',
         description: '',
       };
     case EVENT_TYPES.fieldGrant:
@@ -570,7 +570,7 @@ export function getEventContent(event) {
       };
     case EVENT_TYPES.form9:
       return {
-        title: 'Form 9 Received',
+        title: 'Form 9 received',
         description: '',
       };
     case EVENT_TYPES.ssoc:
@@ -590,12 +590,12 @@ export function getEventContent(event) {
       };
     case EVENT_TYPES.hearingCancelled:
       return {
-        title: 'Hearing Cancelled',
+        title: 'Hearing canceled',
         description: '',
       };
     case EVENT_TYPES.hearingNoShow:
       return {
-        title: 'Hearing No Show',
+        title: 'Hearing no show',
         description: '',
       };
     case EVENT_TYPES.bvaDecision:
@@ -605,7 +605,7 @@ export function getEventContent(event) {
       };
     case EVENT_TYPES.bvaRemand:
       return {
-        title: 'Board Remand',
+        title: 'Board remand',
         description: '',
       };
     case EVENT_TYPES.withdrawn:
@@ -620,22 +620,22 @@ export function getEventContent(event) {
       };
     case EVENT_TYPES.cavcDecision:
       return {
-        title: 'CAVC Decision',
+        title: 'CAVC decision',
         description: '',
       };
     case EVENT_TYPES.recordDesignation:
       return {
-        title: 'Designation of Record',
+        title: 'Designation of record',
         description: '',
       };
     case EVENT_TYPES.reconsideration:
       return {
-        title: 'Reconsideration by Letter',
+        title: 'Reconsideration by letter',
         description: '',
       };
     default:
       return {
-        title: 'Unknown Event',
+        title: 'Unknown event',
         description: '',
       };
   }
@@ -645,8 +645,8 @@ export function getEventContent(event) {
 const DECISION_REVIEW_CONTENT = (
   <div>
     <p>
-      A Veterans Law Judge, working with their team of attorneys, will review all of the
-      available evidence and write a decision. For each issue you are appealing, they can
+      A Veterans Law Judge, working with their team of attorneys, will review all the
+      available evidence and write a decision. For each issue you’re appealing, they can
       decide to:
     </p>
     <ul className="decision-review-list">
@@ -656,7 +656,7 @@ const DECISION_REVIEW_CONTENT = (
       </li>
       <li><strong>Deny:</strong> The judge upholds the original decision.</li>
       <li>
-        <strong>Remand:</strong> The judge is sending the issue back to the Veterans
+        <strong>Remand:</strong> The judge sends the issue back to the Veterans
         Benefits Administration to gather more evidence or to fix a mistake before
         making a decision.
       </li>
@@ -743,10 +743,10 @@ export function getNextEvents(currentStatus, details) {
             title: 'The Veterans Benefits Administration will grant some or all of your appeal',
             description: (
               <p>
-                <strong>If the Decision Review Officer determines that there is enough evidence to grant
-                one or more of the issues on your appeal</strong>, they will make a new decision. If this
-                decision changes your disability rating or eligibility for VA benefits, you should
-                expect this change to be made in 1 to 2 months.
+                <strong>If the Decision Review Officer determines that there’s enough evidence to grant
+                one or more of the issues on your appeal</strong>, they’ll make a new decision. If this
+                decision changes your disability rating or eligibility for VA benefits, 
+                you should see this change made in 1 to 2 months.
               </p>
             ),
             durationText: '',
@@ -755,8 +755,8 @@ export function getNextEvents(currentStatus, details) {
             title: 'The Veterans Benefits Administration will send you a Statement of the Case',
             description: (
               <p>
-                <strong>If the Decision Review Officer determines that there is not enough evidence to
-                fully grant your appeal</strong>, they will send you their findings in a document called
+                <strong>If the Decision Review Officer determines that there’s not enough evidence to
+                fully grant your appeal</strong>, they’ll send you their findings in a document called
                 a Statement of the Case. You can then decide whether to continue your appeal to the
                 Board of Veterans’ Appeals.
               </p>

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -776,30 +776,30 @@ export function getNextEvents(currentStatus, details) {
           also send in new evidence.`,
         events: [
           {
-            title: 'Your appeal will be sent to the Board',
+            title: 'The Decision Review Officer will send your appeal to the Board',
             description: (
               <p>
                 <strong>If you don’t send in new evidence after the Statement of the Case
                 on {formattedSocDate}</strong>, the Decision Review Officer will finish
-                their review and transfer your case to the Board of Veterans’ Appeals.
+                their review and send your case to the Board of Veterans’ Appeals.
               </p>
             ),
             durationText: certDuration.header,
-            cardDescription: `The Veterans Benefits Administration typically takes ${certDuration.description} to transfer cases to the Board.`
+            cardDescription: `The Veterans Benefits Administration usually takes ${certDuration.description} to send cases to the Board.`
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
               <p>
                 <strong>If you send in new evidence after the Statement of the Case
                 on {formattedSocDate}</strong>, the Decision Review Officer will need
-                to write a new Statement of the Case before transferring your case to
-                the Board of Veterans’ Appeals. Once your appeal is transferred, new
-                evidence can be sent directly to the Board and will not be reviewed by
+                to write a new Statement of the Case before sending it to
+                the Board of Veterans’ Appeals. Once your appeal has been sent, you’ll need to submit any new
+                evidence directly to the Board. It won’t be reviewed by
                 the Veterans Benefits Administration.
               </p>
             ),
             durationText: ssocDuration.header,
-            cardDescription: `The Veterans Benefits Administration typically takes ${ssocDuration.description} to write additional Statements of the Case.`
+            cardDescription: `The Veterans Benefits Administration usually takes ${ssocDuration.description} to write new Statements of the Case.`
           },
         ]
       };
@@ -817,25 +817,25 @@ export function getNextEvents(currentStatus, details) {
               <p>
                 <strong>If you don’t send in new evidence after the Statement of the Case
                 on {formattedSocDate}</strong>, the Decision Review Officer will finish
-                their review and transfer your case to the Board of Veterans’ Appeals.
+                the review and send your case to the Board of Veterans’ Appeals.
               </p>
             ),
             durationText: certDuration.header,
-            cardDescription: `The Veterans Benefits Administration typically takes ${certDuration.description} to transfer cases to the Board.`
+            cardDescription: `The Veterans Benefits Administration usually takes ${certDuration.description} to send cases to the Board.`
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
               <p>
                 <strong>If you send in new evidence after the Statement of the Case
                 on {formattedSocDate}</strong>, the Decision Review Officer will need
-                to write a new Statement of the Case before transferring your case to
-                the Board of Veterans’ Appeals. Once your appeal is transferred, new
-                evidence can be sent directly to the Board and will not be reviewed by
+                to write a new Statement of the Case before sending it to
+                the Board of Veterans’ Appeals. Once your appeal has been sent, you’ll need to submit any new
+                evidence directly to the Board. It won’t be reviewed by
                 the Veterans Benefits Administration.
               </p>
             ),
             durationText: ssocDuration.header,
-            cardDescription: `The Veterans Benefits Administration typically takes ${ssocDuration.description} to write additional Statements of the Case.`
+            cardDescription: `The Veterans Benefits Administration usually takes ${ssocDuration.description} to write new Statements of the Case.`
           }
         ]
       };
@@ -853,25 +853,25 @@ export function getNextEvents(currentStatus, details) {
               <p>
                 <strong>If you don’t send in new evidence after the Statement of the Case
                 on {formattedSocDate}</strong>, the Decision Review Officer will finish
-                their review and transfer your case to the Board of Veterans’ Appeals.
+                the review and send your case to the Board of Veterans’ Appeals.
               </p>
             ),
             durationText: certDuration.header,
-            cardDescription: `The Veterans Benefits Administration typically takes ${certDuration.description} to transfer cases to the Board.`
+            cardDescription: `The Veterans Benefits Administration ususally takes ${certDuration.description} to send cases to the Board.`
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
               <p>
                 <strong>If you send new evidence after the Statement of the Case
                 on {formattedSocDate}</strong>, the Decision Review Officer will
-                need to write a new Statement of the Case before transferring your
-                case to the Board of Veterans’ Appeals. Once your appeal is
-                transferred, new evidence can be sent directly to the Board and
-                will not be reviewed by the Veterans Benefits Administration.
+                need to write a new Statement of the Case before sending it
+                to the Board of Veterans’ Appeals. Once your appeal has
+                been sent, you'll need to submit any new evidence directly to the Board.
+                It won't be reviewed by the Veterans Benefits Administration.
               </p>
             ),
             durationText: ssocDuration.header,
-            cardDescription: `The Veterans Benefits Administration typically takes ${ssocDuration.description} to write additional Statements of the Case.`
+            cardDescription: `The Veterans Benefits Administration usually takes ${ssocDuration.description} to write new Statements of the Case.`
           }
         ]
       };
@@ -894,7 +894,7 @@ export function getNextEvents(currentStatus, details) {
               </p>
             ),
             durationText: returnSsocDuration.header,
-            cardDescription: `The Veterans Benefits Administration typically takes ${returnSsocDuration.description} to return cases to the Board.`,
+            cardDescription: `The Veterans Benefits Administration usually takes ${returnSsocDuration.description} to return cases to the Board.`,
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (
@@ -906,7 +906,7 @@ export function getNextEvents(currentStatus, details) {
               </p>
             ),
             durationText: remandSsocDuration.header,
-            cardDescription: `The Veterans Benefits Administration typically takes ${remandSsocDuration.description} to write additional Statements of the Case.`,
+            cardDescription: `The Veterans Benefits Administration usually takes ${remandSsocDuration.description} to write new Statements of the Case.`,
           }
         ]
       };
@@ -916,12 +916,12 @@ export function getNextEvents(currentStatus, details) {
         header: '', // intentionally empty
         events: [
           {
-            title: `You will have your ${getHearingType(details.type)} hearing`,
+            title: `You’ll have your ${getHearingType(details.type)} hearing`,
             description: (
               <p>
                 At your hearing, a Veterans Law Judge will ask you questions about your appeal. A
                 transcript of your hearing will be taken and added to your appeal file. The judge
-                will not make a decision about your appeal at the hearing. Learn more about hearings,
+                won’t make a decision about your appeal at the hearing. Learn more about hearings,
                 including how to request a different kind of hearing or withdraw your hearing
                 request.
               </p>
@@ -937,12 +937,12 @@ export function getNextEvents(currentStatus, details) {
         header: '', // intentionally empty
         events: [
           {
-            title: `You will have your ${getHearingType(details.type)} hearing`,
+            title: `You'll have your ${getHearingType(details.type)} hearing`,
             description: (
               <p>
                 Your hearing is scheduled for {formattedDate} at {details.location}. At your hearing,
                 a Veterans Law Judge will ask you questions about your appeal. A transcript of your
-                hearing will be taken and added to your appeal file. The judge will not make a
+                hearing will be taken and added to your appeal file. The judge won’t make a
                 decision about your appeal at the hearing. Learn more about hearings, including how
                 to prepare for your hearing.
               </p>
@@ -1025,14 +1025,14 @@ export function getNextEvents(currentStatus, details) {
             title: 'The Veterans Benefits Administration completes the remand instructions',
             description: (
               <p>
-                They may contact you to request additional evidence or medical examinations, as
-                needed. When they have completed the remand instructions, they will determine whether
+                They may contact you to request more evidence or medical exams as
+                needed. When they have completed the remand instructions, they’ll determine whether
                 or not they can grant your appeal. If not, your appeal will return to the Board of
                 Veterans’ Appeals for a new decision.
               </p>
             ),
             durationText: remandDuration.header,
-            cardDescription: `The Veterans Benefits Administration typically takes ${remandDuration.description} to complete remand instructions.`
+            cardDescription: `The Veterans Benefits Administration usually takes ${remandDuration.description} to complete remand instructions.`
           }
         ]
       };
@@ -1043,7 +1043,7 @@ export function getNextEvents(currentStatus, details) {
         events: [
           {
             title: 'Unknown event',
-            description: (<p>We could not find the next event in your appeal</p>),
+            description: (<p>We couldn’t find the next event in your appeal</p>),
             durationText: '',
             cardDescription: ''
           }
@@ -1081,11 +1081,11 @@ export function getAlertContent(alert, appealIsActive) {
             <p>
               A VA Form 9 was included with your Statement of the Case. By completing and returning
               the form, you continue your appeal to the Board of Veterans’ Appeals. On this form,
-              you can request a hearing with a Veterans Law Judge, if you would like one.
+              you can request a hearing with a Veterans Law Judge if you’d like one.
             </p>
             <p>
               If you need help understanding your Statement of the Case or completing the Form
-              9, contact your Veteran Service Organization or representative.
+              9, contact your Veterans Service Organization or representative.
             </p>
           </div>
         ),
@@ -1113,9 +1113,9 @@ export function getAlertContent(alert, appealIsActive) {
         title: `You missed your hearing on ${formattedDate}`,
         description: (
           <div>
-            <p>You were scheduled for a hearing on {formattedDate}, but VA records show that you did not attend. If you want to request a new hearing, you will need to send the Board of Veterans’ Appeals a letter that explains why you were unable to attend the hearing. You must send this letter by {formattedDueDate}.</p>
-            <p>Board of Veterans’ Appeals P.O. Box 27063 Washington, DC 20038</p>
-            <p>Please contact your Veteran Service Organization or representative for more information.</p>
+            <p>You were scheduled for a hearing on {formattedDate}, but VA records show that you didn’t attend. If you want to request a new hearing, you'll need to send the Board of Veterans’ Appeals a letter that explains why you didn't go to the hearing. You’ll need to send this letter by {formattedDueDate}.</p>
+            <p>Board of Veterans’ Appeals PO Box 27063 Washington, DC 20038</p>
+            <p>Please contact your Veterans Service Organization or representative for more information.</p>
           </div>
         ),
         displayType: 'take_action',
@@ -1128,8 +1128,8 @@ export function getAlertContent(alert, appealIsActive) {
         title: 'Your appeals case is being held open',
         description: (
           <div>
-            <p>You or your representative asked the Board of Veterans’ Appeals to hold your case open while you gather additional evidence to support your appeal. Please send your evidence to the Board by {formattedDueDate}.</p>
-            <p>Board of Veterans’ Appeals P.O. Box 27063 Washington, DC 20038</p>
+            <p>You or your representative asked the Board of Veterans’ Appeals to hold your case open while you gather more evidence to support your appeal. Please send your evidence to the Board by {formattedDueDate}.</p>
+            <p>Board of Veterans’ Appeals PO Box 27063 Washington, DC 20038</p>
           </div>
         ),
         displayType: 'take_action',
@@ -1142,8 +1142,8 @@ export function getAlertContent(alert, appealIsActive) {
         title: 'This appeal is eligible for the Rapid Appeals Modernization Program',
         description: (
           <div>
-            <p>On {formattedDate}, VA sent you a letter informing you of a new program called the Rapid Appeals Modernization Program (RAMP). The Veterans Appeals Improvement and Modernization Act will create new options in 2019 for Veterans seeking review of VA decisions. RAMP is a program that allows you to opt in to one of the two new "lanes" for review before the new law takes effect. For more information, review the fact sheet that was enclosed with the letter.</p>
-            <p>In order to participate, you must return the RAMP Opt-in Election form. If you choose to participate in RAMP, VA will withdraw all of your eligible appeals and instead review your case using the lane you select. If you do not want to participate in RAMP and wish to continue your appeal under the existing process, no action is required.</p>
+            <p>On {formattedDate}, VA sent you a letter to let you know about a new program called the Rapid Appeals Modernization Program (RAMP). The Veterans Appeals Improvement and Modernization Act will create new options in 2019 for Veterans seeking review of VA decisions. RAMP is a program that allows you to participate in one of the two new "lanes" for review before the new law takes effect. For more information, review the fact sheet that was enclosed with the letter.</p>
+            <p>In order to take part in this program, you must return the RAMP Opt-in Election form. If you choose to participate in RAMP, VA will withdraw all of your eligible appeals and instead review your case using the lane you select. If you don’t want to participate in RAMP and would like to continue your appeal under the existing process, you don’t need to take any action.</p>
           </div>
         ),
         displayType: 'info',
@@ -1154,9 +1154,9 @@ export function getAlertContent(alert, appealIsActive) {
       const statusDescription = appealIsActive ? 'is active at the Board of Veterans’ Appeals' : 'is closed';
       const formattedDate = formatDate(details.date);
       return {
-        title: 'This appeal is not eligible for the Rapid Appeals Modernization Program',
+        title: 'This appeal isn’t eligible for the Rapid Appeals Modernization Program',
         description: (
-          <p>On {formattedDate}, VA sent you a letter informing you of a new program called the Rapid Appeals Modernization Program (RAMP). However, this appeal is not eligible to participate in RAMP because it {statusDescription}. If you have other appeals, they may still be eligible to participate in RAMP.</p>
+          <p>On {formattedDate}, VA sent you a letter to let you know about a new program called the Rapid Appeals Modernization Program (RAMP). However, this appeal is not eligible for RAMP because it {statusDescription}. If you have other appeals, they may be eligible for RAMP.</p>
         ),
         displayType: 'info',
         type,
@@ -1166,16 +1166,16 @@ export function getAlertContent(alert, appealIsActive) {
       return {
         title: 'Decision soon',
         description: (
-          <p>Your appeal will soon receive a Board decision. Sending in new evidence at this time could delay review of your appeal. If you’ve moved recently, please make sure that VA has your current mailing address.</p>
+          <p>Your appeal will soon receive a Board decision. Sending in new evidence at this time could delay review of your appeal. If you’ve moved recently, please make sure that VA has your up-to-date mailing address.</p>
         ),
         displayType: 'info',
         type,
       };
     case ALERT_TYPES.blockedByVso:
       return {
-        title: 'A judge cannot review your appeal',
+        title: 'A judge can’t review your appeal',
         description: (
-          <p>Your appeal is eligible to be assigned to a judge based on its place in line, but they are prevented from reviewing your appeal because your Veteran Service Organization, {details.vsoName}, is currently reviewing it. For more information, please contact your Veteran Service Organization or representative.</p>
+          <p>Your appeal is eligible to be assigned to a judge based on its place in line, but they’re prevented from reviewing your appeal because your Veterans Service Organization, {details.vsoName}, is reviewing it right now. For more information, please contact your Veterans Service Organization or representative.</p>
         ),
         displayType: 'info',
         type,
@@ -1190,7 +1190,7 @@ export function getAlertContent(alert, appealIsActive) {
       return {
         title: 'What if I disagree with my decision?',
         description: (
-          <p>If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You will need to hire a VA-accredited attorney to represent you, or you may represent yourself. You will need to file your Court appeal by {formattedDueDate}. For more information, review the document “Your Rights to Appeal Our Decision” enclosed with the Board’s decision, visit the <a href="https://www.uscourts.cavc.gov/appeal.php">Court’s website</a>, or contact your Veteran Service Organization or representative.</p>
+          <p>If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You’ll need to hire a VA-accredited attorney to represent you, or you may represent yourself. You’ll need to file your Court appeal by {formattedDueDate}. For more information, review the document “Your Rights to Appeal Our Decision” enclosed with the Board’s decision, visit the <a href="https://www.uscourts.cavc.gov/appeal.php">Court’s website</a>, or contact your Veterans Service Organization or representative.</p>
         ),
         displayType: 'info',
         type,

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -854,7 +854,7 @@ export function getNextEvents(currentStatus, details) {
               </p>
             ),
             durationText: certDuration.header,
-            cardDescription: `The Veterans Benefits Administration ususally takes ${certDuration.description} to send cases to the Board.`
+            cardDescription: `The Veterans Benefits Administration usually takes ${certDuration.description} to send cases to the Board.`
           }, {
             title: 'The Veterans Benefits Administration will send you a new Statement of the Case',
             description: (

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -1068,7 +1068,7 @@ export function getNextEvents(currentStatus, details) {
  * @param {alertInput} alert has some properties we match against to generate an alert's content
  * @returns {alertOutput} dynamically-generated title, description, and styling properties
  */
-export function getAlertContent(alert) {
+export function getAlertContent(alert, appealIsActive) {
   const { type, details } = alert;
 
   switch (type) {
@@ -1151,7 +1151,7 @@ export function getAlertContent(alert) {
       };
     }
     case ALERT_TYPES.rampIneligible: {
-      const statusDescription = details.appeal.attributes.active ? 'is active at the Board of Veterans’ Appeals' : 'is closed';
+      const statusDescription = appealIsActive ? 'is active at the Board of Veterans’ Appeals' : 'is closed';
       const formattedDate = formatDate(details.date);
       return {
         title: 'This appeal is not eligible for the Rapid Appeals Modernization Program',

--- a/test/claims-status/utils/helpers.unit.spec.js
+++ b/test/claims-status/utils/helpers.unit.spec.js
@@ -475,8 +475,8 @@ describe('Disability benefits helpers: ', () => {
     it('returns sane object when given unknown type', () => {
       const type = 123;
       const contents = getStatusContents(type);
-      expect(contents.title).to.equal('Current Appeal Status Unknown');
-      expect(contents.description.props.children).to.equal('Your current appeal status is unknown at this time');
+      expect(contents.title).to.equal('We don’t know your appeal status');
+      expect(contents.description.props.children).to.equal('Your appeal status is unknown at this time');
     });
 
     // 'remand' and 'bva_decision' do a fair amount of dynamic content generation and formatting


### PR DESCRIPTION
These changes update the appeals v2 alert content (including [using the details object](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9095)). There are several outstanding questions:
- ~how to access status, and which statusDescription to use for which status in the `ramp_ineligible` alert?~
- ~which duplicate content to use for `decisionSoon`?~
- ~are there other changes [planned](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9095) related to making more use of the details object that would make sense to include in these changes?~