### PR TITLE
Scope gi tool icon style

### DIFF
--- a/src/applications/gi/sass/gi.scss
+++ b/src/applications/gi/sass/gi.scss
@@ -71,4 +71,11 @@
   select.hide-arrows {
     background-image: none
   }
+
+  .search-result {
+    i.fa {
+      background: initial;
+      color: initial;
+   }
+  }
 }


### PR DESCRIPTION
## Description
These changes restore the GI Bill tool icon colors. The other issues on the original ticket appear to be resolved.

## Testing done
Locally tested

## Screenshots
![image](https://user-images.githubusercontent.com/16051172/46029285-cf9c5280-c0a7-11e8-874b-f61051d07f33.png)

Other missing icons already resolved
![image](https://user-images.githubusercontent.com/16051172/46029524-87316480-c0a8-11e8-9d8e-8a4fe3a277b8.png)


## Acceptance criteria
- [x] Restore icon styles for GI Bill Comparison Tool

## Definition of done
- [ ] ~Events are logged appropriately~
- [ ] ~Documentation has been updated, if applicable~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
