### PR TITLE
526 delete uploads mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -27,12 +27,14 @@ import { VA_FORM4142_URL } from '../all-claims/constants';
  * of each object into one array
  * @param {array} dataArray array of objects to inspect
  * @param {string} property the property to inspect in each array item
+ * @param {string} refPropPath the property that tells us whether to inspect at all TODO make this sound better
  * @returns {array} a list of aggregated items pulled from different arrays
  */
-const aggregate = (dataArray, property) => {
+const aggregate = (dataArray, property, refPropPath) => {
   const masterList = [];
   dataArray.forEach(item => {
-    if (item[property]) {
+    const itemIsSelected = get(refPropPath, item, true);
+    if (item[property] && itemIsSelected) {
       item[property].forEach(listItem => masterList.push(listItem));
     }
   });
@@ -110,9 +112,21 @@ export function transform(formConfig, form) {
     ? { servicePeriods, reservesNationalGuardService }
     : { servicePeriods };
 
-  const additionalDocuments = aggregate(disabilities, 'additionalDocuments');
-  const privateRecords = aggregate(disabilities, 'privateRecords');
-  const treatments = aggregate(disabilities, 'treatments');
+  const additionalDocuments = aggregate(
+    disabilities,
+    'additionalDocuments',
+    'view:selectableEvidenceTypes.view:otherEvidence',
+  );
+  const privateRecords = aggregate(
+    disabilities,
+    'privateRecords',
+    'view:selectableEvidenceTypes.view:privateMedicalRecords',
+  );
+  const treatments = aggregate(
+    disabilities,
+    'treatments',
+    'view:selectableEvidenceTypes.view:vaMedicalRecords',
+  );
 
   const transformedData = {
     disabilities: disabilities

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -27,7 +27,8 @@ import { VA_FORM4142_URL } from '../all-claims/constants';
  * of each object into one array
  * @param {array} dataArray array of objects to inspect
  * @param {string} property the property to inspect in each array item
- * @param {string} refPropPath the property that tells us whether to inspect at all TODO make this sound better
+ * @param {string} refPropPath an optional other property to inspect,
+ *                             acts as a condition for the target property
  * @returns {array} a list of aggregated items pulled from different arrays
  */
 const aggregate = (dataArray, property, refPropPath) => {

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -442,6 +442,14 @@ export const evidenceSummaryView = ({ formContext, formData }) => {
     additionalDocuments,
   } = formData;
 
+  const {
+    'view:selectableEvidenceTypes': {
+      'view:vaMedicalRecords': vaRecordsSelected,
+      'view:privateMedicalRecords': privateRecordsSelected,
+      'view:otherEvidence': otherEvidenceSelected,
+    },
+  } = formData;
+
   return (
     <div>
       {formContext.reviewMode && (
@@ -452,29 +460,33 @@ export const evidenceSummaryView = ({ formContext, formData }) => {
         </div>
       )}
       <ul>
-        {treatments && (
-          <li>
-            We’ll get your medical records from {listCenters(treatments)}.
-          </li>
-        )}
-        {privateRecordReleases && (
-          <li>
-            We’ll get your private medical records from{' '}
-            {listCenters(privateRecordReleases)}.
-          </li>
-        )}
-        {privateRecords && (
-          <li>
-            We have received the private medical records you uploaded:
-            {listDocuments(privateRecords)}
-          </li>
-        )}
-        {additionalDocuments && (
-          <li>
-            We have received the additional evidence you uploaded:
-            {listDocuments(additionalDocuments)}
-          </li>
-        )}
+        {treatments &&
+          vaRecordsSelected && (
+            <li>
+              We’ll get your medical records from {listCenters(treatments)}.
+            </li>
+          )}
+        {privateRecordReleases &&
+          privateRecordsSelected && (
+            <li>
+              We’ll get your private medical records from{' '}
+              {listCenters(privateRecordReleases)}.
+            </li>
+          )}
+        {privateRecords &&
+          privateRecordsSelected && (
+            <li>
+              We have received the private medical records you uploaded:
+              {listDocuments(privateRecords)}
+            </li>
+          )}
+        {additionalDocuments &&
+          otherEvidenceSelected && (
+            <li>
+              We have received the additional evidence you uploaded:
+              {listDocuments(additionalDocuments)}
+            </li>
+          )}
       </ul>
     </div>
   );

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -129,19 +129,21 @@ export function transform(formConfig, form) {
     'view:selectableEvidenceTypes.view:vaMedicalRecords',
   );
 
+  const attachments = additionalDocuments.concat(privateRecords);
+
   const transformedData = {
     disabilities: disabilities
       .filter(disability => disability['view:selected'] === true)
       .map(filtered => pick(filtered, disabilityProperties)),
     // Pull phone & email out of phoneEmailCard and into veteran property
     veteran: setPhoneEmailPaths(veteran),
-    attachments: additionalDocuments.concat(privateRecords),
     privacyAgreementAccepted,
     serviceInformation,
     standardClaim,
     // treatments has a minItems: 1 requirement so only include the property
     // if there is at least one treatment to send
     ...(treatments.length && { treatments }),
+    ...(attachments.length && { attachments }),
   };
 
   const withoutViewFields = filterViewFields(transformedData);

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -27,9 +27,13 @@ import { VA_FORM4142_URL } from '../all-claims/constants';
  * of each object into one array
  * @param {array} dataArray array of objects to inspect
  * @param {string} property the property to inspect in each array item
- * @param {string} refPropPath an optional other property to inspect,
- *                             acts as a condition for the target property
- * @returns {array} a list of aggregated items pulled from different arrays
+ * @param {string} [refPropPath] Path to a property used to determine if the
+ *                               `property` should be aggregated. E.g., pointing
+ *                               to a boolean `view:thingIsSelected` property will
+ *                               ensure that only subarrays with a value of `true`
+ *                               for this reference property are pulled into the
+ *                               aggregated list.
+ * @returns {array} an array of aggregated items pulled from different nested arrays
  */
 const aggregate = (dataArray, property, refPropPath) => {
   const masterList = [];

--- a/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
@@ -69,28 +69,6 @@ describe('526 helpers', () => {
           primaryPhone: '4445551212',
           emailAddress: 'test2@test1.net',
         },
-        attachments: [
-          {
-            name: 'Screen Shot 2018-07-09 at 11.25.49 AM.png',
-            confirmationCode: '9664f488-1243-4b25-805e-75ad7e4cf765',
-            attachmentId: 'L105',
-          },
-          {
-            name: 'Screen Shot 2018-07-09 at 11.24.39 AM.png',
-            confirmationCode: '66bfab89-6e2b-4361-a905-754dfbff7df7',
-            attachmentId: 'L105',
-          },
-          {
-            name: 'Screen Shot 2018-07-09 at 3.29.08 PM.png',
-            confirmationCode: 'a58ae568-d190-49cd-aa04-b1b1da5eae35',
-            attachmentId: 'L105',
-          },
-          {
-            name: 'Screen Shot 2018-07-09 at 2.02.39 PM.png',
-            confirmationCode: 'f23194e4-c534-42c6-9e96-16c08d8230a5',
-            attachmentId: 'L105',
-          },
-        ],
         privacyAgreementAccepted: true,
         serviceInformation: {
           servicePeriods: [
@@ -139,6 +117,28 @@ describe('526 helpers', () => {
             },
           },
         ],
+        attachments: [
+          {
+            name: 'Screen Shot 2018-07-09 at 11.25.49 AM.png',
+            confirmationCode: '9664f488-1243-4b25-805e-75ad7e4cf765',
+            attachmentId: 'L105',
+          },
+          {
+            name: 'Screen Shot 2018-07-09 at 11.24.39 AM.png',
+            confirmationCode: '66bfab89-6e2b-4361-a905-754dfbff7df7',
+            attachmentId: 'L105',
+          },
+          {
+            name: 'Screen Shot 2018-07-09 at 3.29.08 PM.png',
+            confirmationCode: 'a58ae568-d190-49cd-aa04-b1b1da5eae35',
+            attachmentId: 'L105',
+          },
+          {
+            name: 'Screen Shot 2018-07-09 at 2.02.39 PM.png',
+            confirmationCode: 'f23194e4-c534-42c6-9e96-16c08d8230a5',
+            attachmentId: 'L105',
+          },
+        ],
       },
     };
     it('should return stringified, transformed data for submit', () => {
@@ -146,7 +146,24 @@ describe('526 helpers', () => {
         JSON.stringify(transformedData),
       );
     });
+
+    it('should not submit uploads when corresponding evidence type not selected', () => {
+      const noAttachments = _.merge(maximalData, {
+        disabilities: [
+          {
+            'view:selectableEvidenceTypes': {
+              'view:privateMedicalRecords': false,
+              'view:otherEvidence': false,
+            },
+          },
+        ],
+      });
+
+      const transformedNoAttachments = transform(null, noAttachments);
+      expect(transformedNoAttachments.attachments).to.be.undefined;
+    });
   });
+
   describe('validateDisability', () => {
     it('should reject invalid disability data', () => {
       expect(validateDisability(invalidDisability)).to.equal(false);


### PR DESCRIPTION
## Description
- Only show evidence summary for evidence types that were selected
- Only submit evidence that's been selected.
- Don't submit an empty array for attachments, leave the property off the submission instead.

Users may change their mind on sending / submitting a given type of evidence even after they've filled out the corresponding questions in the form (e.g., they upload private medical records, but then decide to unselect the 'Private Medical Records' evidence type because for whatever reason they no longer want to submit those with the form).

## Testing done
- Tested locally
- Added test case
- Updated existing tests

## Screenshots
No visual changes

## Acceptance criteria
- [x] User doesn't see evidence summary for a type of evidence they deselected
- [x] Evidence only gets submitted when the corresponding evidence type is selected at time of submission

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
