### PR TITLE
526 update upload mg

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#84887dc7cb0ccee2ae2c8156b5664697c2850b1d",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0582ee6d9969a63c7145907511acf7764c993668",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d1dd07494caaf68e8b860b6882ae0944d5746a9f",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -1,9 +1,9 @@
 import _ from '../../../../platform/utilities/data';
 
-import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
+// import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
 // NOTE: Easier to run schema locally with hot reload for dev
+import fullSchema526EZ from '/Users/adhocteam/Sites/vets-json-schema/dist/21-526EZ-schema.json';
 
-// import fullSchema526EZ from '/local/path/vets-json-schema/dist/21-526EZ-schema.json';
 import fileUploadUI from 'us-forms-system/lib/js/definitions/file';
 import ServicePeriodView from '../../../../platform/forms/components/ServicePeriodView';
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
@@ -71,7 +71,8 @@ const {
     properties: {
       homelessness
     }
-  }
+  },
+  attachments: uploadSchema
 } = fullSchema526EZ.properties;
 
 const {
@@ -752,6 +753,13 @@ const formConfig = {
                         confirmationCode: response.data.attributes.guid
                       };
                     },
+                    // this is the uiSchema passed to FileField for the attachmentId schema
+                    // FileField requires this name be used
+                    attachmentSchema: {
+                      'ui:title': 'Document type'
+                    },
+                    // this is the uiSchema passed to FileField for the name schema
+                    // FileField requires this name be used
                     attachmentName: {
                       'ui:title': 'Document name'
                     }
@@ -770,24 +778,7 @@ const formConfig = {
                   type: 'object',
                   required: ['privateRecords'],
                   properties: {
-                    privateRecords: {
-                      type: 'array',
-                      items: {
-                        type: 'object',
-                        required: ['name'],
-                        properties: {
-                          name: {
-                            type: 'string'
-                          },
-                          size: {
-                            type: 'integer'
-                          },
-                          confirmationCode: {
-                            type: 'string'
-                          }
-                        }
-                      }
-                    }
+                    privateRecords: uploadSchema
                   }
                 }
               }
@@ -823,6 +814,13 @@ const formConfig = {
                         confirmationCode: response.data.attributes.guid
                       };
                     },
+                    // this is the uiSchema passed to FileField for the attachmentId schema
+                    // FileField requires this name be used
+                    attachmentSchema: {
+                      'ui:title': 'Document type'
+                    },
+                    // this is the uiSchema passed to FileField for the name schema
+                    // FileField requires this name be used
                     attachmentName: {
                       'ui:title': 'Document name'
                     }
@@ -841,24 +839,7 @@ const formConfig = {
                   type: 'object',
                   required: ['additionalDocuments'],
                   properties: {
-                    additionalDocuments: {
-                      type: 'array',
-                      items: {
-                        type: 'object',
-                        required: ['name'],
-                        properties: {
-                          name: {
-                            type: 'string'
-                          },
-                          size: {
-                            type: 'integer'
-                          },
-                          confirmationCode: {
-                            type: 'string'
-                          }
-                        }
-                      }
-                    }
+                    additionalDocuments: uploadSchema
                   }
                 }
               }

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -1,8 +1,8 @@
 import _ from '../../../../platform/utilities/data';
 
-// import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
+import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
 // NOTE: Easier to run schema locally with hot reload for dev
-import fullSchema526EZ from '/Users/adhocteam/Sites/vets-json-schema/dist/21-526EZ-schema.json';
+// import fullSchema526EZ from '/path/Sites/vets-json-schema/dist/21-526EZ-schema.json';
 
 import fileUploadUI from 'us-forms-system/lib/js/definitions/file';
 import ServicePeriodView from '../../../../platform/forms/components/ServicePeriodView';

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -118,6 +118,9 @@ export function transform(formConfig, form) {
     ? { servicePeriods, reservesNationalGuardService }
     : { servicePeriods };
 
+  const additionalDocuments = aggregate(disabilities, 'additionalDocuments');
+  const privateRecords = aggregate(disabilities, 'privateRecords');
+
   const transformedData = {
     disabilities: disabilities
       .filter(disability => (disability['view:selected'] === true))
@@ -126,6 +129,7 @@ export function transform(formConfig, form) {
     veteran: setPhoneEmailPaths(veteran),
     // Extract treatments into one top-level array
     treatments: aggregate(disabilities, 'treatments'),
+    attachments: additionalDocuments.concat(privateRecords),
     privacyAgreementAccepted,
     serviceInformation,
     standardClaim,

--- a/src/applications/disability-benefits/526EZ/tests/config/documentUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/documentUpload.unit.spec.jsx
@@ -8,11 +8,13 @@ import { DefinitionTester, // selectCheckbox
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
 
+// NOTE: This file probably duplicates recordUpload
 const invalidDocumentData = {
   disabilities: [
     {
       additionalDocuments: [{
-        confirmationCode: 'testing'
+        confirmationCode: 'testing',
+        name: 'someFile.pdf'
       }],
       disability: { // Is this extra nesting necessary?
         diagnosticText: 'PTSD',
@@ -73,7 +75,8 @@ const validDocumentData = {
     {
       additionalDocuments: [{
         name: 'Form526.pdf',
-        confirmationCode: 'testing'
+        confirmationCode: 'testing',
+        attachmentId: 'L015'
       }],
       disability: { // Is this extra nesting necessary?
         diagnosticText: 'PTSD',

--- a/src/applications/disability-benefits/526EZ/tests/config/recordUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/recordUpload.unit.spec.jsx
@@ -12,7 +12,8 @@ const invalidDocumentData = {
   disabilities: [
     {
       privateRecords: [{
-        confirmationCode: 'testing'
+        confirmationCode: 'testing',
+        name: 'someDocument.pdf'
       }],
       disability: { // Is this extra nesting necessary?
         diagnosticText: 'PTSD',
@@ -73,7 +74,8 @@ const validDocumentData = {
     {
       privateRecords: [{
         name: 'Form526.pdf',
-        confirmationCode: 'testing'
+        confirmationCode: '123456',
+        attachmentId: 'L015'
       }],
       disability: { // Is this extra nesting necessary?
         diagnosticText: 'PTSD',

--- a/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
@@ -102,6 +102,28 @@ describe('526 helpers', () => {
             }
           }
         ],
+        attachments: [
+          {
+            name: 'Screen Shot 2018-07-09 at 11.25.49 AM.png',
+            confirmationCode: '9664f488-1243-4b25-805e-75ad7e4cf765',
+            attachmentId: 'L105'
+          },
+          {
+            name: 'Screen Shot 2018-07-09 at 11.24.39 AM.png',
+            confirmationCode: '66bfab89-6e2b-4361-a905-754dfbff7df7',
+            attachmentId: 'L105'
+          },
+          {
+            name: 'Screen Shot 2018-07-09 at 3.29.08 PM.png',
+            confirmationCode: 'a58ae568-d190-49cd-aa04-b1b1da5eae35',
+            attachmentId: 'L105'
+          },
+          {
+            name: 'Screen Shot 2018-07-09 at 2.02.39 PM.png',
+            confirmationCode: 'f23194e4-c534-42c6-9e96-16c08d8230a5',
+            attachmentId: 'L105'
+          }
+        ],
         privacyAgreementAccepted: true,
         serviceInformation: {
           servicePeriods: [

--- a/src/applications/disability-benefits/526EZ/tests/schema/maximal-test.json
+++ b/src/applications/disability-benefits/526EZ/tests/schema/maximal-test.json
@@ -16,21 +16,25 @@
            "additionalDocuments":[
               {
                  "name":"Screen Shot 2018-07-09 at 11.25.49 AM.png",
-                 "confirmationCode":"9664f488-1243-4b25-805e-75ad7e4cf765"
+                 "confirmationCode":"9664f488-1243-4b25-805e-75ad7e4cf765",
+                 "attachmentId": "L105"
               },
               {
                  "name":"Screen Shot 2018-07-09 at 11.24.39 AM.png",
-                 "confirmationCode":"66bfab89-6e2b-4361-a905-754dfbff7df7"
+                 "confirmationCode":"66bfab89-6e2b-4361-a905-754dfbff7df7",
+                 "attachmentId": "L105"
               }
            ],
            "privateRecords":[
               {
                  "name":"Screen Shot 2018-07-09 at 3.29.08 PM.png",
-                 "confirmationCode":"a58ae568-d190-49cd-aa04-b1b1da5eae35"
+                 "confirmationCode":"a58ae568-d190-49cd-aa04-b1b1da5eae35",
+                 "attachmentId": "L105"
               },
               {
                  "name":"Screen Shot 2018-07-09 at 2.02.39 PM.png",
-                 "confirmationCode":"f23194e4-c534-42c6-9e96-16c08d8230a5"
+                 "confirmationCode":"f23194e4-c534-42c6-9e96-16c08d8230a5",
+                 "attachmentId": "L105"
               }
            ],
            "view:uploadPrivateRecords":"yes",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10070,9 +10070,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#0582ee6d9969a63c7145907511acf7764c993668":
-  version "3.67.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0582ee6d9969a63c7145907511acf7764c993668"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#d1dd07494caaf68e8b860b6882ae0944d5746a9f":
+  version "3.70.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d1dd07494caaf68e8b860b6882ae0944d5746a9f"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
Updates the attachments schema to support new upload requirements

- Pulls attachment schema for private records and buddy statements from vets-json-schema
- Adds a new (well, it used to be there) 'Document type' dropdown to the uploader UI
- Functionally, changes attachments schema to `{ name, confirmationCode, attachmentId }`
  - `attachmentId` is actually the document type (from the VA-supplied upload types list)
  - `name` is the file name
  - `confirmationCode` is actually the GUID returned from `vets-api` upon successful document upload (used for matching form submissions to the right supporting document uploads)
- Pulls the attachments out of each disability and puts them into one array within `formData` for submission.

<img width="664" alt="screen shot 2018-08-01 at 5 45 59 pm" src="https://user-images.githubusercontent.com/24251447/43553047-cc2c472e-95b2-11e8-9b29-999ff12961b4.png">


<img width="1005" alt="screen shot 2018-08-01 at 5 46 24 pm" src="https://user-images.githubusercontent.com/24251447/43553061-d7970e14-95b2-11e8-9f6c-ee1b4bc525de.png">
