### PR TITLE
Fixed broken reference to currentlyLoggedIn.

### DIFF
--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -66,7 +66,7 @@ export class Main extends React.Component {
   bindNavbarLinks = () => {
     [...document.querySelectorAll('.login-required')].forEach(el => {
       el.addEventListener('click', e => {
-        if (!this.props.login.currentlyLoggedIn) {
+        if (!this.props.currentlyLoggedIn) {
           e.preventDefault();
           const nextQuery = { next: el.getAttribute('href') };
           const nextPath = appendQuery('/', nextQuery);

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -1,60 +1,26 @@
 import React from 'react';
-import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
-import sinon from 'sinon';
+import { shallow } from 'enzyme';
 
-import Main from '../../containers/Main';
-import createCommonStore from '../../../../startup/store';
+import { Main } from '../../containers/Main';
 
-const store = createCommonStore();
-
-let fetchMock;
-let windowOpen;
-let windowOnload;
-let oldFetch;
-let oldWindow;
-
-const setup = () => {
-  global.sessionStorage = { userToken: '1234' };
-  oldFetch = global.fetch;
-  fetchMock = sinon.stub();
-  global.fetch = fetchMock;
-
-  oldWindow = global.window;
-  windowOpen = sinon.stub();
-  global.window = {
-    open: windowOpen,
-    onload: windowOnload,
-    dataLayer: []
-  };
-};
-
-const teardown = () => {
-  global.fetch = oldFetch;
-  global.window = oldWindow;
+const defaultProps = {
+  currentlyLoggedIn: false,
+  isProfileLoading: false,
+  isLOA3: false,
+  userGreeting: null,
+  showLoginModal: false,
+  utilitiesMenuIsOpen: {
+    search: false,
+    help: false,
+    account: false
+  }
 };
 
 describe('<Main>', () => {
-  beforeEach(setup);
-  const tree = SkinDeep.shallowRender(<Main store={store} location={{ pathname: '/blah' }}/>);
-
   it('should render', () => {
-    const vdom = tree.getRenderOutput();
-    expect(vdom).to.not.be.undefined;
+    const wrapper = shallow(<Main {...defaultProps}/>);
+    expect(wrapper.find('SearchHelpSignIn').exists()).to.be.true;
+    expect(wrapper.find('SignInModal').exists()).to.be.true;
   });
-
-  it('should fetch urls', () => {
-    // TODO: make this return something so that the loginUrl fields are assigned
-    fetchMock.returns({
-      then: (fn) => fn({ json: () => Promise.resolve() })
-    });
-    // TODO: check that it's called twice and that props are updated
-    /*
-    expect(fetchMock.called).to.be.true;
-    expect(tree.props.loginUrl).to.be.defined; // put in the value here
-    expect(tree.props.verifyUrl).to.be.defined; // put in the value hereb
-     */
-  });
-
-  afterEach(teardown);
 });

--- a/src/platform/user/tests/unauthed-flows.e2e.spec.js
+++ b/src/platform/user/tests/unauthed-flows.e2e.spec.js
@@ -1,22 +1,9 @@
-const AccountCreationHelpers = require('../../testing/e2e/account-creation-helpers');
-const E2eHelpers = require('../../testing/e2e/helpers');
-const GibsHelpers = require('../../../applications/post-911-gib-status/tests/post-911-gib-status-helpers');
-const LettersHelpers = require('../../../applications/letters/tests/letters-helpers');
-const MessagingHelpers = require('../../../applications/messaging/tests/messaging-helpers');
 const Auth = require('../../testing/e2e/auth');
-const RxHelpers = require('../../../applications/rx/tests/rx-helpers');
+const E2eHelpers = require('../../testing/e2e/helpers');
+const Timeouts = require('../../testing/e2e/timeouts');
 
 module.exports = E2eHelpers.createE2eTest(
   (client) => {
-    const token = Auth.getUserToken();
-
-    // init mocks
-    AccountCreationHelpers.initMHVTermsMocks(token);
-    GibsHelpers.initApplicationMock(token);
-    LettersHelpers.initApplicationMock(token);
-    MessagingHelpers.initApplicationSubmitMock(token);
-    RxHelpers.initApplicationSubmitMock(token);
-
     const appPaths = [
       // While the page is in maintenance, it doesn't need authed
       '/education/gi-bill/post-9-11/ch-33-benefit/status',
@@ -26,6 +13,15 @@ module.exports = E2eHelpers.createE2eTest(
       'download-va-letters/letters',
       '/track-claims',
     ];
+
+    // Test clicking login required links
+    client
+      .url(E2eHelpers.baseUrl)
+      .waitForElementVisible('body', Timeouts.normal)
+      .click('[aria-controls="vetnav-benefits"]')
+      .waitForElementVisible('#vetnav-benefits', Timeouts.normal)
+      .click('#vetnav-benefits .login-required')
+      .waitForElementVisible('#signin-signup-modal', Timeouts.normal);
 
     // Test flow for unauthed and LOA1 users
     appPaths.forEach(path => {


### PR DESCRIPTION
There have been a lot of Sentry issues around the `currentlyLoggedIn` path being undefined. This should fix them. Also added checks in our unauthed E2E test to catch this if it ever breaks again.

http://sentry.vetsgov-internal/vets-gov/website-production/?query=is%3Aunresolved+currentlyLoggedIn&sort=priority

