### PR TITLE
Switch to using an aria-label directly on the button element.

### DIFF
--- a/content/includes/footer.html
+++ b/content/includes/footer.html
@@ -76,9 +76,8 @@ Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">E
 
       <h3>Get help from Veterans Crisis Line</h3>
 
-      <button class="va-modal-close va-overlay-close" type="button">
+      <button class="va-modal-close va-overlay-close" type="button" aria-label="Close this modal">
         <i class="fa fa-close va-overlay-close"></i>
-        <span class="usa-sr-only va-overlay-close">Close this modal</span>
       </button>
 
       <div class="va-overlay-body va-crisis-panel-body">

--- a/src/applications/claims-status/components/ConsolidatedClaims.jsx
+++ b/src/applications/claims-status/components/ConsolidatedClaims.jsx
@@ -8,9 +8,9 @@ export default function ConsolidatedClaims({ onClose }) {
       <button
         className="va-modal-close"
         type="button"
+        aria-label="Close this modal"
         onClick={onClose}>
         <i className="fa fa-close"></i>
-        <span className="usa-sr-only">Close this modal</span>
       </button>
       <div>
         If you turn in a new claim while we’re reviewing another one from you, we’ll add any new information to the original claim and close the new claim, with no action required from you.

--- a/src/applications/claims-status/components/MailOrFax.jsx
+++ b/src/applications/claims-status/components/MailOrFax.jsx
@@ -8,9 +8,9 @@ export default function MailOrFax({ onClose }) {
       <button
         className="va-modal-close"
         type="button"
+        aria-label="Close this modal"
         onClick={onClose}>
         <i className="fa fa-close"></i>
-        <span className="usa-sr-only">Close this modal</span>
       </button>
       <p>
         Please upload your documents online here to help us process your claim quickly.

--- a/src/applications/rx/components/ConfirmRefillModal.jsx
+++ b/src/applications/rx/components/ConfirmRefillModal.jsx
@@ -31,7 +31,13 @@ class ConfirmRefillModal extends React.Component {
       innerElement = (
         <form onSubmit={this.handleConfirmRefill}>
           <div className="rx-modal-refillinfo">
-            <button className="va-modal-close" type="button" onClick={this.handleCloseModal}><i className="fa fa-close"></i><span className="usa-sr-only">Close this modal</span></button>
+            <button
+              className="va-modal-close"
+              type="button"
+              aria-label="Close this modal"
+              onClick={this.handleCloseModal}>
+              <i className="fa fa-close"></i>
+            </button>
             <span className="rx-modal-drug">
               {prescription.prescriptionName}
             </span>

--- a/src/applications/rx/components/GlossaryModal.jsx
+++ b/src/applications/rx/components/GlossaryModal.jsx
@@ -21,7 +21,13 @@ class GlossaryModal extends React.Component {
       element = (
         <div>
           <GlossaryList terms={this.props.content}/>
-          <button className="va-modal-close" type="button" onClick={this.handleCloseModal}><i className="fa fa-close"></i><span className="usa-sr-only">Close this modal</span></button>
+          <button
+            className="va-modal-close"
+            type="button"
+            aria-label="Close this modal"
+            onClick={this.handleCloseModal}>
+            <i className="fa fa-close"></i>
+          </button>
           <Link
             to="/glossary"
             onClick={this.props.onCloseModal}>


### PR DESCRIPTION
This seems to be a more modern, standards-compliant way to add
screen reader hints and fixes department-of-veterans-affairs/vets.gov-team#11698