### PR TITLE
retry around yarn install

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,8 +94,10 @@ node('vetsgov-general-purpose') {
 
       dockerImage = docker.build("vets-website:${imageTag}")
       args = "-v ${pwd()}:/application"
-      dockerImage.inside(args) {
-        sh "cd /application && yarn install --production=false"
+      retry(5) {
+        dockerImage.inside(args) {
+          sh "cd /application && yarn install --production=false"
+        }
       }
     } catch (error) {
       notify()


### PR DESCRIPTION
Until we can get proper caching in place, this hopefully masks some of the intermittent issues we're seeing on builds.