### PR TITLE
iHub/Appointments: Add flag for preventing API request in prod

### DIFF
--- a/src/applications/personalization/dashboard/containers/AppointmentsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/AppointmentsWidget.jsx
@@ -10,16 +10,20 @@ import {
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 
+const IS_PRODUCTION = document.location.hostname === 'www.vets.gov';
+
 class AppointmentsWidget extends React.Component {
   componentDidMount() {
-    if (!this.props.loading) {
-      this.props.fetchAppointments();
+    if (!IS_PRODUCTION) {
+      if (!this.props.loading) {
+        this.props.fetchAppointments();
+      }
     }
   }
 
   render() {
     // do not show in production
-    if (document.location.hostname === 'www.vets.gov') {
+    if (IS_PRODUCTION) {
       return null;
     }
 


### PR DESCRIPTION
Even though the Appointment widget is disabled in Production on the Dashboard, the lifecycle method `componentDidMount` is still sending the request. This PR adds the feature flag there. More info -
http://sentry.vetsgov-internal/vets-gov/platform-api-production/issues/43807/