### PR TITLE
Convert manifest loader to ES5

### DIFF
--- a/config/manifest-loader.js
+++ b/config/manifest-loader.js
@@ -6,10 +6,10 @@
 function manifestLoader(source) {
   return `
     ${source}
-    (() => {
+    (function() {
       if (module.exports.receiveContentProps) {
         const applicationSettings = window.settings.applications[module.exports.entryName];
-        module.exports.receiveContentProps(...applicationSettings.contentProps);
+        module.exports.receiveContentProps.apply(module.exports, applicationSettings.contentProps);
       }
     })();
   `;


### PR DESCRIPTION
## Description

It looks like the manifest loader runs after Babel and so the code needs to be ES5.

## Testing done

Tested GI Bill feedback tool locally in Chrome and on Browserstack in IE11

## Acceptance criteria
- [x] Apps using manifest.js open in IE

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
