### PR TITLE
Remove unused verified logic

### DIFF
--- a/src/applications/edu-benefits/0993/config/form.js
+++ b/src/applications/edu-benefits/0993/config/form.js
@@ -48,7 +48,6 @@ const formConfig = {
           title: 'Applicant Information',
           path: 'claimant-information',
           initialData: {
-            // verified: true,
             // claimantFullName: {
             //   first: 'test',
             //   last: 'test'
@@ -72,7 +71,7 @@ const formConfig = {
               }
             }),
             claimantSocialSecurityNumber: _.assign(ssnUI, {
-              'ui:required': (formData) => !formData.verified && !formData['view:noSSN'],
+              'ui:required': (formData) => !formData['view:noSSN'],
               'ui:title': 'Your Social Security number'
             }),
             'view:noSSN': {
@@ -82,7 +81,7 @@ const formConfig = {
               }
             },
             vaFileNumber: {
-              'ui:required': (formData) => !formData.verified && formData['view:noSSN'],
+              'ui:required': (formData) => formData['view:noSSN'],
               'ui:title': 'Your VA file number',
               'ui:options': {
                 expandUnder: 'view:noSSN'

--- a/src/applications/edu-benefits/0993/helpers.js
+++ b/src/applications/edu-benefits/0993/helpers.js
@@ -1,14 +1,17 @@
-import _ from 'lodash/fp';
+// import _ from 'lodash/fp';
 import { transformForSubmit } from 'us-forms-system/lib/js/helpers';
 
-export function prefillTransformer(pages, formData, metadata, state) {
-  const { verified } = state.user.profile;
+export function prefillTransformer(pages, formData, metadata) {
+  // TODO: enable this to implement the review card UI for verified users
+  // TODO: add 'state' to arguments
 
-  const newFormData = _.set('verified', !!verified, formData);
+  // const { verified } = state.user.profile;
+
+  // const newFormData = _.set('view:isVerified', !!verified, formData);
 
   return {
     metadata,
-    formData: newFormData,
+    formData,
     pages
   };
 }


### PR DESCRIPTION
These changes remove remaining unused verified logic not included in the work done in https://github.com/department-of-veterans-affairs/vets-website/pull/8045, now that we will be displaying the prefilled fields for verified users.