### PR TITLE
Use `apiRequest` helper in burials helpers

### DIFF
--- a/src/applications/burials/tests/helpers.unit.spec.jsx
+++ b/src/applications/burials/tests/helpers.unit.spec.jsx
@@ -6,9 +6,12 @@ import { submit } from '../helpers.jsx';
 import { mockFetch, resetFetch } from '../../../platform/testing/unit/helpers';
 import conditionalStorage from '../../../platform/utilities/storage/conditionalStorage';
 
-function setFetchResponse(stub, data) {
+function setFetchResponse(stub, data, headers = {}) {
   const response = new Response();
   response.ok = true;
+  response.headers.get = headerID => {
+    return headers[headerID] || null;
+  };
   response.json = () => Promise.resolve(data);
   stub.resolves(response);
 }
@@ -41,29 +44,41 @@ describe('Burials helpers', () => {
     });
     it('should resolve if polling state is success', () => {
       mockFetch();
-      setFetchResponse(global.fetch.onFirstCall(), {
-        data: {
-          attributes: {
-            guid: 'test'
+      setFetchResponse(
+        global.fetch.onFirstCall(),
+        {
+          data: {
+            attributes: {
+              guid: 'test'
+            }
           }
-        }
-      });
-      setFetchResponse(global.fetch.onSecondCall(), {
-        data: {
-          attributes: {
-            state: 'pending'
+        },
+        { 'Content-Type': 'application/json' }
+      );
+      setFetchResponse(
+        global.fetch.onSecondCall(),
+        {
+          data: {
+            attributes: {
+              state: 'pending'
+            }
           }
-        }
-      });
+        },
+        { 'Content-Type': 'application/json' }
+      );
       const response = {};
-      setFetchResponse(global.fetch.onThirdCall(), {
-        data: {
-          attributes: {
-            state: 'success',
-            response
+      setFetchResponse(
+        global.fetch.onThirdCall(),
+        {
+          data: {
+            attributes: {
+              state: 'success',
+              response
+            }
           }
-        }
-      });
+        },
+        { 'Content-Type': 'application/json' }
+      );
       const formConfig = {
         chapters: {}
       };
@@ -78,27 +93,39 @@ describe('Burials helpers', () => {
     });
     it('should reject if polling state is failed', () => {
       mockFetch();
-      setFetchResponse(global.fetch.onFirstCall(), {
-        data: {
-          attributes: {
-            guid: 'test'
+      setFetchResponse(
+        global.fetch.onFirstCall(),
+        {
+          data: {
+            attributes: {
+              guid: 'test'
+            }
           }
-        }
-      });
-      setFetchResponse(global.fetch.onSecondCall(), {
-        data: {
-          attributes: {
-            state: 'pending'
+        },
+        { 'Content-Type': 'application/json' }
+      );
+      setFetchResponse(
+        global.fetch.onSecondCall(),
+        {
+          data: {
+            attributes: {
+              state: 'pending'
+            }
           }
-        }
-      });
-      setFetchResponse(global.fetch.onThirdCall(), {
-        data: {
-          attributes: {
-            state: 'failed'
+        },
+        { 'Content-Type': 'application/json' }
+      );
+      setFetchResponse(
+        global.fetch.onThirdCall(),
+        {
+          data: {
+            attributes: {
+              state: 'failed'
+            }
           }
-        }
-      });
+        },
+        { 'Content-Type': 'application/json' }
+      );
       const formConfig = {
         chapters: {}
       };


### PR DESCRIPTION
## Description
Convert Burials fetch helpers to use `apiRequest` instead

## Testing done
Unit tests

## Acceptance criteria
- [x] `apiRequest` helper used when possible

## Definition of done
~~- [ ] Events are logged appropriately~~
~~- [ ] Documentation has been updated, if applicable~~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
