### PR TITLE
Add polyfills script

### DIFF
--- a/script/configure-assets.js
+++ b/script/configure-assets.js
@@ -52,6 +52,7 @@ function addAssetHashes() {
       'styleConsolidated.css',
       'static-pages.css',
       'vendor.entry.js',
+      'polyfills.entry.js',
     ].forEach(unhashedName => {
       const hashedName = manifest[unhashedName];
 


### PR DESCRIPTION
## Description
Add additional hash-less script for polyfills on IE11

## Testing done
Successful build on local machine

## Screenshots


## Acceptance criteria
- [x] Polyfill entry js should have a hash-less copy in the javascript build folder

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14008
