### PR TITLE
Fixed bug that allowed attempt at account creation even if MHV services were not accessible

### DIFF
--- a/src/js/common/containers/MHVApp.jsx
+++ b/src/js/common/containers/MHVApp.jsx
@@ -44,7 +44,11 @@ export class MHVApp extends React.Component {
 
   isAccessible = () => ['existing', 'upgraded'].includes(this.props.account.state);
 
+  isIneligible = () => this.props.account.state === 'ineligible';
+
   handleAccountState = () => {
+    if (this.isIneligible()) { return; }
+
     if (this.needsTermsAcceptance()) {
       this.props.fetchLatestTerms(TERMS_NAME);
     } else if (!this.isAccessible()) {
@@ -108,7 +112,7 @@ export class MHVApp extends React.Component {
 }
 
 MHVApp.propTypes = {
-  children: PropTypes.element
+  children: PropTypes.node
 };
 
 const mapStateToProps = (state) => {

--- a/src/js/health-records/containers/HealthRecordsApp.jsx
+++ b/src/js/health-records/containers/HealthRecordsApp.jsx
@@ -22,7 +22,15 @@ function AppContent({ children, isDataAvailable }) {
     view = children;
   }
 
-  return <div className="bb-app">{view}</div>;
+  return (
+    <div className="bb-app">
+      <div className="row">
+        <div className="columns small-12">
+          {view}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export class HealthRecordsApp extends React.Component {
@@ -33,25 +41,19 @@ export class HealthRecordsApp extends React.Component {
         serviceRequired="health-records"
         userProfile={this.props.profile}>
         <DowntimeNotification appTitle="health records tool" dependencies={[services.mhv]}>
-          <MHVApp>
-            <AppContent>
-              <div>
-                <div className="row">
-                  <div className="columns small-12">
-                    <Breadcrumbs location={this.props.location}/>
-                    {this.props.children}
-                  </div>
-                </div>
-                <Modal
-                  cssClass="bb-modal"
-                  contents={this.props.modal.content}
-                  id="bb-glossary-modal"
-                  onClose={this.props.closeModal}
-                  title={this.props.modal.title}
-                  visible={this.props.modal.visible}/>
-              </div>
-            </AppContent>
-          </MHVApp>
+          <AppContent>
+            <Breadcrumbs location={this.props.location}/>
+            <MHVApp>
+              {this.props.children}
+              <Modal
+                cssClass="bb-modal"
+                contents={this.props.modal.content}
+                id="bb-glossary-modal"
+                onClose={this.props.closeModal}
+                title={this.props.modal.title}
+                visible={this.props.modal.visible}/>
+            </MHVApp>
+          </AppContent>
         </DowntimeNotification>
       </RequiredLoginView>
     );

--- a/src/js/messaging/containers/MessagingApp.jsx
+++ b/src/js/messaging/containers/MessagingApp.jsx
@@ -59,8 +59,8 @@ class MessagingApp extends React.Component {
         serviceRequired="messaging"
         userProfile={this.props.profile}>
         <DowntimeNotification appTitle="secure messaging tool" dependencies={[services.mhv]}>
-          <MHVApp>
-            <AppContent>
+          <AppContent>
+            <MHVApp>
               <div id="messaging-app-header">
                 <AlertBox
                   headline={this.props.alert.headline}
@@ -76,8 +76,8 @@ class MessagingApp extends React.Component {
                 {this.renderWarningBanner()}
               </div>
               {this.props.children}
-            </AppContent>
-          </MHVApp>
+            </MHVApp>
+          </AppContent>
         </DowntimeNotification>
       </RequiredLoginView>
     );

--- a/src/js/rx/containers/RxRefillsApp.jsx
+++ b/src/js/rx/containers/RxRefillsApp.jsx
@@ -43,24 +43,22 @@ class RxRefillsApp extends React.Component {
         serviceRequired="rx"
         userProfile={this.props.profile}>
         <DowntimeNotification appTitle="prescription refill tool" dependencies={[services.mhv]}>
-          <div>
+          <AppContent>
             <Breadcrumbs location={this.props.location} prescription={this.props.prescription}/>
             <MHVApp>
-              <AppContent>
-                {this.props.children}
-                <ConfirmRefillModal
-                  prescription={this.props.refillModal.prescription}
-                  isLoading={this.props.refillModal.loading}
-                  isVisible={this.props.refillModal.visible}
-                  refillPrescription={this.props.refillPrescription}
-                  onCloseModal={this.props.closeRefillModal}/>
-                <GlossaryModal
-                  content={this.props.glossaryModal.content}
-                  isVisible={this.props.glossaryModal.visible}
-                  onCloseModal={this.props.closeGlossaryModal}/>
-              </AppContent>
+              {this.props.children}
+              <ConfirmRefillModal
+                prescription={this.props.refillModal.prescription}
+                isLoading={this.props.refillModal.loading}
+                isVisible={this.props.refillModal.visible}
+                refillPrescription={this.props.refillPrescription}
+                onCloseModal={this.props.closeRefillModal}/>
+              <GlossaryModal
+                content={this.props.glossaryModal.content}
+                isVisible={this.props.glossaryModal.visible}
+                onCloseModal={this.props.closeGlossaryModal}/>
             </MHVApp>
-          </div>
+          </AppContent>
         </DowntimeNotification>
       </RequiredLoginView>
     );


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#9219.

The introduction of the `DowntimeNotification` component as an intermediate gating component failed to propagate the `isDataAvailable` flag that gets passed down from `RequiredLoginView`. Part of the problem is that I failed to check for that anyway first thing before doing anything in `MHVApp`, but foremost is that it wasn't propagating anymore.

This fix will prevent `MHVApp` from doing anything account creation related when the user is ineligible, which will result in showing the MHV access error with the three possible reasons. Longer term, I'd like to revamp `RequiredLoginView`, not only to stop using `loa`, but also to introduce a more reliable mechanism to handle inaccessible services.

I also shuffled order of wrapper components, which fixes visual margin problems when we we get account creation errors.
> <img width="841" alt="screen shot 2018-03-13 at 4 00 40 pm" src="https://user-images.githubusercontent.com/1067024/37366744-ae579644-26d7-11e8-8aa3-cd8a72ebc3c6.png">
