### PR TITLE
Point to preview instead of staging for va.gov links

### DIFF
--- a/script/options.js
+++ b/script/options.js
@@ -93,11 +93,12 @@ function applyEnvironmentOverrides(options) {
 
 function applyBrandConsolidationOverrides(options) {
   let currentEnv = 'dev';
-  if (
-    options.buildtype.includes(environments.STAGING) ||
-    options.buildtype === environments.PREVIEW
-  ) {
+  if (options.buildtype.includes(environments.STAGING)) {
     currentEnv = 'staging';
+  }
+
+  if (options.buildtype === environments.PREVIEW) {
+    currentEnv = 'preview';
   }
 
   // This list also exists in stagingDomains.js

--- a/src/platform/utilities/environment/stagingDomains.js
+++ b/src/platform/utilities/environment/stagingDomains.js
@@ -1,6 +1,10 @@
 let currentEnv = 'dev';
-if (__BUILDTYPE__.includes('staging') || __BUILDTYPE__ === 'preview') {
+if (__BUILDTYPE__.includes('staging')) {
   currentEnv = 'staging';
+}
+
+if (__BUILDTYPE__ === 'preview') {
+  currentEnv = 'preview';
 }
 
 // This list also exists in script/options.js


### PR DESCRIPTION
## Description

The goal is to have the Teamsite header injected on preview.va.gov links, so this updates our url rewriting to point to preview.va.gov instead of staging.va.gov.

## Testing done
Built in preview mode locally.

## Acceptance criteria
- [ ] www.va.gov links are transformed to preview.va.gov links in menu, footer, and content pages

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
