### PR TITLE
[WIP] BAH 4142 Shell page in the 526EZ flow

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -46,8 +46,8 @@ import {
   privateRecordsChoiceHelp,
   facilityDescription,
   treatmentView,
-  download4142Notice,
-  authorizationToDisclose,
+  // download4142Notice, related to authorization to disclose section below
+  // authorizationToDisclose,
   // recordReleaseWarning, // TODO: Re-enable after 4142 PDF integration
   documentDescription,
   evidenceSummaryView,
@@ -538,13 +538,13 @@ const formConfig = {
                     }
                   }
                 },
-                'view:privateRecords4142Notice': {
-                  'ui:description': download4142Notice,
-                  'ui:options': {
-                    expandUnder: 'view:uploadPrivateRecords',
-                    expandUnderCondition: 'no'
-                  }
-                },
+                // 'view:privateRecords4142Notice': {
+                //   'ui:description': download4142Notice,
+                //   'ui:options': {
+                //     expandUnder: 'view:uploadPrivateRecords',
+                //     expandUnderCondition: 'no'
+                //   }
+                // },
                 'view:privateRecordsChoiceHelp': {
                   'ui:description': privateRecordsChoiceHelp
                 }
@@ -564,11 +564,11 @@ const formConfig = {
                       type: 'string',
                       'enum': ['yes', 'no']
                     },
-                    'view:privateRecords4142Notice': {
-                      type: 'object',
-                      'ui:collapsed': true,
-                      properties: {}
-                    },
+                    // 'view:privateRecords4142Notice': {
+                    //   type: 'object',
+                    //   'ui:collapsed': true,
+                    //   properties: {}
+                    // },
                     'view:privateRecordsChoiceHelp': {
                       type: 'object',
                       properties: {}
@@ -579,9 +579,9 @@ const formConfig = {
             }
           }
         },
-        authorizationToDisclose: {
+        privateMedicalRecordFacilities: {
           title: '',
-          path: 'supporting-evidence/:index/authorization-to-disclose',
+          path: 'supporting-evidence/:index/private-medical-record-request',
           showPagePerItem: true,
           itemFilter: (item) => _.get('view:selected', item),
           arrayPath: 'disabilities',
@@ -593,7 +593,7 @@ const formConfig = {
           uiSchema: {
             disabilities: {
               items: {
-                'ui:description': authorizationToDisclose
+                'ui:title': disabilityNameTitle
               }
             }
           },
@@ -610,6 +610,39 @@ const formConfig = {
             }
           }
         },
+        // Commented out for now. Will most likely remove, but want to make sure.
+        // authorizationToDisclose: {
+        //   title: '',
+        //   path: 'supporting-evidence/:index/authorization-to-disclose',
+        //   showPagePerItem: true,
+        //   itemFilter: (item) => _.get('view:selected', item),
+        //   arrayPath: 'disabilities',
+        //   depends: (formData, index) => {
+        //     const hasRecords = _.get(`disabilities.${index}.view:selectableEvidenceTypes.view:privateMedicalRecords`, formData);
+        //     const requestsRecords = _.get(`disabilities.${index}.view:uploadPrivateRecords`, formData) === 'no';
+        //     return hasRecords && requestsRecords;
+        //   },
+        //   uiSchema: {
+        //     disabilities: {
+        //       items: {
+        //         'ui:description': authorizationToDisclose
+        //       }
+        //     }
+        //   },
+        //   schema: {
+        //     type: 'object',
+        //     properties: {
+        //       disabilities: {
+        //         type: 'array',
+        //         items: {
+        //           type: 'object',
+        //           properties: {}
+        //         }
+        //       }
+        //     }
+        //   }
+        // },
+        // Leaving this in just for a reference while building out the form.
         // TODO: Re-enable after 4142 PDF integration
         // privateMedicalRecordRelease: {
         //   title: '',

--- a/src/applications/disability-benefits/526EZ/tests/config/privateMedicalRecordFacilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/privateMedicalRecordFacilities.unit.spec.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { expect } from 'chai';
+// import sinon from 'sinon';
+import { mount } from 'enzyme';
+
+import {
+  DefinitionTester, // selectCheckbox
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import formConfig from '../../config/form.js';
+import initialData from '../schema/initialData.js';
+
+describe('Disability benefits 4142 provider medical records facility information', () => {
+  const {
+    schema,
+    uiSchema,
+    arrayPath
+  } = formConfig.chapters.supportingEvidence.pages.privateMedicalRecordFacilities;
+
+  it('should render 4142 form', () => {
+    const form = mount(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={initialData}
+        uiSchema={uiSchema}/>
+    );
+
+    // Commented out until the form is fully moved over
+    expect(form);
+    // expect(form.find('input').length).to.equal(9);
+    // expect(form.find('select').length).to.equal(6);
+  });
+
+//   it('does not submit without required info', () => {
+//     const onSubmit = sinon.spy();
+//     const form = mount(
+//       <DefinitionTester
+//         definitions={formConfig.defaultDefinitions}
+//         schema={schema}
+//         data={{
+//           privateMedicalProviders: [
+//             {
+//               privateProviderName: '',
+//               privateProviderStreetAddressLine1: '',
+//               privateProviderCity: null,
+//               privateProviderPostalCode: null,
+//               privateProviderCountry: '',
+//               privateProviderState: '',
+//             },
+//           ],
+//         }}
+//         formData={{}}
+//         onSubmit={onSubmit}
+//         uiSchema={uiSchema}/>,
+//     );
+
+//     form.find('form').simulate('submit');
+//     expect(form.find('.usa-input-error').length).to.equal(6);
+
+//     expect(onSubmit.called).to.be.false;
+//   });
+
+//   it('should submit with required info', () => {
+//     const onSubmit = sinon.spy();
+//     const form = mount(
+//       <DefinitionTester
+//         definitions={formConfig.defaultDefinitions}
+//         schema={schema}
+//         data={{
+//           privateMedicalProvider: [
+//             {
+//               privateProviderName: 'Testy',
+//               privateProviderStreetAddressLine1: '123 Nonesuch Street',
+//               privateProviderCity: 'No',
+//               privateProviderPostalCode: '29445',
+//               privateProviderCountry: 'USA',
+//               privateProviderState: 'South Carolina',
+//             },
+//           ],
+//         }}
+//         formData={{}}
+//         onSubmit={onSubmit}
+//         uiSchema={uiSchema}/>,
+//     );
+
+//     form.find('form').simulate('submit');
+//     expect(form.find('.usa-input-error').length).to.equal(0);
+
+//     expect(onSubmit.called).to.be.true;
+//   });
+});


### PR DESCRIPTION
## Description
This PR creates the initial shell page for the 4142 form and includes the contention name at the top of the screen. This change ensures that the page is accessible in the 526EZ flow and that is will display for each contention with the correct contention displayed.

## Testing done
- Manual testing
- Unit test written and ran

## Testing Plan
- Manual QA testing
- Peer manual testing
- Unit tests ran

## Screenshots
<!-- Please provide screenshots of UI changes if applicable -->

## Acceptance Criteria (Definition of Done)
- Upon choosing the no option for PMR's, the user will be taken to a new page that displays the contention name at the top of the screen
- Route reads: `supporting-evidence/:index/private-medical-record-request` where `:index` is a zero based indicator as to what contention you are adding supporting evidence for.

#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- If the user does not select no, then the user will not be taken to this screen.

#### Applies to all PRs

- [ ] Appropriate logging
- [ ] Documentation has been updated, if applicable
- [ ] Provide link to originating GitHub issue, or connected to it via ZenHub
- [ ] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)

ZenHub Issue: https://app.zenhub.com/workspace/o/department-of-veterans-affairs/vets.gov-team/issues/12853
