### PR TITLE
Update careers hub page for external links opening in new tab

### DIFF
--- a/va-gov/pages/careers-employment/index.md
+++ b/va-gov/pages/careers-employment/index.md
@@ -172,7 +172,7 @@ We can support you in all stages of your job search—from returning to work wit
   </div>
 
   <div class="link">
-    <a href="https://dol.gov/veterans/findajob/"><b>Find a Job (Department of Labor)</b></a>
+    <a href="https://dol.gov/veterans/findajob/" target="_blank"><b>Find a Job (Department of Labor)</b></a>
     <p>Search for jobs, get help translating your military skills and experience to civilian jobs, and access other career resources.</p>
   </div>
 
@@ -182,7 +182,7 @@ We can support you in all stages of your job search—from returning to work wit
   </div>
 
   <div class="link">
-    <a href="https://linkedinforgood.linkedin.com/programs/veterans"><b>Get Free Classes for a Year (LinkedIn)</b></a>
+    <a href="https://linkedinforgood.linkedin.com/programs/veterans" target="_blank"><b>Get Free Classes for a Year (LinkedIn)</b></a>
     <p>Get 1 year of free access to LinkedIn Premium and LinkedIn Learning.</p>
   </div>
 

--- a/va-gov/pages/careers-employment/index.md
+++ b/va-gov/pages/careers-employment/index.md
@@ -172,7 +172,7 @@ We can support you in all stages of your job search—from returning to work wit
   </div>
 
   <div class="link">
-    <a href="https://dol.gov/veterans/findajob/" target="_blank"><b>Find a Job (Department of Labor)</b></a>
+    <a href="https://dol.gov/veterans/findajob/" target="_blank" rel="noopener"><b>Find a Job (Department of Labor)</b></a>
     <p>Search for jobs, get help translating your military skills and experience to civilian jobs, and access other career resources.</p>
   </div>
 
@@ -182,7 +182,7 @@ We can support you in all stages of your job search—from returning to work wit
   </div>
 
   <div class="link">
-    <a href="https://linkedinforgood.linkedin.com/programs/veterans" target="_blank"><b>Get Free Classes for a Year (LinkedIn)</b></a>
+    <a href="https://linkedinforgood.linkedin.com/programs/veterans" target="_blank" rel="noopener"><b>Get Free Classes for a Year (LinkedIn)</b></a>
     <p>Get 1 year of free access to LinkedIn Premium and LinkedIn Learning.</p>
   </div>
 


### PR DESCRIPTION
## Description
Update these kinks on Careers hub page.

- [x] "Find a Job (Department of Labor)"  under Manage Your Career, should open in a new tab
- [x] "Get Free Classes for a Year (Linked In)"  under Manage Your Career, should open in a new tab
- [x] "VetSuccess on Campus" under More Information and Resources, should link here /careers-employment/vetsuccess-on-campus/

## Testing done
Manual Test

## Screenshots


## Acceptance criteria
- [ ] "Find a Job (Department of Labor)"  under Manage Your Career, should open in a new tab
- [ ] "Get Free Classes for a Year (Linked In)"  under Manage Your Career, should open in a new tab
- [ ] "VetSuccess on Campus" under More Information and Resources, should link here /careers-employment/vetsuccess-on-campus/

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
