### PR TITLE
9644 fix object keys null error

### DIFF
--- a/src/js/common/schemaform/save-in-progress/reducers.js
+++ b/src/js/common/schemaform/save-in-progress/reducers.js
@@ -74,7 +74,7 @@ export const saveInProgressReducers = {
 
       // We get an empty object back when we attempt to prefill and there's
       // no information
-      if (Object.keys(action.data.formData).length > 0) {
+      if (_.keys(_.get('data.formData', action)).length > 0) {
         newState.prefillStatus = PREFILL_STATUSES.success;
       } else {
         newState.prefillStatus = PREFILL_STATUSES.unfilled;

--- a/src/js/common/schemaform/save-in-progress/reducers.js
+++ b/src/js/common/schemaform/save-in-progress/reducers.js
@@ -74,7 +74,7 @@ export const saveInProgressReducers = {
 
       // We get an empty object back when we attempt to prefill and there's
       // no information
-      if (_.keys(_.get('data.formData', action)).length > 0) {
+      if (_.keys(action.data.formData).length > 0) {
         newState.prefillStatus = PREFILL_STATUSES.success;
       } else {
         newState.prefillStatus = PREFILL_STATUSES.unfilled;

--- a/test/common/schemaform/save-in-progress/reducers.unit.spec.js
+++ b/test/common/schemaform/save-in-progress/reducers.unit.spec.js
@@ -168,6 +168,19 @@ describe('schemaform createSaveInProgressInitialState', () => {
 
       expect(state.prefillStatus).to.equal(PREFILL_STATUSES.unfilled);
     });
+    it('should handle undefined formData', () => {
+      const state = reducer({
+        data: {},
+        prefillStatus: PREFILL_STATUSES.pending,
+        pages: {}
+      }, {
+        type: SET_IN_PROGRESS_FORM,
+        data: { formData: undefined },
+        pages: {}
+      });
+
+      expect(state.prefillStatus).to.equal(PREFILL_STATUSES.unfilled);
+    });
     it('should set fetch form pending', () => {
       const state = reducer({
       }, {


### PR DESCRIPTION
Assumption: if the formData object is invalid then 
`newState.prefillStatus = PREFILL_STATUSES.unfilled;`

This error doesn't look like it's happening in production anymore.

<img width="315" alt="screen shot 2018-04-04 at 12 10 47" src="https://user-images.githubusercontent.com/4998130/38325783-3c4a6d34-3801-11e8-92ed-b0f84b1ba5ef.png">
