### PR TITLE
Add prefill messaging to GIBFT and track changes to On Behalf Of...

### DIFF
--- a/src/applications/edu-benefits/components/UserInteractionRecorder.jsx
+++ b/src/applications/edu-benefits/components/UserInteractionRecorder.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * This renderless-component is used to register events with Google Analytics
+ * by tying into a US Form System's uiSchema['ui:description'] property. When
+ * the data on the form page changes, this component's `componentDidUpdate()`
+ * method fires and registers an event with Google Analytics (via `recordEvent`)
+ * if the property the component cares about (`selectedValue`) has changed.
+ *
+ * @export
+ * @class UserInteractionRecorder
+ * @extends {React.Component}
+ */
+export default class UserInteractionRecorder extends React.Component {
+  componentDidUpdate(prevProps) {
+    const { trackingEventMap, selectedValue, eventRecorder } = this.props;
+    const { selectedValue: oldSelectedValue } = prevProps;
+    if (selectedValue === oldSelectedValue) {
+      return;
+    }
+    if (trackingEventMap[selectedValue]) {
+      eventRecorder(trackingEventMap[selectedValue]);
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+UserInteractionRecorder.propTypes = {
+  trackingEventMap: PropTypes.objectOf(PropTypes.object),
+  selectedValue: PropTypes.string,
+  eventRecorder: PropTypes.func,
+};

--- a/src/applications/edu-benefits/feedback-tool/config/form.js
+++ b/src/applications/edu-benefits/feedback-tool/config/form.js
@@ -7,6 +7,7 @@ import { validateBooleanGroup, validateMatch } from 'us-forms-system/lib/js/vali
 
 import FormFooter from '../../../../platform/forms/components/FormFooter';
 import fullNameUI from '../../../../platform/forms/definitions/fullName';
+import PrefillMessage from '../../../../platform/forms/save-in-progress/PrefillMessage';
 import dataUtils from '../../../../platform/utilities/data/index';
 
 const { get, omit, set } = dataUtils;
@@ -160,6 +161,7 @@ const formConfig = {
           title: 'Applicant Information',
           depends: isNotAnonymous,
           uiSchema: {
+            'ui:description': PrefillMessage,
             fullName: _.merge(fullNameUI, {
               prefix: {
                 'ui:title': 'Prefix',
@@ -202,6 +204,7 @@ const formConfig = {
           title: 'Service Information',
           depends: isVeteranOrServiceMember,
           uiSchema: {
+            'ui:description': PrefillMessage,
             serviceBranch: {
               'ui:title': 'Branch of service',
             },
@@ -224,6 +227,7 @@ const formConfig = {
           title: 'Contact Information',
           depends: (formData) => formData.onBehalfOf !== anonymous,
           uiSchema: {
+            'ui:description': PrefillMessage,
             address: {
               street: {
                 'ui:title': 'Address line 1'

--- a/src/applications/edu-benefits/feedback-tool/config/form.js
+++ b/src/applications/edu-benefits/feedback-tool/config/form.js
@@ -17,7 +17,7 @@ import ConfirmationPage from '../containers/ConfirmationPage';
 import SchoolSelectField from '../../components/SchoolSelectField.jsx';
 import GetFormHelp from '../../components/GetFormHelp';
 
-import { transform, submit } from '../helpers';
+import { transform, submit, recordApplicantRelationship } from '../helpers';
 
 const {
   address: applicantAddress,
@@ -125,6 +125,7 @@ const formConfig = {
           path: 'applicant-relationship',
           title: 'Applicant Relationship',
           uiSchema: {
+            'ui:description': recordApplicantRelationship,
             onBehalfOf: {
               'ui:widget': 'radio',
               'ui:title': 'I’m submitting feedback on behalf of...',

--- a/src/applications/edu-benefits/sass/edu-benefits.scss
+++ b/src/applications/edu-benefits/sass/edu-benefits.scss
@@ -75,9 +75,6 @@
   }
 
   .radio-button {
-    input[type="radio"] {
-    }
-
     span {
       display: inline-block;
       width: 100%;

--- a/src/applications/edu-benefits/tests/components/UserInteractionRecorder.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/components/UserInteractionRecorder.unit.spec.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import UserInteractionRecorder from '../../components/UserInteractionRecorder';
+
+describe('<UserInteractionRecorder>', () => {
+  let recordEventSpy;
+  let component;
+  const eventMap = {
+    a: 'event-a',
+    b: 'event-b',
+  };
+  beforeEach(() => {
+    recordEventSpy = sinon.spy();
+    component = mount(<UserInteractionRecorder eventRecorder={recordEventSpy} selectedValue="b" trackingEventMap={eventMap}></UserInteractionRecorder>);
+  });
+  it('does not render anything to the DOM', () => {
+    expect(component.children().length).to.equal(0);
+  });
+  describe('when its props change', () => {
+    it('calls the passed-in `recordEvent` function when the new value of selectedValue is in the event map', () => {
+      component.setProps({ selectedValue: 'a' });
+      expect(recordEventSpy.called).to.be.true;
+      expect(recordEventSpy.calledWith('event-a')).to.be.true;
+    });
+
+    it('does not call the passed-in `recordEvent` function when the new value of selectedValue is the same as the old value', () => {
+      component.setProps({ selectedValue: 'b' });
+      expect(recordEventSpy.called).to.be.false;
+    });
+
+    it('does not call the passed-in `recordEvent` function when the new value of props.selectedValue is not in the event map', () => {
+      component.setProps({ selectedValue: 'z' });
+      expect(recordEventSpy.called).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Description
1. Adds prefill messaging to appropriate pages of GIBFT
1. Records GA events when changing who the feedback is being filed on behalf of

## Testing done
- Tested locally to confirm that the prefill message function is called, but was unable to test with a prefill enabled user locally.
- Confirmed that the GA event recording function was called when needed.

## Testing Plan
Manual testing of a user with prefill enabled for the GIBFT. Confirm that the prefill message appears on the following pages:
- [ ] applicant information
- [ ] service information
- [ ] contact information
Also
- [ ] Confirm that the correct events are logged in GA

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

#### Applies to all PRs

- [ ] Appropriate logging N/A
- [ ] Documentation has been updated, if applicable N/A
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable) N/A
