### PR TITLE
Stop hiding promo content on mobile

### DIFF
--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -665,11 +665,6 @@
       padding-top: 1em;
     }
 
-    // internal static-pages
-    #promo {
-      display: none;
-    }
-
     .va-nav-breadcrumbs  {
 
       padding-top: 0.25em;


### PR DESCRIPTION
## Description

According to the linked ticket, we need to show the promo content section on mobile. This enables that.

## Testing done
Tested in Chrome device emulation locally

## Screenshots
![screen shot 2018-09-28 at 9 22 21 am](https://user-images.githubusercontent.com/634932/46210965-4fbcf500-c300-11e8-932b-4bf2c53f8c30.png)


## Acceptance criteria
- [x] Content shows up on mobile

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
