### PR TITLE
fix for MegaMenu to hide the Sign in area and fix for left rail nav c…

### DIFF
--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -468,6 +468,19 @@
   // mobile
   @media (min-width: $xsmall-screen) and (max-width: $medium-screen - 1) {
 
+    button {
+      &.va-sidebarnav-close {
+        position: absolute;
+      }
+    }
+
+    #mega-menu {
+      .login-container {
+        position: relative;
+        top: -50px;
+      }
+    }
+
     #menu-rule {
       border-bottom: 0;
     }


### PR DESCRIPTION
This is a fix for the bug that the MegaMenu should hide the global utilities. I also fixed the weirdness you get when clicking on the close icon on the mobile left rail nav. When you try to click it the first time is moves then you have to click it again to close out the left rail nav. For some reason it changes when the element is on focus and it changes the `position: absolute` to `position: relative`