### PR TITLE
Fix for Login Modal not closing without redirect

### DIFF
--- a/src/platform/site-wide/login/containers/Main.jsx
+++ b/src/platform/site-wide/login/containers/Main.jsx
@@ -30,7 +30,7 @@ export class Main extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate() {
     const { currentlyLoggedIn, showModal } = this.props.login;
     const nextParam = this.getRedirectUrl();
 

--- a/src/platform/site-wide/login/containers/Main.jsx
+++ b/src/platform/site-wide/login/containers/Main.jsx
@@ -42,8 +42,7 @@ export class Main extends React.Component {
       window.location.replace(redirectPath);
     }
 
-    const shouldCloseLoginModal =
-      !prevProps.login.currentlyLoggedIn && currentlyLoggedIn && showModal;
+    const shouldCloseLoginModal = currentlyLoggedIn && showModal;
 
     if (shouldCloseLoginModal) { this.props.toggleLoginModal(false); }
   }


### PR DESCRIPTION
The login modal was not closing without the `?next` parameter. It appears a React lifecycle method was executing twice, causing `prevProps` to not contain the expected values.

Resolves department-of-veterans-affairs/vets.gov-team/issues/10219