### PR TITLE
13315 logo and breadcrumb linking

### DIFF
--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -8,6 +8,10 @@
     }
   }
 
+  #dashboard-title {
+    margin-top: 0;
+  }
+
   #va-header-logo-menu {
     align-items: center;
   }

--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -15,11 +15,12 @@ function NewBadge() {
 
 class PersonalizationDropdown extends React.Component {
   componentDidMount() {
-    document.addEventListener('click', this.checkLink);
+    // remove checkLink function when refactoring out isBrandConsolidationEnabled
+    if (brandConsolidationEnabled) { document.addEventListener('click', this.checkLink); }
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.checkLink);
+    if (brandConsolidationEnabled) { document.removeEventListener('click', this.checkLink); }
   }
 
   checkLink = (event) => {

--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -16,11 +16,11 @@ function NewBadge() {
 class PersonalizationDropdown extends React.Component {
   componentDidMount() {
     // remove checkLink function when refactoring out isBrandConsolidationEnabled
-    if (brandConsolidationEnabled) { document.addEventListener('click', this.checkLink); }
+    if (!brandConsolidationEnabled) { document.addEventListener('click', this.checkLink); }
   }
 
   componentWillUnmount() {
-    if (brandConsolidationEnabled) { document.removeEventListener('click', this.checkLink); }
+    if (!brandConsolidationEnabled) { document.removeEventListener('click', this.checkLink); }
   }
 
   checkLink = (event) => {

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -24,6 +24,9 @@ import SearchHelpSignIn from '../components/SearchHelpSignIn';
 import { selectUserGreeting } from '../selectors';
 
 import dashboardManifest from '../../../../applications/personalization/dashboard/manifest.json';
+import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
+
+const brandConsolidationEnabled = isBrandConsolidationEnabled();
 
 const DASHBOARD_URL = dashboardManifest.rootUrl;
 
@@ -74,6 +77,9 @@ export class Main extends React.Component {
     const nextParam = this.getNextParameter();
     if (nextParam) return nextParam;
 
+    if (brandConsolidationEnabled) return null;
+
+    // remove this line when refacotring isBrandConsolidationEnabled
     return window.location.pathname === '/' && DASHBOARD_URL;
   };
 

--- a/va-gov/pages/dashboard/index.md
+++ b/va-gov/pages/dashboard/index.md
@@ -3,8 +3,10 @@ title: Your Vets.gov Dashboard
 layout: page-react.html
 entryname: dashboard
 ---
-<nav class="va-nav-breadcrumbs">
-  <ul class="row va-nav-breadcrumbs-list columns" role="menubar" aria-label="Primary">
-    <li></li>
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+id="va-breadcrumbs">
+  <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    <li><a href="/">Home</a></li>
+    <li><a aria-current="page" href="/dashboard">My VA</a></li>
   </ul>
 </nav>


### PR DESCRIPTION
## Description
- [x] All "Home" breadcrumbs should go to the site's home page (change from /dashboard)
- [x] Logo should go to the site's home page (change from /dashboard)
- [x] Breadcrumbs are now visible on dashboard (previously hidden)
- [x] Dashboard breadcrumb is labeled: My VA and follows this pattern when user is on the page: 
   - Home > My VA

## Testing done
verified locally

## Screenshots
![screen shot 2018-09-25 at 14 49 05](https://user-images.githubusercontent.com/4998130/46042261-39315680-c0d2-11e8-8075-ca87c902ed92.png)

## Definition of done
~- [ ] Events are logged appropriately~
~- [ ] Documentation has been updated, if applicable~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
