### PR TITLE
Set up confirmation page

### DIFF
--- a/src/applications/edu-benefits/opt-out/config/form.js
+++ b/src/applications/edu-benefits/opt-out/config/form.js
@@ -21,6 +21,7 @@ const formConfig = {
     noAuth: 'Please sign in again to continue your application for declaration of status of dependents.'
   },
   title: 'Opt Out of Sharing VA Education Benefits Information',
+  subTitle: 'VA Form 22-0993',
   defaultDefinitions: {
   },
   chapters: {

--- a/src/applications/edu-benefits/opt-out/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/opt-out/containers/ConfirmationPage.jsx
@@ -32,7 +32,7 @@ export class ConfirmationPage extends React.Component {
         <h2 className="schemaform-confirmation-section-header">What happens after I submit my opt-out form?</h2>
         <p>We’ll send you a letter in the mail confirming that we’ve received your opt-out form. After we receive your form, it’ll take us about 48 hours to remove schools’ access to your education benefit information.</p>
         <h2 className="schemaform-confirmation-section-header">What should I do if I change my mind and no longer want to opt out?</h2>
-        <p>You’ll need to call the Education Call Center at <a href="tel:+18884424551">1-888-442-4551</a>, Monday through Friday, 8:00 a.m. to 7:00 p.m. (ET), to o ask VA to start sharing your education benefits information again.</p>
+        <p>You’ll need to call the Education Call Center at <a href="tel:+18884424551">1-888-442-4551</a>, Monday through Friday, 8:00 a.m. to 7:00 p.m. (ET), to ask VA to start sharing your education benefits information again.</p>
         <h2 className="schemaform-confirmation-section-header">If I’ve opted out, what type of information do I need to give my school?</h2>
         <p>You’ll need to provide your school with a copy of your education benefits paperwork. If you transfer schools, you’ll also need to make sure your new school has your paperwork.</p>
         <div className="inset">

--- a/src/applications/edu-benefits/opt-out/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/opt-out/containers/ConfirmationPage.jsx
@@ -23,26 +23,48 @@ export class ConfirmationPage extends React.Component {
   render() {
     const { submission, data } = this.props.form;
     const { response } = submission;
-    const name = data.veteranFullName;
+    const name = data.veteranFullName || { first: 'First', last: 'Last' }; // TODO: remove mock data
 
     return (
       <div>
-        <h3 className="confirmation-page-title">Claim received</h3>
-        <p>We usually process claims within <strong>a week</strong>.</p>
-        <p>
-          We may contact you for more information or documents.<br/>
-          <i>Please print this page for your records.</i>
-        </p>
+        <h2 className="schemaform-confirmation-section-header">Your opt-out form has been submitted</h2>
+        <p>We may contact you if we have questions or need more information. You can print this page for your records.</p>
+        <h2 className="schemaform-confirmation-section-header">What happens after I submit my opt-out form?</h2>
+        <p>We’ll send you a letter in the mail confirming that we’ve received your opt-out form. After we receive your form, it’ll take us about 48 hours to remove schools’ access to your education benefit information.</p>
+        <h2 className="schemaform-confirmation-section-header">What should I do if I change my mind and no longer want to opt out?</h2>
+        <p>You’ll need to call the Education Call Center at <a href="tel:+18884424551">1-888-442-4551</a>, Monday through Friday, 8:00 a.m. to 7:00 p.m. (ET), to o ask VA to start sharing your education benefits information again.</p>
+        <h2 className="schemaform-confirmation-section-header">If I’ve opted out, what type of information do I need to give my school?</h2>
+        <p>You’ll need to provide your school with a copy of your education benefits paperwork. If you transfer schools, you’ll also need to make sure your new school has your paperwork.</p>
         <div className="inset">
-          <h4>686 Dependent-status form Claim <span className="additional">(Form 686)</span></h4>
+          <h4>Opt Out of Sharing VA Education Benefits Information</h4>
           <span>for {name.first} {name.middle} {name.last} {name.suffix}</span>
 
           {response && <ul className="claim-list">
             <li>
-              <strong>Date received</strong><br/>
+              <strong>Confirmation number</strong><br/>
+              <span>{response.confirmationNumber}</span>
+            </li>
+            <li>
+              <strong>Date submitted</strong><br/>
               <span>{moment(response.timestamp).format('MMM D, YYYY')}</span>
             </li>
           </ul>}
+        </div>
+        <div className="confirmation-guidance-container">
+          <h4 className="confirmation-guidance-heading">Need help?</h4>
+          <p className="confirmation-guidance-message help-talk">For help filling out this form, please call the Education Call Center:</p>
+          <p className="help-phone-number">
+            <a className="help-phone-number-link" href="tel:+1-888-442-4551">1-888-442-4551</a><br/>
+        Monday &#8211; Friday, 8:00 a.m. &#8211; 7:00 p.m. (ET)<br/>
+            <a className="help-phone-number-link" href="https://gibill.custhelp.com/app/utils/login_form/redirect/ask">Submit a question to Education Service</a>
+          </p>
+          <p className="help-talk">To report a problem with this form,<br/>
+          please call the Vets.gov Technical Help Desk:</p>
+          <p className="help-phone-number">
+            <a className="help-phone-number-link" href="tel:+1-855-574-7286">1-855-574-7286</a><br/>
+            TTY: <a className="help-phone-number-link" href="tel:+18008778339">1-800-877-8339</a><br/>
+            Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)
+          </p>
         </div>
       </div>
     );

--- a/src/applications/edu-benefits/tests/opt-out/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/opt-out/containers/ConfirmationPage.unit.spec.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import { ConfirmationPage } from '../../../opt-out/containers/ConfirmationPage';
+
+describe('Opt Out <ConfirmationPage>', () => {
+  it('should render', () => {
+    const form = {
+      submission: {
+        response: {
+          timestamp: '2010-01-01',
+          confirmationNumber: '3702390024'
+        }
+      },
+      data: {
+        veteranFullName: {
+          first: 'Joe',
+          middle: 'Marjorie',
+          last: 'Smith',
+          suffix: 'Sr.'
+        }
+      }
+    };
+
+    const tree = shallow(
+      <ConfirmationPage form={form}/>
+    );
+
+    expect(tree.find('.schemaform-confirmation-section-header').at(0).text()).to.contain('Your opt-out form has been submitted');
+    expect(tree.find('.claim-list').exists()).to.be.true;
+    expect(tree.find('span').at(1).text()).to.contain('3702390024');
+    expect(tree.find('span').at(2).text()).to.contain('Jan. 1, 2010');
+    expect(tree.find('p').first().text()).to.contain('We may contact you if we have questions or need more information. You can print this page for your records.');
+  });
+
+  it('should render without the response properties', () => {
+
+    const form = {
+      submission: {
+      },
+      data: {
+        veteranFullName: {
+          first: 'Joe',
+          middle: 'Marjorie',
+          last: 'Smith',
+          suffix: 'Sr.'
+        }
+      }
+    };
+    const tree = shallow(
+      <ConfirmationPage form={form}/>
+    );
+
+    expect(tree.find('.schemaform-confirmation-section-header').at(0).text()).to.contain('Your opt-out form has been submitted');
+    expect(tree.find('.claim-list').exists()).to.be.false;
+    expect(tree.find('p').first().text()).to.contain('We may contact you if we have questions or need more information. You can print this page for your records.');
+  });
+});


### PR DESCRIPTION
These changes set up the Opt Out form confirmation page per issue [11293](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11293).

![localhost_3001_education_opt-out_form_confirmation 1](https://user-images.githubusercontent.com/16051172/42404581-2ba737be-813f-11e8-81ba-a9723f68661f.png)

