### PR TITLE
526 address logic mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -15,6 +15,9 @@ const siblings = ['treatments', 'privateRecordReleases', 'privateRecords', 'addi
 import { PREFILL_STATUSES } from '../../common/schemaform/save-in-progress/actions';
 import { DateWidget } from '../../common/schemaform/review/widgets';
 
+export const USA = 'USA';
+export const MILITARY_STATES = ['AA', 'AE', 'AP'];
+export const MILITARY_CITIES = ['APO', 'DPO', 'FPO'];
 
 /*
  * Flatten nested array form data into sibling properties
@@ -508,47 +511,38 @@ const EffectiveDateViewField = ({ formData }) => {
 };
 
 const AddressViewField = ({ formData }) => {
-  const {
-    addressLine1, addressLine2, addressLine3, city, state,
-    zipCode, militaryStateCode, militaryPostOfficeTypeCode
-  } = formData;
+  const { addressLine1, addressLine2, addressLine3, city, state, country, zipCode } = formData;
   let zipString;
-  let stateString;
-  let cityString;
   if (zipCode) {
     const firstFive = zipCode.slice(0, 5);
     const lastChunk = zipCode.length > 5 ? `-${zipCode.slice(5)}` : '';
     zipString = `${firstFive}${lastChunk}`;
   }
-  if (city || militaryPostOfficeTypeCode) {
-    cityString = `${city},` || `${militaryPostOfficeTypeCode},`;
-  }
-  if (state || militaryStateCode) {
-    stateString = `${state}` || `${militaryStateCode}`;
+
+  let lastLine;
+  if (country === USA) {
+    lastLine = `${city}, ${state} ${zipString}`;
+  } else {
+    lastLine = `${city}, ${country}`;
   }
   return (
     <div>
       {addressLine1 && <p>{addressLine1}</p>}
       {addressLine2 && <p>{addressLine2}</p>}
       {addressLine3 && <p>{addressLine3}</p>}
-      <p>{cityString} {stateString} {zipString}</p>
+      <p>{lastLine}</p>
     </div>
   );
 };
 
 export const PrimaryAddressViewField = ({ formData }) => {
   const {
-    mailingAddress, primaryPhone, secondaryPhone,
-    emailAddress, forwardingAddress
-  } = formData;
+    mailingAddress, primaryPhone, emailAddress, forwardingAddress } = formData;
   return (
     <div>
       <AddressViewField formData={mailingAddress}/>
       {primaryPhone && (
         <PhoneViewField formData={primaryPhone} name="Primary phone"/>
-      )}
-      {secondaryPhone && (
-        <PhoneViewField formData={secondaryPhone} name="Secondary phone"/>
       )}
       {emailAddress && (
         <EmailViewField formData={emailAddress} name="Email address"/>

--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -3,11 +3,15 @@ import _ from 'lodash';
 import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
 
 import dateUI from '../../../common/schemaform/definitions/date';
-import SSNWidget from '../../../common/schemaform/widgets/SSNWidget';
+import PhoneNumberWidget from '../../../common/schemaform/widgets/PhoneNumberWidget';
 
 import ReviewCardField from '../components/ReviewCardField';
 
 import { PrimaryAddressViewField } from '../helpers';
+
+// Used in our validations
+const MILITARY_STATES = ['AA', 'AE', 'AP'];
+const MILITARY_CITIES = ['APO', 'DPO', 'FPO'];
 
 function isValidZIP(value) {
   if (value !== null) {
@@ -37,11 +41,21 @@ function validateZIP(errors, zip) {
   }
 }
 
-const typeLabels = {
-  DOMESTIC: 'Domestic',
-  MILITARY: 'Military',
-  INTERNATIONAL: 'International'
-};
+function validateMilitaryCity(errors, city, formData, schema, messages, options) {
+  const isMilitaryState = MILITARY_STATES.includes(formData.veteran[options.addressName].state);
+  const isMilitaryCity = MILITARY_CITIES.includes(city.toUpperCase());
+  if (isMilitaryState && !isMilitaryCity) {
+    errors.addError('City must match APO, DPO, or FPO when using a military state code');
+  }
+}
+
+function validateMilitaryState(errors, state, formData, schema, messages, options) {
+  const isMilitaryCity = MILITARY_CITIES.includes(formData.veteran[options.addressName].city.toUpperCase());
+  const isMilitaryState = MILITARY_STATES.includes(state);
+  if (isMilitaryCity && !isMilitaryState) {
+    errors.addError('State must be AA, AE, or AP when using a military city');
+  }
+}
 
 const states = [
   'AL',
@@ -392,91 +406,71 @@ const countries = [
   'Zimbabwe'
 ];
 
-export const militaryPostOfficeTypeLabels = { // TODO: determine whether these are necessary
-  APO: 'Army Post Office',
-  FPO: 'Fleet Post Office',
-  DPO: 'Diplomatic Post Office'
-};
-
 const addressUISchema = (addressName, title) => {
   return {
+    'ui:order': [
+      'country',
+      'addressLine1',
+      'addressLine2',
+      'addressLine3',
+      'city',
+      'state',
+      'zipCode'
+    ],
     'ui:title': title,
-    type: {
-      'ui:title': 'Type',
-      'ui:options': {
-        labels: typeLabels
-      }
-    },
     country: {
       'ui:title': 'Country'
     },
-    state: {
-      'ui:title': 'State',
-      'ui:options': {
-        labels: stateLabels,
-        hideIf: formData => {
-          return (
-            _.get(formData, `veteran[${addressName}].country`) !== 'USA'
-          );
-        }
-      }
-    },
     addressLine1: {
-      'ui:title': 'Street'
+      'ui:title': 'Street address'
     },
     addressLine2: {
-      'ui:title': 'Line 2'
+      'ui:title': 'Street address (optional)'
     },
     addressLine3: {
-      'ui:title': 'Line 3'
+      'ui:title': 'Street address (optional)'
     },
     city: {
-      'ui:title': 'City'
+      'ui:title': 'City',
+      'ui:validations': [{
+        options: { addressName },
+        validator: validateMilitaryCity
+      }]
     },
-    militaryStateCode: {
-      'ui:title': 'Military State Code',
+    state: {
+      'ui:title': 'State',
+      'ui:required': ({ veteran }) => (veteran.mailingAddress.country === 'USA'),
       'ui:options': {
         labels: stateLabels,
-        hideIf: formData => _.get(formData, `veteran[${addressName}].type`) !== 'MILITARY'
-      }
+        hideIf: ({ veteran }) => (veteran.mailingAddress.country !== 'USA'),
+      },
+      'ui:validations': [{
+        options: { addressName },
+        validator: validateMilitaryState
+      }]
     },
     zipCode: {
       'ui:title': 'ZIP code',
       'ui:validations': [validateZIP],
+      'ui:required': ({ veteran }) => (veteran.mailingAddress.country === 'USA'),
       'ui:errorMessages': {
-        pattern: 'Please enter a valid 9 digit ZIP code (dashes allowed)'
+        pattern: 'Please enter a valid 5- or 9- digit ZIP code (dashes allowed)'
       },
       'ui:options': {
         widgetClassNames: 'va-input-medium-large',
-        hideIf: formData =>
-          _.get(formData, `veteran[${addressName}].type`) !== 'DOMESTIC'
+        hideIf: ({ veteran }) => (veteran.mailingAddress.country !== 'USA')
       }
     },
-    militaryPostOfficeTypeCode: {
-      'ui:title': 'Military Post Office Type Code',
-      'ui:options': {
-        labels: militaryPostOfficeTypeLabels,
-        hideIf: formData => _.get(formData, `veteran[${addressName}].type`) !== 'MILITARY'
-      }
-    }
   };
 };
 
 const addressSchema = {
   type: 'object',
-  required: ['country', 'addressLine1'],
+  required: ['country', 'city', 'addressLine1'],
   properties: {
-    type: {
-      type: 'string',
-      'enum': ['MILITARY', 'DOMESTIC', 'INTERNATIONAL']
-    },
     country: {
       type: 'string',
       'enum': countries
-    },
-    state: {
-      type: 'string',
-      'enum': states
     },
     addressLine1: {
       type: 'string',
@@ -498,16 +492,12 @@ const addressSchema = {
       maxLength: 35,
       pattern: "([a-zA-Z0-9-'.#]([a-zA-Z0-9-'.# ])?)+$"
     },
+    state: {
+      type: 'string',
+      'enum': states
+    },
     zipCode: {
       type: 'string'
-    },
-    militaryPostOfficeTypeCode: {
-      type: 'string',
-      'enum': ['APO', 'DPO', 'FPO']
-    },
-    militaryStateCode: {
-      type: 'string',
-      'enum': ['AA', 'AE', 'AP']
     }
   }
 };
@@ -519,21 +509,17 @@ export const uiSchema = {
     'ui:options': {
       viewComponent: PrimaryAddressViewField
     },
+    'ui:order': [
+      'mailingAddress',
+      'primaryPhone',
+      'emailAddress',
+      'view:hasForwardingAddress',
+      'forwardingAddress'
+    ],
     mailingAddress: addressUISchema('mailingAddress'),
     primaryPhone: {
       'ui:title': 'Primary telephone number',
-      'ui:widget': SSNWidget, // TODO: determine whether to rename widget
-      'ui:validations': [validatePhone],
-      'ui:errorMessages': {
-        pattern: 'Phone numbers must be at least 10 digits (dashes allowed)'
-      },
-      'ui:options': {
-        widgetClassNames: 'va-input-medium-large'
-      }
-    },
-    secondaryPhone: {
-      'ui:title': 'Secondary telephone number',
-      'ui:widget': SSNWidget,
+      'ui:widget': PhoneNumberWidget, // TODO: determine whether to rename widget
       'ui:validations': [validatePhone],
       'ui:errorMessages': {
         pattern: 'Phone numbers must be at least 10 digits (dashes allowed)'
@@ -558,13 +544,39 @@ export const uiSchema = {
         'ui:options': {
           expandUnder: 'view:hasForwardingAddress'
         },
+        'ui:order': [
+          'effectiveDate',
+          'country',
+          'addressLine1',
+          'addressLine2',
+          'addressLine3',
+          'city',
+          'state',
+          'zipCode'
+        ],
+        effectiveDate: dateUI('Effective date'),
         country: {
-          'ui:required': formData => _.get("veteran['view:hasForwardingAddress']", formData)
+          'ui:required': ({ veteran }) => (veteran['view:hasForwardingAddress'] === true),
+
         },
         addressLine1: {
-          'ui:required': formData => _.get("veteran['view:hasForwardingAddress']", formData)
+          'ui:required': ({ veteran }) => (veteran['view:hasForwardingAddress'] === true)
         },
-        effectiveDate: dateUI('Effective date')
+        city: {
+          'ui:required': ({ veteran }) => (veteran['view:hasForwardingAddress'] === true)
+        },
+        state: {
+          'ui:required': ({ veteran }) => (veteran.forwardingAddress.country === 'USA'),
+          'ui:options': {
+            hideIf: ({ veteran }) => (veteran.forwardingAddress.country !== 'USA')
+          }
+        },
+        zipCode: {
+          'ui:required': ({ veteran }) => (veteran.forwardingAddress.country === 'USA'),
+          'ui:options': {
+            hideIf: ({ veteran }) => (veteran.forwardingAddress.country !== 'USA')
+          }
+        }
       }
     )
   }
@@ -578,9 +590,6 @@ export const primaryAddressSchema = {
       properties: {
         mailingAddress: addressSchema,
         primaryPhone: {
-          type: 'string'
-        },
-        secondaryPhone: {
           type: 'string'
         },
         emailAddress: {

--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -17,21 +17,6 @@ function isValidZIP(value) {
   return true;
 }
 
-function isValidPhone(value) {
-  if (value !== null) {
-    return /^\d{10}$/.test(value) || /^\d{11}$/.test(value);
-  }
-  return true;
-}
-
-function validatePhone(errors, phone) {
-  if (phone && !isValidPhone(phone)) {
-    errors.addError(
-      'Phone numbers must be at least 10 digits (dashes allowed)'
-    );
-  }
-}
-
 function validateZIP(errors, zip) {
   if (zip && !isValidZIP(zip)) {
     errors.addError('Please enter a valid 9 digit ZIP (dashes allowed)');
@@ -518,10 +503,9 @@ export const uiSchema = {
     mailingAddress: addressUISchema('mailingAddress'),
     primaryPhone: {
       'ui:title': 'Primary telephone number',
-      'ui:widget': PhoneNumberWidget, // TODO: determine whether to rename widget
-      'ui:validations': [validatePhone],
+      'ui:widget': PhoneNumberWidget,
       'ui:errorMessages': {
-        pattern: 'Phone numbers must be at least 10 digits (dashes allowed)'
+        pattern: 'Phone numbers must be 10 digits (dashes allowed)'
       },
       'ui:options': {
         widgetClassNames: 'va-input-medium-large'
@@ -597,7 +581,8 @@ export const primaryAddressSchema = {
       properties: {
         mailingAddress: addressSchema,
         primaryPhone: {
-          type: 'string'
+          type: 'string',
+          pattern: '^\\d{10}$'
         },
         emailAddress: {
           type: 'string',

--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -39,7 +39,7 @@ function validateMilitaryState(errors, state, formData, schema, messages, option
   }
 }
 
-const hasForwardingAddress = (veteran) => (veteran['view:hasForwardingAddress'] === true);
+const hasForwardingAddress = (veteran) => (_.get(veteran, 'view:hasForwardingAddress', false));
 
 const states = [
   'AL',
@@ -555,17 +555,23 @@ export const uiSchema = {
         state: {
           'ui:required': ({ veteran }) => (
             hasForwardingAddress(veteran)
-            && veteran.forwardingAddress.country === USA),
+            && veteran.forwardingAddress.country === USA
+          ),
           'ui:options': {
-            hideIf: ({ veteran }) => (veteran.forwardingAddress.country !== USA)
+            hideIf: ({ veteran }) => (
+              hasForwardingAddress(veteran)
+              && veteran.forwardingAddress.country !== USA)
           }
         },
         zipCode: {
           'ui:required': ({ veteran }) => (
             hasForwardingAddress(veteran)
-            && veteran.forwardingAddress.country === USA),
+            && veteran.forwardingAddress.country === USA
+          ),
           'ui:options': {
-            hideIf: ({ veteran }) => (veteran.forwardingAddress.country !== USA)
+            hideIf: ({ veteran }) => (
+              hasForwardingAddress(veteran)
+              && veteran.forwardingAddress.country !== USA)
           }
         }
       }

--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -24,7 +24,9 @@ function validateZIP(errors, zip) {
 }
 
 function validateMilitaryCity(errors, city, formData, schema, messages, options) {
-  const isMilitaryState = MILITARY_STATES.includes(formData.veteran[options.addressName].state);
+  const isMilitaryState = MILITARY_STATES.includes(
+    _.get(formData, `veteran[${options.addressName}].state`, '')
+  );
   const isMilitaryCity = MILITARY_CITIES.includes(city.trim().toUpperCase());
   if (isMilitaryState && !isMilitaryCity) {
     errors.addError('City must match APO, DPO, or FPO when using a military state code');
@@ -32,7 +34,9 @@ function validateMilitaryCity(errors, city, formData, schema, messages, options)
 }
 
 function validateMilitaryState(errors, state, formData, schema, messages, options) {
-  const isMilitaryCity = MILITARY_CITIES.includes(formData.veteran[options.addressName].city.trim().toUpperCase());
+  const isMilitaryCity = MILITARY_CITIES.includes(
+    _.get(formData, `veteran[${options.addressName}].city`, '').trim().toUpperCase()
+  );
   const isMilitaryState = MILITARY_STATES.includes(state);
   if (isMilitaryCity && !isMilitaryState) {
     errors.addError('State must be AA, AE, or AP when using a military city');

--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -7,12 +7,8 @@ import PhoneNumberWidget from '../../../common/schemaform/widgets/PhoneNumberWid
 
 import ReviewCardField from '../components/ReviewCardField';
 
-import { PrimaryAddressViewField } from '../helpers';
+import { PrimaryAddressViewField, MILITARY_STATES, MILITARY_CITIES, USA } from '../helpers';
 import { omitRequired } from '../../../common/schemaform/helpers.js';
-
-// Used in our validations
-const MILITARY_STATES = ['AA', 'AE', 'AP'];
-const MILITARY_CITIES = ['APO', 'DPO', 'FPO'];
 
 function isValidZIP(value) {
   if (value !== null) {
@@ -442,10 +438,10 @@ const addressUISchema = (addressName, title) => {
     },
     state: {
       'ui:title': 'State',
-      'ui:required': ({ veteran }) => (veteran.mailingAddress.country === 'USA'),
+      'ui:required': ({ veteran }) => (veteran.mailingAddress.country === USA),
       'ui:options': {
         labels: stateLabels,
-        hideIf: ({ veteran }) => (veteran.mailingAddress.country !== 'USA'),
+        hideIf: ({ veteran }) => (veteran.mailingAddress.country !== USA),
       },
       'ui:validations': [{
         options: { addressName },
@@ -455,13 +451,13 @@ const addressUISchema = (addressName, title) => {
     zipCode: {
       'ui:title': 'ZIP code',
       'ui:validations': [validateZIP],
-      'ui:required': ({ veteran }) => (veteran.mailingAddress.country === 'USA'),
+      'ui:required': ({ veteran }) => (veteran.mailingAddress.country === USA),
       'ui:errorMessages': {
         pattern: 'Please enter a valid 5- or 9- digit ZIP code (dashes allowed)'
       },
       'ui:options': {
         widgetClassNames: 'va-input-medium-large',
-        hideIf: ({ veteran }) => (veteran.mailingAddress.country !== 'USA')
+        hideIf: ({ veteran }) => (veteran.mailingAddress.country !== USA)
       }
     },
   };
@@ -571,17 +567,17 @@ export const uiSchema = {
         state: {
           'ui:required': ({ veteran }) => (
             hasForwardingAddress(veteran)
-            && veteran.forwardingAddress.country === 'USA'),
+            && veteran.forwardingAddress.country === USA),
           'ui:options': {
-            hideIf: ({ veteran }) => (veteran.forwardingAddress.country !== 'USA')
+            hideIf: ({ veteran }) => (veteran.forwardingAddress.country !== USA)
           }
         },
         zipCode: {
           'ui:required': ({ veteran }) => (
             hasForwardingAddress(veteran)
-            && veteran.forwardingAddress.country === 'USA'),
+            && veteran.forwardingAddress.country === USA),
           'ui:options': {
-            hideIf: ({ veteran }) => (veteran.forwardingAddress.country !== 'USA')
+            hideIf: ({ veteran }) => (veteran.forwardingAddress.country !== USA)
           }
         }
       }

--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -8,6 +8,7 @@ import PhoneNumberWidget from '../../../common/schemaform/widgets/PhoneNumberWid
 import ReviewCardField from '../components/ReviewCardField';
 
 import { PrimaryAddressViewField } from '../helpers';
+import { omitRequired } from '../../../common/schemaform/helpers.js';
 
 // Used in our validations
 const MILITARY_STATES = ['AA', 'AE', 'AP'];
@@ -56,6 +57,8 @@ function validateMilitaryState(errors, state, formData, schema, messages, option
     errors.addError('State must be AA, AE, or AP when using a military city');
   }
 }
+
+const hasForwardingAddress = (veteran) => (veteran['view:hasForwardingAddress'] === true);
 
 const states = [
   'AL',
@@ -556,23 +559,27 @@ export const uiSchema = {
         ],
         effectiveDate: dateUI('Effective date'),
         country: {
-          'ui:required': ({ veteran }) => (veteran['view:hasForwardingAddress'] === true),
+          'ui:required': ({ veteran }) => (hasForwardingAddress(veteran)),
 
         },
         addressLine1: {
-          'ui:required': ({ veteran }) => (veteran['view:hasForwardingAddress'] === true)
+          'ui:required': ({ veteran }) => (hasForwardingAddress(veteran))
         },
         city: {
-          'ui:required': ({ veteran }) => (veteran['view:hasForwardingAddress'] === true)
+          'ui:required': ({ veteran }) => (hasForwardingAddress(veteran))
         },
         state: {
-          'ui:required': ({ veteran }) => (veteran.forwardingAddress.country === 'USA'),
+          'ui:required': ({ veteran }) => (
+            hasForwardingAddress(veteran)
+            && veteran.forwardingAddress.country === 'USA'),
           'ui:options': {
             hideIf: ({ veteran }) => (veteran.forwardingAddress.country !== 'USA')
           }
         },
         zipCode: {
-          'ui:required': ({ veteran }) => (veteran.forwardingAddress.country === 'USA'),
+          'ui:required': ({ veteran }) => (
+            hasForwardingAddress(veteran)
+            && veteran.forwardingAddress.country === 'USA'),
           'ui:options': {
             hideIf: ({ veteran }) => (veteran.forwardingAddress.country !== 'USA')
           }
@@ -599,7 +606,7 @@ export const primaryAddressSchema = {
         'view:hasForwardingAddress': {
           type: 'boolean'
         },
-        forwardingAddress: _.merge({}, addressSchema, {
+        forwardingAddress: _.merge({}, omitRequired(addressSchema), {
           type: 'object',
           properties: {
             effectiveDate: fullSchema526EZ.definitions.date

--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -553,7 +553,11 @@ export const uiSchema = {
           'state',
           'zipCode'
         ],
-        effectiveDate: dateUI('Effective date'),
+        effectiveDate: _.merge(
+          {},
+          dateUI('Effective date'),
+          { 'ui:required': ({ veteran }) => (hasForwardingAddress(veteran)) }
+        ),
         country: {
           'ui:required': ({ veteran }) => (hasForwardingAddress(veteran)),
 

--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -44,14 +44,14 @@ function validateZIP(errors, zip) {
 
 function validateMilitaryCity(errors, city, formData, schema, messages, options) {
   const isMilitaryState = MILITARY_STATES.includes(formData.veteran[options.addressName].state);
-  const isMilitaryCity = MILITARY_CITIES.includes(city.toUpperCase());
+  const isMilitaryCity = MILITARY_CITIES.includes(city.trim().toUpperCase());
   if (isMilitaryState && !isMilitaryCity) {
     errors.addError('City must match APO, DPO, or FPO when using a military state code');
   }
 }
 
 function validateMilitaryState(errors, state, formData, schema, messages, options) {
-  const isMilitaryCity = MILITARY_CITIES.includes(formData.veteran[options.addressName].city.toUpperCase());
+  const isMilitaryCity = MILITARY_CITIES.includes(formData.veteran[options.addressName].city.trim().toUpperCase());
   const isMilitaryState = MILITARY_STATES.includes(state);
   if (isMilitaryCity && !isMilitaryState) {
     errors.addError('State must be AA, AE, or AP when using a military city');

--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -43,7 +43,7 @@ function validateMilitaryState(errors, state, formData, schema, messages, option
   }
 }
 
-const hasForwardingAddress = (veteran) => (_.get(veteran, 'view:hasForwardingAddress', false));
+const hasForwardingAddress = (formData) => (_.get(formData, 'veteran[view:hasForwardingAddress]', false));
 
 const states = [
   'AL',
@@ -544,38 +544,38 @@ export const uiSchema = {
         effectiveDate: _.merge(
           {},
           dateUI('Effective date'),
-          { 'ui:required': ({ veteran }) => (hasForwardingAddress(veteran)) }
+          { 'ui:required': hasForwardingAddress }
         ),
         country: {
-          'ui:required': ({ veteran }) => (hasForwardingAddress(veteran)),
+          'ui:required': hasForwardingAddress,
 
         },
         addressLine1: {
-          'ui:required': ({ veteran }) => (hasForwardingAddress(veteran))
+          'ui:required': hasForwardingAddress
         },
         city: {
-          'ui:required': ({ veteran }) => (hasForwardingAddress(veteran))
+          'ui:required': hasForwardingAddress
         },
         state: {
-          'ui:required': ({ veteran }) => (
-            hasForwardingAddress(veteran)
-            && veteran.forwardingAddress.country === USA
+          'ui:required': (formData) => (
+            hasForwardingAddress(formData)
+            && formData.veteran.forwardingAddress.country === USA
           ),
           'ui:options': {
-            hideIf: ({ veteran }) => (
-              hasForwardingAddress(veteran)
-              && veteran.forwardingAddress.country !== USA)
+            hideIf: (formData) => (
+              hasForwardingAddress(formData)
+              && formData.veteran.forwardingAddress.country !== USA)
           }
         },
         zipCode: {
-          'ui:required': ({ veteran }) => (
-            hasForwardingAddress(veteran)
-            && veteran.forwardingAddress.country === USA
+          'ui:required': (formData) => (
+            hasForwardingAddress(formData)
+            && formData.veteran.forwardingAddress.country === USA
           ),
           'ui:options': {
-            hideIf: ({ veteran }) => (
-              hasForwardingAddress(veteran)
-              && veteran.forwardingAddress.country !== USA)
+            hideIf: (formData) => (
+              hasForwardingAddress(formData)
+              && formData.veteran.forwardingAddress.country !== USA)
           }
         }
       }

--- a/src/applications/disability-benefits/526EZ/tests/config/primaryAddress.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/primaryAddress.unit.spec.jsx
@@ -9,7 +9,7 @@ import { DefinitionTester, // selectCheckbox
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
 
-describe.only('Disability benefits 526EZ primary address', () => {
+describe('Disability benefits 526EZ primary address', () => {
   const {
     schema,
     uiSchema

--- a/src/applications/disability-benefits/526EZ/tests/schema/initialData.js
+++ b/src/applications/disability-benefits/526EZ/tests/schema/initialData.js
@@ -20,7 +20,6 @@ export default {
     secondaryPhone: '3242342342',
     emailAddress: 'test@test.com',
     mailingAddress: {
-      type: 'DOMESTIC',
       country: 'USA',
       city: 'Detroit',
       state: 'MI',


### PR DESCRIPTION
- Updates mailingAddress and forwardingAddress fields to latest shape
- Adds conditional display logic for certain fields that should only be shown under certain conditions
- Adds conditional required logic for certain fields that should only be required under certain conditions
- Updates a bunch of tests and adds more tests for the new logic
- Cleans up the 'view' UI for the address card (a little)

Separate issues need to be created to:
- Update `vets-json-schema` to strip PCIU address common def and create a new, very basic schema for our addresses
- Update the schema in the form config to pull from vets-json-schema instead of creating the schema in the config directly (once the above is done)
- Clean up the address view card, especially WRT forwarding addresses
- Update / review content for all of the validation errors

## Screenshots!
### Domestic Address:
![screen shot 2018-06-08 at 1 30 00 pm](https://user-images.githubusercontent.com/24251447/41174734-9ddde4a2-6b20-11e8-886a-835644bfbf6e.png)
-----
### International Address:
![screen shot 2018-06-08 at 1 30 41 pm](https://user-images.githubusercontent.com/24251447/41174748-acbb3bf0-6b20-11e8-94e9-16cb9a8429e7.png)
-----
### Military Address - Bad State:
![screen shot 2018-06-08 at 1 31 52 pm](https://user-images.githubusercontent.com/24251447/41174811-c717e8a4-6b20-11e8-8f24-fa5608f47628.png)
-----
### Military Address - Bad City:
![screen shot 2018-06-08 at 1 32 06 pm](https://user-images.githubusercontent.com/24251447/41174837-d6a1db18-6b20-11e8-8b05-1edc696e8319.png)
-----
### Forwarding Address - Works the same as mailing address
![screen shot 2018-06-08 at 1 32 45 pm](https://user-images.githubusercontent.com/24251447/41174869-e8dbc352-6b20-11e8-81a5-9930e00d2282.png)
