### PR TITLE
Only send 'facilityCode' string to backend

### DIFF
--- a/src/applications/edu-benefits/components/SchoolSelectField.jsx
+++ b/src/applications/edu-benefits/components/SchoolSelectField.jsx
@@ -46,7 +46,7 @@ export class SchoolSelectField extends React.Component {
 
   componentDidMount() {
     // hydrate search if restoring from SiP
-    // if there is a seach term stored in the form data
+    // if there is a search term stored in the form data
     // if the search term in the form data isn't already in the redux state and displayed
     const institutionSelected = this.props.formData['view:institutionSelected'];
     const searchTermToRestore = this.props.formData['view:institutionQuery'];
@@ -82,19 +82,11 @@ export class SchoolSelectField extends React.Component {
     });
   }
 
-  handleOptionClick = ({ address1, address2, address3, city, facilityCode, name, state }) => {
-    this.props.selectInstitution({ address1, address2, address3, city, facilityCode, name, state });
+  handleOptionClick = ({ facilityCode }) => {
+    this.props.selectInstitution({ facilityCode });
     this.props.onChange({
       ...this.props.formData,
       facilityCode,
-      'view:institutionSelected': {
-        address1,
-        address2,
-        address3,
-        city,
-        name,
-        state
-      }
     });
   }
 
@@ -281,7 +273,7 @@ export class SchoolSelectField extends React.Component {
                       name={`page-${currentPageNumber}`}
                       type="radio"
                       onKeyDown={this.onKeyDown}
-                      onChange={() => this.handleOptionClick({ address1, address2, address3, city, facilityCode, name, state })}
+                      onChange={() => this.handleOptionClick({ facilityCode })}
                       value={facilityCode}/>
                     <label
                       id={`institution-${index}-label`}

--- a/src/applications/edu-benefits/tests/components/SchoolSelectField.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/components/SchoolSelectField.unit.spec.jsx
@@ -311,14 +311,6 @@ describe('<SchoolSelectField>', () => {
     tree.find('#page-1-0').first().simulate('change');
     expect(onChange.firstCall.args[0]).to.eql({
       facilityCode: 'test',
-      'view:institutionSelected': {
-        address1: 'testAddress1',
-        address2: 'testAddress2',
-        address3: 'testAddress3',
-        city: 'testcity',
-        name: 'testName',
-        state: 'testState'
-      }
     });
     expect(selectInstitution.firstCall.args[0]).to.eql(institutions[0]);
   });


### PR DESCRIPTION
## Description
Adjusted school select component to only set `facilityCode` instead of all school address info.

## Testing done
Tested locally to confirm the correct JSON is being submitted. Updated unit tests.

## Testing Plan
Manually confirm that the backend is getting the correct data when using the school search function

## Screenshots
N/A

## Acceptance Criteria (Definition of Done)

#### Unique to this PR

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Documentation has been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
