### PR TITLE
heroku github auth

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,6 +8,9 @@
     },
     "HEROKU_APP_NAME": {
       "required": true
+    },
+    "FOO": {
+      "required": true
     }
   },
   "addons":[],

--- a/app.json
+++ b/app.json
@@ -9,7 +9,7 @@
     "HEROKU_APP_NAME": {
       "required": true
     },
-    "FOO": {
+    "GH_TOKEN": {
       "required": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-analyze": "NODE_ENV=production npm run build -- --buildtype production --analyzer; npm run analyze",
     "prebuild": "node script/prebuild.js",
     "heroku-serve": "http-server",
-    "heroku-postbuild": "npm run build --  --entry static-pages,style",
+    "heroku-postbuild": "env",
     "lint": "npm run lint:js && npm run lint:sass",
     "lint:changed": "npm run lint:js:changed && npm run lint:sass",
     "lint:js": "eslint --quiet --ext .js --ext .jsx .",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-analyze": "NODE_ENV=production npm run build -- --buildtype production --analyzer; npm run analyze",
     "prebuild": "node script/prebuild.js",
     "heroku-serve": "http-server",
-    "heroku-postbuild": "env",
+    "heroku-postbuild": "npm run build --  --entry static-pages,style",
     "lint": "npm run lint:js && npm run lint:sass",
     "lint:changed": "npm run lint:js:changed && npm run lint:sass",
     "lint:js": "eslint --quiet --ext .js --ext .jsx .",

--- a/script/heroku-helper.js
+++ b/script/heroku-helper.js
@@ -10,7 +10,7 @@ function applyHerokuOptions(options) {
       'User-Agent': 'vets-website-builder'
     }
     if (process.env.GH_TOKEN) {
-      headers['Authorization'] = `token ${process.env.GH_TOKEN}a`;
+      headers['Authorization'] = `token ${process.env.GH_TOKEN}`;
     }
     const res = request(
       'GET',

--- a/script/heroku-helper.js
+++ b/script/heroku-helper.js
@@ -6,13 +6,15 @@ function applyHerokuOptions(options) {
   options.destination = path.resolve(__dirname, '../build/heroku');
   try {
     const pullRequestNumber = process.env.HEROKU_APP_NAME.split('vetsgov-pr-')[1];
+    var headers = {
+      'User-Agent': 'vets-website-builder',
+      'Authorization': `token ${process.env.GH_TOKEN}`
+    }
     const res = request(
       'GET',
       `https://api.github.com/repos/department-of-veterans-affairs/vets-website/pulls/${pullRequestNumber}`,
       {
-        headers: {
-          'User-Agent': 'vets-website-builder'
-        },
+        headers: headers,
         json: true
       }
     );

--- a/script/heroku-helper.js
+++ b/script/heroku-helper.js
@@ -7,8 +7,10 @@ function applyHerokuOptions(options) {
   try {
     const pullRequestNumber = process.env.HEROKU_APP_NAME.split('vetsgov-pr-')[1];
     var headers = {
-      'User-Agent': 'vets-website-builder',
-      'Authorization': `token ${process.env.GH_TOKEN}`
+      'User-Agent': 'vets-website-builder'
+    }
+    if (process.env.GH_TOKEN) {
+      headers['Authorization'] = `token ${process.env.GH_TOKEN}`;
     }
     const res = request(
       'GET',

--- a/script/heroku-helper.js
+++ b/script/heroku-helper.js
@@ -10,7 +10,7 @@ function applyHerokuOptions(options) {
       'User-Agent': 'vets-website-builder'
     }
     if (process.env.GH_TOKEN) {
-      headers['Authorization'] = `token ${process.env.GH_TOKEN}`;
+      headers['Authorization'] = `token ${process.env.GH_TOKEN}a`;
     }
     const res = request(
       'GET',

--- a/script/heroku-helper.js
+++ b/script/heroku-helper.js
@@ -6,19 +6,19 @@ function applyHerokuOptions(options) {
   options.destination = path.resolve(__dirname, '../build/heroku');
   try {
     const pullRequestNumber = process.env.HEROKU_APP_NAME.split('vetsgov-pr-')[1];
-    var headers = {
-      'User-Agent': 'vets-website-builder'
-    }
+    let requestOptions = {
+      headers: {
+        'User-Agent': 'vets-website-builder'
+      },
+      json: true
+    };
     if (process.env.GH_TOKEN) {
-      headers['Authorization'] = `token ${process.env.GH_TOKEN}`;
+      headers.Authorization = `token ${process.env.GH_TOKEN}`;
     }
     const res = request(
       'GET',
       `https://api.github.com/repos/department-of-veterans-affairs/vets-website/pulls/${pullRequestNumber}`,
-      {
-        headers: headers,
-        json: true
-      }
+      requestOptions
     );
     const respObj = JSON.parse(res.getBody('utf8'));
 

--- a/script/heroku-helper.js
+++ b/script/heroku-helper.js
@@ -6,7 +6,7 @@ function applyHerokuOptions(options) {
   options.destination = path.resolve(__dirname, '../build/heroku');
   try {
     const pullRequestNumber = process.env.HEROKU_APP_NAME.split('vetsgov-pr-')[1];
-    let requestOptions = {
+    const requestOptions = {
       headers: {
         'User-Agent': 'vets-website-builder'
       },

--- a/script/heroku-helper.js
+++ b/script/heroku-helper.js
@@ -13,7 +13,7 @@ function applyHerokuOptions(options) {
       json: true
     };
     if (process.env.GH_TOKEN) {
-      headers.Authorization = `token ${process.env.GH_TOKEN}`;
+      requestOptions.headers.Authorization = `token ${process.env.GH_TOKEN}`;
     }
     const res = request(
       'GET',


### PR DESCRIPTION
## Description
Provides authentication to API call back to GitHub from the Heroku review application build process. Auth isn't necessary to read the data we need (and the token has zero privileges), but helps us avoid rate-limiting.

## Testing done
Only affects builds in Heroku, tested there

#### Unique to this PR
- [x] authenticates requests back to GitHub

#### Applies to all PRs

- [x] Appropriate logging
- [x] Documentation has been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)


https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12115