### PR TITLE
Remove Hurricane Florence banner

### DIFF
--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -3,7 +3,7 @@ layout: home.html
 body_class: home
 title: Home
 plainlanguage: 11-1-16 Ready for Beth review
-enablewarning: true
+enablewarning: false
 description: Apply for and manage the VA benefits and services you’ve earned as a Veteran, Servicemember, or family member—like health care, disability, education, and more.
 majorlinks:
   - heading:


### PR DESCRIPTION
## Description
The homepage banner is ready to come down 🙂 

Resolves department-of-veterans-affairs/vets.gov-team/issues/13171

## Acceptance criteria
- [x] Homepage banner is removed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
