### PR TITLE
add temporary nsp exceptions

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,6 @@
+{
+  "exceptions": [
+    "https://nodesecurity.io/advisories/577",
+    "https://nodesecurity.io/advisories/157"
+  ]
+}


### PR DESCRIPTION
This adds exceptions for the two `nsp` vulns.  It allows us to complete `vets-website` builds again.  