### PR TITLE
Profile: Clean up actions and formatters

### DIFF
--- a/src/applications/personalization/profile360/vet360/actions/ui.js
+++ b/src/applications/personalization/profile360/vet360/actions/ui.js
@@ -1,5 +1,5 @@
-import { isValidEmail, isValidPhone } from '../../../../../platform/forms/validations';
-import { MILITARY_STATES } from '../../../../letters/utils/constants';
+// import { isValidEmail, isValidPhone } from '../../../../../platform/forms/validations';
+// import { MILITARY_STATES } from '../../../../letters/utils/constants';
 
 export const UPDATE_PROFILE_FORM_FIELD = 'UPDATE_PROFILE_FORM_FIELD';
 export const OPEN_MODAL = 'OPEN_MODAL';
@@ -8,152 +8,15 @@ export function openModal(modal) {
   return { type: OPEN_MODAL, modal };
 }
 
-function validateEmail({ emailAddress: email }) {
+export function updateFormField(fieldName, cleanDataForUpdate, validator, value, property, skipValidation) {
+  const cleanValue = cleanDataForUpdate(value);
+  const validations = skipValidation ? validator(cleanValue, property) : {};
   return {
-    emailAddress: email && isValidEmail(email) ? '' : 'Please enter your email address again, following a standard format like name@domain.com.'
-  };
-}
-
-function validateTelephone({ inputPhoneNumber }) {
-  return {
-    inputPhoneNumber: inputPhoneNumber && isValidPhone(inputPhoneNumber) ? '' : 'Please enter a valid phone.'
-  };
-}
-
-function inferAddressType(countryName, stateCode) {
-  let addressType = 'DOMESTIC';
-  if (countryName !== 'United States') {
-    addressType = 'INTERNATIONAL';
-  } else if (MILITARY_STATES.has(stateCode)) {
-    addressType = 'OVERSEAS MILITARY';
-  }
-
-  return addressType;
-}
-
-function validateAddress({ addressLine1, city, stateCode,  internationalPostalCode, zipCode, countryName }, fieldName) {
-  const isInternational = inferAddressType(countryName, stateCode) === 'INTERNATIONAL';
-  const validateAll = !fieldName;
-
-  return {
-    addressLine1: (fieldName === 'addressLine1' || validateAll) && !addressLine1 ? 'Street address is required' : '',
-    city: (fieldName === 'city' || validateAll) && !city ? 'City is required' : '',
-    stateCode: (fieldName === 'stateCode' || validateAll) && !isInternational && !stateCode ? 'State is required' : '',
-    zipCode: (fieldName === 'zipCode' || validateAll) && !isInternational && !zipCode ? 'Zip code is required' : '',
-    internationalPostalCode: (fieldName === 'internationalPostalCode' || validateAll) && isInternational && !internationalPostalCode ? 'Postal code is required' : '',
-  };
-}
-
-// @todo It might be cleaner to have this in the edit-modals themselves rather than here.
-function cleanEmailDataForUpdate(value) {
-  const {
-    id,
-    emailAddress,
-  } = value;
-
-  return {
-    id,
-    emailAddress,
-  };
-}
-
-function cleanPhoneDataForUpdate(value) {
-  const {
-    id,
-    countryCode,
-    extension,
-    phoneType,
-    inputPhoneNumber,
-  } = value;
-
-  const strippedPhone = (inputPhoneNumber || '').replace(/[^\d]/g, '');
-  const strippedExtension = (extension || '').replace(/[^a-zA-Z0-9]/g, '');
-
-  return {
-    id,
-    areaCode: strippedPhone.substring(0, 3),
-    countryCode,
-    extension: strippedExtension,
-    phoneType,
-    phoneNumber: strippedPhone.substring(3),
-    isInternational: countryCode !== '1',
-    inputPhoneNumber,
-  };
-}
-
-// @todo Consolidate this logic with consolidateAddress, which is intended to make address formats
-// consistent for display within the edit-address modal. Maybe they should go directly in that modal instead.
-// Also, should probably do something with the updaters' createAddressObject here too.
-export function cleanAddressDataForUpdate(value) {
-  const {
-    id,
-    addressLine1,
-    addressLine2,
-    addressLine3,
-    addressPou,
-    city,
-    countryName,
-    stateCode,
-    zipCode,
-    internationalPostalCode,
-    province,
-  } = value;
-
-  const addressType = inferAddressType(countryName, stateCode);
-
-  return {
-    id,
-    addressLine1,
-    addressLine2,
-    addressLine3,
-    addressPou,
-    addressType,
-    city,
-    countryName,
-    province: addressType === 'INTERNATIONAL' ? province : null,
-    stateCode: addressType === 'INTERNATIONAL' ? null : stateCode,
-    zipCode: addressType !== 'INTERNATIONAL' ? zipCode : null,
-    internationalPostalCode: addressType === 'INTERNATIONAL' ? internationalPostalCode : null,
-  };
-}
-
-function updateProfileFormField(field, validator, type) {
-  return (value, fieldName, skipValidation) => {
-    let cleanValue = value;
-
-    switch (type) {
-      case 'email':
-        cleanValue = cleanEmailDataForUpdate(value);
-        break;
-      case 'phone':
-        cleanValue = cleanPhoneDataForUpdate(value);
-        break;
-      case 'address':
-        cleanValue = cleanAddressDataForUpdate(value);
-        break;
-      default:
+    type: UPDATE_PROFILE_FORM_FIELD,
+    field: fieldName,
+    newState: {
+      value: cleanValue,
+      validations
     }
-
-    const validations = validator && !skipValidation ? validator(cleanValue, fieldName) : {};
-
-    return {
-      type: UPDATE_PROFILE_FORM_FIELD,
-      field,
-      newState: {
-        value: cleanValue,
-        validations
-      }
-    };
   };
 }
-
-export const updateFormField = {
-  email: updateProfileFormField('email', validateEmail, 'email'),
-  faxNumber: updateProfileFormField('faxNumber', validateTelephone, 'phone'),
-  homePhone: updateProfileFormField('homePhone', validateTelephone, 'phone'),
-  mailingAddress: updateProfileFormField('mailingAddress', validateAddress, 'address'),
-  mobilePhone: updateProfileFormField('mobilePhone', validateTelephone, 'phone'),
-  residentialAddress: updateProfileFormField('residentialAddress', validateAddress, 'address'),
-  temporaryPhone: updateProfileFormField('temporaryPhone', validateTelephone, 'phone'),
-  workPhone: updateProfileFormField('workPhone', validateTelephone, 'phone'),
-};

--- a/src/applications/personalization/profile360/vet360/actions/ui.js
+++ b/src/applications/personalization/profile360/vet360/actions/ui.js
@@ -1,6 +1,3 @@
-// import { isValidEmail, isValidPhone } from '../../../../../platform/forms/validations';
-// import { MILITARY_STATES } from '../../../../letters/utils/constants';
-
 export const UPDATE_PROFILE_FORM_FIELD = 'UPDATE_PROFILE_FORM_FIELD';
 export const OPEN_MODAL = 'OPEN_MODAL';
 
@@ -8,9 +5,9 @@ export function openModal(modal) {
   return { type: OPEN_MODAL, modal };
 }
 
-export function updateFormField(fieldName, cleanDataForUpdate, validator, value, property, skipValidation) {
-  const cleanValue = cleanDataForUpdate(value);
-  const validations = skipValidation ? validator(cleanValue, property) : {};
+export function updateFormField(fieldName, convertNextValueToCleanData, validateCleanData, value, property, skipValidation = false) {
+  const cleanValue = convertNextValueToCleanData(value);
+  const validations = skipValidation ? {} : validateCleanData(cleanValue, property);
   return {
     type: UPDATE_PROFILE_FORM_FIELD,
     field: fieldName,

--- a/src/applications/personalization/profile360/vet360/components/AddressField/EditModal.jsx
+++ b/src/applications/personalization/profile360/vet360/components/AddressField/EditModal.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import {
   FIELD_NAMES,
-  ADDRESS_FORM_VALUES
+  ADDRESS_FORM_VALUES,
+  USA
 } from '../../constants';
 
 import Vet360EditModal from '../base/EditModal';
@@ -24,7 +25,7 @@ export default class AddressEditModal extends React.Component {
   }
 
   getInitialFormValues = () => {
-    return this.props.data || { countryName: 'United States' };
+    return this.props.data || { countryName: USA.COUNTRY_NAME };
   }
 
   copyMailingAddress = (mailingAddress) => {
@@ -35,7 +36,11 @@ export default class AddressEditModal extends React.Component {
   renderForm = () => {
     return (
       <div>
-        {this.props.fieldName === FIELD_NAMES.RESIDENTIAL_ADDRESS && <CopyMailingAddress copyMailingAddress={this.copyMailingAddress}/>}
+        {this.props.fieldName === FIELD_NAMES.RESIDENTIAL_ADDRESS && (
+          <CopyMailingAddress
+            convertNextValueToCleanData={this.props.convertNextValueToCleanData}
+            copyMailingAddress={this.copyMailingAddress}/>
+        )}
         <AddressForm
           address={this.props.field.value}
           onInput={this.onInput}

--- a/src/applications/personalization/profile360/vet360/components/AddressField/EditModal.jsx
+++ b/src/applications/personalization/profile360/vet360/components/AddressField/EditModal.jsx
@@ -5,11 +5,6 @@ import {
   ADDRESS_FORM_VALUES
 } from '../../constants';
 
-import {
-  consolidateAddress,
-  expandAddress
-} from '../../../../../../platform/forms/address/helpers';
-
 import Vet360EditModal from '../base/EditModal';
 
 import CopyMailingAddress from '../../containers/CopyMailingAddress';
@@ -28,17 +23,8 @@ export default class AddressEditModal extends React.Component {
     this.props.onChange(newFieldValue, field);
   }
 
-  onSubmit = () => {
-    this.props.onSubmit(expandAddress(this.props.field.value));
-  }
-
   getInitialFormValues = () => {
-    if (this.props.data) {
-      return consolidateAddress(this.props.data);
-    }
-    return {
-      countryName: 'United States',
-    };
+    return this.props.data || { countryName: 'United States' };
   }
 
   copyMailingAddress = (mailingAddress) => {

--- a/src/applications/personalization/profile360/vet360/components/AddressField/index.jsx
+++ b/src/applications/personalization/profile360/vet360/components/AddressField/index.jsx
@@ -4,10 +4,12 @@ import pickBy from 'lodash/pickBy';
 
 import {
   API_ROUTES,
-  FIELD_NAMES
+  FIELD_NAMES,
+  ADDRESS_FORM_VALUES,
+  ADDRESS_TYPES,
+  ADDRESS_POU,
+  USA
 } from '../../constants';
-
-import { MILITARY_STATES } from '../../../../../letters/utils/constants';
 
 import Vet360ProfileField from '../../containers/ProfileField';
 
@@ -26,11 +28,11 @@ export default class AddressField extends React.Component {
   };
 
   inferAddressType(countryName, stateCode) {
-    let addressType = 'DOMESTIC';
-    if (countryName !== 'United States') {
-      addressType = 'INTERNATIONAL';
-    } else if (MILITARY_STATES.has(stateCode)) {
-      addressType = 'OVERSEAS MILITARY';
+    let addressType = ADDRESS_TYPES.DOMESTIC;
+    if (countryName !== USA.COUNTRY_NAME) {
+      addressType = ADDRESS_TYPES.INTERNATIONAL;
+    } else if (ADDRESS_FORM_VALUES.MILITARY_STATES.has(stateCode)) {
+      addressType = ADDRESS_TYPES.OVERSEAS_MILITARY;
     }
 
     return addressType;
@@ -62,15 +64,15 @@ export default class AddressField extends React.Component {
       addressType,
       city,
       countryName,
-      province: addressType === 'INTERNATIONAL' ? province : null,
-      stateCode: addressType === 'INTERNATIONAL' ? null : stateCode,
-      zipCode: addressType !== 'INTERNATIONAL' ? zipCode : null,
-      internationalPostalCode: addressType === 'INTERNATIONAL' ? internationalPostalCode : null,
+      province: addressType === ADDRESS_TYPES.INTERNATIONAL ? province : null,
+      stateCode: addressType === ADDRESS_TYPES.INTERNATIONAL ? null : stateCode,
+      zipCode: addressType !== ADDRESS_TYPES.INTERNATIONAL ? zipCode : null,
+      internationalPostalCode: addressType === ADDRESS_TYPES.INTERNATIONAL ? internationalPostalCode : null,
     };
   }
 
   validateCleanData({ addressLine1, city, stateCode,  internationalPostalCode, zipCode, countryName }, property) {
-    const isInternational = this.inferAddressType(countryName, stateCode) === 'INTERNATIONAL';
+    const isInternational = this.inferAddressType(countryName, stateCode) === ADDRESS_TYPES.INTERNATIONAL;
     const validateAll = !property;
 
     return {
@@ -95,7 +97,7 @@ export default class AddressField extends React.Component {
       internationalPostalCode: cleanData.internationalPostalCode,
       zipCode: cleanData.zipCode,
       province: cleanData.province,
-      addressPou: fieldName === FIELD_NAMES.MAILING_ADDRESS ? 'CORRESPONDENCE' : 'RESIDENCE/CHOICE',
+      addressPou: fieldName === FIELD_NAMES.MAILING_ADDRESS ? ADDRESS_POU.CORRESPONDENCE : ADDRESS_POU.RESIDENCE,
     }, e => !!e);
   }
 

--- a/src/applications/personalization/profile360/vet360/components/AddressField/index.jsx
+++ b/src/applications/personalization/profile360/vet360/components/AddressField/index.jsx
@@ -38,7 +38,7 @@ export default class AddressField extends React.Component {
     return addressType;
   }
 
-  convertNextValueToCleanData(value) {
+  convertNextValueToCleanData = (value) => {
     const {
       id,
       addressLine1,
@@ -71,7 +71,7 @@ export default class AddressField extends React.Component {
     };
   }
 
-  validateCleanData({ addressLine1, city, stateCode,  internationalPostalCode, zipCode, countryName }, property) {
+  validateCleanData = ({ addressLine1, city, stateCode,  internationalPostalCode, zipCode, countryName }, property) => {
     const isInternational = this.inferAddressType(countryName, stateCode) === ADDRESS_TYPES.INTERNATIONAL;
     const validateAll = !property;
 
@@ -84,7 +84,7 @@ export default class AddressField extends React.Component {
     };
   }
 
-  convertCleanDataToPayload(cleanData, fieldName) {
+  convertCleanDataToPayload = (cleanData, fieldName) => {
     return pickBy({
       id: cleanData.id,
       addressLine1: cleanData.addressLine1,

--- a/src/applications/personalization/profile360/vet360/components/AddressField/index.jsx
+++ b/src/applications/personalization/profile360/vet360/components/AddressField/index.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import pickBy from 'lodash/pickBy';
 
 import {
-  API_ROUTES
+  API_ROUTES,
+  FIELD_NAMES
 } from '../../constants';
 
 import { MILITARY_STATES } from '../../../../../letters/utils/constants';
@@ -12,91 +14,103 @@ import Vet360ProfileField from '../../containers/ProfileField';
 import AddressEditModal from './EditModal';
 import AddressView from './View';
 
-function inferAddressType(countryName, stateCode) {
-  let addressType = 'DOMESTIC';
-  if (countryName !== 'United States') {
-    addressType = 'INTERNATIONAL';
-  } else if (MILITARY_STATES.has(stateCode)) {
-    addressType = 'OVERSEAS MILITARY';
+export default class AddressField extends React.Component {
+
+  static propTypes = {
+    title: PropTypes.string.isRequired,
+    deleteDisabled: PropTypes.bool,
+    fieldName: PropTypes.oneOf([
+      FIELD_NAMES.MAILING_ADDRESS,
+      FIELD_NAMES.RESIDENTIAL_ADDRESS
+    ]).isRequired
+  };
+
+  inferAddressType(countryName, stateCode) {
+    let addressType = 'DOMESTIC';
+    if (countryName !== 'United States') {
+      addressType = 'INTERNATIONAL';
+    } else if (MILITARY_STATES.has(stateCode)) {
+      addressType = 'OVERSEAS MILITARY';
+    }
+
+    return addressType;
   }
 
-  return addressType;
-}
+  convertNextValueToCleanData(value) {
+    const {
+      id,
+      addressLine1,
+      addressLine2,
+      addressLine3,
+      addressPou,
+      city,
+      countryName,
+      stateCode,
+      zipCode,
+      internationalPostalCode,
+      province,
+    } = value;
 
-export function cleanEditedData(value) {
-  const {
-    id,
-    addressLine1,
-    addressLine2,
-    addressLine3,
-    addressPou,
-    city,
-    countryName,
-    stateCode,
-    zipCode,
-    internationalPostalCode,
-    province,
-  } = value;
+    const addressType = this.inferAddressType(countryName, stateCode);
 
-  const addressType = inferAddressType(countryName, stateCode);
+    return {
+      id,
+      addressLine1,
+      addressLine2,
+      addressLine3,
+      addressPou,
+      addressType,
+      city,
+      countryName,
+      province: addressType === 'INTERNATIONAL' ? province : null,
+      stateCode: addressType === 'INTERNATIONAL' ? null : stateCode,
+      zipCode: addressType !== 'INTERNATIONAL' ? zipCode : null,
+      internationalPostalCode: addressType === 'INTERNATIONAL' ? internationalPostalCode : null,
+    };
+  }
 
-  return {
-    id,
-    addressLine1,
-    addressLine2,
-    addressLine3,
-    addressPou,
-    addressType,
-    city,
-    countryName,
-    province: addressType === 'INTERNATIONAL' ? province : null,
-    stateCode: addressType === 'INTERNATIONAL' ? null : stateCode,
-    zipCode: addressType !== 'INTERNATIONAL' ? zipCode : null,
-    internationalPostalCode: addressType === 'INTERNATIONAL' ? internationalPostalCode : null,
-  };
-}
+  validateCleanData({ addressLine1, city, stateCode,  internationalPostalCode, zipCode, countryName }, property) {
+    const isInternational = this.inferAddressType(countryName, stateCode) === 'INTERNATIONAL';
+    const validateAll = !property;
 
-function validateEditedData({ addressLine1, city, stateCode,  internationalPostalCode, zipCode, countryName }, fieldName) {
-  const isInternational = inferAddressType(countryName, stateCode) === 'INTERNATIONAL';
-  const validateAll = !fieldName;
+    return {
+      addressLine1: (property === 'addressLine1' || validateAll) && !addressLine1 ? 'Street address is required' : '',
+      city: (property === 'city' || validateAll) && !city ? 'City is required' : '',
+      stateCode: (property === 'stateCode' || validateAll) && !isInternational && !stateCode ? 'State is required' : '',
+      zipCode: (property === 'zipCode' || validateAll) && !isInternational && !zipCode ? 'Zip code is required' : '',
+      internationalPostalCode: (property === 'internationalPostalCode' || validateAll) && isInternational && !internationalPostalCode ? 'Postal code is required' : '',
+    };
+  }
 
-  return {
-    addressLine1: (fieldName === 'addressLine1' || validateAll) && !addressLine1 ? 'Street address is required' : '',
-    city: (fieldName === 'city' || validateAll) && !city ? 'City is required' : '',
-    stateCode: (fieldName === 'stateCode' || validateAll) && !isInternational && !stateCode ? 'State is required' : '',
-    zipCode: (fieldName === 'zipCode' || validateAll) && !isInternational && !zipCode ? 'Zip code is required' : '',
-    internationalPostalCode: (fieldName === 'internationalPostalCode' || validateAll) && isInternational && !internationalPostalCode ? 'Postal code is required' : '',
-  };
-}
+  convertCleanDataToPayload(cleanData, fieldName) {
+    return pickBy({
+      id: cleanData.id,
+      addressLine1: cleanData.addressLine1,
+      addressLine2: cleanData.addressLine2,
+      addressLine3: cleanData.addressLine3,
+      addressType: cleanData.addressType,
+      city: cleanData.city,
+      countryName: cleanData.countryName,
+      stateCode: cleanData.stateCode,
+      internationalPostalCode: cleanData.internationalPostalCode,
+      zipCode: cleanData.zipCode,
+      province: cleanData.province,
+      addressPou: fieldName === FIELD_NAMES.MAILING_ADDRESS ? 'CORRESPONDENCE' : 'RESIDENCE/CHOICE',
+    }, e => !!e);
+  }
 
-function getPayload(addressFormData, fieldName) {
-  return pickBy({
-    id: addressFormData.id,
-    addressLine1: addressFormData.addressLine1,
-    addressLine2: addressFormData.addressLine2,
-    addressLine3: addressFormData.addressLine3,
-    addressType: addressFormData.addressType,
-    city: addressFormData.city,
-    countryName: addressFormData.countryName,
-    stateCode: addressFormData.stateCode,
-    internationalPostalCode: addressFormData.internationalPostalCode,
-    zipCode: addressFormData.zipCode,
-    province: addressFormData.province,
-    addressPou: fieldName === 'mailingAddress' ? 'CORRESPONDENCE' : 'RESIDENCE/CHOICE',
-  }, e => !!e);
-}
-
-export default function Vet360Address({ title, fieldName, deleteDisabled }) {
-  return (
-    <Vet360ProfileField
-      title={title}
-      fieldName={fieldName}
-      apiRoute={API_ROUTES.ADDRESSES}
-      getPayload={getPayload}
-      cleanEditedData={cleanEditedData}
-      validateEditedData={validateEditedData}
-      deleteDisabled={deleteDisabled}
-      Content={AddressView}
-      EditModal={AddressEditModal}/>
-  );
+  render() {
+    return (
+      <Vet360ProfileField
+        title={this.props.title}
+        fieldName={this.props.fieldName}
+        apiRoute={API_ROUTES.ADDRESSES}
+        convertNextValueToCleanData={this.convertNextValueToCleanData}
+        validateCleanData={this.validateCleanData}
+        convertCleanDataToPayload={this.convertCleanDataToPayload}
+        deleteDisabled={this.props.deleteDisabled}
+        Content={AddressView}
+        EditModal={AddressEditModal}/>
+    );
+  }
 }

--- a/src/applications/personalization/profile360/vet360/components/AddressField/index.jsx
+++ b/src/applications/personalization/profile360/vet360/components/AddressField/index.jsx
@@ -1,26 +1,101 @@
 import React from 'react';
+import pickBy from 'lodash/pickBy';
 
 import {
-  isEmptyAddress
-} from '../../../../../../platform/forms/address/helpers';
+  API_ROUTES
+} from '../../constants';
+
+import { MILITARY_STATES } from '../../../../../letters/utils/constants';
 
 import Vet360ProfileField from '../../containers/ProfileField';
 
 import AddressEditModal from './EditModal';
 import AddressView from './View';
 
-function isEmpty({ data: addressData } = {}) {
-  return isEmptyAddress(addressData);
+function inferAddressType(countryName, stateCode) {
+  let addressType = 'DOMESTIC';
+  if (countryName !== 'United States') {
+    addressType = 'INTERNATIONAL';
+  } else if (MILITARY_STATES.has(stateCode)) {
+    addressType = 'OVERSEAS MILITARY';
+  }
+
+  return addressType;
 }
 
-export default function Vet360Address({ title, fieldName, analyticsSectionName, deleteDisabled }) {
+export function cleanEditedData(value) {
+  const {
+    id,
+    addressLine1,
+    addressLine2,
+    addressLine3,
+    addressPou,
+    city,
+    countryName,
+    stateCode,
+    zipCode,
+    internationalPostalCode,
+    province,
+  } = value;
+
+  const addressType = inferAddressType(countryName, stateCode);
+
+  return {
+    id,
+    addressLine1,
+    addressLine2,
+    addressLine3,
+    addressPou,
+    addressType,
+    city,
+    countryName,
+    province: addressType === 'INTERNATIONAL' ? province : null,
+    stateCode: addressType === 'INTERNATIONAL' ? null : stateCode,
+    zipCode: addressType !== 'INTERNATIONAL' ? zipCode : null,
+    internationalPostalCode: addressType === 'INTERNATIONAL' ? internationalPostalCode : null,
+  };
+}
+
+function validateEditedData({ addressLine1, city, stateCode,  internationalPostalCode, zipCode, countryName }, fieldName) {
+  const isInternational = inferAddressType(countryName, stateCode) === 'INTERNATIONAL';
+  const validateAll = !fieldName;
+
+  return {
+    addressLine1: (fieldName === 'addressLine1' || validateAll) && !addressLine1 ? 'Street address is required' : '',
+    city: (fieldName === 'city' || validateAll) && !city ? 'City is required' : '',
+    stateCode: (fieldName === 'stateCode' || validateAll) && !isInternational && !stateCode ? 'State is required' : '',
+    zipCode: (fieldName === 'zipCode' || validateAll) && !isInternational && !zipCode ? 'Zip code is required' : '',
+    internationalPostalCode: (fieldName === 'internationalPostalCode' || validateAll) && isInternational && !internationalPostalCode ? 'Postal code is required' : '',
+  };
+}
+
+function getPayload(addressFormData, fieldName) {
+  return pickBy({
+    id: addressFormData.id,
+    addressLine1: addressFormData.addressLine1,
+    addressLine2: addressFormData.addressLine2,
+    addressLine3: addressFormData.addressLine3,
+    addressType: addressFormData.addressType,
+    city: addressFormData.city,
+    countryName: addressFormData.countryName,
+    stateCode: addressFormData.stateCode,
+    internationalPostalCode: addressFormData.internationalPostalCode,
+    zipCode: addressFormData.zipCode,
+    province: addressFormData.province,
+    addressPou: fieldName === 'mailingAddress' ? 'CORRESPONDENCE' : 'RESIDENCE/CHOICE',
+  }, e => !!e);
+}
+
+export default function Vet360Address({ title, fieldName, deleteDisabled }) {
   return (
     <Vet360ProfileField
       title={title}
       fieldName={fieldName}
-      analyticsSectionName={analyticsSectionName}
+      apiRoute={API_ROUTES.ADDRESSES}
+      getPayload={getPayload}
+      cleanEditedData={cleanEditedData}
+      validateEditedData={validateEditedData}
       deleteDisabled={deleteDisabled}
-      isEmpty={isEmpty}
       Content={AddressView}
       EditModal={AddressEditModal}/>
   );

--- a/src/applications/personalization/profile360/vet360/components/EmailField/index.jsx
+++ b/src/applications/personalization/profile360/vet360/components/EmailField/index.jsx
@@ -1,16 +1,42 @@
 import React from 'react';
 
+import {
+  API_ROUTES
+} from '../../constants';
+
+import { isValidEmail } from '../../../../../../platform/forms/validations';
+
 import Vet360ProfileField from '../../containers/ProfileField';
 import EmailEditModal from './EditModal';
 
 import EmailView from './View';
 
-export default function Vet360Email({ title = 'Email address', fieldName = 'email', analyticsSectionName = 'email' }) {
+function cleanEditedData(value) {
+  const {
+    id,
+    emailAddress,
+  } = value;
+
+  return {
+    id,
+    emailAddress,
+  };
+}
+
+function validateEditedData({ emailAddress: email }) {
+  return {
+    emailAddress: email && isValidEmail(email) ? '' : 'Please enter your email address again, following a standard format like name@domain.com.'
+  };
+}
+
+export default function Vet360Email({ title = 'Email address', fieldName = 'email' }) {
   return (
     <Vet360ProfileField
       title={title}
       fieldName={fieldName}
-      analyticsSectionName={analyticsSectionName}
+      apiRoute={API_ROUTES.EMAILS}
+      cleanEditedData={cleanEditedData}
+      validateEditedData={validateEditedData}
       Content={EmailView}
       EditModal={EmailEditModal}/>
   );

--- a/src/applications/personalization/profile360/vet360/components/EmailField/index.jsx
+++ b/src/applications/personalization/profile360/vet360/components/EmailField/index.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
-  API_ROUTES
+  API_ROUTES,
+  FIELD_NAMES
 } from '../../constants';
 
 import { isValidEmail } from '../../../../../../platform/forms/validations';
@@ -11,33 +13,43 @@ import EmailEditModal from './EditModal';
 
 import EmailView from './View';
 
-function cleanEditedData(value) {
-  const {
-    id,
-    emailAddress,
-  } = value;
+export default class EmailField extends React.Component {
 
-  return {
-    id,
-    emailAddress,
+  static propTypes = {
+    title: PropTypes.string.isRequired,
+    fieldName: PropTypes.oneOf([
+      FIELD_NAMES.EMAIL
+    ]).isRequired
   };
-}
 
-function validateEditedData({ emailAddress: email }) {
-  return {
-    emailAddress: email && isValidEmail(email) ? '' : 'Please enter your email address again, following a standard format like name@domain.com.'
-  };
-}
+  convertNextValueToCleanData(value) {
+    const {
+      id,
+      emailAddress,
+    } = value;
 
-export default function Vet360Email({ title = 'Email address', fieldName = 'email' }) {
-  return (
-    <Vet360ProfileField
-      title={title}
-      fieldName={fieldName}
-      apiRoute={API_ROUTES.EMAILS}
-      cleanEditedData={cleanEditedData}
-      validateEditedData={validateEditedData}
-      Content={EmailView}
-      EditModal={EmailEditModal}/>
-  );
+    return {
+      id,
+      emailAddress,
+    };
+  }
+
+  validateCleanData({ emailAddress: email }) {
+    return {
+      emailAddress: email && isValidEmail(email) ? '' : 'Please enter your email address again, following a standard format like name@domain.com.'
+    };
+  }
+
+  render() {
+    return (
+      <Vet360ProfileField
+        title={this.props.title}
+        fieldName={this.props.fieldName}
+        apiRoute={API_ROUTES.EMAILS}
+        convertNextValueToCleanData={this.convertNextValueToCleanData}
+        validateCleanData={this.validateCleanData}
+        Content={EmailView}
+        EditModal={EmailEditModal}/>
+    );
+  }
 }

--- a/src/applications/personalization/profile360/vet360/components/PhoneField/EditModal.jsx
+++ b/src/applications/personalization/profile360/vet360/components/PhoneField/EditModal.jsx
@@ -59,10 +59,6 @@ export default class PhoneEditModal extends React.Component {
     return defaultFieldValue;
   }
 
-  isEmpty = () => {
-    return !(this.props.data && this.props.data.phoneNumber);
-  }
-
   renderForm = () => {
     return (
       <div>

--- a/src/applications/personalization/profile360/vet360/components/PhoneField/index.jsx
+++ b/src/applications/personalization/profile360/vet360/components/PhoneField/index.jsx
@@ -5,7 +5,8 @@ import pickBy from 'lodash/pickBy';
 import {
   API_ROUTES,
   FIELD_NAMES,
-  PHONE_TYPE
+  PHONE_TYPE,
+  USA
 } from '../../constants';
 
 import { isValidPhone } from '../../../../../../platform/forms/validations';
@@ -47,7 +48,7 @@ export default class PhoneField extends React.Component {
       extension: strippedExtension,
       phoneType,
       phoneNumber: strippedPhone.substring(3),
-      isInternational: countryCode !== '1',
+      isInternational: countryCode !== USA.COUNTRY_CODE,
       inputPhoneNumber,
     };
   }
@@ -62,7 +63,7 @@ export default class PhoneField extends React.Component {
     return pickBy({
       id: cleanData.id,
       areaCode: cleanData.areaCode,
-      countryCode: '1', // currently no international phone number support
+      countryCode: USA.COUNTRY_CODE, // currently no international phone number support
       extension: cleanData.extension,
       phoneNumber: cleanData.phoneNumber,
       isInternational: false, // currently no international phone number support

--- a/src/applications/personalization/profile360/vet360/components/PhoneField/index.jsx
+++ b/src/applications/personalization/profile360/vet360/components/PhoneField/index.jsx
@@ -1,16 +1,70 @@
 import React from 'react';
+import pickBy from 'lodash/pickBy';
+
+import {
+  API_ROUTES,
+  PHONE_TYPE
+} from '../../constants';
+
+import { isValidPhone } from '../../../../../../platform/forms/validations';
 
 import Vet360ProfileField from '../../containers/ProfileField';
 
 import PhoneEditModal from './EditModal';
 import PhoneView from './View';
 
-export default function Vet360Phone({ title, fieldName, analyticsSectionName }) {
+function cleanEditedData(value) {
+  const {
+    id,
+    countryCode,
+    extension,
+    phoneType,
+    inputPhoneNumber,
+  } = value;
+
+  const strippedPhone = (inputPhoneNumber || '').replace(/[^\d]/g, '');
+  const strippedExtension = (extension || '').replace(/[^a-zA-Z0-9]/g, '');
+
+  return {
+    id,
+    areaCode: strippedPhone.substring(0, 3),
+    countryCode,
+    extension: strippedExtension,
+    phoneType,
+    phoneNumber: strippedPhone.substring(3),
+    isInternational: countryCode !== '1',
+    inputPhoneNumber,
+  };
+}
+
+function validateEditedData({ inputPhoneNumber }) {
+  return {
+    inputPhoneNumber: inputPhoneNumber && isValidPhone(inputPhoneNumber) ? '' : 'Please enter a valid phone.'
+  };
+}
+
+function getPayload(phoneFormData, fieldName) {
+  // strip falsy values like '', null so vet360 does not reject
+  return pickBy({
+    id: phoneFormData.id,
+    areaCode: phoneFormData.areaCode,
+    countryCode: '1', // currently no international phone number support
+    extension: phoneFormData.extension,
+    phoneNumber: phoneFormData.phoneNumber,
+    isInternational: false, // currently no international phone number support
+    phoneType: PHONE_TYPE[fieldName],
+  }, e => !!e);
+}
+
+export default function Vet360Phone({ title, fieldName }) {
   return (
     <Vet360ProfileField
       title={title}
       fieldName={fieldName}
-      analyticsSectionName={analyticsSectionName}
+      apiRoute={API_ROUTES.TELEPHONES}
+      validateEditedData={validateEditedData}
+      getPayload={getPayload}
+      cleanEditedData={cleanEditedData}
       Content={PhoneView}
       EditModal={PhoneEditModal}/>
   );

--- a/src/applications/personalization/profile360/vet360/components/base/EditModal.jsx
+++ b/src/applications/personalization/profile360/vet360/components/base/EditModal.jsx
@@ -18,7 +18,7 @@ export default class Vet360EditModal extends React.Component {
       validations: PropTypes.object
     }),
     hasValidationError: PropTypes.func,
-    isEmpty: PropTypes.func.isRequired,
+    isEmpty: PropTypes.bool.isRequired,
     onCancel: PropTypes.func.isRequired,
     onChange: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
@@ -102,7 +102,7 @@ export default class Vet360EditModal extends React.Component {
             title={title}
             analyticsSectionName={analyticsSectionName}
             transactionRequest={transactionRequest}
-            deleteEnabled={!isEmpty() && !deleteDisabled}>
+            deleteEnabled={!isEmpty && !deleteDisabled}>
             <LoadingButton data-action="save-edit" isLoading={isLoading}>Update</LoadingButton>
             <button type="button" className="usa-button-secondary" onClick={onCancel}>Cancel</button>
           </Vet360EditModalActionButtons>

--- a/src/applications/personalization/profile360/vet360/constants/index.js
+++ b/src/applications/personalization/profile360/vet360/constants/index.js
@@ -52,3 +52,9 @@ export const ANALYTICS_FIELD_MAP = {
   mailingAddress: 'mailing-address',
   residentialAddress: 'home-address'
 };
+
+export const API_ROUTES = {
+  TELEPHONES: '/profile/telephone',
+  EMAILS: '/profile/email_addresses',
+  ADDRESSES: '/profile/addresses'
+};

--- a/src/applications/personalization/profile360/vet360/constants/index.js
+++ b/src/applications/personalization/profile360/vet360/constants/index.js
@@ -1,9 +1,28 @@
+import { MILITARY_STATES } from '../../../../letters/utils/constants';
+
 import states from './states.json';
 import countries from './countries.json';
 
 export const ADDRESS_FORM_VALUES = {
   STATES: states.map(state => state.stateCode),
-  COUNTRIES: countries.map(country => country.countryName)
+  COUNTRIES: countries.map(country => country.countryName),
+  MILITARY_STATES
+};
+
+export const ADDRESS_TYPES = {
+  DOMESTIC: 'DOMESTIC',
+  INTERNATIONAL: 'INTERNATIONAL',
+  OVERSEAS_MILITARY: 'OVERSEAS_MILITARY'
+};
+
+export const ADDRESS_POU = {
+  CORRESPONDENCE: 'CORRESPONDENCE',
+  RESIDENCE: 'RESIDENCE/CHOICE'
+};
+
+export const USA = {
+  COUNTRY_NAME: 'United States',
+  COUNTRY_CODE: '1'
 };
 
 export const TRANSACTION_CATEGORY_TYPES = {

--- a/src/applications/personalization/profile360/vet360/containers/CopyMailingAddress.jsx
+++ b/src/applications/personalization/profile360/vet360/containers/CopyMailingAddress.jsx
@@ -58,14 +58,15 @@ class CopyMailingAddress extends React.Component {
   }
 }
 
-export function mapStateToProps(state) {
+export function mapStateToProps(state, ownProps) {
+  const { convertNextValueToCleanData } = ownProps;
   const mailingAddress = selectVet360Field(state, FIELD_NAMES.MAILING_ADDRESS);
   const hasEmptyMailingAddress = isEmptyAddress(mailingAddress);
 
   const residentialAddress = selectEditedFormField(state, FIELD_NAMES.RESIDENTIAL_ADDRESS).value;
 
   const checked = !hasEmptyMailingAddress && isEqual(
-    pick(mailingAddress, ADDRESS_PROPS),
+    pick(convertNextValueToCleanData(mailingAddress), ADDRESS_PROPS),
     pick(residentialAddress, ADDRESS_PROPS)
   );
 

--- a/src/applications/personalization/profile360/vet360/containers/CopyMailingAddress.jsx
+++ b/src/applications/personalization/profile360/vet360/containers/CopyMailingAddress.jsx
@@ -16,10 +16,6 @@ import {
   selectEditedFormField
 } from '../selectors';
 
-import {
-  cleanAddressDataForUpdate
-} from '../actions';
-
 const ADDRESS_PROPS = [
   'addressLine1',
   'addressLine2',
@@ -69,7 +65,7 @@ export function mapStateToProps(state) {
   const residentialAddress = selectEditedFormField(state, FIELD_NAMES.RESIDENTIAL_ADDRESS).value;
 
   const checked = !hasEmptyMailingAddress && isEqual(
-    pick(cleanAddressDataForUpdate(mailingAddress), ADDRESS_PROPS),
+    pick(mailingAddress, ADDRESS_PROPS),
     pick(residentialAddress, ADDRESS_PROPS)
   );
 

--- a/src/applications/personalization/profile360/vet360/containers/ProfileField.jsx
+++ b/src/applications/personalization/profile360/vet360/containers/ProfileField.jsx
@@ -56,8 +56,8 @@ class Vet360ProfileField extends React.Component {
   onChange = (value, property, skipValidation) => {
     this.props.updateFormField(
       this.props.fieldName,
-      this.props.cleanEditedData,
-      this.props.validateEditedData,
+      this.props.convertNextValueToCleanData,
+      this.props.validateCleanData,
       value,
       property,
       skipValidation
@@ -66,13 +66,16 @@ class Vet360ProfileField extends React.Component {
 
   onDelete = () => {
     let payload = this.props.data;
-    if (this.props.getPayload) payload = this.props.getPayload(payload, this.props.fieldName);
+    if (this.props.convertCleanDataToPayload) {
+      payload = this.props.convertCleanDataToPayload(payload, this.props.fieldName);
+    }
 
     this.props.createTransaction(
       this.props.apiRoute,
       'DELETE',
       this.props.fieldName,
-      payload
+      payload,
+      this.props.analyticsSectionName
     );
   }
 
@@ -85,7 +88,9 @@ class Vet360ProfileField extends React.Component {
     this.captureEvent('update-button');
 
     let payload = this.props.field.value;
-    if (this.props.getPayload) payload = this.props.getPayload(payload, this.props.fieldName);
+    if (this.props.convertCleanDataToPayload) {
+      payload = this.props.convertCleanDataToPayload(payload, this.props.fieldName);
+    }
 
     const method = payload.id ? 'PUT' : 'POST';
 
@@ -93,7 +98,8 @@ class Vet360ProfileField extends React.Component {
       this.props.apiRoute,
       method,
       this.props.fieldName,
-      payload
+      payload,
+      this.props.analyticsSectionName
     );
   }
 
@@ -113,14 +119,12 @@ class Vet360ProfileField extends React.Component {
     this.props.refreshTransaction(this.props.transaction, this.props.analyticsSectionName);
   }
 
-  captureEvent(actionName, sectionName = this.props.analyticsSectionName) {
-    if (sectionName && actionName) {
-      recordEvent({
-        event: 'profile-navigation',
-        'profile-action': actionName,
-        'profile-section': sectionName,
-      });
-    }
+  captureEvent(actionName) {
+    recordEvent({
+      event: 'profile-navigation',
+      'profile-action': actionName,
+      'profile-section': this.props.analyticsSectionName,
+    });
   }
 
   isEditLinKVisible = () => {
@@ -211,8 +215,9 @@ Vet360ProfileFieldContainer.propTypes = {
   EditModal: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   apiRoute: PropTypes.oneOf(Object.values(VET360.API_ROUTES)).isRequired,
-  cleanEditedData: PropTypes.func.isRequired,
-  validateEditedData: PropTypes.func.isRequired
+  convertNextValueToCleanData: PropTypes.func.isRequired,
+  validateCleanData: PropTypes.func.isRequired,
+  convertCleanDataToPayload: PropTypes.func
 };
 
 export default Vet360ProfileFieldContainer;

--- a/src/applications/personalization/profile360/vet360/containers/ProfileField.jsx
+++ b/src/applications/personalization/profile360/vet360/containers/ProfileField.jsx
@@ -207,6 +207,17 @@ const mapDispatchToProps = {
   updateFormField
 };
 
+/**
+ * Container used to easily create components for Vet360 contact information.
+ * @property {string} fieldName The name of the property as it appears in the user.profile.vet360 object.
+ * @property {func} Content The component used to render the read-display of the field.
+ * @property {func} EditModal The component used to render the contents of the field's edit-modal.
+ * @property {string} title The field name converted to a visible display, such as for labels, modal titles, etc. Example: "mailingAddress" passes "Mailing address" as the title.
+ * @property {string} apiRoute The API route used to create/update/delete the Vet360 field.
+ * @property {func} convertNextValueToCleanData A function called to derive or make changes to form values after form values are changed in the edit-modal. Called prior to validation.
+ * @property {func} validateCleanData A function called to determine validation errors. Called after convertNextValueToCleanData.
+ * @property {func} [convertCleanDataToPayload] An optional function used to convert the clean edited data to a payload for sending to the API. Used to remove any values (especially falsy) that may cause errors in Vet360.
+ */
 const Vet360ProfileFieldContainer = connect(mapStateToProps, mapDispatchToProps)(Vet360ProfileField);
 
 Vet360ProfileFieldContainer.propTypes = {

--- a/src/applications/personalization/profile360/vet360/containers/ProfileField.jsx
+++ b/src/applications/personalization/profile360/vet360/containers/ProfileField.jsx
@@ -11,11 +11,11 @@ import {
 } from '../util/transactions';
 
 import {
-  clearTransactionRequest,
+  createTransaction,
   refreshTransaction,
+  clearTransactionRequest,
   updateFormField,
-  openModal,
-  fieldUpdaters
+  openModal
 } from '../actions';
 
 import {
@@ -31,44 +31,111 @@ import Vet360Transaction from '../components/base/Transaction';
 class Vet360ProfileField extends React.Component {
 
   static propTypes = {
-    clearErrors: PropTypes.func.isRequired,
     Content: PropTypes.func.isRequired,
     data: PropTypes.object,
     EditModal: PropTypes.func.isRequired,
     field: PropTypes.object,
     fieldName: PropTypes.string.isRequired,
     isEditing: PropTypes.bool.isRequired,
-    isEmpty: PropTypes.func,
-    onAdd: PropTypes.func.isRequired,
-    onCancel: PropTypes.func.isRequired,
-    onChange: PropTypes.func.isRequired,
-    onDelete: PropTypes.func.isRequired,
-    onEdit: PropTypes.func.isRequired,
-    onSubmit: PropTypes.func.isRequired,
-    refreshTransaction: PropTypes.func.isRequired,
+    isEmpty: PropTypes.bool.isRequired,
     title: PropTypes.string.isRequired,
     transaction: PropTypes.object,
     transactionRequest: PropTypes.object
   };
 
-  isEmpty = () => {
-    return this.props.isEmpty ? this.props.isEmpty(this.props) : !this.props.data;
+  onAdd = () => {
+    this.captureEvent('add-link');
+    this.openEditModal();
   }
 
-  isEditLinKVisible() {
+  onCancel = () => {
+    this.captureEvent('cancel-button');
+    this.closeModal();
+  }
+
+  onChange = (value, property, skipValidation) => {
+    this.props.updateFormField(
+      this.props.fieldName,
+      this.props.cleanEditedData,
+      this.props.validateEditedData,
+      value,
+      property,
+      skipValidation
+    );
+  }
+
+  onDelete = () => {
+    let payload = this.props.data;
+    if (this.props.getPayload) payload = this.props.getPayload(payload, this.props.fieldName);
+
+    this.props.createTransaction(
+      this.props.apiRoute,
+      'DELETE',
+      this.props.fieldName,
+      payload
+    );
+  }
+
+  onEdit = () => {
+    this.captureEvent('edit-link');
+    this.openEditModal();
+  }
+
+  onSubmit = () => {
+    this.captureEvent('update-button');
+
+    let payload = this.props.field.value;
+    if (this.props.getPayload) payload = this.props.getPayload(payload, this.props.fieldName);
+
+    const method = payload.id ? 'PUT' : 'POST';
+
+    this.props.createTransaction(
+      this.props.apiRoute,
+      method,
+      this.props.fieldName,
+      payload
+    );
+  }
+
+  clearErrors = () => {
+    this.props.clearTransactionRequest(this.props.fieldName);
+  }
+
+  closeModal = () => {
+    this.props.openModal(null);
+  }
+
+  openEditModal = () => {
+    this.props.openModal(this.props.fieldName);
+  }
+
+  refreshTransaction = () => {
+    this.props.refreshTransaction(this.props.transaction, this.props.analyticsSectionName);
+  }
+
+  captureEvent(actionName, sectionName = this.props.analyticsSectionName) {
+    if (sectionName && actionName) {
+      recordEvent({
+        event: 'profile-navigation',
+        'profile-action': actionName,
+        'profile-section': sectionName,
+      });
+    }
+  }
+
+  isEditLinKVisible = () => {
     let transactionPending = false;
     if (this.props.transaction) {
       transactionPending = isPendingTransaction(this.props.transaction);
     }
-    return !this.isEmpty() && !transactionPending;
+    return !this.props.isEmpty && !transactionPending;
   }
 
   render() {
     const {
       fieldName,
       isEditing,
-      onAdd,
-      onEdit,
+      isEmpty,
       Content,
       EditModal,
       title,
@@ -76,23 +143,35 @@ class Vet360ProfileField extends React.Component {
       transactionRequest
     } = this.props;
 
+    const childProps = {
+      ...this.props,
+      refreshTransaction: this.refreshTransaction,
+      clearErrors: this.clearErrors,
+      onAdd: this.onAdd,
+      onEdit: this.onEdit,
+      onChange: this.onChange,
+      onDelete: this.onDelete,
+      onCancel: this.onCancel,
+      onSubmit: this.onSubmit
+    };
+
     return (
       <div className="vet360-profile-field" data-field-name={fieldName}>
-        <Vet360ProfileFieldHeading onEditClick={this.isEditLinKVisible() && onEdit}>{title}</Vet360ProfileFieldHeading>
-        {isEditing && <EditModal {...this.props} isEmpty={this.isEmpty}/>}
+        <Vet360ProfileFieldHeading onEditClick={this.isEditLinKVisible() && this.onEdit}>{title}</Vet360ProfileFieldHeading>
+        {isEditing && <EditModal {...childProps}/>}
         <Vet360Transaction
           title={title}
           transaction={transaction}
           transactionRequest={transactionRequest}
           refreshTransaction={this.props.refreshTransaction.bind(this, transaction)}>
-          {this.isEmpty() ? (
+          {isEmpty ? (
             <button
               type="button"
-              onClick={onAdd}
+              onClick={this.onAdd}
               className="va-button-link va-profile-btn">
               Please add your {title.toLowerCase()}
             </button>
-          ) : <Content {...this.props}/>}
+          ) : <Content {...childProps}/>}
         </Vet360Transaction>
       </div>
     );
@@ -102,83 +181,26 @@ class Vet360ProfileField extends React.Component {
 const mapStateToProps = (state, ownProps) => {
   const { fieldName } = ownProps;
   const { transaction, transactionRequest } = selectVet360Transaction(state, fieldName);
+  const data = selectVet360Field(state, fieldName);
+  const isEmpty = !data;
 
   return {
     analyticsSectionName: VET360.ANALYTICS_FIELD_MAP[fieldName],
-    data: selectVet360Field(state, fieldName),
+    data,
     field: selectEditedFormField(state, fieldName),
     isEditing: selectCurrentlyOpenEditModal(state) === fieldName,
+    isEmpty,
     transaction,
     transactionRequest
   };
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => {
-  const {
-    fieldName
-  } = ownProps;
-
-  const sectionName = VET360.ANALYTICS_FIELD_MAP[fieldName];
-
-  const captureEvent = (actionName) => {
-    if (sectionName && actionName) {
-      recordEvent({
-        event: 'profile-navigation',
-        'profile-action': actionName,
-        'profile-section': sectionName,
-      });
-    }
-  };
-
-  const {
-    [fieldName]: {
-      update: updateField,
-      destroy: deleteField
-    }
-  } = fieldUpdaters;
-
-  const updateFormState = updateFormField[fieldName];
-
-  const closeEditModal = () => dispatch(openModal(null));
-  const openEditModal = () => dispatch(openModal(fieldName));
-
-  return {
-    clearErrors() {
-      dispatch(clearTransactionRequest(fieldName));
-    },
-
-    refreshTransaction(transaction) {
-      dispatch(refreshTransaction(transaction, sectionName));
-    },
-
-    onAdd() {
-      captureEvent('add-link');
-      openEditModal();
-    },
-
-    onCancel() {
-      captureEvent('cancel-button');
-      closeEditModal();
-    },
-
-    onChange(...args) {
-      dispatch(updateFormState(...args));
-    },
-
-    onDelete(...args) {
-      dispatch(deleteField(...args));
-    },
-
-    onEdit() {
-      captureEvent('edit-link');
-      openEditModal();
-    },
-
-    onSubmit(...args) {
-      captureEvent('update-button');
-      dispatch(updateField(...args));
-    }
-  };
+const mapDispatchToProps = {
+  clearTransactionRequest,
+  refreshTransaction,
+  openModal,
+  createTransaction,
+  updateFormField
 };
 
 const Vet360ProfileFieldContainer = connect(mapStateToProps, mapDispatchToProps)(Vet360ProfileField);
@@ -187,7 +209,10 @@ Vet360ProfileFieldContainer.propTypes = {
   fieldName: PropTypes.oneOf(Object.values(VET360.FIELD_NAMES)).isRequired,
   Content: PropTypes.func.isRequired,
   EditModal: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  apiRoute: PropTypes.oneOf(Object.values(VET360.API_ROUTES)).isRequired,
+  cleanEditedData: PropTypes.func.isRequired,
+  validateEditedData: PropTypes.func.isRequired
 };
 
 export default Vet360ProfileFieldContainer;


### PR DESCRIPTION
This PR wraps up the remaining items of technical debt on the Vet360 form components extracted from the Profile 360. Changes include:

- Action creators are derived within the `ProfileField` rather than exporting a map of field-names and update/destroy action creators.
    - I was able to delete a lot of old code because of this.
- Functions for formatting and validating edited data have been renamed and moved from the actions files into the corresponding component for each field and passed to `ProfileField` as a prop. They are then passed as arguments to the action creators during certain events. 
    - They have been renamed to try to clarify the flow of the data and the order of which they are called. This looks like:
        1. `convertNextValueToCleanData`
        2. `validateCleanData`
        3.  `convertCleanDataToPayload`
- In `actions/transactions.js`, `updateVet360Field` and `deleteVet360Field` have been consolidated into a single `createTransaction` function, which requires a few more parameters but removes a lot of redundancy. It also reduces the file to functions that pertain only to transactions that are indifferent to what type of data they are working with.
- Switches to class-syntax rather than plain functions in creating the field components. I felt that this grouped the functions more clearly.
- Adds prop-types and JSDoc comments.
- Some miscellaneous cleanup.

Resolves department-of-veterans-affairs/vets.gov-team/issues/11642
Resolves department-of-veterans-affairs/vets.gov-team/issues/11643