### PR TITLE
remove `changePostalToZip` function for form 1010ez

### DIFF
--- a/src/js/hca/helpers.jsx
+++ b/src/js/hca/helpers.jsx
@@ -10,32 +10,9 @@ import {
 } from '../common/schemaform/helpers';
 import { getInactivePages } from '../../platform/forms/helpers';
 
-function changePostalToZip(address) {
-  if (address.country === 'USA') {
-    const newAddress = _.set('zipcode', address.postalCode, address);
-    delete newAddress.postalCode;
-    return newAddress;
-  }
-
-  return address;
-}
-
 export function transform(formConfig, form) {
-  let updatedForm = _.set(
-    'data.veteranAddress',
-    changePostalToZip(form.data.veteranAddress),
-    form
-  );
-  if (_.get('data.view:spouseContactInformation.spouseAddress', form)) {
-    updatedForm = _.set(
-      'data.view:spouseContactInformation.spouseAddress',
-      changePostalToZip(form.data['view:spouseContactInformation'].spouseAddress),
-      updatedForm
-    );
-  }
-
-  const inactivePages = getInactivePages(createFormPageList(formConfig), updatedForm.data);
-  const withoutInactivePages = filterInactivePages(inactivePages, updatedForm);
+  const inactivePages = getInactivePages(createFormPageList(formConfig), form.data);
+  const withoutInactivePages = filterInactivePages(inactivePages, form);
   let withoutViewFields = filterViewFields(withoutInactivePages);
 
   // add back dependents here, because it could have been removed in filterViewFields

--- a/src/js/hca/tests/schema/schema.unit.spec.js
+++ b/src/js/hca/tests/schema/schema.unit.spec.js
@@ -24,18 +24,6 @@ describe('hca schema tests', () => {
         if (!result.valid) {
           console.log(result.errors); // eslint-disable-line
         }
-        if (data.veteranAddress.country === 'USA') {
-          expect(data.veteranAddress.zipcode).to.not.be.empty;
-          expect(typeof data.veteranAddress.postalCode).to.equal('undefined');
-        }
-        if (data.veteranAddress.country !== 'USA') {
-          expect(data.veteranAddress.postalCode).to.not.be.empty;
-          expect(typeof data.veteranAddress.zipcode).to.equal('undefined');
-        }
-        if (data.spouseAddress && data.spouseAddress.country === 'USA') {
-          expect(data.spouseAddress.zipcode).to.not.be.empty;
-          expect(typeof data.spouseAddress.postalCode).to.equal('undefined');
-        }
         expect(typeof data.dependents).not.to.equal('undefined');
         expect(result.valid).to.be.true;
       });


### PR DESCRIPTION
remove `changePostalToZip` function, formerly used when submitting 1010ez form