### PR TITLE
Profile360: Limit messaging to just one success, one error banner

### DIFF
--- a/src/applications/personalization/profile360/actions/updaters.js
+++ b/src/applications/personalization/profile360/actions/updaters.js
@@ -62,7 +62,8 @@ export function refreshTransaction(transaction, analyticsSectionName) {
       });
 
       if (isSuccessfulTransaction(transactionRefreshed)) {
-        dispatch(refreshProfile());
+        const forceCacheClear = true;
+        dispatch(refreshProfile(forceCacheClear));
       } else if (isFailedTransaction(transactionRefreshed) && analyticsSectionName) {
         recordEvent({
           event: 'profile-edit-failure',

--- a/src/applications/personalization/profile360/containers/Vet360TransactionReporter.jsx
+++ b/src/applications/personalization/profile360/containers/Vet360TransactionReporter.jsx
@@ -7,7 +7,9 @@ import scrollToTop from '../../../../platform/utilities/ui/scrollToTop';
 
 import {
   selectVet360SuccessfulTransactions,
-  selectVet360FailedTransactions
+  selectVet360FailedTransactions,
+  selectMostRecentSuccessfulTransaction,
+  selectMostRecentErroredTransaction
 } from '../selectors';
 
 import {
@@ -26,32 +28,34 @@ class Vet360TransactionReporter extends React.Component {
     if (newMessageVisible) scrollToTop();
   }
 
+  clearAllSuccessfulTransactions = () => {
+    this.props.successfulTransactions.forEach(this.props.clearTransaction);
+  }
+
+  clearAllErroredTransactions = () => {
+    this.props.erroredTransactions.forEach(this.props.clearTransaction);
+  }
+
   render() {
     const {
-      successfulTransactions,
-      erroredTransactions
+      mostRecentSuccessfulTransaction,
+      mostRecentErroredTransaction
     } = this.props;
 
     return (
       <div className="vet360-transaction-reporter">
-        {successfulTransactions.map((transaction) => {
-          return (
-            <AlertBox
-              key={transaction.data.attributes.transactionId}
-              isVisible
-              status="success"
-              onCloseAlert={this.props.clearTransaction.bind(null, transaction)}
-              content={<h4>We saved your updated information.</h4>}/>
-          );
-        })}
-        {erroredTransactions.map((transaction) => {
-          return (
-            <Vet360TransactionErrorBanner
-              key={transaction.data.attributes.transactionId}
-              transaction={transaction}
-              clearTransaction={this.props.clearTransaction.bind(null, transaction)}/>
-          );
-        })}
+        {mostRecentSuccessfulTransaction && (
+          <AlertBox
+            isVisible
+            status="success"
+            onCloseAlert={this.clearAllSuccessfulTransactions}
+            content={<h4>We saved your updated information.</h4>}/>
+        )}
+        {mostRecentErroredTransaction && (
+          <Vet360TransactionErrorBanner
+            transaction={mostRecentErroredTransaction}
+            clearTransaction={this.clearAllErroredTransactions}/>
+        )}
       </div>
     );
   }
@@ -59,6 +63,8 @@ class Vet360TransactionReporter extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
+    mostRecentSuccessfulTransaction: selectMostRecentSuccessfulTransaction(state),
+    mostRecentErroredTransaction: selectMostRecentErroredTransaction(state),
     successfulTransactions: selectVet360SuccessfulTransactions(state),
     erroredTransactions: selectVet360FailedTransactions(state)
   };

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -49,6 +49,40 @@ export function selectVet360FailedTransactions(state) {
   return state.vet360.transactions.filter(isFailedTransaction);
 }
 
+export function selectMostRecentSuccessfulTransaction(state) {
+  const {
+    vet360: {
+      transactions,
+      metadata: {
+        mostRecentSuccessfulTransactionId
+      }
+    }
+  } = state;
+
+  let transaction = null;
+  if (mostRecentSuccessfulTransactionId) {
+    transaction = transactions.find(t => t.data.attributes.transactionId === mostRecentSuccessfulTransactionId);
+  }
+  return transaction;
+}
+
+export function selectMostRecentErroredTransaction(state) {
+  const {
+    vet360: {
+      transactions,
+      metadata: {
+        mostRecentErroredTransactionId
+      }
+    }
+  } = state;
+
+  let transaction = null;
+  if (mostRecentErroredTransactionId) {
+    transaction = transactions.find(t => t.data.attributes.transactionId === mostRecentErroredTransactionId);
+  }
+  return transaction;
+}
+
 export function selectVet360PendingCategoryTransactions(state, type) {
   const {
     vet360: {

--- a/src/platform/user/profile/actions/index.js
+++ b/src/platform/user/profile/actions/index.js
@@ -26,10 +26,14 @@ export function profileLoadingFinished() {
   };
 }
 
-export function refreshProfile() {
+export function refreshProfile(forceCacheClear = false) {
   return async (dispatch) => {
-    const cacheBreaker = new Date().getTime();
-    const response = await fetch(`${environment.API_URL}/v0/user?now=${cacheBreaker}`, {
+    let url = `${environment.API_URL}/v0/user`;
+    if (forceCacheClear) {
+      url += `?now=${new Date().getTime()}`;
+    }
+
+    const response = await fetch(url, {
       method: 'GET',
       headers: new Headers({
         Authorization: `Token token=${sessionStorage.userToken}`


### PR DESCRIPTION
Also modifies the `/v0/user` route to only add the cache-busting parameter when explicitly told. This way we can preserve caching except when we modify the data in Vet360.

Resolves department-of-veterans-affairs/vets.gov-team/issues/11297