### PR TITLE
Remove duplicate order property

### DIFF
--- a/va-gov/pages/gi-bill-comparison-tool/index.md
+++ b/va-gov/pages/gi-bill-comparison-tool/index.md
@@ -5,7 +5,6 @@ description: Use our GI Bill Comparison Tool to help you decide which education 
 layout: page-react.html
 entryname: gi
 collection: education
-order: 1
 spoke: More Resources
 order: 4
 ---


### PR DESCRIPTION
## Description
These changes allow the GI Bill Comparison Tool to render in the brand consolidation build. The original bug affecting the accordion has already been fixed.

## Testing done
- Tested locally via `yarn run watch:brand-consolidation` and navigating to /gi-bill-comparison-tool

## Screenshots
Multiple accordions are now able to open simultaneously with ease (no additional clicks required)
![image](https://user-images.githubusercontent.com/16051172/45985714-628fab00-c01c-11e8-8ee1-d7a40c51afeb.png)


## Acceptance criteria
- [ ] Allow GI Bill Comparison Tool to render in the brand consolidation build, and multiple accordions to open simultaneously.

## Definition of done
- [ ] ~Events are logged appropriately~
- [ ] ~Documentation has been updated, if applicable~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
