### PR TITLE
Brand consolidation -  Fix for source maps

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -183,9 +183,24 @@ const configGenerator = (options, apps) => {
   };
 
   if (['production', 'staging', 'preview', 'vagovstaging'].includes(options.buildtype)) {
-    let sourceMap = 'https://s3-us-gov-west-1.amazonaws.com/staging.vets.gov';
-    if (options.buildtype === 'production') {
-      sourceMap = 'https://s3-us-gov-west-1.amazonaws.com/www.vets.gov';
+    let sourceMap = null;
+
+    switch (options.buildtype) {
+      case 'production':
+        sourceMap = 'https://s3-us-gov-west-1.amazonaws.com/www.vets.gov';
+        break;
+
+      case 'staging':
+        sourceMap = 'https://s3-us-gov-west-1.amazonaws.com/staging.vets.gov';
+        break;
+
+      case 'vagovstaging':
+        sourceMap = 'https://s3-us-gov-west-1.amazonaws.com/staging.va.gov';
+        break;
+
+      case 'preview':
+      default:
+        sourceMap = 'https://s3-us-gov-west-1.amazonaws.com/preview.va.gov';
     }
 
     baseConfig.plugins.push(new webpack.SourceMapDevToolPlugin({


### PR DESCRIPTION
## Description
We were missing the configuration for our source maps in the `vagovstaging` and `preview` environments. This PR adds a switch statement to configure that.

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13591

## Testing done
None, yet

## Acceptance criteria
- [ ] Source maps are enabled correctly on staging.va.gov and preview.va.gov

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
