### PR TITLE
Change location of fields and reviewFields in SchemaForm

### DIFF
--- a/script/run-unit-test.sh
+++ b/script/run-unit-test.sh
@@ -10,7 +10,7 @@ fi
 
 # No test specified; run all of them
 if [[ -z "$1" ]] || [[ $1 == -* ]]; then
-  BABEL_ENV=test $MOCHA test/helper.js --recursive '$SCRIPT_DIR/../test/**/*.unit.spec.js?(x)' "$@"
+    BABEL_ENV=test $MOCHA --recursive '$SCRIPT_DIR/../test/**/*.unit.spec.js?(x)' test/helper.js "$@"
   exit $?
 fi
 

--- a/src/js/common/schemaform/components/SchemaForm.jsx
+++ b/src/js/common/schemaform/components/SchemaForm.jsx
@@ -18,21 +18,6 @@ import TitleField from '../fields/TitleField';
 import ReviewObjectField from '../review/ObjectField';
 import { scrollToFirstError } from '../../utils/helpers';
 
-const fields = {
-  ObjectField,
-  ArrayField,
-  BasicArrayField,
-  TitleField
-};
-
-const reviewFields = {
-  ObjectField: ReviewObjectField,
-  ArrayField: ReadOnlyArrayField,
-  BasicArrayField,
-  address: ReviewObjectField,
-  StringField
-};
-
 /*
  * Each page uses this component and passes in config. This is where most of the page level
  * form logic should live.
@@ -136,6 +121,21 @@ class SchemaForm extends React.Component {
   }
 
   render() {
+    const fields = {
+      ObjectField,
+      ArrayField,
+      BasicArrayField,
+      TitleField
+    };
+
+    const reviewFields = {
+      ObjectField: ReviewObjectField,
+      ArrayField: ReadOnlyArrayField,
+      BasicArrayField,
+      address: ReviewObjectField,
+      StringField
+    };
+
     const {
       data,
       schema,

--- a/src/js/common/schemaform/components/SchemaForm.jsx
+++ b/src/js/common/schemaform/components/SchemaForm.jsx
@@ -32,6 +32,20 @@ class SchemaForm extends React.Component {
     this.onBlur = this.onBlur.bind(this);
     this.setTouched = this.setTouched.bind(this);
     this.state = this.getEmptyState(props);
+    this.fields = {
+      ObjectField,
+      ArrayField,
+      BasicArrayField,
+      TitleField
+    };
+
+    this.reviewFields = {
+      ObjectField: ReviewObjectField,
+      ArrayField: ReadOnlyArrayField,
+      BasicArrayField,
+      address: ReviewObjectField,
+      StringField
+    };
   }
 
   componentWillReceiveProps(newProps) {
@@ -121,21 +135,6 @@ class SchemaForm extends React.Component {
   }
 
   render() {
-    const fields = {
-      ObjectField,
-      ArrayField,
-      BasicArrayField,
-      TitleField
-    };
-
-    const reviewFields = {
-      ObjectField: ReviewObjectField,
-      ArrayField: ReadOnlyArrayField,
-      BasicArrayField,
-      address: ReviewObjectField,
-      StringField
-    };
-
     const {
       data,
       schema,
@@ -168,7 +167,7 @@ class SchemaForm extends React.Component {
           showErrorList={false}
           formData={data}
           widgets={useReviewMode ? reviewWidgets : widgets}
-          fields={useReviewMode ? reviewFields : fields}
+          fields={useReviewMode ? this.reviewFields : this.fields}
           transformErrors={this.transformErrors}>
           {children}
         </Form>


### PR DESCRIPTION
avoids a random test order error where 'fields' is modified causing `ArrayField`
to be set to undefined causing subsequent tests to error

One source of inexplicable build failures down!