### PR TITLE
Remove unnecessary 'note' at bottom of paymentInfo page

### DIFF
--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -702,14 +702,10 @@ export const AddressDescription = () => (
 );
 
 export const PaymentDescription = () => (
-  <div>
-    <p>
-      This is the bank account information we have on file for you. We’ll pay your
-      disability benefit to this account. If you need to update your bank information,
-      please go to eBenefits.
-    </p>
-    <p>
-      <a target="blank" href={E_BENEFITS_URL}>Go to eBenefits</a>.
-    </p>
-  </div>
+  <p>
+    This is the bank account information we have on file for you. We’ll pay your
+    disability benefit to this account. If you need to update your bank information,
+    please call Veterans Benefits Assistance at <a href="tel:1-800-827-1000">1-800-827-1000</a>,
+    Monday through Friday, 8:00 a.m. to 9:00 p.m. (ET).
+  </p>
 );

--- a/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
+++ b/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
@@ -55,10 +55,6 @@ export const viewComponent = (response) => {
         {routingNumberString}
         {bankNameString}
       </div>
-      <p>
-        <strong>Note:</strong> If you need to update your bank information, please call Veterans Benefits Assistance
-        at <a href="tel:+18008271000">1-800-827-1000</a>, Monday – Friday, 8:00 a.m. to 9:00 p.m. (ET).
-      </p>
     </div>
   );
 };


### PR DESCRIPTION
This fixes a little content bug where we were giving conflicting information about how to update your accounts above and below the Payment Info content:

![screen shot 2018-06-22 at 2 15 34 pm](https://user-images.githubusercontent.com/24251447/41794968-cb3ae0e2-7626-11e8-841c-7a8df2229875.png)

This is now:
![screen shot 2018-06-22 at 2 17 14 pm](https://user-images.githubusercontent.com/24251447/41795019-fd6f4f76-7626-11e8-9987-43d497715404.png)


Per the content in issue:
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/10403
(Can't link it because it's already connected to another PR)