### PR TITLE
Add alt text to header image

### DIFF
--- a/va-gov/includes/top-nav.html
+++ b/va-gov/includes/top-nav.html
@@ -28,7 +28,7 @@
   <div class="row va-flex usa-grid usa-grid-full" id="va-header-logo-menu">
     <div role="banner" class="va-header-logo-wrapper">
       <a href="/" class="va-header-logo" title="Go to VA.gov">
-      <img src="/img/header-logo.png"/>
+      <img src="/img/header-logo.png" alt="Deptartment of Veterans Affairs logo"/>
       </a>
     </div>
     <div id="va-nav-controls"></div>

--- a/va-gov/includes/top-nav.html
+++ b/va-gov/includes/top-nav.html
@@ -28,7 +28,7 @@
   <div class="row va-flex usa-grid usa-grid-full" id="va-header-logo-menu">
     <div role="banner" class="va-header-logo-wrapper">
       <a href="/" class="va-header-logo">
-      <img src="/img/header-logo.png" title="Go to VA.gov"/>
+      <img src="/img/header-logo.png" alt="Go to VA.gov"/>
       </a>
     </div>
     <div id="va-nav-controls"></div>

--- a/va-gov/includes/top-nav.html
+++ b/va-gov/includes/top-nav.html
@@ -27,8 +27,8 @@
 
   <div class="row va-flex usa-grid usa-grid-full" id="va-header-logo-menu">
     <div role="banner" class="va-header-logo-wrapper">
-      <a href="/" class="va-header-logo" title="Go to VA.gov">
-      <img src="/img/header-logo.png" alt="Deptartment of Veterans Affairs logo"/>
+      <a href="/" class="va-header-logo">
+      <img src="/img/header-logo.png" title="Go to VA.gov"/>
       </a>
     </div>
     <div id="va-nav-controls"></div>


### PR DESCRIPTION
## Description

Adds alt text to header logo, to fix 508 error.

## Acceptance criteria
- [x] Image has alt text

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
