### PR TITLE
Patient acknowledgement

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -64,10 +64,6 @@ import {
 } from '../helpers';
 
 import {
-  patientAcknowledgement,
-} from '../../4142/helpers';
-
-import {
   hasGuardOrReservePeriod
 } from '../../all-claims/utils';
 
@@ -569,7 +565,7 @@ const formConfig = {
                   },
                   'view:acknowledgment': {
                     'ui:title': 'Patient Acknowledgment',
-                    'ui:required': ({ disabilities }, index) => (_.get(disabilities, `disabilities[${index}].view:patientAcknowledgement.view:acknowledgement`, '')),
+                    'ui:required': (formData, index) => (_.get(`disabilities[${index}].view:patientAcknowledgement.view:acknowledgement`, formData.disabilities)),
                   },
                 },
                 'view:privateRecordsChoiceHelp': {
@@ -596,7 +592,7 @@ const formConfig = {
                       properties: {
                         'view:acknowledgment': {
                           type: 'boolean',
-                          default: true
+                          'default': true
                         }
                       }
                     },

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -59,7 +59,8 @@ import {
   getEvidenceTypesDescription,
   veteranInfoDescription,
   editNote,
-  validateBooleanIfEvidence
+  validateBooleanIfEvidence,
+  patientAcknowledgementText,
 } from '../helpers';
 
 import {
@@ -561,6 +562,7 @@ const formConfig = {
                 },
                 'view:patientAcknowledgement': {
                   'ui:title': 'Patient Acknowledgement',
+                  'ui:description': patientAcknowledgementText,
                   'ui:options': {
                     expandUnder: 'view:uploadPrivateRecords',
                     expandUnderCondition: 'no',

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -60,7 +60,7 @@ import {
   veteranInfoDescription,
   editNote,
   validateBooleanIfEvidence,
-  patientAcknowledgementText,
+  patientAcknowledgmentText,
 } from '../helpers';
 
 import {
@@ -560,15 +560,15 @@ const formConfig = {
                     }
                   }
                 },
-                'view:patientAcknowledgement': {
-                  'ui:title': 'Patient Acknowledgement',
-                  'ui:description': patientAcknowledgementText,
+                'view:patientAcknowledgment': {
+                  'ui:title': 'Patient Acknowledgment',
+                  'ui:description': patientAcknowledgmentText,
                   'ui:options': {
                     expandUnder: 'view:uploadPrivateRecords',
                     expandUnderCondition: 'no',
                   },
-                  'view:acknowledgement': {
-                    'ui:title': 'Patient Acknowledgement',
+                  'view:acknowledgment': {
+                    'ui:title': 'Patient Acknowledgment',
                     'ui:required': ({ disabilities }, index) => (_.get(disabilities, `disabilities[${index}].view:patientAcknowledgement.view:acknowledgement`, '')),
                   },
                 },
@@ -591,10 +591,10 @@ const formConfig = {
                       type: 'string',
                       'enum': ['yes', 'no']
                     },
-                    'view:patientAcknowledgement': {
+                    'view:patientAcknowledgment': {
                       type: 'object',
                       properties: {
-                        'view:acknowledgement': {
+                        'view:acknowledgment': {
                           type: 'boolean',
                           default: true
                         }

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -579,7 +579,7 @@ const formConfig = {
                 type: 'array',
                 items: {
                   type: 'object',
-                  required: ['view:uploadPrivateRecords'],
+                  required: ['view:uploadPrivateRecords', 'view:patientAcknowledgement'],
                   properties: {
                     'view:uploadPrivateRecords': {
                       type: 'string',

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -566,10 +566,10 @@ const formConfig = {
                   'ui:options': {
                     expandUnder: 'view:uploadPrivateRecords',
                     expandUnderCondition: 'no',
-                  }
-                },
-                'view:acknowledgement': {
-                  'ui:title': 'Patient Acknowledgement'
+                  },
+                  'view:acknowledgement': {
+                    'ui:title': 'Patient Acknowledgement'
+                  },
                 },
                 'view:privateRecordsChoiceHelp': {
                   'ui:description': privateRecordsChoiceHelp

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -568,7 +568,8 @@ const formConfig = {
                     expandUnderCondition: 'no',
                   },
                   'view:acknowledgement': {
-                    'ui:title': 'Patient Acknowledgement'
+                    'ui:title': 'Patient Acknowledgement',
+                    'ui:required': ({ disabilities }, index) => (_.get(disabilities, `disabilities[${index}].view:patientAcknowledgement.view:acknowledgement`, '')),
                   },
                 },
                 'view:privateRecordsChoiceHelp': {
@@ -584,7 +585,7 @@ const formConfig = {
                 type: 'array',
                 items: {
                   type: 'object',
-                  required: ['view:uploadPrivateRecords', 'view:acknowledgement'],
+                  required: ['view:uploadPrivateRecords'],
                   properties: {
                     'view:uploadPrivateRecords': {
                       type: 'string',

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -585,7 +585,7 @@ const formConfig = {
                 type: 'array',
                 items: {
                   type: 'object',
-                  required: ['view:uploadPrivateRecords', 'view:acknowledgement'],
+                  required: ['view:uploadPrivateRecords'],
                   properties: {
                     'view:uploadPrivateRecords': {
                       type: 'string',

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -585,7 +585,7 @@ const formConfig = {
                 type: 'array',
                 items: {
                   type: 'object',
-                  required: ['view:uploadPrivateRecords'],
+                  required: ['view:uploadPrivateRecords', 'view:acknowledgement'],
                   properties: {
                     'view:uploadPrivateRecords': {
                       type: 'string',

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -566,6 +566,9 @@ const formConfig = {
                     expandUnderCondition: 'no',
                   }
                 },
+                'view:acknowledgement': {
+                  'ui:title': 'Patient Acknowledgement'
+                },
                 'view:privateRecordsChoiceHelp': {
                   'ui:description': privateRecordsChoiceHelp
                 }
@@ -579,14 +582,20 @@ const formConfig = {
                 type: 'array',
                 items: {
                   type: 'object',
-                  required: ['view:uploadPrivateRecords', 'view:patientAcknowledgement'],
+                  required: ['view:uploadPrivateRecords', 'view:acknowledgement'],
                   properties: {
                     'view:uploadPrivateRecords': {
                       type: 'string',
                       'enum': ['yes', 'no']
                     },
                     'view:patientAcknowledgement': {
-                      type: 'boolean',
+                      type: 'object',
+                      properties: {
+                        'view:acknowledgement': {
+                          type: 'boolean',
+                          default: true
+                        }
+                      }
                     },
                     'view:privateRecordsChoiceHelp': {
                       type: 'object',

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -46,7 +46,6 @@ import {
   privateRecordsChoiceHelp,
   facilityDescription,
   treatmentView,
-  // download4142Notice, related to authorization to disclose section below
   // authorizationToDisclose,
   // recordReleaseWarning, // TODO: Re-enable after 4142 PDF integration
   documentDescription,
@@ -61,6 +60,10 @@ import {
   veteranInfoDescription,
   editNote
 } from '../helpers';
+
+import {
+  patientAcknowledgement,
+} from '../../4142/helpers';
 
 import {
   hasGuardOrReservePeriod
@@ -538,13 +541,13 @@ const formConfig = {
                     }
                   }
                 },
-                // 'view:privateRecords4142Notice': {
-                //   'ui:description': download4142Notice,
-                //   'ui:options': {
-                //     expandUnder: 'view:uploadPrivateRecords',
-                //     expandUnderCondition: 'no'
-                //   }
-                // },
+                'view:patientAcknowledgement': {
+                  'ui:title': 'Patient Acknowledgement',
+                  'ui:options': {
+                    expandUnder: 'view:uploadPrivateRecords',
+                    expandUnderCondition: 'no',
+                  }
+                },
                 'view:privateRecordsChoiceHelp': {
                   'ui:description': privateRecordsChoiceHelp
                 }
@@ -564,11 +567,9 @@ const formConfig = {
                       type: 'string',
                       'enum': ['yes', 'no']
                     },
-                    // 'view:privateRecords4142Notice': {
-                    //   type: 'object',
-                    //   'ui:collapsed': true,
-                    //   properties: {}
-                    // },
+                    'view:patientAcknowledgement': {
+                      type: 'boolean',
+                    },
                     'view:privateRecordsChoiceHelp': {
                       type: 'object',
                       properties: {}

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -394,6 +394,9 @@ const claimsIntakeAddress = (
   </p>
 );
 
+export const patientAcknowledgementText = (
+  <div><a href="">Read the full text</a></div>
+);
 
 export const download4142Notice = (
   <div className="usa-alert usa-alert-warning no-background-image">

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -399,6 +399,44 @@ const claimsIntakeAddress = (
 
 export const patientAcknowledgmentText = (
   <AdditionalInfo triggerText="Read the full text.">
+    <h4>PATIENT AUTHORIZATION:</h4>
+    <p>
+      I voluntarily authorize and request disclosure (including paper,
+      oral, and electronic interchange) of: All my medical records;
+      including information related to my ability to perform tasks of
+      daily living. This includes specific permission to release:
+      <ol>
+        <li>All records and other information regarding my treatment,
+          hospitalization, and outpatient care for my impairment(s)
+          including, but not limited to:
+          <ul>
+            <li>Psychological, psychiatric, or other mental impairment(s)
+              excluding "psychotherapy notes" as defined in 45 C.F.R. §164.501,</li>
+            <li>Drug abuse, alcoholism, or other substance abuse,</li>
+            <li>Sickle cell anemia,</li>
+            <li>Records which may indicate the presence of a communicable
+              or non-communicable disease; and tests for or records of HIV/AIDS,</li>
+            <li>Gene-related impairments (including genetic test results)</li>
+          </ul>
+        </li>
+        <li>Information about how my impairment(s) affects my ability to
+          complete tasks and activities of daily living, and affects my ability to work.</li>
+        <li>Information created within 12 months after the date this authorization
+          is signed in Item 11, as well as past information.</li>
+      </ol>
+    </p>
+    <p>
+      YOU SHOULD NOT COMPLETE THIS FORM UNLESS YOU WANT THE VA TO
+      OBTAIN PRIVATE TREATMENT RECORDS ON YOUR BEHALF. IF YOU HAVE
+      ALREADY PROVIDED THESE RECORDS OR INTEND TO OBTAIN THEM YOURSELF,
+      THERE IS NO NEED TO FILL OUT THIS FORM. DOING SO WILL LENGTHEN
+      YOUR CLAIM PROCESSING TIME.
+    </p>
+    <h4>IMPORTANT:</h4>
+    <p>
+      In accordance with 38 C.F.R. §3.159(c), "VA will not pay any fees
+      charged by a custodian to provide records requested."
+    </p>
     <h4>PATIENT ACKNOWLEDGMENT:</h4>
     <p>
       I HEREBY AUTHORIZE the sources listed in Section IV, to release
@@ -435,7 +473,7 @@ export const patientAcknowledgmentText = (
     </p>
     <p>
       NOTE: For additional information regarding VA Form 21-4142, refer to
-      the following website: <a href="https://www.benefits.va.gov/privateproviders/">https://www.benefits.va.gov/privateproviders/</a>.
+      the following website: <a href="https://www.benefits.va.gov/privateproviders/" target="_blank">https://www.benefits.va.gov/privateproviders/</a>.
     </p>
   </AdditionalInfo>
 );

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -311,28 +311,31 @@ export const privateRecordsChoice = ({ formData }) => {
 
 
 export const privateRecordsChoiceHelp = (
-  <AdditionalInfo triggerText="Which should I choose?">
-    <h4>You upload your medical records</h4>
-    <p>
-      If you upload a digital copy of all your medical records, we can review
-      your claim more quickly. Uploading a digital file works best if you have
-      a computer with a fast Internet connection. The digital file could be
-      uploaded as a .pdf or other photo file format, like a .jpeg or .png.
-    </p>
-    <h4>We get your medical records for you</h4>
-    <p>
-      If you tell us which VA medical center treated you for your condition, we
-      can get your medical records for you. Getting your records may take us some
-      time, and this could mean that it’ll take us longer to make a decision on
-      your claim. You’ll need to first fill out an Authorization to Disclose
-      Information to the VA (VA Form 21-4142) so we can request your records.
-    </p>
-    <p>
-      <a href={VA_FORM4142_URL} target="_blank">
-        Download VA Form 21-4142
-      </a>.
-    </p>
-  </AdditionalInfo>
+  <div>
+    <p>&nbsp;</p>
+    <AdditionalInfo triggerText="Which should I choose?">
+      <h4>You upload your medical records</h4>
+      <p>
+        If you upload a digital copy of all your medical records, we can review
+        your claim more quickly. Uploading a digital file works best if you have
+        a computer with a fast Internet connection. The digital file could be
+        uploaded as a .pdf or other photo file format, like a .jpeg or .png.
+      </p>
+      <h4>We get your medical records for you</h4>
+      <p>
+        If you tell us which VA medical center treated you for your condition, we
+        can get your medical records for you. Getting your records may take us some
+        time, and this could mean that it’ll take us longer to make a decision on
+        your claim. You’ll need to first fill out an Authorization to Disclose
+        Information to the VA (VA Form 21-4142) so we can request your records.
+      </p>
+      <p>
+        <a href={VA_FORM4142_URL} target="_blank">
+          Download VA Form 21-4142
+        </a>.
+      </p>
+    </AdditionalInfo>
+  </div>
 );
 
 

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -395,7 +395,46 @@ const claimsIntakeAddress = (
 );
 
 export const patientAcknowledgementText = (
-  <div><a href="">Read the full text</a></div>
+  <AdditionalInfo triggerText="Read the full text.">
+    <h4>PATIENT ACKNOWLEDGMENT:</h4>
+    <p>
+      I HEREBY AUTHORIZE the sources listed in Section IV, to release
+      any information that may have been obtained in connection with
+      a physical, psychological or psychiatric examination or treatment,
+      with the understanding that VA will use this information in determining
+      my eligibility to veterans benefits I have claimed.
+    </p>
+    <p>
+      I understand that the source being asked to provide the Veterans
+      Benefits Administration with records under this authorization may
+      not require me to execute this authorization before it provides me
+      with treatment, payment for health care, enrollment in a health plan,
+      or eligibility for benefits provided by it.
+    </p>
+    <p>
+      I understand that once my source sends this information to VA under
+      this authorization, the information will no longer be protected by
+      the HIPAA Privacy Rule, but will be protected by the Federal Privacy Act,
+      5 USC 552a, and VA may disclose this information as authorized by law.
+    </p>
+    <p>
+      I also understand that I may revoke this authorization in writing,
+      at any time except to the extent a source of information has already
+      relied on it to take an action. To revoke, I must send a written
+      statement to the VA Regional Office handling my claim or the Board
+      of Veterans' Appeals (if my claim is related to an appeal) and also
+      send a copy directly to any of my sources that I no longer wish to
+      disclose information about me.
+    </p>
+    <p>
+      I understand that VA may use information disclosed prior to revocation
+      to decide my claim.
+    </p>
+    <p>
+      NOTE: For additional information regarding VA Form 21-4142, refer to
+      the following website: <a href="https://www.benefits.va.gov/privateproviders/">https://www.benefits.va.gov/privateproviders/</a>.
+    </p>
+  </AdditionalInfo>
 );
 
 export const download4142Notice = (

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -397,7 +397,7 @@ const claimsIntakeAddress = (
   </p>
 );
 
-export const patientAcknowledgementText = (
+export const patientAcknowledgmentText = (
   <AdditionalInfo triggerText="Read the full text.">
     <h4>PATIENT ACKNOWLEDGMENT:</h4>
     <p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@department-of-veterans-affairs/formation@^1.4.10":
-  version "1.4.10"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.4.10.tgz#2c43bc28af9ea59d6dde3eef3bffe010b17b74c9"
+"@department-of-veterans-affairs/formation@^1.4.11":
+  version "1.4.12"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.4.12.tgz#e4c1242bb1883328b7db2974a180006e7c13ec3b"
   dependencies:
     classnames "^2.2.5"
     font-awesome "4"


### PR DESCRIPTION
## Description
As a Vets.gov administrator I need to ensure that the Veteran is presented with, and required to accept, the 'Patient Acknowledgment' for Form 4142 prior to submission of the 526EZ.

## Testing done


## Screenshots


## Acceptance criteria
- [x] The Patient Acknowledgment check box is hidden until the user selects 'No, get my medical records for me'
 - [x] The Patient Acknowledgment check box is automatically checked by default when the user selects 'No, get my medical records for me'
- [x] There is a link to the authorization verbiage
- [x] Once the user clicks the link then the authorization verbiage that displays to the user is:

![patient ack](https://user-images.githubusercontent.com/41083101/44867430-c27d7680-ac55-11e8-8302-31209b4f4fbb.png)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
