### PR TITLE
Provide currency format validation

### DIFF
--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -62,7 +62,7 @@ import DemographicField from '../components/DemographicField';
 
 import { createDependentSchema, uiSchema as dependentUI, createDependentIncomeSchema, dependentIncomeUiSchema } from '../definitions/dependent';
 
-import { validateServiceDates, validateMarriageDate } from '../validation';
+import { validateServiceDates, validateMarriageDate, validateCurrency } from '../validation';
 
 const dependentSchema = createDependentSchema(fullSchemaHca);
 const dependentIncomeSchema = createDependentIncomeSchema(fullSchemaHca);
@@ -660,9 +660,9 @@ const formConfig = {
           uiSchema: {
             'ui:title': 'Annual income',
             'ui:description': incomeDescription,
-            veteranGrossIncome: currencyUI('Veteran gross annual income from employment'),
-            veteranNetIncome: currencyUI('Veteran net income from your farm, ranch, property or business'),
-            veteranOtherIncome: currencyUI('Veteran other income amount'),
+            veteranGrossIncome: _.set('ui:validations', [validateCurrency], currencyUI('Veteran gross annual income from employment')),
+            veteranNetIncome: _.set('ui:validations', [validateCurrency], currencyUI('Veteran net income from your farm, ranch, property or business')),
+            veteranOtherIncome: _.set('ui:validations', [validateCurrency], currencyUI('Veteran other income amount')),
             'view:spouseIncome': {
               'ui:title': 'Spouse income',
               'ui:options': {
@@ -670,13 +670,16 @@ const formConfig = {
                 (formData.maritalStatus.toLowerCase() !== 'married' && formData.maritalStatus.toLowerCase() !== 'separated')
               },
               spouseGrossIncome: _.merge(currencyUI('Spouse gross annual income from employment'), {
-                'ui:required': (formData) => formData.maritalStatus && (formData.maritalStatus.toLowerCase() === 'married' || formData.maritalStatus.toLowerCase() === 'separated')
+                'ui:required': (formData) => formData.maritalStatus && (formData.maritalStatus.toLowerCase() === 'married' || formData.maritalStatus.toLowerCase() === 'separated'),
+                'ui:validations': [validateCurrency]
               }),
               spouseNetIncome: _.merge(currencyUI('Spouse net income from your farm, ranch, property or business'), {
-                'ui:required': (formData) => formData.maritalStatus && (formData.maritalStatus.toLowerCase() === 'married' || formData.maritalStatus.toLowerCase() === 'separated')
+                'ui:required': (formData) => formData.maritalStatus && (formData.maritalStatus.toLowerCase() === 'married' || formData.maritalStatus.toLowerCase() === 'separated'),
+                'ui:validations': [validateCurrency]
               }),
               spouseOtherIncome: _.merge(currencyUI('Spouse other income amount'), {
-                'ui:required': (formData) => formData.maritalStatus && (formData.maritalStatus.toLowerCase() === 'married' || formData.maritalStatus.toLowerCase() === 'separated')
+                'ui:required': (formData) => formData.maritalStatus && (formData.maritalStatus.toLowerCase() === 'married' || formData.maritalStatus.toLowerCase() === 'separated'),
+                'ui:validations': [validateCurrency]
               })
             },
             dependents: {
@@ -719,14 +722,14 @@ const formConfig = {
           uiSchema: {
             'ui:title': 'Previous Calendar Year’s Deductible Expenses',
             'ui:description': deductibleExpensesDescription,
-            deductibleMedicalExpenses: currencyUI('Amount you or your spouse paid in non-reimbursable medical expenses this past year.'),
+            deductibleMedicalExpenses: _.set('ui:validations', [validateCurrency], currencyUI('Amount you or your spouse paid in non-reimbursable medical expenses this past year.')),
             'view:expensesIncomeWarning1': {
               'ui:description': expensesGreaterThanIncomeWarning,
               'ui:options': {
                 hideIf: expensesLessThanIncome('deductibleMedicalExpenses')
               }
             },
-            deductibleFuneralExpenses: currencyUI('Amount you paid in funeral or burial expenses for a deceased spouse or child this past year.'),
+            deductibleFuneralExpenses: _.set('ui:validations', [validateCurrency], currencyUI('Amount you paid in funeral or burial expenses for a deceased spouse or child this past year.')),
             'view:expensesIncomeWarning2': {
               'ui:description': expensesGreaterThanIncomeWarning,
               'ui:options': {

--- a/src/applications/hca/tests/validation.unit.spec.js
+++ b/src/applications/hca/tests/validation.unit.spec.js
@@ -5,7 +5,8 @@ import moment from 'moment';
 import {
   validateServiceDates,
   validateDependentDate,
-  validateMarriageDate
+  validateMarriageDate,
+  validateCurrency,
 } from '../validation';
 
 describe('hca validation', () => {
@@ -128,6 +129,44 @@ describe('hca validation', () => {
             }
           ]
         }, null, null, 0);
+
+      expect(errors.addError.callCount).to.equal(0);
+    });
+  });
+  describe('validateCurrency', () => {
+    it('should set message if value has three decimals', () => {
+      const errors = {
+        addError: sinon.spy()
+      };
+      validateCurrency(errors,
+        '234.234');
+
+      expect(errors.addError.callCount).to.equal(1);
+    });
+    it('should set message if value has trailing whitespace', () => {
+      const errors = {
+        addError: sinon.spy()
+      };
+      validateCurrency(errors,
+        '234234 ');
+
+      expect(errors.addError.callCount).to.equal(1);
+    });
+    it('should set message if value has leading whitespace', () => {
+      const errors = {
+        addError: sinon.spy()
+      };
+      validateCurrency(errors,
+        ' 234234');
+
+      expect(errors.addError.callCount).to.equal(1);
+    });
+    it('should not set message if value includes dollar sign', () => {
+      const errors = {
+        addError: sinon.spy()
+      };
+      validateCurrency(errors,
+        '$234,234');
 
       expect(errors.addError.callCount).to.equal(0);
     });

--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -53,3 +53,11 @@ export function validateDependentDate(errors, dependentDate, formData, schema, m
   }
   validateCurrentOrPastDate(errors, dependentDate);
 }
+
+export function validateCurrency(errors, currencyAmount) {
+  // Source: https://stackoverflow.com/a/16242575
+  // HACK: Due to us-forms-system issue 269 (https://github.com/usds/us-forms-system/issues/269)
+  if (!/(?=.*?\d)^\$?(([1-9]\d{0,2}(,\d{3})*)|\d+)?(\.\d{1,2})?$/.test(currencyAmount)) {
+    errors.addError('Please enter a valid dollar amount');
+  }
+}


### PR DESCRIPTION
## Description
These changes validate the format of currency values in the HCA form.

## Testing done
Manual testing done.

## Screenshots
previous:
![image](https://user-images.githubusercontent.com/16051172/45643670-7bbeb780-ba70-11e8-8373-9a8d617e68c8.png)

proposed:
![image](https://user-images.githubusercontent.com/16051172/45643702-8c6f2d80-ba70-11e8-8e18-5f252f45a45a.png)

## Acceptance criteria
- [x] [Issue](https://github.com/usds/us-forms-system/issues/269) created on us-forms-system

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
