### PR TITLE
Letters/DowntimeNotifications - Add banner component

### DIFF
--- a/src/applications/letters/containers/LettersApp.jsx
+++ b/src/applications/letters/containers/LettersApp.jsx
@@ -3,7 +3,8 @@ import Raven from 'raven-js';
 import { connect } from 'react-redux';
 
 import RequiredLoginView from '../../../platform/user/authorization/components/RequiredLoginView';
-import DowntimeNotification, { services } from '../../../platform/monitoring/DowntimeNotification';
+import { services } from '../../../platform/monitoring/DowntimeNotification';
+import DowntimeBanner from '../../../platform/monitoring/DowntimeNotification/components/Banner';
 
 const UNREGISTERED_ERROR = 'vets_letters_user_unregistered';
 
@@ -58,13 +59,12 @@ export class LettersApp extends React.Component {
         verify
         serviceRequired="evss-claims"
         user={this.props.user}>
-        <DowntimeNotification appTitle="Letters Generator" dependencies={[services.evss]}>
-          <AppContent>
-            <div>
-              {this.props.children}
-            </div>
-          </AppContent>
-        </DowntimeNotification>
+        <AppContent>
+          <DowntimeBanner appTitle="Letters Generator" dependencies={[services.evss]}/>
+          <div>
+            {this.props.children}
+          </div>
+        </AppContent>
       </RequiredLoginView>
     );
   }

--- a/src/platform/monitoring/DowntimeNotification/components/Banner.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/Banner.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
 import DowntimeNotification, { serviceStatus } from '../index';
@@ -28,3 +30,9 @@ export default function DowntimeBanner({ appTitle, dependencies, children }) {
       dependencies={dependencies}/>
   );
 }
+
+DowntimeBanner.propTypes = {
+  appTitle: PropTypes.string,
+  dependencies: PropTypes.arrayOf(PropTypes.string).isRequired,
+  children: PropTypes.node
+};

--- a/src/platform/monitoring/DowntimeNotification/components/Banner.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/Banner.jsx
@@ -4,6 +4,11 @@ import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 import DowntimeNotification, { serviceStatus } from '../index';
 import { DownMessaging } from './Down';
 
+/**
+ * A banner component for simple downtime messaging
+ * @param {object} props appTitle, dependencies, children
+ * @module platorm/monitoring/DowntimeNotification/Banner
+ */
 export default function DowntimeBanner({ appTitle, dependencies, children }) {
   return (
     <DowntimeNotification

--- a/src/platform/monitoring/DowntimeNotification/components/Banner.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/Banner.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
+import DowntimeNotification, { serviceStatus } from '../index';
+import { DownMessaging } from './Down';
+
+export default function DowntimeBanner({ appTitle, dependencies, children }) {
+  return (
+    <DowntimeNotification
+      appTitle={appTitle}
+      render={(downtime) => {
+        if (downtime.status === serviceStatus.down) {
+          return (
+            <AlertBox
+              status="info"
+              isVisible
+              content={children || <DownMessaging appTitle={appTitle} {...downtime}/>}/>
+          );
+        }
+        return <div/>;
+      }}
+      loadingIndicator={<div/>}
+      dependencies={dependencies}/>
+  );
+}

--- a/src/platform/monitoring/DowntimeNotification/components/Banner.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/Banner.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
-import DowntimeNotification, { serviceStatus } from '../index';
+import DowntimeNotification, { services, serviceStatus } from '../index';
 import { DownMessaging } from './Down';
 
 /**
@@ -33,6 +33,6 @@ export default function DowntimeBanner({ appTitle, dependencies, children }) {
 
 DowntimeBanner.propTypes = {
   appTitle: PropTypes.string,
-  dependencies: PropTypes.arrayOf(PropTypes.string).isRequired,
+  dependencies: PropTypes.arrayOf(PropTypes.oneOf(Object.values(services))).isRequired,
   children: PropTypes.node
 };

--- a/src/platform/monitoring/DowntimeNotification/components/Down.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/Down.jsx
@@ -2,18 +2,19 @@ import React from 'react';
 import serviceStatus from '../config/serviceStatus';
 import DowntimeNotificationWrapper from './Wrapper';
 
-export default function Down({ endTime, appTitle }) {
-  let message = <p>We’re making some updates to the {appTitle}. We’re sorry it’s not working right now. Please check back soon.</p>;
+export function DownMessaging({ endTime, appTitle }) {
   if (endTime) {
-    message = (
-      <p>We’re making some updates to the {appTitle}. We’re sorry it’s not working right now, and we hope to be finished by {endTime.format('MMMM Do, LT')} Please check back soon.</p>
-    );
+    return <p>We’re making some updates to the {appTitle}. We’re sorry it’s not working right now, and we hope to be finished by {endTime.format('MMMM Do, LT')} Please check back soon.</p>;
   }
+  return  <p>We’re making some updates to the {appTitle}. We’re sorry it’s not working right now. Please check back soon.</p>;
+}
+
+export default function Down({ endTime, appTitle }) {
   return (
     <DowntimeNotificationWrapper status={serviceStatus.down}>
       <div className="usa-content">
         <h3>The {appTitle} is down for maintenance</h3>
-        {message}
+        <DownMessaging endTime={endTime} appTitle={appTitle}/>
       </div>
     </DowntimeNotificationWrapper>
   );


### PR DESCRIPTION
This adds a DowntimeBanner component that can be used for really simple messaging about services being offline and implements it in Letters.

Resolves department-of-veterans-affairs/vets.gov-team/issues/10601

CC @wyattwalter (if you want to test), @melwoodard (if you want to change messaging)

Screenshot -
![image](https://user-images.githubusercontent.com/1915775/40498387-e96f2780-5f4c-11e8-92f7-9f076fed4920.png)