### PR TITLE
Fix autosuggest issues on preneed form

### DIFF
--- a/src/applications/common/schemaform/fields/AutosuggestField.jsx
+++ b/src/applications/common/schemaform/fields/AutosuggestField.jsx
@@ -143,16 +143,16 @@ export default class AutosuggestField extends React.Component {
     if (formContext.reviewMode) {
       const readOnlyData = <span>{getInput(formData, uiSchema, schema)}</span>;
 
-      // If we're using an enum, this is a string field and the label will
+      // If this is an non-object field then the label will
       // be included by ReviewFieldTemplate
-      if (this.useEnum) {
+      if (schema.type !== 'object') {
         return readOnlyData;
       }
 
       return (
         <div className="review-row">
           <dt>{this.props.uiSchema['ui:title']}</dt>
-          <dd><span>{readOnlyData}</span></dd>
+          <dd>{readOnlyData}</dd>
         </div>
       );
     }

--- a/src/applications/common/schemaform/fields/AutosuggestField.jsx
+++ b/src/applications/common/schemaform/fields/AutosuggestField.jsx
@@ -100,7 +100,7 @@ export default class AutosuggestField extends React.Component {
         }
       }
 
-      this.props.onChange(item);
+      this.props.onChange(this.useEnum ? inputValue : item);
 
       this.setState({
         input: inputValue,
@@ -141,10 +141,18 @@ export default class AutosuggestField extends React.Component {
     const id = idSchema.$id;
 
     if (formContext.reviewMode) {
+      const readOnlyData = <span>{getInput(formData, uiSchema, schema)}</span>;
+
+      // If we're using an enum, this is a string field and the label will
+      // be included by ReviewFieldTemplate
+      if (this.useEnum) {
+        return readOnlyData;
+      }
+
       return (
         <div className="review-row">
           <dt>{this.props.uiSchema['ui:title']}</dt>
-          <dd><span>{getInput(formData, uiSchema, schema)}</span></dd>
+          <dd><span>{readOnlyData}</span></dd>
         </div>
       );
     }
@@ -174,6 +182,7 @@ export default class AutosuggestField extends React.Component {
             <input {...getInputProps({
               id,
               name: id,
+              className: 'autosuggest-input',
               onBlur: isOpen ? undefined : this.handleBlur,
               onKeyDown: this.handleKeyDown
             })}/>

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -553,6 +553,11 @@ legend.schemaform-label.schemaform-file-label {
   position: relative;
 }
 
+.autosuggest-input {
+  // override accordion styles, which are the bane of our existence
+  background-image: none !important;
+}
+
 .autosuggest-list {
   background: $color-white;
   border: 1px solid $color-gray;


### PR DESCRIPTION
This fixes some bugs in the autosuggest field for pre-need.

One is that we were duplicating the label on the review page if the field was a string field. That's fixed:

![screen shot 2018-05-25 at 11 34 46 am](https://user-images.githubusercontent.com/634932/40553237-017ab1c8-6010-11e8-959c-d9a5e8411cc9.png)

Also, you couldn't type on fields that used an enum, and there was also an errant accordion plus icon. Fixed now:

![screen shot 2018-05-25 at 11 34 55 am](https://user-images.githubusercontent.com/634932/40553235-016beb20-6010-11e8-9ffd-c6c44e346a40.png)
