### PR TITLE
Provide complaint-tool to SIP dashboard helpers

### DIFF
--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -118,6 +118,7 @@ export const trackingPrefixes = {
   '22-5495': 'edu-5495-',
   '40-10007': 'preneed-',
   VIC: 'veteran-id-card-',
+  'complaint-tool': 'gi_bill_feedback',
   'FEEDBACK-TOOL': 'gi_bill_feedback',
   '21-686C': '686-',
 };
@@ -137,6 +138,7 @@ export const sipEnabledForms = new Set([
   '22-5495',
   '40-10007',
   'VIC',
+  'complaint-tool',
   'FEEDBACK-TOOL',
 ]);
 

--- a/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
@@ -89,6 +89,7 @@ describe('profile helpers:', () => {
       const sipEnabledFormIds = sipEnabledConfigs.map(
         sipEnabledConfig => sipEnabledConfig.formId,
       );
+      sipEnabledFormIds.push('complaint-tool');
       expect(allFormIds).to.deep.equal(allMappedIds);
       expect(sipEnabledForms).to.deep.equal(new Set(sipEnabledFormIds));
     });


### PR DESCRIPTION
## Description
These changes provide SIP-related dashboard helpers for complaint-tool forms

## Testing done
- verified locally

## Screenshots
![image](https://user-images.githubusercontent.com/16051172/46558265-5e2b8380-c8a1-11e8-965c-8761d347da2d.png)


## Acceptance criteria
- [x] Allow users to navigate to feedback tool

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
