### PR TITLE
Hide ihub widget in staging

### DIFF
--- a/src/applications/personalization/dashboard/containers/AppointmentsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/AppointmentsWidget.jsx
@@ -11,10 +11,11 @@ import {
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 
 const IS_PRODUCTION = document.location.hostname === 'www.vets.gov';
+const IS_STAGING = document.location.hostname === 'staging.vets.gov';
 
 class AppointmentsWidget extends React.Component {
   componentDidMount() {
-    if (!IS_PRODUCTION) {
+    if (!IS_PRODUCTION && !IS_STAGING) {
       if (!this.props.loading) {
         this.props.fetchAppointments();
       }
@@ -22,8 +23,8 @@ class AppointmentsWidget extends React.Component {
   }
 
   render() {
-    // do not show in production
-    if (IS_PRODUCTION) {
+    // do not show in production or in staging
+    if (IS_PRODUCTION || IS_STAGING) {
       return null;
     }
 


### PR DESCRIPTION
## Description
Hides ihub widget in staging

## Testing done
Local testing

## Screenshots


## Acceptance criteria
- [x] iHub widget should not show up in staging environment

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13847
