### PR TITLE
Minify css for production build

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -75,7 +75,7 @@ const configGenerator = (options, apps) => {
           use: ExtractTextPlugin.extract({
             fallback: 'style-loader',
             use: [
-              { loader: 'css-loader' },
+              { loader: 'css-loader', options: { minimize: ['production', 'staging', 'preview'].includes(options.buildtype) } },
               { loader: 'sass-loader' }
             ]
           })


### PR DESCRIPTION
## Description

Improves performance by decreasing overall file size of CSS assets when in Prod environments.
Related to https://github.com/department-of-veterans-affairs/vets-website/issues/8391

## Testing done
Ran build command in prod settings locally

## Screenshots
N/A

## Acceptance criteria
- [x] CSS got smaller
- [x] Site looks ok

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
