### PR TITLE
EVSS Gate

### DIFF
--- a/src/applications/disability-benefits/526EZ/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/526EZ/Form526EZApp.jsx
@@ -5,15 +5,18 @@ import formConfig from './config/form';
 
 import ITFWrapper from './containers/ITFWrapper';
 import DisabilityGate from './containers/DisabilityGate';
+import EVSSClaimsGate from './containers/EVSSClaimsGate';
 
 export default function Form526Entry({ location, children }) {
   return (
-    <ITFWrapper location={location}>
-      <DisabilityGate>
-        <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-          {children}
-        </RoutedSavableApp>
-      </DisabilityGate>
-    </ITFWrapper>
+    <EVSSClaimsGate location={location}>
+      <ITFWrapper location={location}>
+        <DisabilityGate>
+          <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+            {children}
+          </RoutedSavableApp>
+        </DisabilityGate>
+      </ITFWrapper>
+    </EVSSClaimsGate>
   );
 }

--- a/src/applications/disability-benefits/526EZ/containers/DisabilityGate.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/DisabilityGate.jsx
@@ -20,7 +20,7 @@ export const DisabilityGate = ({ prefillStatus, disabilities = [], children }) =
 
   if (prefillStatus === PREFILL_STATUSES.unfilled) {
     return (
-      <div className="usa-grid" style={{ marginBottom: '2em' }}>
+      <div className="usa-grid full-page-alert">
         <AlertBox
           isVisible
           headline="We're sorry"
@@ -34,7 +34,7 @@ export const DisabilityGate = ({ prefillStatus, disabilities = [], children }) =
   const hasEligibleDisability = disabilities.reduce((hasEligible, disability) => hasEligible || !disability.ineligible, false);
   if (!hasEligibleDisability) {
     return (
-      <div className="usa-grid" style={{ marginBottom: '2em' }}>
+      <div className="usa-grid full-page-alert">
         <AlertBox
           isVisible
           headline="We're sorry"

--- a/src/applications/disability-benefits/526EZ/containers/EVSSClaimsGate.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/EVSSClaimsGate.jsx
@@ -18,7 +18,7 @@ export function EVSSClaimsGate({ user, location, children }) {
         <AlertBox
           isVisible
           headline="We’re sorry. It looks like we’re missing some information needed for your application"
-          content="Please call Veterans Benefits Assistance at 1-800-827-1000, Monday – Friday, 8:00 a.m. to 9:00 p.m. (ET)."
+          content="For help with your application, please call Veterans Benefits Assistance at 1-800-827-1000, Monday – Friday, 8:00 a.m. to 9:00 p.m. (ET)."
           status="error"/>
       </div>
     );

--- a/src/applications/disability-benefits/526EZ/containers/EVSSClaimsGate.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/EVSSClaimsGate.jsx
@@ -17,8 +17,8 @@ export function EVSSClaimsGate({ user, location, children }) {
       <div className="usa-grid full-page-alert">
         <AlertBox
           isVisible
-          headline="Nope"
-          content="Looks like we don't have all the information we need. Please call the call center."
+          headline="We’re sorry. It looks like we’re missing some information needed for your application"
+          content="Please call Veterans Benefits Assistance at 1-800-827-1000, Monday – Friday, 8:00 a.m. to 9:00 p.m. (ET)."
           status="error"/>
       </div>
     );

--- a/src/applications/disability-benefits/526EZ/containers/EVSSClaimsGate.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/EVSSClaimsGate.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
+import RequiredLoginView from '../../../../platform/user/authorization/components/RequiredLoginView';
+import backendServices from '../../../../platform/user/profile/constants/backendServices';
+
+export function EVSSClaimsGate({ user, location, children }) {
+  // Short-circuit the check on the intro page
+  if (location.pathname === '/introduction') {
+    return children;
+  }
+
+  if (user.login.currentlyLoggedIn && !user.profile.services.includes(backendServices.EVSS_CLAIMS)) {
+    return (
+      <div className="usa-grid full-page-alert">
+        <AlertBox
+          isVisible
+          headline="Nope"
+          content="Looks like we don't have all the information we need. Please call the call center."
+          status="error"/>
+      </div>
+    );
+  }
+
+  return (
+    <RequiredLoginView
+      serviceRequired={backendServices.EVSS_CLAIMS}
+      user={user}
+      verify>
+      {children}
+    </RequiredLoginView>
+  );
+}
+
+const mapStateToProps = (store) => ({
+  user: store.user
+});
+
+export default connect(mapStateToProps)(EVSSClaimsGate);

--- a/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ITFWrapper.jsx
@@ -20,7 +20,7 @@ const outputDateFormat = 'MMMM DD, YYYY';
 const displayDate = (dateString) => moment(dateString, evssDateFormat).format(outputDateFormat);
 
 const itfMessage = (headline, content, status) => (
-  <div className="usa-grid" style={{ marginBottom: '2em' }}>
+  <div className="usa-grid full-page-alert">
     <AlertBox
       isVisible
       headline={headline}
@@ -42,7 +42,8 @@ export class ITFWrapper extends React.Component {
   // When we first enter the form...
   componentDidMount() {
     // ...fetch the ITF if needed
-    if (!noITFPages.includes(this.props.location.pathname)) {
+    if (!noITFPages.includes(this.props.location.pathname)
+      && this.props.itf.fetchCallState === requestStates.notCalled) {
       this.props.fetchITF();
     }
   }

--- a/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
@@ -156,3 +156,7 @@
     margin: 0.5em 0;
   }
 }
+
+.full-page-alert {
+  margin-bottom: 2em;
+}

--- a/src/applications/disability-benefits/526EZ/tests/containers/EVSSClaimsGate.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/containers/EVSSClaimsGate.unit.spec.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+
+import { EVSSClaimsGate } from '../../containers/EVSSClaimsGate';
+
+describe('EVSSClaimsGate', () => {
+  const disallowedUser = {
+    login: { currentlyLoggedIn: true },
+    profile: {
+      services: []
+    }
+  };
+
+  it('should not gate the form on the intro page', () => {
+    const tree = mount(
+      <EVSSClaimsGate
+        user={disallowedUser}
+        location={{ pathname: '/introduction' }}>
+        <p>It worked!</p>
+      </EVSSClaimsGate>
+    );
+    expect(tree.text()).to.equal('It worked!');
+  });
+
+  it('should render a RequiredLoginView', () => {
+    const tree = shallow(
+      <EVSSClaimsGate
+        user={disallowedUser}
+        location={{ pathname: '/middle-of-the-form' }}>
+        <p>It worked!</p>
+      </EVSSClaimsGate>
+    );
+    expect(tree.find('RequiredLoginView').length).to.equal(1);
+  });
+});

--- a/src/applications/disability-benefits/526EZ/tests/containers/EVSSClaimsGate.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/containers/EVSSClaimsGate.unit.spec.jsx
@@ -4,11 +4,20 @@ import { shallow, mount } from 'enzyme';
 
 import { EVSSClaimsGate } from '../../containers/EVSSClaimsGate';
 
+import backendServices from '../../../../../platform/user/profile/constants/backendServices';
+
 describe('EVSSClaimsGate', () => {
   const disallowedUser = {
     login: { currentlyLoggedIn: true },
     profile: {
       services: []
+    }
+  };
+
+  const allowedUser = {
+    login: { currentlyLoggedIn: true },
+    profile: {
+      services: [backendServices.EVSS_CLAIMS]
     }
   };
 
@@ -26,7 +35,7 @@ describe('EVSSClaimsGate', () => {
   it('should render a RequiredLoginView', () => {
     const tree = shallow(
       <EVSSClaimsGate
-        user={disallowedUser}
+        user={allowedUser}
         location={{ pathname: '/middle-of-the-form' }}>
         <p>It worked!</p>
       </EVSSClaimsGate>


### PR DESCRIPTION
This PR does 3 things:
1. Includes a `EVSSClaimsGate` which doesn't allow the user into the form unless the they have `evss-claims` in their services list
2. Wraps everything under `EVSSClaimsGate` in a `RequiredLoginView` so we're not trying to make an ITF call when we know it'll fail
    - We were still redirecting to the login before, but only after the ITF call
    - I don't know _how_ we were redirecting to the login screen before, so I wasn't able to remove that... :grimacing: 
3. Fixes a newly-introduced bug wherein the ITF would be fetched twice in the following scenario:
    1. We log in
    2. We go to the middle of a form
        - The ITF is fetched / created here
    3. We back out to the intro page using the form controls
    4. We start the form
        - The ITF was being fetched again here in `ITFWrapper`'s `componentDidMount`

### Screenshot
![image](https://user-images.githubusercontent.com/12970166/43151378-b536ec1a-8f20-11e8-944d-bb50716fcbe2.png)
