### PR TITLE
Add Error capture

### DIFF
--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -1247,6 +1247,9 @@ export function getAlertContent(alert, appealIsActive) {
  * @returns {string} status code or 'unknown'
  */
 export const getStatus = (response) => {
+  if (response instanceof Error) {
+    Raven.captureException(response, { tags: { location: 'getStatus' } });
+  }
   return (response.errors && response.errors.length)
     ? response.errors[0].status
     : 'unknown';


### PR DESCRIPTION
Adds some Sentry logging for strange response errors in appeals.
Should be temporary until cause of current issues is identified.