### PR TITLE
Allow uploads to be canceled on forms

### DIFF
--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -213,15 +213,6 @@ export function uploadFile(file, uiOptions, onProgress, onChange, onError) {
       onError();
     });
 
-    req.addEventListener('abort', () => {
-      onChange({
-        name: file.name,
-        errorMessage: 'Upload aborted'
-      });
-      Raven.captureMessage('vets_upload_error: Upload aborted');
-      onError();
-    });
-
     req.upload.addEventListener('progress', (evt) => {
       if (evt.lengthComputable && onProgress) {
         // setting this at 80, because there's some time after we get to 100%

--- a/src/js/common/schemaform/actions.js
+++ b/src/js/common/schemaform/actions.js
@@ -140,7 +140,7 @@ export function submitForm(formConfig, form) {
   };
 }
 
-export function uploadFile(file, onChange, uiOptions, progressCallback) {
+export function uploadFile(file, onChange, uiOptions, progressCallback, provideRequest) {
   return (dispatch, getState) => {
     if (file.size > uiOptions.maxSize) {
       onChange({
@@ -231,6 +231,7 @@ export function uploadFile(file, onChange, uiOptions, progressCallback) {
 
       req.setRequestHeader('X-Key-Inflection', 'camel');
       req.send(payload);
+      provideRequest(req);
     });
   };
 }

--- a/src/js/common/schemaform/fields/FileField.jsx
+++ b/src/js/common/schemaform/fields/FileField.jsx
@@ -35,23 +35,18 @@ export default class FileField extends React.Component {
       if (idx === null) {
         idx = files.length === 0 ? 0 : files.length;
       }
-      this.props.formContext.uploadFile(
+      this.uploadRequest = this.props.formContext.uploadFile(
         event.target.files[0],
-        (file) => {
-          this.props.onChange(_.set(idx, file, this.props.formData || []));
-          this.cancelUploadRequest = null;
-        },
         this.props.uiSchema['ui:options'],
         this.updateProgress,
-        (req) => {
-          this.cancelUploadRequest = () => req.abort();
+        (file) => {
+          this.props.onChange(_.set(idx, file, this.props.formData || []));
+          this.uploadRequest = null;
+        },
+        () => {
+          this.uploadRequest = null;
         }
-      ).catch(() => {
-        // rather not use the promise here, but seems better than trying to pass
-        // a blur function
-        // this.props.onBlur(`${this.props.idSchema.$id}_${idx}`);
-        this.cancelUploadRequest = null;
-      });
+      );
     }
   }
 
@@ -68,8 +63,8 @@ export default class FileField extends React.Component {
   }
 
   cancelUpload = (index) => {
-    if (this.cancelUploadRequest) {
-      this.cancelUploadRequest();
+    if (this.uploadRequest) {
+      this.uploadRequest.abort();
     }
     this.removeFile(index);
   }
@@ -136,7 +131,7 @@ export default class FileField extends React.Component {
                     </div>
                   }
                   {!file.uploading && <span>{file.name}</span>}
-                  {!hasErrors && itemSchema.properties.attachmentId &&
+                  {!hasErrors && _.get('properties.attachmentId', itemSchema) &&
                     <div className="schemaform-file-attachment">
                       <SchemaField
                         name="attachmentId"

--- a/src/js/common/schemaform/fields/FileField.jsx
+++ b/src/js/common/schemaform/fields/FileField.jsx
@@ -39,13 +39,18 @@ export default class FileField extends React.Component {
         event.target.files[0],
         (file) => {
           this.props.onChange(_.set(idx, file, this.props.formData || []));
+          this.cancelUploadRequest = null;
         },
         this.props.uiSchema['ui:options'],
-        this.updateProgress
+        this.updateProgress,
+        (req) => {
+          this.cancelUploadRequest = () => req.abort();
+        }
       ).catch(() => {
         // rather not use the promise here, but seems better than trying to pass
         // a blur function
         // this.props.onBlur(`${this.props.idSchema.$id}_${idx}`);
+        this.cancelUploadRequest = null;
       });
     }
   }
@@ -60,6 +65,13 @@ export default class FileField extends React.Component {
 
   updateProgress = (progress) => {
     this.setState({ progress });
+  }
+
+  cancelUpload = (index) => {
+    if (this.cancelUploadRequest) {
+      this.cancelUploadRequest();
+    }
+    this.removeFile(index);
   }
 
   removeFile = (index) => {
@@ -116,6 +128,11 @@ export default class FileField extends React.Component {
                     <div className="schemaform-file-uploading">
                       <span>{file.name}</span><br/>
                       <ProgressBar percent={this.state.progress}/>
+                      <button type="button" className="va-button-link" onClick={() => {
+                        this.cancelUpload(index);
+                      }}>
+                        Cancel
+                      </button>
                     </div>
                   }
                   {!file.uploading && <span>{file.name}</span>}

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -233,11 +233,11 @@ export default class PhotoField extends React.Component {
       this.props.uiSchema['ui:options'],
       this.updateProgress,
       (formData) => {
-        this.uploadRequest = null;
         if (formData.confirmationCode) {
           this.props.onChange(Object.assign({}, formData, {
             file
           }));
+          this.uploadRequest = null;
         } else {
           this.props.onChange(formData);
         }

--- a/src/js/vic-v2/config/form.js
+++ b/src/js/vic-v2/config/form.js
@@ -37,7 +37,7 @@ const {
   gender
 } = fullSchemaVIC.definitions;
 
-const TWENTY_FIVE_MB = 26214400;
+const TWENTY_FIVE_MB = 26214400000;
 const TEN_MB = 10485760;
 
 const formConfig = {
@@ -229,6 +229,7 @@ const formConfig = {
                 'jpg',
                 'gif',
                 'tif',
+                'zip',
                 'tiff'
               ],
               maxSize: TWENTY_FIVE_MB,

--- a/src/js/vic-v2/config/form.js
+++ b/src/js/vic-v2/config/form.js
@@ -4,10 +4,11 @@ import fullSchemaVIC from 'vets-json-schema/dist/VIC-schema.json';
 
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
+import IdentityFieldsWarning from '../components/IdentityFieldsWarning';
 import asyncLoader from '../../common/components/asyncLoader';
 import DD214Description from '../components/DD214Description';
 import PhotoDescription from '../components/PhotoDescription';
-import { prefillTransformer, submit } from '../helpers';
+import { prefillTransformer, submit, identityMatchesPrefill } from '../helpers';
 
 import fullNameUI from '../../common/schemaform/definitions/fullName';
 import ssnUI from '../../common/schemaform/definitions/ssn';
@@ -68,6 +69,7 @@ const formConfig = {
           path: 'veteran-information',
           title: 'Veteran information',
           uiSchema: {
+            'ui:description': IdentityFieldsWarning,
             veteranFullName: fullNameUI,
             veteranSocialSecurityNumber: ssnUI,
             gender: {
@@ -217,7 +219,7 @@ const formConfig = {
           path: 'documents/discharge',
           title: 'Discharge document upload',
           reviewTitle: 'Discharge document review',
-          depends: form => !form.verified,
+          depends: form => !form.verified || !identityMatchesPrefill(form),
           uiSchema: {
             'ui:description': DD214Description,
             dd214: fileUploadUI('Upload your discharge document', {

--- a/src/js/vic-v2/config/form.js
+++ b/src/js/vic-v2/config/form.js
@@ -4,11 +4,10 @@ import fullSchemaVIC from 'vets-json-schema/dist/VIC-schema.json';
 
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
-import IdentityFieldsWarning from '../components/IdentityFieldsWarning';
 import asyncLoader from '../../common/components/asyncLoader';
 import DD214Description from '../components/DD214Description';
 import PhotoDescription from '../components/PhotoDescription';
-import { prefillTransformer, submit, identityMatchesPrefill } from '../helpers';
+import { prefillTransformer, submit } from '../helpers';
 
 import fullNameUI from '../../common/schemaform/definitions/fullName';
 import ssnUI from '../../common/schemaform/definitions/ssn';
@@ -38,7 +37,7 @@ const {
   gender
 } = fullSchemaVIC.definitions;
 
-const TWENTY_FIVE_MB = 26214400000;
+const TWENTY_FIVE_MB = 26214400;
 const TEN_MB = 10485760;
 
 const formConfig = {
@@ -69,7 +68,6 @@ const formConfig = {
           path: 'veteran-information',
           title: 'Veteran information',
           uiSchema: {
-            'ui:description': IdentityFieldsWarning,
             veteranFullName: fullNameUI,
             veteranSocialSecurityNumber: ssnUI,
             gender: {
@@ -219,7 +217,7 @@ const formConfig = {
           path: 'documents/discharge',
           title: 'Discharge document upload',
           reviewTitle: 'Discharge document review',
-          depends: form => !form.verified || !identityMatchesPrefill(form),
+          depends: form => !form.verified,
           uiSchema: {
             'ui:description': DD214Description,
             dd214: fileUploadUI('Upload your discharge document', {
@@ -231,7 +229,6 @@ const formConfig = {
                 'jpg',
                 'gif',
                 'tif',
-                'zip',
                 'tiff'
               ],
               maxSize: TWENTY_FIVE_MB,

--- a/test/common/schemaform/fields/FileField.unit.spec.jsx
+++ b/test/common/schemaform/fields/FileField.unit.spec.jsx
@@ -157,7 +157,7 @@ describe('Schemaform <FileField>', () => {
     );
 
     expect(tree.find('ProgressBar').exists()).to.be.true;
-    expect(tree.find('button').exists()).to.be.false;
+    expect(tree.find('button').text()).to.equal('Cancel');
   });
 
   it('should update progress', () => {
@@ -321,7 +321,7 @@ describe('Schemaform <FileField>', () => {
         fileField: fileSchema
       }
     };
-    const uploadFile = sinon.stub().returns(Promise.resolve());
+    const uploadFile = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
         schema={schema}
@@ -338,9 +338,10 @@ describe('Schemaform <FileField>', () => {
     formDOM.files('input[type=file]', [{}]);
 
     expect(uploadFile.firstCall.args[0]).to.eql({});
-    expect(uploadFile.firstCall.args[1]).to.be.a('function');
-    expect(uploadFile.firstCall.args[2]).to.eql(uiSchema['ui:options']);
+    expect(uploadFile.firstCall.args[1]).to.eql(uiSchema['ui:options']);
+    expect(uploadFile.firstCall.args[2]).to.be.a('function');
     expect(uploadFile.firstCall.args[3]).to.be.a('function');
+    expect(uploadFile.firstCall.args[4]).to.be.a('function');
   });
   it('should render file with attachment type', () => {
     const idSchema = {


### PR DESCRIPTION
This also refactors the uploadFile function to not use a promise, because we keep adding callbacks and it's confusing. It also lets us return the xhr object and abort it.

![screen shot 2018-03-07 at 3 20 00 pm](https://user-images.githubusercontent.com/634932/37121410-03b59df4-222b-11e8-98ed-8ec9bd3c45f5.png)
