### PR TITLE
Feedback tool confirmation page: Add and update edu phone number

### DIFF
--- a/src/applications/edu-benefits/complaint-tool/config/form.js
+++ b/src/applications/edu-benefits/complaint-tool/config/form.js
@@ -6,18 +6,18 @@ import fullNameUI from 'us-forms-system/lib/js/definitions/fullName';
 import dateUI from 'us-forms-system/lib/js/definitions/date';
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import phoneUI from 'us-forms-system/lib/js/definitions/phone';
-
 import { validateBooleanGroup } from 'us-forms-system/lib/js/validation';
+
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import SchoolSelectField from '../../components/SchoolSelectField.jsx';
 import GetFormHelp from '../../components/GetFormHelp';
 
+import { transform } from '../helpers';
+
 const { educationDetails } = fullSchema.properties;
 
 const { school } = educationDetails;
-
-import { transform } from '../helpers';
 
 const {
   name: schoolName,

--- a/src/applications/edu-benefits/complaint-tool/config/form.js
+++ b/src/applications/edu-benefits/complaint-tool/config/form.js
@@ -1,20 +1,21 @@
 import _ from 'lodash/fp';
 import React from 'react';
 import fullSchema from 'vets-json-schema/dist/complaint-tool-schema.json';
-
-import IntroductionPage from '../containers/IntroductionPage';
-import ConfirmationPage from '../containers/ConfirmationPage';
-import SchoolSelectField from '../../components/SchoolSelectField.jsx';
-
-const { educationDetails } = fullSchema.properties;
-
-const { school } = educationDetails;
+import FormFooter from '../../../../platform/forms/components/FormFooter';
 import fullNameUI from 'us-forms-system/lib/js/definitions/fullName';
 import dateUI from 'us-forms-system/lib/js/definitions/date';
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import phoneUI from 'us-forms-system/lib/js/definitions/phone';
 
 import { validateBooleanGroup } from 'us-forms-system/lib/js/validation';
+import IntroductionPage from '../containers/IntroductionPage';
+import ConfirmationPage from '../containers/ConfirmationPage';
+import SchoolSelectField from '../../components/SchoolSelectField.jsx';
+import GetFormHelp from '../../components/GetFormHelp';
+
+const { educationDetails } = fullSchema.properties;
+
+const { school } = educationDetails;
 
 import { transform } from '../helpers';
 
@@ -101,6 +102,8 @@ const formConfig = {
     noAuth: 'Please sign in again to continue your application for declaration of status of dependents.'
   },
   title: 'GI Bill® School Feedback Tool',
+  getHelp: GetFormHelp,
+  footerContent: FormFooter,
   transformForSubmit: transform,
   chapters: {
     applicantInformation: {

--- a/src/applications/edu-benefits/complaint-tool/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/complaint-tool/containers/ConfirmationPage.jsx
@@ -4,6 +4,9 @@ import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
 import { focusElement } from '../../../../platform/utilities/ui';
+import AskVAQuestions from '../../../../platform/forms/components/AskVAQuestions';
+
+import GetFormHelp from '../../components/GetFormHelp';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
@@ -44,6 +47,11 @@ export class ConfirmationPage extends React.Component {
             </li>
           </ul>}
         </div>}
+        <div>
+          <AskVAQuestions>
+            <GetFormHelp/>
+          </AskVAQuestions>
+        </div>
       </div>
     );
   }

--- a/src/applications/edu-benefits/components/GetFormHelp.jsx
+++ b/src/applications/edu-benefits/components/GetFormHelp.jsx
@@ -6,7 +6,7 @@ function GetFormHelp() {
       <p className="help-talk">For help filling out this form,<br/>
       ask the Education Call Center:</p>
       <p className="help-phone-number">
-        <a className="help-phone-number-link" href="tel:+1-888-442-4551">1-888-442-4551</a><br/>
+        <a className="help-phone-number-link" href="tel:+1-888-442-4551">1-888-442-4551 (1-888-GIBILL1)</a><br/>
         Monday &#8211; Friday, 8:00 a.m. &#8211; 7:00 p.m. (ET)<br/>
         <a className="help-phone-number-link" href="https://gibill.custhelp.com/app/utils/login_form/redirect/ask">Submit a question to Education Service</a>
       </p>


### PR DESCRIPTION
These changes add the call center information to the feedback tool form pages and confirmation page, and update the call center information.

Form page
![image](https://user-images.githubusercontent.com/16051172/43742478-f1d536ac-9986-11e8-8e8d-e925861af454.png)

Confirmation page
![image](https://user-images.githubusercontent.com/16051172/43742582-5888968c-9987-11e8-88a6-4d2435380f2d.png)
