### PR TITLE
Set up special circumstances page

### DIFF
--- a/src/js/disability-benefits/526EZ/config/form.js
+++ b/src/js/disability-benefits/526EZ/config/form.js
@@ -105,17 +105,44 @@ const formConfig = {
         }
       }
     },
-    chapterTwo: {
-      title: 'Chapter Two',
+    reviewVeteranDetails: {
+      title: 'Review Veteran Details',
       pages: {
-        pageOne: {
-          title: 'Page One',
-          path: 'chapter-two/page-one',
-          uiSchema: {},
+        specialCircumstances: {
+          title: 'Special Circumstances',
+          path: 'special-circumstances',
+          uiSchema: {
+            'ui:description': 'To help us better understand your situation, please tell us if any of the below situations apply to you. Are you:',
+            'view:suicidal': {
+              'ui:title': 'In crisis or thinking of suicide?'
+            },
+            'view:homeless': {
+              'ui:title': 'Homeless or in danger of becoming homless?'
+            },
+            'view:extremeFinancialHardship': {
+              'ui:title': 'Suffering from extreme financial hardship?'
+            },
+            'view:blindOrSightImpaired': {
+              'ui:title': 'Blind or sight-impaired?'
+            }
+          },
           schema: {
             type: 'object',
-            properties: {}
-          },
+            properties: {
+              'view:suicidal': {
+                type: 'boolean'
+              },
+              'view:homeless': {
+                type: 'boolean'
+              },
+              'view:extremeFinancialHardship': {
+                type: 'boolean'
+              },
+              'view:blindOrSightImpaired': {
+                type: 'boolean'
+              }
+            }
+          }
         }
       }
     },

--- a/src/js/disability-benefits/526EZ/config/form.js
+++ b/src/js/disability-benefits/526EZ/config/form.js
@@ -112,12 +112,18 @@ const formConfig = {
           title: 'Special Circumstances',
           path: 'special-circumstances',
           uiSchema: {
-            'ui:description': 'To help us better understand your situation, please tell us if any of the below situations apply to you. Are you:',
+            'ui:description': (
+              <p>
+                To help us better understand your situation, please tell us if
+                any of the below situations apply to you.{' '}
+                <strong>Are you:</strong>
+              </p>
+            ),
             'view:suicidal': {
               'ui:title': 'In crisis or thinking of suicide?'
             },
             'view:homeless': {
-              'ui:title': 'Homeless or in danger of becoming homless?'
+              'ui:title': 'Homeless or at risk of becoming homeless?'
             },
             'view:extremeFinancialHardship': {
               'ui:title': 'Suffering from extreme financial hardship?'
@@ -156,7 +162,7 @@ const formConfig = {
           schema: {
             type: 'object',
             properties: {}
-          },
+          }
         }
       }
     },

--- a/src/js/disability-benefits/526EZ/config/form.js
+++ b/src/js/disability-benefits/526EZ/config/form.js
@@ -23,7 +23,8 @@ import {
   documentDescription,
   evidenceSummaryView,
   additionalDocumentDescription,
-  releaseView
+  releaseView,
+  specialCircumstancesDescription
 } from '../helpers';
 
 const {
@@ -112,13 +113,7 @@ const formConfig = {
           title: 'Special Circumstances',
           path: 'special-circumstances',
           uiSchema: {
-            'ui:description': (
-              <p>
-                To help us better understand your situation, please tell us if
-                any of the below situations apply to you.{' '}
-                <strong>Are you:</strong>
-              </p>
-            ),
+            'ui:description': specialCircumstancesDescription,
             'view:suicidal': {
               'ui:title': 'In crisis or thinking of suicide?'
             },

--- a/src/js/disability-benefits/526EZ/helpers.jsx
+++ b/src/js/disability-benefits/526EZ/helpers.jsx
@@ -285,10 +285,7 @@ export const evidenceSummaryView = ({ formData }) => {
 };
 
 export const specialCircumstancesDescription = (
-  <p>
-    To help us better understand your situation, please tell us if
-    any of the below situations apply to you.{' '}
-    <strong>Are you:</strong>
-  </p>
+  <p>To help us better understand your situation, please tell us if
+      any of the below situations apply to you. <strong>Are you:</strong></p>
 );
 

--- a/src/js/disability-benefits/526EZ/helpers.jsx
+++ b/src/js/disability-benefits/526EZ/helpers.jsx
@@ -283,3 +283,12 @@ export const evidenceSummaryView = ({ formData }) => {
     </div>
   );
 };
+
+export const specialCircumstancesDescription = (
+  <p>
+    To help us better understand your situation, please tell us if
+    any of the below situations apply to you.{' '}
+    <strong>Are you:</strong>
+  </p>
+);
+

--- a/test/disability-benefits/526EZ/config/specialCircumstances.unit.spec.jsx
+++ b/test/disability-benefits/526EZ/config/specialCircumstances.unit.spec.jsx
@@ -8,7 +8,7 @@ import formConfig from '../../../../src/js/disability-benefits/526EZ/config/form
 
 describe('Disability benefits 526EZ special circumstances', () => {
   const { schema, uiSchema } = formConfig.chapters.reviewVeteranDetails.pages.specialCircumstances;
-  it('renders evidence type form', () => {
+  it('renders special circumstances form', () => {
     const onSubmit = sinon.spy();
     const form = mount(<DefinitionTester
       onSubmit={onSubmit}

--- a/test/disability-benefits/526EZ/config/specialCircumstances.unit.spec.jsx
+++ b/test/disability-benefits/526EZ/config/specialCircumstances.unit.spec.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+
+import { DefinitionTester } from '../../../../src/platform/testing/unit/schemaform-utils.jsx';
+import formConfig from '../../../../src/js/disability-benefits/526EZ/config/form.js';
+
+describe('Disability benefits 526EZ special circumstances', () => {
+  const { schema, uiSchema } = formConfig.chapters.reviewVeteranDetails.pages.specialCircumstances;
+  it('renders evidence type form', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(<DefinitionTester
+      onSubmit={onSubmit}
+      definitions={formConfig.defaultDefinitions}
+      schema={schema}
+      data={{}}
+      formData={{}}
+      uiSchema={uiSchema}/>
+    );
+
+    expect(form.find('input').length).to.equal(4);
+  });
+
+  it('submit empty form', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        onSubmit={onSubmit}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{}}
+        formData={{}}
+        uiSchema={uiSchema}/>
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+});


### PR DESCRIPTION
These changes set up the special circumstances page.

There are some questions here regarding how this data should be stored (as none of the fields map to the backend schema), what conditional additional pages or fields this should present to the applicant (e.g. point of contact information), and whether the chapter name should reflect the page name (e.g. "Special Circumstances") as the applicant is not reviewing anything here.

![image](https://user-images.githubusercontent.com/16051172/38637863-47d37f80-3d81-11e8-92ab-ce75437dcc81.png)
