### PR TITLE
Unicorn tools rebranding cv

### DIFF
--- a/src/applications/claims-status/components/AppealsUnavailable.jsx
+++ b/src/applications/claims-status/components/AppealsUnavailable.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
 
-const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 class AppealsUnavailable extends React.Component {
   render() {
@@ -10,7 +10,7 @@ class AppealsUnavailable extends React.Component {
         <div className="usa-alert-body">
           <h4 className="claims-alert-header">Appeal status is unavailable</h4>
           <p className="usa-alert-text">
-            {propertyName} is having trouble loading appeals information at this
+            {siteName} is having trouble loading appeals information at this
             time. Please check back again in a hour. Please note: You are still
             able to review claims information.
           </p>

--- a/src/applications/claims-status/components/AppealsUnavailable.jsx
+++ b/src/applications/claims-status/components/AppealsUnavailable.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
 class AppealsUnavailable extends React.Component {
   render() {

--- a/src/applications/claims-status/components/ClaimsAppealsUnavailable.jsx
+++ b/src/applications/claims-status/components/ClaimsAppealsUnavailable.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
 class ClaimsAppealsUnavailable extends React.Component {
   render() {

--- a/src/applications/claims-status/components/ClaimsAppealsUnavailable.jsx
+++ b/src/applications/claims-status/components/ClaimsAppealsUnavailable.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
 
-const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 class ClaimsAppealsUnavailable extends React.Component {
   render() {
@@ -12,8 +12,8 @@ class ClaimsAppealsUnavailable extends React.Component {
             Claim and Appeal status is unavailable
           </h4>
           <p className="usa-alert-text">
-            {propertyName} is having trouble loading claims and appeals
-            information at this time. Please check back again in a hour.
+            {siteName} is having trouble loading claims and appeals information
+            at this time. Please check back again in a hour.
           </p>
         </div>
       </div>

--- a/src/applications/claims-status/components/ClaimsUnavailable.jsx
+++ b/src/applications/claims-status/components/ClaimsUnavailable.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
+
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 class ClaimsUnavailable extends React.Component {
   render() {
@@ -7,9 +10,9 @@ class ClaimsUnavailable extends React.Component {
         <div className="usa-alert-body">
           <h4 className="claims-alert-header">Claim status is unavailable</h4>
           <p className="usa-alert-text">
-            Vets.gov is having trouble loading claims information at this time.
-            Please check back again in a hour. Please note: You are still able
-            to review appeals information.
+            {siteName} is having trouble loading claims information at this
+            time. Please check back again in a hour. Please note: You are still
+            able to review appeals information.
           </p>
         </div>
       </div>

--- a/src/applications/claims-status/components/ClaimsUnavailable.jsx
+++ b/src/applications/claims-status/components/ClaimsUnavailable.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
 class ClaimsUnavailable extends React.Component {
   render() {

--- a/src/applications/claims-status/containers/AppealInfo.jsx
+++ b/src/applications/claims-status/containers/AppealInfo.jsx
@@ -19,6 +19,9 @@ import {
   RECORD_NOT_FOUND_ERROR,
   AVAILABLE,
 } from '../utils/appeals-v2-helpers';
+import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
+
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 const appealsDownMessage = (
   <div className="row" id="appealsDownMessage">
@@ -27,7 +30,7 @@ const appealsDownMessage = (
         <h3>We’re sorry. Something went wrong on our end.</h3>
         <p>
           Please refresh this page or try again later. If it still doesn’t work,
-          you can call the Vets.gov Help Desk at{' '}
+          you can call the {siteName} Help Desk at{' '}
           <a href="tel:+18555747286">1-855-574-7286</a> (TTY:{' '}
           <a href="tel:+18008294833">1-800-829-4833</a>
           ). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. (ET).
@@ -44,7 +47,7 @@ const recordsNotFoundMessage = (
         <h3>We’re sorry. We can’t find your records in our system.</h3>
         <p>
           If you think they should be here, please try again later or call the
-          Vets.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a>{' '}
+          {siteName} Help Desk at <a href="tel:+18555747286">1-855-574-7286</a>{' '}
           (TTY: <a href="tel:+18008294833">1-800-829-4833</a>
           ). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. (ET).
         </p>

--- a/src/applications/claims-status/containers/AppealInfo.jsx
+++ b/src/applications/claims-status/containers/AppealInfo.jsx
@@ -19,9 +19,7 @@ import {
   RECORD_NOT_FOUND_ERROR,
   AVAILABLE,
 } from '../utils/appeals-v2-helpers';
-import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
 const appealsDownMessage = (
   <div className="row" id="appealsDownMessage">

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -35,6 +35,10 @@ import ClosedClaimMessage from '../components/ClosedClaimMessage';
 import { scrollToTop, setUpPage, setPageFocus } from '../utils/page';
 import Breadcrumbs from '../components/Breadcrumbs';
 
+import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
+
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+
 class YourClaimsPageV2 extends React.Component {
   constructor(props) {
     super(props);
@@ -42,7 +46,7 @@ class YourClaimsPageV2 extends React.Component {
   }
 
   componentDidMount() {
-    document.title = 'Track Claims: Vets.gov';
+    document.title = `Track Claims: ${siteName}`;
     if (this.props.canAccessClaims) {
       this.props.getClaimsV2();
     }

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -35,9 +35,7 @@ import ClosedClaimMessage from '../components/ClosedClaimMessage';
 import { scrollToTop, setUpPage, setPageFocus } from '../utils/page';
 import Breadcrumbs from '../components/Breadcrumbs';
 
-import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
 class YourClaimsPageV2 extends React.Component {
   constructor(props) {

--- a/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
@@ -2,6 +2,9 @@ const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
 const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
 const Auth = require('../../../../platform/testing/e2e/auth');
+const isBrandConsolidationEnabled = require('../../../../platform/brand-consolidation/feature-flag');
+
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();
@@ -10,7 +13,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
   // Claim is visible
   Auth.logIn(token, client, '/track-claims', 3)
-    .assert.title('Track Claims: Vets.gov')
+    .assert.title(`Track Claims: ${siteName}`)
     .waitForElementVisible('.claim-list-item-container', Timeouts.slow)
     .axeCheck('.main'); // TODO: Figure out why this is failing
 

--- a/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
@@ -2,7 +2,6 @@ const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
 const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
 const Auth = require('../../../../platform/testing/e2e/auth');
-const siteName = require('../../../../platform/brand-consolidation/site-name');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();
@@ -11,7 +10,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
   // Claim is visible
   Auth.logIn(token, client, '/track-claims', 3)
-    .assert.title(`Track Claims: ${siteName}`)
     .waitForElementVisible('.claim-list-item-container', Timeouts.slow)
     .axeCheck('.main'); // TODO: Figure out why this is failing
 

--- a/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
@@ -2,9 +2,7 @@ const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
 const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
 const Auth = require('../../../../platform/testing/e2e/auth');
-const isBrandConsolidationEnabled = require('../../../../platform/brand-consolidation/feature-flag');
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+const siteName = require('../../../../platform/brand-consolidation/site-name');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -3,6 +3,9 @@ import sinon from 'sinon';
 import { shallow } from 'enzyme';
 
 import conditionalStorage from '../../../../platform/utilities/storage/conditionalStorage';
+import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
+
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 import {
   groupTimelineActivity,
@@ -481,7 +484,7 @@ describe('Disability benefits helpers: ', () => {
       const contents = getStatusContents(type);
       expect(contents.title).to.equal('We don’t know your appeal status');
       expect(contents.description.props.children).to.equal(
-        'We’re sorry, Vets.gov will soon be updated to show your status.',
+        `We’re sorry, ${siteName} will soon be updated to show your status.`,
       );
     });
 

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -483,9 +483,12 @@ describe('Disability benefits helpers: ', () => {
       const type = 123;
       const contents = getStatusContents(type);
       expect(contents.title).to.equal('We don’t know your appeal status');
-      expect(contents.description.props.children).to.equal(
-        `We’re sorry, ${siteName} will soon be updated to show your status.`,
-      );
+      expect(contents.description.props.children).to.eql([
+        // React splits it up into separate nodes when variables are inserted
+        'We’re sorry, ',
+        siteName,
+        ' will soon be updated to show your status.',
+      ]);
     });
 
     // 'remand' and 'bva_decision' do a fair amount of dynamic content generation and formatting

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -3,9 +3,7 @@ import sinon from 'sinon';
 import { shallow } from 'enzyme';
 
 import conditionalStorage from '../../../../platform/utilities/storage/conditionalStorage';
-import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+import siteName from '../../../../platform/brand-consolidation/site-name';
 
 import {
   groupTimelineActivity,

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -3,9 +3,7 @@ import moment from 'moment';
 import _ from 'lodash';
 import Raven from 'raven-js';
 import { Link } from 'react-router';
-import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
 // This literally determines how many rows are displayed per page on the v2 index page
 export const ROWS_PER_PAGE = 10;

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -3,6 +3,9 @@ import moment from 'moment';
 import _ from 'lodash';
 import Raven from 'raven-js';
 import { Link } from 'react-router';
+import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
+
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 // This literally determines how many rows are displayed per page on the v2 index page
 export const ROWS_PER_PAGE = 10;
@@ -170,7 +173,7 @@ function getHearingType(type) {
   const typeMaps = {
     video: 'videoconference',
     travel: 'travel board',
-    central_office: 'Washington, DC central office' // eslint-disable-line
+    central_office: 'Washington, DC central office', // eslint-disable-line
   };
 
   return typeMaps[type] || type;
@@ -531,7 +534,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
             Veterans Service Organization or representative as soon as possible.
           </p>
           <p>
-            At this time, Vets.gov isn’t able to provide information about
+            At this time, {siteName} isn’t able to provide information about
             appeals that are part of RAMP.
           </p>
         </div>
@@ -591,7 +594,7 @@ export function getStatusContents(statusType, details = {}, name = {}) {
     default:
       contents.title = 'We don’t know your appeal status';
       contents.description = (
-        <p>We’re sorry, Vets.gov will soon be updated to show your status.</p>
+        <p>We’re sorry, {siteName} will soon be updated to show your status.</p>
       );
   }
 

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -11,9 +11,7 @@ import {
 } from '../content/confirmation-poll';
 
 import { submissionStatuses } from '../constants';
-import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+import siteName from '../../../../platform/brand-consolidation/site-name';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -11,6 +11,9 @@ import {
 } from '../content/confirmation-poll';
 
 import { submissionStatuses } from '../constants';
+import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
+
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
@@ -152,7 +155,7 @@ export default class ConfirmationPage extends React.Component {
           <div className="small-6 usa-width-one-half medium-6 columns">
             <a href="/">
               <button className="usa-button-primary">
-                Go Back to Vets.gov
+                Go Back to {siteName}
               </button>
             </a>
           </div>

--- a/src/applications/disability-benefits/526EZ/content/confirmation-poll.jsx
+++ b/src/applications/disability-benefits/526EZ/content/confirmation-poll.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
+import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
+
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 export const successMessage = claimId => (
   <div>
@@ -36,7 +39,7 @@ export const checkLaterMessage = jobId => (
     </p>
     <p>
       If you don’t see your increased disability claim online after 24 hours,
-      please call Vets.gov Help Desk at{' '}
+      please call {siteName} Help Desk at{' '}
       <a href="tel:+18555747286">1-855-574-7286</a>, Monday – Friday, 8:00 a.m.
       – 9:00 a.m. (ET).
     </p>

--- a/src/applications/disability-benefits/526EZ/content/confirmation-poll.jsx
+++ b/src/applications/disability-benefits/526EZ/content/confirmation-poll.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
-import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+import siteName from '../../../../platform/brand-consolidation/site-name';
 
 export const successMessage = claimId => (
   <div>

--- a/src/applications/disability-benefits/526EZ/tests/00-all-fields.e2e.spec.js
+++ b/src/applications/disability-benefits/526EZ/tests/00-all-fields.e2e.spec.js
@@ -3,7 +3,6 @@ const Timeouts = require('../../../../platform/testing/e2e/timeouts');
 const PageHelpers = require('./disability-benefits-helpers');
 const testData = require('./schema/maximal-test.json');
 const FormsTestHelpers = require('../../../../platform/testing/e2e/form-helpers');
-const siteName = require('../../../../platform/brand-consolidation/site-name');
 
 const runTest = E2eHelpers.createE2eTest(client => {
   PageHelpers.initDocumentUploadMock();
@@ -18,7 +17,6 @@ const runTest = E2eHelpers.createE2eTest(client => {
         }/disability-benefits/apply/form-526-disability-claim`,
       )
       .waitForElementVisible('body', Timeouts.normal)
-      .assert.title(`Apply for education benefits: ${siteName}`)
       .waitForElementVisible('.schemaform-title', Timeouts.slow) // First render of React may be slow.
       .click('.schemaform-intro .usa-button-primary');
 

--- a/src/applications/disability-benefits/526EZ/tests/00-all-fields.e2e.spec.js
+++ b/src/applications/disability-benefits/526EZ/tests/00-all-fields.e2e.spec.js
@@ -3,9 +3,7 @@ const Timeouts = require('../../../../platform/testing/e2e/timeouts');
 const PageHelpers = require('./disability-benefits-helpers');
 const testData = require('./schema/maximal-test.json');
 const FormsTestHelpers = require('../../../../platform/testing/e2e/form-helpers');
-const isBrandConsolidationEnabled = require('../../../../platform/brand-consolidation/feature-flag');
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+const siteName = require('../../../../platform/brand-consolidation/site-name');
 
 const runTest = E2eHelpers.createE2eTest(client => {
   PageHelpers.initDocumentUploadMock();

--- a/src/applications/disability-benefits/526EZ/tests/00-all-fields.e2e.spec.js
+++ b/src/applications/disability-benefits/526EZ/tests/00-all-fields.e2e.spec.js
@@ -3,6 +3,9 @@ const Timeouts = require('../../../../platform/testing/e2e/timeouts');
 const PageHelpers = require('./disability-benefits-helpers');
 const testData = require('./schema/maximal-test.json');
 const FormsTestHelpers = require('../../../../platform/testing/e2e/form-helpers');
+const isBrandConsolidationEnabled = require('../../../../platform/brand-consolidation/feature-flag');
+
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 const runTest = E2eHelpers.createE2eTest(client => {
   PageHelpers.initDocumentUploadMock();
@@ -17,7 +20,7 @@ const runTest = E2eHelpers.createE2eTest(client => {
         }/disability-benefits/apply/form-526-disability-claim`,
       )
       .waitForElementVisible('body', Timeouts.normal)
-      .assert.title('Apply for education benefits: Vets.gov')
+      .assert.title(`Apply for education benefits: ${siteName}`)
       .waitForElementVisible('.schemaform-title', Timeouts.slow) // First render of React may be slow.
       .click('.schemaform-intro .usa-button-primary');
 

--- a/src/applications/disability-benefits/526EZ/tests/components/DisabilityWizard.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/DisabilityWizard.unit.spec.jsx
@@ -6,9 +6,7 @@ import createCommonStore from '../../../../../platform/startup/store';
 import conditionalStorage from '../../../../../platform/utilities/storage/conditionalStorage';
 import DisabilityWizard from '../../components/DisabilityWizard';
 import { layouts } from '../../wizardHelpers';
-import isBrandConsolidationEnabled from '../../../../../platform/brand-consolidation/feature-flag';
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+import siteName from '../../../../../platform/brand-consolidation/site-name';
 
 const { chooseUpdate, applyGuidance } = layouts;
 

--- a/src/applications/disability-benefits/526EZ/tests/components/DisabilityWizard.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/DisabilityWizard.unit.spec.jsx
@@ -6,6 +6,9 @@ import createCommonStore from '../../../../../platform/startup/store';
 import conditionalStorage from '../../../../../platform/utilities/storage/conditionalStorage';
 import DisabilityWizard from '../../components/DisabilityWizard';
 import { layouts } from '../../wizardHelpers';
+import isBrandConsolidationEnabled from '../../../../../platform/brand-consolidation/feature-flag';
+
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 const { chooseUpdate, applyGuidance } = layouts;
 
@@ -56,7 +59,7 @@ describe('<DisabilityWizard>', () => {
     tree.setState({ disabilityStatus: 'first', currentLayout: applyGuidance });
     expect(tree.find('a').text()).to.equal('Go to eBenefits »');
     expect(tree.find('p').text()).to.equal(
-      'We’re sorry. We’re not set up to accept original claims on Vets.gov at this time. Since you’re filing your first disability claim, you’ll need to file on eBenefits.',
+      `We’re sorry. We’re not set up to accept original claims on ${siteName} at this time. Since you’re filing your first disability claim, you’ll need to file on eBenefits.`,
     );
   });
   it('should show ebenefits guidance page for new claims', () => {

--- a/src/applications/disability-benefits/526EZ/wizardHelpers.jsx
+++ b/src/applications/disability-benefits/526EZ/wizardHelpers.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
+
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 export const GetStartedMessage = ({ checkDisabilityStatus, isVerified }) => {
   const {
@@ -12,8 +15,7 @@ export const GetStartedMessage = ({ checkDisabilityStatus, isVerified }) => {
     : ' To apply for a disability increase, you’ll need to sign in and verify your account.';
   let getStartedMessage = `Since you have a condition that’s gotten worse to add to your claim, you’ll need to file a claim for increased disability.${signInMessage}`;
   if (isFirst) {
-    getStartedMessage =
-      'We’re sorry. We’re not set up to accept original claims on Vets.gov at this time. Since you’re filing your first disability claim, you’ll need to file on eBenefits.';
+    getStartedMessage = `We’re sorry. We’re not set up to accept original claims on ${siteName} at this time. Since you’re filing your first disability claim, you’ll need to file on eBenefits.`;
   }
   if (isAppeal) {
     getStartedMessage = (

--- a/src/applications/disability-benefits/526EZ/wizardHelpers.jsx
+++ b/src/applications/disability-benefits/526EZ/wizardHelpers.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
 export const GetStartedMessage = ({ checkDisabilityStatus, isVerified }) => {
   const {

--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -4,9 +4,7 @@ import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
 import { focusElement } from '../../../../platform/utilities/ui';
-import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
-
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+import siteName from '../../../../platform/brand-consolidation/site-name';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {

--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -4,6 +4,9 @@ import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
 import { focusElement } from '../../../../platform/utilities/ui';
+import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
+
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
@@ -102,7 +105,7 @@ class ConfirmationPage extends React.Component {
           <div className="small-6 usa-width-one-half medium-6 columns">
             <a href="/">
               <button className="usa-button-primary">
-                Go Back to Vets.gov
+                Go Back to {siteName}
               </button>
             </a>
           </div>

--- a/src/applications/letters/containers/LettersApp.jsx
+++ b/src/applications/letters/containers/LettersApp.jsx
@@ -6,9 +6,8 @@ import backendServices from '../../../platform/user/profile/constants/backendSer
 import RequiredLoginView from '../../../platform/user/authorization/components/RequiredLoginView';
 import { externalServices } from '../../../platform/monitoring/DowntimeNotification';
 import DowntimeBanner from '../../../platform/monitoring/DowntimeNotification/components/Banner';
-import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
-const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 const UNREGISTERED_ERROR = 'vets_letters_user_unregistered';
 
 // This needs to be a React component for RequiredLoginView to pass down

--- a/src/applications/letters/containers/LettersApp.jsx
+++ b/src/applications/letters/containers/LettersApp.jsx
@@ -6,7 +6,9 @@ import backendServices from '../../../platform/user/profile/constants/backendSer
 import RequiredLoginView from '../../../platform/user/authorization/components/RequiredLoginView';
 import { externalServices } from '../../../platform/monitoring/DowntimeNotification';
 import DowntimeBanner from '../../../platform/monitoring/DowntimeNotification/components/Banner';
+import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
 
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 const UNREGISTERED_ERROR = 'vets_letters_user_unregistered';
 
 // This needs to be a React component for RequiredLoginView to pass down
@@ -39,7 +41,7 @@ export class AppContent extends React.Component {
         <h4>
           We weren’t able to find information about your VA letters. If you
           think you should be able to access this information, please call the
-          Vets.gov Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>,
+          {siteName} Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>,
           TTY: <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211;
           Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).
         </h4>

--- a/src/platform/brand-consolidation/site-name.js
+++ b/src/platform/brand-consolidation/site-name.js
@@ -1,5 +1,5 @@
 import isBrandConsolidationEnabled from './feature-flag';
 
-const siteName = isBrandConsolidationEnabled() ? 'Vets.gov' : 'VA.gov';
+const siteName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 export default siteName;

--- a/src/platform/brand-consolidation/site-name.js
+++ b/src/platform/brand-consolidation/site-name.js
@@ -1,0 +1,5 @@
+import isBrandConsolidationEnabled from './feature-flag';
+
+const siteName = isBrandConsolidationEnabled() ? 'Vets.gov' : 'VA.gov';
+
+export default siteName;

--- a/va-gov/pages/disability/file-an-appeal.md
+++ b/va-gov/pages/disability/file-an-appeal.md
@@ -21,7 +21,7 @@ You have the right to appeal any benefits decision made by the Veterans Benefits
 
 ### Have you already filed an appeal?
 
-When the Veterans Benefits Administration Regional Office receives your Notice of Disagreement, you’ll be able to check the status of your appeal on Vets.gov.
+When the Veterans Benefits Administration Regional Office receives your Notice of Disagreement, you’ll be able to check the status of your appeal on VA.gov.
 
 <a class="usa-button-primary" href="/track-claims">Track Your Appeal</a>
 

--- a/va-gov/pages/disability/va-claim-exam.md
+++ b/va-gov/pages/disability/va-claim-exam.md
@@ -89,7 +89,7 @@ If you canâ€™t make it to your appointment, let us know right away. You can most
 </ul>
 </div>
 
-<br>  
+<br>
 
 ### What to expect at your VA claim exam
 
@@ -180,7 +180,7 @@ If you have what we consider to be a good reason for missing your exam (called â
 </ul>
 </div>
 
-<br>  
+<br>
 
 ### After your VA claim exam
 
@@ -196,7 +196,7 @@ Each claim is different, but it usually takes us about 3 to 4 months to process 
 
 [See our most recent estimate for the average number of days to complete a claim](/disability/how-to-file-claim/#days-to-complete-claim).
 
-[Sign in to Vets.gov to track your claim](/track-claims/).
+[Sign in to VA.gov to track your claim](/track-claims/).
 
 </div>
 </li>
@@ -241,5 +241,3 @@ We may ask you to have a claim exam if you appeal your disability benefits decis
 * [Get answers to your questions about the VA claim exam](https://www.benefits.va.gov/compensation/claimexam.asp).
 * [Download the VA claim exam fact sheet](https://www.benefits.va.gov/compensation/docs/claimexam-factsheet.pdf#).
 * [Download the VA claim exam tip sheet](https://www.benefits.va.gov/compensation/docs/claimexam-tipssheet.pdf#).
-
- 

--- a/va-gov/pages/records/download-va-letters.md
+++ b/va-gov/pages/records/download-va-letters.md
@@ -61,7 +61,7 @@ Yes. If you're totally and permanently disabled because of your service-connecte
 
 ### What if I have trouble downloading a VA letter?
 
-Call the Vets.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a> (TTY: <a href="tel:+18008778339">1-800-877-8339</a>).
+Call the VA.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a> (TTY: <a href="tel:+18008778339">1-800-877-8339</a>).
 We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. (<abbr title="eastern time">ET</abbr>).
 
 </section>


### PR DESCRIPTION
## Description
This PR changes instances of `Vets.gov` to use `VA.gov` as needed in the following tools:
- VA Letters
- Claims and Appeals
- 526 Form

## Testing done
Some of them are hard to reproduce, but I looked at the ones that weren't. Mostly I'm trusting on eslint to not let me import from a place that doesn't exist (getting the right number of `../`s for the brand consolidation flag import) and not letting me _not_ use a variable (`siteName`).

## Screenshots
Rather than taking a screenshot of _all_ the changes, I took couple of examples.

## Brand consolidation enabled
![image](https://user-images.githubusercontent.com/12970166/46640240-ab1c8d80-cb1f-11e8-9c29-d7da492f2bae.png)

## Brand consolidation not enabled
![image](https://user-images.githubusercontent.com/12970166/46640328-2aaa5c80-cb20-11e8-8827-cf3add5494e3.png)


## Acceptance criteria
- [x] `Vets.gov` is replaced with `VA.gov` in the tools listed above when the brand consolidation flag is enabled

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
