### PR TITLE
Add alt text to promo image

### DIFF
--- a/va-gov/components/merger-promo.html
+++ b/va-gov/components/merger-promo.html
@@ -16,7 +16,7 @@ See https://help.shopify.com/themes/liquid/tags/theme-tags#include
 
     {% if group.image != empty %}
 
-      <img src="{{group.image}}"/>
+      <img src="{{group.image}}" alt="{{group.alt}}" />
 
     {% endif %}
 

--- a/va-gov/pages/life-insurance/index.md
+++ b/va-gov/pages/life-insurance/index.md
@@ -9,6 +9,7 @@ order: 1
 icon: icon-large white fa fa-users hub-background-life-insurance
 promo:
   - image: /img/megamenu/life-insurance-illustration.png
+    alt:
     heading: SGLI Online Enrollment System (SOES)
     url: "https://www.benefits.va.gov/INSURANCE/SOES.asp"
     description: Learn about our new online enrollment system for Servicemembers' Group Life Insurance.


### PR DESCRIPTION
## Description
The `#promo > img` image has no alt text, and is throwing an error in the aXe scanner.

## Testing done
* Manually checked each path listed below in browser, ensuring alt text is present and aXe plugin does not report violation.

### Pages Affected
* http://127.0.0.1:3001/life-insurance/
* http://127.0.0.1:3001/careers-employment/
* http://127.0.0.1:3001/burials-memorials/
* http://127.0.0.1:3001/health-care/
* http://127.0.0.1:3001/disability/
* http://127.0.0.1:3001/education/
* http://127.0.0.1:3001/housing-assistance/
* http://127.0.0.1:3001/pension/
* http://127.0.0.1:3001/records/

## Screenshots


## Acceptance criteria
- [x] As a screenreader user, I want alt text to convey meaning of images I can't see, or skip them altogether if they have no purpose other than art direction or visual interest.


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
