### PR TITLE
Update vets-json-schema version

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#84887dc7cb0ccee2ae2c8156b5664697c2850b1d",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#3f84ce729b16767dd9e7ff4841782cd320259606",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2b1e3463725279589728e666f478a756769bf580",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10070,9 +10070,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#3f84ce729b16767dd9e7ff4841782cd320259606":
-  version "3.75.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#3f84ce729b16767dd9e7ff4841782cd320259606"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#2b1e3463725279589728e666f478a756769bf580":
+  version "3.76.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2b1e3463725279589728e666f478a756769bf580"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
These changes make use of the updated HCA schema, and its new maxlength configuration for spouse address.

new (left), current (right)

![image](https://user-images.githubusercontent.com/16051172/44123954-92369ac4-9fdf-11e8-85fc-f8c390c3f8a9.png)
