### PR TITLE
Load the USA toggle for Vets.gov

### DIFF
--- a/src/platform/site-wide/index.js
+++ b/src/platform/site-wide/index.js
@@ -17,6 +17,10 @@ import startVAFooter from './va-footer';
 
 import brandConsolidation from '../brand-consolidation';
 
+if (!brandConsolidation.isEnabled()) {
+  require('./usa-banner-toggle');
+}
+
 /**
  * Start up the site-wide components that live on every page, like
  * the login widget, the header menus, and the feedback widget.


### PR DESCRIPTION
## Description
The JS powering the USA toggle ("Here's how you know" link) was removed from Brand Consolidation because the USWDS imports were conflicting with it, and that strategy is being reworked. However, Vets.gov still needs it. This PR adds that JS back for Vets.gov builds.

## Testing done
Local testing

## Screenshots


## Acceptance criteria
- [x] USA toggle works on Vets.gov and Brand Consolidation builds

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
