### PR TITLE
conditionally remove the facility code before submit

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#f476ed0ff038403d04e531bbbae41f72290e23b5",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#f73f9c313f64c1d455bb48dce717381724000be8",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6490dc3ffe58717846dc45697d3fb59a2b5fba3c",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx
+++ b/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx
@@ -117,7 +117,7 @@ export class SchoolSelectField extends React.Component {
     this.props.onChange({
       ...this.props.formData,
       name,
-      'view:facilityCode': facilityCode,
+      facilityCode,
       address,
     });
   };
@@ -157,7 +157,7 @@ export class SchoolSelectField extends React.Component {
     this.props.onChange({
       ...this.props.formData,
       name: null,
-      'view:facilityCode': null,
+      facilityCode: null,
       address: {},
       'view:manualSchoolEntryChecked': false,
       'view:institutionQuery': this.props.searchInputValue,
@@ -462,7 +462,7 @@ const mapStateToProps = (state, ownProps) => {
   const currentPageNumber = selectCurrentPageNumber(state);
   const errorMessages = selectFacilityCodeErrorMessages(ownProps);
   const facilityCodeSelected = ownProps.formData
-    ? ownProps.formData['view:facilityCode']
+    ? ownProps.formData.facilityCode
     : '';
   const institutionQuery = selectInstitutionQuery(state);
   const institutions = selectInstitutions(state);

--- a/src/applications/edu-benefits/feedback-tool/config/form.js
+++ b/src/applications/edu-benefits/feedback-tool/config/form.js
@@ -59,7 +59,11 @@ const {
 } = fullSchema.properties;
 
 const { assistance, programs, school } = educationDetails.properties;
-const { address: schoolAddress, name: schoolName } = school.properties;
+const {
+  address: schoolAddress,
+  name: schoolName,
+  facilityCode,
+} = school.properties;
 const domesticSchoolAddress = schoolAddress.anyOf[0];
 const internationalSchoolAddress = schoolAddress.anyOf[1];
 const countries = domesticSchoolAddress.properties.country.enum.concat(
@@ -464,7 +468,7 @@ const formConfig = {
             educationDetails: {
               school: {
                 'view:searchSchoolSelect': {
-                  'view:facilityCode': {
+                  facilityCode: {
                     'ui:required': manualSchoolEntryIsNotChecked,
                   },
                   'ui:field': SchoolSelectField,
@@ -535,9 +539,7 @@ const formConfig = {
                       'view:searchSchoolSelect': {
                         type: 'object',
                         properties: {
-                          'view:facilityCode': {
-                            type: 'string',
-                          },
+                          facilityCode,
                         },
                       },
                       'view:manualSchoolEntry': {

--- a/src/applications/edu-benefits/feedback-tool/helpers.js
+++ b/src/applications/edu-benefits/feedback-tool/helpers.js
@@ -12,7 +12,7 @@ import UserInteractionRecorder from '../components/UserInteractionRecorder';
 
 export const trackingPrefix = 'edu-feedback-tool-';
 
-const { get, set } = dataUtils;
+const { get, unset } = dataUtils;
 const domesticSchoolAddressFields = get(
   'properties.educationDetails.properties.school.properties.address.anyOf[0].properties',
   fullSchema,
@@ -58,7 +58,7 @@ export function fetchInstitutions({ institutionQuery, page, onDone, onError }) {
   );
 }
 
-// Helper to clear out the facility code. Needed if the code was set via the
+// Helper to remove the facility code. Needed if the code was set via the
 // search tool and then manual address entry was selected. if this is not
 // cleared out the (incorrect) facility code will be sent along with the
 // manually entered school address.
@@ -69,9 +69,8 @@ function removeFacilityCodeIfManualEntry(form) {
       form,
     )
   ) {
-    return set(
+    return unset(
       'data.educationDetails.school.view:searchSchoolSelect.facilityCode',
-      '',
       form,
     );
   }

--- a/src/applications/edu-benefits/feedback-tool/helpers.js
+++ b/src/applications/edu-benefits/feedback-tool/helpers.js
@@ -62,7 +62,7 @@ export function fetchInstitutions({ institutionQuery, page, onDone, onError }) {
 // search tool and then manual address entry was selected. if this is not
 // cleared out the (incorrect) facility code will be sent along with the
 // manually entered school address.
-function removeFacilityCodeIfManualEntry(form) {
+export function removeFacilityCodeIfManualEntry(form) {
   if (
     get(
       'data.educationDetails.school.view:searchSchoolSelect.view:manualSchoolEntryChecked',
@@ -77,12 +77,12 @@ function removeFacilityCodeIfManualEntry(form) {
   return form;
 }
 
-export function transform(formConfig, form) {
-  const formData = transformForSubmit(
-    formConfig,
-    removeFacilityCodeIfManualEntry(form),
-    null,
-  );
+export function transform(
+  formConfig,
+  form,
+  formTransformer = removeFacilityCodeIfManualEntry,
+) {
+  const formData = transformForSubmit(formConfig, formTransformer(form), null);
   return JSON.stringify({
     giBillFeedback: {
       form: formData,

--- a/src/applications/edu-benefits/feedback-tool/helpers.js
+++ b/src/applications/edu-benefits/feedback-tool/helpers.js
@@ -12,7 +12,7 @@ import UserInteractionRecorder from '../components/UserInteractionRecorder';
 
 export const trackingPrefix = 'edu-feedback-tool-';
 
-const { get } = dataUtils;
+const { get, set } = dataUtils;
 const domesticSchoolAddressFields = get(
   'properties.educationDetails.properties.school.properties.address.anyOf[0].properties',
   fullSchema,
@@ -58,8 +58,32 @@ export function fetchInstitutions({ institutionQuery, page, onDone, onError }) {
   );
 }
 
+// Helper to clear out the facility code. Needed if the code was set via the
+// search tool and then manual address entry was selected. if this is not
+// cleared out the (incorrect) facility code will be sent along with the
+// manually entered school address.
+function removeFacilityCodeIfManualEntry(form) {
+  if (
+    get(
+      'data.educationDetails.school.view:searchSchoolSelect.view:manualSchoolEntryChecked',
+      form,
+    )
+  ) {
+    return set(
+      'data.educationDetails.school.view:searchSchoolSelect.facilityCode',
+      '',
+      form,
+    );
+  }
+  return form;
+}
+
 export function transform(formConfig, form) {
-  const formData = transformForSubmit(formConfig, form, null);
+  const formData = transformForSubmit(
+    formConfig,
+    removeFacilityCodeIfManualEntry(form),
+    null,
+  );
   return JSON.stringify({
     giBillFeedback: {
       form: formData,

--- a/src/applications/edu-benefits/feedback-tool/selectors/schoolSearch.js
+++ b/src/applications/edu-benefits/feedback-tool/selectors/schoolSearch.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 export const selectCurrentPageNumber = state =>
   _.get(state, 'schoolSelect.currentPageNumber');
 export const selectFacilityCodeErrorMessages = ownProps =>
-  _.get(ownProps, 'errorSchema.view:facilityCode.__errors');
+  _.get(ownProps, 'errorSchema.facilityCode.__errors');
 export const selectFormSubmitted = ownProps =>
   _.get(ownProps, 'formContext.submitted');
 export const selectInstitutionQuery = state =>

--- a/src/applications/edu-benefits/tests/feedback-tool/components/SchoolSelectField.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/feedback-tool/components/SchoolSelectField.unit.spec.jsx
@@ -344,7 +344,7 @@ describe('<SchoolSelectField>', () => {
       expect(onChange.firstCall.args[0]).to.eql({
         address: {},
         name: null,
-        'view:facilityCode': null,
+        facilityCode: null,
         'view:manualSchoolEntryChecked': false,
         'view:institutionQuery': 'test',
       });
@@ -419,7 +419,7 @@ describe('<SchoolSelectField>', () => {
           street3: domesticInstitution.address3,
         },
         name: domesticInstitution.name,
-        'view:facilityCode': domesticInstitution.facilityCode,
+        facilityCode: domesticInstitution.facilityCode,
       });
       expect(selectInstitution.firstCall.args[0]).to.eql({
         address1: domesticInstitution.address1,
@@ -448,7 +448,7 @@ describe('<SchoolSelectField>', () => {
           street3: internationalInstitution.address3,
         },
         name: internationalInstitution.name,
-        'view:facilityCode': internationalInstitution.facilityCode,
+        facilityCode: internationalInstitution.facilityCode,
       });
       expect(selectInstitution.firstCall.args[0]).to.eql({
         address1: internationalInstitution.address1,

--- a/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
@@ -13,6 +13,8 @@ import {
   prefillTransformer,
   submit,
   removeEmptyStringProperties,
+  removeFacilityCodeIfManualEntry,
+  transform,
   transformSearchToolAddress,
 } from '../../feedback-tool/helpers';
 
@@ -154,6 +156,70 @@ describe('feedback-tool helpers:', () => {
       };
       const address = transformSearchToolAddress(inputData);
       expect(address).to.eql(expectedAddress);
+    });
+  });
+
+  describe('removeFacilityCodeIfManualEntry', () => {
+    it('removes the facility code if manual entry is used', () => {
+      const form = {
+        data: {
+          educationDetails: {
+            school: {
+              'view:searchSchoolSelect': {
+                facilityCode: 123456,
+                'view:manualSchoolEntryChecked': true,
+              },
+            },
+          },
+        },
+      };
+      const actual = removeFacilityCodeIfManualEntry(form);
+      const expected = {
+        data: {
+          educationDetails: {
+            school: {
+              'view:searchSchoolSelect': {
+                'view:manualSchoolEntryChecked': true,
+              },
+            },
+          },
+        },
+      };
+      expect(actual).to.eql(expected);
+    });
+    it('does not manipulate the object if manual entry is not used', () => {
+      const form = {
+        data: {
+          educationDetails: {
+            school: {
+              'view:searchSchoolSelect': {
+                facilityCode: 123456,
+                'view:manualSchoolEntryChecked': false,
+              },
+            },
+          },
+        },
+      };
+      const actual = removeFacilityCodeIfManualEntry(form);
+      expect(actual).to.eql(form);
+    });
+  });
+
+  describe('transform', () => {
+    const formConfig = {
+      chapters: {
+        chapter1: {
+          pages: {
+            page1: {},
+          },
+        },
+      },
+    };
+    it('calls the `formTransformer` with the `form` object', () => {
+      const form = { data: {} };
+      const formTransformerSpy = sinon.spy(data => data);
+      transform(formConfig, form, formTransformerSpy);
+      expect(formTransformerSpy.calledWith(form)).to.be.true;
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9731,9 +9731,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#f73f9c313f64c1d455bb48dce717381724000be8":
-  version "3.98.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#f73f9c313f64c1d455bb48dce717381724000be8"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#6490dc3ffe58717846dc45697d3fb59a2b5fba3c":
+  version "3.99.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6490dc3ffe58717846dc45697d3fb59a2b5fba3c"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
## Description
Send the facilityCode to the backend. But only send it if the school was selected with the search tool.

TODO:
- [x] Add unit tests if this is a decent approach for this problem.

## Testing done
Tested locally. Confirmed the JSON payload when entering the school manually and when entering it with the search tool. Confirmed that after picking a school with the search tool and then switching to manual entry, the facility code was still not sent.

## Acceptance criteria
- [ ]

## Definition of done
~~- [ ] Events are logged appropriately~~
~~- [ ] Documentation has been updated, if applicable~~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
