### PR TITLE
Use regex for noITFPages

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
@@ -19,8 +19,12 @@ import {
 
 const fetchWaitingStates = [requestStates.notCalled, requestStates.pending];
 
-const noITFPages = ['/introduction', '/confirmation'];
 export class ITFWrapper extends React.Component {
+  static defaultProps = {
+    noITFPages: [/\/introduction/, /\/confirmation/],
+    /* noITFPages: ['/introduction', '/confirmation'], */
+  };
+
   constructor(props) {
     super(props);
     this.state = {
@@ -32,7 +36,7 @@ export class ITFWrapper extends React.Component {
   componentDidMount() {
     // ...fetch the ITF if needed
     if (
-      !noITFPages.includes(this.props.location.pathname) &&
+      !this.shouldBlockITF(this.props.location.pathname) &&
       this.props.itf.fetchCallState === requestStates.notCalled
     ) {
       this.props.fetchITF();
@@ -42,7 +46,7 @@ export class ITFWrapper extends React.Component {
   componentWillReceiveProps(nextProps) {
     const { itf, location } = nextProps;
 
-    if (noITFPages.includes(location.pathname)) {
+    if (this.shouldBlockITF(location.pathname)) {
       return;
     }
 
@@ -75,13 +79,23 @@ export class ITFWrapper extends React.Component {
     }
   }
 
+  /**
+   * Checks to see if the given pathname should be blocked from making any ITF calls.
+   */
+  shouldBlockITF(pathname) {
+    return this.props.noITFPages.some(
+      noITFPath =>
+        noITFPath.test ? noITFPath.test(pathname) : noITFPath === pathname,
+    );
+  }
+
   render() {
     const { location, children, itf } = this.props;
     // If the location is the intro or confirmation pages, don't show an ITF message
     let message;
     let content;
 
-    if (noITFPages.includes(location.pathname)) {
+    if (this.shouldBlockITF(location.pathname)) {
       message = null;
       content = children;
     } else if (fetchWaitingStates.includes(itf.fetchCallState)) {
@@ -170,6 +184,9 @@ ITFWrapper.propTypes = {
   }),
   fetchITF: PropTypes.func.isRequired,
   createITF: PropTypes.func.isRequired,
+  noITFPages: PropTypes.arrayOf(
+    PropTypes.oneOf([PropTypes.string, PropTypes.instanceOf(RegExp)]),
+  ),
 };
 
 const mapStateToProps = store => ({

--- a/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
@@ -22,7 +22,6 @@ const fetchWaitingStates = [requestStates.notCalled, requestStates.pending];
 export class ITFWrapper extends React.Component {
   static defaultProps = {
     noITFPages: [/\/introduction/, /\/confirmation/],
-    /* noITFPages: ['/introduction', '/confirmation'], */
   };
 
   constructor(props) {


### PR DESCRIPTION
## Description
There was a bug where if we went to the introduction page with a trailing slash, it would make ITF calls because the `pathname` didn't exactly match `/introduction` (since it was, in fact, `/introduction/`).

While I was here, I also opened it up to accept the list of `noITFPages` as a prop for when we get around to using this properly in all claims. (BDD claims won't file an ITF, so we won't want to start that on the first few pages until we're sure it isn't going to be BDD. I think that's how we'll want to handle that, anyhow.)

## Testing done
Manually tested; no ITF is made on the `/introduction/` or `/introduction` page(s), but _is_ made on the next one (increase only).

## Screenshots
N/A

## Acceptance criteria
- [x] No ITF call is made on either the `/introduction` or `/introduction/` page(s)
- [x] An ITF call is made on the next page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
    - No issue was filed for this; I just...fixed it...
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
