### PR TITLE
Update to allow zero-dollar monthly award amounts

### DIFF
--- a/src/applications/letters/tests/utils/helpers.unit.spec.jsx
+++ b/src/applications/letters/tests/utils/helpers.unit.spec.jsx
@@ -87,9 +87,10 @@ describe('Letters helpers: ', () => {
 
     it('should only be defined if value is valid', () => {
       _.forEach(option => {
+        expect(getBenefitOptionText(option, 0, true)).not.to.be.undefined;
         expect(getBenefitOptionText(option, 20, true)).not.to.be.undefined;
         expect(getBenefitOptionText(option, undefined, true)).to.be.undefined;
-        expect(getBenefitOptionText(option, 'unavailable', true)).to.be.undefined;
+        expect(getBenefitOptionText(option, null, true)).to.be.undefined;
       }, ['monthlyAwardAmount', 'serviceConnectedPercentage']);
     });
 

--- a/src/applications/letters/utils/helpers.jsx
+++ b/src/applications/letters/utils/helpers.jsx
@@ -6,7 +6,6 @@ import { apiRequest as commonApiClient } from '../../../platform/utilities/api';
 import environment from '../../../platform/utilities/environment';
 import { formatDateShort } from '../../../platform/utilities/date';
 import {
-  AVAILABILITY_STATUSES,
   BENEFIT_OPTIONS,
   STATE_CODE_TO_NAME,
   ADDRESS_TYPES,
@@ -255,7 +254,8 @@ export function getBenefitOptionText(option, value, isVeteran, awardEffectiveDat
     valueString = value;
   }
 
-  const isAvailable = value && value !== AVAILABILITY_STATUSES.unavailable;
+  // NOTE: $0 award is a legitimate number for award amounts
+  const isAvailable = (value === 0 || value);
   const availableOptions = new Set([BENEFIT_OPTIONS.awardEffectiveDate, BENEFIT_OPTIONS.monthlyAwardAmount, BENEFIT_OPTIONS.serviceConnectedPercentage]);
 
   if (!availableOptions.has(option)) {


### PR DESCRIPTION
Updates logic for showing monthly award amount text in the benefit summary letter to allow zero-dollar award amounts.

This is a re-implementation of a merged PR that got rolled back due to evss not having the necessary changes made in the letter generator to support a $0 option for the BSL. Now that they've deployed their updates, this feature can be merged.