### PR TITLE
Show cavcOption alert after "What happens next?"

### DIFF
--- a/src/js/claims-status/components/appeals-v2/AlertsList.jsx
+++ b/src/js/claims-status/components/appeals-v2/AlertsList.jsx
@@ -10,15 +10,13 @@ const AlertsList = ({ alerts, appealIsActive }) => {
 
   const allAlertsContent = alerts.map((alert) => getAlertContent(alert, appealIsActive));
 
-  const takeActionAlerts = allAlertsContent.filter((alert) => (alert.displayType === 'take_action'));
-  const infoAlert = allAlertsContent.filter((alert) => (alert.displayType === 'info'));
+  const takeActionAlertsPresent = allAlertsContent.some((alert) => (alert.displayType === 'take_action'));
 
-  const takeActionHeader = (takeActionAlerts.length)
+  const takeActionHeader = takeActionAlertsPresent
     ? (<h3>Take Action</h3>)
     : null;
 
-  const alertsList = takeActionAlerts
-    .concat(infoAlert)
+  const alertsList = allAlertsContent
     .map((alert, index) => {
       const key = `${alert.type}-${index}`;
       return (<Alert

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -78,9 +78,9 @@ const AppealsV2StatusPage = ({ appeal, fullName }) => {
         isClosed={!appealIsActive}/>
       <AlertsList alerts={filteredAlerts} appealIsActive/>
       {appealIsActive && <WhatsNext nextEvents={nextEvents}/>}
-      {afterNextAlerts}
       {shouldShowDocket && <Docket {...docket} aod={aod} form9Date={form9Date} appealType={appealType}/>}
       {!appealIsActive && <div className="closed-appeal-notice">This appeal is now closed</div>}
+      {afterNextAlerts}
     </div>
   );
 };

--- a/src/js/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/js/claims-status/containers/AppealsV2StatusPage.jsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getStatusContents, getNextEvents, APPEAL_TYPES, EVENT_TYPES, STATUS_TYPES } from '../utils/appeals-v2-helpers';
+import {
+  getAlertContent,
+  getStatusContents,
+  getNextEvents,
+  ALERT_TYPES,
+  APPEAL_TYPES,
+  EVENT_TYPES,
+  STATUS_TYPES
+} from '../utils/appeals-v2-helpers';
 
 import Timeline from '../components/appeals-v2/Timeline';
 import CurrentStatus from '../components/appeals-v2/CurrentStatus';
@@ -43,6 +51,24 @@ const AppealsV2StatusPage = ({ appeal, fullName }) => {
     !hideDocketStatusTypes.includes(status.type) &&
     !hideDocketAppealTypes.includes(appealType);
 
+  const filteredAlerts = alerts.filter(a => a.type !== ALERT_TYPES.cavcOption);
+  const afterNextAlerts = (
+    <div>
+      {alerts
+        .filter(a => a.type === ALERT_TYPES.cavcOption)
+        .map((a, i) => {
+          const alert = getAlertContent(a, appealIsActive);
+          return (
+            <div key={`after-next-alert-${i}`}>
+              <h2>{alert.title}</h2>
+              <div>{alert.description}</div>
+            </div>
+          );
+        })
+      }
+    </div>
+  );
+
   return (
     <div>
       <Timeline events={events} missingEvents={incompleteHistory}/>
@@ -50,8 +76,9 @@ const AppealsV2StatusPage = ({ appeal, fullName }) => {
         title={currentStatus.title}
         description={currentStatus.description}
         isClosed={!appealIsActive}/>
-      <AlertsList alerts={alerts} appealIsActive/>
+      <AlertsList alerts={filteredAlerts} appealIsActive/>
       {appealIsActive && <WhatsNext nextEvents={nextEvents}/>}
+      {afterNextAlerts}
       {shouldShowDocket && <Docket {...docket} aod={aod} form9Date={form9Date} appealType={appealType}/>}
       {!appealIsActive && <div className="closed-appeal-notice">This appeal is now closed</div>}
     </div>

--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -1177,7 +1177,7 @@ export function getAlertContent(alert, appealIsActive) {
           </div>
         ),
         displayType: 'info',
-        type,
+        type
       };
     }
     case ALERT_TYPES.rampIneligible: {
@@ -1189,7 +1189,7 @@ export function getAlertContent(alert, appealIsActive) {
           <p>On {formattedDate}, VA sent you a letter to let you know about a new program called the Rapid Appeals Modernization Program (RAMP). However, this appeal isn’t eligible for RAMP because it {statusDescription}. If you have other appeals, they may be eligible for RAMP.</p>
         ),
         displayType: 'info',
-        type,
+        type
       };
     }
     case ALERT_TYPES.decisionSoon:
@@ -1199,7 +1199,7 @@ export function getAlertContent(alert, appealIsActive) {
           <p>Your appeal will soon receive a Board decision. Submitting new evidence at this time could delay review of your appeal. If you’ve moved recently, please make sure that VA has your up-to-date mailing address.</p>
         ),
         displayType: 'info',
-        type,
+        type
       };
     case ALERT_TYPES.blockedByVso:
       return {
@@ -1208,7 +1208,7 @@ export function getAlertContent(alert, appealIsActive) {
           <p>Your appeal is eligible to be assigned to a judge based on its place in line, but they’re prevented from reviewing your appeal because your Veterans Service Organization, {details.vsoName}, is reviewing it right now. For more information, please contact your Veterans Service Organization or representative.</p>
         ),
         displayType: 'info',
-        type,
+        type
       };
     case ALERT_TYPES.cavcOption: {
       const formattedDueDate = formatDate(details.dueDate);
@@ -1224,8 +1224,10 @@ export function getAlertContent(alert, appealIsActive) {
             </ul>
           </div>
         ),
-        displayType: 'info',
-        type,
+        // displayType is blank because it doesn't apply; this gets pulled out and displayed as a
+        //  non-alert after "What happens next?"
+        displayType: '',
+        type
       };
     }
     default:
@@ -1233,7 +1235,7 @@ export function getAlertContent(alert, appealIsActive) {
         title: '',
         description: null,
         displayType: '',
-        type,
+        type
       };
   }
 }


### PR DESCRIPTION
Ignore the current status and docket line surrounding the "alert"--I just threw this alert into a random appeal to make sure it displayed where it was supposed to go and not where it wasn't supposed to go.
![image](https://user-images.githubusercontent.com/12970166/37741005-029c8a52-2d1d-11e8-8745-c5decd3b2014.png)
