### PR TITLE
Add VA environments/deploys

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,14 @@
 import org.kohsuke.github.GitHub
 
-def envNames = ['development', 'staging', 'production', 'preview']
+def envNames = [
+  // Vets.gov envs
+  'development', 'staging', 'production',
+  // VA.gov envs
+  'preview', 'vagovdev', 'vagovstaging'
+]
 
 def devBranch = 'master'
-def stagingBranch = 'master'
+def stagsingBranch = 'master'
 def prodBranch = 'master'
 
 def isReviewable = {
@@ -247,20 +252,20 @@ node('vetsgov-general-purpose') {
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),
         ], wait: false
-        //build job: 'deploys/vets-website-vagovdev', parameters: [
-        //  booleanParam(name: 'notify_slack', value: true),
-        //  stringParam(name: 'ref', value: commit),
-        //], wait: false
+        build job: 'deploys/vets-website-vagovdev', parameters: [
+          booleanParam(name: 'notify_slack', value: true),
+          stringParam(name: 'ref', value: commit),
+        ], wait: false
       }
       if (env.BRANCH_NAME == stagingBranch) {
         build job: 'deploys/vets-website-staging', parameters: [
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),
         ], wait: false
-        //build job: 'deploys/vets-website-preview', parameters: [
-        //  booleanParam(name: 'notify_slack', value: true),
-        //  stringParam(name: 'ref', value: commit),
-        //], wait: false
+        build job: 'deploys/vets-website-vagovstaging', parameters: [
+          booleanParam(name: 'notify_slack', value: true),
+          stringParam(name: 'ref', value: commit),
+        ], wait: false
       }
     } catch (error) {
       notify()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ def envNames = [
 ]
 
 def devBranch = 'master'
-def stagsingBranch = 'master'
+def stagingBranch = 'master'
 def prodBranch = 'master'
 
 def isReviewable = {

--- a/src/platform/brand-consolidation/README.md
+++ b/src/platform/brand-consolidation/README.md
@@ -1,8 +1,8 @@
-# Brand-Consolidation
-The Brand-Consolidation initiative is the migration of Vets.gov to VA.gov.
+# Brand Consolidation
+The Brand Consolidation initiative is the migration of Vets.gov to VA.gov.
 
 ## Where it lives on GitHub
-The work currently lives on the [`brand-consolidation` branch](https://github.com/department-of-veterans-affairs/vets-website/tree/brand-consolidation) of the `vets-website` repository. It was originally branched off of master.
+The work currently lives on the `master` branch of the `vets-website` repository. It was originally a longstanding branch off of master called `brand-consolidation`, but it has since been merged into `master` as of this [pull request](https://github.com/department-of-veterans-affairs/vets-website/pull/8511).
 
 ## How to build VA.gov
 To build the site, the build argument `--brand-consolidation-enabled` is passed to the build script (`script/build.js`). A shortcut for building the site in watch-mode is using `npm run watch:brand-consolidation`. Another useful command is to simply build the site, which will also run the Metalsmith link checker, `npm run build -- --brand-consolidation-enabled`. As URLs are mapped from the Vets.gov `content` directory to the new VA.gov `va-gov` directory and each instance of the former path (`href`) is updated to its new location, this command is crucial to run after any large URL changes.
@@ -14,15 +14,12 @@ The brand-consolidated VA.gov site currently lives at the following locations:
 - Staging: https://staging.va.gov
 - Production: https://preview.va.gov
 
-Dev and Staging are built automatically when a change is merged into the `brand-consolidation` branch. Production has to be built manually, however, by running a Preview build in the Jenkins Deploy menu and passing the latest commit SHA of the `brand-consolidation` branch.
+As with Vets.gov environments, the VA.gov Dev and VA.gov Staging environments are built automatically when a change is merged into the `master` branch. Production has to be built manually, however, by running a Preview build in the Jenkins Deploy menu and passing the latest commit SHA.
 
 Even though it exists at the "preview" subdomain, the Production environment should be treated as any other production environment, as it is demoed and reviewed regularly.
 
 ## Review Instances
-When issuing a pull request to `brand-consolidation`, if you prefix the name of your branch with `va-gov/`, the corresponding review instance for the pull request will be built using the `--brand-consolidation-enabled` to deploy it as a VA.gov site.
-
-## Code Reviews
-`brand-consolidation` is a protected branch, so a pull request must be issued and approved by another engineer. Because there were incompatible changes between `brand-consolidation` and `master`, along with the rapid development to meet changing requirements, automated tests were disabld so as a result you do not have the safety of those checks. We are working to merge `brand-consolidation` into `master` as soon as possible.
+When issuing a pull request, if you prefix the name of your branch with `va-gov/`, the corresponding review instance for the pull request will be built using the `--brand-consolidation-enabled` to deploy it as a VA.gov site.
 
 ## Frontend Architecture and Feature Flag
 The Metalsmith website currently exists in a separate directory, `va-gov/`. This is because the website layout has changed entirely, and the Vets.gov content has been mapped over to new locations for the brand-consolidated VA.gov. For this reason, we should not need access to the feature flag within Metalsmith. With that said, there may be some instances of checking a boolean named `mergedbuild` to render certain components. This was implemented presumably before the decision was made to create new Metalsmith components.
@@ -53,8 +50,6 @@ export default function  SomeComponent() {
     );
 }
 ```
-
-Even though the Brand Consolidation work currently lives on its own branch, we should leverage that feature flag so as not to increase our technical debt for the eventual merge to `master`. If possible, we should write each change to be completely compatible with both branches.
 
 ## Zenhub
 To filter to issues concerning FE engineers on the brand-consolidation project, filter using the `brand-consolidation`, `front end`, and possibly `Hydra` labels.


### PR DESCRIPTION
## Description
With `brand-consolidation` merged into `master` from PR https://github.com/department-of-veterans-affairs/vets-website/pull/8511, we can now begin building the brand-consolidated VA.gov off of `master`. 

### Ticket
Resolves department-of-veterans-affairs/vets.gov-team/issues/13512

## Testing done
- [x] All Vets.gov and VA.gov build jobs are executed on the Jenkins dashboard

## Acceptance criteria
- [x] `master` becomes the controlling branch for all builds

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
