### PR TITLE
want to use success_relay=preview_vagov for preview & dev-preview

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -9,7 +9,7 @@ import brandConsolidation from '../../brand-consolidation';
 
 let successRelay = 'vetsgov';
 if (brandConsolidation.isEnabled()) {
-  if (brandConsolidation.isPreview()) {
+  if (brandConsolidation.isPreview() || brandConsolidation.isDevPreview()) {
     successRelay = 'preview_vagov';
   } else {
     successRelay = 'vagov';


### PR DESCRIPTION
Sorry for https://github.com/department-of-veterans-affairs/vets-website/pull/8342 , this PR actually is targeted to merge into `brand-consolidation` instead of `master` this time 😄 

A slight logic fix to make dev-preivew append the proper ?success_relay=preview_vagov when fetching the authn url.