### PR TITLE
add base url logic for mhv domains

### DIFF
--- a/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
@@ -10,6 +10,7 @@ import backendServices from '../../../../platform/user/profile/constants/backend
 import recordEvent from '../../../../platform/monitoring/record-event';
 import { fetchFolder, fetchRecipients } from '../../../messaging/actions';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
+import { mhvBaseUrl } from '../../../../platform/site-wide/cta-widget/helpers';
 
 function recordDashboardClick(product) {
   return () => {
@@ -98,7 +99,7 @@ class MessagingWidget extends React.Component {
         <p>
           {isBrandConsolidationEnabled() ? (
             <a
-              href="https://www.myhealth.va.gov/mhv-portal-web/secure-messaging"
+              href={`${mhvBaseUrl()}/mhv-portal-web/secure-messaging`}
               target="_blank"
             >
               View all your secure messages

--- a/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
@@ -10,6 +10,7 @@ import recordEvent from '../../../../platform/monitoring/record-event';
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 import PrescriptionCard from '../components/PrescriptionCard';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
+import { mhvBaseUrl } from '../../../../platform/site-wide/cta-widget/helpers';
 
 const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
@@ -73,7 +74,9 @@ class PrescriptionsWidget extends React.Component {
           <p>
             {isBrandConsolidationEnabled() ? (
               <a
-                href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/refill-prescriptions"
+                href={`${mhvBaseUrl()}/mhv-portal-web/${
+                  mhvBaseUrl().includes('www') ? 'web/myhealthevet/' : ''
+                }refill-prescriptions`}
                 target="_blank"
               >
                 View all your prescriptions

--- a/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
@@ -75,7 +75,7 @@ class PrescriptionsWidget extends React.Component {
             {isBrandConsolidationEnabled() ? (
               <a
                 href={`${mhvBaseUrl()}/mhv-portal-web/${
-                  mhvBaseUrl().includes('www') ? 'web/myhealthevet/' : ''
+                  __BUILDTYPE__ === 'production' ? 'web/myhealthevet/' : ''
                 }refill-prescriptions`}
                 target="_blank"
               >

--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -13,7 +13,7 @@ export const frontendApps = {
   VETERAN_ID_CARD: 'vic',
 };
 
-const mhvBaseUrl = () => {
+export const mhvBaseUrl = () => {
   const lowerEnvironments = [
     'development',
     'vagovdev',

--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { logout } from '../../../user/authentication/utilities';
 import dashboardManifest from '../../../../applications/personalization/dashboard/manifest';
 import recordEvent from '../../../../platform/monitoring/record-event';
+import { mhvBaseUrl } from '../../../../platform/site-wide/cta-widget/helpers';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 
 const LEFT_CLICK = 1;
@@ -49,10 +50,7 @@ class PersonalizationDropdown extends React.Component {
         )}
         {brandConsolidationEnabled && (
           <li>
-            <a
-              href="https://www.myhealth.va.gov/mhv-portal-web/home"
-              target="_blank"
-            >
+            <a href={`${mhvBaseUrl()}/mhv-portal-web/home`} target="_blank">
               My Health
             </a>
           </li>

--- a/src/platform/utilities/environment/stagingDomains.js
+++ b/src/platform/utilities/environment/stagingDomains.js
@@ -1,3 +1,5 @@
+import { mhvBaseUrl } from '../../site-wide/cta-widget/helpers';
+
 let currentEnv = 'dev';
 if (__BUILDTYPE__.includes('staging')) {
   currentEnv = 'staging';
@@ -10,6 +12,7 @@ if (__BUILDTYPE__ === 'preview') {
 // This list also exists in script/options.js
 const domainReplacements = [
   { from: 'www\\.va\\.gov', to: `${currentEnv}.va.gov` },
+  { from: 'https://www\\.myhealth\\.va\\.gov', to: mhvBaseUrl() },
 ];
 
 // This doesn't include preview because we want to redirect to staging urls


### PR DESCRIPTION
## Description
### preview.va.gov links point here:
"My Health" (in top nav) -> https://www.myhealth.va.gov/
"View all your secure messages" -> https://www.myhealth.va.gov/mhv-portal-web/secure-messaging
"View all your prescriptions" -> https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/refill-prescriptions
### staging.va.gov links point here
"My Health" (in top nav) -> https://mhv-intb.myhealth.va.gov/
"View all your secure messages" -> https://mhv-intb.myhealth.va.gov/mhv-portal-web/secure-messaging
"View all your prescriptions" -> https://mhv-intb.myhealth.va.gov/mhv-portal-web/refill-prescriptions

## Testing done
verified locally 

## Screenshots dev
![screen shot 2018-10-09 at 11 16 27](https://user-images.githubusercontent.com/4998130/46686201-cdacb600-cbb4-11e8-87bb-64b044902f94.png)
![screen shot 2018-10-09 at 11 05 29](https://user-images.githubusercontent.com/4998130/46686202-cdacb600-cbb4-11e8-8ce3-431b1a541080.png)
![screen shot 2018-10-09 at 10 47 25](https://user-images.githubusercontent.com/4998130/46686203-cdacb600-cbb4-11e8-969d-4da64be1b91e.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
