### PR TITLE
add signin dashboard widget to homepage

### DIFF
--- a/src/applications/static-pages/createMyVALoginWidget.js
+++ b/src/applications/static-pages/createMyVALoginWidget.js
@@ -1,0 +1,19 @@
+import { isLoggedIn } from '../../platform/user/selectors';
+
+export default function createMyVALoginWidget(store) {
+  const root = document.getElementById('myva-login');
+  const homePageStoreListener = () => {
+    if (root && isLoggedIn(store.getState())) {
+      root.innerHTML = '<button class="homepage-button primary-darker">' +
+        '<a href="/dashboard">' +
+        '<div class="icon-wrapper">' +
+        '<i class="fa fa-user-circle"></i>' +
+        '</div>' +
+        '<div class="button-inner">' +
+        '<p>Track claims, prescriptions, and more with “My VA”</p>' +
+        '</div>' +
+        '</a>';
+    }
+  };
+  store.subscribe(homePageStoreListener);
+}

--- a/src/applications/static-pages/createMyVALoginWidget.js
+++ b/src/applications/static-pages/createMyVALoginWidget.js
@@ -2,6 +2,7 @@ import { isLoggedIn } from '../../platform/user/selectors';
 
 export default function createMyVALoginWidget(store) {
   const root = document.getElementById('myva-login');
+  let unsubscribe;
   const homePageStoreListener = () => {
     if (root && isLoggedIn(store.getState())) {
       root.innerHTML = '<button class="homepage-button primary-darker">' +
@@ -13,7 +14,8 @@ export default function createMyVALoginWidget(store) {
         '<p>Track claims, prescriptions, and more with “My VA”</p>' +
         '</div>' +
         '</a>';
+      unsubscribe();
     }
   };
-  store.subscribe(homePageStoreListener);
+  unsubscribe = store.subscribe(homePageStoreListener);
 }

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -5,6 +5,7 @@ import startSitewideComponents from '../../platform/site-wide';
 
 import createApplicationStatus from './createApplicationStatus';
 import createCallToActionWidget from './createCallToActionWidget';
+import createMyVALoginWidget from './createMyVALoginWidget';
 import createDisabilityIncreaseApplicationStatus from '../disability-benefits/526EZ/components/createDisabilityIncreaseApplicationStatus';
 import createEducationApplicationStatus from '../edu-benefits/components/createEducationApplicationStatus';
 import createOptOutApplicationStatus from '../edu-benefits/components/createOptOutApplicationStatus';
@@ -103,4 +104,9 @@ if (disabilityPages.has(location.pathname) && __BUILDTYPE__ !== 'production') {
 
 if (location.pathname === '/disability-benefits/increase-claims-testing/') {
   create526EmailForm(store);
+}
+
+// homepage widgets
+if (location.pathname === '/') {
+  createMyVALoginWidget(store);
 }

--- a/va-gov/layouts/home.html
+++ b/va-gov/layouts/home.html
@@ -101,7 +101,7 @@
         </button>
       </div>
 
-      <div class="usa-width-one-third">
+      <div class="usa-width-one-third" id="myva-login">
         <button class="homepage-button primary-darker signin-signup-modal-trigger">
           <a href=#>
             <div class="icon-wrapper">


### PR DESCRIPTION
## Description
When the user is not signed in and clicks on the sign-in button on the VA.gov homepage, then the sign-in modal should activate and after the user successfully signs in they are returned to the VA.gov homepage.

If a user is signed in, the copy in this button on the VA.gov homepage should be updated to direct people to My VA.

## Testing done
verified locally 

## Screenshots
![screen shot 2018-09-26 at 11 49 12](https://user-images.githubusercontent.com/4998130/46098696-34c47680-c182-11e8-8a67-23ce7abcc087.png)
![screen shot 2018-09-26 at 11 48 37](https://user-images.githubusercontent.com/4998130/46098698-34c47680-c182-11e8-9c8c-527cf7f9ca97.png)


## Definition of done
~- [ ] Events are logged appropriately~
~- [ ] Documentation has been updated, if applicable~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
