### PR TITLE
526 e2e -- The case of the missing page

### DIFF
--- a/test/disability-benefits/526EZ/00-all-fields.e2e.spec.js
+++ b/test/disability-benefits/526EZ/00-all-fields.e2e.spec.js
@@ -42,7 +42,7 @@ const runTest = E2eHelpers.createE2eTest(
         .click('.form-panel .usa-button-primary');
       E2eHelpers.expectNavigateAwayFrom(client, '/supporting-evidence/orientation');
 
-      // Evidence Type
+      // Evidence Type -- first condition
       client.axeCheck('.main');
       PageHelpers.completeEvidenceTypeInformation(client, testData.data);
       client.click('.form-panel .usa-button-primary');
@@ -59,7 +59,21 @@ const runTest = E2eHelpers.createE2eTest(
       client.click('.form-panel .usa-button-primary');
       E2eHelpers.expectNavigateAwayFrom(client, '/supporting-evidence/0/va-facilities');
 
-      // Evidence type
+      // Private records intro
+      client.axeCheck('.main');
+      client.click('.form-panel .usa-button-primary');
+      E2eHelpers.expectNavigateAwayFrom(client, 'supporting-evidence/0/private-medical-records-intro');
+
+      // Private records upload choice
+      // client.axeCheck('.main');
+      // PageHelpers.completePrivateMedicalRecordsChoice(client, testData.data);
+      // client.click('.form-panel .usa-button-primary');
+      // E2eHelpers.expectNavigateAwayFrom(client, 'supporting-evidence/0/private-medical-records-choice');
+
+      // Private records upload
+      // TODO: Fill this in
+
+      // Evidence type -- second condition
       client.axeCheck('.main');
       client.click('.form-panel .usa-button-primary');
       E2eHelpers.expectNavigateAwayFrom(client, '/supporting-evidence/1/evidence-type');

--- a/test/disability-benefits/526EZ/schema/maximal-test.json
+++ b/test/disability-benefits/526EZ/schema/maximal-test.json
@@ -1,8 +1,5 @@
 {
   "data": {
-    "view:vaMedicalRecords": true,
-    "view:privateMedicalRecords": true,
-    "view:otherEvidence": true,
     "treatments": [
       {
         "treatmentCenterName": "Local facility",
@@ -12,6 +9,14 @@
         "endTreatmentDay": 2,
         "startTreatmentYear": 2007,
         "endTreatmentYear": 2008
+      }
+    ],
+    "disabilities": [
+      {
+        "view:uploadPrivateRecords": "yes",
+        "view:vaMedicalRecords": true,
+        "view:privateMedicalRecords": true,
+        "view:otherEvidence": true
       }
     ]
   }

--- a/test/e2e/disability-benefits-helpers.js
+++ b/test/e2e/disability-benefits-helpers.js
@@ -11,9 +11,9 @@ function completeApplicantInformation(client, data) {
 
 function completeEvidenceTypeInformation(client, data) {
   client
-    .fillCheckbox('input[name="root_view:vaMedicalRecords"]', data['view:vaMedicalRecords'])
-    .fillCheckbox('input[name="root_view:privateMedicalRecords"]', data['view:privateMedicalRecords'])
-    .fillCheckbox('input[name="root_view:otherEvidence"]', data['view:otherEvidence']);
+    .fillCheckbox('input[name="root_view:vaMedicalRecords"]', data.disabilities[0]['view:vaMedicalRecords'])
+    .fillCheckbox('input[name="root_view:privateMedicalRecords"]', data.disabilities[0]['view:privateMedicalRecords'])
+    .fillCheckbox('input[name="root_view:otherEvidence"]', data.disabilities[0]['view:otherEvidence']);
 }
 
 function completeVAFacilitiesInformation(client, data) {
@@ -25,6 +25,11 @@ function completeVAFacilitiesInformation(client, data) {
     .selectDropdown('root_treatments_0_treatment_endTreatmentDay', data.treatments[0].endTreatmentDay)
     .fill('input[name="root_treatments_0_treatment_endTreatmentYear"]', data.treatments[0].endTreatmentYear)
     .fill('input[name="root_treatments_0_treatment_treatmentCenterName"]', data.treatments[0].treatmentCenterName);
+}
+
+function completePrivateMedicalRecordsChoice(client, data) {
+  client
+    .selectRadio('root_view:uploadPrivateRecords', data.disabilities[0]['view:uploadPrivateRecords']);
 }
 
 function initApplicationSubmitMock() {
@@ -60,5 +65,6 @@ module.exports = {
   initDocumentUploadMock,
   completeApplicantInformation,
   completeEvidenceTypeInformation,
-  completeVAFacilitiesInformation
+  completeVAFacilitiesInformation,
+  completePrivateMedicalRecordsChoice
 };


### PR DESCRIPTION
Due to a couple PRs getting merged into master at once, the e2e test was failing. This adds the missing page to the test which was causing the failure. It _doesn't_ add the page missing from master right now.

If you find your knowledge in this missing something, don't worry--you're not missing much. Let's just say I tried a thing, but it was a swing and a miss. I was close, but missed the mark.

Too much?