### PR TITLE
Rolls back PR 7549 (need to wait for sustainment)

### DIFF
--- a/src/js/letters/utils/helpers.jsx
+++ b/src/js/letters/utils/helpers.jsx
@@ -6,6 +6,7 @@ import { apiRequest as commonApiClient } from '../../common/helpers/api';
 import environment from '../../common/helpers/environment';
 import { formatDateShort } from '../../common/utils/helpers';
 import {
+  AVAILABILITY_STATUSES,
   BENEFIT_OPTIONS,
   STATE_CODE_TO_NAME,
   ADDRESS_TYPES,
@@ -254,8 +255,7 @@ export function getBenefitOptionText(option, value, isVeteran, awardEffectiveDat
     valueString = value;
   }
 
-  // NOTE: $0 award is a legitimate number for award amounts
-  const isAvailable = (value === 0 || value);
+  const isAvailable = value && value !== AVAILABILITY_STATUSES.unavailable;
   const availableOptions = new Set([BENEFIT_OPTIONS.awardEffectiveDate, BENEFIT_OPTIONS.monthlyAwardAmount, BENEFIT_OPTIONS.serviceConnectedPercentage]);
 
   if (!availableOptions.has(option)) {

--- a/test/letters/utils/helpers.unit.spec.jsx
+++ b/test/letters/utils/helpers.unit.spec.jsx
@@ -89,7 +89,7 @@ describe('Letters helpers: ', () => {
       _.forEach(option => {
         expect(getBenefitOptionText(option, 20, true)).not.to.be.undefined;
         expect(getBenefitOptionText(option, undefined, true)).to.be.undefined;
-        expect(getBenefitOptionText(option, null, true)).to.be.undefined;
+        expect(getBenefitOptionText(option, 'unavailable', true)).to.be.undefined;
       }, ['monthlyAwardAmount', 'serviceConnectedPercentage']);
     });
 


### PR DESCRIPTION
Reverts https://github.com/department-of-veterans-affairs/vets-website/pull/7549

Sustainment needs to make changes to the letter generator to handle $0 award amounts. These changes are in the pipeline but the next deploy isn't til May 2nd. We need to wait to deploy the changes in 7549 until the Letter Generator is ready.