### PR TITLE
fix www prefix on about-va links

### DIFF
--- a/src/platform/site-wide/mega-menu/data.json
+++ b/src/platform/site-wide/mega-menu/data.json
@@ -590,31 +590,31 @@
               "links": [
                   {
                       "text": "Veterans Health Administration",
-                      "href": "https://va.gov/health/"
+                      "href": "https://www.va.gov/health/"
                   },
                   {
                       "text": "Veterans Benefits Administration",
-                      "href": "https://benefits.va.gov/benefits/"
+                      "href": "https://www.benefits.va.gov/benefits/"
                   },
                   {
                       "text": "National Cemetery Administration",
-                      "href": "https://cem.va.gov"
+                      "href": "https://www.cem.va.gov"
                   },
                   {
                       "text": "VA Leadership",
-                      "href": "https://va.gov/opa/bios/index.asp"
+                      "href": "https://www.va.gov/opa/bios/index.asp"
                   },
                   {
                       "text": "Public Affairs",
-                      "href": "https://va.gov/OPA/index.asp"
+                      "href": "https://www.va.gov/OPA/index.asp"
                   },
                   {
                       "text": "Congressional Affairs",
-                      "href": "https://va.gov/oca/index.asp"
+                      "href": "https://www.va.gov/oca/index.asp"
                   },
                   {
                       "text": "All VA Offices and Organizations",
-                      "href": "https://va.gov/landing_organizations.htm"
+                      "href": "https://www.va.gov/landing_organizations.htm"
                   }
               ]
           },
@@ -623,35 +623,35 @@
               "links": [
                   {
                       "text": "Health Research",
-                      "href": "https://research.va.gov"
+                      "href": "https://www.research.va.gov"
                   },
                   {
                       "text": "Public Health",
-                      "href": "https://publichealth.va.gov"
+                      "href": "https://www.publichealth.va.gov"
                   },
                   {
                       "text": "Veterans Choice Program",
-                      "href": "https://va.gov/COMMUNITYCARE/programs/veterans/VCP/index.asp"
+                      "href": "https://www.va.gov/COMMUNITYCARE/programs/veterans/VCP/index.asp"
                   },
                   {
                       "text": "VA Open Data",
-                      "href": "https://data.va.gov"
+                      "href": "https://www.data.va.gov"
                   },
                   {
                       "text": "Veterans Analysis and Statistics",
-                      "href": "https://va.gov/VETDATA/index.asp"
+                      "href": "https://www.va.gov/VETDATA/index.asp"
                   },
                   {
                       "text": "Appeals Modernization",
-                      "href": "https://benefits.va.gov/benefits/appeals.asp"
+                      "href": "https://www.benefits.va.gov/benefits/appeals.asp"
                   },
                   {
                       "text": "VA Center for Innovation",
-                      "href": "https://innovation.va.gov"
+                      "href": "https://www.innovation.va.gov"
                   },
                   {
                       "text": "Recovery Act",
-                      "href": "https://va.gov/recovery/"
+                      "href": "https://www.va.gov/recovery/"
                   }
               ]
           },
@@ -660,23 +660,23 @@
               "links": [
                   {
                       "text": "VA Mission, Vision, and Values",
-                      "href": "https://va.gov/ABOUT_VA/index.asp"
+                      "href": "https://www.va.gov/ABOUT_VA/index.asp"
                   },
                   {
                       "text": "History of VA",
-                      "href": "https://va.gov/about_va/vahistory.asp"
+                      "href": "https://www.va.gov/about_va/vahistory.asp"
                   },
                   {
                       "text": "VA Plans, Budget, and Performance",
-                      "href": "https://va.gov/performance/"
+                      "href": "https://www.va.gov/performance/"
                   },
                   {
                       "text": "National Cemetery History Program",
-                      "href": "https://cem.va.gov/cem/history/index.asp"
+                      "href": "https://www.cem.va.gov/cem/history/index.asp"
                   },
                   {
                       "text": "Veterans Legacy Program",
-                      "href": "https://cem.va.gov/cem/legacy/index.asp"
+                      "href": "https://www.cem.va.gov/cem/legacy/index.asp"
                   },
                   {
                       "text": "Volunteer or Donate",


### PR DESCRIPTION
## Description
Fixes issue with links in about VA submenu not having `www` prefix

## Testing done
local testing

## Testing Plan
<!-- Please explain testing planned this can include
automated testing, manual testing, cross browser testing -->

## Screenshots
<!-- Please provide screenshots of UI changes if applicable -->

## Acceptance Criteria (Definition of Done)
Links in About VA menu have www prefix

#### Unique to this PR

#### Applies to all PRs

- [x] Appropriate logging
- [x] Documentation has been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
