### PR TITLE
Stop sending empty school address strings to the BE

### DIFF
--- a/src/applications/edu-benefits/feedback-tool/helpers.js
+++ b/src/applications/edu-benefits/feedback-tool/helpers.js
@@ -229,6 +229,25 @@ export function issueUIDescription({ formContext }) {
   return null;
 }
 
+/**
+ * Checks the values of an object's properties and completely removes the
+ * property if its value is an empty string. Immutable and shallow.
+ *
+ * @param {Object} obj - the object to strip properties off of
+ * @returns {Object} - the object without top-level properties that were empty
+ * strings
+ */
+export function removeEmptyStringProperties(obj) {
+  const cleanObject = { ...obj };
+  Object.keys(cleanObject).forEach(key => {
+    const value = cleanObject[key];
+    if (typeof value === 'string' && value.trim() === '') {
+      delete cleanObject[key];
+    }
+  });
+  return cleanObject;
+}
+
 /*
  * A helper that takes data from the SchoolSelectField back end and transforms
  * it to a valid format as specified by the FEEDBACK-TOOL's
@@ -240,8 +259,9 @@ export function issueUIDescription({ formContext }) {
  */
 export function transformSearchToolAddress({ address1, address2, address3, city, country, state, zip }) {
   const isDomesticAddress = country === 'USA';
+  let address = {};
   if (isDomesticAddress) {
-    return {
+    address = {
       country: 'United States',
       street: address1 && address1.slice(0, domesticSchoolAddressFields.street.maxLength),
       street2: address2 && address2.slice(0, domesticSchoolAddressFields.street2.maxLength),
@@ -250,16 +270,18 @@ export function transformSearchToolAddress({ address1, address2, address3, city,
       state: state && state.slice(0, domesticSchoolAddressFields.state.maxLength),
       postalCode: zip && zip.slice(0, domesticSchoolAddressFields.postalCode.maxLength),
     };
+  } else {
+    address = {
+      country,
+      street: address1 && address1.slice(0, searchToolSchoolAddressFields.street.maxLength),
+      street2: address2 && address2.slice(0, searchToolSchoolAddressFields.street2.maxLength),
+      street3: address3 && address3.slice(0, searchToolSchoolAddressFields.street3.maxLength),
+      city: city && city.slice(0, searchToolSchoolAddressFields.city.maxLength),
+      state: state && state.slice(0, searchToolSchoolAddressFields.state.maxLength),
+      postalCode: zip && zip.slice(0, searchToolSchoolAddressFields.postalCode.maxLength),
+    };
   }
-  return {
-    country,
-    street: address1 && address1.slice(0, searchToolSchoolAddressFields.street.maxLength),
-    street2: address2 && address2.slice(0, searchToolSchoolAddressFields.street2.maxLength),
-    street3: address3 && address3.slice(0, searchToolSchoolAddressFields.street3.maxLength),
-    city: city && city.slice(0, searchToolSchoolAddressFields.city.maxLength),
-    state: state && state.slice(0, searchToolSchoolAddressFields.state.maxLength),
-    postalCode: zip && zip.slice(0, searchToolSchoolAddressFields.postalCode.maxLength),
-  };
+  return removeEmptyStringProperties(address);
 }
 
 function addPrefilledFlagsToFormData(formData) {

--- a/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
@@ -9,6 +9,7 @@ import {
   PREFILL_FLAGS,
   prefillTransformer,
   submit,
+  removeEmptyStringProperties,
   transformSearchToolAddress,
 } from '../../feedback-tool/helpers';
 
@@ -21,6 +22,18 @@ function setFetchResponse(stub, data, headers = {}) {
   response.json = () => Promise.resolve(data);
   stub.resolves(response);
 }
+
+describe('removeEmptyStringProperties', () => {
+  it('removes keys that have empty string values', () => {
+    expect(removeEmptyStringProperties({ key: '' })).to.eql({});
+    expect(removeEmptyStringProperties({ key: '  ' })).to.eql({});
+  });
+  it('converts preserves non-empty strings', () => {
+    expect(removeEmptyStringProperties({ key: 'hello' })).to.eql({ key: 'hello' });
+    expect(removeEmptyStringProperties({ key: '  ', key2: 'hello' })).to.eql({ key2: 'hello' });
+  });
+});
+
 
 describe('feedback-tool helpers:', () => {
   describe('transformSearchToolAddress', () => {
@@ -109,6 +122,26 @@ describe('feedback-tool helpers:', () => {
       const address2 = transformSearchToolAddress(inputData2);
       expect(address1).to.eql(expectedAddress1);
       expect(address2).to.eql(expectedAddress2);
+    });
+    it('converts empty strings to `undefined`', () => {
+      const inputData = {
+        address1: '1840 NE ARGYLE',
+        address2: '',
+        address3: '',
+        city: 'PORTLAND',
+        country: 'USA',
+        state: 'OR',
+        zip: '97211',
+      };
+      const expectedAddress = {
+        street: '1840 NE ARGYLE',
+        city: 'PORTLAND',
+        country: 'United States',
+        state: 'OR',
+        postalCode: '97211',
+      };
+      const address = transformSearchToolAddress(inputData);
+      expect(address).to.eql(expectedAddress);
     });
   });
 


### PR DESCRIPTION
## Description
Stop sending empty school address strings to the backend. This was only an issue with schools selected via the search tool. Added a simple transformation layer that removes properties from the address object if their values are empty strings.

## Testing done
Updated unit tests. Added unit tests for the new transformation helper. Confirmed in local testing that empty street2 and street3 fields are not sent to the backend like they have been.

## Acceptance criteria
- [ ] 

## Definition of done
~~- [ ] Events are logged appropriately~~
~~- [ ] Documentation has been updated, if applicable~~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
