### PR TITLE
put back the node filter on jenkins job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ def comment_broken_links = {
              "\n\n _Note: Long file names or URLs may be cut-off_")
 }
 
-node('xxlarge') {
+node('vetsgov-general-purpose') {
   properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', daysToKeepStr: '60']]]);
   def dockerImage, args, ref, imageTag
 


### PR DESCRIPTION
I was using a temporary node label name on the job and forgot to revert it before merging PR https://github.com/department-of-veterans-affairs/vets-website/pull/7842/files :(