### PR TITLE
 Fixed invisible sign-in modal close button

### DIFF
--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -1033,3 +1033,9 @@
     margin-top: 10px;
   }
 }
+
+#signin-signup-modal {
+  .fa {
+    color: inherit;
+  }
+}

--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -1026,16 +1026,16 @@
       }
     }
   }
+
+  .va-modal-close {
+    .fa {
+      color: inherit;
+    }
+  }
 }
 
 .va-sign-in-alert {
   .usa-button-primary {
     margin-top: 10px;
-  }
-}
-
-#signin-signup-modal {
-  .fa {
-    color: inherit;
   }
 }


### PR DESCRIPTION
There's a site-wide style rule that makes all Font Awesome icons white for merger.

This is too broad of a rule, and we should consider narrowing it down later, but this is to fix at least instances in modals where the close button does not appear to be visible due to its color.