### PR TITLE
WIP - 11412 autocomplete widget

### DIFF
--- a/src/applications/edu-benefits/complaint-tool/config/form.js
+++ b/src/applications/edu-benefits/complaint-tool/config/form.js
@@ -41,24 +41,6 @@ const formConfig = {
               'Search for some schools',
               value => fetchAutocompleteSuggestions(value)
                 .then(transformAutocompletePayloadForAutosuggestField),
-              /*
-              (value) => {
-
-                return new Promise(resolve => {
-                  setTimeout(() => resolve([
-                    { label: 'option1', value: 'option1' },
-                    { label: 'option2', value: 'option1' },
-                    { label: 'option3', value: 'option1' },
-                    { label: 'option4', value: 'option1' },
-                    { label: 'option5', value: 'option1' },
-                    { label: 'option6', value: 'option1' },
-                    { label: 'option7', value: 'option1' },
-                    { label: 'option8', value: 'option1' },
-                    { label: 'option9', value: 'option1' }
-                  ]), 1000);
-                })
-              },
-              */
               {
                 'ui:options': {
                   queryForResults: true,
@@ -72,11 +54,9 @@ const formConfig = {
                   pattern: 'Please enter a valid name.'
                 }
               }
-            ),
-              {
-                'ui:field': AutosuggestField
-              }
-            )
+            ), {
+              'ui:field': AutosuggestField
+            })
           },
           schema: {
             type: 'object',

--- a/src/applications/edu-benefits/complaint-tool/config/form.js
+++ b/src/applications/edu-benefits/complaint-tool/config/form.js
@@ -38,7 +38,7 @@ const formConfig = {
           title: 'First Page',
           uiSchema: {
             name: _.merge(autoSuggestUiSchema(
-              'Label',
+              'Search for some schools',
               value => fetchAutocompleteSuggestions(value)
                 .then(transformAutocompletePayloadForAutosuggestField),
               /*
@@ -63,7 +63,8 @@ const formConfig = {
                 'ui:options': {
                   queryForResults: true,
                   freeInput: true,
-                  debounceRate: 250
+                  debounceRate: 250,
+                  listLabel: 'Select one of options or submit to search'
                 },
                 'ui:errorMessages': {
                   // If the maxLength changes, we'll want to update the message too

--- a/src/applications/edu-benefits/complaint-tool/config/form.js
+++ b/src/applications/edu-benefits/complaint-tool/config/form.js
@@ -1,9 +1,13 @@
 // import fullSchema from 'vets-json-schema/dist/686-schema.json';
+import _ from 'lodash/fp';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import AutosuggestField from '../../components/AutosuggestField.jsx';
 import { uiSchema as autoSuggestUiSchema } from 'us-forms-system/lib/js/definitions/autosuggest';
-import _ from 'lodash/fp';
+import {
+  fetchAutocompleteSuggestions,
+  transformAutocompletePayloadForAutosuggestField
+} from '../helpers';
 
 // const { } = fullSchema.properties;
 
@@ -35,11 +39,31 @@ const formConfig = {
           uiSchema: {
             name: _.merge(autoSuggestUiSchema(
               'Label',
-              (value) => Promise.resolve(['option1', 'option2', 'option3', 'option4', 'option5', 'option6', 'option7', 'option8', 'option9', 'option10']),
+              value => fetchAutocompleteSuggestions(value)
+                .then(transformAutocompletePayloadForAutosuggestField),
+              /*
+              (value) => {
+
+                return new Promise(resolve => {
+                  setTimeout(() => resolve([
+                    { label: 'option1', value: 'option1' },
+                    { label: 'option2', value: 'option1' },
+                    { label: 'option3', value: 'option1' },
+                    { label: 'option4', value: 'option1' },
+                    { label: 'option5', value: 'option1' },
+                    { label: 'option6', value: 'option1' },
+                    { label: 'option7', value: 'option1' },
+                    { label: 'option8', value: 'option1' },
+                    { label: 'option9', value: 'option1' }
+                  ]), 1000);
+                })
+              },
+              */
               {
                 'ui:options': {
                   queryForResults: true,
                   freeInput: true,
+                  debounceRate: 250
                 },
                 'ui:errorMessages': {
                   // If the maxLength changes, we'll want to update the message too

--- a/src/applications/edu-benefits/complaint-tool/config/form.js
+++ b/src/applications/edu-benefits/complaint-tool/config/form.js
@@ -35,7 +35,7 @@ const formConfig = {
           uiSchema: {
             name: _.merge(autoSuggestUiSchema(
               'Label',
-              (value) => Promise.resolve(['option1', 'option2']),
+              (value) => Promise.resolve(['option1', 'option2', 'option3', 'option4', 'option5', 'option6', 'option7', 'option8', 'option9', 'option10']),
               {
                 'ui:options': {
                   queryForResults: true,

--- a/src/applications/edu-benefits/complaint-tool/config/form.js
+++ b/src/applications/edu-benefits/complaint-tool/config/form.js
@@ -1,7 +1,9 @@
 // import fullSchema from 'vets-json-schema/dist/686-schema.json';
-
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
+import AutosuggestField from '../../components/AutosuggestField.jsx';
+import { uiSchema as autoSuggestUiSchema } from 'us-forms-system/lib/js/definitions/autosuggest';
+import _ from 'lodash/fp';
 
 // const { } = fullSchema.properties;
 
@@ -31,6 +33,25 @@ const formConfig = {
           path: 'form-page',
           title: 'First Page',
           uiSchema: {
+            name: _.merge(autoSuggestUiSchema(
+              'Label',
+              (value) => Promise.resolve(['option1', 'option2']),
+              {
+                'ui:options': {
+                  queryForResults: true,
+                  freeInput: true,
+                },
+                'ui:errorMessages': {
+                  // If the maxLength changes, we'll want to update the message too
+                  maxLength: 'Please enter a name with fewer than 100 characters.',
+                  pattern: 'Please enter a valid name.'
+                }
+              }
+            ),
+              {
+                'ui:field': AutosuggestField
+              }
+            )
           },
           schema: {
             type: 'object',

--- a/src/applications/edu-benefits/complaint-tool/helpers.js
+++ b/src/applications/edu-benefits/complaint-tool/helpers.js
@@ -1,0 +1,30 @@
+import environment from '../../../platform/utilities/environment';
+
+export function transformAutocompletePayloadForAutosuggestField({ payload, error, searchTerm }) {
+  if (payload) {
+    return {
+      options: payload
+      .data
+      .map(({ value, label }) => ({ value, label })),
+      searchTerm
+    };
+  }
+  return [];
+}
+export function fetchAutocompleteSuggestions(text, version) {
+  const url = `${environment.API_URL}/v0/gi/institutions/autocomplete?term=${text}`;
+
+  return fetch(url, {
+    headers: {
+      'X-Key-Inflection': 'camel'
+    }
+  })
+    .then(res => res.json())
+    .then(
+      payload => ({
+        payload,
+        searchTerm: text
+      }),
+      error => { error }
+    );
+};

--- a/src/applications/edu-benefits/components/AutosuggestField.jsx
+++ b/src/applications/edu-benefits/components/AutosuggestField.jsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import Downshift from 'downshift';
+import classNames from 'classnames';
+
+export default class AutosuggestField extends React.Component {
+  constructor(props) {
+    super(props);
+    const { uiSchema, schema, formData } = props;
+
+    this.state = {
+      options: []
+    };
+  }
+
+    /*(
+  filterItems(
+    items,
+    inputValue,
+    getInputProps,
+    getItemProps,
+    highlightedIndex
+  ) {
+    if (this.props.loading) {
+      return (
+        <li className="ds-c-autocomplete__list-item--message">
+          {this.props.loadingMessage}
+        </li>
+      );
+    }
+
+    if (items.length) {
+      return items.map((item, index) => (
+      ));
+    }
+
+    return (
+      <li className="ds-c-autocomplete__list-item--message">
+        {this.props.noResultsMessage}
+      </li>
+    );
+  }
+  */
+
+  componentDidMount() {
+    this.getOptions();
+  }
+
+  getOptions = (inputValue) => {
+    const getOptions = this.props.uiSchema['ui:options'].getOptions;
+    if (getOptions) {
+      getOptions(inputValue).then((items) => {
+        this.setState({ items });
+      });
+    }
+  }
+  handleInputValueChange = (inputValue) => {
+    if (inputValue !== this.state.input) {
+      this.setState({
+        input: inputValue
+      });
+    }
+    /*
+      const uiOptions = this.props.uiSchema['ui:options'];
+      if (uiOptions.queryForResults) {
+        this.debouncedGetOptions(inputValue);
+      }
+
+      let item = { widget: 'autosuggest', label: inputValue };
+  // once the input is long enough, check for exactly matching strings so that we don't
+  // force a user to click on an item when they've typed an exact match of a label
+      if (inputValue && inputValue.length > 3) {
+        const matchingItem = this.state.suggestions.find(suggestion => suggestion.label === inputValue);
+        if (matchingItem) {
+          item = this.getFormData(matchingItem);
+        }
+      }
+
+      this.props.onChange((this.props.uiSchema['ui:options'].freeInput || this.useEnum) ? inputValue : item);
+      this.setState({
+        input: inputValue,
+        suggestions: this.getSuggestions(this.state.options, inputValue)
+      });
+    } else if (inputValue === '') {
+      this.props.onChange();
+      this.setState({
+        input: inputValue,
+        suggestions: this.getSuggestions(this.state.options, inputValue)
+      });
+    }
+    */
+}
+
+render() {
+  console.log(this.state.items);
+  const loading = false; // tie this to the fetch TODO
+  const label = 'some heading'; // turn this into a prop with a default value TODO
+  const {
+    items,
+  } = this.state;
+
+  // TODO
+  // pull in styles
+  //
+  // maybe add back className that comes in from props (CMS)
+  const rootClassName = classNames(
+    'ds-u-clearfix',
+    'ds-c-autocomplete'
+  );
+  // maybe add back autocompleteProps (CMS) TODO
+  //
+  // forms system is passing custom props into input
+  return (
+    <Downshift
+      onInputValueChange={this.handleInputValueChange}
+      inputValue={this.state.input}
+      render={({
+        clearSelection,
+        getInputProps,
+        getItemProps,
+        highlightedIndex,
+        inputValue,
+        isOpen
+      }) => (
+        <div className={rootClassName}>
+          <input {...getInputProps()} />
+          {isOpen && (loading || items) ? (
+            <div className="ds-u-border--1 ds-u-padding--1 ds-c-autocomplete__list">
+              {label &&
+                  !loading && (
+                    <h5
+                      className="ds-u-margin--0 ds-u-padding--1"
+                      id={this.labelId}
+                    >
+                      {label}
+                    </h5>
+                  )}
+
+                  <ul
+                    aria-labelledby={label ? this.labelId : null}
+                    className="ds-c-list--bare"
+                    id={this.listboxId}
+                    role="listbox"
+                  >
+                    {items.map((item, index) => (
+                      <li
+                        aria-selected={highlightedIndex === index}
+                        className={
+                          highlightedIndex === index
+                            ? 'ds-c-autocomplete__list-item ds-c-autocomplete__list-item--active'
+                            : 'ds-c-autocomplete__list-item'
+                        }
+                        key={index}
+                        role="option"
+                        {...getItemProps({ item })}
+                      >
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+          ) : null}
+
+          <a
+            aria-label={'ariaClearLabel TODO'}
+            className="ds-u-float--right ds-u-padding-right--0"
+            onClick={clearSelection}
+            size="small"
+            variation="transparent"
+          >
+            {'clearInputText TODO'}
+          </a>
+        </div>
+      )}
+    />
+  );
+}
+}

--- a/src/applications/edu-benefits/components/AutosuggestField.jsx
+++ b/src/applications/edu-benefits/components/AutosuggestField.jsx
@@ -60,6 +60,7 @@ export default class AutosuggestField extends React.Component {
     this.debouncedGetOptions = debounce(debounceRate, this.getOptions);
 
     this.state = {
+      listLabel: uiOptions.listLabel,
       loading: false,
       options,
       input,
@@ -197,9 +198,7 @@ export default class AutosuggestField extends React.Component {
       loading,
       options: items
     } = this.state;
-    const label = loading ? 'Loading...' : 'label';
-    console.log(loading);
-    console.log(label);
+    const listLabel = loading ? 'Loading...' : this.state.listLabel;
 
     if (formContext.reviewMode) {
       const readOnlyData = <span>{getInput(formData, uiSchema, schema)}</span>;
@@ -241,52 +240,68 @@ export default class AutosuggestField extends React.Component {
             highlightedIndex
           }) => (
             <div className="edu-complaint-input-controls">
-              <input {...getInputProps()} />
-              {isOpen && (loading || items) ? (
-                <div className="ds-u-border--1 ds-u-padding--1 ds-c-autocomplete__list">
-                  {label && (
-                    <h5
-                      className="ds-u-margin--0 ds-u-padding--1"
-                      id={this.labelId}
-                    >
-                      {label}
-                    </h5>
-                  )}
+              {console.log(highlightedIndex)}
+              <input {...getInputProps({
+                onKeyDown: event => {
+                  // if no item is selected and enter is pressed, then trigger change
+                  if (highlightedIndex === null && event.key === 'Enter') {
+                    // Prevent Downshift's default 'Enter' behavior.
+                      event.nativeEvent.preventDownshiftDefault = true
 
-                  <ul
-                    aria-labelledby={label ? this.labelId : null}
-                    className="ds-c-list--bare"
-                    id={this.listboxId}
-                    role="listbox"
+                    this.handleChange({ label: this.state.input, value: null });
+                  }
+                }
+              })} />
+            {isOpen && (loading || items) ? (
+              <div className="ds-u-border--1 ds-u-padding--1 ds-c-autocomplete__list">
+                {listLabel && (
+                  <h5
+                    className="ds-u-margin--0 ds-u-padding--1"
+                    id={this.labelId}
                   >
-                    {!loading && this.state.suggestions
-                        .map(({ label: itemLabel, value: itemValue }, index) => (
-                          <li
-                            aria-selected={highlightedIndex === index}
-                            className={
-                              highlightedIndex === index
-                                ? 'ds-c-autocomplete__list-item ds-c-autocomplete__list-item--active'
-                                : 'ds-c-autocomplete__list-item'
-                            }
-                            key={index}
-                            role="option"
-                            {...getItemProps({ item: itemLabel })}
-                          >
-                            {itemLabel}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-              ) : null}
+                    {listLabel}
+                  </h5>
+                )}
 
-              <button
-                aria-label={'ariaClearLabel TODO'}
-                className="ds-u-float--right ds-u-padding-right--0"
-                onClick={this.clearSelection}
-              >
-                {'Clear search'}
-              </button>
-            </div>
+                <ul
+                  aria-labelledby={listLabel ? this.labelId : null}
+                  className="ds-c-list--bare"
+                  id={this.listboxId}
+                  role="listbox"
+                >
+                  {!loading && this.state.suggestions
+                      .map(({ label: itemLabel, value: itemValue }, index) => (
+                        <li
+                          aria-selected={highlightedIndex === index}
+                          className={
+                            highlightedIndex === index
+                              ? 'ds-c-autocomplete__list-item ds-c-autocomplete__list-item--active'
+                              : 'ds-c-autocomplete__list-item'
+                          }
+                          key={index}
+                          role="option"
+                          {...getItemProps({
+                            item: {
+                              label: itemLabel,
+                              value: itemValue
+                            }
+                          })}
+                        >
+                          {itemLabel}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+            ) : null}
+
+            <button
+              aria-label={'ariaClearLabel TODO'}
+              className="ds-u-float--right ds-u-padding-right--0"
+              onClick={this.clearSelection}
+            >
+              {'Clear search'}
+            </button>
+          </div>
           )}>
         </Downshift>
         <h1>test</h1>

--- a/src/applications/edu-benefits/components/AutosuggestField.jsx
+++ b/src/applications/edu-benefits/components/AutosuggestField.jsx
@@ -110,6 +110,7 @@ render() {
   //
   // forms system is passing custom props into input
   return (
+    <div>
     <Downshift
       onInputValueChange={this.handleInputValueChange}
       inputValue={this.state.input}
@@ -172,6 +173,8 @@ render() {
         </div>
       )}
     />
+    <h1>test</h1>
+  </div>
   );
 }
 }

--- a/src/applications/edu-benefits/components/AutosuggestField.jsx
+++ b/src/applications/edu-benefits/components/AutosuggestField.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import _ from 'lodash/fp';
 import Downshift from 'downshift';
-import classNames from 'classnames';
 
 import debounce from 'us-forms-system/lib/js/utilities/data/debounce';
 import sortListByFuzzyMatch from 'us-forms-system/lib/js/utilities/fuzzy-matching';
@@ -79,14 +78,6 @@ export default class AutosuggestField extends React.Component {
     this.debouncedGetOptions.cancel();
   }
 
-  clearSelection = () => {
-    this.setState({
-      input: '',
-      searchTerm: '',
-      loading: false
-    });
-  }
-
   getOptions = (inputValue) => {
     const getOptions = this.props.uiSchema['ui:options'].getOptions;
     if (getOptions) {
@@ -102,7 +93,7 @@ export default class AutosuggestField extends React.Component {
     if (!this.unmounted) {
       const optionsOrDefault = options.length > 0 ?
         options :
-        [{ value: null, label: 'No results'}];
+        [{ value: null, label: 'No results' }];
       this.setState({
         loading: false,
         searchTerm: '',
@@ -133,6 +124,16 @@ export default class AutosuggestField extends React.Component {
     }
 
     return _.set('widget', 'autosuggest', suggestion);
+  }
+
+  handleClearSelection = (e, downshiftClear) => {
+    e.preventDefault();
+    // using Downshift's clear sets the correct focus state after using clear
+    downshiftClear(() => this.setState({
+      input: '',
+      searchTerm: '',
+      loading: false
+    }));
   }
 
   handleInputValueChange = (inputValue) => {
@@ -191,8 +192,7 @@ export default class AutosuggestField extends React.Component {
   }
 
   render() {
-    const { idSchema, formContext, formData, uiSchema, schema } = this.props;
-    const id = idSchema.$id;
+    const { formContext, formData, uiSchema, schema } = this.props;
 
     const {
       loading,
@@ -233,43 +233,30 @@ export default class AutosuggestField extends React.Component {
             return item.label;
           }}
           render={({
+            clearSelection,
             getInputProps,
             getItemProps,
             isOpen,
-            selectedItem,
             highlightedIndex
           }) => (
             <div className="edu-complaint-input-controls">
-              {console.log(highlightedIndex)}
-              <input {...getInputProps({
-                onKeyDown: event => {
-                  // if no item is selected and enter is pressed, then trigger change
-                  if (highlightedIndex === null && event.key === 'Enter') {
-                    // Prevent Downshift's default 'Enter' behavior.
-                      event.nativeEvent.preventDownshiftDefault = true
+              <input {...getInputProps()}/>
+              {isOpen && (loading || items) ? (
+                <div className="ds-u-border--1 ds-u-padding--1 ds-c-autocomplete__list">
+                  {listLabel && (
+                    <h5
+                      className="ds-u-margin--0 ds-u-padding--1"
+                      id={this.labelId}>
+                      {listLabel}
+                    </h5>
+                  )}
 
-                    this.handleChange({ label: this.state.input, value: null });
-                  }
-                }
-              })} />
-            {isOpen && (loading || items) ? (
-              <div className="ds-u-border--1 ds-u-padding--1 ds-c-autocomplete__list">
-                {listLabel && (
-                  <h5
-                    className="ds-u-margin--0 ds-u-padding--1"
-                    id={this.labelId}
-                  >
-                    {listLabel}
-                  </h5>
-                )}
-
-                <ul
-                  aria-labelledby={listLabel ? this.labelId : null}
-                  className="ds-c-list--bare"
-                  id={this.listboxId}
-                  role="listbox"
-                >
-                  {!loading && this.state.suggestions
+                  <ul
+                    aria-labelledby={listLabel ? this.labelId : null}
+                    className="ds-c-list--bare"
+                    id={this.listboxId}
+                    role="listbox">
+                    {!loading && this.state.suggestions
                       .map(({ label: itemLabel, value: itemValue }, index) => (
                         <li
                           aria-selected={highlightedIndex === index}
@@ -285,23 +272,21 @@ export default class AutosuggestField extends React.Component {
                               label: itemLabel,
                               value: itemValue
                             }
-                          })}
-                        >
+                          })}>
                           {itemLabel}
                         </li>
                       ))}
-                    </ul>
-                  </div>
-            ) : null}
+                  </ul>
+                </div>
+              ) : null}
 
-            <button
-              aria-label={'ariaClearLabel TODO'}
-              className="ds-u-float--right ds-u-padding-right--0"
-              onClick={this.clearSelection}
-            >
-              {'Clear search'}
-            </button>
-          </div>
+              <button
+                aria-label={'clear all fields on this page'}
+                className="ds-u-float--right ds-u-padding-right--0"
+                onClick={e => this.handleClearSelection(e, clearSelection)}>
+                {'Clear search'}
+              </button>
+            </div>
           )}>
         </Downshift>
         <h1>test</h1>

--- a/src/applications/edu-benefits/components/AutosuggestField.jsx
+++ b/src/applications/edu-benefits/components/AutosuggestField.jsx
@@ -78,6 +78,14 @@ export default class AutosuggestField extends React.Component {
     this.debouncedGetOptions.cancel();
   }
 
+  clearSelection = () => {
+    this.setState({
+      input: '',
+      searchTerm: '',
+      loading: false
+    });
+  }
+
   getOptions = (inputValue) => {
     const getOptions = this.props.uiSchema['ui:options'].getOptions;
     if (getOptions) {
@@ -91,10 +99,14 @@ export default class AutosuggestField extends React.Component {
 
   setOptions = (options) => {
     if (!this.unmounted) {
+      const optionsOrDefault = options.length > 0 ?
+        options :
+        [{ value: null, label: 'No results'}];
       this.setState({
         loading: false,
-        options,
-        suggestions: this.getSuggestions(options, this.state.input)
+        searchTerm: '',
+        options: optionsOrDefault,
+        suggestions: this.getSuggestions(optionsOrDefault, this.state.input)
       });
     }
   }
@@ -228,7 +240,7 @@ export default class AutosuggestField extends React.Component {
             selectedItem,
             highlightedIndex
           }) => (
-            <div>
+            <div className="edu-complaint-input-controls">
               <input {...getInputProps()} />
               {isOpen && (loading || items) ? (
                 <div className="ds-u-border--1 ds-u-padding--1 ds-c-autocomplete__list">
@@ -267,13 +279,13 @@ export default class AutosuggestField extends React.Component {
                     </div>
               ) : null}
 
-              <a
+              <button
                 aria-label={'ariaClearLabel TODO'}
                 className="ds-u-float--right ds-u-padding-right--0"
                 onClick={this.clearSelection}
               >
-                {'clearInputText TODO'}
-              </a>
+                {'Clear search'}
+              </button>
             </div>
           )}>
         </Downshift>

--- a/src/applications/edu-benefits/sass/edu-benefits.scss
+++ b/src/applications/edu-benefits/sass/edu-benefits.scss
@@ -28,3 +28,49 @@
 .row .edu-intro-spacing {
   margin-bottom: 7rem;
 }
+
+// autocomplete component
+.ds-c-autocomplete__list {
+  background-color: $color-white;
+  box-sizing: border-box;
+  max-height: 320px;
+  overflow-y: auto;
+  position: absolute;
+  max-width: 46rem;
+  width: 100%;
+  z-index: 1000;
+}
+
+.ds-c-autocomplete__list-item {
+  color: $color-primary;
+  padding: 8px;
+}
+
+.ds-c-autocomplete__list-item--active {
+  background-color: $color-primary-alt-darkest;
+  color: $color-white;
+}
+
+.ds-c-autocomplete__list-item--message {
+  color: #5b616b;
+  padding: 8px;
+}
+
+.ds-u-border--1 {
+  // Example: border: 1px !important;
+  border: 1px solid #d6d7d9;
+}
+
+.ds-u-padding--1 {
+  padding: 8px
+}
+
+.ds-u-margin--0 {
+  margin: 0;
+}
+
+.ds-c-list--bare {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}

--- a/src/applications/edu-benefits/sass/edu-benefits.scss
+++ b/src/applications/edu-benefits/sass/edu-benefits.scss
@@ -33,6 +33,9 @@
 .ds-c-autocomplete__list {
   background-color: $color-white;
   box-sizing: border-box;
+  left: 0;
+  right: 0;
+  top: 4.2rem;
   max-height: 320px;
   overflow-y: auto;
   position: absolute;
@@ -62,7 +65,7 @@
 }
 
 .ds-u-padding--1 {
-  padding: 8px
+  padding: 8px;
 }
 
 .ds-u-margin--0 {
@@ -73,4 +76,29 @@
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.ds-u-padding-right--0 {
+    padding-right: 0!important;
+}
+
+.ds-u-float--right {
+    float: right!important;
+}
+
+.edu-complaint-input-controls {
+  max-width: 46rem;
+  position: relative;
+
+  button {
+    background-color: transparent;
+    color: #0071bc;
+    display: inline-block;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.3;
+    padding: 0;
+    text-decoration: none;
+    width: auto;
+  }
 }


### PR DESCRIPTION
 This widget attempts to combine functionality from three existing autocomplete widgets from vets-website, CMS, and the forms library. 

## Prior art
### vets-website
The GI Bill Comparison [tool](https://www.vets.gov/gi-bill-comparison-tool/) provides a search and select experience. Users can
- select from a list, or
- search any term by typing a term and pressing enter. 

Notes
- only partially accessibility compliant- it deviates from some of the idiomatic approaches documented in the [Downshift](https://github.com/paypal/downshift) library
- changes the layout of the pay to display the results i.e. the results window are not absolutely positioned. 
- does not use the forms library as a data source
![gibillautofill](https://user-images.githubusercontent.com/4998130/42895466-415e7cf2-8a77-11e8-9863-56538098ead5.gif)

## CMS design sytem
The CMS Design system has an Autocomplete [component](https://design.cms.gov/components/autocomplete/) that provides a select experience. This component includes a
- loading state
- no results state
- results heading 
- clear search button 

Notes
- does not use the forms library as a data source
- externalizes the loading of data to a props functions i.e. it is a simply a view component 
- has hard dependencies on other components in the CMS design system e.g. it requires exactly one child input from a custom component type
- has a hard height limit but displays a scrollable list when the number of items exceeds that length 
![cmsautocomplete](https://user-images.githubusercontent.com/4998130/42895800-30603bd8-8a78-11e8-9473-ef416613d8e4.gif)

## US forms library
The US forms library has an auto suggest component that provides a select experience. Users can
- select from a list, or
- search any term by typing a term and pressing enter. 

Notes
- has existing schema and is integrated into `vets-website` on few forms 
- lacks a clear search function
- has a hard height limit but displays a scrollable list when the number of items exceeds that length 
![usformsautocomplete](https://user-images.githubusercontent.com/4998130/42913566-ed8d21e6-8ab2-11e8-85c4-e9d0a807d35b.gif)

## Technical approach
- This approach uses the [AutosuggestField](https://github.com/usds/us-forms-system/blob/0fc545d47a10c530ee6b944a7040853e828c3d94/src/js/fields/AutosuggestField.jsx) to provide most of the functionality to connect to the current form generator.
- The render from the AutosuggestField was replaced with the [render](https://github.com/CMSgov/design-system/blob/8545784ebd078f784f287ec64e68ea0d19dcc081/packages/core/src/components/Autocomplete/Autocomplete.jsx#L110-L163) from the CMS system

![complaintautocomplete](https://user-images.githubusercontent.com/4998130/42949770-bc2c1a44-8b2f-11e8-919a-4feda0a297d1.gif)

Figma [comments](http://click.figma.com/wf/click?upn=9VbdpUDlorGWg71nAPf92O2pWG3v5YSFKcYChjtVRKCP0TuIgeOroryIqhT7b1pTVFiFVEUUI4RvDz21fYLpKqt-2Fd5bzRmm5U63a97LuWKo-3D_Exu8NnyglQ-2BH0XbbqX2dDRYbD9VJ5qOpBv2M-2FYMy2mRZ8AxpWH9CHIpNbFPNjF4Vszr8DLu6Sugnbmh2QqJJctRORMgLyCK3qfxFbEG-2Bzp7rw7SOFj1Kj6eXOKVElPpNt-2F3sLrtM2Uf8KKE5j8G5PqwhiVtFZfgnec7KLGZFrf7d6VMLdVExWtkniMp6s9LTligGLcvWRb7BI2-2FBQA-2FD2hpgkub-2FXqiyYLH364nDdNJTIxtJIPEOv8W9ZI-2BJ9NU45rA6fZOuibhSJ1lIEQZtVA-3D-3D)

Todo:
- [ ] add tests
- [ ] rename classes to match vets-website
- [ ] fetch institution details callback that populates form data
- [ ] figure out how to use callback to clear all of the form data on the page 