### PR TITLE
Update 674 download link on 686 confirmation page

### DIFF
--- a/src/applications/disability-benefits/686/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/686/containers/ConfirmationPage.jsx
@@ -45,7 +45,12 @@ export class ConfirmationPage extends React.Component {
           you’ll need to also fill out a Request for Approval of School
           Attendance (VA Form 21-674).
         </p>
-        <a href="https://www.vets.gov">Download VA Form 21-674.</a>
+        <a
+          target="_blank"
+          href="https://www.vba.va.gov/pubs/forms/VBA-21-674-ARE.pdf"
+        >
+          Download VA Form 21-674.
+        </a>
         <div className="confirmation-guidance-container">
           <h4 className="confirmation-guidance-heading">
             What happens after I apply?


### PR DESCRIPTION
## Description
These changes update the 674 download link on the 686 confirmation page.

## Testing done
Verified locally

## Screenshots
![image](https://user-images.githubusercontent.com/16051172/46554620-bbb9d300-c895-11e8-85b5-03ae96d38c50.png)


## Acceptance criteria
- [x] Sends user to 674 form pdf to download

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
