### PR TITLE
Add alt text to home 1,2,3 images

### DIFF
--- a/va-gov/layouts/home.html
+++ b/va-gov/layouts/home.html
@@ -195,19 +195,19 @@
 
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-one-third homepage-news-story">
-        <img src="/img/homepage/home-1.jpg"/>
+        <img src="/img/homepage/home-1.jpg" alt="Four Veterans standing together in front of the United States flag."/>
         <h4 class="homepage-news-story-title"><a href=https://maketheconnection.net/>Make the Connection Website</a></h4>
         <p class="homepage-news-story-desc">Hear Veterans share their stories of recovery, and find resources near you.</p>
       </div>
 
       <div class="usa-width-one-third homepage-news-story">
-        <img src="/img/homepage/home-2.jpg"/>
+        <img src="/img/homepage/home-2.jpg" alt="Prescription medicine bottles being processed through the automated system at the VA Mail Order Pharmacy."/>
         <h4 class="homepage-news-story-title"><a href=https://www.accesstocare.va.gov/>Health Care Access and Quality</a></h4>
         <p class="homepage-news-story-desc">Get wait times and compare quality and patient-satisfaction data for VA health facilities.</p>
       </div>
 
       <div class="usa-width-one-third homepage-news-story">
-        <img src="/img/homepage/home-3.jpg"/>
+        <img src="/img/homepage/home-3.jpg" alt="Close-up of an American flag patch on the sleeve of a U.S. military combat uniform."/>
         <h4 class="homepage-news-story-title"><a href=https://www.blogs.va.gov/VAntage/48141/vas-rapid-appeals-modernization-program-ramp-now-open-appeals/>VA Rapid Appeals</a></h4>
         <p class="homepage-news-story-desc">Find out how to get a faster decision on a pending disability compensation appeal through the VA Rapid Appeals Modernization Program (RAMP).</p>
       </div>


### PR DESCRIPTION
## Description
The home-1, home-2, and home-3 images has no alt text, and are throwing errors in the aXe scanner. Screenshot below.

## Testing done
Manually tested that alt text is present and ensured that aXe scanner does not raise violation.

## Acceptance criteria
- [x] As a screenreader user, I want to hear the image descriptions read aloud when I am moving through the page one step at a time.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
