### PR TITLE
Add **CSP_NONCE** to all inline script to support CSP nonce whitelisting

### DIFF
--- a/content/includes/footer.html
+++ b/content/includes/footer.html
@@ -101,14 +101,14 @@ visit <a href="https://www.veteranscrisisline.net/">VeteransCrisisLine.net</a> f
 
 <!-- htmllint attr-bans="[]" -->
 {% if buildtype === 'development' %}
-  <script>
+  <script nonce="**CSP_NONCE**">
     window.dataLayer = window.dataLayer || [];
     window.dataLayer.push({ environment: '{{ buildtype }}' });
   </script>
   <script async src="/js/google-analytics-dev.js"></script>
 {% else %}
   <!-- Google Tag Manager -->
-  <script>
+  <script nonce="**CSP_NONCE**">
     // Always use push with GTM: https://www.simoahava.com/gtm-tips/datalayer-declaration-vs-push/
     window.dataLayer = window.dataLayer || [];
     window.dataLayer.push({ environment: '{{ buildtype }}' });
@@ -128,7 +128,7 @@ visit <a href="https://www.veteranscrisisline.net/">VeteransCrisisLine.net</a> f
 “To care for him who shall have borne the battle and for his widow, and his orphan.”
 - Abraham Lincoln
 -->
-<script type="text/javascript">
+<script nonce="**CSP_NONCE**" type="text/javascript">
   function footerNavClick(elem) {
     const eventLabel = 'nav-' + elem.parentElement.parentElement.id
     window.dataLayer.push({
@@ -138,7 +138,7 @@ visit <a href="https://www.veteranscrisisline.net/">VeteransCrisisLine.net</a> f
   }
 </script>
 {% if widgets %}
-<script type="text/javascript">
+<script nonce="**CSP_NONCE**" type="text/javascript">
 (function() {
   var widgets = {{ widgets | json }};
   var module = {};

--- a/content/includes/header.html
+++ b/content/includes/header.html
@@ -81,7 +81,7 @@
 
 <script src="/js/settings.js"></script>
 
-<script>
+<script nonce="**CSP_NONCE**">
 //<![CDATA[
 window.webpackManifest = 'CHUNK_MANIFEST_PLACEHOLDER';
 //]]>

--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -277,7 +277,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="**CSP_NONCE**">
 function reportHeaderNav(navpath) {
   window.dataLayer.push({
     event: 'nav-header-link',

--- a/content/pages/404.md
+++ b/content/pages/404.md
@@ -43,7 +43,7 @@ private: true
 {% include "content/includes/common-and-popular.html" %}
 
 <script src="/js/usa-search.js"></script>
-<script>
+<script nonce="**CSP_NONCE**">
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({ event: 'nav-404-error' });
 </script>

--- a/content/pages/employment/index.md
+++ b/content/pages/employment/index.md
@@ -67,7 +67,7 @@ We can support you in all stages of your job search—from returning to work wit
   </div>
 </div>
 
-<script type="text/javascript">
+<script nonce="**CSP_NONCE**" type="text/javascript">
 
   // Toggle the expandable crisis info
   document.getElementById('crisis-expander-link')

--- a/content/pages/faq.md
+++ b/content/pages/faq.md
@@ -272,7 +272,7 @@ display_title: Frequently Asked Questions
 
 
 <script src="https://standards.usa.gov/assets/js/vendor/uswds.min.js" type="text/javascript"></script>
-<script type="text/javascript">
+<script nonce="**CSP_NONCE**" type="text/javascript">
 (function() {
   var openAccordion = function(id) {
     document.querySelector('[aria-controls="' + id + '"]').setAttribute('aria-expanded', true);

--- a/content/pages/health-care/health-conditions/mental-health.md
+++ b/content/pages/health-care/health-conditions/mental-health.md
@@ -121,7 +121,7 @@ You may still be able to get care:
 [Find more resources for help in a crisis](https://www.mentalhealth.va.gov/gethelp.asp).<br />
 [Access additional resources for ongoing support](https://www.mentalhealth.va.gov/Resources.asp).
 
-<script type="text/javascript">
+<script nonce="**CSP_NONCE**" type="text/javascript">
 
   // Toggle the expandable crisis info
   document.getElementById('crisis-expander-link')

--- a/content/pages/health-care/health-conditions/mental-health/depression.md
+++ b/content/pages/health-care/health-conditions/mental-health/depression.md
@@ -94,7 +94,7 @@ You may still be able to get care:
 - Call the VA general information hotline at <a href="tel:+1-800-827-1000">1-800-827-1000</a>.
 
 
-<script type="text/javascript">
+<script nonce="**CSP_NONCE**" type="text/javascript">
 
   // Toggle the expandable crisis info
   document.getElementById('crisis-expander-link')

--- a/content/pages/health-care/health-conditions/mental-health/ptsd.md
+++ b/content/pages/health-care/health-conditions/mental-health/ptsd.md
@@ -121,7 +121,7 @@ If you have symptoms of PTSD and suffered a serious injury, personal trauma, sex
 - See our Self-Help Resources guide for books, web resources, and mobile applications recommended by VA experts. [Get self-help resources](https://www.mentalhealth.va.gov/self_help.asp).
 - Call the VA general information hotline at <a href="tel:+1-800-827-1000">1-800-827-1000</a>.
 
-<script type="text/javascript">
+<script nonce="**CSP_NONCE**" type="text/javascript">
 
   // Toggle the expandable crisis info
   document.getElementById('crisis-expander-link')

--- a/content/pages/health-care/health-conditions/military-sexual-trauma.md
+++ b/content/pages/health-care/health-conditions/military-sexual-trauma.md
@@ -108,7 +108,7 @@ Or, get help applying for disability compensation by:
 - Go to our Make the Connection website to hear stories from Veterans about their own experiences with the effects of MST, and find more resources and support. [Visit Make the Connection](https://maketheconnection.net/).
 - Go to the Department of Defense (DoD) Safe Helpline website, a crisis support service for members of the DOD community affected by sexual assault. When you contact the Safe Helpline, you can remain anonymous (meaning you don’t have to give your name). You can get 1-on-1 advice, support, and information 24/7—by phone, text, or online chat. You can also connect with a sexual assault response coordinator near your base or installation. [Visit SafeHelpline.org](https://www.safehelpline.org/).
 
-<script type="text/javascript">
+<script nonce="**CSP_NONCE**" type="text/javascript">
 
   // Toggle the expandable crisis info
   document.getElementById('crisis-expander-link')

--- a/content/pages/health-care/health-conditions/substance-use-problems.md
+++ b/content/pages/health-care/health-conditions/substance-use-problems.md
@@ -117,7 +117,7 @@ You may still be able to get care:
 - Visit the resources section of our VA website to find more trusted resources outside VA that can offer information and support. [Find resources](https://www.mentalhealth.va.gov/substanceabuse.asp).
 - Download our Stay Quit Coach mobile app—designed to help Veterans with PTSD quit smoking. We based this app on steps proven to work to help people quit smoking. It includes tools to control cravings and manage smoking triggers, messages to keep you going, medication reminders, and more. [Get the Stay Quit Coach app](https://mobile.va.gov/app/stay-quit-coach).
 
-<script type="text/javascript">
+<script nonce="**CSP_NONCE**" type="text/javascript">
 
   // Toggle the expandable crisis info
   document.getElementById('crisis-expander-link')

--- a/content/pages/health-care/index.md
+++ b/content/pages/health-care/index.md
@@ -83,7 +83,7 @@ With VA health care, you’re covered for regular checkups with your primary car
 </div>
 
 
-<script type="text/javascript">
+<script nonce="**CSP_NONCE**" type="text/javascript">
 
   // Toggle the expandable crisis info
   document.getElementById('crisis-expander-link')

--- a/content/pages/health-care/schedule-an-appointment.md
+++ b/content/pages/health-care/schedule-an-appointment.md
@@ -102,7 +102,7 @@ If you have a Vets.gov account or a My Health*e*Vet Premium account, you can sen
 </div> <!-- closes overall FAQ -->
 <br>
 
-<script type="text/javascript">
+<script nonce="**CSP_NONCE**" type="text/javascript">
 
   // Toggle the expandable crisis info
   document.getElementById('crisis-expander-link')

--- a/content/pages/housing-assistance/index.md
+++ b/content/pages/housing-assistance/index.md
@@ -40,7 +40,7 @@ If you’re a Veteran, Servicemember, or surviving spouse, we may be able to hel
   </div>
 </div>
 
-<script type="text/javascript">
+<script nonce="**CSP_NONCE**" type="text/javascript">
 
   // Toggle the expandable crisis info
   document.getElementById('crisis-expander-link')

--- a/content/pages/logout.md
+++ b/content/pages/logout.md
@@ -16,7 +16,7 @@ private: true
   </div>
 </div>
 
-<script>
+<script nonce="**CSP_NONCE**">
 if (location.search.substring(1) === 'success=true') {
   window.opener.sessionStorage.clear();
   window.opener.document.location.href = '/';


### PR DESCRIPTION
The `**CSP_NONCE**` will be replaced by a random string matching a nonce header by nginx so we can disable unsafe-inline in our Content-Security-Policy for vets.gov. 