### PR TITLE
Dashboard - Fetch RX, Messaging only after confirming user is authorized for that service

### DIFF
--- a/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
@@ -25,8 +25,10 @@ function recordDashboardClick(product) {
 
 class MessagingWidget extends React.Component {
   componentDidMount() {
-    this.props.fetchRecipients();
-    this.props.fetchFolder(0, { page: 1, sort: '-sent_date' });
+    if (this.props.canAccessMessaging) {
+      this.props.fetchRecipients();
+      this.props.fetchFolder(0, { page: 1, sort: '-sent_date' });
+    }
   }
 
   render() {

--- a/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
@@ -24,7 +24,7 @@ function recordDashboardClick(product) {
 
 class PrescriptionsWidget extends React.Component {
   componentDidMount() {
-    if (!this.props.loading) {
+    if (this.props.canAccessRx) {
       this.props.loadPrescriptions({ active: true, sort: '-refill_submit_date' });
     }
   }


### PR DESCRIPTION
## Description
This PR updates the RX and Messaging widgets to check the user's services before sending the API request.

Resolves department-of-veterans-affairs/vets.gov-team/issues/12020

## Testing done
Monitored the network panel to ensure that requests are not being sent for users who aren't in the service, but requests are still being sent for users that are.

## Acceptance criteria
- [x] Saves some resources on the API

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

