### PR TITLE
Provide form item information for complaint tool

### DIFF
--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -45,6 +45,7 @@ export const formConfigs = {
   '22-5495': edu5495Config,
   '40-10007': preneedConfig,
   VIC: vicV2Config,
+  'complaint-tool': feedbackConfig,
   'FEEDBACK-TOOL': feedbackConfig,
 };
 
@@ -62,6 +63,7 @@ export const formBenefits = {
   '22-5495': 'education benefits',
   '40-10007': 'pre-need determination of eligibility in a VA national cemetery',
   VIC: 'Veteran ID Card',
+  'complaint-tool': 'feedback',
   'FEEDBACK-TOOL': 'feedback',
   '21-686C': 'dependent status',
 };
@@ -72,7 +74,7 @@ export const formTitles = Object.keys(formBenefits).reduce((titles, key) => {
     formNumber = '';
   } else if (key === '1010ez') {
     formNumber = ' (10-10EZ)';
-  } else if (key === 'FEEDBACK-TOOL') {
+  } else if (key === 'FEEDBACK-TOOL' || key === 'complaint-tool') {
     formNumber = ' (GI Bill School Feedback Tool)';
   } else {
     formNumber = ` (${key})`;
@@ -97,6 +99,7 @@ export const formLinks = {
   '40-10007': `${preneedManifest.rootUrl}/`,
   // Not active, will need a new url if we start using this post WBC
   VIC: '/veteran-id-card/apply/',
+  'complaint-tool': `${feedbackManifest.rootUrl}/`,
   'FEEDBACK-TOOL': `${feedbackManifest.rootUrl}/`,
   '21-686C': `${dependentStatusManifest.rootUrl}/`,
 };


### PR DESCRIPTION
## Description
These change provide form item information for complaint tool, to allow users to navigate to saved feedback form.

## Testing done
Verified locally

## Screenshots
![image](https://user-images.githubusercontent.com/16051172/46550857-1a2d8400-c88b-11e8-855d-02390bb86391.png)


## Acceptance criteria
- [ ] Allow navigation to saved feedback form

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
