### PR TITLE
526 itf wrapper

### DIFF
--- a/src/applications/disability-benefits/526EZ/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/526EZ/Form526EZApp.jsx
@@ -3,10 +3,14 @@ import React from 'react';
 import RoutedSavableApp from '../../../platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
+import ITFWrapper from './containers/ITFWrapper';
+
 export default function Form526Entry({ location, children }) {
   return (
-    <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
-    </RoutedSavableApp>
+    <ITFWrapper location={location}>
+      <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+        {children}
+      </RoutedSavableApp>
+    </ITFWrapper>
   );
 }

--- a/src/applications/disability-benefits/526EZ/actions/index.js
+++ b/src/applications/disability-benefits/526EZ/actions/index.js
@@ -1,163 +1,35 @@
 import { apiRequest } from '../../../../platform/utilities/api';
-import get from '../../../../platform/utilities/data/get';
-import existingITFData from '../tests/itfData';
 
-export const PRESTART_STATUS_SET = 'PRESTART_STATUS_SET';
-export const PRESTART_DATA_SET = 'PRESTART_DATA_SET';
-export const PRESTART_STATE_RESET = 'PRESTART_STATE_RESET';
-export const PRESTART_DISPLAY_RESET = 'PRESTART_DISPLAY_RESET';
+export const ITF_FETCH_INITIATED = 'ITF_FETCH_INITIATED';
+export const ITF_FETCH_SUCCEEDED = 'ITF_FETCH_SUCCEEDED';
+export const ITF_FETCH_FAILED = 'ITF_FETCH_FAILED';
 
-export const PRESTART_STATUSES = {
-  notAttempted: 'not-attempted',
-  pending: 'pending',
-  succeeded: 'succeeded',
-  failed: 'failed'
-};
+export const ITF_CREATION_INITIATED = 'ITF_CREATION_INITIATED';
+export const ITF_CREATION_SUCCEEDED = 'ITF_CREATION_SUCCEEDED';
+export const ITF_CREATION_FAILED = 'ITF_CREATION_FAILED';
 
-export const PRESTART_VERIFICATION_TYPES = {
-  retrieve: 'retrieve',
-  create: 'create'
-};
+export function fetchITF() {
+  return (dispatch) => {
+    dispatch({ type: ITF_FETCH_INITIATED });
 
-export const ITF_STATUSES = {
-  expired: 'expired',
-  active: 'active'
-};
-
-export function setPrestartStatus(status) {
-  return {
-    type: PRESTART_STATUS_SET,
-    status
+    return apiRequest(
+      '/intent_to_file',
+      null,
+      ({ data }) => dispatch({ type: ITF_FETCH_SUCCEEDED, data }),
+      () => dispatch({ type: ITF_FETCH_FAILED })
+    );
   };
 }
 
-export function setPrestartData(data) {
-  return {
-    type: PRESTART_DATA_SET,
-    data
-  };
-}
+export function createITF() {
+  return (dispatch) => {
+    dispatch({ type: ITF_CREATION_INITIATED });
 
-export function resetPrestartState() {
-  return {
-    type: PRESTART_STATE_RESET
-  };
-}
-
-export function resetPrestartDisplay() {
-  return {
-    type: PRESTART_DISPLAY_RESET
-  };
-}
-
-// Returns most recent timestamp from a list of timestamps
-export const getLatestTimestamp = (timestamps) => timestamps.sort((a, b) => new Date(b) - new Date(a))[0];
-export const getITFsByStatus = (itfs, status) => itfs.filter(itf => itf.status === status);
-
-export const handleCheckSuccess = (data, dispatch) => {
-
-  const itfList = get('attributes.intentToFile', data);
-
-  // If the user does not have any existing ITFs, create one
-  if (itfList.length === 0) {
-    return true;
-  }
-
-  // Check for an active ITF, the user should only have one
-  const activeITF = getITFsByStatus(itfList, ITF_STATUSES.active)[0];
-  const expiredITFs = getITFsByStatus(itfList, ITF_STATUSES.expired);
-  // If the user has an active ITF, set currentExpirationDate
-  if (activeITF) {
-    dispatch(setPrestartData({ currentExpirationDate: activeITF.expirationDate }));
-    dispatch(setPrestartStatus(PRESTART_STATUSES.succeeded));
-    return false;
-  }
-  // If the user doesn't have any active ITFs
-  // Check for expired ITFs, and if found, use the latest to set previousExpirationDate
-  // and create a new ITF
-  if (expiredITFs.length > 0) {
-    const latestExpiredITFExpirationDate = getLatestTimestamp(expiredITFs.map(itf => itf.expirationDate));
-    dispatch(setPrestartData({ previousExpirationDate: latestExpiredITFExpirationDate }));
-    return true;
-  }
-
-  // If the user does not have any expired or active ITFs, create one
-  return true;
-};
-
-export const handleCheckFailure = (dispatch) => {
-  dispatch(setPrestartStatus(PRESTART_STATUSES.failed));
-  return false;
-};
-
-export function checkITFRequest(dispatch) {
-  dispatch(setPrestartData({ verificationType: PRESTART_VERIFICATION_TYPES.retrieve }));
-
-  return apiRequest(
-    '/intent_to_file',
-    null,
-    ({ data }) => handleCheckSuccess(data, dispatch),
-    () => handleCheckFailure(dispatch)
-  );
-}
-
-const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
-
-const fakeITFRequest = async (url, options, success) => {
-  await delay(1000);
-  const response = new Response();
-  response.data = existingITFData;
-  return success(response);
-};
-
-// TODO: remove this mock and its helpers once user testing is complete
-export function mockCheckITFRequest(dispatch) {
-  dispatch(setPrestartData({ verificationType: PRESTART_VERIFICATION_TYPES.retrieve }));
-
-  return fakeITFRequest(
-    '/intent_to_file',
-    null,
-    ({ data }) => handleCheckSuccess(data, dispatch),
-    () => handleCheckFailure(dispatch)
-  );
-}
-
-export const handleSubmitSuccess = (data, dispatch) => {
-  const expirationDate = data.attributes.intentToFile.expirationDate;
-  dispatch(setPrestartData({ currentExpirationDate: expirationDate }));
-  dispatch(setPrestartStatus(PRESTART_STATUSES.succeeded));
-};
-
-export const handleSubmitFailure = (dispatch) => {
-  dispatch(setPrestartStatus(PRESTART_STATUSES.failed));
-};
-
-export function submitITFRequest(dispatch) {
-  dispatch(setPrestartData({ verificationType: PRESTART_VERIFICATION_TYPES.create }));
-
-  return apiRequest(
-    '/intent_to_file/compensation',
-    { method: 'POST' },
-    ({ data }) => handleSubmitSuccess(data, dispatch),
-    () => handleSubmitFailure(dispatch)
-  );
-}
-
-export function verifyIntentToFile() {
-  return async (dispatch) => {
-
-    dispatch(setPrestartStatus(PRESTART_STATUSES.pending));
-
-    const existingITFNotFound = await mockCheckITFRequest(dispatch);
-
-    if (existingITFNotFound) {
-      submitITFRequest(dispatch);
-    }
-  };
-}
-
-export function submitIntentToFile(formConfig, onChange) { // TODO: replace with ITF react work
-  return () => {
-    onChange('active');
+    return apiRequest(
+      '/intent_to_file',
+      { method: 'POST' },
+      ({ data }) => dispatch({ type: ITF_CREATION_SUCCEEDED, data }),
+      () => dispatch({ type: ITF_CREATION_FAILED })
+    );
   };
 }

--- a/src/applications/disability-benefits/526EZ/actions/index.js
+++ b/src/applications/disability-benefits/526EZ/actions/index.js
@@ -1,3 +1,5 @@
+import Raven from 'raven-js';
+
 import { apiRequest } from '../../../../platform/utilities/api';
 
 export const ITF_FETCH_INITIATED = 'ITF_FETCH_INITIATED';
@@ -16,7 +18,10 @@ export function fetchITF() {
       '/intent_to_file',
       null,
       ({ data }) => dispatch({ type: ITF_FETCH_SUCCEEDED, data }),
-      () => dispatch({ type: ITF_FETCH_FAILED })
+      () => {
+        Raven.captureMessage('itf_fetch_failed');
+        dispatch({ type: ITF_FETCH_FAILED });
+      }
     );
   };
 }
@@ -29,7 +34,10 @@ export function createITF() {
       '/intent_to_file/compensation',
       { method: 'POST' },
       ({ data }) => dispatch({ type: ITF_CREATION_SUCCEEDED, data }),
-      () => dispatch({ type: ITF_CREATION_FAILED })
+      () => {
+        Raven.captureMessage('itf_creation_failed');
+        dispatch({ type: ITF_CREATION_FAILED });
+      }
     );
   };
 }

--- a/src/applications/disability-benefits/526EZ/actions/index.js
+++ b/src/applications/disability-benefits/526EZ/actions/index.js
@@ -26,7 +26,7 @@ export function createITF() {
     dispatch({ type: ITF_CREATION_INITIATED });
 
     return apiRequest(
-      '/intent_to_file',
+      '/intent_to_file/compensation',
       { method: 'POST' },
       ({ data }) => dispatch({ type: ITF_CREATION_SUCCEEDED, data }),
       () => dispatch({ type: ITF_CREATION_FAILED })

--- a/src/applications/disability-benefits/526EZ/components/FormStartControls.jsx
+++ b/src/applications/disability-benefits/526EZ/components/FormStartControls.jsx
@@ -8,7 +8,6 @@ import { VerifiedAlert, UnauthenticatedAlert, UnverifiedAlert } from '../helpers
 export default function FormStartControls(props) {
   const { user } = props;
 
-  const somethingWentWrong = props.errors && props.errors.length;
   return (
     <div>
       {!user.login.currentlyLoggedIn && <div>
@@ -19,7 +18,6 @@ export default function FormStartControls(props) {
         {UnverifiedAlert}
         <a href={`/verify?next=${window.location.pathname}`} className="usa-button-primary verify-link">Verify Your Identity</a>
       </div>}
-      {somethingWentWrong}
       {user.profile.verified && <SaveInProgressIntro
         {...props}
         buttonOnly={props.buttonOnly}
@@ -45,5 +43,6 @@ FormStartControls.PropTypes = {
   messages: PropTypes.array.isRequired,
   pageList: PropTypes.array.isRequired,
   handleLoadPrefill: PropTypes.func.isRequired,
-  startText: PropTypes.string.isRequired
+  startText: PropTypes.string.isRequired,
+  user: PropTypes.object.isRequired
 };

--- a/src/applications/disability-benefits/526EZ/components/FormStartControls.jsx
+++ b/src/applications/disability-benefits/526EZ/components/FormStartControls.jsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 import SaveInProgressIntro from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
 
-import { ITFErrorAlert, VerifiedAlert, UnauthenticatedAlert, UnverifiedAlert, ITFDescription } from '../helpers';
+import { VerifiedAlert, UnauthenticatedAlert, UnverifiedAlert } from '../helpers';
 
 export default function FormStartControls(props) {
   const { user } = props;
 
-  const somethingWentWrong = props.ITFStatus && props.ITFStatus === 'expired' || // This may not be possible
-                             props.errors && props.errors.length;
+  const somethingWentWrong = props.errors && props.errors.length;
   return (
     <div>
       {!user.login.currentlyLoggedIn && <div>
@@ -21,20 +19,17 @@ export default function FormStartControls(props) {
         {UnverifiedAlert}
         <a href={`/verify?next=${window.location.pathname}`} className="usa-button-primary verify-link">Verify Your Identity</a>
       </div>}
-      {somethingWentWrong && ITFErrorAlert}
-      {props.ITFStatus === 'pending' && <LoadingIndicator message="Please wait while we check that your intent to file has been submitted."/>}
-      {!props.ITFStatus && user.profile.verified && <SaveInProgressIntro
+      {somethingWentWrong}
+      {user.profile.verified && <SaveInProgressIntro
         {...props}
         buttonOnly={props.buttonOnly}
         prefillAvailable
-        afterButtonContent={ITFDescription}
         verifiedPrefillAlert={VerifiedAlert}
         unverifiedPrefillAlert={UnauthenticatedAlert}
         verifyRequiredPrefill={props.route.formConfig.verifyRequiredPrefill}
         prefillEnabled={props.route.formConfig.prefillEnabled}
         messages={props.route.formConfig.savedFormMessages}
         pageList={props.route.pageList}
-        beforeStartForm={props.beforeStartForm}
         startText="Start the Disability Compensation Application"
         {...props.saveInProgressActions}
         {...props.saveInProgress}/>}
@@ -52,4 +47,3 @@ FormStartControls.PropTypes = {
   handleLoadPrefill: PropTypes.func.isRequired,
   startText: PropTypes.string.isRequired
 };
-

--- a/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
@@ -10,8 +10,6 @@ import FormTitle from 'us-forms-system/lib/js/components/FormTitle';
 import { introActions, introSelector } from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
 import { toggleLoginModal } from '../../../../platform/site-wide/user-nav/actions';
 
-import formConfig from '../config/form';
-import { submitIntentToFile } from '../actions';
 import FormStartControls from './FormStartControls';
 
 class IntroductionPage extends React.Component {
@@ -26,14 +24,6 @@ class IntroductionPage extends React.Component {
       .find(f => f.form === this.props.formId);
   }
 
-  updateITFStatus = (ITFStatus) => {
-    this.setState({ ITFStatus });
-  }
-
-  beforeStartForm = () => {
-    this.props.submitIntentToFile(formConfig, this.updateITFStatus);
-  }
-
   authenticate = (e) => {
     e.preventDefault();
     this.props.toggleLoginModal(true);
@@ -41,7 +31,6 @@ class IntroductionPage extends React.Component {
 
   render() {
     const { saveInProgress: { user } } = this.props;
-    const ITFStatus = this.state ? this.state.ITFStatus : undefined;
 
     return (
       <div className="schemaform-intro">
@@ -51,9 +40,7 @@ class IntroductionPage extends React.Component {
           pathname={this.props.location.pathname}
           user={user}
           authenticate={this.authenticate}
-          ITFStatus={ITFStatus}
-          {...this.props}
-          beforeStartForm={this.beforeStartForm}/>
+          {...this.props}/>
         <h4>Follow the steps below to apply for increased disability compensation.</h4>
         <div className="process schemaform-process">
           <ol>
@@ -99,10 +86,8 @@ class IntroductionPage extends React.Component {
           pathname={this.props.location.pathname}
           user={user}
           authenticate={this.authenticate}
-          ITFStatus={ITFStatus}
           {...this.props}
-          buttonOnly
-          beforeStartForm={this.beforeStartForm}/>
+          buttonOnly/>
         {/* TODO: Remove inline style after I figure out why .omb-info--container has a left padding */}
         <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
           <OMBInfo resBurden={25} ombNumber="2900-0747" expDate="11/30/2017"/>
@@ -122,9 +107,6 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     saveInProgressActions: bindActionCreators(introActions, dispatch),
-    submitIntentToFile: (config, onChange) => {
-      dispatch(submitIntentToFile(config, onChange));
-    },
     toggleLoginModal: (update) => {
       dispatch(toggleLoginModal(update));
     }

--- a/src/applications/disability-benefits/526EZ/constants.js
+++ b/src/applications/disability-benefits/526EZ/constants.js
@@ -1,3 +1,5 @@
+import { constantHandler } from '../../../platform/utilities/constants';
+
 export const PCIU_STATES = [
   { label: 'Alabama', value: 'AL' },
   { label: 'Alaska', value: 'AK' },
@@ -84,3 +86,12 @@ export const ADDRESS_TYPES = {
   mailingAddress: 'mailingAddress',
   forwardingAddress: 'forwardingAddress'
 };
+
+export const itfStatuses = new Proxy({
+  noneFound: 'none found',
+  active: 'active',
+  expired: 'expired',
+  claimRecieved: 'claim_recieved',
+  duplicate: 'duplicate',
+  incomplete: 'incomplete'
+}, constantHandler);

--- a/src/applications/disability-benefits/526EZ/constants.js
+++ b/src/applications/disability-benefits/526EZ/constants.js
@@ -88,7 +88,6 @@ export const ADDRESS_TYPES = {
 };
 
 export const itfStatuses = new Proxy({
-  noneFound: 'none found',
   active: 'active',
   expired: 'expired',
   claimRecieved: 'claim_recieved',

--- a/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
@@ -12,7 +12,6 @@ import { createITF as createITFAction, fetchITF as fetchITFAction } from '../act
 
 
 const fetchWaitingStates = [requestStates.notCalled, requestStates.pending];
-const fulfilledStates = [requestStates.succeeded, requestStates.failed];
 
 const noITFPages = ['/introduction', '/confirmation'];
 
@@ -75,10 +74,9 @@ export class ITFWrapper extends React.Component {
     }
 
     // If we've already fetched the ITFs, have none active, and haven't already called createITF, submit a new ITF
-    const fetchITFReturned = fulfilledStates.includes(itf.fetchCallState);
     const hasActiveITF = itf.currentITF && itf.currentITF.status === itfStatuses.active;
     const createITFCalled = itf.creationCallState !== requestStates.notCalled;
-    if (fetchITFReturned && !hasActiveITF && !createITFCalled) {
+    if (itf.fetchCallState === requestStates.succeeded && !hasActiveITF && !createITFCalled) {
       nextProps.createITF();
     }
 

--- a/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
@@ -12,66 +13,96 @@ import { createITF as createITFAction, fetchITF as fetchITFAction } from '../act
 const fetchWaitingStates = [requestStates.notCalled, requestStates.pending];
 
 
-export const ITFWrapper = ({ location, children, itf, fetchITF, createITF }) => {
-  // If the location is the intro or confirmation pages, don't fetch an ITF
-  if (['/introduction', '/confirmation'].includes(location.pathname)) {
-    return children;
-  }
+export class ITFWrapper extends React.Component {
+  render() {
+    const { location, children, itf, fetchITF, createITF } = this.props;
+    // If the location is the intro or confirmation pages, don't fetch an ITF
+    if (['/introduction', '/confirmation'].includes(location.pathname)) {
+      return children;
+    }
 
-  // If we haven't checked the ITF status yet, do so
-  if (itf.fetchCallState === requestStates.notCalled) {
-    fetchITF();
-  }
+    // If we haven't checked the ITF status yet, do so
+    if (itf.fetchCallState === requestStates.notCalled) {
+      fetchITF();
+    }
 
-  // While we're waiting, show the loading indicator...
-  if (fetchWaitingStates.includes(itf.fetchCallState)) {
-    return <LoadingIndicator message="Checking your Intent to File status..."/>;
-  }
+    // While we're waiting, show the loading indicator...
+    if (fetchWaitingStates.includes(itf.fetchCallState)) {
+      return <LoadingIndicator message="Checking your Intent to File status..."/>;
+    }
 
-  // We'll get here after the fetchITF promise is fulfilled
+    // We'll get here after the fetchITF promise is fulfilled
 
-  if (itf.fetchCallState === requestStates.failed) {
-    // TODO: Get better content for this
+    if (itf.fetchCallState === requestStates.failed) {
+      // TODO: Get better content for this
+      return (
+        <div className="usa-grid" style={{ marginBottom: '2em' }}>
+          <AlertBox
+            isVisible
+            headline="Something went wrong"
+            content="Sorry, we’re unable to check your ITF status right now."
+            status="error"/>
+        </div>
+      );
+    }
+
+    // If we have an active ITF, we're good to go--render that form!
+    if (itf.currentITF && itf.currentITF.status === itfStatuses.active) {
+      // TODO: Render a success alert box (only the first time)
+      //  Probably will have to use state for this
+      return children;
+    }
+
+    // If not, try to submit a new ITF
+    if (itf.creationCallState === requestStates.notCalled) {
+      createITF();
+    }
+
+    // While we're waiting (again), show the loading indicator...again
+    if (fetchWaitingStates.includes(itf.creationCallState)) {
+      return <LoadingIndicator message="Submitting a new Intent to File..."/>;
+    }
+
+    // We'll get here after the createITF promise is fulfilled and we have no active ITF
+    //  because of a failed creation call
+    // TODO: Get better content for this content
     return (
       <div className="usa-grid" style={{ marginBottom: '2em' }}>
         <AlertBox
           isVisible
           headline="Something went wrong"
-          content="Sorry, we’re unable to check your ITF status right now."
+          content="We’re sorry, we couldn’t find an active ITF nor file a new one for you. Please try again later."
           status="error"/>
       </div>
     );
   }
+}
 
-  // If we have an active ITF, we're good to go--render that form!
-  if (itf.currentITF && itf.currentITF.status === itfStatuses.active) {
-    // TODO: Render a success alert box (only the first time)
-    //  Probably will have to use state for this
-    return children;
-  }
 
-  // If not, try to submit a new ITF
-  if (itf.creationCallState === requestStates.notCalled) {
-    createITF();
-  }
+const requestStateEnum = Object.keys(requestStates);
 
-  // While we're waiting (again), show the loading indicator...again
-  if (fetchWaitingStates.includes(itf.creationCallState)) {
-    return <LoadingIndicator message="Submitting a new Intent to File..."/>;
-  }
+const itfShape = {
+  id: PropTypes.string,
+  creationDate: PropTypes.string,
+  expirationDate: PropTypes.string.isRequired,
+  participantId: PropTypes.number,
+  source: PropTypes.string,
+  status: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired
+};
 
-  // We'll get here after the createITF promise is fulfilled and we have no active ITF
-  //  because of a failed creation call
-  // TODO: Get better content for this content
-  return (
-    <div className="usa-grid" style={{ marginBottom: '2em' }}>
-      <AlertBox
-        isVisible
-        headline="Something went wrong"
-        content="We’re sorry, we couldn’t find an active ITF nor file a new one for you. Please try again later."
-        status="error"/>
-    </div>
-  );
+ITFWrapper.propTypes = {
+  location: PropTypes.shape({
+    pathname: PropTypes.string
+  }).isRequired,
+  itf: PropTypes.shape({
+    fetchCallState: PropTypes.oneOf(requestStateEnum).isRequired,
+    creationCallState: PropTypes.oneOf(requestStateEnum).isRequired,
+    currentITF: PropTypes.shape(itfShape),
+    previousITF: PropTypes.shape(itfShape)
+  }),
+  fetchITF: PropTypes.func.isRequired,
+  createITF: PropTypes.func.isRequired
 };
 
 

--- a/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
@@ -31,7 +31,7 @@ export const ITFWrapper = ({ location, children, itf, fetchITF, createITF }) => 
   // We'll get here after the fetchITF promise is fulfilled
 
   if (itf.fetchCallState === requestStates.failed) {
-    // TODO: Get better content for this content
+    // TODO: Get better content for this
     return (
       <div className="usa-grid" style={{ marginBottom: '2em' }}>
         <AlertBox
@@ -44,8 +44,9 @@ export const ITFWrapper = ({ location, children, itf, fetchITF, createITF }) => 
   }
 
   // If we have an active ITF, we're good to go--render that form!
-  if (itf.currentITF.status === itfStatuses.active) {
+  if (itf.currentITF && itf.currentITF.status === itfStatuses.active) {
     // TODO: Render a success alert box (only the first time)
+    //  Probably will have to use state for this
     return children;
   }
 

--- a/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
@@ -1,88 +1,85 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
-import { fetchStates } from '../../../../platform/utilities/constants';
+import { requestStates } from '../../../../platform/utilities/constants';
+import { itfStatuses } from '../constants';
+import { createITF as createITFAction, fetchITF as fetchITFAction } from '../actions';
 
 
-const fetchWaitingStates = [fetchStates.notCalled, fetchStates.pending];
+const fetchWaitingStates = [requestStates.notCalled, requestStates.pending];
 
 
-export default class ITFWrapper extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      createITFCallState: fetchStates.notCalled,
-      itfFetchState: fetchStates.notCalled,
-      itfIsActive: null
-    };
+export const ITFWrapper = ({ location, children, itf, fetchITF, createITF }) => {
+  // If the location is the intro or confirmation pages, don't fetch an ITF
+  if (['/introduction', '/confirmation'].includes(location.pathname)) {
+    return children;
   }
 
-
-  fetchITF() {
-    // Set the itfFetchState to pending
-    // Fetch the ITF
-    // If it's successful, set itfFetchState to succeeded
-    //   Set itfIsActive to true or false accordingly
-    // Else set it to failed
+  // If we haven't checked the ITF status yet, do so
+  if (itf.fetchCallState === requestStates.notCalled) {
+    fetchITF();
   }
 
-
-  submitITF() {
-    // Set createITFCall to pending
-    // Make the call
-    // If successfull, set createITFCallState to success
-    //   Set itfIsActive to true or false accordingly (probably just true?)
-    // Else set it to failed
+  // While we're waiting, show the loading indicator...
+  if (fetchWaitingStates.includes(itf.fetchCallState)) {
+    return <LoadingIndicator message="Checking your Intent to File status..."/>;
   }
 
+  // We'll get here after the fetchITF promise is fulfilled
 
-  render() {
-    const { location, children } = this.props;
-
-    // If the location is the intro or confirmation pages, don't fetch an ITF
-    if (['/introduction', '/confirmation'].includes(location.pathname)) {
-      return children;
-    }
-
-    // If we haven't checked the ITF status yet, do so
-    if (this.state.itfFetchState === fetchStates.notCalled) {
-      this.fetchITF();
-    }
-
-    // While we're waiting, show the loading indicator...
-    if (fetchWaitingStates.includes(this.state.itfFetchState)) {
-      return <LoadingIndicator message="Checking your Intent to File status..."/>;
-    }
-
-    // We'll get here after the fetchITF promise is fulfilled
-
-    if (this.itfFetchState === fetchStates.failed) {
-      // render error alert
-    }
-
-    // If we have an active ITF, we're good to go--render that form!
-    if (this.state.itfIsActive) {
-      return children;
-    }
-
-    // If not, try to submit a new ITF
-    if (this.state.createITFCallState === fetchStates.notCalled) {
-      this.submitITF();
-    }
-
-    // While we're waiting (again), show the loading indicator...again
-    if (fetchWaitingStates.includes(this.state.itfFetchState)) {
-      return <LoadingIndicator message="Submitting a new Intent to File..."/>;
-    }
-
-    // We'll get here after the createITF promise is fulfilled and we have no active ITF
-    //  because of a failed creation call
+  if (itf.fetchCallState === requestStates.failed) {
+    // TODO: Get better content for this content
     return (
-      <AlertBox
-        status="error"
-        headline="We’re sorry, we couldn’t find an active ITF nor file a new one for you. Please try again later."/>
+      <div className="usa-grid" style={{ marginBottom: '2em' }}>
+        <AlertBox
+          isVisible
+          headline="Something went wrong"
+          content="Sorry, we’re unable to check your ITF status right now."
+          status="error"/>
+      </div>
     );
   }
-}
+
+  // If we have an active ITF, we're good to go--render that form!
+  if (itf.currentITF.status === itfStatuses.active) {
+    return children;
+  }
+
+  // If not, try to submit a new ITF
+  if (itf.creationCallState === requestStates.notCalled) {
+    createITF();
+  }
+
+  // While we're waiting (again), show the loading indicator...again
+  if (fetchWaitingStates.includes(itf.creationCallState)) {
+    return <LoadingIndicator message="Submitting a new Intent to File..."/>;
+  }
+
+  // We'll get here after the createITF promise is fulfilled and we have no active ITF
+  //  because of a failed creation call
+  // TODO: Get better content for this content
+  return (
+    <div className="usa-grid" style={{ marginBottom: '2em' }}>
+      <AlertBox
+        isVisible
+        headline="Something went wrong"
+        content="We’re sorry, we couldn’t find an active ITF nor file a new one for you. Please try again later."
+        status="error"/>
+    </div>
+  );
+};
+
+
+const mapStateToProps = (store) => ({
+  itf: store.itf
+});
+
+const mapDispatchToProps = {
+  createITF: createITFAction,
+  fetchITF: fetchITFAction
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ITFWrapper);

--- a/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+
+import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
+import { fetchStates } from '../../../../platform/utilities/constants';
+
+
+const fetchWaitingStates = [fetchStates.notCalled, fetchStates.pending];
+
+
+export default class ITFWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      createITFCallState: fetchStates.notCalled,
+      itfFetchState: fetchStates.notCalled,
+      itfIsActive: null
+    };
+  }
+
+
+  fetchITF() {
+    // Set the itfFetchState to pending
+    // Fetch the ITF
+    // If it's successful, set itfFetchState to succeeded
+    //   Set itfIsActive to true or false accordingly
+    // Else set it to failed
+  }
+
+
+  submitITF() {
+    // Set createITFCall to pending
+    // Make the call
+    // If successfull, set createITFCallState to success
+    //   Set itfIsActive to true or false accordingly (probably just true?)
+    // Else set it to failed
+  }
+
+
+  render() {
+    const { location, children } = this.props;
+
+    // If the location is the intro or confirmation pages, don't fetch an ITF
+    if (['/introduction', '/confirmation'].includes(location.pathname)) {
+      return children;
+    }
+
+    // If we haven't checked the ITF status yet, do so
+    if (this.state.itfFetchState === fetchStates.notCalled) {
+      this.fetchITF();
+    }
+
+    // While we're waiting, show the loading indicator...
+    if (fetchWaitingStates.includes(this.state.itfFetchState)) {
+      return <LoadingIndicator message="Checking your Intent to File status..."/>;
+    }
+
+    // We'll get here after the fetchITF promise is fulfilled
+
+    if (this.itfFetchState === fetchStates.failed) {
+      // render error alert
+    }
+
+    // If we have an active ITF, we're good to go--render that form!
+    if (this.state.itfIsActive) {
+      return children;
+    }
+
+    // If not, try to submit a new ITF
+    if (this.state.createITFCallState === fetchStates.notCalled) {
+      this.submitITF();
+    }
+
+    // While we're waiting (again), show the loading indicator...again
+    if (fetchWaitingStates.includes(this.state.itfFetchState)) {
+      return <LoadingIndicator message="Submitting a new Intent to File..."/>;
+    }
+
+    // We'll get here after the createITF promise is fulfilled and we have no active ITF
+    //  because of a failed creation call
+    return (
+      <AlertBox
+        status="error"
+        headline="We’re sorry, we couldn’t find an active ITF nor file a new one for you. Please try again later."/>
+    );
+  }
+}

--- a/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
@@ -5,7 +5,6 @@ import moment from 'moment';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
-import AdditionalInfo from '@department-of-veterans-affairs/formation/AdditionalInfo';
 
 import { requestStates } from '../../../../platform/utilities/constants';
 import { itfStatuses } from '../constants';
@@ -106,11 +105,11 @@ export class ITFWrapper extends React.Component {
         const submitSuccessContent = (
           <div>
             <p>Thank you for submitting your Intent to File request for disability compensation. Your Intent to File will expire on {displayDate(itf.currentITF.expirationDate)}.</p>
-            {itf.previousITF && <AdditionalInfo triggerText="Not what you expected?">
+            {itf.previousITF &&
               <p>
-                We found a previous ITF that expired on {displayDate(itf.previousITF.expirationDate)}. This might have been from an application that you started and did not finish before expiration, or from an earlier claim that you submitted.
+                <strong>Please note:</strong> We found a previous Intent to File request in our records that expired on {displayDate(itf.previousITF.expirationDate)}. This ITF might have been from an application you started, but didn’t finish before the ITF expired. Or, it could have been from a claim you already submitted.
               </p>
-            </AdditionalInfo>}
+            }
           </div>
         );
 

--- a/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
@@ -45,6 +45,7 @@ export const ITFWrapper = ({ location, children, itf, fetchITF, createITF }) => 
 
   // If we have an active ITF, we're good to go--render that form!
   if (itf.currentITF.status === itfStatuses.active) {
+    // TODO: Render a success alert box (only the first time)
     return children;
   }
 

--- a/src/applications/disability-benefits/526EZ/reducer.js
+++ b/src/applications/disability-benefits/526EZ/reducer.js
@@ -1,43 +1,71 @@
-
-import _ from 'lodash/fp';
+import get from '../../../platform/utilities/data/get';
+import set from '../../../platform/utilities/data/set';
+import { requestStates } from '../../../platform/utilities/constants';
+import { itfStatuses } from './constants';
+import {
+  ITF_FETCH_INITIATED,
+  ITF_FETCH_SUCCEEDED,
+  ITF_FETCH_FAILED,
+  ITF_CREATION_INITIATED,
+  ITF_CREATION_SUCCEEDED,
+  ITF_CREATION_FAILED,
+} from './actions';
 
 import formConfig from './config/form';
 import { createSaveInProgressFormReducer } from '../../../platform/forms/save-in-progress/reducers';
 
-import {
-  PRESTART_STATUS_SET,
-  PRESTART_DATA_SET,
-  PRESTART_STATE_RESET,
-  PRESTART_DISPLAY_RESET,
-  PRESTART_STATUSES
-} from './actions';
 
 const initialState = {
-  status: PRESTART_STATUSES.notAttempted,
-  data: {
-    verificationType: null,
-    currentExpirationDate: null,
-    previousExpirationDate: null
-  },
-  display: false
+  fetchCallState: requestStates.notCalled,
+  creationCallState: requestStates.notCalled,
+  currentITF: null,
+  previousITF: null
 };
 
-export const prestart = (state = initialState, action) => {
+
+/**
+ * Finds the last ITF with a given status
+ */
+function findLastITF(itfList) {
+  // The full list is potentially more than just compensation ITFs, but we don't need those
+  return itfList.sort((a, b) => new Date(a.expirationDate) - new Date(b.expirationDate))[0];
+}
+
+
+export const itf = (state = initialState, action) => {
   switch (action.type) {
-    case PRESTART_STATUS_SET: {
-      const newState = _.set('status', action.status, state);
-      newState.display = true;
+    case ITF_FETCH_INITIATED:
+      return set('fetchCallState', requestStates.pending, state);
+    case ITF_FETCH_SUCCEEDED: {
+      const newState = set('fetchCallState', requestStates.succeeded, state);
+
+      const itfList = get('attributes.intentToFile', action.data).filter(i => i.type === 'compensation');
+      const activeITF = itfList.find(i => i.status === itfStatuses.active);
+
+      // Set the curentITFStatus
+      if (activeITF) {
+        // Pulled the active ITF out like this in case it's not technically the latest (not sure that's possible, though)
+        newState.currentITF = activeITF;
+        return newState;
+      }
+
+      // No active ITF found; use the one with the last expiration date
+      newState.currentITF = findLastITF(itfList);
+
       return newState;
     }
-    case PRESTART_DATA_SET: {
-      return _.set('data', action.data, state);
+    case ITF_FETCH_FAILED:
+      return set('fetchCallState', requestStates.failed, state);
+    case ITF_CREATION_INITIATED:
+      return set('creationCallState', requestStates.pending, state);
+    case ITF_CREATION_SUCCEEDED: {
+      const newState = set('creationCallState', requestStates.succeeded, state);
+      newState.previousITF = state.currentITF;
+      newState.currentITF = action.data.attributes.intentToFile;
+      return newState;
     }
-    case PRESTART_STATE_RESET: {
-      return initialState;
-    }
-    case PRESTART_DISPLAY_RESET: {
-      return _.set('display', false, state);
-    }
+    case ITF_CREATION_FAILED:
+      return set('creationCallState', requestStates.failed, state);
     default:
       return state;
   }
@@ -45,5 +73,5 @@ export const prestart = (state = initialState, action) => {
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),
-  prestart
+  itf
 };

--- a/src/applications/disability-benefits/526EZ/reducer.js
+++ b/src/applications/disability-benefits/526EZ/reducer.js
@@ -25,9 +25,10 @@ const initialState = {
 
 /**
  * Finds the last ITF with a given status
+ *
+ * Note: This can return undefined
  */
 function findLastITF(itfList) {
-  // The full list is potentially more than just compensation ITFs, but we don't need those
   return itfList.sort((a, b) => new Date(a.expirationDate) - new Date(b.expirationDate))[0];
 }
 
@@ -39,6 +40,7 @@ export const itf = (state = initialState, action) => {
     case ITF_FETCH_SUCCEEDED: {
       const newState = set('fetchCallState', requestStates.succeeded, state);
 
+      // The full list is potentially more than just compensation ITFs, but we don't need those
       const itfList = get('attributes.intentToFile', action.data).filter(i => i.type === 'compensation');
       const activeITF = itfList.find(i => i.status === itfStatuses.active);
 

--- a/src/applications/disability-benefits/526EZ/reducer.js
+++ b/src/applications/disability-benefits/526EZ/reducer.js
@@ -29,7 +29,7 @@ const initialState = {
  * Note: This can return undefined
  */
 function findLastITF(itfList) {
-  return itfList.sort((a, b) => new Date(a.expirationDate) - new Date(b.expirationDate))[0];
+  return itfList.sort((a, b) => new Date(b.expirationDate) - new Date(a.expirationDate))[0];
 }
 
 

--- a/src/applications/disability-benefits/526EZ/tests/actions/actions.unit.spec.js
+++ b/src/applications/disability-benefits/526EZ/tests/actions/actions.unit.spec.js
@@ -1,281 +1,77 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { mockFetch, mockApiRequest } from '../../../../../platform/testing/unit/helpers.js';
+import { mockApiRequest } from '../../../../../platform/testing/unit/helpers.js';
 
 import {
-  getLatestTimestamp,
-  getITFsByStatus,
-  PRESTART_STATUS_SET,
-  PRESTART_DATA_SET,
-  PRESTART_STATE_RESET,
-  PRESTART_DISPLAY_RESET,
-  PRESTART_STATUSES,
-  PRESTART_VERIFICATION_TYPES,
-  ITF_STATUSES,
-  setPrestartStatus,
-  setPrestartData,
-  resetPrestartState,
-  resetPrestartDisplay,
-  handleCheckSuccess,
-  handleCheckFailure,
-  handleSubmitSuccess,
-  handleSubmitFailure,
-  checkITFRequest,
-  submitITFRequest,
-  verifyIntentToFile
+  fetchITF,
+  createITF,
+  ITF_FETCH_INITIATED,
+  ITF_FETCH_SUCCEEDED,
+  ITF_FETCH_FAILED,
+  ITF_CREATION_INITIATED,
+  ITF_CREATION_SUCCEEDED,
+  ITF_CREATION_FAILED
 } from '../../actions';
 
-import existingData from '../itfData';
+const originalFetch = global.fetch;
 
-const noData = {
-  id: '',
-  type: 'evss_intent_to_file_intent_to_files_responses',
-  attributes: {
-    intentToFile: []
-  }
-};
 
-const incompleteData = {
-  id: '',
-  type: 'evss_intent_to_file_intent_to_files_responses',
-  attributes: {
-    intentToFile: [
-      {
-        id: '2510',
-        creationDate: '2015-03-30T16:19:09.000+00:00',
-        expirationDate: '2016-03-30T16:19:09.000+00:00',
-        participantId: 600043186,
-        source: 'EBN',
-        status: 'incomplete',
-        type: 'compensation'
-      },
-      {
-        id: '2510',
-        creationDate: '2015-03-30T16:19:09.000+00:00',
-        expirationDate: '2016-03-30T16:19:09.000+00:00',
-        participantId: 600043186,
-        source: 'EBN',
-        status: 'claim_recieved',
-        type: 'compensation'
-      }
-    ]
-  }
-};
-const expiredData = {
-  id: '',
-  type: 'evss_intent_to_file_intent_to_files_responses',
-  attributes: {
-    intentToFile: [
-      {
-        id: '2510',
-        creationDate: '2015-03-30T16:19:09.000+00:00',
-        expirationDate: '2016-03-30T16:19:09.000+00:00',
-        participantId: 600043186,
-        source: 'EBN',
-        status: 'expired',
-        type: 'compensation'
-      }
-    ]
-  }
-};
-const createdData = {
-  id: '',
-  type: 'evss_intent_to_file_intent_to_files_responses',
-  attributes: {
-    intentToFile: {
-      id: '166837',
-      creationDate: '2018-04-10T15:12:36.000+00:00',
-      expirationDate: '2019-04-10T15:12:34.000+00:00',
-      participantId: 600043186,
-      source: 'EBN',
-      status: 'active',
-      type: 'compensation'
-    }
-  }
-};
-
-describe('ITF retrieve / submit actions:', () => {
-  const originalFetch = global.fetch;
-
-  describe('getLatestTimestamp', () => {
-    it('should return the most recent timestamp in a list of timestamps', () => {
-      const timestamps = ['2015-03-30T16:19:09.000+00:00', '2016-03-30T16:19:09.000+00:00'];
-      const latestTimestamp = getLatestTimestamp(timestamps);
-      expect(latestTimestamp).to.equal('2016-03-30T16:19:09.000+00:00');
+describe('ITF actions', () => {
+  describe('fetchITF', () => {
+    afterEach(() => {
+      global.fetch = originalFetch;
     });
-  });
-  describe('getITFsByStatus', () => {
-    it('should return a list of ITFs filtered by a given status', () => {
-      expect(getITFsByStatus(existingData.attributes.intentToFile, ITF_STATUSES.active).length).to.equal(1);
-    });
-  });
-  describe('setPrestartStatus', () => {
-    it('should return action', () => {
-      const status = PRESTART_STATUSES.succeeded;
-      const action = setPrestartStatus(status);
 
-      expect(action.type).to.equal(PRESTART_STATUS_SET);
-      expect(action.status).to.equal(status);
-    });
-  });
-  describe('setPrestartData', () => {
-    it('should return action', () => {
-      const data = '2019-04-10T15:12:34.000+00:00';
-      const action = setPrestartData(data);
-
-      expect(action.type).to.equal(PRESTART_DATA_SET);
-      expect(action.data).to.equal('2019-04-10T15:12:34.000+00:00');
-    });
-  });
-  describe('resetPrestartState', () => {
-    it('should return action', () => {
-      const action = resetPrestartState();
-
-      expect(action.type).to.equal(PRESTART_STATE_RESET);
-    });
-  });
-  describe('resetPrestartDisplay', () => {
-    it('should return action', () => {
-      const action = resetPrestartDisplay();
-
-      expect(action.type).to.equal(PRESTART_DISPLAY_RESET);
-    });
-  });
-  describe('handleCheckSuccess', () => {
-    it('should return true if no existing ITFs are retrieved', () => {
+    it('should dispatch a fetch succeeded action with data', () => {
+      const mockData = { data: 'asdf' };
+      mockApiRequest(mockData);
       const dispatch = sinon.spy();
-
-      expect(handleCheckSuccess(noData, dispatch)).to.be.true;
-    });
-    it('should return true if no expired or active ITFs are retrieved', () => {
-      const dispatch = sinon.spy();
-
-      expect(handleCheckSuccess(incompleteData, dispatch)).to.be.true;
-    });
-    it('should set previousExpirationDate and return true if retrieved ITFs include expired but not active ITFs', () => {
-      const dispatch = sinon.spy();
-
-      expect(handleCheckSuccess(expiredData, dispatch)).to.be.true;
-      expect(dispatch.calledWith(setPrestartData({ previousExpirationDate: '2016-03-30T16:19:09.000+00:00' }))).to.be.true;
-    });
-    it('should set succeeded status and return false if active ITFs are retrieved', () => {
-      const dispatch = sinon.spy();
-
-      expect(handleCheckSuccess(existingData, dispatch)).to.be.false;
-      expect(dispatch.calledWith(setPrestartStatus(PRESTART_STATUSES.succeeded))).to.be.true;
-      expect(dispatch.calledWith(setPrestartData({ currentExpirationDate: '2019-04-10T15:12:34.000+00:00' }))).to.be.true;
-    });
-  });
-  describe('handleCheckFailure', () => {
-    it('should set failed status and return false', () => {
-      const dispatch = sinon.spy();
-
-      expect(handleCheckFailure(dispatch)).to.be.false;
-      expect(dispatch.calledWith(setPrestartStatus(PRESTART_STATUSES.failed))).to.be.true;
-    });
-  });
-  describe('handleSubmitSuccess', () => {
-    it('should dispatch status and data', () => {
-      const dispatch = sinon.spy();
-
-      handleSubmitSuccess(createdData, dispatch);
-      expect(dispatch.calledWith(setPrestartData({ currentExpirationDate: '2019-04-10T15:12:34.000+00:00' }))).to.be.true;
-      expect(dispatch.calledWith(setPrestartStatus(PRESTART_STATUSES.succeeded))).to.be.true;
-    });
-  });
-  describe('handleSubmitFailure', () => {
-    it('should dispatch error status', () => {
-      const dispatch = sinon.spy();
-
-      handleSubmitFailure(dispatch);
-      expect(dispatch.calledWith(setPrestartStatus(PRESTART_STATUSES.failed))).to.be.true;
-    });
-  });
-  describe('checkITFRequest', () => {
-    afterEach(() => { global.fetch = originalFetch; });
-    it('should handle success', (done) => {
-      const dispatch = sinon.spy();
-      mockApiRequest({ data: existingData });
-      const thunk = checkITFRequest;
-      const verificationType = PRESTART_VERIFICATION_TYPES.retrieve;
-      const status = PRESTART_STATUSES.succeeded;
-
-      thunk(dispatch).then((result) => {
-        expect(dispatch.calledWith(setPrestartData({ verificationType }))).to.be.true;
-        expect(dispatch.calledWith(setPrestartData({ currentExpirationDate: '2019-04-10T15:12:34.000+00:00' }))).to.be.true;
-        expect(dispatch.calledWith(setPrestartStatus(status))).to.be.true;
-        expect(result).to.be.false;
-        done();
-      }).catch((err) => {
-        done(err);
+      return fetchITF()(dispatch).then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(ITF_FETCH_INITIATED);
+        expect(dispatch.secondCall.args[0]).to.eql({
+          type: ITF_FETCH_SUCCEEDED,
+          data: mockData.data
+        });
       });
     });
-    it('should handle error', (done) => {
-      mockFetch(new Error('No network connection'), false);
+
+    it('should dispatch a fetch failed action', () => {
+      const mockData = { data: 'asdf' };
+      mockApiRequest(mockData, false);
       const dispatch = sinon.spy();
-      const thunk = checkITFRequest;
-      const verificationType = PRESTART_VERIFICATION_TYPES.retrieve;
-      const status = PRESTART_STATUSES.failed;
-
-
-      thunk(dispatch).then((result) => {
-        expect(dispatch.calledWith(setPrestartData({ verificationType }))).to.be.true;
-        expect(dispatch.calledWith(setPrestartStatus(status))).to.be.true;
-        expect(result).to.equal(false);
-        done();
-      }).catch((err) => {
-        done(err);
+      return fetchITF()(dispatch).then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(ITF_FETCH_INITIATED);
+        expect(dispatch.secondCall.args[0].type).to.equal(ITF_FETCH_FAILED);
       });
     });
   });
-  describe('submitITFRequest', () => {
-    afterEach(() => { global.fetch = originalFetch; });
-    it('should handle success', (done) => {
-      mockApiRequest({ data: createdData });
-      const dispatch = sinon.spy();
-      const thunk = submitITFRequest;
-      const successStatus = PRESTART_STATUSES.succeeded;
-      const verificationType = PRESTART_VERIFICATION_TYPES.create;
 
-      thunk(dispatch).then(() => {
-        expect(dispatch.calledWith(setPrestartData({ verificationType }))).to.be.true;
-        expect(dispatch.calledWith(setPrestartData({ currentExpirationDate: '2019-04-10T15:12:34.000+00:00' }))).to.be.true;
-        expect(dispatch.calledWith(setPrestartStatus(successStatus))).to.be.true;
-        done();
-      }).catch((err) => {
-        done(err);
+  describe('createITF', () => {
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('should dispatch a fetch succeeded action with data', () => {
+      const mockData = { data: 'asdf' };
+      mockApiRequest(mockData);
+      const dispatch = sinon.spy();
+      return createITF()(dispatch).then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(ITF_CREATION_INITIATED);
+        expect(dispatch.secondCall.args[0]).to.eql({
+          type: ITF_CREATION_SUCCEEDED,
+          data: mockData.data
+        });
       });
     });
-    it('should handle error', (done) => {
-      mockFetch(new Error('No network connection'), false);
+
+    it('should dispatch a fetch failed action', () => {
+      const mockData = { data: 'asdf' };
+      mockApiRequest(mockData, false);
       const dispatch = sinon.spy();
-      const thunk = submitITFRequest;
-      const errorStatus = PRESTART_STATUSES.failed;
-      const verificationType = PRESTART_VERIFICATION_TYPES.create;
-
-      thunk(dispatch).then(() => {
-        expect(dispatch.calledWith(setPrestartData({ verificationType }))).to.be.true;
-        expect(dispatch.calledWith(setPrestartStatus(errorStatus))).to.be.true;
-        done();
-      }).catch((err) => {
-        done(err);
-      });
-    });
-  });
-  xdescribe('verifyIntentToFile', () => { // TODO: enable once user testing mocks are removed
-    afterEach(() => { global.fetch = originalFetch; });
-
-    it('dispatches a pending status', (done) => {
-      mockFetch();
-      const thunk = verifyIntentToFile();
-      const dispatch = sinon.spy();
-
-      thunk(dispatch).then(() => {
-        expect(dispatch.calledWith(setPrestartStatus(PRESTART_STATUSES.pending))).to.be.true;
-        done();
-      }).catch((err) => {
-        done(err);
+      return createITF()(dispatch).then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(ITF_CREATION_INITIATED);
+        expect(dispatch.secondCall.args[0].type).to.eql(ITF_CREATION_FAILED);
       });
     });
   });

--- a/src/applications/disability-benefits/526EZ/tests/components/FormStartControls.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/FormStartControls.unit.spec.jsx
@@ -71,43 +71,4 @@ describe('526 <FormStartControls>', () => {
 
     expect(tree.find('Connect').exists()).to.be.true;
   });
-  it('should render loading view', () => {
-    const tree = shallow(
-      <FormStartControls
-        ITFStatus={'pending'}
-        user={{
-          login: {
-            currentlyLoggedIn: true
-          },
-          profile: {
-            verified: true,
-            savedForms: [],
-            services: []
-          }
-        }}/>
-    );
-
-    expect(tree.find('LoadingIndicator').exists()).to.be.true;
-  });
-  it('should render ITF error view', () => {
-    const tree = shallow(
-      <FormStartControls
-        ITFStatus={'expired'}
-        user={{
-          login: {
-            currentlyLoggedIn: true
-          },
-          profile: {
-            verified: true,
-            savedForms: [],
-            services: []
-          }
-        }}/>
-    );
-
-    expect(tree.find('.usa-alert').text()).to.contain('intent');
-    expect(tree.find('SaveInProgressIntro').exists()).to.be.false;
-    expect(tree.find('button').exists()).to.be.false;
-    expect(tree.find('a').exists()).to.be.false;
-  });
 });

--- a/src/applications/disability-benefits/526EZ/tests/containers/ITFWrapper.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/containers/ITFWrapper.unit.spec.jsx
@@ -34,7 +34,7 @@ describe('526 ITFWrapper', () => {
 
   it('should not make an api call on the intro page', () => {
     global.fetch = sinon.spy();
-    const tree = shallow(
+    const tree = mount(
       <ITFWrapper location={{ pathname: '/introduction' }}>
         <p>It worked!</p>
       </ITFWrapper>
@@ -46,7 +46,7 @@ describe('526 ITFWrapper', () => {
 
   it('should not make an api call on the confirmation page', () => {
     global.fetch = sinon.spy();
-    const tree = shallow(
+    const tree = mount(
       <ITFWrapper location={{ pathname: '/confirmation' }}>
         <p>It worked!</p>
       </ITFWrapper>
@@ -57,7 +57,7 @@ describe('526 ITFWrapper', () => {
 
 
   it('should fetch the ITF if the form is loaded not on the intro or confirmation pages', () => {
-    shallow(
+    mount(
       <ITFWrapper {...defaultProps}>
         <p>Shouldn't see me yet...</p>
       </ITFWrapper>
@@ -103,6 +103,23 @@ describe('526 ITFWrapper', () => {
       </ITFWrapper>
     );
     expect(tree.find('AlertBox').length).to.equal(1);
+  });
+
+
+  it('should not submit a new ITF if the fetch failed', () => {
+    const props = merge(defaultProps, {
+      itf: {
+        fetchCallState: requestStates.pending
+      }
+    });
+    const tree = mount(
+      <ITFWrapper {...props}>
+        <p>Shouldn't see me yet...</p>
+      </ITFWrapper>
+    );
+    // The ITF call happens in componentWillReceiveProps, so trigger that function call
+    tree.setProps(merge(props, { itf: { fetchCallState: requestStates.failed } }));
+    expect(createITF.called).to.be.false;
   });
 
 

--- a/src/applications/disability-benefits/526EZ/tests/containers/ITFWrapper.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/containers/ITFWrapper.unit.spec.jsx
@@ -196,11 +196,8 @@ describe('526 ITFWrapper', () => {
       </ITFWrapper>
     );
     expect(tree.find('AlertBox').length).to.equal(1);
-    expect(tree.text()).to.contain('August 28, 2015');
-    const additionalInfo = tree.find('AdditionalInfo');
-    expect(additionalInfo.length).to.equal(1);
-    additionalInfo.find('button').simulate('click');
-    expect(additionalInfo.text()).to.contain('August 28, 2014');
+    expect(tree.text()).to.contain('will expire on August 28, 2015');
+    expect(tree.text()).to.contain('expired on August 28, 2014');
   });
 
 

--- a/src/applications/disability-benefits/526EZ/tests/containers/ITFWrapper.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/containers/ITFWrapper.unit.spec.jsx
@@ -169,7 +169,7 @@ describe('526 ITFWrapper', () => {
       </ITFWrapper>
     );
     expect(tree.find('AlertBox').length).to.equal(1);
-    expect(tree.text()).to.contain(expirationDate);
+    expect(tree.text()).to.contain('August 28, 2015');
     expect(tree.find('AdditionalInfo').length).to.equal(0);
   });
 
@@ -196,11 +196,11 @@ describe('526 ITFWrapper', () => {
       </ITFWrapper>
     );
     expect(tree.find('AlertBox').length).to.equal(1);
-    expect(tree.text()).to.contain(expirationDate);
+    expect(tree.text()).to.contain('August 28, 2015');
     const additionalInfo = tree.find('AdditionalInfo');
     expect(additionalInfo.length).to.equal(1);
     additionalInfo.find('button').simulate('click');
-    expect(additionalInfo.text()).to.contain(previousExpirationDate);
+    expect(additionalInfo.text()).to.contain('August 28, 2014');
   });
 
 

--- a/src/applications/disability-benefits/526EZ/tests/containers/ITFWrapper.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/containers/ITFWrapper.unit.spec.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+// import { mockMultipleApiRequest } from '../../../../../platform/testing/unit/helpers';
+import { ITFWrapper } from '../../containers/ITFWrapper';
+
+const originalFetch = global.fetch;
+
+describe('526 ITFWrapper', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('should not make an api call on the intro page', () => {
+    global.fetch = sinon.spy();
+    const tree = shallow(
+      <ITFWrapper location={{ pathname: '/introduction' }}>
+        <p>It worked!</p>
+      </ITFWrapper>
+    );
+    expect(fetch.called).to.be.false;
+    expect(tree.text()).to.equal('It worked!');
+  });
+
+  it('should not make an api call on the confirmation page', () => {
+    global.fetch = sinon.spy();
+    const tree = shallow(
+      <ITFWrapper location={{ pathname: '/introduction' }}>
+        <p>It worked!</p>
+      </ITFWrapper>
+    );
+    expect(fetch.called).to.be.false;
+    expect(tree.text()).to.equal('It worked!');
+  });
+
+  it('should fetch the ITF if not on the intro or confirmation pages', () => {});
+  it('should render a loading indicator', () => {});
+  it('should render an error message if the ITF fetch failed', () => {});
+  it('should submit a new ITF if no active ITF is found', () => {});
+  it('should render an error message if the ITF creation failed', () => {});
+  it('should render an success message with the current expiration date', () => {});
+  it('should render an success message with the previous expiration date', () => {});
+});

--- a/src/applications/disability-benefits/526EZ/tests/reducers.unit.spec.js
+++ b/src/applications/disability-benefits/526EZ/tests/reducers.unit.spec.js
@@ -1,88 +1,120 @@
 import { expect } from 'chai';
 
+import { requestStates } from '../../../../platform/utilities/constants';
+import { itfStatuses } from '../constants';
 
 import {
-  PRESTART_STATUS_SET,
-  PRESTART_DATA_SET,
-  PRESTART_STATE_RESET,
-  PRESTART_DISPLAY_RESET,
-  PRESTART_STATUSES,
-  PRESTART_VERIFICATION_TYPES
+  ITF_FETCH_INITIATED,
+  ITF_FETCH_SUCCEEDED,
+  ITF_FETCH_FAILED,
+  ITF_CREATION_INITIATED,
+  ITF_CREATION_SUCCEEDED,
+  ITF_CREATION_FAILED
 } from '../actions';
 
-import { prestart } from '../reducer';
+import { itf } from '../reducer';
 
-describe('prestart', () => {
-  it('creates a reducer with initial state', () => {
-    const reducer = prestart;
-    const state = reducer(undefined, { type: PRESTART_DISPLAY_RESET });
-    expect(state.status).to.equal(PRESTART_STATUSES.notAttempted);
-    expect(state.data).to.deep.equal({
-      verificationType: null,
-      currentExpirationDate: null,
-      previousExpirationDate: null
-    });
-    expect(state.display).to.be.false;
+
+const initialState = {
+  fetchCallState: requestStates.notCalled,
+  creationCallState: requestStates.notCalled,
+  currentITF: null,
+  previousITF: null
+};
+
+
+describe('ITF reducer', () => {
+  it('should handle ITF_FETCH_INITIATED', () => {
+    const newState = itf(initialState, { type: ITF_FETCH_INITIATED });
+    expect(newState.fetchCallState).to.equal(requestStates.pending);
   });
 
-  describe('reducer', () => {
-    const reducer = prestart;
-    it('should set prestart status', () => {
-      const state = reducer(undefined, {
-        type: PRESTART_STATUS_SET,
-        status: PRESTART_STATUSES.succeeded
-      });
-
-      expect(state.status).to.equal(PRESTART_STATUSES.succeeded);
-      expect(state.display).to.be.true;
-    });
-    it('should set prestart data', () => {
-      const state = reducer(undefined, {
-        type: PRESTART_DATA_SET,
+  describe('ITF_FETCH_SUCCEEDED', () => {
+    // These also test that it filters for compensation ITFs
+    it('should set the currentITF to the active one if present', () => {
+      const action = {
+        type: ITF_FETCH_SUCCEEDED,
         data: {
-          verificationType: PRESTART_VERIFICATION_TYPES.retrieve,
-          currentExpirationDate: '2019-04-10T15:12:34.000+00:00'
+          attributes: {
+            intentToFile: [
+              {
+                type: 'something not compensation',
+                status: itfStatuses.active
+              },
+              {
+                type: 'compensation',
+                status: itfStatuses.active,
+                expirationDate: '2014-07-28T19:53:45.810+0000'
+              },
+              {
+                // duplicate ITF with later expiration date; should use the active one
+                type: 'compensation',
+                status: itfStatuses.duplicate,
+                expirationDate: '2015-07-28T19:53:45.810+0000'
+              }
+            ]
+          }
         }
-      });
-
-      expect(state.data.verificationType).to.equal(PRESTART_VERIFICATION_TYPES.retrieve);
-      expect(state.data.currentExpirationDate).to.equal('2019-04-10T15:12:34.000+00:00');
+      };
+      const newState = itf(initialState, action);
+      expect(newState.currentITF.status).to.equal(itfStatuses.active);
     });
-    it('should reinitialize state', () => {
-      const state = reducer({
-        display: true,
-        status: PRESTART_STATUSES.succeeded,
+
+    it('should set the currentITF to the one with the latest expiration date if no active one is present', () => {
+      const action = {
+        type: ITF_FETCH_SUCCEEDED,
         data: {
-          verificationType: PRESTART_VERIFICATION_TYPES.create,
-          currentExpirationDate: '2019-04-10T15:12:34.000+00:00',
-          previousExpirationDate: '2019-04-10T15:12:34.000+00:00'
+          attributes: {
+            intentToFile: [
+              {
+                type: 'something not compensation',
+                status: itfStatuses.active
+              },
+              {
+                type: 'compensation',
+                status: itfStatuses.expired,
+                expirationDate: '2014-07-28T19:53:45.810+0000'
+              },
+              {
+                type: 'compensation',
+                status: itfStatuses.duplicate,
+                expirationDate: '2015-07-28T19:53:45.810+0000'
+              }
+            ]
+          }
         }
-      }, {
-        type: PRESTART_STATE_RESET,
-      });
-
-      expect(state.status).to.equal(PRESTART_STATUSES.notAttempted);
-      expect(state.data).to.deep.equal({
-        verificationType: null,
-        currentExpirationDate: null,
-        previousExpirationDate: null
-      });
-      expect(state.display).to.be.false;
+      };
+      const newState = itf(initialState, action);
+      expect(newState.currentITF.status).to.equal(itfStatuses.duplicate);
     });
-    it('should reset prestart display', () => {
-      const state = reducer({
-        display: true,
-        status: PRESTART_STATUSES.succeeded,
-        data: {
-          verificationType: PRESTART_VERIFICATION_TYPES.create,
-          currentExpirationDate: '2019-04-10T15:12:34.000+00:00',
-          previousExpirationDate: '2019-04-10T15:12:34.000+00:00'
+  });
+
+  it('should handle ITF_FETCH_FAILED', () => {
+    const newState = itf(initialState, { type: ITF_FETCH_FAILED });
+    expect(newState.fetchCallState).to.equal(requestStates.failed);
+  });
+
+  it('should handle ITF_CREATION_INITIATED', () => {
+    const newState = itf(initialState, { type: ITF_CREATION_INITIATED });
+    expect(newState.creationCallState).to.equal(requestStates.pending);
+  });
+
+  it('should handle ITF_CREATION_SUCCEEDED', () => {
+    const action = {
+      type: ITF_CREATION_SUCCEEDED,
+      data: {
+        attributes: {
+          intentToFile: 'new itf'
         }
-      }, {
-        type: PRESTART_DISPLAY_RESET,
-      });
+      }
+    };
+    const newState = itf({ currentITF: 'old itf' }, action);
+    expect(newState.previousITF).to.equal('old itf');
+    expect(newState.currentITF).to.equal('new itf');
+  });
 
-      expect(state.display).to.be.false;
-    });
+  it('should handle ITF_CREATION_FAILED', () => {
+    const newState = itf(initialState, { type: ITF_CREATION_FAILED });
+    expect(newState.creationCallState).to.equal(requestStates.failed);
   });
 });

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -157,7 +157,6 @@ class SaveInProgressIntro extends React.Component {
           returnUrl={this.props.returnUrl}
           migrations={this.props.migrations}
           prefillTransformer={this.props.prefillTransformer}
-          beforeStartForm={this.props.beforeStartForm}
           fetchInProgressForm={this.props.fetchInProgressForm}
           removeInProgressForm={this.props.removeInProgressForm}
           prefillAvailable={prefillAvailable}

--- a/src/platform/testing/unit/helpers.js
+++ b/src/platform/testing/unit/helpers.js
@@ -10,10 +10,10 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 /**
- * Wraps the given children with a new component with context from 
+ * Wraps the given children with a new component with context from
  * context and contextTypes.
  *
- * @param {object} context The context object for the new component 
+ * @param {object} context The context object for the new component
  * @param {object} contextTypes An object with a prop type description of
  * @param {React.Element} children React elements that the new component will wrap
  * @returns {React.Element} A new React element that wraps children with context
@@ -96,28 +96,53 @@ export function resetFetch() {
   global.fetch.reset();
 }
 
+
+const getApiRequestObject = (returnVal) => ({
+  headers: {
+    get: () => 'application/json',
+  },
+  ok: true,
+  json: () => Promise.resolve(returnVal)
+});
+
+
 /**
  * This doesn't so much _mock_ the function as it does set up the fetch to return what we
  * need it to from apiRequest(). Feel free to rename this to something more appropriate.
  *
- * @param returnVal The value to return from the json promise
+ * @param {} returnVal The value to return from the json promise
  * @param {boolean} [shouldResolve=true] Returns a rejected promise if this is false
  * @param {string} [userToken='foo'] The token to set in sessionStorage, to simulate
  * and authenticated request
  */
 export function mockApiRequest(returnVal, shouldResolve = true, userToken = 'foo') {
-  const returnObj = {
-    headers: {
-      get: () => 'application/json',
-    },
-    ok: true,
-    json: () => Promise.resolve(returnVal)
-  };
+  const returnObj = getApiRequestObject(returnVal);
 
   mockFetch(returnObj, shouldResolve);
   global.sessionStorage = {
     userToken
   };
 }
+
+
+/**
+ * @typedef {Object} Response
+ * @property {} response - The value the fake fetch should return
+ * @property {boolean} shouldResolve - Whether the fetch promise should resolve or not
+ * ---
+ * @param {Response[]} responses - An array of responses which subsequent fetch calls should return
+ * @param {string} userToken - The user token
+ */
+export function mockMultipleApiRequests(responses, userToken = 'foo') {
+  global.fetch = sinon.stub();
+  responses.forEach((res, index) => {
+    const { response, shouldResolve } = res;
+    global.fetch.onCall(index).returns(shouldResolve ? Promise.resolve(response) : Promise.reject(response));
+  });
+  global.sessionStorage = {
+    userToken
+  };
+}
+
 
 export { chai, expect, wrapWithContext, wrapWithRouterContext, fillDate };

--- a/src/platform/utilities/constants.js
+++ b/src/platform/utilities/constants.js
@@ -10,7 +10,7 @@ export const constantHandler = {
 };
 
 
-export const fetchStates = new Proxy({
+export const requestStates = new Proxy({
   notCalled: 'not called',
   pending: 'pending',
   succeeded: 'succeeded',

--- a/src/platform/utilities/constants.js
+++ b/src/platform/utilities/constants.js
@@ -1,0 +1,18 @@
+// TODO: Rename this to something that makes more sense
+export const constantHandler = {
+  get(target, propName) {
+    if (!(propName in target)) {
+      throw new Error(`${propName} not in target.`);
+    }
+
+    return target[propName];
+  }
+};
+
+
+export const fetchStates = new Proxy({
+  notCalled: 'not called',
+  pending: 'pending',
+  succeeded: 'succeeded',
+  failed: 'failed'
+}, constantHandler);


### PR DESCRIPTION
## ITF success
![image](https://user-images.githubusercontent.com/12970166/42542574-4c13af62-845c-11e8-918b-14ae000acfe7.png)
**Context:** The veteran either:
1) Had an active ITF on file already
2) Had no ITFs on file (active, expired, what have you), but the ITF creation succeeded
    - This probably won't happen for increase only, but...I feel like it's safer this way since I don't know if ITFs are removed from the veteran's record after the original claim has gone through

Also shown in this screenshot is where these success alerts will be displayed.

## ITF creation success with old ITF
![image](https://user-images.githubusercontent.com/12970166/42542612-80f8f89a-845c-11e8-914b-6d28a108a492.png)
**Context:** The veteran had an old, non-active ITF on file and we were able to submit a new one.

![image](https://user-images.githubusercontent.com/12970166/42542926-19621070-845e-11e8-8c7b-c2a91a5786e4.png)

## ITF fetch failure
![image](https://user-images.githubusercontent.com/12970166/42542821-7c8c1af2-845d-11e8-91f1-2e732db439c5.png)
**Context:** The request to get the list of ITFs failed.

## ITF creation failure
![image](https://user-images.githubusercontent.com/12970166/42542892-dfd6096a-845d-11e8-975a-1a603ea5723c.png)
**Context:** Fetching the list of ITFs succeeded, but no active ITF was found, so we tried to create one. This creation request failed.