### PR TITLE
Add Metalsmith middleware for processing "aliases" property into redirects

### DIFF
--- a/script/build.js
+++ b/script/build.js
@@ -72,10 +72,6 @@ if (isHerokuBuild) {
   applyHerokuOptions(options);
 }
 
-// Pages can contain an "alias" property in their metadata, which is processed into
-// separate pages that will each redirect to the original page.
-smith.use(createRedirects(options));
-
 switch (options.buildtype) {
   case 'development':
   // No extra checks needed in dev.
@@ -705,6 +701,10 @@ smith.use(redirect({
   '/2015/11/11/why-we-are-designing-in-beta.html': '/2015/11/11/why-we-are-designing-in-beta/',
   '/education/apply-for-education-benefits/': '/education/apply/'
 }));
+
+// Pages can contain an "alias" property in their metadata, which is processed into
+// separate pages that will each redirect to the original page.
+smith.use(createRedirects(options));
 
 /*
 Add nonce attribute with substition string to all inline script tags

--- a/script/build.js
+++ b/script/build.js
@@ -23,6 +23,7 @@ const webpack = require('./metalsmith-webpack').webpackPlugin;
 const webpackConfigGenerator = require('../config/webpack.config');
 const webpackDevServer = require('./metalsmith-webpack').webpackDevServerPlugin;
 const createBuildSettings = require('./create-build-settings');
+const createRedirects = require('./create-redirects');
 const nonceTransformer = require('./metalsmith/nonceTransformer');
 const {
   getRoutes,
@@ -70,6 +71,10 @@ if (isHerokuBuild) {
   const applyHerokuOptions = require('./heroku-helper');
   applyHerokuOptions(options);
 }
+
+// Pages can contain an "alias" property in their metadata, which is processed into
+// separate pages that will each redirect to the original page.
+smith.use(createRedirects(options));
 
 switch (options.buildtype) {
   case 'development':

--- a/script/create-redirects.js
+++ b/script/create-redirects.js
@@ -1,0 +1,50 @@
+/* eslint-disable no-param-reassign, no-continue, no-console */
+const path = require('path');
+
+function getPagePath(fileName, fileData) {
+  const { permalink } = fileData;
+  return permalink ? permalink.replace('index.html', '') : `/${fileName.replace('.md', '')}/`;
+}
+
+function getRedirectPage(redirectToPath) {
+  return `
+    <!doctype html>
+    <head>
+      <meta http-equiv=refresh content="1; url=${redirectToPath}">
+      <link rel=canonical href="${redirectToPath}">
+      <title>Page Moved</title>
+    </head>
+    <body>
+      New location: <a href="${redirectToPath}">${redirectToPath}</a>
+    </body>`;
+}
+
+function createRedirects(options) {
+  return (files, metalsmith, done) => {
+
+    for (const fileName of Object.keys(files)) {
+      const fileData = files[fileName];
+      const {
+        aliases
+      } = fileData;
+
+      if (!aliases) continue;
+
+      const redirectToPath = getPagePath(fileName, fileData);
+      const redirectPage = {
+        contents: new Buffer(getRedirectPage(redirectToPath))
+      };
+
+      for (let alias of aliases) {
+        if (!path.extname(alias)) alias = path.join(alias, 'index.html');
+
+        alias = path.join(options.destination, alias);
+        files[alias] = redirectPage;
+      }
+    }
+
+    done();
+  };
+}
+
+module.exports = createRedirects;

--- a/script/create-redirects.js
+++ b/script/create-redirects.js
@@ -31,14 +31,13 @@ function createRedirects(options) {
         contents: new Buffer(getRedirectPage(redirectToPath))
       };
 
-      for (let alias of aliases) {
-        if (!path.extname(alias)) alias = path.join(alias, 'index.html');
+      for (const alias of aliases) {
+        let absolutePath = path.join(options.destination, alias);
+        if (!path.extname(absolutePath)) absolutePath = path.join(absolutePath, 'index.html');
 
-        alias = path.join(options.destination, alias);
-
-        files[alias] = {
+        files[absolutePath] = {
           ...redirectPage,
-          path: alias
+          path: absolutePath
         };
       }
     }

--- a/script/create-redirects.js
+++ b/script/create-redirects.js
@@ -1,21 +1,17 @@
-/* eslint-disable no-param-reassign, no-continue, no-console */
+/* eslint-disable no-param-reassign, no-continue */
 const path = require('path');
 
-function getPagePath(fileName, fileData) {
-  const { permalink } = fileData;
-  return permalink ? permalink.replace('index.html', '') : `/${fileName.replace('.md', '')}/`;
-}
-
 function getRedirectPage(redirectToPath) {
+  const absolutePath = `/${redirectToPath}/`;
   return `
     <!doctype html>
     <head>
-      <meta http-equiv=refresh content="1; url=${redirectToPath}">
-      <link rel=canonical href="${redirectToPath}">
+      <meta http-equiv=refresh content="1; url=${absolutePath}">
+      <link rel=canonical href="${absolutePath}">
       <title>Page Moved</title>
     </head>
     <body>
-      New location: <a href="${redirectToPath}">${redirectToPath}</a>
+      New location: <a href="${absolutePath}">${absolutePath}</a>
     </body>`;
 }
 
@@ -25,12 +21,12 @@ function createRedirects(options) {
     for (const fileName of Object.keys(files)) {
       const fileData = files[fileName];
       const {
-        aliases
+        aliases,
+        path: redirectToPath
       } = fileData;
 
       if (!aliases) continue;
 
-      const redirectToPath = getPagePath(fileName, fileData);
       const redirectPage = {
         contents: new Buffer(getRedirectPage(redirectToPath))
       };
@@ -39,7 +35,11 @@ function createRedirects(options) {
         if (!path.extname(alias)) alias = path.join(alias, 'index.html');
 
         alias = path.join(options.destination, alias);
-        files[alias] = redirectPage;
+
+        files[alias] = {
+          ...redirectPage,
+          path: alias
+        };
       }
     }
 

--- a/script/create-redirects.js
+++ b/script/create-redirects.js
@@ -2,7 +2,9 @@
 const path = require('path');
 
 function getRedirectPage(redirectToPath) {
-  const absolutePath = `/${redirectToPath}/`;
+  let absolutePath = `/${redirectToPath}`;
+  if (!absolutePath.endsWith('/')) absolutePath += '/';
+
   return `
     <!doctype html>
     <head>


### PR DESCRIPTION
## Description
This PR adds Metalsmith middleware into the build so that when an "aliases" property exists in a page it is processed into redirect pages. Example -

**/some-path/index.md**
```
title: Some Path
aliases:
  - /some-old-path/
  - /another-old-path
```

During the build, `/some-old-path/index.html` and `/another-old-path/index.html` will be generated as an HTML page containing a meta property that will briefly tell the user that the page has moved before automatically navigating to `/some-page/`. 

This is valuable as part of the `brand-consolidation` work. Many pages are being moved around, and in the event we miss a link, this redirect will act as a fallback for the time being. This will also allow us to leave the `src/` directories untouched, because we can allow the old links to remain until we're further along.

#### Unique to this PR
There is no impact to master on this PR, as no pages contain an "aliases" property.
