### PR TITLE
Patching an issue where additional text was appearing in mobile breadcrumb

### DIFF
--- a/assets/js/breadcrumbs/mobile-breadcrumb.js
+++ b/assets/js/breadcrumbs/mobile-breadcrumb.js
@@ -65,10 +65,10 @@
     breadcrumbList[0].classList.add(config.mobileClass);
     breadcrumbLink.innerText = breadcrumbLink.innerText.trim();
     breadcrumbLink.removeAttribute('aria-current');
-    breadcrumbLink.setAttribute(
-      'aria-label',
-      'Previous step: ' + breadcrumbLink.innerText
-    );
+    // breadcrumbLink.setAttribute(
+    //   'aria-label',
+    //   'Previous step: ' + breadcrumbLink.innerText
+    // );
   
     return breadcrumbList;
   }

--- a/content/pages/account/index.md
+++ b/content/pages/account/index.md
@@ -7,7 +7,7 @@ entryname: account
   <nav aria-label="Breadcrumb" aria-live="polite" aria-relevant="additions text" class="va-nav-breadcrumbs js-visual"
   id="va-breadcrumbs">
     <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">Home</a></li>
+      <li><a href="/" id="account-home">Home</a></li>
       <li><a aria-current="page" href="/account/">Your Account Settings</a></li>
     </ul>
   </nav>
@@ -22,3 +22,12 @@ entryname: account
   </div>
   <!-- Account Beta End -->
 </div>
+
+<script>
+  (function() {
+    var accountHomeLink = document.getElementById('account-home');
+    accountHomeLink.addEventListener('click', function(ev) {
+      recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });
+    });
+  })();
+</script>

--- a/content/pages/profile/index.md
+++ b/content/pages/profile/index.md
@@ -7,7 +7,7 @@ entryname: va-profile
   <nav aria-label="Breadcrumb" aria-live="polite" aria-relevant="additions text" class="va-nav-breadcrumbs js-visual"
   id="va-breadcrumbs">
     <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">Home</a></li>
+      <li><a href="/" id="account-home">Home</a></li>
       <li><a aria-current="page" href="/profile/">Your Profile</a></li>
     </ul>
   </nav>
@@ -22,3 +22,12 @@ entryname: va-profile
   </div>
   <!-- Profile Beta End -->
 </div>
+
+<script>
+  (function() {
+    var accountHomeLink = document.getElementById('account-home');
+    accountHomeLink.addEventListener('click', function(ev) {
+      recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });
+    });
+  })();
+</script>

--- a/content/pages/profile360/index.md
+++ b/content/pages/profile360/index.md
@@ -6,7 +6,7 @@ entryname: profile-360
 <div id="main">
   <nav class="va-nav-breadcrumbs">
     <ul class="row va-nav-breadcrumbs-list columns" role="menubar" aria-label="Primary">
-      <li><a href="/" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">Home</a></li>
+      <li><a href="/" id="account-home">Home</a></li>
     </ul>
   </nav>
 
@@ -20,3 +20,12 @@ entryname: profile-360
   </div>
   <!-- Profile Beta End -->
 </div>
+
+<script>
+  (function() {
+    var accountHomeLink = document.getElementById('account-home');
+    accountHomeLink.addEventListener('click', function(ev) {
+      recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });
+    });
+  })();
+</script>


### PR DESCRIPTION
The mobile breadcrumb script is picking up some extra text from an analytics handler, and making the back by one link too long on the account, profile, and profile360 pages. This moves that handler to its own script, and removes the `aria-label` attribute from the back by one mobile breadcrumb.