### PR TITLE
Fix security bug in the next parameter redirect

### DIFF
--- a/src/js/login/components/Signin.jsx
+++ b/src/js/login/components/Signin.jsx
@@ -21,14 +21,15 @@ class Signin extends React.Component {
   checkLoggedInStatus(loggedIn) {
     if (this.props.currentlyLoggedIn || loggedIn) {
       const nextParams = new URLSearchParams(window.location.search);
-      const nextPath = nextParams.get('next');
+      const nextPath = nextParams.get('next') || '';
 
       if (this.props.onLoggedIn) {
         this.props.onLoggedIn();
       }
 
       if (nextPath && window.location.pathname.indexOf('verify') === -1) {
-        window.location.replace(nextPath || '/');
+        const path = nextPath.startsWith('/') ? nextPath : `/${nextPath}`;
+        window.location.replace(path);
       }
     }
   }


### PR DESCRIPTION
I have been looking at how that `?next=` parameter works and noticed that you can put any URL there and after login the user will be redirected there. For example -

https://dev.vets.gov/?next=https%3A%2F%2Fsecurity.stackexchange.com%2Fquestions%2F121643%2Fis-it-safe-to-redirect-to-url-parameter-without-filtering

I haven't tested this in production so maybe there is a patch there. But otherwise, if someone realized this they could drop a malicious URL as that parameter and send that link out. Then any veterans will be redirected there post-login, or immediately if they're already logged in.