### PR TITLE
Award amounts of 0.0 should show in the UI

### DIFF
--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -255,7 +255,8 @@ export function getBenefitOptionText(option, value, isVeteran, awardEffectiveDat
     valueString = value;
   }
 
-  const isAvailable = value && value !== AVAILABILITY_STATUSES.unavailable;
+  // NOTE: 0 is a legitimate return value
+  const isAvailable = (value === 0 || value) && value !== AVAILABILITY_STATUSES.unavailable;
   const availableOptions = new Set([BENEFIT_OPTIONS.awardEffectiveDate, BENEFIT_OPTIONS.monthlyAwardAmount, BENEFIT_OPTIONS.serviceConnectedPercentage]);
 
   if (!availableOptions.has(option)) {

--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -6,7 +6,6 @@ import { apiRequest as commonApiClient } from '../../common/helpers/api';
 import environment from '../../common/helpers/environment';
 import { formatDateShort } from '../../common/utils/helpers';
 import {
-  AVAILABILITY_STATUSES,
   BENEFIT_OPTIONS,
   STATE_CODE_TO_NAME,
   ADDRESS_TYPES,

--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -256,7 +256,7 @@ export function getBenefitOptionText(option, value, isVeteran, awardEffectiveDat
   }
 
   // NOTE: $0 award is a legitimate number for award amounts
-  const isAvailable = (value === 0 || value) && value !== AVAILABILITY_STATUSES.unavailable;
+  const isAvailable = (value === 0 || value);
   const availableOptions = new Set([BENEFIT_OPTIONS.awardEffectiveDate, BENEFIT_OPTIONS.monthlyAwardAmount, BENEFIT_OPTIONS.serviceConnectedPercentage]);
 
   if (!availableOptions.has(option)) {

--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -255,7 +255,7 @@ export function getBenefitOptionText(option, value, isVeteran, awardEffectiveDat
     valueString = value;
   }
 
-  // NOTE: 0 is a legitimate return value
+  // NOTE: $0 award is a legitimate number for award amounts
   const isAvailable = (value === 0 || value) && value !== AVAILABILITY_STATUSES.unavailable;
   const availableOptions = new Set([BENEFIT_OPTIONS.awardEffectiveDate, BENEFIT_OPTIONS.monthlyAwardAmount, BENEFIT_OPTIONS.serviceConnectedPercentage]);
 

--- a/test/letters/utils/helpers.unit.spec.jsx
+++ b/test/letters/utils/helpers.unit.spec.jsx
@@ -89,7 +89,7 @@ describe('Letters helpers: ', () => {
       _.forEach(option => {
         expect(getBenefitOptionText(option, 20, true)).not.to.be.undefined;
         expect(getBenefitOptionText(option, undefined, true)).to.be.undefined;
-        expect(getBenefitOptionText(option, 'unavailable', true)).to.be.undefined;
+        expect(getBenefitOptionText(option, null, true)).to.be.undefined;
       }, ['monthlyAwardAmount', 'serviceConnectedPercentage']);
     });
 
@@ -98,16 +98,6 @@ describe('Letters helpers: ', () => {
       expect(tree.text()).to.contain('The effective date');
     });
   });
-
-  /*
-  describe('getStateName', () => {
-    // Seems kind of pointless...
-    it('should return valid state names', () => {});
-
-    // Can we really test for this?
-    it('should send an error to sentry if the state code is unknown', () => {});
-  });
-  */
 
   describe('inferAddressType', () => {
     it('should set the type to international if USA isn\'t selected', () => {


### PR DESCRIPTION
Per discussion, a monthly allowance of 0 is a legitimate amount that should show (as compared to a `null` value, which indicates no monthly award and shouldn't be shown). We had been treating these the same and they're not.