### PR TITLE
Bump vets-json-schema version

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#84887dc7cb0ccee2ae2c8156b5664697c2850b1d",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#364656a5065e44f695cd631deaeb6d087674d1d7",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#46f758005675cfa61db71d8e720bdbf8387eec1e",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10061,9 +10061,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#364656a5065e44f695cd631deaeb6d087674d1d7":
-  version "3.92.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#364656a5065e44f695cd631deaeb6d087674d1d7"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#46f758005675cfa61db71d8e720bdbf8387eec1e":
+  version "3.93.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#46f758005675cfa61db71d8e720bdbf8387eec1e"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
## Description
Bump vets-json-schema version to limit length of 'highest rank' field on burial pre-need.
Specifically pulling in [these changes](https://github.com/department-of-veterans-affairs/vets-json-schema/commit/46f758005675cfa61db71d8e720bdbf8387eec1e)

## Testing done
Unit tests. Manually checked that the string length limit is enforced on the form.

## Screenshots
N/A

## Acceptance criteria
- [x] User cannot enter more than 20 characters in the Highest Rank Attained field

## Definition of done
~~- [ ] Events are logged appropriately~~
~~- [ ] Documentation has been updated, if applicable~~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
