### PR TITLE
Fix IE layout and remove normal layout mode on cropper

### DIFF
--- a/src/js/common/schemaform/containers/FormPage.jsx
+++ b/src/js/common/schemaform/containers/FormPage.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import Scroll from 'react-scroll';
 import _ from 'lodash/fp';
+import classNames from 'classnames';
 
 import SchemaForm from '../components/SchemaForm';
 import ProgressButton from '../../components/form-elements/ProgressButton';
@@ -92,6 +93,7 @@ class FormPage extends React.Component {
       uiSchema
     } = form.pages[route.pageConfig.pageKey];
 
+    const pageClasses = classNames('form-panel', route.pageConfig.pageClass);
     let data = form.data;
 
     if (route.pageConfig.showPagePerItem) {
@@ -105,7 +107,7 @@ class FormPage extends React.Component {
     }
 
     return (
-      <div className="form-panel">
+      <div className={pageClasses}>
         <SchemaForm
           name={route.pageConfig.pageKey}
           title={route.pageConfig.title}

--- a/src/js/vic-v2/components/CropperController.jsx
+++ b/src/js/vic-v2/components/CropperController.jsx
@@ -4,8 +4,7 @@ import Cropper from 'react-cropper';
 import classNames from 'classnames';
 
 const MIN_SIZE = 350;
-const SMALL_CROP_BOX_SIZE = 240;
-const LARGE_CROP_BOX_SIZE = 300;
+const CROP_BOX_SIZE = 240;
 const LARGE_SCREEN = 1201;
 const WARN_RATIO = 1.3;
 const MAX_CROPPED_HEIGHT_WIDTH = 600;
@@ -128,7 +127,6 @@ export default class CropperControls extends React.Component {
 
     const windowWidth = window.innerWidth;
     this.state = {
-      smallCropBox: props.forceNarrowLayout || windowWidth < LARGE_SCREEN,
       windowWidth,
       zoomMin: 0.2,
       zoomMax: 1.7,
@@ -323,7 +321,7 @@ export default class CropperControls extends React.Component {
   setCropBox = () => {
     // use container and cropbox constants to set cropbox size
     const containerWidth = this.refs.cropper.getContainerData().width;
-    const heightWidth = this.state.smallCropBox ? SMALL_CROP_BOX_SIZE : LARGE_CROP_BOX_SIZE;
+    const heightWidth = CROP_BOX_SIZE;
     const left = (containerWidth / 2) - (heightWidth / 2);
     this.refs.cropper.setCropBoxData({
       top: 0,
@@ -343,8 +341,7 @@ export default class CropperControls extends React.Component {
   detectWidth = () => {
     const windowWidth = window.innerWidth;
     this.setState({
-      windowWidth,
-      smallCropBox: this.props.forceNarrowLayout || windowWidth < LARGE_SCREEN
+      windowWidth
     });
   }
 
@@ -421,12 +418,8 @@ export default class CropperControls extends React.Component {
   // use the windowWidth as a key to for the component to remount when the window width changes
   render() {
 
-    // narrow-layout class controls visiblity of elements based on window width
-    // if layout is forced narrow, remove this behavior
-    const narrowLayoutButtonsClassNames = classNames('cropper-control-row', { 'narrow-layout': !this.props.forceNarrowLayout });
-
-    // prevent the cropper from re-mounting when forcing narrow layout and width is in large screen range
-    const cropperKey = this.props.forceNarrowLayout && this.state.windowWidth >= LARGE_SCREEN ? LARGE_SCREEN : this.state.windowWidth;
+    // prevent the cropper from re-mounting when width is in large screen range
+    const cropperKey = this.state.windowWidth >= LARGE_SCREEN ? LARGE_SCREEN : this.state.windowWidth;
 
     return (
       <div className="cropper-container-outer">
@@ -441,7 +434,7 @@ export default class CropperControls extends React.Component {
           cropstart={this.onCropstart}
           cropend={this.onCropend}
           cropmove={() => true}
-          minContainerHeight={this.state.smallCropBox ? SMALL_CROP_BOX_SIZE : LARGE_CROP_BOX_SIZE}
+          minContainerHeight={CROP_BOX_SIZE}
           toggleDragModeOnDblclick={false}
           dragMode="move"
           guides={false}
@@ -450,7 +443,6 @@ export default class CropperControls extends React.Component {
         <div className="cropper-zoom-container">
           <button className="cropper-control cropper-control-zoom cropper-control-zoom-out va-button va-button-link" type="button" onClick={this.onZoomOut}>
             <span className="cropper-control-label">
-              {this.props.forceNarrowLayout || <span className="normal-layout">Make smaller</span>}
               <i className="fa fa-search-minus">
               </i>
             </span>
@@ -470,14 +462,13 @@ export default class CropperControls extends React.Component {
             value={this.state.zoomValue}/>
           <button className="cropper-control cropper-control-zoom cropper-control-zoom-in va-button va-button-link" type="button" onClick={this.onZoomIn}>
             <span className="cropper-control-label">
-              {this.props.forceNarrowLayout || <span className="normal-layout">Make larger</span>}
               <i className="fa fa-search-plus">
               </i>
             </span>
           </button>
         </div>
         <div className="cropper-control-container">
-          <div className={narrowLayoutButtonsClassNames}>
+          <div className="cropper-control-row">
             <button className="cropper-control cropper-control-label-container va-button va-button-link" type="button" onClick={this.onZoomOut}>
               <span className="cropper-control-label">Make smaller</span>
             </button>
@@ -486,21 +477,21 @@ export default class CropperControls extends React.Component {
             </button>
           </div>
           <div className="cropper-control-row">
-            <MoveRotateButton disabled={this.state.moveUpDisabled} onClick={this.onMoveUp} label="Move up" iconClassName="fa fa-arrow-up"/>
-            <MoveRotateButton disabled={this.state.moveDownDisabled} onClick={this.onMoveDown} label="Move down" iconClassName="fa fa-arrow-down"/>
-          </div>
-          <div className="cropper-control-row">
-            <MoveRotateButton disabled={this.state.moveLeftDisabled} onClick={this.onMoveLeft} label="Move left" iconClassName="fa fa-arrow-left"/>
-            <MoveRotateButton disabled={this.state.moveRightDisabled} onClick={this.onMoveRight} label="Move right" iconClassName="fa fa-arrow-right"/>
+            <div>
+              <MoveRotateButton disabled={this.state.moveUpDisabled} onClick={this.onMoveUp} label="Move up" iconClassName="fa fa-arrow-up"/>
+              <MoveRotateButton disabled={this.state.moveDownDisabled} onClick={this.onMoveDown} label="Move down" iconClassName="fa fa-arrow-down"/>
+            </div>
+            <div>
+              <MoveRotateButton disabled={this.state.moveLeftDisabled} onClick={this.onMoveLeft} label="Move left" iconClassName="fa fa-arrow-left"/>
+              <MoveRotateButton disabled={this.state.moveRightDisabled} onClick={this.onMoveRight} label="Move right" iconClassName="fa fa-arrow-right"/>
+            </div>
           </div>
           <div className="cropper-control-row">
             <MoveRotateButton onClick={this.onRotateLeft} label="Rotate left" iconClassName="fa fa-rotate-left"/>
             <MoveRotateButton onClick={this.onRotateRight} label="Rotate left" iconClassName="fa fa-rotate-right"/>
           </div>
         </div>
-        <div style={{ margin: '1em 1em 4em' }}>
-          {this.state.warningMessage && <div className="photo-warning">{this.state.warningMessage}</div>}
-        </div>
+        {this.state.warningMessage && <div className="photo-warning">{this.state.warningMessage}</div>}
         <div className="crop-button-container">
           <button type="button" className="usa-button-primary" onClick={this.onDone}>
             I’m Done
@@ -512,7 +503,6 @@ export default class CropperControls extends React.Component {
 }
 
 CropperControls.PropTypes = {
-  forceNarrowLayout: React.PropTypes.bool,
   onPhotoCropped: React.PropTypes.func.isRequired,
   src: React.PropTypes.string.isRequired
 };

--- a/src/js/vic-v2/components/PhotoField.jsx
+++ b/src/js/vic-v2/components/PhotoField.jsx
@@ -275,7 +275,6 @@ export default class PhotoField extends React.Component {
     const { formData, formContext } = this.props;
     const file = formData || {};
     const onReview = formContext.reviewMode;
-    const forceNarrowLayout = this.props.formContext.pageTitle === 'Photo review';
 
     if (onReview) {
       return (
@@ -328,7 +327,7 @@ export default class PhotoField extends React.Component {
     }
 
     return (
-      <fieldset>
+      <fieldset className="photo-fieldset">
         <legend className="schemaform-label photo-label">{label}<span className="form-required-span">(*Required)</span></legend>
         <div ref={element => { this.borderBox = element; }} className={errorMessage ? 'error-box' : 'border-box'}>
           {currentLayout === layouts.cropPhoto && <span className="sr-only">
@@ -364,7 +363,6 @@ export default class PhotoField extends React.Component {
             </button>
           </div>}
           {currentLayout === layouts.cropPhoto && <CropperController
-            forceNarrowLayout={forceNarrowLayout}
             windowWidth={this.state.windowWidth}
             onPhotoCropped={blob => this.uploadPhoto(blob)}
             src={this.state.src}/>
@@ -398,7 +396,7 @@ export default class PhotoField extends React.Component {
             {(currentLayout === layouts.choosePhoto || currentLayout === layouts.cropPhoto) && <ErrorableFileInput
               accept={cropperTypes.map(type => `.${type}`).join(',')}
               onChange={this.onChange}
-              buttonText={<span>Upload <i className="fa fa-upload narrow-layout"></i><span className="normal-layout">{uploadButtonText}</span></span>}
+              buttonText={`Upload ${uploadButtonText}`}
               aria-describedby="croppingToolDescription"
               name="fileUpload"/>}
             {currentLayout === layouts.choosePhoto && <ErrorableFileInput

--- a/src/js/vic-v2/config/form.js
+++ b/src/js/vic-v2/config/form.js
@@ -172,6 +172,7 @@ const formConfig = {
           path: 'documents/photo',
           title: 'Photo upload',
           reviewTitle: 'Photo review',
+          pageClass: 'photo-field-page',
           uiSchema: {
             'ui:title': 'Upload Your Photo',
             'ui:description': PhotoDescription,

--- a/src/sass/vic-v2.scss
+++ b/src/sass/vic-v2.scss
@@ -126,7 +126,7 @@ input[type=range] {
 
 .cropper-container-outer {
   @media (min-width: $large-screen) {
-    padding: 10px 50px;
+    padding: 10px 20px;
   }
   .form-review-panel-page & {
     padding: 0;
@@ -136,9 +136,6 @@ input[type=range] {
 .cropper-container {
   height: 240px !important;
   width: 100% !important;
-  @media (min-width: $large-screen) {
-    height: 300px !important;
-  }
   .form-review-panel-page & {
     height: 240px !important;
   }
@@ -196,9 +193,6 @@ input[type=range] {
   justify-content: space-around;
   flex-flow: row wrap;
   margin-bottom: 30px;
-  @media (min-width: $large-screen) {
-    min-width: 600px;
-  }
   .form-review-panel-page & {
     min-width: auto;
   }
@@ -207,7 +201,8 @@ input[type=range] {
 .cropper-control-row {
   display: flex;
   width: 100%;
-  justify-content: space-around;
+  justify-content: center;
+  flex-wrap: wrap;
   @media (min-width: $large-screen) {
     width: inherit;
   }
@@ -254,10 +249,6 @@ input[type=range] {
 .cropper-control.cropper-control-zoom {
   width: auto !important;
   padding: 0 10px !important;
-  @media (min-width: $large-screen) {
-    padding: 0px !important;
-    width: 25% !important;
-  }
   .form-review-panel-page & {
     width: auto !important;
     padding: 0 10px !important;
@@ -268,9 +259,6 @@ input[type=range] {
       margin-right: 20px;
     }
     .cropper-control-label {
-      @media (min-width: $large-screen) {
-        float: right;
-      }
       .form-review-panel-page & {
         float: auto;
       }
@@ -280,25 +268,6 @@ input[type=range] {
     .cropper-control-label {
       float: left;
     }
-  }
-}
-
-.narrow-layout {
-  @media (min-width: $large-screen) {
-    display: none;
-  }
-}
-
-.normal-layout {
-  display: none;
-  @media (min-width: $large-screen) {
-    display: inline;
-  }
-}
-
-.fa {
-  @media (min-width: $large-screen) {
-    padding: 0 15px 0 5px !important;
   }
 }
 
@@ -313,11 +282,6 @@ input[type=range] {
 
 .fa-search-plus {
   font-size: 2em !important;
-  @media (min-width: $large-screen) {
-    font-size: 1.07em !important;
-    padding: 0 5px !important;
-    float: left;
-  }
   .form-review-panel-page & {
     font-size: 2em !important;
     padding: 0 !important;
@@ -327,11 +291,6 @@ input[type=range] {
 
 .fa-search-minus {
   font-size: 2em !important;
-  @media (min-width: $large-screen) {
-    font-size: 1.07em !important;
-    padding: 0 4px 0 4px !important;
-    float: right;
-  }
   .form-review-panel-page & {
     font-size: 2em !important;
     padding: auto !important;
@@ -546,4 +505,8 @@ input[type=range] {
 
 .vic-processing-warning {
   margin-bottom: 2em;
+}
+
+.photo-field-page {
+  max-width: 100%;
 }


### PR DESCRIPTION
The original problem is that the cropper control container is set at a minimum width of 600px for large screens. This is wider than the normal form page width, and Chrome handles this by expanding the whole page. IE, though, only expands that particular div. Either way, we shouldn't be making the cropper tool wider than the grid column it's in, but the normal width of the page is too small for the "normal" layout. So I've pulled that out, done what's possible to make the width larger, and made the move/rotation buttons more responsive.

![screen shot 2018-03-15 at 12 32 53 pm](https://user-images.githubusercontent.com/634932/37480482-bb62b90c-2855-11e8-9f79-4d5f55bea8c8.png)
![screen shot 2018-03-15 at 12 32 33 pm](https://user-images.githubusercontent.com/634932/37480483-bb7173b6-2855-11e8-95f0-73bd984c89bc.png)
