### PR TITLE
Brand Consolidation - Add GA Events

### DIFF
--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -43,10 +43,16 @@ export class Main extends React.Component {
   };
 
   linkClicked = (link) => {
+    // @todo Implement in Design System component
     recordEvent({
       event: 'nav-header-link',
       'nav-header-action': `Navigation - Header - Open Link - ${link.text}`
     });
+  };
+
+  columnThreeLinkClicked = () => {
+    // @todo Implement in Design System component
+    recordEvent({ event: 'nav-hub-containers' });
   };
 
   toggleDisplayHidden = (hidden) => {
@@ -59,7 +65,8 @@ export class Main extends React.Component {
       toggleDisplayHidden: this.toggleDisplayHidden,
       toggleDropDown: this.toggleDropDown,
       updateCurrentSection: this.updateCurrentSection,
-      linkClicked: this.linkClicked
+      linkClicked: this.linkClicked,
+      columnThreeLinkClicked: this.columnThreeLinkClicked
     };
 
     return <MegaMenu {...childProps}/>;

--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -2,12 +2,11 @@ import React from 'react';
 import { connect } from 'react-redux';
 import defaultLinkData from '../mega-menu-link-data.json';
 import authenticatedUserLinkData from '../mega-menu-link-data-for-authenticated-users.json';
-import { togglePanelOpen, toggleMobileDisplayHidden } from '../actions';
+import { togglePanelOpen, toggleMobileDisplayHidden, updateCurrentSection } from '../actions';
+import recordEvent from '../../../monitoring/record-event';
 import { isLoggedIn } from '../../../user/selectors';
 
 import MegaMenu from '@department-of-veterans-affairs/formation/MegaMenu';
-
-// const SESSION_REFRESH_INTERVAL_MINUTES = 45;
 
 export function flagCurrentPageInTopLevelLinks(links = [], pathName = window.location.pathname) {
   return links.map(link => {
@@ -23,10 +22,47 @@ export function getAuthorizedLinkData(loggedIn, authenticatedLinks = authenticat
 }
 
 export class Main extends React.Component {
+
+  toggleDropDown = (currentDropdown) => {
+    const isVisible = !!currentDropdown;
+    if (isVisible) {
+      recordEvent({
+        event: 'nav-header-top-level',
+        'nav-header-action': `Navigation - Header - Open Top Level - ${currentDropdown}`
+      });
+    }
+    this.props.togglePanelOpen(currentDropdown);
+  };
+
+  updateCurrentSection = (currentSection) => {
+    recordEvent({
+      event: 'nav-header-second-level',
+      'nav-header-action': `Navigation - Header - Open Second Level - ${currentSection}`
+    });
+    this.props.updateCurrentSection(currentSection);
+  };
+
+  linkClicked = (link) => {
+    recordEvent({
+      event: 'nav-header-link',
+      'nav-header-action': `Navigation - Header - Open Link - ${link.text}`
+    });
+  };
+
+  toggleDisplayHidden = (hidden) => {
+    this.props.toggleMobileDisplayHidden(hidden);
+  };
+
   render() {
-    return (
-      <MegaMenu {...this.props}></MegaMenu>
-    );
+    const childProps = {
+      ...this.props,
+      toggleDisplayHidden: this.toggleDisplayHidden,
+      toggleDropDown: this.toggleDropDown,
+      updateCurrentSection: this.updateCurrentSection,
+      linkClicked: this.linkClicked
+    };
+
+    return <MegaMenu {...childProps}/>;
   }
 }
 
@@ -39,21 +75,10 @@ const mapStateToProps = (state) => {
   };
 };
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    toggleDisplayHidden: (hidden) => {
-      dispatch(toggleMobileDisplayHidden(hidden));
-    },
-    toggleDropDown: (currentDropdown) => {
-      dispatch(togglePanelOpen(currentDropdown));
-    },
-    updateCurrentSection: (currentSection) => {
-      dispatch({
-        type: 'UPDATE_CURRENT_SECTION',
-        currentSection,
-      });
-    }
-  };
+const mapDispatchToProps = {
+  toggleMobileDisplayHidden,
+  togglePanelOpen,
+  updateCurrentSection
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Main);

--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -43,15 +43,14 @@ export class Main extends React.Component {
   };
 
   linkClicked = (link) => {
-    // @todo Implement in Design System component
+    const linkName = link.text || link.title;
     recordEvent({
       event: 'nav-header-link',
-      'nav-header-action': `Navigation - Header - Open Link - ${link.text}`
+      'nav-header-action': `Navigation - Header - Open Link - ${linkName}`
     });
   };
 
   columnThreeLinkClicked = () => {
-    // @todo Implement in Design System component
     recordEvent({ event: 'nav-hub-containers' });
   };
 

--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -50,8 +50,11 @@ export class Main extends React.Component {
     });
   };
 
-  columnThreeLinkClicked = () => {
-    recordEvent({ event: 'nav-hub-containers' });
+  columnThreeLinkClicked = (link) => {
+    recordEvent({
+      event: 'nav-hub-containers',
+      'nav-hub-action': link.text
+    });
   };
 
   toggleDisplayHidden = (hidden) => {

--- a/src/platform/site-wide/va-footer/containers/Main.jsx
+++ b/src/platform/site-wide/va-footer/containers/Main.jsx
@@ -3,6 +3,22 @@ import groupBy from 'lodash/groupBy';
 import orderBy from 'lodash/orderBy';
 import links from '../../../static-data/footer-links.json';
 import { isWideScreen, isEnter } from '../../../utilities/accessibility/index';
+import recordEvent from '../../../monitoring/record-event';
+
+const FOOTER_COLUMNS = {
+  PROGRAMS: '1',
+  RESOURCES: '2',
+  CONNECT: '3',
+  CONTACT: '4'
+};
+
+const FOOTER_EVENTS = {
+  [FOOTER_COLUMNS.PROGRAMS]: 'nav-footer-programs',
+  [FOOTER_COLUMNS.RESOURCES]: 'nav-footer-resources',
+  [FOOTER_COLUMNS.CONNECT]: 'nav-footer-connect',
+  [FOOTER_COLUMNS.CONTACT]: 'nav-footer-contact',
+  CRISIS_LINE: 'nav-footer-crisis',
+};
 
 export class Main extends React.Component {
   constructor(props) {
@@ -24,13 +40,17 @@ export class Main extends React.Component {
   openModal = () => {
     this.setState({ modalOpen: true });
   }
-  generateLinkItems = (column, direction = 'asc') => (
-    <ul className="va-footer-links">
-      {orderBy(this.linkObj[column], 'order', direction).map(link =>
-        <li key={`${link.column}-${link.order}`}><a href={link.href} target={link.target}>{link.title}</a></li>
-      )}
-    </ul>
-  )
+
+  generateLinkItems = (column, direction = 'asc') => {
+    const captureEvent = () => recordEvent(FOOTER_EVENTS[column]);
+    return (
+      <ul className="va-footer-links">
+        {orderBy(this.linkObj[column], 'order', direction).map(link =>
+          <li key={`${link.column}-${link.order}`}><a href={link.href} onClick={captureEvent} target={link.target}>{link.title}</a></li>
+        )}
+      </ul>
+    );
+  }
   handleKeyPress = (e) => {
     if (isEnter(e)) {
       this.openModal();

--- a/src/platform/site-wide/va-footer/containers/Main.jsx
+++ b/src/platform/site-wide/va-footer/containers/Main.jsx
@@ -95,7 +95,7 @@ export class Main extends React.Component {
               </h4>
             </li>
             <li className={innerClassName} id="veteran-contact" aria-hidden="true">
-              {this.generateLinkItems('4')}
+              {this.generateLinkItems(FOOTER_COLUMNS.CONTACT)}
             </li>
           </ul>
         ]
@@ -117,7 +117,7 @@ export class Main extends React.Component {
           </h4>
         </li>
         <li id="veteran-contact" aria-hidden="true">
-          {this.generateLinkItems('4')}
+          {this.generateLinkItems(FOOTER_COLUMNS.CONTACT)}
         </li>
       </ul>
     );
@@ -180,7 +180,7 @@ export class Main extends React.Component {
                 </h4>
               </li>
               <li className={innerClassName} id="veteran-programs" aria-hidden="true">
-                {this.generateLinkItems('1')}
+                {this.generateLinkItems(FOOTER_COLUMNS.PROGRAMS)}
               </li>
             </ul>
             <ul className={className} id="footer-services">
@@ -190,7 +190,7 @@ export class Main extends React.Component {
                 </h4>
               </li>
               <li className={innerClassName} id="veteran-resources" aria-hidden="true">
-                {this.generateLinkItems('2')}
+                {this.generateLinkItems(FOOTER_COLUMNS.RESOURCES)}
               </li>
             </ul>
             <ul className={className} id="footer-popular">
@@ -201,7 +201,7 @@ export class Main extends React.Component {
               </li>
 
               <li className={innerClassName} id="veteran-connect" aria-hidden="true">
-                {this.generateLinkItems('3')}
+                {this.generateLinkItems(FOOTER_COLUMNS.CONTACT)}
               </li>
             </ul>
             {contactVCL}

--- a/src/platform/site-wide/va-footer/containers/Main.jsx
+++ b/src/platform/site-wide/va-footer/containers/Main.jsx
@@ -38,11 +38,12 @@ export class Main extends React.Component {
     });
   }
   openModal = () => {
+    recordEvent({ event: FOOTER_EVENTS.CRISIS_LINE });
     this.setState({ modalOpen: true });
   }
 
   generateLinkItems = (column, direction = 'asc') => {
-    const captureEvent = () => recordEvent(FOOTER_EVENTS[column]);
+    const captureEvent = () => recordEvent({ event: FOOTER_EVENTS[column] });
     return (
       <ul className="va-footer-links">
         {orderBy(this.linkObj[column], 'order', direction).map(link =>

--- a/src/platform/site-wide/va-footer/containers/Main.jsx
+++ b/src/platform/site-wide/va-footer/containers/Main.jsx
@@ -201,7 +201,7 @@ export class Main extends React.Component {
               </li>
 
               <li className={innerClassName} id="veteran-connect" aria-hidden="true">
-                {this.generateLinkItems(FOOTER_COLUMNS.CONTACT)}
+                {this.generateLinkItems(FOOTER_COLUMNS.CONNECT)}
               </li>
             </ul>
             {contactVCL}

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -19,9 +19,11 @@ const handleIdMe = loginHandler('idme');
 
 class SignInModal extends React.Component {
   componentDidUpdate(prevProps) {
-    if (!prevProps.visible && this.props.visible) {
-      recordEvent({ event: 'login-modal-opened' });
-    }
+    const justOpened = !prevProps.visible && this.props.visible;
+    const justClosed = prevProps.visible && !this.props.visible;
+
+    if (justOpened) recordEvent({ event: 'login-modal-opened' });
+    else if (justClosed) recordEvent({ event: 'login-modal-closed' });
   }
   renderModalContent = () => {
     return (

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -19,11 +19,9 @@ const handleIdMe = loginHandler('idme');
 
 class SignInModal extends React.Component {
   componentDidUpdate(prevProps) {
-    const justOpened = !prevProps.visible && this.props.visible;
-    const justClosed = prevProps.visible && !this.props.visible;
-
-    if (justOpened) recordEvent({ event: 'login-modal-opened' });
-    else if (justClosed) recordEvent({ event: 'login-modal-closed' });
+    if (!prevProps.visible && this.props.visible) {
+      recordEvent({ event: 'login-modal-opened' });
+    }
   }
   renderModalContent = () => {
     return (

--- a/va-gov/layouts/home.html
+++ b/va-gov/layouts/home.html
@@ -77,7 +77,7 @@
       <!-- check these against Trevor's accessibility rules -->
       <div class="usa-width-one-third">
 
-        <button class="homepage-button primary-darker">
+        <button onclick="recordEvent({ event: 'nav-main-health' });" class="homepage-button primary-darker">
           <a href="/facilities/">
             <div class="icon-wrapper">
               <i class="fa far fa-map-marker"></i>
@@ -91,7 +91,7 @@
       </div>
 
       <div class="usa-width-one-third">
-        <button class="homepage-button secondary-dark va-overlay-trigger" data-show="#modal-crisisline">
+        <button onclick="recordEvent({ event: 'nav-main-vcl' });" class="homepage-button secondary-dark va-overlay-trigger" data-show="#modal-crisisline">
           <div class="icon-wrapper">
             <span class="vcl"></span>
           </div>
@@ -103,7 +103,7 @@
 
       <div class="usa-width-one-third" id="myva-login">
         <button class="homepage-button primary-darker signin-signup-modal-trigger">
-          <a href=#>
+          <a onclick="recordEvent({ event: 'nav-main-sign-in' });" href=#>
             <div class="icon-wrapper">
               <i class="fa fa-user-circle"></i>
             </div>
@@ -126,17 +126,17 @@
       <div class="usa-grid">
 
         <div class="usa-width-one-third">
-          <h4><a href=/health-care/><i class="icon-small fa fa-medkit"></i>Health Care</a></h4>
+          <h4><a href="/health-care/" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small fa fa-medkit"></i>Health Care</a></h4>
           <p>Apply for VA health care, find out how to access services, and manage your health and benefits online.</p>
         </div>
 
         <div class="usa-width-one-third">
-          <h4><a href=/disability/><i class="icon-small fa fa-handshake-o"></i>Disability</a></h4>
+          <h4><a href="/disability/" onclick="recordEvent({ event: 'nav-linkslist' });"></a><i class="icon-small fa fa-handshake-o"></i>Disability</a></h4>
           <p>File a claim for disability compensation for conditions related to your military service, and manage your benefits over time.</p>
         </div>
 
         <div class="usa-width-one-third">
-          <h4><a href=/education/><i class="icon-small fa fa-book"></i>Education and Training</a></h4>
+          <h4><a href="/education/" onclick="recordEvent({ event: 'nav-linkslist' });"></a><i class="icon-small fa fa-book"></i>Education and Training</a></h4>
           <p>Apply for and manage your GI Bill and other education benefits to help pay for college and training programs.</p>
         </div>
 
@@ -145,17 +145,17 @@
       <div class="usa-grid">
 
         <div class="usa-width-one-third">
-          <h4><a href=/careers-employment/><i class="icon-small fa fa-briefcase"></i>Careers and Employment</a></h4>
+          <h4><a href="/careers-employment/" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small fa fa-briefcase"></i>Careers and Employment</a></h4>
           <p>Apply for vocational rehabilitation services, get support for your Veteran-owned small business, and access other career resources.</p>
         </div>
 
         <div class="usa-width-one-third">
-          <h4><a href=/pension/><i class="icon-small fa fa-money"></i>Pension</a></h4>
+          <h4><a href="/pension/" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small fa fa-money"></i>Pension</a></h4>
           <p>Apply for monthly payments for wartime Veterans and survivors with limited or no income who meet certain age and disability requirements.</p>
         </div>
 
         <div class="usa-width-one-third">
-          <h4><a href=/housing-assistance/><i class="icon-small fa fa-home"></i>Housing Assistance</a></h4>
+          <h4><a href="/housing-assistance/" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small fa fa-home"></i>Housing Assistance</a></h4>
           <p>Find out if you're eligible for a VA direct or VA-backed loan to help you buy, build, repair, or keep a home. If you have a service-connected disability, see if you qualify for a housing grant to help you live more independently.</p>
         </div>
 
@@ -164,17 +164,17 @@
       <div class="usa-grid">
 
         <div class="usa-width-one-third">
-          <h4><a href=/life-insurance/><i class="icon-small fa fa-users"></i>Life Insurance</a></h4>
+          <h4><a href="/life-insurance/" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small fa fa-users"></i>Life Insurance</a></h4>
           <p>Explore VA life insurance options for Veterans, Servicemembers, and families. Manage your policy online, file claims for benefits, and access helpful resources.</p>
         </div>
 
         <div class="usa-width-one-third">
-          <h4><a href=/burials-memorials/><i class="icon-small fa fa-star"></i>Burials and Memorials</a></h4>
+          <h4><a href="/burials-memorials/" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small fa fa-star"></i>Burials and Memorials</a></h4>
           <p>Get help planning a burial in a VA national cemetery, order a headstone or other memorial item to honor a Veteran's service, and apply for survivor and dependent benefits.</p>
         </div>
 
         <div class="usa-width-one-third">
-          <h4><a href=/records/><i class="icon-small fa fa-id-card"></i>Records</a></h4>
+          <h4><a href="/records/" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small fa fa-id-card"></i>Records</a></h4>
           <p>Apply for a printed Veteran ID card, get your VA benefit letters and medical records, and learn how to apply for a discharge upgrade.</p>
         </div>
 
@@ -221,4 +221,5 @@
   </section>
 
 </main>
+
 {% include "va-gov/includes/footer.html" %}


### PR DESCRIPTION
## Description
This pull request implements the event-tracking required by Brand Consolidation.

### Blocked by

Unblocked by https://github.com/department-of-veterans-affairs/design-system/pull/174
- [x] Add `linkClicked` into Mega Menu component in Design System
- [x] Add `columnThreeLinkClicked` into Mega Menu component in Design System
    - We need to capture when links like [this](https://user-images.githubusercontent.com/24525739/44674573-efcee800-a9fb-11e8-831b-12a152318d95.png) are clicked.

Unblocked when we have confirmation to question asked at https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12464#issuecomment-425747513
- [x] Confirm whether the `nav-header-second-level` event should fire with the default value when the dropdown is initially opened.
    - Should clicking "VA Benefits and Health Care" also fire an event capture for the Health Care submenu?

Resolves department-of-veterans-affairs/vets.gov-team/issues/12464

## Testing done
Added `console.log` statement to `recordEvent` to confirm the events were firing at the right times with the right data.

## Acceptance criteria
- [x] Events are firing properly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
