### PR TITLE
Add 526 beta testing banner to home page

### DIFF
--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -23,6 +23,11 @@ const config = {
       component: ClaimIncreaseBanner
     },
     {
+      name: 'claim-increase',
+      paths: /^\/$/,
+      component: ClaimIncreaseBanner
+    },
+    {
       name: 'personalization',
       paths: /(.)/,
       component: PersonalizationBanner


### PR DESCRIPTION
## Description
Just like it says in the title, this PR adds the 526 beta testing banner to the home page.

## Testing done
Tested manually

## Screenshots
### Still works on the apply page
![image](https://user-images.githubusercontent.com/12970166/46163986-9c8dc680-c241-11e8-9787-638a5b4e7692.png)

### Shows up on the home page
![image](https://user-images.githubusercontent.com/12970166/46164003-ad3e3c80-c241-11e8-890d-7f794771e494.png)

### Does not show up on some arbitrary page
![image](https://user-images.githubusercontent.com/12970166/46164042-c2b36680-c241-11e8-92e7-610be5ea6f3a.png)


## Acceptance criteria
- [x] The banner shows up on the apply page
- [x] The banner shows up on the home page
- [x] The banner does **not** show up on any other page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
