### PR TITLE
Fix failing keyword search test in master

### DIFF
--- a/src/applications/gi/tests/components/KeywordSearch.unit.spec.jsx
+++ b/src/applications/gi/tests/components/KeywordSearch.unit.spec.jsx
@@ -10,6 +10,7 @@ describe('<KeywordSearch>', () => {
     const tree = mount(
       <KeywordSearch
         label="test"
+        location={{ query: 'test' }}
         autocomplete={{
           searchTerm: 'hello',
           suggestions: [{ a: 1 }, { b: 2 }]
@@ -29,6 +30,7 @@ describe('<KeywordSearch>', () => {
     const tree = mount(
       <KeywordSearch
         label="test"
+        location={{ query: 'test' }}
         autocomplete={{
           searchTerm: '',
           suggestions: [{ label: 'item1' }, { label: 'item2' }]
@@ -55,6 +57,7 @@ describe('<KeywordSearch>', () => {
     const tree = mount(
       <KeywordSearch
         label="test"
+        location={{ query: 'test' }}
         autocomplete={{
           searchTerm: '',
           suggestions: [{ label: 'item1' }, { label: 'item2' }]


### PR DESCRIPTION
Looks like sometimes the debounce finishes and tries to run some code that relies on a prop being passed in that wasn't. I've added that prop.