### PR TITLE
526 upload types mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -704,9 +704,9 @@ const formConfig = {
                 privateRecords: Object.assign({},
                   fileUploadUI('Upload your private medical records', {
                     itemDescription: 'Adding additional evidence:',
-                    fileUploadUrl: `${environment.API_URL}/v0/preneeds/preneed_attachments`, // TODO: update this with correct endpoint (e.g. '/v0/21-526EZ/medical_records')
+                    fileUploadUrl: `${environment.API_URL}/v0/upload_supporting_evidence`,
                     addAnotherLabel: 'Add Another Document',
-                    fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
+                    fileTypes: ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'tif', 'tiff', 'txt'],
                     maxSize: FIFTY_MB,
                     createPayload: (file) => {
                       const payload = new FormData();

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -717,7 +717,7 @@ const formConfig = {
                     parseResponse: (response, file) => {
                       return {
                         name: file.name,
-                        confirmationCode: response.guid
+                        confirmationCode: response.data.attributes.guid
                       };
                     },
                     attachmentName: {
@@ -788,7 +788,7 @@ const formConfig = {
                     parseResponse: (response, file) => {
                       return {
                         name: file.name,
-                        confirmationCode: response.guid
+                        confirmationCode: response.data.attributes.guid
                       };
                     },
                     attachmentName: {

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -710,14 +710,14 @@ const formConfig = {
                     maxSize: FIFTY_MB,
                     createPayload: (file) => {
                       const payload = new FormData();
-                      payload.append('preneed_attachment[file_data]', file); // TODO: update this with correct property (e.g. 'health_record[file_data]')
+                      payload.append('supporting_evidence_attachment[file_data]', file);
 
                       return payload;
                     },
                     parseResponse: (response, file) => {
                       return {
                         name: file.name,
-                        confirmationCode: response.data.attributes.guid
+                        confirmationCode: response.guid
                       };
                     },
                     attachmentName: {
@@ -775,20 +775,20 @@ const formConfig = {
                 additionalDocuments: Object.assign({},
                   fileUploadUI('Lay statements or other evidence', {
                     itemDescription: 'Adding additional evidence:',
-                    fileUploadUrl: `${environment.API_URL}/v0/preneeds/preneed_attachments`, // TODO: update this with correct endpoint (e.g. '/v0/21-526EZ/medical_records')
+                    fileUploadUrl: `${environment.API_URL}/v0/upload_supporting_evidence`,
                     addAnotherLabel: 'Add Another Document',
-                    fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
+                    fileTypes: ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'tif', 'tiff', 'txt'],
                     maxSize: FIFTY_MB,
                     createPayload: (file) => {
                       const payload = new FormData();
-                      payload.append('preneed_attachment[file_data]', file); // TODO: update this with correct property (e.g. 'health_record[file_data]')
+                      payload.append('supporting_evidence_attachment[file_data]', file);
 
                       return payload;
                     },
                     parseResponse: (response, file) => {
                       return {
                         name: file.name,
-                        confirmationCode: response.data.attributes.guid
+                        confirmationCode: response.guid
                       };
                     },
                     attachmentName: {


### PR DESCRIPTION
For PMR Evidence and Lay Evidence:
- Updates accepted file types
- Updates endpoints to actual one for 526 documents
- Updates response parsing to get the correct `GUID` for each file

Also resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/10681