### PR TITLE
Update error message on 526 form

### DIFF
--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -53,7 +53,7 @@ export default class ConfirmationPage extends React.Component {
         submissionMessage = checkLaterMessage(jobId);
         break;
       default:
-        submissionMessage = errorMessage(jobId);
+        submissionMessage = errorMessage();
     }
 
     // TODO: Verify we need this

--- a/src/applications/disability-benefits/526EZ/content/confirmation-poll.jsx
+++ b/src/applications/disability-benefits/526EZ/content/confirmation-poll.jsx
@@ -23,12 +23,10 @@ export const checkLaterMessage = (jobId) => (
   </div>
 );
 
-export const errorMessage = (jobId) => (
+export const errorMessage = () => (
   <div>
-    <p>We’re sorry. Something went wrong on our end when we tried to submit your application. For help, please call the Vets.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a>, Monday – Friday, 8:00 a.m. – 9:00 a.m. (ET).</p>
-    <strong>Confirmation number</strong>
-    <div>{jobId}</div>
-    <br/>
+    <p>We're sorry. Something went wrong on our end when we tried to submit your application. For help submitting your claim, please call VA Benefits Call Center at <a href="tel:18008271000">1-800-827-1000</a>, Monday – Friday, 8:30 a.m. – 4:30 p.m. (ET). Or, you can get in touch with your nearest Veterans Service Officer (VSO).</p>
+    <p><a href="/disability-benefits/apply/help/">Contact your nearest VSO.</a></p>
   </div>
 );
 

--- a/src/applications/disability-benefits/526EZ/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -97,7 +97,6 @@ describe('Disability Benefits 526EZ <ConfirmationPage>', () => {
     const wrapper = shallow(<ConfirmationPage {...defaultProps} submissionStatus={submissionStatuses.failed}/>);
     const text = wrapper.render().text();
     expect(text).to.not.contain('Please allow 24 hours');
-    expect(text).to.contain('Confirmation number');
-    expect(text).to.contain(defaultProps.jobId);
+    expect(text).to.contain('Something went wrong');
   });
 });


### PR DESCRIPTION
## Description
This updates the non-retryable error message text according to the linked ticket.

## Testing done
Viewed the error on the confirmation page to make sure it rendered correctly


## Screenshots
![screen shot 2018-09-07 at 3 38 08 pm](https://user-images.githubusercontent.com/634932/45239808-93e64800-b2b4-11e8-8e3b-0e7b52132349.png)

## Acceptance Criteria (Definition of Done)

#### Unique to this PR
- [x] New text is up to date

#### Applies to all PRs

- [x] Appropriate logging
- [x] Documentation has been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
