### PR TITLE
Medallia/Foresee - Add Metalsmith logic for determining JavaScript snippets for survey tools

### DIFF
--- a/assets/js/foresee/production.js
+++ b/assets/js/foresee/production.js
@@ -1,0 +1,14 @@
+// ForeSee Production Embed Script v2.01
+// DO NOT MODIFY BELOW THIS LINE *****************************************
+;(function (g) {
+  var d = document, am = d.createElement('script'), h = d.head || d.getElementsByTagName("head")[0], fsr = 'fsReady',
+  aex = {
+    "src": "//gateway.foresee.com/sites/vets-gov/production/gateway.min.js",
+    "type": "text/javascript",
+    "async": "true",
+    "data-vendor": "fs",
+    "data-role": "gateway"
+  };
+  for (var attr in aex) { am.setAttribute(attr, aex[attr]); } h.appendChild(am); g[fsr] || (g[fsr] = function () { var aT = '__' + fsr + '_stk__'; g[aT] = g[aT] || []; g[aT].push(arguments); });
+  })(window);
+  // DO NOT MODIFY ABOVE THIS LINE *****************************************

--- a/content/includes/footer.html
+++ b/content/includes/footer.html
@@ -99,10 +99,6 @@ visit <a href="https://www.veteranscrisisline.net/">VeteransCrisisLine.net</a> f
   {% include "content/includes/modal.html" %}
 {% endif %}
 
-{% if buildtype === 'staging' %}
-  <script src="/js/foresee/staging.js"></script>
-{% endif %}
-
 <!-- htmllint attr-bans="[]" -->
 {% if buildtype === 'development' %}
   <script>
@@ -150,9 +146,7 @@ visit <a href="https://www.veteranscrisisline.net/">VeteransCrisisLine.net</a> f
 </script>
 {% endif %}
 
-{% if buildtype !== 'production' %}
-<script type="text/javascript" src="https://resources.digital-cloud-gov.voice.medallia.com/wdcgov/2/onsite/embed.js" async></script>
-{% endif %}
+{% include "content/includes/survey-tools.html" %}
 
 </body>
 </html>

--- a/content/includes/survey-tools.html
+++ b/content/includes/survey-tools.html
@@ -1,0 +1,8 @@
+{% if buildtype === 'development' %}
+  {% assign loa3_entrynames = 'burials, claims-status, letters, post-911-gib-status, hca, health-records, messaging, rx, pensions, profile-360, claims-status' %}
+  {% if loa3_entrynames contains entryname %}
+    <script type="text/javascript" src="/js/foresee/{{ buildtype }}.js"></script>
+  {% else %}
+    <script type="text/javascript" src="https://resources.digital-cloud-gov.voice.medallia.com/wdcgov/2/onsite/embed.js" async></script>
+  {% endif %}
+{% endif %}

--- a/content/includes/survey-tools.html
+++ b/content/includes/survey-tools.html
@@ -1,4 +1,4 @@
-{% if buildtype === 'staging' %}
+{% if buildtype == 'staging' %}
   {% assign auth_required_entrynames = 'claims-status, letters, health-records, messaging, rx, profile-360' | split: ', ' %}
   {% if auth_required_entrynames contains entryname  %}
     <script type="text/javascript" src="/js/foresee/{{ buildtype }}.js"></script>

--- a/content/includes/survey-tools.html
+++ b/content/includes/survey-tools.html
@@ -1,6 +1,6 @@
 {% if buildtype === 'staging' %}
-  {% assign loa3_entrynames = 'burials, claims-status, letters, post-911-gib-status, hca, health-records, messaging, rx, pensions, profile-360, claims-status' %}
-  {% if loa3_entrynames contains entryname %}
+  {% assign loa3_entrynames = 'burials, claims-status, letters, post-911-gib-status, hca, health-records, messaging, rx, pensions, profile-360' | split: ', ' %}
+  {% if loa3_entrynames contains entryname  %}
     <script type="text/javascript" src="/js/foresee/{{ buildtype }}.js"></script>
   {% else %}
     <script type="text/javascript" src="https://resources.digital-cloud-gov.voice.medallia.com/wdcgov/2/onsite/embed.js" async></script>

--- a/content/includes/survey-tools.html
+++ b/content/includes/survey-tools.html
@@ -1,4 +1,4 @@
-{% if buildtype === 'development' %}
+{% if buildtype === 'staging' %}
   {% assign loa3_entrynames = 'burials, claims-status, letters, post-911-gib-status, hca, health-records, messaging, rx, pensions, profile-360, claims-status' %}
   {% if loa3_entrynames contains entryname %}
     <script type="text/javascript" src="/js/foresee/{{ buildtype }}.js"></script>

--- a/content/includes/survey-tools.html
+++ b/content/includes/survey-tools.html
@@ -1,6 +1,6 @@
 {% if buildtype === 'staging' %}
-  {% assign loa3_entrynames = 'claims-status, letters, health-records, messaging, rx, profile-360' | split: ', ' %}
-  {% if loa3_entrynames contains entryname  %}
+  {% assign auth_required_entrynames = 'claims-status, letters, health-records, messaging, rx, profile-360' | split: ', ' %}
+  {% if auth_required_entrynames contains entryname  %}
     <script type="text/javascript" src="/js/foresee/{{ buildtype }}.js"></script>
   {% else %}
     <script type="text/javascript" src="https://resources.digital-cloud-gov.voice.medallia.com/wdcgov/2/onsite/embed.js" async></script>

--- a/content/includes/survey-tools.html
+++ b/content/includes/survey-tools.html
@@ -1,5 +1,5 @@
 {% if buildtype === 'staging' %}
-  {% assign loa3_entrynames = 'burials, claims-status, letters, post-911-gib-status, hca, health-records, messaging, rx, pensions, profile-360' | split: ', ' %}
+  {% assign loa3_entrynames = 'claims-status, letters, health-records, messaging, rx, profile-360' | split: ', ' %}
   {% if loa3_entrynames contains entryname  %}
     <script type="text/javascript" src="/js/foresee/{{ buildtype }}.js"></script>
   {% else %}


### PR DESCRIPTION
## Description
- Added the Foresee Production code 
    -  Both Foresee and Medallia are limited to Staging anyway, but I didn't want to lose the snippet.
- Added Metalsmith include for processing which survey to render based on Frontmatter `entryname` property
    - We are supposed to embed Foresee on LOA3 pages; Medallia on all others. The simplest way I could think to do that was checking the Webpack entryname.

## Testing done
Checked generated HTML on localhost to see if LOA3/non-LOA3 pages were generating Foresee or Medallia script links. 

Related ticket - department-of-veterans-affairs/vets.gov-team/issues/12914