### PR TITLE
add new lower environment names to build configs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 import org.kohsuke.github.GitHub
 
-def envNames = ['devpreview', 'preview']
+def envNames = ['devpreview', 'preview', 'vagovdev', 'vagovstaging']
 
 def devBranch = 'master'
 def stagingBranch = 'master'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -254,6 +254,11 @@ node('vetsgov-general-purpose') {
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),
         ], wait: false
+
+        build job: 'deploys/vets-website-vagovdev', parameters: [
+          booleanParam(name: 'notify_slack', value: true),
+          stringParam(name: 'ref', value: commit),
+        ], wait: false
       }
       if (env.BRANCH_NAME == stagingBranch) {
         build job: 'deploys/vets-website-staging', parameters: [

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -34,8 +34,8 @@ const configGenerator = (options, apps) => {
     output: {
       path: `${options.destination}/generated`,
       publicPath: '/generated/',
-      filename: (['development', 'devpreview'].includes(options.buildtype)) ? '[name].entry.js' : `[name].entry.[chunkhash]-${timestamp}.js`,
-      chunkFilename: (['development', 'devpreview'].includes(options.buildtype)) ? '[name].entry.js' : `[name].entry.[chunkhash]-${timestamp}.js`
+      filename: (['development', 'devpreview', 'vagovdev'].includes(options.buildtype)) ? '[name].entry.js' : `[name].entry.[chunkhash]-${timestamp}.js`,
+      chunkFilename: (['development', 'devpreview', 'vagovdev'].includes(options.buildtype)) ? '[name].entry.js' : `[name].entry.[chunkhash]-${timestamp}.js`
     },
     module: {
       rules: [
@@ -169,13 +169,13 @@ const configGenerator = (options, apps) => {
       }),
 
       new ExtractTextPlugin({
-        filename: (['development', 'devpreview'].includes(options.buildtype)) ? '[name].css' : `[name].[contenthash]-${timestamp}.css`
+        filename: (['development', 'devpreview', 'vagovdev'].includes(options.buildtype)) ? '[name].css' : `[name].[contenthash]-${timestamp}.css`
       }),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     ],
   };
 
-  if (['production', 'staging', 'preview'].includes(options.buildtype)) {
+  if (['production', 'staging', 'preview', 'vagovstaging'].includes(options.buildtype)) {
     let sourceMap = 'https://s3-us-gov-west-1.amazonaws.com/staging.vets.gov';
     if (options.buildtype === 'production') {
       sourceMap = 'https://s3-us-gov-west-1.amazonaws.com/www.vets.gov';

--- a/script/build.js
+++ b/script/build.js
@@ -269,7 +269,7 @@ if (!BUILD_OPTIONS.watch && !(process.env.CHECK_BROKEN_LINKS === 'no')) {
   }));
 }
 
-if (BUILD_OPTIONS.buildtype !== 'development' && BUILD_OPTIONS.buildtype !== 'devpreview') {
+if (!['development', 'devpreview', 'vagovdev'].includes(BUILD_OPTIONS.buildtype)) {
 
   // In non-development modes, we add hashes to the names of asset files in order to support
   // cache busting. That is done via WebPack, but WebPack doesn't know anything about our HTML

--- a/script/options.js
+++ b/script/options.js
@@ -64,6 +64,8 @@ function applyEnvironmentOverrides(options) {
       }
       break;
 
+    case 'vagovdev':
+    case 'vagovstaging':
     case 'devpreview':
     case 'preview':
       options['brand-consolidation-enabled'] = true;

--- a/src/platform/utilities/environment/index.js
+++ b/src/platform/utilities/environment/index.js
@@ -3,6 +3,8 @@ const _Environments = {
   staging: { API_URL: 'https://staging-api.vets.gov', BASE_URL: 'https://staging.vets.gov' },
   preview: { API_URL: 'https://staging-api.vets.gov', BASE_URL: 'https://preview.va.gov' },
   devpreview: { API_URL: 'https://dev-api.vets.gov', BASE_URL: 'https://dev-preview.va.gov' },
+  vagovdev: { API_URL: 'https://dev-api.va.gov', BASE_URL: 'https://dev.va.gov' },
+  vagovstaging: { API_URL: 'https://staging-api.va.gov', BASE_URL: 'https://staging.va.gov' },
   development: { API_URL: (process.env.API_URL || 'https://dev-api.vets.gov'), BASE_URL: (process.env.BASE_URL || 'https://dev.vets.gov') },
   local: { API_URL: `http://${location.hostname}:3000`, BASE_URL: `http://${location.hostname}:3001` },
   e2e: { API_URL: `http://localhost:${process.env.API_PORT || 3000}`, BASE_URL: `http://localhost:${process.env.WEB_PORT || 3333}` }


### PR DESCRIPTION
## Description
Creates new builds for new environment names we now have available. The dev one will replace devpreview once we've been able to make the transition and staging will become the new staging to preview can move. It's a lot of envs right now as we make that transition.

ref: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12332

## Testing done
Built locally so far.

## Testing Plan
Testing builds in Jenkins, ensuring each can be built and deployed (will do so in Jenkins once corresponding PR has been reviewed).

## Screenshots
NA

## Acceptance Criteria (Definition of Done)
Jenkins can build for the new environment and pick up deployments for the dev environment automatically once branch is merged.

#### Unique to this PR


#### Applies to all PRs

- [x] Appropriate logging
- [x] Documentation has been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
