### PR TITLE
Change div to span to avoid React error

### DIFF
--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -579,10 +579,10 @@ export const editNote = (name) => (
  */
 export const srSubstitute = (srIgnored, substitutionText) => {
   return (
-    <div style={{ display: 'inline' }}>
+    <span>
       <span aria-hidden>{srIgnored}</span>
       <span className="sr-only">{substitutionText}</span>
-    </div>
+    </span>
   );
 };
 


### PR DESCRIPTION
Taking on the complicated problems today.

I don't see any style differences based on changing this (it's only on the payment page, from what I can tell), but I also don't see any commentary about why this was initially created as a `div` but with `display: inline` instead of a `span`.