### PR TITLE
add online learning and distance learning filters

### DIFF
--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -128,6 +128,16 @@ class InstitutionFilterForm extends React.Component {
           name="independentStudy"
           label="Independent Study"
           onChange={this.handleCheckboxChange}/>
+        {__BUILDTYPE__ !== 'production' && <Checkbox
+          checked={filters.onlineOnly}
+          name="onlineOnly"
+          label="Online Only"
+          onChange={this.handleCheckboxChange}/>}
+        {__BUILDTYPE__ !== 'production' && <Checkbox
+          checked={filters.distanceLearning}
+          name="distanceLearning"
+          label="Distance Learning"
+          onChange={this.handleCheckboxChange}/>}
       </div>
     );
   }
@@ -171,6 +181,7 @@ class InstitutionFilterForm extends React.Component {
 InstitutionFilterForm.propTypes = {
   filters: PropTypes.shape({
     category: PropTypes.string,
+    distanceLearning: PropTypes.bool,
     type: PropTypes.string,
     country: PropTypes.string,
     priorityEnrollment: PropTypes.bool,
@@ -178,6 +189,7 @@ InstitutionFilterForm.propTypes = {
     state: PropTypes.string,
     studentVetGroup: PropTypes.bool,
     yellowRibbonScholarship: PropTypes.bool,
+    onlineLearning: PropTypes.bool,
     principlesOfExcellence: PropTypes.bool,
     eightKeysToVeteranSuccess: PropTypes.bool,
     stemOffered: PropTypes.bool
@@ -185,6 +197,7 @@ InstitutionFilterForm.propTypes = {
   onFilterChange: PropTypes.func,
   search: PropTypes.shape({
     category: PropTypes.object,
+    distanceLearning: PropTypes.object,
     type: PropTypes.object,
     state: PropTypes.object,
     country: PropTypes.object,
@@ -192,6 +205,7 @@ InstitutionFilterForm.propTypes = {
     yellowRibbonScholarship: PropTypes.object,
     principlesOfExcellence: PropTypes.object,
     eightKeysToVeteranSuccess: PropTypes.object,
+    onlineLearning: PropTypes.bool,
     priorityEnrollment: PropTypes.object,
     independentStudy: PropTypes.object,
     stemOffered: PropTypes.object

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -63,8 +63,10 @@ export class SearchPage extends React.Component {
 
   updateSearchResults() {
     const programFilters = [
+      'distanceLearning',
       'studentVeteranGroup',
       'yellowRibbonScholarship',
+      'onlineOnly',
       'principlesOfExcellence',
       'eightKeysToVeteranSuccess',
       'stemOffered',

--- a/src/applications/gi/tests/reducers/filter.unit.spec.js
+++ b/src/applications/gi/tests/reducers/filter.unit.spec.js
@@ -25,6 +25,7 @@ describe('filter reducer', () => {
         type: 'INSTITUTION_FILTER_CHANGED',
         filter: {
           category: 'ALL',
+          distanceLearning: false,
           type: 'ALL',
           country: 'ALL',
           state: 'WA',
@@ -32,6 +33,7 @@ describe('filter reducer', () => {
           yellowRibbonScholarship: false,
           principlesOfExcellence: true,
           eightKeysToVeteranSuccess: false,
+          onlineOnly: false,
           priorityEnrollment: false,
           independentStudy: false,
           stemOffered: true,
@@ -41,11 +43,13 @@ describe('filter reducer', () => {
     );
 
     expect(state.category).to.eql('ALL');
+    expect(state.distanceLearning).to.eql(false);
     expect(state.type).to.eql('ALL');
     expect(state.country).to.eql('ALL');
     expect(state.state).to.eql('WA');
     expect(state.studentVeteranGroup).to.eql(false);
     expect(state.yellowRibbonScholarship).to.eql(false);
+    expect(state.onlineOnly).to.eql(false);
     expect(state.principlesOfExcellence).to.eql(true);
     expect(state.eightKeysToVeteranSuccess).to.eql(false);
     expect(state.independentStudy).to.eql(false);


### PR DESCRIPTION
## Description
This partially completes the associated ticket by adding two new programs to the search filters. See local example: http://localhost:3001/gi-bill-comparison-tool/search?distanceLearning=true&name=utah&onlineOnly=true



## Testing done
ran locally and verified that selecting the new filters creates an xhr request with the selected filters (see images)


## Screenshots
![screen shot 2018-09-10 at 13 53 37](https://user-images.githubusercontent.com/4998130/45320998-5aeee300-b501-11e8-8f25-f0857b7d77ae.png)
![screen shot 2018-09-10 at 13 53 42](https://user-images.githubusercontent.com/4998130/45321006-63471e00-b501-11e8-8beb-cb9a96333cb6.png)


## Acceptance Criteria (Definition of Done)
See testing done 

#### Applies to all PRs

- [x] Provide [link](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12610) to originating GitHub issue, or connected to it via ZenHub
