### PR TITLE
fix for search on 404 page

### DIFF
--- a/content/pages/404.md
+++ b/content/pages/404.md
@@ -29,7 +29,7 @@ private: true
                 <input name="utf8" type="hidden" value="&#x2713;" />
               </div>
               <div class="va-flex va-flex--top va-flex--jctr">
-                <input id="affiliate-1" name="affiliate-1" type="hidden" value="vets.gov_search" />
+                <input id="affiliate" name="affiliate" type="hidden" value="vets.gov_search" />
                   <label for="mobile-query">Search:</label>
                   <input autocomplete="off" class="usagov-search-autocomplete full-width" id="mobile-query" name="query" type="text" />
                   <input name="commit" type="submit" value="Search">


### PR DESCRIPTION
Steps to check:

1. go to 404 page (locally: "/404.html", heroku: "/askshkd")
2. In the search input box search for "Health"
3. Click on the Search button
4. It should redirect you to the search page and not vets.gov home page.