### PR TITLE
pointing Facility Locator at the new controller for cached data

### DIFF
--- a/src/js/facility-locator/config.js
+++ b/src/js/facility-locator/config.js
@@ -2,7 +2,7 @@ import environment from '../common/helpers/environment';
 
 // Base URL to be used in API requests.
 export const api = {
-  url: `${environment.API_URL}/v0/facilities/va`,
+  url: `${environment.API_URL}/vbeta/facilities/va`,
   settings: {
     headers: {
       'X-Key-Inflection': 'camel',

--- a/test/e2e/facility-helpers.js
+++ b/test/e2e/facility-helpers.js
@@ -203,11 +203,11 @@ const resultsData = {
     },
   ],
   links: {
-    self: 'http://www.example.com/v0/facilities/va?bbox%5B%5D=-118.53149414062501&bbox%5B%5D=33.91487347147951&bbox%5B%5D=-118.07762145996095&bbox%5B%5D=34.199308935560154&page=1',
-    first: 'http://www.example.com/v0/facilities/va?bbox%5B%5D=-118.53149414062501&bbox%5B%5D=33.91487347147951&bbox%5B%5D=-118.07762145996095&bbox%5B%5D=34.199308935560154&page=1&per_page=20',
+    self: 'http://www.example.com/vbeta/facilities/va?bbox%5B%5D=-118.53149414062501&bbox%5B%5D=33.91487347147951&bbox%5B%5D=-118.07762145996095&bbox%5B%5D=34.199308935560154&page=1',
+    first: 'http://www.example.com/vbeta/facilities/va?bbox%5B%5D=-118.53149414062501&bbox%5B%5D=33.91487347147951&bbox%5B%5D=-118.07762145996095&bbox%5B%5D=34.199308935560154&page=1&per_page=20',
     prev: null,
     next: null,
-    last: 'http://www.example.com/v0/facilities/va?bbox%5B%5D=-118.53149414062501&bbox%5B%5D=33.91487347147951&bbox%5B%5D=-118.07762145996095&bbox%5B%5D=34.199308935560154&page=1&per_page=20'
+    last: 'http://www.example.com/vbeta/facilities/va?bbox%5B%5D=-118.53149414062501&bbox%5B%5D=33.91487347147951&bbox%5B%5D=-118.07762145996095&bbox%5B%5D=34.199308935560154&page=1&per_page=20'
   },
   meta: {
     pagination: {
@@ -222,13 +222,13 @@ const resultsData = {
 // Create API routes
 function initApplicationMock(token) {
   mock(token, {
-    path: '/v0/facilities/va',
+    path: '/vbeta/facilities/va',
     verb: 'get',
     value: resultsData,
   });
 
   mock(token, {
-    path: '/v0/facilities/va/vha_691GE',
+    path: '/vbeta/facilities/va/vha_691GE',
     verb: 'get',
     value: {
       data: resultsData.data[0]


### PR DESCRIPTION
This will be a temporary change. In a subsequent vets-api change we will replace the v0 controller and delete the vbeta controller. This interim step of having both available in the api will allow us to rollback the change very quickly if there is a problem.