### PR TITLE
Switch between fieldset and div for object field in forms

### DIFF
--- a/src/js/common/schemaform/fields/ObjectField.jsx
+++ b/src/js/common/schemaform/fields/ObjectField.jsx
@@ -190,49 +190,61 @@ class ObjectField extends React.Component {
       );
     };
 
-    return (
-      <fieldset className={fieldsetClassNames}>
-        <div className={containerClassNames}>
-          {hasTitleOrDescription && <div className="schemaform-block-header">
-            {CustomTitleField && !showFieldLabel
-              ? <CustomTitleField
-                id={`${idSchema.$id}__title`}
-                formData={formData}
-                formContext={formContext}
-                required={required}/> : null}
-            {!CustomTitleField && title && !showFieldLabel
-              ? <TitleField
-                id={`${idSchema.$id}__title`}
-                title={title}
-                required={required}
-                formContext={formContext}/> : null}
-            {textDescription && <p>{textDescription}</p>}
-            {DescriptionField && <DescriptionField formData={formData} formContext={formContext} options={uiSchema['ui:options']}/>}
-            {!textDescription && !DescriptionField && description}
-          </div>}
-          {this.orderedProperties.map((objectFields, index) => {
-            if (objectFields.length > 1) {
-              const [first, ...rest] = objectFields;
-              const visible = rest.filter(prop => !_.get(['properties', prop, 'ui:collapsed'], schema));
-              return (
-                <ExpandingGroup open={visible.length > 0} key={index}>
-                  {renderProp(first)}
-                  <div className={_.get([first, 'ui:options', 'expandUnderClassNames'], uiSchema)}>
-                    {visible.map(renderProp)}
-                  </div>
-                </ExpandingGroup>
-              );
-            }
-
-            // if fields have expandUnder, but are the only item, that means the
-            // field they’re expanding under is hidden, and they should be hidden, too
-            return !_.get([objectFields[0], 'ui:options', 'expandUnder'], uiSchema)
-              ? renderProp(objectFields[0], index)
-              : undefined;
-          })
+    const fieldContent = (
+      <div className={containerClassNames}>
+        {hasTitleOrDescription && <div className="schemaform-block-header">
+          {CustomTitleField && !showFieldLabel
+            ? <CustomTitleField
+              id={`${idSchema.$id}__title`}
+              formData={formData}
+              formContext={formContext}
+              required={required}/> : null}
+          {!CustomTitleField && title && !showFieldLabel
+            ? <TitleField
+              id={`${idSchema.$id}__title`}
+              title={title}
+              required={required}
+              formContext={formContext}/> : null}
+          {textDescription && <p>{textDescription}</p>}
+          {DescriptionField && <DescriptionField formData={formData} formContext={formContext} options={uiSchema['ui:options']}/>}
+          {!textDescription && !DescriptionField && description}
+        </div>}
+        {this.orderedProperties.map((objectFields, index) => {
+          if (objectFields.length > 1) {
+            const [first, ...rest] = objectFields;
+            const visible = rest.filter(prop => !_.get(['properties', prop, 'ui:collapsed'], schema));
+            return (
+              <ExpandingGroup open={visible.length > 0} key={index}>
+                {renderProp(first)}
+                <div className={_.get([first, 'ui:options', 'expandUnderClassNames'], uiSchema)}>
+                  {visible.map(renderProp)}
+                </div>
+              </ExpandingGroup>
+            );
           }
-        </div>
-      </fieldset>
+
+          // if fields have expandUnder, but are the only item, that means the
+          // field they’re expanding under is hidden, and they should be hidden, too
+          return !_.get([objectFields[0], 'ui:options', 'expandUnder'], uiSchema)
+            ? renderProp(objectFields[0], index)
+            : undefined;
+        })
+        }
+      </div>
+    );
+
+    if (title) {
+      return (
+        <fieldset className={fieldsetClassNames}>
+          {fieldContent}
+        </fieldset>
+      );
+    }
+
+    return (
+      <div className={fieldsetClassNames}>
+        {fieldContent}
+      </div>
     );
   }
 }

--- a/src/js/common/schemaform/fields/TitleField.jsx
+++ b/src/js/common/schemaform/fields/TitleField.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import classNames from 'classnames';
 
 export default function TitleField({ id, title }) {
   const isRoot = id === 'root__title';
 
-  return isRoot
-    ? <legend className="schemaform-block-title" id={id}>{title}</legend>
-    : <h5 className="schemaform-block-title" id={id}>{title}</h5>;
+  const classes = classNames('schemaform-block-title', {
+    'schemaform-block-subtitle': !isRoot
+  });
+
+  return <legend className={classes} id={id}>{title}</legend>;
 }

--- a/src/sass/modules/_m-schemaform.scss
+++ b/src/sass/modules/_m-schemaform.scss
@@ -198,8 +198,11 @@ label {
     margin-top: 0.5em;
   }
 }
+.schemaform-block-title {
+  font-family: $font-serif;
+}
 .schemaform-block-subtitle {
-  font-size: 1.7rem;
+  font-size: 1.5rem;
   font-weight: 700;
 }
 

--- a/src/sass/modules/_m-schemaform.scss
+++ b/src/sass/modules/_m-schemaform.scss
@@ -200,6 +200,7 @@ label {
 }
 .schemaform-block-title {
   font-family: $font-serif;
+  font-size: 1.8rem;
 }
 .schemaform-block-subtitle {
   font-size: 1.5rem;

--- a/src/sass/modules/_m-schemaform.scss
+++ b/src/sass/modules/_m-schemaform.scss
@@ -198,6 +198,10 @@ label {
     margin-top: 0.5em;
   }
 }
+.schemaform-block-subtitle {
+  font-size: 1.7rem;
+  font-weight: 700;
+}
 
 .schemaform-first-field {
   .schemaform-label, > .usa-input-error {

--- a/test/common/schemaform/fields/TitleField.unit.spec.jsx
+++ b/test/common/schemaform/fields/TitleField.unit.spec.jsx
@@ -12,11 +12,11 @@ describe('Schemaform <TitleField>', () => {
 
     expect(tree.subTree('legend')).not.to.be.false;
   });
-  it('should render h5 for non-root', () => {
+  it('should render subtitle for non-root', () => {
     const tree = SkinDeep.shallowRender(
       <TitleField id="root_someField"/>
     );
 
-    expect(tree.subTree('h5')).not.to.be.false;
+    expect(tree.subTree('.schemaform-block-subtitle')).not.to.be.false;
   });
 });


### PR DESCRIPTION
Switches between fieldset and div, so that we don't have fieldsets that don't have a legend in them. Also changes the code so that we always use legend, instead of switching between that and h5. I had done that for style reasons, but it's not a good practice for a11y.

