### PR TITLE
Profile360: Show loading indicator during delete

### DIFF
--- a/src/applications/personalization/profile360/components/Vet360EditModal.jsx
+++ b/src/applications/personalization/profile360/components/Vet360EditModal.jsx
@@ -5,7 +5,7 @@ import Modal from '@department-of-veterans-affairs/formation/Modal';
 
 import Vet360EditModalErrorMessage from '../components/Vet360EditModalErrorMessage';
 import LoadingButton from '../components/LoadingButton';
-import FormActionButtons from '../components/FormActionButtons';
+import Vet360EditModalActionButtons from '../components/Vet360EditModalActionButtons';
 
 export default class Vet360EditModal extends React.Component {
 
@@ -85,15 +85,16 @@ export default class Vet360EditModal extends React.Component {
           {error && <Vet360EditModalErrorMessage title={title} error={error} clearErrors={clearErrors}/>}
           {isFormReady && render()}
           <br/>
-          <FormActionButtons
+          <Vet360EditModalActionButtons
             onCancel={onCancel}
             onDelete={onDelete}
             title={title}
             analyticsSectionName={analyticsSectionName}
+            transactionRequest={transactionRequest}
             deleteEnabled={!isEmpty() && !deleteDisabled}>
             <LoadingButton isLoading={isLoading}>Update</LoadingButton>
             <button type="button" className="usa-button-secondary" onClick={onCancel}>Cancel</button>
-          </FormActionButtons>
+          </Vet360EditModalActionButtons>
         </form>
       </Modal>
     );

--- a/src/applications/personalization/profile360/components/Vet360EditModalActionButtons.jsx
+++ b/src/applications/personalization/profile360/components/Vet360EditModalActionButtons.jsx
@@ -6,7 +6,7 @@ import { toLower } from 'lodash';
 import recordEvent from '../../../../platform/monitoring/record-event';
 import LoadingButton from './LoadingButton';
 
-class FormActionButtons extends React.Component {
+class Vet360EditModalActionButtons extends React.Component {
 
   constructor(props) {
     super(props);
@@ -65,7 +65,11 @@ class FormActionButtons extends React.Component {
         <h3>Are you sure?</h3>
         <p>This will delete your {toLower(this.props.title)} across many VA records. You can always come back to your profile later if you'd like to add this information back in.</p>
         <div>
-          <LoadingButton isLoading={this.props.isLoading} onClick={this.confirmDeleteAction}>Confirm</LoadingButton>
+          <LoadingButton
+            isLoading={this.props.transactionRequest && this.props.transactionRequest.isPending}
+            onClick={this.confirmDeleteAction}>
+            Confirm
+          </LoadingButton>
           <button type="button" className="usa-button-secondary" onClick={this.cancelDeleteAction}>Cancel</button>
         </div>
       </div>
@@ -89,15 +93,16 @@ class FormActionButtons extends React.Component {
   }
 }
 
-FormActionButtons.propTypes = {
+Vet360EditModalActionButtons.propTypes = {
   deleteEnabled: PropTypes.bool,
   title: PropTypes.string.isRequired,
   onDelete: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
+  transactionRequest: PropTypes.object
 };
 
-FormActionButtons.defaultProps = {
+Vet360EditModalActionButtons.defaultProps = {
   deleteEnabled: true,
 };
 
-export default FormActionButtons;
+export default Vet360EditModalActionButtons;

--- a/src/applications/personalization/profile360/reducers/vet360.js
+++ b/src/applications/personalization/profile360/reducers/vet360.js
@@ -57,10 +57,10 @@ export default function vet360(state = initialState, action) {
         fieldTransactionMap: {
           ...state.fieldTransactionMap,
           [action.fieldName]: {
+            ...state.fieldTransactionMap[action.fieldName],
             isPending: false,
             isFailed: true,
-            error: action.error,
-            ...state.fieldTransactionMap[action.fieldName]
+            error: action.error
           }
         }
       };
@@ -72,9 +72,9 @@ export default function vet360(state = initialState, action) {
         fieldTransactionMap: {
           ...state.fieldTransactionMap,
           [action.fieldName]: {
+            ...state.fieldTransactionMap[action.fieldName],
             isPending: false,
-            transactionId: action.transaction.data.attributes.transactionId,
-            ...state.fieldTransactionMap[action.fieldName]
+            transactionId: action.transaction.data.attributes.transactionId
           }
         }
       };


### PR DESCRIPTION
- Changes name of `FormActionButtons` to `Vet360EditModalActionButtons`
- Passes `transactionRequest` down props to delete button
- Fixes bug in Vet360 reducer
    - Should have been using the spread operator as the first step of generating new object props, not the last.

Resolves department-of-veterans-affairs/vets.gov-team/issues/11353