### PR TITLE
Add section about running the site in production-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ VRT works by gathering the links for the site using the sitemap, then using Nigh
 
 There are some [limitations](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/Visual%20Regression%20Testing.md), one of which is that VRG only tests the page on the initial load on a single viewport - it does not interact with the page or resize the window. This means that if there are dynamic elements they will not be covered. If this is functionality that interests you, you are welcome to join a discussion about the next phase of VRG.
 
-To run Visual Regression Testing for a certain build, see the above section, [Executing Nightwatch Tests For a Certain Environment](####Executing-Nightwatch-Tests-For-a-Certain Environment).
+To run Visual Regression Testing for a certain build, see the above section, [Executing Nightwatch Tests For a Certain Environment](#Executing-Nightwatch-Tests-For-a-Certain Environment).
 
 ### Automated Accessibility Testing -- aXe
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ For example, to execute the E2E tests for Production:
 
 1. `NODE_ENV=production npm run build -- --buildtype=production`
 2. `BUILDTYPE=production npm run test:e2e`
-    - The Nightwatch startup script will see that port `3001` is not blocked (as it would be by the watch-task), and will start a [static webserver](##static-webserver) for the production build.
+    - The Nightwatch startup script will see that port `3001` is not blocked (as it would be by the watch-task), and will start a [static webserver](#static-webserver) for the production build.
 
 ### Visual Regression Testing
 This is the first iteration of visual regression testing. It is useful to detect side effects or scope of visual changes.
@@ -270,7 +270,7 @@ VRT works by gathering the links for the site using the sitemap, then using Nigh
 
 There are some [limitations](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/Visual%20Regression%20Testing.md), one of which is that VRG only tests the page on the initial load on a single viewport - it does not interact with the page or resize the window. This means that if there are dynamic elements they will not be covered. If this is functionality that interests you, you are welcome to join a discussion about the next phase of VRG.
 
-To run Visual Regression Testing for a certain build, see the above section, [Executing Nightwatch Tests For a Certain Environment](#Executing-Nightwatch-Tests-For-a-Certain Environment).
+To run Visual Regression Testing for a certain build, see the above section, about how to [execute Nightwatch in a certain environment](#Executing-Nightwatch-Tests-For-a-Certain-Environment).
 
 ### Automated Accessibility Testing -- aXe
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ VRT works by gathering the links for the site using the sitemap, then using Nigh
 
 There are some [limitations](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/Visual%20Regression%20Testing.md), one of which is that VRG only tests the page on the initial load on a single viewport - it does not interact with the page or resize the window. This means that if there are dynamic elements they will not be covered. If this is functionality that interests you, you are welcome to join a discussion about the next phase of VRG.
 
-To run Visual Regression Testing for a certain build, see the above section, about how to [execute Nightwatch in a certain environment](#Executing-Nightwatch-Tests-For-a-Certain-Environment).
+To run Visual Regression Testing for a certain build, see the above section, about how to [execute Nightwatch in a certain environment](#executing-nightwatch-tests-for-a-certain-environment).
 
 ### Automated Accessibility Testing -- aXe
 

--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ It is sometimes useful to ensure that a certain feature of the site will functio
 1. `NODE_ENV=production npm run build -- --buildtype=production`
   - This will generate the complete static website in `build/production`.
   - NOTE: You will likely see files already in the `build/development` directory. This contains the generated content files from Metalsmith, but unless you recently executed a development build, it most like does not contain the Webpack-compiled assets (JS/CSS) which are served from memory and not written to the file system during the watch-task.
-2. `node src/platform/testing/e2e/test-server.js buildtype=production`
-  - You should see console output indicating that a local webserver has started for the production build-type.
+2. `node src/platform/testing/e2e/test-server.js --buildtype=production`
+  - You should see console output indicating that a local webserver has started for the production build-type. The port
 
 ### End-to-end Test -- nightwatch
 

--- a/README.md
+++ b/README.md
@@ -213,10 +213,10 @@ The site comes bundled with a static webserver, which is used for serving the fi
 It is sometimes useful to ensure that a certain feature of the site will function correctly in a certain environment. For example, a common use case is to render a certain feature in all environments outside of production. In this case, it would be beneficial to ensure the production environment is not impacted. To locally run a production build of the website, follow these steps:
 
 1. `NODE_ENV=production npm run build -- --buildtype=production`
-  - This will generate the complete static website in `build/production`.
-  - NOTE: You will likely see files already in the `build/development` directory. This contains the generated content files from Metalsmith, but unless you recently executed a development build, it most likely does not contain the Webpack-compiled assets (JS/CSS) which are served from memory and not written to the file system during the watch-task.
+    - This will generate the complete static website in `build/production`.
+    - NOTE: You will likely see files already in the `build/development` directory. This contains the generated content files from Metalsmith, but unless you recently executed a development build, it most likely does not contain the Webpack-compiled assets (JS/CSS) which are served from memory and not written to the file system during the watch-task.
 2. `node src/platform/testing/e2e/test-server.js --buildtype=production`
-  - You should see console output indicating that a local webserver has started, which port it is running on, and for which build-type.
+    - You should see console output indicating that a local webserver has started, which port it is running on, and for which build-type.
 
 ### End-to-end Test -- nightwatch
 

--- a/README.md
+++ b/README.md
@@ -207,16 +207,16 @@ the unittests. This is why babel configuration is kept in `.babelrc`, so it can
 be shared between build and test.
 
 ### Static Webserver
-The site comes bundled with a static webserver, whic is used for serving the files of a certain build-type from the build directory. If there isn't already a server running on port `3001` as is the case with `npm run watch`, the static webserver will automatically be started during Nightwatch tests (E2E and Visual Regression) that will serve the files of the corresponding build.
+The site comes bundled with a static webserver, which is used for serving the files of a certain build-type from the build directory. If there isn't already a server running on port `3001` as is the case with `npm run watch`, the static webserver will automatically be started during Nightwatch tests (E2E and Visual Regression) that will serve the files of the corresponding build.
 
 #### Running the site in production
 It is sometimes useful to ensure that a certain feature of the site will function correctly in a certain environment. For example, a common use case is to render a certain feature in all environments outside of production. In this case, it would be beneficial to ensure the production environment is not impacted. To locally run a production build of the website, follow these steps:
 
 1. `NODE_ENV=production npm run build -- --buildtype=production`
   - This will generate the complete static website in `build/production`.
-  - NOTE: You will likely see files already in the `build/development` directory. This contains the generated content files from Metalsmith, but unless you recently executed a development build, it most like does not contain the Webpack-compiled assets (JS/CSS) which are served from memory and not written to the file system during the watch-task.
+  - NOTE: You will likely see files already in the `build/development` directory. This contains the generated content files from Metalsmith, but unless you recently executed a development build, it most likely does not contain the Webpack-compiled assets (JS/CSS) which are served from memory and not written to the file system during the watch-task.
 2. `node src/platform/testing/e2e/test-server.js --buildtype=production`
-  - You should see console output indicating that a local webserver has started for the production build-type. The port
+  - You should see console output indicating that a local webserver has started, which port it is running on, and for which build-type.
 
 ### End-to-end Test -- nightwatch
 
@@ -230,7 +230,7 @@ for tests. On Jenkins, Headless Chrome is used.
 Nightwatch is a wrapper on Selenium. It is configured in `config/nightwatch.js`.
 To run a nightwatch test, 3 things need to execute:
 
-  1. [A webserver with our site](##static-webserver)
+  1. [A webserver with our site](#static-webserver)
   2. The selenium server (which will spawn browsers like PhanomJS)
   3. The nightwatch client that talks to the Selenium server
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,18 @@ Note that because mocha is running the test files directly, it needs to use
 the unittests. This is why babel configuration is kept in `.babelrc`, so it can
 be shared between build and test.
 
+### Static Webserver
+The site comes bundled with a static webserver, whic is used for serving the files of a certain build-type from the build directory. If there isn't already a server running on port `3001` as is the case with `npm run watch`, the static webserver will automatically be started during Nightwatch tests (E2E and Visual Regression) that will serve the files of the corresponding build.
+
+#### Running the site in production
+It is sometimes useful to ensure that a certain feature of the site will function correctly in a certain environment. For example, a common use case is to render a certain feature in all environments outside of production. In this case, it would be beneficial to ensure the production environment is not impacted. To locally run a production build of the website, follow these steps:
+
+1. `NODE_ENV=production npm run build -- --buildtype=production`
+  - This will generate the complete static website in `build/production`.
+  - NOTE: You will likely see files already in the `build/development` directory. This contains the generated content files from Metalsmith, but unless you recently executed a development build, it most like does not contain the Webpack-compiled assets (JS/CSS) which are served from memory and not written to the file system during the watch-task.
+2. `node src/platform/testing/e2e/test-server.js buildtype=production`
+  - You should see console output indicating that a local webserver has started for the production build-type.
+
 ### End-to-end Test -- nightwatch
 
 All end-to-end tests are under `test/\*` and are named with the suffix `.e2e.spec.js`.
@@ -218,7 +230,7 @@ for tests. On Jenkins, Headless Chrome is used.
 Nightwatch is a wrapper on Selenium. It is configured in `config/nightwatch.js`.
 To run a nightwatch test, 3 things need to execute:
 
-  1. A webserver with our site
+  1. [A webserver with our site](##static-webserver)
   2. The selenium server (which will spawn browsers like PhanomJS)
   3. The nightwatch client that talks to the Selenium server
 
@@ -240,12 +252,25 @@ and you should see:
 ```
 * Selenium requires **Java 8** to run
 
+#### Executing Nightwatch Tests For a Certain Environment
+A webserver is required for Nightwatch to execute. Locally, you will likely execute E2E tests while running the local development server via `npm run watch`, followed by `npm run test:e2e`.
+
+However, it is sometimes useful to execute E2E tests for a certain build-type, which is done by first running a build for that build-type, then executing the tests with the build-type passed as an argument.
+
+For example, to execute the E2E tests for Production:
+
+1. `NODE_ENV=production npm run build -- --buildtype=production`
+2. `BUILDTYPE=production npm run test:e2e`
+    - The Nightwatch startup script will see that port `3001` is not blocked (as it would be by the watch-task), and will start a [static webserver](##static-webserver) for the production build.
+
 ### Visual Regression Testing
 This is the first iteration of visual regression testing. It is useful to detect side effects or scope of visual changes.
 
 VRT works by gathering the links for the site using the sitemap, then using Nightwatch to navigate throughout the site, capturing an image of each page that will either be used as the baseline for future comparisons or compared to the baseline. The developer must first create the baseline image set for comparisons (sometimes called the golden set), then after making their changes, run an additional task to execute the comparison. See the chart above for the commands.
 
 There are some [limitations](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/Visual%20Regression%20Testing.md), one of which is that VRG only tests the page on the initial load on a single viewport - it does not interact with the page or resize the window. This means that if there are dynamic elements they will not be covered. If this is functionality that interests you, you are welcome to join a discussion about the next phase of VRG.
+
+To run Visual Regression Testing for a certain build, see the above section, [Executing Nightwatch Tests For a Certain Environment](####Executing-Nightwatch-Tests-For-a-Certain Environment).
 
 ### Automated Accessibility Testing -- aXe
 


### PR DESCRIPTION
## Description
Now that the pattern of using the environment as feature-flags to toggle certain pieces of site functionality is being used more often, coupled with the amount of work that will take place during the brand-consolidation transition, I thought it would be valuable to add information to our readme about how to locally start a webserver running a production build of the website, and also how to execute Nightwatch tests using that build.

## Testing done
- Ran the commands on my computer to make sure they were working okay

## Acceptance criteria
- [ ] Information makes sense to other engineers

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
