### PR TITLE
Double restart bugfix cv

### DIFF
--- a/src/applications/disability-benefits/526EZ/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/526EZ/Form526EZApp.jsx
@@ -12,7 +12,11 @@ export default function Form526Entry({ location, children }) {
     <EVSSClaimsGate location={location}>
       <ITFWrapper location={location}>
         <DisabilityGate>
-          <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+          {/*
+              Skipping pre-fill because this will be re-mounted after ITFWrapper fetches the ITF data and
+              mounting on the first page will cause RoutedSavableApp to fetch the in-progress form again.
+          */}
+          <RoutedSavableApp formConfig={formConfig} currentLocation={location} skipPrefill>
             {children}
           </RoutedSavableApp>
         </DisabilityGate>

--- a/src/applications/disability-benefits/526EZ/components/FormStartControls.jsx
+++ b/src/applications/disability-benefits/526EZ/components/FormStartControls.jsx
@@ -22,7 +22,6 @@ export default function FormStartControls(props) {
         {...props}
         buttonOnly={props.buttonOnly}
         prefillAvailable
-        noPrefill={props.noPrefill}
         verifiedPrefillAlert={VerifiedAlert}
         unverifiedPrefillAlert={UnauthenticatedAlert}
         verifyRequiredPrefill={props.route.formConfig.verifyRequiredPrefill}

--- a/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
@@ -40,7 +40,6 @@ class IntroductionPage extends React.Component {
           pathname={this.props.location.pathname}
           user={user}
           authenticate={this.authenticate}
-          noPrefill
           {...this.props}/>
         <h4>Follow the steps below to apply for increased disability compensation.</h4>
         <div className="process schemaform-process">
@@ -87,7 +86,6 @@ class IntroductionPage extends React.Component {
           pathname={this.props.location.pathname}
           user={user}
           authenticate={this.authenticate}
-          noPrefill
           {...this.props}
           buttonOnly/>
         {/* TODO: Remove inline style after I figure out why .omb-info--container has a left padding */}

--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -24,7 +24,7 @@ class FormStartControls extends React.Component {
   }
 
   handleLoadPrefill = () => {
-    if (this.props.prefillAvailable && !this.props.skipPrefill) {
+    if (this.props.prefillAvailable) {
       this.props.fetchInProgressForm(this.props.formId, this.props.migrations, true, this.props.prefillTransformer);
     } else {
       this.goToBeginning();
@@ -101,9 +101,6 @@ FormStartControls.propTypes = {
   formSaved: PropTypes.bool.isRequired,
   // prefillAvailable = whether the form can be pre-filled
   prefillAvailable: PropTypes.bool.isRequired,
-  // skipPrefill = whether the form _should_ be pre-filled
-  // This is mostly useful if we've already made the call or know we will later
-  skipPrefill: PropTypes.bool,
   startPage: PropTypes.string.isRequired,
   startText: PropTypes.string,
   resumeOnly: PropTypes.bool

--- a/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
@@ -128,15 +128,21 @@ class RoutedSavableApp extends React.Component {
     // Stop a user that's been redirected to be redirected again after logging in
     this.shouldRedirectOrLoad = false;
 
-
     const firstPagePath = props.routes[props.routes.length - 1].pageList[0].path;
+    const firstNonIntroPagePath = props.routes[props.routes.length - 1].pageList[1].path;
     // If we're logged in and have a saved / pre-filled form, load that
     if (props.isLoggedIn) {
       const currentForm = props.formConfig.formId;
       const isSaved = props.savedForms.some((savedForm) => savedForm.form === currentForm);
       const hasPrefillData = props.prefillsAvailable.includes(currentForm);
-      if (isSaved || hasPrefillData) {
-        props.fetchInProgressForm(currentForm, props.formConfig.migrations, !isSaved && hasPrefillData, props.formConfig.prefillTransformer);
+
+      if (isSaved) {
+        props.fetchInProgressForm(currentForm, props.formConfig.migrations, false, props.formConfig.prefillTransformer);
+      } else if (props.skipPrefill) {
+        // Just need to go to the page after the introduction
+        props.router.replace(firstNonIntroPagePath);
+      } else if (hasPrefillData) {
+        props.fetchInProgressForm(currentForm, props.formConfig.migrations, true, props.formConfig.prefillTransformer);
       } else {
         // No forms to load; go to the beginning
         // If the first page is not the intro and uses `depends`, this will probably break

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -158,7 +158,6 @@ class SaveInProgressIntro extends React.Component {
           returnUrl={this.props.returnUrl}
           migrations={this.props.migrations}
           prefillTransformer={this.props.prefillTransformer}
-          noPrefill={this.props.noPrefill}
           fetchInProgressForm={this.props.fetchInProgressForm}
           removeInProgressForm={this.props.removeInProgressForm}
           prefillAvailable={prefillAvailable}
@@ -191,7 +190,6 @@ SaveInProgressIntro.propTypes = {
   messages: PropTypes.object,
   migrations: PropTypes.array,
   prefillTransformer: PropTypes.func,
-  noPrefill: PropTypes.bool,
   returnUrl: PropTypes.string,
   lastSavedDate: PropTypes.number,
   user: PropTypes.object.isRequired,

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -7,6 +7,7 @@ import environment from '../../utilities/environment';
 import conditionalStorage from '../../utilities/storage/conditionalStorage';
 import { sanitizeForm } from '../helpers';
 import { removeFormApi, saveFormApi } from './api';
+import { REMOVING_SAVED_FORM_SUCCESS } from '../../user/profile/actions';
 
 export const SET_SAVE_FORM_STATUS = 'SET_SAVE_FORM_STATUS';
 export const SET_AUTO_SAVE_FORM_STATUS = 'SET_AUTO_SAVE_FORM_STATUS';
@@ -96,6 +97,7 @@ export function setPrefillComplete() {
     type: SET_PREFILL_UNFILLED,
   };
 }
+
 /**
  * Transforms the data from an old version of a form to be used in the latest
  *  version.
@@ -343,6 +345,8 @@ export function removeInProgressForm(formId, migrations, prefillTransformer) {
         recordEvent({
           event: `${trackingPrefix}sip-form-start-over`
         });
+        // This action removes the form from the profile list
+        dispatch({ type: REMOVING_SAVED_FORM_SUCCESS, formId });
         // after deleting, go fetch prefill info if they’ve got it
         return dispatch(fetchInProgressForm(formId, migrations, true, prefillTransformer));
       })


### PR DESCRIPTION
I figured out how to fix the double fetch bug by preventing `RoutedSavableApp` from calling `fetchInProgressForm` if we pass it the `skipPrefill` prop. The only time we should want this behavior is when we deliberately wrap the component in another one which will cause it to be mounted, unmouted, and mounted again on a different page, so this seemed like a safe way to do it.

That aside, the double restart bug was happening because `RoutedSavableApp` thought the form was still saved when it wasn't. The scenario went a little something like this:

1) Load the intro page with a saved form
2) Hit start over
3) This would trigger the form delete, which would return successfully from api
4) This would trigger a `fetchInProgressForm`
5) Upon success, we'd get sent to the first page in the form, `/veteran-information`
6) This would trigger the `ITFWrapper` to do its thing and unmount `RoutedSavableApp` to display a loading spinner
7) After `ITFWrapper` was done, it'd mount a new `RoutedSavableApp` which would then check to see if it needed to fetch the form since it was being mounted in the middle of the form
8) It would see the list of saved forms with the 526 in it because that was never updated when we removed it
9) It would try to fetch the saved form and get an error

The main change here is to call the profile action `REMOVING_SAVED_FORM_SUCCESS` with the form ID which removes it from the list of saved forms `RoutedSavableApp` is hooked up to.