### PR TITLE
Sign-in Modal/DSLogon Downtime - Remove loading indicator (checking the undefined status)

### DIFF
--- a/src/platform/monitoring/DowntimeNotification/components/Banner.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/Banner.jsx
@@ -17,11 +17,12 @@ export default function DowntimeBanner({ appTitle, dependencies, children }) {
       appTitle={appTitle}
       render={(downtime) => {
         if (downtime.status === serviceStatus.down) {
+          if (children) return children;
           return (
             <AlertBox
               status="info"
               isVisible
-              content={children || <DownMessaging appTitle={appTitle} {...downtime}/>}/>
+              content={<DownMessaging appTitle={appTitle} {...downtime}/>}/>
           );
         }
         return <div/>;

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -5,7 +5,8 @@ import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 import Modal from '@department-of-veterans-affairs/formation/Modal';
 import recordEvent from '../../../monitoring/record-event';
 import { login, signup } from '../../../user/authentication/utilities';
-import DowntimeNotification, { services, serviceStatus } from '../../../../platform/monitoring/DowntimeNotification';
+import { services } from '../../../../platform/monitoring/DowntimeNotification';
+import DowntimeBanner from '../../../../platform/monitoring/DowntimeNotification/components/Banner';
 
 const loginHandler = (loginType) => () => {
   recordEvent({ event: `login-attempted-${loginType}` });
@@ -22,30 +23,6 @@ class SignInModal extends React.Component {
       recordEvent({ event: 'login-modal-opened' });
     }
   }
-
-  renderDSLogonDowntimeBanner = (downtime) => {
-    if (downtime.status === serviceStatus.down) {
-      return (
-        <div className="downtime-notification row">
-          <div className="columns small-12">
-            <div className="form-warning-banner">
-              <AlertBox
-                headline="DS Logon isn't working quite right"
-                content="If you're having trouble signing in to Vets.gov using your DS Logon username and password, please try again later. Or, you can try signing in with your My HealtheVet username and password or through ID.me."
-                isVisible
-                status="warning"/>
-              <br/>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <div></div>
-    );
-  }
-
   renderModalContent = () => {
     return (
       <main className="login">
@@ -69,7 +46,20 @@ class SignInModal extends React.Component {
               <h2>One site. A lifetime of benefits and services at your fingertips.</h2>
             </div>
           </div>
-          <DowntimeNotification render={this.renderDSLogonDowntimeBanner} dependencies={[services.dslogon]}></DowntimeNotification>
+          <DowntimeBanner dependencies={[services.dslogon]}>
+            <div className="downtime-notification row">
+              <div className="columns small-12">
+                <div className="form-warning-banner">
+                  <AlertBox
+                    headline="DS Logon isn't working quite right"
+                    content="If you're having trouble signing in to Vets.gov using your DS Logon username and password, please try again later. Or, you can try signing in with your My HealtheVet username and password or through ID.me."
+                    isVisible
+                    status="warning"/>
+                  <br/>
+                </div>
+              </div>
+            </div>
+          </DowntimeBanner>
           <div className="row">
             <div className="columns usa-width-one-half medium-6">
               <div className="signin-actions-container">


### PR DESCRIPTION
`monitoring/DowntimeNotifications/components/Banner.jsx` was designed for basic messaging about services being down and renders children components only if the dependencies are offline. This PR implements it into the Sign-in Modal to get rid of that "checking the undefined status" loading message.

Resolves department-of-veterans-affairs/vets.gov-team/issues/10760
More info - department-of-veterans-affairs/vets.gov-team/issues/9390