### PR TITLE
Remove Proxy

### DIFF
--- a/src/applications/disability-benefits/526EZ/constants.js
+++ b/src/applications/disability-benefits/526EZ/constants.js
@@ -1,5 +1,3 @@
-import { constantHandler } from '../../../platform/utilities/constants';
-
 export const PCIU_STATES = [
   { label: 'Alabama', value: 'AL' },
   { label: 'Alaska', value: 'AK' },
@@ -87,10 +85,10 @@ export const ADDRESS_TYPES = {
   forwardingAddress: 'forwardingAddress'
 };
 
-export const itfStatuses = new Proxy({
+export const itfStatuses = {
   active: 'active',
   expired: 'expired',
   claimRecieved: 'claim_recieved',
   duplicate: 'duplicate',
   incomplete: 'incomplete'
-}, constantHandler);
+};

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -3,7 +3,6 @@ import recordEvent from '../../monitoring/record-event';
 import environment from '../../utilities/environment';
 import 'isomorphic-fetch';
 import { logOut } from '../../user/authentication/actions';
-import { constantHandler } from '../../utilities/constants';
 
 import { removeFormApi, saveFormApi } from './api';
 import { sanitizeForm } from '../helpers';
@@ -47,12 +46,12 @@ export const LOAD_STATUSES = Object.freeze({
   success: 'success'
 });
 
-export const PREFILL_STATUSES = new Proxy({
+export const PREFILL_STATUSES = {
   notAttempted: 'not-attempted',
   pending: 'pending',
   success: 'success',
   unfilled: 'unfilled'
-}, constantHandler);
+};
 
 export function setSaveFormStatus(saveType, status, lastSavedDate = null, expirationDate = null) {
   return {

--- a/src/platform/utilities/constants.js
+++ b/src/platform/utilities/constants.js
@@ -1,18 +1,7 @@
 // TODO: Rename this to something that makes more sense
-export const constantHandler = {
-  get(target, propName) {
-    if (!(propName in target)) {
-      throw new Error(`${propName} not in target.`);
-    }
-
-    return target[propName];
-  }
-};
-
-
-export const requestStates = new Proxy({
+export const requestStates = {
   notCalled: 'not called',
   pending: 'pending',
   succeeded: 'succeeded',
   failed: 'failed'
-}, constantHandler);
+};


### PR DESCRIPTION
[Ticket](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11582#event-1740887603) - Bug: Infinite Page Loader for Preneed Intro Page Load in Dev/Staging 

As per babel's [site](https://old.babeljs.io/learn-es2015/#proxies):

> Due to the limitations of ES5, Proxies cannot be transpiled or polyfilled.

This seems to impact all IE 11 production traffic to React apps 