### PR TITLE
 Fixed broken style for user nav dropdown and sign-in links.

### DIFF
--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -54,7 +54,7 @@ class SearchHelpSignIn extends React.Component {
     return (
       <div className="sign-in-links">
         <button className={buttonClasses} onClick={this.handleSignInSignUp}>Sign In</button>
-        <span className="signin-spacer">|</span>
+        <span className="sign-in-spacer">|</span>
         <button className={buttonClasses} onClick={this.handleSignInSignUp}>Sign Up</button>
       </div>
     );

--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -52,7 +52,7 @@ class SearchHelpSignIn extends React.Component {
     });
 
     return (
-      <div>
+      <div className="sign-in-links">
         <button className={buttonClasses} onClick={this.handleSignInSignUp}>Sign In</button>
         <span className="signin-spacer">|</span>
         <button className={buttonClasses} onClick={this.handleSignInSignUp}>Sign Up</button>

--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -48,8 +48,7 @@ class SearchHelpSignIn extends React.Component {
 
     const buttonClasses = classNames({
       'va-button-link': true,
-      'sign-in-link': true,
-      disabled: isLoading
+      'sign-in-link': true
     });
 
     return (

--- a/src/platform/site-wide/user-nav/components/SignInProfileMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SignInProfileMenu.jsx
@@ -21,7 +21,7 @@ class SignInProfileMenu extends React.Component {
       <DropDownPanel
         buttonText={this.props.greeting}
         clickHandler={this.props.clickHandler}
-        id="accountMenu"
+        id="account-menu"
         icon={icon}
         isOpen={this.props.isOpen}
         disabled={this.props.disabled}>

--- a/src/platform/site-wide/user-nav/sass/user-nav.scss
+++ b/src/platform/site-wide/user-nav/sass/user-nav.scss
@@ -237,7 +237,6 @@ span.sidelines {
 
 .sign-in-nav {
   color: $color-white;
-  margin-left: 1rem;
   white-space: nowrap;
 
   a {
@@ -257,6 +256,9 @@ span.sidelines {
   }
 }
 
+.sign-in-links {
+  margin-left: 1rem;
+}
 
 .sign-in-link {
   color: inherit !important;

--- a/src/platform/site-wide/user-nav/sass/user-nav.scss
+++ b/src/platform/site-wide/user-nav/sass/user-nav.scss
@@ -236,33 +236,37 @@ span.sidelines {
 }
 
 .sign-in-nav {
+  color: $color-white;
   margin-left: 1rem;
   white-space: nowrap;
+
+  a {
+    color: inherit;
+    text-decoration: none;
+
+    &:visited {
+      color: inherit;
+    }
+  }
+
+  button {
+    &:disabled {
+      background-color: inherit;
+      opacity: 0.7;
+    }
+  }
 }
 
+
 .sign-in-link {
-  color: $color-white !important;
+  color: inherit !important;
   text-decoration: none;
-
-  &:disabled {
-    background-color: inherit;
-    opacity: 0.7;
-  }
-
-  &:visited {
-    color: inherit;
-  }
-
-  &.disabled {
-    opacity: 0.7;
-    pointer-events: none;
-  }
 
   &:hover {
     color: $color-gold !important;
     text-decoration: underline;
   }
-};
+}
 
 .signin-spacer {
   color: $color-white;

--- a/src/platform/site-wide/user-nav/sass/user-nav.scss
+++ b/src/platform/site-wide/user-nav/sass/user-nav.scss
@@ -270,15 +270,7 @@ span.sidelines {
   }
 }
 
-.signin-spacer {
+.sign-in-spacer {
   color: $color-white;
   margin: 0 0.6em;
-}
-
-.signin-greeting {
-  display: none;
-
-  @media(min-width: 768px) {
-    display: inline;
-  }
 }

--- a/src/platform/site-wide/user-nav/tests/user-nav.e2e.spec.js
+++ b/src/platform/site-wide/user-nav/tests/user-nav.e2e.spec.js
@@ -3,8 +3,8 @@ const Timeouts = require('../../../testing/e2e/timeouts.js');
 const Auth = require('../../../testing/e2e/auth');
 
 const selectors = {
-  menu: '#login-root button[aria-controls="accountMenu"]',
-  signOut: '#accountMenu > ul > li:nth-child(2) > a'
+  menu: '#login-root button[aria-controls="account-menu"]',
+  signOut: '#account-menu > ul > li:nth-child(2) > a'
 };
 
 module.exports = E2eHelpers.createE2eTest(


### PR DESCRIPTION
#### Correct text color and no underline on links in the dropdown.
> <img width="104" alt="screen shot 2018-05-17 at 9 33 48 pm" src="https://user-images.githubusercontent.com/1067024/40211685-fd75f502-5a19-11e8-9147-f58998eac32a.png">

#### Hover effect on "Sign In". Right is default.
> <img width="137" alt="screen shot 2018-05-17 at 9 33 58 pm" src="https://user-images.githubusercontent.com/1067024/40211686-feeae6fe-5a19-11e8-93a4-1a9f58e005ff.png">

Also fixed the weird gray background behind the user's name when loading the page.