### PR TITLE
address duplicates identified by linter in master

### DIFF
--- a/src/applications/personalization/va-profile/components/ProfileView.jsx
+++ b/src/applications/personalization/va-profile/components/ProfileView.jsx
@@ -77,7 +77,6 @@ class ProfileView extends React.Component {
       fetchMilitaryInformation,
       fetchHero,
       fetchPersonalInformation,
-      user,
       message,
       profile: {
         hero,

--- a/src/applications/personalization/va-profile/containers/VAProfileApp.jsx
+++ b/src/applications/personalization/va-profile/containers/VAProfileApp.jsx
@@ -37,7 +37,6 @@ class VAProfileApp extends React.Component {
               fetchHero={this.props.fetchHero}
               fetchMilitaryInformation={this.props.fetchMilitaryInformation}
               fetchPersonalInformation={this.props.fetchPersonalInformation}
-              user={this.props.account}
               profile={this.props.profile}
               message={{
                 content: this.props.profile.message,


### PR DESCRIPTION
Fixes issue with builds on master.

```
> vets-website@1.0.0 lint:js /application

> eslint --quiet --ext .js --ext .jsx .





/application/src/applications/personalization/va-profile/components/ProfileView.jsx

  80:7  error  'user' is already defined  no-redeclare



/application/src/applications/personalization/va-profile/containers/VAProfileApp.jsx

  40:15  error  No duplicate props allowed  react/jsx-no-duplicate-props



✖ 2 problems (2 errors, 0 warnings)
```

Looks like this was caused by the combination of https://github.com/department-of-veterans-affairs/vets-website/pull/7768 and https://github.com/department-of-veterans-affairs/vets-website/pull/7766 both adding the same variable, but in different locations.