### PR TITLE
Add primaryPhone and emailAddress as required

### DIFF
--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -226,6 +226,7 @@ export const primaryAddressSchema = {
   properties: {
     veteran: {
       type: 'object',
+      required: ['primaryPhone', 'emailAddress'],
       properties: {
         mailingAddress,
         primaryPhone: {

--- a/src/applications/disability-benefits/526EZ/tests/config/primaryAddress.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/primaryAddress.unit.spec.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+/*  */import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
 
-import { DefinitionTester, // selectCheckbox 
+import { DefinitionTester, // selectCheckbox
 } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
@@ -15,6 +15,11 @@ describe('Disability benefits 526EZ primary address', () => {
     schema,
     uiSchema
   } = formConfig.chapters.veteranDetails.pages.primaryAddress;
+
+  const primaryPhone = '1231231234';
+  const emailAddress = 'test@testing.com';
+
+
   it('renders primary address form', () => {
     const form = mount(
       <DefinitionTester
@@ -119,7 +124,7 @@ describe('Disability benefits 526EZ primary address', () => {
     );
 
     const stateDropdownOptions = form.find('#root_veteran_mailingAddress_state > option');
-    // The `+1` is for the empty option in the dropdown 
+    // The `+1` is for the empty option in the dropdown
     expect(stateDropdownOptions.length).to.equal(STATE_VALUES.length + 1);
   });
 
@@ -131,6 +136,8 @@ describe('Disability benefits 526EZ primary address', () => {
         schema={schema}
         data={{
           veteran: {
+            primaryPhone,
+            emailAddress,
             mailingAddress: {
               country: 'USA',
               addressLine1: '123 Any Street',
@@ -158,6 +165,8 @@ describe('Disability benefits 526EZ primary address', () => {
         schema={schema}
         data={{
           veteran: {
+            primaryPhone,
+            emailAddress,
             mailingAddress: {
               country: 'USA',
               addressLine1: '123 Any Street',
@@ -213,6 +222,8 @@ describe('Disability benefits 526EZ primary address', () => {
         schema={schema}
         data={{
           veteran: {
+            primaryPhone,
+            emailAddress,
             'view:hasForwardingAddress': true,
             mailingAddress: {
               country: 'USA',
@@ -249,6 +260,8 @@ describe('Disability benefits 526EZ primary address', () => {
         schema={schema}
         data={{
           veteran: {
+            primaryPhone,
+            emailAddress,
             'view:hasForwardingAddress': true,
             mailingAddress: {
               country: 'USA',
@@ -305,7 +318,7 @@ describe('Disability benefits 526EZ primary address', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(7);
+    expect(form.find('.usa-input-error-message').length).to.equal(9);
     expect(onSubmit.called).to.be.false;
   });
 
@@ -317,6 +330,8 @@ describe('Disability benefits 526EZ primary address', () => {
         schema={schema}
         data={{
           veteran: {
+            primaryPhone,
+            emailAddress,
             'view:hasForwardingAddress': true,
             mailingAddress: {
               country: 'USA',

--- a/src/applications/disability-benefits/526EZ/tests/config/primaryAddress.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/primaryAddress.unit.spec.jsx
@@ -1,4 +1,4 @@
-/*  */import React from 'react';
+import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';


### PR DESCRIPTION
This is the only thing I could find that didn't match. They're marked as required in the schema, but we're not using the schema for this part, so there's a disconnect.

I think we'll catch any remaining outliers like this when we do the data transformation and unit tests. :crossed_fingers: 