### PR TITLE
Fix for Blue arrow on MegaMenu Mobile on View All link

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^1.7.5",
+    "@department-of-veterans-affairs/formation": "^1.7.7",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "blob-polyfill": "^2.0.20171115",


### PR DESCRIPTION
## Description
Fix for Blue arrow on MegaMenu Mobile on View All link

## Testing done
Manual tests

## Screenshots
<img width="364" alt="screen shot 2018-10-05 at 11 27 21 am" src="https://user-images.githubusercontent.com/5377648/46553208-c6726900-c891-11e8-8aca-ed819bdec0b0.png">

## Acceptance criteria
- [ ] Should not have a blue arrow next to the View All link in the MegaMenu

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
