### PR TITLE
Make service before 1977 fields required on 1990 form

### DIFF
--- a/src/js/edu-benefits/1990/config/form.js
+++ b/src/js/edu-benefits/1990/config/form.js
@@ -18,6 +18,7 @@ import postHighSchoolTrainingsUI from '../../definitions/postHighSchoolTrainings
 import currentOrPastMonthYearUI from '../../../common/schemaform/definitions/currentOrPastMonthYear';
 import yearUI from '../../../common/schemaform/definitions/year';
 import * as toursOfDuty from '../../definitions/toursOfDuty';
+import serviceBefore1977UI from '../../definitions/serviceBefore1977';
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 
@@ -510,25 +511,12 @@ const formConfig = {
           depends: hasServiceBefore1977,
           uiSchema: {
             'ui:title': 'Dependents',
-            serviceBefore1977: {
-              married: {
-                'ui:title': 'Are you married?',
-                'ui:widget': 'yesNo'
-              },
-              haveDependents: {
-                'ui:title': 'Do you have any children who are under age 18? Or do you have any children who are over age 18 but under 23, not married, and attending school? Or do you have any children of any age who are permanently disabled for mental or physical reasons?',
-                'ui:widget': 'yesNo'
-              },
-              parentDependent: {
-                'ui:title': 'Do you have a parent who is dependent on your financial support?',
-                'ui:widget': 'yesNo'
-              }
-            }
+            serviceBefore1977: serviceBefore1977UI
           },
           schema: {
             type: 'object',
             properties: {
-              serviceBefore1977: _.unset('required', serviceBefore1977)
+              serviceBefore1977
             }
           }
         },

--- a/test/edu-benefits/1990/config/dependents.unit.spec.jsx
+++ b/test/edu-benefits/1990/config/dependents.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('Edu 1990 dependents', () => {
 
     expect(formDOM.querySelectorAll('input, select').length).to.equal(6);
   });
-  it('should submit form without information', () => {
+  it('should show errors if submitted without information', () => {
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
         schema={schema}
@@ -42,7 +42,7 @@ describe('Edu 1990 dependents', () => {
     const formDOM = getFormDOM(form);
     formDOM.submitForm();
 
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(3);
   });
   it('should show page only if served before 1977', () => {
     expect(depends({


### PR DESCRIPTION
These fields have been required in the schema and not in the form for a while, but apparently we don't have many people submitting who have service before 1977, since we have only one error because of it. 

Making these fields required is the simplest solution and won't disrupt other users, since this page is only shown if you have service before 1977. This also matches how the 1995 works.