### PR TITLE
add query params to action creator

### DIFF
--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -67,7 +67,9 @@ export class SearchPage extends React.Component {
       'yellowRibbonScholarship',
       'principlesOfExcellence',
       'eightKeysToVeteranSuccess',
-      'stemOffered'
+      'stemOffered',
+      'priorityEnrollment',
+      'independentStudy'
     ];
 
     const query = _.pick(this.props.location.query, [


### PR DESCRIPTION
The way I validated this before was incorrect. 

- Point your gids in your `settings.yml` in `vets-api` to staging. 
- after adding the priority enrollment or independent study filters to the [gi bill search](http://localhost:3001/gi-bill-comparison-tool/search?), the client should make an XHR request similar to this: http://localhost:3000/v0/gi/institutions/search?name=west&priority_enrollment=true&independent_study=true