### PR TITLE
Fix styling of alerts on GIBFT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ coverage
 yalc.lock
 /test-results.xml
 package-lock.json
+
+# Ignore user's editor/IDE prefs
+.vscode/
+.idea/

--- a/src/applications/edu-benefits/complaint-tool/config/form.js
+++ b/src/applications/edu-benefits/complaint-tool/config/form.js
@@ -116,9 +116,9 @@ const formConfig = {
               'ui:title': 'I’m submitting feedback on behalf of...',
               'ui:options': {
                 nestedContent: {
-                  [myself]: () => <div className="usa-alert-info no-background-image"><i>(We’ll only share your name with the school.)</i></div>,
-                  [someoneElse]: () => <div className="usa-alert-info no-background-image"><i>(Your name is shared with the school, not the name of the person you’re submitting feedback for.)</i></div>,
-                  [anonymous]: () => <div className="usa-alert-info no-background-image"><i>(Anonymous feedback is shared with the school. Your personal information, however, isn’t shared with anyone outside of VA.)</i></div>
+                  [myself]: () => <div className="usa-alert usa-alert-info no-background-image">We’ll only share your name with the school.</div>,
+                  [someoneElse]: () => <div className="usa-alert usa-alert-info no-background-image">Your name is shared with the school, not the name of the person you’re submitting feedback for.</div>,
+                  [anonymous]: () => <div className="usa-alert usa-alert-info no-background-image">Anonymous feedback is shared with the school. Your personal information, however, isn’t shared with anyone outside of VA.</div>
                 },
                 expandUnderClassNames: 'schemaform-expandUnder',
               }


### PR DESCRIPTION
Styling has been made consistent with other similar alerts.
<img width="704" alt="screen shot 2018-08-09 at 6 43 00 am" src="https://user-images.githubusercontent.com/20728956/43903150-9e048318-9ba0-11e8-82ee-ea479d3654a7.png">
<img width="696" alt="screen shot 2018-08-09 at 6 43 12 am" src="https://user-images.githubusercontent.com/20728956/43903157-a1f575cc-9ba0-11e8-8099-ef2d9c849e36.png">
