### PR TITLE
Implement data property for opening links as popups

### DIFF
--- a/src/platform/site-wide/index.js
+++ b/src/platform/site-wide/index.js
@@ -7,6 +7,7 @@ import '../monitoring/sentry.js';
 import './legacy/menu'; // Used in the footer.
 import './accessible-VCL-modal';
 import './moment-setup';
+import './popups';
 import addMenuListeners from './accessible-menus';
 import startUserNavWidget from './user-nav';
 import startMegaMenuWidget from './mega-menu';

--- a/src/platform/site-wide/popups.js
+++ b/src/platform/site-wide/popups.js
@@ -1,0 +1,20 @@
+function openPopup(event) {
+  event.preventDefault();
+  window.open(
+    this.href,
+    '_blank',
+    'resizable=yes,scrollbars=1,top=50,left=500,width=500,height=750',
+  );
+}
+
+/**
+ * Attaches onclick events to links that contain a data-popup attribute to open their HREF in a new window instead of tab.
+ */
+export function addPopupEventListeners() {
+  const popupLinks = Array.from(
+    document.querySelectorAll('a[href][data-popup]'),
+  );
+  for (const link of popupLinks) link.addEventListener('click', openPopup);
+}
+
+document.addEventListener('DOMContentLoaded', addPopupEventListeners);

--- a/va-gov/pages/life-insurance/file-appeal-for-tsgli.md
+++ b/va-gov/pages/life-insurance/file-appeal-for-tsgli.md
@@ -103,7 +103,7 @@ Send your appeal to your branch of service by mail, fax, or email. You’ll find
 <div itemprop="text">
 
 You’ll need to complete an Application for TSGLI Benefits (SGLV-8600).<br>
-<a onclick="event.preventDefault(); window.open(this.href, '_blank', 'resizable=yes,scrollbars=1,top=50,left=500,width=500,height=750');" href="https://www.benefits.va.gov/INSURANCE/forms/TSGLIForm.htm">Download Form SGLV-8600</a>.
+<a data-popup href="https://www.benefits.va.gov/INSURANCE/forms/TSGLIForm.htm">Download Form SGLV-8600</a>.
 
 </div>
 </div>


### PR DESCRIPTION
## Description
Certain links should open as popups rather than in new tabs. To avoid copying over a large of chunk of code into each link, this PR attaches event listeners to elements that contain the `data-popup` attribute and adds an `onclick` event to open its HREF in a new window.

### Ticket
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14018

### More info on links that should be open as popups
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3384

## Testing done
1. Navigated to `/life-insurance/file-appeal-for-tsgli/`
2. Clicked the link to `Download Form SGLV-8600`
3. Opens in new window

## Acceptance criteria
- [ ] Content team members only have to add `data-popup` for a link to open as a popup, instead of a whole chunk of code.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
