### PR TITLE
Adding retry to nsp Security step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,8 +116,10 @@ node('vetsgov-general-purpose') {
 
         // Check package.json for known vulnerabilities
         security: {
-          dockerImage.inside(args) {
-            sh "cd /application && nsp check"
+          retry(3) {
+            dockerImage.inside(args) {
+              sh "cd /application && nsp check"
+            }
           }
         },
 


### PR DESCRIPTION
Adds a 3 * retry to the `nsp` security scan step. Tested on the Jenkins server by replaying an already run job with a modified Jenkinsfile pipeline. `Security` step modified to fail in order to verify the `retry` function.
(output snippet)
```
[security] [testing_vets-website_master-ALDDKSEIQV2LG4R74AE7J2MKQOCIF4APA3VFWVSHARRXIEYSSCTA] Running shell script
[security] + exit 1
[Pipeline] [security] }
[security] $ docker stop --time=1 1a9efd87ad1992868bd96ce3fb2de872441846554a3e9fa11f994fde2d83906a
[security] $ docker rm -f 1a9efd87ad1992868bd96ce3fb2de872441846554a3e9fa11f994fde2d83906a
[Pipeline] [security] // withDockerContainer
[Pipeline] [security] }
[security] ERROR: script returned exit code 1
[security] Retrying
[Pipeline] [security] {
[Pipeline] [security] sh
[security] [testing_vets-website_master-ALDDKSEIQV2LG4R74AE7J2MKQOCIF4APA3VFWVSHARRXIEYSSCTA] Running shell script
[security] + docker inspect -f . vets-website:jenkins-testing-vets-website-master-2281
[security] .
[Pipeline] [security] withDockerContainer
[security] vetsgov-general-purpose-65bbf242 does not seem to be running inside a container
```