### PR TITLE
display the save in progress card on the opt out static introduction page

### DIFF
--- a/src/applications/edu-benefits/components/createOptOutApplicationStatus.jsx
+++ b/src/applications/edu-benefits/components/createOptOutApplicationStatus.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
+const eduForms = new Set(['22-0993']);
 
 export default function createOptOutApplicationStatus(store) {
   const root = document.getElementById('react-applicationStatus');
@@ -11,6 +12,7 @@ export default function createOptOutApplicationStatus(store) {
       ReactDOM.render((
         <Provider store={store}>
           <ApplicationStatus
+            formIds={eduForms}
             formType="education"
             showApplyButton={root.getAttribute('data-hide-apply-button') === null}
             stayAfterDelete

--- a/src/applications/personalization/profile360/util/helpers.jsx
+++ b/src/applications/personalization/profile360/util/helpers.jsx
@@ -5,7 +5,7 @@ export const formBenefits = {
   '21P-527EZ': 'Veterans pension benefits',
   '21P-530': 'burial benefits',
   '1010ez': 'health care',
-  '22-0993': 'education benefits',
+  '22-0993': 'opt out',
   '22-1990': 'education benefits',
   '22-1990E': 'education benefits',
   '22-1990N': 'education benefits',


### PR DESCRIPTION
These changes display the save in progress card on the opt out static introduction page.

![image](https://user-images.githubusercontent.com/16051172/43217295-19c8498c-8ff6-11e8-8fcf-1a6caed8865d.png)
