### PR TITLE
Make React footer version the default crisis line modal

### DIFF
--- a/src/platform/site-wide/va-footer/containers/Main.jsx
+++ b/src/platform/site-wide/va-footer/containers/Main.jsx
@@ -285,6 +285,7 @@ export class Main extends React.Component {
         >
           <div className="va-crisis-panel va-modal-inner">
             <button
+              aria-label="Close this modal"
               className="va-modal-close va-overlay-close va-crisis-panel-close"
               type="button"
             >
@@ -292,9 +293,6 @@ export class Main extends React.Component {
                 className="fa fa-times-circle-o va-overlay-close"
                 aria-hidden="true"
               />
-              <span className="usa-sr-only va-overlay-close">
-                Close this modal
-              </span>
             </button>
 
             <div className="va-overlay-body va-crisis-panel-body">

--- a/va-gov/includes/footer.html
+++ b/va-gov/includes/footer.html
@@ -3,42 +3,6 @@
   <div id="footerNav"></div> <!-- let's try this React thing -->
 </footer>
 
-<!-- End mobile crisis line overlay. See desktop overlay at end of footer -->
-<div id="modal-crisisline" class="va-overlay va-modal va-modal-large" role="alertdialog">
-  <div class="va-crisis-panel va-modal-inner">
-
-    <button aria-label="Close this modal" class="va-modal-close va-overlay-close va-crisis-panel-close" type="button">
-      <i class="fa fa-times-circle-o va-overlay-close" aria-hidden="true"></i>
-    </button>
-
-    <div class="va-overlay-body va-crisis-panel-body">
-      <h3 class="va-crisis-panel-title">We're here anytime, day or night</h3>
-      <p>Whatever you're struggling with, our responders can offer confidential help 24/7. Many of them are Veterans themselves.</p>
-      <ul class="va-crisis-panel-list">
-        <li>
-          <i class="fa fa-phone va-crisis-panel-icon" aria-hidden="true"></i>
-          <a href="tel:18002738255">Call <strong>1-800-273-8255 (Press 1)</strong></a>
-        </li>
-        <li>
-          <i class="fa fa-mobile va-crisis-panel-icon" aria-hidden="true"></i>
-          <a href="sms:838255">Text <strong>838255</strong></a>
-        </li>
-        <li>
-          <i class="fa fa-comments-o va-crisis-panel-icon" aria-hidden="true"></i>
-          <a class="no-external-icon" href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat">Start a confidential chat</a>
-        </li>
-        <li>
-          <i class="fa fa-deaf va-crisis-panel-icon" aria-hidden="true"></i>
-          <a href="tel:18007994889">Call TTY if you have hearing loss <strong>1-800-799-4889</strong></a>
-        </li>
-      </ul>
-
-      Get more resources at <a class="no-external-icon" href="https://www.veteranscrisisline.net/">VeteransCrisisLine.net</a>.
-    </div>
-  </div>
-</div>
-<!-- End mobile crisis line overlay -->
-
 <!-- Begin generic overlay modal -->
 {% if modal %}
   {% include "va-gov/includes/modal.html" %}


### PR DESCRIPTION
## Description

An accessibility fix was made in the html version of the VCL without realizing that the modal was re-added to the React component. This removes the html version and makes the a11y fix in the React version.

Previously, I had wanted the html version to be the canonical version, but putting it in the React footer component is more convenient for Teamsite pages at the moment.

## Testing done

Tested locally

## Acceptance criteria
- [x] Accessibility fix exists again

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
