### PR TITLE
Fix hanging spinner on disability benefits pages

### DIFF
--- a/content/includes/footer.html
+++ b/content/includes/footer.html
@@ -141,7 +141,7 @@ visit <a href="https://www.veteranscrisisline.net/">VeteransCrisisLine.net</a> f
   var widgets = {{ widgets | json }};
   var module = {};
   {% include "src/applications/static-pages/static-page-widgets.js" %}
-  mountWidgets(widgets, '{{ buildtype }}');
+  mountWidgets(widgets, '{{ buildtype }}' === 'production');
 })();
 </script>
 {% endif %}

--- a/content/includes/footer.html
+++ b/content/includes/footer.html
@@ -141,7 +141,7 @@ visit <a href="https://www.veteranscrisisline.net/">VeteransCrisisLine.net</a> f
   var widgets = {{ widgets | json }};
   var module = {};
   {% include "src/applications/static-pages/static-page-widgets.js" %}
-  mountWidgets(widgets);
+  mountWidgets(widgets, '{{ buildtype }}');
 })();
 </script>
 {% endif %}

--- a/content/pages/disability-benefits/index.md
+++ b/content/pages/disability-benefits/index.md
@@ -9,7 +9,7 @@ template: level2-index
 widgets:
   - root: react-applicationStatus
     timeout: 20
-    buildtype: staging
+    production: false
     loadingMessage: Checking your application status.
     errorMessage: <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br/>Please try refreshing your browser in a few minutes.
 majorlinks:

--- a/content/pages/disability-benefits/index.md
+++ b/content/pages/disability-benefits/index.md
@@ -9,6 +9,7 @@ template: level2-index
 widgets:
   - root: react-applicationStatus
     timeout: 20
+    buildtype: staging
     loadingMessage: Checking your application status.
     errorMessage: <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br/>Please try refreshing your browser in a few minutes.
 majorlinks:

--- a/docs/ReactOnStaticPages.md
+++ b/docs/ReactOnStaticPages.md
@@ -20,6 +20,7 @@ There's a simple static page widget feature that you can use to help with the fi
 - widgets
   - root: react-applicationStatus
     timeout: 20
+    production: true
     showSpinnerUnauthed: false
     slowLoadingThreshold: 6
     loadingMessage: Loading
@@ -29,6 +30,7 @@ There's a simple static page widget feature that you can use to help with the fi
 
 - root: The id of the div where the React component will mount.
 - timeout: The amount of time in seconds before the error message is shown.
+- production: If this widget should be rendered in production. Assumed to be true if left blank.
 - showSpinnerUnauthed: By default, a spinner is shown only if a user has a session token. This will override that and show it always.
 - slowLoadingThreshold: The amount of time in seconds before the slow loading message is shown. This is skipped if the threshold is greater than the overall timeout. Defaulted to 6 seconds.
 - slowMessage: Message shown when the slowThreshold is passed. Defaulted to message above.

--- a/src/applications/static-pages/static-page-widgets.js
+++ b/src/applications/static-pages/static-page-widgets.js
@@ -1,16 +1,7 @@
-function mountWidgets(widgets, buildtype) {
+function mountWidgets(widgets, isProduction) {
   widgets
     .filter(function (widget) {
-      if (widget.buildtype === buildtype) {
-        return true;
-      }
-
-      // Show the widget on lower environment if set to staging
-      if (widget.buildtype === 'staging' && buildtype === 'development') {
-        return true;
-      }
-
-      if (widget.buildtype) {
+      if (widget.production === false && isProduction) {
         return false;
       }
 

--- a/src/applications/static-pages/static-page-widgets.js
+++ b/src/applications/static-pages/static-page-widgets.js
@@ -1,5 +1,21 @@
-function mountWidgets(widgets) {
+function mountWidgets(widgets, buildtype) {
   widgets
+    .filter(function (widget) {
+      if (widget.buildtype === buildtype) {
+        return true;
+      }
+
+      // Show the widget on lower environment if set to staging
+      if (widget.buildtype === 'staging' && buildtype === 'development') {
+        return true;
+      }
+
+      if (widget.buildtype) {
+        return false;
+      }
+
+      return true;
+    })
     .forEach(function (widget) {
       var root = document.getElementById(widget.root);
       var timeout = (widget.timeout || 0) * 1000;

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -47,8 +47,7 @@ if (healthcarePages.has(location.pathname)) {
 }
 if (eduPages.has(location.pathname)) {
   createEducationApplicationStatus(store);
-}
-if (location.pathname === eduOptOutPage) {
+} if (location.pathname === eduOptOutPage) {
   createOptOutApplicationStatus(store);
 }
 if (burialPages.has(location.pathname)) {

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -47,7 +47,8 @@ if (healthcarePages.has(location.pathname)) {
 }
 if (eduPages.has(location.pathname)) {
   createEducationApplicationStatus(store);
-} if (location.pathname === eduOptOutPage) {
+}
+if (location.pathname === eduOptOutPage) {
   createOptOutApplicationStatus(store);
 }
 if (burialPages.has(location.pathname)) {

--- a/src/applications/static-pages/tests/static-page-widgets.unit.spec.js
+++ b/src/applications/static-pages/tests/static-page-widgets.unit.spec.js
@@ -12,7 +12,7 @@ describe('static page widget', () => {
     };
 
     document.body.insertAdjacentHTML('beforeend', '<div id="testRoot"></div>');
-    mountWidgets([widget]);
+    mountWidgets([widget], 'development');
 
     expect(document.querySelector('#testRoot .loading-indicator')).to.not.be.null;
     expect(document.querySelector('#testRoot .loading-indicator-message').textContent).to.equal(widget.loadingMessage);
@@ -29,7 +29,7 @@ describe('static page widget', () => {
     };
 
     document.body.insertAdjacentHTML('beforeend', '<div id="testRoot"></div>');
-    mountWidgets([widget]);
+    mountWidgets([widget], 'development');
 
     setTimeout(() => {
       expect(document.querySelector('#testRoot .loading-indicator-message').textContent).to.equal(widget.slowMessage);
@@ -47,7 +47,7 @@ describe('static page widget', () => {
     };
 
     document.body.insertAdjacentHTML('beforeend', '<div id="testRoot"></div>');
-    mountWidgets([widget]);
+    mountWidgets([widget], 'development');
 
     setTimeout(() => {
       expect(document.querySelector('#testRoot .usa-alert-error').textContent).to.equal(widget.errorMessage);
@@ -65,7 +65,7 @@ describe('static page widget', () => {
     };
 
     document.body.insertAdjacentHTML('beforeend', '<div id="testRoot"></div>');
-    mountWidgets([widget]);
+    mountWidgets([widget], 'development');
 
     document.querySelector('#testRoot').innerHTML = '';
 

--- a/src/applications/static-pages/tests/static-page-widgets.unit.spec.js
+++ b/src/applications/static-pages/tests/static-page-widgets.unit.spec.js
@@ -12,7 +12,7 @@ describe('static page widget', () => {
     };
 
     document.body.insertAdjacentHTML('beforeend', '<div id="testRoot"></div>');
-    mountWidgets([widget], 'development');
+    mountWidgets([widget], false);
 
     expect(document.querySelector('#testRoot .loading-indicator')).to.not.be.null;
     expect(document.querySelector('#testRoot .loading-indicator-message').textContent).to.equal(widget.loadingMessage);
@@ -29,7 +29,7 @@ describe('static page widget', () => {
     };
 
     document.body.insertAdjacentHTML('beforeend', '<div id="testRoot"></div>');
-    mountWidgets([widget], 'development');
+    mountWidgets([widget], false);
 
     setTimeout(() => {
       expect(document.querySelector('#testRoot .loading-indicator-message').textContent).to.equal(widget.slowMessage);
@@ -47,7 +47,7 @@ describe('static page widget', () => {
     };
 
     document.body.insertAdjacentHTML('beforeend', '<div id="testRoot"></div>');
-    mountWidgets([widget], 'development');
+    mountWidgets([widget], false);
 
     setTimeout(() => {
       expect(document.querySelector('#testRoot .usa-alert-error').textContent).to.equal(widget.errorMessage);
@@ -65,7 +65,7 @@ describe('static page widget', () => {
     };
 
     document.body.insertAdjacentHTML('beforeend', '<div id="testRoot"></div>');
-    mountWidgets([widget], 'development');
+    mountWidgets([widget], false);
 
     document.querySelector('#testRoot').innerHTML = '';
 
@@ -73,5 +73,21 @@ describe('static page widget', () => {
       expect(document.querySelector('#testRoot .usa-alert-error')).to.be.null;
       done();
     }, 600);
+  });
+
+  it('should skip mounting if hidden in prod', () => {
+    const widget = {
+      root: 'testRoot',
+      spinner: true,
+      production: false,
+      loadingMessage: 'Loading',
+      timeout: 0
+    };
+
+    document.body.insertAdjacentHTML('beforeend', '<div id="testRoot"></div>');
+    mountWidgets([widget], true);
+
+    expect(document.querySelector('#testRoot .loading-indicator')).to.be.null;
+    expect(document.querySelector('#testRoot .loading-indicator-message')).to.be.null;
   });
 });


### PR DESCRIPTION
## Description
Update the static widgets code to allow you to set a buildtype, in order to exclude the widgets in certain environments.

## Testing done
Tested locally, updated unit tests

## Testing Plan
We should verify this still allows the widget to show up in dev and staging.

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] Spinner no longer hangs in production
- [ ] Status widget still works in staging

#### Applies to all PRs

- [x] Appropriate logging
- [x] Documentation has been updated, if applicable
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
