### PR TITLE
Make eslint valid JSON

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,122 +1,141 @@
 {
   // All rules should be disabled or they should produce errors. No warnings.
-  'extends': 'airbnb',
-  'plugins': ['mocha'],
-  'parser': 'babel-eslint',
-  'env': {
-    'browser': true,
-    'commonjs': true,
-    'es6': true,
-    'mocha': true
+  "extends": "airbnb",
+  "plugins": ["mocha"],
+  "parser": "babel-eslint",
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": true,
+    "mocha": true
   },
-  'globals': {
-    '__BUILDTYPE__': true
+  "globals": {
+    "__BUILDTYPE__": true
   },
-  'rules': {
+  "rules": {
     // Override airbnb style.
-    'arrow-body-style': 0,  // Leave bracing to code reviewer discretion.
-    'camelcase': [2, {'properties': 'always'}],
-    'comma-dangle': 0,  // Dangling commas are wonderful. It's JSON that's stupid.
-    'func-names': 2,
-    'no-console': 2,
-    'no-negated-condition': 0,  // Sometimes negated conditions are easier to understand.
-    'no-unused-vars': [2, {'args': 'after-used', 'argsIgnorePattern': '^_', 'vars': 'local'}],
-    'prefer-rest-params': 2,
-    'quote-props': [2, 'as-needed', { 'keywords': true }],
-    'space-unary-ops': 2,
-    'max-len': [0],  // No agreed upon max length and react lines get > 100 chars easily.
-    'arrow-parens': 0, // We don't have an agreed upon pattern here
-    'no-underscore-dangle': 0, // We have build flags that use this
+    "arrow-body-style": 0, // Leave bracing to code reviewer discretion.
+    "camelcase": [2, { "properties": "always" }],
+    "comma-dangle": 0, // Dangling commas are wonderful. It's JSON that's stupid.
+    "func-names": 2,
+    "no-console": 2,
+    "no-negated-condition": 0, // Sometimes negated conditions are easier to understand.
+    "no-unused-vars": [
+      2,
+      { "args": "after-used", "argsIgnorePattern": "^_", "vars": "local" }
+    ],
+    "prefer-rest-params": 2,
+    "quote-props": [2, "as-needed", { "keywords": true }],
+    "space-unary-ops": 2,
+    "max-len": [0], // No agreed upon max length and react lines get > 100 chars easily.
+    "arrow-parens": 0, // We don't have an agreed upon pattern here
+    "no-underscore-dangle": 0, // We have build flags that use this
 
     // Disabled rules with rationale.
-    'react/no-multi-comp': 0,      // Leave organization to code reviewer discretion.
-    'react/prefer-stateless-function': 0, // Leave statelessness to code reviewer discretion.
+    "react/no-multi-comp": 0, // Leave organization to code reviewer discretion.
+    "react/prefer-stateless-function": 0, // Leave statelessness to code reviewer discretion.
 
-    'react/jsx-closing-bracket-location': [2, 'after-props'],
-    'react/jsx-equals-spacing': 2,
-    'react/jsx-key': 2,
-    'react/jsx-no-bind': [0, {'ignoreRefs': true}],  // TODO: Enable after fixing.
-    'react/jsx-pascal-case': 2,
-    'react/sort-prop-types': [0, {'callbacksLast': true, 'requiredFirst': true}],  // TODO(awong): Too hard to turn on.
-    'react/jsx-sort-props': [0, {'callbacksLast': true, 'shorthandFirst': true}],  // TODO(awong): Too hard to turn on.
-    'react/jsx-no-duplicate-props': 2,
-    'react/no-danger': 2,
-    'react/no-deprecated': 2,
-    'react/no-direct-mutation-state': 2,
-    'react/no-string-refs': 0,       // TODO(awong): Enable.
-    'react/prop-types': 0,           // TODO(awong): Enable.
-    'react/jsx-tag-spacing': [2, { 'beforeSelfClosing': 'never' }],
-    'import/no-extraneous-dependencies': 0,
+    "react/jsx-closing-bracket-location": [2, "after-props"],
+    "react/jsx-equals-spacing": 2,
+    "react/jsx-key": 2,
+    "react/jsx-no-bind": [0, { "ignoreRefs": true }], // TODO: Enable after fixing.
+    "react/jsx-pascal-case": 2,
+    "react/sort-prop-types": [
+      0,
+      { "callbacksLast": true, "requiredFirst": true }
+    ], // TODO(awong): Too hard to turn on.
+    "react/jsx-sort-props": [
+      0,
+      { "callbacksLast": true, "shorthandFirst": true }
+    ], // TODO(awong): Too hard to turn on.
+    "react/jsx-no-duplicate-props": 2,
+    "react/no-danger": 2,
+    "react/no-deprecated": 2,
+    "react/no-direct-mutation-state": 2,
+    "react/no-string-refs": 0, // TODO(awong): Enable.
+    "react/prop-types": 0, // TODO(awong): Enable.
+    "react/jsx-tag-spacing": [2, { "beforeSelfClosing": "never" }],
+    "import/no-extraneous-dependencies": 0,
 
     // this is the airbnb default, minus for..of
-    'no-restricted-syntax': [2, 'error',
+    "no-restricted-syntax": [
+      2,
+      "error",
       {
-        selector: 'ForInStatement',
-        message: 'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+        "selector": "ForInStatement",
+        "message": "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array."
       },
       {
-        selector: 'LabeledStatement',
-        message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+        "selector": "LabeledStatement",
+        "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand."
       },
       {
-        selector: 'WithStatement',
-        message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
-      }],
-    'no-plusplus': 0,
-    'react/jsx-indent-props': 0,
+        "selector": "WithStatement",
+        "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize."
+      }
+    ],
+    "no-plusplus": 0,
+    "react/jsx-indent-props": 0,
 
     // TODO: evaluate and potentially turn these rules back on
-    'import/extensions': 0,
-    'react/jsx-filename-extension': 0,
-    'import/first': 0,
-    'react/jsx-curly-spacing': 0, // on before
-    'react/jsx-no-target-blank': 0,
-    'react/no-unescaped-entities': 0,
-    'react/require-default-props': 0,
-    'block-spacing': 0,
-    'class-methods-use-this': 0,
-    'import/no-named-as-default': 0,
-    'react/forbid-prop-types': 0,
-    'react/self-closing-comp': 0,
-    'no-mixed-operators': 0,
-    'react/jsx-first-prop-new-line': 0,
-    'react/jsx-max-props-per-line': 0,
-    'react/no-array-index-key': 0,
-    'react/no-unused-prop-types': 0,
-    'no-multi-spaces': 0,
-    'no-undef-init': 0,
-    'padded-blocks': 0,
-    'jsx-a11y/no-static-element-interactions': 0,
-    'import/prefer-default-export': 0,
-    'global-require': 0,
-    'no-lonely-if': 0,
-    'lines-around-directive': 0,
-    'jsx-a11y/href-no-hash': 0,
-    'mocha/no-exclusive-tests': 2,
+    "import/extensions": 0,
+    "react/jsx-filename-extension": 0,
+    "import/first": 0,
+    "react/jsx-curly-spacing": 0, // on before
+    "react/jsx-no-target-blank": 0,
+    "react/no-unescaped-entities": 0,
+    "react/require-default-props": 0,
+    "block-spacing": 0,
+    "class-methods-use-this": 0,
+    "import/no-named-as-default": 0,
+    "react/forbid-prop-types": 0,
+    "react/self-closing-comp": 0,
+    "no-mixed-operators": 0,
+    "react/jsx-first-prop-new-line": 0,
+    "react/jsx-max-props-per-line": 0,
+    "react/no-array-index-key": 0,
+    "react/no-unused-prop-types": 0,
+    "no-multi-spaces": 0,
+    "no-undef-init": 0,
+    "padded-blocks": 0,
+    "jsx-a11y/no-static-element-interactions": 0,
+    "import/prefer-default-export": 0,
+    "global-require": 0,
+    "no-lonely-if": 0,
+    "lines-around-directive": 0,
+    "jsx-a11y/href-no-hash": 0,
+    "mocha/no-exclusive-tests": 2
   },
-  'overrides': [{
-    'files': [
-      "src/platform/**/*.js",
-      "src/platform/**/*.jsx",
-      "src/applications/site-wide/**/*.js",
-      "src/applications/site-wide/**/*.jsx",
-      "src/applications/static-pages/**/*.js",
-      "src/applications/static-pages/**/*.jsx"
-    ],
-    'rules': {
-      'no-restricted-imports': ['error', 'lodash/fp']
+  "overrides": [
+    {
+      "files": [
+        "src/platform/**/*.js",
+        "src/platform/**/*.jsx",
+        "src/applications/site-wide/**/*.js",
+        "src/applications/site-wide/**/*.jsx",
+        "src/applications/static-pages/**/*.js",
+        "src/applications/static-pages/**/*.jsx"
+      ],
+      "rules": {
+        "no-restricted-imports": ["error", "lodash/fp"]
+      }
+    },
+    {
+      "files": [
+        "**/*.spec.jsx",
+        "**/*.spec.js",
+        "src/platform/testing/**/*.js",
+        "src/platform/testing/**/*.jsx"
+      ],
+      "rules": {
+        "react/no-find-dom-node": 0,
+        "no-unused-expressions": 0,
+        "no-restricted-imports": 0
+      }
     }
-  }, {
-    'files': ["**/*.spec.jsx", "**/*.spec.js", "src/platform/testing/**/*.js", "src/platform/testing/**/*.jsx"],
-    'rules': {
-      'react/no-find-dom-node': 0,
-      'no-unused-expressions': 0,
-      'no-restricted-imports': 0
-    }
-  }],
-  'parserOptions': {
-    'ecmaVersion': 6,
-    'sourceType': 'module'
+  ],
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module"
   }
 }
-


### PR DESCRIPTION
Using single-quotes in JSON isn't valid. And my editor *loooooves* to tell me about it. This PR simply runs the `.eslintrc` through Prettier's default JSON formatter to convert the quotes to double-quotes.

The bigger reason for this PR is so that when I make the PR to implement Prettier's eslint rules those legit code changes don't get mixed in with this reformatting.

<img width="717" alt="eslint-invalid-json" src="https://user-images.githubusercontent.com/20728956/46018767-7e806480-c08f-11e8-8a06-d23b95977267.png">
