### PR TITLE
Fix for the watch-task crashing while reloading content

### DIFF
--- a/config/webpack-metalsmith-connect/index.js
+++ b/config/webpack-metalsmith-connect/index.js
@@ -28,13 +28,18 @@ function getEntryPoints(buildOptions) {
 }
 
 function compileAssets(buildOptions) {
-  return (files, metalsmith, done) => {
-    const convertPathsMiddleware = convertPathsToRelative(buildOptions);
-    const apps = getEntryPoints(buildOptions);
-    const webpackConfig = generateWebpackConfig(buildOptions, apps);
-    const webpackMiddleware = webpackPlugin(webpackConfig);
+  let compileMiddleware = null;
+  let convertPathsMiddleware = null;
 
-    webpackMiddleware(files, metalsmith, (err) => {
+  return (files, metalsmith, done) => {
+    if (!compileMiddleware) {
+      const apps = getEntryPoints(buildOptions);
+      const webpackConfig = generateWebpackConfig(buildOptions, apps);
+      compileMiddleware = webpackPlugin(webpackConfig);
+      convertPathsMiddleware = convertPathsToRelative(buildOptions);
+    }
+
+    compileMiddleware(files, metalsmith, (err) => {
       if (err) throw err;
       convertPathsMiddleware(files, metalsmith, done);
     });
@@ -42,14 +47,19 @@ function compileAssets(buildOptions) {
 }
 
 function watchAssets(buildOptions) {
-  return (files, metalsmith, done) => {
-    const convertPathsMiddleware = convertPathsToRelative(buildOptions);
-    const apps = getEntryPoints(buildOptions);
-    const webpackConfig = generateWebpackConfig(buildOptions, apps);
-    const webpackDevServerConfig = generateWebpackDevConfig(buildOptions);
-    const webpackMiddleware = webpackDevServerPlugin(webpackConfig, webpackDevServerConfig);
+  let devServerMiddleware = null;
+  let convertPathsMiddleware = null;
 
-    webpackMiddleware(files, metalsmith, (err) => {
+  return (files, metalsmith, done) => {
+    if (!devServerMiddleware) {
+      const apps = getEntryPoints(buildOptions);
+      const webpackConfig = generateWebpackConfig(buildOptions, apps);
+      const webpackDevServerConfig = generateWebpackDevConfig(buildOptions);
+      devServerMiddleware = webpackDevServerPlugin(webpackConfig, webpackDevServerConfig);
+      convertPathsMiddleware = convertPathsToRelative(buildOptions);
+    }
+
+    devServerMiddleware(files, metalsmith, (err) => {
       if (err) throw err;
       convertPathsMiddleware(files, metalsmith, done);
     });


### PR DESCRIPTION
## Description
This PR fixes an issue with the webpack-metalsmith-middleware.  The problem occurred from the middleware attempting to reinitialize the WebpackDevServer plugin inside the middleware chain, when that should only be done once. 

## Testing done
1. `npm run watch`
2. Edit file in content
3. Save the content file
4. 🤞 
5. Doesn't crash

## Acceptance criteria
- [x] The watch task runs without crashing during a content change

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
