### PR TITLE
content updates

### DIFF
--- a/src/applications/personalization/profile360/components/ContactInformation.jsx
+++ b/src/applications/personalization/profile360/components/ContactInformation.jsx
@@ -55,7 +55,7 @@ export default class ContactInformation extends React.Component {
           <div>
             {this.renderContent()}
             <div>
-              <h3>How do I update the email I use to sign in to Vets.gov?</h3>
+              <h3>How do I update the email I use to sign in to VA.gov?</h3>
               <a href={accountManifest.rootUrl} onClick={() => { recordEvent({ event: 'profile-navigation', 'profile-action': 'view-link', 'profile-section': 'account-settings' }); }}>Go to your account settings</a>
             </div>
           </div>

--- a/src/applications/personalization/profile360/components/ContactInformationExplanation.jsx
+++ b/src/applications/personalization/profile360/components/ContactInformationExplanation.jsx
@@ -10,10 +10,6 @@ export default function ContactInformationExplanation() {
       <div style={{ marginBottom: 10 }}>
         <AlertBox status="info" isVisible>
           <p>We’ll use this information to contact you about certain benefits and services, including disability compensation, pension benefits, and claims and appeals. If you’re enrolled in the VA health care program, your health care team may also use this information to communicate with you.</p>
-          <a
-            href="/health-care/"
-            onClick={() => { recordEvent({ event: 'profile-navigation', 'profile-action': 'view-link', 'profile-section': 'learn-more-va-benefits' }); }}>
-          Learn more about VA health benefits</a>.
         </AlertBox>
       </div>
       <AdditionalInfo

--- a/src/applications/personalization/profile360/components/IdentityVerification.jsx
+++ b/src/applications/personalization/profile360/components/IdentityVerification.jsx
@@ -10,7 +10,7 @@ export default function IdentityVerification({ learnMoreClick, faqClick, verifyC
 
       <div>
         <div onClick={learnMoreClick}>
-          <AdditionalInfo triggerText="How will Vets.gov verify my identity?">
+          <AdditionalInfo triggerText="How will VA.gov verify my identity?">
             <p>We use ID.me, our Veteran-owned technology partner that provides the strongest identity verification system available to prevent fraud and identity theft.</p>
             <p><strong>To verify your identity, you’ll need both of these:</strong>
               <ul>
@@ -33,7 +33,7 @@ export default function IdentityVerification({ learnMoreClick, faqClick, verifyC
         <h4>What if I’m having trouble verifying my identity?</h4>
         <p><a href="/faq/" target="_blank" onClick={faqClick}>Get answers to Frequently Asked Questions</a></p>
         <p>
-          Or call the Vets.gov Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a> (TTY: <a href="tel:18008778339">1-800-877-8339</a>). We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)
+          Or call the VA.gov Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a> (TTY: <a href="tel:18008778339">1-800-877-8339</a>). We’re here Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)
         </p>
       </div>
     </div>

--- a/src/applications/personalization/profile360/components/MVIError.jsx
+++ b/src/applications/personalization/profile360/components/MVIError.jsx
@@ -7,7 +7,7 @@ export default function MVIError({ facilitiesClick }) {
       <h4>We’re having trouble matching your information to our Veteran records</h4>
       <p>We’re sorry. We’re having trouble matching your information to our Veteran records, so we can’t give you access to tools for managing your health and benefits.</p>
 
-      <p>If you’d like to use these tools on Vets.gov, please contact your nearest VA medical center. Let them know you need to verify the information in your records, and update it as needed. The operator, or a patient advocate, can connect you with the right person who can help.</p>
+      <p>If you’d like to use these tools on VA.gov, please contact your nearest VA medical center. Let them know you need to verify the information in your records, and update it as needed. The operator, or a patient advocate, can connect you with the right person who can help.</p>
 
       <p><a href="/facilities/" onClick={facilitiesClick}>Find your nearest VA Medical Center</a>.</p>
     </div>


### PR DESCRIPTION
## Description
`/profile` should navigate to the profile page (this works locally)
remove vets.gov from profile page
remove link from blue box

## Testing done
verified locally

## Screenshots
![screencapture-localhost-3001-profile-2018-09-27-15_14_22](https://user-images.githubusercontent.com/4998130/46175206-6ca5e980-c268-11e8-848a-e973711490a1.png)
![screencapture-localhost-3001-profile-2018-09-27-15_13_08](https://user-images.githubusercontent.com/4998130/46175207-6d3e8000-c268-11e8-9553-4d4d6d1aa63a.png)
![screencapture-localhost-3001-profile-2018-09-27-15_11_27](https://user-images.githubusercontent.com/4998130/46175208-6d3e8000-c268-11e8-9e9e-ea43130b062f.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
