### PR TITLE
VCL button css fix on teamsite injected header

### DIFF
--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -19,6 +19,10 @@ header.merger {
 
   .va-crisis-line {
     top: 20px;
+
+    button.va-crisis-line-button {
+      background-image: none;
+    }
   }
 }
 

--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -15,7 +15,7 @@
 }
 
 header.merger {
-  z-index: 999;
+  z-index: 300;
 
   .va-crisis-line {
     top: 20px;


### PR DESCRIPTION
## Description
VA.gov pages have styles that are adding a background image to the VCL button on injected headers

## Testing done
Local testing

## Screenshots


## Acceptance criteria
- [x] VA.gov injected headers should not have extraneous and conflicting background images on VCL button

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

Fix for https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14059
Fix for https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14075