### PR TITLE
[Brand Consolidation] Open sign-in modal with the mega-menu sign-in button

### DIFF
--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -32,6 +32,7 @@ const DASHBOARD_URL = dashboardManifest.rootUrl;
 export class Main extends React.Component {
   componentDidMount() {
     window.addEventListener('message', this.setToken);
+    this.bindModalTriggers();
     this.bindNavbarLinks();
 
     // In some cases this component is mounted on a url that is part of the login process and doesn't need to make another
@@ -83,6 +84,12 @@ export class Main extends React.Component {
     if (shouldRedirect) {
       window.location.replace(redirectUrl);
     }
+  }
+
+  bindModalTriggers = () => {
+    const triggers = document.querySelectorAll('.signin-signup-modal-trigger');
+    const openLoginModal = () => this.props.toggleLoginModal(true);
+    triggers.forEach(t => t.addEventListener('click', openLoginModal));
   }
 
   bindNavbarLinks = () => {

--- a/va-gov/layouts/home.html
+++ b/va-gov/layouts/home.html
@@ -102,7 +102,7 @@
       </div>
 
       <div class="usa-width-one-third">
-        <button class="homepage-button primary-darker">
+        <button class="homepage-button primary-darker signin-signup-modal-trigger">
           <a href=#>
             <div class="icon-wrapper">
               <i class="fa fa-user-circle"></i>


### PR DESCRIPTION
## Description
Bound the mega-menu login button to a handler that opens the login modal.
Resolves department-of-veterans-affairs/vets.gov-team#13072.

NOTE: This change will give any element with the class `.signin-signup-modal-trigger` the ability to open the login modal, even if the element is not in a React component (where it would have access to the Redux action).

## Testing done
Local testing.

## Acceptance criteria
- [x] Clicking the login button in the mega-menu should open the login modal.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
