### PR TITLE
526 homelessness poc mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -243,6 +243,13 @@ const formConfig = {
                   'ui:title': 'Contact full name',
                   'ui:errorMessages': {
                     pattern: "Full names can only contain letters, numbers, spaces, dashes ('-'), and forward slashes ('/')"
+                  },
+                  'ui:required': (formData) => {
+                    const { veteran } = formData;
+                    if (!veteran['view:homelessness'] || !veteran.homelessness) {
+                      return false;
+                    }
+                    return !!veteran.homelessness.primaryPhone;
                   }
                 },
                 primaryPhone: {
@@ -250,6 +257,13 @@ const formConfig = {
                   'ui:widget': SSNWidget, // probably not the best name for this widget...
                   'ui:errorMessages': {
                     pattern: 'Phone numbers must be 10 digits (dashes allowed)'
+                  },
+                  'ui:required': (formData) => {
+                    const { veteran } = formData;
+                    if (!veteran['view:homelessness'] || !veteran.homelessness) {
+                      return false;
+                    }
+                    return !!veteran.homelessness.pointOfContactName;
                   }
                 }
               }

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -229,41 +229,43 @@ const formConfig = {
           uiSchema: {
             veteran: {
               'ui:title': 'Homelessness',
-              'view:homelessness': {
-                'ui:title': 'Are you homeless or at risk of becoming homeless?',
-                'ui:widget': 'yesNo',
-              },
               homelessness: {
-                'ui:description': 'Please provide the name and number of a person we should call if we need to get in touch with you.',
-                'ui:options': {
-                  expandUnder: 'view:homelessness',
-                  expandUnderCondition: (homelessOrAtRisk) => (homelessOrAtRisk === true)
+                isHomeless: {
+                  'ui:title': 'Are you homeless or at risk of becoming homeless?',
+                  'ui:widget': 'yesNo',
                 },
-                pointOfContactName: {
-                  'ui:title': 'Name of person we should contact',
-                  'ui:errorMessages': {
-                    pattern: "Full names can only contain letters, numbers, spaces, dashes ('-'), and forward slashes ('/')"
+                pointOfContact: {
+                  'ui:description': 'Please provide the name and number of a person we should call if we need to get in touch with you.',
+                  'ui:options': {
+                    expandUnder: 'isHomeless',
+                    expandUnderCondition: (homelessOrAtRisk) => (homelessOrAtRisk === true)
                   },
-                  'ui:required': (formData) => {
-                    const { veteran } = formData;
-                    if (veteran['view:homelessness'] !== true || !veteran.homelessness) {
-                      return false;
+                  pointOfContactName: {
+                    'ui:title': 'Name of person we should contact',
+                    'ui:errorMessages': {
+                      pattern: "Full names can only contain letters, numbers, spaces, dashes ('-'), and forward slashes ('/')"
+                    },
+                    'ui:required': (formData) => {
+                      const { homelessness } = formData.veteran;
+                      if (homelessness.isHomeless !== true) {
+                        return false;
+                      }
+                      return !!homelessness.pointOfContact.primaryPhone;
                     }
-                    return !!veteran.homelessness.primaryPhone;
-                  }
-                },
-                primaryPhone: {
-                  'ui:title': 'Phone number',
-                  'ui:widget': PhoneNumberWidget,
-                  'ui:errorMessages': {
-                    pattern: 'Phone numbers must be 10 digits (dashes allowed)'
                   },
-                  'ui:required': (formData) => {
-                    const { veteran } = formData;
-                    if (veteran['view:homelessness'] !== true || !veteran.homelessness) {
-                      return false;
+                  primaryPhone: {
+                    'ui:title': 'Phone number',
+                    'ui:widget': PhoneNumberWidget,
+                    'ui:errorMessages': {
+                      pattern: 'Phone numbers must be 10 digits (dashes allowed)'
+                    },
+                    'ui:required': (formData) => {
+                      const { homelessness } = formData.veteran;
+                      if (homelessness.isHomeless !== true) {
+                        return false;
+                      }
+                      return !!homelessness.pointOfContact.pointOfContactName;
                     }
-                    return !!veteran.homelessness.pointOfContactName;
                   }
                 }
               }
@@ -274,24 +276,29 @@ const formConfig = {
             properties: {
               veteran: {
                 type: 'object',
-                required: ['view:homelessness'],
                 properties: {
-                  'view:homelessness': {
-                    type: 'boolean'
-                  },
-                  // TODO: Update to use 526 homelessness schema once
+                  // TODO: Update to use 526 homelessness schema once in vets-json-schema
                   homelessness: {
                     type: 'object',
+                    required: ['isHomeless'],
                     properties: {
-                      pointOfContactName: {
-                        type: 'string',
-                        minLength: 1,
-                        maxLength: 100,
-                        pattern: '^([a-zA-Z0-9-/]+( ?))*$'
+                      isHomeless: {
+                        type: 'boolean'
                       },
-                      primaryPhone: { // common: definitions.usaPhone
-                        type: 'string',
-                        pattern: '^\\d{10}$'
+                      pointOfContact: {
+                        type: 'object',
+                        properties: {
+                          pointOfContactName: {
+                            type: 'string',
+                            minLength: 1,
+                            maxLength: 100,
+                            pattern: '^([a-zA-Z0-9-/]+( ?))*$'
+                          },
+                          primaryPhone: { // common: definitions.usaPhone
+                            type: 'string',
+                            pattern: '^\\d{10}$'
+                          }
+                        }
                       }
                     }
                   }

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -68,12 +68,14 @@ import {
 
 import { requireOneSelected } from '../validations';
 import { validateBooleanGroup } from '../../../common/schemaform/validation';
+import SSNWidget from '../../../common/schemaform/widgets/SSNWidget';
 
 const {
   treatments: treatmentsSchema,
   privateRecordReleases,
   serviceInformation,
   standardClaim,
+  // veteran
 } = fullSchema526EZ.properties;
 
 const {
@@ -225,18 +227,61 @@ const formConfig = {
           title: 'Special Circumstances',
           path: 'special-circumstances',
           uiSchema: {
-            'ui:title': 'Homelessness',
-            'view:homelessness': {
-              'ui:title': 'Are you homeless or at risk of becoming homeless?',
-              'ui:widget': 'yesNo',
-            },
+            veteran: {
+              'ui:title': 'Homelessness',
+              'view:homelessness': {
+                'ui:title': 'Are you homeless or at risk of becoming homeless?',
+                'ui:widget': 'yesNo',
+              },
+              homelessness: {
+                'ui:description': 'If you have a person who we should contact to get in touch with you, please provide their name and number here.',
+                'ui:options': {
+                  expandUnder: 'view:homelessness',
+                  expandUnderCondition: (homelessOrAtRisk) => (homelessOrAtRisk === true)
+                },
+                pointOfContactName: {
+                  'ui:title': 'Contact full name',
+                  'ui:errorMessages': {
+                    pattern: "Full names can only contain letters, numbers, spaces, dashes ('-'), and forward slashes ('/')"
+                  }
+                },
+                primaryPhone: {
+                  'ui:title': 'Contact phone number',
+                  'ui:widget': SSNWidget, // probably not the best name for this widget...
+                  'ui:errorMessages': {
+                    pattern: 'Phone numbers must be 10 digits (dashes allowed)'
+                  }
+                }
+              }
+            }
           },
           schema: {
             type: 'object',
             properties: {
-              'view:homelessness': {
-                type: 'boolean'
-              },
+              veteran: {
+                type: 'object',
+                properties: {
+                  'view:homelessness': {
+                    type: 'boolean'
+                  },
+                  // TODO: Update to use 526 homelessness schema once
+                  homelessness: {
+                    type: 'object',
+                    properties: {
+                      pointOfContactName: {
+                        type: 'string',
+                        minLength: 1,
+                        maxLength: 100,
+                        pattern: '^([a-zA-Z0-9-/]+( ?))*$'
+                      },
+                      primaryPhone: { // common: definitions.usaPhone
+                        type: 'string',
+                        pattern: '^\\d{10}$'
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -75,7 +75,6 @@ const {
   privateRecordReleases,
   serviceInformation,
   standardClaim,
-  // veteran
 } = fullSchema526EZ.properties;
 
 const {

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -246,7 +246,7 @@ const formConfig = {
                   },
                   'ui:required': (formData) => {
                     const { veteran } = formData;
-                    if (!veteran['view:homelessness'] || !veteran.homelessness) {
+                    if (veteran['view:homelessness'] !== true || !veteran.homelessness) {
                       return false;
                     }
                     return !!veteran.homelessness.primaryPhone;
@@ -260,7 +260,7 @@ const formConfig = {
                   },
                   'ui:required': (formData) => {
                     const { veteran } = formData;
-                    if (!veteran['view:homelessness'] || !veteran.homelessness) {
+                    if (veteran['view:homelessness'] !== true || !veteran.homelessness) {
                       return false;
                     }
                     return !!veteran.homelessness.pointOfContactName;

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -68,7 +68,7 @@ import {
 
 import { requireOneSelected } from '../validations';
 import { validateBooleanGroup } from '../../../common/schemaform/validation';
-import SSNWidget from '../../../common/schemaform/widgets/SSNWidget';
+import PhoneNumberWidget from '../../../common/schemaform/widgets/PhoneNumberWidget';
 
 const {
   treatments: treatmentsSchema,
@@ -234,13 +234,13 @@ const formConfig = {
                 'ui:widget': 'yesNo',
               },
               homelessness: {
-                'ui:description': 'If you have a person who we should contact to get in touch with you, please provide their name and number here.',
+                'ui:description': 'Please provide the name and number of a person we should call if we need to get in touch with you.',
                 'ui:options': {
                   expandUnder: 'view:homelessness',
                   expandUnderCondition: (homelessOrAtRisk) => (homelessOrAtRisk === true)
                 },
                 pointOfContactName: {
-                  'ui:title': 'Contact full name',
+                  'ui:title': 'Name of person we should contact',
                   'ui:errorMessages': {
                     pattern: "Full names can only contain letters, numbers, spaces, dashes ('-'), and forward slashes ('/')"
                   },
@@ -253,8 +253,8 @@ const formConfig = {
                   }
                 },
                 primaryPhone: {
-                  'ui:title': 'Contact phone number',
-                  'ui:widget': SSNWidget, // probably not the best name for this widget...
+                  'ui:title': 'Phone number',
+                  'ui:widget': PhoneNumberWidget,
                   'ui:errorMessages': {
                     pattern: 'Phone numbers must be 10 digits (dashes allowed)'
                   },
@@ -274,6 +274,7 @@ const formConfig = {
             properties: {
               veteran: {
                 type: 'object',
+                required: ['view:homelessness'],
                 properties: {
                   'view:homelessness': {
                     type: 'boolean'

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -237,7 +237,6 @@ const formConfig = {
                   'ui:description': 'Please provide the name and number of a person we should call if we need to get in touch with you.',
                   'ui:options': {
                     expandUnder: 'isHomeless',
-                    expandUnderCondition: (homelessOrAtRisk) => (homelessOrAtRisk === true)
                   },
                   pointOfContactName: {
                     'ui:title': 'Name of person we should contact',

--- a/src/applications/disability-benefits/526EZ/tests/config/specialCircumstances.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/specialCircumstances.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
-describe.only('Disability benefits 526EZ special circumstances', () => {
+describe('Disability benefits 526EZ special circumstances', () => {
   const { schema, uiSchema } = formConfig.chapters.veteranDetails.pages.specialCircumstances;
 
   const defaultFormData = {

--- a/src/applications/disability-benefits/526EZ/tests/config/specialCircumstances.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/specialCircumstances.unit.spec.jsx
@@ -6,15 +6,24 @@ import { mount } from 'enzyme';
 import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
-describe('Disability benefits 526EZ special circumstances', () => {
+describe.only('Disability benefits 526EZ special circumstances', () => {
   const { schema, uiSchema } = formConfig.chapters.veteranDetails.pages.specialCircumstances;
+
+  const defaultFormData = {
+    veteran: {
+      homelessness: {
+        pointOfContact: {}
+      }
+    }
+  };
+
   it('renders special circumstances form', () => {
     const onSubmit = sinon.spy();
     const form = mount(<DefinitionTester
       onSubmit={onSubmit}
       definitions={formConfig.defaultDefinitions}
       schema={schema}
-      data={{}}
+      data={defaultFormData}
       formData={{}}
       uiSchema={uiSchema}/>
     );
@@ -22,14 +31,150 @@ describe('Disability benefits 526EZ special circumstances', () => {
     expect(form.find('input[type="radio"]').length).to.equal(2);
   });
 
-  it('submit empty form', () => {
+  it('should not submit form without required fields', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
         definitions={formConfig.defaultDefinitions}
         schema={schema}
-        data={{}}
+        data={defaultFormData}
+        formData={{}}
+        uiSchema={uiSchema}/>
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should submit form when veteran indicates not homeless', () => {
+    const onSubmit = sinon.spy();
+    const formData = {
+      veteran: {
+        homelessness: {
+          isHomeless: false
+        }
+      }
+    };
+
+    const form = mount(
+      <DefinitionTester
+        onSubmit={onSubmit}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={formData}
+        formData={{}}
+        uiSchema={uiSchema}/>
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+
+  it('should submit form when veteran indicates they are homeless but have no POC', () => {
+    const onSubmit = sinon.spy();
+    const formData = {
+      veteran: {
+        homelessness: {
+          isHomeless: true,
+          pointOfContact: {}
+        }
+      }
+    };
+
+    const form = mount(
+      <DefinitionTester
+        onSubmit={onSubmit}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={formData}
+        formData={{}}
+        uiSchema={uiSchema}/>
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+
+  it('should not submit form when veteran indicates only POC name', () => {
+    const onSubmit = sinon.spy();
+    const formData = {
+      veteran: {
+        homelessness: {
+          isHomeless: true,
+          pointOfContact: {
+            pointOfContactName: 'Abraham Lincoln'
+          }
+        }
+      }
+    };
+
+    const form = mount(
+      <DefinitionTester
+        onSubmit={onSubmit}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={formData}
+        formData={{}}
+        uiSchema={uiSchema}/>
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should not submit form when veteran indicates only POC phone', () => {
+    const onSubmit = sinon.spy();
+    const formData = {
+      veteran: {
+        homelessness: {
+          isHomeless: true,
+          pointOfContact: {
+            primaryPhone: '1234567890'
+          }
+        }
+      }
+    };
+
+    const form = mount(
+      <DefinitionTester
+        onSubmit={onSubmit}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={formData}
+        formData={{}}
+        uiSchema={uiSchema}/>
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should submit form when veteran indicates all required POC info', () => {
+    const onSubmit = sinon.spy();
+    const formData = {
+      veteran: {
+        homelessness: {
+          isHomeless: true,
+          pointOfContact: {
+            pointOfContactName: 'Abraham Lincoln',
+            primaryPhone: '1234567890'
+          }
+        }
+      }
+    };
+
+    const form = mount(
+      <DefinitionTester
+        onSubmit={onSubmit}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={formData}
         formData={{}}
         uiSchema={uiSchema}/>
     );


### PR DESCRIPTION
- Adds homelessness POC data capture into form (name, phone number) as a conditional expander when a veteran indicates they are / are at risk of becoming homeless
- Requires that either both name & number be entered, or neither

(Still working out a couple of failing unit tests)

Note: Requires separate PR to migrate the added POC schema into `vets-json-schema`, where it should live long-term.

### Default UI:
![screen shot 2018-06-04 at 4 42 15 pm](https://user-images.githubusercontent.com/24251447/40943383-75d94dbe-6816-11e8-883b-4511ceedaa04.png)
-----

### Expanded UI ['Yes' selected]:
![screen shot 2018-06-04 at 4 42 47 pm](https://user-images.githubusercontent.com/24251447/40943382-75b766c2-6816-11e8-8a8c-4be015de5ab1.png)
-----

### Name / phone fields conditionally required:
![conditionally_required](https://user-images.githubusercontent.com/24251447/40943564-33773ade-6817-11e8-8728-4bc1b8bcb8a4.gif)
