### PR TITLE
update VA Claim Exam on Pension

### DIFF
--- a/va-gov/pages/pension/va-claim-exam.md
+++ b/va-gov/pages/pension/va-claim-exam.md
@@ -1,6 +1,6 @@
 ---
 title: VA Claim Exam (C&P Exam)
-href: https://www.benefits.va.gov/compensation/claimexam.asp
+href: /disability/va-claim-exam/
 spoke: More Resources
 order: 4
 private: true


### PR DESCRIPTION
## Description
VA Claim Exam is currently linking to ebenefits. It should link to /disability/va-claim-exam/ per the spreadsheet.

## Testing done
Manual Test

## Screenshots


## Acceptance criteria
- [ ] VA Claim Exam in LeftRailNav in Pension should go to the link in the description.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
