### PR TITLE
Configures preview for Vet360 updates

### DIFF
--- a/src/applications/personalization/profile360/vet360/util/local-vet360.js
+++ b/src/applications/personalization/profile360/vet360/util/local-vet360.js
@@ -4,7 +4,8 @@ import * as VET360_CONSTANTS from '../constants';
 export function isVet360Configured() {
   return [
     'staging.vets.gov',
-    'www.vets.gov'
+    'www.vets.gov',
+    'preview.va.gov'
   ].includes(document.location.hostname);
 }
 


### PR DESCRIPTION
## Description
On preview.va.gov , when updating contact information on profile, the user goes through the entire flow, only to see stale data at the end (the field has not updated).

I tried making an update to a user's profile in both https://preview.va.gov/profile/ and https://staging.vets.gov/profile/ .

In staging, in the network tab, a PUT is being called, and things are being updated as expected.

In preview, however, there is no PUT being called at all, and things are not being updated.

Per @ncksllvn [here](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13150#issuecomment-421169404):

> (there is) a tiny helper to determine whether the API has Vet360 support, or whether we should mock that request locally instead. Since that environment is configured for Vet360, we can just add its domain to https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/personalization/profile360/vet360/util/local-vet360.js#L4

## Acceptance criteria
- [x] Makes preview.va.gov available for Vet360 updates

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
