### PR TITLE
Get past rated disabilities selection

### DIFF
--- a/src/js/common/schemaform/helpers.js
+++ b/src/js/common/schemaform/helpers.js
@@ -540,3 +540,22 @@ export function getActiveChapters(formConfig, formData) {
 
   return _.uniq(expandedPageList.map(p => p.chapterKey).filter(key => !!key && key !== 'review'));
 }
+
+/**
+ * Returns the schema, omitting all `required` arrays.
+ *
+ * @param schema {Object}
+ * @returns {Object} The schema without any `required` arrays
+ */
+export function omitRequired(schema) {
+  if (typeof schema !== 'object' || Array.isArray(schema)) {
+    return schema;
+  }
+
+  const newSchema = _.omit('required', schema);
+  Object.keys(newSchema).forEach(key => {
+    newSchema[key] = omitRequired(newSchema[key]);
+  });
+
+  return newSchema;
+}

--- a/src/js/disability-benefits/526EZ/config/form.js
+++ b/src/js/disability-benefits/526EZ/config/form.js
@@ -1,5 +1,7 @@
 import _ from '../../../../platform/utilities/data';
 
+import { omitRequired } from '../../../common/schemaform/helpers';
+
 import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
 // NOTE: Easier to run schema locally with hot reload for dev
 // import fullSchema526EZ from '/local/path/vets-json-schema/dist/21-526EZ-schema.json';
@@ -113,7 +115,7 @@ const formConfig = {
     fullName,
     // files
     dateRange,
-    disabilities: disabiltiesDefinition,
+    disabilities: omitRequired(disabiltiesDefinition),
     specialIssues,
     servicePeriods,
     privateTreatmentCenterAddress

--- a/src/js/disability-benefits/526EZ/tests/config/privateMedicalRecordsRelease.unit.spec.jsx
+++ b/src/js/disability-benefits/526EZ/tests/config/privateMedicalRecordsRelease.unit.spec.jsx
@@ -7,7 +7,7 @@ import { DefinitionTester, fillData } from '../../../../../platform/testing/unit
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
 
-describe('Disability benefits 526EZ VA facility', () => {
+xdescribe('Disability benefits 526EZ VA facility', () => {
   const { schema, uiSchema, arrayPath } = formConfig.chapters.supportingEvidence.pages.privateMedicalRecordRelease;
   it('renders private medical records release form', () => {
     const form = mount(<DefinitionTester
@@ -33,11 +33,11 @@ describe('Disability benefits 526EZ VA facility', () => {
       uiSchema={uiSchema}/>
     );
 
-    fillData(form, 'input#root_treatments_0_treatmentCenterCountry', 'USA');
+    fillData(form, 'input#root_treatments_0_treatment_treatmentCenterCountry', 'USA');
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error').length).to.equal(1);
-    fillData(form, 'input#root_treatments_0_treatmentCenterState', 'NY');
-    fillData(form, 'input#root_treatments_0_treatmentCenterPostalCode', 12);
+    fillData(form, 'input#root_treatments_0_treatment_treatmentCenterState', 'NY');
+    fillData(form, 'input#root_treatments_0_treatment_treatmentCenterPostalCode', 12);
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error').length).to.equal(1);
   });
@@ -55,25 +55,25 @@ describe('Disability benefits 526EZ VA facility', () => {
         uiSchema={uiSchema}/>
     );
 
-    fillData(form, 'input#root_disabilities_0_treatmentCenterName', 'Local hospital');
-    fillData(form, 'select#root_disabilities_0_startTreatmentMonth', '1');
-    fillData(form, 'select#root_disabilities_0_startTreatmentDay', '3');
-    fillData(form, 'input#root_disabilities_0_startTreatmentYear', '1950');
-    fillData(form, 'select#root_disabilities_0_endTreatmentMonth', '1');
-    fillData(form, 'select#root_disabilities_0_endTreatmentDay', '3');
-    fillData(form, 'input#root_disabilities_0_endTreatmentYear', '1955');
-    fillData(form, 'input#root_disabilities_0_treatmentCenterName', 'Local facility');
+    fillData(form, 'input#root_treatments_0_treatment_treatmentCenterName', 'Local hospital');
+    fillData(form, 'select#root_treatments_0_treatment_startTreatmentMonth', '1');
+    fillData(form, 'select#root_treatments_0_treatment_startTreatmentDay', '3');
+    fillData(form, 'input#root_treatments_0_treatment_startTreatmentYear', '1950');
+    fillData(form, 'select#root_treatments_0_treatment_endTreatmentMonth', '1');
+    fillData(form, 'select#root_treatments_0_treatment_endTreatmentDay', '3');
+    fillData(form, 'input#root_treatments_0_treatment_endTreatmentYear', '1955');
+    fillData(form, 'input#root_treatments_0_treatment_treatmentCenterName', 'Local facility');
 
     form.find('.va-growable-add-btn').simulate('click');
 
-    fillData(form, 'input#root_disabilities_1_treatmentCenterName', 'Local doctor');
-    fillData(form, 'select#root_disabilities_1_startTreatmentMonth', '1');
-    fillData(form, 'select#root_disabilities_1_startTreatmentDay', '3');
-    fillData(form, 'input#root_disabilities_1_startTreatmentYear', '1951');
-    fillData(form, 'select#root_disabilities_1_endTreatmentMonth', '1');
-    fillData(form, 'select#root_disabilities_1_endTreatmentDay', '3');
-    fillData(form, 'input#root_disabilities_1_endTreatmentYear', '1955');
-    fillData(form, 'input#root_disabilities_1_treatmentCenterName', 'Local facility');
+    fillData(form, 'input#root_treatments_1_treatment_treatmentCenterName', 'Local doctor');
+    fillData(form, 'select#root_treatments_1_treatment_startTreatmentMonth', '1');
+    fillData(form, 'select#root_treatments_1_treatment_startTreatmentDay', '3');
+    fillData(form, 'input#root_treatments_1_treatment_startTreatmentYear', '1951');
+    fillData(form, 'select#root_treatments_1_treatment_endTreatmentMonth', '1');
+    fillData(form, 'select#root_treatments_1_treatment_endTreatmentDay', '3');
+    fillData(form, 'input#root_treatments_1_treatment_endTreatmentYear', '1955');
+    fillData(form, 'input#root_treatments_1_treatment_treatmentCenterName', 'Local facility');
 
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error').length).to.equal(0);

--- a/src/js/disability-benefits/526EZ/tests/config/privateMedicalRecordsRelease.unit.spec.jsx
+++ b/src/js/disability-benefits/526EZ/tests/config/privateMedicalRecordsRelease.unit.spec.jsx
@@ -7,7 +7,7 @@ import { DefinitionTester, fillData } from '../../../../../platform/testing/unit
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
 
-xdescribe('Disability benefits 526EZ VA facility', () => {
+describe('Disability benefits 526EZ VA facility', () => {
   const { schema, uiSchema, arrayPath } = formConfig.chapters.supportingEvidence.pages.privateMedicalRecordRelease;
   it('renders private medical records release form', () => {
     const form = mount(<DefinitionTester
@@ -33,11 +33,11 @@ xdescribe('Disability benefits 526EZ VA facility', () => {
       uiSchema={uiSchema}/>
     );
 
-    fillData(form, 'input#root_treatments_0_treatment_treatmentCenterCountry', 'USA');
+    fillData(form, 'input#root_treatments_0_treatmentCenterCountry', 'USA');
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error').length).to.equal(1);
-    fillData(form, 'input#root_treatments_0_treatment_treatmentCenterState', 'NY');
-    fillData(form, 'input#root_treatments_0_treatment_treatmentCenterPostalCode', 12);
+    fillData(form, 'input#root_treatments_0_treatmentCenterState', 'NY');
+    fillData(form, 'input#root_treatments_0_treatmentCenterPostalCode', 12);
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error').length).to.equal(1);
   });
@@ -55,25 +55,25 @@ xdescribe('Disability benefits 526EZ VA facility', () => {
         uiSchema={uiSchema}/>
     );
 
-    fillData(form, 'input#root_treatments_0_treatment_treatmentCenterName', 'Local hospital');
-    fillData(form, 'select#root_treatments_0_treatment_startTreatmentMonth', '1');
-    fillData(form, 'select#root_treatments_0_treatment_startTreatmentDay', '3');
-    fillData(form, 'input#root_treatments_0_treatment_startTreatmentYear', '1950');
-    fillData(form, 'select#root_treatments_0_treatment_endTreatmentMonth', '1');
-    fillData(form, 'select#root_treatments_0_treatment_endTreatmentDay', '3');
-    fillData(form, 'input#root_treatments_0_treatment_endTreatmentYear', '1955');
-    fillData(form, 'input#root_treatments_0_treatment_treatmentCenterName', 'Local facility');
+    fillData(form, 'input#root_disabilities_0_treatmentCenterName', 'Local hospital');
+    fillData(form, 'select#root_disabilities_0_startTreatmentMonth', '1');
+    fillData(form, 'select#root_disabilities_0_startTreatmentDay', '3');
+    fillData(form, 'input#root_disabilities_0_startTreatmentYear', '1950');
+    fillData(form, 'select#root_disabilities_0_endTreatmentMonth', '1');
+    fillData(form, 'select#root_disabilities_0_endTreatmentDay', '3');
+    fillData(form, 'input#root_disabilities_0_endTreatmentYear', '1955');
+    fillData(form, 'input#root_disabilities_0_treatmentCenterName', 'Local facility');
 
     form.find('.va-growable-add-btn').simulate('click');
 
-    fillData(form, 'input#root_treatments_1_treatment_treatmentCenterName', 'Local doctor');
-    fillData(form, 'select#root_treatments_1_treatment_startTreatmentMonth', '1');
-    fillData(form, 'select#root_treatments_1_treatment_startTreatmentDay', '3');
-    fillData(form, 'input#root_treatments_1_treatment_startTreatmentYear', '1951');
-    fillData(form, 'select#root_treatments_1_treatment_endTreatmentMonth', '1');
-    fillData(form, 'select#root_treatments_1_treatment_endTreatmentDay', '3');
-    fillData(form, 'input#root_treatments_1_treatment_endTreatmentYear', '1955');
-    fillData(form, 'input#root_treatments_1_treatment_treatmentCenterName', 'Local facility');
+    fillData(form, 'input#root_disabilities_1_treatmentCenterName', 'Local doctor');
+    fillData(form, 'select#root_disabilities_1_startTreatmentMonth', '1');
+    fillData(form, 'select#root_disabilities_1_startTreatmentDay', '3');
+    fillData(form, 'input#root_disabilities_1_startTreatmentYear', '1951');
+    fillData(form, 'select#root_disabilities_1_endTreatmentMonth', '1');
+    fillData(form, 'select#root_disabilities_1_endTreatmentDay', '3');
+    fillData(form, 'input#root_disabilities_1_endTreatmentYear', '1955');
+    fillData(form, 'input#root_disabilities_1_treatmentCenterName', 'Local facility');
 
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error').length).to.equal(0);

--- a/src/js/disability-benefits/526EZ/tests/schema/initialData.js
+++ b/src/js/disability-benefits/526EZ/tests/schema/initialData.js
@@ -39,7 +39,8 @@ export default {
   ],
   disabilities: [
     {
-      diagnosticCode: '123',
+      // Temporarily using a number to get past the rated disabilities page until the new schema comes in
+      diagnosticCode: 123,
       name: 'Post-Traumatic Stress Disorder. This could also be claimed as Insomnia.',
       ratingPercentage: 30,
       // Is this supposed to be an array?
@@ -50,22 +51,22 @@ export default {
         }
       ],
       ratedDisabilityId: '12345',
-      disabilityActionType: 'Filler text',
+      disabilityActionType: 'INCREASE',
       ratingDecisionId: '67890',
       classificationCode: 'Filler Code',
       secondaryDisabilities: [
         {
           name: 'First secondary disability',
-          disabilityActionType: 'Filler text'
+          disabilityActionType: 'INCREASE'
         },
         {
           name: 'Second secondary disability',
-          disabilityActionType: 'Filler text'
+          disabilityActionType: 'INCREASE'
         }
       ]
     },
     {
-      diagnosticCode: '1234',
+      diagnosticCode: 1234,
       name: 'Intervertebral Disc Degeneration and Osteoarthritisstatus post-anterior disc fusion L4-S1 and L5-S1 microdiscectomy. Also claimed as muscle spasms back, herniated disc L4-L5, L5-S1.',
       ratingPercentage: 20,
       // Is this supposed to be an array?
@@ -76,17 +77,17 @@ export default {
         }
       ],
       ratedDisabilityId: '54321',
-      disabilityActionType: 'Filler text',
+      disabilityActionType: 'INCREASE',
       ratingDecisionId: '09876',
       classificationCode: 'Filler Code',
       secondaryDisabilities: [
         {
           name: 'First secondary disability',
-          disabilityActionType: 'Filler text'
+          disabilityActionType: 'INCREASE'
         },
         {
           name: 'Second secondary disability',
-          disabilityActionType: 'Filler text'
+          disabilityActionType: 'INCREASE'
         }
       ]
     }
@@ -100,19 +101,19 @@ export default {
         specialIssueName: 'Filler text'
       },
       ratedDisabilityId: '12345',
-      disabilityActionType: 'Filler text',
+      disabilityActionType: 'INCREASE',
       ratingDecisionId: '67890',
-      diagnosticCode: 'Filler text',
+      diagnosticCode: 12345,
       classificationCode: 'Filler Code',
       // Presumably, this should be an array...
       secondaryDisabilities: [
         {
           name: 'First secondary disability',
-          disabilityActionType: 'Filler text'
+          disabilityActionType: 'INCREASE'
         },
         {
           name: 'Second secondary disability',
-          disabilityActionType: 'Filler text'
+          disabilityActionType: 'INCREASE'
         }
       ]
     },
@@ -124,19 +125,19 @@ export default {
         specialIssueName: 'Filler text'
       },
       ratedDisabilityId: '54321',
-      disabilityActionType: 'Filler text',
+      disabilityActionType: 'INCREASE',
       ratingDecisionId: '09876',
-      diagnosticCode: 'Filler text',
+      diagnosticCode: 123456,
       classificationCode: 'Filler Code',
       // Presumably, this should be an array...
       secondaryDisabilities: [
         {
           name: 'First secondary disability',
-          disabilityActionType: 'Filler text'
+          disabilityActionType: 'INCREASE'
         },
         {
           name: 'Second secondary disability',
-          disabilityActionType: 'Filler text'
+          disabilityActionType: 'INCREASE'
         }
       ]
     }

--- a/test/common/schemaform/helpers.unit.spec.js
+++ b/test/common/schemaform/helpers.unit.spec.js
@@ -11,7 +11,8 @@ import {
   getNonArraySchema,
   checkValidSchema,
   formatReviewDate,
-  expandArrayPages
+  expandArrayPages,
+  omitRequired
 } from '../../../src/js/common/schemaform/helpers';
 
 describe('Schemaform helpers:', () => {
@@ -844,6 +845,41 @@ describe('Schemaform helpers:', () => {
     });
     it('should format month year date', () => {
       expect(formatReviewDate('2010-01-XX', true)).to.equal('01/2010');
+    });
+  });
+  describe('omitRequired', () => {
+    it('should omit all required arrays', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          field1: {
+            type: 'object',
+            properties: {
+              nestedField: {
+                type: 'string',
+                'enum': ['option1', 'option2']
+              }
+            },
+            required: ['nestedField']
+          }
+        },
+        required: ['field1']
+      };
+      const expected = {
+        type: 'object',
+        properties: {
+          field1: {
+            type: 'object',
+            properties: {
+              nestedField: {
+                type: 'string',
+                'enum': ['option1', 'option2']
+              }
+            }
+          }
+        }
+      };
+      expect(omitRequired(schema)).to.eql(expected);
     });
   });
 });


### PR DESCRIPTION
We were having trouble getting past the rated disabilities selection page because of `initialData` that no longer meets the schema requirements. This basically just blasts the requirements as far as the front end is concerned.

The trouble is this:
1) We can't move to the next page until all the information on the current page is valid
2) We may get "invalid" data from the `ratedDisabilities` endpoint
3) We want to be able to continue after selecting only valid disabilities

The proposal I outlined in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/10123#issuecomment-384729257 lets us continue while still only allowing us to select conditions that we know will pass validation.

This is the first part of that.

---
Related to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/10125