### PR TITLE
Fixed eBenefits button on Get VA Medical Records page.

### DIFF
--- a/va-gov/pages/health-care/get-medical-records.md
+++ b/va-gov/pages/health-care/get-medical-records.md
@@ -28,7 +28,7 @@ Our online tools can help you view, organize, and share your VA medical records 
   <div class="usa-alert-body">
     <h4 class="usa-alert-heading">You'll need to go to eBenefits to authorize us to share your health information through the Veterans Health Information Exchange.</h4><br>
     <p class="usa-alert-text">To use this feature, you'll need a Premium <b>DS Logon</b> account. Your My HealtheVet or ID.me credentials won’t work on the eBenefits website. Go to eBenefits to sign in, register, or upgrade your <b>DS Logon</b> account to Premium.<br>
-      <button class="usa-button-primary" href="https://www.ebenefits.va.gov/ebenefits/vapii">Go to eBenefits</button>
+      <a class="usa-button-primary" href="https://www.ebenefits.va.gov/ebenefits/vapii" target="_blank">Go to eBenefits</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
## Description
Clicking will now open eBenefits in a new tab.

## Testing done
Local testing.

## Acceptance criteria
- [x] "Go to eBenefits" button should open eBenefits in a new tab.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs