### PR TITLE
Brand consolidation - Fix for mobile menu backdrop not extending to the bottom of screen

### DIFF
--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -527,9 +527,9 @@
     }
 
     #mega-menu {
-      #vetnav {
-        min-height: unset;
-      }
+      // #vetnav {
+      //   min-height: unset;
+      // }
       .login-container {
         position: relative;
         top: -40px;


### PR DESCRIPTION
## Description
Somehow this fix was lost during the merging process, but it should finish https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12870.

## Testing done
Local testing and messing with the navigation

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/1915775/46110047-6c4a1780-c1b0-11e8-8520-307393b3ca41.png)

### After
![image](https://user-images.githubusercontent.com/1915775/46110057-723ff880-c1b0-11e8-95b9-b96422a8841c.png)

## Acceptance criteria
- [ ] Mobile nav looks OK

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
