### PR TITLE
Fixed blank greeting when user has null first name.

### DIFF
--- a/src/platform/site-wide/user-nav/selectors.js
+++ b/src/platform/site-wide/user-nav/selectors.js
@@ -7,7 +7,7 @@ export const selectUserGreeting = createSelector(
   state => selectProfile(state).email,
   () => window.sessionStorage.userFirstName,
   (name, email, sessionFirstName) => {
-    if (name || sessionFirstName) {
+    if (name.first || sessionFirstName) {
       return _.startCase(_.toLower(
         name.first || sessionFirstName
       ));

--- a/src/platform/site-wide/user-nav/tests/selectors.unit.spec.js
+++ b/src/platform/site-wide/user-nav/tests/selectors.unit.spec.js
@@ -1,46 +1,38 @@
-import { selectUserGreeting } from '../selectors';
 import { expect } from 'chai';
+import { set } from 'lodash/fp';
+import { selectUserGreeting } from '../selectors';
 
 describe('User navigation selectors', () => {
   describe('selectUserGreeting', () => {
-    it('should return email', () => {
-      const result = selectUserGreeting({
-        user: {
-          profile: {
-            email: 'test@test.gov'
-          }
+    const state = {
+      user: {
+        profile: {
+          userFullName: { first: null },
+          email: 'test@test.gov'
         }
-      });
+      }
+    };
 
+    it('should return email', () => {
+      const result = selectUserGreeting(state);
       expect(result).to.equal('test@test.gov');
     });
+
     it('should return session name', () => {
       window.sessionStorage.userFirstName = 'Joe';
-      const result = selectUserGreeting({
-        user: {
-          profile: {
-            userFullName: {},
-            email: 'test@test.gov'
-          }
-        }
-      });
-
+      const result = selectUserGreeting(state);
       expect(result).to.equal('Joe');
     });
+
     it('should return profile name', () => {
       window.sessionStorage.userFirstName = 'Joe';
-      const result = selectUserGreeting({
-        user: {
-          profile: {
-            userFullName: {
-              first: 'Jane'
-            },
-            email: 'test@test.gov'
-          }
-        }
-      });
-
+      const result = selectUserGreeting(
+        set('user.profile.userFullName.first', 'Jane', state)
+      );
       expect(result).to.equal('Jane');
+    });
+
+    afterEach(() => {
       delete window.sessionStorage.userFirstName;
     });
   });


### PR DESCRIPTION
The default object for `userFullName` is something like `{ first: null, last: null, middle: null, suffix: null }`. and the selector only checks whether `userFullName` is falsey. Reproduced the issue of having nothing next to the dropdown arrow by signing in with an LOA1 user.

> <img width="325" alt="screen shot 2018-06-05 at 6 02 13 pm" src="https://user-images.githubusercontent.com/1067024/41005191-7d0a5f7c-68ea-11e8-8538-54ac46be5d61.png">
