### PR TITLE
VA Facilities Test Fix

### DIFF
--- a/src/applications/disability-benefits/526EZ/tests/config/vaFacilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/vaFacilities.unit.spec.jsx
@@ -3,11 +3,22 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester, fillData, fillDate } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester, fillData, fillDate } from '../../../../../platform/testing/unit/schemaform-utils';
+import { mockApiRequest } from '../../../../../platform/testing/unit/helpers';
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
 
+const originalFetch = global.fetch;
+
 describe('Disability benefits 526EZ VA facility', () => {
+  beforeEach(() => {
+    mockApiRequest({ data: [] });
+  });
+
+  after(() => {
+    global.fetch = originalFetch;
+  });
+
   const { schema, uiSchema, arrayPath } = formConfig.chapters.supportingEvidence.pages.vaFacilities;
   it('renders VA facility form', () => {
     const form = mount(<DefinitionTester
@@ -24,7 +35,7 @@ describe('Disability benefits 526EZ VA facility', () => {
     expect(form.find('input').length).to.equal(3);
   });
 
-  xit('should add a VA facility', () => {
+  it('should add a VA facility', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
@@ -55,7 +66,7 @@ describe('Disability benefits 526EZ VA facility', () => {
     expect(onSubmit.called).to.be.true;
   });
 
-  xit('should validate the treatmentCenterName', () => {
+  it('should validate the treatmentCenterName', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester


### PR DESCRIPTION
To be perfectly honest, I'm not sure _why_ this works. In fact, I'm not sure _how_ @jbalboni figured out which tests were the offenders in the first place. After I got that information, I had to ponder about this for a while.

It had to be some side effect that was causing completely unrelated tests to fail. The only side effects I could think of here were filling out the treatment center name; that would query the api. Since it's not mocked, it'd try to _actually_ query the api.

Another solution would be to set up a little mock server like we have for the e2e tests, but it seems like that's the wrong approach for unit tests (less isolation and all that).