### PR TITLE
526 remove special issues mg

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#84887dc7cb0ccee2ae2c8156b5664697c2850b1d",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#b2e0d5328e6d1f2c84ca2ec3dc2bbb753d02b692",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#986cb1080339c19630ee2c36f0abc7f5a13c0d3a",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -96,7 +96,6 @@ const {
   dateRangeFromRequired,
   dateRangeAllRequired,
   disabilities,
-  specialIssues,
   vaTreatmentCenterAddress
 } = fullSchema526EZ.definitions;
 
@@ -133,7 +132,6 @@ const formConfig = {
     dateRangeFromRequired,
     dateRangeAllRequired,
     disabilities,
-    specialIssues,
   },
   title: 'Apply for increased disability compensation',
   subTitle: 'Form 21-526EZ',

--- a/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
@@ -29,12 +29,6 @@ describe('526 helpers', () => {
           {
             name: 'Diabetes mellitus0',
             disabilityActionType: 'INCREASE',
-            specialIssues: [
-              {
-                code: 'TRM',
-                name: 'Personal Trauma PTSD'
-              }
-            ],
             ratedDisabilityId: '0',
             ratingDecisionId: '63655',
             diagnosticCode: 5238
@@ -42,12 +36,6 @@ describe('526 helpers', () => {
           {
             name: 'Diabetes mellitus1',
             disabilityActionType: 'INCREASE',
-            specialIssues: [
-              {
-                code: 'TRM',
-                name: 'Personal Trauma PTSD'
-              }
-            ],
             ratedDisabilityId: '1',
             ratingDecisionId: '63655',
             diagnosticCode: 5238

--- a/src/applications/disability-benefits/526EZ/tests/schema/maximal-test.json
+++ b/src/applications/disability-benefits/526EZ/tests/schema/maximal-test.json
@@ -66,12 +66,6 @@
 
            },
            "name":"Diabetes mellitus0",
-           "specialIssues":[
-              {
-                 "code":"TRM",
-                 "name":"Personal Trauma PTSD"
-              }
-           ],
            "ratedDisabilityId":"0",
            "ratingDecisionId":"63655",
            "diagnosticCode":5238,
@@ -95,12 +89,6 @@
 
            },
            "name":"Diabetes mellitus1",
-           "specialIssues":[
-              {
-                 "code":"TRM",
-                 "name":"Personal Trauma PTSD"
-              }
-           ],
            "ratedDisabilityId":"1",
            "ratingDecisionId":"63655",
            "diagnosticCode":5238,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10177,9 +10177,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#b2e0d5328e6d1f2c84ca2ec3dc2bbb753d02b692":
-  version "3.82.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#b2e0d5328e6d1f2c84ca2ec3dc2bbb753d02b692"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#986cb1080339c19630ee2c36f0abc7f5a13c0d3a":
+  version "3.85.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#986cb1080339c19630ee2c36f0abc7f5a13c0d3a"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
## Description
This removes specialIssues config, and also ensures we don't send specialIssues on submit (by updating the vets-json-schema dependency, which has removed specialIssues from the 526 schema).

## Testing done
- Tested locally with a betamocks user matching the the data of the UAT participant that ran into problems
- Tested pre/post change to ensure we fixed the right thing

## Testing Plan
- Set up another UAT session with a production user who has `specialIssues`; ensure they can advance past disabilities page and can submit.

## Screenshots
No UI changes

## Acceptance Criteria (Definition of Done)
- Special issues not submitted with form
- Users with invalid specialIssues are able to advance past the disabilities picker page

#### Applies to all PRs
- [x] Appropriate logging
- [x] Documentation has been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
