### PR TITLE
Redirect v1 ids

### DIFF
--- a/src/js/claims-status/actions/index.jsx
+++ b/src/js/claims-status/actions/index.jsx
@@ -94,10 +94,23 @@ export function getAppeals(filter) {
 }
 
 export function fetchAppealsSuccess(response) {
+  const appeals = response.data;
+  const v1ToV2IdMap = {};
+  appeals.forEach(appeal => {
+    // In case there are no v1 appeal ids
+    if (!appeal.attributes.appealIds) {
+      return;
+    }
+
+    appeal.attributes.appealIds.forEach(id => {
+      v1ToV2IdMap[id] = appeal.id;
+    });
+  });
+
   return {
     type: FETCH_APPEALS_SUCCESS,
-    // filter: filter, // No idea why this would be needed, but it's in the old version
-    appeals: response.data
+    appeals,
+    v1ToV2IdMap
   };
 }
 

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -117,11 +117,12 @@ AppealInfo.propTypes = {
 
 function mapStateToProps(state, ownProps) {
   const { appealsLoading, appealsAvailability } = state.disability.status.claimsV2;
+  const { v1ToV2IdMap } = state.disability.status.appeals;
   return {
-    appeal: isolateAppeal(state, ownProps.params.id),
+    appeal: isolateAppeal(state, ownProps.params.id, v1ToV2IdMap),
     appealsLoading,
     appealsAvailability,
-    fullName: state.user.profile.userFullName
+    fullName: state.user.profile.userFullName,
   };
 }
 

--- a/src/js/claims-status/reducers/appeals.js
+++ b/src/js/claims-status/reducers/appeals.js
@@ -63,6 +63,7 @@ export default function appealsReducer(state = initialState, action) {
       return _.merge(state, {
         appealsLoading: false,
         available: true,
+        v1ToV2IdMap: action.v1ToV2IdMap
         // v2Availability: AVAILABLE // New and improved! More bits of info!
       });
     }

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -148,13 +148,15 @@ export function addStatusToIssues(issues) {
 }
 
 /**
- * Finds an appeal from the Redux store with ID matching arg ID
+ * Finds an appeal from the Redux store with ID matching arg ID.
+ * `id` may be a v1 id or a v2 id.
+ *
  * @param {object} state Full redux store state tree
  * @param {string} id Appeal ID of the appeal to find
  * @returns {object} One appeal object or undefined if not found in the array
  */
-export function isolateAppeal(state, id) {
-  return _.find(state.disability.status.claimsV2.appeals, (a) => a.id === id);
+export function isolateAppeal(state, id, v1ToV2IdMap) {
+  return _.find(state.disability.status.claimsV2.appeals, (a) => a.id === id || v1ToV2IdMap[id]);
 }
 
 export function formatDate(date) {

--- a/test/claims-status/utils/appealsV2Actions.unit.spec.js
+++ b/test/claims-status/utils/appealsV2Actions.unit.spec.js
@@ -24,7 +24,9 @@ const setup = () => {
   global.fetch.returns(Promise.resolve({
     headers: { get: () => 'application/json' },
     ok: true,
-    json: () => Promise.resolve({})
+    json: () => Promise.resolve({
+      data: []
+    })
   }));
 };
 
@@ -48,12 +50,6 @@ describe('getAppealsV2', () => {
   });
 
   it('dispatches FETCH_APPEALS_SUCCESS', (done) => {
-    global.fetch.returns(Promise.resolve({
-      headers: { get: () => 'application/json' },
-      ok: true,
-      json: () => Promise.resolve({})
-    }));
-
     const thunk = getAppealsV2();
     const dispatch = sinon.spy();
     thunk(dispatch)


### PR DESCRIPTION
This assumes v2 ids will never "override" v1 ids. That is, it assumes that a v2 id will never point to a _different_ v1 appeal. Is this assumption correct, @cmgiven? (If that's not clear, I can try to rephrase to make more sense...)