### PR TITLE
Profile360: Fix for Edit Phone Field input value not clearing after corresponding field is deleted

### DIFF
--- a/src/applications/personalization/profile360/components/PhoneEditModal.jsx
+++ b/src/applications/personalization/profile360/components/PhoneEditModal.jsx
@@ -60,7 +60,7 @@ export default class PhoneEditModal extends React.Component {
   }
 
   isEmpty = () => {
-    return !(this.props.data && this.props.data.inputPhoneNumber);
+    return !(this.props.data && this.props.data.phoneNumber);
   }
 
   renderForm = () => {

--- a/src/applications/personalization/profile360/components/PhoneEditModal.jsx
+++ b/src/applications/personalization/profile360/components/PhoneEditModal.jsx
@@ -52,7 +52,7 @@ export default class PhoneEditModal extends React.Component {
       defaultFieldValue = {
         countryCode: '1',
         extension: '',
-        phoneNumber: ''
+        inputPhoneNumber: ''
       };
     }
 
@@ -60,7 +60,7 @@ export default class PhoneEditModal extends React.Component {
   }
 
   isEmpty = () => {
-    return !(this.props.data && this.props.data.phoneNumber);
+    return !(this.props.data && this.props.data.inputPhoneNumber);
   }
 
   renderForm = () => {


### PR DESCRIPTION
I hope that this is as simple as the updates here, but it's hard to test without a working Vet360 configuration.

This is weird though, because Redux tools is saying we have the expected props being passed.

![image](https://user-images.githubusercontent.com/1915775/42113329-f30e28e4-7bb8-11e8-9399-b82d8a8e0e2b.png)

If not this I would suspect something in the `PhoneTextInput` in causing weird behavior.

(Maybe) Resolves department-of-veterans-affairs/vets.gov-team/issues/11338