### PR TITLE
Brand-consolidation - add safety check into feature flag for unit tests

### DIFF
--- a/src/platform/brand-consolidation/feature-flag.js
+++ b/src/platform/brand-consolidation/feature-flag.js
@@ -4,5 +4,5 @@
  * @module platform/brand-consolidation/feature-flag
  */
 export default function isBrandConsolidationEnabled() {
-  return window.settings.brandConsolidationEnabled;
+  return window.settings && window.settings.brandConsolidationEnabled;
 }


### PR DESCRIPTION
`window.settings` doesn't exist during unit tests, so this PR adds a safety check into the feature-flag so unit tests can execute.