### PR TITLE
Personalization: Change wording for Beta Enrollment button

### DIFF
--- a/src/js/personalization/beta-enrollment/containers/BetaEnrollmentButton.jsx
+++ b/src/js/personalization/beta-enrollment/containers/BetaEnrollmentButton.jsx
@@ -52,7 +52,6 @@ class BetaEnrollmentButton extends React.Component {
 
     if (this.props.user.profile.loading) buttonText = 'Loading Profile...';
     else if (this.state.isEnrolling) buttonText = 'Turning On Beta Tools';
-    else if (!this.props.user.login.currentlyLoggedIn) buttonText = 'Go To Login To Turn On Beta Tools';
 
     const disabled = this.state.isEnrolling || this.props.user.profile.loading;
 


### PR DESCRIPTION
Changes button text to say "Turn On Beta Tools" regardless of whether they are logged in