### PR TITLE
Fix a11y issues on VCL: close button tabbing and focus state after closing

### DIFF
--- a/src/platform/site-wide/accessible-VCL-modal.js
+++ b/src/platform/site-wide/accessible-VCL-modal.js
@@ -46,6 +46,9 @@ export function addFocusBehaviorToCrisisLineModal() {
     openControl.focus();
   }
 
+  // We're saving the element that triggered this modal
+  // in openControl, so that we can focus back on it later,
+  // when the modal is closed
   triggers.forEach(trigger => {
     trigger.addEventListener('click', () => {
       openControl = trigger;

--- a/src/platform/site-wide/accessible-VCL-modal.js
+++ b/src/platform/site-wide/accessible-VCL-modal.js
@@ -15,7 +15,9 @@ export function addFocusBehaviorToCrisisLineModal() {
   let openControl;
   const closeControl = tabbableElements[0];
   const lastTabbableElement = tabbableElements[tabbableElements.length - 1];
-  const triggers = document.querySelectorAll('[data-show="#modal-crisisline"]');
+  const triggers = Array.from(
+    document.querySelectorAll('[data-show="#modal-crisisline"]'),
+  );
 
   function captureFocus(e) {
     if (e.target === closeControl) {

--- a/src/platform/site-wide/accessible-VCL-modal.js
+++ b/src/platform/site-wide/accessible-VCL-modal.js
@@ -15,12 +15,7 @@ export function addFocusBehaviorToCrisisLineModal() {
   let openControl;
   const closeControl = tabbableElements[0];
   const lastTabbableElement = tabbableElements[tabbableElements.length - 1];
-
-  function setOpenControl(e) {
-    if (e.target.classList.contains('va-overlay-trigger')) {
-      openControl = e.target;
-    }
-  }
+  const triggers = document.querySelectorAll('[data-show="#modal-crisisline"]');
 
   function captureFocus(e) {
     if (e.target === closeControl) {
@@ -45,8 +40,18 @@ export function addFocusBehaviorToCrisisLineModal() {
     }
   }
 
-  document.body.addEventListener('click', setOpenControl);
+  function resetFocus() {
+    openControl.focus();
+  }
+
+  triggers.forEach(trigger => {
+    trigger.addEventListener('click', () => {
+      openControl = trigger;
+    });
+  });
+
   modal.addEventListener('keydown', closeModal);
+  closeControl.addEventListener('click', resetFocus);
   closeControl.addEventListener('keydown', captureFocus);
   lastTabbableElement.addEventListener('keydown', captureFocus);
 }

--- a/va-gov/includes/footer.html
+++ b/va-gov/includes/footer.html
@@ -7,9 +7,8 @@
 <div id="modal-crisisline" class="va-overlay va-modal va-modal-large" role="alertdialog">
   <div class="va-crisis-panel va-modal-inner">
 
-    <button class="va-modal-close va-overlay-close va-crisis-panel-close" type="button">
+    <button aria-label="Close this modal" class="va-modal-close va-overlay-close va-crisis-panel-close" type="button">
       <i class="fa fa-times-circle-o va-overlay-close" aria-hidden="true"></i>
-      <span class="usa-sr-only va-overlay-close">Close this modal</span>
     </button>
 
     <div class="va-overlay-body va-crisis-panel-body">


### PR DESCRIPTION
## Description

This updates the VCL modal to remove the double close button tabbing issue in NVDA and also to correctly set the focus back to the triggering element when closing the modal. For some reason, we were only doing this when you used Escape to close the modal.

## Testing done

Tested locally in VoiceOver, bugged Trevor to do testing in other screen readers for me.

## Acceptance criteria
- [x] Close button doesn't read allow you to focus on close text
- [x] Focus is returned to correct element after closing modal

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

Also linked to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13949