### PR TITLE
Opt out confirmation fixes

### DIFF
--- a/src/applications/edu-benefits/0993/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/0993/containers/ConfirmationPage.jsx
@@ -33,7 +33,7 @@ export class ConfirmationPage extends React.Component {
         <h2 className="schemaform-confirmation-section-header">Your opt-out form has been submitted</h2>
         <p>We may contact you if we have questions or need more information. You can print this page for your records.</p>
         <h2 className="schemaform-confirmation-section-header">What happens after I submit my opt-out form?</h2>
-        <p>We’ll send you a letter in the mail confirming that we’ve received your opt-out form. After we receive your request, it may take us up to a week to remove schools’ access to your education benefit information.</p>
+        <p>After we receive your request, it may take us up to a week to remove schools’ access to your education benefits information.</p>
         <h2 className="schemaform-confirmation-section-header">What should I do if I change my mind and no longer want to opt out?</h2>
         <p>You’ll need to call the Education Call Center at <a href="tel:+18884424551">1-888-442-4551</a>, Monday through Friday, 8:00 a.m. to 7:00 p.m. (ET), to ask VA to start sharing your education benefits information again.</p>
         <h2 className="schemaform-confirmation-section-header">If I’ve opted out, what type of information do I need to give my school?</h2>

--- a/src/applications/edu-benefits/0993/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/0993/containers/ConfirmationPage.jsx
@@ -26,14 +26,14 @@ export class ConfirmationPage extends React.Component {
   render() {
     const { submission, data } = this.props.form;
     const { response } = submission;
-    const name = data.veteranFullName || { first: 'First', last: 'Last' }; // TODO: remove mock data
+    const name = data.claimantFullName || { first: 'First', last: 'Last' }; // TODO: remove mock data
 
     return (
       <div>
         <h2 className="schemaform-confirmation-section-header">Your opt-out form has been submitted</h2>
         <p>We may contact you if we have questions or need more information. You can print this page for your records.</p>
         <h2 className="schemaform-confirmation-section-header">What happens after I submit my opt-out form?</h2>
-        <p>We’ll send you a letter in the mail confirming that we’ve received your opt-out form. After we receive your form, it’ll take us about 48 hours to remove schools’ access to your education benefit information.</p>
+        <p>We’ll send you a letter in the mail confirming that we’ve received your opt-out form. After we receive your request, it may take us up to a week to remove schools’ access to your education benefit information.</p>
         <h2 className="schemaform-confirmation-section-header">What should I do if I change my mind and no longer want to opt out?</h2>
         <p>You’ll need to call the Education Call Center at <a href="tel:+18884424551">1-888-442-4551</a>, Monday through Friday, 8:00 a.m. to 7:00 p.m. (ET), to ask VA to start sharing your education benefits information again.</p>
         <h2 className="schemaform-confirmation-section-header">If I’ve opted out, what type of information do I need to give my school?</h2>

--- a/src/applications/edu-benefits/tests/0993/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/0993/containers/ConfirmationPage.unit.spec.jsx
@@ -16,7 +16,7 @@ describe('Opt Out <ConfirmationPage>', () => {
         }
       },
       data: {
-        veteranFullName: {
+        claimantFullName: {
           first: 'Joe',
           middle: 'Marjorie',
           last: 'Smith',
@@ -42,7 +42,7 @@ describe('Opt Out <ConfirmationPage>', () => {
       submission: {
       },
       data: {
-        veteranFullName: {
+        claimantFullName: {
           first: 'Joe',
           middle: 'Marjorie',
           last: 'Smith',


### PR DESCRIPTION
These changes address the following:
- [content fix](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11472)
- update the form data property accessed to obtain the claimant's full name
![localhost_3001_education_opt-out-information-sharing_opt-out-form-0993_claimant-information](https://user-images.githubusercontent.com/16051172/42785162-3dee0a46-8906-11e8-84fc-30c517bab230.png)
