### PR TITLE
Migrate pension and burials form to new zip code format

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "reselect": "^2.5.4",
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#86263a396bfe2b13153797bac78c424a913b450d",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2ae649607e5e747729f6cb872d4c0c386b733fd0",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/src/applications/burials/config/form.js
+++ b/src/applications/burials/config/form.js
@@ -34,7 +34,11 @@ import currentOrPastDateUI from '../../common/schemaform/definitions/currentOrPa
 import toursOfDutyUI from '../definitions/toursOfDuty';
 import fileUploadUI from '../../common/schemaform/definitions/file';
 import currencyUI from '../../common/schemaform/definitions/currency';
-import { validateBurialAndDeathDates } from '../validation';
+import {
+  validateBurialAndDeathDates,
+  validateCentralMailPostalCode
+} from '../validation';
+import migrations from '../migrations';
 
 const {
   relationship,
@@ -89,7 +93,8 @@ const formConfig = {
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   formId: '21P-530',
-  version: 0,
+  version: 1,
+  migrations,
   prefillEnabled: true,
   downtime: {
     dependencies: [services.icmhs]
@@ -506,7 +511,11 @@ const formConfig = {
                 hideIf: form => _.get('relationship.isEntity', form) !== true
               }
             },
-            claimantAddress: address.uiSchema('Address'),
+            claimantAddress: _.set(
+              'ui:validations[1]',
+              validateCentralMailPostalCode,
+              address.uiSchema('Address')
+            ),
             claimantEmail: {
               'ui:title': 'Email address'
             },

--- a/src/applications/burials/config/form.js
+++ b/src/applications/burials/config/form.js
@@ -527,7 +527,7 @@ const formConfig = {
             properties: {
               firmName,
               officialPosition,
-              claimantAddress: address.schema(fullSchemaBurials, true),
+              claimantAddress: address.schema(fullSchemaBurials, true, 'centralMailAddress'),
               claimantEmail,
               claimantPhone
             }

--- a/src/applications/burials/migrations.js
+++ b/src/applications/burials/migrations.js
@@ -1,0 +1,16 @@
+import { isValidCentralMailPostalCode } from '../../platform/forms/address/validations';
+
+export default [
+  // 0 > 1, move user back to address page if zip code is bad
+  ({ formData, metadata }) => {
+    let newMetadata = metadata;
+
+    if (formData.claimantAddress && !isValidCentralMailPostalCode(formData.claimantAddress)) {
+      newMetadata = Object.assign({}, metadata, {
+        returnUrl: '/claimant-contact-information'
+      });
+    }
+
+    return { formData, metadata: newMetadata };
+  }
+];

--- a/src/applications/burials/tests/migrations.unit.spec.js
+++ b/src/applications/burials/tests/migrations.unit.spec.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+
+import migrations from '../migrations';
+
+describe('Burials migrations', () => {
+  it('should set url to address page if zip is bad', () => {
+    const { formData, metadata } = migrations[0]({
+      formData: {
+        claimantAddress: {
+          country: 'USA',
+          postalCode: '234444'
+        }
+      },
+      metadata: {
+        returnUrl: 'asdf'
+      }
+    });
+
+    expect(metadata.returnUrl).to.equal('/claimant-contact-information');
+    expect(formData).to.be.an('object');
+  });
+});
+

--- a/src/applications/burials/validation.js
+++ b/src/applications/burials/validation.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { isValidCentralMailPostalCode } from '../../platform/forms/address/validations';
 
 export function validateBurialAndDeathDates(errors, page) {
   const { burialDate, deathDate, veteranDateOfBirth } = page;
@@ -7,5 +8,11 @@ export function validateBurialAndDeathDates(errors, page) {
   }
   if (deathDate && veteranDateOfBirth && moment(deathDate).isBefore(moment(veteranDateOfBirth))) {
     errors.deathDate.addError('Date of death must be after date of birth');
+  }
+}
+
+export function validateCentralMailPostalCode(errors, address) {
+  if (!isValidCentralMailPostalCode(address)) {
+    errors.postalCode.addError('Please enter a valid postal code (e.g. 12345 or 12345-6789)');
   }
 }

--- a/src/applications/common/schemaform/definitions/address.js
+++ b/src/applications/common/schemaform/definitions/address.js
@@ -72,6 +72,8 @@ const requiredFields = ['street', 'city', 'country', 'state', 'postalCode'];
  *
  * @param {object} schema - Schema for a full form, including address definition in definitions
  * @param {boolean} isRequired - If the address is required or not, defaults to false
+ * @param {string} addressProperty - The name of the address definition to use from the common
+ *   definitions in currentSchema
  */
 export function schema(currentSchema, isRequired = false, addressProperty = 'address') {
   const addressSchema = currentSchema.definitions[addressProperty];

--- a/src/applications/common/schemaform/definitions/address.js
+++ b/src/applications/common/schemaform/definitions/address.js
@@ -73,8 +73,9 @@ const requiredFields = ['street', 'city', 'country', 'state', 'postalCode'];
  * @param {object} schema - Schema for a full form, including address definition in definitions
  * @param {boolean} isRequired - If the address is required or not, defaults to false
  */
-export function schema(currentSchema, isRequired = false) {
-  const addressSchema = currentSchema.definitions.address || currentSchema.definitions.addressWithRequiredZip;
+export function schema(currentSchema, isRequired = false, addressProperty = 'address') {
+  const addressSchema = currentSchema.definitions[addressProperty];
+
   return {
     type: 'object',
     required: isRequired ? requiredFields : [],

--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -188,7 +188,7 @@ const formConfig = {
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   formId: '21P-527EZ',
-  version: 1,
+  version: 2,
   migrations,
   prefillEnabled: true,
   downtime: {

--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -64,7 +64,11 @@ import createNonRequiredFullName from '../../common/schemaform/definitions/nonRe
 import otherExpensesUI from '../definitions/otherExpenses';
 import currencyUI from '../../common/schemaform/definitions/currency';
 
-import { validateServiceBirthDates, validateAfterMarriageDate } from '../validation';
+import {
+  validateServiceBirthDates,
+  validateAfterMarriageDate,
+  validateCentralMailPostalCode
+} from '../validation';
 import migrations from '../migrations';
 
 const {
@@ -1544,7 +1548,11 @@ const formConfig = {
           path: 'additional-information/contact',
           uiSchema: {
             'ui:title': 'Contact information',
-            veteranAddress: address.uiSchema('Mailing address'),
+            veteranAddress: _.set(
+              'ui:validations[1]',
+              validateCentralMailPostalCode,
+              address.uiSchema('Mailing address')
+            ),
             email: {
               'ui:title': 'Primary email'
             },

--- a/src/applications/pensions/migrations.js
+++ b/src/applications/pensions/migrations.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp';
 import { isValidDateRange } from '../../platform/forms/validations';
 import { convertToDateField } from '../common/schemaform/validation';
+import { isValidCentralMailPostalCode } from '../../platform/forms/address/validations';
 
 export default [
   // 0 -> 1, we've added some date validation and need to move users back to particular pages
@@ -55,5 +56,17 @@ export default [
       }
     }
     return { formData, metadata };
+  },
+  // 1 > 2, move user back to address page if zip code is bad
+  ({ formData, metadata }) => {
+    let newMetadata = metadata;
+
+    if (formData.veteranAddress && !isValidCentralMailPostalCode(formData.veteranAddress)) {
+      newMetadata = Object.assign({}, metadata, {
+        returnUrl: '/additional-information/contact'
+      });
+    }
+
+    return { formData, metadata: newMetadata };
   }
 ];

--- a/src/applications/pensions/tests/migrations.unit.spec.js
+++ b/src/applications/pensions/tests/migrations.unit.spec.js
@@ -96,5 +96,21 @@ describe('Pension migrations', () => {
     expect(metadata.returnUrl).to.equal('test');
     expect(formData).to.be.an('object');
   });
+  it.only('should set url to address page if zip is bad', () => {
+    const { formData, metadata } = migrations[1]({
+      formData: {
+        veteranAddress: {
+          country: 'USA',
+          postalCode: '234444'
+        }
+      },
+      metadata: {
+        returnUrl: 'asdf'
+      }
+    });
+
+    expect(metadata.returnUrl).to.equal('/additional-information/contact');
+    expect(formData).to.be.an('object');
+  });
 });
 

--- a/src/applications/pensions/tests/migrations.unit.spec.js
+++ b/src/applications/pensions/tests/migrations.unit.spec.js
@@ -96,7 +96,7 @@ describe('Pension migrations', () => {
     expect(metadata.returnUrl).to.equal('test');
     expect(formData).to.be.an('object');
   });
-  it.only('should set url to address page if zip is bad', () => {
+  it('should set url to address page if zip is bad', () => {
     const { formData, metadata } = migrations[1]({
       formData: {
         veteranAddress: {

--- a/src/applications/pensions/validation.js
+++ b/src/applications/pensions/validation.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp';
 import { isValidDateRange } from '../../platform/forms/validations';
 import { convertToDateField } from '../common/schemaform/validation';
+import { isValidCentralMailPostalCode } from '../../platform/forms/address/validations';
 
 export function validateAfterMarriageDate(errors, dateOfSeparation, formData) {
   const fromDate = convertToDateField(formData.dateOfMarriage);
@@ -17,5 +18,11 @@ export function validateServiceBirthDates(errors, service, formData) {
 
   if (!isValidDateRange(fromDate, toDate)) {
     errors.activeServiceDateRange.from.addError('Date entering active service should be after birth date');
+  }
+}
+
+export function validateCentralMailPostalCode(errors, address) {
+  if (!isValidCentralMailPostalCode(address)) {
+    errors.postalCode.addError('Please enter a valid postal code (e.g. 12345 or 12345-6789)');
   }
 }

--- a/src/platform/forms/address/validations.js
+++ b/src/platform/forms/address/validations.js
@@ -1,0 +1,14 @@
+// The icmhs api requires zip codes in a 5 or 9 digit with a dash format
+// for the main address
+export function isValidCentralMailPostalCode({ country, postalCode } = {}) {
+  const fiveDigitZip = /^\d{5}$/;
+  const nineDigitZip = /^\d{5}-\d{4}$/;
+  if (country === 'USA'
+    && postalCode
+    && !fiveDigitZip.exec(postalCode)
+    && !nineDigitZip.exec(postalCode)) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/platform/forms/tests/address/validations.unit.spec.js
+++ b/src/platform/forms/tests/address/validations.unit.spec.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+
+import {
+  isValidCentralMailPostalCode
+} from '../../address/validations';
+
+describe('Forms address validations:', () => {
+  describe('isValidCentralMailPostalCode', () => {
+    it('should return valid on non-USA addresses', () => {
+      expect(isValidCentralMailPostalCode({
+        country: 'CAN',
+        postalCode: '234444'
+      })).to.be.true;
+    });
+    it('should return valid on five digit USA zips', () => {
+      expect(isValidCentralMailPostalCode({
+        country: 'USA',
+        postalCode: '23444'
+      })).to.be.true;
+    });
+    it('should return valid on nine digit USA zips', () => {
+      expect(isValidCentralMailPostalCode({
+        country: 'USA',
+        postalCode: '23444-1233'
+      })).to.be.true;
+    });
+    it('should return invalid on unformatted nine digit USA zips', () => {
+      expect(isValidCentralMailPostalCode({
+        country: 'USA',
+        postalCode: '234441233'
+      })).to.be.true;
+    });
+  });
+});

--- a/src/platform/forms/tests/address/validations.unit.spec.js
+++ b/src/platform/forms/tests/address/validations.unit.spec.js
@@ -28,7 +28,7 @@ describe('Forms address validations:', () => {
       expect(isValidCentralMailPostalCode({
         country: 'USA',
         postalCode: '234441233'
-      })).to.be.true;
+      })).to.be.false;
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9990,9 +9990,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#86263a396bfe2b13153797bac78c424a913b450d":
-  version "3.46.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#86263a396bfe2b13153797bac78c424a913b450d"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#2ae649607e5e747729f6cb872d4c0c386b733fd0":
+  version "3.47.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2ae649607e5e747729f6cb872d4c0c386b733fd0"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
Adds new validation and migrations for ICMHS zip code handling, since there are some restrictions on the format for US addresses.

![screen shot 2018-06-04 at 9 43 46 am](https://user-images.githubusercontent.com/634932/40920882-e3ce55e8-67db-11e8-8513-1793050f1471.png)
