### PR TITLE
Fix 686 spouse information chapter title bug

### DIFF
--- a/src/applications/disability-benefits/686/config/form.js
+++ b/src/applications/disability-benefits/686/config/form.js
@@ -446,7 +446,7 @@ const formConfig = {
       }
     },
     currentSpouseInfo: {
-      title: 'Current Spouse’s Information',
+      title: 'Spouse Information',
       pages: {
         spouseInfo: {
           title: 'Spouse information',


### PR DESCRIPTION
These changes use a more generic chapter title for spouse information in the 686 form.

![image](https://user-images.githubusercontent.com/16051172/42978805-c341c726-8b83-11e8-82f6-c1d4149d9b59.png)
