### PR TITLE
add error handling to get claims

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -190,7 +190,10 @@ export function getClaimsV2(poll = pollClaimsStatus) {
     dispatch({ type: FETCH_CLAIMS_PENDING });
 
     poll({
-      onError: () => dispatch({ type: FETCH_CLAIMS_ERROR }),
+      onError: response => {
+        Raven.captureException(`vets_claims_v2_err_get_claims ${getStatus(response)}`);
+        dispatch({ type: FETCH_CLAIMS_ERROR });
+      },
       onSuccess: response => dispatch(fetchClaimsSuccess(response)),
       pollingInterval: window.VetsGov.pollTimeout || 1000,
       shouldFail: response => getSyncStatus(response) === 'FAILED',

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -265,7 +265,7 @@ describe('Actions', () => {
         const pollStatusSpy = sinon.spy();
         getClaimsV2(pollStatusSpy)(dispatchSpy);
 
-        pollStatusSpy.firstCall.args[0].onError();
+        pollStatusSpy.firstCall.args[0].onError({ errors: [] });
 
         expect(dispatchSpy.secondCall.args[0]).to.eql({ type: 'FETCH_CLAIMS_ERROR' });
       });


### PR DESCRIPTION
## Description
Add error logging to get claims fetch to address this [todo](https://github.com/department-of-veterans-affairs/vets-website/blob/5db1378e4b27c0b9a7ed95250aab8d50dd630fab/src/applications/claims-status/actions/index.jsx#L157).

## Testing done
tried to run locally but no network activity suggests Raven did anything

## Testing Plan
none - there's no infrastructure in the testing environment to trigger an error condition for our endpoints to test again

