### PR TITLE
Reformat formId in upper case

### DIFF
--- a/src/applications/edu-benefits/complaint-tool/config/form.js
+++ b/src/applications/edu-benefits/complaint-tool/config/form.js
@@ -100,7 +100,7 @@ const formConfig = {
   trackingPrefix: 'gi_bill_feedback',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
-  formId: 'complaint-tool',
+  formId: 'COMPLAINT-TOOL',
   version: 0,
   prefillEnabled: true,
   defaultDefinitions: {

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -14,7 +14,7 @@ export const formBenefits = {
   '22-5495': 'education benefits',
   '40-10007': 'pre-need determination of eligibility in a VA national cemetery',
   VIC: 'Veteran ID Card',
-  'complaint-tool': 'feedback',
+  'COMPLAINT-TOOL': 'feedback',
   '21-686C': 'dependent status'
 };
 
@@ -46,7 +46,7 @@ export const formLinks = {
   '22-5495': '/education/apply-for-education-benefits/application/5495/',
   '40-10007': '/burials-and-memorials/pre-need/form-10007-apply-for-eligibility/',
   VIC: '/veteran-id-card/apply/',
-  'complaint-tool': '/education/complaint-tool/form',
+  'COMPLAINT-TOOL': '/education/gi-bill-school-feedback',
   '21-686C': '/disability-benefits/686/dependent-status/'
 };
 
@@ -82,7 +82,7 @@ export const sipEnabledForms = new Set([
   '22-5495',
   '40-10007',
   'VIC',
-  'complaint-tool'
+  'COMPLAINT-TOOL'
 ]);
 
 

--- a/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
@@ -41,7 +41,7 @@ const schemaToConfigIds = {
   '22-5495': '5495',
   '40-10007': '40-10007',
   VIC: 'VIC',
-  'complaint-tool': 'complaint-tool',
+  'complaint-tool': 'COMPLAINT-TOOL',
   definitions: 'N/A'
 };
 

--- a/src/platform/forms/tests/migrations.unit.spec.js
+++ b/src/platform/forms/tests/migrations.unit.spec.js
@@ -63,6 +63,7 @@ describe('form migrations:', () => {
     const allFormIds = Object.keys(schemas).filter(formId => !excludedForms.has(formId));
     const reformattedIds = mappedIds.slice(0);
     reformattedIds.splice(0, 1, '1010ez');
+    reformattedIds.splice(-2, 1, 'COMPLAINT-TOOL');
     reformattedIds.pop();
     const includedFormIds = configs.map(form => form.formId);
     expect(allFormIds).to.deep.equal(mappedIds);


### PR DESCRIPTION
## Description
This change reformats the feedback tool's formId to be upper case, to be consistent with how other formIds are formatted and how we check for prefill availability in `SaveInProgressIntro.jsx`

## Testing done
Prefill should be determined to be available (e.g. line 134 in `SaveInProgressIntro.jsx`) when signed in for this form.

## Testing Plan
N/A

## Screenshots
N/A

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Documentation has been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
