### PR TITLE
use relative paths for internal links so they do not show with exit-icon

### DIFF
--- a/src/js/discharge-wizard/components/InstructionsPage.jsx
+++ b/src/js/discharge-wizard/components/InstructionsPage.jsx
@@ -70,9 +70,9 @@ class InstructionsPage extends React.Component {
                                 <p>If you experienced sexual assault or harassment while in the military, or need mental health services related to PTSD or other mental health conditions linked to your service, you may qualify immediately for VA health benefits, even without a VA Character of Discharge review or a discharge upgrade.</p>
                                 <p>Learn more about:</p>
                                 <ul>
-                                  <li><a href="https://www.vets.gov/health-care/health-conditions/military-sexual-trauma/">VA health benefits for Veterans who have experienced military sexual trauma</a></li>
-                                  <li><a href="https://www.vets.gov/health-care/health-conditions/mental-health/">VA health benefits for Veterans with mental health conditions</a></li>
-                                  <li><a href="https://www.vets.gov/health-care/health-conditions/mental-health/ptsd/">VA health benefits for Veterans with PTSD</a></li>
+                                  <li><a href="/health-care/health-conditions/military-sexual-trauma/">VA health benefits for Veterans who have experienced military sexual trauma</a></li>
+                                  <li><a href="/health-care/health-conditions/mental-health/">VA health benefits for Veterans with mental health conditions</a></li>
+                                  <li><a href="/health-care/health-conditions/mental-health/ptsd/">VA health benefits for Veterans with PTSD</a></li>
                                 </ul>
                               </div>
                             </div>

--- a/src/js/discharge-wizard/containers/GuidancePage.jsx
+++ b/src/js/discharge-wizard/containers/GuidancePage.jsx
@@ -344,9 +344,9 @@ class GuidancePage extends React.Component {
 
     return (
       <ul>
-        <li><a target="_blank" href="https://www.vets.gov/health-care/health-conditions/military-sexual-trauma/">VA health benefits for Veterans who experience military sexual trauma</a></li>
-        <li><a target="_blank" href="https://www.vets.gov/health-care/health-conditions/mental-health/">VA health benefits for Veterans with mental health conditions</a></li>
-        <li><a target="_blank" href="https://www.vets.gov/health-care/health-conditions/mental-health/ptsd/">VA health benefits for Veterans with PTSD</a></li>
+        <li><a target="_blank" href="/health-care/health-conditions/military-sexual-trauma/">VA health benefits for Veterans who experience military sexual trauma</a></li>
+        <li><a target="_blank" href="/health-care/health-conditions/mental-health/">VA health benefits for Veterans with mental health conditions</a></li>
+        <li><a target="_blank" href="/health-care/health-conditions/mental-health/ptsd/">VA health benefits for Veterans with PTSD</a></li>
         <li><a target="_blank" href="https://www.benefits.va.gov/BENEFITS/docs/COD_Factsheet.pdf">VA Guidance on Character of Discharge Reviews</a></li>
         {serviceBranch === 'army' && <li><a target="_blank" href="http://arba.army.pentagon.mil">Army Review Boards Agency</a></li>}
         {serviceBranch === 'army' && board(this.props.formValues).abbr === 'DRB' && <li><a target="_blank" href="http://arba.army.pentagon.mil/adrb-overview.html">Army Discharge Review Board</a></li>}


### PR DESCRIPTION
There is an overarching css rule that gives any link that starts with ^http an exit icon. Since these resources are relative to the project I turned them into relative links. I search the codebase and ensured that relative links are used in other parts of the application but if there is a reason not to take this approach, let me know and I'll do something different.