### PR TITLE
Add documentation/unit tests for site-wide Announcements

### DIFF
--- a/src/platform/site-wide/announcements/README.md
+++ b/src/platform/site-wide/announcements/README.md
@@ -6,6 +6,8 @@ In the following example, anything that matches the `paths` property will render
 
 **config/index**
 ```jsx
+import React from 'react';
+
 const config = {
   announcements: [
     {

--- a/src/platform/site-wide/announcements/README.md
+++ b/src/platform/site-wide/announcements/README.md
@@ -13,7 +13,7 @@ const config = {
     {
       name: 'New Education Feature',
       paths: /^(\/education\/)$/,
-      component: ({ announcement, dismiss }) => {
+      component: ({ announcement, dismiss, isLoggedIn, profile }) => {
         return (
           <div className="education-announcement">
             {announcement.name}

--- a/src/platform/site-wide/announcements/README.md
+++ b/src/platform/site-wide/announcements/README.md
@@ -1,0 +1,38 @@
+# Announcements
+Announcements were designed to be configurable site-wide without messing with the source code of other applications or digging into Metalsmith layout files to conditionally render. They are configured in `config/index.js` using regular expressions to determine which announcements render on what pages.
+
+## Basic Use Cases
+In the following example, anything that matches the `paths` property will render the corresponding component in the `component` property. The `name` property should be unique. The `relatedAnnouncements` property refers to the names of other announcements, which should also be disabled when this announcement is dismissed by the user.
+
+**config/index**
+```jsx
+const config = {
+  announcements: [
+    {
+      name: 'New Education Feature',
+      paths: /^(\/education\/)$/,
+      component: ({ announcement, dismiss }) => {
+        return (
+          <div className="education-announcement">
+            {announcement.name}
+            <a href="/education/new-feature" onClick={dismiss}>Check out our new Education feature</a>
+          </div>
+        );
+      },
+      relatedAnnouncements: ['education-intro']
+    }
+  ]
+};
+```
+The `announcement` property in the rendered component will contain the announcement as stored in the config, so in this case `announcement.name` will render `New Education Feature`. The `dismiss` property will disable the announcement "permanently" by storing its name in localStorage. Any related announcements will also be disabled by being stored there as well.
+
+## Architecture
+The Announcement entry point uses React to bind to an element above the footer of the website. It was designed this way because announcement will always render as fixed elements or as modal dialogs. If no announcement matches the current path, or if the matching announcement has been dismissed, it will render as an empty div.
+
+## E2E Tests
+Announcements are disabled during E2E tests for two reasons -
+
+1. Philosophically, because they change overtime while E2E tests should run consistently.
+2. Functionally, because it is likely that announcements will use "position: fixed" in their style, which will interrupt Nightwatch's browser focus while tests are running and break things.
+
+The helper for disabling announcements is named `disableAnnouncements` and is located in `platform/testing/e2e/helpers.js`.

--- a/src/platform/site-wide/announcements/README.md
+++ b/src/platform/site-wide/announcements/README.md
@@ -2,7 +2,7 @@
 Announcements were designed to be configurable site-wide without messing with the source code of other applications or digging into Metalsmith layout files to conditionally render. They are configured in `config/index.js` using regular expressions to determine which announcements render on what pages.
 
 ## Basic Use Cases
-In the following example, anything that matches the `paths` property will render the corresponding component in the `component` property. The `name` property should be unique. The `relatedAnnouncements` property refers to the names of other announcements, which should also be disabled when this announcement is dismissed by the user.
+In the following example, any pages that matches the `paths` property will render the corresponding component in the `component` property. The `name` property should be unique. The `relatedAnnouncements` property refers to the names of other announcements, which should also be disabled when this announcement is dismissed by the user.
 
 **config/index**
 ```jsx

--- a/src/platform/site-wide/announcements/README.md
+++ b/src/platform/site-wide/announcements/README.md
@@ -21,7 +21,11 @@ const config = {
           </div>
         );
       },
-      relatedAnnouncements: ['education-intro']
+      relatedAnnouncements: ['Education Intro']
+    },
+    {
+      name: 'Education Intro',
+      // ...
     }
   ]
 };

--- a/src/platform/site-wide/announcements/README.md
+++ b/src/platform/site-wide/announcements/README.md
@@ -25,6 +25,7 @@ const config = {
     }
   ]
 };
+
 export default config;
 ```
 The `announcement` property in the rendered component will contain the announcement as stored in the config, so in this case `announcement.name` will render `New Education Feature`. The `dismiss` property will disable the announcement "permanently" by storing its name in localStorage. Any related announcements will also be disabled by being stored there as well.

--- a/src/platform/site-wide/announcements/README.md
+++ b/src/platform/site-wide/announcements/README.md
@@ -23,6 +23,7 @@ const config = {
     }
   ]
 };
+export default config;
 ```
 The `announcement` property in the rendered component will contain the announcement as stored in the config, so in this case `announcement.name` will render `New Education Feature`. The `dismiss` property will disable the announcement "permanently" by storing its name in localStorage. Any related announcements will also be disabled by being stored there as well.
 

--- a/src/platform/site-wide/announcements/actions/index.js
+++ b/src/platform/site-wide/announcements/actions/index.js
@@ -1,29 +1,27 @@
 export const INIT_DISMISSED_ANNOUNCEMENTS = 'INIT_DISMISSED_ANNOUNCEMENTS';
 export const DISMISS_ANNOUNCEMENT = 'DISMISS_ANNOUNCEMENT';
 
-const localAnnouncements = (() => {
-  const DISMISSED_ANNOUNCEMENTS = 'DISMISSED_ANNOUNCEMENTS';
+export const ANNOUNCEMENTS_LOCAL_STORAGE = 'DISMISSED_ANNOUNCEMENTS';
 
-  return (appTitle) => {
-    const fromLocalStorage = window.localStorage[DISMISSED_ANNOUNCEMENTS];
-    let parsed = [];
+function localAnnouncements(dismissedAnnouncementName) {
+  const fromLocalStorage = window.localStorage[ANNOUNCEMENTS_LOCAL_STORAGE];
+  let parsed = [];
 
-    if (fromLocalStorage) {
-      try {
-        parsed = JSON.parse(fromLocalStorage);
-      } catch (err) {
-        // Value will default to an empty array
-      }
+  if (fromLocalStorage) {
+    try {
+      parsed = JSON.parse(fromLocalStorage);
+    } catch (err) {
+      // Value will default to an empty array
     }
+  }
 
-    if (appTitle) {
-      parsed.push(appTitle);
-      window.localStorage[DISMISSED_ANNOUNCEMENTS] = JSON.stringify(parsed);
-    }
+  if (dismissedAnnouncementName) {
+    parsed.push(dismissedAnnouncementName);
+    window.localStorage[ANNOUNCEMENTS_LOCAL_STORAGE] = JSON.stringify(parsed);
+  }
 
-    return parsed;
-  };
-})();
+  return parsed;
+}
 
 export function initDismissedAnnouncements() {
   return {

--- a/src/platform/site-wide/announcements/selectors.js
+++ b/src/platform/site-wide/announcements/selectors.js
@@ -1,14 +1,15 @@
-import config from './config';
+import _config from './config';
 
-export function selectAnnouncement(state) {
+export function selectAnnouncement(state, config = _config, path = document.location.pathname) {
   const announcements = state.announcements;
-  let announcement = null;
+  let announcement;
 
   if (announcements.isInitialized) {
-    const path = document.location.pathname;
-    announcement = config.announcements.find(a => a.paths.test(path));
+    announcement = config.announcements
+      .filter(a => !a.disabled)
+      .find(a => a.paths.test(path));
 
-    if (announcements.dismissed.includes(announcement.name) || announcement.disabled) {
+    if (announcement && announcements.dismissed.includes(announcement.name)) {
       announcement = null;
     }
   }

--- a/src/platform/site-wide/announcements/tests/actions/index.unit.spec.js
+++ b/src/platform/site-wide/announcements/tests/actions/index.unit.spec.js
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+
+import * as announcementActions from '../../actions';
+
+const old = {
+  localStorage: global.window.localStorage
+};
+
+const hooks = {
+  beforeEach() {
+    global.window.localStorage = [];
+  },
+  after() {
+    window.localStorage = old.localStorage;
+  }
+};
+
+describe('initDismissedAnnouncements', () => {
+  beforeEach(hooks.beforeEach);
+  after(hooks.after);
+
+  it('returns dismissed announcements from localStorage', () => {
+    let result = announcementActions.initDismissedAnnouncements();
+    expect(result).to.be.deep.equal({
+      type: announcementActions.INIT_DISMISSED_ANNOUNCEMENTS,
+      dismissedAnnouncements: []
+    });
+
+    // Repeat the test, with a value in localStorage.
+    global.window.localStorage[announcementActions.ANNOUNCEMENTS_LOCAL_STORAGE] = JSON.stringify(['dummy1']);
+    result = announcementActions.initDismissedAnnouncements();
+
+    expect(result).to.be.deep.equal({
+      type: announcementActions.INIT_DISMISSED_ANNOUNCEMENTS,
+      dismissedAnnouncements: ['dummy1']
+    });
+  });
+});
+
+describe('dismissAnnouncement', () => {
+  beforeEach(hooks.beforeEach);
+  after(hooks.after);
+
+  it('adds dismissed announcements into localStorage', () => {
+    let result = announcementActions.dismissAnnouncement('dummy');
+    expect(result).to.be.deep.equal({
+      type: announcementActions.DISMISS_ANNOUNCEMENT,
+      announcement: 'dummy'
+    });
+
+    // initDismissedAnnouncements should now pull that announcement from localStorage
+    result = announcementActions.initDismissedAnnouncements();
+    expect(result).to.be.deep.equal({
+      type: announcementActions.INIT_DISMISSED_ANNOUNCEMENTS,
+      dismissedAnnouncements: ['dummy']
+    });
+  });
+});

--- a/src/platform/site-wide/announcements/tests/containers/Announcement.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/containers/Announcement.unit.spec.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import enzyme from 'enzyme';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { Announcement } from '../../containers/Announcement';
+
+describe('<Announcement/>', () => {
+  let props = null;
+
+  beforeEach(() => {
+    props = {
+      isInitialized: true,
+      announcement: null,
+      isLoggedIn: true,
+      profile: {},
+      dismissed: [],
+      initDismissedAnnouncements() {},
+      dismissAnnouncement() {}
+    };
+  });
+
+  it('calls the init action when isInitialized is false', () => {
+    props.isInitialized = false;
+    props.initDismissedAnnouncements = sinon.stub();
+    enzyme.shallow(<Announcement {...props}/>);
+    expect(props.initDismissedAnnouncements.called).to.be.true;
+  });
+
+  it('renders an empty div when there is no announcement', () => {
+    const wrapper = enzyme.shallow(<Announcement {...props}/>);
+    expect(wrapper.html()).to.be.equal('<div></div>');
+  });
+
+  it('renders a child announcement component when there is an announcement prop', () => {
+    props.announcement = {
+      name: 'dummy',
+      component: ({ announcement }) => {
+        return (
+          <span>{announcement.name}</span>
+        );
+      }
+    };
+    const wrapper = enzyme.shallow(<Announcement {...props}/>);
+    expect(wrapper.html()).to.be.equal('<span>dummy</span>');
+  });
+
+  it('can dismiss announcements and any related announcements using a dismiss prop', () => {
+    props.dismissAnnouncement = sinon.stub();
+    props.announcement = {
+      name: 'dummy',
+      relatedAnnouncements: ['dummy2', 'dummy3'],
+      component: ({ announcement, dismiss }) => {
+        return (
+          <button type="button" onClick={dismiss}>{announcement.name}</button>
+        );
+      }
+    };
+
+    const wrapper = enzyme.shallow(<Announcement {...props}/>);
+    const button = wrapper.find('component').dive();
+
+    button.simulate('click');
+
+    expect(button.text()).to.be.equal('dummy');
+    expect(props.dismissAnnouncement.callCount).to.be.equal(3);
+    expect(props.dismissAnnouncement.getCall(0).args[0]).to.be.equal('dummy');
+    expect(props.dismissAnnouncement.getCall(1).args[0]).to.be.equal('dummy2');
+    expect(props.dismissAnnouncement.getCall(2).args[0]).to.be.equal('dummy3');
+  });
+});

--- a/src/platform/site-wide/announcements/tests/reducers/index.unit.spec.js
+++ b/src/platform/site-wide/announcements/tests/reducers/index.unit.spec.js
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+
+import * as announcementActions from '../../actions';
+import reducer from '../../reducers';
+
+describe('announcementsReducer', () => {
+  let state;
+  let action;
+
+  beforeEach(() => {
+    state = undefined;
+    action = { type: 'NOT_RELEVANT' };
+  });
+
+  it('defaults isInitialized to false', () => {
+    const newState = reducer(state, action);
+    expect(newState.isInitialized).to.be.false;
+  });
+
+  it('flips isInitialized to true when the init action is dispatched', () => {
+    action = {
+      type: announcementActions.INIT_DISMISSED_ANNOUNCEMENTS,
+      dismissedAnnouncements: ['dummy']
+    };
+    const newState = reducer(state, action);
+    expect(newState.isInitialized).to.be.true;
+    expect(newState.dismissed).to.be.deep.equal(['dummy']);
+  });
+
+  it('adds dismissed announcements into state', () => {
+    action = {
+      type: announcementActions.DISMISS_ANNOUNCEMENT,
+      announcement: 'dummy'
+    };
+    let newState = reducer(state, action);
+    expect(newState.dismissed).to.be.deep.equal(['dummy']);
+
+    action.announcement = 'dummy2';
+    newState = reducer(newState, action);
+    expect(newState.dismissed).to.be.deep.equal(['dummy', 'dummy2']);
+  });
+
+});

--- a/src/platform/site-wide/announcements/tests/selectors.unit.spec.js
+++ b/src/platform/site-wide/announcements/tests/selectors.unit.spec.js
@@ -1,0 +1,81 @@
+import { expect } from 'chai';
+import * as selectors from '../selectors';
+
+describe('selectAnnouncement', () => {
+  let state = null;
+  let config = null;
+
+  beforeEach(() => {
+    state = {
+      announcements: {
+        isInitialized: true,
+        dismissed: []
+      }
+    };
+
+    config = {
+      announcements: [
+        {
+          name: 'dummy1',
+          paths: /^(\/some-route-1\/)$/
+        },
+        {
+          name: 'dummy2',
+          paths: /^(\/some-route-2\/)$/
+        },
+        {
+          name: 'dummy3',
+          paths: /^(\/some-route-3\/)$/
+        },
+        {
+          name: 'dummy4',
+          paths: /^(\/some-route-4\/)$/
+        },
+        {
+          name: 'dummy5',
+          paths: /^(\/some-route-5\/)$/
+        },
+        {
+          name: 'disabled dummy6',
+          paths: /^(\/some-route-6\/)$/,
+          disabled: true
+        },
+        {
+          name: 'dummy6',
+          paths: /^(\/some-route-6\/)$/
+        },
+      ]
+    };
+  });
+
+  it('returns undefined when there is no announcement', () => {
+    const emptyConfig = {
+      announcements: []
+    };
+
+    let result = selectors.selectAnnouncement(state, emptyConfig, '/dummy');
+    expect(result).to.be.undefined;
+
+    result = selectors.selectAnnouncement(state, config, '/not-a-match');
+    expect(result).to.be.undefined;
+  });
+
+  it('selects an announcement based on path and configuration', () => {
+    const result = selectors.selectAnnouncement(state, config, '/some-route-3/');
+    expect(result.name).to.be.equal('dummy3');
+  });
+
+  it('returns null when a matched annoucement has been dismissed', () => {
+    state.announcements.dismissed = [
+      'dummy3'
+    ];
+    const result = selectors.selectAnnouncement(state, config, '/some-route-3/');
+    expect(result).to.be.null;
+  });
+
+  it('bypasses disabled announcements and looks instead for the next match', () => {
+    const result = selectors.selectAnnouncement(state, config, '/some-route-6/');
+    expect(result.name).to.be.equal('dummy6', '"disabled dummy6" preceded "dummy6" but was ignored because of the disabled flag.');
+  });
+
+});

--- a/src/platform/site-wide/announcements/tests/selectors.unit.spec.js
+++ b/src/platform/site-wide/announcements/tests/selectors.unit.spec.js
@@ -66,9 +66,7 @@ describe('selectAnnouncement', () => {
   });
 
   it('returns null when a matched annoucement has been dismissed', () => {
-    state.announcements.dismissed = [
-      'dummy3'
-    ];
+    state.announcements.dismissed.push('dummy3');
     const result = selectors.selectAnnouncement(state, config, '/some-route-3/');
     expect(result).to.be.null;
   });


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team/issues/10600

[Source for Announcements](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/site-wide/announcements)

(Copied from Readme)

# Announcements
Announcements were designed to be configurable site-wide without messing with the source code of other applications or digging into Metalsmith layout files to conditionally render. They are configured in `config/index.js` using regular expressions to determine which announcements render on what pages.

## Basic Use Cases
In the following example, anything that matches the `paths` property will render the corresponding component in the `component` property. The `name` property should be unique. The `relatedAnnouncements` property refers to the names of other announcements, which should also be disabled when this announcement is dismissed by the user.

**config/index**
```jsx
import React from 'react';

const config = {
  announcements: [
    {
      name: 'New Education Feature',
      paths: /^(\/education\/)$/,
      component: ({ announcement, dismiss, isLoggedIn, profile }) => {
        return (
          <div className="education-announcement">
            {announcement.name}
            <a href="/education/new-feature" onClick={dismiss}>Check out our new Education feature</a>
          </div>
        );
      },
      relatedAnnouncements: ['Education Intro']
    },
    {
      name: 'Education Intro',
      // ...
    }
  ]
};

export default config;
```
The `announcement` property in the rendered component will contain the announcement as stored in the config, so in this case `announcement.name` will render `New Education Feature`. The `dismiss` property will disable the announcement "permanently" by storing its name in localStorage. Any related announcements will also be disabled by being stored there as well.

## Architecture
The Announcement entry point uses React to bind to an element above the footer of the website. It was designed this way because announcement will always render as fixed elements or as modal dialogs. If no announcement matches the current path, or if the matching announcement has been dismissed, it will render as an empty div.

## E2E Tests
Announcements are disabled during E2E tests for two reasons -

1. Philosophically, because they change overtime while E2E tests should run consistently.
2. Functionally, because it is likely that announcements will use "position: fixed" in their style, which will interrupt Nightwatch's browser focus while tests are running and break things.

The helper for disabling announcements is named `disableAnnouncements` and is located in `platform/testing/e2e/helpers.js`.
