### PR TITLE
526 add no evidence mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -59,7 +59,8 @@ import {
   queryForFacilities,
   getEvidenceTypesDescription,
   veteranInfoDescription,
-  editNote
+  editNote,
+  validateBooleanIfEvidence
 } from '../helpers';
 
 import {
@@ -342,13 +343,26 @@ const formConfig = {
             disabilities: {
               items: {
                 'ui:title': disabilityNameTitle,
+                'view:hasEvidence': {
+                  'ui:title': 'Do you have any evidence that you would like to submit with your claim?',
+                  'ui:description': '',
+                  'ui:widget': 'yesNo',
+                },
                 'view:selectableEvidenceTypes': {
                   'ui:options': {
                     // Only way to get access to the disability info like 'name' within this nested schema
                     updateSchema: (form, schema, uiSchema, index) => ({ title: getEvidenceTypesDescription(form, index) }),
-                    showFieldLabel: true
+                    showFieldLabel: true,
+                    hideIf: (formData, index) => {
+                      return !_.get(`disabilities[${index}].view:hasEvidence`, formData, true);
+                    }
                   },
-                  'ui:validations': [validateBooleanGroup],
+                  'ui:validations': [{
+                    validator: validateBooleanIfEvidence,
+                    options: {
+                      wrappedValidator: validateBooleanGroup
+                    }
+                  }],
                   'ui:errorMessages': {
                     atLeastOne: 'Please select at least one type of supporting evidence'
                   },
@@ -361,9 +375,6 @@ const formConfig = {
                   'view:otherEvidence': {
                     'ui:title': 'Lay statements or other evidence'
                   },
-                  'view:noEvidence': {
-                    'ui:title': 'I don’t have any evidence, but I still want to submit a claim.'
-                  }
                 },
                 'view:evidenceTypeHelp': {
                   'ui:description': evidenceTypeHelp
@@ -379,6 +390,10 @@ const formConfig = {
                 items: {
                   type: 'object',
                   properties: {
+                    'view:hasEvidence': {
+                      type: 'boolean',
+                      'default': true
+                    },
                     'view:selectableEvidenceTypes': {
                       type: 'object',
                       properties: {
@@ -389,9 +404,6 @@ const formConfig = {
                           type: 'boolean'
                         },
                         'view:otherEvidence': {
-                          type: 'boolean'
-                        },
-                        'view:noEvidence': {
                           type: 'boolean'
                         }
                       }
@@ -853,7 +865,7 @@ const formConfig = {
           title: 'Summary of evidence',
           path: 'supporting-evidence/:index/evidence-summary',
           showPagePerItem: true,
-          itemFilter: (item) => _.get('view:selected', item),
+          itemFilter: (item) => (_.get('view:hasEvidence', item) && _.get('view:selected', item)),
           arrayPath: 'disabilities',
           uiSchema: {
             disabilities: {

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -360,6 +360,9 @@ const formConfig = {
                   },
                   'view:otherEvidence': {
                     'ui:title': 'Lay statements or other evidence'
+                  },
+                  'view:noEvidence': {
+                    'ui:title': 'I don’t have any evidence, but I still want to submit a claim.'
                   }
                 },
                 'view:evidenceTypeHelp': {
@@ -386,6 +389,9 @@ const formConfig = {
                           type: 'boolean'
                         },
                         'view:otherEvidence': {
+                          type: 'boolean'
+                        },
+                        'view:noEvidence': {
                           type: 'boolean'
                         }
                       }

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -516,6 +516,12 @@ const listDocuments = (documents) => {
 
 
 export const evidenceSummaryView = ({ formData }) => {
+  if (formData['view:selectableEvidenceTypes']['view:noEvidence']) {
+    return (
+      <p>You chose to not include any evidence with your claim.</p>
+    );
+  }
+
   const {
     treatments,
     privateRecordReleases,

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -516,11 +516,6 @@ const listDocuments = (documents) => {
 
 
 export const evidenceSummaryView = ({ formData }) => {
-  if (formData['view:selectableEvidenceTypes']['view:noEvidence']) {
-    return (
-      <p>You chose to not include any evidence with your claim.</p>
-    );
-  }
 
   const {
     treatments,
@@ -876,3 +871,10 @@ export const PaymentDescription = () => (
     disability benefit to this account.
   </p>
 );
+
+export const validateBooleanIfEvidence = (errors, fieldData, formData, schema, messages, options, index) => {
+  const { wrappedValidator } = options;
+  if (get('view:hasEvidence', formData, true)) {
+    wrappedValidator(errors, fieldData, formData, schema, messages, index);
+  }
+};

--- a/src/applications/disability-benefits/526EZ/tests/config/evidenceType.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/evidenceType.unit.spec.jsx
@@ -22,7 +22,7 @@ describe('Disability benefits 526EZ evidence type', () => {
       uiSchema={uiSchema}/>
     );
 
-    expect(form.find('input').length).to.equal(3);
+    expect(form.find('input').length).to.equal(5);
   });
 
   it('should fill in evidence type information', () => {


### PR DESCRIPTION
## Description
- Adds a qualifying question to the evidence types screen to allow veterans to not submit any evidence with their 526 submission.
- Only requires an evidence type be selected if the user selected that they have evidence they would like to submit
- Skips the 'evidence summary' page when veteran indicates that they don't have any evidence on the preceding page

## Testing done
Went through all the flows locally

## Testing Plan
Test out on staging

## Screenshots
Default view when user hits this page:
![screen shot 2018-09-10 at 2 29 18 pm](https://user-images.githubusercontent.com/24251447/45320039-1fefae00-b507-11e8-8093-2c1b6a283f8e.png)

View if user selects 'no':
![screen shot 2018-09-10 at 2 29 29 pm](https://user-images.githubusercontent.com/24251447/45320057-3138ba80-b507-11e8-9b40-8361ae249189.png)



## Acceptance Criteria (Definition of Done)

#### Unique to this PR
This may change once we remove looping from the form flow.