### PR TITLE
Profile: Change app-wide downtime 

### DIFF
--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -65,7 +65,7 @@ class ProfileView extends React.Component {
     if (user.profile.verified) {
       if (user.profile.status === 'OK') {
         content = (
-          <DowntimeNotification appTitle={appTitle} render={this.handleDowntime} dependencies={[externalServices.emis, externalServices.evss, externalServices.mvi]}>
+          <DowntimeNotification appTitle={appTitle} render={this.handleDowntime} dependencies={[externalServices.emis, externalServices.vet360, externalServices.mvi]}>
             <div>
               <Vet360TransactionReporter/>
               <Hero fetchHero={fetchHero} hero={hero} militaryInformation={militaryInformation}/>


### PR DESCRIPTION
I forgot to update the site-wide downtime notification handler for when downtime is approaching (but not in-effect.) This PR changes the `evss` dependency to `vet360`.