### PR TITLE
Switch metrics environments from dev/staging to preview

### DIFF
--- a/src/platform/monitoring/frontend-metrics/feature-flag.js
+++ b/src/platform/monitoring/frontend-metrics/feature-flag.js
@@ -4,7 +4,7 @@
  * @module platform/monitoring/frontend-metrics/feature-flag
  */
 export default function isMetricsEnabled() {
-  const environments = ['preview'];
+  const environments = ['vagovdev', 'vagovstaging', 'preview'];
 
   return !!environments.includes(__BUILDTYPE__);
 }

--- a/src/platform/monitoring/frontend-metrics/feature-flag.js
+++ b/src/platform/monitoring/frontend-metrics/feature-flag.js
@@ -4,7 +4,7 @@
  * @module platform/monitoring/frontend-metrics/feature-flag
  */
 export default function isMetricsEnabled() {
-  const environments = ['vagovdev', 'vagovstaging'];
+  const environments = ['preview'];
 
   return !!environments.includes(__BUILDTYPE__);
 }


### PR DESCRIPTION
## Description
This PR amends the enabled environments for FE metrics to enable the metrics capture in preview.va.gov as a result of [this conversation](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13402#issuecomment-428363887)

## Testing done
N/a

## Screenshots


## Acceptance criteria
- [ ] FE Metrics are being captured and reported from preview.va.gov

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
