### PR TITLE
Add label above the manual school input checkbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^1.4.10",
+    "@department-of-veterans-affairs/formation": "^1.4.11",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "blob-polyfill": "^2.0.20171115",

--- a/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx
+++ b/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx
@@ -269,7 +269,7 @@ export class SchoolSelectField extends React.Component {
           <ErrorableCheckbox
             checked={manualSchoolEntryChecked}
             onValueChange={() => this.handleManualSchoolEntryToggled(manualSchoolEntryChecked)}
-            label={<span>I want to type in my school's name and address.</span>}/>
+            label={<span>I want to type in my school’s name and address.</span>}/>
           <div
             aria-live="polite"
             aria-relevant="additions text">

--- a/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx
+++ b/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx
@@ -269,7 +269,7 @@ export class SchoolSelectField extends React.Component {
           <ErrorableCheckbox
             checked={manualSchoolEntryChecked}
             onValueChange={() => this.handleManualSchoolEntryToggled(manualSchoolEntryChecked)}
-            label={<span>Check the box to manually type in your school's name and address</span>}/>
+            label={<span>I want to type in my school's name and address.</span>}/>
           <div
             aria-live="polite"
             aria-relevant="additions text">

--- a/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx
+++ b/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx
@@ -269,6 +269,7 @@ export class SchoolSelectField extends React.Component {
           <ErrorableCheckbox
             checked={manualSchoolEntryChecked}
             onValueChange={() => this.handleManualSchoolEntryToggled(manualSchoolEntryChecked)}
+            labelAboveCheckbox="If you don’t find your school in the search results, then check the box to enter in your school information manually."
             label={<span>I want to type in my school’s name and address.</span>}/>
           <div
             aria-live="polite"


### PR DESCRIPTION
## Description
Using the new `labelAboveCheckbox` feature on ErrorableCheckbox to make the checkbox for informative. This PR is dependent on this Design System PR: https://github.com/department-of-veterans-affairs/design-system/pull/162 
 
## Testing done
Previewed locally with and without the label to check on style

## Testing Plan

## Screenshots
**AFTER:**
<img width="677" alt="checkbox-with-label-above" src="https://user-images.githubusercontent.com/20728956/45226024-b7889e80-b272-11e8-9293-69d635b35dd0.png">
**BEFORE:**
<img width="675" alt="checkbox-without-label-above" src="https://user-images.githubusercontent.com/20728956/45226026-b7889e80-b272-11e8-92dc-b317f332005c.png">

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [ ] Design review

#### Applies to all PRs
- [ ] Appropriate logging
- [ ] Documentation has been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [ ] Provide which alerts would indicate a problem with this functionality (if applicable)
