### PR TITLE
Heroku preview style builds

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run heroku-serve -- build/development -p $PORT
+web: npm run heroku-serve -- build/heroku -p $PORT

--- a/app.json
+++ b/app.json
@@ -8,9 +8,6 @@
     },
     "HEROKU_APP_NAME": {
       "required": true
-    },
-    "HEROKU_PARENT_APP_NAME": {
-      "required": true
     }
   },
   "addons":[],

--- a/app.json
+++ b/app.json
@@ -5,6 +5,12 @@
     "CHECK_BROKEN_LINKS": "no",
     "YARN_PRODUCTION":{
       "required": true
+    },
+    "HEROKU_APP_NAME": {
+      "required": true
+    },
+    "HEROKU_PARENT_APP_NAME": {
+      "required": true
     }
   },
   "addons":[],

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -32,7 +32,7 @@ const configGenerator = (options, apps) => {
     mode: 'development',
     entry: entryFiles,
     output: {
-      path: path.join(__dirname, `../build/${options.buildtype}/generated`),
+      path: `${options.destination}/generated`,
       publicPath: '/generated/',
       filename: (['development', 'devpreview'].includes(options.buildtype)) ? '[name].entry.js' : `[name].entry.[chunkhash]-${timestamp}.js`,
       chunkFilename: (['development', 'devpreview'].includes(options.buildtype)) ? '[name].entry.js' : `[name].entry.[chunkhash]-${timestamp}.js`

--- a/package.json
+++ b/package.json
@@ -230,6 +230,7 @@
     "react-cropper": "^1.0.1",
     "react-dropzone": "^4.2.5",
     "reselect": "^2.5.4",
+    "sync-request": "^6.0.0",
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#84887dc7cb0ccee2ae2c8156b5664697c2850b1d",

--- a/script/build.js
+++ b/script/build.js
@@ -79,7 +79,7 @@ if (process.env.HEROKU_APP_NAME) {
     );
     const respObj = JSON.parse(res.getBody('utf8'));
 
-    if (/^vagov\/.*/.test(respObj.head.ref)) {
+    if (/^va-gov\/.*/.test(respObj.head.ref)) {
       // eslint-disable-next-line no-console
       console.log('Build type set to devpreview due to branch name');
       options.buildtype = 'devpreview';

--- a/script/build.js
+++ b/script/build.js
@@ -72,14 +72,14 @@ if (process.env.HEROKU_APP_NAME) {
       `https://api.github.com/repos/department-of-veterans-affairs/vets-website/pulls/${pr}`,
       {
         headers: {
-          'User-Agent': 'request'
+          'User-Agent': 'vets-website-builder'
         },
         json: true
       }
     );
     const respObj = JSON.parse(res.getBody('utf8'));
 
-    if (/^ww-.*/.test(respObj.head.ref)) {
+    if (/^vagov\/.*/.test(respObj.head.ref)) {
       // eslint-disable-next-line no-console
       console.log('Build type set to devpreview due to branch name');
       options.buildtype = 'devpreview';

--- a/script/heroku-helper.js
+++ b/script/heroku-helper.js
@@ -1,0 +1,37 @@
+const path = require('path');
+const request = require('sync-request');
+
+function applyHerokuOptions(options) {
+  // eslint-disable-next-line no-param-reassign
+  options.destination = path.resolve(__dirname, '../build/heroku');
+  try {
+    const pullRequestNumber = process.env.HEROKU_APP_NAME.split('vetsgov-pr-')[1];
+    const res = request(
+      'GET',
+      `https://api.github.com/repos/department-of-veterans-affairs/vets-website/pulls/${pullRequestNumber}`,
+      {
+        headers: {
+          'User-Agent': 'vets-website-builder'
+        },
+        json: true
+      }
+    );
+    const respObj = JSON.parse(res.getBody('utf8'));
+
+    const branchName = respObj.head.ref;
+
+    if (/^va-gov\/.*/.test(branchName)) {
+      // eslint-disable-next-line no-console
+      console.log('Build type set to devpreview due to branch name');
+      // eslint-disable-next-line no-param-reassign
+      options.buildtype = 'devpreview';
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.log(err.message);
+    // eslint-disable-next-line no-console
+    console.log(`Did not receive branch info from GitHub, falling back to ${options.buildtype} build type`);
+  }
+}
+
+module.exports = applyHerokuOptions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,13 +25,41 @@
     prop-types "^15.6.1"
     setimmediate "^1.0.5"
 
+"@types/concat-stream@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@types/concat-stream/-/concat-stream-1.6.0.tgz#394dbe0bb5fee46b38d896735e8b68ef2390d00d"
+  dependencies:
+    "@types/node" "*"
+
+"@types/form-data@0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-0.0.33.tgz#c9ac85b2a5fd18435b8c85d9ecb50e6d6c893ff8"
+  dependencies:
+    "@types/node" "*"
+
+"@types/node@*":
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.7.1.tgz#b704d7c259aa40ee052eec678758a68d07132a2e"
+
 "@types/node@^6.0.46":
   version "6.0.87"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.87.tgz#5ab5774f8351a33a935099fa6be850aa0b0ad564"
 
+"@types/node@^8.0.0":
+  version "8.10.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.26.tgz#950e3d4e6b316ba6e1ae4e84d9155aba67f88c2f"
+
 "@types/node@^8.0.14":
   version "8.0.47"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.47.tgz#968e596f91acd59069054558a00708c445ca30c2"
+
+"@types/node@^9.3.0", "@types/node@^9.4.1":
+  version "9.6.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.28.tgz#198927ce0786106ec2a7c8652d46d5f8b87bfc5f"
+
+"@types/qs@^6.2.31":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.5.1.tgz#a38f69c62528d56ba7bd1f91335a8004988d72f7"
 
 CSSselect@~0.4.0:
   version "0.4.1"
@@ -2083,6 +2111,12 @@ combine-source-map@~0.7.1:
     lodash.memoize "~3.0.3"
     source-map "~0.5.3"
 
+combined-stream@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -3973,6 +4007,14 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
+form-data@^2.2.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
 form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
@@ -4172,6 +4214,10 @@ get-env@^0.4.0:
 get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+
+get-port@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -4571,6 +4617,17 @@ htmlparser2@~3.8.1:
     entities "1.0"
     readable-stream "1.1"
 
+http-basic@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/http-basic/-/http-basic-7.0.0.tgz#82f0a506be942732ec8deebee80e746ef5736dba"
+  dependencies:
+    "@types/concat-stream" "^1.6.0"
+    "@types/node" "^9.4.1"
+    caseless "~0.12.0"
+    concat-stream "^1.4.6"
+    http-response-object "^3.0.1"
+    parse-cache-control "^1.0.1"
+
 http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
@@ -4620,6 +4677,12 @@ http-proxy@^1.16.2, http-proxy@^1.8.1:
   dependencies:
     eventemitter3 "1.x.x"
     requires-port "1.x.x"
+
+http-response-object@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/http-response-object/-/http-response-object-3.0.1.tgz#90174d44c27b5e797cf6efe51a043bc889ae64bf"
+  dependencies:
+    "@types/node" "^9.3.0"
 
 http-server@^0.9.0:
   version "0.9.0"
@@ -7198,6 +7261,10 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
 
+parse-cache-control@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
@@ -7684,6 +7751,12 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+promise@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.1.tgz#e45d68b00a17647b6da711bf85ed6ed47208f450"
+  dependencies:
+    asap "~2.0.3"
+
 prop-types@^15.5.0, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
@@ -7800,6 +7873,10 @@ qs@6.4.0, qs@~6.4.0:
 qs@6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
+qs@^6.4.0:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
 qs@~2.2.3:
   version "2.2.5"
@@ -9479,6 +9556,20 @@ symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
+sync-request@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/sync-request/-/sync-request-6.0.0.tgz#db867eccc4ed31bbcb9fa3732393a3413da582ed"
+  dependencies:
+    http-response-object "^3.0.1"
+    sync-rpc "^1.2.1"
+    then-request "^6.0.0"
+
+sync-rpc@^1.2.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/sync-rpc/-/sync-rpc-1.3.4.tgz#24bcbdb2ffcb98f23690c15b304660085cdd206c"
+  dependencies:
+    get-port "^3.1.0"
+
 syntax-error@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/syntax-error/-/syntax-error-1.3.0.tgz#1ed9266c4d40be75dc55bf9bb1cb77062bb96ca1"
@@ -9568,6 +9659,22 @@ text-loader@^0.0.1:
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+then-request@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/then-request/-/then-request-6.0.0.tgz#2cab198e48f2d8e79c8c1ed260198368a4a0bcba"
+  dependencies:
+    "@types/concat-stream" "^1.6.0"
+    "@types/form-data" "0.0.33"
+    "@types/node" "^8.0.0"
+    "@types/qs" "^6.2.31"
+    caseless "~0.12.0"
+    concat-stream "^1.6.0"
+    form-data "^2.2.0"
+    http-basic "^7.0.0"
+    http-response-object "^3.0.1"
+    promise "^8.0.0"
+    qs "^6.4.0"
 
 through2@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
Adds support for Heroku to dynamically do build types based upon the branch name in a PR. Any property of a PR is fair game, but so far we're just using branch name.

This uses a new property called `HEROKU_APP_NAME` which gets set to `vetsgov-pr-8191` and calls back to GitHub API. I didn't really add any error handling except to just print a message in the log and fall back to the default `development`. If we think this is a decent approach, I can add support for authenticating back to GitHub API so we don't get rate-limited and start seeing failures from that.

I had to mess with the output destination of Webpack and Metalsmith in Heroku builds because the Procfile uses a static web server and the logic to decide which path to use wouldn't have been easy to contain.

ref: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12115