### PR TITLE
526 show summary of evidence on review page

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -332,7 +332,7 @@ const formConfig = {
           }
         },
         evidenceType: {
-          title: (formData, { pagePerItemIndex }) => _.get(`disabilities.${pagePerItemIndex}.name`, formData),
+          title: (formData) => `${formData.name} supporting evidence`,
           path: 'supporting-evidence/:index/evidence-type',
           showPagePerItem: true,
           itemFilter: (item) => _.get('view:selected', item),
@@ -417,7 +417,7 @@ const formConfig = {
           }
         },
         vaMedicalRecordsIntro: {
-          title: '',
+          title: 'Testing',
           path: 'supporting-evidence/:index/va-medical-records-intro',
           showPagePerItem: true,
           itemFilter: (item) => _.get('view:selected', item),
@@ -445,7 +445,7 @@ const formConfig = {
           }
         },
         vaFacilities: {
-          title: '',
+          title: 'Testing',
           path: 'supporting-evidence/:index/va-facilities',
           showPagePerItem: true,
           itemFilter: (item) => _.get('view:selected', item),
@@ -860,7 +860,7 @@ const formConfig = {
           }
         },
         evidenceSummary: {
-          title: 'Summary of evidence',
+          title: (formData) => `${formData.name} evidence summary`,
           path: 'supporting-evidence/:index/evidence-summary',
           showPagePerItem: true,
           itemFilter: (item) => (_.get('view:hasEvidence', item) && _.get('view:selected', item)),

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -869,7 +869,7 @@ const formConfig = {
             disabilities: {
               items: {
                 'ui:title': 'Summary of evidence',
-                'ui:description': evidenceSummaryView
+                'ui:field': evidenceSummaryView
               }
             }
           },
@@ -880,7 +880,8 @@ const formConfig = {
                 type: 'array',
                 items: {
                   type: 'object',
-                  properties: {}
+                  properties: {
+                  }
                 }
               }
             }

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -880,8 +880,7 @@ const formConfig = {
                 type: 'array',
                 items: {
                   type: 'object',
-                  properties: {
-                  }
+                  properties: {}
                 }
               }
             }

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -417,7 +417,7 @@ const formConfig = {
           }
         },
         vaMedicalRecordsIntro: {
-          title: 'Testing',
+          title: '',
           path: 'supporting-evidence/:index/va-medical-records-intro',
           showPagePerItem: true,
           itemFilter: (item) => _.get('view:selected', item),
@@ -445,7 +445,7 @@ const formConfig = {
           }
         },
         vaFacilities: {
-          title: 'Testing',
+          title: '',
           path: 'supporting-evidence/:index/va-facilities',
           showPagePerItem: true,
           itemFilter: (item) => _.get('view:selected', item),

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -511,8 +511,7 @@ const listDocuments = (documents) => {
 };
 
 
-export const evidenceSummaryView = ({ formData }) => {
-
+export const evidenceSummaryView = ({ formContext, formData }) => {
   const {
     treatments,
     privateRecordReleases,
@@ -522,6 +521,9 @@ export const evidenceSummaryView = ({ formData }) => {
 
   return (
     <div>
+      {formContext.reviewMode && <div className="form-review-panel-page-header-row">
+        <h5 className="form-review-panel-page-header">{formContext.pageTitle(formData)}</h5>
+      </div>}
       <ul>
         {treatments &&
         <li>We’ll get your medical records from {listCenters(treatments)}.</li>}


### PR DESCRIPTION
## Description

The summary of evidence was not showing up on the review page, because descriptions are hidden on the review page. I changed the content to be a custom field and display the title conditionally if on the review page.

## Testing done

Checked locally on review page and normal pages.

## Screenshots

![screen shot 2018-09-13 at 2 08 16 pm](https://user-images.githubusercontent.com/634932/45507655-b79c0900-b760-11e8-9d02-2b8700106714.png)

## Acceptance criteria
- [x] Evidence shows up on review page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
