### PR TITLE
remove legend focusing behavior

### DIFF
--- a/src/js/common/schemaform/containers/FormPage.jsx
+++ b/src/js/common/schemaform/containers/FormPage.jsx
@@ -14,12 +14,7 @@ import { getNextPagePath, getPreviousPagePath } from '../routing';
 import { focusElement } from '../../../../platform/utilities/ui';
 
 function focusForm() {
-  const legend = document.querySelector('.form-panel legend:not(.schemaform-label)');
-  if (legend && legend.getBoundingClientRect().height > 0) {
-    focusElement(legend);
-  } else {
-    focusElement('.nav-header');
-  }
+  focusElement('.nav-header');
 }
 
 const scroller = Scroll.scroller;


### PR DESCRIPTION
I tested this on a couple forms- it changes the default behavior to focus on the progress bar test when changing pages.

This behavior was originally added as part of this [issue](https://github.com/department-of-veterans-affairs/vets-website/pull/4715). @jbalboni I want to make sure that there aren't specific test cases we should regression test on i.e. was the legend just an add-on or does it act as a replacement for the `.nav-header` in some places. 