### PR TITLE
deprecate dev preview

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 import org.kohsuke.github.GitHub
 
-def envNames = ['devpreview', 'preview', 'vagovdev', 'vagovstaging']
+def envNames = ['preview', 'vagovdev', 'vagovstaging']
 
 def devBranch = 'master'
 def stagingBranch = 'master'
@@ -250,11 +250,6 @@ node('vetsgov-general-purpose') {
         ], wait: false
       }
       if (env.BRANCH_NAME == 'brand-consolidation') {
-        build job: 'deploys/vets-website-devpreview', parameters: [
-          booleanParam(name: 'notify_slack', value: true),
-          stringParam(name: 'ref', value: commit),
-        ], wait: false
-
         build job: 'deploys/vets-website-vagovdev', parameters: [
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -34,8 +34,8 @@ const configGenerator = (options, apps) => {
     output: {
       path: `${options.destination}/generated`,
       publicPath: '/generated/',
-      filename: (['development', 'devpreview', 'vagovdev'].includes(options.buildtype)) ? '[name].entry.js' : `[name].entry.[chunkhash]-${timestamp}.js`,
-      chunkFilename: (['development', 'devpreview', 'vagovdev'].includes(options.buildtype)) ? '[name].entry.js' : `[name].entry.[chunkhash]-${timestamp}.js`
+      filename: (['development', 'vagovdev'].includes(options.buildtype)) ? '[name].entry.js' : `[name].entry.[chunkhash]-${timestamp}.js`,
+      chunkFilename: (['development', 'vagovdev'].includes(options.buildtype)) ? '[name].entry.js' : `[name].entry.[chunkhash]-${timestamp}.js`
     },
     module: {
       rules: [
@@ -169,7 +169,7 @@ const configGenerator = (options, apps) => {
       }),
 
       new ExtractTextPlugin({
-        filename: (['development', 'devpreview', 'vagovdev'].includes(options.buildtype)) ? '[name].css' : `[name].[contenthash]-${timestamp}.css`
+        filename: (['development', 'vagovdev'].includes(options.buildtype)) ? '[name].css' : `[name].[contenthash]-${timestamp}.css`
       }),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     ],

--- a/script/build.js
+++ b/script/build.js
@@ -276,7 +276,7 @@ if (!BUILD_OPTIONS.watch && !(process.env.CHECK_BROKEN_LINKS === 'no')) {
   }));
 }
 
-if (!['development', 'devpreview', 'vagovdev'].includes(BUILD_OPTIONS.buildtype)) {
+if (!['development', 'vagovdev'].includes(BUILD_OPTIONS.buildtype)) {
 
   // In non-development modes, we add hashes to the names of asset files in order to support
   // cache busting. That is done via WebPack, but WebPack doesn't know anything about our HTML

--- a/script/heroku-helper.js
+++ b/script/heroku-helper.js
@@ -26,9 +26,9 @@ function applyHerokuOptions(options) {
 
     if (/^va-gov\/.*/.test(branchName)) {
       // eslint-disable-next-line no-console
-      console.log('Build type set to devpreview due to branch name');
+      console.log('Build type set to vagovdev due to branch name');
       // eslint-disable-next-line no-param-reassign
-      options.buildtype = 'devpreview';
+      options.buildtype = 'vagovdev';
     }
   } catch (err) {
     // eslint-disable-next-line no-console

--- a/script/options.js
+++ b/script/options.js
@@ -66,7 +66,6 @@ function applyEnvironmentOverrides(options) {
 
     case 'vagovdev':
     case 'vagovstaging':
-    case 'devpreview':
     case 'preview':
       options['brand-consolidation-enabled'] = true;
       break;

--- a/src/applications/static-pages/createCallToActionWidget.js
+++ b/src/applications/static-pages/createCallToActionWidget.js
@@ -3,7 +3,6 @@ import conditionalStorage from '../../platform/utilities/storage/conditionalStor
 const lowerEnvironments = [
   'development',
   'staging',
-  'dev-preview',
   'preview',
   'vagovdev',
   'vagovstaging'

--- a/src/platform/brand-consolidation/index.js
+++ b/src/platform/brand-consolidation/index.js
@@ -1,16 +1,11 @@
 import isBrandConsolidationEnabled from './feature-flag';
 
-export const DEV_PREVIEW_VA_DOMAIN = 'dev-preview.va.gov';
 export const PREVIEW_VA_DOMAIN = 'preview.va.gov';
 export const PRODUCTION_VA_DOMAIN = 'www.va.gov';
 
 export default {
   isEnabled() {
     return isBrandConsolidationEnabled();
-  },
-
-  isDevPreview() {
-    return document.location.hostname === DEV_PREVIEW_VA_DOMAIN;
   },
 
   isPreview() {

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -9,7 +9,7 @@ import brandConsolidation from '../../brand-consolidation';
 
 let successRelay = 'vetsgov';
 if (brandConsolidation.isEnabled()) {
-  if (brandConsolidation.isPreview() || brandConsolidation.isDevPreview()) {
+  if (brandConsolidation.isPreview()) {
     successRelay = 'preview_vagov';
   } else {
     successRelay = 'vagov';

--- a/src/platform/utilities/environment/index.js
+++ b/src/platform/utilities/environment/index.js
@@ -2,7 +2,6 @@ const _Environments = {
   production: { API_URL: 'https://api.vets.gov', BASE_URL: 'https://www.vets.gov' },
   staging: { API_URL: 'https://staging-api.vets.gov', BASE_URL: 'https://staging.vets.gov' },
   preview: { API_URL: 'https://staging-api.vets.gov', BASE_URL: 'https://preview.va.gov' },
-  devpreview: { API_URL: 'https://dev-api.vets.gov', BASE_URL: 'https://dev-preview.va.gov' },
   vagovdev: { API_URL: 'https://dev-api.va.gov', BASE_URL: 'https://dev.va.gov' },
   vagovstaging: { API_URL: 'https://staging-api.va.gov', BASE_URL: 'https://staging.va.gov' },
   development: { API_URL: (process.env.API_URL || 'https://dev-api.vets.gov'), BASE_URL: (process.env.BASE_URL || 'https://dev.vets.gov') },


### PR DESCRIPTION
## Description
Remove configuration as we deprecate the dev-preview hostname.

ref: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12978

## Testing done

## Testing Plan
- [x] test Heroku builds in a separate branch (for the branch name related build configs)

## Acceptance Criteria (Definition of Done)
No more references or extra builds for dev-preview.va.gov

#### Applies to all PRs

- [x] Appropriate logging
- [x] Documentation has been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
