### PR TITLE
add external links for messages

### DIFF
--- a/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
@@ -12,6 +12,7 @@ import {
   fetchFolder,
   fetchRecipients,
 } from '../../../messaging/actions';
+import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 
 function recordDashboardClick(product) {
   return () => {
@@ -94,7 +95,12 @@ class MessagingWidget extends React.Component {
       <div id="msg-widget">
         <h2>Check Secure Messages</h2>
         {content}
-        <p><Link href="/health-care/messaging" onClick={recordDashboardClick('view-all-messages')}>View all your secure messages</Link>.</p>
+        <p>
+          {isBrandConsolidationEnabled() ?
+            (<a href="https://www.myhealth.va.gov/mhv-portal-web/secure-messaging" target="_blank">View all your secure messages</a>) :
+            (<span><Link href="/health-care/messaging" onClick={recordDashboardClick('view-all-messages')}>View all your secure messages</Link>.</span>)
+          }
+        </p>
       </div>
     );
   }

--- a/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
@@ -11,6 +11,7 @@ import recordEvent from '../../../../platform/monitoring/record-event';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 import PrescriptionCard from '../components/PrescriptionCard';
+import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 
 function recordDashboardClick(product) {
   return () => {
@@ -58,7 +59,13 @@ class PrescriptionsWidget extends React.Component {
           <div>
             {content}
           </div>
-          <p><Link href="/health-care/prescriptions" onClick={recordDashboardClick('view-all-prescriptions')}>View all your prescriptions</Link>.</p>
+          <p>
+            {isBrandConsolidationEnabled() ?
+              (<a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/refill-prescriptions" target="_blank">View all your prescriptions</a>) :
+              (<span><Link href="/health-care/prescriptions" onClick={recordDashboardClick('view-all-prescriptions')}>View all your prescriptions</Link>.</span>)
+            }
+          </p>
+
         </div>
       );
     }


### PR DESCRIPTION
## Description
update links 
as per [this](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12852#issuecomment-426003939) comment, this PR only addresses two links instead of the original description 

## Testing done
build app (not able to test with user 264 and none of other mocks have messages that show these features)

## Screenshots
![screen shot 2018-10-02 at 11 20 52](https://user-images.githubusercontent.com/4998130/46365230-48b22180-c635-11e8-8fb8-e76c5c680574.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A [link](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12852) has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
