### PR TITLE
Tweak the relationship of the boolean's requiredness to the parent object.

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -451,13 +451,12 @@ const formConfig = {
           showPagePerItem: true,
           itemFilter: item => _.get('view:selected', item),
           arrayPath: 'disabilities',
-          depends: (formData, index) =>
-            _.get(
-              `disabilities.${
-                index
-              }.view:selectableEvidenceTypes.view:vaMedicalRecords`,
-              formData,
-            ),
+          depends: (formData, index) => _.get(
+            `disabilities.${
+              index
+            }.view:selectableEvidenceTypes.view:vaMedicalRecords`,
+            formData,
+          ),
           uiSchema: {
             disabilities: {
               items: {
@@ -485,13 +484,12 @@ const formConfig = {
           showPagePerItem: true,
           itemFilter: item => _.get('view:selected', item),
           arrayPath: 'disabilities',
-          depends: (formData, index) =>
-            _.get(
-              `disabilities.${
-                index
-              }.view:selectableEvidenceTypes.view:vaMedicalRecords`,
-              formData,
-            ),
+          depends: (formData, index) => _.get(
+            `disabilities.${
+              index
+            }.view:selectableEvidenceTypes.view:vaMedicalRecords`,
+            formData,
+          ),
           uiSchema: {
             disabilities: {
               items: {
@@ -552,13 +550,12 @@ const formConfig = {
           showPagePerItem: true,
           itemFilter: item => _.get('view:selected', item),
           arrayPath: 'disabilities',
-          depends: (formData, index) =>
-            _.get(
-              `disabilities.${
-                index
-              }.view:selectableEvidenceTypes.view:privateMedicalRecords`,
-              formData,
-            ),
+          depends: (formData, index) => _.get(
+            `disabilities.${
+              index
+            }.view:selectableEvidenceTypes.view:privateMedicalRecords`,
+            formData,
+          ),
           uiSchema: {
             disabilities: {
               items: {
@@ -586,13 +583,12 @@ const formConfig = {
           showPagePerItem: true,
           itemFilter: item => _.get('view:selected', item),
           arrayPath: 'disabilities',
-          depends: (formData, index) =>
-            _.get(
-              `disabilities.${
-                index
-              }.view:selectableEvidenceTypes.view:privateMedicalRecords`,
-              formData,
-            ),
+          depends: (formData, index) => _.get(
+            `disabilities.${
+              index
+            }.view:selectableEvidenceTypes.view:privateMedicalRecords`,
+            formData,
+          ),
           uiSchema: {
             disabilities: {
               items: {
@@ -680,8 +676,7 @@ const formConfig = {
               }.view:selectableEvidenceTypes.view:privateMedicalRecords`,
               formData,
             );
-            const requestsRecords =
-              _.get(
+            const requestsRecords = _.get(
                 `disabilities.${index}.view:uploadPrivateRecords`,
                 formData,
               ) === 'no';
@@ -860,8 +855,7 @@ const formConfig = {
               }.view:selectableEvidenceTypes.view:privateMedicalRecords`,
               formData,
             );
-            const uploadRecords =
-              _.get(
+            const uploadRecords = _.get(
                 `disabilities.${index}.view:uploadPrivateRecords`,
                 formData,
               ) === 'yes';
@@ -943,13 +937,12 @@ const formConfig = {
         },
         documentUpload: {
           title: 'Lay statements or other evidence',
-          depends: (formData, index) =>
-            _.get(
-              `disabilities.${
-                index
-              }.view:selectableEvidenceTypes.view:otherEvidence`,
-              formData,
-            ),
+          depends: (formData, index) => _.get(
+            `disabilities.${
+              index
+            }.view:selectableEvidenceTypes.view:otherEvidence`,
+            formData,
+          ),
           path: 'supporting-evidence/:index/additionalDocuments',
           showPagePerItem: true,
           itemFilter: item => _.get('view:selected', item),

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -610,16 +610,23 @@ const formConfig = {
                   },
                 },
                 'view:patientAcknowledgment': {
-                  'ui:title': 'Patient Acknowledgment',
-                  'ui:description': patientAcknowledgmentText,
+                  'ui:title': ' ',
+                  'ui:help': patientAcknowledgmentText,
                   'ui:options': {
                     expandUnder: 'view:uploadPrivateRecords',
                     expandUnderCondition: 'no',
+                    showFieldLabel: true,
                   },
                   'view:acknowledgment': {
                     'ui:title': 'Patient Acknowledgment',
-                    'ui:required': (formData, index) => (_.get(`disabilities[${index}].view:patientAcknowledgement.view:acknowledgement`, formData.disabilities)),
                   },
+                  'ui:validations': [
+                    (errors, item) => {
+                      if (!item['view:acknowledgment']) {
+                        errors.addError('You must accept the acknowledgement');
+                      }
+                    }
+                  ]
                 },
                 'view:privateRecordsChoiceHelp': {
                   'ui:description': privateRecordsChoiceHelp,
@@ -642,6 +649,7 @@ const formConfig = {
                     },
                     'view:patientAcknowledgment': {
                       type: 'object',
+                      required: ['view:acknowledgment'],
                       properties: {
                         'view:acknowledgment': {
                           type: 'boolean',


### PR DESCRIPTION
## Description
Tweak the relationship of the booleans requiredness to the parent object. e.g. Make the object care about the value of the boolean, instead of the state caring.

## Testing done
n/a

## Screenshots
n/a

## Acceptance criteria
- [ ] As a Vets.gov administrator I need to ensure that the Veteran is presented with, and required to accept, the 'Patient Acknowledgement' for Form 4142 prior to submission of the 526EZ.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
