### PR TITLE
Update month abbreviations

### DIFF
--- a/src/platform/startup/moment-setup.js
+++ b/src/platform/startup/moment-setup.js
@@ -10,8 +10,8 @@ moment.updateLocale('en', {
   monthsShort: [
     'Jan.',
     'Feb.',
-    'Mar.',
-    'Apr.',
+    'March',
+    'April',
     'May',
     'June',
     'July',


### PR DESCRIPTION
These changes spell out the months of March and April rather than abbreviate them, as [indicated ](https://github.com/department-of-veterans-affairs/vets-website/pull/7672#issuecomment-395909961) by @peggygannon on https://github.com/department-of-veterans-affairs/vets-website/pull/7672.