### PR TITLE
Add Metalsmith middleware for aliases

### DIFF
--- a/va-gov/pages/health-care/about-affordable-care-act.md
+++ b/va-gov/pages/health-care/about-affordable-care-act.md
@@ -6,6 +6,8 @@ display_title:
 collection: healthCare
 lastupdate: 2018-02-13
 order: 10
+aliases:
+  - /health-care/affordable-care-act/
 ---
 
 <div class="va-introtext">

--- a/va-gov/pages/health-care/about-va-health-benefits.md
+++ b/va-gov/pages/health-care/about-va-health-benefits.md
@@ -7,6 +7,8 @@ lastupdate: 2017-06-28
 collection: healthCare
 children: healthCareCoverage
 order: 1
+aliases:
+  - /health-care/about-va-health-care/
 relatedlinks:
   - heading: Related benefits you may qualify for
     links:

--- a/va-gov/pages/health-care/about-va-health-benefits/dental-care.md
+++ b/va-gov/pages/health-care/about-va-health-benefits/dental-care.md
@@ -7,6 +7,8 @@ description: Find out if you qualify for VA dental benefits, or how to buy denta
 concurrence: complete
 lastupdate: 2017-06-28
 order: 5
+aliases:
+  - /health-care/about-va-health-care/dental-care/
 relatedlinks:
   - heading: More information about your benefits
     links:

--- a/va-gov/pages/health-care/about-va-health-benefits/long-term-care.md
+++ b/va-gov/pages/health-care/about-va-health-benefits/long-term-care.md
@@ -7,6 +7,8 @@ description: Find out how to access VA home health care benefits if you're a sic
 concurrence: complete
 lastupdate: 2017-06-28
 order: 4
+aliases:
+  - /health-care/about-va-health-care/assisted-living-and-home-health-care/
 relatedlinks:
   - heading: More information about your benefits
     links:

--- a/va-gov/pages/health-care/about-va-health-benefits/va-health-care-and-other-insurance.md
+++ b/va-gov/pages/health-care/about-va-health-benefits/va-health-care-and-other-insurance.md
@@ -7,6 +7,8 @@ description: Find out how your VA health care benefits work with other health in
 concurrence: complete
 lastupdate: 2017-06-28
 order: 3
+aliases:
+  - /health-care/about-va-health-care/va-health-care-and-other-insurance/
 relatedlinks:
   - heading: More information about your benefits
     links:

--- a/va-gov/pages/health-care/about-va-health-benefits/vision-care.md
+++ b/va-gov/pages/health-care/about-va-health-benefits/vision-care.md
@@ -9,6 +9,8 @@ lastupdate: 2017-06-28
 collection: healthCareCoverage
 children: healthCareCoverageVision
 order: 6
+aliases:
+  - /health-care/about-va-health-care/vision-care/
 relatedlinks:
   - heading: More information about your benefits
     links:

--- a/va-gov/pages/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services.md
+++ b/va-gov/pages/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services.md
@@ -6,6 +6,8 @@ display_title: Care for Blind and Low Vision Veterans
 concurrence: complete
 lastupdate: 2017-06-28
 order: 1
+aliases:
+  - /health-care/about-va-health-care/vision-care/blind-and-low-vision-veterans/
 relatedlinks:
   - heading: More information about your benefits
     links:

--- a/va-gov/pages/health-care/about-va-health-benefits/where-you-go-for-care.md
+++ b/va-gov/pages/health-care/about-va-health-benefits/where-you-go-for-care.md
@@ -7,6 +7,8 @@ description: Find out where you'll get care through VA after you sign up. Health
 concurrence: complete
 lastupdate: 2018-01-09
 order: 2
+aliases:
+  - /health-care/about-va-health-care/where-you-get-care/
 relatedlinks:
   - heading: More information about your benefits
     links:

--- a/va-gov/pages/health-care/about-va-health-benefits/your-care-team.md
+++ b/va-gov/pages/health-care/about-va-health-benefits/your-care-team.md
@@ -7,6 +7,8 @@ description: Learn  about the VA health care providers on your VA health care t
 concurrence: complete
 lastupdate: 2018-01-09
 order: 1
+aliases:
+  - /health-care/about-va-health-care/your-care-team/
 relatedlinks:
   - heading: More information about your benefits
     links:
@@ -21,7 +23,7 @@ relatedlinks:
       description: Find out how to access VA services for mental health, women’s health, and other specific needs.
     - url: /disability-benefits/
       title: Disability Benefits
-      description: Have an illness or injury that was caused—or made worse—by your active-duty service? Find out if you can get disability compensation (monthly payments) from VA.  
+      description: Have an illness or injury that was caused—or made worse—by your active-duty service? Find out if you can get disability compensation (monthly payments) from VA.
 ---
 
 <div class="va-introtext">

--- a/va-gov/pages/health-care/apply-for-health-care-form-10-10ez/index.md
+++ b/va-gov/pages/health-care/apply-for-health-care-form-10-10ez/index.md
@@ -3,6 +3,8 @@ title: Apply for VA Health Care Online (VA Form 10-10EZ)
 entryname: hca
 layout: page-react.html
 description: Apply for VA health care benefits. Find out which documents you’ll need, and start your online application today.
+aliases:
+  - /health-care/apply/application/
 body_class: page-healthcare
 in_maintenance: false
 maintenance_line1: We’re sorry. The health care application is currently down while we fix a few things. We’ll be back up as soon as we can.

--- a/va-gov/pages/health-care/family-caregiver-benefits.md
+++ b/va-gov/pages/health-care/family-caregiver-benefits.md
@@ -7,6 +7,8 @@ collection: healthCare
 children: healthCareCoverageFamily
 lastupdate: 2018-02-13
 order: 9
+aliases:
+  - /health-care/family-caregiver-health-benefits/
 ---
 
 <div class="va-introtext">

--- a/va-gov/pages/health-care/family-caregiver-benefits/champva.md
+++ b/va-gov/pages/health-care/family-caregiver-benefits/champva.md
@@ -6,6 +6,8 @@ display_title:
 concurrence: complete
 lastupdate: 2018-02-13
 order: 1
+aliases:
+  - /health-care/family-caregiver-health-benefits/CHAMPVA/
 ---
 
 <div class="va-introtext">

--- a/va-gov/pages/health-care/family-caregiver-benefits/comprehensive-assistance.md
+++ b/va-gov/pages/health-care/family-caregiver-benefits/comprehensive-assistance.md
@@ -6,6 +6,8 @@ display_title: Comprehensive Assistance to Family Caregivers
 concurrence: complete
 lastupdate: 2018-02-13
 order: 2
+aliases:
+  - /health-care/family-caregiver-health-benefits/comprehensive-assistance-family-caregivers/
 ---
 <div class="va-introtext">
 
@@ -57,7 +59,7 @@ Health Eligibility Center<br>
 Atlanta, GA 30329-1647
 </p>
 
-Or apply in person by bringing the application to your local VA Medical Center Caregiver Support Coordinator. 
+Or apply in person by bringing the application to your local VA Medical Center Caregiver Support Coordinator.
 
 **To find the name of your local coordinator:**
 

--- a/va-gov/pages/health-care/health-needs-conditions.md
+++ b/va-gov/pages/health-care/health-needs-conditions.md
@@ -9,6 +9,8 @@ lastupdate: 2017-06-28
 collection: healthCare
 order: 5
 children: healthCareConditions
+aliases:
+  - /health-care/health-conditions/
 relatedlinks:
   - heading: Other helpful information
     links:
@@ -33,12 +35,12 @@ At VA, we offer many services and programs for Veterans with specific needs—li
 </div>
 
 <div class="feature" markdown=“1”>
-  
+
 ### Are there any health concerns I should be aware of based on my service history?
 
 Yes. Certain health concerns may be more likely to affect Veterans who served in a specific time and place. Find out which health concerns you should be aware of depending on when and where you served. <br>
 
-[Get health information by service dates and locations](/health-care/health-needs-conditions/health-issues-related-to-service-era/). 
+[Get health information by service dates and locations](/health-care/health-needs-conditions/health-issues-related-to-service-era/).
 
 </div>
 
@@ -46,7 +48,7 @@ Yes. Certain health concerns may be more likely to affect Veterans who served in
 
 <h4 itemprop="name">How do I find out how to get health services for a specific condition or need?</h4>
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
-<div itemprop="text"> 
+<div itemprop="text">
 
 **Mental health problems**
 

--- a/va-gov/pages/health-care/health-needs-conditions/chemical-hazardous-materials-exposure.md
+++ b/va-gov/pages/health-care/health-needs-conditions/chemical-hazardous-materials-exposure.md
@@ -6,6 +6,8 @@ display_title: Exposure to Hazardous Materials
 concurrence: complete
 lastupdate: 2017-06-28
 order: 5
+aliases:
+  - /health-care/health-conditions/exposure-to-hazardous-materials/
 relatedlinks:
   - heading: More information about your benefits
     links:

--- a/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era.md
+++ b/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era.md
@@ -3,12 +3,14 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: Veterans Health Issues Related to Service History
 display_title: Concerns Related to Service History
-description: Learn what health conditions you may be at risk of developing depending on where and when you served on active duty.  
+description: Learn what health conditions you may be at risk of developing depending on where and when you served on active duty.
 concurrence: complete
 lastupdate: 2017-06-28
 order: 1
+aliases:
+  - /health-care/health-conditions/conditions-related-to-service-era/
 children: healthCareServiceRelated
-majorlinks: 
+majorlinks:
   - heading:
     links:
     - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom/

--- a/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war.md
+++ b/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war.md
@@ -2,11 +2,13 @@
 layout: page-breadcrumbs.html
 template: detail-page
 title: Cold War Veterans Health Issues
-display_title: 
+display_title:
 description: Learn what health conditions you might be at risk of developing if you’re a Cold War era Veteran. Find out what to do next to take care of your health.
 concurrence: complete
 lastupdate: 2017-06-28
 order: 4
+aliases:
+  - /health-care/health-conditions/conditions-related-to-service-era/cold-war-era/
 relatedlinks:
   - heading: More information about your benefits
     links:
@@ -33,8 +35,8 @@ If you served during the Cold War era—anytime between 1945 and 1991—you may 
 
 You may be at risk of illnesses or injuries caused by contact with:
 
-- **[Radiation](/disability-benefits/conditions/exposure-to-hazardous-materials/radiation-exposure/):** A type of radiation exposure from atmospheric and underground nuclear weapons tests 
-- **[Mustard gas](/disability-benefits/conditions/exposure-to-hazardous-materials/mustard-gas/):** An odorless poisonous gas used in military tests in the 1940s 
+- **[Radiation](/disability-benefits/conditions/exposure-to-hazardous-materials/radiation-exposure/):** A type of radiation exposure from atmospheric and underground nuclear weapons tests
+- **[Mustard gas](/disability-benefits/conditions/exposure-to-hazardous-materials/mustard-gas/):** An odorless poisonous gas used in military tests in the 1940s
 - **[Herbicides](/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/):** Agent Orange and other herbicides used in Vietnam and tested or stored in other locations
 - **[Occupational (job-related) hazards](https://www.publichealth.va.gov/exposures/categories/occupational-hazards.asp):** Chemicals, paints, radiation, and other hazards you may have come in contact with through your military job
 - **[Noise](https://www.publichealth.va.gov/exposures/noise/index.asp):** Harmful sounds from guns, explosives, rockets, heavy weapons, jets and aircraft, and machinery that can cause or contribute to hearing loss and tinnitus (ringing in the ears)
@@ -56,7 +58,7 @@ Take these steps to make sure you’re taking care of your health:
 <ol class="process">
 <li class="process-step list-one">
 
-Talk to your primary health care provider or your local VA environmental health coordinator about any health concerns related to your military service. [Find your local VA environmental health coordinator](https://www.publichealth.va.gov/exposures/coordinators.asp). 
+Talk to your primary health care provider or your local VA environmental health coordinator about any health concerns related to your military service. [Find your local VA environmental health coordinator](https://www.publichealth.va.gov/exposures/coordinators.asp).
 
 </li>
 
@@ -68,7 +70,7 @@ Ask your local VA environmental health coordinator about getting a free Ionizing
 
 <li class="process-step list-three">
 
-Find out if you can get disability compensation (monthly payments) and other benefits if you have an illness or injury caused—or made worse—by your active-duty service. [See if you qualify for disability benefits due to contact with hazardous materials](/disability-benefits/conditions/exposure-to-hazardous-materials/). 
+Find out if you can get disability compensation (monthly payments) and other benefits if you have an illness or injury caused—or made worse—by your active-duty service. [See if you qualify for disability benefits due to contact with hazardous materials](/disability-benefits/conditions/exposure-to-hazardous-materials/).
 
 </li>
 </ol>

--- a/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war.md
+++ b/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war.md
@@ -7,6 +7,8 @@ description: Learn what health conditions you might be at risk of developing if 
 concurrence: complete
 lastupdate: 2017-06-28
 order: 3
+aliases:
+  - /health-care/health-conditions/conditions-related-to-service-era/gulf-war/
 relatedlinks:
   - heading: More information about your benefits
     links:
@@ -34,8 +36,8 @@ If you served in the Gulf War in Operation Desert Shield or Operation Desert Sto
 You may be at risk of:
 
 - Health problems caused by toxic chemicals or other hazardous materials in the environment, like:
-  - **[Sand, dust, and particulates](http://www.publichealth.va.gov/exposures/sand-dust-particulates/index.asp):** Tiny matter found in the air 
-  - **[Depleted uranium](http://www.publichealth.va.gov/exposures/depleted_uranium/index.asp):** Uranium used in military tank armor and some bullets 
+  - **[Sand, dust, and particulates](http://www.publichealth.va.gov/exposures/sand-dust-particulates/index.asp):** Tiny matter found in the air
+  - **[Depleted uranium](http://www.publichealth.va.gov/exposures/depleted_uranium/index.asp):** Uranium used in military tank armor and some bullets
   - **[Oil well fires](http://www.publichealth.va.gov/exposures/gulfwar/sources/oil-well-fires.asp):** Oil or gas wells that caught on fire and burned
   - **[Chemical and biological weapons (Khamisiyah, Iraq)](http://www.publichealth.va.gov/exposures/gulfwar/sources/chem-bio-weapons.asp):** Chemicals released into the atmosphere from the demolition of a munitions storage depot in Khamisiyah, Iraq
   - **[Chemical Agent Resistant Coating (CARC) paint](http://www.publichealth.va.gov/exposures/gulfwar/sources/chem-bio-weapons.asp):** A paint used on military vehicles to resist corrosion and chemical agents
@@ -43,14 +45,14 @@ You may be at risk of:
 
 - Illnesses and injuries caused by:
   - **[Extreme heat](http://www.publichealth.va.gov/exposures/heat-injuries/index.asp):** Health problems (like heat stroke, heat exhaustion, and sunburn) that can be caused by serving in hot desert climates
-  - **[Toxic embedded fragments](http://www.publichealth.va.gov/exposures/toxic_fragments/index.asp):** Shrapnel and other metals (some containing chemicals) that stay in your body after an injury and can cause injury at the site of the fragment or in other parts of your body 
+  - **[Toxic embedded fragments](http://www.publichealth.va.gov/exposures/toxic_fragments/index.asp):** Shrapnel and other metals (some containing chemicals) that stay in your body after an injury and can cause injury at the site of the fragment or in other parts of your body
   - **[Noise](http://www.publichealth.va.gov/exposures/noise/index.asp):** Harmful sounds from guns, explosives, rockets, heavy weapons, jets and aircraft, and machinery that can cause or contribute to hearing loss and tinnitus (ringing in the ears)
-  - **[Infectious diseases](http://www.publichealth.va.gov/exposures/infectious-diseases/index.asp):** There are 9 infectious diseases related to Southwest Asia and Afghanistan military service. These are malaria, brucellosis, campylobacter jejuni, coxiella burnetii (Q Fever), mycobacterium tuberculosis, nontyphoid salmonella, shigella, visceral leishmaniasis, and West Nile Virus. 
+  - **[Infectious diseases](http://www.publichealth.va.gov/exposures/infectious-diseases/index.asp):** There are 9 infectious diseases related to Southwest Asia and Afghanistan military service. These are malaria, brucellosis, campylobacter jejuni, coxiella burnetii (Q Fever), mycobacterium tuberculosis, nontyphoid salmonella, shigella, visceral leishmaniasis, and West Nile Virus.
   - **[Occupational (job-related) hazards](http://www.publichealth.va.gov/exposures/categories/occupational-hazards.asp):** Chemicals, paints, radiation, and other hazards you may have come in contact with through your military job
 
 - Possible side effects of:
   - **[Vaccinations](http://www.publichealth.va.gov/exposures/gulfwar/sources/vaccinations.asp):** Vaccines given to help prevent infectious diseases as well as anthrax and botulinum toxoid. These vaccines are being studied as one possible cause of chronic multi-symptom illnesses in Gulf War Veterans.
-  - **[Pyridostigmine bromide (PB)](http://www.publichealth.va.gov/exposures/gulfwar/sources/pyridostigmine-bromide.asp):** An anti-nerve agent pill used as a pretreatment to protect military personnel in the event of an attack with the nerve agent soman. So far, research shows that there’s no evidence to link PB to multi-symptom illnesses in Gulf War Veterans, but we continue to monitor these Veterans’ health issues. 
+  - **[Pyridostigmine bromide (PB)](http://www.publichealth.va.gov/exposures/gulfwar/sources/pyridostigmine-bromide.asp):** An anti-nerve agent pill used as a pretreatment to protect military personnel in the event of an attack with the nerve agent soman. So far, research shows that there’s no evidence to link PB to multi-symptom illnesses in Gulf War Veterans, but we continue to monitor these Veterans’ health issues.
 
 </div>
 
@@ -61,9 +63,9 @@ Take these steps to make sure you’re taking care of your health:
 <ol class="process">
 <li class="process-step list-one">
 
-Talk to your primary health care provider or your local VA environmental health coordinator about any health concerns related to your military service. [Find your local VA environmental health coordinator](https://www.publichealth.va.gov/exposures/coordinators.asp). 
+Talk to your primary health care provider or your local VA environmental health coordinator about any health concerns related to your military service. [Find your local VA environmental health coordinator](https://www.publichealth.va.gov/exposures/coordinators.asp).
 
-- **If you have embedded fragments,** ask about getting an exam through the Toxic Embedded Fragment Surveillance Center. [Download our Toxic Embedded Fragments fact sheet](http://www.publichealth.va.gov/docs/exposures/TEFSC-veterans-fact-sheet.pdf).  
+- **If you have embedded fragments,** ask about getting an exam through the Toxic Embedded Fragment Surveillance Center. [Download our Toxic Embedded Fragments fact sheet](http://www.publichealth.va.gov/docs/exposures/TEFSC-veterans-fact-sheet.pdf).
 
 - **If you think you had contact with depleted uranium,** ask about getting screened through the Depleted Uranium Follow-up Program. [Learn more about the Depleted Uranium Follow-up Program](http://www.publichealth.va.gov/exposures/depleted_uranium/followup_program.asp).
 
@@ -73,7 +75,7 @@ Talk to your primary health care provider or your local VA environmental health 
 
 Ask about getting a free exam and joining these registries to document your exposures and health concerns:
 <br />
-[The Airborne Hazards and Open Burn Pit Registry](https://veteran.mobilehealth.va.gov/AHBurnPitRegistry/) 
+[The Airborne Hazards and Open Burn Pit Registry](https://veteran.mobilehealth.va.gov/AHBurnPitRegistry/)
 <br />
 [The Gulf War Registry](http://www.publichealth.va.gov/exposures/gulfwar/benefits/registry-exam.asp)
 <br />
@@ -83,7 +85,7 @@ Ask about getting a free exam and joining these registries to document your expo
 
 <li class="process-step list-three">
 
-Find out if you can get disability compensation (monthly payments) and other benefits if you have an illness or injury caused—or made worse—by your active-duty service. 
+Find out if you can get disability compensation (monthly payments) and other benefits if you have an illness or injury caused—or made worse—by your active-duty service.
 <br />
 [See if you qualify for disability benefits due to Gulf War Illness](/disability-benefits/conditions/exposure-to-hazardous-materials/gulf-war-illness/).
 <br />

--- a/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war.md
+++ b/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war.md
@@ -7,6 +7,8 @@ description: Learn what health conditions you might be at risk of developing if 
 concurrence: complete
 lastupdate: 2017-06-28
 order: 2
+aliases:
+  - /health-care/health-conditions/conditions-related-to-service-era/iraq-war/
 relatedlinks:
   - heading: More information about your benefits
     links:
@@ -34,16 +36,16 @@ If you served in Iraq during Operation Iraqi Freedom or Operation New Dawn—any
 You may be at risk of:
 
 - Health problems caused by toxic chemicals or other hazardous materials in the environment, like:
-  - **[Sand, dust, and particulates](http://www.publichealth.va.gov/exposures/sand-dust-particulates/index.asp):** Tiny matter found in the air 
-  - **[Burn pit smoke](http://www.publichealth.va.gov/exposures/burnpits/index.asp):** Smoke from open-air pits often used to get rid of waste (like chemicals, paints, munitions, and other substances) at military sites in Iraq  
+  - **[Sand, dust, and particulates](http://www.publichealth.va.gov/exposures/sand-dust-particulates/index.asp):** Tiny matter found in the air
+  - **[Burn pit smoke](http://www.publichealth.va.gov/exposures/burnpits/index.asp):** Smoke from open-air pits often used to get rid of waste (like chemicals, paints, munitions, and other substances) at military sites in Iraq
   - **[Depleted uranium](http://www.publichealth.va.gov/exposures/depleted_uranium/index.asp):** Uranium used in military tank armor and some bullets
-  - **[Sulfur fire (Al Mishraq, Iraq)](http://www.publichealth.va.gov/exposures/mishraq-sulfur-fire/index.asp):** A fire at a sulfur plant that burned for almost a month in June 2003 and released large amounts of sulfur dioxide into the air 
+  - **[Sulfur fire (Al Mishraq, Iraq)](http://www.publichealth.va.gov/exposures/mishraq-sulfur-fire/index.asp):** A fire at a sulfur plant that burned for almost a month in June 2003 and released large amounts of sulfur dioxide into the air
   - **[Chemical warfare agents (OIF)](http://www.publichealth.va.gov/exposures/chemical-warfare-agents-oif.asp):** Exposure to mustard or nerve agents from demolishing or handling explosive ordinance in Iraq
-  - **[Chromium (Qarmat Ali, Basrah, Iraq)](http://www.publichealth.va.gov/exposures/qarmat-ali/index.asp):** Hexavalent chromium (a chemical known to cause cancer) found in contaminated sodium dichromate dust at the Qarmat Ali Water Treatment Facility in 2003 
+  - **[Chromium (Qarmat Ali, Basrah, Iraq)](http://www.publichealth.va.gov/exposures/qarmat-ali/index.asp):** Hexavalent chromium (a chemical known to cause cancer) found in contaminated sodium dichromate dust at the Qarmat Ali Water Treatment Facility in 2003
 
 - Injuries caused by:
   - **[Extreme heat](http://www.publichealth.va.gov/exposures/heat-injuries/index.asp):** Health problems (like heat stroke, heat exhaustion, and sunburn) that can be caused by serving in hot desert climates
-  - **[Toxic embedded fragments](http://www.publichealth.va.gov/exposures/toxic_fragments/index.asp):** Shrapnel and other metals (some containing chemicals) that stay in your body after an injury and can cause injury at the site of the fragment or in other parts of your body 
+  - **[Toxic embedded fragments](http://www.publichealth.va.gov/exposures/toxic_fragments/index.asp):** Shrapnel and other metals (some containing chemicals) that stay in your body after an injury and can cause injury at the site of the fragment or in other parts of your body
   - **[Explosions](http://www.publichealth.va.gov/exposures/traumatic-brain-injury.asp):** Explosions that can cause concussions and traumatic brain injury (TBI), an injury to the head that affects the way your brain works
   - **[Noise](http://www.publichealth.va.gov/exposures/noise/index.asp):** Harmful sounds from guns, explosives, rockets, heavy weapons, jets and aircraft, and machinery that can cause or contribute to hearing loss and tinnitus (ringing in the ears)
 
@@ -53,7 +55,7 @@ You may be at risk of:
 
 - **[Illnesses or injuries caused by occupational (job-related) hazards](http://www.publichealth.va.gov/exposures/categories/occupational-hazards.asp):** Chemicals, paints, radiation, and other hazards you may have come in contact with through your military job
 
-- **[Side effects of Mefloquine (brand name: Lariam®)](http://www.publichealth.va.gov/exposures/mefloquine-lariam.asp):** A drug given to military personnel to help protect against malaria (an infectious disease transmitted by mosquitoes) 
+- **[Side effects of Mefloquine (brand name: Lariam®)](http://www.publichealth.va.gov/exposures/mefloquine-lariam.asp):** A drug given to military personnel to help protect against malaria (an infectious disease transmitted by mosquitoes)
 
 </div>
 
@@ -64,9 +66,9 @@ Take these steps to make sure you’re taking care of your health:
 <ol class="process">
 <li class="process-step list-one">
 
-Talk to your primary health care provider or your local VA environmental health coordinator about any health concerns related to your military service. [Find your local VA environmental health coordinator](https://www.publichealth.va.gov/exposures/coordinators.asp). 
+Talk to your primary health care provider or your local VA environmental health coordinator about any health concerns related to your military service. [Find your local VA environmental health coordinator](https://www.publichealth.va.gov/exposures/coordinators.asp).
 
-- **If you have embedded fragments,** ask about getting an exam through the Toxic Embedded Fragment Surveillance Center. [Download our Toxic Embedded Fragments fact sheet](http://www.publichealth.va.gov/docs/exposures/TEFSC-veterans-fact-sheet.pdf).  
+- **If you have embedded fragments,** ask about getting an exam through the Toxic Embedded Fragment Surveillance Center. [Download our Toxic Embedded Fragments fact sheet](http://www.publichealth.va.gov/docs/exposures/TEFSC-veterans-fact-sheet.pdf).
 - **If you think you had contact with depleted uranium,** ask about getting screened through the Depleted Uranium Follow-up Program. [Learn more about the Depleted Uranium Follow-up Program](http://www.publichealth.va.gov/exposures/depleted_uranium/followup_program.asp).
 
 </li>
@@ -75,7 +77,7 @@ Talk to your primary health care provider or your local VA environmental health 
 
 Ask about joining these registries to document your exposures and health concerns:
 <br>
-[The Airborne Hazards and Open Burn Pit Registry](https://veteran.mobilehealth.va.gov/AHBurnPitRegistry/) 
+[The Airborne Hazards and Open Burn Pit Registry](https://veteran.mobilehealth.va.gov/AHBurnPitRegistry/)
 <br>
 [The Gulf War Registry](http://www.publichealth.va.gov/exposures/gulfwar/benefits/registry-exam.asp)
 
@@ -83,7 +85,7 @@ Ask about joining these registries to document your exposures and health concern
 
 <li class="process-step list-three">
 
-Find out if you can get disability compensation (monthly payments) and other benefits if you have an illness or injury caused—or made worse—by your active-duty service. 
+Find out if you can get disability compensation (monthly payments) and other benefits if you have an illness or injury caused—or made worse—by your active-duty service.
 <br>
 [See if you qualify for disability benefits due to Gulf War Illness](/disability-benefits/conditions/exposure-to-hazardous-materials/gulf-war-illness/).
 <br>

--- a/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war.md
+++ b/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war.md
@@ -6,6 +6,8 @@ display_title: Korean War
 concurrence: complete
 lastupdate: 2017-06-28
 order: 6
+aliases:
+  - /health-care/health-conditions/conditions-related-to-service-era/korean-war/
 relatedlinks:
   - heading: More information about your benefits
     links:

--- a/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom.md
+++ b/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom.md
@@ -7,6 +7,8 @@ description: Learn what health conditions you might be at risk of developing if 
 concurrence: complete
 lastupdate: 2017-06-28
 order: 1
+aliases:
+  - /health-care/health-conditions/conditions-related-to-service-era/operation-enduring-freedom/
 relatedlinks:
   - heading: More information about your benefits
     links:
@@ -33,8 +35,8 @@ If you served in Afghanistan during Operation Enduring Freedom (OEF) any time af
 You may be at risk of:
 
 - Health problems caused by toxic chemicals or other hazardous materials in the environment, like:
-  - **[Sand, dust, and particulates](http://www.publichealth.va.gov/exposures/sand-dust-particulates/index.asp):** Tiny matter found in the air 
-  - **[Burn pit smoke](http://www.publichealth.va.gov/exposures/burnpits/index.asp):** Smoke from open-air pits often used to get rid of waste (like chemicals, paints, munitions, and other substances) at military sites in Afghanistan  
+  - **[Sand, dust, and particulates](http://www.publichealth.va.gov/exposures/sand-dust-particulates/index.asp):** Tiny matter found in the air
+  - **[Burn pit smoke](http://www.publichealth.va.gov/exposures/burnpits/index.asp):** Smoke from open-air pits often used to get rid of waste (like chemicals, paints, munitions, and other substances) at military sites in Afghanistan
   - **[Depleted uranium](http://www.publichealth.va.gov/exposures/depleted_uranium/index.asp):** Uranium used in military tank armor and some bullets
 
 - Injuries caused by:
@@ -50,7 +52,7 @@ You may be at risk of:
 
 - **[Occupational (job-related) hazards](http://www.publichealth.va.gov/exposures/categories/occupational-hazards.asp):** Chemicals, paints, radiation, and other hazards you may have come in contact with through your military job
 
-- **[Side effects of Mefloquine (brand name: Lariam®)](http://www.publichealth.va.gov/exposures/mefloquine-lariam.asp):** A drug given to military personnel to help protect against malaria (an infectious disease transmitted by mosquitoes) 
+- **[Side effects of Mefloquine (brand name: Lariam®)](http://www.publichealth.va.gov/exposures/mefloquine-lariam.asp):** A drug given to military personnel to help protect against malaria (an infectious disease transmitted by mosquitoes)
 
 </div>
 
@@ -61,27 +63,27 @@ Take these steps to make sure you’re taking care of your health:
 <ol class="process">
 <li class="process-step list-one">
 
-Join the Airborne Hazards and Open Burn Pit Registry to document your exposures and health concerns. [Join the registry](https://veteran.mobilehealth.va.gov/AHBurnPitRegistry/). 
+Join the Airborne Hazards and Open Burn Pit Registry to document your exposures and health concerns. [Join the registry](https://veteran.mobilehealth.va.gov/AHBurnPitRegistry/).
 
 </li>
 
 <li class="process-step list-two">
 
-Talk to your primary health care provider or your local VA environmental health coordinator about any health concerns related to your military service. [Find your local VA environmental health coordinator](https://www.publichealth.va.gov/exposures/coordinators.asp). 
+Talk to your primary health care provider or your local VA environmental health coordinator about any health concerns related to your military service. [Find your local VA environmental health coordinator](https://www.publichealth.va.gov/exposures/coordinators.asp).
 
-- **If you have embedded fragments,** ask about getting an exam through the Toxic Embedded Fragment Surveillance Center. [Download our Toxic Embedded Fragments fact sheet](http://www.publichealth.va.gov/docs/exposures/TEFSC-veterans-fact-sheet.pdf).  
+- **If you have embedded fragments,** ask about getting an exam through the Toxic Embedded Fragment Surveillance Center. [Download our Toxic Embedded Fragments fact sheet](http://www.publichealth.va.gov/docs/exposures/TEFSC-veterans-fact-sheet.pdf).
 
-- **If you think you had contact with depleted uranium,** ask about getting screened through the Depleted Uranium Follow-up Program. [Learn more about the Depleted Uranium Follow-up Program](http://www.publichealth.va.gov/exposures/depleted_uranium/followup_program.asp). 
+- **If you think you had contact with depleted uranium,** ask about getting screened through the Depleted Uranium Follow-up Program. [Learn more about the Depleted Uranium Follow-up Program](http://www.publichealth.va.gov/exposures/depleted_uranium/followup_program.asp).
 
 </li>
 
 <li class="process-step list-three">
 
-Find out if you can get disability compensation (monthly payments) and other benefits if you have an illness or injury caused—or made worse—by your active-duty service. 
+Find out if you can get disability compensation (monthly payments) and other benefits if you have an illness or injury caused—or made worse—by your active-duty service.
 <br>
 [See if you qualify for disability benefits due to Gulf War Illness from service in Afghanistan](/disability-benefits/conditions/exposure-to-hazardous-materials/gulf-war-illness-from-service-in-afghanistan/).
 <br>
-[See if you qualify for disability benefits due to contact with hazardous materials](/disability-benefits/conditions/exposure-to-hazardous-materials/). 
+[See if you qualify for disability benefits due to contact with hazardous materials](/disability-benefits/conditions/exposure-to-hazardous-materials/).
 
 </li>
 </ol>

--- a/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war.md
+++ b/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war.md
@@ -2,11 +2,13 @@
 layout: page-breadcrumbs.html
 template: detail-page
 title: Vietnam War Veterans Health Issues
-display_title: 
+display_title:
 description: Learn what health conditions you might be at risk of developing if you’re a Vietnam War Veteran.
 concurrence: complete
 lastupdate: 2017-06-28
 order: 5
+aliases:
+  - /health-care/health-conditions/conditions-related-to-service-era/vietnam-war/
 relatedlinks:
   - heading: More information about your benefits
     links:
@@ -59,7 +61,7 @@ Ask your local VA environmental health coordinator about getting a free Agent Or
 
 <li class="process-step list-three">
 
-Find out if you can get disability compensation (monthly payments) and other benefits if you have an illness or injury caused—or made worse—by your active-duty service. 
+Find out if you can get disability compensation (monthly payments) and other benefits if you have an illness or injury caused—or made worse—by your active-duty service.
 <br>
 [See if you qualify for disability benefits due to conditions related to Agent Orange](/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/).
 <br>

--- a/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii.md
+++ b/va-gov/pages/health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii.md
@@ -2,10 +2,12 @@
 layout: page-breadcrumbs.html
 template: detail-page
 title: World War II Veterans Health Issues
-display_title: 
+display_title:
 concurrence: complete
 lastupdate: 2017-06-28
 order: 7
+aliases:
+  - /health-care/health-conditions/conditions-related-to-service-era/world-war-ii/
 relatedlinks:
   - heading: More information about your benefits
     links:
@@ -36,7 +38,7 @@ You may be at risk of illnesses or injuries caused by:
 - **[Ionizing Radiation](/disability-benefits/conditions/exposure-to-hazardous-materials/radiation-exposure/):** A type of radiation exposure from atmospheric and underground nuclear weapons tests
 - **[Occupational (job-related) hazards](http://www.publichealth.va.gov/exposures/categories/occupational-hazards.asp):** Chemicals, paints, radiation, and other hazards you may have come in contact with through your military job
 - **[Extreme cold](http://www.publichealth.va.gov/exposures/cold-injuries/index.asp):** Health problems (like skin cancer in frostbite scars or pain, tingling, or numbness, in the fingers and toes) caused by the effects of cold climates. You’re at higher risk if you served during the Battle of the Bulge, conducted from December 1944 through January 1945 under conditions of extreme cold.
-- **[Mustard gas](/disability-benefits/conditions/exposure-to-hazardous-materials/mustard-gas/):** An odorless, poisonous gas used during combat in World Wars I and II 
+- **[Mustard gas](/disability-benefits/conditions/exposure-to-hazardous-materials/mustard-gas/):** An odorless, poisonous gas used during combat in World Wars I and II
 
 </div>
 

--- a/va-gov/pages/health-care/health-needs-conditions/mental-health.md
+++ b/va-gov/pages/health-care/health-needs-conditions/mental-health.md
@@ -3,11 +3,13 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: VA Mental Health Services
 display_title:
-description: Find out if you qualify for VA benefits for mental health, or how to get care for certain mental health conditions if you don't have VA health care.   
+description: Find out if you qualify for VA benefits for mental health, or how to get care for certain mental health conditions if you don't have VA health care.
 concurrence: complete
 lastupdate: 2017-06-28
 order: 2
 children: healthCareMentalHealth
+aliases:
+  - /health-care/health-conditions/mental-health/
 ---
 
 <div class="va-introtext">
@@ -23,13 +25,13 @@ If you qualify for VA health care, you can get high-quality mental health servic
 	<div id="crisis-expander-content" class="expander-content expander-content-closed">
 	  <div class="expander-content-inner usa-alert-text">
 	    <p>Whatever you’re struggling with—chronic pain, anxiety, depression, trouble sleeping, anger, or even homelessness—we can support you. Our Veterans Crisis Line is confidential (private), free, and available 24/7.</p>
-	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>	  
+	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>
 	    <ul>
               <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
 	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
   	      <li>Text <a href="sms:838255">838255</a>.</li>
             </ul>
-     	    <p><strong>You can also:</strong></p>	  
+     	    <p><strong>You can also:</strong></p>
             <ul>
               <li>Call <a href="tel:911">911</a>.</li>
 	      <li>Go to the nearest emergency room.</li>

--- a/va-gov/pages/health-care/health-needs-conditions/mental-health/depression.md
+++ b/va-gov/pages/health-care/health-needs-conditions/mental-health/depression.md
@@ -6,6 +6,8 @@ display_title:
 concurrence: complete
 lastupdate: 2017-06-28
 order: 2
+aliases:
+  - /health-care/health-conditions/mental-health/depression/
 relatedlinks:
   - heading: Related health problems you may want to learn about
     links:
@@ -36,13 +38,13 @@ Depression is a serious illness, but this common mental health problem is also h
 	<div id="crisis-expander-content" class="expander-content expander-content-closed">
 	  <div class="expander-content-inner usa-alert-text">
 	    <p>Whatever you’re struggling with—chronic pain, anxiety, depression, trouble sleeping, anger, or even homelessness—we can support you. Our Veterans Crisis Line is confidential (private), free, and available 24/7.</p>
-	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>	  
+	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>
 	    <ul>
               <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
 	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
   	      <li>Text <a href="sms:838255">838255</a>.</li>
             </ul>
-     	    <p><strong>You can also:</strong></p>	  
+     	    <p><strong>You can also:</strong></p>
             <ul>
               <li>Call <a href="tel:911">911</a>.</li>
 	      <li>Go to the nearest emergency room.</li>

--- a/va-gov/pages/health-care/health-needs-conditions/mental-health/ptsd.md
+++ b/va-gov/pages/health-care/health-needs-conditions/mental-health/ptsd.md
@@ -7,6 +7,8 @@ description: Find out how to get VA health care benefits and services for posttr
 concurrence: complete
 lastupdate: 2017-06-28
 order: 1
+aliases:
+  - /health-care/health-conditions/mental-health/ptsd/
 relatedlinks:
   - heading: Related health problems you may want to learn about
     links:
@@ -39,13 +41,13 @@ Our National Center for PTSD is the world leader in PTSD research, education, an
 	<div id="crisis-expander-content" class="expander-content expander-content-closed">
 	  <div class="expander-content-inner usa-alert-text">
 	    <p>Whatever you’re struggling with—chronic pain, anxiety, depression, trouble sleeping, anger, or even homelessness—we can support you. Our Veterans Crisis Line is confidential (private), free, and available 24/7.</p>
-	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>	  
+	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>
 	    <ul>
               <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
 	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
   	      <li>Text <a href="sms:838255">838255</a>.</li>
             </ul>
-     	    <p><strong>You can also:</strong></p>	  
+     	    <p><strong>You can also:</strong></p>
             <ul>
               <li>Call <a href="tel:911">911</a>.</li>
 	      <li>Go to the nearest emergency room.</li>

--- a/va-gov/pages/health-care/health-needs-conditions/mental-health/suicide-prevention.md
+++ b/va-gov/pages/health-care/health-needs-conditions/mental-health/suicide-prevention.md
@@ -6,6 +6,8 @@ display_title:
 concurrence: complete
 lastupdate: 2017-06-28
 order: 3
+aliases:
+  - /health-care/health-conditions/mental-health/suicide-prevention/
 relatedlinks:
   - heading: Related health problems you may want to learn about
     links:
@@ -36,13 +38,13 @@ If you’re a Veteran in a mental health crisis and you’re thinking about hurt
 	<div id="crisis-expander-content" class="expander-content expander-content-closed">
 	  <div class="expander-content-inner usa-alert-text">
 	    <p>Whatever you’re struggling with—chronic pain, anxiety, depression, trouble sleeping, anger, or even homelessness—we can support you. Our Veterans Crisis Line is confidential (private), free, and available 24/7.</p>
-	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>	  
+	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>
 	    <ul>
               <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
 	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
   	      <li>Text <a href="sms:838255">838255</a>.</li>
             </ul>
-     	    <p><strong>You can also:</strong></p>	  
+     	    <p><strong>You can also:</strong></p>
             <ul>
               <li>Call <a href="tel:911">911</a>.</li>
 	      <li>Go to the nearest emergency room.</li>

--- a/va-gov/pages/health-care/health-needs-conditions/military-sexual-trauma.md
+++ b/va-gov/pages/health-care/health-needs-conditions/military-sexual-trauma.md
@@ -3,10 +3,12 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: Military Sexual Trauma (MST)
 display_title:
-description: If you're a Veteran who experienced military sexual trauma (MST) while serving, find out if you can get VA health care benefits and services to help you recover.  
+description: If you're a Veteran who experienced military sexual trauma (MST) while serving, find out if you can get VA health care benefits and services to help you recover.
 concurrence: complete
 lastupdate: 2017-06-28
 order: 3
+aliases:
+  - /health-care/health-conditions/military-sexual-trauma/
 relatedlinks:
   - heading: Related health problems you may want to learn about
     links:
@@ -37,13 +39,13 @@ Military sexual trauma (MST) refers to sexual assault or repeated, threatening s
 	<div id="crisis-expander-content" class="expander-content expander-content-closed">
 	  <div class="expander-content-inner usa-alert-text">
 	    <p>Whatever you’re struggling with—chronic pain, anxiety, depression, trouble sleeping, anger, or even homelessness—we can support you. Our Veterans Crisis Line is confidential (private), free, and available 24/7.</p>
-	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>	  
+	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>
 	    <ul>
               <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
 	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
   	      <li>Text <a href="sms:838255">838255</a>.</li>
             </ul>
-     	    <p><strong>You can also:</strong></p>	  
+     	    <p><strong>You can also:</strong></p>
             <ul>
               <li>Call <a href="tel:911">911</a>.</li>
 	      <li>Go to the nearest emergency room.</li>
@@ -88,7 +90,7 @@ If you’re a Veteran who has experienced MST, you can get help through VA. You 
 - **If you’re homeless or at risk of becoming homeless:**
   - Contact the National Call Center for Homeless Veterans at 1-877-4AID-VET (<a href="tel:+18774243838">1-877-424-3838</a>) for help 24 hours a day, 7 days a week. A trained VA counselor will offer information about VA homeless programs, health care, and other services in your area. The call is free and confidential.
   - Visit our website to learn about VA programs for Veterans who are homeless.<br>
-  [Learn about our homelessness programs](https://www.va.gov/homeless/).  
+  [Learn about our homelessness programs](https://www.va.gov/homeless/).
   - Call or visit your local VA Community Resource and Referral Center. Even if you don’t qualify for VA health care, our staff can help you find non-VA resources you may qualify for in your community. <br>
   [Find your local Community Resource and Referral Center]( https://www.va.gov/HOMELESS/Crrc.asp).
 
@@ -124,9 +126,9 @@ Or get help applying for disability compensation by:
 [Watch the video](https://www.youtube.com/watch?v=b9snig5gZfk).
 - Access more fact sheets, articles, and resources, and learn more about our programs and services on the VA.gov website.<br>
 [Go to the VA.gov MST website](https://www.mentalhealth.va.gov/msthome.asp).
-- Go to our Make the Connection website to hear stories from Veterans about their own experiences with the effects of MST, and find more resources and support.<br> 
+- Go to our Make the Connection website to hear stories from Veterans about their own experiences with the effects of MST, and find more resources and support.<br>
 [Visit Make the Connection](https://maketheconnection.net/).
-- Go to the Department of Defense (DoD) Safe Helpline website, a crisis support service for members of the DOD community affected by sexual assault. When you contact the Safe Helpline, you can remain anonymous (meaning you don’t have to give your name). You can get 1-on-1 advice, support, and information 24/7—by phone, text, or online chat. You can also connect with a sexual assault response coordinator near your base or installation.<br> 
+- Go to the Department of Defense (DoD) Safe Helpline website, a crisis support service for members of the DOD community affected by sexual assault. When you contact the Safe Helpline, you can remain anonymous (meaning you don’t have to give your name). You can get 1-on-1 advice, support, and information 24/7—by phone, text, or online chat. You can also connect with a sexual assault response coordinator near your base or installation.<br>
 [Visit SafeHelpline.org](https://www.safehelpline.org/).
 
 <script type="text/javascript">

--- a/va-gov/pages/health-care/health-needs-conditions/substance-use-problems.md
+++ b/va-gov/pages/health-care/health-needs-conditions/substance-use-problems.md
@@ -6,6 +6,8 @@ display_title:
 concurrence: complete
 lastupdate: 2017-06-28
 order: 6
+aliases:
+  - /health-care/health-conditions/substance-use-problems
 relatedlinks:
   - heading: Related health problems you may want to learn about
     links:
@@ -33,13 +35,13 @@ If you’re struggling with substance use problems, you’re not alone. Many Vet
 	<div id="crisis-expander-content" class="expander-content expander-content-closed">
 	  <div class="expander-content-inner usa-alert-text">
 	    <p>Whatever you’re struggling with—chronic pain, anxiety, depression, trouble sleeping, anger, or even homelessness—we can support you. Our Veterans Crisis Line is confidential (private), free, and available 24/7.</p>
-	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>	  
+	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>
 	    <ul>
               <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
 	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
   	      <li>Text <a href="sms:838255">838255</a>.</li>
             </ul>
-     	    <p><strong>You can also:</strong></p>	  
+     	    <p><strong>You can also:</strong></p>
             <ul>
               <li>Call <a href="tel:911">911</a>.</li>
 	      <li>Go to the nearest emergency room.</li>

--- a/va-gov/pages/health-care/health-needs-conditions/womens-health-needs.md
+++ b/va-gov/pages/health-care/health-needs-conditions/womens-health-needs.md
@@ -6,6 +6,8 @@ display_title: Women’s Health Care
 concurrence: complete
 lastupdate: 2017-06-28
 order: 4
+aliases:
+  - /health-care/health-conditions/womens-health-care-needs/
 relatedlinks:
   - heading: More information about your benefits
     links:

--- a/va-gov/pages/health-care/how-to-apply.md
+++ b/va-gov/pages/health-care/how-to-apply.md
@@ -8,6 +8,8 @@ lastupdate: 2017-08-28
 collection: healthCare
 order: 3
 description: Find out what documents you'll need to apply for VA health care benefits. Apply online for VA health care benefits today.
+aliases:
+  - /health-care/apply
 widgets:
   - root: react-applicationStatus
     timeout: 20
@@ -45,7 +47,7 @@ Find out how to apply for VA health care benefits as a Veteran or Servicemember.
 
 </div>
 </div>
-</div> 
+</div>
 
 <div itemprop="steps" itemscope itemtype ="http://schema.org/HowToSection">
 <div id="react-applicationStatus" class="static-page-widget">
@@ -84,7 +86,7 @@ Or get help through your state's Department of Veterans Affairs. <br>
 
 ##### With the help of a trained professional
 
-You can work with a trained professional called an accredited representative to get help applying for health care benefits. <br> 
+You can work with a trained professional called an accredited representative to get help applying for health care benefits. <br>
 [Get help filing your claim](/disability-benefits/apply/help/index.html).
 
 </div>

--- a/va-gov/pages/health-care/refill-track-prescriptions/index.md
+++ b/va-gov/pages/health-care/refill-track-prescriptions/index.md
@@ -8,6 +8,8 @@ concurrence:
 lastupdate: 2018-08-22
 collection: healthCare
 order: 6
+aliases:
+  - /health-care/prescriptions
 children:
 ---
 <div itemscope itemtype="http://schema.org/FAQPage">

--- a/va-gov/pages/health-care/schedule-view-va-appointments.md
+++ b/va-gov/pages/health-care/schedule-view-va-appointments.md
@@ -6,6 +6,8 @@ display_title:
 collection: healthCare
 lastupdate: 2017-10-23
 order: 8
+aliases:
+  - /health-care/schedule-an-appointment/
 relatedlinks:
   - heading: More information about your benefits
     links:
@@ -38,13 +40,13 @@ If you're a Veteran with VA health care benefits, you can make health care appoi
     <div id="crisis-expander-content" class="expander-content expander-content-closed">
       <div class="expander-content-inner usa-alert-text">
         <p>Whatever you’re struggling with—chronic pain, anxiety, depression, trouble sleeping, anger, or even homelessness—we can support you. Our Veterans Crisis Line is confidential (private), free, and available 24/7.</p>
-        <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>      
+        <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>
         <ul>
              <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
           <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
            <li>Text <a href="sms:838255">838255</a>.</li>
            </ul>
-            <p><strong>You can also:</strong></p>      
+            <p><strong>You can also:</strong></p>
            <ul>
              <li>Call <a href="tel:911">911</a>.</li>
           <li>Go to the nearest emergency room.</li>

--- a/va-gov/pages/health-care/secure-messaging/index.md
+++ b/va-gov/pages/health-care/secure-messaging/index.md
@@ -6,4 +6,6 @@ gatePage: true
 collection: healthCare
 order: 7
 includeBreadcrumbs: true
+aliases:
+  - /health-care/messaging
 ---


### PR DESCRIPTION
## Description
This PR adds an "aliases" property to each of the health-care pages that were affected by the brand-consolidation Healthcare URL mapping. The "alias" property is set to the former location of the each page. This way, if anyone lands on the former location (from an outdated or external link), they'll be automatically redirected to the new location.

Related ticket - department-of-veterans-affairs/vets.gov-team/issues/12804