### PR TITLE
Copied and culled increase-only app

### DIFF
--- a/content/pages/disability-benefits/apply/form-526-all-claims.md
+++ b/content/pages/disability-benefits/apply/form-526-all-claims.md
@@ -1,0 +1,26 @@
+---
+title: Apply for disability benefits
+entryname: 526EZ-all-claims
+layout: page-react.html
+description: Learn how to apply online for disability compensation.
+hideFromSidebar: true
+---
+<div id="main">
+  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+  id="va-breadcrumbs">
+    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+      <li><a href="/">Home</a></li>
+      <li><a href="/disability-benefits/">Disability Benefits</a></li>
+      <li><a aria-current="page" href="/disability-benefits/apply/form-526-all-claims/">Apply for Disability Benefits</a></li>
+    </ul>
+  </nav>
+  <div class="section">
+    <div id="react-root">
+      <div class="loading-message">
+        <div class="loading-indicator-container">
+          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import RoutedSavableApp from '../../../platform/forms/save-in-progress/RoutedSavableApp';
+import formConfig from './config/form';
+
+import ITFWrapper from './containers/ITFWrapper';
+import EVSSClaimsGate from './containers/EVSSClaimsGate';
+
+export default function Form526Entry({ location, children }) {
+  return (
+    <EVSSClaimsGate location={location}>
+      <ITFWrapper location={location}>
+        <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+          {children}
+        </RoutedSavableApp>
+      </ITFWrapper>
+    </EVSSClaimsGate>
+  );
+}

--- a/src/applications/disability-benefits/all-claims/actions/index.js
+++ b/src/applications/disability-benefits/all-claims/actions/index.js
@@ -1,0 +1,43 @@
+import Raven from 'raven-js';
+
+import { apiRequest } from '../../../../platform/utilities/api';
+
+export const ITF_FETCH_INITIATED = 'ITF_FETCH_INITIATED';
+export const ITF_FETCH_SUCCEEDED = 'ITF_FETCH_SUCCEEDED';
+export const ITF_FETCH_FAILED = 'ITF_FETCH_FAILED';
+
+export const ITF_CREATION_INITIATED = 'ITF_CREATION_INITIATED';
+export const ITF_CREATION_SUCCEEDED = 'ITF_CREATION_SUCCEEDED';
+export const ITF_CREATION_FAILED = 'ITF_CREATION_FAILED';
+
+export function fetchITF() {
+  return (dispatch) => {
+    dispatch({ type: ITF_FETCH_INITIATED });
+
+    return apiRequest(
+      '/intent_to_file',
+      null,
+      ({ data }) => dispatch({ type: ITF_FETCH_SUCCEEDED, data }),
+      () => {
+        Raven.captureMessage('itf_fetch_failed');
+        dispatch({ type: ITF_FETCH_FAILED });
+      }
+    );
+  };
+}
+
+export function createITF() {
+  return (dispatch) => {
+    dispatch({ type: ITF_CREATION_INITIATED });
+
+    return apiRequest(
+      '/intent_to_file/compensation',
+      { method: 'POST' },
+      ({ data }) => dispatch({ type: ITF_CREATION_SUCCEEDED, data }),
+      () => {
+        Raven.captureMessage('itf_creation_failed');
+        dispatch({ type: ITF_CREATION_FAILED });
+      }
+    );
+  };
+}

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import moment from 'moment';
+
+import { focusElement } from '../../../../platform/utilities/ui';
+import OMBInfo from '@department-of-veterans-affairs/formation/OMBInfo';
+import FormTitle from 'us-forms-system/lib/js/components/FormTitle';
+import { introActions, introSelector } from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import { toggleLoginModal } from '../../../../platform/site-wide/user-nav/actions';
+
+class IntroductionPage extends React.Component {
+  componentDidMount() {
+    focusElement('.va-nav-breadcrumbs-list');
+  }
+
+  hasSavedForm = () => {
+    const { saveInProgress: { user } } = this.props;
+    return user.profile && user.profile.savedForms
+      .filter(f => moment.unix(f.metadata.expires_at).isAfter())
+      .find(f => f.form === this.props.formId);
+  }
+
+  authenticate = (e) => {
+    e.preventDefault();
+    this.props.toggleLoginModal(true);
+  }
+
+  render() {
+    return (
+      <div className="schemaform-intro">
+        <FormTitle title="Apply for increased disability compensation"/>
+        <p>Equal to VA Form 21-526EZ (Application for Disability Compensation and Related Compensation Benefits).</p>
+        <button>Start your form [change me]</button>
+        <h4>Follow the steps below to apply for increased disability compensation.</h4>
+        <div className="process schemaform-process">
+          <ol>
+            <li className="process-step list-one">
+              <div><h5>Prepare</h5></div>
+              <div><h6>When you apply for a disability increase, be sure to have these on hand:</h6></div>
+              <ul>
+                <li>Your Social Security number</li>
+                <li>VA medical and hospital records that show your rated disability has gotten worse</li>
+                <li>Private medical and hospital records that show your rated disability has gotten worse</li>
+              </ul>
+              <p>In some cases, you may need to turn in one or more supplemental forms to support your claim. For example, you’ll need to fill out another form if you’re claiming a dependent or applying for aid and attendance benefits.<br/> <a href="/disability-benefits/apply/supplemental-forms/">Learn what additional forms you may need to file with your disability claim</a>.</p>
+              <p><strong>What if I need help filling out my application?</strong></p>
+              <p>An accredited representative, like a Veterans Service Officer (VSO), can help you fill out your claim. </p>
+              <p><a href="/disability-benefits/apply/help/index.html">Get help filing your claim</a>.</p>
+              <div>
+                <div className="usa-alert usa-alert-info schemaform-sip-alert">
+                  <div className="usa-alert-body">
+                    <p><strong>Disability ratings</strong></p>
+                    <p>For each disability claim, we assign a severity rating from 0% to 100%. This rating can change if your condition changes. We’ll decide a claim for increase based on the medical evidence and supporting documents you turn in with your claim.</p>
+                    <p><a href="/disability-benefits/eligibility/ratings/">Learn how VA assigns disability ratings</a>.</p>
+                  </div>
+                </div>
+                <br/>
+              </div>
+            </li>
+            <li className="process-step list-two">
+              <div><h5>Apply</h5></div>
+              <p>Complete this disability compensation benefits form.</p>
+              <p>After submitting the form, you’ll get a confirmation message. You can print this for your records.</p>
+            </li>
+            <li className="process-step list-three">
+              <div><h5>VA Review</h5></div>
+              <p>We usually process claims within <strong>99 days</strong>.</p>
+            </li>
+            <li className="process-step list-four">
+              <div><h5>Decision</h5></div>
+              <p>Once we’ve processed your claim, you’ll get a notice in the mail with our decision.</p>
+            </li>
+          </ol>
+        </div>
+        <button>Start form here!</button>
+        {/* TODO: Remove inline style after I figure out why .omb-info--container has a left padding */}
+        <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
+          <OMBInfo resBurden={25} ombNumber="2900-0747" expDate="11/30/2017"/>
+        </div>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    form: state.form,
+    saveInProgress: introSelector(state)
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    saveInProgressActions: bindActionCreators(introActions, dispatch),
+    toggleLoginModal: (update) => {
+      dispatch(toggleLoginModal(update));
+    }
+  };
+}
+
+IntroductionPage.PropTypes = {
+  saveInProgress: PropTypes.object.isRequired,
+  toggleLoginModal: PropTypes.func.isRequired,
+  verifyUrl: PropTypes.string.isRequired,
+  loginUrl: PropTypes.string.isRequired
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(IntroductionPage);
+
+export { IntroductionPage };

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -1,0 +1,33 @@
+import environment from '../../../../platform/utilities/environment';
+
+import IntroductionPage from '../components/IntroductionPage';
+import ConfirmationPage from '../containers/ConfirmationPage';
+
+const formConfig = {
+  urlPrefix: '/',
+  intentToFileUrl: '/evss_claims/intent_to_file/compensation',
+  submitUrl: `${environment.API_URL}/v0/disability_compensation_form/submit`,
+  trackingPrefix: 'disability-526EZ-',
+  formId: '21-526EZ',
+  version: 1,
+  migrations: [],
+  // prefillTransformer,
+  prefillEnabled: true,
+  verifyRequiredPrefill: true,
+  savedFormMessages: {
+    notFound: 'Please start over to apply for disability claims increase.',
+    noAuth: 'Please sign in again to resume your application for disability claims increase.'
+  },
+  // transformForSubmit: transform,
+  introduction: IntroductionPage,
+  confirmation: ConfirmationPage,
+  // footerContent: FormFooter,
+  // getHelp: GetFormHelp,
+  defaultDefinitions: {},
+  title: 'Apply for increased disability compensation',
+  subTitle: 'Form 21-526EZ',
+  // getHelp: GetFormHelp, // TODO: May need updated form help content
+  chapters: {}
+};
+
+export default formConfig;

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -1,0 +1,7 @@
+export const itfStatuses = {
+  active: 'active',
+  expired: 'expired',
+  claimRecieved: 'claim_recieved',
+  duplicate: 'duplicate',
+  incomplete: 'incomplete'
+};

--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import moment from 'moment';
+import { connect } from 'react-redux';
+import Scroll from 'react-scroll';
+
+import { focusElement } from '../../../../platform/utilities/ui';
+
+const scroller = Scroll.scroller;
+const scrollToTop = () => {
+  scroller.scrollTo('topScrollElement', {
+    duration: 500,
+    delay: 0,
+    smooth: true
+  });
+};
+
+class ConfirmationPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { isExpanded: false };
+  }
+
+  componentDidMount() {
+    focusElement('.confirmation-page-title');
+    scrollToTop();
+  }
+
+  render() {
+    const {
+      fullName: { first, middle, last, suffix },
+      disabilities,
+      claimId,
+      submittedAt
+    } = this.props;
+
+    return (
+      <div>
+        <h3 className="confirmation-page-title">Your claim has been submitted.</h3>
+        <p>We usually process claims within <strong>99 days</strong>.</p>
+        <p>We may contact you if we have questions or need more information.
+        You can print this page for your records.</p>
+        <h4 className="confirmation-guidance-heading">
+          What happens after I apply?
+        </h4>
+        <p className="confirmation-guidance-message">
+          You don’t need to do anything unless we send you a letter asking for
+          more information. You can check the status of your claim online. The
+          time frame you see may vary based on how complex your claim is.
+        </p>
+        <a href="/disability-benefits/track-claims">
+          Check the status of your disability claim.
+        </a>
+        <br/>
+        <a href="/disability-benefits/after-you-apply/">
+          Learn more about what happens after you file a disability claim.
+        </a>
+        <div className="inset">
+          <h4>Disability Compensation Claim for Increase <span className="additional">(Form 21-526EZ)</span></h4>
+          <span>
+            For {first} {middle} {last} {suffix}
+          </span>
+          <ul className="claim-list">
+            <strong>Conditions claimed</strong>
+            <br/>
+            <ul className="disability-list">
+              {disabilities.filter(item => item['view:selected']).map((disability, i) => {
+                return <li key={i}>{disability.name}</li>;
+              })}
+            </ul>
+            <li>
+              <strong>Confirmation number</strong>
+              <br/>
+              <span>{claimId}</span>
+            </li>
+            <li>
+              <strong>Date submitted</strong>
+              <br/>
+              <span>{moment(submittedAt).format('MMM D, YYYY')}</span>
+            </li>
+          </ul>
+        </div>
+        <div className="confirmation-guidance-container">
+          <h4 className="confirmation-guidance-heading">Need help?</h4>
+          <p className="confirmation-guidance-message">If you have questions, please call <a href="tel:+18772228387">1-877-222-8387</a>, Monday &#8211;
+            Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).
+          </p>
+        </div>
+        <div className="row form-progress-buttons schemaform-back-buttons">
+          <div className="small-6 usa-width-one-half medium-6 columns">
+            <a href="/">
+              <button className="usa-button-primary">
+                Go Back to Vets.gov
+              </button>
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    fullName: state.user.profile.userFullName,
+    disabilities: state.form.data.disabilities,
+    claimId: state.form.submission.response.attributes.claimId,
+    submittedAt: state.form.submission.submittedAt
+  };
+}
+
+export default connect(mapStateToProps)(ConfirmationPage);
+export { ConfirmationPage };

--- a/src/applications/disability-benefits/all-claims/containers/EVSSClaimsGate.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/EVSSClaimsGate.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
+import RequiredLoginView from '../../../../platform/user/authorization/components/RequiredLoginView';
+import backendServices from '../../../../platform/user/profile/constants/backendServices';
+
+export function EVSSClaimsGate({ user, location, children }) {
+  // Short-circuit the check on the intro page
+  if (location.pathname === '/introduction') {
+    return children;
+  }
+
+  if (user.login.currentlyLoggedIn && !user.profile.services.includes(backendServices.EVSS_CLAIMS)) {
+    return (
+      <div className="usa-grid full-page-alert">
+        <AlertBox
+          isVisible
+          headline="We’re sorry. It looks like we’re missing some information needed for your application"
+          content="For help with your application, please call Veterans Benefits Assistance at 1-800-827-1000, Monday – Friday, 8:00 a.m. to 9:00 p.m. (ET)."
+          status="error"/>
+      </div>
+    );
+  }
+
+  return (
+    <RequiredLoginView
+      serviceRequired={backendServices.EVSS_CLAIMS}
+      user={user}
+      verify>
+      {children}
+    </RequiredLoginView>
+  );
+}
+
+const mapStateToProps = (store) => ({
+  user: store.user
+});
+
+export default connect(mapStateToProps)(EVSSClaimsGate);

--- a/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import moment from 'moment';
+
+import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
+import { requestStates } from '../../../../platform/utilities/constants';
+import { itfStatuses } from '../constants';
+import { createITF as createITFAction, fetchITF as fetchITFAction } from '../actions';
+
+
+const fetchWaitingStates = [requestStates.notCalled, requestStates.pending];
+
+const noITFPages = ['/introduction', '/confirmation'];
+// EVSS returns dates like '2014-07-28T19:53:45.810+0000'
+const evssDateFormat = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
+const outputDateFormat = 'MMMM DD, YYYY';
+const displayDate = (dateString) => moment(dateString, evssDateFormat).format(outputDateFormat);
+
+const itfMessage = (headline, content, status) => (
+  <div className="usa-grid full-page-alert">
+    <AlertBox
+      isVisible
+      headline={headline}
+      content={content}
+      status={status}/>
+  </div>
+);
+
+
+export class ITFWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasDisplayedSuccess: false
+    };
+  }
+
+
+  // When we first enter the form...
+  componentDidMount() {
+    // ...fetch the ITF if needed
+    if (!noITFPages.includes(this.props.location.pathname)
+      && this.props.itf.fetchCallState === requestStates.notCalled) {
+      this.props.fetchITF();
+    }
+  }
+
+
+  componentWillReceiveProps(nextProps) {
+    const { itf, location } = nextProps;
+
+    if (noITFPages.includes(location.pathname)) {
+      return;
+    }
+
+    // We now know we've navigated to a page that requires ITF logic
+
+    if (itf.fetchCallState === requestStates.notCalled) {
+      nextProps.fetchITF();
+    }
+
+    // If we've already fetched the ITFs, have none active, and haven't already called createITF, submit a new ITF
+    const hasActiveITF = itf.currentITF && itf.currentITF.status === itfStatuses.active;
+    const createITFCalled = itf.creationCallState !== requestStates.notCalled;
+    if (itf.fetchCallState === requestStates.succeeded && !hasActiveITF && !createITFCalled) {
+      nextProps.createITF();
+    }
+
+    // If we've already displayed the itf success banner, toggle it off when the location changes
+    if (hasActiveITF && !this.state.hasDisplayedSuccess
+      && nextProps.location.pathname !== this.props.location.pathname) {
+      // This will take effect at the same time the re-render for the location change does
+      this.setState({ hasDisplayedSuccess: true });
+    }
+  }
+
+
+  render() {
+    const { location, children, itf } = this.props;
+    // If the location is the intro or confirmation pages, don't fetch an ITF
+    if (noITFPages.includes(location.pathname)) {
+      return children;
+    }
+
+    // componentDidMount or componentWillRecieveProps called fetchITF
+
+    // While we're waiting, show the loading indicator...
+    if (fetchWaitingStates.includes(itf.fetchCallState)) {
+      return <LoadingIndicator message="Checking your Intent to File status..."/>;
+    }
+
+    // We'll get here after the fetchITF promise is fulfilled
+
+    if (itf.fetchCallState === requestStates.failed) {
+      // TODO: Get better content for this
+      return itfMessage('We’re sorry. Something went wrong on our end', 'We can’t access your Intent to File request right now. Please try applying again tomorrow.', 'error');
+    }
+
+    // If we have an active ITF, we're good to go--render that form!
+    if (itf.currentITF && itf.currentITF.status === itfStatuses.active) {
+      if (itf.previousITF) {
+        // If there was a previous ITF, we created one; show the creation success message
+        const submitSuccessContent = (
+          <div>
+            <p>Thank you for submitting your Intent to File request for disability compensation. Your Intent to File will expire on {displayDate(itf.currentITF.expirationDate)}.</p>
+            {itf.previousITF &&
+              <p>
+                <strong>Please note:</strong> We found a previous Intent to File request in our records that expired on {displayDate(itf.previousITF.expirationDate)}. This ITF might have been from an application you started, but didn’t finish before the ITF expired. Or, it could have been from a claim you already submitted.
+              </p>
+            }
+          </div>
+        );
+
+        return (
+          <div>
+            {!this.state.hasDisplayedSuccess && itfMessage('Your Intent to File request has been submitted', submitSuccessContent, 'success')}
+            {children}
+          </div>
+        );
+      }
+
+      // We fetched an active ITF
+      return (
+        <div>
+          {!this.state.hasDisplayedSuccess && itfMessage(
+            'You already have an Intent to File',
+            `Our records show that you already have an Intent to File for disability compensation. Your Intent to File will expire on ${displayDate(itf.currentITF.expirationDate)}.`,
+            'success')}
+          {children}
+        </div>
+      );
+    }
+
+    // componentWillRecieveProps called createITF if there was no active ITF found
+
+    // While we're waiting (again), show the loading indicator...again
+    if (fetchWaitingStates.includes(itf.creationCallState)) {
+      return <LoadingIndicator message="Submitting a new Intent to File..."/>;
+    }
+
+    // We'll get here after the createITF promise is fulfilled and we have no active ITF
+    //  because of a failed creation call
+    // TODO: Get better content for this
+    return itfMessage('Your Intent to File didn’t go through', 'We’re sorry. Your Intent to File request didn’t go through because something went wrong on our end. Please try applying again tomorrow.', 'error');
+  }
+}
+
+
+const requestStateEnum = Object.values(requestStates);
+
+const itfShape = {
+  id: PropTypes.string,
+  creationDate: PropTypes.string,
+  expirationDate: PropTypes.string.isRequired,
+  participantId: PropTypes.number,
+  source: PropTypes.string,
+  status: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired
+};
+
+ITFWrapper.propTypes = {
+  location: PropTypes.shape({
+    pathname: PropTypes.string
+  }).isRequired,
+  itf: PropTypes.shape({
+    fetchCallState: PropTypes.oneOf(requestStateEnum).isRequired,
+    creationCallState: PropTypes.oneOf(requestStateEnum).isRequired,
+    currentITF: PropTypes.shape(itfShape),
+    previousITF: PropTypes.shape(itfShape)
+  }),
+  fetchITF: PropTypes.func.isRequired,
+  createITF: PropTypes.func.isRequired
+};
+
+
+const mapStateToProps = (store) => ({
+  itf: store.itf
+});
+
+const mapDispatchToProps = {
+  createITF: createITFAction,
+  fetchITF: fetchITFAction
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ITFWrapper);

--- a/src/applications/disability-benefits/all-claims/form-entry.jsx
+++ b/src/applications/disability-benefits/all-claims/form-entry.jsx
@@ -1,0 +1,14 @@
+import '../../../platform/polyfills';
+import './sass/disability-benefits.scss';
+
+import startApp from '../../../platform/startup';
+
+import routes from './routes';
+import reducer from './reducers';
+import manifest from './manifest.json';
+
+startApp({
+  url: manifest.rootUrl,
+  reducer,
+  routes
+});

--- a/src/applications/disability-benefits/all-claims/manifest.json
+++ b/src/applications/disability-benefits/all-claims/manifest.json
@@ -1,0 +1,7 @@
+{
+  "appName": "21-526EZ disability compensation claim form",
+  "entryFile": "./form-entry.jsx",
+  "entryName": "526EZ-all-claims",
+  "rootUrl": "/disability-benefits/apply/form-526-all-claims",
+  "production": false
+}

--- a/src/applications/disability-benefits/all-claims/reducers/index.js
+++ b/src/applications/disability-benefits/all-claims/reducers/index.js
@@ -1,0 +1,9 @@
+import itf from './itf';
+import formConfig from '../config/form';
+
+import { createSaveInProgressFormReducer } from '../../../../platform/forms/save-in-progress/reducers';
+
+export default {
+  form: createSaveInProgressFormReducer(formConfig),
+  itf
+};

--- a/src/applications/disability-benefits/all-claims/reducers/itf.js
+++ b/src/applications/disability-benefits/all-claims/reducers/itf.js
@@ -1,0 +1,71 @@
+import get from '../../../../platform/utilities/data/get';
+import set from '../../../../platform/utilities/data/set';
+import { requestStates } from '../../../../platform/utilities/constants';
+import { itfStatuses } from '../constants';
+import {
+  ITF_FETCH_INITIATED,
+  ITF_FETCH_SUCCEEDED,
+  ITF_FETCH_FAILED,
+  ITF_CREATION_INITIATED,
+  ITF_CREATION_SUCCEEDED,
+  ITF_CREATION_FAILED,
+} from '../actions';
+
+
+const initialState = {
+  fetchCallState: requestStates.notCalled,
+  creationCallState: requestStates.notCalled,
+  currentITF: null,
+  previousITF: null
+};
+
+
+/**
+ * Finds the last ITF with a given status
+ *
+ * Note: This can return undefined
+ */
+function findLastITF(itfList) {
+  return itfList.sort((a, b) => new Date(b.expirationDate) - new Date(a.expirationDate))[0];
+}
+
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case ITF_FETCH_INITIATED:
+      return set('fetchCallState', requestStates.pending, state);
+    case ITF_FETCH_SUCCEEDED: {
+      const newState = set('fetchCallState', requestStates.succeeded, state);
+
+      // The full list is potentially more than just compensation ITFs, but we don't need those
+      const itfList = get('attributes.intentToFile', action.data).filter(i => i.type === 'compensation');
+      const activeITF = itfList.find(i => i.status === itfStatuses.active);
+
+      // Set the curentITFStatus
+      if (activeITF) {
+        // Pulled the active ITF out like this in case it's not technically the latest (not sure that's possible, though)
+        newState.currentITF = activeITF;
+        return newState;
+      }
+
+      // No active ITF found; use the one with the last expiration date
+      newState.currentITF = findLastITF(itfList);
+
+      return newState;
+    }
+    case ITF_FETCH_FAILED:
+      return set('fetchCallState', requestStates.failed, state);
+    case ITF_CREATION_INITIATED:
+      return set('creationCallState', requestStates.pending, state);
+    case ITF_CREATION_SUCCEEDED: {
+      const newState = set('creationCallState', requestStates.succeeded, state);
+      newState.previousITF = state.currentITF;
+      newState.currentITF = action.data.attributes.intentToFile;
+      return newState;
+    }
+    case ITF_CREATION_FAILED:
+      return set('creationCallState', requestStates.failed, state);
+    default:
+      return state;
+  }
+};

--- a/src/applications/disability-benefits/all-claims/routes.jsx
+++ b/src/applications/disability-benefits/all-claims/routes.jsx
@@ -1,0 +1,15 @@
+import { createRoutesWithSaveInProgress } from '../../../platform/forms/save-in-progress/helpers';
+
+import Form526EZApp from './Form526EZApp';
+import formConfig from './config/form';
+
+const routes = [
+  {
+    path: '/',
+    component: Form526EZApp,
+    indexRoute: { onEnter: (nextState, replace) => replace('/introduction') },
+    childRoutes: createRoutesWithSaveInProgress(formConfig),
+  }
+];
+
+export default routes;

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -1,0 +1,14 @@
+// Variables
+
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+@import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
+@import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
+@import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
+@import "../../../../platform/forms/sass/m-schemaform";
+// @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
+// @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
+@import "../../../../platform/forms/sass/m-form-confirmation";
+
+.full-page-alert {
+  margin-bottom: 2em;
+}

--- a/src/applications/disability-benefits/all-claims/tests/actions/actions.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/actions/actions.unit.spec.js
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { mockApiRequest } from '../../../../../platform/testing/unit/helpers.js';
+
+import {
+  fetchITF,
+  createITF,
+  ITF_FETCH_INITIATED,
+  ITF_FETCH_SUCCEEDED,
+  ITF_FETCH_FAILED,
+  ITF_CREATION_INITIATED,
+  ITF_CREATION_SUCCEEDED,
+  ITF_CREATION_FAILED
+} from '../../actions';
+
+const originalFetch = global.fetch;
+
+
+describe('ITF actions', () => {
+  describe('fetchITF', () => {
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('should dispatch a fetch succeeded action with data', () => {
+      const mockData = { data: 'asdf' };
+      mockApiRequest(mockData);
+      const dispatch = sinon.spy();
+      return fetchITF()(dispatch).then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(ITF_FETCH_INITIATED);
+        expect(dispatch.secondCall.args[0]).to.eql({
+          type: ITF_FETCH_SUCCEEDED,
+          data: mockData.data
+        });
+      });
+    });
+
+    it('should dispatch a fetch failed action', () => {
+      const mockData = { data: 'asdf' };
+      mockApiRequest(mockData, false);
+      const dispatch = sinon.spy();
+      return fetchITF()(dispatch).then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(ITF_FETCH_INITIATED);
+        expect(dispatch.secondCall.args[0].type).to.equal(ITF_FETCH_FAILED);
+      });
+    });
+  });
+
+  describe('createITF', () => {
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('should dispatch a fetch succeeded action with data', () => {
+      const mockData = { data: 'asdf' };
+      mockApiRequest(mockData);
+      const dispatch = sinon.spy();
+      return createITF()(dispatch).then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(ITF_CREATION_INITIATED);
+        expect(dispatch.secondCall.args[0]).to.eql({
+          type: ITF_CREATION_SUCCEEDED,
+          data: mockData.data
+        });
+      });
+    });
+
+    it('should dispatch a fetch failed action', () => {
+      const mockData = { data: 'asdf' };
+      mockApiRequest(mockData, false);
+      const dispatch = sinon.spy();
+      return createITF()(dispatch).then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(ITF_CREATION_INITIATED);
+        expect(dispatch.secondCall.args[0].type).to.eql(ITF_CREATION_FAILED);
+      });
+    });
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -1,0 +1,1 @@
+describe('Disability Benefits 526EZ <ConfirmationPage>', () => {});

--- a/src/applications/disability-benefits/all-claims/tests/containers/EVSSClaimsGate.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/EVSSClaimsGate.unit.spec.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+
+import { EVSSClaimsGate } from '../../containers/EVSSClaimsGate';
+
+import backendServices from '../../../../../platform/user/profile/constants/backendServices';
+
+describe('EVSSClaimsGate', () => {
+  const disallowedUser = {
+    login: { currentlyLoggedIn: true },
+    profile: {
+      services: []
+    }
+  };
+
+  const allowedUser = {
+    login: { currentlyLoggedIn: true },
+    profile: {
+      services: [backendServices.EVSS_CLAIMS]
+    }
+  };
+
+  it('should not gate the form on the intro page', () => {
+    const tree = mount(
+      <EVSSClaimsGate
+        user={disallowedUser}
+        location={{ pathname: '/introduction' }}>
+        <p>It worked!</p>
+      </EVSSClaimsGate>
+    );
+    expect(tree.text()).to.equal('It worked!');
+  });
+
+  it('should render a RequiredLoginView', () => {
+    const tree = shallow(
+      <EVSSClaimsGate
+        user={allowedUser}
+        location={{ pathname: '/middle-of-the-form' }}>
+        <p>It worked!</p>
+      </EVSSClaimsGate>
+    );
+    expect(tree.find('RequiredLoginView').length).to.equal(1);
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+import { merge } from 'lodash/fp';
+
+import { ITFWrapper } from '../../containers/ITFWrapper';
+import { itfStatuses } from '../../constants';
+import { requestStates } from '../../../../../platform/utilities/constants';
+
+const fetchITF = sinon.spy();
+const createITF = sinon.spy();
+
+const defaultProps = {
+  location: { pathname: '/middle' },
+  // Copied this from the reducer initial state
+  itf: {
+    fetchCallState: requestStates.notCalled,
+    creationCallState: requestStates.notCalled,
+    currentITF: null,
+    previousITF: null
+  },
+  fetchITF,
+  createITF
+};
+
+
+describe('526 ITFWrapper', () => {
+  afterEach(() => {
+    fetchITF.reset();
+    createITF.reset();
+  });
+
+
+  it('should not make an api call on the intro page', () => {
+    global.fetch = sinon.spy();
+    const tree = mount(
+      <ITFWrapper location={{ pathname: '/introduction' }}>
+        <p>It worked!</p>
+      </ITFWrapper>
+    );
+    expect(fetchITF.called).to.be.false;
+    expect(tree.text()).to.equal('It worked!');
+  });
+
+
+  it('should not make an api call on the confirmation page', () => {
+    global.fetch = sinon.spy();
+    const tree = mount(
+      <ITFWrapper location={{ pathname: '/confirmation' }}>
+        <p>It worked!</p>
+      </ITFWrapper>
+    );
+    expect(fetchITF.called).to.be.false;
+    expect(tree.text()).to.equal('It worked!');
+  });
+
+
+  it('should fetch the ITF if the form is loaded not on the intro or confirmation pages', () => {
+    mount(
+      <ITFWrapper {...defaultProps}>
+        <p>Shouldn't see me yet...</p>
+      </ITFWrapper>
+    );
+    expect(fetchITF.called).to.be.true;
+  });
+
+
+  it('should fetch the ITF if the form is loaded on the intro and navigated to the next page', () => {
+    const props = merge(defaultProps, { location: { pathname: '/introduction' } });
+    const tree = shallow(
+      <ITFWrapper {...props}>
+        <p>Shouldn't see me yet...</p>
+      </ITFWrapper>
+    );
+    expect(fetchITF.called).to.be.false;
+    tree.setProps(merge(props, { location: { pathname: '/middle' } }));
+    expect(fetchITF.called).to.be.true;
+  });
+
+
+  it('should render a loading indicator', () => {
+    const tree = shallow(
+      <ITFWrapper {...defaultProps}>
+        <p>Shouldn't see me yet...</p>
+      </ITFWrapper>
+    );
+    expect(tree.find('LoadingIndicator').length).to.equal(1);
+    tree.setProps(merge(defaultProps, { itf: { fetchCallState: requestStates.pending } }));
+    expect(tree.find('LoadingIndicator').length).to.equal(1);
+  });
+
+
+  it('should render an error message if the ITF fetch failed', () => {
+    const props = merge(defaultProps, {
+      itf: {
+        fetchCallState: requestStates.failed
+      }
+    });
+    const tree = shallow(
+      <ITFWrapper {...props}>
+        <p>Shouldn't see me yet...</p>
+      </ITFWrapper>
+    );
+    expect(tree.find('AlertBox').length).to.equal(1);
+  });
+
+
+  it('should not submit a new ITF if the fetch failed', () => {
+    const props = merge(defaultProps, {
+      itf: {
+        fetchCallState: requestStates.pending
+      }
+    });
+    const tree = mount(
+      <ITFWrapper {...props}>
+        <p>Shouldn't see me yet...</p>
+      </ITFWrapper>
+    );
+    // The ITF call happens in componentWillReceiveProps, so trigger that function call
+    tree.setProps(merge(props, { itf: { fetchCallState: requestStates.failed } }));
+    expect(createITF.called).to.be.false;
+  });
+
+
+  it('should submit a new ITF if no active ITF is found', () => {
+    const tree = shallow(
+      <ITFWrapper {...defaultProps}>
+        <p>Shouldn't see me yet...</p>
+      </ITFWrapper>
+    );
+    // Fetch succeded, but no ITFs were returned
+    tree.setProps(merge(defaultProps, { itf: { fetchCallState: requestStates.succeeded } }));
+    expect(createITF.called).to.be.true;
+  });
+
+
+  it('should render an error message if the ITF creation failed', () => {
+    const props = merge(defaultProps, {
+      itf: {
+        fetchCallState: requestStates.succeeded,
+        // But no ITF is found
+        creationCallState: requestStates.failed
+      }
+    });
+    const tree = shallow(
+      <ITFWrapper {...props}>
+        <p>I'm a ninja; you can't see me!</p>
+      </ITFWrapper>
+    );
+    expect(tree.find('AlertBox').length).to.equal(1);
+  });
+
+
+  it('should render a success message with the current expiration date', () => {
+    const expirationDate = '2015-08-28T19:47:52.786+00:00';
+    const props = merge(defaultProps, {
+      itf: {
+        fetchCallState: requestStates.succeeded,
+        currentITF: {
+          status: itfStatuses.active,
+          expirationDate
+        }
+      }
+    });
+    const tree = mount(
+      <ITFWrapper {...props}>
+        <p>Hello, world.</p>
+      </ITFWrapper>
+    );
+    expect(tree.find('AlertBox').length).to.equal(1);
+    expect(tree.text()).to.contain('August 28, 2015');
+    expect(tree.find('AdditionalInfo').length).to.equal(0);
+  });
+
+
+  it('should render a success message with the previous expiration date', () => {
+    const expirationDate = '2015-08-28T19:47:52.786+00:00';
+    const previousExpirationDate = '2014-08-28T19:47:52.786+00:00';
+    const props = merge(defaultProps, {
+      itf: {
+        fetchCallState: requestStates.succeeded,
+        currentITF: {
+          status: itfStatuses.active,
+          expirationDate
+        },
+        creationCallState: requestStates.succeeded,
+        previousITF: {
+          expirationDate: previousExpirationDate
+        }
+      }
+    });
+    const tree = mount(
+      <ITFWrapper {...props}>
+        <p>Hello, world.</p>
+      </ITFWrapper>
+    );
+    expect(tree.find('AlertBox').length).to.equal(1);
+    expect(tree.text()).to.contain('will expire on August 28, 2015');
+    expect(tree.text()).to.contain('expired on August 28, 2014');
+  });
+
+
+  it('should not render a success message after the location changes', () => {
+    const expirationDate = '2015-08-28T19:47:52.786+00:00';
+    const props = merge(defaultProps, {
+      itf: {
+        fetchCallState: requestStates.succeeded,
+        currentITF: {
+          status: itfStatuses.active,
+          expirationDate
+        }
+      }
+    });
+    const tree = mount(
+      <ITFWrapper {...props}>
+        <p>Hello, world.</p>
+      </ITFWrapper>
+    );
+    expect(tree.find('AlertBox').length).to.equal(1);
+    tree.setProps(merge(props, { location: { pathname: '/something-else' } }));
+    expect(tree.find('AlertBox').length).to.equal(0);
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/itfData.js
+++ b/src/applications/disability-benefits/all-claims/tests/itfData.js
@@ -1,0 +1,1243 @@
+// The spelling of these status types has been validated with the partner team
+
+export default {
+  id: '',
+  type: 'evss_intent_to_file_intent_to_files_responses',
+  attributes: {
+    intentToFile: [
+      {
+        id: '2510',
+        creationDate: '2015-03-30T16:19:09.000+00:00',
+        expirationDate: '2016-03-30T16:19:09.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '2555',
+        creationDate: '2015-03-30T20:20:21.000+00:00',
+        expirationDate: '2016-03-30T20:20:20.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '2601',
+        creationDate: '2015-04-01T13:10:26.000+00:00',
+        expirationDate: '2016-04-01T13:10:25.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '2923',
+        creationDate: '2015-04-08T14:43:08.000+00:00',
+        expirationDate: '2016-04-08T14:43:07.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'expired',
+        type: 'compensation'
+      },
+      {
+        id: '2983',
+        creationDate: '2015-04-09T15:16:25.000+00:00',
+        expirationDate: '2016-04-09T15:16:24.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '3115',
+        creationDate: '2015-04-15T16:53:46.000+00:00',
+        expirationDate: '2016-04-15T16:53:45.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '3565',
+        creationDate: '2015-04-24T15:24:45.000+00:00',
+        expirationDate: '2016-04-24T15:24:45.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '3568',
+        creationDate: '2015-04-24T15:38:38.000+00:00',
+        expirationDate: '2016-04-24T15:38:38.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '5037',
+        creationDate: '2015-06-10T15:53:48.000+00:00',
+        expirationDate: '2016-06-10T15:53:47.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '5356',
+        creationDate: '2015-06-17T14:22:21.000+00:00',
+        expirationDate: '2016-06-17T14:22:21.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '5379',
+        creationDate: '2015-06-17T16:03:38.000+00:00',
+        expirationDate: '2016-06-17T16:03:37.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '5490',
+        creationDate: '2015-06-18T21:09:03.000+00:00',
+        expirationDate: '2016-06-18T21:09:03.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '5694',
+        creationDate: '2015-06-24T18:28:37.000+00:00',
+        expirationDate: '2016-06-24T18:28:34.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6074',
+        creationDate: '2015-07-16T13:50:55.000+00:00',
+        expirationDate: '2016-07-16T13:50:54.000+00:00',
+        participantId: 600043186,
+        source: 'SEP',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6075',
+        creationDate: '2015-07-16T14:05:44.000+00:00',
+        expirationDate: '2016-07-16T14:05:43.000+00:00',
+        participantId: 600043186,
+        source: 'SEP',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6369',
+        creationDate: '2015-08-03T21:09:05.000+00:00',
+        expirationDate: '2016-08-03T21:09:04.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6443',
+        creationDate: '2015-08-06T19:53:27.000+00:00',
+        expirationDate: '2016-08-06T19:53:27.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6445',
+        creationDate: '2015-08-06T21:33:00.000+00:00',
+        expirationDate: '2016-08-06T21:32:59.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6446',
+        creationDate: '2015-08-06T21:59:12.000+00:00',
+        expirationDate: '2016-08-06T21:59:12.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6447',
+        creationDate: '2015-08-06T22:14:38.000+00:00',
+        expirationDate: '2016-08-06T22:14:37.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6454',
+        creationDate: '2015-08-07T14:39:25.000+00:00',
+        expirationDate: '2016-08-07T14:39:24.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6457',
+        creationDate: '2015-08-07T14:58:55.000+00:00',
+        expirationDate: '2016-08-07T14:58:54.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6460',
+        creationDate: '2015-08-07T15:22:55.000+00:00',
+        expirationDate: '2016-08-07T15:22:54.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6466',
+        creationDate: '2015-08-07T17:21:59.000+00:00',
+        expirationDate: '2016-08-07T17:21:58.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6467',
+        creationDate: '2015-08-07T17:23:47.000+00:00',
+        expirationDate: '2016-08-07T17:23:46.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6468',
+        creationDate: '2015-08-07T17:58:03.000+00:00',
+        expirationDate: '2016-08-07T17:58:02.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6469',
+        creationDate: '2015-08-07T18:31:29.000+00:00',
+        expirationDate: '2016-08-07T18:31:29.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6471',
+        creationDate: '2015-08-07T19:39:28.000+00:00',
+        expirationDate: '2016-08-07T19:39:28.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6476',
+        creationDate: '2015-08-07T21:00:22.000+00:00',
+        expirationDate: '2016-08-07T21:00:22.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '6834',
+        creationDate: '2015-08-25T22:38:45.000+00:00',
+        expirationDate: '2016-08-25T22:38:44.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '7936',
+        creationDate: '2015-10-29T12:41:47.000+00:00',
+        expirationDate: '2016-10-29T12:41:47.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '7998',
+        creationDate: '2015-11-02T16:18:58.000+00:00',
+        expirationDate: '2016-11-02T15:18:58.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '7999',
+        creationDate: '2015-11-02T16:54:14.000+00:00',
+        expirationDate: '2016-11-02T15:54:14.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '8001',
+        creationDate: '2015-11-02T17:25:37.000+00:00',
+        expirationDate: '2016-11-02T16:25:37.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '8004',
+        creationDate: '2015-11-02T20:35:39.000+00:00',
+        expirationDate: '2016-11-02T19:35:39.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '8017',
+        creationDate: '2015-11-03T19:48:15.000+00:00',
+        expirationDate: '2016-11-03T18:48:14.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '8027',
+        creationDate: '2015-11-04T16:52:08.000+00:00',
+        expirationDate: '2016-11-04T15:52:08.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '8059',
+        creationDate: '2015-11-05T16:21:24.000+00:00',
+        expirationDate: '2016-11-05T15:21:23.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '8122',
+        creationDate: '2015-11-10T16:10:22.000+00:00',
+        expirationDate: '2016-11-10T16:10:21.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '8136',
+        creationDate: '2015-11-11T14:57:10.000+00:00',
+        expirationDate: '2016-11-11T14:57:10.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '8151',
+        creationDate: '2015-11-12T14:11:48.000+00:00',
+        expirationDate: '2016-11-12T14:11:47.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '8187',
+        creationDate: '2015-11-15T16:14:17.000+00:00',
+        expirationDate: '2016-11-15T16:14:16.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '8289',
+        creationDate: '2015-11-19T13:59:54.000+00:00',
+        expirationDate: '2016-11-19T13:59:53.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '8332',
+        creationDate: '2015-11-20T14:33:51.000+00:00',
+        expirationDate: '2016-11-20T14:33:51.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '8394',
+        creationDate: '2015-11-24T00:20:49.000+00:00',
+        expirationDate: '2016-11-24T00:20:48.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '8604',
+        creationDate: '2015-11-25T13:01:58.000+00:00',
+        expirationDate: '2016-11-25T13:01:57.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '8762',
+        creationDate: '2015-11-28T00:55:01.000+00:00',
+        expirationDate: '2016-11-28T00:55:00.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '8886',
+        creationDate: '2015-12-01T02:52:28.000+00:00',
+        expirationDate: '2016-12-01T02:52:27.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '8972',
+        creationDate: '2015-12-01T20:31:53.000+00:00',
+        expirationDate: '2016-12-01T20:31:53.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '9028',
+        creationDate: '2015-12-02T14:03:56.000+00:00',
+        expirationDate: '2016-12-02T14:03:56.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '9289',
+        creationDate: '2015-12-03T14:19:10.000+00:00',
+        expirationDate: '2016-12-03T14:19:09.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '9489',
+        creationDate: '2015-12-03T19:36:59.000+00:00',
+        expirationDate: '2016-12-02T05:00:00.000+00:00',
+        participantId: 600043186,
+        source: 'CENTMAIL',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '9535',
+        creationDate: '2015-12-03T23:02:24.000+00:00',
+        expirationDate: '2016-12-03T23:02:24.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '9536',
+        creationDate: '2015-12-04T00:09:27.000+00:00',
+        expirationDate: '2016-12-04T00:09:27.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '9782',
+        creationDate: '2015-12-07T23:22:47.000+00:00',
+        expirationDate: '2016-12-07T23:22:46.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '9967',
+        creationDate: '2015-12-08T23:11:20.000+00:00',
+        expirationDate: '2016-12-08T23:11:19.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '10261',
+        creationDate: '2015-12-16T16:10:40.000+00:00',
+        expirationDate: '2016-12-16T16:10:39.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '10301',
+        creationDate: '2015-12-17T00:27:57.000+00:00',
+        expirationDate: '2016-12-17T00:27:56.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '10326',
+        creationDate: '2015-12-18T04:13:56.000+00:00',
+        expirationDate: '2016-12-18T04:13:55.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '10476',
+        creationDate: '2015-12-30T15:06:11.000+00:00',
+        expirationDate: '2016-12-30T15:06:10.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '10478',
+        creationDate: '2015-12-30T18:54:17.000+00:00',
+        expirationDate: '2016-12-30T18:54:16.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '10503',
+        creationDate: '2016-01-04T16:35:29.000+00:00',
+        expirationDate: '2017-01-04T16:35:29.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '10559',
+        creationDate: '2016-01-06T20:20:08.000+00:00',
+        expirationDate: '2017-01-06T20:20:08.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '10569',
+        creationDate: '2016-01-07T13:33:30.000+00:00',
+        expirationDate: '2017-01-07T13:33:29.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '10619',
+        creationDate: '2016-01-08T00:09:30.000+00:00',
+        expirationDate: '2017-01-08T00:09:30.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '10644',
+        creationDate: '2016-01-09T16:29:22.000+00:00',
+        expirationDate: '2017-01-09T16:29:21.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '10813',
+        creationDate: '2016-01-17T14:03:31.000+00:00',
+        expirationDate: '2017-01-17T14:03:31.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '10951',
+        creationDate: '2016-01-20T18:29:17.000+00:00',
+        expirationDate: '2017-01-20T18:29:17.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '11088',
+        creationDate: '2016-01-25T16:54:36.000+00:00',
+        expirationDate: '2017-01-25T16:54:35.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '11339',
+        creationDate: '2016-01-28T14:30:59.000+00:00',
+        expirationDate: '2017-01-28T14:30:58.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '11508',
+        creationDate: '2016-02-01T21:29:40.000+00:00',
+        expirationDate: '2017-02-01T21:29:39.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '11573',
+        creationDate: '2016-02-02T22:51:05.000+00:00',
+        expirationDate: '2017-02-02T22:51:04.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '11615',
+        creationDate: '2016-02-03T19:36:48.000+00:00',
+        expirationDate: '2017-02-03T19:36:47.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '11643',
+        creationDate: '2016-02-04T13:08:44.000+00:00',
+        expirationDate: '2017-02-04T13:08:44.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '11708',
+        creationDate: '2016-02-05T13:28:46.000+00:00',
+        expirationDate: '2017-02-05T13:28:46.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '11842',
+        creationDate: '2016-02-09T16:05:49.000+00:00',
+        expirationDate: '2017-02-09T16:05:49.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '11919',
+        creationDate: '2016-02-10T17:10:54.000+00:00',
+        expirationDate: '2017-02-10T17:10:54.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '12108',
+        creationDate: '2016-02-15T19:56:27.000+00:00',
+        expirationDate: '2017-02-15T19:56:27.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '12261',
+        creationDate: '2016-02-23T13:26:28.000+00:00',
+        expirationDate: '2017-02-23T13:26:28.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '12530',
+        creationDate: '2016-03-08T22:47:41.000+00:00',
+        expirationDate: '2017-03-08T22:47:41.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '12560',
+        creationDate: '2016-03-09T17:19:00.000+00:00',
+        expirationDate: '2017-03-09T17:18:59.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '13547',
+        creationDate: '2016-03-28T15:23:18.000+00:00',
+        expirationDate: '2017-03-28T15:23:18.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '13583',
+        creationDate: '2016-03-29T01:30:55.000+00:00',
+        expirationDate: '2017-03-29T01:30:55.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '13609',
+        creationDate: '2016-03-30T15:46:21.000+00:00',
+        expirationDate: '2017-03-30T15:46:20.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '13680',
+        creationDate: '2016-04-01T22:20:23.000+00:00',
+        expirationDate: '2017-04-01T22:20:22.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '13705',
+        creationDate: '2016-04-04T13:39:35.000+00:00',
+        expirationDate: '2017-04-04T13:39:35.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '13799',
+        creationDate: '2016-04-06T18:09:14.000+00:00',
+        expirationDate: '2017-04-06T18:09:14.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '13844',
+        creationDate: '2016-04-07T22:31:11.000+00:00',
+        expirationDate: '2017-04-07T22:31:10.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '14197',
+        creationDate: '2016-04-18T16:06:22.000+00:00',
+        expirationDate: '2017-04-18T16:06:21.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '14239',
+        creationDate: '2016-04-19T18:42:35.000+00:00',
+        expirationDate: '2017-04-19T18:42:35.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '14775',
+        creationDate: '2016-05-12T21:44:45.000+00:00',
+        expirationDate: '2017-05-12T21:44:42.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '15284',
+        creationDate: '2016-06-06T14:32:17.000+00:00',
+        expirationDate: '2017-06-06T14:32:16.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '18143',
+        creationDate: '2016-09-07T22:53:25.000+00:00',
+        expirationDate: '2017-09-07T22:53:24.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '18220',
+        creationDate: '2016-09-14T13:32:41.000+00:00',
+        expirationDate: '2017-09-14T13:32:40.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '18749',
+        creationDate: '2016-10-13T17:42:34.000+00:00',
+        expirationDate: '2017-10-13T17:42:34.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '18803',
+        creationDate: '2016-10-17T16:53:31.000+00:00',
+        expirationDate: '2017-10-17T16:53:30.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '18852',
+        creationDate: '2016-10-19T19:16:38.000+00:00',
+        expirationDate: '2017-10-19T19:16:38.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '19515',
+        creationDate: '2016-11-08T21:54:29.000+00:00',
+        expirationDate: '2017-11-08T21:54:29.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '19607',
+        creationDate: '2016-11-14T15:57:09.000+00:00',
+        expirationDate: '2017-11-14T15:57:09.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '19667',
+        creationDate: '2016-11-16T15:33:36.000+00:00',
+        expirationDate: '2017-11-16T15:33:36.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '19676',
+        creationDate: '2016-11-16T21:42:08.000+00:00',
+        expirationDate: '2017-11-16T21:42:07.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '19683',
+        creationDate: '2016-11-17T15:15:38.000+00:00',
+        expirationDate: '2017-11-17T15:15:37.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '20007',
+        creationDate: '2016-12-05T18:34:05.000+00:00',
+        expirationDate: '2017-12-05T18:34:03.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '20045',
+        creationDate: '2016-12-06T22:19:00.000+00:00',
+        expirationDate: '2017-12-06T22:18:59.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '20326',
+        creationDate: '2017-01-04T18:47:38.000+00:00',
+        expirationDate: '2018-01-04T18:47:37.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '20328',
+        creationDate: '2017-01-04T18:53:43.000+00:00',
+        expirationDate: '2018-01-04T18:53:42.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '20412',
+        creationDate: '2017-01-10T19:56:38.000+00:00',
+        expirationDate: '2018-01-10T19:56:37.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '20467',
+        creationDate: '2017-01-12T14:56:21.000+00:00',
+        expirationDate: '2018-01-12T14:56:20.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '20873',
+        creationDate: '2017-01-26T19:24:48.000+00:00',
+        expirationDate: '2018-01-26T19:24:47.000+00:00',
+        participantId: 600043186,
+        source: 'SEP',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '20987',
+        creationDate: '2017-01-30T20:34:03.000+00:00',
+        expirationDate: '2018-01-30T20:34:03.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '21232',
+        creationDate: '2017-02-07T14:18:00.000+00:00',
+        expirationDate: '2018-02-07T14:17:47.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '21345',
+        creationDate: '2017-02-08T21:37:39.000+00:00',
+        expirationDate: '2018-02-08T21:37:39.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '21381',
+        creationDate: '2017-02-10T17:15:38.000+00:00',
+        expirationDate: '2018-02-10T17:15:37.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '21444',
+        creationDate: '2017-02-14T14:42:57.000+00:00',
+        expirationDate: '2018-02-14T14:42:57.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '21631',
+        creationDate: '2017-02-20T22:02:53.000+00:00',
+        expirationDate: '2018-02-20T22:02:52.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '21899',
+        creationDate: '2017-03-03T21:26:07.000+00:00',
+        expirationDate: '2018-03-03T21:26:06.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '22763',
+        creationDate: '2017-04-06T00:11:03.000+00:00',
+        expirationDate: '2018-04-06T00:11:02.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '23904',
+        creationDate: '2017-05-25T14:29:33.000+00:00',
+        expirationDate: '2018-05-25T14:29:33.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'incomplete',
+        type: 'compensation'
+      },
+      {
+        id: '23985',
+        creationDate: '2017-05-31T18:19:52.000+00:00',
+        expirationDate: '2018-05-31T18:19:52.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'incomplete',
+        type: 'compensation'
+      },
+      {
+        id: '23987',
+        creationDate: '2017-05-31T18:29:14.000+00:00',
+        expirationDate: '2018-05-31T18:29:13.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'incomplete',
+        type: 'compensation'
+      },
+      {
+        id: '23988',
+        creationDate: '2017-05-31T18:31:57.000+00:00',
+        expirationDate: '2018-05-31T18:31:56.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'incomplete',
+        type: 'compensation'
+      },
+      {
+        id: '23989',
+        creationDate: '2017-05-31T18:34:40.000+00:00',
+        expirationDate: '2018-05-31T18:34:39.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'incomplete',
+        type: 'compensation'
+      },
+      {
+        id: '23990',
+        creationDate: '2017-05-31T18:37:10.000+00:00',
+        expirationDate: '2018-05-31T18:37:09.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'incomplete',
+        type: 'compensation'
+      },
+      {
+        id: '23991',
+        creationDate: '2017-05-31T18:39:39.000+00:00',
+        expirationDate: '2018-05-31T18:39:38.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'incomplete',
+        type: 'compensation'
+      },
+      {
+        id: '23992',
+        creationDate: '2017-05-31T18:53:38.000+00:00',
+        expirationDate: '2018-05-31T18:53:37.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'incomplete',
+        type: 'compensation'
+      },
+      {
+        id: '23996',
+        creationDate: '2017-06-01T12:56:48.000+00:00',
+        expirationDate: '2018-05-26T13:54:04.000+00:00',
+        participantId: 600043186,
+        source: 'VDC',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '24030',
+        creationDate: '2017-06-01T20:47:10.000+00:00',
+        expirationDate: '2018-06-01T20:47:08.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '24060',
+        creationDate: '2017-06-05T18:41:55.000+00:00',
+        expirationDate: '2018-06-05T18:41:54.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '24777',
+        creationDate: '2017-06-21T12:56:40.000+00:00',
+        expirationDate: '2018-06-21T12:56:39.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '26580',
+        creationDate: '2017-08-28T15:19:25.000+00:00',
+        expirationDate: '2018-08-28T15:19:24.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '26606',
+        creationDate: '2017-08-29T20:26:11.000+00:00',
+        expirationDate: '2018-08-29T20:26:10.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '26657',
+        creationDate: '2017-09-07T13:56:03.000+00:00',
+        expirationDate: '2018-09-07T13:56:03.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '31183',
+        creationDate: '2017-10-05T13:43:16.000+00:00',
+        expirationDate: '2018-10-05T13:43:14.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'claim_recieved',
+        type: 'compensation'
+      },
+      {
+        id: '31718',
+        creationDate: '2017-11-03T12:56:29.000+00:00',
+        expirationDate: '2018-11-03T12:56:28.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '144335',
+        creationDate: '2018-01-18T22:03:32.000+00:00',
+        expirationDate: '2019-01-18T22:03:10.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '144532',
+        creationDate: '2018-01-22T19:48:14.000+00:00',
+        expirationDate: '2019-01-22T19:48:11.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'duplicate',
+        type: 'compensation'
+      },
+      {
+        id: '166837',
+        creationDate: '2018-04-10T15:12:36.000+00:00',
+        expirationDate: '2019-04-10T15:12:34.000+00:00',
+        participantId: 600043186,
+        source: 'EBN',
+        status: 'active',
+        type: 'compensation'
+      }
+    ]
+  }
+};

--- a/src/applications/disability-benefits/all-claims/tests/reducers.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/reducers.unit.spec.js
@@ -1,0 +1,122 @@
+import { expect } from 'chai';
+
+import { requestStates } from '../../../../platform/utilities/constants';
+import { itfStatuses } from '../constants';
+
+import {
+  ITF_FETCH_INITIATED,
+  ITF_FETCH_SUCCEEDED,
+  ITF_FETCH_FAILED,
+  ITF_CREATION_INITIATED,
+  ITF_CREATION_SUCCEEDED,
+  ITF_CREATION_FAILED
+} from '../actions';
+
+import reducers from '../reducers';
+
+
+const initialState = {
+  fetchCallState: requestStates.notCalled,
+  creationCallState: requestStates.notCalled,
+  currentITF: null,
+  previousITF: null
+};
+
+
+describe('ITF reducer', () => {
+  const { itf } = reducers;
+
+  it('should handle ITF_FETCH_INITIATED', () => {
+    const newState = itf(initialState, { type: ITF_FETCH_INITIATED });
+    expect(newState.fetchCallState).to.equal(requestStates.pending);
+  });
+
+  describe('ITF_FETCH_SUCCEEDED', () => {
+    // These also test that it filters for compensation ITFs
+    it('should set the currentITF to the active one if present', () => {
+      const action = {
+        type: ITF_FETCH_SUCCEEDED,
+        data: {
+          attributes: {
+            intentToFile: [
+              {
+                type: 'something not compensation',
+                status: itfStatuses.active
+              },
+              {
+                type: 'compensation',
+                status: itfStatuses.active,
+                expirationDate: '2014-07-28T19:53:45.810+0000'
+              },
+              {
+                // duplicate ITF with later expiration date; should use the active one
+                type: 'compensation',
+                status: itfStatuses.duplicate,
+                expirationDate: '2015-07-28T19:53:45.810+0000'
+              }
+            ]
+          }
+        }
+      };
+      const newState = itf(initialState, action);
+      expect(newState.currentITF.status).to.equal(itfStatuses.active);
+    });
+
+    it('should set the currentITF to the one with the latest expiration date if no active one is present', () => {
+      const action = {
+        type: ITF_FETCH_SUCCEEDED,
+        data: {
+          attributes: {
+            intentToFile: [
+              {
+                type: 'something not compensation',
+                status: itfStatuses.active
+              },
+              {
+                type: 'compensation',
+                status: itfStatuses.expired,
+                expirationDate: '2014-07-28T19:53:45.810+0000'
+              },
+              {
+                type: 'compensation',
+                status: itfStatuses.duplicate,
+                expirationDate: '2015-07-28T19:53:45.810+0000'
+              }
+            ]
+          }
+        }
+      };
+      const newState = itf(initialState, action);
+      expect(newState.currentITF.status).to.equal(itfStatuses.duplicate);
+    });
+  });
+
+  it('should handle ITF_FETCH_FAILED', () => {
+    const newState = itf(initialState, { type: ITF_FETCH_FAILED });
+    expect(newState.fetchCallState).to.equal(requestStates.failed);
+  });
+
+  it('should handle ITF_CREATION_INITIATED', () => {
+    const newState = itf(initialState, { type: ITF_CREATION_INITIATED });
+    expect(newState.creationCallState).to.equal(requestStates.pending);
+  });
+
+  it('should handle ITF_CREATION_SUCCEEDED', () => {
+    const action = {
+      type: ITF_CREATION_SUCCEEDED,
+      data: {
+        attributes: {
+          intentToFile: 'new itf'
+        }
+      }
+    };
+    const newState = itf({ currentITF: 'old itf' }, action);
+    expect(newState.previousITF).to.equal('old itf');
+    expect(newState.currentITF).to.equal('new itf');
+  });
+
+  it('should handle ITF_CREATION_FAILED', () => {
+    const newState = itf(initialState, { type: ITF_CREATION_FAILED });
+    expect(newState.creationCallState).to.equal(requestStates.failed);
+  });
+});


### PR DESCRIPTION
I copied the increase only app and removed most (if not all) of the unnecessary stuff...and probably a little bit more, but we can copy from the increase only app when we need it.

It's not doing the SPA routing quite right; when refreshing on `/introduction`, it goes to the home page instead of serving the app and letting it handle the routing. That's worth investigating at some point, but I'm leaving it for now to unblock the other tickets.