### PR TITLE
Separate getProfile into refresh/restore

### DIFF
--- a/src/applications/personalization/dashboard/actions/index.js
+++ b/src/applications/personalization/dashboard/actions/index.js
@@ -1,5 +1,5 @@
 import { removeFormApi } from '../../../common/schemaform/save-in-progress/api';
-import { getProfile } from '../../../../platform/user/profile/actions';
+import { refreshProfile } from '../../../../platform/user/profile/actions';
 
 export const PROFILE_LOADING_FINISHED = 'PROFILE_LOADING_FINISHED';
 export const REMOVING_SAVED_FORM = 'REMOVING_SAVED_FORM';
@@ -37,7 +37,7 @@ export function removeSavedForm(formId) {
     return removeFormApi(formId)
       .then(() => {
         dispatch(removingSavedFormSuccess(formId));
-        dispatch(getProfile());
+        dispatch(refreshProfile());
       })
       .catch(() => dispatch(removingSavedFormFailure()));
   };

--- a/src/applications/personalization/profile360/actions/updaters.js
+++ b/src/applications/personalization/profile360/actions/updaters.js
@@ -1,5 +1,5 @@
 import { apiRequest } from '../../../../platform/utilities/api';
-import { getProfile } from '../../../../platform/user/profile/actions';
+import { refreshProfile } from '../../../../platform/user/profile/actions';
 // import recordEvent from '../../../../platform/monitoring/record-event';
 // import { kebabCase } from 'lodash';
 import { pickBy } from 'lodash';
@@ -46,7 +46,7 @@ export function getTransactionStatus(transaction, fieldName) {
       if (response.data.attributes.transactionStatus === VET360_CONSTANTS.TRANSACTION_STATUS.COMPLETED_SUCCESS) {
 
         // Refresh the profile object
-        await dispatch(getProfile());
+        await dispatch(refreshProfile());
 
         // Remove the transaction from the VA Profile
         dispatch({

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -11,7 +11,7 @@ import {
   isProfileLoading,
   isLOA3
 } from '../../../user/selectors';
-import { restoreProfile } from '../../../user/profile/actions';
+import { initializeProfile } from '../../../user/profile/actions';
 import { updateLoggedInStatus } from '../../../user/authentication/actions';
 
 import {
@@ -58,7 +58,7 @@ export class Main extends React.Component {
   }
 
   setToken = (event) => {
-    if (event.data === sessionStorage.userToken) { this.props.restoreProfile(); }
+    if (event.data === sessionStorage.userToken) { this.props.initializeProfile(); }
   }
 
   getRedirectUrl = () => (new URLSearchParams(window.location.search)).get('next');
@@ -88,7 +88,7 @@ export class Main extends React.Component {
       this.props.updateLoggedInStatus(false);
       if (this.getRedirectUrl()) { this.props.toggleLoginModal(true); }
     } else {
-      this.props.restoreProfile();
+      this.props.initializeProfile();
     }
   }
 
@@ -130,7 +130,7 @@ const mapDispatchToProps = {
   toggleLoginModal,
   toggleSearchHelpUserMenu,
   updateLoggedInStatus,
-  restoreProfile
+  initializeProfile
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Main);

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -11,7 +11,7 @@ import {
   isProfileLoading,
   isLOA3
 } from '../../../user/selectors';
-import { getProfile } from '../../../user/profile/actions';
+import { restoreProfile } from '../../../user/profile/actions';
 import { updateLoggedInStatus } from '../../../user/authentication/actions';
 
 import {
@@ -58,7 +58,7 @@ export class Main extends React.Component {
   }
 
   setToken = (event) => {
-    if (event.data === sessionStorage.userToken) { this.props.getProfile(); }
+    if (event.data === sessionStorage.userToken) { this.props.restoreProfile(); }
   }
 
   getRedirectUrl = () => (new URLSearchParams(window.location.search)).get('next');
@@ -88,7 +88,7 @@ export class Main extends React.Component {
       this.props.updateLoggedInStatus(false);
       if (this.getRedirectUrl()) { this.props.toggleLoginModal(true); }
     } else {
-      this.props.getProfile();
+      this.props.restoreProfile();
     }
   }
 
@@ -130,7 +130,7 @@ const mapDispatchToProps = {
   toggleLoginModal,
   toggleSearchHelpUserMenu,
   updateLoggedInStatus,
-  getProfile
+  restoreProfile
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Main);

--- a/src/platform/user/profile/actions/index.js
+++ b/src/platform/user/profile/actions/index.js
@@ -47,7 +47,7 @@ export function refreshProfile() {
   };
 }
 
-export function restoreProfile() {
+export function initializeProfile() {
   return async (dispatch) => {
     try {
       const payload = await dispatch(refreshProfile());

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -1,3 +1,4 @@
+import recordEvent from '../../../monitoring/record-event';
 import camelCaseObjectKeys from '../../../utilities/data/camelCaseObjectKeys';
 import { isVet360Configured, mockContactInformation } from '../../../../applications/personalization/profile360/util/local-vet360';
 
@@ -63,4 +64,21 @@ export function mapRawUserDataToState(json) {
       veteranStatus
     }
   };
+}
+
+export function setupProfileSession(payload) {
+  const userData = payload.data.attributes.profile;
+  // sessionStorage coerces everything into String. this if-statement
+  // is to prevent the firstname being set to the string 'Null'
+  if (userData.first_name) {
+    sessionStorage.setItem('userFirstName', userData.first_name);
+  }
+  // Report out the current level of assurance for the user
+  recordEvent({ event: `login-loa-current-${userData.loa.current}` });
+}
+
+export function teardownProfileSession() {
+  for (const key of ['entryTime', 'userToken', 'userFirstName']) {
+    sessionStorage.removeItem(key);
+  }
 }

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -44,8 +44,12 @@ export function mapRawUserDataToState(json) {
     isVeteran,
     loa,
     mhv: {
-      account: mhvAccountState,
-      terms: healthTermsCurrent
+      account: {
+        state: mhvAccountState
+      },
+      terms: {
+        accepted: healthTermsCurrent
+      }
     },
     multifactor,
     prefillsAvailable,


### PR DESCRIPTION
There are occasions where we want to refresh the user's profile (by hitting the /user API route) but the single `getProfile` action creator wasn't really designed for that - it contained analytics reporting, caching/tearing down session variables, and dispatching other actions that may cause unknown side effects.

This PR separate `getProfile` into `restoreProfile`, which is used for the first load of the user profile, and `refreshProfile`, used for subsequent loads.