### PR TITLE
Remove minItems from spouse marriages

### DIFF
--- a/src/applications/disability-benefits/686/config/form.js
+++ b/src/applications/disability-benefits/686/config/form.js
@@ -596,7 +596,6 @@ const formConfig = {
             properties: {
               spouseMarriages: {
                 type: 'array',
-                minItems: 1,
                 items: {
                   type: 'object',
                   required: [


### PR DESCRIPTION
There's a validation error at the end of the form about minItems not being met, since we still have that property left over from before we moved to the page per item format.