### PR TITLE
Configures staging.va.gov for Vet360 updates

### DIFF
--- a/src/applications/personalization/profile360/vet360/util/local-vet360.js
+++ b/src/applications/personalization/profile360/vet360/util/local-vet360.js
@@ -6,7 +6,9 @@ export function isVet360Configured() {
     'staging.vets.gov',
     'www.vets.gov',
     'preview.va.gov',
-    'staging.va.gov'
+    'staging.va.gov',
+    'va.gov',
+    'www.va.gov'
   ].includes(document.location.hostname);
 }
 

--- a/src/applications/personalization/profile360/vet360/util/local-vet360.js
+++ b/src/applications/personalization/profile360/vet360/util/local-vet360.js
@@ -5,7 +5,8 @@ export function isVet360Configured() {
   return [
     'staging.vets.gov',
     'www.vets.gov',
-    'preview.va.gov'
+    'preview.va.gov',
+    'staging.va.gov'
   ].includes(document.location.hostname);
 }
 


### PR DESCRIPTION
## Description
On staging.va.gov , when updating contact information on profile, the user goes through the entire flow, only to see stale data at the end (the field has not updated).

In staging.va.gov, there is no PUT being called at all, and things are not being updated.j

Similar historical issue, for reference:  https://github.com/department-of-veterans-affairs/vets-website/pull/8418

## Testing done

Manually tested in staging.va.gov with user vets.gov.user+271@gmail.com

## Acceptance criteria
- [x] Vet360 updates are being made

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
