### PR TITLE
fix for scroll, megamenu background mobile too short, and more in thi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^1.4.5",
+    "@department-of-veterans-affairs/formation": "^1.4.6",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "blob-polyfill": "^2.0.20171115",

--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -54,7 +54,6 @@
 
     #vetnav-menu, #vetnav {
       margin-top: 0;
-      min-height: 0;
     }
 
     .mm-marketing-container {
@@ -911,6 +910,7 @@
       top: 0;
       margin: 0;
       width: 100%;
+      z-index: 2;
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@department-of-veterans-affairs/formation@^1.4.5":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.4.5.tgz#055805d1805eefe4d4bc4c8390e8ca224a31860b"
+"@department-of-veterans-affairs/formation@^1.4.6":
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.4.6.tgz#a944c1d168cb458449afb75c1fbcce29198fd8db"
   dependencies:
     classnames "^2.2.5"
     font-awesome "4"


### PR DESCRIPTION
These are the 3 fixes. You will have to test the scrolling on a IOS Simulator or a device.

Fixes

1. Scrolling on mobile causes the MegaMenu to hide
2. Background for the MegaMenu should be longer
3. More Sections on mobile get hidden behind the login alert box when scrolling.