### PR TITLE
Include claimId on confirmation page

### DIFF
--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -96,7 +96,7 @@ class ConfirmationPage extends React.Component {
               <strong>Confirmation number</strong>
               <br/>
               <span>V-DCCI-3986</span>
-              {/* <span>{response.confirmationNumber}</span> */}
+              {/* <span>{response.claimId}</span> */}
             </li>
             <li>
               <strong>Date submitted</strong>


### PR DESCRIPTION
This change includes the claimId on the confirmation page per #11381.