### PR TITLE
Profile: Reorganize and restructure Vet360 components, reducer for portability 

### DIFF
--- a/src/applications/personalization/profile360/actions/index.js
+++ b/src/applications/personalization/profile360/actions/index.js
@@ -1,9 +1,6 @@
 import { apiRequest } from '../../../../platform/utilities/api';
 import { isVet360Configured } from '../util/local-vet360';
 import sendAndMergeApiRequests from '../util/sendAndMergeApiRequests';
-import _ from 'lodash';
-import countries from '../constants/countries.json';
-import states from '../constants/states.json';
 
 export const FETCH_HERO_SUCCESS = 'FETCH_HERO_SUCCESS';
 export const FETCH_PERSONAL_INFORMATION_SUCCESS = 'FETCH_PERSONAL_INFORMATION_SUCCESS';
@@ -51,16 +48,6 @@ export function fetchMilitaryInformation() {
   };
 }
 
-export function fetchAddressConstants() {
-  return ({
-    type: FETCH_ADDRESS_CONSTANTS_SUCCESS,
-    addressConstants: {
-      states: _.map(states, 'stateCode'),
-      countries: _.map(countries, 'countryName'),
-    }
-  });
-}
-
 export function fetchTransactions() {
   return async (dispatch) => {
     try {
@@ -79,14 +66,5 @@ export function fetchTransactions() {
     } catch (err) {
       // If we sync transactions in the background and fail, is it worth telling the user?
     }
-  };
-}
-
-export function startup() {
-  return async (dispatch) => {
-    dispatch(fetchHero());
-    dispatch(fetchAddressConstants());
-    dispatch(fetchPersonalInformation());
-    dispatch(fetchMilitaryInformation());
   };
 }

--- a/src/applications/personalization/profile360/components/AddressEditModal.jsx
+++ b/src/applications/personalization/profile360/components/AddressEditModal.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import {
-  FIELD_NAMES
+  FIELD_NAMES,
+  ADDRESS_FORM_VALUES
 } from '../constants/vet360';
 
 import {
@@ -54,8 +55,8 @@ export default class AddressEditModal extends React.Component {
           onInput={this.onInput}
           onBlur={this.onBlur}
           errorMessages={this.props.field.validations}
-          states={this.props.addressConstants.states}
-          countries={this.props.addressConstants.countries}/>
+          states={ADDRESS_FORM_VALUES.STATES}
+          countries={ADDRESS_FORM_VALUES.COUNTRIES}/>
       </div>
     );
   }

--- a/src/applications/personalization/profile360/components/AddressSection.jsx
+++ b/src/applications/personalization/profile360/components/AddressSection.jsx
@@ -33,13 +33,12 @@ function isEmpty({ data: addressData } = {}) {
   return isEmptyAddress(addressData);
 }
 
-export default function Vet360Address({ title, fieldName, analyticsSectionName, addressConstants, deleteDisabled }) {
+export default function Vet360Address({ title, fieldName, analyticsSectionName, deleteDisabled }) {
   return (
     <Vet360ProfileField
       title={title}
       fieldName={fieldName}
       analyticsSectionName={analyticsSectionName}
-      addressConstants={addressConstants}
       deleteDisabled={deleteDisabled}
       isEmpty={isEmpty}
       Content={AddressView}

--- a/src/applications/personalization/profile360/components/ContactInformation.jsx
+++ b/src/applications/personalization/profile360/components/ContactInformation.jsx
@@ -4,15 +4,20 @@ import React from 'react';
 import DowntimeNotification, { externalServices } from '../../../../platform/monitoring/DowntimeNotification';
 import recordEvent from '../../../../platform/monitoring/record-event';
 import accountManifest from '../../account/manifest.json';
-import { FIELD_NAMES, TRANSACTION_CATEGORY_TYPES } from '../constants/vet360';
+import { TRANSACTION_CATEGORY_TYPES } from '../constants/vet360';
 import Vet360PendingTransactionCategory from '../containers/Vet360PendingTransactionCategory';
-import PhoneSection from './PhoneSection';
-import AddressSection from './AddressSection';
-import EmailSection from './EmailSection';
 import LoadFail from './LoadFail';
 import { handleDowntimeForSection } from './DowntimeBanner';
 import MissingVet360IDError from './MissingVet360IDError';
 import ContactInformationExplanation from './ContactInformationExplanation';
+
+import MailingAddress from '../vet360/components/MailingAddress';
+import ResidentialAddress from '../vet360/components/ResidentialAddress';
+import HomePhone from '../vet360/components/HomePhone';
+import MobilePhone from '../vet360/components/MobilePhone';
+import WorkPhone from '../vet360/components/WorkPhone';
+import FaxNumber from '../vet360/components/FaxNumber';
+import Email from '../vet360/components/Email';
 
 export default class ContactInformation extends React.Component {
 
@@ -39,43 +44,19 @@ export default class ContactInformation extends React.Component {
         <ContactInformationExplanation/>
 
         <Vet360PendingTransactionCategory categoryType={TRANSACTION_CATEGORY_TYPES.ADDRESS}>
-          <AddressSection
-            title="Mailing address"
-            fieldName={FIELD_NAMES.MAILING_ADDRESS}
-            analyticsSectionName="mailing-address"
-            deleteDisabled
-            addressConstants={addressConstants}/>
-          <AddressSection
-            title="Home address"
-            fieldName={FIELD_NAMES.RESIDENTIAL_ADDRESS}
-            analyticsSectionName="home-address"
-            addressConstants={addressConstants}/>
+          <MailingAddress addressConstants={addressConstants}/>
+          <ResidentialAddress addressConstants={addressConstants}/>
         </Vet360PendingTransactionCategory>
 
         <Vet360PendingTransactionCategory categoryType={TRANSACTION_CATEGORY_TYPES.PHONE}>
-          <PhoneSection
-            title="Home phone number"
-            fieldName={FIELD_NAMES.HOME_PHONE}
-            analyticsSectionName="home-telephone"/>
-          <PhoneSection
-            title="Mobile phone number"
-            fieldName={FIELD_NAMES.MOBILE_PHONE}
-            analyticsSectionName="mobile-telephone"/>
-          <PhoneSection
-            title="Work phone number"
-            fieldName={FIELD_NAMES.WORK_PHONE}
-            analyticsSectionName="work-telephone"/>
-          <PhoneSection
-            title="Fax number"
-            fieldName={FIELD_NAMES.FAX_NUMBER}
-            analyticsSectionName="fax-telephone"/>
+          <HomePhone/>
+          <MobilePhone/>
+          <WorkPhone/>
+          <FaxNumber/>
         </Vet360PendingTransactionCategory>
 
         <Vet360PendingTransactionCategory categoryType={TRANSACTION_CATEGORY_TYPES.EMAIL}>
-          <EmailSection
-            title="Email address"
-            fieldName={FIELD_NAMES.EMAIL}
-            analyticsSectionName="email"/>
+          <Email/>
         </Vet360PendingTransactionCategory>
       </div>
     );

--- a/src/applications/personalization/profile360/components/ContactInformation.jsx
+++ b/src/applications/personalization/profile360/components/ContactInformation.jsx
@@ -21,17 +21,12 @@ import Email from '../vet360/components/Email';
 
 export default class ContactInformation extends React.Component {
 
-  componentDidMount() {
-    this.props.fetchAddressConstants();
-  }
-
   renderContent = () => {
     if (every(Object.keys(this.props.user.profile.vet360), false)) {
       return <LoadFail information="contact"/>;
     }
 
     const {
-      addressConstants,
       isVet360AvailableForUser,
     } =  this.props;
 
@@ -44,8 +39,8 @@ export default class ContactInformation extends React.Component {
         <ContactInformationExplanation/>
 
         <Vet360PendingTransactionCategory categoryType={TRANSACTION_CATEGORY_TYPES.ADDRESS}>
-          <MailingAddress addressConstants={addressConstants}/>
-          <ResidentialAddress addressConstants={addressConstants}/>
+          <MailingAddress/>
+          <ResidentialAddress/>
         </Vet360PendingTransactionCategory>
 
         <Vet360PendingTransactionCategory categoryType={TRANSACTION_CATEGORY_TYPES.PHONE}>

--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -35,12 +35,10 @@ class ProfileView extends React.Component {
     const {
       user,
       isVet360AvailableForUser,
-      fetchAddressConstants,
       fetchMilitaryInformation,
       fetchHero,
       fetchPersonalInformation,
       profile: {
-        addressConstants,
         hero,
         personalInformation,
         militaryInformation
@@ -59,7 +57,7 @@ class ProfileView extends React.Component {
             <div>
               <Vet360TransactionReporter/>
               <Hero fetchHero={fetchHero} hero={hero} militaryInformation={militaryInformation}/>
-              <ContactInformation fetchAddressConstants={fetchAddressConstants} addressConstants={addressConstants} isVet360AvailableForUser={isVet360AvailableForUser} user={user}/>
+              <ContactInformation isVet360AvailableForUser={isVet360AvailableForUser} user={user}/>
               <PersonalInformation fetchPersonalInformation={fetchPersonalInformation} personalInformation={personalInformation}/>
               <MilitaryInformation fetchMilitaryInformation={fetchMilitaryInformation} militaryInformation={militaryInformation}/>
             </div>

--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -19,7 +19,6 @@ class ProfileView extends React.Component {
   static propTypes = {
     downtimeData: PropTypes.object,
     isVet360AvailableForUser: PropTypes.bool,
-    fetchAddressConstants: PropTypes.func.isRequired,
     fetchTransactions: PropTypes.func.isRequired,
     fetchMilitaryInformation: PropTypes.func.isRequired,
     fetchHero: PropTypes.func.isRequired,

--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -25,7 +25,6 @@ class ProfileView extends React.Component {
     fetchHero: PropTypes.func.isRequired,
     fetchPersonalInformation: PropTypes.func.isRequired,
     profile: PropTypes.shape({
-      addressConstants: PropTypes.object,
       hero: PropTypes.object,
       personalInformation: PropTypes.object,
       militaryInformation: PropTypes.object

--- a/src/applications/personalization/profile360/constants/vet360.js
+++ b/src/applications/personalization/profile360/constants/vet360.js
@@ -1,3 +1,11 @@
+import states from './states.json';
+import countries from './countries.json';
+
+export const ADDRESS_FORM_VALUES = {
+  STATES: states.map(state => state.stateCode),
+  COUNTRIES: countries.map(country => country.countryName)
+};
+
 export const TRANSACTION_CATEGORY_TYPES = {
   PHONE: 'AsyncTransaction::Vet360::PhoneTransaction',
   EMAIL: 'AsyncTransaction::Vet360::EmailTransaction',

--- a/src/applications/personalization/profile360/containers/VAProfileApp.jsx
+++ b/src/applications/personalization/profile360/containers/VAProfileApp.jsx
@@ -9,7 +9,6 @@ import {
 
 import {
   fetchTransactions,
-  fetchAddressConstants,
   fetchHero,
   fetchMilitaryInformation,
   fetchPersonalInformation
@@ -37,7 +36,6 @@ class VAProfileApp extends React.Component {
             isVet360AvailableForUser={this.props.isVet360AvailableForUser}
             profile={this.props.profile}
             user={this.props.account}
-            fetchAddressConstants={this.props.fetchAddressConstants}
             fetchHero={this.props.fetchHero}
             fetchMilitaryInformation={this.props.fetchMilitaryInformation}
             fetchPersonalInformation={this.props.fetchPersonalInformation}
@@ -64,7 +62,6 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = {
   fetchTransactions,
-  fetchAddressConstants,
   fetchHero,
   fetchMilitaryInformation,
   fetchPersonalInformation,

--- a/src/applications/personalization/profile360/containers/VAProfileApp.jsx
+++ b/src/applications/personalization/profile360/containers/VAProfileApp.jsx
@@ -33,7 +33,6 @@ class VAProfileApp extends React.Component {
             isVet360AvailableForUser={this.props.isVet360AvailableForUser}
             profile={this.props.profile}
             user={this.props.user}
-            fetchAddressConstants={this.props.fetchAddressConstants}
             fetchHero={this.props.fetchHero}
             fetchMilitaryInformation={this.props.fetchMilitaryInformation}
             fetchPersonalInformation={this.props.fetchPersonalInformation}

--- a/src/applications/personalization/profile360/containers/Vet360ProfileField.jsx
+++ b/src/applications/personalization/profile360/containers/Vet360ProfileField.jsx
@@ -115,9 +115,10 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   const {
-    fieldName,
-    analyticsSectionName: sectionName
+    fieldName
   } = ownProps;
+
+  const sectionName = VET360.ANALYTICS_FIELD_MAP[fieldName];
 
   const captureEvent = (actionName) => {
     if (sectionName && actionName) {
@@ -183,7 +184,6 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 const Vet360ProfileFieldContainer = connect(mapStateToProps, mapDispatchToProps)(Vet360ProfileField);
 
 Vet360ProfileFieldContainer.propTypes = {
-  analyticsSectionName: PropTypes.string.isRequired,
   fieldName: PropTypes.oneOf(Object.values(VET360.FIELD_NAMES)).isRequired,
   Content: PropTypes.func.isRequired,
   EditModal: PropTypes.func.isRequired,

--- a/src/applications/personalization/profile360/containers/Vet360ProfileField.jsx
+++ b/src/applications/personalization/profile360/containers/Vet360ProfileField.jsx
@@ -31,7 +31,6 @@ import Vet360Transaction from '../components/Vet360Transaction';
 class Vet360ProfileField extends React.Component {
 
   static propTypes = {
-    analyticsSectionName: PropTypes.string.isRequired,
     clearErrors: PropTypes.func.isRequired,
     Content: PropTypes.func.isRequired,
     data: PropTypes.object,

--- a/src/applications/personalization/profile360/reducers/index.js
+++ b/src/applications/personalization/profile360/reducers/index.js
@@ -1,28 +1,15 @@
 import vet360 from '../vet360/reducers';
 
 import {
-  // Fetch actions
   FETCH_HERO_SUCCESS,
   FETCH_PERSONAL_INFORMATION_SUCCESS,
-  FETCH_MILITARY_INFORMATION_SUCCESS,
-  FETCH_ADDRESS_CONSTANTS_SUCCESS,
-
-  // Miscellaneous actions
-  VET360_TRANSACTION_REQUEST_SUCCEEDED,
-  UPDATE_PROFILE_FORM_FIELD,
-  OPEN_MODAL
+  FETCH_MILITARY_INFORMATION_SUCCESS
 } from '../actions';
 
 const initialState = {
   hero: null,
-  contactInformation: null,
   personalInformation: null,
-  militaryInformation: null,
-  addressConstants: null,
-  modal: null,
-  formFields: {},
-  message: null,
-  transactions: {}
+  militaryInformation: null
 };
 
 function vaProfile(state = initialState, action) {
@@ -37,26 +24,6 @@ function vaProfile(state = initialState, action) {
 
     case FETCH_MILITARY_INFORMATION_SUCCESS:
       return { ...state, militaryInformation: action.militaryInformation };
-
-    case FETCH_ADDRESS_CONSTANTS_SUCCESS: {
-      const flattened = {
-        states: action.addressConstants.states,
-        countries: action.addressConstants.countries,
-      };
-      return { ...state, addressConstants: flattened };
-    }
-
-    // Miscellaneous
-    case UPDATE_PROFILE_FORM_FIELD: {
-      const formFields = { ...state.formFields, [action.field]: action.newState };
-      return { ...state, formFields };
-    }
-
-    case OPEN_MODAL:
-      return { ...state, modal: action.modal };
-
-    case VET360_TRANSACTION_REQUEST_SUCCEEDED:
-      return { ...state, modal: null };
 
     default:
       return state;

--- a/src/applications/personalization/profile360/reducers/index.js
+++ b/src/applications/personalization/profile360/reducers/index.js
@@ -1,4 +1,4 @@
-import vet360 from './vet360';
+import vet360 from '../vet360/reducers';
 
 import {
   // Fetch actions

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -96,9 +96,9 @@ export function selectVet360PendingCategoryTransactions(state, type) {
 }
 
 export function selectEditedFormField(state, fieldName) {
-  return state.vaProfile.formFields[fieldName];
+  return state.vet360.formFields[fieldName];
 }
 
 export function selectCurrentlyOpenEditModal(state) {
-  return state.vaProfile.modal;
+  return state.vet360.modal;
 }

--- a/src/applications/personalization/profile360/tests/containers/CopyMailingAddress.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/containers/CopyMailingAddress.unit.spec.jsx
@@ -22,7 +22,7 @@ describe('<CopyMailingAddress/>', () => {
             }
           }
         },
-        vaProfile: {
+        vet360: {
           formFields: {
             [FIELD_NAMES.MAILING_ADDRESS]: null
           }
@@ -34,7 +34,7 @@ describe('<CopyMailingAddress/>', () => {
       const mailingAddress = { city: 'some city' };
 
       state.user.profile.vet360[FIELD_NAMES.MAILING_ADDRESS] = mailingAddress;
-      state.vaProfile.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = { city: 'some other city' };
+      state.vet360.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = { city: 'some other city' };
 
       const result = mapStateToProps(state);
 
@@ -69,7 +69,7 @@ describe('<CopyMailingAddress/>', () => {
       };
 
       // This is the same address as above, but converted to the edit-modal form.
-      state.vaProfile.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
+      state.vet360.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
         value: {
           addressLine1: '1493 Martin Luther King Rd',
           addressLine2: 'string',

--- a/src/applications/personalization/profile360/tests/reducers/index.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/reducers/index.unit.spec.js
@@ -23,19 +23,6 @@ describe('index reducer', () => {
     expect(state.personalInformation).to.eql('personalInformation');
   });
 
-  it('should fetch address constants', () => {
-    const state = vaProfile({}, {
-      type: 'FETCH_ADDRESS_CONSTANTS_SUCCESS',
-      addressConstants: {
-        states: ['states'],
-        countries: ['countries']
-      },
-    });
-
-    expect(state.addressConstants.states).to.eql(['states']);
-    expect(state.addressConstants.countries).to.eql(['countries']);
-  });
-
   it('should update profile form fields', () => {
     const state = vaProfile({}, {
       type: 'UPDATE_PROFILE_FORM_FIELD',

--- a/src/applications/personalization/profile360/tests/reducers/index.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/reducers/index.unit.spec.js
@@ -23,34 +23,4 @@ describe('index reducer', () => {
     expect(state.personalInformation).to.eql('personalInformation');
   });
 
-  it('should update profile form fields', () => {
-    const state = vaProfile({}, {
-      type: 'UPDATE_PROFILE_FORM_FIELD',
-      field: 'fieldName',
-      newState: {
-        fieldValue: 'value'
-      }
-    });
-
-    expect(state.formFields.fieldName).to.eql({
-      fieldValue: 'value'
-    });
-  });
-
-  it('should open modal', () => {
-    const state = vaProfile({}, {
-      type: 'OPEN_MODAL',
-      modal: 'modalName'
-    });
-
-    expect(state.modal).to.eql('modalName');
-  });
-
-  it('should close modal', () => {
-    const state = vaProfile({}, {
-      type: 'VET360_TRANSACTION_REQUEST_SUCCEEDED',
-    });
-
-    expect(state.modal).to.eql(null);
-  });
 });

--- a/src/applications/personalization/profile360/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/selectors.unit.spec.js
@@ -22,6 +22,8 @@ const hooks = {
     };
 
     const vet360 = {
+      modal: null,
+      formFields: {},
       transactions: [],
       fieldTransactionMap: {},
       metadata: {
@@ -29,15 +31,9 @@ const hooks = {
       }
     };
 
-    const vaProfile = {
-      modal: null,
-      formFields: {}
-    };
-
     state = {
       user,
-      vet360,
-      vaProfile
+      vet360
     };
   }
 };
@@ -171,7 +167,7 @@ describe('selectors', () => {
     it('looks up the form value in state for a given field name', () => {
       const fieldName = 'someField';
       const fieldValue = 'someFieldValue';
-      state.vaProfile.formFields[fieldName] = fieldValue;
+      state.vet360.formFields[fieldName] = fieldValue;
 
       expect(selectors.selectEditedFormField(state, fieldName)).to.be.equal(fieldValue);
     });
@@ -181,7 +177,7 @@ describe('selectors', () => {
     beforeEach(hooks.beforeEach);
     it('looks up the form value in state for a given field name', () => {
       const currentlyOpenModal = 'someField';
-      state.vaProfile.modal = currentlyOpenModal;
+      state.vet360.modal = currentlyOpenModal;
 
       expect(selectors.selectCurrentlyOpenEditModal(state)).to.be.equal(currentlyOpenModal);
     });

--- a/src/applications/personalization/profile360/vet360/components/Email.jsx
+++ b/src/applications/personalization/profile360/vet360/components/Email.jsx
@@ -10,7 +10,6 @@ export default function Email() {
   return (
     <EmailSection
       title="Email address"
-      fieldName={FIELD_NAMES.EMAIL}
-      analyticsSectionName="email"/>
+      fieldName={FIELD_NAMES.EMAIL}/>
   );
 }

--- a/src/applications/personalization/profile360/vet360/components/Email.jsx
+++ b/src/applications/personalization/profile360/vet360/components/Email.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import EmailSection from '../../components/EmailSection';
+
+import {
+  FIELD_NAMES
+} from '../../constants/vet360';
+
+export default function Email() {
+  return (
+    <EmailSection
+      title="Email address"
+      fieldName={FIELD_NAMES.EMAIL}
+      analyticsSectionName="email"/>
+  );
+}

--- a/src/applications/personalization/profile360/vet360/components/FaxNumber.jsx
+++ b/src/applications/personalization/profile360/vet360/components/FaxNumber.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import PhoneSection from '../../components/PhoneSection';
+
+import {
+  FIELD_NAMES
+} from '../../constants/vet360';
+
+export default function FaxNumber() {
+  return (
+    <PhoneSection
+      title="Fax number"
+      fieldName={FIELD_NAMES.FAX_NUMBER}
+      analyticsSectionName="fax-telephone"/>
+  );
+}

--- a/src/applications/personalization/profile360/vet360/components/FaxNumber.jsx
+++ b/src/applications/personalization/profile360/vet360/components/FaxNumber.jsx
@@ -10,7 +10,6 @@ export default function FaxNumber() {
   return (
     <PhoneSection
       title="Fax number"
-      fieldName={FIELD_NAMES.FAX_NUMBER}
-      analyticsSectionName="fax-telephone"/>
+      fieldName={FIELD_NAMES.FAX_NUMBER}/>
   );
 }

--- a/src/applications/personalization/profile360/vet360/components/HomePhone.jsx
+++ b/src/applications/personalization/profile360/vet360/components/HomePhone.jsx
@@ -10,7 +10,6 @@ export default function HomePhone() {
   return (
     <PhoneSection
       title="Home phone number"
-      fieldName={FIELD_NAMES.HOME_PHONE}
-      analyticsSectionName="home-telephone"/>
+      fieldName={FIELD_NAMES.HOME_PHONE}/>
   );
 }

--- a/src/applications/personalization/profile360/vet360/components/HomePhone.jsx
+++ b/src/applications/personalization/profile360/vet360/components/HomePhone.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import PhoneSection from '../../components/PhoneSection';
+
+import {
+  FIELD_NAMES
+} from '../../constants/vet360';
+
+export default function HomePhone() {
+  return (
+    <PhoneSection
+      title="Home phone number"
+      fieldName={FIELD_NAMES.HOME_PHONE}
+      analyticsSectionName="home-telephone"/>
+  );
+}

--- a/src/applications/personalization/profile360/vet360/components/MailingAddress.jsx
+++ b/src/applications/personalization/profile360/vet360/components/MailingAddress.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import AddressSection from '../../components/AddressSection';
+
+import {
+  FIELD_NAMES
+} from '../../constants/vet360';
+
+export default function MailingAddress({ addressConstants }) {
+  return (
+    <AddressSection
+      title="Mailing address"
+      fieldName={FIELD_NAMES.MAILING_ADDRESS}
+      analyticsSectionName="mailing-address"
+      deleteDisabled
+      addressConstants={addressConstants}/>
+  );
+}
+
+MailingAddress.propTypes = {
+  addressProps: PropTypes.shape({
+    states: PropTypes.array,
+    countries: PropTypes.array
+  })
+};

--- a/src/applications/personalization/profile360/vet360/components/MailingAddress.jsx
+++ b/src/applications/personalization/profile360/vet360/components/MailingAddress.jsx
@@ -19,8 +19,8 @@ export default function MailingAddress({ addressConstants }) {
 }
 
 MailingAddress.propTypes = {
-  addressProps: PropTypes.shape({
-    states: PropTypes.array,
-    countries: PropTypes.array
+  addressConstants: PropTypes.shape({
+    states: PropTypes.arrayOf(PropTypes.string),
+    countries: PropTypes.arrayOf(PropTypes.string)
   })
 };

--- a/src/applications/personalization/profile360/vet360/components/MailingAddress.jsx
+++ b/src/applications/personalization/profile360/vet360/components/MailingAddress.jsx
@@ -11,7 +11,6 @@ export default function MailingAddress() {
     <AddressSection
       title="Mailing address"
       fieldName={FIELD_NAMES.MAILING_ADDRESS}
-      analyticsSectionName="mailing-address"
       deleteDisabled/>
   );
 }

--- a/src/applications/personalization/profile360/vet360/components/MailingAddress.jsx
+++ b/src/applications/personalization/profile360/vet360/components/MailingAddress.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import AddressSection from '../../components/AddressSection';
 
@@ -7,20 +6,12 @@ import {
   FIELD_NAMES
 } from '../../constants/vet360';
 
-export default function MailingAddress({ addressConstants }) {
+export default function MailingAddress() {
   return (
     <AddressSection
       title="Mailing address"
       fieldName={FIELD_NAMES.MAILING_ADDRESS}
       analyticsSectionName="mailing-address"
-      deleteDisabled
-      addressConstants={addressConstants}/>
+      deleteDisabled/>
   );
 }
-
-MailingAddress.propTypes = {
-  addressConstants: PropTypes.shape({
-    states: PropTypes.arrayOf(PropTypes.string),
-    countries: PropTypes.arrayOf(PropTypes.string)
-  })
-};

--- a/src/applications/personalization/profile360/vet360/components/MobilePhone.jsx
+++ b/src/applications/personalization/profile360/vet360/components/MobilePhone.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import PhoneSection from '../../components/PhoneSection';
+
+import {
+  FIELD_NAMES
+} from '../../constants/vet360';
+
+export default function MobilePhone() {
+  return (
+    <PhoneSection
+      title="Mobile phone number"
+      fieldName={FIELD_NAMES.MOBILE_PHONE}
+      analyticsSectionName="mobile-telephone"/>
+  );
+}

--- a/src/applications/personalization/profile360/vet360/components/MobilePhone.jsx
+++ b/src/applications/personalization/profile360/vet360/components/MobilePhone.jsx
@@ -10,7 +10,6 @@ export default function MobilePhone() {
   return (
     <PhoneSection
       title="Mobile phone number"
-      fieldName={FIELD_NAMES.MOBILE_PHONE}
-      analyticsSectionName="mobile-telephone"/>
+      fieldName={FIELD_NAMES.MOBILE_PHONE}/>
   );
 }

--- a/src/applications/personalization/profile360/vet360/components/ResidentialAddress.jsx
+++ b/src/applications/personalization/profile360/vet360/components/ResidentialAddress.jsx
@@ -10,7 +10,6 @@ export default function ResidentialAddress() {
   return (
     <AddressSection
       title="Home address"
-      fieldName={FIELD_NAMES.RESIDENTIAL_ADDRESS}
-      analyticsSectionName="home-address"/>
+      fieldName={FIELD_NAMES.RESIDENTIAL_ADDRESS}/>
   );
 }

--- a/src/applications/personalization/profile360/vet360/components/ResidentialAddress.jsx
+++ b/src/applications/personalization/profile360/vet360/components/ResidentialAddress.jsx
@@ -18,8 +18,8 @@ export default function ResidentialAddress({ addressConstants }) {
 }
 
 ResidentialAddress.propTypes = {
-  addressProps: PropTypes.shape({
-    states: PropTypes.array,
-    countries: PropTypes.array
+  addressConstants: PropTypes.shape({
+    states: PropTypes.arrayOf(PropTypes.string),
+    countries: PropTypes.arrayOf(PropTypes.string)
   })
 };

--- a/src/applications/personalization/profile360/vet360/components/ResidentialAddress.jsx
+++ b/src/applications/personalization/profile360/vet360/components/ResidentialAddress.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import AddressSection from '../../components/AddressSection';
+
+import {
+  FIELD_NAMES
+} from '../../constants/vet360';
+
+export default function ResidentialAddress({ addressConstants }) {
+  return (
+    <AddressSection
+      title="Home address"
+      fieldName={FIELD_NAMES.RESIDENTIAL_ADDRESS}
+      analyticsSectionName="home-address"
+      addressConstants={addressConstants}/>
+  );
+}
+
+ResidentialAddress.propTypes = {
+  addressProps: PropTypes.shape({
+    states: PropTypes.array,
+    countries: PropTypes.array
+  })
+};

--- a/src/applications/personalization/profile360/vet360/components/ResidentialAddress.jsx
+++ b/src/applications/personalization/profile360/vet360/components/ResidentialAddress.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import AddressSection from '../../components/AddressSection';
 
@@ -7,19 +6,11 @@ import {
   FIELD_NAMES
 } from '../../constants/vet360';
 
-export default function ResidentialAddress({ addressConstants }) {
+export default function ResidentialAddress() {
   return (
     <AddressSection
       title="Home address"
       fieldName={FIELD_NAMES.RESIDENTIAL_ADDRESS}
-      analyticsSectionName="home-address"
-      addressConstants={addressConstants}/>
+      analyticsSectionName="home-address"/>
   );
 }
-
-ResidentialAddress.propTypes = {
-  addressConstants: PropTypes.shape({
-    states: PropTypes.arrayOf(PropTypes.string),
-    countries: PropTypes.arrayOf(PropTypes.string)
-  })
-};

--- a/src/applications/personalization/profile360/vet360/components/WorkPhone.jsx
+++ b/src/applications/personalization/profile360/vet360/components/WorkPhone.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import PhoneSection from '../../components/PhoneSection';
+
+import {
+  FIELD_NAMES
+} from '../../constants/vet360';
+
+export default function WorkPhone() {
+  return (
+    <PhoneSection
+      title="Work phone number"
+      fieldName={FIELD_NAMES.WORK_PHONE}
+      analyticsSectionName="work-telephone"/>
+  );
+}

--- a/src/applications/personalization/profile360/vet360/components/WorkPhone.jsx
+++ b/src/applications/personalization/profile360/vet360/components/WorkPhone.jsx
@@ -10,7 +10,6 @@ export default function WorkPhone() {
   return (
     <PhoneSection
       title="Work phone number"
-      fieldName={FIELD_NAMES.WORK_PHONE}
-      analyticsSectionName="work-telephone"/>
+      fieldName={FIELD_NAMES.WORK_PHONE}/>
   );
 }

--- a/src/applications/personalization/profile360/vet360/reducers/index.js
+++ b/src/applications/personalization/profile360/vet360/reducers/index.js
@@ -8,11 +8,11 @@ import {
   VET360_TRANSACTION_REQUEST_CLEARED,
   VET360_TRANSACTION_UPDATE_REQUESTED,
   VET360_TRANSACTION_UPDATE_FAILED
-} from '../actions';
+} from '../../actions';
 
 import {
   isFailedTransaction
-} from '../util/transactions';
+} from '../../util/transactions';
 
 const initialState = {
   transactions: [],

--- a/src/applications/personalization/profile360/vet360/reducers/index.js
+++ b/src/applications/personalization/profile360/vet360/reducers/index.js
@@ -1,4 +1,6 @@
 import {
+  UPDATE_PROFILE_FORM_FIELD,
+  OPEN_MODAL,
   VET360_TRANSACTIONS_FETCH_SUCCESS,
   VET360_TRANSACTION_REQUESTED,
   VET360_TRANSACTION_REQUEST_SUCCEEDED,
@@ -15,6 +17,8 @@ import {
 } from '../../util/transactions';
 
 const initialState = {
+  modal: null,
+  formFields: {},
   transactions: [],
   fieldTransactionMap: {},
   transactionsAwaitingUpdate: [],
@@ -66,6 +70,7 @@ export default function vet360(state = initialState, action) {
     case VET360_TRANSACTION_REQUEST_SUCCEEDED: {
       return {
         ...state,
+        modal: null,
         transactions: state.transactions.concat(action.transaction),
         fieldTransactionMap: {
           ...state.fieldTransactionMap,
@@ -146,6 +151,17 @@ export default function vet360(state = initialState, action) {
         fieldTransactionMap
       };
     }
+
+    case UPDATE_PROFILE_FORM_FIELD: {
+      const formFields = {
+        ...state.formFields,
+        [action.field]: action.newState
+      };
+      return { ...state, formFields };
+    }
+
+    case OPEN_MODAL:
+      return { ...state, modal: action.modal };
 
     default:
       return state;

--- a/src/applications/personalization/profile360/vet360/tests/reducers/index.unit.spec.js
+++ b/src/applications/personalization/profile360/vet360/tests/reducers/index.unit.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-import vet360 from '../../reducers/vet360';
-import * as VET360 from '../../constants/vet360';
+import vet360 from '../../reducers';
+import * as VET360 from '../../../constants/vet360';
 
 describe('vet360 reducer', () => {
   it('should return array of transaction data', () => {
@@ -76,6 +76,7 @@ describe('vet360 reducer', () => {
       }
     });
 
+    expect(state.modal, 'The modal was closed').to.be.null;
     expect(state.transactions.length).to.eql(1);
     expect(state.transactions[0].data.attributes.transactionId).to.eql(111);
     expect(state.fieldTransactionMap).to.eql({
@@ -214,4 +215,28 @@ describe('vet360 reducer', () => {
 
     expect(state.fieldTransactionMap.name).to.eql(undefined);
   });
+
+  it('should update profile form fields', () => {
+    const state = vet360({}, {
+      type: 'UPDATE_PROFILE_FORM_FIELD',
+      field: 'fieldName',
+      newState: {
+        fieldValue: 'value'
+      }
+    });
+
+    expect(state.formFields.fieldName).to.eql({
+      fieldValue: 'value'
+    });
+  });
+
+  it('should open modal', () => {
+    const state = vet360({}, {
+      type: 'OPEN_MODAL',
+      modal: 'modalName'
+    });
+
+    expect(state.modal).to.eql('modalName');
+  });
+
 });


### PR DESCRIPTION
Documentation describing to other engineers how to use our Vet360 components will come in a later PR so that they aren't exposed to all of this reorganization/cleanup.

##### Todo
- [x] Confirm portability
    -  I confirmed portability by disabling the index (`vaProfile`) reducer, then disabling the `Hero`, `PersonalInformtion`, and `MilitaryInformation` components. This ensured that the `ContactInformation` and its children components were only reliant on the `vet360` reducer.
- [x] Update tests. Specifically, the reducers

##### Changes
These are the changes necessary to make the Vet360 portion of the Profile portable into other applications.
- Actions
    - Removes all references to the `addressConstants`, and instead directly imports the constants in the `AddressEditModal`.
- Components
    - Creates a Vet360 component for each field, rather than passing configuration to each field-type component and implement them all in `ContactInformation`
    - Derives the `analyticsSectionName` properties in the container, rather than passing it as a prop
- Reducers
    - Moves the `modal`, `formFields` properties from the `vaProfile` reducer into `vet360`
    - Moves the `vet360.js` reducer to `profile360/vet360/reducers/index.js`

##### Relevant issues
department-of-veterans-affairs/vets.gov-team/issues/11649
department-of-veterans-affairs/vets.gov-team/issues/11641
department-of-veterans-affairs/vets.gov-team/issues/11650

Resolves department-of-veterans-affairs/vets.gov-team/issues/11646