### PR TITLE
User testing fixes: Enable form load/prefill for opt out form app, implement back button

### DIFF
--- a/src/applications/edu-benefits/0993/containers/RoutedSavableSinglePageFormApp.jsx
+++ b/src/applications/edu-benefits/0993/containers/RoutedSavableSinglePageFormApp.jsx
@@ -151,7 +151,7 @@ class RoutedSavableSinglePageFormApp extends React.Component {
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
     let content;
     const loadingForm = trimmedPathname.endsWith('resume') || loadedStatus === LOAD_STATUSES.pending;
-    if (!formConfig.disableSave && loadingForm && this.props.prefillStatus === LOAD_STATUSES.pending) {
+    if (!formConfig.disableSave && loadingForm && this.props.prefillStatus === PREFILL_STATUSES.pending) {
       content = <LoadingIndicator message="Retrieving your profile information..."/>;
     } else if (!formConfig.disableSave && loadingForm) {
       content = <LoadingIndicator message="Retrieving your saved form..."/>;

--- a/src/applications/edu-benefits/0993/containers/SinglePageForm.jsx
+++ b/src/applications/edu-benefits/0993/containers/SinglePageForm.jsx
@@ -13,7 +13,7 @@ import DowntimeMessage from '../../../../platform/forms/save-in-progress/RoutedS
 
 import SchemaForm from 'us-forms-system/lib/js/components/SchemaForm';
 import { setData, uploadFile } from 'us-forms-system/lib/js/actions';
-import { getNextPagePath, getPreviousPagePath } from 'us-forms-system/lib/js/routing';
+import { getNextPagePath } from 'us-forms-system/lib/js/routing';
 import { focusElement } from 'us-forms-system/lib/js/utilities/ui';
 
 function focusForm() {
@@ -66,13 +66,6 @@ class SinglePageForm extends React.Component {
     }
 
     const path = getNextPagePath(route.pageList, form.data, location.pathname);
-
-    this.props.router.push(path);
-  }
-
-  goBack = () => {
-    const { form, route: { pageList }, location } = this.props;
-    const path = getPreviousPagePath(pageList, form.data, location.pathname);
 
     this.props.router.push(path);
   }

--- a/src/applications/edu-benefits/0993/containers/SubmitController.jsx
+++ b/src/applications/edu-benefits/0993/containers/SubmitController.jsx
@@ -8,8 +8,6 @@ import PrivacyAgreement from 'us-forms-system/lib/js/components/PrivacyAgreement
 import { isValidForm } from 'us-forms-system/lib/js/validation';
 import {
   createPageListByChapter,
-  expandArrayPages,
-  getActivePages,
 } from 'us-forms-system/lib/js/helpers';
 import {
   setPrivacyAgreement,
@@ -29,16 +27,7 @@ class SubmitController extends React.Component {
   }
 
   goBack = () => {
-    const {
-      form,
-      pageList,
-      router
-    } = this.props;
-
-    const eligiblePageList = getActivePages(pageList, form.data);
-    const expandedPageList = expandArrayPages(eligiblePageList, this.props.form.data);
-
-    router.push(expandedPageList[expandedPageList.length - 2].path);
+    this.props.router.goBack();
   }
 
   handleSubmit = () => {

--- a/src/applications/edu-benefits/tests/0993/containers/RoutedSavableSinglePageFormApp.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/0993/containers/RoutedSavableSinglePageFormApp.unit.spec.jsx
@@ -31,7 +31,7 @@ describe('Schemaform <RoutedSavableSinglePageFormApp>', () => {
   it('should render children', () => {
     const formConfig = {};
     const currentLocation = {
-      pathname: 'introduction',
+      pathname: 'confirmation',
       search: ''
     };
     const routes = [{
@@ -188,17 +188,17 @@ describe('Schemaform <RoutedSavableSinglePageFormApp>', () => {
 
     expect(router.push.calledWith('/error')).to.be.true;
   });
-  it('should route to the first page if started in the middle and not logged in', () => {
+  it('should not load form if not on form’s single page', () => {
     const formConfig = {
       title: 'Testing'
     };
     const currentLocation = {
-      pathname: 'test',
+      pathname: '/confirmation',
       search: ''
     };
     const routes = [{
       pageList: [
-        { path: '/introduction' },
+        { path: '/claimant-information' },
         { path: currentLocation.pathname }, // You are here
         { path: '/lastPage' }
       ]
@@ -206,10 +206,8 @@ describe('Schemaform <RoutedSavableSinglePageFormApp>', () => {
     const router = {
       replace: sinon.spy()
     };
+    const fetchInProgressForm = sinon.spy();
 
-    // Only redirects in production or if ?redirect is in the URL
-    const buildType = __BUILDTYPE__;
-    __BUILDTYPE__ = 'production';
     const tree = SkinDeep.shallowRender(
       <RoutedSavableSinglePageFormApp
         formConfig={formConfig}
@@ -223,10 +221,45 @@ describe('Schemaform <RoutedSavableSinglePageFormApp>', () => {
 
     tree.getMountedInstance().componentDidMount();
 
-    expect(router.replace.calledWith('/introduction')).to.be.true;
-    __BUILDTYPE__ = buildType;
+    expect(fetchInProgressForm.calledWith(formConfig.formId, formConfig.migrations, false))
+      .to.be.false;
   });
-  it('should load a saved form when starting in the middle of a form and logged in', () => {
+  it('should not load form if on form’s single page and not logged in', () => {
+    const formConfig = {
+      title: 'Testing'
+    };
+    const currentLocation = {
+      pathname: 'test',
+      search: ''
+    };
+    const routes = [{
+      pageList: [
+        { path: currentLocation.pathname }, // You are here
+        { path: '/lastPage' }
+      ]
+    }];
+    const router = {
+      replace: sinon.spy()
+    };
+    const fetchInProgressForm = sinon.spy();
+
+    const tree = SkinDeep.shallowRender(
+      <RoutedSavableSinglePageFormApp
+        formConfig={formConfig}
+        routes={routes}
+        router={router}
+        currentLocation={currentLocation}
+        loadedStatus={LOAD_STATUSES.pending}>
+        <div className="child"/>
+      </RoutedSavableSinglePageFormApp>
+    );
+
+    tree.getMountedInstance().componentDidMount();
+
+    expect(fetchInProgressForm.calledWith(formConfig.formId, formConfig.migrations, false))
+      .to.be.false;
+  });
+  it('should load a saved form when on the form’s single page and logged in', () => {
     const formConfig = {
       title: 'Testing',
       formId: 'testForm'
@@ -237,7 +270,6 @@ describe('Schemaform <RoutedSavableSinglePageFormApp>', () => {
     };
     const routes = [{
       pageList: [
-        { path: '/introduction' },
         { path: currentLocation.pathname }, // You are here
         { path: '/lastPage' }
       ]
@@ -248,9 +280,6 @@ describe('Schemaform <RoutedSavableSinglePageFormApp>', () => {
     };
     const fetchInProgressForm = sinon.spy();
 
-    // Only redirects in production or if ?redirect is in the URL
-    const buildType = __BUILDTYPE__;
-    __BUILDTYPE__ = 'production';
     const tree = SkinDeep.shallowRender(
       <RoutedSavableSinglePageFormApp
         formConfig={formConfig}
@@ -278,9 +307,8 @@ describe('Schemaform <RoutedSavableSinglePageFormApp>', () => {
 
     expect(fetchInProgressForm.calledWith(formConfig.formId, formConfig.migrations, false))
       .to.be.true;
-    __BUILDTYPE__ = buildType;
   });
-  it('should load a pre-filled form when starting in the middle of a form and logged in', () => {
+  it('should load a pre-filled form when logged in at the form’s single page', () => {
     const formConfig = {
       title: 'Testing',
       formId: 'testForm'
@@ -291,7 +319,6 @@ describe('Schemaform <RoutedSavableSinglePageFormApp>', () => {
     };
     const routes = [{
       pageList: [
-        { path: '/introduction' },
         { path: currentLocation.pathname }, // You are here
         { path: '/lastPage' }
       ]
@@ -302,9 +329,6 @@ describe('Schemaform <RoutedSavableSinglePageFormApp>', () => {
     };
     const fetchInProgressForm = sinon.spy();
 
-    // Only redirects in production or if ?redirect is in the URL
-    const buildType = __BUILDTYPE__;
-    __BUILDTYPE__ = 'production';
     const tree = SkinDeep.shallowRender(
       <RoutedSavableSinglePageFormApp
         formConfig={formConfig}
@@ -332,7 +356,6 @@ describe('Schemaform <RoutedSavableSinglePageFormApp>', () => {
 
     expect(fetchInProgressForm.calledWith(formConfig.formId, formConfig.migrations, true))
       .to.be.true;
-    __BUILDTYPE__ = buildType;
   });
 });
 

--- a/src/applications/edu-benefits/tests/0993/containers/RoutedSavableSinglePageFormApp.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/0993/containers/RoutedSavableSinglePageFormApp.unit.spec.jsx
@@ -259,7 +259,7 @@ describe('Schemaform <RoutedSavableSinglePageFormApp>', () => {
     expect(fetchInProgressForm.calledWith(formConfig.formId, formConfig.migrations, false))
       .to.be.false;
   });
-  it('should load a saved form when on the form’s single page and logged in', () => {
+  it('should load a saved form when on the form’s single page and logged in with a saved form', () => {
     const formConfig = {
       title: 'Testing',
       formId: 'testForm'

--- a/src/applications/edu-benefits/tests/0993/containers/SinglePageForm.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/0993/containers/SinglePageForm.unit.spec.jsx
@@ -135,69 +135,6 @@ describe('Schemaform <SinglePageForm>', () => {
 
       expect(router.push.calledWith('next-page'));
     });
-    it('back', () => {
-      tree.getMountedInstance().goBack();
-
-      expect(router.push.calledWith('previous-page'));
-    });
-  });
-  it('should go back to the beginning if current page isn\'t found', () => {
-    const route = {
-      formConfig: fullSchema0993,
-      pageConfig: {
-        pageKey: 'testPage',
-        schema: {},
-        uiSchema: {},
-        errorMessages: {},
-        title: ''
-      },
-      pageList: [
-        {
-          path: 'first-page'
-        },
-        {
-          path: 'previous-page'
-        },
-        {
-          path: 'testing',
-          pageKey: 'testPage'
-        }
-      ]
-    };
-    const form = {
-      pages: {
-        testPage: {
-          depends: () => false,
-          schema: {},
-          uiSchema: {},
-        }
-      },
-      data: {}
-    };
-    const user = {
-      profile: {
-        savedForms: []
-      },
-      login: {
-        currentlyLoggedIn: false
-      }
-    };
-    const router = {
-      push: sinon.spy()
-    };
-
-    const tree = SkinDeep.shallowRender(
-      <SinglePageForm
-        router={router}
-        form={form}
-        user={user}
-        route={route}
-        location={location}/>
-    );
-
-    tree.getMountedInstance().goBack();
-
-    expect(router.push.calledWith('first-page'));
   });
   it('should render array page', () => {
     const route = {

--- a/src/applications/edu-benefits/tests/0993/containers/SubmitController.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/0993/containers/SubmitController.unit.spec.jsx
@@ -269,7 +269,7 @@ describe('Schemaform review: SubmitController', () => {
   });
   it('should go back', () => {
     const router = {
-      push: sinon.spy()
+      goBack: sinon.spy()
     };
     const formConfig = {
       chapters: {
@@ -307,13 +307,13 @@ describe('Schemaform review: SubmitController', () => {
       <SubmitController
         form={form}
         formConfg={formConfig}
-        pageList={['chapter1', 'chatper2']}
+        pageList={['chapter1', 'chapter2']}
         router={router}
         submission={submission}/>
     ).instance();
 
     tree.goBack();
 
-    expect(router.push.calledWith('previous-page'));
+    expect(router.goBack.calledWith('previous-page'));
   });
 });


### PR DESCRIPTION
These changes fix bugs discovered during user testing, including:

- The opt out form application should load/prefill the form if the user is logged in and they have routed to the opt out applicant's only form page (/claimant-information), or rather have not navigated to any of the form's non-input pages (confirmation, form-saved, etc.). The opt out form application currently only does so if the form is being "resumed" (path ends with /resume).

- The back button should navigate to the previous page in the browser's history (pending @emilywaggoner's [input](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11331#issuecomment-405766654))