### PR TITLE
AsyncDisplayWidget

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
+++ b/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
@@ -86,7 +86,7 @@ export default class AsyncDisplayWidget extends React.Component {
             isVisible
             headline="We're sorry, we can't seem to find your information right now."
             content="That's a real bummer, we know. Maybe try again later."
-            className="fetch-fail-alert"/>
+            className="async-display-widget-alert-box"/>
         );
         break;
       }

--- a/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
+++ b/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
@@ -27,7 +27,7 @@ export default class AsyncDisplayWidget extends React.Component {
     }
 
     if (typeof uiOptions.viewComponent !== 'function') {
-      throw new Error('AsyncDisplayWidget requires viewComponent in ui:options to be a React element.');
+      throw new Error('AsyncDisplayWidget requires viewComponent in ui:options to be a React component.');
     }
 
     if (typeof uiOptions.callback !== 'function') {

--- a/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
+++ b/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
@@ -80,7 +80,7 @@ export default class AsyncDisplayWidget extends React.Component {
         // Show error message or error component passed in
         const CustomAlert = uiOptions.failureComponent;
         // TODO: Get generic headline and content
-        content = <CustomAlert/> || (
+        content = CustomAlert ? <CustomAlert/> : (
           <AlertBox
             status="error"
             isVisible

--- a/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
+++ b/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
@@ -80,7 +80,7 @@ export default class AsyncDisplayWidget extends React.Component {
         // Show error message or error component passed in
         const CustomAlert = uiOptions.failureComponent;
         // TODO: Get generic headline and content
-        content = CustomAlert || (
+        content = <CustomAlert/> || (
           <AlertBox
             status="error"
             isVisible

--- a/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
+++ b/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
@@ -30,6 +30,10 @@ export default class AsyncDisplayWidget extends React.Component {
       throw new Error('AsyncDisplayWidget requires viewComponent in ui:options to be a React component.');
     }
 
+    if (uiOptions.failureComponent && typeof uiOptions.failureComponent !== 'function') {
+      throw new Error('AsyncDisplayWidget requires the optional failureComponent in ui:options to be a React component.');
+    }
+
     if (typeof uiOptions.callback !== 'function') {
       throw new Error('AsyncDisplayWidget requires callback in ui:options to be a function.');
     }

--- a/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
+++ b/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
@@ -33,9 +33,12 @@ export default class AsyncDisplayWidget extends React.Component {
     if (typeof uiOptions.callback !== 'function') {
       throw new Error('AsyncDisplayWidget requires callback in ui:options to be a function.');
     }
+  }
 
+
+  componentDidMount() {
     // TODO: Don't call the callback _every_ time the component is mounted
-    const cbPromise = uiOptions.callback();
+    const cbPromise = this.props.options.callback();
     if (cbPromise instanceof Promise) {
       cbPromise.then((data) => {
         this.setState({

--- a/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
+++ b/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+
+import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
+const PENDING = 'PENDING';
+const RESOLVED = 'RESOLVED';
+const REJECTED = 'REJECTED';
+
+
+/**
+ * Handles the various display statuses when calling an asynchronous function.
+ */
+export default class AsyncDisplayWidget extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      data: null,
+      promiseState: PENDING
+    };
+
+    // Make sure we configured it correctly
+    // StringField passes 'ui:options' as the options prop
+    const uiOptions = props.options;
+    if (!uiOptions) {
+      throw new Error('No ui:options supplied to AsyncDisplayWidget.');
+    }
+
+    if (typeof uiOptions.viewComponent !== 'function') {
+      throw new Error('AsyncDisplayWidget requires viewComponent in ui:options to be a React element.');
+    }
+
+    if (typeof uiOptions.callback !== 'function') {
+      throw new Error('AsyncDisplayWidget requires callback in ui:options to be a function.');
+    }
+
+    // TODO: Don't call the callback _every_ time the component is mounted
+    const cbPromise = uiOptions.callback();
+    if (cbPromise instanceof Promise) {
+      cbPromise.then((data) => {
+        this.setState({
+          data,
+          promiseState: RESOLVED
+        });
+      }).catch((data) => {
+        if (data instanceof Error) {
+          throw data;
+        }
+
+        this.setState({
+          data,
+          promiseState: REJECTED
+        });
+      });
+    } else {
+      throw new Error(`AsyncDisplayWidget: Expected callback to return a Promise, but got ${typeof cbPromise}.`);
+    }
+  }
+
+
+  // Not sure if this will be useful yet
+  // componentDidUnmount() {
+  //   // Cancel the promise if it isn't already fulfilled
+  // }
+
+
+  render() {
+    const uiOptions = this.props.options;
+
+    // Depending on the state of the promise, we'll render different things
+    let content;
+    switch (this.state.promiseState) {
+      case RESOLVED: {
+        // Show view component
+        const ViewComponent = uiOptions.viewComponent;
+        content = (<ViewComponent {...this.state.data}/>);
+        break;
+      }
+      case REJECTED: {
+        // Show error message or error component passed in
+        const CustomAlert = uiOptions.failureComponent;
+        // TODO: Get generic headline and content
+        content = CustomAlert || (
+          <AlertBox
+            status="error"
+            isVisible
+            headline="We're sorry, we can't seem to find your information right now."
+            content="That's a real bummer, we know. Maybe try again later."
+            className="fetch-fail-alert"/>
+        );
+        break;
+      }
+      case PENDING:
+      default: {
+        // Show loading spinner or pending component passed in
+        const loadingMessage = uiOptions.loadingMessage || 'Loading...';
+        content = (<LoadingIndicator message={loadingMessage}/>);
+        break;
+      }
+    }
+
+    return content;
+  }
+}

--- a/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
+++ b/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
@@ -82,13 +82,14 @@ export default class AsyncDisplayWidget extends React.Component {
       case REJECTED: {
         // Show error message or error component passed in
         const CustomAlert = uiOptions.failureComponent;
+        const { errorHeadline, errorContent } = uiOptions;
         // TODO: Get generic headline and content
         content = CustomAlert ? <CustomAlert/> : (
           <AlertBox
             status="error"
             isVisible
-            headline="We're sorry, we can't seem to find your information right now."
-            content="That's a real bummer, we know. Maybe try again later."
+            headline={errorHeadline || 'We can’t find your information'}
+            content={errorContent || 'We’re sorry. We can’t find your information in our system right now. Please try again later.'}
             className="async-display-widget-alert-box"/>
         );
         break;
@@ -96,8 +97,7 @@ export default class AsyncDisplayWidget extends React.Component {
       case PENDING:
       default: {
         // Show loading spinner or pending component passed in
-        const loadingMessage = uiOptions.loadingMessage || 'Loading...';
-        content = (<LoadingIndicator message={loadingMessage}/>);
+        content = (<LoadingIndicator message={uiOptions.loadingMessage || 'Please wait while we load your information.'}/>);
         break;
       }
     }

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -8,9 +8,7 @@ import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
 import fileUploadUI from '../../../common/schemaform/definitions/file';
 import ServicePeriodView from '../../../common/schemaform/components/ServicePeriodView';
 import dateRangeUI from '../../../common/schemaform/definitions/dateRange';
-import {
-  uiSchema as autoSuggestUiSchema
-} from '../../../common/schemaform/definitions/autosuggest';
+import { uiSchema as autoSuggestUiSchema } from '../../../common/schemaform/definitions/autosuggest';
 
 import FormFooter from '../../../../platform/forms/components/FormFooter';
 import environment from '../../../../platform/utilities/environment';
@@ -69,9 +67,7 @@ import {
   getEvidenceTypesDescription
 } from '../helpers';
 
-import {
-  requireOneSelected,
-} from '../validations';
+import { requireOneSelected } from '../validations';
 import { validateBooleanGroup } from '../../../common/schemaform/validation';
 
 const {

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -380,7 +380,7 @@ const DateOfBirthViewField = ({ formData }) => {
 
 const GenderViewField = ({ formData }) => <p>Gender: {genderLabels[formData]}</p>;
 
-export const veteranInformationViewField = ({ formData }) => {
+export const veteranInformationViewField = (formData) => {
   return (
     <div>
       <FullNameViewField formData={formData.fullName}/>
@@ -660,4 +660,3 @@ export const get4142Selection = (disabilities) => {
     return false;
   }, false);
 };
-

--- a/src/applications/disability-benefits/526EZ/pages/veteranInfo.js
+++ b/src/applications/disability-benefits/526EZ/pages/veteranInfo.js
@@ -8,7 +8,8 @@ export const uiSchema = {
   'ui:title': 'Veteran information',
   'ui:options': {
     viewComponent: veteranInformationViewField,
-    loadingMessage: 'Fetching your information...',
+    errorHeadline: '',
+    errorContent: 'We’re sorry. We can’t find your personal details in our system right now. Please try again later.',
     callback: () => {
       // TODO: Actually fetch the information
       return Promise.resolve({

--- a/src/applications/disability-benefits/526EZ/pages/veteranInfo.js
+++ b/src/applications/disability-benefits/526EZ/pages/veteranInfo.js
@@ -1,64 +1,31 @@
-import { merge } from 'lodash/fp';
+import AsyncDisplayWidget from '../components/AsyncDisplayWidget';
 
-import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
-
-import currentOrPastDateUI from '../../../common/schemaform/definitions/currentOrPastDate';
-import fullNameUI from '../../../common/schemaform/definitions/fullName';
-import ssnUI from '../../../common/schemaform/definitions/ssn';
-import { genderLabels } from '../../../../platform/static-data/labels';
-
-import ReviewCardField from '../components/ReviewCardField';
-
-import {
-  veteranInformationViewField,
-  VAFileNumberDescription
-} from '../helpers';
+import { veteranInformationViewField } from '../helpers';
 
 export const uiSchema = {
-  'ui:field': ReviewCardField,
+  'ui:field': 'StringField',
+  'ui:widget': AsyncDisplayWidget,
   'ui:title': 'Veteran information',
   'ui:options': {
-    viewComponent: veteranInformationViewField
-  },
-  fullName: fullNameUI,
-  socialSecurityNumber: merge(ssnUI, {
-    'ui:title': 'Social Security number (must have this or a VA file number)',
-    'ui:required': form => !form.vaFileNumber
-  }),
-  vaFileNumber: {
-    'ui:title': 'VA file number (must have this or a Social Security number)',
-    'ui:required': form => !form.socialSecurityNumber,
-    'ui:help': VAFileNumberDescription,
-    'ui:errorMessages': {
-      pattern: 'Your VA file number must be between 7 to 9 digits'
-    }
-  },
-  dateOfBirth: currentOrPastDateUI('Date of birth'),
-  gender: {
-    'ui:title': 'Gender',
-    'ui:options': {
-      labels: genderLabels
+    viewComponent: veteranInformationViewField,
+    loadingMessage: 'Fetching your information...',
+    callback: () => {
+      // TODO: Actually fetch the information
+      return Promise.resolve({
+        fullName: {
+          first: 'Sally',
+          last: 'Alphonse'
+        },
+        socialSecurityNumber: '234234234',
+        vaFileNumber: '345345345',
+        gender: 'F',
+        dateOfBirth: '1990-04-02'
+      });
     }
   }
 };
 
 export const schema = {
   type: 'object',
-  required: ['fullName', 'gender', 'dateOfBirth'],
-  properties: {
-    fullName: fullSchema526EZ.definitions.fullName,
-    socialSecurityNumber: {
-      type: 'string'
-    },
-    vaFileNumber: {
-      type: 'string',
-      pattern: '^[cC]{0,1}\\d{7,9}$'
-    },
-    gender: {
-      type: 'string',
-      'enum': ['F', 'M']
-    },
-    dateOfBirth: fullSchema526EZ.definitions.date
-  }
+  properties: {}
 };
-

--- a/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
@@ -142,6 +142,6 @@
   max-width: 100%;
 }
 
-.fetch-fail-alert {
+.async-display-widget-alert-box {
   margin-bottom: 1em;
 }

--- a/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
@@ -138,14 +138,10 @@
   }
 }
 
-.disability-increase-wizard {
+.disability-increase-wizard .fieldset-input .legend-label {
+  max-width: 100%;
+}
 
-  .fieldset-input {
-
-    .legend-label {
-      max-width: 100%;
-    }
-
-  }
-
+.fetch-fail-alert {
+  margin-bottom: 1em;
 }

--- a/src/applications/disability-benefits/526EZ/tests/components/AsyncDisplayWidget.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/AsyncDisplayWidget.unit.spec.jsx
@@ -1,23 +1,96 @@
-// import { expect } from 'chai';
-// import { shallow } from 'enzyme';
+import React from 'react';
 
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import AsyncDisplayWidget from '../../components/AsyncDisplayWidget';
+
+
+const viewComponent = () => <div id="view-component">View component</div>;
 
 describe('AsyncDisplayWidget', () => {
-  it('should throw an error if ui:options are not present', () => {});
+  it('should throw an error if ui:options are not present', () => {
+    expect(() => shallow(<AsyncDisplayWidget/>)).to.throw('No ui:options supplied');
+  });
 
-  it('should throw an error if viewComponent is not a React element', () => {});
+  it('should throw an error if viewComponent is not a React element', () => {
+    const props = {
+      options: {
+        viewComponent: 'not a function'
+      }
+    };
+    expect(() => shallow(<AsyncDisplayWidget {...props}/>)).to.throw('requires viewComponent');
+  });
 
   it('should fire the callback provided', () => {});
 
-  it('should throw an error if callback does not return a promise', () => {});
+  it('should throw an error if callback does not return a promise', () => {
+    const props = {
+      options: {
+        viewComponent,
+        callback: () => 'not a promise'
+      }
+    };
+    expect(() => shallow(<AsyncDisplayWidget {...props}/>)).to.throw('callback to return a Promise');
+  });
 
-  it('should initially render a loading indicator', () => {});
+  it('should initially render a loading indicator', () => {
+    const props = {
+      options: {
+        viewComponent,
+        // May need to set a timeout if this proves flaky
+        callback: () => Promise.resolve()
+      }
+    };
+    const widget = shallow(<AsyncDisplayWidget {...props}/>);
+    // It'll only show the LoadingIndicator for the briefest of moments
+    expect(widget.find('LoadingIndicator').length).to.equal(1);
+  });
 
-  it('should render a custom loading indicator', () => {});
+  it('should render a failure message if the callback promise is rejected', () => {
+    const props = {
+      options: {
+        viewComponent,
+        // May need to set a timeout if this proves flaky
+        callback: () => Promise.reject()
+      }
+    };
+    const widget = shallow(<AsyncDisplayWidget {...props}/>);
+    // After briefly flashing the LoadingIndicator, it'll display the error
+    setTimeout(() => {
+      expect(widget.find('AlertBox').length).to.equal(1);
+    });
+  });
 
-  it('should render a failure message if the callback promise is rejected', () => {});
+  it('should render a custom failure message', () => {
+    const failureComponent = () => <div>Failure</div>;
+    const props = {
+      options: {
+        viewComponent,
+        // May need to set a timeout if this proves flaky
+        callback: () => Promise.reject(),
+        failureComponent
+      }
+    };
+    const widget = shallow(<AsyncDisplayWidget {...props}/>);
+    // After briefly flashing the LoadingIndicator, it'll display the error
+    setTimeout(() => {
+      expect(widget.find('CustomAlert').length).to.equal(1);
+    });
+  });
 
-  it('should render a custom failure message', () => {});
-
-  it('should render a the viewComponent if the callback promise is resolved', () => {});
+  it('should render a the viewComponent if the callback promise is resolved', () => {
+    const props = {
+      options: {
+        viewComponent,
+        // May need to set a timeout if this proves flaky
+        callback: () => Promise.resolve()
+      }
+    };
+    const widget = shallow(<AsyncDisplayWidget {...props}/>);
+    // After briefly flashing the LoadingIndicator, it'll display the viewComponent
+    setTimeout(() => {
+      expect(widget.find('#view-component').length).to.equal(1);
+    });
+  });
 });

--- a/src/applications/disability-benefits/526EZ/tests/components/AsyncDisplayWidget.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/AsyncDisplayWidget.unit.spec.jsx
@@ -1,0 +1,23 @@
+// import { expect } from 'chai';
+// import { shallow } from 'enzyme';
+
+
+describe('AsyncDisplayWidget', () => {
+  it('should throw an error if ui:options are not present', () => {});
+
+  it('should throw an error if viewComponent is not a React element', () => {});
+
+  it('should fire the callback provided', () => {});
+
+  it('should throw an error if callback does not return a promise', () => {});
+
+  it('should initially render a loading indicator', () => {});
+
+  it('should render a custom loading indicator', () => {});
+
+  it('should render a failure message if the callback promise is rejected', () => {});
+
+  it('should render a custom failure message', () => {});
+
+  it('should render a the viewComponent if the callback promise is resolved', () => {});
+});

--- a/src/applications/disability-benefits/526EZ/tests/components/AsyncDisplayWidget.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/AsyncDisplayWidget.unit.spec.jsx
@@ -57,9 +57,8 @@ describe('AsyncDisplayWidget', () => {
     };
     const widget = shallow(<AsyncDisplayWidget {...props}/>);
     // After briefly flashing the LoadingIndicator, it'll display the error
-    setTimeout(() => {
-      expect(widget.find('AlertBox').length).to.equal(1);
-    });
+    widget.setState({ promiseState: 'REJECTED' });
+    expect(widget.find('AlertBox').length).to.equal(1);
   });
 
   it('should render a custom failure message', () => {
@@ -70,13 +69,13 @@ describe('AsyncDisplayWidget', () => {
         // May need to set a timeout if this proves flaky
         callback: () => Promise.reject(),
         failureComponent
-      }
+      },
+      debug: true
     };
     const widget = shallow(<AsyncDisplayWidget {...props}/>);
     // After briefly flashing the LoadingIndicator, it'll display the error
-    setTimeout(() => {
-      expect(widget.find('CustomAlert').length).to.equal(1);
-    });
+    widget.setState({ promiseState: 'REJECTED' });
+    expect(widget.find('failureComponent').length).to.equal(1);
   });
 
   it('should render a the viewComponent if the callback promise is resolved', () => {
@@ -89,9 +88,8 @@ describe('AsyncDisplayWidget', () => {
     };
     const widget = shallow(<AsyncDisplayWidget {...props}/>);
     // After briefly flashing the LoadingIndicator, it'll display the viewComponent
-    setTimeout(() => {
-      expect(widget.find('#view-component').length).to.equal(1);
-    });
+    widget.setState({ promiseState: 'RESOLVED' });
+    expect(widget.find('viewComponent').length).to.equal(1);
   });
 
   it('should pass the callback return result to viewComponent', () => {
@@ -105,8 +103,47 @@ describe('AsyncDisplayWidget', () => {
     };
     const widget = shallow(<AsyncDisplayWidget {...props}/>);
     // After briefly flashing the LoadingIndicator, it'll display the viewComponent
+    widget.setState({ data: viewComponentProps, promiseState: 'RESOLVED' });
+    expect(widget.find('viewComponent').props()).to.eql(viewComponentProps);
+  });
+
+  it('should set the promise state and data when the promise resolves', (done) => {
+    const viewComponentProps = { prop1: 'adf', prop2: 'asdff' };
+    const props = {
+      options: {
+        viewComponent,
+        // May need to set a timeout if this proves flaky
+        callback: () => new Promise((resolve) => {
+          setTimeout(() => resolve(viewComponentProps), 100);
+        })
+      }
+    };
+    const widget = shallow(<AsyncDisplayWidget {...props}/>);
     setTimeout(() => {
-      expect(widget.find('#view-component').props).to.equal(viewComponentProps);
-    });
+      const { promiseState, data } = widget.state();
+      expect(promiseState).to.equal('RESOLVED');
+      expect(data).to.eql(viewComponentProps);
+      done();
+    }, 200);
+  });
+
+  it('should set the promise state to rejeted when the promise is rejected', (done) => {
+    const viewComponentProps = { prop1: 'adf', prop2: 'asdff' };
+    const props = {
+      options: {
+        viewComponent,
+        // May need to set a timeout if this proves flaky
+        callback: () => new Promise((resolve, reject) => {
+          setTimeout(() => reject(viewComponentProps), 100);
+        })
+      }
+    };
+    const widget = shallow(<AsyncDisplayWidget {...props}/>);
+    setTimeout(() => {
+      const { promiseState, data } = widget.state();
+      expect(promiseState).to.equal('REJECTED');
+      expect(data).to.eql(viewComponentProps);
+      done();
+    }, 200);
   });
 });

--- a/src/applications/disability-benefits/526EZ/tests/components/AsyncDisplayWidget.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/AsyncDisplayWidget.unit.spec.jsx
@@ -93,4 +93,20 @@ describe('AsyncDisplayWidget', () => {
       expect(widget.find('#view-component').length).to.equal(1);
     });
   });
+
+  it('should pass the callback return result to viewComponent', () => {
+    const viewComponentProps = { prop1: 'adf', prop2: 'asdff' };
+    const props = {
+      options: {
+        viewComponent,
+        // May need to set a timeout if this proves flaky
+        callback: () => Promise.resolve(viewComponentProps)
+      }
+    };
+    const widget = shallow(<AsyncDisplayWidget {...props}/>);
+    // After briefly flashing the LoadingIndicator, it'll display the viewComponent
+    setTimeout(() => {
+      expect(widget.find('#view-component').props).to.equal(viewComponentProps);
+    });
+  });
 });

--- a/src/applications/disability-benefits/526EZ/tests/config/veteranInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/veteranInformation.unit.spec.jsx
@@ -22,39 +22,22 @@ describe('526EZ veteran information', () => {
       uiSchema={uiSchema}/>
     );
 
-    expect(form.find('select').length).to.equal(3);
-    expect(form.find('input').length).to.equal(6);
+    expect(form.find('AsyncDisplayWidget').length).to.equal(1);
   });
 
-  it('should not submit without required info', () => {
+  it('should submit without validation errors', () => {
     const onSubmit = sinon.spy();
     const form = mount(<DefinitionTester
       definitions={formConfig.defaultDefinitions}
       schema={schema}
       formData={{}}
       data={{}}
-      uiSchema={uiSchema}/>
-    );
-
-    form.find('form').simulate('submit');
-
-    expect(form.find('.usa-input-error-message').length).to.equal(6);
-    expect(onSubmit.called).to.be.false;
-  });
-
-  it('should submit with valid data', () => {
-    const onSubmit = sinon.spy();
-    const form = mount(<DefinitionTester
-      definitions={formConfig.defaultDefinitions}
-      schema={schema}
-      formData={initialData}
-      data={initialData}
       onSubmit={onSubmit}
       uiSchema={uiSchema}/>
     );
 
-
     form.find('form').simulate('submit');
+
     expect(form.find('.usa-input-error-message').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
   });


### PR DESCRIPTION
## Screenshots

### Loading
![image](https://user-images.githubusercontent.com/12970166/40814203-b1be21c2-64f3-11e8-9ca6-8ad983a0da57.png)
Still need to get a copy edit on this. Shown is the default message, but it's customizable.
@peggygannon Can I get both a default message and what we should show on this page (if they're different)? The default message will be used whenever we use the `AsyncDisplayWidget` to fetch data (presumably about the veteran) in a form when they can't edit it themselves in the form but that information may be changed between sessions.

### Success
![image](https://user-images.githubusercontent.com/12970166/40814164-763dd3ae-64f3-11e8-90fb-60664b701470.png)
It doesn't look like much yet, but that'll change when we use it "for real" in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/10440.

### Failure
![image](https://user-images.githubusercontent.com/12970166/40814318-6db992c6-64f4-11e8-9462-cae88185fd3f.png)
So....yeah...there's a reason I'm not a copy writer.
@peggygannon Same thing as the loading screen. Can I get content for both the default and page-specific alert?