### PR TITLE
Pre-need form address updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "reselect": "^2.5.4",
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#86263a396bfe2b13153797bac78c424a913b450d",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#80bbe9ff577324df326eba42ff74144db90e39af",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/src/applications/pre-need/config/form.jsx
+++ b/src/applications/pre-need/config/form.jsx
@@ -5,7 +5,7 @@ import fullSchemaPreNeed from 'vets-json-schema/dist/40-10007-schema.json';
 import FormFooter from '../../../platform/forms/components/FormFooter';
 import environment from '../../../platform/utilities/environment';
 
-import * as address from '../../common/schemaform/definitions/address';
+import * as address from '../definitions/address';
 import currentOrPastDateUI from '../../common/schemaform/definitions/currentOrPastDate';
 import dateRangeUI from '../../common/schemaform/definitions/dateRange';
 import fileUploadUI from '../../common/schemaform/definitions/file';

--- a/src/applications/pre-need/definitions/address.js
+++ b/src/applications/pre-need/definitions/address.js
@@ -25,7 +25,8 @@ export const countriesWithStateCodes = new Set(['USA', 'CAN']);
 function validateAddress(errors, address, formData, currentSchema) {
   // Adds error message for state if it is blank and one of the following countries:
   // USA, Canada, or Mexico
-  if (address.state === undefined
+  if (countriesWithStateCodes.has(address.country)
+    && address.state === undefined
     && currentSchema.required.length) {
     errors.state.addError('Please select a state or province');
   }
@@ -71,7 +72,7 @@ const requiredFields = ['street', 'city', 'country', 'state', 'postalCode'];
  * @param {boolean} isRequired - If the address is required or not, defaults to false
  */
 export function schema(currentSchema, isRequired = false) {
-  const addressSchema = currentSchema.definitions.address || currentSchema.definitions.addressWithRequiredZip;
+  const addressSchema = currentSchema.definitions.address;
   return {
     type: 'object',
     required: isRequired ? requiredFields : [],
@@ -89,7 +90,7 @@ export function schema(currentSchema, isRequired = false) {
       },
       postalCode: {
         type: 'string',
-        maxLength: 10
+        maxLength: 6
       }
     })
   };

--- a/src/applications/pre-need/definitions/address.js
+++ b/src/applications/pre-need/definitions/address.js
@@ -167,6 +167,7 @@ export function uiSchema(label = 'Address', useStreet3 = false, isRequired = nul
         schemaUpdate.properties = _.set('state.enumNames', militaryLabels, withEnum);
       }
 
+      // Hide the state field for non US and CAN addresses
       if (!stateList && !schemaUpdate.properties.state['ui:hidden']) {
         schemaUpdate.properties = _.set('state.ui:hidden', true, schemaUpdate.properties);
       } else if (stateList && schemaUpdate.properties.state['ui:hidden']) {

--- a/src/applications/pre-need/definitions/address.js
+++ b/src/applications/pre-need/definitions/address.js
@@ -24,7 +24,7 @@ export const countriesWithStateCodes = new Set(['USA', 'CAN']);
 
 function validateAddress(errors, address, formData, currentSchema) {
   // Adds error message for state if it is blank and one of the following countries:
-  // USA, Canada, or Mexico
+  // USA, Canada
   if (countriesWithStateCodes.has(address.country)
     && address.state === undefined
     && currentSchema.required.length) {

--- a/src/applications/pre-need/definitions/address.js
+++ b/src/applications/pre-need/definitions/address.js
@@ -89,7 +89,7 @@ export function schema(currentSchema, isRequired = false) {
       },
       postalCode: {
         type: 'string',
-        maxLength: 5
+        maxLength: 10
       }
     })
   };
@@ -167,6 +167,12 @@ export function uiSchema(label = 'Address', useStreet3 = false, isRequired = nul
         schemaUpdate.properties = _.set('state.enumNames', militaryLabels, withEnum);
       }
 
+      if (!stateList && !schemaUpdate.properties.state['ui:hidden']) {
+        schemaUpdate.properties = _.set('state.ui:hidden', true, schemaUpdate.properties);
+      } else if (stateList && schemaUpdate.properties.state['ui:hidden']) {
+        schemaUpdate.properties = _.unset('state.ui:hidden', schemaUpdate.properties);
+      }
+
       return schemaUpdate;
     }
   );
@@ -210,7 +216,6 @@ export function uiSchema(label = 'Address', useStreet3 = false, isRequired = nul
     city: {
       'ui:title': 'City'
     },
-    state: {},
     postalCode: {
       'ui:title': 'Postal code',
       'ui:options': {

--- a/src/applications/pre-need/definitions/address.js
+++ b/src/applications/pre-need/definitions/address.js
@@ -8,7 +8,7 @@ function validatePostalCodes(errors, address) {
 
   // Checks if postal code is valid
   if (address.country === 'USA') {
-    isValidPostalCode = isValidPostalCode && isValidUSZipCode(address.postalCode);
+    isValidPostalCode = isValidUSZipCode(address.postalCode);
   }
   if (address.country === 'CAN') {
     isValidPostalCode = isValidPostalCode && isValidCanPostalCode(address.postalCode);
@@ -115,7 +115,7 @@ export function uiSchema(label = 'Address', useStreet3 = false, isRequired = nul
   const addressChangeSelector = createSelector(
     ({ formData, path }) => _.get(path.concat('country'), formData),
     ({ formData, path }) => _.get(path.concat('city'), formData),
-    _.get('addressSchema'),
+    ({ addressSchema }) => addressSchema,
     (currentCountry, city, addressSchema) => {
       const schemaUpdate = {
         properties: addressSchema.properties,

--- a/src/applications/pre-need/definitions/address.js
+++ b/src/applications/pre-need/definitions/address.js
@@ -1,0 +1,221 @@
+import _ from 'lodash/fp';
+import { createSelector } from 'reselect';
+
+import { countries, states, isValidUSZipCode, isValidCanPostalCode } from '../../../platform/forms/address';
+
+function validatePostalCodes(errors, address) {
+  let isValidPostalCode = true;
+
+  // Checks if postal code is valid
+  if (address.country === 'USA') {
+    isValidPostalCode = isValidPostalCode && isValidUSZipCode(address.postalCode);
+  }
+  if (address.country === 'CAN') {
+    isValidPostalCode = isValidPostalCode && isValidCanPostalCode(address.postalCode);
+  }
+
+  // Add error message for postal code if it is invalid
+  if (address.postalCode && !isValidPostalCode) {
+    errors.postalCode.addError('Please provide a valid postal code');
+  }
+}
+
+export const countriesWithStateCodes = new Set(['USA', 'CAN']);
+
+function validateAddress(errors, address, formData, currentSchema) {
+  // Adds error message for state if it is blank and one of the following countries:
+  // USA, Canada, or Mexico
+  if (address.state === undefined
+    && currentSchema.required.length) {
+    errors.state.addError('Please select a state or province');
+  }
+
+  const hasAddressInfo = countriesWithStateCodes.has(address.country)
+    && !currentSchema.required.length
+    && typeof address.street !== 'undefined'
+    && typeof address.city !== 'undefined'
+    && typeof address.postalCode !== 'undefined';
+
+  if (hasAddressInfo && typeof address.state === 'undefined') {
+    errors.state.addError('Please enter a state or province, or remove other address information.');
+  }
+
+  validatePostalCodes(errors, address);
+}
+
+const countryValues = countries.map(object => object.value);
+const countryNames = countries.map(object => object.label);
+const militaryStates = states.USA
+  .filter(state => state.value === 'AE' || state.value === 'AP' || state.value === 'AA')
+  .map(state => state.value);
+const militaryLabels = states.USA
+  .filter(state => state.value === 'AE' || state.value === 'AP' || state.value === 'AA')
+  .map(state => state.label);
+const usaStates = states.USA.map(state => state.value);
+const usaLabels = states.USA.map(state => state.label);
+const canProvinces = states.CAN.map(state => state.value);
+const canLabels = states.CAN.map(state => state.label);
+
+function isMilitaryCity(city = '') {
+  const lowerCity = city.toLowerCase().trim();
+
+  return lowerCity === 'apo' || lowerCity === 'fpo' || lowerCity === 'dpo';
+}
+
+const requiredFields = ['street', 'city', 'country', 'state', 'postalCode'];
+
+/*
+ * Create schema for addresses
+ *
+ * @param {object} schema - Schema for a full form, including address definition in definitions
+ * @param {boolean} isRequired - If the address is required or not, defaults to false
+ */
+export function schema(currentSchema, isRequired = false) {
+  const addressSchema = currentSchema.definitions.address || currentSchema.definitions.addressWithRequiredZip;
+  return {
+    type: 'object',
+    required: isRequired ? requiredFields : [],
+    properties: _.assign(addressSchema.properties, {
+      country: {
+        'default': 'USA',
+        type: 'string',
+        'enum': countryValues,
+        enumNames: countryNames
+      },
+      state: {
+        title: 'State',
+        type: 'string',
+        maxLength: 3
+      },
+      postalCode: {
+        type: 'string',
+        maxLength: 5
+      }
+    })
+  };
+}
+
+/*
+ * Create uiSchema for addresses
+ *
+ * @param {string} label - Block label for the address
+ * @param {boolean} useStreet3 - Show a third line in the address
+ * @param {function} isRequired - A function for conditionally setting if an address is required.
+ *   Receives formData and an index (if in an array item)
+ * @param {boolean} ignoreRequired - Ignore the required fields array, to avoid overwriting form specific
+ *   customizations
+ */
+export function uiSchema(label = 'Address', useStreet3 = false, isRequired = null, ignoreRequired = false) {
+  let fieldOrder = ['country', 'street', 'street2', 'street3', 'city', 'state', 'postalCode'];
+  if (!useStreet3) {
+    fieldOrder = fieldOrder.filter(field => field !== 'street3');
+  }
+
+  const addressChangeSelector = createSelector(
+    ({ formData, path }) => _.get(path.concat('country'), formData),
+    ({ formData, path }) => _.get(path.concat('city'), formData),
+    _.get('addressSchema'),
+    (currentCountry, city, addressSchema) => {
+      const schemaUpdate = {
+        properties: addressSchema.properties,
+        required: addressSchema.required
+      };
+      const country = currentCountry || addressSchema.properties.country.default;
+      const required = addressSchema.required.length > 0;
+
+      let stateList;
+      let labelList;
+      if (country === 'USA') {
+        stateList = usaStates;
+        labelList = usaLabels;
+      } else if (country === 'CAN') {
+        stateList = canProvinces;
+        labelList = canLabels;
+      }
+
+      if (stateList) {
+        // We have a list and it’s different, so we need to make schema updates
+        if (addressSchema.properties.state.enum !== stateList) {
+          const withEnum = _.set('state.enum', stateList, schemaUpdate.properties);
+          schemaUpdate.properties = _.set('state.enumNames', labelList, withEnum);
+
+          // all the countries with state lists require the state field, so add that if necessary
+          if (!ignoreRequired && required && !addressSchema.required.some(field => field === 'state')) {
+            schemaUpdate.required = addressSchema.required.concat('state');
+          }
+        }
+      // We don’t have a state list for the current country, but there’s an enum in the schema
+      // so we need to update it
+      } else if (addressSchema.properties.state.enum) {
+        const withoutEnum = _.unset('state.enum', schemaUpdate.properties);
+        schemaUpdate.properties = _.unset('state.enumNames', withoutEnum);
+        if (!ignoreRequired && required) {
+          schemaUpdate.required = addressSchema.required.filter(field => field !== 'state');
+        }
+      }
+
+      // Canada has a different title than others, so set that when necessary
+      if (country === 'CAN' && addressSchema.properties.state.title !== 'Province') {
+        schemaUpdate.properties = _.set('state.title', 'Province', schemaUpdate.properties);
+      } else if (country !== 'CAN' && addressSchema.properties.state.title !== 'State') {
+        schemaUpdate.properties = _.set('state.title', 'State', schemaUpdate.properties);
+      }
+
+      // We constrain the state list when someone picks a city that’s a military base
+      if (country === 'USA' && isMilitaryCity(city) && schemaUpdate.properties.state.enum !== militaryStates) {
+        const withEnum = _.set('state.enum', militaryStates, schemaUpdate.properties);
+        schemaUpdate.properties = _.set('state.enumNames', militaryLabels, withEnum);
+      }
+
+      return schemaUpdate;
+    }
+  );
+
+  return {
+    'ui:title': label,
+    'ui:validations': [
+      validateAddress
+    ],
+    'ui:options': {
+      updateSchema: (formData, addressSchema, addressUiSchema, index, path) => {
+        let currentSchema = addressSchema;
+        if (isRequired) {
+          const required = isRequired(formData, index);
+          if (required && currentSchema.required.length === 0) {
+            currentSchema = _.set('required', requiredFields, currentSchema);
+          } else if (!required && currentSchema.required.length > 0) {
+            currentSchema = _.set('required', [], currentSchema);
+          }
+        }
+        return addressChangeSelector({
+          formData,
+          addressSchema: currentSchema,
+          path
+        });
+      }
+    },
+    'ui:order': fieldOrder,
+    country: {
+      'ui:title': 'Country'
+    },
+    street: {
+      'ui:title': 'Street'
+    },
+    street2: {
+      'ui:title': 'Line 2'
+    },
+    street3: {
+      'ui:title': 'Line 3'
+    },
+    city: {
+      'ui:title': 'City'
+    },
+    state: {},
+    postalCode: {
+      'ui:title': 'Postal code',
+      'ui:options': {
+        widgetClassNames: 'usa-input-medium'
+      }
+    }
+  };
+}

--- a/src/applications/pre-need/tests/definitions/address.unit.spec.jsx
+++ b/src/applications/pre-need/tests/definitions/address.unit.spec.jsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+import { DefinitionTester, fillData } from '../../../../platform/testing/unit/schemaform-utils.jsx';
+import { schema, uiSchema } from '../../definitions/address';
+import { address } from 'vets-json-schema/dist/definitions.json';
+
+const addressSchema = {
+  definitions: {
+    address
+  }
+};
+
+describe('Pre-need definition address', () => {
+  it('should render address', () => {
+    const s = schema(addressSchema, false);
+    const uis = uiSchema();
+    const form = mount(
+      <DefinitionTester
+        schema={s}
+        uiSchema={uis}/>
+    );
+
+    // Count the form elements
+    const inputs = form.find('input');
+    const selects = form.find('select');
+    expect(inputs.length).to.equal(4);
+    expect(selects.length).to.equal(2);
+
+    // Postal code should be small
+    expect(inputs.last().is('.usa-input-medium')).to.be.true;
+
+    // country is USA and there is no blank option
+    expect(selects.first().props().value).to.equal('USA');
+    expect(selects.first().find('option').everyWhere(n => !!n.props().value)).to.be.true;
+  }).timeout(4000);
+
+  it('should have required inputs if required', () => {
+    const s = schema(addressSchema, true);
+    const uis = uiSchema();
+    const form = mount(
+      <DefinitionTester
+        schema={s}
+        uiSchema={uis}/>
+    );
+
+    // Ideally, we'd get the required inputs, not the <span>s denoting required
+    //  fields but this doesn't work.
+    // const requiredInputs = formDOM.querySelectorAll('input[required=true]');
+    const requiredInputs = form.find('label').find('span.schemaform-required-span');
+    expect(requiredInputs.length).to.not.equal(0);
+  }).timeout(4000);
+
+  it('should update labels and state selection conditionally', () => {
+    const s = schema(addressSchema, false);
+    const uis = uiSchema();
+    const form = mount(
+      <DefinitionTester
+        schema={s}
+        uiSchema={uis}/>
+    );
+
+    const labels = form.find('label');
+    const postalCodeLabel = labels.findWhere(label => label.props().htmlFor === 'root_postalCode');
+    const stateLabel = labels.findWhere(label => label.props().htmlFor === 'root_state');
+    const stateField = form.find('select#root_state');
+
+    // Check the labels' text
+    expect(postalCodeLabel.text()).to.equal('Postal code');
+    expect(stateLabel.text()).to.equal('State');
+
+    // And state input type / options
+    expect(stateField.find('option').someWhere(n => n.props().value === 'OR')).to.be.true;
+
+    // Entering a military city should result in different "state" options
+    fillData(form, 'input#root_city', 'apo');
+    expect(stateField.find('option').someWhere(n => n.props().value === 'AA')).to.be.true;
+
+    // Change the country
+    fillData(form, 'select#root_country', 'CAN');
+
+    // Check to see if the postal code and state updated
+    expect(stateLabel.text()).to.equal('Province');
+    expect(postalCodeLabel.text()).to.equal('Postal code');
+    expect(form.find('select#root_state').find('option').someWhere(n => n.props().value === 'QC')).to.be.true;
+
+    fillData(form, 'select#root_country', 'BEL');
+    expect(form.find('input#root_state').exists()).to.be.false;
+  }).timeout(4000);
+
+  it('should update address field', () => {
+    const s = schema(addressSchema, false);
+    const uis = uiSchema();
+    const form = mount(
+      <DefinitionTester
+        schema={s}
+        uiSchema={uis}/>
+    );
+
+    fillData(form, 'input#root_street', '123 street');
+
+    expect(form.find('input#root_street').props().value).to.equal('123 street');
+  }).timeout(4000);
+
+  it('should update country field in empty address', () => {
+    const s = schema(addressSchema, false);
+    const uis = uiSchema();
+    const form = mount(
+      <DefinitionTester
+        schema={s}
+        uiSchema={uis}/>
+    );
+
+    fillData(form, 'select#root_country', 'CAN');
+
+    expect(form.find('select#root_country').props().value).to.equal('CAN');
+  }).timeout(4000);
+
+  it('should require state for non-required addresses with other info', () => {
+    const s = schema(addressSchema, false);
+    const uis = uiSchema();
+    const form = mount(
+      <DefinitionTester
+        schema={s}
+        uiSchema={uis}/>
+    );
+
+    fillData(form, 'input#root_street', '123 st');
+    fillData(form, 'input#root_city', 'Northampton');
+    fillData(form, 'input#root_postalCode', '12345');
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+  }).timeout(4000);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9990,9 +9990,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#86263a396bfe2b13153797bac78c424a913b450d":
-  version "3.46.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#86263a396bfe2b13153797bac78c424a913b450d"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#80bbe9ff577324df326eba42ff74144db90e39af":
+  version "3.48.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#80bbe9ff577324df326eba42ff74144db90e39af"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
This makes a couple updates to the pre-need address fields. I did this by copying the common address  definition, since that seems more comprehensible than trying to extend it. The changes are:

- Remove Mexican state list dropdown
- Update State validation to 3 characters
- Hide State field for non US/CAN addresses
- Update to schema with updated field lengths