### PR TITLE
Block first SiP call

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/FormStartControls.jsx
+++ b/src/applications/disability-benefits/526EZ/components/FormStartControls.jsx
@@ -22,6 +22,7 @@ export default function FormStartControls(props) {
         {...props}
         buttonOnly={props.buttonOnly}
         prefillAvailable
+        noPrefill={props.noPrefill}
         verifiedPrefillAlert={VerifiedAlert}
         unverifiedPrefillAlert={UnauthenticatedAlert}
         verifyRequiredPrefill={props.route.formConfig.verifyRequiredPrefill}

--- a/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
@@ -40,6 +40,7 @@ class IntroductionPage extends React.Component {
           pathname={this.props.location.pathname}
           user={user}
           authenticate={this.authenticate}
+          noPrefill
           {...this.props}/>
         <h4>Follow the steps below to apply for increased disability compensation.</h4>
         <div className="process schemaform-process">
@@ -86,6 +87,7 @@ class IntroductionPage extends React.Component {
           pathname={this.props.location.pathname}
           user={user}
           authenticate={this.authenticate}
+          noPrefill
           {...this.props}
           buttonOnly/>
         {/* TODO: Remove inline style after I figure out why .omb-info--container has a left padding */}

--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -24,7 +24,7 @@ class FormStartControls extends React.Component {
   }
 
   handleLoadPrefill = () => {
-    if (this.props.prefillAvailable && !this.props.noPrefill) {
+    if (this.props.prefillAvailable && !this.props.skipPrefill) {
       this.props.fetchInProgressForm(this.props.formId, this.props.migrations, true, this.props.prefillTransformer);
     } else {
       this.goToBeginning();
@@ -101,9 +101,9 @@ FormStartControls.propTypes = {
   formSaved: PropTypes.bool.isRequired,
   // prefillAvailable = whether the form can be pre-filled
   prefillAvailable: PropTypes.bool.isRequired,
-  // noPrefill = whether the form _should_ be pre-filled
+  // skipPrefill = whether the form _should_ be pre-filled
   // This is mostly useful if we've already made the call or know we will later
-  noPrefill: PropTypes.bool,
+  skipPrefill: PropTypes.bool,
   startPage: PropTypes.string.isRequired,
   startText: PropTypes.string,
   resumeOnly: PropTypes.bool

--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -23,7 +23,7 @@ class FormStartControls extends React.Component {
   }
 
   handleLoadPrefill = () => {
-    if (this.props.prefillAvailable) {
+    if (this.props.prefillAvailable && !this.props.noPrefill) {
       this.props.fetchInProgressForm(this.props.formId, this.props.migrations, true, this.props.prefillTransformer);
     } else {
       this.goToBeginning();

--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -5,6 +5,7 @@ import { withRouter } from 'react-router';
 import ProgressButton from '@department-of-veterans-affairs/formation/ProgressButton';
 import Modal from '@department-of-veterans-affairs/formation/Modal';
 
+
 class FormStartControls extends React.Component {
   constructor(props) {
     super(props);
@@ -46,7 +47,6 @@ class FormStartControls extends React.Component {
   }
 
   render() {
-
     if (this.props.formSaved) {
       return (
         <div>
@@ -99,7 +99,11 @@ FormStartControls.propTypes = {
   removeInProgressForm: PropTypes.func.isRequired,
   router: PropTypes.object.isRequired,
   formSaved: PropTypes.bool.isRequired,
+  // prefillAvailable = whether the form can be pre-filled
   prefillAvailable: PropTypes.bool.isRequired,
+  // noPrefill = whether the form _should_ be pre-filled
+  // This is mostly useful if we've already made the call or know we will later
+  noPrefill: PropTypes.bool,
   startPage: PropTypes.string.isRequired,
   startText: PropTypes.string,
   resumeOnly: PropTypes.bool

--- a/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
@@ -136,7 +136,7 @@ class RoutedSavableApp extends React.Component {
       const isSaved = props.savedForms.some((savedForm) => savedForm.form === currentForm);
       const hasPrefillData = props.prefillsAvailable.includes(currentForm);
       if (isSaved || hasPrefillData) {
-        props.fetchInProgressForm(currentForm, props.formConfig.migrations, !isSaved && hasPrefillData);
+        props.fetchInProgressForm(currentForm, props.formConfig.migrations, !isSaved && hasPrefillData, props.formConfig.prefillTransformer);
       } else {
         // No forms to load; go to the beginning
         // If the first page is not the intro and uses `depends`, this will probably break

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -158,6 +158,7 @@ class SaveInProgressIntro extends React.Component {
           returnUrl={this.props.returnUrl}
           migrations={this.props.migrations}
           prefillTransformer={this.props.prefillTransformer}
+          noPrefill={this.props.noPrefill}
           fetchInProgressForm={this.props.fetchInProgressForm}
           removeInProgressForm={this.props.removeInProgressForm}
           prefillAvailable={prefillAvailable}
@@ -189,6 +190,8 @@ SaveInProgressIntro.propTypes = {
   formId: PropTypes.string.isRequired,
   messages: PropTypes.object,
   migrations: PropTypes.array,
+  prefillTransformer: PropTypes.func,
+  noPrefill: PropTypes.bool,
   returnUrl: PropTypes.string,
   lastSavedDate: PropTypes.number,
   user: PropTypes.object.isRequired,


### PR DESCRIPTION
After _much_ debugging, Mark and I finally figured out what the problem was and outlined it in the connected ticket. I then hit my head against a wall for a few days trying to block the second SiP call, but kept running into cascading issues.

In the end, I had something of an epiphany and ended up feeling like an idiot for not thinking about this route sooner.

When a user hit the start button, we'd call `fetchInProgressForm` twice.
1) The common SiP `FormStartControls` called it properly when the button was hit
2) After that comes through successfully, we're redirected to the first page of the form
3) The ITFWrapper then makes its service call and renders a loading screen while we wait
4) After it comes through, it renders its children again
5) This causes `RoutedSavableApp` to believe it's getting started in the middle of a form and fetches the pre-fill data again, but this time, without the `prefillTransformer`
6) The `SET_IN_PROGRESS_FORM` action would then be called again and the old state (with the transformed data) would be merged with the new state (with the non-transformed data) and we'd get to an awkward state wherein some disabilities would have a rating when they shouldn't and any disabilities that _should_ have been filtered out now no longer have a `disabilityActionType` which prevents us from getting past the rated disabilities screen

My epiphany was to not stop the second SiP call (which was proving to be hugely bothersome), but to stop the _first_ one from `FormStartControls`. I still had to pass the `prefillTransformer` from `RoutedSavableApp`, but since `fetchInProgressForm()` checks to see if it's been prefilled or not before applying the transformer, I thought this was safe.