### PR TITLE
Set up goBack on opt out form page

### DIFF
--- a/src/applications/edu-benefits/0993/containers/SubmitController.jsx
+++ b/src/applications/edu-benefits/0993/containers/SubmitController.jsx
@@ -27,7 +27,11 @@ class SubmitController extends React.Component {
   }
 
   goBack = () => {
-    this.props.router.goBack();
+    const formPageUrl = window.location.pathname;
+    let introductionPageUrl = formPageUrl.split('/');
+    introductionPageUrl.splice(-2);
+    introductionPageUrl = introductionPageUrl.join('/');
+    window.location.replace(`${introductionPageUrl}`);
   }
 
   handleSubmit = () => {

--- a/src/applications/edu-benefits/tests/0993/containers/SubmitController.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/0993/containers/SubmitController.unit.spec.jsx
@@ -268,8 +268,12 @@ describe('Schemaform review: SubmitController', () => {
     expect(submitForm.called).to.be.true;
   });
   it('should go back', () => {
-    const router = {
-      goBack: sinon.spy()
+    const oldWindow = global.window;
+    global.window = {
+      location: {
+        pathname: '/benefit/static/form/page',
+        replace: sinon.spy()
+      }
     };
     const formConfig = {
       chapters: {
@@ -308,12 +312,12 @@ describe('Schemaform review: SubmitController', () => {
         form={form}
         formConfg={formConfig}
         pageList={['chapter1', 'chapter2']}
-        router={router}
         submission={submission}/>
     ).instance();
 
     tree.goBack();
 
-    expect(router.goBack.calledWith('previous-page'));
+    expect(global.window.location.replace.calledWith('/benefit/static'));
+    global.window = oldWindow;
   });
 });


### PR DESCRIPTION
These changes send the user back to the introduction page when pressing the back button on the opt out form per @emilywaggoner's [comment](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11331#issuecomment-405998236).