### PR TITLE
Profile: Add year to lastEvent.date formatting for Appeals item

### DIFF
--- a/content/pages/profile/index.md
+++ b/content/pages/profile/index.md
@@ -1,5 +1,5 @@
 ---
-title: Your Vets.gov Profile
+title: Your Profile
 layout: page-react.html
 entryname: profile-360
 ---

--- a/src/applications/personalization/dashboard/components/AppealsListItemV2.jsx
+++ b/src/applications/personalization/dashboard/components/AppealsListItemV2.jsx
@@ -36,7 +36,7 @@ export default function AppealListItem({ appeal, name }) {
         Appeal of {appealTypeMap[appeal.attributes.programArea]} - Decision Received {moment(firstEvent.date).format('MMMM D, YYYY')}
       </h3>
       <div className="card-status">
-        <p><strong>{moment(lastEvent.date).format('MMM D')}</strong> - {getStatusContents(status.type, status.details, name).title}</p>
+        <p><strong>{moment(lastEvent.date).format('MMM D, YYYY')}</strong> - {getStatusContents(status.type, status.details, name).title}</p>
       </div>
       <p>
         <Link className="usa-button usa-button-primary" href={`/track-claims/appeals/${appeal.id}/status`}>View appeal<i className="fa fa-chevron-right"/></Link>

--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -16,13 +16,6 @@ import MVIError from './MVIError';
 
 class ProfileView extends React.Component {
 
-  componentDidUpdate(oldProps) {
-    if (this.props.profile !== oldProps.profile && this.props.profile.hero && this.props.profile.hero.userFullName) {
-      const { first, last } = this.props.profile.hero.userFullName;
-      document.title = `Profile: ${first} ${last}`;
-    }
-  }
-
   handleDowntime = (downtime, children) => {
     if (downtime.status === externalServiceStatus.downtimeApproaching) {
       return (


### PR DESCRIPTION
We received some user feedback about confusion between the date in the title of the first event and the date of the most recent event below that. We think showing the year of the last event should help clarify the timeline.

This PR also removes the dynamic page title of the profile, and instead remains `Your Profile: Vets.gov` at all times.