### PR TITLE
526 require all selected mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -545,6 +545,7 @@ const formConfig = {
                 type: 'array',
                 items: {
                   type: 'object',
+                  required: ['view:uploadPrivateRecords'],
                   properties: {
                     'view:uploadPrivateRecords': {
                       type: 'string',
@@ -753,6 +754,7 @@ const formConfig = {
                 type: 'array',
                 items: {
                   type: 'object',
+                  required: ['privateRecords'],
                   properties: {
                     privateRecords: {
                       type: 'array',
@@ -823,6 +825,7 @@ const formConfig = {
                 type: 'array',
                 items: {
                   type: 'object',
+                  required: ['additionalDocuments'],
                   properties: {
                     additionalDocuments: {
                       type: 'array',

--- a/src/applications/disability-benefits/526EZ/tests/config/documentUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/documentUpload.unit.spec.jsx
@@ -146,7 +146,7 @@ describe('526EZ document upload', () => {
     expect(form.find('input').length).to.equal(1);
   });
 
-  it('should submit empty form', () => {
+  it('should not submit without an upload', () => {
     const onSubmit = sinon.spy();
     const form = mount(<DefinitionTester
       arrayPath={arrayPath}
@@ -160,8 +160,8 @@ describe('526EZ document upload', () => {
 
     form.find('form').simulate('submit');
 
-    expect(form.find('.usa-input-error-message').length).to.equal(0);
-    expect(onSubmit.called).to.be.true;
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
   });
 
   it('should not submit without required info', () => {

--- a/src/applications/disability-benefits/526EZ/tests/config/recordUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/recordUpload.unit.spec.jsx
@@ -146,7 +146,7 @@ describe('526EZ record upload', () => {
     expect(form.find('input').length).to.equal(1);
   });
 
-  it('should submit empty form', () => {
+  it('should not submit without an upload', () => {
     const onSubmit = sinon.spy();
     const form = mount(<DefinitionTester
       arrayPath={arrayPath}
@@ -160,8 +160,8 @@ describe('526EZ record upload', () => {
 
     form.find('form').simulate('submit');
 
-    expect(form.find('.usa-input-error-message').length).to.equal(0);
-    expect(onSubmit.called).to.be.true;
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
   });
 
   it('should not submit without required info', () => {


### PR DESCRIPTION
Adds schema requirements to ensure that the user can't submit a form without any supporting evidence. Except for PMR -> My Doctor has my records. The intent with that flow in particular is to let the user not upload anything - they will submit a 4142 on their own (for the time being).