### PR TITLE
Add titles for 526 evidence pages

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -332,7 +332,7 @@ const formConfig = {
           }
         },
         evidenceType: {
-          title: (formData, { pagePerItemIndex }) => _.get(`disabilities.${pagePerItemIndex}.name`, formData),
+          title: (formData) => `${formData.name} supporting evidence`,
           path: 'supporting-evidence/:index/evidence-type',
           showPagePerItem: true,
           itemFilter: (item) => _.get('view:selected', item),
@@ -417,7 +417,7 @@ const formConfig = {
           }
         },
         vaMedicalRecordsIntro: {
-          title: '',
+          title: 'Testing',
           path: 'supporting-evidence/:index/va-medical-records-intro',
           showPagePerItem: true,
           itemFilter: (item) => _.get('view:selected', item),
@@ -445,7 +445,7 @@ const formConfig = {
           }
         },
         vaFacilities: {
-          title: '',
+          title: 'Testing',
           path: 'supporting-evidence/:index/va-facilities',
           showPagePerItem: true,
           itemFilter: (item) => _.get('view:selected', item),
@@ -860,7 +860,7 @@ const formConfig = {
           }
         },
         evidenceSummary: {
-          title: 'Summary of evidence',
+          title: (formData) => `${formData.name} evidence summary`,
           path: 'supporting-evidence/:index/evidence-summary',
           showPagePerItem: true,
           itemFilter: (item) => (_.get('view:hasEvidence', item) && _.get('view:selected', item)),

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -417,7 +417,7 @@ const formConfig = {
           }
         },
         vaMedicalRecordsIntro: {
-          title: 'Testing',
+          title: '',
           path: 'supporting-evidence/:index/va-medical-records-intro',
           showPagePerItem: true,
           itemFilter: (item) => _.get('view:selected', item),
@@ -445,7 +445,7 @@ const formConfig = {
           }
         },
         vaFacilities: {
-          title: 'Testing',
+          title: '',
           path: 'supporting-evidence/:index/va-facilities',
           showPagePerItem: true,
           itemFilter: (item) => _.get('view:selected', item),


### PR DESCRIPTION
## Description

This adds missing titles on the review page for the evidence pages.

## Testing done
Viewed locally.

## Screenshots
![screen shot 2018-09-13 at 11 56 35 am](https://user-images.githubusercontent.com/634932/45504603-54a67400-b758-11e8-9ab0-3b10929c7e1b.png)


## Acceptance criteria
- [x] Titles are correct

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
