### PR TITLE
Require the privacy agreement on the GI Bill School Feedback Tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#f476ed0ff038403d04e531bbbae41f72290e23b5",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#de7453dc550f390b4225a7574596ac4cbe00c575",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#f73f9c313f64c1d455bb48dce717381724000be8",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/src/applications/edu-benefits/feedback-tool/config/form.js
+++ b/src/applications/edu-benefits/feedback-tool/config/form.js
@@ -9,6 +9,7 @@ import FormFooter from '../../../../platform/forms/components/FormFooter';
 import fullNameUI from '../../../../platform/forms/definitions/fullName';
 import PrefillMessage from '../../../../platform/forms/save-in-progress/PrefillMessage';
 import dataUtils from '../../../../platform/utilities/data/index';
+import preSubmitInfo from '../../../../platform/forms/preSubmitInfo';
 
 const { get, omit, set } = dataUtils;
 
@@ -139,6 +140,7 @@ const formConfig = {
     noAuth: 'Please sign in again to continue your application for declaration of status of dependents.'
   },
   title: 'GI Bill® School Feedback Tool',
+  preSubmitInfo,
   getHelp: GetFormHelp,
   footerContent: FormFooter,
   transformForSubmit: transform,


### PR DESCRIPTION
## Description
These changes require the privacy agreement on the GI Bill School Feedback Tool.

## Testing done
- manually tested

## Screenshots
![image](https://user-images.githubusercontent.com/16051172/46321834-801fc000-c59a-11e8-8daa-252b6fe881f3.png)
![image](https://user-images.githubusercontent.com/16051172/46321840-8f067280-c59a-11e8-936a-2bcca183a3df.png)

## Acceptance criteria
- [x] Submission requires checking the privacy agreement box

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
