### PR TITLE
add font-face selector outside of .consolidate

### DIFF
--- a/src/platform/site-wide/sass/style-consolidated.scss
+++ b/src/platform/site-wide/sass/style-consolidated.scss
@@ -1,6 +1,15 @@
 $font-path: "~uswds/src/fonts";
 $image-path: "~uswds/src/img";
 
+@font-face {
+  font-family: "FontAwesome";
+  src: url("~font-awesome/fonts/fontawesome-webfont.woff2") format("woff2"),
+    url("~font-awesome/fonts/fontawesome-webfont.woff") format("woff"),
+    url("~font-awesome/fonts/fontawesome-webfont.eot") format("eot");
+  font-weight: normal;
+  font-style: normal;
+}
+
 .consolidated {
   font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
 


### PR DESCRIPTION
## Description
fix font-face statement so that browser will download font awesome 

## Testing done
built locally and proxied stylesheet into team site 

## Screenshots
![screen shot 2018-10-03 at 12 33 46](https://user-images.githubusercontent.com/4998130/46431351-cf83fe80-c708-11e8-9b56-dd9e123fdeff.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
