### PR TITLE
Use the review PhoneNumberWidget in ui:reviewWidget

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -75,7 +75,7 @@ import {
 import { requireOneSelected } from '../validations';
 import { validateBooleanGroup } from 'us-forms-system/lib/js/validation';
 import PhoneNumberWidget from 'us-forms-system/lib/js/widgets/PhoneNumberWidget';
-import { TextWidget } from 'us-forms-system/lib/js/review/widgets';
+import PhoneNumberReviewWidget from 'us-forms-system/lib/js/review/PhoneNumberWidget';
 
 const {
   treatments,
@@ -245,7 +245,7 @@ const formConfig = {
                   primaryPhone: {
                     'ui:title': 'Phone number',
                     'ui:widget': PhoneNumberWidget,
-                    'ui:reviewWidget': TextWidget,
+                    'ui:reviewWidget': PhoneNumberReviewWidget,
                     'ui:options': {
                       widgetClassNames: 'va-input-medium-large'
                     },

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -75,6 +75,7 @@ import {
 import { requireOneSelected } from '../validations';
 import { validateBooleanGroup } from 'us-forms-system/lib/js/validation';
 import PhoneNumberWidget from 'us-forms-system/lib/js/widgets/PhoneNumberWidget';
+import { TextWidget } from 'us-forms-system/lib/js/review/widgets';
 
 const {
   treatments,
@@ -244,6 +245,7 @@ const formConfig = {
                   primaryPhone: {
                     'ui:title': 'Phone number',
                     'ui:widget': PhoneNumberWidget,
+                    'ui:reviewWidget': TextWidget,
                     'ui:options': {
                       widgetClassNames: 'va-input-medium-large'
                     },

--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -5,7 +5,7 @@ import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
 
 import dateUI from 'us-forms-system/lib/js/definitions/date';
 import PhoneNumberWidget from 'us-forms-system/lib/js/widgets/PhoneNumberWidget';
-import { TextWidget } from 'us-forms-system/lib/js/review/widgets';
+import PhoneNumberReviewWidget from 'us-forms-system/lib/js/review/PhoneNumberWidget';
 
 import ReviewCardField from '../../all-claims/components/ReviewCardField';
 
@@ -180,7 +180,7 @@ export const uiSchema = {
       primaryPhone: {
         'ui:title': 'Phone number',
         'ui:widget': PhoneNumberWidget,
-        'ui:reviewWidget': TextWidget,
+        'ui:reviewWidget': PhoneNumberReviewWidget,
         'ui:errorMessages': {
           pattern: 'Phone numbers must be 10 digits (dashes allowed)'
         },

--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -5,6 +5,7 @@ import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
 
 import dateUI from 'us-forms-system/lib/js/definitions/date';
 import PhoneNumberWidget from 'us-forms-system/lib/js/widgets/PhoneNumberWidget';
+import { TextWidget } from 'us-forms-system/lib/js/review/widgets';
 
 import ReviewCardField from '../../all-claims/components/ReviewCardField';
 
@@ -179,6 +180,7 @@ export const uiSchema = {
       primaryPhone: {
         'ui:title': 'Phone number',
         'ui:widget': PhoneNumberWidget,
+        'ui:reviewWidget': TextWidget,
         'ui:errorMessages': {
           pattern: 'Phone numbers must be 10 digits (dashes allowed)'
         },


### PR DESCRIPTION
## Description
The phone number fields were in the edit mode on the review page because nothing said they shouldn't be.

Until now.

## Testing done
Made sure it worked locally.

## Screenshots
### Veteran information, review page, not editing
![image](https://user-images.githubusercontent.com/12970166/45567373-7feb9a80-b80e-11e8-992f-2935a1a605c0.png)

### Veteran information, review page, editing
![image](https://user-images.githubusercontent.com/12970166/45566660-3a2dd280-b80c-11e8-9d63-3bf88f14eaf7.png)

### Homelessness contact, review page, not editing
![image](https://user-images.githubusercontent.com/12970166/45567395-8c6ff300-b80e-11e8-84d5-9ee2a339033f.png)

### Homelessness contact, review page, editing
![image](https://user-images.githubusercontent.com/12970166/45566762-78c38d00-b80c-11e8-9c53-04b83ebe9624.png)

## Acceptance criteria
- [x] The phone number fields don't get rendered in edit mode on the review page until we edit

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
