### PR TITLE
Only show prefill message on pages that were prefilled

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   // All rules should be disabled or they should produce errors. No warnings.
   'extends': 'airbnb',
+  'plugins': ['mocha'],
   'parser': 'babel-eslint',
   'env': {
     'browser': true,
@@ -91,6 +92,7 @@
     'no-lonely-if': 0,
     'lines-around-directive': 0,
     'jsx-a11y/href-no-hash': 0,
+    'mocha/no-exclusive-tests': 2,
   },
   'overrides': [{
     'files': ["**/*.spec.jsx", "**/*.spec.js", "src/platform/testing/**/*.js", "src/platform/testing/**/*.jsx"],

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "eslint": "^4.4.1",
     "eslint-config-airbnb": "^15.1.0",
     "eslint-plugin-jsx-a11y": "5.1",
+    "eslint-plugin-mocha": "^5.2.0",
     "eslint-plugin-no-unsafe-innerhtml": "^1.0.14",
     "eslint-plugin-react": "^7.2.1",
     "eslint-plugin-scanjs-rules": "^0.1.4",

--- a/src/applications/edu-benefits/feedback-tool/config/form.js
+++ b/src/applications/edu-benefits/feedback-tool/config/form.js
@@ -20,10 +20,13 @@ import GetFormHelp from '../../components/GetFormHelp';
 import {
   accreditationLabel,
   changeInDegreeLabel,
+  conditionalPrefillMessage,
   creditTransferLabel,
   financialIssuesLabel,
   gradePolicyLabel,
   jobOpportunitiesLabel,
+  PREFILL_FLAGS,
+  prefillTransformer,
   qualityLabel,
   recordApplicantRelationship,
   recruitingLabel,
@@ -121,6 +124,7 @@ const formConfig = {
   formId: 'FEEDBACK-TOOL',
   version: 0,
   prefillEnabled: true,
+  prefillTransformer,
   defaultDefinitions: {
     date,
     dateRange,
@@ -179,7 +183,7 @@ const formConfig = {
           title: 'Applicant Information',
           depends: isNotAnonymous,
           uiSchema: {
-            'ui:description': PrefillMessage,
+            'ui:description': data => conditionalPrefillMessage(PREFILL_FLAGS.APPLICANT_INFORMATION, data, PrefillMessage),
             fullName: _.merge(fullNameUI, {
               prefix: {
                 'ui:title': 'Prefix',
@@ -222,7 +226,7 @@ const formConfig = {
           title: 'Service Information',
           depends: isVeteranOrServiceMember,
           uiSchema: {
-            'ui:description': PrefillMessage,
+            'ui:description': data => conditionalPrefillMessage(PREFILL_FLAGS.SERVICE_INFORMATION, data, PrefillMessage),
             serviceBranch: {
               'ui:title': 'Branch of service',
             },
@@ -245,7 +249,7 @@ const formConfig = {
           title: 'Contact Information',
           depends: (formData) => formData.onBehalfOf !== anonymous,
           uiSchema: {
-            'ui:description': PrefillMessage,
+            'ui:description': data => conditionalPrefillMessage(PREFILL_FLAGS.CONTACT_INFORMATION, data, PrefillMessage),
             address: {
               street: {
                 'ui:title': 'Address line 1'

--- a/src/applications/edu-benefits/feedback-tool/config/form.js
+++ b/src/applications/edu-benefits/feedback-tool/config/form.js
@@ -20,7 +20,7 @@ import GetFormHelp from '../../components/GetFormHelp';
 import {
   accreditationLabel,
   changeInDegreeLabel,
-  conditionalPrefillMessage,
+  conditionallyShowPrefillMessage,
   creditTransferLabel,
   financialIssuesLabel,
   gradePolicyLabel,
@@ -183,7 +183,7 @@ const formConfig = {
           title: 'Applicant Information',
           depends: isNotAnonymous,
           uiSchema: {
-            'ui:description': data => conditionalPrefillMessage(PREFILL_FLAGS.APPLICANT_INFORMATION, data, PrefillMessage),
+            'ui:description': data => conditionallyShowPrefillMessage(PREFILL_FLAGS.APPLICANT_INFORMATION, data, PrefillMessage),
             fullName: _.merge(fullNameUI, {
               prefix: {
                 'ui:title': 'Prefix',
@@ -226,7 +226,7 @@ const formConfig = {
           title: 'Service Information',
           depends: isVeteranOrServiceMember,
           uiSchema: {
-            'ui:description': data => conditionalPrefillMessage(PREFILL_FLAGS.SERVICE_INFORMATION, data, PrefillMessage),
+            'ui:description': data => conditionallyShowPrefillMessage(PREFILL_FLAGS.SERVICE_INFORMATION, data, PrefillMessage),
             serviceBranch: {
               'ui:title': 'Branch of service',
             },
@@ -249,7 +249,7 @@ const formConfig = {
           title: 'Contact Information',
           depends: (formData) => formData.onBehalfOf !== anonymous,
           uiSchema: {
-            'ui:description': data => conditionalPrefillMessage(PREFILL_FLAGS.CONTACT_INFORMATION, data, PrefillMessage),
+            'ui:description': data => conditionallyShowPrefillMessage(PREFILL_FLAGS.CONTACT_INFORMATION, data, PrefillMessage),
             address: {
               street: {
                 'ui:title': 'Address line 1'

--- a/src/applications/edu-benefits/feedback-tool/helpers.js
+++ b/src/applications/edu-benefits/feedback-tool/helpers.js
@@ -27,11 +27,11 @@ const searchToolSchoolAddressFields = get(
 // conditionalPrefillMessage()
 export const PREFILL_FLAGS = {
   // if formData.fullName is set:
-  APPLICANT_INFORMATION: 'view:prefilledApplicantInformation',
+  APPLICANT_INFORMATION: 'view:applicantInformationWasPrefilled',
   // if formData.serviceBranch or formData.serviceDateRange is set:
-  SERVICE_INFORMATION: 'view:prefilledServiceInformation',
+  SERVICE_INFORMATION: 'view:serviceInformationWasPrefilled',
   // if formData.address or formData.phone or formData.applicantEmail is set:
-  CONTACT_INFORMATION: 'view:prefilledContactInformation',
+  CONTACT_INFORMATION: 'view:contactInformationWasPrefilled',
 };
 
 // For a given PREFILL_FLAG, what data needs to exist in the prefilled data for
@@ -277,13 +277,9 @@ export function transformSearchToolAddress({ address1, address2, address3, city,
 function addPrefilledFlagsToFormData(formData) {
   const newFormData = { ...formData };
   Object.keys(prefillFlagsToFieldsMap).forEach(flag => {
-    prefillFlagsToFieldsMap[flag].forEach(field => {
-      // if the value of this field is set on formData, add the flag to
-      // newFormData
-      if (get(field, formData)) {
-        newFormData[flag] = true;
-      }
-    });
+    if (prefillFlagsToFieldsMap[flag].some(field => get(field, formData))) {
+      newFormData[flag] = true;
+    }
   });
   return newFormData;
 }
@@ -302,7 +298,11 @@ export function prefillTransformer(pages, formData, metadata) {
  * @param {React Component} messageComponent - The React component to render
  * @returns {React Component|null}
  */
-export function conditionalPrefillMessage(prefillFlag, data, messageComponent) {
+export function conditionallyShowPrefillMessage(
+  prefillFlag,
+  data,
+  messageComponent,
+) {
   if (data.formData[prefillFlag]) {
     return messageComponent(data);
   }

--- a/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
@@ -5,7 +5,8 @@ import { mockFetch, resetFetch } from '../../../../platform/testing/unit/helpers
 import conditionalStorage from '../../../../platform/utilities/storage/conditionalStorage';
 
 import {
-  conditionalPrefillMessage,
+  conditionallyShowPrefillMessage,
+  PREFILL_FLAGS,
   prefillTransformer,
   submit,
   transformSearchToolAddress,
@@ -221,12 +222,12 @@ describe('feedback-tool helpers:', () => {
       formData = {};
       metadata = {};
     });
-    describe('"view:prefilledApplicantInformation" flag', () => {
+    describe(`"${PREFILL_FLAGS.APPLICANT_INFORMATION}" flag`, () => {
       it('is added when a `fullName` is set on the formData', () => {
         formData.fullName = { first: 'Pat' };
         const expectedFormData = {
           ...formData,
-          'view:prefilledApplicantInformation': true
+          [PREFILL_FLAGS.APPLICANT_INFORMATION]: true
         };
         const result = prefillTransformer(pages, formData, metadata);
         expect(result.metadata).to.eql(metadata);
@@ -243,12 +244,12 @@ describe('feedback-tool helpers:', () => {
         expect(result.formData).to.eql(expectedFormData);
       });
     });
-    describe('"view:prefilledServiceInformation" flag', () => {
+    describe(`"${PREFILL_FLAGS.SERVICE_INFORMATION}" flag`, () => {
       it('is added when a `serviceBranch` is set on the formData', () => {
         formData.serviceBranch = 'Air Force';
         const expectedFormData = {
           ...formData,
-          'view:prefilledServiceInformation': true
+          [PREFILL_FLAGS.SERVICE_INFORMATION]: true
         };
         const result = prefillTransformer(pages, formData, metadata);
         expect(result.metadata).to.eql(metadata);
@@ -262,7 +263,7 @@ describe('feedback-tool helpers:', () => {
         };
         const expectedFormData = {
           ...formData,
-          'view:prefilledServiceInformation': true
+          [PREFILL_FLAGS.SERVICE_INFORMATION]: true
         };
         const result = prefillTransformer(pages, formData, metadata);
         expect(result.metadata).to.eql(metadata);
@@ -279,12 +280,12 @@ describe('feedback-tool helpers:', () => {
         expect(result.formData).to.eql(expectedFormData);
       });
     });
-    describe('"view:prefilledContactInfo" flag', () => {
+    describe(`"${PREFILL_FLAGS.CONTACT_INFORMATION}" flag`, () => {
       it('is added when an `applicantEmail` is set on the formData', () => {
         formData.applicantEmail = 'foo@bar.com';
         const expectedFormData = {
           ...formData,
-          'view:prefilledContactInformation': true
+          [PREFILL_FLAGS.CONTACT_INFORMATION]: true
         };
         const result = prefillTransformer(pages, formData, metadata);
         expect(result.metadata).to.eql(metadata);
@@ -295,7 +296,7 @@ describe('feedback-tool helpers:', () => {
         formData.phone = '4151234567';
         const expectedFormData = {
           ...formData,
-          'view:prefilledContactInformation': true
+          [PREFILL_FLAGS.CONTACT_INFORMATION]: true
         };
         const result = prefillTransformer(pages, formData, metadata);
         expect(result.metadata).to.eql(metadata);
@@ -306,7 +307,7 @@ describe('feedback-tool helpers:', () => {
         formData.address = { country: 'US' };
         const expectedFormData = {
           ...formData,
-          'view:prefilledContactInformation': true
+          [PREFILL_FLAGS.CONTACT_INFORMATION]: true
         };
         const result = prefillTransformer(pages, formData, metadata);
         expect(result.metadata).to.eql(metadata);
@@ -336,12 +337,12 @@ describe('feedback-tool helpers:', () => {
       messageComponent = sinon.spy(() => 'dom');
     });
     it('calls the `messageComponent` param if the correct flag is set on data.formData', () => {
-      const result = conditionalPrefillMessage('goodFlag', data, messageComponent);
+      const result = conditionallyShowPrefillMessage('goodFlag', data, messageComponent);
       expect(messageComponent.called).to.be.true;
       expect(result).to.eql('dom');
     });
     it('does not call the `messageComponent` param if the correct flag is not set data.formData', () => {
-      const result = conditionalPrefillMessage('badFlag', data, messageComponent);
+      const result = conditionallyShowPrefillMessage('badFlag', data, messageComponent);
       expect(messageComponent.called).to.be.false;
       expect(result).to.eql(null);
     });

--- a/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
@@ -4,7 +4,12 @@ import sinon from 'sinon';
 import { mockFetch, resetFetch } from '../../../../platform/testing/unit/helpers';
 import conditionalStorage from '../../../../platform/utilities/storage/conditionalStorage';
 
-import { submit, transformSearchToolAddress } from '../../feedback-tool/helpers';
+import {
+  conditionalPrefillMessage,
+  prefillTransformer,
+  submit,
+  transformSearchToolAddress,
+} from '../../feedback-tool/helpers';
 
 function setFetchResponse(stub, data) {
   const response = new Response();
@@ -206,4 +211,140 @@ describe('feedback-tool helpers:', () => {
       delete window.URL;
     });
   });
+
+  describe('prefillTransformer', () => {
+    let pages;
+    let formData;
+    let metadata;
+    beforeEach(() => {
+      pages = {};
+      formData = {};
+      metadata = {};
+    });
+    describe('"view:prefilledApplicantInformation" flag', () => {
+      it('is added when a `fullName` is set on the formData', () => {
+        formData.fullName = { first: 'Pat' };
+        const expectedFormData = {
+          ...formData,
+          'view:prefilledApplicantInformation': true
+        };
+        const result = prefillTransformer(pages, formData, metadata);
+        expect(result.metadata).to.eql(metadata);
+        expect(result.pages).to.eql(pages);
+        expect(result.formData).to.eql(expectedFormData);
+      });
+      it('is not added when a `fullName` is not set on the formData', () => {
+        const expectedFormData = {
+          ...formData,
+        };
+        const result = prefillTransformer(pages, formData, metadata);
+        expect(result.metadata).to.eql(metadata);
+        expect(result.pages).to.eql(pages);
+        expect(result.formData).to.eql(expectedFormData);
+      });
+    });
+    describe('"view:prefilledServiceInformation" flag', () => {
+      it('is added when a `serviceBranch` is set on the formData', () => {
+        formData.serviceBranch = 'Air Force';
+        const expectedFormData = {
+          ...formData,
+          'view:prefilledServiceInformation': true
+        };
+        const result = prefillTransformer(pages, formData, metadata);
+        expect(result.metadata).to.eql(metadata);
+        expect(result.pages).to.eql(pages);
+        expect(result.formData).to.eql(expectedFormData);
+      });
+      it('is added when a `serviceDateRange` is set on the formData', () => {
+        formData.serviceDateRange = {
+          from: '2001-03-21',
+          to: '2014-07-21',
+        };
+        const expectedFormData = {
+          ...formData,
+          'view:prefilledServiceInformation': true
+        };
+        const result = prefillTransformer(pages, formData, metadata);
+        expect(result.metadata).to.eql(metadata);
+        expect(result.pages).to.eql(pages);
+        expect(result.formData).to.eql(expectedFormData);
+      });
+      it('is not added when neither `serviceBranch` or `serviceDateRange` are not set on the formData', () => {
+        const expectedFormData = {
+          ...formData,
+        };
+        const result = prefillTransformer(pages, formData, metadata);
+        expect(result.metadata).to.eql(metadata);
+        expect(result.pages).to.eql(pages);
+        expect(result.formData).to.eql(expectedFormData);
+      });
+    });
+    describe('"view:prefilledContactInfo" flag', () => {
+      it('is added when an `applicantEmail` is set on the formData', () => {
+        formData.applicantEmail = 'foo@bar.com';
+        const expectedFormData = {
+          ...formData,
+          'view:prefilledContactInformation': true
+        };
+        const result = prefillTransformer(pages, formData, metadata);
+        expect(result.metadata).to.eql(metadata);
+        expect(result.pages).to.eql(pages);
+        expect(result.formData).to.eql(expectedFormData);
+      });
+      it('is added when a `phone` is set on the formData', () => {
+        formData.phone = '4151234567';
+        const expectedFormData = {
+          ...formData,
+          'view:prefilledContactInformation': true
+        };
+        const result = prefillTransformer(pages, formData, metadata);
+        expect(result.metadata).to.eql(metadata);
+        expect(result.pages).to.eql(pages);
+        expect(result.formData).to.eql(expectedFormData);
+      });
+      it('is added when an `address` is set on the formData', () => {
+        formData.address = { country: 'US' };
+        const expectedFormData = {
+          ...formData,
+          'view:prefilledContactInformation': true
+        };
+        const result = prefillTransformer(pages, formData, metadata);
+        expect(result.metadata).to.eql(metadata);
+        expect(result.pages).to.eql(pages);
+        expect(result.formData).to.eql(expectedFormData);
+      });
+      it('is not added when neither `address`, `phone`, or `applicantEmail` are set on the formData', () => {
+        const expectedFormData = {
+          ...formData,
+        };
+        const result = prefillTransformer(pages, formData, metadata);
+        expect(result.metadata).to.eql(metadata);
+        expect(result.pages).to.eql(pages);
+        expect(result.formData).to.eql(expectedFormData);
+      });
+    });
+  });
+
+  describe('conditionalPrefillMessage', () => {
+    let messageComponent;
+    const data = {
+      formData: {
+        goodFlag: true
+      }
+    };
+    beforeEach(() => {
+      messageComponent = sinon.spy(() => 'dom');
+    });
+    it('calls the `messageComponent` param if the correct flag is set on data.formData', () => {
+      const result = conditionalPrefillMessage('goodFlag', data, messageComponent);
+      expect(messageComponent.called).to.be.true;
+      expect(result).to.eql('dom');
+    });
+    it('does not call the `messageComponent` param if the correct flag is not set data.formData', () => {
+      const result = conditionalPrefillMessage('badFlag', data, messageComponent);
+      expect(messageComponent.called).to.be.false;
+      expect(result).to.eql(null);
+    });
+  });
+
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3277,6 +3277,12 @@ eslint-plugin-jsx-a11y@5.1:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^1.4.0"
 
+eslint-plugin-mocha@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-5.2.0.tgz#d8786d9fff8cb8b5f6e4b61e40395d6568a5c4e2"
+  dependencies:
+    ramda "^0.25.0"
+
 eslint-plugin-no-unsafe-innerhtml@^1.0.14:
   version "1.0.16"
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-unsafe-innerhtml/-/eslint-plugin-no-unsafe-innerhtml-1.0.16.tgz#7d02878c8e9bf7916b88836d5ac122b42f151932"
@@ -7926,6 +7932,10 @@ railroad-diagrams@^1.0.0:
 ramda@^0.23.0:
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.23.0.tgz#ccd13fff73497a93974e3e86327bfd87bd6e8e2b"
+
+ramda@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
 
 randexp@^0.4.2:
   version "0.4.6"


### PR DESCRIPTION
## Description
Added a new `conditionalPrefillMessage` function to act as a wrapper around the `prefillMessage` component. The `prefillMessage` will now only be shown on a form page if fields on that page were prefilled. Previously the prefill message would be shown on all form pages regardless of if that particular page we prefilled.

**BONUS:** Added a new eslint rule that will prevent us from submitting code with Mocha `.only()` statements to address this issue: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11940

## Testing done
Added unit tests. Tested locally with mock prefill data.

## Screenshots


## Acceptance criteria
- [ ] Prefill messages show up only on pages that were prefilled; do not show the prefill message universally on all form pages.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
