### PR TITLE
Check for .then() instead of instanceof Promise

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
+++ b/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
@@ -44,7 +44,7 @@ export default class AsyncDisplayWidget extends React.Component {
     // TODO: Don't call the callback _every_ time the component is mounted
     const cbPromise = this.props.options.callback();
     // instanceof Promise doesn't work in Firefox, so we just check for .then() and hope it's a promise
-    if (typeof cbPromise.then === 'function') {
+    if (cbPromise && typeof cbPromise.then === 'function') {
       cbPromise.then((data) => {
         this.setState({
           data,

--- a/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
+++ b/src/applications/disability-benefits/526EZ/components/AsyncDisplayWidget.jsx
@@ -43,7 +43,8 @@ export default class AsyncDisplayWidget extends React.Component {
   componentDidMount() {
     // TODO: Don't call the callback _every_ time the component is mounted
     const cbPromise = this.props.options.callback();
-    if (cbPromise instanceof Promise) {
+    // instanceof Promise doesn't work in Firefox, so we just check for .then() and hope it's a promise
+    if (typeof cbPromise.then === 'function') {
       cbPromise.then((data) => {
         this.setState({
           data,


### PR DESCRIPTION
Turns out Firefox handles Promise constructors [a bit differently](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#Browser_compatibility). [`instanceof`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) checks the prototype chain for the constructor prototype, but...turns out that doesn't work on Firefox. :man_shrugging: