### PR TITLE
Profile: Move "veteran is deceased" error handler into modal

### DIFF
--- a/src/applications/personalization/profile360/components/Vet360EditModalErrorMessage.jsx
+++ b/src/applications/personalization/profile360/components/Vet360EditModalErrorMessage.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
 import {
-  LOW_CONFIDENCE_ADDRESS_ERROR_CODES
+  LOW_CONFIDENCE_ADDRESS_ERROR_CODES,
+  DECEASED_ERROR_CODES
 } from  '../util/transactions';
 
 function hasError(codes, errors) {
@@ -15,6 +16,15 @@ export default function Vet360EditModalErrorMessage({ error: { errors = [] }, cl
   switch (true) {
     case hasError(LOW_CONFIDENCE_ADDRESS_ERROR_CODES, errors):
       content = <p>We’re sorry. We looked up the address you entered and we're not sure mail can be delivered there. Please try entering your address again.</p>;
+      break;
+
+    case hasError(DECEASED_ERROR_CODES, errors):
+      content = (
+        <div>
+          <p>We can’t make this update because our records show the Veteran is deceased. If this isn’t true, please contact your nearest VA medical center.</p>
+          <a href="/facilities/">Find your nearest VA medical center</a>
+        </div>
+      );
       break;
 
     default:

--- a/src/applications/personalization/profile360/components/Vet360TransactionErrorBanner.jsx
+++ b/src/applications/personalization/profile360/components/Vet360TransactionErrorBanner.jsx
@@ -4,8 +4,7 @@ import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 import {
   hasGenericUpdateError,
   hasMVIError,
-  hasMVINotFoundError,
-  hasUserIsDeceasedError
+  hasMVINotFoundError
 } from '../util/transactions';
 
 export function GenericUpdateError(props) {
@@ -48,28 +47,10 @@ export function MVIError(props) {
   );
 }
 
-export function UserIsDeceasedError(props) {
-  return (
-    <AlertBox {...props}
-      status="error"
-      content={(
-        <div>
-          <h4>We can’t accept updates to this profile</h4>
-          <p>We’re sorry. We’ve locked this profile because our records show the Veteran is deceased. If this is an error, please contact your nearest VA medical center. Let them know you need to fix this information in your records. The operator, or a patient advocate, can connect you with the right person who can help.</p>
-          <a href="/facilities/">Find your nearest VA medical center</a>
-        </div>
-      )}/>
-  );
-}
-
 export default function Vet360TransactionErrorBanner({ transaction, clearTransaction }) {
   let TransactionError = null;
 
   switch (true) {
-    case hasUserIsDeceasedError(transaction):
-      TransactionError = UserIsDeceasedError;
-      break;
-
     case hasMVINotFoundError(transaction):
       TransactionError = MVILookupFailError;
       break;

--- a/src/applications/personalization/profile360/components/Vet360TransactionInlineErrorMessage.jsx
+++ b/src/applications/personalization/profile360/components/Vet360TransactionInlineErrorMessage.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
 
-import {
-  hasUserIsDeceasedError
-} from '../util/transactions';
+// import {
+//   hasUserIsDeceasedError
+// } from '../util/transactions';
 
-export default function Vet360TransactionInlineErrorMessage({ title: fieldTitle, transaction }) {
+export default function Vet360TransactionInlineErrorMessage({ title: fieldTitle }) {
   let content = null;
   switch (true) {
-    case hasUserIsDeceasedError(transaction):
-      content = <span>We can’t make this update because our records show the Veteran is deceased. If this isn’t true, please contact your nearest VA medical center. <a href="/facilities/">Find your nearest VA medical center</a>.</span>;
-      break;
+    // case hasUserIsDeceasedError(transaction):
+    //   content = <span>We can’t make this update because our records show the Veteran is deceased. If this isn’t true, please contact your nearest VA medical center. <a href="/facilities/">Find your nearest VA medical center</a>.</span>;
+    //   break;
 
     default:
       content = <span>We couldn’t save your recent {fieldTitle.toLowerCase()} update. Please try again later.</span>;

--- a/src/applications/personalization/profile360/components/Vet360TransactionInlineErrorMessage.jsx
+++ b/src/applications/personalization/profile360/components/Vet360TransactionInlineErrorMessage.jsx
@@ -1,19 +1,9 @@
 import React from 'react';
 
-// import {
-//   hasUserIsDeceasedError
-// } from '../util/transactions';
-
 export default function Vet360TransactionInlineErrorMessage({ title: fieldTitle }) {
-  let content = null;
-  switch (true) {
-    // case hasUserIsDeceasedError(transaction):
-    //   content = <span>We can’t make this update because our records show the Veteran is deceased. If this isn’t true, please contact your nearest VA medical center. <a href="/facilities/">Find your nearest VA medical center</a>.</span>;
-    //   break;
-
-    default:
-      content = <span>We couldn’t save your recent {fieldTitle.toLowerCase()} update. Please try again later.</span>;
-  }
-
-  return <div className="usa-input-error-message">{content}</div>;
+  return (
+    <div className="usa-input-error-message">
+      We couldn’t save your recent {fieldTitle.toLowerCase()} update. Please try again later.
+    </div>
+  );
 }

--- a/src/platform/site-wide/announcements/components/DashboardIntro.jsx
+++ b/src/platform/site-wide/announcements/components/DashboardIntro.jsx
@@ -11,7 +11,7 @@ export default function DashboardIntro({ dismiss }) {
         <img alt="profile icon" src="/img/dashboard-announcement.svg"/>
       </div>
       <h3 className="announcement-title">Welcome to your new personalized homepage</h3>
-      <p>Now, see all your latest updates in one place—like the status of your prescription refills or disability claims and new secure messages from your health care team.</p>
+      <p>Now, you can see important updates in one place—like the status of your prescription refills or disability claims and new secure messages from your health care team.</p>
       <button type="button" aria-label="Dismiss this announcement" onClick={dismiss}>Continue</button>
     </Modal>
   );


### PR DESCRIPTION
Turns out this error code is returned directly during an update, rather than during a transaction lookup.

Resolves department-of-veterans-affairs/vets.gov-team/issues/10944
Resolves department-of-veterans-affairs/vets.gov-team/issues/11335