### PR TITLE
Allow editing of file name and provide length validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#84887dc7cb0ccee2ae2c8156b5664697c2850b1d",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#364656a5065e44f695cd631deaeb6d087674d1d7",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#46f758005675cfa61db71d8e720bdbf8387eec1e",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/src/applications/pre-need/config/form.jsx
+++ b/src/applications/pre-need/config/form.jsx
@@ -598,6 +598,9 @@ const formConfig = {
                 },
                 attachmentSchema: {
                   'ui:title': 'What kind of document is this?'
+                },
+                attachmentName: {
+                  'ui:title': 'Document name'
                 }
               })
             }
@@ -610,7 +613,11 @@ const formConfig = {
                 properties: {
                   preneedAttachments: _.merge(preneedAttachments, {
                     items: {
+                      required: ['name', 'attachmentId'],
                       properties: {
+                        name: {
+                          maxLength: 50
+                        },
                         attachmentId: {
                           'enum': [
                             '1',

--- a/src/applications/pre-need/config/form.jsx
+++ b/src/applications/pre-need/config/form.jsx
@@ -611,34 +611,7 @@ const formConfig = {
               application: {
                 type: 'object',
                 properties: {
-                  preneedAttachments: _.merge(preneedAttachments, {
-                    items: {
-                      required: ['name', 'attachmentId'],
-                      properties: {
-                        name: {
-                          maxLength: 50
-                        },
-                        attachmentId: {
-                          'enum': [
-                            '1',
-                            '2',
-                            '3',
-                            // '4',
-                            '5',
-                            '6'
-                          ],
-                          enumNames: [
-                            'Discharge',
-                            'Marriage related',
-                            'Dependent related',
-                            // 'VA preneed form',
-                            'Letter',
-                            'Other'
-                          ]
-                        }
-                      }
-                    }
-                  })
+                  preneedAttachments
                 }
               }
             }

--- a/src/applications/pre-need/tests/config/documents.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/documents.unit.spec.jsx
@@ -60,10 +60,33 @@ describe('Pre-need attachments', () => {
     const formDOM = getFormDOM(form);
 
     formDOM.submitForm();
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(2);
     expect(onSubmit.called).to.be.false;
   });
 
+  it('should not submit without required fields', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        schema={schema}
+        data={{
+          application: {
+            preneedAttachments: [{
+              confirmationCode: 'testing'
+            }]
+          }
+        }}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+        uiSchema={uiSchema}/>
+    );
+
+    const formDOM = getFormDOM(form);
+
+    formDOM.submitForm();
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(2);
+    expect(onSubmit.called).to.be.false;
+  });
   it('should submit with valid data', () => {
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
@@ -73,10 +96,12 @@ describe('Pre-need attachments', () => {
           application: {
             preneedAttachments: [{
               attachmentId: '1',
-              confirmationCode: 'testing'
+              confirmationCode: 'testing',
+              name: 'abc'
             }, {
               attachmentId: '1',
-              confirmationCode: 'testing2'
+              confirmationCode: 'testing2',
+              name: 'abc'
             }]
           }
         }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10061,9 +10061,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#364656a5065e44f695cd631deaeb6d087674d1d7":
-  version "3.92.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#364656a5065e44f695cd631deaeb6d087674d1d7"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#46f758005675cfa61db71d8e720bdbf8387eec1e":
+  version "3.93.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#46f758005675cfa61db71d8e720bdbf8387eec1e"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
## Description
These changes make the name field editable for preneed attachments.

## Testing done
- unit tests updated

## Screenshots
![image](https://user-images.githubusercontent.com/16051172/45852807-a15cf280-bcf6-11e8-8e91-5de4a013b5d4.png)


## Acceptance criteria
- [x] use updated schema in progress [here](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/260/files)

## Definition of done
- [ ] ~Events are logged appropriately~
- [ ] ~Documentation has been updated, if applicable~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
