### PR TITLE
526 confirmation poll

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
@@ -54,6 +54,7 @@ const errorMessage = (jobId) => (
     <p>We’re sorry. Something went wrong on our end when we tried to submit your application. For help, please call the Vets.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
     <strong>Confirmation number</strong>
     <div>{jobId}</div>
+    <br/>
   </div>
 );
 
@@ -98,8 +99,7 @@ export class ConfirmationPoll extends React.Component {
       return;
     }
 
-    // apiRequest(`/disability_compensation_form/submission_status/${this.props.jobId}`)
-    apiRequest('/disability_compensation_form/submission_status/1f67ef1799012b1972d3772c')
+    apiRequest(`/disability_compensation_form/submission_status/${this.props.jobId}`)
       .then((response) => {
         // Don't process the request once it comes back if the component is no longer mounted
         if (!this.__isMounted) {

--- a/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import Raven from 'raven-js';
 
+// import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
 import get from '../../../../platform/utilities/data/get';
 
 import { apiRequest } from '../../../../platform/utilities/api';
@@ -15,6 +17,47 @@ export const submissionStatuses = {
   // When the api serves a failure
   apiFailure: 'apiFailure'
 };
+
+const messageTemplate = (idSection) => (
+  <div>
+    <h3>We’ve received your application</h3>
+    <p>Thank you for filing a claim for increased disability compensation.</p>
+    {idSection}
+    <p>You can check the status of your claim online. Please allow 24 hours for your increased disability claim to show up there.</p>
+    <p><a href="/track-claims">Check the status of your claim.</a></p>
+    <p>If you don’t see your increased disability claim online after 24 hours, please call Veterans Benefits Assistance at <a href="tel:+18008271000">1-800-827-1000</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
+  </div>
+);
+
+const successMessage = (claimId) => messageTemplate(
+  <div>
+    <strong>Claim ID number</strong>
+    <div>{claimId}</div>
+  </div>
+);
+
+/* const checkLaterMessage = (jobId) => messageTemplate(
+ *   <div>
+ *     <strong>Confirmation number</strong>
+ *     <div>{jobId}</div>
+ *   </div>
+ * );
+ *
+ * const errorMessage = (jobId) => (
+ *   <div>
+ *     <h3>Thank you for filing a claim for increased disability compensation.</h3>
+ *     <strong>Confirmation number</strong>
+ *     <div>{jobId}</div>
+ *     <p>We're sorry. Something went wrong on our end when we tried to submit your application. For help, please call the Vets.gov Help Desk at <a href="tel:+18008271000">1-800-827-1000</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
+ *   </div>
+ * );
+ *
+ * const pendingMessage = (
+ *   <AlertBox
+ *     isVisible
+ *     status="info"
+ *     content="Please wait while we submit your application."/>
+ * ); */
 
 export default class ConfirmationPoll extends React.Component {
   static defaultProps = {
@@ -46,7 +89,8 @@ export default class ConfirmationPoll extends React.Component {
       return;
     }
 
-    apiRequest(`disability_compensation_form/submission_status/${this.props.jobId}`)
+    // apiRequest(`/disability_compensation_form/submission_status/${this.props.jobId}`)
+    apiRequest('/disability_compensation_form/submission_status/1f67ef1799012b1972d3772c')
       .then((response) => {
         // Check status
         const status = response.data.attributes.transactionStatus;
@@ -72,18 +116,11 @@ export default class ConfirmationPoll extends React.Component {
 
   render() {
     switch (this.state.submissionStatus) {
+      case submissionStatuses.succeeded:
+        return successMessage(this.state.claimId);
       case submissionStatuses.retry: {
         // What should we do here?
-        return <p><strong>This is taking a while.</strong> Please check on the Claims Status tool later.</p>;
-      }
-      case submissionStatuses.succeeded: {
-        return (
-          <div>
-            <strong>Confirmation number</strong>
-            <br/>
-            {this.state.claimId}
-          </div>
-        );
+        return null;
       }
       case submissionStatuses.exhausted: {
         // TODO: What should we do here?

--- a/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
@@ -108,7 +108,11 @@ export default class ConfirmationPoll extends React.Component {
             statusCode: this.state.failureCode
           }
         });
-        return null;
+        return (
+          <div>
+            <p>Looks like something went wrong. That's a bummer.</p>
+          </div>
+        );
       }
       default: {
         // pending

--- a/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
@@ -27,25 +27,26 @@ export class ConfirmationPoll extends React.Component {
   }
 
   componentDidMount() {
-    this.isMounted = true;
+    // Using __ because it fails the unit test without it; something about enzyme using that property, I'm sure
+    this.__isMounted = true;
     this.startTime = Date.now();
     this.poll();
   }
 
   componentWillUnmount() {
-    this.isMounted = false;
+    this.__isMounted = false;
   }
 
   poll = () => {
     // Don't continue to request after the component is unmounted
-    if (!this.isMounted) {
+    if (!this.__isMounted) {
       return;
     }
 
     apiRequest(`/disability_compensation_form/submission_status/${this.props.jobId}`)
       .then((response) => {
         // Don't process the request once it comes back if the component is no longer mounted
-        if (!this.isMounted) {
+        if (!this.__isMounted) {
           return;
         }
 
@@ -71,7 +72,7 @@ export class ConfirmationPoll extends React.Component {
       })
       .catch((response) => {
         // Don't process the request once it comes back if the component is no longer mounted
-        if (!this.isMounted) {
+        if (!this.__isMounted) {
           return;
         }
 

--- a/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
@@ -1,68 +1,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
-
 import get from '../../../../platform/utilities/data/get';
 import { apiRequest } from '../../../../platform/utilities/api';
 
 import ConfirmationPage from '../containers/ConfirmationPage';
+import { pendingMessage } from '../content/confirmation-poll';
 
-export const submissionStatuses = {
-  // Statuses returned by the API
-  pending: 'submitted', // Submitted to EVSS, waiting response
-  retry: 'retrying',
-  succeeded: 'received', // Submitted to EVSS, received response
-  exhausted: 'exhausted', // EVSS is down or something; ran out of retries
-  failed: 'non_retryable_error', // EVSS responded with some error
-  // When the api serves a failure
-  apiFailure: 'apiFailure'
-};
-
-const terminalStatuses = new Set([
-  submissionStatuses.succeeded,
-  submissionStatuses.exhausted,
-  submissionStatuses.retry,
-  submissionStatuses.failed
-]);
-
-const successMessage = (claimId) => (
-  <div>
-    <p>Thank you for filing a claim for increased disability compensation.</p>
-    <strong>Claim ID number</strong>
-    <div>{claimId}</div>
-    <p>You can check the status of your claim online. Please allow 24 hours for your increased disability claim to show up there.</p>
-    <p><a href="/track-claims">Check the status of your claim.</a></p>
-    <p>If you don’t see your increased disability claim online after 24 hours, please call Veterans Benefits Assistance at <a href="tel:+18008271000">1-800-827-1000</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
-  </div>
-);
-
-const checkLaterMessage = (jobId) => (
-  <div>
-    <p>Thank you for filing a claim for increased disability compensation.</p>
-    <strong>Confirmation number</strong>
-    <div>{jobId}</div>
-    <p>You can check the status of your claim online. Please allow 24 hours for your increased disability claim to show up there.</p>
-    <p><a href="/track-claims">Check the status of your claim.</a></p>
-    <p>If you don’t see your increased disability claim online after 24 hours, please call Vets.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
-  </div>
-);
-
-const errorMessage = (jobId) => (
-  <div>
-    <p>We’re sorry. Something went wrong on our end when we tried to submit your application. For help, please call the Vets.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
-    <strong>Confirmation number</strong>
-    <div>{jobId}</div>
-    <br/>
-  </div>
-);
-
-const pendingMessage = (longWait) => {
-  const message = !longWait
-    ? 'Please wait while we submit your application and give you a confirmation number.'
-    : 'We’re sorry. It’s taking us longer than expected to submit your application. Thank you for your patience.';
-  return <LoadingIndicator message={message}/>;
-};
+import { submissionStatuses, terminalStatuses } from '../constants';
 
 export class ConfirmationPoll extends React.Component {
   // Using it as a prop for easy testing
@@ -139,29 +84,18 @@ export class ConfirmationPoll extends React.Component {
   }
 
   render() {
-    if (this.state.submissionStatus === submissionStatuses.pending) {
+    const { submissionStatus, claimId } = this.state;
+    if (submissionStatus === submissionStatuses.pending) {
       return pendingMessage(this.state.longWait);
     }
 
     const { fullName, disabilities, submittedAt, jobId } = this.props;
 
-    let submissionMessage;
-    switch (this.state.submissionStatus) {
-      case submissionStatuses.succeeded:
-        submissionMessage = successMessage(this.state.claimId);
-        break;
-      case submissionStatuses.retry:
-      case submissionStatuses.exhausted:
-      case submissionStatuses.apiFailure:
-        submissionMessage = checkLaterMessage(jobId);
-        break;
-      default:
-        submissionMessage = errorMessage(jobId);
-    }
-
     return (
       <ConfirmationPage
-        submissionMessage={submissionMessage}
+        submissionStatus={submissionStatus}
+        claimId={claimId}
+        jobId={jobId}
         fullName={fullName}
         disabilities={disabilities}
         submittedAt={submittedAt}/>

--- a/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Raven from 'raven-js';
 
-// import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
 import get from '../../../../platform/utilities/data/get';
 
@@ -18,46 +18,48 @@ export const submissionStatuses = {
   apiFailure: 'apiFailure'
 };
 
-const messageTemplate = (idSection) => (
+const terminalStatuses = [
+  submissionStatuses.succeeded,
+  submissionStatuses.exhausted,
+  submissionStatuses.failed
+];
+
+const successMessage = (claimId) => (
   <div>
-    <h3>We’ve received your application</h3>
     <p>Thank you for filing a claim for increased disability compensation.</p>
-    {idSection}
+    <strong>Claim ID number</strong>
+    <div>{claimId}</div>
     <p>You can check the status of your claim online. Please allow 24 hours for your increased disability claim to show up there.</p>
     <p><a href="/track-claims">Check the status of your claim.</a></p>
     <p>If you don’t see your increased disability claim online after 24 hours, please call Veterans Benefits Assistance at <a href="tel:+18008271000">1-800-827-1000</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
   </div>
 );
 
-const successMessage = (claimId) => messageTemplate(
+const checkLaterMessage = (jobId) => (
   <div>
-    <strong>Claim ID number</strong>
-    <div>{claimId}</div>
+    <p>Thank you for filing a claim for increased disability compensation.</p>
+    <strong>Confirmation number</strong>
+    <div>{jobId}</div>
+    <p>You can check the status of your claim online. Please allow 24 hours for your increased disability claim to show up there.</p>
+    <p><a href="/track-claims">Check the status of your claim.</a></p>
+    <p>If you don’t see your increased disability claim online after 24 hours, please call Vets.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
   </div>
 );
 
-/* const checkLaterMessage = (jobId) => messageTemplate(
- *   <div>
- *     <strong>Confirmation number</strong>
- *     <div>{jobId}</div>
- *   </div>
- * );
- *
- * const errorMessage = (jobId) => (
- *   <div>
- *     <h3>Thank you for filing a claim for increased disability compensation.</h3>
- *     <strong>Confirmation number</strong>
- *     <div>{jobId}</div>
- *     <p>We're sorry. Something went wrong on our end when we tried to submit your application. For help, please call the Vets.gov Help Desk at <a href="tel:+18008271000">1-800-827-1000</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
- *   </div>
- * );
- *
- * const pendingMessage = (
- *   <AlertBox
- *     isVisible
- *     status="info"
- *     content="Please wait while we submit your application."/>
- * ); */
+const errorMessage = (jobId) => (
+  <div>
+    <p>We're sorry. Something went wrong on our end when we tried to submit your application. For help, please call the Vets.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
+    <strong>Confirmation number</strong>
+    <div>{jobId}</div>
+  </div>
+);
+
+const pendingMessage = (
+  <AlertBox
+    isVisible
+    status="info"
+    content="Please wait while we submit your application."/>
+);
 
 export default class ConfirmationPoll extends React.Component {
   static defaultProps = {
@@ -67,6 +69,7 @@ export default class ConfirmationPoll extends React.Component {
   constructor(props) {
     super(props);
 
+    this.__pollCount = 0;
     this.state = {
       submissionStatus: submissionStatuses.pending,
       claimId: null,
@@ -89,23 +92,35 @@ export default class ConfirmationPoll extends React.Component {
       return;
     }
 
+    this.__pollCount++;
+
     // apiRequest(`/disability_compensation_form/submission_status/${this.props.jobId}`)
     apiRequest('/disability_compensation_form/submission_status/1f67ef1799012b1972d3772c')
       .then((response) => {
         // Check status
         const status = response.data.attributes.transactionStatus;
-        if (status !== submissionStatuses.pending) {
+        if (terminalStatuses.includes(status)) {
           this.setState({
             submissionStatus: status,
             claimId: get('data.attributes.metadata.claimId', response) || null
           });
         } else {
-          // Wait for 5 seconds and recurse
-          setTimeout(this.poll, this.props.pollRate);
+          // Wait for a bit and recurse
+          const waitTime = status === submissionStatuses.pending
+            ? this.props.pollRate
+            : this.props.pollRate * 2; // Seems like we don't need to poll as frequently when we get here
+          setTimeout(this.poll, waitTime);
         }
       })
       .catch((response) => {
-        // The call to the API failed; show a message or something
+        // The call to the API failed
+        Raven.captureMessage('526_submission_status_poll_failure', {
+          context: {
+            jobId: this.props.jobId,
+            statusCode: this.state.failureCode
+          }
+        });
+
         this.setState({
           submissionStatus: submissionStatuses.apiFailure,
           // NOTE: I don't know that it'll always take this shape.
@@ -118,47 +133,15 @@ export default class ConfirmationPoll extends React.Component {
     switch (this.state.submissionStatus) {
       case submissionStatuses.succeeded:
         return successMessage(this.state.claimId);
-      case submissionStatuses.retry: {
-        // What should we do here?
-        return null;
-      }
-      case submissionStatuses.exhausted: {
-        // TODO: What should we do here?
-        return (
-          <div>
-            <p>This is taking a while; check back later.</p>
-          </div>
-        );
-      }
-      case submissionStatuses.failed: {
-        // TODO: What should we do here?
-        return (
-          <div>
-            <p>There was an error submitting to EVSS. Please try again later</p>
-          </div>
-        );
-      }
-      case submissionStatuses.apiFailure: {
-        // What should we do here?
-        Raven.captureMessage('526_submission_failure', {
-          context: {
-            statusCode: this.state.failureCode
-          }
-        });
-        return (
-          <div>
-            <p>Looks like something went wrong. That's a bummer.</p>
-          </div>
-        );
-      }
-      default: {
+      case submissionStatuses.retry:
+      case submissionStatuses.exhausted:
+      case submissionStatuses.apiFailure:
+        return checkLaterMessage(this.props.jobId);
+      case submissionStatuses.failed:
+        return errorMessage(this.props.jobId);
+      default:
         // pending
-        return (
-          <div>
-            <p>Please wait while we submit your application.</p>
-          </div>
-        );
-      }
+        return pendingMessage(this.__pollCount);
     }
   }
 }

--- a/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import Raven from 'raven-js';
+
+const statuses = {
+  // The status returned by the API
+  pending: 'pending',
+  retry: 'retry',
+  succeeded: 'succeeded',
+  failed: 'failed',
+  // When the api serves a failure
+  apiFailure: 'apiFailure'
+};
+
+export class ConfirmationPoll extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      submissionStatus: statuses.pending,
+      confirmationNumber: null,
+      failureCode: null,
+    };
+  }
+
+  componentDidMount() {
+    this.poll();
+  }
+
+  poll() {
+    fetch()
+      .then((response) => {
+        // Check status
+        // TODO: Get where this actually comes from in the response
+        if (response.status !== statuses.pending) {
+          this.setState({
+            submissionStatus: response.status,
+            // TODO: Get where this actually comes from in the response
+            confirmationNumber: response.confirmationNumber || null
+          });
+        } else {
+          // Wait for 5 seconds and recurse
+          setTimeout(this.poll, 5000);
+        }
+      })
+      .catch((response) => {
+        // console.log('API call failed:', response);
+        // The call to the API failed; show a message or something
+        this.setState({
+          submissionStatus: statuses.apiFailure,
+          // TODO: Make sure this is the right variable
+          failureCode: response.code
+        });
+      });
+  }
+
+  render() {
+    switch (this.state.submissionStatus) {
+      case statuses.retry: {
+        // What should we do here?
+        return null;
+      }
+      case statuses.succeeded: {
+        return (
+          <div>
+            <strong>Confirmation number</strong>
+            <br/>
+            {this.state.confirmationNumber}
+          </div>
+        );
+      }
+      case statuses.failed: {
+        return null;
+      }
+      case statuses.apiFailure: {
+        Raven.captureMessage('526_submission_failure', {
+          context: {
+            statusCode: this.state.failureCode
+          }
+        });
+        return null;
+      }
+      default: {
+        // pending
+        return (
+          <div>
+            <strong>Confirmation number goes here</strong>
+          </div>
+        );
+      }
+    }
+  }
+}

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -13,7 +13,7 @@ import FormFooter from '../../../../platform/forms/components/FormFooter';
 import environment from '../../../../platform/utilities/environment';
 
 import IntroductionPage from '../components/IntroductionPage';
-import ConfirmationPage from '../containers/ConfirmationPage';
+import ConfirmationPoll from '../components/ConfirmationPoll';
 
 import {
   uiSchema as primaryAddressUiSchema,
@@ -134,7 +134,7 @@ const formConfig = {
   },
   transformForSubmit: transform,
   introduction: IntroductionPage,
-  confirmation: ConfirmationPage,
+  confirmation: ConfirmationPoll,
   footerContent: FormFooter,
   getHelp: GetFormHelp,
   defaultDefinitions: {

--- a/src/applications/disability-benefits/526EZ/constants.js
+++ b/src/applications/disability-benefits/526EZ/constants.js
@@ -97,3 +97,21 @@ export const RESERVE_GUARD_TYPES = {
   nationalGuard: 'National Guard',
   reserve: 'Reserve'
 };
+
+export const submissionStatuses = {
+  // Statuses returned by the API
+  pending: 'submitted', // Submitted to EVSS, waiting response
+  retry: 'retrying',
+  succeeded: 'received', // Submitted to EVSS, received response
+  exhausted: 'exhausted', // EVSS is down or something; ran out of retries
+  failed: 'non_retryable_error', // EVSS responded with some error
+  // When the api serves a failure
+  apiFailure: 'apiFailure'
+};
+
+export const terminalStatuses = new Set([
+  submissionStatuses.succeeded,
+  submissionStatuses.exhausted,
+  submissionStatuses.retry,
+  submissionStatuses.failed
+]);

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -99,11 +99,11 @@ export default class ConfirmationPage extends React.Component {
           <ul className="claim-list">
             <strong>Conditions claimed for increase</strong>
             <br/>
-            {/* <ul className="disability-list">
-                {disabilities.filter(item => item['view:selected']).map((disability, i) => {
+            <ul className="disability-list">
+              {disabilities.filter(item => item['view:selected']).map((disability, i) => {
                 return <li key={i}>{disability.name}</li>;
-                })}
-                </ul> */}
+              })}
+            </ul>
             {submissionMessage}
             <li>
               <strong>Date submitted</strong>

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -5,6 +5,7 @@ import Scroll from 'react-scroll';
 
 import { focusElement } from '../../../../platform/utilities/ui';
 import { get4142Selection } from '../helpers';
+import ConfirmationPoll from '../components/ConfirmationPoll';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
@@ -30,7 +31,6 @@ class ConfirmationPage extends React.Component {
     const {
       fullName: { first, middle, last, suffix },
       disabilities,
-      claimId,
       submittedAt
     } = this.props;
 
@@ -94,9 +94,7 @@ class ConfirmationPage extends React.Component {
               })}
             </ul>
             <li>
-              <strong>Confirmation number</strong>
-              <br/>
-              <span>{claimId}</span>
+              <ConfirmationPoll/>
             </li>
             <li>
               <strong>Date submitted</strong>
@@ -129,7 +127,6 @@ function mapStateToProps(state) {
   return {
     fullName: state.user.profile.userFullName,
     disabilities: state.form.data.disabilities,
-    claimId: state.form.submission.response.attributes.claimId,
     submittedAt: state.form.submission.submittedAt
   };
 }

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -34,6 +34,7 @@ class ConfirmationPage extends React.Component {
       submittedAt
     } = this.props;
 
+    // TODO: Verify we need this
     const selected4142 = get4142Selection(disabilities || []);
 
     const privateRecordReleaseContent = (
@@ -61,49 +62,50 @@ class ConfirmationPage extends React.Component {
     return (
       <div>
         <h3 className="confirmation-page-title">Your claim has been submitted.</h3>
-        <p>We usually process claims within <strong>99 days</strong>.</p>
-        <p>We may contact you if we have questions or need more information.
-        You can print this page for your records.</p>
-        <ConfirmationPoll jobId={this.props.jobId}/>
-        { selected4142 && privateRecordReleaseContent}
-        <h4 className="confirmation-guidance-heading">
-          What happens after I apply?
-        </h4>
-        <p className="confirmation-guidance-message">
-          You don’t need to do anything unless we send you a letter asking for
-          more information. You can check the status of your claim online. The
-          time frame you see may vary based on how complex your claim is.
+        <p>
+          We process applications in the order we receive them.
+          We may contact you if we have questions or need more information.
+          You can print this page for your records.
         </p>
-        <a href="/disability-benefits/track-claims">
-          Check the status of your disability claim.
-        </a>
-        <br/>
-        <a href="/disability-benefits/after-you-apply/">
-          Learn more about what happens after you file a disability claim.
-        </a>
+        { selected4142 && privateRecordReleaseContent}
+
         <div className="inset">
           <h4>Disability Compensation Claim <span className="additional">(Form 21-526EZ)</span></h4>
           <span>
             For {first} {middle} {last} {suffix}
           </span>
           <ul className="claim-list">
-            <strong>Conditions claimed</strong>
+            <strong>Conditions claimed for increase</strong>
             <br/>
             {/* <ul className="disability-list">
                 {disabilities.filter(item => item['view:selected']).map((disability, i) => {
                 return <li key={i}>{disability.name}</li>;
                 })}
                 </ul> */}
+            <ConfirmationPoll jobId={this.props.jobId}/>
             <li>
               <strong>Date submitted</strong>
               <br/>
               <span>{moment(submittedAt).format('MMM D, YYYY')}</span>
             </li>
+            <ConfirmationPoll jobId={this.props.jobId}/>
           </ul>
         </div>
+
+        <h4 className="confirmation-guidance-heading">
+          What happens after I apply?
+        </h4>
+        <p className="confirmation-guidance-message">
+          You don’t need to do anything unless we send you a letter asking for more information.
+        </p>
+        <br/>
+        <a href="/disability-benefits/after-you-apply/">
+          Learn more about what happens after you file a disability claim.
+        </a>
         <div className="confirmation-guidance-container">
           <h4 className="confirmation-guidance-heading">Need help?</h4>
-          <p className="confirmation-guidance-message">If you have questions, please call <a href="tel:+18772228387">1-877-222-8387</a>, Monday &#8211;
+          <p className="confirmation-guidance-message">
+            If you have questions, please call <a href="tel:+18772228387">1-877-222-8387</a>, Monday &#8211;
             Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).
           </p>
         </div>

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import moment from 'moment';
-import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
 import { focusElement } from '../../../../platform/utilities/ui';
 import { get4142Selection } from '../helpers';
-import ConfirmationPoll from '../components/ConfirmationPoll';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
@@ -16,7 +14,7 @@ const scrollToTop = () => {
   });
 };
 
-class ConfirmationPage extends React.Component {
+export default class ConfirmationPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = { isExpanded: false };
@@ -82,13 +80,12 @@ class ConfirmationPage extends React.Component {
                 return <li key={i}>{disability.name}</li>;
                 })}
                 </ul> */}
-            <ConfirmationPoll jobId={this.props.jobId}/>
+            {this.props.submissionMessage}
             <li>
               <strong>Date submitted</strong>
               <br/>
               <span>{moment(submittedAt).format('MMM D, YYYY')}</span>
             </li>
-            <ConfirmationPoll jobId={this.props.jobId}/>
           </ul>
         </div>
 
@@ -122,15 +119,3 @@ class ConfirmationPage extends React.Component {
     );
   }
 }
-
-function mapStateToProps(state) {
-  return {
-    fullName: state.user.profile.userFullName,
-    disabilities: state.form.data.disabilities,
-    submittedAt: state.form.submission.submittedAt,
-    jobId: state.form.submission.response.attributes.jobId
-  };
-}
-
-export default connect(mapStateToProps)(ConfirmationPage);
-export { ConfirmationPage };

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -88,11 +88,11 @@ class ConfirmationPage extends React.Component {
           <ul className="claim-list">
             <strong>Conditions claimed</strong>
             <br/>
-            <ul className="disability-list">
-              {disabilities.filter(item => item['view:selected']).map((disability, i) => {
+            {/* <ul className="disability-list">
+                {disabilities.filter(item => item['view:selected']).map((disability, i) => {
                 return <li key={i}>{disability.name}</li>;
-              })}
-            </ul>
+                })}
+                </ul> */}
             <li>
               <ConfirmationPoll/>
             </li>

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -4,6 +4,13 @@ import Scroll from 'react-scroll';
 
 import { focusElement } from '../../../../platform/utilities/ui';
 import { get4142Selection } from '../helpers';
+import {
+  successMessage,
+  checkLaterMessage,
+  errorMessage
+} from '../content/confirmation-poll';
+
+import { submissionStatuses } from '../constants';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
@@ -29,8 +36,25 @@ export default class ConfirmationPage extends React.Component {
     const {
       fullName: { first, middle, last, suffix },
       disabilities,
-      submittedAt
+      submittedAt,
+      claimId,
+      jobId,
+      submissionStatus
     } = this.props;
+
+    let submissionMessage;
+    switch (submissionStatus) {
+      case submissionStatuses.succeeded:
+        submissionMessage = successMessage(claimId);
+        break;
+      case submissionStatuses.retry:
+      case submissionStatuses.exhausted:
+      case submissionStatuses.apiFailure:
+        submissionMessage = checkLaterMessage(jobId);
+        break;
+      default:
+        submissionMessage = errorMessage(jobId);
+    }
 
     // TODO: Verify we need this
     const selected4142 = get4142Selection(disabilities || []);
@@ -80,7 +104,7 @@ export default class ConfirmationPage extends React.Component {
                 return <li key={i}>{disability.name}</li>;
                 })}
                 </ul> */}
-            {this.props.submissionMessage}
+            {submissionMessage}
             <li>
               <strong>Date submitted</strong>
               <br/>

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -64,6 +64,7 @@ class ConfirmationPage extends React.Component {
         <p>We usually process claims within <strong>99 days</strong>.</p>
         <p>We may contact you if we have questions or need more information.
         You can print this page for your records.</p>
+        <ConfirmationPoll jobId={this.props.jobId}/>
         { selected4142 && privateRecordReleaseContent}
         <h4 className="confirmation-guidance-heading">
           What happens after I apply?
@@ -81,7 +82,7 @@ class ConfirmationPage extends React.Component {
           Learn more about what happens after you file a disability claim.
         </a>
         <div className="inset">
-          <h4>Disability Compensation Claim for Increase <span className="additional">(Form 21-526EZ)</span></h4>
+          <h4>Disability Compensation Claim <span className="additional">(Form 21-526EZ)</span></h4>
           <span>
             For {first} {middle} {last} {suffix}
           </span>
@@ -93,9 +94,6 @@ class ConfirmationPage extends React.Component {
                 return <li key={i}>{disability.name}</li>;
                 })}
                 </ul> */}
-            <li>
-              <ConfirmationPoll/>
-            </li>
             <li>
               <strong>Date submitted</strong>
               <br/>
@@ -127,7 +125,8 @@ function mapStateToProps(state) {
   return {
     fullName: state.user.profile.userFullName,
     disabilities: state.form.data.disabilities,
-    submittedAt: state.form.submission.submittedAt
+    submittedAt: state.form.submission.submittedAt,
+    jobId: state.form.submission.response.attributes.jobId
   };
 }
 

--- a/src/applications/disability-benefits/526EZ/content/confirmation-poll.jsx
+++ b/src/applications/disability-benefits/526EZ/content/confirmation-poll.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
+
+export const successMessage = (claimId) => (
+  <div>
+    <p>Thank you for filing a claim for increased disability compensation.</p>
+    <strong>Claim ID number</strong>
+    <div>{claimId}</div>
+    <p>You can check the status of your claim online. Please allow 24 hours for your increased disability claim to show up there.</p>
+    <p><a href="/track-claims">Check the status of your claim.</a></p>
+    <p>If you don’t see your increased disability claim online after 24 hours, please call Veterans Benefits Assistance at <a href="tel:+18008271000">1-800-827-1000</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
+  </div>
+);
+
+export const checkLaterMessage = (jobId) => (
+  <div>
+    <p>Thank you for filing a claim for increased disability compensation.</p>
+    <strong>Confirmation number</strong>
+    <div>{jobId}</div>
+    <p>You can check the status of your claim online. Please allow 24 hours for your increased disability claim to show up there.</p>
+    <p><a href="/track-claims">Check the status of your claim.</a></p>
+    <p>If you don’t see your increased disability claim online after 24 hours, please call Vets.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
+  </div>
+);
+
+export const errorMessage = (jobId) => (
+  <div>
+    <p>We’re sorry. Something went wrong on our end when we tried to submit your application. For help, please call the Vets.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
+    <strong>Confirmation number</strong>
+    <div>{jobId}</div>
+    <br/>
+  </div>
+);
+
+export const pendingMessage = (longWait) => {
+  const message = !longWait
+    ? 'Please wait while we submit your application and give you a confirmation number.'
+    : 'We’re sorry. It’s taking us longer than expected to submit your application. Thank you for your patience.';
+  return <LoadingIndicator message={message}/>;
+};

--- a/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
+++ b/src/applications/disability-benefits/526EZ/pages/paymentInfo.jsx
@@ -18,17 +18,17 @@ const NOBANK = 'NOBANK';
 
 export const viewComponent = (response) => {
   const {
-    accountType,
-    accountNumber,
-    financialInstitutionRoutingNumber: routingNumber,
-    financialInstitutionName: bankName,
+    accountType = '',
+    accountNumber = '',
+    financialInstitutionRoutingNumber: routingNumber = '',
+    financialInstitutionName: bankName = '',
   } = response;
   let accountNumberString;
   let routingNumberString;
   let bankNameString;
   const mask = (string, unmaskedLength) => {
     // If no string is given, tell the screen reader users the account or routing number is blank
-    if (string === '') {
+    if (!string) {
       return srSubstitute('', 'is blank');
     }
     const repeatCount = string.length > unmaskedLength ? string.length - unmaskedLength : 0;

--- a/src/applications/disability-benefits/526EZ/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { mockApiRequest, mockMultipleApiRequests } from '../../../../../platform/testing/unit/helpers';
+
+import ConfirmationPoll, { submissionStatuses } from '../../components/ConfirmationPoll';
+
+const originalFetch = global.fetch;
+
+const pendingResponse = {
+  shouldResolve: true,
+  response: { status: submissionStatuses.pending }
+};
+const successResponse = {
+  shouldResolve: true,
+  response: {
+    status: submissionStatuses.succeeded,
+    confirmationNumber: '123abc'
+  }
+};
+const failureResponse = {
+  shouldResolve: true,
+  response: { status: submissionStatuses.failed }
+};
+
+describe('ConfirmationPoll', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('should make an api call after mounting', () => {
+    mockApiRequest(successResponse);
+    shallow(<ConfirmationPoll/>);
+    expect(global.fetch.calledOnce).to.be.true;
+  });
+
+  it('should continue to make api calls until the response is not pending', (done) => {
+    mockMultipleApiRequests([pendingResponse, pendingResponse, successResponse, failureResponse]);
+    shallow(<ConfirmationPoll pollRate={10}/>);
+    // Should stop after the first success
+    setTimeout(() => {
+      expect(global.fetch.callCount).to.equal(3);
+      done();
+    }, 50);
+  });
+
+  it('should render a pending message', () => {});
+  it('should render a retry message', () => {});
+  it('should render a success message', () => {});
+  it('should render a failure message', () => {});
+});

--- a/src/applications/disability-benefits/526EZ/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -1,43 +1,74 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
 
 import { mockApiRequest, mockMultipleApiRequests } from '../../../../../platform/testing/unit/helpers';
 
-import ConfirmationPoll, { submissionStatuses } from '../../components/ConfirmationPoll';
+import { ConfirmationPoll } from '../../components/ConfirmationPoll';
+import { submissionStatuses } from '../../constants';
 
 const originalFetch = global.fetch;
 
 const pendingResponse = {
   shouldResolve: true,
-  response: { status: submissionStatuses.pending }
+  response: {
+    data: {
+      attributes: {
+        transactionStatus: submissionStatuses.pending
+      }
+    }
+  }
 };
+
 const successResponse = {
   shouldResolve: true,
   response: {
-    status: submissionStatuses.succeeded,
-    confirmationNumber: '123abc'
+    data: {
+      attributes: {
+        transactionStatus: submissionStatuses.succeeded,
+        metadata: {
+          claimId: '123abc'
+        }
+      }
+    }
   }
 };
+
 const failureResponse = {
   shouldResolve: true,
-  response: { status: submissionStatuses.failed }
+  response: {
+    data: {
+      attributes: {
+        transactionStatus: submissionStatuses.failed
+      }
+    }
+  }
 };
 
+
 describe('ConfirmationPoll', () => {
+  const defaultProps = {
+    jobId: '12345',
+    fullName: { first: 'asdf', last: 'fdsa' },
+    disabilities: [],
+    submittedAt: Date.now()
+  };
+
   afterEach(() => {
     global.fetch = originalFetch;
   });
 
   it('should make an api call after mounting', () => {
-    mockApiRequest(successResponse);
+    mockApiRequest(successResponse.response);
     shallow(<ConfirmationPoll/>);
     expect(global.fetch.calledOnce).to.be.true;
   });
 
   it('should continue to make api calls until the response is not pending', (done) => {
     mockMultipleApiRequests([pendingResponse, pendingResponse, successResponse, failureResponse]);
-    shallow(<ConfirmationPoll pollRate={10}/>);
+    // TODO: Figure out why this is causing an error in the console even though the test passes
+    //  It may have something to do with unmounting the component before a `setState` goes through
+    mount(<ConfirmationPoll pollRate={10}/>);
     // Should stop after the first success
     setTimeout(() => {
       expect(global.fetch.callCount).to.equal(3);
@@ -45,8 +76,23 @@ describe('ConfirmationPoll', () => {
     }, 50);
   });
 
-  it('should render a pending message', () => {});
-  it('should render a retry message', () => {});
-  it('should render a success message', () => {});
-  it('should render a failure message', () => {});
+  it('should render the confirmation page', (done) => {
+    mockApiRequest(successResponse.response);
+    const tree = shallow(<ConfirmationPoll {...defaultProps} pollRate={10}/>);
+    setTimeout(() => {
+      // Without this update, it wasn't catching the last render even though the function was running first
+      tree.update();
+      const confirmationPage = tree.find('ConfirmationPage');
+      expect(confirmationPage.length).to.equal(1);
+      expect(confirmationPage.first().props()).to.eql({
+        submissionStatus: submissionStatuses.succeeded,
+        claimId: '123abc',
+        jobId: defaultProps.jobId,
+        fullName: defaultProps.fullName,
+        disabilities: defaultProps.disabilities,
+        submittedAt: defaultProps.submittedAt
+      });
+      done();
+    }, 500);
+  });
 });

--- a/src/platform/testing/unit/helpers.js
+++ b/src/platform/testing/unit/helpers.js
@@ -137,7 +137,8 @@ export function mockMultipleApiRequests(responses, userToken = 'foo') {
   global.fetch = sinon.stub();
   responses.forEach((res, index) => {
     const { response, shouldResolve } = res;
-    global.fetch.onCall(index).returns(shouldResolve ? Promise.resolve(response) : Promise.reject(response));
+    const formattedResponse = getApiRequestObject(response);
+    global.fetch.onCall(index).returns(shouldResolve ? Promise.resolve(formattedResponse) : Promise.reject(formattedResponse));
   });
   conditionalStorage().setItem('userToken', userToken);
 }

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -30,7 +30,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
 
   const settings = merge(defaultSettings, optionalSettings);
 
-  return fetch(url, settings)
+  const fetchPromise = fetch(url, settings)
     .catch(err => {
       Raven.captureMessage(`vets_client_error: ${err.message}`, {
         extra: {
@@ -60,7 +60,14 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
       }
 
       return data;
-    })
-    .then(success)
-    .catch(error);
+    });
+
+  if (success) {
+    fetchPromise.then(success);
+  }
+  if (error) {
+    fetchPromise.catch(error);
+  }
+
+  return fetchPromise;
 }


### PR DESCRIPTION
## Description
This PR creates a `ConfirmationPoll` and uses it as the `confirmationPage` in the form config. `ConfirmationPoll` renders `ConfirmationPage` so we can show a loading spinner over the top of the confirmation page content without mucking about with redux.

## Screenshots
### Submitted (less than 30 seconds)
![image](https://user-images.githubusercontent.com/12970166/44693626-24539b80-aa1e-11e8-820b-aefeead5213b.png)

### Submitted (30 seconds or more)
![image](https://user-images.githubusercontent.com/12970166/44693640-35041180-aa1e-11e8-9b23-d3e482c7cefb.png)

### Retrying / exhausted / api call failure
![image](https://user-images.githubusercontent.com/12970166/44693652-43522d80-aa1e-11e8-948a-c202bee5db0c.png)

### Success
Only the blue box content changes.
![image](https://user-images.githubusercontent.com/12970166/44693672-59f88480-aa1e-11e8-8be7-76cce16e1505.png)

### Non-retryable error
![image](https://user-images.githubusercontent.com/12970166/44693685-709edb80-aa1e-11e8-99fc-5f74a5b869be.png)