### PR TITLE
import from moment startup to fix unstable test

### DIFF
--- a/src/applications/claims-status/components/ClaimsDecision.jsx
+++ b/src/applications/claims-status/components/ClaimsDecision.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import moment from '../../../platform/startup/moment-setup';
 
 class ClaimsDecision extends React.Component {
   render() {


### PR DESCRIPTION
This fixes a test I've observed failing a few times on the format of the date string coming out of `moment.format()`. It's reproducible with `CHOMA_SEED=81fYlOF4gS npm --no-color run test:coverag`. I'll admit that I'm not 100% sure why this ever works except that it must be some sort of ordering issue where the short month name defaults are being set in another test or script.

We seem to include moment fairly inconsistently. Sometimes we use this method which injects some settings overrides, sometimes we inject these settings directly in the file. There may or may not be a good reason to keep the current method, I didn't address that part of the issue here.