### PR TITLE
Re-title your claims and appeals

### DIFF
--- a/content/includes/footer.html
+++ b/content/includes/footer.html
@@ -25,7 +25,7 @@
       {% endif %}
       <li><a href="/health-care/apply/" onClick="footerNavClick(this);">Apply for health care</a></li>
       <li><a href="/education/apply-for-education-benefits/" onClick="footerNavClick(this);">Apply for education benefits</a></li>
-      <li><a href="/track-claims/" onClick="footerNavClick(this);">Check your claim and appeal status</a></li>
+      <li><a href="/track-claims/" onClick="footerNavClick(this);">Track your claims and appeals</a></li>
       <li><a href="/gi-bill-comparison-tool/" onClick="footerNavClick(this);">Education benefits by school</a></li>
       <li><a href="/health-care/prescriptions/" onClick="footerNavClick(this);">Refill prescriptions</a></li>
       <li><a href="/letters/" onClick="footerNavClick(this);">VA Letters</a></li>

--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -37,7 +37,7 @@
                   <li><a href="/disability-benefits/eligibility/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Eligibility</a></li>
                   <li><a href="/disability-benefits/apply/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Application Process</a></li>
                   <li><a href="/disability-benefits/conditions/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Conditions</a></li>
-                  <li><a class="login-required" href="/track-claims/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Track Claims and Appeals</a></li>
+                  <li><a class="login-required" href="/track-claims/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Track Your Claims and Appeals</a></li>
                   <li><a href="/disability-benefits/claims-appeal/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Appeals Process</a></li>
                   <li><a class="usa-button va-button-primary va-external--light" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Go to eBenefits to Apply {% include "assets/img/icons/exit-icon-white.svg" %}</a></li>
                 </ul>

--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -37,7 +37,7 @@
                   <li><a href="/disability-benefits/eligibility/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Eligibility</a></li>
                   <li><a href="/disability-benefits/apply/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Application Process</a></li>
                   <li><a href="/disability-benefits/conditions/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Conditions</a></li>
-                  <li><a class="login-required" href="/track-claims/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Check Claim and Appeal Status</a></li>
+                  <li><a class="login-required" href="/track-claims/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Track Claims and Appeals</a></li>
                   <li><a href="/disability-benefits/claims-appeal/" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Appeals Process</a></li>
                   <li><a class="usa-button va-button-primary va-external--light" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation" onClick="reportHeaderNav('Explore Benefits->Disabilty');">Go to eBenefits to Apply {% include "assets/img/icons/exit-icon-white.svg" %}</a></li>
                 </ul>

--- a/content/pages/disability-benefits/index.md
+++ b/content/pages/disability-benefits/index.md
@@ -19,7 +19,7 @@ majorlinks:
       title: Conditions
       description: Discover which illnesses or injuries qualify you for benefits.
     - url: /track-claims/
-      title: Check Claim and Appeal Status
+      title: Track Your Claims and Appeals
       description: Track the status of your disability claims and appeals.
     - url: /disability-benefits/claims-appeal/
       title: Appeals Process

--- a/content/pages/disability-benefits/track-claims/index.md
+++ b/content/pages/disability-benefits/track-claims/index.md
@@ -1,6 +1,6 @@
 ---
 title: Track Claims
-display_title: Check Claim Status
+display_title: Track Your Claims and Appeals
 description: Track the status of your VA claims and appeals by signing in to your Vets.gov account.
 entryname: claims-status
 layout: page-react.html

--- a/src/js/claims-status/components/AppealLayout.jsx
+++ b/src/js/claims-status/components/AppealLayout.jsx
@@ -7,7 +7,7 @@ export default function AppealLayout({ children }) {
     <div>
       <div className="row">
         <Breadcrumbs>
-          <li><Link to="your-claims">Your Claims and Appeals</Link></li>
+          <li><Link to="your-claims">Track Your Claims and Appeals</Link></li>
         </Breadcrumbs>
       </div>
       {children}

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -55,7 +55,7 @@ export class AppealInfo extends React.Component {
         <div>
           <div className="row">
             <Breadcrumbs>
-              <li><Link to="your-claims">Your Claims and Appeals</Link></li>
+              <li><Link to="your-claims">Track Your Claims and Appeals</Link></li>
               <li><strong>{claimHeading}</strong></li>
             </Breadcrumbs>
           </div>

--- a/src/js/claims-status/containers/YourClaimsPage.jsx
+++ b/src/js/claims-status/containers/YourClaimsPage.jsx
@@ -203,7 +203,7 @@ class YourClaimsPage extends React.Component {
           <div className="small-12 usa-width-two-thirds medium-8 columns">
             <div className="row">
               <div className="small-12 columns">
-                <h1 className="claims-container-title">Your Claims and Appeals</h1>
+                <h1 className="claims-container-title">Track Your Claims and Appeals</h1>
               </div>
               <div className="small-12 columns">
                 {this.renderErrorMessages()}

--- a/src/js/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/js/claims-status/containers/YourClaimsPageV2.jsx
@@ -162,7 +162,7 @@ class YourClaimsPageV2 extends React.Component {
           <div className="small-12 usa-width-two-thirds medium-8 columns">
             <div className="row">
               <div className="small-12 columns">
-                <h1 className="claims-container-title">Your Compensation Appeals and Claims</h1>
+                <h1 className="claims-container-title">Track Your Compensation Appeals and Claims</h1>
               </div>
               <div className="small-12 columns">
                 {this.renderErrorMessages()}

--- a/test/claims-status/e2e/00.claims-list.e2e.spec.js
+++ b/test/claims-status/e2e/00.claims-list.e2e.spec.js
@@ -29,7 +29,7 @@ module.exports = E2eHelpers.createE2eTest(
     client
       .expect
       .element('.claims-container h1')
-      .text.to.equal('Your Claims and Appeals');
+      .text.to.equal('Track Your Claims and Appeals');
 
     client
       .expect


### PR DESCRIPTION
These changes re-title "Your Claims and Appeals" as"Track Your Claims and Appeals" ([Issue](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9182))