### PR TITLE
Hook up Opt Out to Google Analytics

### DIFF
--- a/src/applications/claims-status/reducers/appeals.js
+++ b/src/applications/claims-status/reducers/appeals.js
@@ -36,13 +36,13 @@ const initialState = {
 //   //     ]
 //   //   }
 //   // ];
-// 
+//
 //   return _.orderBy([appeal => {
 //     const dates = appeal.events.map(e => moment(e.date).unix());
 //     const latestDate = dates.reduce((latest, date) => {
 //       return date > latest ? date : latest;
 //     }, 0);
-// 
+//
 //     return latestDate;
 //   }], 'desc', list);
 // }
@@ -72,7 +72,7 @@ export default function appealsReducer(state = initialState, action) {
       return _.set('available', true, state);
     case SET_APPEALS_UNAVAILABLE: // Appeals v1
       return _.set('available', false, state);
-    // Following are reducers for Appeals v2 error states  
+    // Following are reducers for Appeals v2 error states
     // case USER_FORBIDDEN_ERROR:
     //   return _.merge(state, {
     //     appealsLoading: false,

--- a/src/applications/disability-benefits/526EZ/tests/config/documentUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/documentUpload.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester, // selectCheckbox 
+import { DefinitionTester, // selectCheckbox
 } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';

--- a/src/applications/disability-benefits/526EZ/tests/config/recordUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/recordUpload.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester, // selectCheckbox 
+import { DefinitionTester, // selectCheckbox
 } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';

--- a/src/applications/edu-benefits/0993/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/0993/containers/ConfirmationPage.jsx
@@ -20,7 +20,9 @@ const scrollToTop = () => {
 
 export class ConfirmationPage extends React.Component {
   componentDidMount() {
-    recordEvent({ event: 'edu-opt-out-submission-successful' });
+    if (this.props.form.submission.response) {
+      recordEvent({ event: 'edu-opt-out-submission-successful' });
+    }
     focusElement('.schemaform-title > h1');
     scrollToTop();
   }

--- a/src/applications/edu-benefits/0993/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/0993/containers/ConfirmationPage.jsx
@@ -5,6 +5,7 @@ import Scroll from 'react-scroll';
 
 import { focusElement } from '../../../../platform/utilities/ui';
 import AskVAQuestions from '../../../../platform/forms/components/AskVAQuestions';
+import recordEvent from '../../../../platform/monitoring/record-event';
 
 import GetFormHelp from '../../components/GetFormHelp';
 
@@ -19,6 +20,7 @@ const scrollToTop = () => {
 
 export class ConfirmationPage extends React.Component {
   componentDidMount() {
+    recordEvent({ event: 'edu-opt-out-submission-successful' });
     focusElement('.schemaform-title > h1');
     scrollToTop();
   }

--- a/src/applications/edu-benefits/0993/containers/FormPage.jsx
+++ b/src/applications/edu-benefits/0993/containers/FormPage.jsx
@@ -11,6 +11,7 @@ import SchemaForm from 'us-forms-system/lib/js/components/SchemaForm';
 import { setData, uploadFile } from 'us-forms-system/lib/js/actions';
 import { getNextPagePath } from 'us-forms-system/lib/js/routing';
 import { focusElement } from 'us-forms-system/lib/js/utilities/ui';
+import recordEvent from '../../../../platform/monitoring/record-event';
 
 function focusForm() {
   focusElement('.nav-header');
@@ -52,6 +53,8 @@ class FormPage extends React.Component {
   }
 
   onSubmit = ({ formData }) => {
+    // TODO: do the below only on final form submit
+    // recordEvent({ event: 'edu-navigation', 'edu-action': 'submit' });
     const { form, params, route, location } = this.props;
 
     // This makes sure defaulted data on a page with no changes is saved
@@ -67,6 +70,8 @@ class FormPage extends React.Component {
   }
 
   goBack = () => {
+    // TODO: also do the below when clicking BACK on the final form page
+    recordEvent({ event: 'edu-navigation', 'edu-action': 'back' });
     const formPageUrl = window.location.pathname;
     let introductionPageUrl = formPageUrl.split('/');
     introductionPageUrl.splice(-2);

--- a/src/applications/edu-benefits/0993/containers/FormPage.jsx
+++ b/src/applications/edu-benefits/0993/containers/FormPage.jsx
@@ -53,8 +53,9 @@ class FormPage extends React.Component {
   }
 
   onSubmit = ({ formData }) => {
-    // TODO: do the below only on final form submit
+    // TODO: do the below on final form submit
     // recordEvent({ event: 'edu-navigation', 'edu-action': 'submit' });
+    recordEvent({ event: 'edu-navigation', 'edu-action': 'continue' });
     const { form, params, route, location } = this.props;
 
     // This makes sure defaulted data on a page with no changes is saved

--- a/src/applications/edu-benefits/components/OptOutWizard.jsx
+++ b/src/applications/edu-benefits/components/OptOutWizard.jsx
@@ -1,17 +1,25 @@
 import React from 'react';
 import Modal from '@department-of-veterans-affairs/formation/Modal';
 
+import recordEvent from '../../../platform/monitoring/record-event';
+
 export default class OptOutWizard extends React.Component {
   constructor(props) {
     super(props);
     this.state = { modalOpen: false };
   }
 
+  confirmOptOut = () => {
+    recordEvent({ event: 'edu-navigation', 'edu-action': 'confirm' });
+  }
+
   closeModal = () => {
+    recordEvent({ event: 'edu-navigation', 'edu-action': 'cancel' });
     this.setState({ modalOpen: false });
   }
 
   openModal = () => {
+    recordEvent({ event: 'edu-navigation', 'edu-action': 'opt-out-button' });
     this.setState({ modalOpen: true });
   }
 
@@ -41,6 +49,7 @@ export default class OptOutWizard extends React.Component {
           <p><strong>Please note:</strong> If you opt out and then change your mind, you’ll need to call the Education Call Center at <a className="help-phone-number-link" href="tel:+1-888-442-4551">1-888-442-4551</a> to opt back in.</p>
           <div>
             <a
+              onClick={this.confirmOptOut}
               href="/education/opt-out-information-sharing/opt-out-form-0993"
               className="usa-button-primary">
               Yes, I Want to Opt Out

--- a/src/applications/edu-benefits/tests/0993/containers/FormPage.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/0993/containers/FormPage.unit.spec.jsx
@@ -140,7 +140,8 @@ describe('Schemaform <FormPage>', () => {
       location: {
         pathname: '/benefit/static/form/page',
         replace: sinon.spy()
-      }
+      },
+      dataLayer: []
     };
     const route = {
       pageConfig: {
@@ -196,6 +197,8 @@ describe('Schemaform <FormPage>', () => {
 
     tree.getMountedInstance().goBack();
 
+    expect(window.dataLayer.length).to.equal(1);
+    expect(window.dataLayer.pop()).to.eql({ event: 'edu-navigation', 'edu-action': 'back' });
     expect(global.window.location.replace.calledWith('/benefit/static'));
     global.window = oldWindow;
   });

--- a/src/platform/site-wide/legacy/menu.js
+++ b/src/platform/site-wide/legacy/menu.js
@@ -1,5 +1,5 @@
 /*
- * Creates trigger function that opens/closes mobile menu, 
+ * Creates trigger function that opens/closes mobile menu,
  * mobile search menu, and the Veterans Crisis Line.
  */
 
@@ -10,12 +10,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const overlayTarget = domEvent.currentTarget; // The overlay to open or close
     const clickTarget = domEvent.target; // The element clicked
 
-    /* 
-    overlayId will be _either_    
+    /*
+    overlayId will be _either_
     - The value of element.getAttribute('href')
     - The value of element.dataset.show
-    
-    A .va-overlay-trigger element should have either a data-show attribute 
+
+    A .va-overlay-trigger element should have either a data-show attribute
     (preferred) or an href attribute.
     */
     const overlayId = overlayTarget.getAttribute('href') || overlayTarget.dataset.show;

--- a/src/platform/startup/index.js
+++ b/src/platform/startup/index.js
@@ -17,7 +17,7 @@ import startReactApp from './react';
  * components (like the header menus and login widget), and wraps the provided
  * routes in the Redux and React Router boilerplate common to most applications.
  *
- * @param {object} appInfo The UI and business logic of your React application 
+ * @param {object} appInfo The UI and business logic of your React application
  * @param {Route|array<Route>} appInfo.routes The routes for the application
  * @param {ReactElement} appInfo.component A React element to render. Only used if routes
  * is not passed

--- a/src/platform/testing/unit/schemaform-utils.jsx
+++ b/src/platform/testing/unit/schemaform-utils.jsx
@@ -1,4 +1,4 @@
-/** 
+/**
  * Utilities for testing forms built with our schema based form library
  */
 
@@ -41,7 +41,7 @@ function getDefaultData(schema) {
  * to render as a pagePerItem page
  * @property {number} pagePerItemIndex When simulating a page per item form page,
  * this is the index for the item to render.
- * @property {boolean} reviewMode Renders the form in review mode if true 
+ * @property {boolean} reviewMode Renders the form in review mode if true
  * @property {function} onSubmit Will be called if a form is submitted
  * @property {function} onFileUpload Will be called if a file upload is triggered
  */
@@ -305,7 +305,7 @@ export function selectRadio(form, fieldName, value) {
  * given date string.
  *
  * @param {Enzyme} form The enzyme object that contains a form
- * @param {string} partialId The id for the date field, without the month/day/year prefix 
+ * @param {string} partialId The id for the date field, without the month/day/year prefix
  * @param {string} dateString The date to fill in the input
  */
 export function fillDate(form, partialId, dateString) {


### PR DESCRIPTION
- [x] Click on opt-out on /education/opt-out-information-sharing/ | When user clicks, fire this event: `dataLayer.push({event: 'edu-navigation', 'edu-action': 'opt-out-button'})`
- [ ] "Are You Sure You Want to Opt-Out?" modal appears | When modal appears, fire this event - `dataLayer.push({event: 'edu-opt-out-modal'})`
- [x] Click on "Yes I want to Opt Out" | When user clicks, fire this event: `dataLayer.push({event: 'edu-navigation', 'edu-action': 'confirm'})`
- [x] Click on Cancel in Modal | `dataLayer.push({event: 'edu-navigation', 'edu-action': 'cancel'})`
- [x] On confirmation page for successful submission | Push event: `dataLayer.push({event: 'edu-opt-out-submission-successful'})`

This one fires on page one of the form but needs to fire on page two:
- [ ] Click on Back on /education/opt-out-information-sharing/opt-out-form-0993/claimant-information | `dataLayer.push({event: 'edu-navigation', 'edu-action': 'back'})`

Need to figure out a good way to pass additional actions to the buttons on the final page of multi-page forms:
- [ ] Click on Submit on /education/opt-out-information-sharing/opt-out-form-0993/claimant-information | `dataLayer.push({event: 'edu-navigation', 'edu-action': 'submit'})`

@nedierecel confirmed that it would be nice to add GA integration with other forms so we should figure out a proper way to wire up the actions to the buttons on a form's final page.