### PR TITLE
526 remove pmr mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -47,6 +47,7 @@ import {
   privateRecordsChoiceHelp,
   facilityDescription,
   treatmentView,
+  download4142Notice,
   recordReleaseWarning,
   // validateAddress, // TODO: This needs to be fleshed out
   documentDescription,
@@ -504,10 +505,16 @@ const formConfig = {
                     }
                   }
                 },
+                'view:privateRecords4142Notice': {
+                  'ui:description': download4142Notice,
+                  'ui:options': {
+                    expandUnder: 'view:uploadPrivateRecords',
+                    expandUnderCondition: 'no'
+                  }
+                },
                 'view:privateRecordsChoiceHelp': {
                   'ui:description': privateRecordsChoiceHelp
                 }
-                // probably need another thing here for the 'no' alert
               }
             }
           },
@@ -522,6 +529,11 @@ const formConfig = {
                     'view:uploadPrivateRecords': {
                       type: 'string',
                       'enum': ['yes', 'no']
+                    },
+                    'view:privateRecords4142Notice': {
+                      type: 'object',
+                      'ui:collapsed': true,
+                      properties: {}
                     },
                     'view:privateRecordsChoiceHelp': {
                       type: 'object',

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -507,6 +507,7 @@ const formConfig = {
                 'view:privateRecordsChoiceHelp': {
                   'ui:description': privateRecordsChoiceHelp
                 }
+                // probably need another thing here for the 'no' alert
               }
             }
           },
@@ -538,11 +539,13 @@ const formConfig = {
           showPagePerItem: true,
           itemFilter: (item) => _.get('view:selected', item),
           arrayPath: 'disabilities',
-          depends: (formData, index) => {
-            const hasRecords = _.get(`disabilities.${index}.view:selectableEvidenceTypes.view:privateMedicalRecords`, formData);
-            const requestsRecords = _.get(`disabilities.${index}.view:uploadPrivateRecords`, formData) === 'no';
-            return hasRecords && requestsRecords;
-          },
+          // TODO: Re-enable actual depends logic for page once 4142 PDF generation is working through vets-api
+          depends: () => false,
+          // depends: (formData, index) => {
+          //   const hasRecords = _.get(`disabilities.${index}.view:selectableEvidenceTypes.view:privateMedicalRecords`, formData);
+          //   const requestsRecords = _.get(`disabilities.${index}.view:uploadPrivateRecords`, formData) === 'no';
+          //   return hasRecords && requestsRecords;
+          // },
           uiSchema: {
             disabilities: {
               items: {

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -502,7 +502,7 @@ const formConfig = {
                   'ui:options': {
                     labels: {
                       yes: 'Yes',
-                      no: 'No, my doctor has my medical records'
+                      no: 'No, my doctor has my medical records.'
                     }
                   }
                 },

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -48,6 +48,7 @@ import {
   facilityDescription,
   treatmentView,
   download4142Notice,
+  authorizationToDisclose,
   recordReleaseWarning,
   // validateAddress, // TODO: This needs to be fleshed out
   documentDescription,
@@ -540,6 +541,37 @@ const formConfig = {
                       properties: {}
                     }
                   }
+                }
+              }
+            }
+          }
+        },
+        authorizationToDisclose: {
+          title: '',
+          path: 'supporting-evidence/:index/authorization-to-disclose',
+          showPagePerItem: true,
+          itemFilter: (item) => _.get('view:selected', item),
+          arrayPath: 'disabilities',
+          depends: (formData, index) => {
+            const hasRecords = _.get(`disabilities.${index}.view:selectableEvidenceTypes.view:privateMedicalRecords`, formData);
+            const requestsRecords = _.get(`disabilities.${index}.view:uploadPrivateRecords`, formData) === 'no';
+            return hasRecords && requestsRecords;
+          },
+          uiSchema: {
+            disabilities: {
+              items: {
+                'ui:description': authorizationToDisclose
+              }
+            }
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              disabilities: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {}
                 }
               }
             }

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -500,7 +500,7 @@ const formConfig = {
                   'ui:options': {
                     labels: {
                       yes: 'Yes',
-                      no: 'No, please get them from my doctor'
+                      no: 'No, my doctor has my medical records'
                     }
                   }
                 },

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
 import { focusElement } from '../../../../platform/utilities/ui';
+import { get4142Selection } from '../helpers';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
@@ -31,13 +32,10 @@ class ConfirmationPage extends React.Component {
     // ? this.props.form.submission.response.attributes
     // : {};
     const { fullName, disabilities } = formData;
+    const selected4142 = get4142Selection(disabilities || []);
 
-    return (
+    const privateRecordReleaseContent = (
       <div>
-        <h3 className="confirmation-page-title">Claim submitted</h3>
-        <p>We usually process claims within <strong>103 days</strong>.</p>
-        <p>We may contact you if we have questions or need more information.
-        You can print this page for your records.</p>
         <p>
           <strong>If you need us to get your private medical records from your
           doctor,</strong> you’ll need to fill out an Authorization to Disclose
@@ -55,6 +53,16 @@ class ConfirmationPage extends React.Component {
           PO Box 4444<br/>
           Janesville, WI 53547-4444
         </p>
+      </div>
+    );
+
+    return (
+      <div>
+        <h3 className="confirmation-page-title">Claim submitted</h3>
+        <p>We usually process claims within <strong>103 days</strong>.</p>
+        <p>We may contact you if we have questions or need more information.
+        You can print this page for your records.</p>
+        { selected4142 && privateRecordReleaseContent}
         <h4 className="confirmation-guidance-heading">
           What happens after I apply?
         </h4>

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -37,13 +37,17 @@ class ConfirmationPage extends React.Component {
         <h3 className="confirmation-page-title">Claim submitted</h3>
         <p>We usually process claims within <strong>103 days</strong>.</p>
         <p>We may contact you if we have questions or need more information.
-        You can print this page for your records. <strong>If you need us to get
-        your private medical records from your doctor,</strong> you’ll need to
-        fill out an Authorization to Disclose Information to the VA (VA Form
-        21-4142). If you didn’t upload this form to your application, you can
-        download it here and mail it in.</p>
-        <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">
-        Download VA Form 21-4142</a>
+        You can print this page for your records.</p>
+        <p>
+          <strong>If you need us to get your private medical records from your
+          doctor,</strong> you’ll need to fill out an Authorization to Disclose
+          Information to the VA (VA Form 21-4142).
+        </p>
+        <p>
+          <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">
+            Download VA Form 21-4142
+          </a>.
+        </p>
         <p>Please print the form, fill it out, and send it to:</p>
         <p className="va-address-block">
           Department of Veterans Affairs<br/>

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -36,8 +36,21 @@ class ConfirmationPage extends React.Component {
       <div>
         <h3 className="confirmation-page-title">Claim submitted</h3>
         <p>We usually process claims within <strong>103 days</strong>.</p>
-        <p>We may contact you if we have questions or need more information. You can print this page for your records.</p>
-
+        <p>We may contact you if we have questions or need more information.
+        You can print this page for your records. <strong>If you need us to get
+        your private medical records from your doctor,</strong> you’ll need to
+        fill out an Authorization to Disclose Information to the VA (VA Form
+        21-4142). If you didn’t upload this form to your application, you can
+        download it here and mail it in.</p>
+        <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">
+        Download VA Form 21-4142</a>
+        <p>
+          Please print the form, fill it out, and send it to:<br/>
+          Department of Veterans Affairs<br/>
+          Claims Intake Center<br/>
+          PO Box 4444<br/>
+          Janesville, WI 53547-4444<br/>
+        </p>
         <h4 className="confirmation-guidance-heading">
           What happens after I apply?
         </h4>

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -44,12 +44,12 @@ class ConfirmationPage extends React.Component {
         download it here and mail it in.</p>
         <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">
         Download VA Form 21-4142</a>
-        <p>
-          Please print the form, fill it out, and send it to:<br/>
+        <p>Please print the form, fill it out, and send it to:</p>
+        <p className="va-address-block">
           Department of Veterans Affairs<br/>
           Claims Intake Center<br/>
           PO Box 4444<br/>
-          Janesville, WI 53547-4444<br/>
+          Janesville, WI 53547-4444
         </p>
         <h4 className="confirmation-guidance-heading">
           What happens after I apply?

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -163,10 +163,15 @@ export const privateRecordsChoiceHelp = (
   <AdditionalInfo triggerText="Which should I choose?">
     <h4>You upload your medical records</h4>
     <p>If you upload a digital copy of all your medical records, we can review your claim more quickly. Uploading a digital
-      file works best if you have a computer with a fast Internet connection. The digital file could be uploaded as a .pdf
-      or other photo file format, like a .jpeg or .png.</p>
+    file works best if you have a computer with a fast Internet connection. The digital file could be uploaded as a .pdf
+    or other photo file format, like a .jpeg or .png.</p>
     <h4>We get your medical records for you</h4>
-    <p>If you tell us which VA medical center treated you for your condition, we can get your medical records for you. Getting your records may take us some time. This could take us longer to make a decision on your claim.</p>
+    <p>If you tell us which VA medical center treated you for your condition, we can get your
+    medical records for you. Getting your records may take us some time, and this could mean that
+    it’ll take us longer to make a decision on your claim. You’ll need to first fill out an
+    Authorization to Disclose Information to the VA (VA Form 21-4142) so we can request your
+    records.</p>
+    <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">Download VA Form 21-4142</a>
   </AdditionalInfo>
 );
 

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -220,7 +220,7 @@ export function validateAddress(errors, formData) {
 
 export const download4142Notice = (
   <div className="usa-alert usa-alert-warning no-background-image">
-    <p>Since your doctor has your private medical records, you'll need to fill
+    <p>Since your doctor has your private medical records, you’ll need to fill
     out an Authorization to Disclose Information to the VA (VA Form 21-4142) so
     we can request your records.</p>
     <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf">Download VA Form 21-4142</a>

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -227,7 +227,16 @@ export const download4142Notice = (
   <div className="usa-alert usa-alert-warning no-background-image">
     <p>Since your doctor has your private medical records, you’ll need to fill
     out an Authorization to Disclose Information to the VA (VA Form 21-4142) so
-    we can request your records.</p>
+    we can request your records. You’ll need to fill out a form for each doctor.</p>
+    <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">Download VA Form 21-4142</a>
+  </div>
+);
+
+export const authorizationToDisclose = (
+  <div>
+    <p>Since your medical records are with your doctor, you'll need to fill out an Authorization to Disclose
+    Information to the VA (VA Form 21-4142) so we can request your records. You'll need to fill out a form for
+    each doctor.</p>
     <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">Download VA Form 21-4142</a>
     <p>
       Please print the form, fill it out, and send it to:<br/>
@@ -236,7 +245,8 @@ export const download4142Notice = (
       PO Box 4444<br/>
       Janesville, WI 53547-4444<br/>
     </p>
-    <p>Or you can upload a completed VA Form 21-4142 to your online application.</p>
+    <p>Or you can upload a completed VA Form 21-4142 to your online
+    application. You'll have a chance later to upload your documents.</p>
   </div>
 );
 

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -253,8 +253,8 @@ export const download4142Notice = (
 
 export const authorizationToDisclose = (
   <div>
-    <p>Since your medical records are with your doctor, you'll need to fill out an Authorization to Disclose
-    Information to the VA (VA Form 21-4142) so we can request your records. You'll need to fill out a form for
+    <p>Since your medical records are with your doctor, you’ll need to fill out an Authorization to Disclose
+    Information to the VA (VA Form 21-4142) so we can request your records. You’ll need to fill out a form for
     each doctor.</p>
     <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">Download VA Form 21-4142</a>
     <p>Please print the form, fill it out, and send it to:</p>

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -266,7 +266,7 @@ export const authorizationToDisclose = (
       Department of Veterans Affairs<br/>
       Claims Intake Center<br/>
       PO Box 4444<br/>
-      Janesville, WI 53547-4444>
+      Janesville, WI 53547-4444
     </p>
   </div>
 );

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -218,6 +218,21 @@ export function validateAddress(errors, formData) {
   validatePostalCodes(errors, formData);
 }
 
+export const download4142Notice = (
+  <div className="usa-alert usa-alert-warning no-background-image">
+    <p>Since your doctor has your private medical records, you'll need to fill
+    out an Authorization to Disclose Information to the VA (VA Form 21-4142) so
+    we can request your records.</p>
+    <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf">Download VA Form 21-4142</a>
+    <p>Please print the form, fill it out, and send it to:<br/>
+    Department of Veterans Affairs<br/>
+    Claims Intake Center<br/>
+    PO Box 4444<br/>
+    Janesville, WI 53547-4444<br/></p>
+    <p>Or you can upload a completed VA Form 21-4142 to your online application.</p>
+  </div>
+);
+
 export const recordReleaseWarning = (
   <div className="usa-alert usa-alert-warning no-background-image">
     <span>Limiting consent means that your doctor can only share records that are

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -153,7 +153,11 @@ export const privateRecordsChoice = ({ formData }) => {
   return (
     <div>
       <h4>About private medical records</h4>
-      <p>You said you were treated for {getDiagnosticCodeName(formData.diagnosticCode)} by a private doctor. If you have those records, you can upload them here, or we can get them for you. If you want us to get your records, you’ll need to authorize their release.</p>
+      <p>
+        You said you were treated for {getDiagnosticCodeName(formData.diagnosticCode)} by a private
+        doctor. If you have those records, you can upload them here, or we can get them for you. If
+        you want us to get your records, you’ll need to authorize their release.
+      </p>
     </div>
   );
 };
@@ -162,16 +166,25 @@ export const privateRecordsChoice = ({ formData }) => {
 export const privateRecordsChoiceHelp = (
   <AdditionalInfo triggerText="Which should I choose?">
     <h4>You upload your medical records</h4>
-    <p>If you upload a digital copy of all your medical records, we can review your claim more quickly. Uploading a digital
-    file works best if you have a computer with a fast Internet connection. The digital file could be uploaded as a .pdf
-    or other photo file format, like a .jpeg or .png.</p>
-    <h4>We get your medical records for you</h4>
-    <p>If you tell us which VA medical center treated you for your condition, we can get your
-    medical records for you. Getting your records may take us some time, and this could mean that
-    it’ll take us longer to make a decision on your claim. You’ll need to first fill out an
-    Authorization to Disclose Information to the VA (VA Form 21-4142) so we can request your
-    records.</p>
-    <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">Download VA Form 21-4142</a>
+    <p>
+      If you upload a digital copy of all your medical records, we can review
+      your claim more quickly. Uploading a digital file works best if you have
+      a computer with a fast Internet connection. The digital file could be
+      uploaded as a .pdf or other photo file format, like a .jpeg or .png.
+    </p>
+    <h4>We get your medical records from your doctor</h4>
+    <p>
+      We can get your medical records for you, but you’ll first need to fill
+      out an Authorization to Disclose Information to VA (VA Form 21-4142) so
+      we can request your records. Getting your records might take us some
+      time, and this could mean it’ll take us longer to make a decision on
+      your claim.
+    </p>
+    <p>
+      <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">
+        Download VA Form 21-4142
+      </a>.
+    </p>
   </AdditionalInfo>
 );
 
@@ -225,10 +238,16 @@ export function validateAddress(errors, formData) {
 
 export const download4142Notice = (
   <div className="usa-alert usa-alert-warning no-background-image">
-    <p>Since your doctor has your private medical records, you’ll need to fill
-    out an Authorization to Disclose Information to the VA (VA Form 21-4142) so
-    we can request your records. You’ll need to fill out a form for each doctor.</p>
-    <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">Download VA Form 21-4142</a>
+    <p>
+      Since your doctor has your private medical records, you’ll need to fill
+      out an Authorization to Disclose Information to the VA (VA Form 21-4142) so
+      we can request your records. You’ll need to fill out a form for each doctor.
+    </p>
+    <p>
+      <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">
+        Download VA Form 21-4142
+      </a>.
+    </p>
   </div>
 );
 
@@ -245,8 +264,6 @@ export const authorizationToDisclose = (
       PO Box 4444<br/>
       Janesville, WI 53547-4444>
     </p>
-    <p>Or you can upload a completed VA Form 21-4142 to your online
-    application. You'll have a chance later to upload your documents.</p>
   </div>
 );
 

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -256,7 +256,11 @@ export const authorizationToDisclose = (
     <p>Since your medical records are with your doctor, you’ll need to fill out an Authorization to Disclose
     Information to the VA (VA Form 21-4142) so we can request your records. You’ll need to fill out a form for
     each doctor.</p>
-    <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">Download VA Form 21-4142</a>
+    <p>
+      <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">
+        Download VA Form 21-4142
+      </a>.
+    </p>
     <p>Please print the form, fill it out, and send it to:</p>
     <p className="va-address-block">
       Department of Veterans Affairs<br/>

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -228,7 +228,7 @@ export const download4142Notice = (
     <p>Since your doctor has your private medical records, you’ll need to fill
     out an Authorization to Disclose Information to the VA (VA Form 21-4142) so
     we can request your records.</p>
-    <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf">Download VA Form 21-4142</a>
+    <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">Download VA Form 21-4142</a>
     <p>Please print the form, fill it out, and send it to:<br/>
     Department of Veterans Affairs<br/>
     Claims Intake Center<br/>

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -238,12 +238,12 @@ export const authorizationToDisclose = (
     Information to the VA (VA Form 21-4142) so we can request your records. You'll need to fill out a form for
     each doctor.</p>
     <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">Download VA Form 21-4142</a>
-    <p>
-      Please print the form, fill it out, and send it to:<br/>
+    <p>Please print the form, fill it out, and send it to:</p>
+    <p className="va-address-block">
       Department of Veterans Affairs<br/>
       Claims Intake Center<br/>
       PO Box 4444<br/>
-      Janesville, WI 53547-4444<br/>
+      Janesville, WI 53547-4444>
     </p>
     <p>Or you can upload a completed VA Form 21-4142 to your online
     application. You'll have a chance later to upload your documents.</p>

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -229,11 +229,13 @@ export const download4142Notice = (
     out an Authorization to Disclose Information to the VA (VA Form 21-4142) so
     we can request your records.</p>
     <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf" target="_blank">Download VA Form 21-4142</a>
-    <p>Please print the form, fill it out, and send it to:<br/>
-    Department of Veterans Affairs<br/>
-    Claims Intake Center<br/>
-    PO Box 4444<br/>
-    Janesville, WI 53547-4444<br/></p>
+    <p>
+      Please print the form, fill it out, and send it to:<br/>
+      Department of Veterans Affairs<br/>
+      Claims Intake Center<br/>
+      PO Box 4444<br/>
+      Janesville, WI 53547-4444<br/>
+    </p>
     <p>Or you can upload a completed VA Form 21-4142 to your online application.</p>
   </div>
 );

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -619,3 +619,27 @@ const evidenceTypesDescription = (disabilityName) => {
 export const getEvidenceTypesDescription = (form, index) => {
   return evidenceTypesDescription(getDiagnosticCodeName(form.disabilities[index].diagnosticCode));
 };
+
+/**
+ * If user chooses private medical record supporting evidence, he/she has a choice
+ * to either upload PMRs directly or fill out a 4142. Here, we determine if the user
+ * chose the 4142 option for any of his/her disabilities
+ * @param {array} disabilities
+ * @returns {boolean} true if user selected option to fill out 4142 on their own
+ */
+export const get4142Selection = (disabilities) => {
+  return disabilities.reduce((selected, disability) => {
+    if (selected === true) {
+      return true;
+    }
+
+    const {
+      'view:selected': viewSelected,
+      'view:uploadPrivateRecords': viewUploadPMR
+    } = disability;
+    if (viewSelected === true && viewUploadPMR === 'no') {
+      return true;
+    }
+    return false;
+  }, false);
+};

--- a/src/applications/disability-benefits/526EZ/tests/config/privateRecordReleases.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/privateRecordReleases.unit.spec.jsx
@@ -7,7 +7,12 @@ import { DefinitionTester, fillData } from '../../../../../platform/testing/unit
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
 
-describe('Disability benefits 526EZ VA facility', () => {
+// We don't allow users to hit this page for the time being, because we have
+// nothing that we can do with this information. The page is always skipped in
+// the config. Also, these tests possibly duplicate
+// privateMedicalRecordsRelease.unit.spec.jsx so we probably want to delete one
+// of these two files down the road.
+xdescribe('Disability benefits 526EZ VA facility', () => {
   const { schema, uiSchema, arrayPath } = formConfig.chapters.supportingEvidence.pages.privateMedicalRecordRelease;
   it('renders private record release form', () => {
     const form = mount(<DefinitionTester

--- a/src/applications/disability-benefits/526EZ/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -31,4 +31,80 @@ describe('Disability Benefits 526EZ <ConfirmationPage>', () => {
     expect(tree.find('p').at(1).render().text()).to.contain('We may contact you if we have questions or need more information. You can print this page for your records.');
     expect(tree.find('.disability-list').render().text()).to.contain('Post traumatic stress disorder');
   });
+
+  it('should render 4142 helper text when 4142 option selected for any disability', () => {
+    const newData = {
+      fullName: {
+        first: 'Sally',
+        last: 'Alphonse'
+      },
+      disabilities: [
+        {
+          name: 'Post traumatic stress disorder',
+          'view:selected': true,
+          'view:uploadPrivateRecords': 'no'
+        },
+        {
+          name: 'Intervertebral disc syndrome',
+          'view:selected': true,
+          'view:uploadPrivateRecords': 'yes'
+        }
+      ]
+    };
+
+    const newForm = {
+      submission: {
+        response: {
+          attributes: {
+            confirmationNumber: 'V-DCCI-3986'
+          }
+        }
+      },
+      data: newData
+    };
+
+    const wrapper = shallow(<ConfirmationPage form={newForm}/>);
+    expect(wrapper.render().text()).to.contain(
+      'you’ll need to fill out an Authorization to Disclose Information to the VA (VA Form 21-4142).'
+    );
+  });
+
+  it('should not render 4142 helper text when 4142 option not selected for any disability', () => {
+    const newData = {
+      fullName: {
+        first: 'Sally',
+        last: 'Alphonse'
+      },
+      disabilities: [
+        {
+          name: 'Post traumatic stress disorder',
+          'view:selected': true
+        },
+        {
+          name: 'Intervertebral disc syndrome',
+          'view:selected': true,
+          'view:uploadPrivateRecords': 'yes'
+        },
+        {
+          name: 'Third Disability',
+        }
+      ]
+    };
+
+    const newForm = {
+      submission: {
+        response: {
+          attributes: {
+            confirmationNumber: 'V-DCCI-3986'
+          }
+        }
+      },
+      data: newData
+    };
+
+    const wrapper = shallow(<ConfirmationPage form={newForm}/>);
+    expect(wrapper.render().text()).to.not.contain(
+      'you’ll need to fill out an Authorization to Disclose Information to the VA (VA Form 21-4142).'
+    );
+  });
 });

--- a/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
@@ -2,7 +2,8 @@ import { expect } from 'chai';
 import {
   flatten,
   isPrefillDataComplete,
-  prefillTransformer
+  prefillTransformer,
+  get4142Selection
 } from '../helpers.jsx';
 import initialData from './schema/initialData.js';
 
@@ -42,6 +43,52 @@ describe('526 helpers', () => {
     });
     it('should not record if the form was not completely prefilled', () => {
       expect(incompletePrefill.prefilled).to.be.undefined;
+    });
+  });
+
+  describe('get4142Selection', () => {
+    const fullDisabilities = [
+      {
+        tag: 'shouldReturnTrue',
+        'view:selected': true,
+        'view:uploadPrivateRecords': 'no'
+      },
+      {
+        tag: 'shouldReturnFalse'
+      },
+      {
+        tag: 'shouldReturnFalse',
+        'view:selected': true,
+        'view:uploadPrivateRecords': 'yes'
+      },
+      {
+        tag: 'shouldReturnFalse',
+        'view:selected': true
+      }
+    ];
+
+    it('should return true when at least one disability has 4142 selected', () => {
+      expect(get4142Selection(fullDisabilities)).to.equal(true);
+    });
+
+    it('should return false when disability not selected for increase', () => {
+      const disabilities = fullDisabilities.slice(1, 2);
+      expect(get4142Selection(disabilities)).to.equal(false);
+    });
+
+    it('should return false when disability has upload PMR selected', () => {
+      const disabilities = fullDisabilities.slice(2, 3);
+      expect(get4142Selection(disabilities)).to.equal(false);
+    });
+
+    it('should return false when disability has no PMR supporting evidence', () => {
+      const disabilities = fullDisabilities.slice(3);
+      expect(get4142Selection(disabilities)).to.equal(false);
+    });
+
+    it('should return false when no disabilities have 4142 selected', () => {
+      const disabilities = fullDisabilities.slice(1);
+      expect(get4142Selection(disabilities)).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
- Removes ability to request a private medical records (PMR) release
- Adds info on how to submit a 4142 in lieu of requesting PMR release through the 526 form
- Updates help text for 'which option should I choose' with 4142 instructions
- Adds a new 'next page' if user selects option indicating doctor has their medical records. This new page contains content on 4142 submission process.
- Updates confirmation page with 4142 info (only if they chose to 1. use PMR and 2. not upload PMR directly, for any of their rated disabilities)

### ----------_Base page UI:_----------
![screen shot 2018-05-18 at 9 49 54 am](https://user-images.githubusercontent.com/24251447/40241758-71566260-5a81-11e8-9cd3-52b3ffb6501b.png)


### ----------_New expander under 'no' option:_----------
![screen shot 2018-05-18 at 9 50 23 am](https://user-images.githubusercontent.com/24251447/40241770-7a595a7a-5a81-11e8-8af5-b322e63c1cc4.png)


### ----------_New 'Which Should I choose?' text:_----------
![screen shot 2018-05-18 at 9 50 13 am](https://user-images.githubusercontent.com/24251447/40241802-8b70b3ee-5a81-11e8-83d6-3ec37cc8e682.png)


### ----------_New Page after selecting No -> Continue_ ----------
<img width="539" alt="screen shot 2018-05-18 at 5 37 02 pm" src="https://user-images.githubusercontent.com/24251447/40260771-2172f0c4-5ac2-11e8-948b-a367d7210ca8.png">



### ----------_Confirmation Page:_----------
![screen shot 2018-05-18 at 9 52 29 am](https://user-images.githubusercontent.com/24251447/40241837-9cd03dee-5a81-11e8-955a-e6285c9cfea5.png)

