### PR TITLE
Update sip cards in new homepage

### DIFF
--- a/src/applications/personalization/dashboard/components/FormItem.jsx
+++ b/src/applications/personalization/dashboard/components/FormItem.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import moment from 'moment';
 
 import recordEvent from '../../../../platform/monitoring/record-event';
-import { formTitles, formLinks, disabledForms } from '../helpers';
+import { formTitles, formLinks } from '../helpers';
 
 class FormItem extends React.Component {
   recordDashboardClick = (formId, actionType = 'continue-button') => {
@@ -32,11 +32,10 @@ class FormItem extends React.Component {
             <p><strong>Expires on:</strong> {expirationDate}</p>
           </div>}
         </div>
-        {!!disabledForms[formId] && <div>{disabledForms[formId]}</div>}
         <div className="row small-collapse">
           <div className="small-12 medium-8 large-8 columns">
             <div className="application-route-container resume">
-              {!disabledForms[formId] && <a className="usa-button-primary application-route" href={`${formLinks[formId]}resume`} onClick={this.recordDashboardClick(formId)}>Continue Your Application</a>}
+              <a className="usa-button-primary application-route" href={`${formLinks[formId]}resume`} onClick={this.recordDashboardClick(formId)}>Continue Your Application</a>
             </div>
           </div>
           <div className="small-12 medium-4 large-4 columns">

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import Raven from 'raven-js';
 
 export const formBenefits = {
+  '21-526EZ': 'increased disability compensation',
   '21P-527EZ': 'Veterans pension benefits',
   '21P-530': 'burial benefits',
   '1010ez': 'health care',
@@ -11,12 +11,14 @@ export const formBenefits = {
   '22-1995': 'education benefits',
   '22-5490': 'education benefits',
   '22-5495': 'education benefits',
-  '40-10007': 'pre-need determination of eligibility in a VA national cemetery'
+  '40-10007': 'pre-need determination of eligibility in a VA national cemetery',
+  VIC: 'Veteran ID Card',
+  '21-686C': 'dependent status'
 };
 
 export const formTitles = Object.keys(formBenefits).reduce((titles, key) => {
   let formNumber;
-  if (key === '40-10007') {
+  if (key === '40-10007' || key === 'VIC') {
     formNumber = '';
   } else if (key === '1010ez') {
     formNumber = ' (10-10EZ)';
@@ -29,6 +31,7 @@ export const formTitles = Object.keys(formBenefits).reduce((titles, key) => {
 }, {});
 
 export const formLinks = {
+  '21-526EZ': '/disability-benefits/526/apply-for-increase/',
   '21P-527EZ': '/pension/application/527EZ/',
   '21P-530': '/burials-and-memorials/application/530/',
   '1010ez': '/health-care/apply/application/',
@@ -38,10 +41,13 @@ export const formLinks = {
   '22-1995': '/education/apply-for-education-benefits/application/1995/',
   '22-5490': '/education/apply-for-education-benefits/application/5490/',
   '22-5495': '/education/apply-for-education-benefits/application/5495/',
-  '40-10007': '/burials-and-memorials/pre-need/form-10007-apply-for-eligibility/'
+  '40-10007': '/burials-and-memorials/pre-need/form-10007-apply-for-eligibility/',
+  VIC: '/veteran-id-card/apply/',
+  '21-686C': '/disability-benefits/686/dependent-status/'
 };
 
 export const trackingPrefixes = {
+  '21-526EZ': 'disability-526EZ-',
   '21P-527EZ': 'pensions-527EZ-',
   '21P-530': 'burials-530-',
   '1010ez': 'hca-',
@@ -51,11 +57,15 @@ export const trackingPrefixes = {
   '22-1995': 'edu-1995-',
   '22-5490': 'edu-5490-',
   '22-5495': 'edu-5495-',
-  '40-10007': 'preneed-'
+  '40-10007': 'preneed-',
+  VIC: 'veteran-id-card-',
+  '21-686C': '686-'
 };
 
 export const sipEnabledForms = new Set([
   '1010ez',
+  '21-686C',
+  '21-526EZ',
   '21P-527EZ',
   '21P-530',
   '22-1990',
@@ -64,8 +74,10 @@ export const sipEnabledForms = new Set([
   '22-1995',
   '22-5490',
   '22-5495',
-  '40-10007'
+  '40-10007',
+  'VIC'
 ]);
+
 
 export function isSIPEnabledForm(savedForm) {
   const formNumber = savedForm.form;
@@ -78,8 +90,3 @@ export function isSIPEnabledForm(savedForm) {
   }
   return true;
 }
-
-export const disabledForms = {
-  '21P-527EZ': <div><span className="error">We’re sorry. We can’t give you access to your saved form right now. We’re working on ways to make it easier for you to apply for benefits online. Please check back later or apply by mail.</span><a href="/pension/apply/">Find out how to apply by mail</a>.</div>,
-  '21P-530': <div><span className="error">We’re sorry. We can’t give you access to your saved form right now. We’re working on ways to make it easier for you to apply for benefits online. Please check back later or apply by mail.</span><a href="/burials-and-memorials/survivor-and-dependent-benefits/burial-costs/">Find out how to apply by mail</a>.</div>
-};


### PR DESCRIPTION
It looks like the new dashboard has some copied code that go out of sync with other changes we've been making. This updates to allow you to resume pension and burial forms from the new homepage.

<img width="730" alt="screen shot 2018-06-07 at 11 29 19 am" src="https://user-images.githubusercontent.com/634932/41109881-1034f490-6a46-11e8-95dc-e08d78981f16.png">
