### PR TITLE
using facility classification for va_cemetery type to distinguish between national and state entries

### DIFF
--- a/src/applications/facility-locator/components/FacilityTypeDescription.jsx
+++ b/src/applications/facility-locator/components/FacilityTypeDescription.jsx
@@ -3,8 +3,7 @@ import { facilityTypes } from '../config';
 
 class FacilityTypeDescription extends Component {
   renderFacilityType() {
-    const { facility } = this.props;
-    const { facilityType, classification } = facility.attributes;
+    const { facilityType, classification } = this.props.facility.attributes;
 
     return (facilityType === 'va_cemetery' ? classification : facilityTypes[facilityType]);
   }

--- a/src/applications/facility-locator/components/FacilityTypeDescription.jsx
+++ b/src/applications/facility-locator/components/FacilityTypeDescription.jsx
@@ -1,0 +1,21 @@
+import React, { Component } from 'react';
+import { facilityTypes } from '../config';
+
+class FacilityTypeDescription extends Component {
+  renderFacilityType() {
+    const { facility } = this.props;
+    const { facilityType, classification } = facility.attributes;
+
+    return (facilityType === 'va_cemetery' ? classification : facilityTypes[facilityType]);
+  }
+
+  render() {
+    return (
+      <p>
+        <span><strong>Facility type:</strong> {this.renderFacilityType()}</span>
+      </p>
+    );
+  }
+}
+
+export default FacilityTypeDescription;

--- a/src/applications/facility-locator/components/search-results/FacilityInfoBlock.jsx
+++ b/src/applications/facility-locator/components/search-results/FacilityInfoBlock.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router';
 import FacilityAddress from './FacilityAddress';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { facilityTypes } from '../../config';
+import FacilityTypeDescription from '../FacilityTypeDescription';
 
 class FacilityInfoBlock extends Component {
   renderDistance() {
@@ -27,16 +27,14 @@ class FacilityInfoBlock extends Component {
 
   render() {
     const { facility } = this.props;
-    const { name, facilityType } = facility.attributes;
+    const { name } = facility.attributes;
 
     return (
       <div>
         <Link to={`facility/${facility.id}`}>
           <h5>{name}</h5>
         </Link>
-        <p>
-          <span><strong>Facility type:</strong> {facilityTypes[facilityType]}</span>
-        </p>
+        <FacilityTypeDescription facility={facility}/>
         <p>
           <FacilityAddress facility={facility}/>
         </p>

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -11,7 +11,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingI
 import React, { Component } from 'react';
 import ServicesAtFacility from '../components/ServicesAtFacility';
 import AppointmentInfo from '../components/AppointmentInfo';
-import { facilityTypes } from '../config';
+import FacilityTypeDescription from '../components/FacilityTypeDescription';
 
 class FacilityDetail extends Component {
   componentWillMount() {
@@ -38,15 +38,13 @@ class FacilityDetail extends Component {
 
   renderFacilityInfo() {
     const { facility } = this.props;
-    const { name, facilityType } = facility.attributes;
+    const { name } = facility.attributes;
 
     return (
       <div>
         <h1>{name}</h1>
         <div className="p1">
-          <p>
-            <span><strong>Facility type:</strong> {facilityTypes[facilityType]}</span>
-          </p>
+          <FacilityTypeDescription facility={facility}/>
           <FacilityAddress facility={facility}/>
         </div>
         <div>


### PR DESCRIPTION
Once we load state cemetery data we don't currently have a way to show any difference between state and national entries. This PR will change 'Cemetery' to either 'National Cemetery' or 'State Cemetery' by displaying the `classification` property when the facility type is va_cemetery.

Search results listing:
![screen shot 2018-07-30 at 11 11 32 am](https://user-images.githubusercontent.com/299180/43406373-12977302-93ea-11e8-9367-b2adbfc694a5.png)

Detail listing:
![screen shot 2018-07-30 at 11 11 44 am](https://user-images.githubusercontent.com/299180/43406387-1b9118e6-93ea-11e8-829c-251fe84c2e9b.png)
