### PR TITLE
always include megamenu state

### DIFF
--- a/src/platform/startup/store.js
+++ b/src/platform/startup/store.js
@@ -14,15 +14,9 @@ import profile from '../user/profile/reducers';
 import buildSettings from '../monitoring/BuildSettings/reducer';
 import megaMenu from '../site-wide/mega-menu/reducers';
 
-import isBrandConsolidationEnabled from '../brand-consolidation/feature-flag';
-
-let brandConsolidatedReducers = null;
-
-if (isBrandConsolidationEnabled()) {
-  brandConsolidatedReducers = {
-    megaMenu
-  };
-}
+const brandConsolidatedReducers = {
+  megaMenu
+};
 
 /**
  * Reducer object containing all of the site-wide reducers


### PR DESCRIPTION
## Description
This PR ensures that megamenu state is always included in state so that the menus in the TeamSite header/footer injection are functional.

## Testing done

Manual testing to ensure that inclusion of megamenu state has no side effects on existing applications.

## Screenshots


## Acceptance criteria
- [x] Megamenu works properly regardless of status of brand consolidation build flag

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
