### PR TITLE
526 treatment address mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -20,6 +20,8 @@ import {
   primaryAddressSchema
 } from '../pages/primaryAddress';
 
+import treatmentAddressUiSchema from '../pages/treatmentAddress';
+
 import {
   uiSchema as paymentInfoUiSchema,
   schema as paymentInfoSchema
@@ -76,12 +78,12 @@ const {
   date,
   fullName,
   phone,
-  // files
   dateRange,
   dateRangeFromRequired,
   dateRangeAllRequired,
   disabilities,
   specialIssues,
+  vaTreatmentCenterAddress
 } = fullSchema526EZ.definitions;
 
 const FIFTY_MB = 52428800;
@@ -98,7 +100,7 @@ const treatments = ((treatmentsCommonDef) => {
       // TODO: use standard required property once treatmentCenterType added
       // back in schema (because it's required)
       required: ['treatmentCenterName'],
-      properties: _.omit(['treatmentCenterAddress', 'treatmentCenterType'], items.properties)
+      properties: _.omit(['treatmentCenterType'], items.properties)
     }
   };
 
@@ -127,6 +129,7 @@ const formConfig = {
   getHelp: GetFormHelp,
   defaultDefinitions: {
     address,
+    vaTreatmentCenterAddress,
     date,
     fullName,
     phone,
@@ -459,9 +462,7 @@ const formConfig = {
                       'Date of last treatment (This date doesn’t have to be exact.)',
                       'Date of last treatment must be after date of first treatment'
                     ),
-                    // TODO: Put these back as hidden in the UI once typeahead fills this out
-                    // treatmentCenterType: {},
-                    // treatmentCenterAddress: {}
+                    treatmentCenterAddress: treatmentAddressUiSchema
                   }
                 }
               }

--- a/src/applications/disability-benefits/526EZ/pages/treatmentAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/treatmentAddress.js
@@ -1,21 +1,14 @@
-import _ from 'lodash';
-
-import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
-// import fullSchema526EZ from '/path/vets-json-schema/dist/21-526EZ-schema.json';
+import get from '../../../../platform/utilities/data/get';
 
 import  {
   MILITARY_CITIES,
-  MILITARY_STATE_LABELS,
   MILITARY_STATE_VALUES,
-  STATE_LABELS,
-  STATE_VALUES,
   USA,
-  ADDRESS_TYPES
 } from '../constants';
 
 function validateMilitaryCity(errors, city, formData, schema, messages, index) {
   const isMilitaryState = MILITARY_STATE_VALUES.includes(
-    _.get(formData, `treatments[${index}].treatmentCenterAddress.state`, '')
+    get(formData, `treatments[${index}].treatmentCenterAddress.state`, '')
   );
   const isMilitaryCity = MILITARY_CITIES.includes(city.trim().toUpperCase());
   if (isMilitaryState && !isMilitaryCity) {
@@ -24,11 +17,8 @@ function validateMilitaryCity(errors, city, formData, schema, messages, index) {
 }
 
 function validateMilitaryState(errors, state, formData, schema, messages, index) {
-  // console.log('state: ', state); // current state selection
-  // console.log('formData: ', formData); // current disability
-  // console.log('index: ', index); // index in treatments array
   const isMilitaryCity = MILITARY_CITIES.includes(
-    _.get(formData, `treatments[${index}].treatmentCenterAddress.city`, '').trim().toUpperCase()
+    get(formData, `treatments[${index}].treatmentCenterAddress.city`, '').trim().toUpperCase()
   );
   const isMilitaryState = MILITARY_STATE_VALUES.includes(state);
   if (isMilitaryCity && !isMilitaryState) {
@@ -49,14 +39,9 @@ const uiSchema = {
     'ui:title': 'State',
     'ui:validations': [validateMilitaryState],
     'ui:options': {
-      hideIf: (formData, index) => {
-        console.log(formData); // disabilities: [{...}. [...}]
-        console.log(index); // index in treatments array for current disability
-        console.log(_.get(formData, `treatments[${index}].treatmentCenterAddress.country`, 'nothing'));
-        return _.get(formData, `treatments[${index}].treatmentCenterAddress.country`, '') !== USA;
-      }
-    //   updateSchema: () => {}
-    }
+      expandUnder: 'country',
+      expandUnderCondition: USA
+    },
   }
 };
 

--- a/src/applications/disability-benefits/526EZ/pages/treatmentAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/treatmentAddress.js
@@ -1,4 +1,4 @@
-import get from '../../../../platform/utilities/data/get';
+import { get } from 'lodash';
 
 import  {
   MILITARY_CITIES,

--- a/src/applications/disability-benefits/526EZ/pages/treatmentAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/treatmentAddress.js
@@ -27,7 +27,7 @@ function validateMilitaryState(errors, state, formData, schema, messages, index)
 }
 
 const uiSchema = {
-  'ui:order': ['country', 'city', 'state'],
+  'ui:order': ['country', 'state', 'city'],
   country: {
     'ui:title': 'Country'
   },

--- a/src/applications/disability-benefits/526EZ/pages/treatmentAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/treatmentAddress.js
@@ -1,0 +1,63 @@
+import _ from 'lodash';
+
+import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
+// import fullSchema526EZ from '/path/vets-json-schema/dist/21-526EZ-schema.json';
+
+import  {
+  MILITARY_CITIES,
+  MILITARY_STATE_LABELS,
+  MILITARY_STATE_VALUES,
+  STATE_LABELS,
+  STATE_VALUES,
+  USA,
+  ADDRESS_TYPES
+} from '../constants';
+
+function validateMilitaryCity(errors, city, formData, schema, messages, index) {
+  const isMilitaryState = MILITARY_STATE_VALUES.includes(
+    _.get(formData, `treatments[${index}].treatmentCenterAddress.state`, '')
+  );
+  const isMilitaryCity = MILITARY_CITIES.includes(city.trim().toUpperCase());
+  if (isMilitaryState && !isMilitaryCity) {
+    errors.addError('City must match APO, DPO, or FPO when using a military state code');
+  }
+}
+
+function validateMilitaryState(errors, state, formData, schema, messages, index) {
+  // console.log('state: ', state); // current state selection
+  // console.log('formData: ', formData); // current disability
+  // console.log('index: ', index); // index in treatments array
+  const isMilitaryCity = MILITARY_CITIES.includes(
+    _.get(formData, `treatments[${index}].treatmentCenterAddress.city`, '').trim().toUpperCase()
+  );
+  const isMilitaryState = MILITARY_STATE_VALUES.includes(state);
+  if (isMilitaryCity && !isMilitaryState) {
+    errors.addError('State must be AA, AE, or AP when using a military city');
+  }
+}
+
+const uiSchema = {
+  'ui:order': ['country', 'city', 'state'],
+  country: {
+    'ui:title': 'Country'
+  },
+  city: {
+    'ui:title': 'City',
+    'ui:validations': [validateMilitaryCity]
+  },
+  state: {
+    'ui:title': 'State',
+    'ui:validations': [validateMilitaryState],
+    'ui:options': {
+      hideIf: (formData, index) => {
+        console.log(formData); // disabilities: [{...}. [...}]
+        console.log(index); // index in treatments array for current disability
+        console.log(_.get(formData, `treatments[${index}].treatmentCenterAddress.country`, 'nothing'));
+        return _.get(formData, `treatments[${index}].treatmentCenterAddress.country`, '') !== USA;
+      }
+    //   updateSchema: () => {}
+    }
+  }
+};
+
+export default uiSchema;

--- a/src/applications/disability-benefits/526EZ/tests/config/vaFacilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/vaFacilities.unit.spec.jsx
@@ -31,8 +31,8 @@ describe('Disability benefits 526EZ VA facility', () => {
       uiSchema={uiSchema}/>
     );
 
-    expect(form.find('select').length).to.equal(4);
-    expect(form.find('input').length).to.equal(3);
+    expect(form.find('select').length).to.equal(6); // from/to months, days; country, state
+    expect(form.find('input').length).to.equal(4); // facility name, from/to years, city
   });
 
   it('should add a VA facility', () => {
@@ -49,18 +49,21 @@ describe('Disability benefits 526EZ VA facility', () => {
         uiSchema={uiSchema}/>
     );
 
-
-    fillDate(form, 'root_treatments_0_treatmentDateRange_from', '1950-1-3');
-    fillDate(form, 'root_treatments_0_treatmentDateRange_to', '1955-1-3');
+    // Minimum requirements. Country defaults to USA
     fillData(form, 'input#root_treatments_0_treatmentCenterName', 'Local facility');
+    fillDate(form, 'root_treatments_0_treatmentDateRange_from', '1950-1-3');
+    fillDate(form, 'root_treatments_0_treatmentDateRange_to', '1951-1-3');
 
     form.find('.va-growable-add-btn').simulate('click');
     expect(form.find('.usa-input-error').length).to.equal(0);
 
+    // All fields filled
+    fillData(form, 'input#root_treatments_1_treatmentCenterName', 'Local facility');
     fillDate(form, 'root_treatments_1_treatmentDateRange_from', '1951-1-3');
     fillDate(form, 'root_treatments_1_treatmentDateRange_to', '1955-1-3');
-    fillData(form, 'input#root_treatments_1_treatmentCenterName', 'Local facility');
-
+    fillData(form, 'select#root_treatments_1_treatmentCenterAddress_country', 'USA');
+    fillData(form, 'select#root_treatments_1_treatmentCenterAddress_state', 'AK');
+    fillData(form, 'input#root_treatments_1_treatmentCenterAddress_city', 'Anyville');
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
@@ -89,5 +92,113 @@ describe('Disability benefits 526EZ VA facility', () => {
     fillData(form, 'input#root_treatments_0_treatmentCenterName', 'This input is entirely too long-winded to fit into this particular field--Whose idea was it to have this as a facility name anyhow');
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error-message').first().text()).to.contain('100 characters');
+  });
+
+  it('validates that state is military type if city is military type', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        onSubmit={onSubmit}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{
+          disabilities: [
+            {
+              treatments: [
+                {
+                  treatmentCenterName: 'Some Facility',
+                  treatmentDateRange: {
+                    from: '1980-06-04',
+                    to: '1981-02-09'
+                  },
+                  treatmentCenterAddress: {
+                    country: 'USA',
+                    state: 'TX',
+                    city: 'APO'
+                  }
+                }
+              ]
+            }
+          ]
+        }}
+        formData={{}}
+        uiSchema={uiSchema}/>
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+  });
+
+  it('validates that city is military type if state is military type', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        onSubmit={onSubmit}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{
+          disabilities: [
+            {
+              treatments: [
+                {
+                  treatmentCenterName: 'Some Facility',
+                  treatmentDateRange: {
+                    from: '1980-06-04',
+                    to: '1981-02-09'
+                  },
+                  treatmentCenterAddress: {
+                    country: 'USA',
+                    state: 'AE',
+                    city: 'Detroit'
+                  }
+                }
+              ]
+            }
+          ]
+        }}
+        formData={{}}
+        uiSchema={uiSchema}/>
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+  });
+
+  it('expands state when country is USA', () => {
+    const form = mount(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{
+          disabilities: [
+            {
+              treatments: [
+                {
+                  treatmentCenterName: 'Some Facility',
+                  treatmentDateRange: {
+                    from: '1980-06-04',
+                    to: '1981-02-09'
+                  },
+                  treatmentCenterAddress: {
+                    city: 'Detroit'
+                  }
+                }
+              ]
+            }
+          ]
+        }}
+        formData={{}}
+        uiSchema={uiSchema}/>
+    );
+
+    expect(form.find('select#root_treatments_0_treatmentCenterAddress_state').length).to.equal(0);
+    fillData(form, 'select#root_treatments_0_treatmentCenterAddress_country', 'USA');
+    expect(form.find('select#root_treatments_0_treatmentCenterAddress_state').length).to.equal(1);
   });
 });


### PR DESCRIPTION
## What this PR Does:
- Adds country, city, and state fields to each VA Treatment Center
- Makes country always required (per swagger)
- Makes city & state always optional (per swagger + discussion with CSRA)
- Validates military cities and military states (if military city -> must be military state & vice-versa)
- Conditionally expands state field when country is USA
- Defaults country to USA
- Adds tests for the above things

## What this PR Does NOT Do:
- Restrict state list to military states when city is military city (the full list is always displayed)
- Conditionally require state / city (which isn't a big deal since they're actually optional)
- hide the state field when country is not USA (instead, it conditionally expands the state field when country is USA)

### Why This PR Doesn't Do These Things:
the VA addresses are part of a treatment. A treatment lives inside an array of treatment objects. The treatment array lives inside a disability. And a disability lives within an array of disabilities. So the schema involves nested arrays, and in its simplest reduction looks like this:
```
disabilities = [
  {
    treatments: [
      { treatmentCenterAddress },
      { treatmentCenterAddress }
    ]
  },
  {
    treatments: [
      { treatmentCenterAddress },
      { treatmentCenterAddress }
    ]
  }
];
```
Many config properties (e.g., `ui:validations`) are passed the index of the data in its array (when the data is in an array). This is helpful to find the right treatment within a given treatments array. However, config properties differ in what they pass into these functions as the `formData`. Some properties pass the data's parent object (`expandUnder, `ui:validations`) while most properties pass the entire `formData` object (`hideIf`, `updateSchema`, `ui:required`, etc.). Passing the entire `formData` object poses a problem because only one index is supplied, so while we can keep track of which treatment within the treatments array is currently being processed, we have no way of keeping track / specifying which treatments array we're looking at in cases where there are multiple disabilities, each with its own treatments array. So, certain things just aren't possible. An issue to this effect will be submitted to the us-forms repo shortly.

## Screenshots:
Country, State, and City show by default (because country defaults to USA - otherwise state would be hidden)
![screen shot 2018-07-10 at 7 31 19 pm](https://user-images.githubusercontent.com/24251447/42544575-5060581a-8478-11e8-8a04-7e9a4cf9da4e.png)
-----

US addresses work as expected:
![screen shot 2018-07-10 at 7 32 04 pm](https://user-images.githubusercontent.com/24251447/42544606-6c526d6a-8478-11e8-9e6f-9269f0a2eaa2.png)
-----

International addresses drop the state:
![screen shot 2018-07-10 at 7 32 26 pm](https://user-images.githubusercontent.com/24251447/42544631-8ca69a82-8478-11e8-89e1-27c78219e5b0.png)
-----

City is validated against military states:
![screen shot 2018-07-10 at 7 32 39 pm](https://user-images.githubusercontent.com/24251447/42544646-9e03e28a-8478-11e8-95bf-0eebadefb8c5.png)
-----

And state is validated against military cities:
![screen shot 2018-07-10 at 7 32 56 pm](https://user-images.githubusercontent.com/24251447/42544659-ab2a1aa6-8478-11e8-9bc5-4ffed6e00f80.png)
-----

The view cards are unaffected, though I'm happy to add address info later if there's a need for that:
![screen shot 2018-07-10 at 7 33 43 pm](https://user-images.githubusercontent.com/24251447/42544679-c713bd30-8478-11e8-9312-5c3366fda392.png)
