### PR TITLE
Add `Last 4 of SSN` field to GIBFT

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#84887dc7cb0ccee2ae2c8156b5664697c2850b1d",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#72e8eb31c05789c9e01f607aa24bdfe75d9ce4a0",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#364656a5065e44f695cd631deaeb6d087674d1d7",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/src/applications/edu-benefits/feedback-tool/config/form.js
+++ b/src/applications/edu-benefits/feedback-tool/config/form.js
@@ -53,6 +53,7 @@ const {
   serviceAffiliation,
   serviceBranch,
   serviceDateRange,
+  socialSecurityNumberLastFour,
 } = fullSchema.properties;
 
 const { assistance, programs, school } = educationDetails.properties;
@@ -75,6 +76,7 @@ const {
   date,
   dateRange,
   usaPhone,
+  ssnLastFour,
 } = fullSchema.definitions;
 
 const myself = 'Myself';
@@ -128,7 +130,8 @@ const formConfig = {
   defaultDefinitions: {
     date,
     dateRange,
-    usaPhone
+    usaPhone,
+    ssnLastFour,
   },
   savedFormMessages: {
     notFound: 'Please start over to apply for declaration of status of dependents.',
@@ -205,6 +208,16 @@ const formConfig = {
               },
               'ui:order': ['prefix', 'first', 'middle', 'last', 'suffix'],
             }),
+            socialSecurityNumberLastFour: {
+              'ui:title': 'Please provide the last 4 digits of your Social Security number',
+              'ui:required': isNotAnonymous,
+              'ui:options': {
+                widgetClassNames: 'usa-input-medium',
+              },
+              'ui:errorMessages': {
+                pattern: 'Please enter a valid last 4 digits'
+              },
+            },
             serviceAffiliation: {
               'ui:title': 'Service affiliation',
               'ui:required': isMyself,
@@ -217,6 +230,7 @@ const formConfig = {
             type: 'object',
             properties: {
               fullName: set('required', ['first', 'last'], fullName),
+              socialSecurityNumberLastFour,
               serviceAffiliation
             }
           }

--- a/src/applications/edu-benefits/tests/feedback-tool/config/applicantInfo.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/config/applicantInfo.unit.spec.js
@@ -20,7 +20,7 @@ describe('feedback tool applicant info', () => {
         uiSchema={uiSchema}/>
     );
 
-    expect(form.find('input').length).to.equal(3);
+    expect(form.find('input').length).to.equal(4);
     expect(form.find('select').length).to.equal(3);
   });
 
@@ -35,7 +35,7 @@ describe('feedback tool applicant info', () => {
         uiSchema={uiSchema}/>
     );
 
-    expect(form.find('input').length).to.equal(3);
+    expect(form.find('input').length).to.equal(4);
     expect(form.find('select').length).to.equal(2);
   });
 
@@ -53,7 +53,7 @@ describe('feedback tool applicant info', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error').length).to.equal(3);
+    expect(form.find('.usa-input-error').length).to.equal(4);
     expect(onSubmit.called).to.be.false;
   });
 
@@ -71,7 +71,7 @@ describe('feedback tool applicant info', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error').length).to.equal(2);
+    expect(form.find('.usa-input-error').length).to.equal(3);
     expect(onSubmit.called).to.be.false;
   });
 
@@ -94,6 +94,7 @@ describe('feedback tool applicant info', () => {
     });
     fillData(form, 'input#root_fullName_first', 'test');
     fillData(form, 'input#root_fullName_last', 'test');
+    fillData(form, 'input#root_socialSecurityNumberLastFour', '1234');
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
@@ -114,6 +115,7 @@ describe('feedback tool applicant info', () => {
 
     fillData(form, 'input#root_fullName_first', 'test');
     fillData(form, 'input#root_fullName_last', 'test');
+    fillData(form, 'input#root_socialSecurityNumberLastFour', '1234');
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error').length).to.equal(0);
     expect(onSubmit.called).to.be.true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10061,9 +10061,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#72e8eb31c05789c9e01f607aa24bdfe75d9ce4a0":
-  version "3.90.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#72e8eb31c05789c9e01f607aa24bdfe75d9ce4a0"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#364656a5065e44f695cd631deaeb6d087674d1d7":
+  version "3.92.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#364656a5065e44f695cd631deaeb6d087674d1d7"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
## Description
Add a field to enter Last 4 of SSN if not filing feedback anonymously.

## Testing done
Tested locally

## Screenshots
**Desktop**
![desktop](https://user-images.githubusercontent.com/20728956/45825832-fde4f100-bca7-11e8-9bcd-f339fe60f936.png)
**Mobile**
![mobile](https://user-images.githubusercontent.com/20728956/45825837-00dfe180-bca8-11e8-974b-f422db005f2e.png)
**Error Message**
<img width="470" alt="error" src="https://user-images.githubusercontent.com/20728956/45826019-69c75980-bca8-11e8-916d-0e838ffbb27d.png">


## Acceptance criteria
- [x] Field for Last 4 is available when filling out the form your Myself or Someone Else
- [x] UX/content approves input field, label, error message.

## Definition of done
~~- [ ] Events are logged appropriately~~
~~- [ ] Documentation has been updated, if applicable~~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
