### PR TITLE
Fix url path in pension upload config

### DIFF
--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -1604,7 +1604,7 @@ const formConfig = {
             'ui:title': 'Document upload',
             'ui:description': fileHelp,
             files: fileUploadUI('', {
-              fileUploadURL: `${environment.API_URL}/v0/claim_attachments`,
+              fileUploadUrl: `${environment.API_URL}/v0/claim_attachments`,
               hideLabelText: true
             }),
             'view:uploadMessage': {


### PR DESCRIPTION
Discovered this while troubleshooting e2e tests, confirmed that it's causing errors in production.