### PR TITLE
Profile360: Add code-specific error messaging for failed/rejected transactions 

### DIFF
--- a/src/applications/personalization/profile360/components/Vet360EditModal.jsx
+++ b/src/applications/personalization/profile360/components/Vet360EditModal.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Modal from '@department-of-veterans-affairs/formation/Modal';
-import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
+import Vet360EditModalErrorMessage from '../components/Vet360EditModalErrorMessage';
 import LoadingButton from '../components/LoadingButton';
 import FormActionButtons from '../components/FormActionButtons';
 
@@ -66,11 +66,7 @@ export default class Vet360EditModal extends React.Component {
         visible={isFormReady}>
         <h3>Edit {title}</h3>
         <form onSubmit={onSubmit}>
-          <AlertBox
-            content={<p>We’re sorry. We couldn’t update your {title.toLowerCase()}. Please try again.</p>}
-            isVisible={!!error}
-            status="error"
-            onCloseAlert={clearErrors}/>
+          {error && <Vet360EditModalErrorMessage title={title} error={error} clearErrors={clearErrors}/>}
           {isFormReady && render()}
           <FormActionButtons
             onCancel={onCancel}

--- a/src/applications/personalization/profile360/components/Vet360EditModalErrorMessage.jsx
+++ b/src/applications/personalization/profile360/components/Vet360EditModalErrorMessage.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
+import {
+  LOW_CONFIDENCE_ADDRESS_ERROR_CODES
+} from  '../util/transactions';
+
+function hasError(errors, codes) {
+  return errors.some(error => codes.has(error.code));
+}
+
+export default function Vet360EditModalErrorMessage({ error: { errors = [] }, clearErrors, title }) {
+  let content = null;
+
+  switch (true) {
+    case hasError(LOW_CONFIDENCE_ADDRESS_ERROR_CODES, errors):
+      content = <p>We’re sorry. We looked up the address you entered and we're not sure mail can be delivered there. Please try entering your address again.</p>;
+      break;
+
+    default:
+      content = <p>We’re sorry. We couldn’t update your {title.toLowerCase()}. Please try again.</p>;
+  }
+
+  return (
+    <AlertBox
+      isVisible
+      status="error"
+      content={content}
+      onCloseAlert={clearErrors}/>
+  );
+}

--- a/src/applications/personalization/profile360/components/Vet360Transaction.jsx
+++ b/src/applications/personalization/profile360/components/Vet360Transaction.jsx
@@ -6,6 +6,7 @@ import {
   isFailedTransaction
 } from '../util/transactions';
 
+import Vet360TransactionInlineErrorMessage from './Vet360TransactionInlineErrorMessage';
 import Vet360TransactionPending from './Vet360TransactionPending';
 
 export default class Vet360Transaction extends React.Component {
@@ -24,11 +25,7 @@ export default class Vet360Transaction extends React.Component {
 
     return (
       <div className={classes}>
-        {hasError && (
-          <div className="usa-input-error-message">
-            We couldn’t save your recent {title.toLowerCase()} update. Please try again later.
-          </div>
-        )}
+        {hasError && <Vet360TransactionInlineErrorMessage transaction={transaction}/>}
         {transaction && isPendingTransaction(transaction) ? (
           <Vet360TransactionPending title={title} refreshTransaction={refreshTransaction}/>
         ) : children}

--- a/src/applications/personalization/profile360/components/Vet360Transaction.jsx
+++ b/src/applications/personalization/profile360/components/Vet360Transaction.jsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 import {
   isPendingTransaction,
-  isErroredTransaction
+  isFailedTransaction
 } from '../util/transactions';
 
 import Vet360TransactionPending from './Vet360TransactionPending';
@@ -17,7 +17,7 @@ export default class Vet360Transaction extends React.Component {
       transaction
     } = this.props;
 
-    const hasError = transaction && isErroredTransaction(transaction);
+    const hasError = transaction && isFailedTransaction(transaction);
     const classes = classNames('vet360-profile-field-content', {
       'usa-input-error': hasError
     });

--- a/src/applications/personalization/profile360/components/Vet360Transaction.jsx
+++ b/src/applications/personalization/profile360/components/Vet360Transaction.jsx
@@ -25,7 +25,7 @@ export default class Vet360Transaction extends React.Component {
 
     return (
       <div className={classes}>
-        {hasError && <Vet360TransactionInlineErrorMessage transaction={transaction}/>}
+        {hasError && <Vet360TransactionInlineErrorMessage {...this.props}/>}
         {transaction && isPendingTransaction(transaction) ? (
           <Vet360TransactionPending title={title} refreshTransaction={refreshTransaction}/>
         ) : children}

--- a/src/applications/personalization/profile360/components/Vet360Transaction.jsx
+++ b/src/applications/personalization/profile360/components/Vet360Transaction.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import {
@@ -10,6 +11,13 @@ import Vet360TransactionInlineErrorMessage from './Vet360TransactionInlineErrorM
 import Vet360TransactionPending from './Vet360TransactionPending';
 
 export default class Vet360Transaction extends React.Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    refreshTransaction: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired,
+    transaction: PropTypes.object
+  };
+
   render() {
     const {
       children,

--- a/src/applications/personalization/profile360/components/Vet360TransactionErrorBanner.jsx
+++ b/src/applications/personalization/profile360/components/Vet360TransactionErrorBanner.jsx
@@ -3,7 +3,6 @@ import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
 import {
   hasGenericUpdateError,
-  hasLowCondidenceAddressError,
   hasMVIError,
   hasMVINotFoundError,
   hasUserIsDeceasedError
@@ -17,19 +16,6 @@ export function GenericUpdateError(props) {
         <div>
           <h4>Your recent profile update didn’t save</h4>
           <p>We’re sorry. Something went wrong on our end and we couldn’t save the recent updates you made to your profile. Please try again later.</p>
-        </div>
-      )}/>
-  );
-}
-
-export function LowConfidenceError(props) {
-  return (
-    <AlertBox {...props}
-      status="error"
-      content={(
-        <div>
-          <h4>Your address didn’t save</h4>
-          <p>We’re sorry. We looked up the address you entered, and we’re not sure mail can be delivered there. Please try entering your address again.</p>
         </div>
       )}/>
   );
@@ -90,10 +76,6 @@ export default function Vet360TransactionErrorBanner({ transaction, clearTransac
 
     case hasMVIError(transaction):
       TransactionError = MVIError;
-      break;
-
-    case hasLowCondidenceAddressError(transaction):
-      TransactionError = LowConfidenceError;
       break;
 
     case hasGenericUpdateError(transaction):

--- a/src/applications/personalization/profile360/components/Vet360TransactionErrorBanner.jsx
+++ b/src/applications/personalization/profile360/components/Vet360TransactionErrorBanner.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
+import {
+  hasGenericUpdateError,
+  hasLowCondidenceError,
+  hasMVIError,
+  hasMVINotFoundError,
+  hasUserIsDeceasedError
+} from '../util/transactions';
+
+export function GenericUpdateError(props) {
+  return (
+    <AlertBox {...props}
+      status="error"
+      content={(
+        <div>
+          <h4>Your recent profile update didn’t save</h4>
+          <p>We’re sorry. Something went wrong on our end and we couldn’t save the recent updates you made to your profile. Please try again later.</p>
+        </div>
+      )}/>
+  );
+}
+
+export function LowConfidenceError(props) {
+  return (
+    <AlertBox {...props}
+      status="error"
+      content={(
+        <div>
+          <h4>Your address didn’t save</h4>
+          <p>We’re sorry. We looked up the address you entered, and we’re not sure mail can be delivered there. Please try entering your address again.</p>
+        </div>
+      )}/>
+  );
+}
+
+export function MVILookupFailError(props) {
+  return (
+    <AlertBox {...props}
+      status="error"
+      content={(
+        <div>
+          <h4>We’re having trouble matching your information to our Veteran records</h4>
+          <p>We’re sorry. We’re having trouble matching your information to our Veteran records, so we can’t give you access to tools for managing your health and benefits.</p>
+          <a href="/facilities/">Find your nearest VA medical center</a>
+        </div>
+      )}/>
+  );
+}
+
+export function MVIError(props) {
+  return (
+    <AlertBox {...props}
+      status="error"
+      content={(
+        <div>
+          <h4>We can’t access your contact information right now.</h4>
+          <p>We’re sorry. Something went wrong on our end. Please refresh this page or try again later.</p>
+        </div>
+      )}/>
+  );
+}
+
+export function UserIsDeceasedError(props) {
+  return (
+    <AlertBox {...props}
+      status="error"
+      content={(
+        <div>
+          <h4>We can’t accept updates to this profile</h4>
+          <p>We’re sorry. We’ve locked this profile because our records show the Veteran is deceased. If this is an error, please contact your nearest VA medical center. Let them know you need to fix this information in your records. The operator, or a patient advocate, can connect you with the right person who can help.</p>
+          <a href="/facilities/">Find your nearest VA medical center</a>
+        </div>
+      )}/>
+  );
+}
+
+export default function Vet360TransactionErrorBanner({ transaction, clearTransaction }) {
+  let TransactionError = null;
+
+  switch (true) {
+    case hasUserIsDeceasedError(transaction):
+      TransactionError = UserIsDeceasedError;
+      break;
+
+    case hasMVINotFoundError(transaction):
+      TransactionError = MVILookupFailError;
+      break;
+
+    case hasMVIError(transaction):
+      TransactionError = MVIError;
+      break;
+
+    case hasLowCondidenceError(transaction):
+      TransactionError = LowConfidenceError;
+      break;
+
+    case hasGenericUpdateError(transaction):
+    default:
+      TransactionError = GenericUpdateError;
+  }
+
+  return <TransactionError onCloseAlert={clearTransaction} isVisible/>;
+}

--- a/src/applications/personalization/profile360/components/Vet360TransactionErrorBanner.jsx
+++ b/src/applications/personalization/profile360/components/Vet360TransactionErrorBanner.jsx
@@ -3,7 +3,7 @@ import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
 import {
   hasGenericUpdateError,
-  hasLowCondidenceError,
+  hasLowCondidenceAddressError,
   hasMVIError,
   hasMVINotFoundError,
   hasUserIsDeceasedError
@@ -92,7 +92,7 @@ export default function Vet360TransactionErrorBanner({ transaction, clearTransac
       TransactionError = MVIError;
       break;
 
-    case hasLowCondidenceError(transaction):
+    case hasLowCondidenceAddressError(transaction):
       TransactionError = LowConfidenceError;
       break;
 

--- a/src/applications/personalization/profile360/components/Vet360TransactionInlineErrorMessage.jsx
+++ b/src/applications/personalization/profile360/components/Vet360TransactionInlineErrorMessage.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import {
-  hasUserIsDeceasedError,
-  hasLowCondidenceAddressError
+  hasUserIsDeceasedError
 } from '../util/transactions';
 
 export default function Vet360TransactionInlineErrorMessage({ title: fieldTitle, transaction }) {
@@ -10,10 +9,6 @@ export default function Vet360TransactionInlineErrorMessage({ title: fieldTitle,
   switch (true) {
     case hasUserIsDeceasedError(transaction):
       content = <span>We can’t make this update because our records show the Veteran is deceased. If this isn’t true, please contact your nearest VA medical center. <a href="/facilities/">Find your nearest VA medical center</a>.</span>;
-      break;
-
-    case hasLowCondidenceAddressError(transaction):
-      content = <span>We’re sorry. We're not sure we can send mail to this address. Please try again.</span>;
       break;
 
     default:

--- a/src/applications/personalization/profile360/components/Vet360TransactionInlineErrorMessage.jsx
+++ b/src/applications/personalization/profile360/components/Vet360TransactionInlineErrorMessage.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import {
+  hasUserIsDeceasedError,
+  hasLowCondidenceAddressError
+} from '../util/transactions';
+
+export default function Vet360TransactionInlineErrorMessage({ title: fieldTitle, transaction }) {
+  let content = null;
+  switch (true) {
+    case hasUserIsDeceasedError(transaction):
+      content = <span>We can’t make this update because our records show the Veteran is deceased. If this isn’t true, please contact your nearest VA medical center. <a href="/facilities/">Find your nearest VA medical center</a>.</span>;
+      break;
+
+    case hasLowCondidenceAddressError(transaction):
+      content = <span>We’re sorry. We're not sure we can send mail to this address. Please try again.</span>;
+      break;
+
+    default:
+      content = <span>We couldn’t save your recent {fieldTitle.toLowerCase()} update. Please try again later.</span>;
+  }
+
+  return <div className="usa-input-error-message">{content}</div>;
+}

--- a/src/applications/personalization/profile360/components/Vet360TransactionPending.jsx
+++ b/src/applications/personalization/profile360/components/Vet360TransactionPending.jsx
@@ -1,13 +1,25 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class Vet360TransactionPending extends React.Component {
+  static propTypes = {
+    title: PropTypes.string.isRequired,
+    refreshTransaction: PropTypes.func.isRequired
+  };
+
   componentDidMount() {
     this.interval = window.setInterval(this.props.refreshTransaction, 1000);
   }
+
   componentWillUnmount() {
     window.clearInterval(this.interval);
   }
+
   render() {
-    return <div>We’re working on saving your new {this.props.title.toLowerCase()}. We’ll show it here once it’s saved.</div>;
+    return (
+      <div className="vet360-profile-field-transaction-pending">
+        We’re working on saving your new {this.props.title.toLowerCase()}. We’ll show it here once it’s saved.
+      </div>
+    );
   }
 }

--- a/src/applications/personalization/profile360/containers/Vet360TransactionReporter.jsx
+++ b/src/applications/personalization/profile360/containers/Vet360TransactionReporter.jsx
@@ -41,7 +41,7 @@ class Vet360TransactionReporter extends React.Component {
               isVisible
               status="success"
               onCloseAlert={this.props.clearTransaction.bind(null, transaction)}
-              content={<h3>Your recent profile update finished.</h3>}/>
+              content={<h4>We saved your updated information.</h4>}/>
           );
         })}
         {erroredTransactions.map((transaction) => {

--- a/src/applications/personalization/profile360/containers/Vet360TransactionReporter.jsx
+++ b/src/applications/personalization/profile360/containers/Vet360TransactionReporter.jsx
@@ -7,12 +7,14 @@ import scrollToTop from '../../../../platform/utilities/ui/scrollToTop';
 
 import {
   selectVet360SuccessfulTransactions,
-  selectVet360ErroredTransactions
+  selectVet360FailedTransactions
 } from '../selectors';
 
 import {
   clearTransaction
 } from '../actions';
+
+import Vet360TransactionErrorBanner from '../components/Vet360TransactionErrorBanner';
 
 class Vet360TransactionReporter extends React.Component {
   componentDidUpdate(prevProps) {
@@ -44,15 +46,10 @@ class Vet360TransactionReporter extends React.Component {
         })}
         {erroredTransactions.map((transaction) => {
           return (
-            <AlertBox
+            <Vet360TransactionErrorBanner
               key={transaction.data.attributes.transactionId}
-              isVisible
-              status="error"
-              onCloseAlert={this.props.clearTransaction.bind(null, transaction)}
-              content={<div>
-                <h3>Your recent profile update didn’t save</h3>
-                <p>We’re sorry. Something went wrong on our end and we couldn’t save the recent updates you made to your profile. Please try again later.</p>
-              </div>}/>
+              transaction={transaction}
+              clearTransaction={this.props.clearTransaction.bind(null, transaction)}/>
           );
         })}
       </div>
@@ -63,7 +60,7 @@ class Vet360TransactionReporter extends React.Component {
 const mapStateToProps = (state) => {
   return {
     successfulTransactions: selectVet360SuccessfulTransactions(state),
-    erroredTransactions: selectVet360ErroredTransactions(state)
+    erroredTransactions: selectVet360FailedTransactions(state)
   };
 };
 

--- a/src/applications/personalization/profile360/sass/profile-360.scss
+++ b/src/applications/personalization/profile360/sass/profile-360.scss
@@ -20,3 +20,8 @@
   background: $color-white;
   box-shadow: none !important;
 }
+
+.vet360-profile-field-transaction-pending {
+  color: $color-primary;
+  font-weight: bold;
+}

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -1,7 +1,7 @@
 import {
   isSuccessfulTransaction,
   isFailedTransaction,
-  isErroredTransaction
+  isErroredUpdateTransaction
 } from './util/transactions';
 
 export function selectVet360Field(state, fieldName) {
@@ -36,7 +36,7 @@ export function selectVet360SuccessfulTransactions(state) {
 
 export function selectVet360ErroredTransactions(state) {
   return state.vet360.transactions.filter(transaction => {
-    return isFailedTransaction(transaction) || isErroredTransaction(transaction);
+    return isFailedTransaction(transaction) || isErroredUpdateTransaction(transaction);
   });
 }
 

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -1,7 +1,6 @@
 import {
   isSuccessfulTransaction,
-  isFailedTransaction,
-  isErroredUpdateTransaction
+  isFailedTransaction
 } from './util/transactions';
 
 export function selectVet360Field(state, fieldName) {
@@ -34,10 +33,8 @@ export function selectVet360SuccessfulTransactions(state) {
   return state.vet360.transactions.filter(isSuccessfulTransaction);
 }
 
-export function selectVet360ErroredTransactions(state) {
-  return state.vet360.transactions.filter(transaction => {
-    return isFailedTransaction(transaction) || isErroredUpdateTransaction(transaction);
-  });
+export function selectVet360FailedTransactions(state) {
+  return state.vet360.transactions.filter(isFailedTransaction);
 }
 
 export function selectEditedFormField(state, fieldName) {

--- a/src/applications/personalization/profile360/util/transactions.js
+++ b/src/applications/personalization/profile360/util/transactions.js
@@ -16,7 +16,7 @@ const FAILURE_STATUSES = new Set([
   VET360.TRANSACTION_STATUS.REJECTED
 ]);
 
-const GENERIC_ERROR_CODES = new Set([
+const UPDATE_ERROR_CODES = new Set([
   'VET360_ADDR200',
   'VET360_ADDR201',
   'VET360_EMAIL200',
@@ -36,6 +36,26 @@ const GENERIC_ERROR_CODES = new Set([
   'VET360_CORE502'
 ]);
 
+const MVI_NOT_FOUND_ERROR_CODES = new Set([
+  'VET360_MVI201'
+]);
+
+const MVI_ERROR_CODES = new Set([
+  'VET360_MVI100',
+  'VET360_MVI101',
+  'VET360_MVI200',
+  'VET360_MVI202',
+  'VET360_MVI203'
+]);
+
+const LOW_CONFIDENCE_ERROR_CODES = new Set([
+  'ADDR306'
+]);
+
+const DECEASED_ERROR_CODES = new Set([
+  'VET360_MVI300'
+]);
+
 export function isPendingTransaction(transaction) {
   return PENDING_STATUSES.has(transaction.data.attributes.transactionStatus);
 }
@@ -48,9 +68,29 @@ export function isFailedTransaction(transaction) {
   return FAILURE_STATUSES.has(transaction.data.attributes.transactionStatus);
 }
 
-export function isErroredTransaction(transaction) {
+function matchErrorCode(codeSet, transaction) {
   const { metadata } = transaction.data.attributes;
   return metadata && metadata.some(error => {
-    return GENERIC_ERROR_CODES.has(error.code);
+    return codeSet.has(error.code);
   });
+}
+
+export function isErroredUpdateTransaction(transaction) {
+  return matchErrorCode(UPDATE_ERROR_CODES, transaction);
+}
+
+export function isNotFoundInMVIError(transaction) {
+  return matchErrorCode(MVI_NOT_FOUND_ERROR_CODES, transaction);
+}
+
+export function isMVIError(transaction) {
+  return matchErrorCode(MVI_ERROR_CODES, transaction);
+}
+
+export function isLowCondidenceError(transaction) {
+  return matchErrorCode(LOW_CONFIDENCE_ERROR_CODES, transaction);
+}
+
+export function isUserIsDeceasedError(transaction) {
+  return matchErrorCode(DECEASED_ERROR_CODES, transaction);
 }

--- a/src/applications/personalization/profile360/util/transactions.js
+++ b/src/applications/personalization/profile360/util/transactions.js
@@ -48,7 +48,7 @@ const MVI_ERROR_CODES = new Set([
   'VET360_MVI203'
 ]);
 
-const LOW_CONFIDENCE_ERROR_CODES = new Set([
+const LOW_CONFIDENCE_ADDRESS_ERROR_CODES = new Set([
   'ADDR306'
 ]);
 
@@ -87,8 +87,8 @@ export function hasMVIError(transaction) {
   return matchErrorCode(MVI_ERROR_CODES, transaction);
 }
 
-export function hasLowCondidenceError(transaction) {
-  return matchErrorCode(LOW_CONFIDENCE_ERROR_CODES, transaction);
+export function hasLowCondidenceAddressError(transaction) {
+  return matchErrorCode(LOW_CONFIDENCE_ADDRESS_ERROR_CODES, transaction);
 }
 
 export function hasUserIsDeceasedError(transaction) {

--- a/src/applications/personalization/profile360/util/transactions.js
+++ b/src/applications/personalization/profile360/util/transactions.js
@@ -49,7 +49,7 @@ const MVI_ERROR_CODES = new Set([
 ]);
 
 const LOW_CONFIDENCE_ADDRESS_ERROR_CODES = new Set([
-  'ADDR306'
+  'VET360_ADDR306'
 ]);
 
 const DECEASED_ERROR_CODES = new Set([

--- a/src/applications/personalization/profile360/util/transactions.js
+++ b/src/applications/personalization/profile360/util/transactions.js
@@ -75,22 +75,22 @@ function matchErrorCode(codeSet, transaction) {
   });
 }
 
-export function isErroredUpdateTransaction(transaction) {
+export function hasGenericUpdateError(transaction) {
   return matchErrorCode(UPDATE_ERROR_CODES, transaction);
 }
 
-export function isNotFoundInMVIError(transaction) {
+export function hasMVINotFoundError(transaction) {
   return matchErrorCode(MVI_NOT_FOUND_ERROR_CODES, transaction);
 }
 
-export function isMVIError(transaction) {
+export function hasMVIError(transaction) {
   return matchErrorCode(MVI_ERROR_CODES, transaction);
 }
 
-export function isLowCondidenceError(transaction) {
+export function hasLowCondidenceError(transaction) {
   return matchErrorCode(LOW_CONFIDENCE_ERROR_CODES, transaction);
 }
 
-export function isUserIsDeceasedError(transaction) {
+export function hasUserIsDeceasedError(transaction) {
   return matchErrorCode(DECEASED_ERROR_CODES, transaction);
 }

--- a/src/applications/personalization/profile360/util/transactions.js
+++ b/src/applications/personalization/profile360/util/transactions.js
@@ -1,22 +1,22 @@
 import * as VET360 from '../constants/vet360';
 
-const PENDING_STATUSES = new Set([
+export const PENDING_STATUSES = new Set([
   VET360.TRANSACTION_STATUS.RECEIVED,
   VET360.TRANSACTION_STATUS.RECEIVED_DEAD_LETTER_QUEUE,
   VET360.TRANSACTION_STATUS.RECEIVED_ERROR_QUEUE
 ]);
 
-const SUCCESS_STATUSES = new Set([
+export const SUCCESS_STATUSES = new Set([
   VET360.TRANSACTION_STATUS.COMPLETED_SUCCESS,
   VET360.TRANSACTION_STATUS.COMPLETED_NO_CHANGES_DETECTED
 ]);
 
-const FAILURE_STATUSES = new Set([
+export const FAILURE_STATUSES = new Set([
   VET360.TRANSACTION_STATUS.COMPLETED_FAILURE,
   VET360.TRANSACTION_STATUS.REJECTED
 ]);
 
-const UPDATE_ERROR_CODES = new Set([
+export const UPDATE_ERROR_CODES = new Set([
   'VET360_ADDR200',
   'VET360_ADDR201',
   'VET360_EMAIL200',
@@ -36,11 +36,11 @@ const UPDATE_ERROR_CODES = new Set([
   'VET360_CORE502'
 ]);
 
-const MVI_NOT_FOUND_ERROR_CODES = new Set([
+export const MVI_NOT_FOUND_ERROR_CODES = new Set([
   'VET360_MVI201'
 ]);
 
-const MVI_ERROR_CODES = new Set([
+export const MVI_ERROR_CODES = new Set([
   'VET360_MVI100',
   'VET360_MVI101',
   'VET360_MVI200',
@@ -48,11 +48,12 @@ const MVI_ERROR_CODES = new Set([
   'VET360_MVI203'
 ]);
 
-const LOW_CONFIDENCE_ADDRESS_ERROR_CODES = new Set([
+// This results as a direct error response from the API, and prior to a transaction being created.
+export const LOW_CONFIDENCE_ADDRESS_ERROR_CODES = new Set([
   'VET360_ADDR306'
 ]);
 
-const DECEASED_ERROR_CODES = new Set([
+export const DECEASED_ERROR_CODES = new Set([
   'VET360_MVI300'
 ]);
 
@@ -85,10 +86,6 @@ export function hasMVINotFoundError(transaction) {
 
 export function hasMVIError(transaction) {
   return matchErrorCode(MVI_ERROR_CODES, transaction);
-}
-
-export function hasLowCondidenceAddressError(transaction) {
-  return matchErrorCode(LOW_CONFIDENCE_ADDRESS_ERROR_CODES, transaction);
 }
 
 export function hasUserIsDeceasedError(transaction) {


### PR DESCRIPTION
This adds the utility functions for inspecting transaction error codes and determining their meaning, then implements those within the top-level transaction error banner and the inline field error message.

Resolves department-of-veterans-affairs/vets.gov-team/issues/10854
Resolves department-of-veterans-affairs/vets.gov-team/issues/10944
Resolves department-of-veterans-affairs/vets.gov-team/issues/11032