### PR TITLE
Avoid IE error by using Array.from

### DIFF
--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -87,7 +87,7 @@ export class Main extends React.Component {
   }
 
   bindModalTriggers = () => {
-    const triggers = document.querySelectorAll('.signin-signup-modal-trigger');
+    const triggers = Array.from(document.querySelectorAll('.signin-signup-modal-trigger'));
     const openLoginModal = () => this.props.toggleLoginModal(true);
     triggers.forEach(t => t.addEventListener('click', openLoginModal));
   }


### PR DESCRIPTION
## Description

IE doesn't support `forEach` on `NodeList`, so we need to use `Array.from` to convert to a normal array first.

## Testing done
Tested in BrowserStack in IE11

## Screenshots


## Acceptance criteria
- [x] User nav menu links work in IE 11

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
