### PR TITLE
FE punchlist: Page navigation (desktop and mobile)

### DIFF
--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -888,6 +888,8 @@
   .va-sidebarnav {
     h4 {
       vertical-align: middle;
+      margin-top: 0;
+      margin-bottom: 0;
     }
 
     .usa-sidenav-list > li {


### PR DESCRIPTION
Please fix these outstanding bugs:

 - [ ] The icon and menu heading are misaligned
 - [ ] The Level O accordions should be in bolded text
 - [ ] Only one accordion should be expanded at a time (i.e., if Get Benefits is expanded and the user expands Manage Benefits, then the Get Benefits menu should collapse as the Manage Benefits menu expands)