### PR TITLE
ITF message interstitial page

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
@@ -59,7 +59,7 @@ export default class ITFBanner extends React.Component {
         {message}
         {this.props.status !== 'error' && (
           <button className="usa-button-primary" onClick={this.dismissMessage}>
-            Capisce? Capisce.
+            Continue
           </button>
         )}
       </div>

--- a/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  itfMessage,
+  itfError,
+  itfSuccess,
+  itfActive,
+} from '../content/itfWrapper';
+
+export default class ITFBanner extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { messageDismissed: false };
+  }
+
+  dismissMessage = () => {
+    this.setState({ messageDismissed: true });
+  };
+
+  render() {
+    if (this.state.messageDismissed) {
+      return <div>{this.props.children}</div>;
+    }
+
+    let message;
+    switch (this.props.status) {
+      case 'error':
+        message = itfMessage(
+          'We’re sorry. Something went wrong on our end.',
+          itfError,
+          'error',
+        );
+        break;
+      case 'itf-found':
+        message = itfMessage(
+          'You already have an Intent to File',
+          itfActive(this.props.currentExpDate),
+          'success',
+        );
+        break;
+      case 'itf-created': {
+        const { previousITF, currentExpDate, previousExpDate } = this.props;
+        message = itfMessage(
+          'Your Intent to File request has been submitted',
+          itfSuccess(previousITF, currentExpDate, previousExpDate),
+          'success',
+        );
+        break;
+      }
+      default:
+        throw new Error(
+          `Unexpected status prop in ITFBanner: ${this.props.status}`,
+        );
+    }
+
+    return (
+      <div className="usa-grid">
+        {message}
+        {this.props.status !== 'error' && (
+          <button className="usa-button-primary" onClick={this.dismissMessage}>
+            Capisce? Capisce.
+          </button>
+        )}
+      </div>
+    );
+  }
+}
+
+ITFBanner.propTypes = {
+  status: PropTypes.oneOf(['error', 'itf-found', 'itf-created']).isRequired,
+  previousITF: PropTypes.object,
+  currentExpDate: PropTypes.string,
+  previousExpDate: PropTypes.string,
+};

--- a/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
@@ -55,7 +55,7 @@ export default class ITFBanner extends React.Component {
     }
 
     return (
-      <div className="usa-grid">
+      <div className="usa-grid" style={{ marginBottom: '2em' }}>
         {message}
         {this.props.status !== 'error' && (
           <button className="usa-button-primary" onClick={this.dismissMessage}>

--- a/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
@@ -4,14 +4,9 @@ import { connect } from 'react-redux';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 
+import ITFBanner from '../components/ITFBanner';
 import { requestStates } from '../../../../platform/utilities/constants';
 import { itfStatuses } from '../constants';
-import {
-  itfMessage,
-  itfError,
-  itfSuccess,
-  itfActive,
-} from '../content/itfWrapper';
 import {
   createITF as createITFAction,
   fetchITF as fetchITFAction,
@@ -23,13 +18,6 @@ export class ITFWrapper extends React.Component {
   static defaultProps = {
     noITFPages: [/\/introduction/, /\/confirmation/],
   };
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      hasDisplayedSuccess: false,
-    };
-  }
 
   // When we first enter the form...
   componentDidMount() {
@@ -66,16 +54,6 @@ export class ITFWrapper extends React.Component {
     ) {
       nextProps.createITF();
     }
-
-    // If we've already displayed the itf success banner, toggle it off when the location changes
-    if (
-      hasActiveITF &&
-      !this.state.hasDisplayedSuccess &&
-      nextProps.location.pathname !== this.props.location.pathname
-    ) {
-      // This will take effect at the same time the re-render for the location change does
-      this.setState({ hasDisplayedSuccess: true });
-    }
   }
 
   /**
@@ -89,73 +67,51 @@ export class ITFWrapper extends React.Component {
   }
 
   render() {
-    const { location, children, itf } = this.props;
-    // If the location is the intro or confirmation pages, don't show an ITF message
-    let message;
-    let content;
+    const { itf } = this.props;
 
     if (this.shouldBlockITF(location.pathname)) {
-      message = null;
-      content = children;
-    } else if (fetchWaitingStates.includes(itf.fetchCallState)) {
+      return this.props.children;
+    } else if (fetchWaitingStates.includes(this.props.itf.fetchCallState)) {
       // If we get here, componentDidMount or componentWillRecieveProps called fetchITF
       // While we're waiting, show the loading indicator...
-      content = (
+      return (
         <LoadingIndicator message="Please wait while we check your ITF status." />
       );
     } else if (itf.fetchCallState === requestStates.failed) {
       // We'll get here after the fetchITF promise is fulfilled
-      message = itfMessage(
-        'We’re sorry. Something went wrong on our end.',
-        itfError,
-        'error',
-      );
+      return <ITFBanner status="error" />;
     } else if (itf.currentITF && itf.currentITF.status === itfStatuses.active) {
-      // If we have an active ITF, we're good to go--render that form!
-      content = children;
-
-      // Only show the message on the first page navigation
-      if (!this.state.hasDisplayedSuccess) {
-        const { expirationDate: currentExpDate } = itf.currentITF;
-        if (itf.previousITF) {
-          const { expirationDate: prevExpDate } = itf.previousITF;
-          // If there was a previous ITF, we created one; show the creation success message
-          message = itfMessage(
-            'Your Intent to File request has been submitted',
-            itfSuccess(itf.previousITF, currentExpDate, prevExpDate),
-            'success',
-          );
-        } else {
-          // We fetched an active ITF
-          message = itfMessage(
-            'You already have an Intent to File',
-            itfActive(currentExpDate),
-            'success',
-          );
-        }
+      const { expirationDate: currentExpDate } = itf.currentITF;
+      if (itf.previousITF) {
+        const { expirationDate: prevExpDate } = itf.previousITF;
+        // If there was a previous ITF, we created one; show the creation success message
+        return (
+          <ITFBanner
+            status="itf-created"
+            previousITF={itf.previousITF}
+            currentExpDate={currentExpDate}
+            previousExpDate={prevExpDate}
+          >
+            {this.props.children}
+          </ITFBanner>
+        );
       }
+
+      // Else we fetched an active ITF
+      return (
+        <ITFBanner status="itf-found" currentExpDate={currentExpDate}>
+          {this.props.children}
+        </ITFBanner>
+      );
     } else if (fetchWaitingStates.includes(itf.creationCallState)) {
       // componentWillRecieveProps called createITF if there was no active ITF found
       // While we're waiting (again), show the loading indicator...again
-      content = (
-        <LoadingIndicator message="Submitting a new Intent to File..." />
-      );
-    } else {
-      // We'll get here after the createITF promise is fulfilled and we have no active ITF
-      //  because of a failed creation call
-      message = itfMessage(
-        'We’re sorry. Something went wrong on our end.',
-        itfError,
-        'error',
-      );
+      return <LoadingIndicator message="Submitting a new Intent to File..." />;
     }
 
-    return (
-      <div>
-        {message}
-        {content}
-      </div>
-    );
+    // We'll get here after the createITF promise is fulfilled and we have no active ITF
+    //  because of a failed creation call
+    return <ITFBanner status="error" />;
   }
 }
 

--- a/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
@@ -69,9 +69,9 @@ export class ITFWrapper extends React.Component {
   render() {
     const { itf } = this.props;
 
-    if (this.shouldBlockITF(location.pathname)) {
+    if (this.shouldBlockITF(this.props.location.pathname)) {
       return this.props.children;
-    } else if (fetchWaitingStates.includes(this.props.itf.fetchCallState)) {
+    } else if (fetchWaitingStates.includes(itf.fetchCallState)) {
       // If we get here, componentDidMount or componentWillRecieveProps called fetchITF
       // While we're waiting, show the loading indicator...
       return (

--- a/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
@@ -12,7 +12,7 @@ const displayDate = dateString =>
 export const itfMessage = (headline, content, status) => (
   // Inline style to match .full-page-alert bottom margin because usa-grid > :last-child has a
   //  bottom margin of 0 and overrides it
-  <div className="full-page-alert" style={{ marginBottom: '2em' }}>
+  <div className="full-page-alert">
     <div>
       <AlertBox
         isVisible

--- a/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
@@ -10,7 +10,9 @@ const displayDate = dateString =>
   moment(dateString, evssDateFormat).format(outputDateFormat);
 
 export const itfMessage = (headline, content, status) => (
-  <div className="usa-grid full-page-alert">
+  // Inline style to match .full-page-alert bottom margin because usa-grid > :last-child has a
+  //  bottom margin of 0 and overrides it
+  <div className="full-page-alert" style={{ marginBottom: '2em' }}>
     <div>
       <AlertBox
         isVisible

--- a/src/applications/disability-benefits/all-claims/tests/components/ITFBanner.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ITFBanner.unit.spec.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+
+import ITFBanner from '../../components/ITFBanner';
+
+describe('ITFBanner', () => {
+  it('should render an error message', () => {
+    const tree = mount(<ITFBanner status="error" />);
+    expect(tree.text()).to.contain(
+      'Your Intent to File request didn’t go through',
+    );
+  });
+
+  it('should render an itf found message', () => {
+    const tree = mount(<ITFBanner status="itf-found" />);
+    expect(tree.text()).to.contain(
+      'Our records show that you already have an Intent to File',
+    );
+  });
+
+  it('should render an itf created message', () => {
+    const tree = mount(<ITFBanner status="itf-created" />);
+    expect(tree.text()).to.contain(
+      'Thank you for submitting your Intent to File request',
+    );
+  });
+
+  it('should throw an error', () => {
+    expect(() => mount(<ITFBanner status="nonsense" />)).to.throw();
+  });
+});


### PR DESCRIPTION
## Description
To avoid the scrolling problem, we're going with an interstitial page to display the ITF message.

**Note:** This will produce a weird bug in the following circumstance:
1) The user starts the form
2) They get an ITF message
3) They go back to the intro page
4) They try to start the form again
5) They'll get the same ITF message as they did before, but without any new ITF calls

I think the only time this _might_ be a problem is when the ITF message is for an error.

**Another note:** This is not the final design (with the alert box), but it should be the final content.
  @goldenmeanie Could you upload mocks for what it should look like?

**One last note:** @peggygannon Remember how I said it should be the final content? That doesn't include the button. I assume it should say something like "Continue", but I wanted to get your input.

## Testing done
- [x] Manually tested all three cases (new ITF, ITF found, and ITF error)
- [x] Unit tests written

## Screenshots

### Error
![image](https://user-images.githubusercontent.com/12970166/46546782-f2382380-c87e-11e8-9de3-7024e14c98fc.png)

### ITF Created
![image](https://user-images.githubusercontent.com/12970166/46547047-9a4dec80-c87f-11e8-9241-22328d3edf98.png)

### ITF Found
![image](https://user-images.githubusercontent.com/12970166/46547082-b5b8f780-c87f-11e8-84a6-875427e7ad6d.png)


## Acceptance criteria
- [x] ITF error is shown when appropriate
- [x] ITF creation message is shown
- [x] ITF found message is shown
- [x] All of the above messages are on a separate "page"
- [x] The user can click through the creation and found messages
- [x] The user cannot click through the error message

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
