### PR TITLE
Remove environment variables from being hard-coded in the library code

### DIFF
--- a/src/applications/burials/config/form.js
+++ b/src/applications/burials/config/form.js
@@ -23,6 +23,7 @@ import { isFullDate } from '../../../platform/forms/validations';
 import { services } from '../../../platform/monitoring/DowntimeNotification';
 import GetFormHelp from '../../../platform/forms/components/GetPensionOrBurialFormHelp';
 import FormFooter from '../../../platform/forms/components/FormFooter';
+import environment from '../../../platform/utilities/environment';
 
 import * as address from '../../common/schemaform/definitions/address';
 import fullNameUI from '../../common/schemaform/definitions/fullName';
@@ -85,6 +86,7 @@ const formConfig = {
   urlPrefix: '/',
   submit,
   trackingPrefix: 'burials-530-',
+  environment,
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   formId: '21P-530',
@@ -531,12 +533,14 @@ const formConfig = {
             'ui:title': 'Document upload',
             'ui:description': fileHelp,
             deathCertificate: _.assign(fileUploadUI('Veteran’s death certificate', {
-              hideIf: form => form.burialAllowanceRequested !== 'service'
+              hideIf: form => form.burialAllowanceRequested !== 'service',
+              'environment': environment,
             }), {
               'ui:required': form => form.burialAllowanceRequested === 'service',
             }),
             transportationReceipts: _.assign(fileUploadUI('Documentation for transportation of the Veteran’s remains or other supporting evidence', {
-              addAnotherLabel: 'Add Another Document'
+              addAnotherLabel: 'Add Another Document',
+              'environment': environment,
             }), {
               'ui:required': form => _.get('view:claimedBenefits.transportation', form) === true,
             }),

--- a/src/applications/burials/config/form.js
+++ b/src/applications/burials/config/form.js
@@ -86,7 +86,6 @@ const formConfig = {
   urlPrefix: '/',
   submit,
   trackingPrefix: 'burials-530-',
-  // environment,
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   formId: '21P-530',
@@ -533,14 +532,14 @@ const formConfig = {
             'ui:title': 'Document upload',
             'ui:description': fileHelp,
             deathCertificate: _.assign(fileUploadUI('Veteran’s death certificate', {
-              endpoint: `${environment.API_URL}/v0/claim_attachments`,
+              fileUploadUrl: `${environment.API_URL}/v0/claim_attachments`,
               hideIf: form => form.burialAllowanceRequested !== 'service',
             }), {
               'ui:required': form => form.burialAllowanceRequested === 'service',
             }),
             transportationReceipts: _.assign(fileUploadUI('Documentation for transportation of the Veteran’s remains or other supporting evidence', {
               addAnotherLabel: 'Add Another Document',
-              endpoint: `${environment.API_URL}/v0/claim_attachments`,
+              fileUploadUrl: `${environment.API_URL}/v0/claim_attachments`,
             }), {
               'ui:required': form => _.get('view:claimedBenefits.transportation', form) === true,
             }),

--- a/src/applications/burials/config/form.js
+++ b/src/applications/burials/config/form.js
@@ -86,7 +86,7 @@ const formConfig = {
   urlPrefix: '/',
   submit,
   trackingPrefix: 'burials-530-',
-  environment,
+  // environment,
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   formId: '21P-530',
@@ -533,14 +533,14 @@ const formConfig = {
             'ui:title': 'Document upload',
             'ui:description': fileHelp,
             deathCertificate: _.assign(fileUploadUI('Veteran’s death certificate', {
+              endpoint: `${environment.API_URL}/v0/claim_attachments`,
               hideIf: form => form.burialAllowanceRequested !== 'service',
-              'environment': environment,
             }), {
               'ui:required': form => form.burialAllowanceRequested === 'service',
             }),
             transportationReceipts: _.assign(fileUploadUI('Documentation for transportation of the Veteran’s remains or other supporting evidence', {
               addAnotherLabel: 'Add Another Document',
-              'environment': environment,
+              endpoint: `${environment.API_URL}/v0/claim_attachments`,
             }), {
               'ui:required': form => _.get('view:claimedBenefits.transportation', form) === true,
             }),

--- a/src/applications/common/schemaform/actions.js
+++ b/src/applications/common/schemaform/actions.js
@@ -3,7 +3,6 @@ import moment from 'moment';
 import recordEvent from '../../../platform/monitoring/record-event';
 import _ from '../../../platform/utilities/data';
 import { transformForSubmit } from './helpers';
-// import environment from '../../../platform/utilities/environment';
 import { timeFromNow } from '../../../platform/utilities/date';
 
 export const SET_EDIT_MODE = 'SET_EDIT_MODE';

--- a/src/applications/common/schemaform/actions.js
+++ b/src/applications/common/schemaform/actions.js
@@ -81,7 +81,7 @@ export function setViewedPages(pageKeys) {
 function submitToUrl(body, submitUrl, trackingPrefix) {
   return new Promise((resolve, reject) => {
     const req = new XMLHttpRequest();
-    req.open('POST', `${submitUrl}`);
+    req.open('POST', submitUrl);
     req.addEventListener('load', () => {
       if (req.status >= 200 && req.status < 300) {
         recordEvent({

--- a/src/applications/common/schemaform/actions.js
+++ b/src/applications/common/schemaform/actions.js
@@ -79,10 +79,10 @@ export function setViewedPages(pageKeys) {
   };
 }
 
-function submitToUrl(body, submitUrl, trackingPrefix, environment) {
+function submitToUrl(body, submitUrl, trackingPrefix) {
   return new Promise((resolve, reject) => {
     const req = new XMLHttpRequest();
-    req.open('POST', `${environment.API_URL}${submitUrl}`);
+    req.open('POST', `${submitUrl}`);
     req.addEventListener('load', () => {
       if (req.status >= 200 && req.status < 300) {
         recordEvent({
@@ -163,7 +163,7 @@ export function submitForm(formConfig, form) {
         ? formConfig.transformForSubmit(formConfig, form)
         : transformForSubmit(formConfig, form);
 
-      promise = submitToUrl(body, formConfig.submitUrl, formConfig.trackingPrefix, formConfig.environment);
+      promise = submitToUrl(body, formConfig.submitUrl, formConfig.trackingPrefix);
     }
 
     return promise
@@ -227,7 +227,7 @@ export function uploadFile(file, uiOptions, onProgress, onChange, onError) {
 
     const req = new XMLHttpRequest();
 
-    req.open('POST', `${uiOptions.environment.API_URL}${uiOptions.endpoint}`);
+    req.open('POST', `${uiOptions.endpoint}`);
     req.addEventListener('load', () => {
       if (req.status >= 200 && req.status < 300) {
         const body = 'response' in req ? req.response : req.responseText;

--- a/src/applications/common/schemaform/actions.js
+++ b/src/applications/common/schemaform/actions.js
@@ -226,7 +226,7 @@ export function uploadFile(file, uiOptions, onProgress, onChange, onError) {
 
     const req = new XMLHttpRequest();
 
-    req.open('POST', `${uiOptions.endpoint}`);
+    req.open('POST', `${uiOptions.fileUploadUrl}`);
     req.addEventListener('load', () => {
       if (req.status >= 200 && req.status < 300) {
         const body = 'response' in req ? req.response : req.responseText;

--- a/src/applications/common/schemaform/actions.js
+++ b/src/applications/common/schemaform/actions.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 import recordEvent from '../../../platform/monitoring/record-event';
 import _ from '../../../platform/utilities/data';
 import { transformForSubmit } from './helpers';
-import environment from '../../../platform/utilities/environment';
+// import environment from '../../../platform/utilities/environment';
 import { timeFromNow } from '../../../platform/utilities/date';
 
 export const SET_EDIT_MODE = 'SET_EDIT_MODE';
@@ -79,7 +79,7 @@ export function setViewedPages(pageKeys) {
   };
 }
 
-function submitToUrl(body, submitUrl, trackingPrefix) {
+function submitToUrl(body, submitUrl, trackingPrefix, environment) {
   return new Promise((resolve, reject) => {
     const req = new XMLHttpRequest();
     req.open('POST', `${environment.API_URL}${submitUrl}`);
@@ -163,7 +163,7 @@ export function submitForm(formConfig, form) {
         ? formConfig.transformForSubmit(formConfig, form)
         : transformForSubmit(formConfig, form);
 
-      promise = submitToUrl(body, formConfig.submitUrl, formConfig.trackingPrefix);
+      promise = submitToUrl(body, formConfig.submitUrl, formConfig.trackingPrefix, formConfig.environment);
     }
 
     return promise
@@ -227,7 +227,7 @@ export function uploadFile(file, uiOptions, onProgress, onChange, onError) {
 
     const req = new XMLHttpRequest();
 
-    req.open('POST', `${environment.API_URL}${uiOptions.endpoint}`);
+    req.open('POST', `${uiOptions.environment.API_URL}${uiOptions.endpoint}`);
     req.addEventListener('load', () => {
       if (req.status >= 200 && req.status < 300) {
         const body = 'response' in req ? req.response : req.responseText;

--- a/src/applications/common/schemaform/actions.js
+++ b/src/applications/common/schemaform/actions.js
@@ -226,7 +226,7 @@ export function uploadFile(file, uiOptions, onProgress, onChange, onError) {
 
     const req = new XMLHttpRequest();
 
-    req.open('POST', `${uiOptions.fileUploadUrl}`);
+    req.open('POST', uiOptions.fileUploadUrl);
     req.addEventListener('load', () => {
       if (req.status >= 200 && req.status < 300) {
         const body = 'response' in req ? req.response : req.responseText;

--- a/src/applications/common/schemaform/definitions/file.js
+++ b/src/applications/common/schemaform/definitions/file.js
@@ -25,7 +25,7 @@ export default function fileUiSchema(label, userOptions = {}) {
           confirmationCode: fileInfo.data.attributes.confirmationCode
         };
       },
-      endpoint: '/v0/claim_attachments',
+      // endpoint: '/v0/claim_attachments',
       addAnotherLabel: 'Add Another',
       showFieldLabel: true,
       keepInPageOnReview: true,

--- a/src/applications/common/schemaform/definitions/file.js
+++ b/src/applications/common/schemaform/definitions/file.js
@@ -25,7 +25,6 @@ export default function fileUiSchema(label, userOptions = {}) {
           confirmationCode: fileInfo.data.attributes.confirmationCode
         };
       },
-      // endpoint: '/v0/claim_attachments',
       addAnotherLabel: 'Add Another',
       showFieldLabel: true,
       keepInPageOnReview: true,

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -776,7 +776,7 @@ const formConfig = {
                 additionalDocuments: Object.assign({},
                   fileUploadUI('Lay statements or other evidence', {
                     itemDescription: 'Adding additional evidence:',
-                    fileUploadUrl: '/v0/preneeds/preneed_attachments', // TODO: update this with correct endpoint (e.g. '/v0/21-526EZ/medical_records')
+                    fileUploadUrl: `${environment.API_URL}/v0/preneeds/preneed_attachments`, // TODO: update this with correct endpoint (e.g. '/v0/21-526EZ/medical_records')
                     addAnotherLabel: 'Add Another Document',
                     fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
                     maxSize: FIFTY_MB,

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -10,6 +10,7 @@ import ServicePeriodView from '../../../common/schemaform/components/ServicePeri
 import dateRangeUI from '../../../common/schemaform/definitions/dateRange';
 
 import FormFooter from '../../../../platform/forms/components/FormFooter';
+import environment from '../../../../platform/utilities/environment';
 
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
@@ -119,7 +120,7 @@ const initialData = {
 const formConfig = {
   urlPrefix: '/',
   intentToFileUrl: '/evss_claims/intent_to_file/compensation',
-  // submitUrl: '/v0/21-526EZ',
+  // submitUrl: `${environment.API_URL}/v0/21-526EZ`,
   submit: () => Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
   trackingPrefix: 'disability-526EZ-',
   formId: '21-526EZ',
@@ -705,7 +706,7 @@ const formConfig = {
                 privateRecords: Object.assign({},
                   fileUploadUI('Upload your private medical records', {
                     itemDescription: 'Adding additional evidence:',
-                    endpoint: '/v0/preneeds/preneed_attachments', // TODO: update this with correct endpoint (e.g. '/v0/21-526EZ/medical_records')
+                    fileUploadUrl: `${environment.API_URL}/v0/preneeds/preneed_attachments`, // TODO: update this with correct endpoint (e.g. '/v0/21-526EZ/medical_records')
                     addAnotherLabel: 'Add Another Document',
                     fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
                     maxSize: FIFTY_MB,

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -776,7 +776,7 @@ const formConfig = {
                 additionalDocuments: Object.assign({},
                   fileUploadUI('Lay statements or other evidence', {
                     itemDescription: 'Adding additional evidence:',
-                    endpoint: '/v0/preneeds/preneed_attachments', // TODO: update this with correct endpoint (e.g. '/v0/21-526EZ/medical_records')
+                    fileUploadUrl: '/v0/preneeds/preneed_attachments', // TODO: update this with correct endpoint (e.g. '/v0/21-526EZ/medical_records')
                     addAnotherLabel: 'Add Another Document',
                     fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
                     maxSize: FIFTY_MB,

--- a/src/applications/disability-benefits/686/config/form.js
+++ b/src/applications/disability-benefits/686/config/form.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 
 import ArrayCountWidget from '../../../common/schemaform/widgets/ArrayCountWidget';
 import FormFooter from '../../../../platform/forms/components/FormFooter';
+import environment from '../../../../platform/utilities/environment';
 import GetFormHelp from '../../components/GetFormHelp.jsx';
 import fullSchema686 from 'vets-json-schema/dist/21-686C-schema.json';
 import currentOrPastDateUI from '../../../common/schemaform/definitions/currentOrPastDate';
@@ -95,7 +96,7 @@ const reasonForSeparation = _.assign(marriageProperties.reasonForSeparation, {
 
 const formConfig = {
   urlPrefix: '/',
-  submitUrl: '/v0/dependents_applications',
+  submitUrl: `${environment.API_URL}/v0/dependents_applications`,
   transformForSubmit: transform,
   trackingPrefix: '686-',
   introduction: IntroductionPage,

--- a/src/applications/edu-benefits/1990/config/form.js
+++ b/src/applications/edu-benefits/1990/config/form.js
@@ -10,6 +10,7 @@ import dateRangeUI from '../../../common/schemaform/definitions/dateRange';
 import { schema as addressSchema, uiSchema as addressUI } from '../../../common/schemaform/definitions/address';
 import phoneUI from '../../../common/schemaform/definitions/phone';
 import FormFooter from '../../../../platform/forms/components/FormFooter';
+import environment from '../../../../platform/utilities/environment';
 
 import seniorRotcUI from '../../definitions/seniorRotc';
 import employmentHistoryPage from '../../pages/employmentHistory';
@@ -81,7 +82,7 @@ const {
 
 const formConfig = {
   urlPrefix: '/',
-  submitUrl: '/v0/education_benefits_claims/1990',
+  submitUrl: `${environment.API_URL}/v0/education_benefits_claims/1990`,
   trackingPrefix: 'edu-',
   formId: '22-1990',
   version: 1,

--- a/src/applications/edu-benefits/1990e/config/form.js
+++ b/src/applications/edu-benefits/1990e/config/form.js
@@ -5,6 +5,7 @@ import fullSchema1990e from 'vets-json-schema/dist/22-1990E-schema.json';
 import additionalBenefits from '../../pages/additionalBenefits';
 import applicantInformation from '../../../common/schemaform/pages/applicantInformation';
 import FormFooter from '../../../../platform/forms/components/FormFooter';
+import environment from '../../../../platform/utilities/environment';
 import GetFormHelp from '../../components/GetFormHelp';
 import createContactInformationPage from '../../pages/contactInformation';
 import createSchoolSelectionPage, { schoolSelectionOptionsFor } from '../../pages/schoolSelection';
@@ -44,7 +45,7 @@ const {
 
 const formConfig = {
   urlPrefix: '/',
-  submitUrl: '/v0/education_benefits_claims/1990e',
+  submitUrl: `${environment.API_URL}/v0/education_benefits_claims/1990e`,
   trackingPrefix: 'edu-1990e-',
   formId: '22-1990E',
   version: 1,

--- a/src/applications/edu-benefits/1990n/config/form.js
+++ b/src/applications/edu-benefits/1990n/config/form.js
@@ -5,6 +5,7 @@ import fullSchema1990n from 'vets-json-schema/dist/22-1990N-schema.json';
 import schoolSelectionPage, { schoolSelectionOptionsFor } from '../../pages/schoolSelection';
 import applicantInformationPage from '../../../common/schemaform/pages/applicantInformation';
 import FormFooter from '../../../../platform/forms/components/FormFooter';
+import environment from '../../../../platform/utilities/environment';
 import GetFormHelp from '../../components/GetFormHelp';
 import additionalBenefitsPage from '../../pages/additionalBenefits';
 import contactInformationPage from '../../pages/contactInformation';
@@ -32,7 +33,7 @@ const {
 
 const formConfig = {
   urlPrefix: '/',
-  submitUrl: '/v0/education_benefits_claims/1990n',
+  submitUrl: `${environment.API_URL}/v0/education_benefits_claims/1990n`,
   trackingPrefix: 'edu-1990n-',
   formId: '22-1990N',
   version: 1,

--- a/src/applications/edu-benefits/1995/config/form.js
+++ b/src/applications/edu-benefits/1995/config/form.js
@@ -10,6 +10,7 @@ import { urlMigration } from '../../config/migrations';
 
 import * as address from '../../../common/schemaform/definitions/address';
 import FormFooter from '../../../../platform/forms/components/FormFooter';
+import environment from '../../../../platform/utilities/environment';
 import GetFormHelp from '../../components/GetFormHelp';
 
 import educationTypeUISchema from '../../definitions/educationType';
@@ -43,7 +44,7 @@ const {
 
 const formConfig = {
   urlPrefix: '/',
-  submitUrl: '/v0/education_benefits_claims/1995',
+  submitUrl: `${environment.API_URL}/v0/education_benefits_claims/1995`,
   trackingPrefix: 'edu-1995-',
   formId: '22-1995',
   version: 1,

--- a/src/applications/edu-benefits/5490/config/form.js
+++ b/src/applications/edu-benefits/5490/config/form.js
@@ -35,6 +35,7 @@ import * as personId from '../../../common/schemaform/definitions/personId';
 import dateRangeUi from '../../../common/schemaform/definitions/dateRange';
 import fullNameUi from '../../../common/schemaform/definitions/fullName';
 import FormFooter from '../../../../platform/forms/components/FormFooter';
+import environment from '../../../../platform/utilities/environment';
 import GetFormHelp from '../../components/GetFormHelp';
 import postHighSchoolTrainingsUi from '../../definitions/postHighSchoolTrainings';
 
@@ -81,7 +82,7 @@ const nonRequiredFullName = createNonRequiredFullName(fullName);
 
 const formConfig = {
   urlPrefix: '/',
-  submitUrl: '/v0/education_benefits_claims/5490',
+  submitUrl: `${environment.API_URL}/v0/education_benefits_claims/5490`,
   trackingPrefix: 'edu-5490-',
   formId: '22-5490',
   version: 1,

--- a/src/applications/edu-benefits/5495/config/form.js
+++ b/src/applications/edu-benefits/5495/config/form.js
@@ -3,6 +3,7 @@ import fullSchema5495 from 'vets-json-schema/dist/22-5495-schema.json';
 
 import applicantInformation from '../../../common/schemaform/pages/applicantInformation';
 import FormFooter from '../../../../platform/forms/components/FormFooter';
+import environment from '../../../../platform/utilities/environment';
 import GetFormHelp from '../../components/GetFormHelp';
 import applicantServicePage from '../../pages/applicantService';
 import createOldSchoolPage from '../../pages/oldSchool';
@@ -42,7 +43,7 @@ const {
 
 const formConfig = {
   urlPrefix: '/',
-  submitUrl: '/v0/education_benefits_claims/5495',
+  submitUrl: `${environment.API_URL}/v0/education_benefits_claims/5495`,
   trackingPrefix: 'edu-5495-',
   formId: '22-5495',
   version: 1,

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -12,7 +12,6 @@ import {
 import { genderLabels } from '../../../platform/static-data/labels';
 import { services } from '../../../platform/monitoring/DowntimeNotification';
 import FormFooter from '../../../platform/forms/components/FormFooter';
-import environment from '../../../platform/utilities/environment';
 
 import applicantDescription from '../../common/schemaform/components/ApplicantDescription';
 import PrefillMessage from '../../common/schemaform/save-in-progress/PrefillMessage';
@@ -139,7 +138,6 @@ const stateLabels = createUSAStateLabels(states);
 const formConfig = {
   urlPrefix: '/',
   submitUrl: '/v0/health_care_applications',
-  environment,
   trackingPrefix: 'hca-',
   formId: '1010ez',
   version: 5,

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -12,6 +12,7 @@ import {
 import { genderLabels } from '../../../platform/static-data/labels';
 import { services } from '../../../platform/monitoring/DowntimeNotification';
 import FormFooter from '../../../platform/forms/components/FormFooter';
+import environment from '../../../platform/utilities/environment';
 
 import applicantDescription from '../../common/schemaform/components/ApplicantDescription';
 import PrefillMessage from '../../common/schemaform/save-in-progress/PrefillMessage';
@@ -137,7 +138,7 @@ const stateLabels = createUSAStateLabels(states);
 
 const formConfig = {
   urlPrefix: '/',
-  submitUrl: '/v0/health_care_applications',
+  submitUrl: `${environment.API_URL}/v0/health_care_applications`,
   trackingPrefix: 'hca-',
   formId: '1010ez',
   version: 5,

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -12,6 +12,7 @@ import {
 import { genderLabels } from '../../../platform/static-data/labels';
 import { services } from '../../../platform/monitoring/DowntimeNotification';
 import FormFooter from '../../../platform/forms/components/FormFooter';
+import environment from '../../../platform/utilities/environment';
 
 import applicantDescription from '../../common/schemaform/components/ApplicantDescription';
 import PrefillMessage from '../../common/schemaform/save-in-progress/PrefillMessage';
@@ -138,6 +139,7 @@ const stateLabels = createUSAStateLabels(states);
 const formConfig = {
   urlPrefix: '/',
   submitUrl: '/v0/health_care_applications',
+  environment,
   trackingPrefix: 'hca-',
   formId: '1010ez',
   version: 5,

--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -6,6 +6,7 @@ import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
 import { isFullDate } from '../../../platform/forms/validations';
 import { services } from '../../../platform/monitoring/DowntimeNotification';
 import FormFooter from '../../../platform/forms/components/FormFooter';
+import environment from '../../../platform/utilities/environment';
 import GetFormHelp from '../../../platform/forms/components/GetPensionOrBurialFormHelp';
 
 import * as address from '../../common/schemaform/definitions/address';
@@ -1594,6 +1595,7 @@ const formConfig = {
             'ui:title': 'Document upload',
             'ui:description': fileHelp,
             files: fileUploadUI('', {
+              fileUploadURL: `${environment.API_URL}/v0/claim_attachments`,
               hideLabelText: true
             }),
             'view:uploadMessage': {

--- a/src/applications/pre-need/config/form.jsx
+++ b/src/applications/pre-need/config/form.jsx
@@ -563,7 +563,7 @@ const formConfig = {
             'ui:description': SupportingDocumentsDescription,
             application: {
               preneedAttachments: fileUploadUI('Select files to upload', {
-                endpoint: `${environment.API_URL}/v0/preneeds/preneed_attachments`,
+                fileUploadUrl: `${environment.API_URL}/v0/preneeds/preneed_attachments`,
                 fileTypes: ['pdf'],
                 maxSize: 15728640,
                 hideLabelText: true,

--- a/src/applications/pre-need/config/form.jsx
+++ b/src/applications/pre-need/config/form.jsx
@@ -3,6 +3,7 @@ import _ from 'lodash/fp';
 import fullSchemaPreNeed from 'vets-json-schema/dist/40-10007-schema.json';
 
 import FormFooter from '../../../platform/forms/components/FormFooter';
+import environment from '../../../platform/utilities/environment';
 
 import * as address from '../../common/schemaform/definitions/address';
 import currentOrPastDateUI from '../../common/schemaform/definitions/currentOrPastDate';
@@ -69,7 +70,7 @@ const nonRequiredFullName = _.omit('required', fullName);
 
 const formConfig = {
   urlPrefix: '/',
-  submitUrl: '/v0/preneeds/burial_forms',
+  submitUrl: `${environment.API_URL}/v0/preneeds/burial_forms`,
   trackingPrefix: 'preneed-',
   transformForSubmit: transform,
   formId: '40-10007',
@@ -562,7 +563,7 @@ const formConfig = {
             'ui:description': SupportingDocumentsDescription,
             application: {
               preneedAttachments: fileUploadUI('Select files to upload', {
-                endpoint: '/v0/preneeds/preneed_attachments',
+                endpoint: `${environment.API_URL}/v0/preneeds/preneed_attachments`,
                 fileTypes: ['pdf'],
                 maxSize: 15728640,
                 hideLabelText: true,

--- a/src/applications/veteran-representative/config/form.js
+++ b/src/applications/veteran-representative/config/form.js
@@ -9,6 +9,8 @@ import * as addressUI from '../../common/schemaform/definitions/address.js';
 import currentOrPastDateUI from '../../common/schemaform/definitions/currentOrPastDate';
 import phoneUI from '../../common/schemaform/definitions/phone';
 
+import environment from '../../../platform/utilities/environment';
+
 const {
   veteranFullName,
   veteranSSN,
@@ -44,7 +46,7 @@ const authorizationToChangeClaimantAddressDescription =
 
 const formConfig = {
   urlPrefix: '/',
-  submitUrl: '/v0/vso_appointments',
+  submitUrl: `${environment.API_URL}/v0/vso_appointments`,
   trackingPrefix: 'form-2122-',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,

--- a/src/applications/vic-v2/config/form.js
+++ b/src/applications/vic-v2/config/form.js
@@ -3,6 +3,7 @@ import _ from 'lodash/fp';
 import fullSchemaVIC from 'vets-json-schema/dist/VIC-schema.json';
 
 import FormFooter from '../../../platform/forms/components/FormFooter';
+import environment from '../../../platform/utilities/environment';
 
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
@@ -180,7 +181,7 @@ const formConfig = {
             'ui:title': 'Upload Your Photo',
             'ui:description': PhotoDescription,
             photo: _.assign(fileUploadUI('Upload a digital photo', {
-              endpoint: '/v0/vic/profile_photo_attachments',
+              fileUploadUrl: `${environment.API_URL}/v0/vic/profile_photo_attachments`,
               fileTypes: [
                 'png',
                 'tiff',
@@ -227,7 +228,7 @@ const formConfig = {
           uiSchema: {
             'ui:description': DD214Description,
             dd214: fileUploadUI('Upload your discharge document', {
-              endpoint: '/v0/vic/supporting_documentation_attachments',
+              fileUploadUrl: `${environment.API_URL}/v0/vic/supporting_documentation_attachments`,
               fileTypes: [
                 'pdf',
                 'png',

--- a/src/applications/vre/chapter31/config/form.js
+++ b/src/applications/vre/chapter31/config/form.js
@@ -16,6 +16,7 @@ import fileUploadUI from '../../../common/schemaform/definitions/file';
 import yearUI from '../../../common/schemaform/definitions/year';
 
 import FormFooter from '../../../../platform/forms/components/FormFooter';
+import environment from '../../../../platform/utilities/environment';
 
 import { disabilityRatingLabels, dischargeTypeLabels, serviceFlagLabels } from '../../utils/labels';
 import createVeteranInfoPage from '../../pages/veteranInfo';
@@ -61,7 +62,7 @@ const expandIfWorking = {
 
 const formConfig = {
   urlPrefix: '/',
-  // submitUrl: '/v0/vre',
+  // submitUrl: `${environment.API_URL}/v0/vre`,
   submit: () => Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
   trackingPrefix: 'vre-chapter-31',
   introduction: IntroductionPage,
@@ -400,6 +401,7 @@ const formConfig = {
           uiSchema: {
             'ui:description': DD214Description,
             dischargeDocuments: fileUploadUI('Upload your discharge document', {
+              fileUploadUrl: `${environment.API_URL}/v0/claim_attachments`,
               fileTypes: [
                 'pdf',
                 'jpeg',

--- a/src/applications/vre/chapter36/config/form.js
+++ b/src/applications/vre/chapter36/config/form.js
@@ -20,6 +20,7 @@ import ssnUI from '../../../common/schemaform/definitions/ssn';
 import { validateMatch } from '../../../common/schemaform/validation';
 
 import FormFooter from '../../../../platform/forms/components/FormFooter';
+// import environment from '../../../../platform/utilities/environment';
 
 const {
   applicantEmail,
@@ -146,7 +147,7 @@ const previousBenefitApplicationsUI = {
 
 const formConfig = {
   urlPrefix: '/',
-  // submitUrl: '/v0/vre',
+  // submitUrl: `${environment.API_URL}/v0/vre`,
   submit: () => Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
   trackingPrefix: 'vre-chapter-36',
   introduction: IntroductionPage,


### PR DESCRIPTION
Connects to https://github.com/usds/us-forms-system/issues/50

There were a couple of changes needed for this PR:
1. `submitToUrl()` in `actions.js` needs a url to submit the form. This was being included directly in the `actions.js` file by importing the `environment` file. Instead, change the `submitUrl` value in each form's config to being the entire url with the environment variable included as opposed to just the last part of the url (e.g., `submitUrl: '${environment.API_URL}/v0/api'` instead of `submitUrl: '/v0/api'`).
2. `uploadFile()` in `actions.js` also required a url to post the file too, and was being included in the same way as the above by importing the `environment` file directly. Instead, change the `fileUploadUI()` definition that is passed to the config to take a `fileUploadUrl` value. 
NOTE: Some instances of `fileUploadUI()` were being passed an `endpoint` value, which was also included as a default in `fileUploadUI()`. Changed this to not include the url as a default and renamed the value to `fileUploadUrl` to be consistent with the `submitUrl` name and for clarity.