### PR TITLE
Add warning banner to gibs intro page

### DIFF
--- a/src/applications/post-911-gib-status/containers/IntroPage.jsx
+++ b/src/applications/post-911-gib-status/containers/IntroPage.jsx
@@ -89,7 +89,6 @@ export class IntroPage extends React.Component {
 
 const mapStateToProps = (state) => {
   const { serviceAvailability } = state.post911GIBStatus;
-  // const { serviceAvailability } = 'down';
   return {
     serviceAvailability
   };

--- a/src/applications/post-911-gib-status/containers/IntroPage.jsx
+++ b/src/applications/post-911-gib-status/containers/IntroPage.jsx
@@ -62,7 +62,7 @@ export class IntroPage extends React.Component {
     return (
       <div className="row">
         <div className="medium-8 columns">
-          <div className="usa-alert usa-alert-warning">
+          <div className="usa-alert usa-alert-warning intro-warning">
             <div className="usa-alert-body">
               We’re sorry. Something’s not working quite right with the GI Bill
               benefits tool. We’re working to fix the problem. If you encounter

--- a/src/applications/post-911-gib-status/containers/IntroPage.jsx
+++ b/src/applications/post-911-gib-status/containers/IntroPage.jsx
@@ -62,6 +62,13 @@ export class IntroPage extends React.Component {
     return (
       <div className="row">
         <div className="medium-8 columns">
+          <div className="usa-alert usa-alert-warning">
+            <div className="usa-alert-body">
+              We’re sorry. Something’s not working quite right with the GI Bill
+              benefits tool. We’re working to fix the problem. If you encounter
+              any errors, please try again later.
+            </div>
+          </div>
           <h1>Post-9/11 GI Bill Statement of Benefits</h1>
           <p>
             If you served on active duty after September 10, 2001, you and your dependents may qualify for Post-9/11 GI Bill education benefits. These benefits can help cover all or some of the costs for school or training. Find out how to check if you have any Post-9/11 GI Bill benefits—and how to track the amount of time you have left to use for your education or training.

--- a/src/applications/post-911-gib-status/containers/IntroPage.jsx
+++ b/src/applications/post-911-gib-status/containers/IntroPage.jsx
@@ -58,17 +58,21 @@ export class IntroPage extends React.Component {
 
 
   render() {
+    const gibsWarning = (
+      <div className="usa-alert usa-alert-warning intro-warning">
+        <div className="usa-alert-body">
+          We’re sorry. Something’s not working quite right with the GI Bill
+          benefits tool. We’re working to fix the problem. If you encounter
+          any errors, please try again later.
+        </div>
+      </div>
+    );
+
     const content = this.getContent();
     return (
       <div className="row">
         <div className="medium-8 columns">
-          <div className="usa-alert usa-alert-warning intro-warning">
-            <div className="usa-alert-body">
-              We’re sorry. Something’s not working quite right with the GI Bill
-              benefits tool. We’re working to fix the problem. If you encounter
-              any errors, please try again later.
-            </div>
-          </div>
+          {this.props.serviceAvailability === SERVICE_AVAILABILITY_STATES.up && gibsWarning}
           <h1>Post-9/11 GI Bill Statement of Benefits</h1>
           <p>
             If you served on active duty after September 10, 2001, you and your dependents may qualify for Post-9/11 GI Bill education benefits. These benefits can help cover all or some of the costs for school or training. Find out how to check if you have any Post-9/11 GI Bill benefits—and how to track the amount of time you have left to use for your education or training.
@@ -85,6 +89,7 @@ export class IntroPage extends React.Component {
 
 const mapStateToProps = (state) => {
   const { serviceAvailability } = state.post911GIBStatus;
+  // const { serviceAvailability } = 'down';
   return {
     serviceAvailability
   };

--- a/src/applications/post-911-gib-status/sass/post-911-gib-status.scss
+++ b/src/applications/post-911-gib-status/sass/post-911-gib-status.scss
@@ -117,5 +117,6 @@
 
 // Remove once temporary alert goes away from the intro page
 .intro-warning {
-  margin-bottom: 1.5em;
+  margin-top: 1em;
+  margin-bottom: 1em;
 }

--- a/src/applications/post-911-gib-status/sass/post-911-gib-status.scss
+++ b/src/applications/post-911-gib-status/sass/post-911-gib-status.scss
@@ -114,3 +114,8 @@
     white-space: nowrap;
   }
 }
+
+// Remove once temporary alert goes away from the intro page
+.intro-warning {
+  margin-bottom: 1.5em;
+}

--- a/src/applications/post-911-gib-status/tests/containers/IntroPage.unit.spec.jsx
+++ b/src/applications/post-911-gib-status/tests/containers/IntroPage.unit.spec.jsx
@@ -35,6 +35,6 @@ describe('<IntroPage/>', () => {
 
   it('should render an alert when GIBS status down', () => {
     const wrapper = shallow(<IntroPage {...defaultProps} serviceAvailability={SERVICE_AVAILABILITY_STATES.down}/>);
-    expect(wrapper.find('.usa-alert')).to.have.lengthOf(2);
+    expect(wrapper.find('.usa-alert')).to.have.lengthOf(1);
   });
 });

--- a/src/applications/post-911-gib-status/tests/containers/IntroPage.unit.spec.jsx
+++ b/src/applications/post-911-gib-status/tests/containers/IntroPage.unit.spec.jsx
@@ -33,8 +33,8 @@ describe('<IntroPage/>', () => {
     expect(wrapper.find('Link').first().props().to).to.equal('status');
   });
 
-  it('should render an alert', () => {
+  it('should render an alert when GIBS status down', () => {
     const wrapper = shallow(<IntroPage {...defaultProps} serviceAvailability={SERVICE_AVAILABILITY_STATES.down}/>);
-    expect(wrapper.find('.usa-alert')).to.have.lengthOf(1);
+    expect(wrapper.find('.usa-alert')).to.have.lengthOf(2);
   });
 });


### PR DESCRIPTION
This adds a warning banner to the GIBS intro page when GIBS status is up (when GIBS status is down, all this content gets replaced by an error message already).

<img width="780" alt="screen shot 2018-08-09 at 4 52 14 pm" src="https://user-images.githubusercontent.com/24251447/43927917-b8958bce-9bf4-11e8-9796-d202fd2916e5.png">

