### PR TITLE
Port search.gov from vets.gov to preview.va.gov

### DIFF
--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -12,8 +12,10 @@ class SearchMenu extends React.Component {
     super(props);
     this.makeForm = this.makeForm.bind(this);
     this.toggleSearchForm = this.toggleSearchForm.bind(this);
-    this.searchAction = isBrandConsolidationEnabled() ? 'https://search.usa.gov/search' : 'https://search.vets.gov/search';
-    this.searchAffiliate = isBrandConsolidationEnabled() ? 'va' : 'vets.gov_search';
+    this.state = {
+      searchAction: isBrandConsolidationEnabled() ? 'https://search.usa.gov/search' : 'https://search.vets.gov/search',
+      searchAffiliate: isBrandConsolidationEnabled() ? 'va' : 'vets.gov_search'
+    };
   }
 
   componentDidUpdate() {
@@ -28,13 +30,13 @@ class SearchMenu extends React.Component {
     return (
       <form
         acceptCharset="UTF-8"
-        action={this.searchAction}
+        action={this.state.searchAction}
         id="search"
         method="get">
         <div className="csp-inline-patch-header">
           <input name="utf8" type="hidden" value="&#x2713;"/>
         </div>
-        <input id="affiliate" name="affiliate" type="hidden" value={this.searchAffiliate}/>
+        <input id="affiliate" name="affiliate" type="hidden" value={this.state.searchAffiliate}/>
         <label htmlFor="query" className="usa-sr-only">Search:</label>
 
         <div className="va-flex">

--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -12,6 +12,8 @@ class SearchMenu extends React.Component {
     super(props);
     this.makeForm = this.makeForm.bind(this);
     this.toggleSearchForm = this.toggleSearchForm.bind(this);
+    this.searchAction = isBrandConsolidationEnabled() ? 'https://search.usa.gov/search' : 'https://search.vets.gov/search';
+    this.searchAffiliate = isBrandConsolidationEnabled() ? 'va' : 'vets.gov_search';
   }
 
   componentDidUpdate() {
@@ -22,17 +24,17 @@ class SearchMenu extends React.Component {
     this.props.clickHandler();
   }
 
-  makeForm(action, affiliate) {
+  makeForm() {
     return (
       <form
         acceptCharset="UTF-8"
-        action={action}
+        action={this.searchAction}
         id="search"
         method="get">
         <div className="csp-inline-patch-header">
           <input name="utf8" type="hidden" value="&#x2713;"/>
         </div>
-        <input id="affiliate" name="affiliate" type="hidden" value={affiliate}/>
+        <input id="affiliate" name="affiliate" type="hidden" value={this.searchAffiliate}/>
         <label htmlFor="query" className="usa-sr-only">Search:</label>
 
         <div className="va-flex">
@@ -54,9 +56,6 @@ class SearchMenu extends React.Component {
 
     const icon = <IconSearch color="#fff"/>;
 
-    const searchAction = isBrandConsolidationEnabled() ? 'https://search.usa.gov/search' : 'https://search.vets.gov/search';
-    const searchAffiliate = isBrandConsolidationEnabled() ? 'va' : 'vets.gov_search';
-
     return (
       <DropDownPanel
         buttonText="Search"
@@ -65,7 +64,7 @@ class SearchMenu extends React.Component {
         id="searchmenu"
         icon={icon}
         isOpen={this.props.isOpen}>
-        {this.makeForm(searchAction, searchAffiliate)}
+        {this.makeForm()}
       </DropDownPanel>
     );
   }

--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -4,6 +4,8 @@ import classNames from 'classnames';
 
 import IconSearch from '@department-of-veterans-affairs/formation/IconSearch';
 import DropDownPanel from '@department-of-veterans-affairs/formation/DropDownPanel';
+import isBrandConsolidationEnabled from '../../../brand-consolidation/feature-flag';
+
 
 class SearchMenu extends React.Component {
   constructor(props) {
@@ -20,17 +22,17 @@ class SearchMenu extends React.Component {
     this.props.clickHandler();
   }
 
-  makeForm() {
+  makeForm(action, affiliate) {
     return (
       <form
         acceptCharset="UTF-8"
-        action="https://search.vets.gov/search"
+        action={action}
         id="search"
         method="get">
         <div className="csp-inline-patch-header">
           <input name="utf8" type="hidden" value="&#x2713;"/>
         </div>
-        <input id="affiliate" name="affiliate" type="hidden" value="vets.gov_search"/>
+        <input id="affiliate" name="affiliate" type="hidden" value={affiliate}/>
         <label htmlFor="query" className="usa-sr-only">Search:</label>
 
         <div className="va-flex">
@@ -52,6 +54,9 @@ class SearchMenu extends React.Component {
 
     const icon = <IconSearch color="#fff"/>;
 
+    const searchAction = isBrandConsolidationEnabled() ? 'https://search.usa.gov/search' : 'https://search.vets.gov/search';
+    const searchAffiliate = isBrandConsolidationEnabled() ? 'va' : 'vets.gov_search';
+
     return (
       <DropDownPanel
         buttonText="Search"
@@ -60,7 +65,7 @@ class SearchMenu extends React.Component {
         id="searchmenu"
         icon={icon}
         isOpen={this.props.isOpen}>
-        {this.makeForm()}
+        {this.makeForm(searchAction, searchAffiliate)}
       </DropDownPanel>
     );
   }


### PR DESCRIPTION
## Description
We want to port over the search.gov search results page for vets.gov to preview.va.gov. This PR will add conditional logic that sends the search query to the preview.va.gov branded site. 

## Testing done
Manually tested locally that these changes work as expected. 

## Acceptance Criteria (Definition of Done)
#### Unique to this PR
<!-- This would be a good place to include feature flag check item and info, specific dashboards and instrumentation check item and info -->
- [x] Search action sends user to search.vets.gov if on vets.gov, or search.usa.gov if on preview.va.gov
- [x] Update URL with as-of-yet undecided subdomain. 

#### Applies to all PRs

- [x] Appropriate logging
- [x] Documentation has been updated, if applicable
- [x] Provide link to originating GitHub issue, or connected to it via ZenHub
- [x] Does not contain any sensitive information (i.e. PII/credentials/internal URLs/etc., in logging, hardcoded, or in specs)
- [x] Provide which alerts would indicate a problem with this functionality (if applicable)
