### PR TITLE
add better validation messages to address page

### DIFF
--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -104,20 +104,32 @@ const addressUISchema = (addressType, title) => {
       'ui:title': 'Country'
     },
     addressLine1: {
-      'ui:title': 'Street address'
+      'ui:title': 'Street address',
+      'ui:errorMessages': {
+        pattern: 'Please fill in a valid address'
+      }
     },
     addressLine2: {
-      'ui:title': 'Street address (optional)'
+      'ui:title': 'Street address (optional)',
+      'ui:errorMessages': {
+        pattern: 'Please fill in a valid address'
+      }
     },
     addressLine3: {
-      'ui:title': 'Street address (optional)'
+      'ui:title': 'Street address (optional)',
+      'ui:errorMessages': {
+        pattern: 'Please fill in a valid address'
+      }
     },
     city: {
       'ui:title': 'City',
       'ui:validations': [{
         options: { addressPath: addressType },
         validator: validateMilitaryCity
-      }]
+      }],
+      'ui:errorMessages': {
+        pattern: 'Please fill in a valid city'
+      }
     },
     state: {
       'ui:title': 'State',


### PR DESCRIPTION
## Description
Updates the validation messages for the primary address to something that's easy to understand.

## Testing done
- tested locally

## Testing Plan
- test on staging

## Screenshots
<img width="543" alt="screen shot 2018-09-05 at 9 47 29 am" src="https://user-images.githubusercontent.com/24251447/45101288-c3e4ee00-b0f0-11e8-82b0-ec855200502b.png">

## Acceptance Criteria (Definition of Done)
- Error messages updated for pattern validation errors
- All address fields on primary address page have pattern validation messages that use latest copy