### PR TITLE
Dashboard - Claims design updates

### DIFF
--- a/src/applications/personalization/dashboard/components/AppealsListItemV2.jsx
+++ b/src/applications/personalization/dashboard/components/AppealsListItemV2.jsx
@@ -28,15 +28,14 @@ export default function AppealListItem({ appeal, name }) {
   // always show merged event on top
   const events = _.orderBy(appeal.attributes.events, [e => e.type === 'merged', e => moment(e.date).unix()], ['desc', 'desc']);
   const firstEvent = events[events.length - 1];
-  const lastEvent = events[0];
 
   return (
     <div className="claim-list-item-container">
       <h3 className="claim-list-item-header-v2">
-        Appeal of {appealTypeMap[appeal.attributes.programArea]} - Decision Received {moment(firstEvent.date).format('MMMM D, YYYY')}
+        Appeal of {appealTypeMap[appeal.attributes.programArea]} Decision Received {moment(firstEvent.date).format('MMMM D, YYYY')}
       </h3>
       <div className="card-status">
-        <p><strong>{moment(lastEvent.date).format('MMM D, YYYY')}</strong> - {getStatusContents(status.type, status.details, name).title}</p>
+        <p><strong>Status</strong>: {getStatusContents(status.type, status.details, name).title}</p>
       </div>
       <p>
         <Link className="usa-button usa-button-primary" href={`/track-claims/appeals/${appeal.id}/status`}>View appeal<i className="fa fa-chevron-right"/></Link>


### PR DESCRIPTION
> For Appeals:
> Remove hyphen between "Compensation" and "Decision"
> Instead of the date, show "Status: [status details]." This information will be pulled from whatever status is populated into the appeal. (This is that caveat that Chris described)

Resolves department-of-veterans-affairs/vets.gov-team/issues/11682