### PR TITLE
Update timeliness property name

### DIFF
--- a/src/js/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/js/claims-status/utils/appeals-v2-helpers.jsx
@@ -764,7 +764,7 @@ export const makeDurationText = (timeliness) => {
 export function getNextEvents(currentStatus, details) {
   switch (currentStatus) {
     case STATUS_TYPES.pendingSoc: {
-      const socDuration = makeDurationText(details.ssocTimeliness);
+      const socDuration = makeDurationText(details.socTimeliness);
       return {
         header: `What happens next depends on whether the Decision Review Officer has enough
           evidence to decide in your favor.`,

--- a/src/js/claims-status/utils/helpers.js
+++ b/src/js/claims-status/utils/helpers.js
@@ -268,7 +268,7 @@ export const mockData = {
           details: {
             lastSocDate: '2015-09-12',
             certificationTimeliness: [1, 4],
-            ssocTimeliness: [2, 16],
+            socTimeliness: [2, 16],
           }
         },
         docket: {


### PR DESCRIPTION
Updates the property name that we pull from to generate `timeliness` ranges because the variable name we use now isn't what the api provides.