### PR TITLE
Profile: Add functionality for copying mailing address into residential edit-modal

### DIFF
--- a/src/applications/personalization/profile360/actions/misc.js
+++ b/src/applications/personalization/profile360/actions/misc.js
@@ -81,7 +81,10 @@ function cleanPhoneDataForUpdate(value) {
   };
 }
 
-function cleanAddressDataForUpdate(value) {
+// @todo Consolidate this logic with consolidateAddress, which is intended to make address formats
+// consistent for display within the edit-address modal. Maybe they should go directly in that modal instead.
+// Also, should probably do something with the updaters' createAddressObject here too.
+export function cleanAddressDataForUpdate(value) {
   const {
     id,
     addressLine1,

--- a/src/applications/personalization/profile360/components/AddressEditModal.jsx
+++ b/src/applications/personalization/profile360/components/AddressEditModal.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
 
 import {
+  FIELD_NAMES
+} from '../constants/vet360';
+
+import {
   consolidateAddress,
   expandAddress
 } from '../../../../platform/forms/address/helpers';
 
 import Vet360EditModal from './Vet360EditModal';
+
+import CopyMailingAddress from '../containers/CopyMailingAddress';
 import Address from './Address';
 
 export default class AddressEditModal extends React.Component {
@@ -34,15 +40,22 @@ export default class AddressEditModal extends React.Component {
     };
   }
 
+  copyMailingAddress = (consolidatedMailingAddress) => {
+    this.props.onChange(consolidatedMailingAddress, null, true);
+  }
+
   renderForm = () => {
     return (
-      <Address
-        address={this.props.field.value}
-        onInput={this.onInput}
-        onBlur={this.onBlur}
-        errorMessages={this.props.field.validations}
-        states={this.props.addressConstants.states}
-        countries={this.props.addressConstants.countries}/>
+      <div>
+        {this.props.fieldName === FIELD_NAMES.RESIDENTIAL_ADDRESS && <CopyMailingAddress copyMailingAddress={this.copyMailingAddress}/>}
+        <Address
+          address={this.props.field.value}
+          onInput={this.onInput}
+          onBlur={this.onBlur}
+          errorMessages={this.props.field.validations}
+          states={this.props.addressConstants.states}
+          countries={this.props.addressConstants.countries}/>
+      </div>
     );
   }
 

--- a/src/applications/personalization/profile360/components/AddressEditModal.jsx
+++ b/src/applications/personalization/profile360/components/AddressEditModal.jsx
@@ -40,8 +40,8 @@ export default class AddressEditModal extends React.Component {
     };
   }
 
-  copyMailingAddress = (consolidatedMailingAddress) => {
-    this.props.onChange(consolidatedMailingAddress, null, true);
+  copyMailingAddress = (mailingAddress) => {
+    this.props.onChange(mailingAddress, null, true);
   }
 
   renderForm = () => {

--- a/src/applications/personalization/profile360/containers/CopyMailingAddress.jsx
+++ b/src/applications/personalization/profile360/containers/CopyMailingAddress.jsx
@@ -4,7 +4,6 @@ import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 
 import {
-  consolidateAddress,
   isEmptyAddress
 } from '../../../../platform/forms/address/helpers';
 
@@ -25,9 +24,7 @@ class CopyMailingAddress extends React.Component {
   onChange = (event) => {
     event.stopPropagation();
     if (event.target.checked) {
-      this.props.copyMailingAddress(
-        consolidateAddress(this.props.mailingAddress)
-      );
+      this.props.copyMailingAddress(this.props.mailingAddress);
     }
   }
 
@@ -71,11 +68,10 @@ export function mapStateToProps(state) {
   const hasEmptyMailingAddress = isEmptyAddress(mailingAddress);
 
   const residentialAddress = selectEditedFormField(state, FIELD_NAMES.RESIDENTIAL_ADDRESS).value;
-
-  const mailingAddressConsolidated = pick(cleanAddressDataForUpdate(consolidateAddress(mailingAddress)), addressProps);
-  const residentialAddressConsolidated = pick(consolidateAddress(residentialAddress), addressProps);
-
-  const checked = isEqual(mailingAddressConsolidated, residentialAddressConsolidated);
+  const checked = isEqual(
+    pick(cleanAddressDataForUpdate(mailingAddress), addressProps),
+    pick(residentialAddress, addressProps)
+  );
 
   return {
     mailingAddress,

--- a/src/applications/personalization/profile360/containers/CopyMailingAddress.jsx
+++ b/src/applications/personalization/profile360/containers/CopyMailingAddress.jsx
@@ -4,7 +4,8 @@ import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 
 import {
-  consolidateAddress
+  consolidateAddress,
+  isEmptyAddress
 } from '../../../../platform/forms/address/helpers';
 
 import {
@@ -51,7 +52,7 @@ class CopyMailingAddress extends React.Component {
   }
 }
 
-function mapStateToProps(state) {
+export function mapStateToProps(state) {
   const addressProps = [
     'addressLine1',
     'addressLine2',
@@ -67,7 +68,7 @@ function mapStateToProps(state) {
   ];
 
   const mailingAddress = selectVet360Field(state, FIELD_NAMES.MAILING_ADDRESS);
-  const hasEmptyMailingAddress = !mailingAddress;
+  const hasEmptyMailingAddress = isEmptyAddress(mailingAddress);
 
   const residentialAddress = selectEditedFormField(state, FIELD_NAMES.RESIDENTIAL_ADDRESS).value;
 

--- a/src/applications/personalization/profile360/containers/CopyMailingAddress.jsx
+++ b/src/applications/personalization/profile360/containers/CopyMailingAddress.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import isEqual from 'lodash/isEqual';
+import pick from 'lodash/pick';
+
+import {
+  consolidateAddress
+} from '../../../../platform/forms/address/helpers';
+
+import {
+  FIELD_NAMES
+} from '../constants/vet360';
+
+import {
+  selectVet360Field,
+  selectEditedFormField
+} from '../selectors';
+
+import {
+  cleanAddressDataForUpdate
+} from '../actions/misc';
+
+class CopyMailingAddress extends React.Component {
+  onChange = (event) => {
+    event.stopPropagation();
+    if (event.target.checked) {
+      this.props.copyMailingAddress(
+        consolidateAddress(this.props.mailingAddress)
+      );
+    }
+  }
+
+  render() {
+    if (this.props.hasEmptyMailingAddress) return <div/>;
+    return (
+      <div className="copy-mailing-address-to-residential-address">
+        <div className="form-checkbox-buttons">
+          <input
+            type="checkbox"
+            name="copy-mailing-address-to-residential-address"
+            id="copy-mailing-address-to-residential-address"
+            autoComplete="false"
+            checked={this.props.checked}
+            onChange={this.onChange}/>
+          <label htmlFor="copy-mailing-address-to-residential-address">
+            My home address is the same as my mailing address.
+          </label>
+        </div>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  const addressProps = [
+    'addressLine1',
+    'addressLine2',
+    'addressLine3',
+    'addressPou',
+    'addressType',
+    'city',
+    'countryName',
+    'internationalPostalCode',
+    'province',
+    'stateCode',
+    'zipCode'
+  ];
+
+  const mailingAddress = selectVet360Field(state, FIELD_NAMES.MAILING_ADDRESS);
+  const hasEmptyMailingAddress = !mailingAddress;
+
+  const residentialAddress = selectEditedFormField(state, FIELD_NAMES.RESIDENTIAL_ADDRESS).value;
+
+  const mailingAddressConsolidated = pick(cleanAddressDataForUpdate(consolidateAddress(mailingAddress)), addressProps);
+  const residentialAddressConsolidated = pick(consolidateAddress(residentialAddress), addressProps);
+
+  const checked = isEqual(mailingAddressConsolidated, residentialAddressConsolidated);
+
+  return {
+    mailingAddress,
+    residentialAddress,
+    mailingAddressConsolidated,
+    residentialAddressConsolidated,
+    hasEmptyMailingAddress,
+    checked
+  };
+}
+
+export default connect(mapStateToProps, null)(CopyMailingAddress);
+export { CopyMailingAddress };

--- a/src/applications/personalization/profile360/containers/CopyMailingAddress.jsx
+++ b/src/applications/personalization/profile360/containers/CopyMailingAddress.jsx
@@ -78,9 +78,6 @@ function mapStateToProps(state) {
 
   return {
     mailingAddress,
-    residentialAddress,
-    mailingAddressConsolidated,
-    residentialAddressConsolidated,
     hasEmptyMailingAddress,
     checked
   };

--- a/src/applications/personalization/profile360/sass/profile-360.scss
+++ b/src/applications/personalization/profile360/sass/profile-360.scss
@@ -62,3 +62,11 @@ input.usa-only-phone {
   right: 1.9rem;
   font-weight: bold;
 }
+
+.copy-mailing-address-to-residential-address {
+  background-color: $color-primary-alt-lightest;
+  padding: 1em;
+  label {
+    margin: 0;
+  }
+}

--- a/src/applications/personalization/profile360/tests/containers/CopyMailingAddress.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/containers/CopyMailingAddress.unit.spec.jsx
@@ -1,0 +1,95 @@
+import { expect } from 'chai';
+
+import {
+  FIELD_NAMES
+} from '../../constants/vet360';
+
+import {
+  mapStateToProps
+} from '../../containers/CopyMailingAddress';
+
+describe('<CopyMailingAddress/>', () => {
+
+  describe('mapStateToProps', () => {
+    let state = null;
+
+    beforeEach(() => {
+      state = {
+        user: {
+          profile: {
+            vet360: {
+              [FIELD_NAMES.MAILING_ADDRESS]: null
+            }
+          }
+        },
+        vaProfile: {
+          formFields: {
+            [FIELD_NAMES.MAILING_ADDRESS]: null
+          }
+        }
+      };
+    });
+
+    it('returns the required props', () => {
+      const mailingAddress = { city: 'some city' };
+
+      state.user.profile.vet360[FIELD_NAMES.MAILING_ADDRESS] = mailingAddress;
+      state.vaProfile.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = { city: 'some other city' };
+
+      const result = mapStateToProps(state);
+
+      expect(result.mailingAddress).to.be.equal(mailingAddress);
+      expect(result.hasEmptyMailingAddress).to.be.false;
+      expect(result.checked).to.be.false;
+    });
+
+    it('returns checked as true when addresses are equal', () => {
+      state.user.profile.vet360[FIELD_NAMES.MAILING_ADDRESS] = {
+        addressLine1: '1493 Martin Luther King Rd',
+        addressLine2: 'string',
+        addressLine3: 'string',
+        addressPou: 'CORRESPONDENCE',
+        addressType: 'domestic',
+        city: 'Fulton',
+        countryCodeFips: 'US',
+        countryCodeIso2: 'US',
+        countryCodeIso3: 'USA',
+        countryName: 'United States',
+        createdAt: '2018-04-21T20:09:50Z',
+        effectiveEndDate: '2018-04-21T20:09:50Z',
+        effectiveStartDate: '2018-04-21T20:09:50Z',
+        id: 123,
+        internationalPostalCode: '54321',
+        province: 'string',
+        sourceDate: '2018-04-21T20:09:50Z',
+        stateCode: 'NY',
+        updatedAt: '2018-04-21T20:09:50Z',
+        zipCode: '97062',
+        zipCodeSuffix: '123'
+      };
+
+      // This is the same address as above, but converted to the edit-modal form.
+      state.vaProfile.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
+        value: {
+          addressLine1: '1493 Martin Luther King Rd',
+          addressLine2: 'string',
+          addressLine3: 'string',
+          addressPou: 'CORRESPONDENCE',
+          addressType: 'DOMESTIC',
+          city: 'Fulton',
+          countryName: 'United States',
+          id: 123,
+          internationalPostalCode: null,
+          province: null,
+          stateCode: 'NY',
+          zipCode: '97062'
+        }
+      };
+
+      const result = mapStateToProps(state);
+      expect(result.checked).to.be.true;
+    });
+
+  });
+
+});


### PR DESCRIPTION
We badly need to consolidate our logic between `consolidateAddress`, `cleanAddressDataForUpdate`, and `createAddressObject`. I think there should only be two forms - the natural address shape from the server, and the consolidated form for rendering in the edit-modal. I think we tied in extra conversations when transitioning between PCIU to Vet360 format. This work is noted here, department-of-veterans-affairs/vets.gov-team/issues/11561.

##### Todo
- [x] Test cases

Resolves department-of-veterans-affairs/vets.gov-team/issues/11298