### PR TITLE
Disable ITF mock

### DIFF
--- a/src/js/common/schemaform/save-in-progress/FormStartControls.jsx
+++ b/src/js/common/schemaform/save-in-progress/FormStartControls.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
-import Raven from 'raven-js';
 
 import ProgressButton from '@department-of-veterans-affairs/jean-pants/ProgressButton';
 import Modal from '@department-of-veterans-affairs/jean-pants/Modal';
@@ -24,13 +23,7 @@ class FormStartControls extends React.Component {
   }
 
   handleLoadPrefill = () => {
-    if (this.props.beforeStartForm) {
-      this.props.beforeStartForm().then(() => {
-        this.props.fetchInProgressForm(this.props.formId, this.props.migrations, true, this.props.prefillTransformer);
-      }, (errorMessage) => {
-        Raven.captureMessage(`vets_itf_error: ${errorMessage}`);
-      });
-    } else if (this.props.prefillAvailable) {
+    if (this.props.prefillAvailable) {
       this.props.fetchInProgressForm(this.props.formId, this.props.migrations, true, this.props.prefillTransformer);
     } else {
       this.goToBeginning();
@@ -40,13 +33,6 @@ class FormStartControls extends React.Component {
   handleLoadForm = () => {
     // If successful, this will set form.loadedData.metadata.returnUrl and will
     //  trickle down to this.props to be caught in componentWillReceiveProps
-    if (this.props.beforeStartForm) {
-      this.props.beforeStartForm().then(() => {
-        this.props.fetchInProgressForm(this.props.formId, this.props.migrations, true, this.props.prefillTransformer);
-      }, (errorMessage) => {
-        Raven.captureMessage(`vets_itf_error: ${errorMessage}`);
-      });
-    }
     return this.props.fetchInProgressForm(this.props.formId, this.props.migrations);
   }
 


### PR DESCRIPTION
The 526 ITF mock (introduced in PR [7524](https://github.com/department-of-veterans-affairs/vets-website/pull/7524/files)) is buggy and needs to be fixed, these changes revert the FormStartControls to their previous state while that is underway.