### PR TITLE
z-index fix for teamsite headers

### DIFF
--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -15,6 +15,8 @@
 }
 
 header.merger {
+  z-index: 999;
+
   .va-crisis-line {
     top: 20px;
   }


### PR DESCRIPTION
## Description
Existing va pages have high z-index attributes on certain child elements. This PR increases the z-index on the injected headers to ensure that the menu shows up over the child elements

## Testing done
Local testing and testing via in-browser css manipulation on dev.va.gov/health

## Screenshots


## Acceptance criteria
- [x] Dropdown menu shows up above high z-index elements on the host pages

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14015
