### PR TITLE
All claims start controls mg

### DIFF
--- a/content/pages/disability-benefits/apply/form-526-all-claims.md
+++ b/content/pages/disability-benefits/apply/form-526-all-claims.md
@@ -14,13 +14,4 @@ hideFromSidebar: true
       <li><a aria-current="page" href="/disability-benefits/apply/form-526-all-claims/">Apply for Disability Benefits</a></li>
     </ul>
   </nav>
-  <div class="section">
-    <div id="react-root">
-      <div class="loading-message">
-        <div class="loading-indicator-container">
-          <div class="loading-indicator" role="progressbar" aria-valuetext="Please wait while we load the application for you." tabIndex="0"></div> Please wait while we load the application for you.
-        </div>
-      </div>
-    </div>
-  </div>
 </div>

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -20,7 +20,7 @@ class IntroductionPage extends React.Component {
         <p>Equal to VA Form 21-526EZ (Application for Disability Compensation and Related Compensation Benefits).</p>
         <SaveInProgressIntro
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
-          formId={this.props.form.formId}
+          formId={this.props.formId}
           pageList={this.props.route.pageList}
           startText="Start the Disability Compensation Application"
           retentionPeriod="1 year"
@@ -108,7 +108,7 @@ class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
-          formId={this.props.form.formId}
+          formId={this.props.formId}
           pageList={this.props.route.pageList}
           startText="Start the Disability Compensation Application"
           {...this.props.saveInProgressActions}
@@ -129,7 +129,7 @@ class IntroductionPage extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    form: state.form,
+    formId: state.form.formId,
     saveInProgress: introSelector(state)
   };
 }
@@ -141,7 +141,7 @@ function mapDispatchToProps(dispatch) {
 }
 
 IntroductionPage.PropTypes = {
-  form: PropTypes.object.isRequired,
+  formId: PropTypes.string.isRequired,
   route: PropTypes.shape({
     formConfig: PropTypes.shape({
       prefillEnabled: PropTypes.bool

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -7,7 +7,7 @@ import moment from 'moment';
 import { focusElement } from '../../../../platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation/OMBInfo';
 import FormTitle from 'us-forms-system/lib/js/components/FormTitle';
-import { introActions, introSelector } from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro, { introActions, introSelector } from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
 import { toggleLoginModal } from '../../../../platform/site-wide/user-nav/actions';
 
 class IntroductionPage extends React.Component {
@@ -32,7 +32,13 @@ class IntroductionPage extends React.Component {
       <div className="schemaform-intro">
         <FormTitle title="Apply for increased disability compensation"/>
         <p>Equal to VA Form 21-526EZ (Application for Disability Compensation and Related Compensation Benefits).</p>
-        <button>Start your form [change me]</button>
+        <SaveInProgressIntro
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
+          formId={this.props.form.formId}
+          pageList={this.props.route.pageList}
+          startText="Start the Disability Compensation Application"
+          {...this.props.saveInProgressActions}
+          {...this.props.saveInProgress}/>
         <h4>Follow the steps below to apply for increased disability compensation.</h4>
         <div className="process schemaform-process">
           <ol>
@@ -74,7 +80,13 @@ class IntroductionPage extends React.Component {
             </li>
           </ol>
         </div>
-        <button>Start form here!</button>
+        <SaveInProgressIntro
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
+          formId={this.props.form.formId}
+          pageList={this.props.route.pageList}
+          startText="Start the Disability Compensation Application"
+          {...this.props.saveInProgressActions}
+          {...this.props.saveInProgress}/>
         {/* TODO: Remove inline style after I figure out why .omb-info--container has a left padding */}
         <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
           <OMBInfo resBurden={25} ombNumber="2900-0747" expDate="11/30/2017"/>

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -7,7 +7,6 @@ import { focusElement } from '../../../../platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation/OMBInfo';
 import FormTitle from 'us-forms-system/lib/js/components/FormTitle';
 import SaveInProgressIntro, { introActions, introSelector } from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
-// import { toggleLoginModal } from '../../../../platform/site-wide/user-nav/actions';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -1,4 +1,3 @@
-// @ts-check
 import React from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -107,6 +107,7 @@ class IntroductionPage extends React.Component {
           </ol>
         </div>
         <SaveInProgressIntro
+          buttonOnly
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
           formId={this.props.formId}
           pageList={this.props.route.pageList}

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -24,6 +24,7 @@ class IntroductionPage extends React.Component {
           formId={this.props.form.formId}
           pageList={this.props.route.pageList}
           startText="Start the Disability Compensation Application"
+          retentionPeriod="1 year"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}/>
         <h4>Follow the steps below to apply for increased disability compensation.</h4>

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -120,8 +120,7 @@ class IntroductionPage extends React.Component {
           start getting benefits. You have 1 year from the day you submit your intent to
           file to complete your application.
         </p>
-        {/* TODO: Remove inline style after I figure out why .omb-info--container has a left padding */}
-        <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
+        <div className="omb-info--container">
           <OMBInfo resBurden={25} ombNumber="2900-0747" expDate="03/31/2021"/>
         </div>
       </div>

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -1,30 +1,18 @@
+// @ts-check
 import React from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import moment from 'moment';
 
 import { focusElement } from '../../../../platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation/OMBInfo';
 import FormTitle from 'us-forms-system/lib/js/components/FormTitle';
 import SaveInProgressIntro, { introActions, introSelector } from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
-import { toggleLoginModal } from '../../../../platform/site-wide/user-nav/actions';
+// import { toggleLoginModal } from '../../../../platform/site-wide/user-nav/actions';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
     focusElement('.va-nav-breadcrumbs-list');
-  }
-
-  hasSavedForm = () => {
-    const { saveInProgress: { user } } = this.props;
-    return user.profile && user.profile.savedForms
-      .filter(f => moment.unix(f.metadata.expires_at).isAfter())
-      .find(f => f.form === this.props.formId);
-  }
-
-  authenticate = (e) => {
-    e.preventDefault();
-    this.props.toggleLoginModal(true);
   }
 
   render() {
@@ -151,17 +139,23 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     saveInProgressActions: bindActionCreators(introActions, dispatch),
-    toggleLoginModal: (update) => {
-      dispatch(toggleLoginModal(update));
-    }
   };
 }
 
 IntroductionPage.PropTypes = {
+  form: PropTypes.object.isRequired,
+  route: PropTypes.shape({
+    formConfig: PropTypes.shape({
+      prefillEnabled: PropTypes.bool
+    }),
+    pageList: PropTypes.array.isRequired
+  }).isRequired,
   saveInProgress: PropTypes.object.isRequired,
-  toggleLoginModal: PropTypes.func.isRequired,
-  verifyUrl: PropTypes.string.isRequired,
-  loginUrl: PropTypes.string.isRequired
+  saveInProgressActions: PropTypes.shape({
+    fetchInProgressForm: PropTypes.func.isRequired,
+    removeInProgressForm: PropTypes.func.isRequired,
+    toggleLoginModal: PropTypes.func.isRequired
+  }).isRequired
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(IntroductionPage);

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -8,7 +8,7 @@ const formConfig = {
   intentToFileUrl: '/evss_claims/intent_to_file/compensation',
   submitUrl: `${environment.API_URL}/v0/disability_compensation_form/submit`,
   trackingPrefix: 'disability-526EZ-',
-  formId: '21-526EZ',
+  formId: '21-526EZ-all-claims',
   version: 1,
   migrations: [],
   // prefillTransformer,

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -13,10 +13,6 @@
   margin-bottom: 2em;
 }
 
-button.temporary-start {
-  margin-top: 1em;
-}
-
 ul.original-disability-list {
   li {
     margin-bottom: 0;

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import { IntroductionPage } from '../../components/IntroductionPage';
+import formConfig from '../../config/form';
+
+describe.only('<IntroductionPage/>', () => {
+  const { formId, prefillEnabled } = formConfig;
+  const defaultProps = {
+    formId,
+    route: {
+      formConfig: {
+        prefillEnabled
+      },
+      pageList: []
+    }
+  };
+
+  it('should render', () => {
+    const wrapper = shallow(<IntroductionPage {...defaultProps}/>);
+    expect(wrapper.length).to.equal(1);
+    expect(wrapper.type()).to.equal('div');
+  });
+
+  it('should render a form title', () => {
+    const wrapper = shallow(<IntroductionPage {...defaultProps}/>);
+    expect(wrapper.find('FormTitle').length).to.equal(1);
+  });
+
+  it('should render 2 SiP intros', () => {
+    const wrapper = shallow(<IntroductionPage {...defaultProps}/>);
+    expect(wrapper.find('Connect(SaveInProgressIntro)').length).to.equal(2);
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { IntroductionPage } from '../../components/IntroductionPage';
 import formConfig from '../../config/form';
 
-describe.only('<IntroductionPage/>', () => {
+describe('<IntroductionPage/>', () => {
   const { formId, prefillEnabled } = formConfig;
   const defaultProps = {
     formId,


### PR DESCRIPTION
Adds standard form start controls to the intro page. This means:
- Users see different info alerts when they're logged in vs. logged out.
- Users are prompted to sign in via the modal if they hit one of the start buttons when they're logged out

Logged out:
<img width="867" alt="screen shot 2018-08-09 at 11 04 08 am" src="https://user-images.githubusercontent.com/24251447/43911067-188bc182-9bc4-11e8-92e4-266379bef4c2.png">

Logged in:
<img width="709" alt="screen shot 2018-08-09 at 11 04 45 am" src="https://user-images.githubusercontent.com/24251447/43911078-1f19ab9a-9bc4-11e8-89f5-9ad7bda81fb6.png">

Bottom is just a button (i.e., not info box):
![screen shot 2018-08-09 at 1 58 44 pm](https://user-images.githubusercontent.com/24251447/43919725-6f890a04-9bdc-11e8-9269-e945f66be75c.png)

