### PR TITLE
Bump Formation to 1.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^1.7.2",
+    "@department-of-veterans-affairs/formation": "^1.7.3",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "blob-polyfill": "^2.0.20171115",

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^1.7.0",
+    "@department-of-veterans-affairs/formation": "^1.7.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "blob-polyfill": "^2.0.20171115",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@department-of-veterans-affairs/formation@^1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.7.2.tgz#71d14c2f9790c6e57777fda1000e48e021db5f00"
+"@department-of-veterans-affairs/formation@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.7.3.tgz#caefce281747247d348441abc7785656db28369e"
   dependencies:
     classnames "^2.2.5"
     font-awesome "4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@department-of-veterans-affairs/formation@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.7.0.tgz#f16b270e4e9bb05fb3c84c854f4d32fd5e1791f3"
+"@department-of-veterans-affairs/formation@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.7.2.tgz#71d14c2f9790c6e57777fda1000e48e021db5f00"
   dependencies:
     classnames "^2.2.5"
     font-awesome "4"


### PR DESCRIPTION
## Description
Bumping to receive updates in https://github.com/department-of-veterans-affairs/design-system/pull/174.

Related ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12464

Blocked by:
Waiting on https://github.com/department-of-veterans-affairs/design-system/pull/176

## Testing done
Started the site 🙂 

## Acceptance criteria
- [x] Formation is updated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
