### PR TITLE
add some error handling to the mocha process

### DIFF
--- a/script/mocha.js
+++ b/script/mocha.js
@@ -11,7 +11,6 @@ require('../test/util/mocha-setup.js');
 require('../test/util/enzyme-setup.js');
 
 let showErrors = false;
-
 // keys for current require.cache
 const unwatchedModules = Object.keys(require.cache).map(file => file);
 
@@ -42,7 +41,6 @@ async function runMochaTests(files) {
 
   // keep errors from polluting the reporter by redirecting the error stream
   let errorStream;
-  const consoleErr = process.stderr.write;
   if (!showErrors) {
     errorStream = new Writable({
       write(chunk, encoding, callback) {
@@ -63,9 +61,13 @@ async function runMochaTests(files) {
     mocha.run()
       .once('end', function() {
         // reattach error stream
-        process.stderr.write = consoleErr;
         fulfill();
       });
+  }).catch(error => {
+    console.log(error);
+    process.send({
+      error
+    });
   });
 }
 

--- a/script/mocha.js
+++ b/script/mocha.js
@@ -17,14 +17,14 @@ const unwatchedModules = Object.keys(require.cache).map(file => file);
 process.on('message', ({tests, shouldShowErrors}) => {
   showErrors = shouldShowErrors;
   runMochaTests(tests).then(() => {
-    // create a list of src and test files imported by mocha
-    const watchedFiles = Object
+    // create a list of src and test files required by mocha
+    const requiredFiles = Object
       .keys(require.cache)
       .filter(file => !unwatchedModules.includes(file) && !file.includes('node_modules'));
     // send list of imported files and unit tests for each src file to the runner
     process.send({
-      watchedFiles,
-      unitTestsForSrc: getUnitTestsForSrc(watchedFiles)
+      requiredFiles,
+      unitTestsForSrc: getUnitTestsForSrc(requiredFiles)
     });
   });
 });
@@ -71,8 +71,8 @@ async function runMochaTests(files) {
   });
 }
 
-function getUnitTestsForSrc(watchedFiles) {
-  return watchedFiles
+function getUnitTestsForSrc(requiredFiles) {
+  return requiredFiles
   // only use files in test directory
     .filter(file => file.includes('test'))
   // iterate over each test file

--- a/script/watch.js
+++ b/script/watch.js
@@ -95,7 +95,7 @@ function runMochaTests(tests) {
         // mocha runner returned an error
         reject(error);
       } else {
-        // mocha runner a list of files it required and a map of unit tests to source files
+        // mocha runner returend a list of files it required and a map of unit tests to source files
         fulfill({ requiredFiles, unitTestsForSrc });
       }
       // kill mocha

--- a/script/watch.js
+++ b/script/watch.js
@@ -90,7 +90,7 @@ function runMochaTests(tests) {
       tests,
       showErrors
     });
-    forked.on('message', ({error, requiredFiles, unitTestsForSrc }) => {
+    forked.on('message', ({ error, requiredFiles, unitTestsForSrc }) => {
       if (error) {
         // mocha runner returned an error
         reject(error);


### PR DESCRIPTION
Mocha doesn't catch errors during the require stage of its setup i.e. if there's a problem with an import, this was failing silently. Now the child process sends an error message when something fails allowing the watcher to 
- handle the error and keep watching if the watcher is set up
- stop the process if the watcher isn't set up. 