### PR TITLE
Va.gov 526 reroute cv

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-education-wizard.scss
+++ b/src/applications/static-pages/sass/modules/_m-education-wizard.scss
@@ -28,6 +28,7 @@
   //  with the border to expand that without the opacity
   &.wizard-content-closed {
     max-height: 0 !important; // To override the id selector height
+    margin: 0;
     visibility: hidden;
 
     .wizard-content-inner {

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -119,7 +119,7 @@ if (burialPages.has(location.pathname)) {
   });
 }
 
-if (disabilityPages.has(location.pathname) && __BUILDTYPE__ !== 'production') {
+if (disabilityPages.has(location.pathname) && brandConsolidation.isEnabled()) {
   createDisabilityIncreaseApplicationStatus(store);
 }
 

--- a/va-gov/layouts/home.html
+++ b/va-gov/layouts/home.html
@@ -34,7 +34,7 @@
             <li><a href="/claim-or-appeal-status">Check your claim or appeal status</a></li>
             <li><a href="/va-payment-history/">View your payment history</a></li>
             <li><a href="/disability/upload-supporting-evidence/">Upload evidence to support your claim</a></li>
-            <li><a href="/disability-benefits/apply/form-526-disability-claim">File for a VA disability increase</a></li>
+            <li><a href="/disability/how-to-file-claim/">File for a VA disability increase</a></li>
             <li><a href="/disability/how-to-file-claim/">File a claim for compensation</a></li>
           </ul>
 

--- a/va-gov/pages/change-direct-deposit-and-contact-information.md
+++ b/va-gov/pages/change-direct-deposit-and-contact-information.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: Change Your VA Direct Deposit and Contact Information
 display_title: Change Direct Deposit and Contact Info
-lastupdate: 
+lastupdate:
 ---
 
 <div itemscope itemtype="http://schema.org/FAQPage">
@@ -55,9 +55,9 @@ Change your direct deposit and contact information for certain VA benefits onlin
 </div>
 
 <div itemprop="text">
-     
+
 <b>And you'll need your:</b>
-<ul> 
+<ul>
 <li>Routing number</li>
 <li>Account number</li>
 </ul>
@@ -89,7 +89,7 @@ Muskogee OK 74401-7004<br>
 
 <h3>By phone</h3>
 
-Call us at <a href="tel:+18008271000">1-800-827-1000</a> (TTY: <a href="tel:+18008294833">1-800-829-4833</a>). 
+Call us at <a href="tel:+18008271000">1-800-827-1000</a> (TTY: <a href="tel:+18008294833">1-800-829-4833</a>).
 
 We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. (ET).
 
@@ -109,10 +109,9 @@ Yes. It’s important to update your information with us if you change your mari
 <a href="https://www.benefits.va.gov/compensation/add-dependents.asp">Find out how to add eligible dependents</a>.
 
 <b>If your disability gets worse</b>, you can file a claim for an increase in benefits. <br>
-<a href="/disability-benefits/apply/form-526-disability-claim/">File for a VA disability increase</a>.
+<a href="/disability/how-to-file-claim/">File for a VA disability increase</a>.
 
 </div>
 </div>
 </div>
 </div>
-

--- a/va-gov/pages/disability/how-to-file-claim.md
+++ b/va-gov/pages/disability/how-to-file-claim.md
@@ -67,18 +67,6 @@ For all disability claims, please provide:
 </div>
 
 
-<div itemprop="steps" itemscope itemtype ="http://schema.org/HowToSection">
-
-<h3 itemprop="name">How do I apply?</h3>
-<div itemprop="itemListElement">
-
-You can apply online right now.
-
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation">Go to eBenefits to Apply</a>
-
-</div>
-</div>
-
 <div id="react-applicationStatus"></div>
 
 <div itemprop="steps" itemscope itemtype ="http://schema.org/HowToSection">

--- a/va-gov/pages/va-payment-history.md
+++ b/va-gov/pages/va-payment-history.md
@@ -85,7 +85,7 @@ Yes. It’s important to update your information with us if you change your mari
 <a href="https://www.benefits.va.gov/compensation/add-dependents.asp">Find out how to add eligible dependents</a>.
 
 <b>If your disability gets worse</b>, you can file a claim for an increase in benefits. <br>
-<a href="/disability-benefits/apply/form-526-disability-claim/">File for a VA disability increase</a>.
+<a href="/disability/how-to-file-claim/">File for a VA disability increase</a>.
 
 </div>
 </div>


### PR DESCRIPTION
## Description
This PR does a few things:
1) Changes all `/disability-benefits/apply/form-526-disability-claim` links to `/disability/how-to-file-claim/`
2) Removes the eBenefits button from the VA.gov page `/disability/how-to-file-claim/`
3) Fixes spacing on the wizard
4) Changes the flag gating the wizard from `__BUILDTYPE__` to the brand consolidation feature flag

## Testing done
Fired up `yarn watch --brand-consolidation-enabled` to see the WBC build and checked the home page to make sure the right link was changed, then checked to make sure the eBenefits button was gone and the spacing looked good.

Fired up `yarn watch` (no brand consolidation flag) and made sure the wizard didn't show up but the eBenefits button did.

## Screenshots
Before spacing fix:
![image](https://user-images.githubusercontent.com/12970166/46634029-75b67680-cb04-11e8-89c5-a387dcdc4b1b.png)

After spacing fix:
![image](https://user-images.githubusercontent.com/12970166/46635510-9a611d00-cb09-11e8-8380-d2e3e4033326.png)

## Acceptance criteria
- [x] The links are correct
- [x] The eBenefits button is removed
- [x] The wizard is only shown when the brand consolidation flag is present

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
