### PR TITLE
Profile360: Add reducer property for storing pending transaction requests

### DIFF
--- a/src/applications/personalization/profile360/actions/updaters.js
+++ b/src/applications/personalization/profile360/actions/updaters.js
@@ -62,6 +62,14 @@ export function refreshTransaction(transaction, analyticsSectionName) {
       });
 
       if (isSuccessfulTransaction(transactionRefreshed)) {
+
+        // @todo This is just a test to see if this forces the Redis cache to clear
+        // after a transaction finishes successfully. We should remove this later if it
+        // doesn't work, or figure out a clearer solution with the BE folks.
+        if (isVet360Configured()) {
+          await apiRequest(`/profile/status/${transactionId}`);
+        }
+
         dispatch(refreshProfile());
       } else if (isFailedTransaction(transactionRefreshed) && analyticsSectionName) {
         recordEvent({

--- a/src/applications/personalization/profile360/reducers/vet360.js
+++ b/src/applications/personalization/profile360/reducers/vet360.js
@@ -5,12 +5,15 @@ import {
   VET360_TRANSACTION_REQUEST_FAILED,
   VET360_TRANSACTION_UPDATED,
   VET360_TRANSACTION_CLEARED,
-  VET360_TRANSACTION_REQUEST_CLEARED
+  VET360_TRANSACTION_REQUEST_CLEARED,
+  VET360_TRANSACTION_UPDATE_REQUESTED,
+  VET360_TRANSACTION_UPDATE_FAILED
 } from '../actions';
 
 const initialState = {
   transactions: [],
-  fieldTransactionMap: {}
+  fieldTransactionMap: {},
+  transactionsAwaitingUpdate: []
 };
 
 export default function vet360(state = initialState, action) {
@@ -63,15 +66,32 @@ export default function vet360(state = initialState, action) {
       };
     }
 
+    case VET360_TRANSACTION_UPDATE_REQUESTED: {
+      const { transactionId } = action.transaction.data.attributes;
+      return {
+        ...state,
+        transactionsAwaitingUpdate: state.transactionsAwaitingUpdate.concat(transactionId)
+      };
+    }
+
     case VET360_TRANSACTION_UPDATED: {
       const { transaction } = action;
       const { transactionId: updatedTransactionId } = transaction.data.attributes;
 
       return {
         ...state,
+        transactionsAwaitingUpdate: state.transactionsAwaitingUpdate.filter(tid => tid !== updatedTransactionId),
         transactions: state.transactions.map(t => {
           return t.data.attributes.transactionId === updatedTransactionId ? transaction : t;
         })
+      };
+    }
+
+    case VET360_TRANSACTION_UPDATE_FAILED: {
+      const { transactionId } = action.transaction.data.attributes;
+      return {
+        ...state,
+        transactionsAwaitingUpdate: state.transactionsAwaitingUpdate.filter(tid => tid !== transactionId)
       };
     }
 

--- a/src/applications/personalization/profile360/util/local-vet360.js
+++ b/src/applications/personalization/profile360/util/local-vet360.js
@@ -89,11 +89,11 @@ export const mockContactInformation = {
 };
 
 
-function asyncReturn(returnValue) {
+function asyncReturn(returnValue, delay = 300) {
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve(returnValue);
-    }, 300);
+    }, delay);
   });
 }
 
@@ -130,10 +130,10 @@ export default {
     });
   },
   updateTransactionRandom(...args) {
-    if (Math.random() > 0.5) {
-      return this.updateTransaction(...args);
-    }
-    return this.updateTransactionToFailure(...args);
+    return asyncReturn(
+      Math.random() > 0.5 ? this.updateTransaction(...args) : this.updateTransactionToFailure(...args),
+      3000
+    );
   },
   updateTransaction(transactionId) {
     return {


### PR DESCRIPTION
Transaction updates were piling up when the server was taking longer than the polling timeout (> 1s), which was causing our success/failure handlers to fire more than once.

Resolves department-of-veterans-affairs/vets.gov-team/issues/11303