### PR TITLE
526 transform submit mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -46,7 +46,10 @@ import {
 
 
 export function transform(formConfig, form) {
-  console.log(form);
+  console.log(form.data);
+  // 1. Remove unselected disabilities
+  const selectedDisabilities = form.data.disabilities.filter(disability => (disability['view:selected'] === true));
+  console.log('selectedDisabilities: ', selectedDisabilities);
   // const formData = fslatten(transformForSubmit(formConfig, form));
   // delete formData.prefilled;
   return JSON.stringify({

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -8,7 +8,8 @@ import fullSchemaIncrease from 'vets-json-schema/dist/21-526EZ-schema.json';
 
 import { isValidUSZipCode, isValidCanPostalCode } from '../../../platform/forms/address';
 import { stateRequiredCountries } from 'us-forms-system/lib/js/definitions/address';
-import { transformForSubmit } from 'us-forms-system/lib/js/helpers';
+// import { transformForSubmit } from 'us-forms-system/lib/js/helpers';
+import { filterViewFields } from 'us-forms-system/lib/js/helpers';
 import cloneDeep from '../../../platform/utilities/data/cloneDeep';
 import set from '../../../platform/utilities/data/set';
 import get from '../../../platform/utilities/data/get';
@@ -57,13 +58,13 @@ export function transform(formConfig, form) {
   // transformForSubmit removes all the disabilities. Why?
   const {
     disabilities,
+    veteran,
     privacyAgreementAccepted,
     servicePeriods,
     standardClaim,
-    veteran
   } = form.data;
 
-  const testObj = {
+  const transformedData = {
     // 1. Remove unselected disabilities
     disabilities: disabilities.filter(disability => (disability['view:selected'] === true)),
     // 2. Put email and phone back into veteran property
@@ -71,16 +72,13 @@ export function transform(formConfig, form) {
     // 3. Extract treatments into one top-level array
     treatments: aggregate(disabilities, 'treatments'),
     privacyAgreementAccepted,
-    servicePeriods,
+    // 4. Pull service periods into service information
+    serviceInformation: { servicePeriods },
     standardClaim,
   };
 
-  console.log('testSubmit: ', testObj);
-  return JSON.stringify({
-    disabilityBenefitsClaim: {
-      form: testObj
-    }
-  });
+  console.log({ form526: transformedData });
+  return JSON.stringify({ form526: transformedData });
 }
 
 export function validateDisability(disability) {

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -63,7 +63,9 @@ export function transform(formConfig, form) {
     standardClaim,
   } = form.data;
 
-  const disabilityProperties = fullSchemaIncrease.definitions.disabilities.items.properties;
+  const disabilityProperties = Object.keys(
+    fullSchemaIncrease.definitions.disabilities.items.properties
+  );
 
   const transformedData = {
     disabilities: disabilities

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -77,7 +77,6 @@ export function transform(formConfig, form) {
     standardClaim,
   };
 
-  console.log({ form526: transformedData });
   return JSON.stringify({ form526: transformedData });
 }
 

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -8,7 +8,6 @@ import fullSchemaIncrease from 'vets-json-schema/dist/21-526EZ-schema.json';
 
 import { isValidUSZipCode, isValidCanPostalCode } from '../../../platform/forms/address';
 import { stateRequiredCountries } from 'us-forms-system/lib/js/definitions/address';
-// import { transformForSubmit } from 'us-forms-system/lib/js/helpers';
 import { filterViewFields } from 'us-forms-system/lib/js/helpers';
 import cloneDeep from '../../../platform/utilities/data/cloneDeep';
 import set from '../../../platform/utilities/data/set';
@@ -54,7 +53,6 @@ const setPhoneEmailPaths = (veteran) => {
 };
 
 export function transform(formConfig, form) {
-  // transformForSubmit removes all the disabilities. Why?
   const {
     disabilities,
     veteran,
@@ -87,7 +85,6 @@ export function transform(formConfig, form) {
   };
 
   const withoutViewFields = filterViewFields(transformedData);
-  console.log(withoutViewFields);
   return JSON.stringify({ form526: withoutViewFields });
 }
 

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -63,15 +63,7 @@ export function transform(formConfig, form) {
     standardClaim,
   } = form.data;
 
-  const disabilityProperties = [
-    'name',
-    'disabilityActionType',
-    'specialIssues',
-    'ratedDisabilityId',
-    'ratingDecisionId',
-    'diagnosticCode',
-    'classificationCode'
-  ];
+  const disabilityProperties = fullSchemaIncrease.definitions.disabilities.items.properties;
 
   const transformedData = {
     disabilities: disabilities

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -12,7 +12,6 @@ import { transformForSubmit } from 'us-forms-system/lib/js/helpers';
 import cloneDeep from '../../../platform/utilities/data/cloneDeep';
 import set from '../../../platform/utilities/data/set';
 import get from '../../../platform/utilities/data/get';
-import omit from '../../../platform/utilities/data/omit';
 import { apiRequest } from '../../../platform/utilities/api';
 import { genderLabels } from '../../../platform/static-data/labels';
 import { getDiagnosticCodeName } from './reference-helpers';
@@ -25,7 +24,11 @@ import {
   E_BENEFITS_URL
 } from './constants';
 
-
+/**
+ * 
+ * @param {*} dataArray 
+ * @param {*} property 
+ */
 const aggregate = (dataArray, property) => {
   const masterList = [];
   dataArray.forEach(item => {
@@ -51,15 +54,21 @@ const setPhoneEmailPaths = (veteran) => {
 };
 
 export function transform(formConfig, form) {
-  const { disabilities, privacyAgreementAccepted, servicePeriods, standardClaim, veteran  } = form.data;
-  // 1. Remove unselected disabilities
-  // 2. Put email and phone back into veteran property
-  // 3. Extract treatments into own schema { treatmentCenter: { name, type, country, state?, city? }, startDate, endDate }
-  // const formData = flatten(transformForSubmit(formConfig, form));
-  // delete formData.prefilled;
+  // transformForSubmit removes all the disabilities. Why?
+  const {
+    disabilities,
+    privacyAgreementAccepted,
+    servicePeriods,
+    standardClaim,
+    veteran
+  } = form.data;
+
   const testObj = {
-    veteran: setPhoneEmailPaths(veteran),
+    // 1. Remove unselected disabilities
     disabilities: disabilities.filter(disability => (disability['view:selected'] === true)),
+    // 2. Put email and phone back into veteran property
+    veteran: setPhoneEmailPaths(veteran),
+    // 3. Extract treatments into one top-level array
     treatments: aggregate(disabilities, 'treatments'),
     privacyAgreementAccepted,
     servicePeriods,

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -29,28 +29,29 @@ import {
  *
  * @param {object} data - Form data for a full form, including nested array properties
  */
-export function flatten(data) {
-  const siblings = ['treatments', 'privateRecordReleases', 'privateRecords', 'additionalDocuments'];
-  const formData = cloneDeep(data);
-  formData.disabilities.forEach((disability, idx) => {
-    siblings.forEach(sibling => {
-      if (disability[sibling]) {
-        formData[sibling] = [];
-        formData[sibling][idx] = disability[sibling];
-        delete disability[sibling]; // eslint-disable-line no-param-reassign
-      }
-    });
-  });
-  return formData;
-}
+// export function flatten(data) {
+//   const siblings = ['treatments', 'privateRecordReleases', 'privateRecords', 'additionalDocuments'];
+//   const formData = cloneDeep(data);
+//   formData.disabilities.forEach((disability, idx) => {
+//     siblings.forEach(sibling => {
+//       if (disability[sibling]) {
+//         formData[sibling] = [];
+//         formData[sibling][idx] = disability[sibling];
+//         delete disability[sibling]; // eslint-disable-line no-param-reassign
+//       }
+//     });
+//   });
+//   return formData;
+// }
 
 
 export function transform(formConfig, form) {
-  const formData = flatten(transformForSubmit(formConfig, form));
-  delete formData.prefilled;
+  console.log(form);
+  // const formData = fslatten(transformForSubmit(formConfig, form));
+  // delete formData.prefilled;
   return JSON.stringify({
     disabilityBenefitsClaim: {
-      form: formData
+      form
     }
   });
 }

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -26,10 +26,12 @@ import {
 } from './constants';
 
 /**
- * 
- * @param {*} dataArray 
- * @param {*} property 
- */
+ * Inspects an array of objects, and attempts to aggregate subarrays at a given property
+ * of each object into one array
+ * @param {array} dataArray array of objects to inspect
+ * @param {string} property the property to inspect in each array item
+ * @returns {array} a list of aggregated items pulled from different arrays
+*/
 const aggregate = (dataArray, property) => {
   const masterList = [];
   dataArray.forEach(item => {

--- a/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
@@ -3,13 +3,13 @@ import { expect } from 'chai';
 import _ from 'lodash';
 
 import {
-  flatten,
   validateDisability,
   transformDisabilities,
   addPhoneEmailToCard,
   prefillTransformer,
   get4142Selection,
-  queryForFacilities
+  queryForFacilities,
+  transform
 } from '../helpers.jsx';
 import initialData from './schema/initialData.js';
 
@@ -17,19 +17,237 @@ describe('526 helpers', () => {
   const prefilledData = _.cloneDeep(initialData);
   const invalidDisability = prefilledData.disabilities[1];
   const validDisability = Object.assign({ disabilityActionType: 'INCREASE' }, invalidDisability);
-  describe('flatten', () => {
-    it('should flatten sibling arrays', () => {
-      const treatments = [
-        {
-          treatment: {
-            treatmentCenterName: 'local VA center'
+  describe('transform', () => {
+    const formData = {
+      data: {
+        disabilities: [
+          {
+            additionalDocuments: [
+              {
+                name: 'Screen Shot 2018-07-09 at 11.25.49 AM.png',
+                confirmationCode: '9664f488-1243-4b25-805e-75ad7e4cf765'
+              },
+              {
+                name: 'Screen Shot 2018-07-09 at 11.24.39 AM.png',
+                confirmationCode: '66bfab89-6e2b-4361-a905-754dfbff7df7'
+              }
+            ],
+            privateRecords: [
+              {
+                name: 'Screen Shot 2018-07-09 at 3.29.08 PM.png',
+                confirmationCode: 'a58ae568-d190-49cd-aa04-b1b1da5eae35'
+              },
+              {
+                name: 'Screen Shot 2018-07-09 at 2.02.39 PM.png',
+                confirmationCode: 'f23194e4-c534-42c6-9e96-16c08d8230a5'
+              }
+            ],
+            'view:uploadPrivateRecords': 'yes',
+            'view:privateRecordsChoiceHelp': {},
+            treatments: [
+              {
+                treatmentCenterName: 'Somerset VA Clinic',
+                treatmentDateRange: {
+                  from: '2000-06-06',
+                  to: '2004-02-06'
+                }
+              },
+              {
+                treatmentCenterName: 'DC VA Regional Medical Center',
+                treatmentDateRange: {
+                  from: '2000-07-04',
+                  to: '2010-01-03'
+                }
+              }
+            ],
+            'view:selectableEvidenceTypes': {
+              'view:vaMedicalRecords': true,
+              'view:privateMedicalRecords': true,
+              'view:otherEvidence': true
+            },
+            'view:evidenceTypeHelp': {},
+            name: 'Diabetes mellitus0',
+            specialIssues: [
+              {
+                code: 'TRM',
+                name: 'Personal Trauma PTSD'
+              }
+            ],
+            ratedDisabilityId: '0',
+            ratingDecisionId: '63655',
+            diagnosticCode: 5238,
+            ratingPercentage: 100,
+            disabilityActionType: 'INCREASE',
+            'view:selected': true
+          },
+          {
+            'view:uploadPrivateRecords': 'no',
+            'view:privateRecords4142Notice': {},
+            'view:privateRecordsChoiceHelp': {},
+            'view:selectableEvidenceTypes': {
+              'view:privateMedicalRecords': true,
+              'view:otherEvidence': false
+            },
+            'view:evidenceTypeHelp': {},
+            name: 'Diabetes mellitus1',
+            specialIssues: [
+              {
+                code: 'TRM',
+                name: 'Personal Trauma PTSD'
+              }
+            ],
+            ratedDisabilityId: '1',
+            ratingDecisionId: '63655',
+            diagnosticCode: 5238,
+            ratingPercentage: 100,
+            disabilityActionType: 'INCREASE',
+            'view:selected': true
           }
-        }
-      ];
-      prefilledData.disabilities[0].treatments = treatments;
-      const flattened = flatten(prefilledData);
-      expect(flattened.treatments).to.exist;
-      expect(flattened.disabilities[0].treatments).to.not.exist;
+        ],
+        veteran: {
+          homelessness: {
+            isHomeless: false
+          },
+          phoneEmailCard: {
+            primaryPhone: '4445551212',
+            emailAddress: 'test2@test1.net'
+          },
+          mailingAddress: {
+            country: 'USA',
+            addressLine1: '123 MAIN ST',
+            addressLine2: 'BEN FRANKLIN VILLAGE',
+            city: 'APO',
+            state: 'AE',
+            zipCode: '09028'
+          },
+          'view:hasForwardingAddress': true,
+          forwardingAddress: {
+            country: 'USA',
+            addressLine1: '123 Anystreet',
+            addressLine2: 'Viking Drive',
+            addressLine3: 'Some Suite',
+            city: 'Anyville',
+            state: 'AK',
+            zipCode: '33492',
+            effectiveDate: '2019-04-04'
+          }
+        },
+        servicePeriods: [
+          {
+            serviceBranch: 'Air National Guard',
+            dateRange: {
+              from: '1980-03-06',
+              to: '1990-02-04'
+            }
+          },
+          {
+            serviceBranch: 'Army Reserve',
+            dateRange: {
+              from: '1990-07-05',
+              to: '2000-02-04'
+            }
+          }
+        ],
+        privacyAgreementAccepted: true,
+        standardClaim: false,
+        'view:fdcWarning': {}
+      }
+    };
+    const transformedData = {
+      form526: {
+        disabilities: [
+          {
+            name: 'Diabetes mellitus0',
+            disabilityActionType: 'INCREASE',
+            specialIssues: [
+              {
+                code: 'TRM',
+                name: 'Personal Trauma PTSD'
+              }
+            ],
+            ratedDisabilityId: '0',
+            ratingDecisionId: '63655',
+            diagnosticCode: 5238
+          },
+          {
+            name: 'Diabetes mellitus1',
+            disabilityActionType: 'INCREASE',
+            specialIssues: [
+              {
+                code: 'TRM',
+                name: 'Personal Trauma PTSD'
+              }
+            ],
+            ratedDisabilityId: '1',
+            ratingDecisionId: '63655',
+            diagnosticCode: 5238
+          }
+        ],
+        veteran: {
+          homelessness: {
+            isHomeless: false
+          },
+          mailingAddress: {
+            country: 'USA',
+            addressLine1: '123 MAIN ST',
+            addressLine2: 'BEN FRANKLIN VILLAGE',
+            city: 'APO',
+            state: 'AE',
+            zipCode: '09028'
+          },
+          forwardingAddress: {
+            country: 'USA',
+            addressLine1: '123 Anystreet',
+            addressLine2: 'Viking Drive',
+            addressLine3: 'Some Suite',
+            city: 'Anyville',
+            state: 'AK',
+            zipCode: '33492',
+            effectiveDate: '2019-04-04'
+          },
+          primaryPhone: '4445551212',
+          emailAddress: 'test2@test1.net'
+        },
+        treatments: [
+          {
+            treatmentCenterName: 'Somerset VA Clinic',
+            treatmentDateRange: {
+              from: '2000-06-06',
+              to: '2004-02-06'
+            }
+          },
+          {
+            treatmentCenterName: 'DC VA Regional Medical Center',
+            treatmentDateRange: {
+              from: '2000-07-04',
+              to: '2010-01-03'
+            }
+          }
+        ],
+        privacyAgreementAccepted: true,
+        serviceInformation: {
+          servicePeriods: [
+            {
+              serviceBranch: 'Air National Guard',
+              dateRange: {
+                from: '1980-03-06',
+                to: '1990-02-04'
+              }
+            },
+            {
+              serviceBranch: 'Army Reserve',
+              dateRange: {
+                from: '1990-07-05',
+                to: '2000-02-04'
+              }
+            }
+          ]
+        },
+        standardClaim: false
+      }
+    };
+    it('should return stringified, transformed data for submit', () => {
+      expect(transform(null, formData)).to.deep.equal(JSON.stringify(transformedData));
     });
   });
   describe('validateDisability', () => {

--- a/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
@@ -11,6 +11,7 @@ import {
   queryForFacilities,
   transform
 } from '../helpers.jsx';
+import maximalData from './schema/maximal-test';
 import initialData from './schema/initialData.js';
 
 describe('526 helpers', () => {
@@ -18,141 +19,7 @@ describe('526 helpers', () => {
   const invalidDisability = prefilledData.disabilities[1];
   const validDisability = Object.assign({ disabilityActionType: 'INCREASE' }, invalidDisability);
   describe('transform', () => {
-    const formData = {
-      data: {
-        disabilities: [
-          {
-            additionalDocuments: [
-              {
-                name: 'Screen Shot 2018-07-09 at 11.25.49 AM.png',
-                confirmationCode: '9664f488-1243-4b25-805e-75ad7e4cf765'
-              },
-              {
-                name: 'Screen Shot 2018-07-09 at 11.24.39 AM.png',
-                confirmationCode: '66bfab89-6e2b-4361-a905-754dfbff7df7'
-              }
-            ],
-            privateRecords: [
-              {
-                name: 'Screen Shot 2018-07-09 at 3.29.08 PM.png',
-                confirmationCode: 'a58ae568-d190-49cd-aa04-b1b1da5eae35'
-              },
-              {
-                name: 'Screen Shot 2018-07-09 at 2.02.39 PM.png',
-                confirmationCode: 'f23194e4-c534-42c6-9e96-16c08d8230a5'
-              }
-            ],
-            'view:uploadPrivateRecords': 'yes',
-            'view:privateRecordsChoiceHelp': {},
-            treatments: [
-              {
-                treatmentCenterName: 'Somerset VA Clinic',
-                treatmentDateRange: {
-                  from: '2000-06-06',
-                  to: '2004-02-06'
-                }
-              },
-              {
-                treatmentCenterName: 'DC VA Regional Medical Center',
-                treatmentDateRange: {
-                  from: '2000-07-04',
-                  to: '2010-01-03'
-                }
-              }
-            ],
-            'view:selectableEvidenceTypes': {
-              'view:vaMedicalRecords': true,
-              'view:privateMedicalRecords': true,
-              'view:otherEvidence': true
-            },
-            'view:evidenceTypeHelp': {},
-            name: 'Diabetes mellitus0',
-            specialIssues: [
-              {
-                code: 'TRM',
-                name: 'Personal Trauma PTSD'
-              }
-            ],
-            ratedDisabilityId: '0',
-            ratingDecisionId: '63655',
-            diagnosticCode: 5238,
-            ratingPercentage: 100,
-            disabilityActionType: 'INCREASE',
-            'view:selected': true
-          },
-          {
-            'view:uploadPrivateRecords': 'no',
-            'view:privateRecords4142Notice': {},
-            'view:privateRecordsChoiceHelp': {},
-            'view:selectableEvidenceTypes': {
-              'view:privateMedicalRecords': true,
-              'view:otherEvidence': false
-            },
-            'view:evidenceTypeHelp': {},
-            name: 'Diabetes mellitus1',
-            specialIssues: [
-              {
-                code: 'TRM',
-                name: 'Personal Trauma PTSD'
-              }
-            ],
-            ratedDisabilityId: '1',
-            ratingDecisionId: '63655',
-            diagnosticCode: 5238,
-            ratingPercentage: 100,
-            disabilityActionType: 'INCREASE',
-            'view:selected': true
-          }
-        ],
-        veteran: {
-          homelessness: {
-            isHomeless: false
-          },
-          phoneEmailCard: {
-            primaryPhone: '4445551212',
-            emailAddress: 'test2@test1.net'
-          },
-          mailingAddress: {
-            country: 'USA',
-            addressLine1: '123 MAIN ST',
-            addressLine2: 'BEN FRANKLIN VILLAGE',
-            city: 'APO',
-            state: 'AE',
-            zipCode: '09028'
-          },
-          'view:hasForwardingAddress': true,
-          forwardingAddress: {
-            country: 'USA',
-            addressLine1: '123 Anystreet',
-            addressLine2: 'Viking Drive',
-            addressLine3: 'Some Suite',
-            city: 'Anyville',
-            state: 'AK',
-            zipCode: '33492',
-            effectiveDate: '2019-04-04'
-          }
-        },
-        servicePeriods: [
-          {
-            serviceBranch: 'Air National Guard',
-            dateRange: {
-              from: '1980-03-06',
-              to: '1990-02-04'
-            }
-          },
-          {
-            serviceBranch: 'Army Reserve',
-            dateRange: {
-              from: '1990-07-05',
-              to: '2000-02-04'
-            }
-          }
-        ],
-        privacyAgreementAccepted: true,
-        standardClaim: false,
-        'view:fdcWarning': {}
-      }
-    };
+    const formData = maximalData;
     const transformedData = {
       form526: {
         disabilities: [
@@ -185,7 +52,11 @@ describe('526 helpers', () => {
         ],
         veteran: {
           homelessness: {
-            isHomeless: false
+            isHomeless: true,
+            pointOfContact: {
+              pointOfContactName: 'John',
+              primaryPhone: '1231231231'
+            }
           },
           mailingAddress: {
             country: 'USA',

--- a/src/applications/disability-benefits/526EZ/tests/schema/maximal-test.json
+++ b/src/applications/disability-benefits/526EZ/tests/schema/maximal-test.json
@@ -1,50 +1,151 @@
 {
-  "data": {
-    "fullName": {
-      "first": "Sally",
-      "last": "Alphonse"
-    },
-    "socialSecurityNumber": "234234234",
-    "vaFileNumber": "234234234",
-    "gender": "F",
-    "dateOfBirth": "1990-12-12",
-    "treatments": [
-      {
-        "treatmentCenterName": "Local facility",
-        "treatmentCenterCountry": "USA",
-        "treatmentCenterStreet": "23 Oak Lane",
-        "treatmentCenterCity": "Springfield",
-        "treatmentCenterState": "MO",
-        "treatmentCenterPostalCode": "98787",
-        "startTreatmentMonth": 2,
-        "endTreatmentMonth": 2,
-        "startTreatmentDay": 2,
-        "endTreatmentDay": 2,
-        "startTreatmentYear": 2007,
-        "endTreatmentYear": 2008
-      },
-      {
-        "treatmentCenterName": "Local facility",
-        "treatmentCenterCountry": "USA",
-        "treatmentCenterStreet": "23 Oak Lane",
-        "treatmentCenterCity": "Springfield",
-        "treatmentCenterState": "MO",
-        "treatmentCenterPostalCode": "98787",
-        "startTreatmentMonth": 2,
-        "endTreatmentMonth": 2,
-        "startTreatmentDay": 2,
-        "endTreatmentDay": 2,
-        "startTreatmentYear": 2007,
-        "endTreatmentYear": 2008
-      }
-    ],
-    "disabilities": [
-      {
-        "view:uploadPrivateRecords": "yes",
-        "view:vaMedicalRecords": true,
-        "view:privateMedicalRecords": true,
-        "view:otherEvidence": true
-      }
-    ]
+  "data":{
+     "disabilities":[
+        {
+           "additionalDocuments":[
+              {
+                 "name":"Screen Shot 2018-07-09 at 11.25.49 AM.png",
+                 "confirmationCode":"9664f488-1243-4b25-805e-75ad7e4cf765"
+              },
+              {
+                 "name":"Screen Shot 2018-07-09 at 11.24.39 AM.png",
+                 "confirmationCode":"66bfab89-6e2b-4361-a905-754dfbff7df7"
+              }
+           ],
+           "privateRecords":[
+              {
+                 "name":"Screen Shot 2018-07-09 at 3.29.08 PM.png",
+                 "confirmationCode":"a58ae568-d190-49cd-aa04-b1b1da5eae35"
+              },
+              {
+                 "name":"Screen Shot 2018-07-09 at 2.02.39 PM.png",
+                 "confirmationCode":"f23194e4-c534-42c6-9e96-16c08d8230a5"
+              }
+           ],
+           "view:uploadPrivateRecords":"yes",
+           "view:privateRecordsChoiceHelp":{
+
+           },
+           "treatments":[
+              {
+                 "treatmentCenterName":"Somerset VA Clinic",
+                 "treatmentDateRange":{
+                    "from":"2000-06-06",
+                    "to":"2004-02-06"
+                 }
+              },
+              {
+                 "treatmentCenterName":"DC VA Regional Medical Center",
+                 "treatmentDateRange":{
+                    "from":"2000-07-04",
+                    "to":"2010-01-03"
+                 }
+              }
+           ],
+           "view:selectableEvidenceTypes":{
+              "view:vaMedicalRecords":true,
+              "view:privateMedicalRecords":true,
+              "view:otherEvidence":true
+           },
+           "view:evidenceTypeHelp":{
+
+           },
+           "name":"Diabetes mellitus0",
+           "specialIssues":[
+              {
+                 "code":"TRM",
+                 "name":"Personal Trauma PTSD"
+              }
+           ],
+           "ratedDisabilityId":"0",
+           "ratingDecisionId":"63655",
+           "diagnosticCode":5238,
+           "ratingPercentage":100,
+           "disabilityActionType":"INCREASE",
+           "view:selected":true
+        },
+        {
+           "view:uploadPrivateRecords":"no",
+           "view:privateRecords4142Notice":{
+
+           },
+           "view:privateRecordsChoiceHelp":{
+
+           },
+           "view:selectableEvidenceTypes":{
+              "view:privateMedicalRecords":true,
+              "view:otherEvidence":false
+           },
+           "view:evidenceTypeHelp":{
+
+           },
+           "name":"Diabetes mellitus1",
+           "specialIssues":[
+              {
+                 "code":"TRM",
+                 "name":"Personal Trauma PTSD"
+              }
+           ],
+           "ratedDisabilityId":"1",
+           "ratingDecisionId":"63655",
+           "diagnosticCode":5238,
+           "ratingPercentage":100,
+           "disabilityActionType":"INCREASE",
+           "view:selected":true
+        }
+     ],
+     "veteran":{
+        "homelessness":{
+           "isHomeless":true,
+           "pointOfContact":{
+              "pointOfContactName":"John",
+              "primaryPhone":"1231231231"
+           }
+        },
+        "phoneEmailCard":{
+           "primaryPhone":"4445551212",
+           "emailAddress":"test2@test1.net"
+        },
+        "mailingAddress":{
+           "country":"USA",
+           "addressLine1":"123 MAIN ST",
+           "addressLine2":"BEN FRANKLIN VILLAGE",
+           "city":"APO",
+           "state":"AE",
+           "zipCode":"09028"
+        },
+        "view:hasForwardingAddress":true,
+        "forwardingAddress":{
+           "country":"USA",
+           "addressLine1":"123 Anystreet",
+           "addressLine2":"Viking Drive",
+           "addressLine3":"Some Suite",
+           "city":"Anyville",
+           "state":"AK",
+           "zipCode":"33492",
+           "effectiveDate":"2019-04-04"
+        }
+     },
+     "servicePeriods":[
+        {
+           "serviceBranch":"Air National Guard",
+           "dateRange":{
+              "from":"1980-03-06",
+              "to":"1990-02-04"
+           }
+        },
+        {
+           "serviceBranch":"Army Reserve",
+           "dateRange":{
+              "from":"1990-07-05",
+              "to":"2000-02-04"
+           }
+        }
+     ],
+     "privacyAgreementAccepted":true,
+     "standardClaim":false,
+     "view:fdcWarning":{
+
+     }
   }
 }


### PR DESCRIPTION
- Works around a bug in forms lib `transformForSubmit` that basically eats `showPagePerItem` array data
- Transforms data from form into something that passes vets-api / 526 schema validations:
  - Strips view fields
  - Strips redundant info
  - Pushes phone and email into the `veteran` property whereas it's naturally located in `veteran.phoneEmailCard`
  - Adds only selected disabilities, and only disability properties that are in the schema
  - Aggregates treatments into one big top-level array, whereas naturally there's a treatments array within each disability, e.g. `disabilities: [{ treatments: [{...}, {...}] }]`
  - Pulls `servicePeriods` into a `serviceInformation` parent, per schema
- Adds a unit test with a pretty elaborate form data setup