### PR TITLE
Fix padding bug

### DIFF
--- a/src/js/claims-status/components/appeals-v2/AppealHeader.jsx
+++ b/src/js/claims-status/components/appeals-v2/AppealHeader.jsx
@@ -19,7 +19,7 @@ const AppealHeader = ({ heading, lastUpdated }) => {
   const description = `Up to date as of ${formattedDateTime}`;
 
   return (
-    <div className="appeal-header">
+    <div className="appeal-header columns">
       <h1>{heading}</h1>
       <p>{description}</p>
     </div>

--- a/src/js/claims-status/containers/AppealInfo.jsx
+++ b/src/js/claims-status/containers/AppealInfo.jsx
@@ -53,7 +53,7 @@ export class AppealInfo extends React.Component {
       const claimHeading = this.createHeading();
       appealContent = (
         <div>
-          <div className="row">
+          <div>
             <Breadcrumbs>
               <li><Link to="your-claims">Your Claims and Appeals</Link></li>
               <li><strong>{claimHeading}</strong></li>


### PR DESCRIPTION
These changes fix a padding bug on the appeals info page ([issue](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/9010)).

<img width="492" alt="screen shot 2018-03-15 at 4 07 11 pm" src="https://user-images.githubusercontent.com/16051172/37495540-fb99012e-286a-11e8-9c8e-65369d0553f6.png">
