### PR TITLE
Mobile typography

### DIFF
--- a/src/sass/mobile_typography.scss
+++ b/src/sass/mobile_typography.scss
@@ -8,16 +8,13 @@
 
   h1 {
     font-size:30px;
-    color:hotpink !important;
   }
 
   h2 {
     font-size:24px;
-    color:hotpink !important;
   }
 
   .va-introtext {
     font-size:16px;
-    color:hotpink !important;
   }
 }

--- a/src/sass/mobile_typography.scss
+++ b/src/sass/mobile_typography.scss
@@ -1,0 +1,23 @@
+//============================================
+// Created: 3/12/18
+// This file contains type overrides for mobile breakpoints only
+// See: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/6214
+// ===========================================
+
+@media (max-width: $small-screen)  {
+
+  h1 {
+    font-size:30px;
+    color:hotpink !important;
+  }
+
+  h2 {
+    font-size:24px;
+    color:hotpink !important;
+  }
+
+  .va-introtext {
+    font-size:16px;
+    color:hotpink !important;
+  }
+}

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -87,6 +87,10 @@
 @import "modules/m-additional-info";
 @import "modules/m-downtime-notification";
 
+// ----- mobile typography -- see #6214 on vets.gov-team ---- //
+
+@import "mobile_typography";
+
 // ----- VA SHAME ---- //
 
 @import "shame";


### PR DESCRIPTION
See: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/6214

Basically, knock down the text size on mobile devices so that the headers don't take up so much real estate. 