### PR TITLE
Make the (+) clickable

### DIFF
--- a/src/js/claims-status/components/appeals-v2/Expander.jsx
+++ b/src/js/claims-status/components/appeals-v2/Expander.jsx
@@ -18,7 +18,7 @@ const Expander = ({ expanded, dateRange, onToggle, missingEvents }) => {
 
   return (
     // eslint-disable-next-line
-    <li className={`process-step clickable ${cssClass}`} onClick={onToggle}>
+    <li className={`past-events-expander process-step clickable ${cssClass}`} onClick={onToggle}>
       {/* Giving this a margin top to help center the text to the li bullet */}
       <button className="va-button-link" onClick={onToggle}>
         <h3 style={{ color: 'inherit' }}>{title}</h3>

--- a/src/js/claims-status/components/appeals-v2/Expander.jsx
+++ b/src/js/claims-status/components/appeals-v2/Expander.jsx
@@ -17,9 +17,10 @@ const Expander = ({ expanded, dateRange, onToggle, missingEvents }) => {
   const alert = (expanded && missingEvents) ? missingEventsAlert : null;
 
   return (
-    <li className={`process-step ${cssClass}`}>
+    // eslint-disable-next-line
+    <li className={`process-step clickable ${cssClass}`} onClick={onToggle}>
       {/* Giving this a margin top to help center the text to the li bullet */}
-      <button onClick={onToggle} className="va-button-link">
+      <button className="va-button-link" onClick={onToggle}>
         <h3 style={{ color: 'inherit' }}>{title}</h3>
       </button>
       <div className="appeal-event-date">{dateRange}</div>
@@ -32,7 +33,7 @@ const Expander = ({ expanded, dateRange, onToggle, missingEvents }) => {
 Expander.propTypes = {
   expanded: PropTypes.bool.isRequired,
   dateRange: PropTypes.string.isRequired,
-  onToggle: PropTypes.func.isRequired,
+  onToggle: PropTypes.func.isRequired, // Make sure this does event.stopPropagation()
   missingEvents: PropTypes.bool.isRequired,
 };
 

--- a/src/js/claims-status/components/appeals-v2/Timeline.jsx
+++ b/src/js/claims-status/components/appeals-v2/Timeline.jsx
@@ -23,7 +23,10 @@ class Timeline extends React.Component {
     return `${first} - ${last}`;
   };
 
-  toggleExpanded = () => this.setState((prevState) => ({ expanded: !prevState.expanded }));
+  toggleExpanded = (e) => {
+    e.stopPropagation();
+    this.setState((prevState) => ({ expanded: !prevState.expanded }));
+  }
 
   render() {
     const { events, missingEvents } = this.props;

--- a/src/sass/base/_b-utils.scss
+++ b/src/sass/base/_b-utils.scss
@@ -71,3 +71,6 @@
   }
 }
 
+.clickable:hover {
+  cursor: pointer;
+}

--- a/src/sass/claims-status.scss
+++ b/src/sass/claims-status.scss
@@ -656,8 +656,16 @@ h1:focus {
     }
   }
 
-  .section-unexpanded {
+  // Only let the (+) and "See / Hide past events" be clickable
+  .past-events-expander {
+    pointer-events: none;
 
+    &:before, button {
+      pointer-events: all;
+    }
+  }
+
+  .section-unexpanded {
     // offset left border with padding so element doesn't move while toggling expander
     &.process-step {
       padding-left: calc(2em + 5px);

--- a/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
+++ b/test/claims-status/components/appeals-v2/Timeline.unit.spec.jsx
@@ -44,10 +44,16 @@ describe('<Timeline/>', () => {
 
   it('should toggle expanded state when toggleExpanded called', () => {
     const wrapper = shallow(<Timeline {...defaultProps}/>);
+    const instance = wrapper.instance();
+    // Just so toggleExpanded() doesn't break
+    const clickEvent = {
+      stopPropagation: () => {}
+    };
+
     expect(wrapper.state('expanded')).to.equal(false);
-    wrapper.instance().toggleExpanded();
+    instance.toggleExpanded(clickEvent);
     expect(wrapper.state('expanded')).to.equal(true);
-    wrapper.instance().toggleExpanded();
+    instance.toggleExpanded(clickEvent);
     expect(wrapper.state('expanded')).to.equal(false);
   });
 


### PR DESCRIPTION
No visual changes here.

I did have to do some fancy footwork with [`pointer-events`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) which I learned is a thing today. It's not the most elegant because we have to have a click event handler on an `<li>`, but that isn't the end of the world, I suppose. We keep it on the button for accessibility and cross-browser compatibility (for keyboard navigation, mostly).

To be fair, I don't know if we _really_ need it on both the parent `<li>` and child `<button>`, but I figured it'd be safer this way. We've got a `e.stopPropagation()` to avoid it from opening and closing in one fell swoop.