### PR TITLE
WIP 13351 build metrics payload

### DIFF
--- a/src/platform/frontend-metrics/metrics.js
+++ b/src/platform/frontend-metrics/metrics.js
@@ -2,12 +2,65 @@ import Raven from 'raven-js';
 import isMetricsEnabled from './feature-flag';
 
 /**
+ * Returns 0 if Paint timing is not supported or the time of first-contentful-paint if present.
+ * @returns (number) The number retrieved from the paintEntries.startTime value, else 0.
+ */
+function contentfulPaintEntry() {
+  const paintEntries = performance.getEntriesByName('first-contentful-paint');
+  // If browser doesn't support first-contentful-paint, we set the value to 0
+  const firstPaint = typeof paintEntries === 'undefined' ? 0 : paintEntries[0].startTime;
+
+  return firstPaint;
+}
+
+/**
+ * Returns a formatted metrics payload FormData object to send to backend
+ * @param (PerformanceNavigationTiming) An object with information from the browser's Performance API
+ * @returns (FormData) A new FormData object with an array of metrics and page_id parameters
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry
+ */
+function buildMetricsPayload(entry) {
+  const totalPageLoad = entry.duration;
+  const firstByte = entry.responseStart;
+  const domProcessing = entry.domComplete - entry.domInteractive;
+  const domComplete = entry.domComplete - entry.requestStart;
+  const domInteractive = entry.domInteractive;
+  const firstPaint = contentfulPaintEntry();
+
+  const metrics = {
+    totalPageLoad,
+    firstByte,
+    domProcessing,
+    domComplete,
+    domInteractive,
+    firstPaint,
+  };
+
+  const metricsData = new FormData();
+  const metricsArray = [];
+  const pageUrl = window.location.pathname;
+
+  Object.keys(metrics).forEach(metric => {
+    metricsArray.push({
+      metric,
+      duration: metrics[metric]
+    });
+  });
+
+  metricsData.append('metrics', JSON.stringify(metricsArray));
+  metricsData.append('page_id', pageUrl);
+
+  return metricsData;
+}
+
+/**
  * Capture metrics with a PerformanceObserver object
  * @see https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe
  */
 function captureMetrics() {
   const observer = new PerformanceObserver(list => {
     list.getEntriesByType('navigation').forEach(entry => {
+      const metricsPayload = buildMetricsPayload(entry);
       window.addEventListener('unload', () => {
         // TODO: Send method to backend outlined in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13355
       });


### PR DESCRIPTION
**CLOSED & SQUASHED INTO #8533**

---


## Description
Within the metrics FE code, we need to build an object consisting of page load metric data in a form that the backend can consume. 

## Testing done

## Acceptance criteria
- [x] Include a page UUID or some other identifier that uniquely maps to a given page/url/resource
- [x] Include all key metrics as determined in #13349 and returned in #13350
- [x] Sync with BE to ensure object meets endpoint contract 
- [ ] Consider any [custom events](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13291#issuecomment-422547266) (see [W3C spec](https://dom.spec.whatwg.org/#interface-customevent))
- [ ] Conditionally add a tag if current page is a TeamSite page 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
