### PR TITLE
Flip the production bit

### DIFF
--- a/src/applications/disability-benefits/526EZ/manifest.json
+++ b/src/applications/disability-benefits/526EZ/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./form-entry.jsx",
   "entryName": "526EZ-claims-increase",
   "rootUrl": "/disability-benefits/apply/form-526-disability-claim",
-  "production": false
+  "production": true
 }


### PR DESCRIPTION
## Goal:
- Put 526 app into production
- Behind a password (Believe this is covered in a separate devops ticket)
- Without any links to the app on vets.gov (i.e., the only way this should be accessible is by knowing the form url directly)

## Rationale:
We're doing UAT this week, and want to have select users see their own prefill data as they fill out the form.

## How this PR was tested:
- Ran a local production build of vets-website using scripts in `readme.md`
- Ran a local server on the `build/production` directory
- Ensured that the form was accessible at its entrypoint, `/disability-benefits/apply/form-526-disability-claim`
- Ensured the wizard that points to the form was **not** available at `/disability-benefits/apply`