### PR TITLE
Send GA client id in HCA submission

### DIFF
--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -29,7 +29,16 @@ export function transform(formConfig, form) {
     return stringifyFormReplacer(key, value);
   }) || '{}';
 
+  let gaClientId;
+  try {
+    // eslint-disable-next-line no-undef
+    gaClientId = ga.getAll()[0].get('clientId');
+  } catch (e) {
+    // don't want to break submitting because of a weird GA issue
+  }
+
   return JSON.stringify({
+    gaClientId,
     asyncCompatible: __BUILDTYPE__ !== 'production',
     form: formData
   });


### PR DESCRIPTION
This includes the GA client id along with HCA submissions, for use in tracking email click events.