### PR TITLE
Standardize the application-loading indicator

### DIFF
--- a/content/layouts/page-react.html
+++ b/content/layouts/page-react.html
@@ -4,8 +4,10 @@
   {% include "content/includes/breadcrumbs.html" %}
 {% endif %}
 
+{% if !loadingMessage %} {% assign loadingMessage = 'Please wait while we load the application for you.' %} {% endif %}
+
 <div id="content">
-<div class="main" role="main">
+<div id="main" class="main" role="main">
   {% if in_maintenance == true %}
     <div class="row">
         <div class="small-12 columns">
@@ -17,8 +19,15 @@
         </div>
       </div>
   {% else %}
+    {{ contents }}
     <div class="section">
-      {{ contents }}
+      <div id="react-root">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="{{ loadingMessage }}" tabIndex="0">
+          </div>
+          {{ loadingMessage }}
+        </div>
+      </div>
     </div>
   {% endif %}
 </div>

--- a/content/pages/account/index.md
+++ b/content/pages/account/index.md
@@ -3,21 +3,9 @@ title: Your Vets.gov Account
 layout: page-react.html
 entryname: account
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">Home</a></li>
-      <li><a aria-current="page" href="/account/">Your Account Settings</a></li>
-    </ul>
-  </nav>
-
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
-      </div>
-    </div>
-  </div>
-  <!-- Account Beta End -->
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">Home</a></li>
+    <li><a aria-current="page" href="/account/">Your Account Settings</a></li>
+  </ul>
+</nav>

--- a/content/pages/auth/login/callback/index.md
+++ b/content/pages/auth/login/callback/index.md
@@ -2,16 +2,5 @@
 title: Auth
 layout: page-react.html
 entryname: auth
+loadingMessage: Please wait while we log you in.
 ---
-
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="lease wait while we log you in." tabIndex="0"></div> Please wait while we log you in.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>

--- a/content/pages/burials-and-memorials/application/530.md
+++ b/content/pages/burials-and-memorials/application/530.md
@@ -3,24 +3,12 @@ title: Apply for burial benefits
 entryname: burials
 layout: page-react.html
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a href="/burials-and-memorials/"> Burials and Memorials </a></li>
-      <li><a href="/burials-and-memorials/survivor-and-dependent-benefits/"> Survivors and Dependents </a></li>
-      <li><a aria-current="page" href="/burials-and-memorials/survivor-and-dependent-benefits/burial-costs/">Handling Burial Costs (Allowances)</a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/burials-and-memorials/"> Burials and Memorials </a></li>
+    <li><a href="/burials-and-memorials/survivor-and-dependent-benefits/"> Survivors and Dependents </a></li>
+    <li><a aria-current="page" href="/burials-and-memorials/survivor-and-dependent-benefits/burial-costs/">Handling Burial Costs (Allowances)</a></li>
+  </ul>
+</nav>

--- a/content/pages/burials-and-memorials/pre-need/form-10007-apply-for-eligibility.md
+++ b/content/pages/burials-and-memorials/pre-need/form-10007-apply-for-eligibility.md
@@ -3,23 +3,11 @@ title: Apply online for pre-need determination of eligibility in a VA National C
 entryname: pre-need
 layout: page-react.html
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a href="/burials-and-memorials/">Burials and Memorials</a></li>
-      <li><a aria-current="page" href="/burials-and-memorials/pre-need/">Pre-need Eligibility Determination</a></li>
-    </ul>
-  </nav>
-
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/burials-and-memorials/">Burials and Memorials</a></li>
+    <li><a aria-current="page" href="/burials-and-memorials/pre-need/">Pre-need Eligibility Determination</a></li>
+  </ul>
+</nav>

--- a/content/pages/dashboard/index.md
+++ b/content/pages/dashboard/index.md
@@ -3,21 +3,8 @@ title: Your Vets.gov Dashboard
 layout: page-react.html
 entryname: dashboard
 ---
-<div id="main">
-  <nav class="va-nav-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" role="menubar" aria-label="Primary">
-      <li></li>
-    </ul>
-  </nav>
-
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Dashboard Application End -->
-</div>
+<nav class="va-nav-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" role="menubar" aria-label="Primary">
+    <li></li>
+  </ul>
+</nav>

--- a/content/pages/disability-benefits/apply/dependents/form-686c-dependents.md
+++ b/content/pages/disability-benefits/apply/dependents/form-686c-dependents.md
@@ -3,22 +3,10 @@ title: Declaration of status of dependents
 entryname: 686-dependent-status
 layout: page-react.html
 ---
-<div id="main">
-  <nav class="va-nav-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" role="menubar" aria-label="Primary">
-      <li><a href="/">Home</a></li>
-      <li><a href="/disability-benefits/"> Disability Benefits </a></li>
-      <li><a href="/disability-benefits/apply/dependents/form-686c-dependents/"> Declaration of Dependents </a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <h1>Working</h1>
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+<nav class="va-nav-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" role="menubar" aria-label="Primary">
+    <li><a href="/">Home</a></li>
+    <li><a href="/disability-benefits/"> Disability Benefits </a></li>
+    <li><a href="/disability-benefits/apply/dependents/form-686c-dependents/"> Declaration of Dependents </a></li>
+  </ul>
+</nav>

--- a/content/pages/disability-benefits/apply/form-526-disability-claim.md
+++ b/content/pages/disability-benefits/apply/form-526-disability-claim.md
@@ -2,42 +2,13 @@
 title: Apply for increased disability benefits
 entryname: 526EZ-claims-increase
 layout: page-react.html
-description: Learn how to apply online for increased disability compensation. 
+description: Learn how to apply online for increased disability compensation.
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a href="/disability-benefits/">Disability Benefits</a></li>
-      <li><a aria-current="page" href="/disability-benefits/apply/form-526-disability-claim/">Apply for Increase</a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Disability Benefits Application End -->
-
-  <!-- Maintenance Page Start -->
-
-  <!-- <div class="main home" role="main">
-    <div class="section main-menu">
-      <div class="row">
-        <div class="small-12 columns">
-          <div class="csp-inline-patch-application">
-          <h3>We’re sorry. The disability benefits application is down right now while we fix a few things. We’ll be back up as soon as we can.</h3>
-          <h4>In the meantime, you can call 1-877-222-VETS (<a href="tel:+18772228387">1-877-222-8387</a>), Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">ET</abbr>) and press 2 to complete this application over the phone.</h4>
-          <a href="/"><button>Go back to Vets.gov</button></a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>-->
-  <!-- Maintenance Page End -->
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/disability-benefits/">Disability Benefits</a></li>
+    <li><a aria-current="page" href="/disability-benefits/apply/form-526-disability-claim/">Apply for Increase</a></li>
+  </ul>
+</nav>

--- a/content/pages/disability-benefits/track-claims/index.md
+++ b/content/pages/disability-benefits/track-claims/index.md
@@ -9,15 +9,3 @@ collection: [disability, disabilityBeta]
 order: 5
 includeBreadcrumbs: true
 ---
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <h1>Working</h1>
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>

--- a/content/pages/discharge-upgrade-instructions/index.md
+++ b/content/pages/discharge-upgrade-instructions/index.md
@@ -5,14 +5,3 @@ display_title: How to Apply for a Discharge Upgrade
 description: Get step-by-step instructions on how to apply for a military discharge upgrade or correction. If your discharge is upgraded, you'll be eligible for VA benefits you earned while serving.
 entryname: discharge-upgrade-instructions
 ---
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>

--- a/content/pages/download-va-letters/letters.md
+++ b/content/pages/download-va-letters/letters.md
@@ -7,17 +7,3 @@ in_maintenance: false
 maintenance_line1: We’re sorry. The page you’re looking for is currently down while we fix a few things. We’ll get it back online as soon as we can.
 maintenance_line2: In the meantime, please try the search box above or one of the options listed below to find more information.
 ---
-<div id="main">
-  <!-- VA Letters Application Begin -->
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- VA Letters Application End -->
-</div>
-

--- a/content/pages/education/apply-for-education-benefits/application/1990.md
+++ b/content/pages/education/apply-for-education-benefits/application/1990.md
@@ -4,40 +4,11 @@ entryname: 1990-edu-benefits
 layout: page-react.html
 description: Use your VA education benefits to pay for college or training programs. Find out which documents you’ll need to apply for benefits, and start your online application today.
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a href="/education/">Education</a></li>
-      <li><a aria-current="page" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Edu Benefits Application End -->
-
-  <!-- Maintenance Page Start -->
-
-  <!-- <div class="main home" role="main">
-    <div class="section main-menu">
-      <div class="row">
-        <div class="small-12 columns">
-          <div class="csp-inline-patch-application">
-          <h3>We’re sorry. The education benefits application is currently down while we fix a few things. We’ll be back up as soon as we can.</h3>
-          <h4>In the meantime, you can call 1-877-222-VETS (<a href="tel:+18772228387">1-877-222-8387</a>), Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">ET</abbr>) and press 2 to complete this application over the phone.</h4>
-          <a href="/"><button>Go back to Vets.gov</button></a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>-->
-  <!-- Maintenance Page End -->
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/education/">Education</a></li>
+    <li><a aria-current="page" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a></li>
+  </ul>
+</nav>

--- a/content/pages/education/apply-for-education-benefits/application/1990E.md
+++ b/content/pages/education/apply-for-education-benefits/application/1990E.md
@@ -4,40 +4,11 @@ entryname: 1990e-edu-benefits
 layout: page-react.html
 description: Use your VA education benefits to pay for college or training programs. Find out which documents you’ll need to apply for benefits, and start your online application today.
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a href="/education/">Education</a></li>
-      <li><a aria-current="page" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Edu Benefits Application End -->
-
-  <!-- Maintenance Page Start -->
-
-  <!-- <div class="main home" role="main">
-    <div class="section main-menu">
-      <div class="row">
-        <div class="small-12 columns">
-          <div class="csp-inline-patch-application">
-          <h3>We’re sorry. The education benefits application is currently down while we fix a few things. We’ll be back up as soon as we can.</h3>
-          <h4>In the meantime, you can call 1-877-222-VETS (<a href="tel:+18772228387">1-877-222-8387</a>), Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">ET</abbr>) and press 2 to complete this application over the phone.</h4>
-          <a href="/"><button>Go back to Vets.gov</button></a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>-->
-  <!-- Maintenance Page End -->
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/education/">Education</a></li>
+    <li><a aria-current="page" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a></li>
+  </ul>
+</nav>

--- a/content/pages/education/apply-for-education-benefits/application/1990N.md
+++ b/content/pages/education/apply-for-education-benefits/application/1990N.md
@@ -4,40 +4,11 @@ entryname: 1990n-edu-benefits
 layout: page-react.html
 description: Use your VA education benefits to pay for college or training programs. Find out which documents you’ll need to apply for benefits, and start your online application today.
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a href="/education/">Education</a></li>
-      <li><a aria-current="page" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Edu Benefits Application End -->
-
-  <!-- Maintenance Page Start -->
-
-  <!-- <div class="main home" role="main">
-    <div class="section main-menu">
-      <div class="row">
-        <div class="small-12 columns">
-          <div class="csp-inline-patch-application">
-          <h3>We’re sorry. The education benefits application is currently down while we fix a few things. We’ll be back up as soon as we can.</h3>
-          <h4>In the meantime, you can call 1-877-222-VETS (<a href="tel:+18772228387">1-877-222-8387</a>), Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">ET</abbr>) and press 2 to complete this application over the phone.</h4>
-          <a href="/"><button>Go back to Vets.gov</button></a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>-->
-  <!-- Maintenance Page End -->
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/education/">Education</a></li>
+    <li><a aria-current="page" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a></li>
+  </ul>
+</nav>

--- a/content/pages/education/apply-for-education-benefits/application/1995.md
+++ b/content/pages/education/apply-for-education-benefits/application/1995.md
@@ -4,40 +4,11 @@ entryname: 1995-edu-benefits
 layout: page-react.html
 description: Use your VA education benefits to pay for college or training programs. Find out which documents you’ll need to apply for benefits, and start your online application today.
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a href="/education/">Education</a></li>
-      <li><a aria-current="page" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Edu Benefits Application End -->
-
-  <!-- Maintenance Page Start -->
-
-  <!-- <div class="main home" role="main">
-    <div class="section main-menu">
-      <div class="row">
-        <div class="small-12 columns">
-          <div class="csp-inline-patch-application">
-          <h3>We’re sorry. The education benefits application is currently down while we fix a few things. We’ll be back up as soon as we can.</h3>
-          <h4>In the meantime, you can call 1-877-222-VETS (<a href="tel:+18772228387">1-877-222-8387</a>), Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">ET</abbr>) and press 2 to complete this application over the phone.</h4>
-          <a href="/"><button>Go back to Vets.gov</button></a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>-->
-  <!-- Maintenance Page End -->
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/education/">Education</a></li>
+    <li><a aria-current="page" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a></li>
+  </ul>
+</nav>

--- a/content/pages/education/apply-for-education-benefits/application/5490.md
+++ b/content/pages/education/apply-for-education-benefits/application/5490.md
@@ -4,40 +4,11 @@ entryname: 5490-edu-benefits
 layout: page-react.html
 description: Use your VA education benefits to pay for college or training programs. Find out which documents you’ll need to apply for benefits, and start your online application today.
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a href="/education/">Education</a></li>
-      <li><a aria-current="page" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Edu Benefits Application End -->
-
-  <!-- Maintenance Page Start -->
-
-  <!-- <div class="main home" role="main">
-    <div class="section main-menu">
-      <div class="row">
-        <div class="small-12 columns">
-          <div class="csp-inline-patch-application">
-          <h3>We’re sorry. The education benefits application is currently down while we fix a few things. We’ll be back up as soon as we can.</h3>
-          <h4>In the meantime, you can call 1-877-222-VETS (<a href="tel:+18772228387">1-877-222-8387</a>), Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">ET</abbr>) and press 2 to complete this application over the phone.</h4>
-          <a href="/"><button>Go back to Vets.gov</button></a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>-->
-  <!-- Maintenance Page End -->
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/education/">Education</a></li>
+    <li><a aria-current="page" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a></li>
+  </ul>
+</nav>

--- a/content/pages/education/apply-for-education-benefits/application/5495.md
+++ b/content/pages/education/apply-for-education-benefits/application/5495.md
@@ -4,40 +4,11 @@ entryname: 5495-edu-benefits
 layout: page-react.html
 description: Use your VA education benefits to pay for college or training programs. Find out which documents you’ll need to apply for benefits, and start your online application today.
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a href="/education/">Education</a></li>
-      <li><a aria-current="page" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Edu Benefits Application End -->
-
-  <!-- Maintenance Page Start -->
-
-  <!-- <div class="main home" role="main">
-    <div class="section main-menu">
-      <div class="row">
-        <div class="small-12 columns">
-          <div class="csp-inline-patch-application">
-          <h3>We’re sorry. The education benefits application is currently down while we fix a few things. We’ll be back up as soon as we can.</h3>
-          <h4>In the meantime, you can call 1-877-222-VETS (<a href="tel:+18772228387">1-877-222-8387</a>), Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">ET</abbr>) and press 2 to complete this application over the phone.</h4>
-          <a href="/"><button>Go back to Vets.gov</button></a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>-->
-  <!-- Maintenance Page End -->
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/education/">Education</a></li>
+    <li><a aria-current="page" href="/education/apply-for-education-benefits/">Apply for Education Benefits</a></li>
+  </ul>
+</nav>

--- a/content/pages/education/complaint-tool/form.md
+++ b/content/pages/education/complaint-tool/form.md
@@ -4,22 +4,11 @@ entryname: complaint-tool
 layout: page-react.html
 description: Use your VA education benefits to pay for college or training programs. Find out which documents you’ll need to apply for benefits, and start your online application today.
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a href="/education/">Education</a></li>
-      <li><a aria-current="page" href="/education/complaint-tool/">GI Bill® School Feedback Tool</a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <h1>Working</h1>
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/education/">Education</a></li>
+    <li><a aria-current="page" href="/education/complaint-tool/">GI Bill® School Feedback Tool</a></li>
+  </ul>
+</nav>

--- a/content/pages/education/gi-bill/post-9-11/ch-33-benefit.md
+++ b/content/pages/education/gi-bill/post-9-11/ch-33-benefit.md
@@ -6,14 +6,3 @@ includeBreadcrumbs: true
 in_maintenance: false
 maintenance_line1: We’re sorry. Our system is temporarily down while we fix a few things. Please try again later.
 ---
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>

--- a/content/pages/education/opt-out-information-sharing/opt-out-form-0993.md
+++ b/content/pages/education/opt-out-information-sharing/opt-out-form-0993.md
@@ -4,22 +4,11 @@ entryname: 0993-edu-benefits
 layout: page-react.html
 description: Use your VA education benefits to pay for college or training programs. Find out which documents you’ll need to apply for benefits, and start your online application today.
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a href="/education/">Education</a></li>
-      <li><a aria-current="page" href="/education/opt-out-information-sharing/opt-out-form-0993">Opt out of sharing your information with schools</a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <h1>Working</h1>
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/education/">Education</a></li>
+    <li><a aria-current="page" href="/education/opt-out-information-sharing/opt-out-form-0993">Opt out of sharing your information with schools</a></li>
+  </ul>
+</nav>

--- a/content/pages/employment/vocational-rehab-and-employment/application/chapter31.md
+++ b/content/pages/employment/vocational-rehab-and-employment/application/chapter31.md
@@ -3,22 +3,10 @@ title: Apply for vocational rehabilitation
 entryname: chapter31-vre
 layout: page-react.html
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a aria-current="page" href="/employment/vocational-rehab-and-employment/">Vocational Rehabilitation and Employment (VR&E)</a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <h1>Working</h1>
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a aria-current="page" href="/employment/vocational-rehab-and-employment/">Vocational Rehabilitation and Employment (VR&E)</a></li>
+  </ul>
+</nav>

--- a/content/pages/employment/vocational-rehab-and-employment/application/chapter36.md
+++ b/content/pages/employment/vocational-rehab-and-employment/application/chapter36.md
@@ -3,22 +3,10 @@ title: Apply for vocational counseling
 entryname: chapter36-vre
 layout: page-react.html
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a aria-current="page" href="/employment/vocational-rehab-and-employment/">Vocational Rehabilitation and Employment (VR&E)</a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <h1>Working</h1>
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a aria-current="page" href="/employment/vocational-rehab-and-employment/">Vocational Rehabilitation and Employment (VR&E)</a></li>
+  </ul>
+</nav>

--- a/content/pages/facilities/index.md
+++ b/content/pages/facilities/index.md
@@ -3,14 +3,4 @@ title: Facility Locator
 layout: page-react.html
 entryname: facilities
 ---
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+

--- a/content/pages/gi-bill-comparison-tool/index.md
+++ b/content/pages/gi-bill-comparison-tool/index.md
@@ -7,14 +7,4 @@ entryname: gi
 collection: education
 order: 4
 ---
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+

--- a/content/pages/health-beta/index.md
+++ b/content/pages/health-beta/index.md
@@ -4,21 +4,8 @@ layout: page-react.html
 entryname: health-beta
 private: true
 ---
-<div id="main">
-  <nav class="va-nav-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
-      <li><a href="/">Home</a></li>
-    </ul>
-  </nav>
-
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- ID Card Beta End -->
-</div>
+<nav class="va-nav-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
+    <li><a href="/">Home</a></li>
+  </ul>
+</nav>

--- a/content/pages/health-care/apply/application.md
+++ b/content/pages/health-care/apply/application.md
@@ -8,25 +8,11 @@ in_maintenance: false
 maintenance_line1: We’re sorry. The health care application is currently down while we fix a few things. We’ll be back up as soon as we can.
 maintenance_line2: In the meantime, you can call 1-877-222-VETS (<a href="tel:+18772228387">1-877-222-8387</a>), Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">ET</abbr>) and press 2 to complete this application over the phone.
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a href="/health-care/">Health Care</a></li>
-      <li><a aria-current="page" href="/health-care/apply/">Apply for VA Health Care</a></li>
-    </ul>
-  </nav>
-
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- HCA Application End -->
-</div>
-
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/health-care/">Health Care</a></li>
+    <li><a aria-current="page" href="/health-care/apply/">Apply for VA Health Care</a></li>
+  </ul>
+</nav>

--- a/content/pages/health-care/health-records/index.md
+++ b/content/pages/health-care/health-records/index.md
@@ -5,15 +5,3 @@ entryname: health-records
 collection: healthCare
 order: 9
 ---
-
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>

--- a/content/pages/health-care/medical-information-terms-conditions.md
+++ b/content/pages/health-care/medical-information-terms-conditions.md
@@ -5,15 +5,4 @@ entryname: terms-and-conditions
 includeBreadcrumbs: true
 ---
 
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
 

--- a/content/pages/health-care/messaging/index.md
+++ b/content/pages/health-care/messaging/index.md
@@ -7,15 +7,3 @@ collection: healthCare
 order: 7
 includeBreadcrumbs: true
 ---
-
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>

--- a/content/pages/health-care/prescriptions/index.md
+++ b/content/pages/health-care/prescriptions/index.md
@@ -5,15 +5,3 @@ entryname: rx
 collection: healthCare
 order: 6
 ---
-
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>

--- a/content/pages/id-card-beta/index.md
+++ b/content/pages/id-card-beta/index.md
@@ -3,20 +3,8 @@ title: Your Vets.gov Account
 layout: page-react.html
 entryname: id-card-beta
 ---
-<div id="main">
-  <nav class="va-nav-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
-      <li><a href="/">Home</a></li>
-    </ul>
-  </nav>
-
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
-      </div>
-    </div>
-  </div>
-  <!-- ID Card Beta End -->
-</div>
+<nav class="va-nav-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
+    <li><a href="/">Home</a></li>
+  </ul>
+</nav>

--- a/content/pages/pension/application/527EZ.md
+++ b/content/pages/pension/application/527EZ.md
@@ -3,23 +3,11 @@ title: Apply for pension benefits
 entryname: pensions
 layout: page-react.html
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a href="/pension/">Pension Benefits</a></li>
-      <li><a aria-current="page" href="/pension/apply/">Apply for Veterans Pension</a></li>
-    </ul>
-  </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <h1>Working</h1>
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a href="/pension/">Pension Benefits</a></li>
+    <li><a aria-current="page" href="/pension/apply/">Apply for Veterans Pension</a></li>
+  </ul>
+</nav>

--- a/content/pages/profile/index.md
+++ b/content/pages/profile/index.md
@@ -3,21 +3,9 @@ title: Your Profile
 layout: page-react.html
 entryname: profile-360
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">Home</a></li>
-      <li><a aria-current="page" href="/profile/">Your Profile</a></li>
-    </ul>
-  </nav>
-
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <h3>Please wait while we load the application for you.</h3>
-        <img src="/img/preloader-primary-darkest.gif" alt="Loading">
-      </div>
-    </div>
-  </div>
-  <!-- Profile Beta End -->
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">Home</a></li>
+    <li><a aria-current="page" href="/profile/">Your Profile</a></li>
+  </ul>
+</nav>

--- a/content/pages/signin.md
+++ b/content/pages/signin.md
@@ -4,15 +4,3 @@ entryname: signin
 layout: page-react.html
 noHeader: true
 ---
-
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>

--- a/content/pages/track-claims/index.md
+++ b/content/pages/track-claims/index.md
@@ -4,15 +4,3 @@ entryname: claims-status
 layout: page-react.html
 description: Log in to your Vets.gov account to track the status of your VA claims and appeals.
 ---
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <h1>Working</h1>
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>

--- a/content/pages/verify.md
+++ b/content/pages/verify.md
@@ -3,15 +3,3 @@ title: Verify
 entryname: verify
 layout: page-react.html
 ---
-
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>

--- a/content/pages/veteran-id-card/apply.md
+++ b/content/pages/veteran-id-card/apply.md
@@ -3,23 +3,10 @@ title: Apply for a Veteran ID Card
 entryname: vic-v2
 layout: page-react.html
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a aria-current="page" href="/veteran-id-card/apply/veteran-information">Apply for an ID Card</a></li>
-    </ul>
-  </nav>
-
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <h1>Working</h1>
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a aria-current="page" href="/veteran-id-card/apply/veteran-information">Apply for an ID Card</a></li>
+  </ul>
+</nav>

--- a/content/pages/veteran-id-card/index.md
+++ b/content/pages/veteran-id-card/index.md
@@ -3,23 +3,10 @@ title: Veteran ID Card
 layout: page-react.html
 entryname: veteran-id-card
 ---
-<div id="main">
-  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
-  id="va-breadcrumbs">
-    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-      <li><a href="/">Home</a></li>
-      <li><a aria-current="page" href="/veteran-id-card/apply/veteran-information">Apply for an ID Card</a></li>
-    </ul>
-  </nav>
-
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- Veteran ID Card End -->
-</div>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a aria-current="page" href="/veteran-id-card/apply/veteran-information">Apply for an ID Card</a></li>
+  </ul>
+</nav>

--- a/content/pages/veteran-representative/index.md
+++ b/content/pages/veteran-representative/index.md
@@ -4,15 +4,3 @@ entryname: veteran-representative
 layout: page-react.html
 description: Appoint a Veterans Service Officer to represent you.
 ---
-<div id="main">
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <h1>Working</h1>
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
-</div>


### PR DESCRIPTION
To create a React application, we create a Markdown file that will be used as the React entry point. We almost always following this template:

```
(metadata)
layout: page-react.html
-------
(optional breadcrumbs)
(loading indicator)
```

Because the loading indicator should always be the same, it makes sense to move that into the `page-react.html` layout, and remove that HTML from each application page. 

This PR also uses switches the application-loading indicator to the standard Vets.gov spinner.

Resolves department-of-veterans-affairs/vets.gov-team/issues/9968