### PR TITLE
Va gov/footer column fix

### DIFF
--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -956,3 +956,7 @@
 [class^="vetnav-controller"] {
   position: relative !important;
 }
+
+.flex-container {
+  display: flex;
+}

--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -290,7 +290,8 @@
 
   // desktop footer stuff
 
-  .va-footer-linkgroup-title {
+  h4.va-footer-linkgroup-title {
+    padding-bottom: 1em;
 
     button {
       -webkit-font-smoothing: antialiased;
@@ -299,7 +300,7 @@
       font-weight: 700;
       font-size: 1.1em;
       margin: 0;
-      padding: 0 0 1em 0;
+      padding: 0;
       text-align: left;
     }
 
@@ -314,12 +315,6 @@
     .va-footer-linkgroup {
       li {
         margin-bottom: 0;
-
-        &:first-child {
-          h4 {
-            padding-bottom: 0;
-          }
-        }
       }
     }
   }
@@ -328,12 +323,6 @@
   .va-footer-linkgroup {
     li {
       margin-bottom: 0;
-
-      &:first-child {
-        h4 {
-          padding-bottom: 0;
-        }
-      }
     }
   }
 
@@ -520,6 +509,9 @@
     #footerNav {
       .va-footer-linkgroup {
         margin-top: 0;
+        h4 {
+          padding: 0;
+        }
         li {
           margin-bottom: 6px;
         }

--- a/src/platform/site-wide/va-footer/containers/Main.jsx
+++ b/src/platform/site-wide/va-footer/containers/Main.jsx
@@ -73,7 +73,7 @@ export class Main extends React.Component {
       return [
         <ul
           key="veteran-crisis-line"
-          className="va-footer-linkgroup usa-width-one-fourth usa-accordion"
+          className="va-footer-linkgroup usa-accordion"
           id="veteran-crisis-line"
           aria-hidden="true"
         >
@@ -110,7 +110,7 @@ export class Main extends React.Component {
           </li>
         </ul>,
         <ul
-          className="va-footer-linkgroup usa-width-one-fourth usa-accordion"
+          className="va-footer-linkgroup usa-accordion"
           id="veteran-contact-us"
           key="veteran-contact-us"
           aria-hidden="true"
@@ -139,10 +139,7 @@ export class Main extends React.Component {
       ];
     }
     return (
-      <ul
-        className="va-footer-linkgroup usa-width-one-fourth"
-        id="veteran-crisis"
-      >
+      <ul className="va-footer-linkgroup" id="veteran-crisis">
         <li>
           <h4 className="va-footer-linkgroup-title">In Crisis? Get Help Now</h4>
         </li>
@@ -174,12 +171,12 @@ export class Main extends React.Component {
     let buttonEnabled = '';
     let buttonClasses = '';
     if (this.state.isMobile) {
-      className = 'va-footer-linkgroup usa-width-one-fourth usa-accordion';
+      className = 'va-footer-linkgroup  usa-accordion';
       innerClassName = 'usa-accordion-content';
       buttonEnabled = '';
       buttonClasses = 'usa-button-unstyled usa-accordion-button';
     } else {
-      className = 'va-footer-linkgroup usa-width-one-fourth';
+      className = 'va-footer-linkgroup';
       innerClassName = '';
       buttonEnabled = 'disabled';
       buttonClasses = 'va-footer-button';
@@ -187,7 +184,7 @@ export class Main extends React.Component {
     return (
       <div>
         <div className="footer-inner">
-          <div className="usa-grid usa-grid-flex-mobile">
+          <div className="usa-grid-full flex-container usa-grid-flex-mobile">
             <ul className={className} id="footer-first-child">
               <li>
                 <h4 className="va-footer-linkgroup-title">

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -218,86 +218,16 @@
   },
   {
     "column": "bottom_rail",
-    "href": "https://www.oprm.va.gov/foia/",
-    "order": 2,
-    "target": null,
-    "title": "FOIA"
-  },
-  {
-    "column": "bottom_rail",
-    "href": "https://www.va.gov/oig/",
-    "order": 3,
-    "target": "_blank",
-    "title": "Inspector General"
-  },
-  {
-    "column": "bottom_rail",
-    "href": "https://www.va.gov/orm/NOFEAR_Select.asp",
-    "order": 4,
-    "target": null,
-    "title": "No FEAR Act"
-  },
-  {
-    "column": "bottom_rail",
-    "href": "https://www.va.gov/about_va/va_notices.asp",
-    "order": 5,
-    "target": null,
-    "title": "Notices"
-  },
-  {
-    "column": "bottom_rail",
     "href": "https://www.va.gov/opa/Plain_Language.asp",
-    "order": 6,
+    "order": 2,
     "target": null,
     "title": "Plain Language"
   },
   {
     "column": "bottom_rail",
     "href": "https://www.va.gov/privacy/",
-    "order": 7,
+    "order": 3,
     "target": null,
     "title": "Privacy Policy"
-  },
-  {
-    "column": "bottom_rail",
-    "href": "https://www.va.gov/orpm/",
-    "order": 8,
-    "target": null,
-    "title": "Regulations"
-  },
-  {
-    "column": "bottom_rail",
-    "href": "https://www.va.gov/transparency/",
-    "order": 9,
-    "target": null,
-    "title": "Transparency"
-  },
-  {
-    "column": "bottom_rail",
-    "href": "https://www.usa.gov",
-    "order": 10,
-    "target": "_blank",
-    "title": "USA.gov"
-  },
-  {
-    "column": "bottom_rail",
-    "href": "https://www.va.gov/webpolicylinks.asp",
-    "order": 11,
-    "target": null,
-    "title": "Web Policies"
-  },
-  {
-    "column": "bottom_rail",
-    "href": "https://www.va.gov/accountability/",
-    "order": 12,
-    "target": null,
-    "title": "Whistleblower Rights and Protections"
-  },
-  {
-    "column": "bottom_rail",
-    "href": "https://www.whitehouse.gov",
-    "order": 13,
-    "target": "_blank",
-    "title": "White House"
   }
 ]


### PR DESCRIPTION
## Description
Updates the footer layout to stay 4 columns wide, until collapsing down to mobile view.

Removes unnecessary super footer urls referenced in [#13936](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13936)


## Testing done
Local testing, visual regression testing



## Screenshots
This is a screen shot at 780px wide:

![screenshot_2018-10-04 home 2](https://user-images.githubusercontent.com/1959628/46507693-a9d12500-c7ee-11e8-8664-17b0d71aebca.png)
