### PR TITLE
All claims 1dot3 mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -9,6 +9,11 @@ import {
   schema as alternateNamesSchema
 } from '../pages/alternateNames';
 
+import {
+  uiSchema as servicePayUISchema,
+  schema as servicePaySchema
+} from '../pages/servicePay';
+
 const formConfig = {
   urlPrefix: '/',
   intentToFileUrl: '/evss_claims/intent_to_file/compensation',
@@ -47,6 +52,12 @@ const formConfig = {
           path: 'alternate-names',
           uiSchema: alternateNamesUISchema,
           schema: alternateNamesSchema
+        },
+        servicePay: {
+          title: 'Service Pay',
+          path: 'service-pay',
+          uiSchema: servicePayUISchema,
+          schema: servicePaySchema
         }
       }
     }

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -2,6 +2,7 @@ import environment from '../../../../platform/utilities/environment';
 
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
+import { hasMilitaryRetiredPay } from '../validations';
 
 import { veteranInfoDescription } from '../content/veteranDetails';
 import {
@@ -13,6 +14,11 @@ import {
   uiSchema as servicePayUISchema,
   schema as servicePaySchema
 } from '../pages/servicePay';
+
+import {
+  uiSchema as waiveRetirementPayUISchema,
+  schema as waiveRetirementPaySchema
+} from '../pages/waiveRetirementPay';
 
 const formConfig = {
   urlPrefix: '/',
@@ -58,6 +64,13 @@ const formConfig = {
           path: 'service-pay',
           uiSchema: servicePayUISchema,
           schema: servicePaySchema
+        },
+        waiveRetirementPay: {
+          title: 'Waiving Retirement Pay',
+          path: 'waive-retirement-pay',
+          depends: hasMilitaryRetiredPay,
+          uiSchema: waiveRetirementPayUISchema,
+          schema: waiveRetirementPaySchema
         }
       }
     }

--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -35,26 +35,17 @@ const schema = {
         }
       }
     },
-    servicePay: {
-      type: 'object',
-      required: ['hasMilitaryRetiredPay'],
-      properties: {
-        hasMilitaryRetiredPay: {
-          type: 'boolean'
-        },
-        militaryRetiredPayBranch: {
-          type: 'string',
-          'enum': [
-            'Air Force',
-            'Army',
-            'Coast Guard',
-            'Marine Corps',
-            'National Oceanic and Atmospheric Administration',
-            'Navy',
-            'Public Health Service'
-          ]
-        }
-      }
+    militaryRetiredPayBranch: {
+      type: 'string',
+      'enum': [
+        'Air Force',
+        'Army',
+        'Coast Guard',
+        'Marine Corps',
+        'National Oceanic and Atmospheric Administration',
+        'Navy',
+        'Public Health Service'
+      ]
     }
   }
 };

--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -46,6 +46,9 @@ const schema = {
         'Navy',
         'Public Health Service'
       ]
+    },
+    waiveRetirementPay: {
+      type: 'boolean'
     }
   }
 };

--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -34,6 +34,27 @@ const schema = {
           }
         }
       }
+    },
+    servicePay: {
+      type: 'object',
+      required: ['hasMilitaryRetiredPay'],
+      properties: {
+        hasMilitaryRetiredPay: {
+          type: 'boolean'
+        },
+        militaryRetiredPayBranch: {
+          type: 'string',
+          'enum': [
+            'Air Force',
+            'Army',
+            'Coast Guard',
+            'Marine Corps',
+            'National Oceanic and Atmospheric Administration',
+            'Navy',
+            'Public Health Service'
+          ]
+        }
+      }
     }
   }
 };

--- a/src/applications/disability-benefits/all-claims/content/waiveRetirementPay.jsx
+++ b/src/applications/disability-benefits/all-claims/content/waiveRetirementPay.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export const waiveRetirementPayDescription = (
+  <p>
+    If you decide to receive VA compensation pay, it may reduce the amount you
+    get for retirement pay. <strong>VA compensation isn’t taxable, so it may be
+    the greater benefit.</strong> If you choose to not receive VA compensation
+    pay so you can continue to get retirement pay, any VA compensation payments
+    you’re already getting will stop, and you won’t get any more from this
+    application.
+  </p>
+);

--- a/src/applications/disability-benefits/all-claims/pages/alternateNames.js
+++ b/src/applications/disability-benefits/all-claims/pages/alternateNames.js
@@ -9,7 +9,7 @@ export const uiSchema = {
     'ui:widget': 'yesNo'
   },
   alternateNames: {
-    'ui:description': 'What names did you serve under?',
+    'ui:description': 'What name did you serve under?',
     'ui:options': {
       viewField: FullNameField,
       reviewTitle: 'Other names',

--- a/src/applications/disability-benefits/all-claims/pages/servicePay.js
+++ b/src/applications/disability-benefits/all-claims/pages/servicePay.js
@@ -1,0 +1,19 @@
+import fullSchema from '../config/schema';
+
+const { servicePay: servicePaySchema } = fullSchema.properties;
+
+export const uiSchema = {
+  hasMilitaryRetiredPay: {
+    'ui:title': 'Are you receiving military retired pay?',
+    'ui:widget': 'yesNo',
+    'ui:options': {}
+  },
+  militaryRetiredPayBranch: {
+    'ui:title': 'Please choose the branch of service that gives you military retired pay',
+    'ui:options': {
+      expandUnder: 'hasMilitaryRetiredPay'
+    },
+  }
+};
+
+export const schema = servicePaySchema;

--- a/src/applications/disability-benefits/all-claims/pages/servicePay.js
+++ b/src/applications/disability-benefits/all-claims/pages/servicePay.js
@@ -1,9 +1,10 @@
 import fullSchema from '../config/schema';
+import { hasMilitaryRetiredPay } from '../validations';
 
-const { servicePay: servicePaySchema } = fullSchema.properties;
+const { militaryRetiredPayBranch: militaryRetiredPayBranchSchema } = fullSchema.properties;
 
 export const uiSchema = {
-  hasMilitaryRetiredPay: {
+  'view:hasMilitaryRetiredPay': {
     'ui:title': 'Are you receiving military retired pay?',
     'ui:widget': 'yesNo',
     'ui:options': {}
@@ -11,9 +12,19 @@ export const uiSchema = {
   militaryRetiredPayBranch: {
     'ui:title': 'Please choose the branch of service that gives you military retired pay',
     'ui:options': {
-      expandUnder: 'hasMilitaryRetiredPay'
+      expandUnder: 'view:hasMilitaryRetiredPay'
     },
+    'ui:required': hasMilitaryRetiredPay
   }
 };
 
-export const schema = servicePaySchema;
+export const schema = {
+  type: 'object',
+  required: ['view:hasMilitaryRetiredPay'],
+  properties: {
+    'view:hasMilitaryRetiredPay': {
+      type: 'boolean',
+    },
+    militaryRetiredPayBranch: militaryRetiredPayBranchSchema
+  }
+};

--- a/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
@@ -23,6 +23,7 @@ export const uiSchema = {
 
 export const schema = {
   type: 'object',
+  required: ['waiveRetirementPay'],
   properties: {
     'view:waiveRetirementPayDescription': {
       type: 'object',

--- a/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
@@ -1,0 +1,33 @@
+import fullSchema from '../config/schema';
+import { waiveRetirementPayDescription } from '../content/waiveRetirementPay';
+
+const { waiveRetirementPay: waiveRetirementPaySchema } = fullSchema.properties;
+
+export const uiSchema = {
+  'view:waiveRetirementPayDescription': {
+    'ui:title': 'Waiving Retirement Pay',
+    'ui:description': waiveRetirementPayDescription,
+  },
+  waiveRetirementPay: {
+    'ui:title': 'Please let us know what type of pay you would like to receive.',
+    'ui:widget': 'yesNo',
+    'ui:options': {
+      yesNoReverse: true, // If veteran elects to not receive VA pay, they waive their VA pay
+      labels: {
+        Y: 'I want to receive VA disability compensation even though it will reduce my retirement pay.',
+        N: 'I don’t want to receive VA compensation pay so I can keep my retirement pay.'
+      }
+    }
+  }
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    'view:waiveRetirementPayDescription': {
+      type: 'object',
+      properties: {}
+    },
+    waiveRetirementPay: waiveRetirementPaySchema
+  }
+};

--- a/src/applications/disability-benefits/all-claims/tests/pages/servicePay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/servicePay.unit.spec.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { mount } from 'enzyme';
+import formConfig from '../../config/form';
+
+describe.only('Service Pay', () => {
+  const { schema, uiSchema } = formConfig.chapters.veteranDetails.pages.servicePay;
+
+  it('should render two radio options by default', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}/>
+    );
+
+    expect(form.find('input[type="radio"]').length).to.equal(2);
+  });
+
+  it("should submit when 'no' option is selected", () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{ 'view:hasMilitaryRetiredPay': false }}
+        formData={{}}
+        onSubmit={onSubmit}/>
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(onSubmit.calledOnce).to.be.true;
+  });
+
+  it("should fail to submit when 'Yes' option selected and no branch provided", () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{ 'view:hasMilitaryRetiredPay': true }}
+        formData={{}}
+        onSubmit={onSubmit}/>
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should submit when all info provided', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          'view:hasMilitaryRetiredPay': true,
+          militaryRetiredPayBranch: 'Army'
+        }}
+        formData={{}}
+        onSubmit={onSubmit}/>
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(onSubmit.calledOnce).to.be.true;
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/pages/waiveRetirementPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/waiveRetirementPay.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 
 describe('Service Pay', () => {
-  const { schema, uiSchema } = formConfig.chapters.veteranDetails.pages.servicePay;
+  const { schema, uiSchema } = formConfig.chapters.veteranDetails.pages.waiveRetirementPay;
 
   it('should render two radio options by default', () => {
     const form = mount(
@@ -21,14 +21,14 @@ describe('Service Pay', () => {
     expect(form.find('input[type="radio"]').length).to.equal(2);
   });
 
-  it("should submit when 'no' option is selected", () => {
+  it('should submit when an option is selected', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
-        data={{ 'view:hasMilitaryRetiredPay': false }}
+        data={{ waiveRetirementPay: false }}
         formData={{}}
         onSubmit={onSubmit}/>
     );
@@ -38,14 +38,14 @@ describe('Service Pay', () => {
     expect(onSubmit.calledOnce).to.be.true;
   });
 
-  it("should fail to submit when 'Yes' option selected and no branch provided", () => {
+  it('should fail to submit when neither option is selected', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
-        data={{ 'view:hasMilitaryRetiredPay': true }}
+        data={{}}
         formData={{}}
         onSubmit={onSubmit}/>
     );
@@ -53,25 +53,5 @@ describe('Service Pay', () => {
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error-message').length).to.equal(1);
     expect(onSubmit.called).to.be.false;
-  });
-
-  it('should submit when all info provided', () => {
-    const onSubmit = sinon.spy();
-    const form = mount(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{
-          'view:hasMilitaryRetiredPay': true,
-          militaryRetiredPayBranch: 'Army'
-        }}
-        formData={{}}
-        onSubmit={onSubmit}/>
-    );
-
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(0);
-    expect(onSubmit.calledOnce).to.be.true;
   });
 });

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -1,0 +1,3 @@
+import _ from '../../../platform/utilities/data';
+
+export const hasMilitaryRetiredPay = (data) => _.get('view:hasMilitaryRetiredPay', data, false);


### PR DESCRIPTION
## Description
Adds 1.3 to the all claims 526 form. This includes two pages:
- whether the veteran receives military retired pay, and if so, what branch gives it to him or her
- If veteran receives military pay, a second page asks the veteran whether or not to waive VA pay

## Testing done
- Tested locally
- Added some unit tests to cover requirements 

## Testing Plan
- Test in staging manually
- Test in production when possible

## Screenshots
First page base questions:
![screen shot 2018-08-21 at 2 35 43 pm](https://user-images.githubusercontent.com/24251447/44424763-aab83b00-a54f-11e8-92dc-e0fc7445c71b.png)

-----

First page expands if the veteran answers 'yes':
![screen shot 2018-08-21 at 2 35 57 pm](https://user-images.githubusercontent.com/24251447/44424786-bb68b100-a54f-11e8-9e7d-921d67d80426.png)
-----
![screen shot 2018-08-21 at 2 36 09 pm](https://user-images.githubusercontent.com/24251447/44424841-e2bf7e00-a54f-11e8-8a38-828c68b78787.png)

-----

Second page shows only if veteran selected 'yes' on first page:
![screen shot 2018-08-21 at 2 36 27 pm](https://user-images.githubusercontent.com/24251447/44424892-08e51e00-a550-11e8-90bd-0557d7c085cb.png)


## Acceptance Criteria (Definition of Done)
- Veteran is able to answer all three questions (receive retired pay, what branch, and waive VA pay)
- Require all three questions when first answer is 'yes'
- Skip next two questions if first answer is 'no'

#### Applies to all PRs

- [x] Appropriate logging
- [x] Documentation has been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
