### PR TITLE
Partially replaced use of LOA with new 'verified' flag.

### DIFF
--- a/src/js/common/helpers/login-helpers.js
+++ b/src/js/common/helpers/login-helpers.js
@@ -85,6 +85,7 @@ export function getUserData(dispatch) {
       authnContext: userData.authn_context,
       loa: userData.loa,
       multifactor: userData.multifactor,
+      verified: userData.verified,
       gender: userData.gender,
       dob: userData.birth_date,
       status: json.data.attributes.va_profile.status,

--- a/src/js/common/schemaform/save-in-progress/FormSaved.jsx
+++ b/src/js/common/schemaform/save-in-progress/FormSaved.jsx
@@ -37,12 +37,10 @@ class FormSaved extends React.Component {
   }
 
   render() {
+    const { formId, lastSavedDate } = this.props;
     const { profile } = this.props.user;
-    const lastSavedDate = this.props.lastSavedDate;
-    const formId = this.props.formId;
+    const { verified } = profile;
     const prefillAvailable = !!(profile && profile.prefillsAvailable.includes(formId));
-    const verifiedAccountType = 3;// verified ID.me accounts are type 3
-    const notVerified = profile.accountType !== verifiedAccountType;
     const { success } = this.props.route.formConfig.savedFormMessages || {};
     const expirationDate = moment.unix(this.props.expirationDate).format('M/D/YYYY');
 
@@ -59,7 +57,7 @@ class FormSaved extends React.Component {
             If you’re logged in through a public computer, please sign out of your account before you log off to keep your information secure.
           </div>
         </div>
-        {notVerified && <div className="usa-alert usa-alert-warning">
+        {!verified && <div className="usa-alert usa-alert-warning">
           <div className="usa-alert-body">
             We want to keep your information safe with the highest level of security. Please <a href={`/verify?next=${window.location.pathname}`} className="verify-link">verify your identity</a>.
           </div>

--- a/src/js/login/components/Verify.jsx
+++ b/src/js/login/components/Verify.jsx
@@ -20,13 +20,13 @@ class Verify extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { accountType } = this.props.profile;
-    const shouldCheckAccount = prevProps.profile.accountType !== accountType;
-    if (shouldCheckAccount) { this.checkAccountAccess(accountType); }
+    const { verified } = this.props.profile;
+    const shouldCheckAccount = prevProps.profile.verified !== verified;
+    if (shouldCheckAccount) { this.checkAccountAccess(); }
   }
 
-  checkAccountAccess(accountType) {
-    if ((accountType > 1) && this.props.shouldRedirect) {
+  checkAccountAccess() {
+    if (this.props.profile.verified && this.props.shouldRedirect) {
       const nextParams = new URLSearchParams(window.location.search);
       const nextPath = nextParams.get('next');
       window.location.replace(nextPath || '/');

--- a/src/js/user-profile/components/UserDataSection.jsx
+++ b/src/js/user-profile/components/UserDataSection.jsx
@@ -112,10 +112,10 @@ class UserDataSection extends React.Component {
   render() {
     const {
       profile: {
-        accountType,
         dob,
         email,
         gender,
+        verified
       },
       name: {
         first: firstName,
@@ -127,7 +127,7 @@ class UserDataSection extends React.Component {
     let content;
     const name = `${firstName || ''} ${middleName || ''} ${lastName || ''}`;
 
-    if (accountType === 3) {
+    if (verified) {
       content = (
         <span>
           <p><span className="label">Name:</span>{_.startCase(_.toLower(name))}</p>
@@ -144,7 +144,7 @@ class UserDataSection extends React.Component {
           {content}
           <p><span className="label">Email address:</span> {email}</p>
           {this.renderMultifactorMessage()}
-          {accountType !== 3 && <p><span className="label"><a href="/verify?next=/profile">Verify your identity</a> to access more services you may be eligible for.</span></p>}
+          {!verified && <p><span className="label"><a href="/verify?next=/profile">Verify your identity</a> to access more services you may be eligible for.</span></p>}
           <p>Want to change your email, password, or other account settings?<br/>
             <a href="https://wallet.id.me/settings" target="_blank">Go to ID.me to manage your account</a>
           </p>

--- a/src/js/user-profile/reducers/profile.js
+++ b/src/js/user-profile/reducers/profile.js
@@ -31,6 +31,7 @@ const initialState = {
   dob: null,
   gender: null,
   accountType: null,
+  verified: false,
   mhv: {
     account: {
       errors: null,

--- a/src/js/veteran-id-card/containers/VeteranIDCard.jsx
+++ b/src/js/veteran-id-card/containers/VeteranIDCard.jsx
@@ -23,12 +23,11 @@ class VeteranIDCard extends React.Component {
   componentWillReceiveProps(nextProps) {
     // Once the login logic is all done...
     // This will occur even for unauthenticated users and should only occur once.
-    if (this.props.profile.loading && !nextProps.profile.loading) {
-      const userProfile = nextProps.profile;
+    if (this.props.user.profile.loading && !nextProps.user.profile.loading) {
+      const userProfile = nextProps.user.profile;
       const { serviceRateLimitedAuthed, serviceRateLimitedUnauthed } = this.props.vicSettings;
-      const { currentlyLoggedIn } = userProfile;
 
-      if (currentlyLoggedIn) {
+      if (nextProps.user.login.currentlyLoggedIn) {
         if (serviceRateLimitedAuthed) {
           window.dataLayer.push({ event: 'vic-authenticated-ratelimited' });
           this.renderEmailCapture = true;
@@ -64,11 +63,9 @@ class VeteranIDCard extends React.Component {
         <RequiredLoginView
           authRequired={3}
           serviceRequired="id-card"
-          userProfile={this.props.profile}
-          loginUrl={this.props.loginUrl}
-          verifyUrl={this.props.verifyUrl}>
+          userProfile={this.props.user.profile}>
           <DowntimeNotification appTitle="Veteran ID Card application" dependencies={[services.vic]}>
-            <RequiredVeteranView userProfile={this.props.profile}>
+            <RequiredVeteranView userProfile={this.props.user.profile}>
               {this.props.children}
             </RequiredVeteranView>
           </DowntimeNotification>
@@ -83,12 +80,7 @@ VeteranIDCard.defaultProps = {
 };
 
 const mapStateToProps = (state) => {
-  const userState = state.user;
-  return {
-    profile: userState.profile,
-    loginUrl: userState.login.loginUrl,
-    verifyUrl: userState.login.verifyUrl
-  };
+  return { user: state.user };
 };
 
 export default connect(mapStateToProps)(VeteranIDCard);

--- a/src/js/veteran-id-card/containers/VeteranIDCard.jsx
+++ b/src/js/veteran-id-card/containers/VeteranIDCard.jsx
@@ -20,17 +20,15 @@ function createVicSettings() {
 }
 
 class VeteranIDCard extends React.Component {
-
   componentWillReceiveProps(nextProps) {
-
     // Once the login logic is all done...
     // This will occur even for unauthenticated users and should only occur once.
     if (this.props.profile.loading && !nextProps.profile.loading) {
       const userProfile = nextProps.profile;
       const { serviceRateLimitedAuthed, serviceRateLimitedUnauthed } = this.props.vicSettings;
-      const isloggedIn = !!userProfile.accountType;
+      const { currentlyLoggedIn } = userProfile;
 
-      if (isloggedIn) {
+      if (currentlyLoggedIn) {
         if (serviceRateLimitedAuthed) {
           window.dataLayer.push({ event: 'vic-authenticated-ratelimited' });
           this.renderEmailCapture = true;

--- a/test/common/schemaform/save-in-progress/FormSaved.unit.spec.jsx
+++ b/test/common/schemaform/save-in-progress/FormSaved.unit.spec.jsx
@@ -68,7 +68,7 @@ describe('Schemaform <FormSaved>', () => {
   });
   it('should not display verify link if user is verified', () => {
     const u = user();
-    u.profile.accountType = 3;
+    u.profile.verified = true;
     const tree = SkinDeep.shallowRender(
       <FormSaved formId={formId} lastSavedDate={lastSavedDate} expirationDate={expirationDate} route={route} user={u}/>
     );


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#9096.
Depends on department-of-veterans-affairs/vets-api#1752.

This makes use of a `verified` flag that is being added to the serialized user object instead of the `loa` object. This is the first part in phasing out usage of `loa` on the front-end. It will be completely phased out once I refactor the RequiredLoginView component, which ends up affecting other teams, so I wanted to make a separate PR for that.

--

Although this remove the explicit reference to LOA for API consumers, having a `verified` flag is still an implicit reference to LOA. It's a short term approach, and will eventually be replaced altogether.

The main purpose of LOA for the front-end right now is to determine whether the user should be prompted to "verify" (or identity proof) their account, which could possibly give them access to certain apps/services. But potentially, there are services that don't automatically become accessible once identity proofed. Being LOA 3 is not necessarily the only criterion for access, and is often only one of many, but the front-end doesn't really handle the nuances of why a user might not be able to access the service.

Ideally, with authZ in the works, we can eventually rely on an API endpoint that doesn't expose the nitty gritty details of an account like LOA. One idea we're currently entertaining is a services hash in the form of something like `{ eligible: false, authorized: false, eligibility_reason: "Not a VA patient" }` that the front-end can handle more granularly. Another idea is that we could introduce a services controller to query for availability along with any relevant data. In any case, the goal is for the API to provide the F/E a minimal and relevant set of data that's sufficient to inform the user flow.

CC: @jkassemi. Wanted to open up discussion in light of authZ refactors and discovery.