### PR TITLE
Profile 360 - Add category-level transaction messaging

### DIFF
--- a/src/applications/personalization/profile360/actions/index.js
+++ b/src/applications/personalization/profile360/actions/index.js
@@ -1,4 +1,5 @@
 import { apiRequest } from '../../../../platform/utilities/api';
+import localVet360, { isVet360Configured } from '../util/local-vet360';
 import sendAndMergeApiRequests from '../util/sendAndMergeApiRequests';
 import _ from 'lodash';
 import countries from '../constants/countries.json';
@@ -63,7 +64,7 @@ export function fetchAddressConstants() {
 export function fetchTransactions() {
   return async (dispatch) => {
     try {
-      const response = await apiRequest('/profile/status/');
+      const response = isVet360Configured() ? await apiRequest('/profile/status/') : localVet360.getUserTransactions();
       dispatch({
         type: VET360_TRANSACTIONS_FETCH_SUCCESS,
         data: response.data

--- a/src/applications/personalization/profile360/components/ContactInformation.jsx
+++ b/src/applications/personalization/profile360/components/ContactInformation.jsx
@@ -4,8 +4,8 @@ import React from 'react';
 import DowntimeNotification, { externalServices } from '../../../../platform/monitoring/DowntimeNotification';
 import recordEvent from '../../../../platform/monitoring/record-event';
 import accountManifest from '../../account/manifest.json';
-import { FIELD_NAMES } from '../constants/vet360';
-import Vet360PendingTransactionCategory, { transactionCategoryTypes } from '../containers/Vet360PendingTransactionCategory';
+import { FIELD_NAMES, TRANSACTION_CATEGORY_TYPES } from '../constants/vet360';
+import Vet360PendingTransactionCategory from '../containers/Vet360PendingTransactionCategory';
 import PhoneSection from './PhoneSection';
 import AddressSection from './AddressSection';
 import EmailSection from './EmailSection';
@@ -38,7 +38,7 @@ export default class ContactInformation extends React.Component {
       <div>
         <ContactInformationExplanation/>
 
-        <Vet360PendingTransactionCategory categoryType={transactionCategoryTypes.ADDRESS}>
+        <Vet360PendingTransactionCategory categoryType={TRANSACTION_CATEGORY_TYPES.ADDRESS}>
           <AddressSection
             title="Mailing address"
             fieldName={FIELD_NAMES.MAILING_ADDRESS}
@@ -51,7 +51,7 @@ export default class ContactInformation extends React.Component {
             addressConstants={addressConstants}/>
         </Vet360PendingTransactionCategory>
 
-        <Vet360PendingTransactionCategory categoryType={transactionCategoryTypes.PHONE}>
+        <Vet360PendingTransactionCategory categoryType={TRANSACTION_CATEGORY_TYPES.PHONE}>
           <PhoneSection
             title="Home phone number"
             fieldName={FIELD_NAMES.HOME_PHONE}
@@ -70,7 +70,7 @@ export default class ContactInformation extends React.Component {
             analyticsSectionName="fax-number"/>
         </Vet360PendingTransactionCategory>
 
-        <Vet360PendingTransactionCategory categoryType={transactionCategoryTypes.EMAIL}>
+        <Vet360PendingTransactionCategory categoryType={TRANSACTION_CATEGORY_TYPES.EMAIL}>
           <EmailSection
             title="Email address"
             fieldName={FIELD_NAMES.EMAIL}

--- a/src/applications/personalization/profile360/components/ContactInformation.jsx
+++ b/src/applications/personalization/profile360/components/ContactInformation.jsx
@@ -5,6 +5,7 @@ import DowntimeNotification, { externalServices } from '../../../../platform/mon
 import recordEvent from '../../../../platform/monitoring/record-event';
 import accountManifest from '../../account/manifest.json';
 import { FIELD_NAMES } from '../constants/vet360';
+import Vet360PendingTransactionCategory, { transactionCategoryTypes } from '../containers/Vet360PendingTransactionCategory';
 import PhoneSection from './PhoneSection';
 import AddressSection from './AddressSection';
 import EmailSection from './EmailSection';
@@ -36,36 +37,45 @@ export default class ContactInformation extends React.Component {
     return (
       <div>
         <ContactInformationExplanation/>
-        <AddressSection
-          title="Mailing address"
-          fieldName={FIELD_NAMES.MAILING_ADDRESS}
-          analyticsSectionName="mailing-address"
-          addressConstants={addressConstants}/>
-        <AddressSection
-          title="Home address"
-          fieldName={FIELD_NAMES.RESIDENTIAL_ADDRESS}
-          analyticsSectionName="residential-address"
-          addressConstants={addressConstants}/>
-        <PhoneSection
-          title="Home phone number"
-          fieldName={FIELD_NAMES.HOME_PHONE}
-          analyticsSectionName="home-telephone"/>
-        <PhoneSection
-          title="Mobile phone number"
-          fieldName={FIELD_NAMES.MOBILE_PHONE}
-          analyticsSectionName="mobile-telephone"/>
-        <PhoneSection
-          title="Work phone number"
-          fieldName={FIELD_NAMES.WORK_PHONE}
-          analyticsSectionName="work-telephone"/>
-        <PhoneSection
-          title="Fax number"
-          fieldName={FIELD_NAMES.FAX_NUMBER}
-          analyticsSectionName="fax-number"/>
-        <EmailSection
-          title="Email address"
-          fieldName={FIELD_NAMES.EMAIL}
-          analyticsSectionName="email"/>
+
+        <Vet360PendingTransactionCategory categoryType={transactionCategoryTypes.ADDRESS}>
+          <AddressSection
+            title="Mailing address"
+            fieldName={FIELD_NAMES.MAILING_ADDRESS}
+            analyticsSectionName="mailing-address"
+            addressConstants={addressConstants}/>
+          <AddressSection
+            title="Home address"
+            fieldName={FIELD_NAMES.RESIDENTIAL_ADDRESS}
+            analyticsSectionName="residential-address"
+            addressConstants={addressConstants}/>
+        </Vet360PendingTransactionCategory>
+
+        <Vet360PendingTransactionCategory categoryType={transactionCategoryTypes.PHONE}>
+          <PhoneSection
+            title="Home phone number"
+            fieldName={FIELD_NAMES.HOME_PHONE}
+            analyticsSectionName="home-telephone"/>
+          <PhoneSection
+            title="Mobile phone number"
+            fieldName={FIELD_NAMES.MOBILE_PHONE}
+            analyticsSectionName="mobile-telephone"/>
+          <PhoneSection
+            title="Work phone number"
+            fieldName={FIELD_NAMES.WORK_PHONE}
+            analyticsSectionName="work-telephone"/>
+          <PhoneSection
+            title="Fax number"
+            fieldName={FIELD_NAMES.FAX_NUMBER}
+            analyticsSectionName="fax-number"/>
+        </Vet360PendingTransactionCategory>
+
+        <Vet360PendingTransactionCategory categoryType={transactionCategoryTypes.EMAIL}>
+          <EmailSection
+            title="Email address"
+            fieldName={FIELD_NAMES.EMAIL}
+            analyticsSectionName="email"/>
+        </Vet360PendingTransactionCategory>
       </div>
     );
   }

--- a/src/applications/personalization/profile360/components/Vet360TransactionPending.jsx
+++ b/src/applications/personalization/profile360/components/Vet360TransactionPending.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 export default class Vet360TransactionPending extends React.Component {
   static propTypes = {
-    title: PropTypes.string.isRequired,
+    title: PropTypes.string,
     refreshTransaction: PropTypes.func.isRequired
   };
 
@@ -16,6 +16,10 @@ export default class Vet360TransactionPending extends React.Component {
   }
 
   render() {
+    if (this.props.children) {
+      return <div>{this.props.children}</div>;
+    }
+
     return (
       <div className="vet360-profile-field-transaction-pending">
         We’re working on saving your new {this.props.title.toLowerCase()}. We’ll show it here once it’s saved.

--- a/src/applications/personalization/profile360/constants/vet360.js
+++ b/src/applications/personalization/profile360/constants/vet360.js
@@ -1,3 +1,9 @@
+export const TRANSACTION_CATEGORY_TYPES = {
+  PHONE: 'AsyncTransaction::Vet360::PhoneTransaction',
+  EMAIL: 'AsyncTransaction::Vet360::EmailTransaction',
+  ADDRESS: 'AsyncTransaction::Vet360::AddressTransaction'
+};
+
 export const TRANSACTION_STATUS = {
   REJECTED: 'REJECTED',
   RECEIVED: 'RECEIVED',

--- a/src/applications/personalization/profile360/containers/Vet360PendingTransactionCategory.jsx
+++ b/src/applications/personalization/profile360/containers/Vet360PendingTransactionCategory.jsx
@@ -9,7 +9,7 @@ import Vet360TransactionPending from '../components/Vet360TransactionPending';
 import { TRANSACTION_CATEGORY_TYPES } from '../constants/vet360';
 import { selectVet360PendingCategoryTransactions } from '../selectors';
 
-function Vet360PendingTransactionCategory({ dispatchRefreshTransaction, transactions, hasPendingCategoryTransaction, categoryType, children }) {
+function Vet360PendingTransactionCategory({ refreshTransaction: dispatchRefreshTransaction, transactions, hasPendingCategoryTransaction, categoryType, children }) {
   if (!hasPendingCategoryTransaction) return <div>{children}</div>;
 
   let plural = 'email';

--- a/src/applications/personalization/profile360/containers/Vet360PendingTransactionCategory.jsx
+++ b/src/applications/personalization/profile360/containers/Vet360PendingTransactionCategory.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
+import { selectVet360PendingCategoryTransactions } from '../selectors';
+
+export const transactionCategoryTypes = {
+  PHONE: 'AsyncTransaction::Vet360::PhoneTransaction',
+  EMAIL: 'AsyncTransaction::Vet360::EmailTransaction',
+  ADDRESS: 'AsyncTransaction::Vet360::AddressTransaction'
+};
+
+function Vet360PendingTransactionCategory({ hasPendingCategoryTransaction, categoryType, children }) {
+  if (!hasPendingCategoryTransaction) return <div>{children}</div>;
+
+  let plural = 'email';
+  if (categoryType === transactionCategoryTypes.PHONE) {
+    plural = 'phone numbers';
+  } else if (categoryType === transactionCategoryTypes.ADDRESS) {
+    plural = 'addresses';
+  }
+
+  return (
+    <AlertBox
+      isVisible
+      status="warning">
+      <h4>We’re updating your {plural}</h4>
+      <p>We’re in the process of saving your changes. We'll show your updated information below as soon as it’s finished saving.</p>
+    </AlertBox>
+  );
+}
+
+const mapStateToProps = (state, ownProps) => {
+  const { categoryType } = ownProps;
+  return {
+    hasPendingCategoryTransaction: selectVet360PendingCategoryTransactions(state, categoryType).length > 0
+  };
+};
+
+export default connect(mapStateToProps, null)(Vet360PendingTransactionCategory);
+export { Vet360PendingTransactionCategory };

--- a/src/applications/personalization/profile360/containers/Vet360PendingTransactionCategory.jsx
+++ b/src/applications/personalization/profile360/containers/Vet360PendingTransactionCategory.jsx
@@ -2,10 +2,14 @@ import React from 'react';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
+import { refreshTransaction } from '../actions/updaters';
+
+import Vet360TransactionPending from '../components/Vet360TransactionPending';
+
 import { TRANSACTION_CATEGORY_TYPES } from '../constants/vet360';
 import { selectVet360PendingCategoryTransactions } from '../selectors';
 
-function Vet360PendingTransactionCategory({ hasPendingCategoryTransaction, categoryType, children }) {
+function Vet360PendingTransactionCategory({ dispatchRefreshTransaction, transactions, hasPendingCategoryTransaction, categoryType, children }) {
   if (!hasPendingCategoryTransaction) return <div>{children}</div>;
 
   let plural = 'email';
@@ -15,22 +19,35 @@ function Vet360PendingTransactionCategory({ hasPendingCategoryTransaction, categ
     plural = 'addresses';
   }
 
+  const refreshAllTransactions = () => {
+    transactions.forEach(dispatchRefreshTransaction);
+  };
+
   return (
-    <AlertBox
-      isVisible
-      status="warning">
-      <h4>We’re updating your {plural}</h4>
-      <p>We’re in the process of saving your changes. We'll show your updated information below as soon as it’s finished saving.</p>
-    </AlertBox>
+    <Vet360TransactionPending refreshTransaction={refreshAllTransactions}>
+      <AlertBox
+        isVisible
+        status="warning">
+        <h4>We’re updating your {plural}</h4>
+        <p>We’re in the process of saving your changes. We'll show your updated information below as soon as it’s finished saving.</p>
+      </AlertBox>
+    </Vet360TransactionPending>
   );
 }
 
 const mapStateToProps = (state, ownProps) => {
   const { categoryType } = ownProps;
+  const pendingTransactions = selectVet360PendingCategoryTransactions(state, categoryType);
+
   return {
-    hasPendingCategoryTransaction: selectVet360PendingCategoryTransactions(state, categoryType).length > 0
+    hasPendingCategoryTransaction: pendingTransactions.length > 0,
+    transactions: pendingTransactions
   };
 };
 
-export default connect(mapStateToProps, null)(Vet360PendingTransactionCategory);
+const mapDispatchToProps = {
+  refreshTransaction
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Vet360PendingTransactionCategory);
 export { Vet360PendingTransactionCategory };

--- a/src/applications/personalization/profile360/containers/Vet360PendingTransactionCategory.jsx
+++ b/src/applications/personalization/profile360/containers/Vet360PendingTransactionCategory.jsx
@@ -2,21 +2,16 @@ import React from 'react';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
+import { TRANSACTION_CATEGORY_TYPES } from '../constants/vet360';
 import { selectVet360PendingCategoryTransactions } from '../selectors';
-
-export const transactionCategoryTypes = {
-  PHONE: 'AsyncTransaction::Vet360::PhoneTransaction',
-  EMAIL: 'AsyncTransaction::Vet360::EmailTransaction',
-  ADDRESS: 'AsyncTransaction::Vet360::AddressTransaction'
-};
 
 function Vet360PendingTransactionCategory({ hasPendingCategoryTransaction, categoryType, children }) {
   if (!hasPendingCategoryTransaction) return <div>{children}</div>;
 
   let plural = 'email';
-  if (categoryType === transactionCategoryTypes.PHONE) {
+  if (categoryType === TRANSACTION_CATEGORY_TYPES.PHONE) {
     plural = 'phone numbers';
-  } else if (categoryType === transactionCategoryTypes.ADDRESS) {
+  } else if (categoryType === TRANSACTION_CATEGORY_TYPES.ADDRESS) {
     plural = 'addresses';
   }
 

--- a/src/applications/personalization/profile360/sass/profile-360.scss
+++ b/src/applications/personalization/profile360/sass/profile-360.scss
@@ -56,5 +56,9 @@ input.usa-only-phone {
 
 .vet360-profile-field-transaction-pending {
   color: $color-primary;
+  border-left: 4px solid $color-primary;
+  padding-left: 1.5rem;
+  position: relative;
+  right: 1.9rem;
   font-weight: bold;
 }

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -6,7 +6,8 @@ import {
 
 import {
   isSuccessfulTransaction,
-  isFailedTransaction
+  isFailedTransaction,
+  isPendingTransaction
 } from './util/transactions';
 
 export function selectIsVet360AvailableForUser(state) {
@@ -46,6 +47,40 @@ export function selectVet360SuccessfulTransactions(state) {
 
 export function selectVet360FailedTransactions(state) {
   return state.vet360.transactions.filter(isFailedTransaction);
+}
+
+export function selectVet360PendingCategoryTransactions(state, type) {
+  const {
+    vet360: {
+      transactions,
+      fieldTransactionMap
+    }
+  } = state;
+
+  const existsWithinFieldTransactionMap = (transaction) => {
+    const transactionId = transaction.data.attributes.transactionId;
+
+    return Object
+      .keys(fieldTransactionMap)
+      .some(fieldName => {
+        const transactionRequest = fieldTransactionMap[fieldName];
+        return transactionRequest.transactionId === transactionId;
+      });
+  };
+
+  return transactions
+    .filter(transaction => {
+      // Do the actual category-type filter.
+      return transaction.data.attributes.type === type;
+    }).filter(transaction => {
+      // Filter to transaction with the pending status
+      return isPendingTransaction(transaction);
+    }).filter(transaction => {
+      // If the transaction has corresponding transaction information in the fieldTransactionMap,
+      // then we know which field that transaction belongs. In this case, we ignore it at the
+      // category-level.
+      return !existsWithinFieldTransactionMap(transaction);
+    });
 }
 
 export function selectEditedFormField(state, fieldName) {

--- a/src/applications/personalization/profile360/util/local-vet360.js
+++ b/src/applications/personalization/profile360/util/local-vet360.js
@@ -108,6 +108,7 @@ export default {
     }).map(transactionType => {
       return {
         attributes: {
+          transactionId: uniqueId('transaction_'),
           transactionStatus: VET360_CONSTANTS.TRANSACTION_STATUS.RECEIVED,
           type: transactionType
         }

--- a/src/applications/personalization/profile360/util/local-vet360.js
+++ b/src/applications/personalization/profile360/util/local-vet360.js
@@ -103,18 +103,16 @@ export default {
       VET360_CONSTANTS.TRANSACTION_CATEGORY_TYPES.ADDRESS,
       VET360_CONSTANTS.TRANSACTION_CATEGORY_TYPES.EMAIL,
       VET360_CONSTANTS.TRANSACTION_CATEGORY_TYPES.PHONE
-    ]
-      .filter(() => {
-        return Math.random() > 0.5;
-      })
-      .map(transactionType => {
-        return {
-          attributes: {
-            transactionStatus: VET360_CONSTANTS.TRANSACTION_STATUS.RECEIVED,
-            transactionType
-          }
-        };
-      });
+    ].filter(() => {
+      return Math.random() > 0.5;
+    }).map(transactionType => {
+      return {
+        attributes: {
+          transactionStatus: VET360_CONSTANTS.TRANSACTION_STATUS.RECEIVED,
+          type: transactionType
+        }
+      };
+    });
 
     // console.log(data);
 

--- a/src/applications/personalization/profile360/util/local-vet360.js
+++ b/src/applications/personalization/profile360/util/local-vet360.js
@@ -98,6 +98,30 @@ function asyncReturn(returnValue) {
 }
 
 export default {
+  getUserTransactions() {
+    const data = [
+      VET360_CONSTANTS.TRANSACTION_CATEGORY_TYPES.ADDRESS,
+      VET360_CONSTANTS.TRANSACTION_CATEGORY_TYPES.EMAIL,
+      VET360_CONSTANTS.TRANSACTION_CATEGORY_TYPES.PHONE
+    ]
+      .filter(() => {
+        return Math.random() > 0.5;
+      })
+      .map(transactionType => {
+        return {
+          attributes: {
+            transactionStatus: VET360_CONSTANTS.TRANSACTION_STATUS.RECEIVED,
+            transactionType
+          }
+        };
+      });
+
+    // console.log(data);
+
+    return {
+      data
+    };
+  },
   createTransaction() {
     return asyncReturn({
       data: {


### PR DESCRIPTION
- Adds left border to field-level updating message
- Adds container for hiding all fields for a given transaction category type, when a pending transaction is found without a field mapping. This may occur on initial page load.

Resolves department-of-veterans-affairs/vets.gov-team/issues/10870