### PR TITLE
Remove delay before redirecting the user post-login

### DIFF
--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -14,12 +14,7 @@ function NewBadge() {
 
 class PersonalizationDropdown extends React.Component {
   componentDidMount() {
-    // If when this component is mounted the user is on the index page without the "next" parameter in the URL...
-    if (window.location.pathname === '/' && !window.location.search) {
-      document.location.href = dashboardLink;
-    } else {
-      document.addEventListener('click', this.checkLink);
-    }
+    document.addEventListener('click', this.checkLink);
   }
 
   componentWillUnmount() {

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -22,6 +22,10 @@ import {
 import SearchHelpSignIn from '../components/SearchHelpSignIn';
 import { selectUserGreeting } from '../selectors';
 
+import dashboardManifest from '../../../../applications/personalization/dashboard/manifest.json';
+
+const DASHBOARD_URL = dashboardManifest.rootUrl;
+
 // const SESSION_REFRESH_INTERVAL_MINUTES = 45;
 
 export class Main extends React.Component {
@@ -38,17 +42,9 @@ export class Main extends React.Component {
 
   componentDidUpdate() {
     const { currentlyLoggedIn, showLoginModal } = this.props;
-    const nextParam = this.getRedirectUrl();
-
-    const shouldRedirect =
-      currentlyLoggedIn && nextParam && !window.location.pathname.includes('verify');
-
-    if (shouldRedirect) {
-      const redirectPath = nextParam.startsWith('/') ? nextParam : `/${nextParam}`;
-      window.location.replace(redirectPath);
-    }
-
     const shouldCloseLoginModal = currentlyLoggedIn && showLoginModal;
+
+    if (currentlyLoggedIn) this.executeRedirect();
 
     if (shouldCloseLoginModal) { this.props.toggleLoginModal(false); }
   }
@@ -58,10 +54,35 @@ export class Main extends React.Component {
   }
 
   setToken = (event) => {
-    if (event.data === sessionStorage.userToken) { this.props.initializeProfile(); }
+    if (event.data === sessionStorage.userToken) {
+      this.executeRedirect();
+      this.props.initializeProfile();
+    }
   }
 
-  getRedirectUrl = () => (new URLSearchParams(window.location.search)).get('next');
+  getRedirectUrlParameter() {
+    const nextParam = (new URLSearchParams(window.location.search)).get('next');
+    if (nextParam) {
+      return nextParam.startsWith('/') ? nextParam : `/${nextParam}`;
+    }
+    return false;
+  }
+
+  getRedirectUrl = () => {
+    const nextParam = this.getRedirectUrlParameter();
+    if (nextParam) return nextParam;
+
+    return window.location.pathname === '/' && DASHBOARD_URL;
+  };
+
+  executeRedirect() {
+    const redirectUrl = this.getRedirectUrl();
+    const shouldRedirect = redirectUrl && !window.location.pathname.includes('verify');
+
+    if (shouldRedirect) {
+      window.location.replace(redirectUrl);
+    }
+  }
 
   bindNavbarLinks = () => {
     [...document.querySelectorAll('.login-required')].forEach(el => {
@@ -86,7 +107,7 @@ export class Main extends React.Component {
   checkTokenStatus = () => {
     if (!sessionStorage.userToken) {
       this.props.updateLoggedInStatus(false);
-      if (this.getRedirectUrl()) { this.props.toggleLoginModal(true); }
+      if (this.getRedirectUrlParameter()) { this.props.toggleLoginModal(true); }
     } else {
       this.props.initializeProfile();
     }

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -60,7 +60,7 @@ export class Main extends React.Component {
     }
   }
 
-  getRedirectUrlParameter() {
+  getNextParameter() {
     const nextParam = (new URLSearchParams(window.location.search)).get('next');
     if (nextParam) {
       return nextParam.startsWith('/') ? nextParam : `/${nextParam}`;
@@ -69,7 +69,7 @@ export class Main extends React.Component {
   }
 
   getRedirectUrl = () => {
-    const nextParam = this.getRedirectUrlParameter();
+    const nextParam = this.getNextParameter();
     if (nextParam) return nextParam;
 
     return window.location.pathname === '/' && DASHBOARD_URL;
@@ -107,7 +107,7 @@ export class Main extends React.Component {
   checkTokenStatus = () => {
     if (!sessionStorage.userToken) {
       this.props.updateLoggedInStatus(false);
-      if (this.getRedirectUrlParameter()) { this.props.toggleLoginModal(true); }
+      if (this.getNextParameter()) { this.props.toggleLoginModal(true); }
     } else {
       this.props.initializeProfile();
     }


### PR DESCRIPTION
After a user logs in, we receive the token from the sign-in window via the `setToken` callback, where we then use that token to request the user's profile information. We then store that user profile information in state. Finally, React components respond to this new data, one of which is the `user-nav/containers/Main.jsx`, which will perform a redirect to a certain application based on the "next" query parameter. The user is redirected to `/dashboard/` if they're on the homepage, `/`.

This PR refactors the login logic so that the application-redirect is executed after the FE is handed a `userToken` but prior to the user-profile being initialized. This way, we only issue the request for the user-profile when we don't need to do a redirect, so that immediately post-login we save some resources and save the user that second of delay (while the request for the user-profile is pending) before being redirected.

There's some more context in the issue below. In summary, it's confusing that after logging in the user sees the regular homepage for just a second before the redirect to their dashboard.

Resolves department-of-veterans-affairs/vets.gov-team/issues/10659