### PR TITLE
Update presubmit transformer

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#84887dc7cb0ccee2ae2c8156b5664697c2850b1d",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#46f758005675cfa61db71d8e720bdbf8387eec1e",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0e089efcc5f6f02f6323f8aeb6cf5a5237dc2d53",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#84887dc7cb0ccee2ae2c8156b5664697c2850b1d",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0e089efcc5f6f02f6323f8aeb6cf5a5237dc2d53",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#de7453dc550f390b4225a7574596ac4cbe00c575",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -118,6 +118,7 @@ export function transform(formConfig, form) {
 
   const additionalDocuments = aggregate(disabilities, 'additionalDocuments');
   const privateRecords = aggregate(disabilities, 'privateRecords');
+  const treatments = aggregate(disabilities, 'treatments');
 
   const transformedData = {
     disabilities: disabilities
@@ -125,12 +126,13 @@ export function transform(formConfig, form) {
       .map(filtered => pick(filtered, disabilityProperties)),
     // Pull phone & email out of phoneEmailCard and into veteran property
     veteran: setPhoneEmailPaths(veteran),
-    // Extract treatments into one top-level array
-    treatments: aggregate(disabilities, 'treatments'),
     attachments: additionalDocuments.concat(privateRecords),
     privacyAgreementAccepted,
     serviceInformation,
     standardClaim,
+    // treatments has a minItems: 1 requirement so only include the property
+    // if there is at least one treatment to send
+    ...treatments.length && { treatments }
   };
 
   const withoutViewFields = filterViewFields(transformedData);

--- a/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
@@ -66,22 +66,6 @@ describe('526 helpers', () => {
           primaryPhone: '4445551212',
           emailAddress: 'test2@test1.net'
         },
-        treatments: [
-          {
-            treatmentCenterName: 'Somerset VA Clinic',
-            treatmentDateRange: {
-              from: '2000-06-06',
-              to: '2004-02-06'
-            }
-          },
-          {
-            treatmentCenterName: 'DC VA Regional Medical Center',
-            treatmentDateRange: {
-              from: '2000-07-04',
-              to: '2010-01-03'
-            }
-          }
-        ],
         attachments: [
           {
             name: 'Screen Shot 2018-07-09 at 11.25.49 AM.png',
@@ -135,7 +119,23 @@ describe('526 helpers', () => {
             waiveVABenefitsToRetainTrainingPay: true
           }
         },
-        standardClaim: false
+        standardClaim: false,
+        treatments: [
+          {
+            treatmentCenterName: 'Somerset VA Clinic',
+            treatmentDateRange: {
+              from: '2000-06-06',
+              to: '2004-02-06'
+            }
+          },
+          {
+            treatmentCenterName: 'DC VA Regional Medical Center',
+            treatmentDateRange: {
+              from: '2000-07-04',
+              to: '2010-01-03'
+            }
+          }
+        ],
       }
     };
     it('should return stringified, transformed data for submit', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9779,9 +9779,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#0e089efcc5f6f02f6323f8aeb6cf5a5237dc2d53":
-  version "3.95.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0e089efcc5f6f02f6323f8aeb6cf5a5237dc2d53"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#de7453dc550f390b4225a7574596ac4cbe00c575":
+  version "3.97.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#de7453dc550f390b4225a7574596ac4cbe00c575"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9779,9 +9779,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#46f758005675cfa61db71d8e720bdbf8387eec1e":
-  version "3.93.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#46f758005675cfa61db71d8e720bdbf8387eec1e"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#0e089efcc5f6f02f6323f8aeb6cf5a5237dc2d53":
+  version "3.95.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0e089efcc5f6f02f6323f8aeb6cf5a5237dc2d53"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
## Description
Updates the pre-submit transformer for the 526 Increase form to only include the `treatments` property when there's at least one treatment in the array.

## Testing done
- Tested locally
- Unit tests

## Screenshots
- No change

## Acceptance criteria
- [x] 526 is submitted without a `treatments` property when veteran does not select VA facility evidence.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
