### PR TITLE
Include flag to use async functionality for hca in staging

### DIFF
--- a/src/js/hca/helpers.jsx
+++ b/src/js/hca/helpers.jsx
@@ -30,6 +30,7 @@ export function transform(formConfig, form) {
   }) || '{}';
 
   return JSON.stringify({
+    asyncCompatible: __BUILDTYPE__ !== 'production',
     form: formData
   });
 }


### PR DESCRIPTION
We're using this flag to tell the backend to use the new logic that chooses between sync and async requests. This should let us do testing, though there are also confirmation page changes.