### PR TITLE
Profile: Fix for stale data showing post-update

### DIFF
--- a/src/applications/personalization/profile360/vet360/actions/transactions.js
+++ b/src/applications/personalization/profile360/vet360/actions/transactions.js
@@ -82,22 +82,24 @@ export function refreshTransaction(transaction, analyticsSectionName) {
 
       const transactionRefreshed = isVet360Configured() ? await apiRequest(`/profile/status/${transactionId}`) : await localVet360.updateTransaction(transactionId);
 
-      dispatch({
-        type: VET360_TRANSACTION_UPDATED,
-        transaction: transactionRefreshed
-      });
-
       if (isSuccessfulTransaction(transactionRefreshed)) {
         const forceCacheClear = true;
         await dispatch(refreshProfile(forceCacheClear));
         dispatch(clearTransaction(transactionRefreshed));
         recordEvent({ event: 'profile-saved' });
-      } else if (isFailedTransaction(transactionRefreshed) && analyticsSectionName) {
-        recordEvent({
-          event: 'profile-edit-failure',
-          'profile-action': 'save-failure',
-          'profile-section': analyticsSectionName,
+      } else {
+        dispatch({
+          type: VET360_TRANSACTION_UPDATED,
+          transaction: transactionRefreshed
         });
+
+        if (isFailedTransaction(transactionRefreshed) && analyticsSectionName) {
+          recordEvent({
+            event: 'profile-edit-failure',
+            'profile-action': 'save-failure',
+            'profile-section': analyticsSectionName,
+          });
+        }
       }
     } catch (err) {
       dispatch({


### PR DESCRIPTION
This PR updates the way updated transactions are processed - if the transaction is successful, we refresh the profile and then the transaction data is simply removed from state; otherwise, the updated transaction is made available in state. Previously, we were aways making the transaction data available, and since successful transactions won't trigger pending-update messaging, the old data was revealed while we were in the process of refreshing the profile. 

Resolves department-of-veterans-affairs/vets.gov-team/issues/11690