### PR TITLE
Open redux dev tools on staging

### DIFF
--- a/src/platform/startup/store.js
+++ b/src/platform/startup/store.js
@@ -36,9 +36,8 @@ export const commonReducer = {
  */
 export default function createCommonStore(appReducer = {}) {
   const reducer = Object.assign({}, appReducer, commonReducer);
-  const useDevTools = __BUILDTYPE__ === 'development' && window.__REDUX_DEVTOOLS_EXTENSION__;
+  const useDevTools = __BUILDTYPE__ !== 'production' && window.__REDUX_DEVTOOLS_EXTENSION__;
 
   return createStore(combineReducers(reducer), compose(
     applyMiddleware(thunk), useDevTools ? window.__REDUX_DEVTOOLS_EXTENSION__() : f => f));
 }
-


### PR DESCRIPTION
## Description
Just like it says on the tin, the idea here is to open the redux dev tools on staging as well as development. Because of the way our staging environment is hooked up to other VA backend environments, there have been quite a few times where the only way we can really test a thing is on staging. Having the redux dev tools available is helpful when this happens.

## Testing done
Not much to say here: I fired it up locally and ran to make sure the dev tools were still open. Nothing broke. :man_shrugging:
