### PR TITLE
Re-enable the unauthed flow test

### DIFF
--- a/test/e2e/unauthed-flows.e2e.spec.js
+++ b/test/e2e/unauthed-flows.e2e.spec.js
@@ -19,7 +19,7 @@ module.exports = E2eHelpers.createE2eTest(
 
     const appPaths = [
       // While the page is in maintenance, it doesn't need authed
-      // '/education/gi-bill/post-9-11/ch-33-benefit',
+      '/education/gi-bill/post-9-11/ch-33-benefit/status',
       '/health-care/health-records',
       '/health-care/messaging',
       '/health-care/prescriptions',


### PR DESCRIPTION
Re-enables the commented out test. Looks like the other test that was disabled has already been re-enabled.