### PR TITLE
Remove dob and update service affiliation enums

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#84887dc7cb0ccee2ae2c8156b5664697c2850b1d",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d1dd07494caaf68e8b860b6882ae0944d5746a9f",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ad74bc0a1aed7649bc0e558d53a09a2cd02eebef",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/src/applications/edu-benefits/complaint-tool/config/form.js
+++ b/src/applications/edu-benefits/complaint-tool/config/form.js
@@ -117,8 +117,8 @@ const formConfig = {
               'ui:options': {
                 nestedContent: {
                   [myself]: () => <div className="usa-alert-info no-background-image"><i>(We’ll only share your name with the school.)</i></div>,
-                  [someoneElse]: () => <div className="usa-alert-info no-background-image"><i>(Your name is shared with the school, not the name of the person you’re submitting on behalf of.)</i></div>,
-                  [anonymous]: () => <div className="usa-alert-info no-background-image"><i>(Anonymous feedback is shared with the school. Your personal information isn’t shared with anyone outside of VA.)</i></div>
+                  [someoneElse]: () => <div className="usa-alert-info no-background-image"><i>(Your name is shared with the school, not the name of the person you’re submitting feedback for.)</i></div>,
+                  [anonymous]: () => <div className="usa-alert-info no-background-image"><i>(Anonymous feedback is shared with the school. Your personal information, however, isn’t shared with anyone outside of VA.)</i></div>
                 },
                 expandUnderClassNames: 'schemaform-expandUnder',
               }

--- a/src/applications/edu-benefits/complaint-tool/config/form.js
+++ b/src/applications/edu-benefits/complaint-tool/config/form.js
@@ -10,7 +10,6 @@ const { educationDetails } = fullSchema.properties;
 
 const { school } = educationDetails;
 import fullNameUI from 'us-forms-system/lib/js/definitions/fullName';
-import dateUI from 'us-forms-system/lib/js/definitions/date';
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import phoneUI from 'us-forms-system/lib/js/definitions/phone';
 
@@ -35,8 +34,7 @@ const {
 const {
   onBehalfOf,
   fullName,
-  dob,
-  // serviceAffiliation,
+  serviceAffiliation,
   serviceBranch,
   serviceDateRange,
   anonymousEmail,
@@ -75,7 +73,7 @@ function hasMyself(formData) {
 }
 
 function isNotVeteranOrServiceMember(formData) {
-  if (!formData.serviceAffiliation || ((formData.serviceAffiliation !== 'Servicemember or Veteran'))) {
+  if (!formData.serviceAffiliation || ((formData.serviceAffiliation !== 'Servicemember') && (formData.serviceAffiliation !== 'Veteran'))) {
     return true;
   }
   return false;
@@ -116,8 +114,8 @@ const formConfig = {
               'ui:options': {
                 nestedContent: {
                   [myself]: () => <div className="usa-alert-info no-background-image"><i>(We’ll only share your name with the school.)</i></div>,
-                  [someoneElse]: () => <div className="usa-alert-info no-background-image"><i>(We’ll only share your name with the school.)</i></div>,
-                  [anonymous]: () => <div className="usa-alert-info no-background-image"><i>(Your personal information won’t be shared with anyone outside of VA.)</i></div>
+                  [someoneElse]: () => <div className="usa-alert-info no-background-image"><i>(Your name is shared with the school, not the name of the person you’re submitting on behalf of.)</i></div>,
+                  [anonymous]: () => <div className="usa-alert-info no-background-image"><i>(Anonymous feedback is shared with the school. Your personal information isn’t shared with anyone outside of VA.)</i></div>
                 },
                 expandUnderClassNames: 'schemaform-expandUnder',
               }
@@ -144,12 +142,6 @@ const formConfig = {
                 'ui:title': 'Your suffix'
               },
               'ui:order': ['prefix', 'first', 'middle', 'last', 'suffix'],
-              'ui:options': {
-                expandUnder: 'onBehalfOf',
-                expandUnderCondition: isNotAnonymous
-              }
-            }),
-            dob: _.merge(dateUI('Date of birth'), {
               'ui:options': {
                 expandUnder: 'onBehalfOf',
                 expandUnderCondition: isNotAnonymous
@@ -199,15 +191,7 @@ const formConfig = {
             properties: {
               onBehalfOf: _.set('enumNames', [myself, someoneElse, anonymousLabel], onBehalfOf),
               fullName,
-              dob,
-              serviceAffiliation: { // TODO: update BE schema and use here
-                type: 'string',
-                'enum': [
-                  'Servicemember or Veteran',
-                  'Spouse or Child',
-                  'Family member'
-                ]
-              },
+              serviceAffiliation,
               serviceBranch,
               serviceDateRange,
               anonymousEmail

--- a/src/applications/edu-benefits/tests/complaint-tool/config/applicantInfo.unit.spec.js
+++ b/src/applications/edu-benefits/tests/complaint-tool/config/applicantInfo.unit.spec.js
@@ -49,7 +49,7 @@ describe('complaint tool applicant info', () => {
     selectRadio(form, 'root_onBehalfOf', 'Myself');
     const select  = form.find('select#root_serviceAffiliation');
     select.simulate('change', {
-      target: { value: 'Servicemember or Veteran' }
+      target: { value: 'Servicemember' }
     });
     fillData(form, 'input#root_fullName_first', 'test');
     fillData(form, 'input#root_fullName_last', 'test');
@@ -69,8 +69,8 @@ describe('complaint tool applicant info', () => {
     );
 
     selectRadio(form, 'root_onBehalfOf', 'Myself');
-    expect(form.find('input').length).to.equal(7);
-    expect(form.find('select').length).to.equal(5);
+    expect(form.find('input').length).to.equal(6);
+    expect(form.find('select').length).to.equal(3);
   });
 
   it('should render myself as a veteran', () => {
@@ -86,11 +86,11 @@ describe('complaint tool applicant info', () => {
     selectRadio(form, 'root_onBehalfOf', 'Myself');
     const select = form.find('select#root_serviceAffiliation');
     select.simulate('change', {
-      target: { value: 'Servicemember or Veteran' }
+      target: { value: 'Veteran' }
     });
 
-    expect(form.find('input').length).to.equal(9);
-    expect(form.find('select').length).to.equal(10);
+    expect(form.find('input').length).to.equal(8);
+    expect(form.find('select').length).to.equal(8);
   });
 
   it('should render someone else', () => {
@@ -104,8 +104,8 @@ describe('complaint tool applicant info', () => {
     );
 
     selectRadio(form, 'root_onBehalfOf', 'Someone else');
-    expect(form.find('input').length).to.equal(7);
-    expect(form.find('select').length).to.equal(4);
+    expect(form.find('input').length).to.equal(6);
+    expect(form.find('select').length).to.equal(2);
   });
 
   it('should render anonymous', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10070,9 +10070,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#d1dd07494caaf68e8b860b6882ae0944d5746a9f":
-  version "3.70.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d1dd07494caaf68e8b860b6882ae0944d5746a9f"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#ad74bc0a1aed7649bc0e558d53a09a2cd02eebef":
+  version "3.71.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ad74bc0a1aed7649bc0e558d53a09a2cd02eebef"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
These changes address the following tickets:

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11888#issuecomment-410854622
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11943
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11944

Change:
When user clicks “I’m submitting feedback on behalf of someone else”
Update message to: (Your name is shared with the school, not the name of the person you’re submitting on behalf of.)
![image](https://user-images.githubusercontent.com/16051172/43743739-e6b79184-998b-11e8-8522-a24e980fc6be.png)

Change:
When user clicks “ I want to submit my feedback anonymously”
Update message to: (Anonymous feedback is shared with the school. Your personal information isn’t shared with anyone outside of VA.)
![image](https://user-images.githubusercontent.com/16051172/43743742-e9ff869e-998b-11e8-9db3-717cbba6467d.png)

Change:
Update Service affiliation drop downs to
Servicemember
Veteran
Spouse
Child
Other
![image](https://user-images.githubusercontent.com/16051172/43743747-ed83ced8-998b-11e8-822c-7053147815c3.png)

Change:
Remove DOB from Feedback tool 
![localhost_3001_education_complaint-tool_form_applicant-information 4](https://user-images.githubusercontent.com/16051172/43743748-ef5f1f5a-998b-11e8-9867-06ecc7bbc136.png)

