### PR TITLE
Implement beta wrapper component into personalization features

### DIFF
--- a/src/js/common/actions/beta.js
+++ b/src/js/common/actions/beta.js
@@ -1,0 +1,42 @@
+import { apiRequest } from '../helpers/api';
+
+export const FETCH_BETA_FEATURES_SUCCESS = 'FETCH_BETA_FEATURES_SUCCESS';
+export const BETA_REGISTERING = 'BETA_REGISTERING';
+export const BETA_REGISTER_SUCCESS = 'BETA_REGISTER_SUCCESS';
+export const BETA_REGISTER_FAILURE = 'BETA_REGISTER_FAILURE';
+
+export const betaFeatures = {
+  healthAccount: 'health_account',
+  veteranIdCard: 'veteran_id_card',
+  personalization: 'personalization'
+};
+
+export function getBetaFeatures() {
+  return { type: FETCH_BETA_FEATURES_SUCCESS, betaFeatures: [] };
+}
+
+export function registerBeta(featureName) {
+  return dispatch => {
+    dispatch({ type: BETA_REGISTERING, featureName });
+
+    const settings = {
+      method: 'POST',
+    };
+
+    apiRequest(`/beta_registration/${featureName}`,
+      settings,
+      response => dispatch({
+        type: BETA_REGISTER_SUCCESS,
+        username: response.user,
+        status: 'succeeded',
+        featureName
+      }),
+      () => dispatch({
+        type: BETA_REGISTER_FAILURE,
+        status: 'failed',
+        featureName
+      })
+    );
+  };
+}
+

--- a/src/js/common/actions/beta.js
+++ b/src/js/common/actions/beta.js
@@ -5,35 +5,47 @@ export const BETA_REGISTERING = 'BETA_REGISTERING';
 export const BETA_REGISTER_SUCCESS = 'BETA_REGISTER_SUCCESS';
 export const BETA_REGISTER_FAILURE = 'BETA_REGISTER_FAILURE';
 
-export const betaFeatures = {
-  healthAccount: 'health_account',
-  veteranIdCard: 'veteran_id_card',
-  personalization: 'personalization'
+export const statuses = {
+  succeeded: 'succeeded',
+  failed: 'failed',
+  pending: 'pending'
 };
 
 export function getBetaFeatures() {
+  // @todo How do we get this information? Can it be included in the user object?
   return { type: FETCH_BETA_FEATURES_SUCCESS, betaFeatures: [] };
+}
+
+export function registerBetaToSession(featureName) {
+  return dispatch => {
+    dispatch({ type: BETA_REGISTERING, featureName });
+    setTimeout(() => {
+      dispatch({
+        type: BETA_REGISTER_SUCCESS,
+        status: statuses.succeeded,
+        featureName
+      });
+    }, 500);
+  };
 }
 
 export function registerBeta(featureName) {
   return dispatch => {
     dispatch({ type: BETA_REGISTERING, featureName });
-
     const settings = {
       method: 'POST',
     };
-
     apiRequest(`/beta_registration/${featureName}`,
       settings,
       response => dispatch({
         type: BETA_REGISTER_SUCCESS,
         username: response.user,
-        status: 'succeeded',
+        status: statuses.succeeded,
         featureName
       }),
       () => dispatch({
         type: BETA_REGISTER_FAILURE,
-        status: 'failed',
+        status: statuses.succeeded,
         featureName
       })
     );

--- a/src/js/common/actions/downtime.js
+++ b/src/js/common/actions/downtime.js
@@ -1,0 +1,27 @@
+import { apiRequest } from '../helpers/api';
+
+export const RETREIVE_SCHEDULED_DOWNTIME = 'RETREIVE_SCHEDULED_DOWNTIME';
+export const RECEIVE_SCHEDULED_DOWNTIME = 'RECEIVE_SCHEDULED_DOWNTIME';
+
+function receiveScheduledDowntime(dispatch, data) {
+  const services = data.map(({ attributes: { externalService: service, description, startTime, endTime } }) => {
+    return {
+      service,
+      description,
+      startTime: new Date(startTime),
+      endTime: endTime && new Date(endTime) // endTime is optional for indefinite outages
+    };
+  });
+  dispatch({ type: RECEIVE_SCHEDULED_DOWNTIME, value: services });
+}
+
+export function getScheduledDowntime() {
+  return (dispatch) => {
+    dispatch({ type: RETREIVE_SCHEDULED_DOWNTIME });
+    return apiRequest(
+      '/maintenance_windows/',
+      undefined,
+      (json) => { receiveScheduledDowntime(dispatch, json.data); },
+      () => { receiveScheduledDowntime(dispatch, []); });
+  };
+}

--- a/src/js/common/actions/index.js
+++ b/src/js/common/actions/index.js
@@ -1,27 +1,2 @@
-import { apiRequest } from '../helpers/api';
-
-export const RETREIVE_SCHEDULED_DOWNTIME = 'RETREIVE_SCHEDULED_DOWNTIME';
-export const RECEIVE_SCHEDULED_DOWNTIME = 'RECEIVE_SCHEDULED_DOWNTIME';
-
-function receiveScheduledDowntime(dispatch, data) {
-  const services = data.map(({ attributes: { externalService: service, description, startTime, endTime } }) => {
-    return {
-      service,
-      description,
-      startTime: new Date(startTime),
-      endTime: endTime && new Date(endTime) // endTime is optional for indefinite outages
-    };
-  });
-  dispatch({ type: RECEIVE_SCHEDULED_DOWNTIME, value: services });
-}
-
-export function getScheduledDowntime() {
-  return (dispatch) => {
-    dispatch({ type: RETREIVE_SCHEDULED_DOWNTIME });
-    return apiRequest(
-      '/maintenance_windows/',
-      undefined,
-      (json) => { receiveScheduledDowntime(dispatch, json.data); },
-      () => { receiveScheduledDowntime(dispatch, []); });
-  };
-}
+export * from './downtime';
+export * from './beta';

--- a/src/js/common/containers/BetaApp.jsx
+++ b/src/js/common/containers/BetaApp.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import objectValues from 'lodash/fp/values';
 import { getBetaFeatures, registerBetaToSession as registerBeta, statuses } from '../actions';
-import LoadingIndicator from '../components/LoadingIndicator';
 import AlertBox from '../components/AlertBox';
 
 export const features = {
@@ -20,7 +19,7 @@ class BetaApp extends React.Component {
       PropTypes.shape({
         feature: PropTypes.string,
         loading: PropTypes.bool,
-        status: PropTypes.oneOf(['succeeded', 'failed'])
+        status: PropTypes.oneOf(objectValues(statuses))
       })
     )
   };
@@ -31,21 +30,21 @@ class BetaApp extends React.Component {
   }
 
   render() {
-    if (this.props.loading) {
-      return <LoadingIndicator message="Loading beta information..."/>;
-    }
-
     if (this.props.feature && this.props.feature.status === statuses.succeeded) return this.props.children;
+
+    const feature = this.props.feature;
+    const pending = feature.status === statuses.pending;
 
     return (
       <div className="row-padded" style={{ marginBottom: 15 }}>
         <h1>This application is currently in beta</h1>
         <button type="button"
+          disabled={pending}
           className="usa-button-primary" onClick={this.registerBeta}>
-          Register for beta access
+          Register for beta access {pending && <i className="fa fa-spin fa-spinner"/>}
         </button>
         <AlertBox
-          isVisible={!!this.props.feature && this.props.feature.status === statuses.failed}
+          isVisible={!!feature && feature.status === statuses.failed}
           status="error"
           content={<h3>Failed to register for beta</h3>}/>
       </div>
@@ -54,10 +53,8 @@ class BetaApp extends React.Component {
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const loading = state.user.profile.loading;
   return {
-    loading,
-    feature: !loading && state.betaFeatures.find(b => b.feature === ownProps.featureName)
+    feature: state.betaFeatures.find(b => b.feature === ownProps.featureName) || {}
   };
 };
 

--- a/src/js/common/containers/BetaApp.jsx
+++ b/src/js/common/containers/BetaApp.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { getBetaFeatures, registerBeta } from '../actions';
+import LoadingIndicator from '../components/LoadingIndicator';
+
+class BetaApp extends React.Component {
+
+  static propTypes = {
+    featureName: PropTypes.string.isRequired,
+    betaFeatures: PropTypes.arrayOf(
+      PropTypes.shape({
+        feature: PropTypes.string,
+        loading: PropTypes.bool,
+        status: PropTypes.oneOf(['succeeded', 'failed'])
+      })
+    )
+  };
+
+  constructor(props) {
+    super(props);
+    this.registerBeta = this.props.registerBeta.bind(this, this.props.featureName);
+  }
+
+  render() {
+    if (this.props.loading) {
+      return <LoadingIndicator message="Loading beta information..."/>;
+    }
+
+    switch (this.props.feature.status) {
+      case 'succeeded':
+        return this.props.children;
+      case 'failed':
+        return <h1>Failed to registered for beta.</h1>;
+      default:
+        return (
+          <div>
+            <h1>This application is currently in beta</h1>
+            <button className="usa-button-primary" onClick={this.registerBeta}>Register for beta access</button>
+          </div>
+        );
+    }
+  }
+}
+
+const mapStateToProps = (state, ownProps) => {
+  const loading = state.user.profile.loading;
+  return {
+    loading,
+    feature: loading && state.betaFeatures.find(b => b.feature === ownProps.featureName)
+  };
+};
+
+const mapDispatchToProps = {
+  getBetaFeatures,
+  registerBeta
+};
+
+export { BetaApp };
+
+export default connect(mapStateToProps, mapDispatchToProps)(BetaApp);

--- a/src/js/common/reducers/beta.js
+++ b/src/js/common/reducers/beta.js
@@ -1,0 +1,31 @@
+import {
+  FETCH_BETA_FEATURES_SUCCESS,
+  BETA_REGISTER_SUCCESS,
+  BETA_REGISTER_FAILURE,
+  BETA_REGISTERING
+} from '../actions';
+
+const initialState = [];
+
+export default function betaFeatures(state = initialState, action) {
+  switch (action.type) {
+    case FETCH_BETA_FEATURES_SUCCESS:
+      return action.betaFeatures;
+
+    case BETA_REGISTERING: {
+      const feature = { feature: action.featureName, isLoading: true };
+      return state.betaFeatures.concat(feature);
+    }
+
+    case BETA_REGISTER_FAILURE:
+    case BETA_REGISTER_SUCCESS: {
+      const feature = { feature: action.featureName, status: action.status, isLoading: false };
+      return state.betaFeatures.map(b => {
+        return b.feature === action.featureName ? feature : b;
+      });
+    }
+
+    default:
+      return state;
+  }
+}

--- a/src/js/common/reducers/beta.js
+++ b/src/js/common/reducers/beta.js
@@ -2,25 +2,40 @@ import {
   FETCH_BETA_FEATURES_SUCCESS,
   BETA_REGISTER_SUCCESS,
   BETA_REGISTER_FAILURE,
-  BETA_REGISTERING
+  BETA_REGISTERING,
+  statuses
 } from '../actions';
 
-const initialState = [];
+function sessionStorageInit() {
+  let initialState = [];
+  if (sessionStorage.betaFeatures) {
+    initialState = JSON.parse(sessionStorage.betaFeatures);
+  }
+  return initialState;
+}
 
-export default function betaFeatures(state = initialState, action) {
+function sessionStorageWrapper(reducer) {
+  return (state, action) => {
+    const newState = reducer(state, action);
+    sessionStorage.betaFeatures = JSON.stringify(newState);
+    return newState;
+  };
+}
+
+function betaFeatures(state = sessionStorageInit(), action) {
   switch (action.type) {
     case FETCH_BETA_FEATURES_SUCCESS:
       return action.betaFeatures;
 
     case BETA_REGISTERING: {
-      const feature = { feature: action.featureName, isLoading: true };
-      return state.betaFeatures.concat(feature);
+      const feature = { feature: action.featureName, status: statuses.pending };
+      return state.concat(feature);
     }
 
     case BETA_REGISTER_FAILURE:
     case BETA_REGISTER_SUCCESS: {
-      const feature = { feature: action.featureName, status: action.status, isLoading: false };
-      return state.betaFeatures.map(b => {
+      const feature = { feature: action.featureName, status: action.status };
+      return state.map(b => {
         return b.feature === action.featureName ? feature : b;
       });
     }
@@ -29,3 +44,5 @@ export default function betaFeatures(state = initialState, action) {
       return state;
   }
 }
+
+export default sessionStorageWrapper(betaFeatures);

--- a/src/js/common/reducers/downtime.js
+++ b/src/js/common/reducers/downtime.js
@@ -1,0 +1,25 @@
+import {
+  RECEIVE_SCHEDULED_DOWNTIME,
+  RETREIVE_SCHEDULED_DOWNTIME
+} from '../actions';
+
+
+const initialState = {
+  isReady: false,
+  values: []
+};
+
+export default function scheduledDowntime(state = initialState, action) {
+  switch (action.type) {
+
+    case RECEIVE_SCHEDULED_DOWNTIME:
+      return {
+        isReady: true,
+        values: action.value
+      };
+
+    case RETREIVE_SCHEDULED_DOWNTIME:
+    default:
+      return state;
+  }
+}

--- a/src/js/common/reducers/index.js
+++ b/src/js/common/reducers/index.js
@@ -1,21 +1,4 @@
-import { RECEIVE_SCHEDULED_DOWNTIME, RETREIVE_SCHEDULED_DOWNTIME } from '../actions';
+import scheduledDowntime from './downtime';
+import betaFeatures from './beta';
 
-const initialState = {
-  scheduledDowntime: {
-    isReady: false,
-    values: []
-  }
-};
-
-export function scheduledDowntime(state = initialState.scheduledDowntime, action) {
-  switch (action.type) {
-    case RECEIVE_SCHEDULED_DOWNTIME:
-      return {
-        isReady: true,
-        values: action.value
-      };
-    case RETREIVE_SCHEDULED_DOWNTIME:
-    default:
-      return state;
-  }
-}
+export default { scheduledDowntime, betaFeatures };

--- a/src/js/common/reducers/index.js
+++ b/src/js/common/reducers/index.js
@@ -1,4 +1,4 @@
 import scheduledDowntime from './downtime';
 import betaFeatures from './beta';
 
-export default { scheduledDowntime, betaFeatures };
+export { scheduledDowntime, betaFeatures };

--- a/src/js/common/store/index.js
+++ b/src/js/common/store/index.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
 import thunk from 'redux-thunk';
-import { scheduledDowntime } from '../reducers';
+import { scheduledDowntime, betaFeatures } from '../reducers';
 import login from '../../login/reducers/login';
 import feedback from '../../feedback/reducers';
 import profile from '../../user-profile/reducers/profile';
@@ -12,7 +12,8 @@ export const commonReducer = {
     profile
   }),
   feedback,
-  scheduledDowntime
+  scheduledDowntime,
+  betaFeatures
 };
 
 export default function createCommonStore(appReducer = {}) {

--- a/src/js/login/components/SearchHelpSignIn.jsx
+++ b/src/js/login/components/SearchHelpSignIn.jsx
@@ -49,7 +49,7 @@ class SearchHelpSignIn extends React.Component {
         clickHandler={() => {
           this.props.toggleSearchHelpUserMenu('account', !login.utilitiesMenuIsOpen.account);
         }}
-        profile={this.props.profile}
+        betaFeatures={this.props.betaFeatures}
         greeting={greeting}
         isOpen={login.utilitiesMenuIsOpen.account}
         onUserLogout={this.props.onUserLogout}/>);
@@ -84,7 +84,8 @@ const mapStateToProps = (state) => {
   const userState = state.user;
   return {
     login: userState.login,
-    profile: userState.profile
+    profile: userState.profile,
+    betaFeatures: state.betaFeatures
   };
 };
 

--- a/src/js/login/components/SignInProfileMenu.jsx
+++ b/src/js/login/components/SignInProfileMenu.jsx
@@ -11,8 +11,8 @@ class SignInProfileMenu extends React.Component {
     const dropDownContents = (
       <ul>
         <li><a href="/dashboard">Dashboard</a></li>
-        {betaProfile && <li key="1"><a href="/profile-beta">Profile</a></li>}
-        {betaProfile && <li key="2"><a href="/account-beta">Account</a></li>}
+        {betaProfile && <li><a href="/profile-beta">Profile</a></li>}
+        {betaProfile && <li><a href="/account-beta">Account</a></li>}
         {!betaProfile && <li><a href="/profile">Profile</a></li>}
         <li><a href="#" onClick={this.props.onUserLogout}>Sign Out</a></li>
       </ul>

--- a/src/js/login/components/SignInProfileMenu.jsx
+++ b/src/js/login/components/SignInProfileMenu.jsx
@@ -2,20 +2,18 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import DropDown from '../../common/components/DropDown';
 import IconUser from '../../common/components/svgicons/IconUser';
+import { features } from '../../common/containers/BetaApp';
 
 class SignInProfileMenu extends React.Component {
   render() {
     const icon = <IconUser color="#fff"/>;
-    // @todo Some type of check here to see if they are registered for the beta.
-    const personalizationBeta = true;
-
+    const betaProfile = this.props.betaFeatures.some(b => b.feature === features.personalization);
     const dropDownContents = (
       <ul>
         <li><a href="/dashboard">Dashboard</a></li>
-        {personalizationBeta ? ([
-          <li key="1"><a href="/profile-beta">Profile</a></li>,
-          <li key="2"><a href="/account-beta">Account</a></li>
-        ]) : (<li><a href="/profile">Profile</a></li>)}
+        {betaProfile && <li key="1"><a href="/profile-beta">Profile</a></li>}
+        {betaProfile && <li key="2"><a href="/account-beta">Account</a></li>}
+        {!betaProfile && <li><a href="/profile">Profile</a></li>}
         <li><a href="#" onClick={this.props.onUserLogout}>Sign Out</a></li>
       </ul>
     );

--- a/src/js/personalization/user-profile-beta/containers/UserProfileApp.jsx
+++ b/src/js/personalization/user-profile-beta/containers/UserProfileApp.jsx
@@ -14,6 +14,7 @@ import {
   openModal
 } from '../actions';
 
+import BetaApp, { features } from '../../../common/containers/BetaApp';
 import RequiredLoginView from '../../../common/components/RequiredLoginView';
 import DowntimeNotification, { services } from '../../../common/containers/DowntimeNotification';
 import ProfileView from '../components/ProfileView';
@@ -34,23 +35,25 @@ class UserProfileApp extends React.Component {
           userProfile={this.props.profile}
           loginUrl={this.props.loginUrl}
           verifyUrl={this.props.verifyUrl}>
-          <DowntimeNotification appTitle="user profile page" dependencies={[services.mvi, services.emis]}>
-            <div className="row user-profile-row">
-              <div className="usa-width-two-thirds medium-8 small-12 columns">
-                <h1>Your Profile</h1>
-                <ProfileView
-                  profile={this.props.profile}
-                  modal={{
-                    open: this.props.openModal,
-                    currentlyOpen: this.props.profile.modal,
-                    pendingSaves: this.props.profile.pendingSaves,
-                    errors: this.props.profile.errors
-                  }}
-                  updateActions={this.props.updateActions}
-                  fetchExtendedProfile={this.props.fetchExtendedProfile}/>
+          <BetaApp featureName={features.personalization}>
+            <DowntimeNotification appTitle="user profile page" dependencies={[services.mvi, services.emis]}>
+              <div className="row user-profile-row">
+                <div className="usa-width-two-thirds medium-8 small-12 columns">
+                  <h1>Your Profile</h1>
+                  <ProfileView
+                    profile={this.props.profile}
+                    modal={{
+                      open: this.props.openModal,
+                      currentlyOpen: this.props.profile.modal,
+                      pendingSaves: this.props.profile.pendingSaves,
+                      errors: this.props.profile.errors
+                    }}
+                    updateActions={this.props.updateActions}
+                    fetchExtendedProfile={this.props.fetchExtendedProfile}/>
+                </div>
               </div>
-            </div>
-          </DowntimeNotification>
+            </DowntimeNotification>
+          </BetaApp>
         </RequiredLoginView>
       </div>
     );
@@ -59,9 +62,6 @@ class UserProfileApp extends React.Component {
 
 const mapStateToProps = (state) => {
   const userState = state.user;
-
-  console.log(state)
-
   return {
     profile: state.extendedProfile,
     loginUrl: userState.login.loginUrl,


### PR DESCRIPTION
Super barebones wrapper component so that the user has to explicitly enroll in the beta to gain access. Doing it this way we shouldn't need to create a separate route for registering users - just share the `/profile-beta` link and make sure that landing component is wrapped in the `<BetaApp>`. For now, it's saving the beta information in the session storage but will need to be adjusted based on what comes out of department-of-veterans-affairs/vets.gov-team/issues/9155.

![image](https://user-images.githubusercontent.com/1915775/37122459-9e6ca13c-222e-11e8-90f3-77bf0c834e2a.png)

Resolves department-of-veterans-affairs/vets.gov-team/issues/9097