### PR TITLE
add style override

### DIFF
--- a/src/applications/edu-benefits/sass/edu-benefits.scss
+++ b/src/applications/edu-benefits/sass/edu-benefits.scss
@@ -26,6 +26,10 @@
   margin-top: 3rem;
 }
 
+.schemaform-first-field label[for="root_school_view:cannotFindSchool"] {
+  margin-top: 3rem;
+}
+
 .row .edu-intro-spacing {
   margin-bottom: 7rem;
 }


### PR DESCRIPTION
![screen shot 2018-08-07 at 17 26 13](https://user-images.githubusercontent.com/4998130/43807716-0192b8c2-9a67-11e8-87ad-a2f2c57619eb.png)

There's a limitation in the forms library where `.schemaform-first-field` is added when a component is mounted by this [method](https://github.com/usds/us-forms-system/blob/ffd15c43556ab4108c1481b8d6163c8a1589a1ea/src/js/fields/ObjectField.jsx#L33). By adding this class, it removes a margin from the first input on the page but does not call this logic again since the element is not unmounted. 

This is kind of an edge case- using a checkbox to hide/ reveal something _above_ it is probably an bad UX pattern which is why I don't think this is bug. 