### PR TITLE
Remove vets.gov from links in va.gov content

### DIFF
--- a/src/applications/discharge-wizard/containers/GuidancePage.jsx
+++ b/src/applications/discharge-wizard/containers/GuidancePage.jsx
@@ -742,19 +742,19 @@ class GuidancePage extends React.Component {
                   <p>Learn more about:</p>
                   <ul>
                     <li>
-                      <a href="https://www.vets.gov/health-care/health-conditions/military-sexual-trauma/">
+                      <a href="/health-care/health-conditions/military-sexual-trauma/">
                         VA health benefits for Veterans who have experienced
                         military sexual trauma
                       </a>
                     </li>
                     <li>
-                      <a href="https://www.vets.gov/health-care/health-conditions/mental-health/">
+                      <a href="/health-care/health-conditions/mental-health/">
                         VA health benefits for Veterans with mental health
                         conditions
                       </a>
                     </li>
                     <li>
-                      <a href="https://www.vets.gov/health-care/health-conditions/mental-health/ptsd/">
+                      <a href="/health-care/health-conditions/mental-health/ptsd/">
                         VA health benefits for Veterans with PTSD
                       </a>
                     </li>

--- a/src/applications/post-911-gib-status/containers/IntroPageSummary.jsx
+++ b/src/applications/post-911-gib-status/containers/IntroPageSummary.jsx
@@ -92,7 +92,7 @@ export default function BrandConsolidationSummary() {
             <li>Received a decision from us on your application</li>
           </ul>
           <p>
-            <a href="https://www.vets.gov/education/apply/">
+            <a href="/education/apply/">
               Find out how to apply for Post-9/11 GI Bill benefits
             </a>
             .

--- a/va-gov/includes/header.html
+++ b/va-gov/includes/header.html
@@ -17,7 +17,7 @@
 <meta name="twitter:card" content="summary">
 <meta name="twitter:site" content="DeptVetAffairs">
 <!-- description, title tags added below-->
-<meta name="twitter:image:src" content="https://www.vets.gov/img/design/logo/og-twitter-image.jpg">
+<meta name="twitter:image:src" content="https://www.va.gov/img/design/logo/og-twitter-image.jpg">
 <!-- end twitter cards -->
 
 {% if lastupdate %}
@@ -39,7 +39,7 @@
 <meta content="{{ description }}" name="twitter:description" >
 <meta content="{{ description }}" name="description">
 {% endif %}
-<meta content="https://www.vets.gov/img/design/logo/og-image.jpg" property="og:image">
+<meta content="https://www.va.gov/img/design/logo/og-image.jpg" property="og:image">
 {% if tags %}
 {% for tag in tags %}
 <meta content="{{ tag }}" property="article:tag">

--- a/va-gov/pages/careers-employment/index.md
+++ b/va-gov/pages/careers-employment/index.md
@@ -202,7 +202,7 @@ We can support you in all stages of your job search—from returning to work wit
   </div>
 
   <div class="link">
-    <a href="/employment/vocational-rehab-and-employment/vetsuccess/"><b>VetSuccess on Campus</b></a>
+    <a href="/careers-employment/vetsuccess-on-campus/"><b>VetSuccess on Campus</b></a>
     <p>Find out if our counselors can help you transition from military to college life.</p>
   </div>
 

--- a/va-gov/pages/careers-employment/index.md
+++ b/va-gov/pages/careers-employment/index.md
@@ -202,7 +202,7 @@ We can support you in all stages of your job search—from returning to work wit
   </div>
 
   <div class="link">
-    <a href="https://vets.gov/employment/vocational-rehab-and-employment/vetsuccess/"><b>VetSuccess on Campus</b></a>
+    <a href="/employment/vocational-rehab-and-employment/vetsuccess/"><b>VetSuccess on Campus</b></a>
     <p>Find out if our counselors can help you transition from military to college life.</p>
   </div>
 

--- a/va-gov/pages/disability/eligibility/special-claims/clothing-allowance.md
+++ b/va-gov/pages/disability/eligibility/special-claims/clothing-allowance.md
@@ -58,6 +58,6 @@ To apply, fill out an Application for Annual Clothing Allowance (VA Form 10-8678
 [Download VA Form 10-8678](https://www.va.gov/vaforms/medical/pdf/10-8678-fill.pdf).
 
 Use our facility locator to find your nearest VA medical center. <br>
-[Find a VA medical center near you](https://www.vets.gov/facilities/).
+[Find a VA medical center near you](/facilities/).
 
 For more information, call us at <a href="tel:+1-800-827-1000">1-800-827-1000</a>, Monday through Friday, 8:00 a.m. to 9:00 p.m. (<abbr title="eastern time">ET</abbr>). We collect applications throughout the year and hold them until the August 1 closing date.

--- a/va-gov/pages/health-care/about-va-health-benefits.md
+++ b/va-gov/pages/health-care/about-va-health-benefits.md
@@ -86,7 +86,7 @@ You should also know that being signed up for VA health care meets your Affordab
   - Kidney dialysis
   - Acute care (short-term treatment for a severe illness or injury or after surgery)
   - Specialized care (including organ transplants, intensive care for mental and physical conditions, and care for traumatic injuries). [See more VA medical and surgical specialty care services](https://www.va.gov/healthbenefits/access/specialty_care_services.asp).
-- Emergency care in a VA hospital, outpatient clinic, or Vet Center. [Find a VA health facility near you](https://www.vets.gov/facilities/).
+- Emergency care in a VA hospital, outpatient clinic, or Vet Center. [Find a VA health facility near you](/facilities/).
 - Emergency care in a non-VA hospital, clinic, or other medical setting—only under certain conditions. For us to consider covering non-VA emergency care for a non-service-connected condition, you’ll need to meet several requirements. [Learn more about non-VA emergency medical care](https://www.va.gov/HEALTHBENEFITS/access/emergency_care.asp).
 - Mental health services to treat certain issues like posttraumatic stress disorder (PTSD), military sexual trauma (MST), depression, and substance use problems. [Learn more about mental health services](/health-care/health-needs-conditions/mental-health/).
 - Assisted living and home health care (depending on your needs and income as well as space in the programs). [Learn more about assisted living and home health care](/health-care/about-va-health-benefits/long-term-care/).

--- a/va-gov/pages/health-care/family-caregiver-benefits/comprehensive-assistance.md
+++ b/va-gov/pages/health-care/family-caregiver-benefits/comprehensive-assistance.md
@@ -48,7 +48,7 @@ Your Veteran can appoint 1 primary (main) caregiver and up to 2 secondary caregi
 
 You’ll need to apply for these benefits. To apply, fill out an Application for the Program of Comprehensive Assistance for Family Caregivers (VA Form 10-10CG). You’ll need identification and health coverage information for both you and your Veteran—and you’ll both need to sign and date the form.<br>
 
-[Download VA Form 10-10CG](https://www.vets.gov/health-care/forms/vha-10-10CG.pdf)
+[Download VA Form 10-10CG](/health-care/forms/vha-10-10CG.pdf)
 
 **Mail the form and any supporting documents to:**
 

--- a/va-gov/pages/health-care/update-health-information.md
+++ b/va-gov/pages/health-care/update-health-information.md
@@ -82,7 +82,7 @@ Yes. You can use this form to update information about your income and deductibl
 <div itemprop="text">
 
 No. You can use this form only to update your information if you’re already enrolled in VA health care.<br>
-[Find out how to apply for VA health care](https://www.vets.gov/health-care/how-to-apply/).
+[Find out how to apply for VA health care](/health-care/how-to-apply/).
 
 </div>
 </div>


### PR DESCRIPTION
## Description
We have several instances of using vets.gov in link urls in content pages, when we don't actually need to.

## Testing done
Viewed pages locally

## Acceptance criteria
- [x] Links all still work and go to the correct page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
