### PR TITLE
Remove temporary prefill available logic

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/FormStartControls.jsx
+++ b/src/applications/disability-benefits/526EZ/components/FormStartControls.jsx
@@ -21,7 +21,6 @@ export default function FormStartControls(props) {
       {user.profile.verified && <SaveInProgressIntro
         {...props}
         buttonOnly={props.buttonOnly}
-        prefillAvailable
         verifiedPrefillAlert={VerifiedAlert}
         unverifiedPrefillAlert={UnauthenticatedAlert}
         verifyRequiredPrefill={props.route.formConfig.verifyRequiredPrefill}

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -18,7 +18,7 @@ class SaveInProgressIntro extends React.Component {
     let alert;
     const { renderSignInMessage, prefillEnabled, verifyRequiredPrefill, verifiedPrefillAlert, unverifiedPrefillAlert } = this.props;
     const { profile, login } = this.props.user;
-    const prefillAvailable = this.props.prefillAvailable || !!(profile && profile.prefillsAvailable.includes(this.props.formId)); // TODO: remove first clause once 526 added to list
+    const prefillAvailable = !!(profile && profile.prefillsAvailable.includes(this.props.formId));
     if (login.currentlyLoggedIn) {
       if (savedForm) {
         const savedAt = this.props.lastSavedDate


### PR DESCRIPTION
## Description
These changes remove temporary prefill logic from the SaveInProgressIntroduction component, as the 526 form is now included in the prefillsAvailable list.

## Acceptance criteria
- [x] Removes temporary logic from SaveInProgressIntroduction
- [x] Removes obsolete configuration in FormStartControls

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
