### PR TITLE
Update appeals overview page content

### DIFF
--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -10,14 +10,14 @@ children: disabilityClaimsAppeal
 ---
 
 <div class="va-introtext">
-You have the right to appeal any benefits decision made by the Veterans Benefits Administration (VBA). The VA appeals process is set in law and is different from other judicial appeals processes. Find out how to file an appeal.
+You have the right to appeal any benefits decision made by the Veterans Benefits Administration. The VA appeals process is set in law and is different from other judicial appeals processes. Find out how to file an appeal.
 </div>
 
 <div class="feature" markdown="0">
 
 ### Have you already filed an appeal?
 
-When the VBA Regional Office (RO) receives your Notice of Disagreement (NOD), you’ll be able to check the status of your appeal on Vets.gov.
+When the Veterans Benefits Administration Regional Office receives your Notice of Disagreement, you’ll be able to check the status of your appeal on Vets.gov.
 
 <a class="usa-button-primary" href="/track-claims">Track Your Appeal</a>
 </div>
@@ -28,7 +28,7 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
 </p>
 
 <span id="time-to-complete-claim"></span>
-  ### How long does it take VA to make a decision on a new appeal?
+  ### How long does it take VA to make a decision?
 
   <div class="card information" markdown="0">
     <span class="number">12-18 months</span>
@@ -36,7 +36,6 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
   </div>
 
   <span id="time-to-complete-claim"></span>
-  ### How long does it take the Board of Veterans’ Appeals to make a decision on an appeal?
   
   <div class="card information" markdown="0">
     <span class="number">5-7 years</span>

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -110,7 +110,7 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
 
 ### What if I disagree with the Board’s decision?
 
-If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You’ll need to hire a VA-accredited attorney to represent you, or you may represent yourself. You’ll need to file your Court appeal 120 days of the Board’s decision.
+If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You’ll need to hire a VA-accredited attorney to represent you, or you may represent yourself. You’ll need to file your Court appeal within 120 days of the Board’s decision.
 [Learn how to file a Court appeal](https://www.uscourts.cavc.gov/appeal.php).
 
 <script src="https://standards.usa.gov/assets/js/vendor/uswds.min.js" type="text/javascript"></script>

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -68,7 +68,7 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
     The Decision Review Officer will finish their review and transfer your case to the Board of Veterans’ Appeals. The Board reviews cases in the order they are received as determined by the date of the VA Form 9. A judge will begin work on your appeal when it is among the oldest appeals that are ready for their review.
     </p>
     <p>
-    If you are suffering a serious illness or are in financial distress, or for other sufficient cause, you can apply to have your appeal Advanced on Docket. If you are older than 75, your appeal will receive this status automatically. Advanced on Docket appeals are prioritized so that they are always at the front of the line. Learn how to request Advanced on Docket status.
+    If you are suffering a serious illness or are in financial distress, or for other sufficient cause, you can apply to have your appeal Advanced on Docket. If you are older than 75, your appeal will receive this status automatically. Advanced on Docket appeals are prioritized so that they are always at the front of the line. <a href="/disability-benefits/claims-appeal/request-a-priority-review/">Learn how to request Advanced on Docket status</a>.
     </p>
   </li>
   <li class="list-group-item">
@@ -160,7 +160,7 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
     <li>
       <button class="usa-button-unstyled usa-accordion-button" aria-controls="dbq7">What happens if I disagree with the Board’s decision?</button>
       <div id="dbq7" class="usa-accordion-content">
-        <p>If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You will need to hire a VA-accredited attorney to represent you, or you may represent yourself. You will need to file your Court appeal 120 days of the Board’s decision. <a href="https://www.uscourts.cavc.gov/appeal.php"> Learn how to file a Court appeal</a>.</p>
+        <p>If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You will need to hire a VA-accredited attorney to represent you, or you may represent yourself. You will need to file your Court appeal 120 days of the Board’s decision. <a href="https://www.uscourts.cavc.gov/appeal.php">Learn how to file a Court appeal</a>.</p>
       </div>
     </li>
     <li>

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -27,29 +27,33 @@ When the VBA Regional Office (RO) receives your Notice of Disagreement (NOD), yo
 After the Veterans Benefits Administration makes a decision on your claim, you can appeal some or all of the decision if you disagree with it. If you want to, you can have a representative help you with your appeal. This person may be a lawyer, claims agent, or Veterans Service Officer. <a href="/disability-benefits/apply/help/">Get help filing your appeal</a>.
 </p>
 
-<section id="time-to-complete-claim">
-  #### How long does it take VA to make a decision?
+<span id="time-to-complete-claim"></span>
+  ### How long does it take VA to make a decision?
 
   <div class="card information" markdown="0">
-    <span class="number">12-18 months</span>
-    <span class="description">The Veterans Benefits Administration typically takes between 12 and 18 months to review new appeals and decide whether to grant some or all of the appeal.</span>
+    <span class="number">12-18 months for new appeals</span>
+    <span class="description">The Veterans Benefits Administration usually takes 12-18 months to review new appeals and decide whether to grant some or all of the appeal.</span>
   </div>
 
   <div class="card information" markdown="0">
-    <span class="number">5-7 years</span>
-    <span class="description">If you are not satisfied with the Veterans Benefits Administration’s review, your appeal could take between 5 and 7 years to get a decision from a Veterans Law Judge at the Board of Veterans’ Appeals.</span>
+    <span class="number">5-7 years for appeals sent to the Board of Veterans’ Appeals</span>
+    <span class="description">When you request a review from a Veterans Law Judge at the Board of Veterans’ Appeals, it could take 5-7 years for you to get a decision.</span>
   </div>
 </section>
 
 <section id="appeal-steps">
-  <h4>An appeal follows these steps</h4>
+  <h4>An appeal follows these steps:</h4>
 
   <ul class="vertical-list-group more-bottom-cushion">
     <li class="list-group-item">
       <div>
         <h4>File a Notice of Disagreement (NOD)</h4>
         <p>
-        By filing a Notice of Disagreement, you begin the appeals process. You’ll need to file a Notice of Disagreement within 1 year of the date on the letter notifying you of the claim decision. <a href="https://www.vba.va.gov/pubs/forms/VBA-21-0958-ARE.pdf">Download a Notice of Disagreement (VA Form 21-0958)</a>. Fill out your Notice of Disagreement and mail it to the address provided on the VA claim decision notice letter you received, or bring it to your local regional office. A representative can help you file a Notice of Disagreement. <a href="/disability-benefits/apply/help/index.html">Get help filing your appeal</a>.
+        By filing a Notice of Disagreement, you begin the appeals process. You’ll need to file a Notice of Disagreement within 1 year of the date on the letter notifying you of the claim decision. <br> 
+        <a href="https://www.vba.va.gov/pubs/forms/VBA-21-0958-ARE.pdf">Download a Notice of Disagreement (VA Form 21-0958)</a>. 
+        </p>
+        <p>
+        Fill out your Notice of Disagreement and mail it to the address provided on the VA claim decision notice letter you received, or bring it to your local regional office. A representative can help you file a Notice of Disagreement. <a href="/disability-benefits/apply/help/index.html">Get help filing your appeal</a>.
         </p>
       </div>
     </li>

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -25,13 +25,19 @@ When the VBA Regional Office (RO) receives your Notice of Disagreement (NOD), yo
 <p>
 After the Veterans Benefits Administration makes a decision on your claim, you can appeal some or all of the decision if you disagree with it. If you want to, you can have a representative help you with your appeal. This person may be a lawyer, claims agent, or Veterans Service Officer. <a href="/disability-benefits/apply/help/">Get help filing your appeal</a>.
 </p>
-<p><strong>How long does an appeal take?</strong>
-<p>
-12-18 months The Veterans Benefits Administration typically takes between 12 and 18 months to review new appeals and decide whether to grant some or all of the appeal.
-</p>
-<p>
-5-7 years If you are not satisfied with the Veterans Benefits Administration's review, your appeal could take between 5 and 7 years to get a decision from a Veterans Law Judge at the Board of Veterans' Appeals.
-</p>
+
+<span id="days-to-complete-claim"></span>
+#### How long does it take VA to make a decision?
+
+<div class="card information" markdown="0">
+<span class="number">12-18 months</span>
+<span class="description">The Veterans Benefits Administration typically takes between 12 and 18 months to review new appeals and decide whether to grant some or all of the appeal.</span>
+</div>
+
+<div class="card information" markdown="0">
+<span class="number">5-7 years</span>
+<span class="description">If you are not satisfied with the Veterans Benefits Administration's review, your appeal could take between 5 and 7 years to get a decision from a Veterans Law Judge at the Board of Veterans’ Appeals.</span>
+</div>
 
 <h4>An appeal follows these steps</h4>
 

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -23,66 +23,71 @@ When the VBA Regional Office (RO) receives your Notice of Disagreement (NOD), yo
 
 <h3>Appeals Process Overview</h3>
 <p>
-After VBA has made a decision on your claim, if you disagree with the outcome, you can file an appeal for some or all of the issues you were seeking benefits for in your claim.
+After the Veterans Benefits Administration makes a decision on your claim, you can appeal some or all of the decision if you disagree with it. If you want to, you can have a representative help you with your appeal. This person may be a lawyer, claims agent, or Veterans Service Officer. <a href="/disability-benefits/apply/help/">Get help filing your appeal</a>.
 </p>
-<p><strong>The process has many steps that can repeat themselves.</strong> At any time in the process, VA can issue a decision on part or all of your appeal, but in general an appeal follows these steps:</p>
+<p><strong>How long does an appeal take?</strong>
+<p>
+12-18 months The Veterans Benefits Administration typically takes between 12 and 18 months to review new appeals and decide whether to grant some or all of the appeal.
+</p>
+<p>
+5-7 years If you are not satisfied with the Veterans Benefits Administration's review, your appeal could take between 5 and 7 years to get a decision from a Veterans Law Judge at the Board of Veterans' Appeals.
+</p>
+
+<h4>An appeal follows these steps</h4>
 
 <ul class="vertical-list-group more-bottom-cushion">
   <li class="list-group-item">
     <div>
       <h4>File a Notice of Disagreement (NOD)</h4>
       <p>
-        By filing an NOD, you begin the appeals process. You’ll need to file an NOD within 1 year from the date on the letter letting you know of the decision on your claim. <a href="https://www.vba.va.gov/pubs/forms/VBA-21-0958-ARE.pdf">Download a Notice of Disagreement (VA Form 21-0958)</a>
+      By filing a Notice of Disagreement, you begin the appeals process. You’ll need to file a Notice of Disagreement within 1 year of the date on the letter notifying you of the claim decision. <a href="https://www.vba.va.gov/pubs/forms/VBA-21-0958-ARE.pdf">Download a Notice of Disagreement (VA Form 21-0958)</a>. Fill out your Notice of Disagreement and mail it to the address provided on the VA claim decision notice letter you received, or bring it to your local regional office. A representative can help you file a Notice of Disagreement. <a href="/disability-benefits/apply/help/index.html">Get help filing your appeal</a>.
       </p>
-      <p>Fill out your NOD and mail it to the address provided on the VA claim decision notice letter you received, or bring it to your local RO.</p>
     </div>
   </li>
   <li class="list-group-item">
-    <h4>RO prepares the Statement of the Case (SOC)</h4>
+    <h4>The Veterans Benefits Administration sends you Statement of the Case</h4>
     <p>
-      After you file your NOD, if the RO can’t grant all or part of your appeal, it will prepare the SOC for the issues in your appeal that were not granted. To do this, they review all the evidence related to your appeal, including any new evidence you submit. You’ll receive a copy of it in the mail.
+      After you file your Notice of Disagreement, a Decision Review Officer will review all of the evidence related to your appeal, including any new evidence you sent. If the Decision Review Officer determines that there is not enough evidence to fully grant your appeal, they will send you their findings in a document called a Statement of the Case. You can then decide whether to continue your appeal to the Board of Veterans’ Appeals.
     </p>
   </li>
   <li class="list-group-item">
-    <h4>Submit a Form 9</h4>
+    <h4>You return the VA Form 9</h4>
     <p>
-      When you receive a copy of the SOC in the mail, you’ll also receive a Form 9. If you disagree with the SOC and want to continue the appeal process, you must return Form 9 within 60 days. This step is also called filing a Substantive Appeal.
+      When you receive a copy of the Statement of the Case in the mail, you’ll also get a VA Form 9. If you disagree with the Statement of the Case and want to continue your appeal to the Board of Veterans’ Appeals, you must return VA Form 9 within 60 days.
     </p>
   </li>
   <li class="list-group-item">
-    <h4>(Optional) RO prepares the Supplemental Statement of the Case (SSOC)</h4>
+    <h4>The Veterans Benefits Administration prepare a new Statement of the Case (optional visual treatment)</h4>
     <p>
-      You can submit new evidence for your appeal at any time in the process. Each time you do, the RO will need to make a decision or prepare an SSOC if the RO can’t grant all or part of your appeal. This may add time to your appeal, but may make your appeal more successful if the evidence supports your argument. This step can happen at any time after the RO prepares the SOC.
+      You can submit new evidence for your appeal at any time in the process. If you submit new evidence after you receive a Statement of the Case, the Decision Review Officer will need to write a new Statement of the Case before transferring your case to the Board of Veterans’ Appeals. Once your appeal is transferred, new evidence can be sent directly to the Board and will not be reviewed by the Veterans Benefits Administration.
     </p>
   </li>
   <li class="list-group-item">
-    <h4>RO certifies your appeal to the Board</h4>
+    <h4>Your appeal is sent to the Board</h4>
     <p>
-      The RO will prepare your appeal and send it to the Board for review. Your appeal will wait in line until the Board is able to review it.
+    The Decision Review Officer will finish their review and transfer your case to the Board of Veterans’ Appeals. The Board reviews cases in the order they are received as determined by the date of the VA Form 9. A judge will begin work on your appeal when it is among the oldest appeals that are ready for their review.
+    </p>
+    <p>
+    If you are suffering a serious illness or are in financial distress, or for other sufficient cause, you can apply to have your appeal Advanced on Docket. If you are older than 75, your appeal will receive this status automatically. Advanced on Docket appeals are prioritized so that they are always at the front of the line. Learn how to request Advanced on Docket status.
     </p>
   </li>
   <li class="list-group-item">
-    <h4>The Board activates your appeal</h4>
+    <h4>You have a hearing (optional visual treatment)</h4>
     <p>
-      The Board now has control of your appeal. Lawyers who are experts in Veterans law and reviewing benefit claims will review it. The review prepares your appeal for a Veterans Law Judge who will make a decision. In most cases, your appeal is reviewed in the order it was received. In some cases, an appeal will be moved to the front of the line—this happens if you’re facing severe financial hardship, over age 75, or have a serious illness.
-    </p>
-  </li>
-  <li class="list-group-item">
-    <h4>(Optional) Hearing</h4>
-    <p>
-      If you request a Board hearing, you’ll be sent a letter at least 30 days before it’s scheduled to happen. <a href="/disability-benefits/claims-appeal/hearings/">Learn more about hearings</a>.
+      You have the option to request a hearing with a Veterans Law Judge. At your hearing, the judge will ask you questions about your appeal. A transcript of your hearing will be made and added to your appeal file. The judge will not make a decision about your appeal at the hearing. <a href="/disability-benefits/claims-appeal/hearings/">Learn more about hearings at the Board</a>.
     </p>
   </li>
   <li class="list-group-item">
     <h4>The Board makes its decision</h4>
     <p>
-      The Board has reviewed your appeal and provides a decision on each issue in your appeal. Each issue will be decided in 1 of 3 ways:
+      The Board reviews your appeal and provides a decision on each issue in your appeal. The Board decides each issue in 1 of 3 ways:
     </p>
     <ul>
       <li><strong>Allowed:</strong> The Board grants benefits.</li>
       <li><strong>Remanded:</strong> The Board needs more evidence to make a decision and will return your appeal to VBA. After VBA obtains the additional evidence, it will then make a new decision on the appeal. If VBA can’t grant all or part of your appeal, it will prepare a new SSOC and return the appeal to the Board.</li>
       <li><strong>Denied:</strong> The Board does not grant benefits.</li>
     </ul>
+    <p><strong>Note:</strong> About 60% of all decisions have at least 1 issue remanded.</p>
   </li>
 </ul>
 
@@ -153,15 +158,9 @@ After VBA has made a decision on your claim, if you disagree with the outcome, y
       </div>
     </li>
     <li>
-      <button class="usa-button-unstyled usa-accordion-button" aria-controls="dbq7">What happens if the Board makes a final decision and I disagree with it?</button>
+      <button class="usa-button-unstyled usa-accordion-button" aria-controls="dbq7">What happens if I disagree with the Board’s decision?</button>
       <div id="dbq7" class="usa-accordion-content">
-        <p>You can:</p>
-        <ul>
-          <li>File a new claim with your RO, <strong>or</strong></li>
-          <li>File a motion asking the Board to reconsider your appeal (there’s no time limit to file this motion), <strong>or</strong></li>
-          <li>File a motion asking the Board to review your appeal again because there was clear and unmistakable error in its decision (there’s no time limit to file this motion), <strong>or</strong></li>
-          <li>File a Notice of Appeal with the Court of Appeals for Veterans Claims (CAVC) within 120 days from the date of the decision by the Board (stamped on the first page of the decision). <a href="https://www.uscourts.cavc.gov/appeal.php">Learn how to file an appeal with the CAVC</a>.</li>
-        </ul>
+        <p>If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You will need to hire a VA-accredited attorney to represent you, or you may represent yourself. You will need to file your Court appeal 120 days of the Board’s decision. <a href="https://www.uscourts.cavc.gov/appeal.php"> Learn how to file a Court appeal</a>.</p>
       </div>
     </li>
     <li>

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -84,7 +84,7 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
       The Decision Review Officer will finish the review and send your case to the Board of Veterans’ Appeals. The Board reviews cases in the order they’re received according to the date on the VA Form 9. A judge will begin work on your appeal when it’s among the oldest appeals ready for their review.
       </p>
       <p>
-      If you suffer from a serious illness, are in financial distress, or have other sufficient cause (a reason for needing your appeal reviewed faster), you can apply to have your appeal Advanced on Docket. If you’re older than 75, your appeal will receive this status automatically. Advanced on Docket appeals are prioritized so they’re always at the front of the line. <a href="/disability-benefits/claims-appeal/request-a-priority-review/">Learn how to request Advanced on Docket status</a>.
+      If you suffer from a serious illness, are in financial distress, or have other sufficient cause (a reason for needing your appeal reviewed faster), you can apply to have your appeal Advanced on Docket. If you’re over 75 years old, your appeal will receive this status automatically. Advanced on Docket appeals are prioritized so they’re always at the front of the line. <a href="/disability-benefits/claims-appeal/request-a-priority-review/">Learn how to request Advanced on Docket status</a>.
       </p>
     </li>
     <li class="list-group-item">

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -64,9 +64,9 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
     </p>
   </li>
   <li class="list-group-item">
-    <h4>The Veterans Benefits Administration prepare a new Statement of the Case (optional)</h4>
+    <h4>The Veterans Benefits Administration prepare a Supplemental Statement of the Case (optional)</h4>
     <p>
-      You can submit new evidence for your appeal at any time in the process. If you submit new evidence after you receive a Statement of the Case, the Decision Review Officer will need to write a new Statement of the Case before transferring your case to the Board of Veterans’ Appeals. Once your appeal is transferred, new evidence can be sent directly to the Board and will not be reviewed by the Veterans Benefits Administration.
+      You can submit new evidence for your appeal at any time in the process. If you submit new evidence after you receive a Statement of the Case, the Decision Review Officer will need to write a Supplemental Statement of the Case before transferring your case to the Board of Veterans’ Appeals. Once your appeal is transferred, new evidence can be sent directly to the Board and will not be reviewed by the Veterans Benefits Administration.
     </p>
   </li>
   <li class="list-group-item">

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -63,7 +63,7 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
     </p>
   </li>
   <li class="list-group-item">
-    <h4>The Veterans Benefits Administration prepare a new Statement of the Case (optional visual treatment)</h4>
+    <h4>The Veterans Benefits Administration prepare a new Statement of the Case (optional)</h4>
     <p>
       You can submit new evidence for your appeal at any time in the process. If you submit new evidence after you receive a Statement of the Case, the Decision Review Officer will need to write a new Statement of the Case before transferring your case to the Board of Veterans’ Appeals. Once your appeal is transferred, new evidence can be sent directly to the Board and will not be reviewed by the Veterans Benefits Administration.
     </p>
@@ -78,7 +78,7 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
     </p>
   </li>
   <li class="list-group-item">
-    <h4>You have a hearing (optional visual treatment)</h4>
+    <h4>You have a hearing (optional)</h4>
     <p>
       You have the option to request a hearing with a Veterans Law Judge. At your hearing, the judge will ask you questions about your appeal. A transcript of your hearing will be made and added to your appeal file. The judge will not make a decision about your appeal at the hearing. <a href="/disability-benefits/claims-appeal/hearings/">Learn more about hearings at the Board</a>.
     </p>

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -56,42 +56,41 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
         <a href="https://www.vba.va.gov/pubs/forms/VBA-21-0958-ARE.pdf">Download a Notice of Disagreement (VA Form 21-0958)</a>. 
         </p>
         <p>
-        Fill out your Notice of Disagreement and mail it to the address provided on the VA claim decision notice letter you received, or bring it to your local regional office. A representative can help you file a Notice of Disagreement. <a href="/disability-benefits/apply/help/index.html">Get help filing your appeal</a>.
+        Fill out your Notice of Disagreement and mail it to the address provided on the VA claim decision notice letter you received, or bring it to your local regional office. An accredited representative can help you file a Notice of Disagreement. <a href="/disability-benefits/apply/help/index.html">Get help filing your appeal</a>.
         </p>
       </div>
     </li>
     <li class="list-group-item">
       <h4>The Veterans Benefits Administration sends you the Statement of the Case</h4>
       <p>
-        After you file your Notice of Disagreement, a Decision Review Officer will review all of the evidence related to your appeal, including any new evidence you sent. If the Decision Review Officer determines that there is not enough evidence to fully grant your appeal, they will send you their findings in a document called a Statement of the Case. You can then decide whether to continue your appeal to the Board of Veterans’ Appeals.
+        After you file your Notice of Disagreement, a Decision Review Officer will review all the evidence related to your appeal, including any new evidence you sent. If the Decision Review Officer determines that there isn’t enough evidence to fully grant your appeal, they'll send you their findings in a document called a Statement of the Case. You can then decide whether to continue your appeal to the Board of Veterans’ Appeals.
       </p>
     </li>
     <li class="list-group-item">
       <h4>You return the VA Form 9</h4>
       <p>
-        When you receive a copy of the Statement of the Case in the mail, you’ll also get a VA Form 9. If you disagree with the Statement of the Case and want to continue your appeal to the Board of Veterans’ Appeals, you must return VA Form 9 within 60 days.
+        When you receive a copy of the Statement of the Case in the mail, you’ll also get a VA Form 9. If you disagree with the Statement of the Case and want to continue your appeal to the Board of Veterans’ Appeals, you’ll need to return VA Form 9 within 60 days.
       </p>
     </li>
     <li class="list-group-item">
-      <h4>The Veterans Benefits Administration prepare a Supplemental Statement of the Case (optional)</h4>
+      <h4>The Veterans Benefits Administration prepares a Supplemental Statement of the Case (optional)</h4>
       <p>
-        You can submit new evidence for your appeal at any time in the process. If you submit new evidence after you receive a Statement of the Case, the Decision Review Officer will need to write a Supplemental Statement of the Case before transferring your case to the Board of Veterans’ Appeals. Once your appeal is transferred, new evidence can be sent directly to the Board and will not be reviewed by the Veterans Benefits Administration.
+        You can submit new evidence for your appeal at any time in the process. If you submit new evidence after you receive a Statement of the Case, the Decision Review Officer will need to write a Supplemental Statement of the Case before sending your case to the Board of Veterans’ Appeals. Once your appeal is sent, you'll need to submit any new evidence directly to the Board. The Veterans Benefits Administration won't review it.
       </p>
     </li>
     <li class="list-group-item">
       <h4>Your appeal is sent to the Board</h4>
       <p>
-      The Decision Review Officer will finish their review and transfer your case to the Board of Veterans’ Appeals. The Board reviews cases in the order they are received as determined by the date of the VA Form 9. A judge will begin work on your appeal when it is among the oldest appeals that are ready for their review.
+      The Decision Review Officer will finish the review and send your case to the Board of Veterans’ Appeals. The Board reviews cases in the order they’re received according to the date on the VA Form 9. A judge will begin work on your appeal when it’s among the oldest appeals ready for their review.
       </p>
       <p>
-      If you are suffering a serious illness or are in financial distress, or for other sufficient cause, you can apply to have your appeal Advanced on Docket. If you are older than 75, your appeal will receive this status automatically. Advanced on Docket appeals are prioritized so that they are always at the front of the line. <a href="#">Learn how to request Advanced on Docket status</a>.
+      If you suffer from a serious illness, are in financial distress, or have other sufficient cause (a reason for needing your appeal reviewed faster), you can apply to have your appeal Advanced on Docket. If you’re older than 75, your appeal will receive this status automatically. Advanced on Docket appeals are prioritized so they’re always at the front of the line. <a href="/disability-benefits/claims-appeal/request-a-priority-review/">Learn how to request Advanced on Docket status</a>.
       </p>
-      <!-- TODO: update link with /disability-benefits/claims-appeal/request-a-priority-review/ -->
     </li>
     <li class="list-group-item">
       <h4>You have a hearing (optional)</h4>
       <p>
-        You have the option to request a hearing with a Veterans Law Judge. At your hearing, the judge will ask you questions about your appeal. A transcript of your hearing will be made and added to your appeal file. The judge will not make a decision about your appeal at the hearing. <a href="/disability-benefits/claims-appeal/hearings/">Learn more about hearings at the Board</a>.
+        You have the option to request a hearing with a Veterans Law Judge. At your hearing, the judge will ask you questions about your appeal. A transcript of your hearing will be made and added to your appeal file. The judge won’t make a decision about your appeal at the hearing. <a href="/disability-benefits/claims-appeal/hearings/">Learn more about hearings at the Board</a>.
       </p>
     </li>
     <li class="list-group-item">
@@ -101,8 +100,8 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
       </p>
       <ul>
         <li><strong>Allowed:</strong> The Board grants benefits.</li>
-        <li><strong>Remanded:</strong> The Board needs more evidence to make a decision and will return your appeal to VBA. After VBA obtains the additional evidence, it will then make a new decision on the appeal. If VBA can’t grant all or part of your appeal, it will prepare a new SSOC and return the appeal to the Board.</li>
-        <li><strong>Denied:</strong> The Board does not grant benefits.</li>
+        <li><strong>Remanded:</strong> The Board needs more evidence to make a decision and returns your appeal to the Veterans Benefits Administration. After the Veterans Benefits Administration gets the requested evidence, it’ll then make a new decision on the appeal. If the Veterans Benefits Administration can’t grant all or part of your appeal, it’ll prepare a new Supplemental Statement of the Case and return the appeal to the Board.</li>
+        <li><strong>Denied:</strong> The Board doesn’t grant benefits.</li>
       </ul>
       <p><strong>Note:</strong> About 60% of all decisions have at least 1 issue remanded.</p>
     </li>
@@ -111,7 +110,7 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
 
 ### What if I disagree with the Board’s decision?
 
-If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You will need to hire a VA-accredited attorney to represent you, or you may represent yourself. You will need to file your Court appeal 120 days of the Board’s decision.
+If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You’ll need to hire a VA-accredited attorney to represent you, or you may represent yourself. You’ll need to file your Court appeal 120 days of the Board’s decision.
 [Learn how to file a Court appeal](https://www.uscourts.cavc.gov/appeal.php).
 
 <script src="https://standards.usa.gov/assets/js/vendor/uswds.min.js" type="text/javascript"></script>

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -52,7 +52,7 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
     </div>
   </li>
   <li class="list-group-item">
-    <h4>The Veterans Benefits Administration sends you Statement of the Case</h4>
+    <h4>The Veterans Benefits Administration sends you the Statement of the Case</h4>
     <p>
       After you file your Notice of Disagreement, a Decision Review Officer will review all of the evidence related to your appeal, including any new evidence you sent. If the Decision Review Officer determines that there is not enough evidence to fully grant your appeal, they will send you their findings in a document called a Statement of the Case. You can then decide whether to continue your appeal to the Board of Veterans’ Appeals.
     </p>

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -34,8 +34,6 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
     <span class="number">12-18 months</span>
     <span class="description">The Veterans Benefits Administration usually takes 12-18 months to review new appeals and decide whether to grant some or all of the appeal.</span>
   </div>
-
-  <span id="time-to-complete-claim"></span>
   
   <div class="card information" markdown="0">
     <span class="number">5-7 years</span>

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -27,82 +27,85 @@ When the VBA Regional Office (RO) receives your Notice of Disagreement (NOD), yo
 After the Veterans Benefits Administration makes a decision on your claim, you can appeal some or all of the decision if you disagree with it. If you want to, you can have a representative help you with your appeal. This person may be a lawyer, claims agent, or Veterans Service Officer. <a href="/disability-benefits/apply/help/">Get help filing your appeal</a>.
 </p>
 
-<span id="days-to-complete-claim"></span>
-#### How long does it take VA to make a decision?
+<section id="time-to-complete-claim">
+  #### How long does it take VA to make a decision?
 
-<div class="card information" markdown="0">
-<span class="number">12-18 months</span>
-<span class="description">The Veterans Benefits Administration typically takes between 12 and 18 months to review new appeals and decide whether to grant some or all of the appeal.</span>
-</div>
+  <div class="card information" markdown="0">
+    <span class="number">12-18 months</span>
+    <span class="description">The Veterans Benefits Administration typically takes between 12 and 18 months to review new appeals and decide whether to grant some or all of the appeal.</span>
+  </div>
 
-<div class="card information" markdown="0">
-<span class="number">5-7 years</span>
-<span class="description">If you are not satisfied with the Veterans Benefits Administration's review, your appeal could take between 5 and 7 years to get a decision from a Veterans Law Judge at the Board of Veterans’ Appeals.</span>
-</div>
+  <div class="card information" markdown="0">
+    <span class="number">5-7 years</span>
+    <span class="description">If you are not satisfied with the Veterans Benefits Administration’s review, your appeal could take between 5 and 7 years to get a decision from a Veterans Law Judge at the Board of Veterans’ Appeals.</span>
+  </div>
+</section>
 
-<h4>An appeal follows these steps</h4>
+<section id="appeal-steps">
+  <h4>An appeal follows these steps</h4>
 
-<ul class="vertical-list-group more-bottom-cushion">
-  <li class="list-group-item">
-    <div>
-      <h4>File a Notice of Disagreement (NOD)</h4>
+  <ul class="vertical-list-group more-bottom-cushion">
+    <li class="list-group-item">
+      <div>
+        <h4>File a Notice of Disagreement (NOD)</h4>
+        <p>
+        By filing a Notice of Disagreement, you begin the appeals process. You’ll need to file a Notice of Disagreement within 1 year of the date on the letter notifying you of the claim decision. <a href="https://www.vba.va.gov/pubs/forms/VBA-21-0958-ARE.pdf">Download a Notice of Disagreement (VA Form 21-0958)</a>. Fill out your Notice of Disagreement and mail it to the address provided on the VA claim decision notice letter you received, or bring it to your local regional office. A representative can help you file a Notice of Disagreement. <a href="/disability-benefits/apply/help/index.html">Get help filing your appeal</a>.
+        </p>
+      </div>
+    </li>
+    <li class="list-group-item">
+      <h4>The Veterans Benefits Administration sends you the Statement of the Case</h4>
       <p>
-      By filing a Notice of Disagreement, you begin the appeals process. You’ll need to file a Notice of Disagreement within 1 year of the date on the letter notifying you of the claim decision. <a href="https://www.vba.va.gov/pubs/forms/VBA-21-0958-ARE.pdf">Download a Notice of Disagreement (VA Form 21-0958)</a>. Fill out your Notice of Disagreement and mail it to the address provided on the VA claim decision notice letter you received, or bring it to your local regional office. A representative can help you file a Notice of Disagreement. <a href="/disability-benefits/apply/help/index.html">Get help filing your appeal</a>.
+        After you file your Notice of Disagreement, a Decision Review Officer will review all of the evidence related to your appeal, including any new evidence you sent. If the Decision Review Officer determines that there is not enough evidence to fully grant your appeal, they will send you their findings in a document called a Statement of the Case. You can then decide whether to continue your appeal to the Board of Veterans’ Appeals.
       </p>
-    </div>
-  </li>
-  <li class="list-group-item">
-    <h4>The Veterans Benefits Administration sends you the Statement of the Case</h4>
-    <p>
-      After you file your Notice of Disagreement, a Decision Review Officer will review all of the evidence related to your appeal, including any new evidence you sent. If the Decision Review Officer determines that there is not enough evidence to fully grant your appeal, they will send you their findings in a document called a Statement of the Case. You can then decide whether to continue your appeal to the Board of Veterans’ Appeals.
-    </p>
-  </li>
-  <li class="list-group-item">
-    <h4>You return the VA Form 9</h4>
-    <p>
-      When you receive a copy of the Statement of the Case in the mail, you’ll also get a VA Form 9. If you disagree with the Statement of the Case and want to continue your appeal to the Board of Veterans’ Appeals, you must return VA Form 9 within 60 days.
-    </p>
-  </li>
-  <li class="list-group-item">
-    <h4>The Veterans Benefits Administration prepare a Supplemental Statement of the Case (optional)</h4>
-    <p>
-      You can submit new evidence for your appeal at any time in the process. If you submit new evidence after you receive a Statement of the Case, the Decision Review Officer will need to write a Supplemental Statement of the Case before transferring your case to the Board of Veterans’ Appeals. Once your appeal is transferred, new evidence can be sent directly to the Board and will not be reviewed by the Veterans Benefits Administration.
-    </p>
-  </li>
-  <li class="list-group-item">
-    <h4>Your appeal is sent to the Board</h4>
-    <p>
-    The Decision Review Officer will finish their review and transfer your case to the Board of Veterans’ Appeals. The Board reviews cases in the order they are received as determined by the date of the VA Form 9. A judge will begin work on your appeal when it is among the oldest appeals that are ready for their review.
-    </p>
-    <p>
-    If you are suffering a serious illness or are in financial distress, or for other sufficient cause, you can apply to have your appeal Advanced on Docket. If you are older than 75, your appeal will receive this status automatically. Advanced on Docket appeals are prioritized so that they are always at the front of the line. <a href="/disability-benefits/claims-appeal/request-a-priority-review/">Learn how to request Advanced on Docket status</a>.
-    </p>
-  </li>
-  <li class="list-group-item">
-    <h4>You have a hearing (optional)</h4>
-    <p>
-      You have the option to request a hearing with a Veterans Law Judge. At your hearing, the judge will ask you questions about your appeal. A transcript of your hearing will be made and added to your appeal file. The judge will not make a decision about your appeal at the hearing. <a href="/disability-benefits/claims-appeal/hearings/">Learn more about hearings at the Board</a>.
-    </p>
-  </li>
-  <li class="list-group-item">
-    <h4>The Board makes its decision</h4>
-    <p>
-      The Board reviews your appeal and provides a decision on each issue in your appeal. The Board decides each issue in 1 of 3 ways:
-    </p>
-    <ul>
-      <li><strong>Allowed:</strong> The Board grants benefits.</li>
-      <li><strong>Remanded:</strong> The Board needs more evidence to make a decision and will return your appeal to VBA. After VBA obtains the additional evidence, it will then make a new decision on the appeal. If VBA can’t grant all or part of your appeal, it will prepare a new SSOC and return the appeal to the Board.</li>
-      <li><strong>Denied:</strong> The Board does not grant benefits.</li>
-    </ul>
-    <p><strong>Note:</strong> About 60% of all decisions have at least 1 issue remanded.</p>
-  </li>
-</ul>
+    </li>
+    <li class="list-group-item">
+      <h4>You return the VA Form 9</h4>
+      <p>
+        When you receive a copy of the Statement of the Case in the mail, you’ll also get a VA Form 9. If you disagree with the Statement of the Case and want to continue your appeal to the Board of Veterans’ Appeals, you must return VA Form 9 within 60 days.
+      </p>
+    </li>
+    <li class="list-group-item">
+      <h4>The Veterans Benefits Administration prepare a Supplemental Statement of the Case (optional)</h4>
+      <p>
+        You can submit new evidence for your appeal at any time in the process. If you submit new evidence after you receive a Statement of the Case, the Decision Review Officer will need to write a Supplemental Statement of the Case before transferring your case to the Board of Veterans’ Appeals. Once your appeal is transferred, new evidence can be sent directly to the Board and will not be reviewed by the Veterans Benefits Administration.
+      </p>
+    </li>
+    <li class="list-group-item">
+      <h4>Your appeal is sent to the Board</h4>
+      <p>
+      The Decision Review Officer will finish their review and transfer your case to the Board of Veterans’ Appeals. The Board reviews cases in the order they are received as determined by the date of the VA Form 9. A judge will begin work on your appeal when it is among the oldest appeals that are ready for their review.
+      </p>
+      <p>
+      If you are suffering a serious illness or are in financial distress, or for other sufficient cause, you can apply to have your appeal Advanced on Docket. If you are older than 75, your appeal will receive this status automatically. Advanced on Docket appeals are prioritized so that they are always at the front of the line. <a href="#">Learn how to request Advanced on Docket status</a>.
+      </p>
+      <!-- TODO: update link with /disability-benefits/claims-appeal/request-a-priority-review/ -->
+    </li>
+    <li class="list-group-item">
+      <h4>You have a hearing (optional)</h4>
+      <p>
+        You have the option to request a hearing with a Veterans Law Judge. At your hearing, the judge will ask you questions about your appeal. A transcript of your hearing will be made and added to your appeal file. The judge will not make a decision about your appeal at the hearing. <a href="/disability-benefits/claims-appeal/hearings/">Learn more about hearings at the Board</a>.
+      </p>
+    </li>
+    <li class="list-group-item">
+      <h4>The Board makes its decision</h4>
+      <p>
+        The Board reviews your appeal and provides a decision on each issue in your appeal. The Board decides each issue in 1 of 3 ways:
+      </p>
+      <ul>
+        <li><strong>Allowed:</strong> The Board grants benefits.</li>
+        <li><strong>Remanded:</strong> The Board needs more evidence to make a decision and will return your appeal to VBA. After VBA obtains the additional evidence, it will then make a new decision on the appeal. If VBA can’t grant all or part of your appeal, it will prepare a new SSOC and return the appeal to the Board.</li>
+        <li><strong>Denied:</strong> The Board does not grant benefits.</li>
+      </ul>
+      <p><strong>Note:</strong> About 60% of all decisions have at least 1 issue remanded.</p>
+    </li>
+  </ul>
+</section>
 
 ### What if I disagree with the Board’s decision?
 
 If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You will need to hire a VA-accredited attorney to represent you, or you may represent yourself. You will need to file your Court appeal 120 days of the Board’s decision.
 [Learn how to file a Court appeal](https://www.uscourts.cavc.gov/appeal.php).
-
 
 <script src="https://standards.usa.gov/assets/js/vendor/uswds.min.js" type="text/javascript"></script>
 

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -28,18 +28,21 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
 </p>
 
 <span id="time-to-complete-claim"></span>
-  ### How long does it take VA to make a decision?
+  ### How long does it take VA to make a decision on a new appeal?
 
   <div class="card information" markdown="0">
-    <span class="number">12-18 months for new appeals</span>
+    <span class="number">12-18 months</span>
     <span class="description">The Veterans Benefits Administration usually takes 12-18 months to review new appeals and decide whether to grant some or all of the appeal.</span>
   </div>
 
+  <span id="time-to-complete-claim"></span>
+  ### How long does it take the Board of Veterans’ Appeals to make a decision on an appeal?
+  
   <div class="card information" markdown="0">
-    <span class="number">5-7 years for appeals sent to the Board of Veterans’ Appeals</span>
+    <span class="number">5-7 years</span>
     <span class="description">When you request a review from a Veterans Law Judge at the Board of Veterans’ Appeals, it could take 5-7 years for you to get a decision.</span>
   </div>
-</section>
+
 
 <section id="appeal-steps">
   <h4>An appeal follows these steps:</h4>

--- a/content/pages/disability-benefits/claims-appeal.md
+++ b/content/pages/disability-benefits/claims-appeal.md
@@ -98,99 +98,10 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
   </li>
 </ul>
 
-### Frequently Asked Questions
+### What if I disagree with the Board’s decision?
 
-<div class="usa-accordion">
-  <ul class="usa-unstyled-list">
-    <li>
-      <button class="usa-button-unstyled usa-accordion-button" aria-controls="dbq1">How long does an appeal take?</button>
-      <div id="dbq1" class="usa-accordion-content">
-        An appeal can take 1 to 7 years to get a final decision. After you file a Notice of Disagreement (NOD), you can <a href="/track-claims">follow the status for your appeal</a>.
-      </div>
-    </li>
-    <li>
-      <button class="usa-button-unstyled usa-accordion-button" aria-controls="dbq2">Can I send my appeal and related paperwork online?</button>
-      <div id="dbq2" class="usa-accordion-content">
-        No. At this time, all forms, evidence, and other paperwork for your appeal have to be sent through the mail. You’ll find the correct mailing address on information sent to you by VA, or you can send it to:<br/>
-        <p class="va-address-block">
-          Chairman (01)<br/>
-          Board of Veterans’ Appeals<br/>
-          PO Box 27063<br/>
-          Washington, DC 20038<br/>
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-button-unstyled usa-accordion-button" aria-controls="dbq3">Can I submit more evidence (supporting documents) or make a new argument to support my appeal?</button>
-      <div id="dbq3" class="usa-accordion-content">
-        <p>Yes. The appeals process has a “continuous open record.” This means you can send in new evidence and/or make new arguments at any point from the beginning to the end of the appeals process. We also follow what’s known as a duty to assist policy. This means that we’ll help you get your treatment records you’ve identified and we’ll provide a physical exam if one is needed.</p>
-        <p>Each time you present new arguments and add or find new evidence, VBA will make a decision or prepare a new Supplemental Statement of the Case (SSOC). This can add time to your appeal, but may make your appeal more successful if the evidence supports your argument.</p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-button-unstyled usa-accordion-button" aria-controls="dbq4">How do I get a representative to help me?</button>
-      <div id="dbq4" class="usa-accordion-content">
-        <p>If you want to, you can have a representative help you with your appeal. This person may be a lawyer, a claims agent, or a Veterans Service Officer (VSO). <a href="/disability-benefits/apply/help">Learn how to get help filing your claim</a>.</p>
-        <p>Once you have a representative, you’ll need to let VA know they have permission to represent you by completing a form.</p>
-        <ul>
-          <li>If your representative is a lawyer or claims agent, fill out the Appointment of Individual as Claimant’s Representative (VA Form 21-22A). <a href="https://www.vba.va.gov/pubs/forms/VBA-21-22A-ARE.pdf">Download VA Form 21-22A</a></li>
-          <li>If your representative is a VSO, fill out the Appointment of Veterans Service Organization as Claimant’s Representative (VA Form 21-22). <a href="https://www.vba.va.gov/pubs/forms/VBA-21-22-ARE.pdf">Download VA Form 21-22</a></li>
-        </ul>
-      </div>
-    </li>
-    <li>
-      <button class="usa-button-unstyled usa-accordion-button" aria-controls="dbq5">What if I decide I don’t want to pursue my appeal anymore?</button>
-      <div id="dbq5" class="usa-accordion-content">
-        <p>If at any time you decide you don’t want to appeal the claim anymore (for any or all of the issues involved in the appeal), you or your authorized representative can send in a written statement. It should include your name, the related Department of Veterans Affairs file number, and a statement that you’re withdrawing the appeal.</p>
-        <p>If you request the withdrawal <em>before</em> you get notice that the appeal has been activated at the Board, send your statement to VBA. After the appeal has been transferred to the Board, you should send it directly to the Board at:</p>
-        <p class="va-address-block">
-          Chairman (01)<br/>
-          Board of Veterans’ Appeals<br/>
-          PO Box 27063<br/>
-          Washington, DC 20038<br/>
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-button-unstyled usa-accordion-button" aria-controls="dbq6">What if I decide I don’t want a Board hearing anymore?</button>
-      <div id="dbq6" class="usa-accordion-content">
-        <p>If at any time you decide you don’t want a Board hearing, you or your authorized representative can send in a written statement. Your statement should include your name, the related Department of Veterans Affairs file number, and a statement that you’re withdrawing the appeal.</p>
-        <p>Send your letter to:</p><br>
-        <p class="va-address-block">
-          Director, Office of Management, Planning and Analysis (014)<br/>
-          Board of Veterans’ Appeals<br/>
-          PO Box 27063<br/>
-          Washington, DC 20038<br/>
-        </p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-button-unstyled usa-accordion-button" aria-controls="dbq7">What happens if I disagree with the Board’s decision?</button>
-      <div id="dbq7" class="usa-accordion-content">
-        <p>If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You will need to hire a VA-accredited attorney to represent you, or you may represent yourself. You will need to file your Court appeal 120 days of the Board’s decision. <a href="https://www.uscourts.cavc.gov/appeal.php">Learn how to file a Court appeal</a>.</p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-button-unstyled usa-accordion-button" aria-controls="dbq8">What is the Court of Appeals for Veterans Claims (CAVC)?</button>
-      <div id="dbq8" class="usa-accordion-content">
-        <p>The CAVC is made up of:</p>
-        <ul>
-          <li>7 permanent (long-term), active judges, and</li>
-          <li>2 more judges as part of a temporary expansion clause</li>
-        </ul>
-        <p>The CAVC has the sole power to accept or overturn Board decisions and is part of the United States Judiciary, not the Department of Veterans Affairs.</p>
-        <p>The CAVC reviews Board decisions based on what was in your file at the time the Board reviewed it, and written and oral arguments you or your representative submitted.</p>
-        <p>The CAVC’s main office is in Washington, DC, but the CAVC holds sessions in other parts of the country a few times each year.</p>
-      </div>
-    </li>
-    <li>
-      <button class="usa-button-unstyled usa-accordion-button" aria-controls="dbq9">How do I file a Notice of Appeal with the CAVC?</button>
-      <div id="dbq9" class="usa-accordion-content">
-        <p>If the Board has sent you a final decision on your appeal, you can appeal the Board’s decision to the CAVC. You’ll need to wait until you have a final decision from the Board—not the VBA RO—before you can appeal to the CAVC. <a href="https://www.uscourts.cavc.gov/appeal.php">Learn how to file an appeal with the CAVC</a>.</p>
-      </div>
-    </li>
-  </ul>
-</div>
+If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You will need to hire a VA-accredited attorney to represent you, or you may represent yourself. You will need to file your Court appeal 120 days of the Board’s decision.
+[Learn how to file a Court appeal](https://www.uscourts.cavc.gov/appeal.php).
 
 
 <script src="https://standards.usa.gov/assets/js/vendor/uswds.min.js" type="text/javascript"></script>

--- a/src/sass/base/_va.scss
+++ b/src/sass/base/_va.scss
@@ -1408,6 +1408,9 @@ p.info-message {
   &:last-child {
     border: none;
   }
+  h4 {
+    clear: none;
+  }
 }
 
 .vertical-list-group .list-group-item:last-child {


### PR DESCRIPTION
These changes update the appeals overview page content. There are a few outstanding questions:

- ~Should the "The Board makes its decision" section discuss the board or a judge?~

TODO: 
- ~Update Advanced on Docket link once page is set up~

![localhost_3001_disability-benefits_claims-appeal_ 3](https://user-images.githubusercontent.com/16051172/37189607-2415726a-230a-11e8-9c76-271a02447c92.png)
