### PR TITLE
Remove Bob's verification file for search console

### DIFF
--- a/content/pages/googlea8237f98bfe9f1e8.html
+++ b/content/pages/googlea8237f98bfe9f1e8.html
@@ -1,5 +1,0 @@
----
-permalink: false
-private: true
----
-google-site-verification: googlea8237f98bfe9f1e8.html


### PR DESCRIPTION
This is a retry of a PR to remove the verification file for my access to Google's Search Console for vets.gov

I'm no longer on the project so the access should be removed. Google won't do it while the file exists. We have a new `vetsdotgovanalytics` account that has a separate verification file to main continuity when mine is removed.