### PR TITLE
Fixed incorrect object path resulting in incorrect last updated date for facility services

### DIFF
--- a/src/applications/facility-locator/components/ServicesAtFacility.jsx
+++ b/src/applications/facility-locator/components/ServicesAtFacility.jsx
@@ -110,7 +110,7 @@ class ServicesAtFacility extends Component {
 
     return (
       <div>
-        <p style={{ margin: '0 0 0.5em' }}>Services current as of <strong>{moment(services.last_updated).format('MMMM D, YYYY')}</strong></p>
+        <p style={{ margin: '0 0 0.5em' }}>Services current as of <strong>{moment(services.lastUpdated).format('MMMM D, YYYY')}</strong></p>
 
         <div className="mb2">
           <AlertBox


### PR DESCRIPTION
Facility Locator uses the `X-Key-Inflection: camel` header in its requests, so the actual key is `lastUpdated`, not `last_updated`. The latter resulted in passing `undefined` to `moment`, which would default to the current date.