### PR TITLE
Fixed redirect issues with MHV upgrade flow.

### DIFF
--- a/src/platform/user/authorization/containers/MHVApp.jsx
+++ b/src/platform/user/authorization/containers/MHVApp.jsx
@@ -85,7 +85,7 @@ export class MHVApp extends React.Component {
     // rendered, but if it hasn't for some reason, we will redirect now.
     if (accountState === 'needs_identity_verification') {
       const nextQuery = { next: window.location.pathname };
-      const verifyUrl = appendQuery('/verify', nextQuery);
+      const verifyUrl = appendQuery('/verify/', nextQuery);
       window.location.replace(verifyUrl);
       return;
     }
@@ -93,7 +93,7 @@ export class MHVApp extends React.Component {
     switch (accountState) {
       case 'needs_terms_acceptance': {
         const redirectQuery = { tc_redirect: window.location.pathname }; // eslint-disable-line camelcase
-        const termsConditionsUrl = appendQuery('/health-care/medical-information-terms-conditions', redirectQuery);
+        const termsConditionsUrl = appendQuery('/health-care/medical-information-terms-conditions/', redirectQuery);
         window.location.replace(termsConditionsUrl);
         break;
       }


### PR DESCRIPTION
## Description
The flow actually works properly without these changes when I tested locally. It looks like the URL automatically appends the trailing slash between the URL and the query param. In contrast, when I tested on Staging, it looks like the URL dropped any query params when they were not separated from the main URL by the slash.

For example, on Staging, I could navigate to `/account/?query_param=testing`, which would keep the query param. But navigating to `/account?query_param=testing` would drop it and become just `/account`. This is clearly problematic when we store the redirect URL in the query param. As I explained above, when I tested locally, either URL would resolve to the one with the trailing slash.

I think this will work for now as a hack (and it's not really much of a hack anyway), but I think the root issue is something with how the routing is configured in other environments. I could've sworn the redirects were working on other environments before, so it's possible that it was a recent change.

Resolves department-of-veterans-affairs/vets.gov-team#12445.

## Testing done
Testing explained above. ^

## Testing Plan
Test verification flow in Staging. Navigate to Secure Messaging as an Advanced user, which should redirect to verify page. Confirm whether the URL retains a `?next=...` query parameter.

If it is retained, compare by removing the slash between the URL and the `?next` param to verify that the param is dropped when there is no trailing slash.

## Acceptance Criteria (Definition of Done)
Verify and T&C acceptance should redirect the user back to the app (Secure Messaging) if they were redirected initially from the app (Secure Messaging).

#### Applies to all PRs
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
