### PR TITLE
Update vets-json-schema version

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#84887dc7cb0ccee2ae2c8156b5664697c2850b1d",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#294e3f0e24d1adfd598a177e5b939ef5737293eb",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4e5d6a1082e8268b79cb3c433ba379ce97343bc0",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
@@ -159,6 +159,13 @@ describe('526 helpers', () => {
       const { formData: transformedPrefill } = prefillTransformer([], prefilledData);
       expect(transformedPrefill.disabilities[0].disabilityActionType).to.equal('INCREASE');
     });
+    it('should transform prefilled data when disability name has special chars', () => {
+      const newName = '//()';
+      const dataClone = _.set(_.cloneDeep(initialData), 'disabilities[0].name', newName);
+      const prefill = prefillTransformer([], dataClone, {});
+      expect(prefill.formData.disabilities[0].name).to.equal(newName);
+      expect(prefill.formData.disabilities[0].name).to.equal(newName);
+    });
   });
   describe('getDisabilityName', () => {
     it('should return string with each word capitalized when name supplied', () => {

--- a/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
@@ -164,7 +164,6 @@ describe('526 helpers', () => {
       const dataClone = _.set(_.cloneDeep(initialData), 'disabilities[0].name', newName);
       const prefill = prefillTransformer([], dataClone, {});
       expect(prefill.formData.disabilities[0].name).to.equal(newName);
-      expect(prefill.formData.disabilities[0].name).to.equal(newName);
     });
   });
   describe('getDisabilityName', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10037,9 +10037,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#294e3f0e24d1adfd598a177e5b939ef5737293eb":
-  version "3.61.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#294e3f0e24d1adfd598a177e5b939ef5737293eb"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#4e5d6a1082e8268b79cb3c433ba379ce97343bc0":
+  version "3.62.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4e5d6a1082e8268b79cb3c433ba379ce97343bc0"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
- Updates vets-json-schema dependency for vets-website (which includes 526 disability schema fixes)
- Adds a test case to double check that special chars in disability names don't cause problems for the prefill transformer.