### PR TITLE
Brand consolidation - Fix for double USWDS imports

### DIFF
--- a/va-gov/pages/disability-benefits/after-you-apply/VA-claim-exam.md
+++ b/va-gov/pages/disability-benefits/after-you-apply/VA-claim-exam.md
@@ -86,7 +86,7 @@ If you canâ€™t make it to your appointment, let us know right away. You can most
 </ul>
 </div>
 
-<br>  
+<br>
 
 ### What to expect at your VA claim exam
 
@@ -177,7 +177,7 @@ If you have what we consider to be a good reason for missing your exam (called â
 </ul>
 </div>
 
-<br>  
+<br>
 
 ### After your VA claim exam
 
@@ -238,5 +238,3 @@ We may ask you to have a claim exam if you appeal your disability benefits decis
 * [Get answers to your questions about the VA claim exam](https://www.benefits.va.gov/compensation/claimexam.asp).
 * [Download the VA claim exam fact sheet](https://www.benefits.va.gov/compensation/docs/claimexam-factsheet.pdf#).
 * [Download the VA claim exam tip sheet](https://www.benefits.va.gov/compensation/docs/claimexam-tipssheet.pdf#).
-
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>

--- a/va-gov/pages/disability-benefits/apply/claim-types.md
+++ b/va-gov/pages/disability-benefits/apply/claim-types.md
@@ -17,7 +17,7 @@ relatedlinks:
       description: Find out how to use the Fully Developed Claims program to get a faster decision on your disability benefits claim by submitting your evidence (supporting documents) along with your claim.
     - url: /disability-benefits/apply/evidence/decision-ready-claims/
       title: Decision Ready Claims Program
-      description: Find out if you can use the Decision Ready Claims program to get a decision on your claim in 30 days or less by working with an accredited Veterans Service Organization (VSO).      
+      description: Find out if you can use the Decision Ready Claims program to get a decision on your claim in 30 days or less by working with an accredited Veterans Service Organization (VSO).
 ---
 
 <div class="va-introtext">
@@ -62,7 +62,7 @@ Learn more about disabilities that may be related to your active-duty service bu
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="claim-special">Special Claim—File a claim for special needs linked to your service-connected disability.</button>
 <div id="claim-special" class="usa-accordion-content">
 
-You can file a special claim to request compensation for special needs. 
+You can file a special claim to request compensation for special needs.
 
 **These may include needs like:**
 - A specially equipped vehicle if your service-connected disability prevents you from driving, **or**
@@ -124,6 +124,3 @@ You can file a secondary claim to get more disability benefits for a new disabil
 </li>
 </ul>
 </div>
-
-<script src="https://standards.usa.gov/assets/js/vendor/uswds.min.js" type="text/javascript"></script>
-<!--- TODO: find a proper place to import USWDS JS for static pages -->

--- a/va-gov/pages/disability-benefits/apply/claim-types/predischarge-claim.md
+++ b/va-gov/pages/disability-benefits/apply/claim-types/predischarge-claim.md
@@ -164,5 +164,3 @@ If you’re found to be medically unfit for duty, IDES will give you a proposed 
 </div>
 
 <br>
-
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>

--- a/va-gov/pages/disability-benefits/apply/evidence/decision-ready-claims.md
+++ b/va-gov/pages/disability-benefits/apply/evidence/decision-ready-claims.md
@@ -1,9 +1,9 @@
 ---
 layout: page-breadcrumbs.html
 title: VA Decision Ready Claims (DRC) Program
-description: 
+description:
 concurrence: incomplete
-plainlanguage: 
+plainlanguage:
 template: detail-page
 order: 1
 relatedlinks:
@@ -23,7 +23,7 @@ relatedlinks:
       description: "You may be able to get disability benefits if you have an illness that started within a year after you were discharged from service."
 ---
 <div itemprop="description" class="va-introtext">
-  
+
 The Decision Ready Claims (DRC) program is the fastest way to get your VA claim processed. Find out if you can use the DRC program to get a decision on your claim in 30 days or less by working with an accredited Veterans Service Organization (VSO).
 
 </div>
@@ -40,7 +40,7 @@ The Decision Ready Claims (DRC) program is the fastest way to get your VA claim 
 - **Presumptive service connection claim** for a condition that we believe is related to your military service even if there's no direct evidence of a link
 - **Secondary service connection claim** for a condition caused or made worse by your service-connected disability
 - **Increased disability claim** for an existing service-connected condition that you have medical evidence to show has gotten worse
-- **[Dependency and Indemnity Compensation (DIC) claim](/burials-and-memorials/survivor-and-dependent-benefits/compensation/)** as the eligible surviving spouse of a Veteran 
+- **[Dependency and Indemnity Compensation (DIC) claim](/burials-and-memorials/survivor-and-dependent-benefits/compensation/)** as the eligible surviving spouse of a Veteran
 - **Pre-discharge claim** for disability compensation as a Servicemember who has less than 90 days before your separation from military service
 
 **Note:** We're working to expand the DRC program to include more types of claims. Come back soon, or check with your VSO, to find out about updates.
@@ -145,7 +145,7 @@ You'll need to follow the steps below. When you work with an accredited VSO and 
   <li class="process-step list-one"><strong>Appoint and work with an accredited VSO</strong><br>
     Accredited VSOs are fully trained on the DRC program. They can help you determine if a DRC is right for you.<br>
     <a href="https://www.ebenefits.va.gov/ebenefits/vso-search">Go to eBenefits to find a VSO near you</a>.
-    </li>  
+    </li>
   <li class="process-step list-two"><strong>Gather all relevant evidence needed to support your claim</strong><br>
     This includes your federal and medical records as well as any related Disability Benefits Questionnaires (DBQs). Your VSO will help you gather everything you need.
     </li>
@@ -154,7 +154,7 @@ You'll need to follow the steps below. When you work with an accredited VSO and 
     </li>
   <li class="process-step list-four"><strong>Submit your claim</strong><br>
     Your VSO will check to make sure your application includes all the needed information and will help you submit your claim online. Giving us all the relevant evidence when you submit your DRC allows us to send your claim directly to a VA Rating Specialist for a decision.
-    </li>  
+    </li>
 </ol>
 
 ### When can I expect a decision on my DRC?
@@ -168,7 +168,7 @@ You can expect a decision within 30 days or less from the time you submit your c
 <li>
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="more-vso">How do I find an accredited VSO?</button>
 <div id="more-vso" class="usa-accordion-content">
- 
+
 **You can find an accredited VSO in couple ways:**
 - Go to eBenefits to find a local VSO by state/territory, zip code, or the organization’s name.<br>
 <a href="https://www.ebenefits.va.gov/ebenefits/vso-search">Go to eBenefits</a>.
@@ -192,13 +192,13 @@ You can expect a decision within 30 days or less from the time you submit your c
 - The Veteran's death certificate
 - The Veteran's medical records
 - The report from your VA claim exam
-    
+
 </div>
 </li>
 <li>
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="more-info">What if I have more questions or want more information?</button>
 <div id="more-info" class="usa-accordion-content">
-  
+
 <a href="https://www.benefits.va.gov/compensation/DRC.asp">Watch a video on the DRC program</a>.
 
 **Download helpful PDFs:**<br>
@@ -213,6 +213,4 @@ Reach out to your local VSO or call our toll-free number at <a href="tel:+1phone
 </li>
 </ul>
 </div>
-
-<script src="https://standards.usa.gov/assets/js/vendor/uswds.min.js" type="text/javascript"></script>
 

--- a/va-gov/pages/disability-benefits/apply/evidence/fully-developed-disability-claims.md
+++ b/va-gov/pages/disability-benefits/apply/evidence/fully-developed-disability-claims.md
@@ -1,19 +1,19 @@
 ---
 layout: page-breadcrumbs.html
 title: VA Fully Developed Claim Program
-plainlanguage: 
+plainlanguage:
 template: detail-page
 order: 2
 relatedlinks:
-  - heading: 
+  - heading:
     links:
-    - url: 
-      title: 
-      description: 
+    - url:
+      title:
+      description:
 ---
 <div itemprop="description" class="va-introtext">
-  
-Find out how you can use the Fully Developed Claims program to get a faster decision on your disability benefits claim by submitting evidence along with your claim. 
+
+Find out how you can use the Fully Developed Claims program to get a faster decision on your disability benefits claim by submitting evidence along with your claim.
 
 </div>
 
@@ -67,7 +67,7 @@ Find out how you can use the Fully Developed Claims program to get a faster deci
 
 No. Filing a fully developed claim won't affect the attention we give to your claim or the benefits you're entitled to receive.
 
-If we determine that we need other non-federal records to make a decision on your claim, we'll simply remove the claim from the Fully Developed Claims program and process it as a standard claim. 
+If we determine that we need other non-federal records to make a decision on your claim, we'll simply remove the claim from the Fully Developed Claims program and process it as a standard claim.
 
 Once you start your fully developed claim, you'll have up to 1 year to complete it. If we approve your claim, you'll be paid back to the day you started it.
 
@@ -182,7 +182,7 @@ You'll need to submit current medical evidence that shows your disability has go
 
 Yes. We can help you through the Fully Developed Claims program.
 
-**We'll:** 
+**We'll:**
 - Request your military service records (with your permission), **and**
 - Request relevant Social Security benefits information and medical records that you identify and authorize us to get from a federal facility, like a VA medical center, **and**
 - Schedule a health exam for you or get a medical opinion from a health care provider if we decide we need it for your claim
@@ -191,7 +191,7 @@ Yes. We can help you through the Fully Developed Claims program.
 
 <br>
 
-### When should I turn in my evidence? 
+### When should I turn in my evidence?
 
 To submit your claim through the Fully Developed Claims program, you’ll need to turn in the information and evidence at the same time as you file your claim.
 
@@ -214,6 +214,4 @@ For some types of claims, you can work with a VSO to submit a decision-ready cla
 You can start your online application right now, or find out how to apply by mail, in person, or with the help of a trained professional.<br>
 [Find out how to apply for disability benefits](/disability-benefits/apply/).
 
-**Note:** Please be sure to upload all medical evidence or supporting documents at the end of the form. 
-
-<script src="https://standards.usa.gov/assets/js/vendor/uswds.min.js" type="text/javascript"></script>
+**Note:** Please be sure to upload all medical evidence or supporting documents at the end of the form.

--- a/va-gov/pages/disability-benefits/claims-appeal.md
+++ b/va-gov/pages/disability-benefits/claims-appeal.md
@@ -36,7 +36,7 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
     <span class="number">12-18 months</span>
     <span class="description">The Veterans Benefits Administration usually takes 12-18 months to review new appeals and decide whether to grant some or all of the appeal.</span>
   </div>
-  
+
   <div class="card information" markdown="0">
     <span class="number">5-7 years</span>
     <span class="description">When you request a review from a Veterans Law Judge at the Board of Veterans’ Appeals, it could take 5-7 years for you to get a decision.</span>
@@ -50,8 +50,8 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
       <div>
         <h4>File a Notice of Disagreement (NOD)</h4>
         <p>
-        By filing a Notice of Disagreement, you begin the appeals process. You’ll need to file a Notice of Disagreement within 1 year of the date on the letter notifying you of the claim decision. <br> 
-        <a href="https://www.vba.va.gov/pubs/forms/VBA-21-0958-ARE.pdf">Download a Notice of Disagreement (VA Form 21-0958)</a>. 
+        By filing a Notice of Disagreement, you begin the appeals process. You’ll need to file a Notice of Disagreement within 1 year of the date on the letter notifying you of the claim decision. <br>
+        <a href="https://www.vba.va.gov/pubs/forms/VBA-21-0958-ARE.pdf">Download a Notice of Disagreement (VA Form 21-0958)</a>.
         </p>
         <p>
         Fill out your Notice of Disagreement and mail it to the address provided on the VA claim decision notice letter you received, or bring it to your local regional office. An accredited representative can help you file a Notice of Disagreement. <a href="/disability-benefits/apply/help/index.html">Get help filing your appeal</a>.
@@ -110,7 +110,3 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
 
 If you disagree with the Board’s decision, you can appeal to the Court of Appeals for Veterans Claims. You’ll need to hire a VA-accredited attorney to represent you, or you may represent yourself. You’ll need to file your Court appeal within 120 days of the Board’s decision.
 [Learn how to file a Court appeal](https://www.uscourts.cavc.gov/appeal.php).
-
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>
-
-<!--- TODO: find a proper place to import USWDS JS for static pages -->

--- a/va-gov/pages/download-va-letters/index.md
+++ b/va-gov/pages/download-va-letters/index.md
@@ -36,7 +36,7 @@ This address will be listed on your letter. If this address isn’t correct, you
 
 ### What if I want to download a letter or document that isn’t available from this tool?
 
-Right now, you can only download the VA letters you see listed when you click the blue **Access Your VA Letters** button above. 
+Right now, you can only download the VA letters you see listed when you click the blue **Access Your VA Letters** button above.
 
 Use these links to get access to other common VA letters and documents you may be eligible for:
 
@@ -67,5 +67,3 @@ We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. (<abbr title="eastern
 <br>
 <br>
 <br>
-
-<script src="https://standards.usa.gov/assets/js/vendor/uswds.min.js" type="text/javascript"></script>

--- a/va-gov/pages/faq.md
+++ b/va-gov/pages/faq.md
@@ -68,7 +68,7 @@ display_title: Frequently Asked Questions
                           <ul>
                             <li>Your driver’s license or passport, <strong>or</strong></li>
                             <li>The ability to answer questions based on private and public data (like your credit report) to prove you’re you</li>
-                          </ul>  
+                          </ul>
                         </ul>
                         <p><a href="/faq/" class="login-required">Sign in now</a>.</p>
                       </div>
@@ -87,9 +87,9 @@ display_title: Frequently Asked Questions
                             <a href="https://www.uscis.gov/i-9-central/acceptable-documents/list-documents/form-i-9-acceptable-documents" class="login-required">See what other documents are accepted</a>.</li>
                           <li>Make sure the VA regional office has your current address on file</li>
                         </ul>
-                        <p>After your <strong>DS Logon</strong> request goes through, you’ll receive a <strong>DS Logon</strong> activation letter by mail in 7-12 business days. You’ll use the information from the letter to activate your account on the <strong>DS Logon</strong> self-service website.</p>  
+                        <p>After your <strong>DS Logon</strong> request goes through, you’ll receive a <strong>DS Logon</strong> activation letter by mail in 7-12 business days. You’ll use the information from the letter to activate your account on the <strong>DS Logon</strong> self-service website.</p>
                         <p><a href="/facilities/">Find a VA regional office near you</a>.</p>
-                        <p><a href="https://myaccess.dmdc.osd.mil/identitymanagement/consent?continueToUrl=%2Fidentitymanagement%2Fauthenticate.do%3Fexecution%3De4s1">Visit the DS Logon self-service website</a>.               
+                        <p><a href="https://myaccess.dmdc.osd.mil/identitymanagement/consent?continueToUrl=%2Fidentitymanagement%2Fauthenticate.do%3Fexecution%3De4s1">Visit the DS Logon self-service website</a>.
                         <h4>Verifying your identity in person if you’re a VA patient</h4>
                         <p>If you’re a VA patient, you can verify your identity at your local VA health care facility as part of the process of getting a premium <strong>My Health<em>e</em>Vet</strong> account. You can then use this account to sign in to Vets.gov without having to verify your identity online.</p>
                         <p><strong>You’ll need to bring:</strong></p>
@@ -99,7 +99,7 @@ display_title: Frequently Asked Questions
                             <a href="/facilities/">Find the phone number for your nearest VA health care facility</a>.</li>
                           <li><strong>A government-issued photo ID.</strong> This can be either your Veteran Health Identification Card or a valid driver’s license.</li>
                         </ul>
-                        <p>A VA staff member will verify your identity. Then they’ll record your information in the <strong>My Health<em>e</em>Vet</strong> system and confirm that you’re eligible for a premium account. A copy of your VA Form 10-5345a-MHV will be added to your VA medical record, and your original paper copy will be shredded to protect your privacy.</p>                        
+                        <p>A VA staff member will verify your identity. Then they’ll record your information in the <strong>My Health<em>e</em>Vet</strong> system and confirm that you’re eligible for a premium account. A copy of your VA Form 10-5345a-MHV will be added to your VA medical record, and your original paper copy will be shredded to protect your privacy.</p>
                         <p><strong>Note:</strong> When you open or download a PDF file, you create a temporary file on your computer. Other people may be able to see this file—and any personal health information you fill in—especially if you’re using a public or shared computer.</p>
                       </div>
                     </div>
@@ -131,7 +131,7 @@ display_title: Frequently Asked Questions
                     <div id="faq-trouble-0" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
                         <p>You can use a premium <strong>My Health<em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account to sign in to Vets.gov with a verified account. Because you already verified your identity when you got your premium account, you won’t need to verify your identity again on Vets.gov.</p>
-                        <h4>How to get a premium DS Logon account</h4>                      
+                        <h4>How to get a premium DS Logon account</h4>
                         <p>Follow these 2 steps to sign up for a premium <strong>DS Logon</strong> account.</p>
                         <p><strong>1. First, make sure you’re enrolled in the Defense Enrollment Eligibility Reporting System (DEERS).</strong> This is the database that records all the people who are eligible for military benefits.</p>
                         <ul>
@@ -146,10 +146,10 @@ display_title: Frequently Asked Questions
                           <li><strong>If you have a Defense Finance and Account Service (DFAS) myPay account,</strong> you can select this option. You’ll be able to upgrade to a premium account right away.</li>
                           <li><strong>If you don’t have a CAC or DFAS myPay account,</strong> select the <strong>None of the above conditions apply</strong> option.</li>
                         </ul>
-                           <p>The registration tool will walk you through the sign-up process for your account and will prompt you to upgrade to a premium account through an online proofing process. Through this process, you’ll be asked a series of questions to prove you’re you—and not someone pretending to be you—to help protect the personal information you’ll have access to with a premium account.</p>                        
+                           <p>The registration tool will walk you through the sign-up process for your account and will prompt you to upgrade to a premium account through an online proofing process. Through this process, you’ll be asked a series of questions to prove you’re you—and not someone pretending to be you—to help protect the personal information you’ll have access to with a premium account.</p>
                            <p><a href="https://myaccess.dmdc.osd.mil/">Go to the DS Logon self-service website</a>.</p>
                         <p><strong>Note:</strong> If you’d rather verify your identity and upgrade to a premium <strong>DS Logon</strong> account in person or by phone, read the instructions in the section above on verifying your identity.</p>
-                        <h4>How to get a premium My Health<em>e</em>Vet account if you’re a VA patient</h4>  
+                        <h4>How to get a premium My Health<em>e</em>Vet account if you’re a VA patient</h4>
                         <p>Follow these 2 steps to sign up for a premium <strong>My Health<em>e</em>Vet</strong> account.</p>
                         <p><strong>1. First, sign up for an account on the My Health<em>e</em>Vet website.</strong> You’ll need to have your Social Security number on hand. Be sure to choose <strong>VA Patient</strong> on the registration form. This will automatically upgrade your account to an advanced account, and then you can upgrade to a premium account.</p>
                         <p><a href="https://www.myhealth.va.gov/mhv-portal-web/user-registration/">Sign up for a My Health<em>e</em>Vet account</a>.</p>
@@ -160,7 +160,7 @@ display_title: Frequently Asked Questions
                         <p>To do this, sign in to <strong>My Health<em>e</em>Vet</strong> using your premium <strong>DS Logon</strong> or ID.me user ID and password.</p>
                         <p>Once signed in, select the <strong>Upgrade Now</strong> button at the top left side of the screen. Then, on the account upgrade page, check the box certifying that you’re the owner of the account and approve the request, and click <strong>Continue</strong>.</p>
                         <p>The system will upgrade you to a premium account.</p>
-                        <p><a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/user-login?redirect=/mhv-portal-web/user-registration/user-login">Sign in to to My Health<em>e</em>Vet</a>.  
+                        <p><a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/user-login?redirect=/mhv-portal-web/user-registration/user-login">Sign in to to My Health<em>e</em>Vet</a>.
                         <h5>Upgrade your account in person at a VA health facility</h5>
                         <p><strong>You’ll need to have:</strong></p>
                         <ul>
@@ -169,15 +169,15 @@ display_title: Frequently Asked Questions
                             <a href="/facilities/">Find the phone number for your nearest VA health care facility</a>.</li>
                           <li><strong>A government-issued photo ID.</strong> This can be either your Veteran Health Identification Card or a valid driver’s license.</li>
                         </ul>
-                        <p>A VA staff member will verify your identity. Then they’ll record your information in the <strong>My Health<em>e</em>Vet</strong> system and confirm you’re eligible for a premium account. A copy of your VA Form 10-5345a-MHV will be added to your VA medical record, and the original paper copy will be shredded to protect your privacy.</p>                        
+                        <p>A VA staff member will verify your identity. Then they’ll record your information in the <strong>My Health<em>e</em>Vet</strong> system and confirm you’re eligible for a premium account. A copy of your VA Form 10-5345a-MHV will be added to your VA medical record, and the original paper copy will be shredded to protect your privacy.</p>
                         <p><strong>Note:</strong> When you open or download a PDF file, you create a temporary file on your computer. Other people may be able to see this file—and any personal health information you fill in—especially if you’re using a public or shared computer.</p>
                      </div>
                     </div>
-                  </li>     
+                  </li>
                  <li markdown="1" itemscope itemtype="http://schema.org/Question">
                     <button class="usa-button-unstyled usa-accordion-button" aria-controls="faq-other-1" itemprop="name">I don’t have a smartphone. How do I verify my identity through ID.me? </button>
                     <div id="faq-other-1" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
-                      <div itemprop="text">                        
+                      <div itemprop="text">
                         <p>You’ll need either a landline or mobile phone and a computer with an Internet connection.</p>
                         <p><strong>At this time, we can’t support:</strong>
                         <ul>
@@ -213,7 +213,7 @@ display_title: Frequently Asked Questions
                     <div id="faq-trouble-3" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
                         <p><strong>If you have a premium My Health<em>e</em>Vet or DS Logon account,</strong> you can sign in using those credentials and you won’t need to verify your identity.</p>
-                        <p><strong>If you’re signing in through your ID.me account,</strong> you’ll need to use your most recent official stateside address and phone number (the information that’ll match records like your credit history)—even if it’s not your current contact information.</p>                        
+                        <p><strong>If you’re signing in through your ID.me account,</strong> you’ll need to use your most recent official stateside address and phone number (the information that’ll match records like your credit history)—even if it’s not your current contact information.</p>
                       </div>
                     </div>
                   </li>
@@ -229,7 +229,7 @@ display_title: Frequently Asked Questions
                           <a href="https://www.experian.com/ncaconline/dispute?intcmp=dispute_app_startNew">Go to Experian to file a dispute</a>.</li>
                           <li>If you’ve recently moved, changed names, or have a different permanent address, try using your previous information.</li>
                           <li>Make sure you enter a phone number that’s registered in your name.</li>
-                        </ul>                                         
+                        </ul>
                       </div>
                     </div>
                   </li>
@@ -238,14 +238,14 @@ display_title: Frequently Asked Questions
                     <div id="faq-trouble-5" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
                         <p><strong>You can try using your driver’s license or passport to verify your identity.</strong> Be sure to follow the image guidelines provided when you upload a copy of your driver’s license or passport.</p>
-                        <p><strong>Note:</strong> If you have a premium <strong>My Health<em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, you can sign in using those credentials and you won’t need to verify your identity. If you don’t have an existing premium account, you can find out how to get one by reading the question above about other options for verifying your identity.</p>                          
+                        <p><strong>Note:</strong> If you have a premium <strong>My Health<em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, you can sign in using those credentials and you won’t need to verify your identity. If you don’t have an existing premium account, you can find out how to get one by reading the question above about other options for verifying your identity.</p>
                       </div>
                     </div>
                   </li>
                   <li markdown="1" itemscope itemtype="http://schema.org/Question">
                     <button class="usa-button-unstyled usa-accordion-button" aria-controls="faq-trouble-6" itemprop="name">I don’t want to add 2-factor authentication. Do I have to? </button>
                     <div id="faq-trouble-6" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
-                      <div itemprop="text">                        
+                      <div itemprop="text">
                         <p>It depends on how you sign in to Vets.gov.</p>
                         <ul>
                           <li><strong>If you set up a verified Vets.gov account through ID.me,</strong> you need to set up 2-factor authentication. Authentication gives you an extra layer of security by letting you into your account only after you’ve signed in with a password and a 6-digit code sent directly to your mobile or home phone. This helps to make sure that no one but you can access your account—even if they get your password.</li>
@@ -253,7 +253,7 @@ display_title: Frequently Asked Questions
                           <li><strong>If you sign in to Vets.gov using your existing basic or advanced My Health<em>e</em>Vet or basic DS Logon account and don’t want to verify your identity,</strong> you don’t need to add 2-factor authentication. But you won’t be able to use the site’s tools that require you to verify your identity and do common tasks, like checking your claims status or sending a secure message to your health care team.</li>
                       </div>
                     </div>
-                  </li>                          
+                  </li>
                 </ul>
                 <br/>
                 <a name="why-verify"></a>
@@ -307,8 +307,8 @@ display_title: Frequently Asked Questions
                     <div id="faq-idme-security-4" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
                         <p>This code is part of the 2-factor authentication process.</p>
-                        <p>When you set up a verified Vets.gov account through ID.me, you need to set up 2-factor authentication. Authentication gives you an extra layer of security by letting you into your account only after you’ve signed in with a password and a 6-digit code sent directly to your mobile or home phone. This helps to make sure that no one but you can access your account—even if they get your password.<p>                        
-                        <p>If you sign in to Vets.gov using your existing basic or advanced <strong>My Health<em>e</em>Vet</strong> or basic <strong>DS Logon</strong> account and don’t want to verify your identity, or if you sign in using your existing premium <strong>My Health <em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your Vets.gov profile page.<p>          
+                        <p>When you set up a verified Vets.gov account through ID.me, you need to set up 2-factor authentication. Authentication gives you an extra layer of security by letting you into your account only after you’ve signed in with a password and a 6-digit code sent directly to your mobile or home phone. This helps to make sure that no one but you can access your account—even if they get your password.<p>
+                        <p>If you sign in to Vets.gov using your existing basic or advanced <strong>My Health<em>e</em>Vet</strong> or basic <strong>DS Logon</strong> account and don’t want to verify your identity, or if you sign in using your existing premium <strong>My Health <em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your Vets.gov profile page.<p>
                       </div>
                     </div>
                   </li>
@@ -321,8 +321,6 @@ display_title: Frequently Asked Questions
     </article>
   </div>
 </main>
-
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>
 
 <script type="text/javascript">
 (function() {
@@ -341,5 +339,3 @@ display_title: Frequently Asked Questions
   }
 })();
 </script>
-
-<!--- TODO: find a proper place to import USWDS JS for static pages -->

--- a/va-gov/pages/health-care/about-va-health-benefits/dental-care.md
+++ b/va-gov/pages/health-care/about-va-health-benefits/dental-care.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: VA Dental Care
 display_title:
-description: Find out if you qualify for VA dental benefits, or how to buy dental insurance if you're not eligible for VA dental care.  
+description: Find out if you qualify for VA dental benefits, or how to buy dental insurance if you're not eligible for VA dental care.
 concurrence: complete
 lastupdate: 2017-06-28
 order: 5
@@ -104,7 +104,7 @@ Click on the statement below that describes you best to find out your benefits c
 - You apply for dental care within 180 days of discharge or release, **and**
 - Your DD214 certificate of discharge doesn’t show that you had a complete dental exam and all needed dental treatment before you were discharged\*
 
-**Please note:** If you got a dental award letter from VBA dated before 1955 stating that your dental conditions aren't compensable, then you are no longer eligible for Class II outpatient dental treatment. This is because of Public Law 83, which was enacted June 16, 1955, and which amended Veterans’ eligibility for outpatient dental services. 
+**Please note:** If you got a dental award letter from VBA dated before 1955 stating that your dental conditions aren't compensable, then you are no longer eligible for Class II outpatient dental treatment. This is because of Public Law 83, which was enacted June 16, 1955, and which amended Veterans’ eligibility for outpatient dental services.
 
 </div>
 </li>
@@ -221,5 +221,3 @@ You may be able to buy dental insurance at a reduced cost through the VA Dental 
 
 
 [Learn more about VADIP](https://www.va.gov/healthbenefits/VADIP/).
-
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>

--- a/va-gov/pages/health-care/family-caregiver-benefits/champva.md
+++ b/va-gov/pages/health-care/family-caregiver-benefits/champva.md
@@ -196,6 +196,3 @@ If you send us only the required documents, it may take 2 to 8 months since weâ€
 <br>
 <br>
 
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>
-
-<!--- TODO: find a proper place to import USWDS JS for static pages -->

--- a/va-gov/pages/housing-assistance/home-loans/apply-for-certificate-of-eligibility.md
+++ b/va-gov/pages/housing-assistance/home-loans/apply-for-certificate-of-eligibility.md
@@ -2,20 +2,20 @@
 layout: page-breadcrumbs.html
 template: detail-page
 title: How to Apply for Your COE
-concurrence: 
+concurrence:
 order: 3
 relatedlinks:
   - heading: Loan Options
     links:
     - url: /housing-assistance/home-loans/loan-options/purchase-loan/
-      title: Purchase Loan 
-      description: Find out how to get a VA-backed purchase loan to buy a home. 
+      title: Purchase Loan
+      description: Find out how to get a VA-backed purchase loan to buy a home.
     - url: /housing-assistance/home-loans/loan-options/nadl/
-      title: Native American Direct Loan (NADL) 
-      description: Find out if you can get a NADL loan to buy, build, or improve a home on Federal Trust Land. 
+      title: Native American Direct Loan (NADL)
+      description: Find out if you can get a NADL loan to buy, build, or improve a home on Federal Trust Land.
     - url: /housing-assistance/home-loans/loan-options/irrrl/
-      title: Interest Rate Reduction Refinance Loan (IRRRL) 
-      description: Find out how to get an IRRRL loan to refinance an existing loan. 
+      title: Interest Rate Reduction Refinance Loan (IRRRL)
+      description: Find out how to get an IRRRL loan to refinance an existing loan.
     - url: /housing-assistance/home-loans/loan-options/cash-out-refinance/
       title: Cash-Out Refinance Loan
       description: Learn how to get cash from your home equity to pay off debts, pay for school, or take care of other needs.
@@ -117,13 +117,13 @@ If you’re a **surviving spouse** who qualifies for home loan benefits, you’l
 - **If you’re not receiving DIC benefits,** you’ll need to fill out and send an Application for DIC, Death Pension and/or Accrued Benefits (VA Form 21P-534EZ), **and**
   - A copy of your marriage license, **and**
   - The Veteran’s death certificate
-  
+
   <br>
- [Download VA Form 21P-534EZ](https://www.vba.va.gov/pubs/forms/VBA-21P-534EZ-ARE.pdf). 
- 
- <br> 
- 
- [Find out if you qualify for home loan benefits](/housing-assistance/home-loans/eligibility/). <br /> 
+ [Download VA Form 21P-534EZ](https://www.vba.va.gov/pubs/forms/VBA-21P-534EZ-ARE.pdf).
+
+ <br>
+
+ [Find out if you qualify for home loan benefits](/housing-assistance/home-loans/eligibility/). <br />
  [Get military service records online](https://www.archives.gov/veterans/military-service-records/).
 
 </div>
@@ -160,7 +160,3 @@ To apply by mail, fill out a Request for a Certificate of Eligibility (VA Form 2
 ### Next steps for getting a VA direct or VA-backed home loan
 
 Applying for your COE is only one part of the process for getting a VA direct or VA-backed home loan. Your next steps will depend on the type of loan you’re looking to get—and on your lender (for most loans, the lender will be a private bank or mortgage company; for the Native American Direct Loan, we’ll be your lender).
-
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>
-
-<!--- TODO: find a proper place to import USWDS JS for static pages -->

--- a/va-gov/pages/housing-assistance/home-loans/eligibility.md
+++ b/va-gov/pages/housing-assistance/home-loans/eligibility.md
@@ -2,14 +2,14 @@
 layout: page-breadcrumbs.html
 template: detail-page
 title: Eligibility
-concurrence: 
+concurrence:
 order: 2
 relatedlinks:
   - heading: Loan Options
     links:
     - url: /housing-assistance/home-loans/loan-options/purchase-loan/
       title: Purchase Loan
-      description: Looking to buy a home? Find out if you can get a VA-backed purchase loan and get better terms than with a private lender loan. 
+      description: Looking to buy a home? Find out if you can get a VA-backed purchase loan and get better terms than with a private lender loan.
     - url: /housing-assistance/home-loans/loan-options/nadl/
       title: Native American Direct Loan (NADL) Program
       description: Are you a Native American Veteran or a Veteran married to a Native American? Find out if you can get a loan through our NADL program to buy, build, or improve a home on Federal Trust Land.
@@ -41,8 +41,8 @@ You may be able to get a COE if you didn't receive a dishonorable discharge and 
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="va-loan-eligibility-vets">Service requirements for Veterans and Servicemembers on active duty</button>
 <div id="va-loan-eligibility-vets" class="usa-accordion-content">
 
-| When did you serve? | You meet the minimum active-duty service requirement if you served for at least this amount of time: | 
-| --- | --- | 
+| When did you serve? | You meet the minimum active-duty service requirement if you served for at least this amount of time: |
+| --- | --- |
 | Between September 16, 1940, and July 25, 1947 (WWII) | 90 total days |
 | Between July 26, 1947, and June 26, 1950 (post-WWII period) | 181 continuous days |
 | Between June 27, 1950, and January 31, 1955 (Korean War) | 90 total days |
@@ -60,8 +60,8 @@ You may be able to get a COE if you didn't receive a dishonorable discharge and 
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="va-loan-eligibility-guard">Service requirements for National Guard and Reserve members</button>
 <div id="va-loan-eligibility-guard" class="usa-accordion-content">
 
-| When did you serve? | You meet the minimum active-duty service requirement if you served for at least this amount of time: | 
-| --- | --- | 
+| When did you serve? | You meet the minimum active-duty service requirement if you served for at least this amount of time: |
+| --- | --- |
 | Between August 2, 1990, and the present (Gulf War) | 90 continuous days of active service |
 | Any time period | 6 creditable years in the Selected Reserve or National Guard, and one of the descriptions below is true for you<br><br>**At least one of these must be true. You:**<br><ul><li>Were discharged honorably, **or**</li><li>Were placed on the retired list, **or**</li><li>Were transferred to the Standby Reserve or an element of the Ready Reserve other than the Selected Reserve after service characterized as honorable, **or**</li><li>Continue to serve in the Selected Reserve</li></ul> |
 
@@ -154,7 +154,3 @@ You may be able to “restore” an entitlement you used in the past to buy anot
 To request an entitlement restoration, fill out a Request for a Certificate of Eligibility (VA Form 26-1880) and send it to the VA regional loan center for your state. <br>
 [Download VA Form 26-1880](https://www.vba.va.gov/pubs/forms/VBA-26-1880-ARE.pdf). <br>
 [Find your state’s VA regional loan center](https://www.benefits.va.gov/homeloans/contact_rlc_info.asp).
-
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>
-
-<!--- TODO: find a proper place to import USWDS JS for static pages -->

--- a/va-gov/pages/life-insurance/options-and-eligibility/fsgli.md
+++ b/va-gov/pages/life-insurance/options-and-eligibility/fsgli.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: Family Servicemembers’ Group Life Insurance (FSGLI)
 display_title: Family Servicemembers’ Group (FSGLI)
-concurrence: 
+concurrence:
 order: 2
 relatedlinks:
   - heading: More information about your benefits
@@ -64,27 +64,27 @@ We’ll automatically insure you under FSGLI. In this case, we’ll automaticall
 
 We won’t automatically cover you. You’ll need to sign up through your Servicemember.
 
-**If your Servicemember’s branch of service has started using the new SGLI Online Enrollment System (SOES),** have your Servicemember sign you up online. 
+**If your Servicemember’s branch of service has started using the new SGLI Online Enrollment System (SOES),** have your Servicemember sign you up online.
 
 To access SOES, have your Servicemember:
 
 <ol class="process" markdown="1">
 
   <li class="process-step list-one">
-  
+
   [Go to milConnect](https://www.dmdc.osd.mil/milconnect/).
-  
+
   </li>
-  
+
   <li class="process-step list-two">
-  
+
   Sign in.
-  
+
   </li>
   <li class="process-step list-three">
-  
+
   Go to Benefits, Life Insurance SOES- SGLI Online Enrollment System to sign up.
-  
+
   </li>
 </ol>
 
@@ -252,26 +252,26 @@ To access SOES, have your Servicemember:
 <ol class="process" markdown="1">
 
   <li class="process-step list-one">
-  
+
   [Go to milConnect](https://www.dmdc.osd.mil/milconnect/).
-  
+
   </li>
-  
+
   <li class="process-step list-two">
-  
+
   Sign in.
-  
+
   </li>
   <li class="process-step list-three">
-  
+
   Go to Benefits, Life Insurance SOES- SGLI Online Enrollment System to update.
-  
+
   </li>
-  
+
   <li class="process-step list-four">
-  
+
   Check their coverage and beneficiary info and make any needed updates.
-  
+
   </li>
  </ol>
 
@@ -292,7 +292,7 @@ Nothing. We provide dependent coverage at no cost until the child is 18 years ol
 
 **To continue receiving dependent coverage after age 18, one of these must be true. The child**:
 - Is a full-time student, **or**
-- Becomes permanently and totally disabled—before turning 18—and can’t support themselves 
+- Becomes permanently and totally disabled—before turning 18—and can’t support themselves
 
 
 <br>
@@ -335,7 +335,3 @@ You can’t convert other types of policies—such as term, variable, or univers
 ### Where can I find more information?
 
 [Read our insurance publications](https://www.benefits.va.gov/INSURANCE/ins_publications.asp).
-
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>
-
-<!--- TODO: find a proper place to import USWDS JS for static pages -->

--- a/va-gov/pages/life-insurance/options-and-eligibility/vgli.md
+++ b/va-gov/pages/life-insurance/options-and-eligibility/vgli.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: Veterans’ Group Life Insurance (VGLI)
 display_title: Veterans’ Group (VGLI)
-concurrence: 
+concurrence:
 order: 4
 relatedlinks:
   - heading: More information about your benefits
@@ -80,7 +80,7 @@ Fax the form to 1-800-236-6142, or mail it to:
 
 ### How much will I pay for these benefits?
 
-VGLI premium rates are based on your age and the amount of insurance coverage you want. 
+VGLI premium rates are based on your age and the amount of insurance coverage you want.
 
 **Choose your age to find monthly premium rates as of July 1, 2014.**
 
@@ -643,22 +643,22 @@ Yes. You can convert your policy into a commercial (civilian) policy at any time
 <ol class="process" markdown="1">
 
   <li class="process-step list-one">
-  
+
   Choose your new insurance company. <br>
   [View our list of companies that take part in this program]( https://www.benefits.va.gov/INSURANCE/forms/SGL133_ed2016-06.pdf).
-  
+
   </li>
-  
+
   <li class="process-step list-two">
-  
+
   Apply at the local sales office of your chosen company.
-  
+
   </li>
-  
+
   <li class="process-step list-three">
-  
+
   Get a letter from OSGLI confirming that you have VGLI coverage (called a VGLI Conversion Notice) and give the letter to the agent who takes your application.
-  
+
   </li>
 </ol>
 
@@ -679,7 +679,3 @@ If you have a severe service-connected disability that we’ve concluded was cau
 To get VMLI, you’ll need to apply for our Specially Adapted Housing (SAH) Grant. The SAH grant can help you buy, build, or make changes (like installing ramps or widening doorways) to a home so you can live more independently. When you receive an SAH grant, your Loan Guaranty agent will tell you if you qualify for VMLI and will help you apply. <br>
 [Find out if you qualify for an SAH grant—and how to apply](https://www.benefits.va.gov/homeloans/adaptedhousing.asp). <br>
 [Find out if you qualify for VMLI—and how to apply](/life-insurance/options-and-eligibility/vmli/).
-
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>
-
-<!--- TODO: find a proper place to import USWDS JS for static pages -->

--- a/va-gov/pages/life-insurance/options-and-eligibility/vmli.md
+++ b/va-gov/pages/life-insurance/options-and-eligibility/vmli.md
@@ -21,7 +21,7 @@ If you have a severe service-connected disability that we’ve concluded was cau
 
 <div class="feature">
 
-### Can I get VMLI? 
+### Can I get VMLI?
 
 You may be able to get VMLI if you have a severe disability, and you meet all of the requirements listed below.
 
@@ -47,13 +47,13 @@ You may be able to get VMLI if you have a severe disability, and you meet all of
 
 ### What kind of life insurance benefits can I get with VMLI?
 
-Up to $200,000 in mortgage life insurance—paid directly to the bank or other lender that holds your mortgage. 
+Up to $200,000 in mortgage life insurance—paid directly to the bank or other lender that holds your mortgage.
 
 #### Important details about VMLI:
 
 - The money will be paid directly to the bank or other lender that holds your mortgage—not to a life insurance beneficiary (a person chosen to receive the money from a policy when the insured dies).
-- The amount of coverage will equal the amount you still owe on your mortgage, but won’t be more than $200,000. 
-- VMLI is a decreasing-term insurance. This means your coverage amount goes down as your mortgage balance goes down. If you pay off your mortgage, your VMLI coverage will end. 
+- The amount of coverage will equal the amount you still owe on your mortgage, but won’t be more than $200,000.
+- VMLI is a decreasing-term insurance. This means your coverage amount goes down as your mortgage balance goes down. If you pay off your mortgage, your VMLI coverage will end.
 - VMLI has no loan or cash value—and it doesn’t pay dividends (cash payments made to policy holders when the company makes a profit).
 
 <br>
@@ -63,7 +63,7 @@ Up to $200,000 in mortgage life insurance—paid directly to the bank or other l
 First, you’ll need to apply for an SAH grant. If you get the SAH grant, your Loan Guaranty agent will tell you if you qualify for VMLI. If you already have an SAH grant, ask your agent about VMLI.
 
 Your agent will help you fill out a Veterans’ Mortgage Life Insurance Statement (VA Form 29-8636).<br>
-[Download VA Form 29-8636](https://www.benefits.va.gov/INSURANCE/forms/29-8636_08-2011.pdf). 
+[Download VA Form 29-8636](https://www.benefits.va.gov/INSURANCE/forms/29-8636_08-2011.pdf).
 
 **Note:** Remember, you must apply for VMLI before your 70th birthday.
 
@@ -103,7 +103,4 @@ Send notice of any changes to:
   Philadelphia, PA 19101<br>
 </p>
 
-[Read our life insurance publications for more guidance](https://www.benefits.va.gov/INSURANCE/ins_publications.asp). 
-
-
-<!--- TODO: find a proper place to import USWDS JS for static pages -->
+[Read our life insurance publications for more guidance](https://www.benefits.va.gov/INSURANCE/ins_publications.asp).

--- a/va-gov/pages/pension/apply/fully-developed-claim.md
+++ b/va-gov/pages/pension/apply/fully-developed-claim.md
@@ -51,7 +51,7 @@ If a person or agency refuses to turn over the evidence, asks for money for the 
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="evidence-must-show">What should the evidence show to support my claim?</button>
 <div id="evidence-must-show" class="usa-accordion-content">
 
-<h4>If you’re claiming non-service-connected pension benefits</h4> 
+<h4>If you’re claiming non-service-connected pension benefits</h4>
 
 The evidence must show that you meet the requirements listed below.
 
@@ -63,8 +63,8 @@ Your net worth and income are within certain limits.
 
 - Served on active duty for any length of time during a period of war and were discharged due to a service-connected disability, **or**
 - Started on active duty before September 8, 1980, and you served at least 90 days (either all at one time or combined over time) on active duty with at least 1 day being during wartime, **or**
-- Started on active duty after September 7, 1980, and you served at least 2 years or the full period for which you were called or ordered to active duty, with at least 1 day being during wartime. Some exceptions may apply to this longer minimum service requirement. 
- 
+- Started on active duty after September 7, 1980, and you served at least 2 years or the full period for which you were called or ordered to active duty, with at least 1 day being during wartime. Some exceptions may apply to this longer minimum service requirement.
+
 **And at least one of these must also be true about your current situation. You:**
 
 - Are at least 65 years old, **or**
@@ -97,7 +97,7 @@ The evidence must show that you meet at least one of the requirements listed bel
   - Single permanent disability that’s 100% disabling, and you’re confined to your home, **or**
   - Disability (rated 60% or higher) in addition to the disability that qualifies you for a pension
 
-<h4>If you’re claiming benefits for a disabled child</h4> 
+<h4>If you’re claiming benefits for a disabled child</h4>
 
 The evidence must show that the child, before turning 18 years old, became unable to support themselves due to a mental or physical disability.
 
@@ -109,7 +109,7 @@ The evidence must show that the child, before turning 18 years old, became unabl
 
 #### FDC Program
 
-Under the FDC program, we’ll handle the evidence-gathering steps listed below. 
+Under the FDC program, we’ll handle the evidence-gathering steps listed below.
 
 **We'll:**
 
@@ -163,9 +163,9 @@ You’ll need to turn in the information and evidence as soon as you can.
 <div id="where-to-send" class="usa-accordion-content">
 
 [Fill out an Application for Pension (VA Form 21P-527EZ)](/pension/application/527EZ/). <br>
-When you file your claim, you'll be able to upload all supporting documents and evidence, like your income information and any medical records related to your claim. 
+When you file your claim, you'll be able to upload all supporting documents and evidence, like your income information and any medical records related to your claim.
 
-   
+
 </div>
 </li>
 <li>
@@ -187,5 +187,3 @@ If you’re:
 
 
 </div>
-
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>

--- a/va-gov/pages/veteran-id-card/how-to-get.md
+++ b/va-gov/pages/veteran-id-card/how-to-get.md
@@ -120,5 +120,3 @@ No. At this time, you don't qualify for a Veteran ID Card based on your service 
 </div>
 
 <br>
-
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>

--- a/va-gov/pages/veteran-id-card/how-to-upload-photo.md
+++ b/va-gov/pages/veteran-id-card/how-to-upload-photo.md
@@ -1,13 +1,13 @@
 ---
 layout: page-breadcrumbs.html
 template: detail-page
-title: Tips for Uploading a Photo for Your Veteran ID Card 
+title: Tips for Uploading a Photo for Your Veteran ID Card
 display_title: Uploading Your Photo
 relatedlinks:
-  - heading: 
+  - heading:
     links:
-    - url: 
-      title: 
+    - url:
+      title:
       description:
 ---
 
@@ -41,8 +41,8 @@ Find out how to upload a good quality photo that meets the requirements for a Ve
 <li>
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="saved-photo">I have a photo saved on my computer. How do I know if my photo is the right size?</button>
 <div id="saved-photo" class="usa-accordion-content">
- 
-To make sure your photo doesn’t look blurry when it’s printed on your card, it should be at least 350 pixels on each side. A pixel is a digital unit of measurement for screens, like a computer or television. Most photos taken with smartphones and digital cameras meet this requirement. 
+
+To make sure your photo doesn’t look blurry when it’s printed on your card, it should be at least 350 pixels on each side. A pixel is a digital unit of measurement for screens, like a computer or television. Most photos taken with smartphones and digital cameras meet this requirement.
 If you’re not sure your photo is big enough, follow these steps to check the dimensions on a PC or Mac.
 
 **To check your photo’s dimensions on a PC:**
@@ -64,7 +64,7 @@ If you’re not sure your photo is big enough, follow these steps to check the d
 <li>
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="right-size">What if my photo isn’t the right size?</button>
 <div id="right-size" class="usa-accordion-content">
- 
+
 If your photo dimensions are less than 350 pixels on any side, we suggest you choose a different photo or take a new photo with a smartphone or digital camera. If you don’t have a smartphone or digital camera, you can get a passport photo taken at your local retail pharmacy or at any other store that offers this service, like Costco.
 
 If your photo isn't square, the Veteran ID Card application includes a tool to help you resize your photo. If you’re using a screen reader, we recommend you start with a square photo, like a passport photo. This will make the application easier to use.
@@ -127,5 +127,3 @@ You can scan a physical photo onto your computer or phone using a flatbed scanne
 </li>
 </ul>
 </div>
-
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>


### PR DESCRIPTION
The footer of the website imports USWDS, so the page-level imports occurring at the bottom of pages containing accordions were causing USWDS to be imported twice and therefore breaking the pages.  

Example of this happening: https://dev-preview.va.gov/health-care/family-caregiver-benefits/champva/
Network panel for that page contains two USWDS script imports, one local and another from the USWDS Design System -
![image](https://user-images.githubusercontent.com/1915775/44635279-43e0ba80-a971-11e8-854c-6d980b8f3aaa.png)

To fix that, this PR removes all of the USWDS imports except for that in the footer. I have confirmed that all of these pages work as of this