### PR TITLE
Hook up payment information to api

### DIFF
--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -390,7 +390,7 @@ export const evidenceSummaryView = ({ formData }) => {
  *                                                           but ignored by screen readers
  * @param {String} substitutionText -- Text for screen readers to say instead of srIgnored
  */
-const srSubstitute = (srIgnored, substitutionText) => {
+export const srSubstitute = (srIgnored, substitutionText) => {
   return (
     <div style={{ display: 'inline' }}>
       <span aria-hidden>{srIgnored}</span>

--- a/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
+++ b/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
@@ -8,12 +8,6 @@ import AsyncDisplayWidget from '../components/AsyncDisplayWidget';
 
 import { srSubstitute } from '../helpers';
 
-export const accountLabels = {
-  CHECKING: 'Checking account',
-  SAVINGS: 'Savings account',
-  NOBANK: 'I don’t have a bank account'
-};
-
 const accountTitleLabels = {
   CHECKING: 'Checking Account',
   SAVINGS: 'Savings Account',

--- a/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
+++ b/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
@@ -1,5 +1,5 @@
-import _ from 'lodash';
 import React from 'react';
+import _ from 'lodash';
 
 import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
 
@@ -118,4 +118,3 @@ export const schema = {
     })
   }
 };
-

--- a/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
+++ b/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
@@ -39,7 +39,7 @@ export const viewComponent = (response) => {
     );
     routingNumberString = (
       <p>
-        Routing number: {mask(routingNumber, 4)}
+        Bank routing number: {mask(routingNumber, 4)}
       </p>
     );
     bankNameString = <p>Bank name: {bankName}</p>;
@@ -47,7 +47,7 @@ export const viewComponent = (response) => {
   return (
     <div>
       <p>
-        This is the bank account that we have on file for you. It’s used to pay both Disability and Pension benefits.
+        This is the bank account information we have on file for you. We pay your disability and pension benefits to this account.
       </p>
       <div className="blue-bar-block">
         <p>
@@ -67,8 +67,8 @@ export const viewComponent = (response) => {
 
 const failureComponent = () => (
   <AlertBox
-    headline="We can’t seem to find your information"
-    content="That’s on us. Sorry about that."
+    headline="We can’t access your information"
+    content="We’re sorry. We can’t access your payment information right now. You can continue to fill out the form and we’ll try again later."
     status="error"
     className="async-display-widget-alert-box"
     isVisible/>

--- a/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
+++ b/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
@@ -29,7 +29,7 @@ export const paymentInformationViewField = (response) => {
   let routingNumberString;
   let bankNameString;
   const mask = (string, unmaskedLength) => {
-    const maskedString = srSubstitute(`${'●'.repeat(string.length - unmaskedLength)}-`, 'ending with');
+    const maskedString = srSubstitute(`${'●'.repeat(string.length - unmaskedLength)}`, 'ending with');
     return <span>{maskedString}{string.slice(unmaskedLength * -1)}</span>;
   };
 
@@ -49,11 +49,20 @@ export const paymentInformationViewField = (response) => {
   return (
     <div>
       <p>
-        <strong>{accountTitleLabels[accountType]}</strong>
+        This is the bank account that we have on file for you. It’s used to pay both Disability and Pension benefits.
       </p>
-      {accountNumberString}
-      {routingNumberString}
-      {bankNameString}
+      <div className="blue-bar-block">
+        <p>
+          <strong>{accountTitleLabels[accountType]}</strong>
+        </p>
+        {accountNumberString}
+        {routingNumberString}
+        {bankNameString}
+      </div>
+      <p>
+        <strong>Note:</strong> If you need to update your bank information, please call Veterans Benefits Assistance
+        at <a href="tel:+18008271000">1-800-827-1000</a>, Monday – Friday, 8:00 a.m. to 9:00 p.m. (ET).
+      </p>
     </div>
   );
 };

--- a/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
+++ b/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
@@ -51,7 +51,7 @@ export const viewComponent = (response) => {
       </p>
       <div className="blue-bar-block">
         <p>
-          <strong>{accountTitleLabels[accountType]}</strong>
+          <strong>{accountTitleLabels[accountType.toUpperCase()]}</strong>
         </p>
         {accountNumberString}
         {routingNumberString}

--- a/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
+++ b/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import Raven from 'raven-js';
 
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
 import { apiRequest } from '../../../../platform/utilities/api';
 import AsyncDisplayWidget from '../components/AsyncDisplayWidget';
 
@@ -20,7 +22,7 @@ const accountTitleLabels = {
 
 const NOBANK = 'NOBANK';
 
-export const paymentInformationViewField = (response) => {
+export const viewComponent = (response) => {
   const {
     accountType,
     accountNumber,
@@ -69,6 +71,15 @@ export const paymentInformationViewField = (response) => {
   );
 };
 
+const failureComponent = () => (
+  <AlertBox
+    headline="We can’t seem to find your information"
+    content="That’s on us. Sorry about that."
+    status="error"
+    className="async-display-widget-alert-box"
+    isVisible/>
+);
+
 function fetchPaymentInformation() {
   return apiRequest('/ppiu/payment_information',
     {},
@@ -89,8 +100,8 @@ export const uiSchema = {
   'ui:widget': AsyncDisplayWidget,
   'ui:options': {
     callback: fetchPaymentInformation,
-    viewComponent: paymentInformationViewField,
-    failureComponent: () => <div>Woops</div>
+    viewComponent,
+    failureComponent
   }
 };
 

--- a/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
+++ b/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
@@ -34,7 +34,7 @@ export const viewComponent = (response) => {
   let bankNameString;
   const mask = (string, unmaskedLength) => {
     const maskedString = srSubstitute(`${'●'.repeat(string.length - unmaskedLength)}`, 'ending with');
-    return <span>{maskedString}{string.slice(unmaskedLength * -1)}</span>;
+    return <span>{maskedString}{string.slice(-unmaskedLength)}</span>;
   };
 
   if (accountType !== NOBANK) {

--- a/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
+++ b/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import Raven from 'raven-js';
 
+import { apiRequest } from '../../../../platform/utilities/api';
 import AsyncDisplayWidget from '../components/AsyncDisplayWidget';
 
 import { srSubstitute } from '../helpers';
@@ -68,54 +70,17 @@ export const paymentInformationViewField = (response) => {
 };
 
 function fetchPaymentInformation() {
-  return Promise.resolve({
-    // Act like we get this from the api
-    data: {
-      attributes: {
-        responses: [
-          {
-            controlInformation: {
-              canUpdateAddress: true,
-              corpAvailIndicator: true,
-              corpRecFoundIndicator: true,
-              hasNoBdnPaymentsIndicator: true,
-              identityIndicator: true,
-              indexIndicator: true,
-              isCompetentIndicator: true,
-              noFiduciaryAssignedIndicator: true,
-              notDeceasedIndicator: true
-            },
-            paymentAccount: {
-              accountNumber: '9876543211234',
-              accountType: 'Checking',
-              financialInstitutionName: 'Comerica',
-              financialInstitutionRoutingNumber: '042102115'
-            },
-            paymentAddress: {
-              addressEffectiveDate: '2018-06-07T22:47:21.873Z',
-              addressOne: 'First street address line',
-              addressTwo: 'Second street address line',
-              addressThree: 'Third street address line',
-              city: 'AdHocville',
-              stateCode: 'OR',
-              countryName: 'USA',
-              militaryPostOfficeTypeCode: 'Military PO',
-              militaryStateCode: 'AP',
-              zipCode: '12345',
-              zipSuffix: '6789',
-              type: 'Domestic'
-            },
-            paymentType: 'CNP'
-          }
-        ]
-      },
-      id: {},
-      type: 'evss_ppiu_payment_information_responses'
+  return apiRequest('/ppiu/payment_information',
+    {},
+    response => {
+      // Return only the bit the UI cares about
+      return response.data.attributes.responses[0].paymentAccount;
+    },
+    () => {
+      Raven.captureMessage('vets_payment_information_fetch_failure');
+      return Promise.reject();
     }
-  }).then(response => {
-    // Return only the bit the UI cares about
-    return response.data.attributes.responses[0].paymentAccount;
-  });
+  );
 }
 
 export const uiSchema = {

--- a/src/applications/disability-benefits/526EZ/tests/config/paymentInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/paymentInformation.unit.spec.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils';
+import { mockApiRequest, resetFetch } from '../../../../../platform/testing/unit/helpers';
+
+import formConfig from '../../config/form.js';
+
+const {
+  schema,
+  uiSchema
+} = formConfig.chapters.veteranDetails.pages.paymentInformation;
+
+const originalFetch = global.fetch;
+
+describe('526 -- fetchPaymentInformation', () => {
+  // Set up the api response before each test; running once before all the tests was
+  //  causing fetch() to return undefined for some reason.
+  beforeEach(() => {
+    mockApiRequest({
+      data: {
+        attributes: {
+          responses: [{
+            paymentAccount: {
+              accountType: 'checking',
+              accountNumber: '1234567890',
+              financialInstitutionRoutingNumber: '0987654321',
+              financialInstitutionName: 'Some bank'
+            }
+          }]
+        }
+      }
+    });
+  });
+
+  // Reset the spy after every test
+  afterEach(() => resetFetch());
+
+  // Tear down the fetch mock when we're done with all the tests
+  after(() => {
+    global.fetch = originalFetch;
+  });
+
+
+  it('should fetch payment information from the api', () => {
+    mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        formData={{}}
+        uiSchema={uiSchema}/>
+    );
+    // expect(global.fetch.calledWith('/ppiu/payment_information')).to.be.true;
+    expect(global.fetch.called).to.be.true;
+  });
+
+  it('should display masked payment information', (done) => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        formData={{}}
+        uiSchema={uiSchema}/>
+    );
+    setTimeout(() => {
+      const text = form.text();
+      // 'ending with' because of the srSubstitute
+      expect(text).to.include('●●●●●●ending with7890');
+      expect(text).to.include('●●●●●●ending with4321');
+      expect(text).to.include('Some bank');
+      expect(text).to.include('Checking Account');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Screenshots!

### Success
![image](https://user-images.githubusercontent.com/12970166/41384910-5f5f7658-6f2d-11e8-9fec-cdfc5e67dbd5.png)

@goldenmeanie I went ahead and made as many circles as there are digits we're masking. The mock had only 6 for each and showed the last 4 digits of both numbers. Should I switch to using 6 circles, or keep this?

Also, we could have a little button to unmask the number if we wanted. Is that a thing that would be useful?

### Error
![image](https://user-images.githubusercontent.com/12970166/41384772-98559e84-6f2c-11e8-8f21-398e9238e0ca.png)

@peggygannon What should this error say? The context for this is the following:
1) The user starts a form
2) Once they get to this page (a few screens in), we query for their most up-to-date payment information
3) The call failed for some reason
    - This could be a number of reasons, but they all mean the same thing to the user; they can't see their most up-to-date payment information
    - This does not stop them from continuing with the form
    - Once they submit, we'll make this same call again to submit their form with the payment information they have on file; if it fails at _that_ point, then we'll have to keep trying until it goes through
      - That might be more information than you or the user need to know, but in case it's helpful, there it is