### PR TITLE
remove display of period when displaying children

### DIFF
--- a/src/platform/forms/save-in-progress/SaveFormLink.jsx
+++ b/src/platform/forms/save-in-progress/SaveFormLink.jsx
@@ -83,7 +83,6 @@ class SaveFormLink extends React.Component {
     const saveLinkMessage = this.props.user.login.currentlyLoggedIn
       ? 'Finish this application later'
       : 'Save and finish this application later';
-
     return (
       <div style={{ display: this.props.children ? 'inline' : null }}>
         <Element name="saveFormLinkTop"/>
@@ -98,7 +97,15 @@ class SaveFormLink extends React.Component {
           </div>
         }
         {savedStatus !== SAVE_STATUSES.noAuth &&
-          <span><button type="button" className="va-button-link schemaform-sip-save-link" onClick={this.saveForm}>{this.props.children || saveLinkMessage}</button>.</span>}
+          <span>
+            <button
+              type="button"
+              className="va-button-link schemaform-sip-save-link"
+              onClick={this.saveForm}>
+              {this.props.children || saveLinkMessage}
+            </button>
+            {!this.props.children && '.'}
+          </span>}
       </div>
     );
   }


### PR DESCRIPTION
## Description
update save form link to not display a period when using children prop 

## Testing done
verified on feedback tool locally 

## Testing Plan
none

## Screenshots
![screen shot 2018-08-21 at 17 01 07](https://user-images.githubusercontent.com/4998130/44433566-26bc7e00-a564-11e8-9e5c-bd00b5163a96.png)

## Acceptance Criteria (Definition of Done)
doesn't display period 

#### Applies to all PRs

- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
