### PR TITLE
Use `apiRequest` helper in GIBFT `submit`

### DIFF
--- a/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
@@ -362,7 +362,7 @@ describe('526 helpers', () => {
       });
     });
 
-    it('should return an empty array if unsuccesful', () => {
+    it('should return an empty array if unsuccessful', () => {
       global.fetch.resolves({ ok: false });
       // Doesn't matter what we call this with since our stub will always return the same thing
       const requestPromise = queryForFacilities('asdf');

--- a/src/applications/edu-benefits/feedback-tool/helpers.js
+++ b/src/applications/edu-benefits/feedback-tool/helpers.js
@@ -54,7 +54,8 @@ export function fetchInstitutions({ institutionQuery, page, onDone, onError }) {
     fetchUrl,
     null,
     payload => onDone(payload),
-    error => onError(error));
+    error => onError(error)
+  );
 }
 
 export function transform(formConfig, form) {
@@ -85,7 +86,8 @@ function checkStatus(guid) {
       }
 
       return Promise.reject(res);
-    }).catch(res => {
+    })
+    .catch(res => {
       if (res instanceof Error) {
         Raven.captureException(res);
         Raven.captureMessage('vets_gi_bill_feedbacks_poll_client_error');
@@ -119,29 +121,19 @@ function pollStatus(guid, onDone, onError) {
   }, window.VetsGov.pollTimeout || POLLING_INTERVAL);
 }
 
-
 export function submit(form, formConfig) {
-  const userToken = conditionalStorage().getItem('userToken');
   const headers = {
-    'Content-Type': 'application/json',
-    'X-Key-Inflection': 'camel',
+    'Content-Type': 'application/json'
   };
 
-  if (userToken) {
-    headers.Authorization = `Token token=${userToken}`;
-  }
-
   const body = transform(formConfig, form);
-  return fetch(`${environment.API_URL}/v0/gi_bill_feedbacks`, {
+  const apiRequestOptions = {
     method: 'POST',
     headers,
     body
-  }).then(res => {
-    if (res.ok) {
-      return res.json();
-    }
-    return Promise.reject(res);
-  }).then(json => {
+  };
+
+  const onSuccess = json => {
     const guid = json.data.attributes.guid;
     return new Promise((resolve, reject) => {
       pollStatus(guid,
@@ -150,9 +142,13 @@ export function submit(form, formConfig) {
             event: `${formConfig.trackingPrefix}-submission-successful`,
           });
           return resolve(response);
-        }, error => reject(error));
+        },
+        error => reject(error)
+      );
     });
-  }).catch(respOrError => {
+  };
+
+  const onFailure = respOrError => {
     if (respOrError instanceof Response) {
       if (respOrError.status === 429) {
         const error = new Error('vets_throttled_error_gi_bill_feedbacks');
@@ -162,7 +158,14 @@ export function submit(form, formConfig) {
       }
     }
     return Promise.reject(respOrError);
-  });
+  };
+
+  return apiRequest(
+    '/gi_bill_feedbacks',
+    apiRequestOptions,
+    onSuccess,
+    onFailure
+  );
 }
 
 /**

--- a/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
@@ -15,6 +15,8 @@ import {
 function setFetchResponse(stub, data) {
   const response = new Response();
   response.ok = true;
+  // So `apiRequest`'s `isJson` helper works. Should this mock be more robust?
+  response.headers.get = () => 'application/json';
   response.json = () => Promise.resolve(data);
   stub.resolves(response);
 }

--- a/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
@@ -12,11 +12,12 @@ import {
   transformSearchToolAddress,
 } from '../../feedback-tool/helpers';
 
-function setFetchResponse(stub, data) {
+function setFetchResponse(stub, data, headers = {}) {
   const response = new Response();
   response.ok = true;
-  // So `apiRequest`'s `isJson` helper works. Should this mock be more robust?
-  response.headers.get = () => 'application/json';
+  response.headers.get = headerID => {
+    return headers[headerID] || null;
+  };
   response.json = () => Promise.resolve(data);
   stub.resolves(response);
 }
@@ -136,30 +137,42 @@ describe('feedback-tool helpers:', () => {
         });
     });
     it('should resolve if polling state is success', () => {
-      mockFetch();
-      setFetchResponse(global.fetch.onFirstCall(), {
-        data: {
-          attributes: {
-            guid: 'test'
-          }
-        }
-      });
-      setFetchResponse(global.fetch.onSecondCall(), {
-        data: {
-          attributes: {
-            state: 'pending'
-          }
-        }
-      });
       const parsedResponse = {};
-      setFetchResponse(global.fetch.onThirdCall(), {
-        data: {
-          attributes: {
-            state: 'success',
-            parsedResponse
+      mockFetch();
+      setFetchResponse(
+        global.fetch.onFirstCall(),
+        {
+          data: {
+            attributes: {
+              guid: 'test'
+            }
           }
-        }
-      });
+        },
+        { 'Content-Type': 'application/json' }
+      );
+      setFetchResponse(
+        global.fetch.onSecondCall(),
+        {
+          data: {
+            attributes: {
+              state: 'pending'
+            }
+          }
+        },
+        { 'Content-Type': 'application/json' }
+      );
+      setFetchResponse(
+        global.fetch.onThirdCall(),
+        {
+          data: {
+            attributes: {
+              state: 'success',
+              parsedResponse
+            }
+          }
+        },
+        { 'Content-Type': 'application/json' }
+      );
       const formConfig = {
         chapters: {}
       };
@@ -173,27 +186,39 @@ describe('feedback-tool helpers:', () => {
     });
     it('should reject if polling state is failed', () => {
       mockFetch();
-      setFetchResponse(global.fetch.onFirstCall(), {
-        data: {
-          attributes: {
-            guid: 'test'
+      setFetchResponse(
+        global.fetch.onFirstCall(),
+        {
+          data: {
+            attributes: {
+              guid: 'test'
+            }
           }
-        }
-      });
-      setFetchResponse(global.fetch.onSecondCall(), {
-        data: {
-          attributes: {
-            state: 'pending'
+        },
+        { 'Content-Type': 'application/json' }
+      );
+      setFetchResponse(
+        global.fetch.onSecondCall(),
+        {
+          data: {
+            attributes: {
+              state: 'pending'
+            }
           }
-        }
-      });
-      setFetchResponse(global.fetch.onThirdCall(), {
-        data: {
-          attributes: {
-            state: 'failed'
+        },
+        { 'Content-Type': 'application/json' }
+      );
+      setFetchResponse(
+        global.fetch.onThirdCall(),
+        {
+          data: {
+            attributes: {
+              state: 'failed'
+            }
           }
-        }
-      });
+        },
+        { 'Content-Type': 'application/json' }
+      );
       const formConfig = {
         chapters: {}
       };

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -5,10 +5,22 @@ import environment from '../environment';
 import conditionalStorage from '../storage/conditionalStorage';
 
 function isJson(response) {
-  const contentType = response.headers.get('content-type');
-  return contentType && contentType.indexOf('application/json') !== -1;
+  const contentType = response.headers.get('Content-Type');
+  return contentType && contentType.includes('application/json');
 }
 
+/**
+ *
+ * @param {string} resource - The URL to fetch. If it starts with a leading "/"
+ * it will be appended to the baseUrl. Otherwise it will be used as an absolute
+ * URL.
+ * @param {Object} [{}] optionalSettings - Custom settings you want to apply to
+ * the fetch request. Will be mixed with, and potentially override, the
+ * defaultSettings
+ * @param {Function} success - Callback to execute after successfully resolving
+ * the initial fetch request.
+ * @param {Function} error - Callback to execute if the fetch fails to resolve.
+ */
 export function apiRequest(resource, optionalSettings = {}, success, error) {
   const baseUrl = `${environment.API_URL}/v0`;
   const url = resource[0] === '/'

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -14,14 +14,14 @@ function isJson(response) {
  * @param {string} resource - The URL to fetch. If it starts with a leading "/"
  * it will be appended to the baseUrl. Otherwise it will be used as an absolute
  * URL.
- * @param {Object} optionalSettings - Custom settings you want to apply to
+ * @param {Object} [{}] optionalSettings - Custom settings you want to apply to
  * the fetch request. Will be mixed with, and potentially override, the
  * defaultSettings
  * @param {Function} success - Callback to execute after successfully resolving
  * the initial fetch request.
  * @param {Function} error - Callback to execute if the fetch fails to resolve.
  */
-export function apiRequest(resource, optionalSettings, success, error) {
+export function apiRequest(resource, optionalSettings = {}, success, error) {
   const baseUrl = `${environment.API_URL}/v0`;
   const url = resource[0] === '/'
     ? [baseUrl, resource].join('')

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -14,14 +14,14 @@ function isJson(response) {
  * @param {string} resource - The URL to fetch. If it starts with a leading "/"
  * it will be appended to the baseUrl. Otherwise it will be used as an absolute
  * URL.
- * @param {Object} [{}] optionalSettings - Custom settings you want to apply to
+ * @param {Object} optionalSettings - Custom settings you want to apply to
  * the fetch request. Will be mixed with, and potentially override, the
  * defaultSettings
  * @param {Function} success - Callback to execute after successfully resolving
  * the initial fetch request.
  * @param {Function} error - Callback to execute if the fetch fails to resolve.
  */
-export function apiRequest(resource, optionalSettings = {}, success, error) {
+export function apiRequest(resource, optionalSettings, success, error) {
   const baseUrl = `${environment.API_URL}/v0`;
   const url = resource[0] === '/'
     ? [baseUrl, resource].join('')

--- a/src/platform/utilities/environment/index.js
+++ b/src/platform/utilities/environment/index.js
@@ -1,11 +1,32 @@
 const _Environments = {
-  production: { API_URL: 'https://api.vets.gov', BASE_URL: 'https://www.vets.gov' },
-  staging: { API_URL: 'https://staging-api.vets.gov', BASE_URL: 'https://staging.vets.gov' },
-  preview: { API_URL: 'https://staging-api.vets.gov', BASE_URL: 'https://preview.va.gov' },
-  devpreview: { API_URL: 'https://dev-api.vets.gov', BASE_URL: 'https://dev-preview.va.gov' },
-  development: { API_URL: (process.env.API_URL || 'https://dev-api.vets.gov'), BASE_URL: (process.env.BASE_URL || 'https://dev.vets.gov') },
-  local: { API_URL: `http://${location.hostname}:3000`, BASE_URL: `http://${location.hostname}:3001` },
-  e2e: { API_URL: `http://localhost:${process.env.API_PORT || 3000}`, BASE_URL: `http://localhost:${process.env.WEB_PORT || 3333}` }
+  production: {
+    API_URL: 'https://api.vets.gov',
+    BASE_URL: 'https://www.vets.gov'
+  },
+  staging: {
+    API_URL: 'https://staging-api.vets.gov',
+    BASE_URL: 'https://staging.vets.gov'
+  },
+  preview: {
+    API_URL: 'https://staging-api.vets.gov',
+    BASE_URL: 'https://preview.va.gov'
+  },
+  devpreview: {
+    API_URL: 'https://dev-api.vets.gov',
+    BASE_URL: 'https://dev-preview.va.gov'
+  },
+  development: {
+    API_URL: (process.env.API_URL || 'https://dev-api.vets.gov'),
+    BASE_URL: (process.env.BASE_URL || 'https://dev.vets.gov')
+  },
+  local: {
+    API_URL: `http://${location.hostname}:3000`,
+    BASE_URL: `http://${location.hostname}:3001`
+  },
+  e2e: {
+    API_URL: `http://localhost:${process.env.API_PORT || 3000}`,
+    BASE_URL: `http://localhost:${process.env.WEB_PORT || 3333}`
+  }
 };
 
 function getEnvironment() {


### PR DESCRIPTION
## Description
Leverage the `apiRequest` helper to make the `fetch` in GIBFT's `submit` function

## Testing done
Confirmed existing `submit` unit tests pass

## Acceptance criteria
- [x] Use `apiRequest` to in place of custom fetch code in the GIBFT `submit` helper and confirm functionality remains the same

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
