### PR TITLE
Bump z-index of mobile navigation menu

### DIFF
--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -358,6 +358,7 @@
       //   min-height: unset;
       // }
       .login-container {
+        z-index: 3001;
         position: relative;
         top: -40px;
       }

--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -358,7 +358,7 @@
       //   min-height: unset;
       // }
       .login-container {
-        z-index: 3001;
+        z-index: 301;
         position: relative;
         top: -40px;
       }


### PR DESCRIPTION
## Description

The mobile navigation menu overlay was not covering the mobile user menu, this fixes that.

## Testing done
Tested locally at different screen sizes

## Screenshots

![screen shot 2018-10-05 at 11 00 50 am](https://user-images.githubusercontent.com/634932/46543569-2f0c1680-c88f-11e8-9e11-d5a1418b5d1a.png)

![screen shot 2018-10-05 at 11 09 12 am](https://user-images.githubusercontent.com/634932/46543544-1f8ccd80-c88f-11e8-9bf9-baa11222d33f.png)
![screen shot 2018-10-05 at 11 09 00 am](https://user-images.githubusercontent.com/634932/46543546-1f8ccd80-c88f-11e8-9c7b-088085b5b25a.png)
![screen shot 2018-10-05 at 11 08 51 am](https://user-images.githubusercontent.com/634932/46543547-1f8ccd80-c88f-11e8-8cef-5b208a70b2ee.png)


## Acceptance criteria
- [x] Mobile menu covers Sign in, Contact us links

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
