### PR TITLE
Fix link to family-caregiver-health-benefits

### DIFF
--- a/va-gov/pages/health-care/index.md
+++ b/va-gov/pages/health-care/index.md
@@ -143,7 +143,7 @@ Whatever you’re struggling with—homelessness, chronic pain, anxiety, depress
   </div>
 
   <div class="link">
-    <a href="/health-care/family-caregiver-benefits/"><b>Family and Caregiver Health Benefits</b></a>
+    <a href="/health-care/family-caregiver-health-benefits/"><b>Family and Caregiver Health Benefits</b></a>
     <p>See if you qualify for VA medical benefits as a spouse, surviving spouse, dependent child, or caregiver.</p>
   </div>
 


### PR DESCRIPTION
This PR fixes the following error occurring during the build -

```
Error: You have 1 broken links:

health-care/index.html >>> href: "/health-care/family-caregiver-benefits/", text: "Family and Caregiver Health Benefits"
```