### PR TITLE
Brand consolidation - Append success_relay query param into login-url API request

### DIFF
--- a/src/platform/brand-consolidation/index.js
+++ b/src/platform/brand-consolidation/index.js
@@ -1,0 +1,23 @@
+import isBrandConsolidationEnabled from './feature-flag';
+
+export const DEV_PREVIEW_VA_DOMAIN = 'dev-preview.va.gov';
+export const PREVIEW_VA_DOMAIN = 'preview.va.gov';
+export const PRODUCTION_VA_DOMAIN = 'www.va.gov';
+
+export default {
+  isEnabled() {
+    return isBrandConsolidationEnabled();
+  },
+
+  isDevPreview() {
+    return document.location.hostname === DEV_PREVIEW_VA_DOMAIN;
+  },
+
+  isPreview() {
+    return document.location.hostname === PREVIEW_VA_DOMAIN;
+  },
+
+  isProduction() {
+    return document.location.hostname === PRODUCTION_VA_DOMAIN;
+  }
+};

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -5,8 +5,19 @@ import recordEvent from '../../monitoring/record-event';
 import { apiRequest } from '../../utilities/api';
 import environment from '../../utilities/environment';
 
+import brandConsolidation from '../../brand-consolidation';
+
+let successRelay = 'vetsgov';
+if (brandConsolidation.isEnabled()) {
+  if (brandConsolidation.isPreview()) {
+    successRelay = 'preview_vagov';
+  } else {
+    successRelay = 'vagov';
+  }
+}
+
 const SESSIONS_URI = `${environment.API_URL}/sessions`;
-const redirectUrl = (type) => `${SESSIONS_URI}/${type}/new`;
+const redirectUrl = (type) => `${SESSIONS_URI}/${type}/new?success_relay=${successRelay}`;
 
 const MHV_URL = redirectUrl('mhv');
 const DSLOGON_URL = redirectUrl('dslogon');


### PR DESCRIPTION
## Description
In order for the API to enable login on VA domains, we have to include an extra parameter in the request for login URL to indicate the callback domain - preview.va.gov, *.va.gov, and vets.gov.

We should also open a PR to master containing the same changes as contained in this PR.

Connects to department-of-veterans-affairs/vets.gov-team/issues/12757
Corresponding API info - Further context - department-of-veterans-affairs/vets-api/pull/2252