### PR TITLE
adding dental to list of health services

### DIFF
--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -26,6 +26,7 @@ export const healthServices = {
   All: 'Show all facilities',
   PrimaryCare: 'Primary Care',
   MentalHealthCare: 'Mental Health Care',
+  DentalServices: 'Dental Services',
   UrgentCare: 'Urgent Care',
   EmergencyCare: 'Emergency Care',
   Audiology: 'Audiology',


### PR DESCRIPTION
fixes #12043 by adding Dental Services to the Health Services drop down list. We've had the data but the entry was missed in my initial creation of the list. This will allow users to search for Dental Services explicitly.