### PR TITLE
Dragons: Fix for "undefined" showing in Address formatting

### DIFF
--- a/src/js/personalization/va-profile-beta/components/AddressSection.jsx
+++ b/src/js/personalization/va-profile-beta/components/AddressSection.jsx
@@ -63,21 +63,27 @@ class EditAddressModal extends React.Component {
 }
 
 function AddressView({ address }) {
-  const street = [
-    address.addressOne,
-    address.addressTwo ? `, ${address.addressTwo}` : '',
-    address.addressThree ? ` ${address.addressThree}` : ''
-  ].join('');
+  /* eslint-disable prefer-template */
+  let street = address.addressOne || '';
+  if (address.addressOne && address.addressTwo) street += ', ';
+  if (address.addressTwo) street += address.addressTwo;
+  if (address.addressThree) street += ' ' + address.addressThree;
 
   const country = address.type === ADDRESS_TYPES.international ? address.countryName : '';
   let cityStateZip = '';
 
   switch (address.type) {
     case ADDRESS_TYPES.domestic:
-      cityStateZip = `${address.city}, ${getStateName(address.state)} ${address.zipCode}`;
+      cityStateZip = address.city || '';
+      if (address.city && address.state) cityStateZip += ', ';
+      if (address.state) cityStateZip += getStateName(address.state);
+      if (address.zipCode) cityStateZip += ' ' + address.zipCode;
       break;
     case ADDRESS_TYPES.military:
-      cityStateZip = `${address.militaryPostOfficeTypeCode}, ${address.militaryStateCode} ${address.zipCode}`;
+      cityStateZip = address.militaryPostOfficeTypeCode || '';
+      if (address.militaryPostOfficeTypeCode && address.militaryStateCode) cityStateZip += ', ';
+      if (address.militaryStateCode) cityStateZip += address.militaryStateCode;
+      if (address.zipCode) cityStateZip += ' ' + address.zipCode;
       break;
     case ADDRESS_TYPES.international:
     default:


### PR DESCRIPTION
This is tricky because there are a lot of values and different formats for different address types. but basically I ditched the template strings for a nice series of ugly conditionals to make sure the address strings are being constructed correctly. There wasn't really any benefits to using the template strings - too many conditions for just adding a single space or comma was confusing with template interpolation.

Resolves department-of-veterans-affairs/vets.gov-team/issues/10222