### PR TITLE
526 landing page

### DIFF
--- a/content/components/navigation-sidebar.html
+++ b/content/components/navigation-sidebar.html
@@ -25,7 +25,7 @@ Used to display a side navigation bar of pages in a collection.
   {% endif %}
   <ul class="usa-sidenav-list">
     {% for page in relatedPages %}
-      {% unless relatedPages.metadata.name == page.display_title or relatedPages.metadata.name == page.title %}
+      {% unless relatedPages.metadata.name == page.display_title or relatedPages.metadata.name == page.title or page.hideFromSidebar %}
         <li>
           <a {% if page.path == path %}class="usa-current"{% endif %}
               href="/{{ page.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">
@@ -39,16 +39,18 @@ Used to display a side navigation bar of pages in a collection.
             {% assign childPages = collections | get: page.children %}
               <ul class="usa-sidenav-sub_list">
               {% for cpage in childPages %}
-                <li>
-                  <a {% if cpage.path == path %}class="usa-current"{% endif %}
-                      href="/{{ cpage.path }}" onClick="recordEvent({ event: 'nav-sidenav-child' });">
-                    {% if cpage.display_title != empty %}
-                      {{ cpage.display_title }}
-                    {% else %}
-                      {{ cpage.title }}
-                    {% endif %}
-                  </a>
-                </li>
+                {% unless cpage.hideFromSidebar %}
+                  <li>
+                    <a {% if cpage.path == path %}class="usa-current"{% endif %}
+                        href="/{{ cpage.path }}" onClick="recordEvent({ event: 'nav-sidenav-child' });">
+                      {% if cpage.display_title != empty %}
+                        {{ cpage.display_title }}
+                      {% else %}
+                        {{ cpage.title }}
+                      {% endif %}
+                    </a>
+                  </li>
+                {% endunless %}
               {% endfor %}
               </ul>
           {% endif %}

--- a/content/pages/disability-benefits/apply/form-526-disability-claim.md
+++ b/content/pages/disability-benefits/apply/form-526-disability-claim.md
@@ -2,7 +2,8 @@
 title: Apply for increased disability benefits
 entryname: 526EZ-claims-increase
 layout: page-react.html
-description: Learn how to apply online for increased disability compensation. 
+description: Learn how to apply online for increased disability compensation.
+hideFromSidebar: true
 ---
 <div id="main">
   <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"

--- a/content/pages/disability-benefits/increase-claims-testing.md
+++ b/content/pages/disability-benefits/increase-claims-testing.md
@@ -1,5 +1,5 @@
 ---
-title: Apply for Increased Disability Compensation
+title: Apply for Increased Disability Benefits
 layout: page-breadcrumbs.html
 description: Search me...
 template: detail-page

--- a/content/pages/disability-benefits/increase-claims-testing.md
+++ b/content/pages/disability-benefits/increase-claims-testing.md
@@ -1,5 +1,5 @@
 ---
-title: Disability Compensation Testing -- Increase Only
+title: Apply for Increased Disability Compensation
 layout: page-breadcrumbs.html
 description: Search me...
 template: detail-page

--- a/content/pages/disability-benefits/increase-claims-testing.md
+++ b/content/pages/disability-benefits/increase-claims-testing.md
@@ -1,0 +1,8 @@
+---
+title: Disability Compensation Testing -- Increase Only
+layout: page-breadcrumbs.html
+description: Search me...
+---
+<div id="main">
+  <p>Stuff goes here</p>
+</div>

--- a/content/pages/disability-benefits/increase-claims-testing.md
+++ b/content/pages/disability-benefits/increase-claims-testing.md
@@ -2,7 +2,18 @@
 title: Disability Compensation Testing -- Increase Only
 layout: page-breadcrumbs.html
 description: Search me...
+template: detail-page
 ---
 <div id="main">
-  <p>Stuff goes here</p>
+  <p>We're launching a new tool so you can file for increased disability compensation online.</p>
+  <div class="feature">
+    <strong>To use this tool, all of these must be true:</strong>
+    <ul>
+      <li>You've already filed a claim for disability benefits</li>
+      <li>You have a service-connected disability that's gotten worse</li>
+      <li>You're signed in to your premium My HealtheVet or DS Logon account. (If you don't have a verified account, you can create an ID.me account to complete the verification process.)</li>
+    </ul>
+  </div>
+  <p>If you meet the above requirements, and you’re interested in trying out our new tool, please give us your email address below. We’ll contact you to schedule a time to show you the tool and the process of filing a claim for increase online.</p>
+  <div id="react-emailForm"></div>
 </div>

--- a/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
+++ b/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
@@ -56,7 +56,7 @@ class EmailForm extends React.Component {
           isVisible
           headline="To use our new tool, you’ll need to sign in with your premium My HealtheVet or DS Logon account"
           content="If you don’t have a verified account, you can create an ID.me account to complete the verification process."
-          status="error"/>
+          status="info"/>
       );
     }
 
@@ -64,7 +64,7 @@ class EmailForm extends React.Component {
       return (
         <AlertBox
           isVisible
-          headline="We’re sorry. It looks like we’re missing some information needed for you to apply online for increased disability compensation"
+          headline="We’re sorry. It looks like we’re missing some information needed for you to apply online for increased disability compensation."
           content="For help, please call Veterans Benefits Assistance at 1-800-827-1000, Monday through Friday, 8:00 a.m. to 9:00 p.m. (ET)."
           status="error"/>
       );

--- a/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
+++ b/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
@@ -65,7 +65,7 @@ class EmailForm extends React.Component {
         <AlertBox
           isVisible
           headline="We’re sorry. It looks like we’re missing some information needed for you to apply online for increased disability compensation"
-          content="For help, please call Veterans Benefits Assistance at 1-800-827-1000, Monday – Friday, 8:00 a.m. to 9:00 p.m. (ET)."
+          content="For help, please call Veterans Benefits Assistance at 1-800-827-1000, Monday through Friday, 8:00 a.m. to 9:00 p.m. (ET)."
           status="error"/>
       );
     }
@@ -75,7 +75,7 @@ class EmailForm extends React.Component {
         <AlertBox
           isVisible
           headline="Thank you."
-          content="We added you to the list."
+          content="We received your email address. We'll contact you to schedule a time to try out the claim for increase tool."
           status="success"/>
       );
     }
@@ -84,8 +84,8 @@ class EmailForm extends React.Component {
       return (
         <AlertBox
           isVisible
-          headline="We’re sorry, the submission didn’t go through."
-          content="Please try again later."
+          headline="We’re sorry. We didn’t receive your email address."
+          content="We're working to fix the problem. Please try again later."
           status="error"/>
       );
     }
@@ -104,7 +104,7 @@ class EmailForm extends React.Component {
           id="submit-button"
           className="usa-input"
           onClick={this.submitEmail}>
-          Submit email
+          Submit Your Email
         </button>
       </form>
     );

--- a/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
+++ b/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
@@ -21,7 +21,7 @@ class EmailForm extends React.Component {
     this.setState({ email: event.target.value });
   }
 
-  submitEmail(event) {
+  submitEmail = (event) => {
     event.preventDefault();
 
     this.setState({ submissionStatus: requestStates.pending });

--- a/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
+++ b/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
@@ -75,7 +75,7 @@ class EmailForm extends React.Component {
         <AlertBox
           isVisible
           headline="Thank you."
-          content="We received your email address. We'll contact you to schedule a time to try out the claim for increase tool."
+          content="We received your email address. We’ll contact you to schedule a time to try out the claim for increase tool."
           status="success"/>
       );
     }

--- a/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
+++ b/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
@@ -26,9 +26,13 @@ class EmailForm extends React.Component {
 
     this.setState({ submissionStatus: requestStates.pending });
 
-    apiRequest('form526_opt_in',
+    /* apiRequest(`/form526_opt_in?email=${this.state.email}`, */
+    apiRequest('/form526_opt_in',
       {
         method: 'POST',
+        headers: {
+          'content-type': 'application/json'
+        },
         body: JSON.stringify({ email: this.state.email })
       },
       () => {

--- a/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
+++ b/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { connect } from 'react-redux';
+
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
+import { apiRequest } from '../../../../platform/utilities/api';
+import { requestStates } from '../../../../platform/utilities/constants';
+import backendServices from '../../../../platform/user/profile/constants/backendServices';
+
+class EmailForm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      submissionStatus: requestStates.notCalled,
+      email: ''
+    };
+  }
+
+  updateEmail = (event) => {
+    this.setState({ email: event.target.value });
+  }
+
+  submitEmail(event) {
+    event.preventDefault();
+
+    this.setState({ submissionStatus: requestStates.pending });
+
+    apiRequest('form526_opt_in',
+      {
+        method: 'POST',
+        body: JSON.stringify({ email: this.state.email })
+      },
+      () => {
+        this.setState({ submissionStatus: requestStates.succeeded });
+      },
+      () => {
+        this.setState({ submissionStatus: requestStates.failed });
+      });
+  }
+
+  render() {
+    const { loading, isLoggedIn, hasEVSSService } = this.props;
+    const { submissionStatus, email } = this.state;
+    if (loading) {
+      return null;
+    }
+
+    if (!isLoggedIn) {
+      return (
+        <AlertBox
+          isVisible
+          headline="To use our new tool, you’ll need to sign in with your premium My HealtheVet or DS Logon account"
+          content="If you don’t have a verified account, you can create an ID.me account to complete the verification process."
+          status="error"/>
+      );
+    }
+
+    if (!hasEVSSService) {
+      return (
+        <AlertBox
+          isVisible
+          headline="We’re sorry. It looks like we’re missing some information needed for you to apply online for increased disability compensation"
+          content="For help, please call Veterans Benefits Assistance at 1-800-827-1000, Monday – Friday, 8:00 a.m. to 9:00 p.m. (ET)."
+          status="error"/>
+      );
+    }
+
+    if (submissionStatus === requestStates.succeeded) {
+      return (
+        <AlertBox
+          isVisible
+          headline="Thank you."
+          content="We added you to the list."
+          status="success"/>
+      );
+    }
+
+    if (submissionStatus === requestStates.failed) {
+      return (
+        <AlertBox
+          isVisible
+          headline="We’re sorry, the submission didn’t go through."
+          content="Please try again later."
+          status="error"/>
+      );
+    }
+
+    const disabled = submissionStatus !== requestStates.notCalled;
+    return (
+      <form className="row">
+        <label htmlFor="email-address" aria-controls="email-address">Email address</label>
+        <input
+          id="email-address"
+          type="email"
+          value={email}
+          disabled={disabled}
+          onChange={this.updateEmail}/>
+        <button
+          id="submit-button"
+          className="usa-input"
+          onClick={this.submitEmail}>
+          Submit email
+        </button>
+      </form>
+    );
+  }
+}
+
+const mapStateToProps = (state) => ({
+  isLoggedIn: state.user.login.currentlyLoggedIn,
+  loading: state.user.profile.loading,
+  hasEVSSService: state.user.profile.services.includes(backendServices.EVSS_CLAIMS)
+});
+
+const ConnectedEmailForm = connect(mapStateToProps)(EmailForm);
+
+export default function createDisabilityIncreaseApplicationStatus(store) {
+  const root = document.getElementById('react-emailForm');
+  if (root) {
+    ReactDOM.render(
+      <ConnectedEmailForm store={store}/>,
+      root
+    );
+  }
+}

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -7,6 +7,7 @@ import createApplicationStatus from './createApplicationStatus';
 import createEducationApplicationStatus from '../edu-benefits/components/createEducationApplicationStatus';
 import createOptOutApplicationStatus from '../edu-benefits/components/createOptOutApplicationStatus';
 import createDisabilityIncreaseApplicationStatus from '../disability-benefits/526EZ/components/createDisabilityIncreaseApplicationStatus';
+import create526EmailForm from '../disability-benefits/526EZ/components/create526EmailForm';
 
 const pensionPages = new Set(['/pension/', '/pension/apply/', '/pension/eligibility/']);
 const healthcarePages = new Set(['/health-care/', '/health-care/apply/', '/health-care/eligibility/']);
@@ -62,4 +63,8 @@ if (burialPages.has(location.pathname)) {
 
 if (disabilityPages.has(location.pathname) && __BUILDTYPE__ !== 'production') {
   createDisabilityIncreaseApplicationStatus(store);
+}
+
+if (location.pathname === '/disability-benefits/increase-claims-testing/') {
+  create526EmailForm(store);
 }


### PR DESCRIPTION
# Scope
This is basically everything we need, but there are still some things we can do to improve upon it including:
- Adding `evss-claims` gating analytics (@djmunoz1 requested this)
- Adding validation

I also have a few content questions for Peggy.

# Screenshots

## Full page
![image](https://user-images.githubusercontent.com/12970166/43433996-b102cbe2-942e-11e8-855c-f70e2b86a8ca.png)

@peggygannon What should the title say?

## Not logged in
![image](https://user-images.githubusercontent.com/12970166/43434207-894f1cb2-942f-11e8-8d4f-ee4d73dccc7f.png)

This is where the rest of the alert boxes will show up.

## No `evss-claims` service
![image](https://user-images.githubusercontent.com/12970166/43434088-1429de9a-942f-11e8-88a7-8676b00a063d.png)

## Submission success
![image](https://user-images.githubusercontent.com/12970166/43434653-808122e0-9431-11e8-8dd2-222637206788.png)

@peggygannon @goldenmeanie What should this box say?

## Submission failure
![image](https://user-images.githubusercontent.com/12970166/43434103-21f99d62-942f-11e8-89f7-873d470d9f4d.png)
@peggygannon What should this box say? (They should be able to try again later.)