### PR TITLE
Profile: Refresh state for profile after Vet360 transaction completes

### DIFF
--- a/src/applications/personalization/profile360/actions/updaters.js
+++ b/src/applications/personalization/profile360/actions/updaters.js
@@ -1,4 +1,5 @@
 import { apiRequest } from '../../../../platform/utilities/api';
+import { getProfile } from '../../../../platform/user/profile/actions';
 // import recordEvent from '../../../../platform/monitoring/record-event';
 // import { kebabCase } from 'lodash';
 import { pickBy } from 'lodash';
@@ -30,7 +31,7 @@ export const VET360_TRANSACTION_FINISHED = 'VET360_TRANSACTION_FINISHED';
 // }
 
 export function getTransactionStatus(transaction, fieldName) {
-  return async (dispatch, getState) => {
+  return async (dispatch) => {
     try {
       const { transactionId } = transaction.data.attributes;
       const response = isVet360Configured() ? await apiRequest(`/profile/status/${transactionId}`) : localVet360.updateTransaction(transactionId);
@@ -43,22 +44,14 @@ export function getTransactionStatus(transaction, fieldName) {
 
       // Check to see if the transaction is finished
       if (response.data.attributes.transactionStatus === VET360_CONSTANTS.TRANSACTION_STATUS.COMPLETED_SUCCESS) {
-        const currentState = getState();
-        const newValue = currentState.vaProfile.formFields[fieldName].value;
 
-        // Remove the transaction with a delay for effect
-        setTimeout(() => {
-          dispatch({
-            type: VET360_TRANSACTION_FINISHED,
-            fieldName
-          });
-        }, 3000);
+        // Refresh the profile object
+        await dispatch(getProfile());
 
-        // Update the property on the FE
+        // Remove the transaction from the VA Profile
         dispatch({
-          type: UPDATE_VET360_PROFILE_FIELD,
-          fieldName,
-          newValue
+          type: VET360_TRANSACTION_FINISHED,
+          fieldName
         });
       }
     } catch (err) {

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -84,28 +84,11 @@ export class Main extends React.Component {
   }
 
   checkTokenStatus = () => {
-    if (sessionStorage.userToken) {
-      // @todo once we have time to replace the confirm dialog with an actual modal we should uncomment this code.
-      // if (moment() > moment(sessionStorage.entryTime).add(SESSION_REFRESH_INTERVAL_MINUTES, 'm')) {
-      //   if (confirm('For security, you’ll be automatically signed out in 2 minutes. To stay signed in, click OK.')) {
-      //     login();
-      //   } else {
-      //     logout();
-      //   }
-      // } else {
-      //   if (this.props.getProfile()) {
-      //     this.props.updateLoggedInStatus(true);
-      //   }
-      // }
-
-      // @todo after doing the above, remove this code.
-      if (this.props.getProfile()) {
-        recordEvent({ event: 'login-user-logged-in' });
-        this.props.updateLoggedInStatus(true);
-      }
-    } else {
+    if (!sessionStorage.userToken) {
       this.props.updateLoggedInStatus(false);
       if (this.getRedirectUrl()) { this.props.toggleLoginModal(true); }
+    } else {
+      this.props.getProfile();
     }
   }
 

--- a/src/platform/user/profile/reducers/index.js
+++ b/src/platform/user/profile/reducers/index.js
@@ -1,6 +1,7 @@
 import { merge, set } from 'lodash/fp';
 
 import { UPDATE_LOGGEDIN_STATUS } from '../../authentication/actions';
+import { mapRawUserDataToState } from '../utilities';
 
 import {
   UPDATE_PROFILE_FIELDS,
@@ -56,8 +57,10 @@ const initialState = {
 
 function profileInformation(state = initialState, action) {
   switch (action.type) {
-    case UPDATE_PROFILE_FIELDS:
-      return merge(state, action.newState);
+    case UPDATE_PROFILE_FIELDS: {
+      const newState = mapRawUserDataToState(action.payload);
+      return merge(state, newState);
+    }
 
     case UPDATE_VET360_PROFILE_FIELD:
       return set(

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -1,0 +1,66 @@
+import camelCaseObjectKeys from '../../../utilities/data/camelCaseObjectKeys';
+import { isVet360Configured, mockContactInformation } from '../../../../applications/personalization/profile360/util/local-vet360';
+
+export function mapRawUserDataToState(json) {
+  const {
+    data: {
+      attributes: {
+        health_terms_current: healthTermsCurrent,
+        in_progress_forms: savedForms,
+        mhv_account_state: mhvAccountState,
+        prefills_available: prefillsAvailable,
+        profile: {
+          authn_context: authnContext,
+          birth_date: dob,
+          email,
+          first_name: first,
+          gender,
+          last_name: last,
+          loa,
+          middle_name: middle,
+          multifactor,
+          verified
+        },
+        services,
+        va_profile: {
+          status
+        },
+        vet360_contact_information: vet360ContactInformation,
+        veteran_status: {
+          is_veteran: isVeteran,
+          status: veteranStatus
+        },
+      }
+    }
+  } = json;
+
+  return {
+    accountType: loa.current,
+    authnContext,
+    dob,
+    email,
+    gender,
+    isVeteran,
+    loa,
+    mhv: {
+      account: mhvAccountState,
+      terms: healthTermsCurrent
+    },
+    multifactor,
+    prefillsAvailable,
+    savedForms,
+    services,
+    status,
+    userFullName: {
+      first,
+      middle,
+      last
+    },
+    verified,
+    vet360: isVet360Configured() ? camelCaseObjectKeys(vet360ContactInformation) : camelCaseObjectKeys(mockContactInformation),
+    veteranStatus: {
+      isVeteran,
+      veteranStatus
+    }
+  };
+}


### PR DESCRIPTION
This moves the mapping function for the profile object from the action creator into its own utility, which is instead called in the reducer. It was refactored so that we could reuse the `getProfile` action creator with the fewest amount of side effects.

Resolves department-of-veterans-affairs/vets.gov-team/issues/10880