### PR TITLE
Update confirmation page on HCA for async processing

### DIFF
--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -26,10 +26,12 @@ export class ConfirmationPage extends React.Component {
     const name = data.veteranFullName;
 
     let title = 'Claim received';
+    let dateTitle = 'Date received';
     let emailMessage;
 
     if (__BUILDTYPE__ !== 'production') {
       title = 'Your claim has been submitted.';
+      dateTitle = 'Date submitted';
       if (data.email) {
         emailMessage =  'We’ll send you an email to let you know when we’ve received your application.';
       }
@@ -49,7 +51,7 @@ export class ConfirmationPage extends React.Component {
 
           {response && <ul className="claim-list">
             <li>
-              <strong>Date submitted</strong><br/>
+              <strong>{dateTitle}</strong><br/>
               <span>{moment(response.timestamp).format('MMM D, YYYY')}</span>
             </li>
           </ul>}

--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -29,7 +29,7 @@ export class ConfirmationPage extends React.Component {
     let emailMessage;
 
     if (__BUILDTYPE__ !== 'production') {
-      title = 'Your claim has been submitted';
+      title = 'Your claim has been submitted.';
       if (data.email) {
         emailMessage =  'We’ll send you an email to let you know when we’ve received your application.';
       }

--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -27,24 +27,20 @@ export class ConfirmationPage extends React.Component {
 
     return (
       <div>
-        <h3 className="confirmation-page-title">Claim received</h3>
+        <h3 className="confirmation-page-title">Your claim has been submitted</h3>
         <p>We usually process claims within <strong>a week</strong>.</p>
         <p>
-          We may contact you for more information or documents.<br/>
-          <i>Please print this page for your records.</i>
+          We may contact you for more information or documents. We’ll send you an email to let you know when we've received your application.<br/>
+          <p><i>Please print this page for your records.</i></p>
         </p>
         <div className="inset">
-          <h4>Health Care Benefit Claim <span className="additional">(Form 10-10EZ)</span></h4>
+          <h4 className="schemaform-confirmation-claim-header">Health Care Benefit Claim <span className="additional">(Form 10-10EZ)</span></h4>
           <span>for {name.first} {name.middle} {name.last} {name.suffix}</span>
 
           {response && <ul className="claim-list">
             <li>
-              <strong>Date received</strong><br/>
+              <strong>Date submitted</strong><br/>
               <span>{moment(response.timestamp).format('MMM D, YYYY')}</span>
-            </li>
-            <li>
-              <strong>Confirmation number</strong><br/>
-              <span>{response.formSubmissionId}</span>
             </li>
           </ul>}
         </div>

--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -25,12 +25,22 @@ export class ConfirmationPage extends React.Component {
     const { response } = submission;
     const name = data.veteranFullName;
 
+    let title = 'Claim received';
+    let emailMessage;
+
+    if (__BUILDTYPE__ !== 'production') {
+      title = 'Your claim has been submitted';
+      if (data.email) {
+        emailMessage =  'We’ll send you an email to let you know when we’ve received your application.';
+      }
+    }
+
     return (
       <div>
-        <h3 className="confirmation-page-title">Your claim has been submitted</h3>
+        <h3 className="confirmation-page-title">{title}</h3>
         <p>We usually process claims within <strong>a week</strong>.</p>
         <p>
-          We may contact you for more information or documents. We’ll send you an email to let you know when we've received your application.<br/>
+          We may contact you for more information or documents. {emailMessage}<br/>
           <p><i>Please print this page for your records.</i></p>
         </p>
         <div className="inset">

--- a/src/applications/hca/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/hca/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -27,7 +27,7 @@ describe('hca <ConfirmationPage>', () => {
       <ConfirmationPage form={form}/>
     );
 
-    expect(tree.subTree('.confirmation-page-title').text()).to.contain('Claim received');
+    expect(tree.subTree('.confirmation-page-title').text()).to.contain('Your claim has been submitted');
     expect(tree.subTree('.claim-list')).to.exist;
     expect(tree.everySubTree('span')[2].text()).to.contain('Jan. 1, 2010');
     expect(tree.everySubTree('span')[3].text()).to.contain('3702390024');
@@ -50,7 +50,7 @@ describe('hca <ConfirmationPage>', () => {
     const tree = SkinDeep.shallowRender(
       <ConfirmationPage form={form}/>
     );
-    expect(tree.subTree('.confirmation-page-title').text()).to.contain('Claim received');
+    expect(tree.subTree('.confirmation-page-title').text()).to.contain('Your claim has been submitted');
     expect(tree.everySubTree('p')[0].text()).to.contain('We usually process claims within a week.');
     expect(tree.subTree('.claim-list')).to.be.false;
     expect(tree.everySubTree('.confirmation-guidance-message')[0].text()).to.contain('Find out what happens after you apply.');

--- a/src/applications/hca/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/hca/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -5,6 +5,15 @@ import SkinDeep from 'skin-deep';
 import { ConfirmationPage } from '../../containers/ConfirmationPage';
 
 describe('hca <ConfirmationPage>', () => {
+  let buildtype;
+  // Remove after HCA async confirmation page changes go live
+  beforeEach(() => {
+    buildtype = __BUILDTYPE__;
+    __BUILDTYPE__ = 'production';
+  });
+  afterEach(() => {
+    __BUILDTYPE__ = buildtype;
+  });
   it('should render', () => {
     const form = {
       submission: {
@@ -27,10 +36,9 @@ describe('hca <ConfirmationPage>', () => {
       <ConfirmationPage form={form}/>
     );
 
-    expect(tree.subTree('.confirmation-page-title').text()).to.contain('Your claim has been submitted');
+    expect(tree.subTree('.confirmation-page-title').text()).to.contain('Claim received');
     expect(tree.subTree('.claim-list')).to.exist;
     expect(tree.everySubTree('span')[2].text()).to.contain('Jan. 1, 2010');
-    expect(tree.everySubTree('span')[3].text()).to.contain('3702390024');
     expect(tree.everySubTree('p')[0].text()).to.contain('We usually process claims within a week.');
     expect(tree.everySubTree('.confirmation-guidance-message')[0].text()).to.contain('Find out what happens after you apply.');
   });
@@ -50,7 +58,7 @@ describe('hca <ConfirmationPage>', () => {
     const tree = SkinDeep.shallowRender(
       <ConfirmationPage form={form}/>
     );
-    expect(tree.subTree('.confirmation-page-title').text()).to.contain('Your claim has been submitted');
+    expect(tree.subTree('.confirmation-page-title').text()).to.contain('Claim received');
     expect(tree.everySubTree('p')[0].text()).to.contain('We usually process claims within a week.');
     expect(tree.subTree('.claim-list')).to.be.false;
     expect(tree.everySubTree('.confirmation-guidance-message')[0].text()).to.contain('Find out what happens after you apply.');


### PR DESCRIPTION
Updates confirmation page copy for HCA async processing. I put the title and email message change behind a prod flag, so that won't go live immediately. The removal of the confirmation number will, since that's currently not useful.

![screen shot 2018-05-15 at 4 50 01 pm](https://user-images.githubusercontent.com/634932/40083021-e5c52ece-5860-11e8-907e-c1ac6f9393b9.png)
