### PR TITLE
Send the same school data regardless of school input method

### DIFF
--- a/src/applications/edu-benefits/components/SchoolSelectField.jsx
+++ b/src/applications/edu-benefits/components/SchoolSelectField.jsx
@@ -46,7 +46,7 @@ export class SchoolSelectField extends React.Component {
 
   componentDidMount() {
     // hydrate search if restoring from SiP
-    // if there is a seach term stored in the form data
+    // if there is a search term stored in the form data
     // if the search term in the form data isn't already in the redux state and displayed
     const institutionSelected = this.props.formData['view:institutionSelected'];
     const searchTermToRestore = this.props.formData['view:institutionQuery'];
@@ -82,18 +82,19 @@ export class SchoolSelectField extends React.Component {
     });
   }
 
-  handleOptionClick = ({ address1, address2, address3, city, facilityCode, name, state }) => {
+  handleOptionClick = ({ address1, address2, address3, city, facilityCode, name, state, zip, country }) => {
     this.props.selectInstitution({ address1, address2, address3, city, facilityCode, name, state });
     this.props.onChange({
       ...this.props.formData,
-      facilityCode,
-      'view:institutionSelected': {
-        address1,
-        address2,
-        address3,
+      name,
+      'view:facilityCode': facilityCode,
+      address: {
+        country,
+        street: address1,
+        street2: address2,
         city,
-        name,
-        state
+        state,
+        postalCode: zip,
       }
     });
   }
@@ -271,7 +272,7 @@ export class SchoolSelectField extends React.Component {
               {`${searchResultsCount} results for ${institutionQuery}`}
             </span>}
             {showSearchResults && showInstitutions && <div>
-              {institutions.map(({ address1, address2, address3, city, country, facilityCode, name, state }, index) => (
+              {institutions.map(({ address1, address2, address3, city, country, facilityCode, name, state, zip }, index) => (
                 <div key={index}>
                   <div className="radio-button">
                     <input
@@ -281,7 +282,7 @@ export class SchoolSelectField extends React.Component {
                       name={`page-${currentPageNumber}`}
                       type="radio"
                       onKeyDown={this.onKeyDown}
-                      onChange={() => this.handleOptionClick({ address1, address2, address3, city, facilityCode, name, state })}
+                      onChange={() => this.handleOptionClick({ address1, address2, address3, city, country, facilityCode, name, state, zip })}
                       value={facilityCode}/>
                     <label
                       id={`institution-${index}-label`}
@@ -328,7 +329,7 @@ export class SchoolSelectField extends React.Component {
 const mapStateToProps = (state, ownProps) => {
   const currentPageNumber = selectCurrentPageNumber(state);
   const errorMessages = selectFacilityCodeErrorMessages(ownProps);
-  const facilityCodeSelected = ownProps.formData ? ownProps.formData.facilityCode : '';
+  const facilityCodeSelected = ownProps.formData ? ownProps.formData['view:facilityCode'] : '';
   const institutionQuery = selectInstitutionQuery(state);
   const institutions = selectInstitutions(state);
   const institutionSelected = selectInstitutionSelected(state);

--- a/src/applications/edu-benefits/components/SchoolSelectField.jsx
+++ b/src/applications/edu-benefits/components/SchoolSelectField.jsx
@@ -84,12 +84,15 @@ export class SchoolSelectField extends React.Component {
 
   handleOptionClick = ({ address1, address2, address3, city, facilityCode, name, state, zip, country }) => {
     this.props.selectInstitution({ address1, address2, address3, city, facilityCode, name, state });
+    const backendFriendlyCountries = {
+      USA: 'United States'
+    };
     this.props.onChange({
       ...this.props.formData,
       name,
       'view:facilityCode': facilityCode,
       address: {
-        country,
+        country: backendFriendlyCountries[country] || country,
         street: address1,
         street2: address2,
         city,

--- a/src/applications/edu-benefits/feedback-tool/config/form.js
+++ b/src/applications/edu-benefits/feedback-tool/config/form.js
@@ -360,7 +360,7 @@ const formConfig = {
             educationDetails: {
               school: {
                 'view:searchSchoolSelect': {
-                  facilityCode: {
+                  'view:facilityCode': {
                     'ui:required': manualSchoolEntryIsNotChecked,
                   },
                   'ui:field': SchoolSelectField,
@@ -428,7 +428,7 @@ const formConfig = {
                       'view:searchSchoolSelect': {
                         type: 'object',
                         properties: {
-                          facilityCode: {
+                          'view:facilityCode': {
                             type: 'string'
                           }
                         }

--- a/src/applications/edu-benefits/feedback-tool/selectors/schoolSearch.js
+++ b/src/applications/edu-benefits/feedback-tool/selectors/schoolSearch.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 export const selectCurrentPageNumber = state => _.get(state, 'schoolSelect.currentPageNumber');
-export const selectFacilityCodeErrorMessages = ownProps => _.get(ownProps, 'errorSchema.facilityCode.__errors');
+export const selectFacilityCodeErrorMessages = ownProps => _.get(ownProps, 'errorSchema.view:facilityCode.__errors');
 export const selectFormSubmitted = ownProps => _.get(ownProps, 'formContext.submitted');
 export const selectInstitutionQuery = state => _.get(state, 'schoolSelect.institutionQuery');
 export const selectInstitutions = state => _.get(state, 'schoolSelect.institutions');

--- a/src/applications/edu-benefits/tests/components/SchoolSelectField.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/components/SchoolSelectField.unit.spec.jsx
@@ -288,7 +288,9 @@ describe('<SchoolSelectField>', () => {
       city: 'testcity',
       facilityCode: 'test',
       name: 'testName',
-      state: 'testState'
+      state: 'testState',
+      zip: '12345',
+      country: 'United States'
     }];
     const tree = mount(<SchoolSelectField
       formData={{}}
@@ -310,17 +312,26 @@ describe('<SchoolSelectField>', () => {
 
     tree.find('#page-1-0').first().simulate('change');
     expect(onChange.firstCall.args[0]).to.eql({
-      facilityCode: 'test',
-      'view:institutionSelected': {
-        address1: 'testAddress1',
-        address2: 'testAddress2',
-        address3: 'testAddress3',
+      address: {
         city: 'testcity',
-        name: 'testName',
-        state: 'testState'
-      }
+        country: 'United States',
+        postalCode: '12345',
+        state: 'testState',
+        street: 'testAddress1',
+        street2: 'testAddress2'
+      },
+      name: 'testName',
+      'view:facilityCode': 'test'
     });
-    expect(selectInstitution.firstCall.args[0]).to.eql(institutions[0]);
+    expect(selectInstitution.firstCall.args[0]).to.eql({
+      address1: 'testAddress1',
+      address2: 'testAddress2',
+      address3: 'testAddress3',
+      city: 'testcity',
+      facilityCode: 'test',
+      name: 'testName',
+      state: 'testState'
+    });
   });
 
   // handleStartOver

--- a/src/applications/edu-benefits/tests/components/SchoolSelectField.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/components/SchoolSelectField.unit.spec.jsx
@@ -290,7 +290,7 @@ describe('<SchoolSelectField>', () => {
       name: 'testName',
       state: 'testState',
       zip: '12345',
-      country: 'United States'
+      country: 'USA'
     }];
     const tree = mount(<SchoolSelectField
       formData={{}}


### PR DESCRIPTION
## Description
Change school search component so that when it is used the same data as sent to the backend as when the user manually enters the school data. [There is a corresponding change to the JSON schema will](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/250).

## Testing done
Tested locally to confirm that the request body matches regardless of the school input method.

## Testing Plan
Manual testing

## Screenshots
N/A

## Acceptance Criteria (Definition of Done)

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Documentation has been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
