### PR TITLE
Form expired messages

### DIFF
--- a/src/applications/burials/components/IntroductionPage.jsx
+++ b/src/applications/burials/components/IntroductionPage.jsx
@@ -29,9 +29,7 @@ class IntroductionPage extends React.Component {
           startText="Start the Burial Benefits Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}
-        >
-          Please complete the 21P-530 form to apply for burial benefits.
-        </SaveInProgressIntro>
+        />
         <div className="process schemaform-process schemaform-process-sip">
           <h4>Follow the steps below to apply for burial benefits.</h4>
           <ol>

--- a/src/applications/disability-benefits/686/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/686/containers/IntroductionPage.jsx
@@ -54,10 +54,7 @@ class IntroductionPage extends React.Component {
             startText="Start the Declaration of Dependents Application"
             {...this.props.saveInProgressActions}
             {...this.props.saveInProgress}
-          >
-            Please complete the 686 form to apply for declaration of status of
-            dependents.
-          </SaveInProgressIntro>
+          />
         </AuthorizationComponent>
         <h4>Follow the steps below to add a dependent to your VA benefits.</h4>
         <div className="process schemaform-process">

--- a/src/applications/edu-benefits/1990/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1990/containers/IntroductionPage.jsx
@@ -25,9 +25,7 @@ export class IntroductionPage extends React.Component {
           startText="Start the Education Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}
-        >
-          Please complete the 22-1990 form to apply for education benefits.
-        </SaveInProgressIntro>
+        />
         <h4>Follow the steps below to apply for education benefits.</h4>
         <div className="process schemaform-process">
           <ol>

--- a/src/applications/edu-benefits/1990e/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1990e/containers/IntroductionPage.jsx
@@ -28,9 +28,7 @@ export class IntroductionPage extends React.Component {
           startText="Start the Education Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}
-        >
-          Please complete the 22-1990E form to apply for education benefits.
-        </SaveInProgressIntro>
+        />
         <h4>Follow the steps below to apply for education benefits.</h4>
         <div className="process schemaform-process">
           <ol>

--- a/src/applications/edu-benefits/1990n/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1990n/containers/IntroductionPage.jsx
@@ -28,9 +28,7 @@ export class IntroductionPage extends React.Component {
           startText="Start the Education Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}
-        >
-          Please complete the 22-1990N form to apply for education benefits.
-        </SaveInProgressIntro>
+        />
         <h4>Follow the steps below to apply for education benefits.</h4>
         <div className="process schemaform-process">
           <ol>

--- a/src/applications/edu-benefits/1995/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1995/containers/IntroductionPage.jsx
@@ -32,9 +32,7 @@ export class IntroductionPage extends React.Component {
           startText="Start the Education Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}
-        >
-          Please complete the 22-1995 form to apply for education benefits.
-        </SaveInProgressIntro>
+        />
         <h4>Follow the steps below to apply for education benefits.</h4>
         <div className="process schemaform-process">
           <ol>

--- a/src/applications/edu-benefits/5490/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/5490/containers/IntroductionPage.jsx
@@ -29,9 +29,7 @@ export class IntroductionPage extends React.Component {
           startText="Start the Education Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}
-        >
-          Please complete the 22-5490 form to apply for education benefits.
-        </SaveInProgressIntro>
+        />
         <h4>Follow the steps below to apply for education benefits.</h4>
         <div className="process schemaform-process">
           <ol>

--- a/src/applications/edu-benefits/5495/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/5495/containers/IntroductionPage.jsx
@@ -29,9 +29,7 @@ export class IntroductionPage extends React.Component {
           startText="Start the Education Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}
-        >
-          Please complete the 22-5495 form to apply for education benefits.
-        </SaveInProgressIntro>
+        />
         <h4>Follow the steps below to apply for education benefits.</h4>
         <div className="process schemaform-process">
           <ol>

--- a/src/applications/hca/containers/IntroductionPage.jsx
+++ b/src/applications/hca/containers/IntroductionPage.jsx
@@ -29,9 +29,7 @@ class IntroductionPage extends React.Component {
           startText="Start the Health Care Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}
-        >
-          Please complete the 10-10EZ form to apply for health care benefits.
-        </SaveInProgressIntro>
+        />
         <h4>Follow the steps below to apply for health care benefits.</h4>
         <div className="process schemaform-process">
           <ol>

--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -29,9 +29,7 @@ class IntroductionPage extends React.Component {
           startText="Start the Pension Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}
-        >
-          Please complete the 21-527EZ form to apply for pension benefits.
-        </SaveInProgressIntro>
+        />
         <h4>Follow the steps below to apply for a Veterans pension.</h4>
         <div className="process schemaform-process schemaform-process-sip">
           <ol>

--- a/src/applications/personalization/profile360/util/helpers.jsx
+++ b/src/applications/personalization/profile360/util/helpers.jsx
@@ -41,7 +41,7 @@ export const formDescriptions = Object.keys(formBenefits).reduce(
     } else {
       formNumber = ` (${key})`;
     }
-    const formTitle = `${formBenefits[key]} application ${formNumber}`;
+    const formTitle = `${formBenefits[key]} application${formNumber}`;
     titles[key] = formTitle; // eslint-disable-line no-param-reassign
     return titles;
   },

--- a/src/applications/personalization/profile360/util/helpers.jsx
+++ b/src/applications/personalization/profile360/util/helpers.jsx
@@ -31,6 +31,23 @@ export const formTitles = Object.keys(formBenefits).reduce((titles, key) => {
   return titles;
 }, {});
 
+export const formDescriptions = Object.keys(formBenefits).reduce(
+  (titles, key) => {
+    let formNumber;
+    if (key === '40-10007' || key === 'VIC') {
+      formNumber = '';
+    } else if (key === '1010ez') {
+      formNumber = ' (10-10EZ)';
+    } else {
+      formNumber = ` (${key})`;
+    }
+    const formTitle = `${formBenefits[key]} application ${formNumber}`;
+    titles[key] = formTitle; // eslint-disable-line no-param-reassign
+    return titles;
+  },
+  {},
+);
+
 export const formLinks = {
   '21-526EZ': '/disability-benefits/apply/form-526-disability-claim/',
   '21P-527EZ': '/pension/application/527EZ/',

--- a/src/applications/personalization/profile360/util/helpers.jsx
+++ b/src/applications/personalization/profile360/util/helpers.jsx
@@ -4,7 +4,7 @@ export const formBenefits = {
   '21-526EZ': 'increased disability compensation',
   '21P-527EZ': 'Veterans pension benefits',
   '21P-530': 'burial benefits',
-  '1010ez': 'health care',
+  '1010ez': 'health care benefits',
   '22-0993': 'opt out',
   '22-1990': 'education benefits',
   '22-1990E': 'education benefits',
@@ -37,11 +37,11 @@ export const formDescriptions = Object.keys(formBenefits).reduce(
     if (key === '40-10007' || key === 'VIC') {
       formNumber = '';
     } else if (key === '1010ez') {
-      formNumber = ' (10-10EZ)';
+      formNumber = '(10-10EZ)';
     } else {
-      formNumber = ` (${key})`;
+      formNumber = `(${key})`;
     }
-    const formTitle = `${formBenefits[key]} application${formNumber}`;
+    const formTitle = `${formBenefits[key]} application ${formNumber}`;
     titles[key] = formTitle; // eslint-disable-line no-param-reassign
     return titles;
   },

--- a/src/applications/pre-need/components/IntroductionPage.jsx
+++ b/src/applications/pre-need/components/IntroductionPage.jsx
@@ -34,9 +34,7 @@ class IntroductionPage extends React.Component {
           startText="Start the Pre-need Eligibility Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}
-        >
-          Please complete the 40-10007 form to apply for pre-need eligibility.
-        </SaveInProgressIntro>
+        />
         <div className="process schemaform-process">
           <ol>
             <li className="process-step list-one">

--- a/src/applications/vre/chapter36/components/IntroductionPage.jsx
+++ b/src/applications/vre/chapter36/components/IntroductionPage.jsx
@@ -31,9 +31,7 @@ class IntroductionPage extends React.Component {
           startText="Start the VR&E Application"
           {...this.props.saveInProgressActions}
           {...this.props.saveInProgress}
-        >
-          Please complete the Chapter 36 form to apply for benefits
-        </SaveInProgressIntro>
+        />
         <div className="process schemaform-process schemaform-process-sip">
           <h4>
             Follow the steps below to apply for educational and vocational

--- a/src/platform/forms/save-in-progress/ApplicationStatus.jsx
+++ b/src/platform/forms/save-in-progress/ApplicationStatus.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 
 import {
   formLinks,
-  formTitles,
   formDescriptions,
   formBenefits,
 } from '../../../applications/personalization/profile360/util/helpers';
@@ -100,11 +99,6 @@ export class ApplicationStatus extends React.Component {
       const expirationDate = moment.unix(expirationTime);
       const isExpired = expirationDate.isBefore();
 
-      const [firstLetter, ...restOfTitle] = formTitles[formId];
-      const cardTitle = `${firstLetter.toUpperCase()}${restOfTitle.join(
-        '',
-      )} application in progress`;
-
       if (!isExpired) {
         const lastSavedDateTime = moment
           .unix(lastSaved)
@@ -112,11 +106,22 @@ export class ApplicationStatus extends React.Component {
 
         return (
           <div className="usa-alert usa-alert-info no-background-image sip-application-status">
-            <h5 className="form-title saved">{cardTitle}</h5>
+            <h5 className="form-title saved">Form is in progress</h5>
+            <span className="saved-form-item-metadata">
+              Your {formDescriptions[formId]} is in progress.
+            </span>
+            <br />
             <span className="saved-form-item-metadata">
               Last saved on {lastSavedDateTime}
             </span>
             <br />
+            <div className="expires-container">
+              You can continue applying now, or come back later to finish your
+              application. Your application{' '}
+              <span className="expires">
+                will expire on {expirationDate.format('M/D/YYYY')}.
+              </span>
+            </div>
             <p>
               <a
                 className="usa-button-primary"
@@ -130,12 +135,6 @@ export class ApplicationStatus extends React.Component {
               >
                 Start Over
               </button>
-            </p>
-            <p className="no-bottom-margin">
-              Your saved application{' '}
-              <strong>
-                will expire on {expirationDate.format('M/D/YYYY')}.
-              </strong>
             </p>
             {multipleForms && (
               <p className="no-bottom-margin">

--- a/src/platform/forms/save-in-progress/ApplicationStatus.jsx
+++ b/src/platform/forms/save-in-progress/ApplicationStatus.jsx
@@ -6,6 +6,8 @@ import { connect } from 'react-redux';
 import {
   formLinks,
   formTitles,
+  formDescriptions,
+  formBenefits,
 } from '../../../applications/personalization/profile360/util/helpers';
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 import ProgressButton from '@department-of-veterans-affairs/formation/ProgressButton';
@@ -166,6 +168,50 @@ export class ApplicationStatus extends React.Component {
           </div>
         );
       }
+      return (
+        <div className="usa-alert usa-alert-warning no-background-image sip-application-status">
+          <h5 className="form-title saved">Form has expired</h5>
+          <span className="saved-form-item-metadata">
+            Your saved {formDescriptions[formId]} application has expired. If
+            you want to apply for
+            {formBenefits[formId]}, please start a new application.
+          </span>
+          <br />
+          <p>
+            <button className="usa-button-primary" onClick={this.toggleModal}>
+              Start Over
+            </button>
+          </p>
+          {multipleForms && (
+            <p className="no-bottom-margin">
+              You have more than one in-progress {formType} form.{' '}
+              <a href="/profile">
+                View and manage your forms on your Account page
+              </a>
+              .
+            </p>
+          )}
+          <Modal
+            cssClass="va-modal-large"
+            id="start-over-modal"
+            onClose={this.toggleModal}
+            title="Starting over will delete your in-progress form."
+            visible={this.state.modalOpen}
+          >
+            <p>Are you sure you want to start over?</p>
+            <ProgressButton
+              onButtonClick={() => this.removeForm(formId)}
+              buttonText="Start Over"
+              buttonClass="usa-button-primary"
+            />
+            <ProgressButton
+              onButtonClick={this.toggleModal}
+              buttonText="Cancel"
+              buttonClass="usa-button-secondary"
+            />
+          </Modal>
+        </div>
+      );
     }
 
     if (showApplyButton && applyRender) {

--- a/src/platform/forms/save-in-progress/ApplicationStatus.jsx
+++ b/src/platform/forms/save-in-progress/ApplicationStatus.jsx
@@ -106,13 +106,13 @@ export class ApplicationStatus extends React.Component {
 
         return (
           <div className="usa-alert usa-alert-info no-background-image sip-application-status">
-            <h5 className="form-title saved">Form is in progress</h5>
+            <h5 className="form-title saved">Your form is in progress</h5>
             <span className="saved-form-item-metadata">
               Your {formDescriptions[formId]} is in progress.
             </span>
             <br />
             <span className="saved-form-item-metadata">
-              Last saved on {lastSavedDateTime}
+              Your application was last saved on {lastSavedDateTime}
             </span>
             <br />
             <div className="expires-container">
@@ -133,7 +133,7 @@ export class ApplicationStatus extends React.Component {
                 className="usa-button-secondary"
                 onClick={this.toggleModal}
               >
-                Start Over
+                Start a New Application
               </button>
             </p>
             {multipleForms && (
@@ -155,7 +155,7 @@ export class ApplicationStatus extends React.Component {
               <p>Are you sure you want to start over?</p>
               <ProgressButton
                 onButtonClick={() => this.removeForm(formId)}
-                buttonText="Start Over"
+                buttonText="Start a New Application"
                 buttonClass="usa-button-primary"
               />
               <ProgressButton
@@ -169,11 +169,10 @@ export class ApplicationStatus extends React.Component {
       }
       return (
         <div className="usa-alert usa-alert-warning no-background-image sip-application-status">
-          <h5 className="form-title saved">Form has expired</h5>
+          <h5 className="form-title saved">Your form has expired</h5>
           <span className="saved-form-item-metadata">
-            Your saved {formDescriptions[formId]} application has expired. If
-            you want to apply for
-            {formBenefits[formId]}, please start a new application.
+            Your saved {formDescriptions[formId]} has expired. If you want to
+            apply for {formBenefits[formId]}, please start a new application.
           </span>
           <br />
           <p>

--- a/src/platform/forms/save-in-progress/ApplicationStatus.jsx
+++ b/src/platform/forms/save-in-progress/ApplicationStatus.jsx
@@ -177,7 +177,7 @@ export class ApplicationStatus extends React.Component {
           <br />
           <p>
             <button className="usa-button-primary" onClick={this.toggleModal}>
-              Start Over
+              Start a New Application
             </button>
           </p>
           {multipleForms && (
@@ -199,7 +199,7 @@ export class ApplicationStatus extends React.Component {
             <p>Are you sure you want to start over?</p>
             <ProgressButton
               onButtonClick={() => this.removeForm(formId)}
-              buttonText="Start Over"
+              buttonText="Start a New Application"
               buttonClass="usa-button-primary"
             />
             <ProgressButton

--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -67,8 +67,12 @@ class FormStartControls extends React.Component {
           {!this.props.resumeOnly && (
             <ProgressButton
               onButtonClick={this.toggleModal}
-              buttonText="Start Over"
-              buttonClass="usa-button-secondary"
+              buttonText="Start a New Application"
+              buttonClass={
+                this.props.isExpired
+                  ? 'usa-button-primary'
+                  : 'usa-button-secondary'
+              }
             />
           )}
           <Modal
@@ -81,7 +85,7 @@ class FormStartControls extends React.Component {
             <p>Are you sure you want to start over?</p>
             <ProgressButton
               onButtonClick={this.startOver}
-              buttonText="Start Over"
+              buttonText="Start a New Application"
               buttonClass="usa-button-primary"
             />
             <ProgressButton

--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -57,11 +57,13 @@ class FormStartControls extends React.Component {
     if (this.props.formSaved) {
       return (
         <div>
-          <ProgressButton
-            onButtonClick={this.handleLoadForm}
-            buttonText="Continue Your Application"
-            buttonClass="usa-button-primary no-text-transform"
-          />
+          {!this.props.isExpired && (
+            <ProgressButton
+              onButtonClick={this.handleLoadForm}
+              buttonText="Continue Your Application"
+              buttonClass="usa-button-primary no-text-transform"
+            />
+          )}
           {!this.props.resumeOnly && (
             <ProgressButton
               onButtonClick={this.toggleModal}

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -44,18 +44,26 @@ class SaveInProgressIntro extends React.Component {
         const isExpired = expiresAt.isBefore();
 
         if (!isExpired) {
+          const lastSavedDateTime = moment
+            .unix(savedAt)
+            .format('M/D/YYYY [at] h:mm a');
           alert = (
             <div>
               <div className="usa-alert usa-alert-info no-background-image schemaform-sip-alert">
                 <div className="schemaform-sip-alert-title">
-                  Application status: <strong>In progress</strong>
+                  Form is in progress
                 </div>
                 <div className="saved-form-metadata-container">
-                  <span className="saved-form-metadata">
-                    Last saved on {savedAt.format('MMM D, YYYY [at] h:mm a')}
+                  <span className="saved-form-item-metadata">
+                    Your {formDescriptions[formId]} is in progress.
+                  </span>
+                  <br />
+                  <span className="saved-form-item-metadata">
+                    Last saved on {lastSavedDateTime}
                   </span>
                   <div className="expires-container">
-                    Your saved application{' '}
+                    You can continue applying now, or come back later to finish
+                    your application. Your application{' '}
                     <span className="expires">
                       will expire on {expirationDate}.
                     </span>
@@ -75,9 +83,9 @@ class SaveInProgressIntro extends React.Component {
                 </div>
                 <div className="saved-form-metadata-container">
                   <span className="saved-form-metadata">
-                    Your saved {formDescriptions[formId]} application has
-                    expired. If you want to apply for {formBenefits[formId]},
-                    please start a new application.
+                    Your saved {formDescriptions[formId]} has expired. If you
+                    want to apply for {formBenefits[formId]}, please start a new
+                    application.
                   </span>
                 </div>
                 <div>{this.props.children}</div>

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -6,6 +6,10 @@ import moment from 'moment';
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 import { getNextPagePath } from 'us-forms-system/lib/js/routing';
 
+import {
+  formDescriptions,
+  formBenefits,
+} from '../../../applications/personalization/profile360/util/helpers';
 import { toggleLoginModal } from '../../site-wide/user-nav/actions';
 import { fetchInProgressForm, removeInProgressForm } from './actions';
 import FormStartControls from './FormStartControls';
@@ -19,6 +23,7 @@ class SaveInProgressIntro extends React.Component {
   getAlert(savedForm) {
     let alert;
     const {
+      formId,
       renderSignInMessage,
       prefillEnabled,
       verifyRequiredPrefill,
@@ -27,39 +32,60 @@ class SaveInProgressIntro extends React.Component {
     } = this.props;
     const { profile, login } = this.props.user;
     const prefillAvailable = !!(
-      profile && profile.prefillsAvailable.includes(this.props.formId)
+      profile && profile.prefillsAvailable.includes(formId)
     );
     if (login.currentlyLoggedIn) {
       if (savedForm) {
         const savedAt = this.props.lastSavedDate
           ? moment(this.props.lastSavedDate)
           : moment.unix(savedForm.lastUpdated);
-        const expirationDate = moment
-          .unix(savedForm.metadata.expiresAt)
-          .format('MMM D, YYYY');
+        const expiresAt = moment.unix(savedForm.metadata.expiresAt);
+        const expirationDate = expiresAt.format('MMM D, YYYY');
+        const isExpired = expiresAt.isBefore();
 
-        alert = (
-          <div>
-            <div className="usa-alert usa-alert-info no-background-image schemaform-sip-alert">
-              <div className="schemaform-sip-alert-title">
-                Application status: <strong>In progress</strong>
+        if (!isExpired) {
+          alert = (
+            <div>
+              <div className="usa-alert usa-alert-info no-background-image schemaform-sip-alert">
+                <div className="schemaform-sip-alert-title">
+                  Application status: <strong>In progress</strong>
+                </div>
+                <div className="saved-form-metadata-container">
+                  <span className="saved-form-metadata">
+                    Last saved on {savedAt.format('MMM D, YYYY [at] h:mm a')}
+                  </span>
+                  <div className="expires-container">
+                    Your saved application{' '}
+                    <span className="expires">
+                      will expire on {expirationDate}.
+                    </span>
+                  </div>
+                </div>
+                <div>{this.props.children}</div>
               </div>
-              <div className="saved-form-metadata-container">
-                <span className="saved-form-metadata">
-                  Last saved on {savedAt.format('MMM D, YYYY [at] h:mm a')}
-                </span>
-                <div className="expires-container">
-                  Your saved application{' '}
-                  <span className="expires">
-                    will expire on {expirationDate}.
+              <br />
+            </div>
+          );
+        } else {
+          alert = (
+            <div>
+              <div className="usa-alert usa-alert-warning no-background-image schemaform-sip-alert">
+                <div className="schemaform-sip-alert-title">
+                  Form has expired
+                </div>
+                <div className="saved-form-metadata-container">
+                  <span className="saved-form-metadata">
+                    Your saved {formDescriptions[formId]} application has
+                    expired. If you want to apply for {formBenefits[formId]},
+                    please start a new application.
                   </span>
                 </div>
+                <div>{this.props.children}</div>
               </div>
-              <div>{this.props.children}</div>
+              <br />
             </div>
-            <br />
-          </div>
-        );
+          );
+        }
       } else if (prefillAvailable && !verifiedPrefillAlert) {
         alert = (
           <div>
@@ -180,13 +206,16 @@ class SaveInProgressIntro extends React.Component {
     const { profile } = this.props.user;
     const startPage = this.getStartPage();
     const savedForm =
-      profile &&
-      profile.savedForms
-        .filter(f => moment.unix(f.metadata.expiresAt).isAfter())
-        .find(f => f.form === this.props.formId);
+      profile && profile.savedForms.find(f => f.form === this.props.formId);
     const prefillAvailable = !!(
       profile && profile.prefillsAvailable.includes(this.props.formId)
     );
+    let expiresAt;
+    let isExpired;
+    if (savedForm) {
+      expiresAt = moment.unix(savedForm.metadata.expiresAt);
+      isExpired = expiresAt.isBefore();
+    }
 
     if (profile.loading && !this.props.resumeOnly) {
       return (
@@ -206,6 +235,7 @@ class SaveInProgressIntro extends React.Component {
         {!this.props.buttonOnly && this.getAlert(savedForm)}
         <FormStartControls
           resumeOnly={this.props.resumeOnly}
+          isExpired={isExpired}
           messages={this.props.messages}
           startText={this.props.startText}
           startPage={startPage}

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -51,7 +51,7 @@ class SaveInProgressIntro extends React.Component {
             <div>
               <div className="usa-alert usa-alert-info no-background-image schemaform-sip-alert">
                 <div className="schemaform-sip-alert-title">
-                  Form is in progress
+                  <strong>Your form is in progress</strong>
                 </div>
                 <div className="saved-form-metadata-container">
                   <span className="saved-form-item-metadata">
@@ -59,7 +59,7 @@ class SaveInProgressIntro extends React.Component {
                   </span>
                   <br />
                   <span className="saved-form-item-metadata">
-                    Last saved on {lastSavedDateTime}
+                    Your application was last saved on {lastSavedDateTime}
                   </span>
                   <div className="expires-container">
                     You can continue applying now, or come back later to finish
@@ -79,7 +79,7 @@ class SaveInProgressIntro extends React.Component {
             <div>
               <div className="usa-alert usa-alert-warning no-background-image schemaform-sip-alert">
                 <div className="schemaform-sip-alert-title">
-                  Form has expired
+                  <strong>Your form has expired</strong>
                 </div>
                 <div className="saved-form-metadata-container">
                   <span className="saved-form-metadata">

--- a/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
@@ -69,7 +69,7 @@ describe('schemaform <ApplicationStatus>', () => {
       'Continue Your Application',
     );
     expect(tree.subTree('.form-title').text()).to.contain(
-      'application in progress',
+      'Form is in progress',
     );
   });
   it('should render expired form', () => {
@@ -129,7 +129,7 @@ describe('schemaform <ApplicationStatus>', () => {
       'Continue Your Application',
     );
     expect(tree.subTree('.form-title').text()).to.contain(
-      'application in progress',
+      'Form is in progress',
     );
   });
   it('should render multiple forms message', () => {

--- a/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
@@ -69,7 +69,7 @@ describe('schemaform <ApplicationStatus>', () => {
       'Continue Your Application',
     );
     expect(tree.subTree('.form-title').text()).to.contain(
-      'Form is in progress',
+      'Your form is in progress',
     );
   });
   it('should render expired form', () => {
@@ -129,7 +129,7 @@ describe('schemaform <ApplicationStatus>', () => {
       'Continue Your Application',
     );
     expect(tree.subTree('.form-title').text()).to.contain(
-      'Form is in progress',
+      'Your form is in progress',
     );
   });
   it('should render multiple forms message', () => {

--- a/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
@@ -72,7 +72,7 @@ describe('schemaform <ApplicationStatus>', () => {
       'application in progress',
     );
   });
-  it('should not render expired form', () => {
+  it('should render expired form', () => {
     const tree = SkinDeep.shallowRender(
       <ApplicationStatus
         formId="21P-527EZ"
@@ -96,11 +96,8 @@ describe('schemaform <ApplicationStatus>', () => {
         }}
       />,
     );
-
-    expect(tree.subTree('.usa-alert-info')).to.be.false;
-    expect(tree.subTree('.usa-button-primary').text()).to.equal(
-      'Apply for benefit',
-    );
+    expect(tree.subTree('.usa-alert-warning')).to.not.be.false;
+    expect(tree.subTree('.usa-button-primary').text()).to.equal('Start Over');
   });
   it('should render saved form from ids', () => {
     const tree = SkinDeep.shallowRender(

--- a/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
@@ -97,7 +97,9 @@ describe('schemaform <ApplicationStatus>', () => {
       />,
     );
     expect(tree.subTree('.usa-alert-warning')).to.not.be.false;
-    expect(tree.subTree('.usa-button-primary').text()).to.equal('Start Over');
+    expect(tree.subTree('.usa-button-primary').text()).to.equal(
+      'Start a New Application',
+    );
   });
   it('should render saved form from ids', () => {
     const tree = SkinDeep.shallowRender(

--- a/src/platform/forms/tests/save-in-progress/FormStartControls.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/FormStartControls.unit.spec.jsx
@@ -47,7 +47,7 @@ describe('Schemaform <FormStartControls>', () => {
 
     expect(tree.everySubTree('ProgressButton').length).to.equal(1);
   });
-  it('should render 1 button when logged in with an expired form', () => {
+  it('should render 3 buttons when logged in with an expired form', () => {
     const routerSpy = {
       push: sinon.spy(),
     };

--- a/src/platform/forms/tests/save-in-progress/FormStartControls.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/FormStartControls.unit.spec.jsx
@@ -47,6 +47,24 @@ describe('Schemaform <FormStartControls>', () => {
 
     expect(tree.everySubTree('ProgressButton').length).to.equal(1);
   });
+  it('should render 1 button when logged in with an expired form', () => {
+    const routerSpy = {
+      push: sinon.spy(),
+    };
+    const fetchSpy = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <FormStartControls
+        formId="1010ez"
+        migrations={[]}
+        isExpired
+        formSaved
+        startPage={startPage}
+        router={routerSpy}
+        fetchInProgressForm={fetchSpy}
+      />,
+    );
+    expect(tree.everySubTree('ProgressButton').length).to.equal(3);
+  });
   it('should render 4 buttons when logged in with a saved form', () => {
     const routerSpy = {
       push: sinon.spy(),

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -50,7 +50,9 @@ describe('Schemaform <SaveInProgressIntro>', () => {
       />,
     );
 
-    expect(tree.find('.usa-alert').text()).to.contain('Form is in progress');
+    expect(tree.find('.usa-alert').text()).to.contain(
+      'Your form is in progress',
+    );
     expect(tree.find('.usa-alert').text()).to.contain('will expire on');
     expect(tree.find('withRouter(FormStartControls)').exists()).to.be.true;
     expect(tree.find('withRouter(FormStartControls)').props().prefillAvailable)
@@ -322,9 +324,9 @@ describe('Schemaform <SaveInProgressIntro>', () => {
       />,
     );
 
-    expect(tree.find('.usa-alert').text()).to.contain('Form has expired');
+    expect(tree.find('.usa-alert').text()).to.contain('Your form has expired');
     expect(tree.find('.usa-alert').text()).to.contain(
-      'Your saved health care application (10-10EZ) has expired. If you want to apply for health care, please start a new application.',
+      'Your saved health care benefits application (10-10EZ) has expired. If you want to apply for health care benefits, please start a new application.',
     );
     expect(tree.find('withRouter(FormStartControls)').exists()).to.be.true;
   });

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -294,13 +294,13 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     expect(tree.find('withRouter(FormStartControls)').exists()).to.be.false;
   });
 
-  it('should render message if signed in with an expired form', () => {
+  it('should render expired message if signed in with an expired form', () => {
     const user = {
       profile: {
         savedForms: [
           {
             form: '1010ez',
-            metadata: { lastUpdated: 3000, expiresAt: moment().unix() - 1000 },
+            metadata: { lastUpdated: 3000, expiresAt: moment().unix() },
           },
         ],
         prefillsAvailable: [],
@@ -322,8 +322,9 @@ describe('Schemaform <SaveInProgressIntro>', () => {
       />,
     );
 
+    expect(tree.find('.usa-alert').text()).to.contain('Form has expired');
     expect(tree.find('.usa-alert').text()).to.contain(
-      'You can save this form in progress',
+      'Your saved health care (10-10EZ) application has expired. If you want to apply for health care, please start a new application.',
     );
     expect(tree.find('withRouter(FormStartControls)').exists()).to.be.true;
   });

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -50,7 +50,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
       />,
     );
 
-    expect(tree.find('.usa-alert').text()).to.contain('In progress');
+    expect(tree.find('.usa-alert').text()).to.contain('Form is in progress');
     expect(tree.find('.usa-alert').text()).to.contain('will expire on');
     expect(tree.find('withRouter(FormStartControls)').exists()).to.be.true;
     expect(tree.find('withRouter(FormStartControls)').props().prefillAvailable)
@@ -324,7 +324,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
 
     expect(tree.find('.usa-alert').text()).to.contain('Form has expired');
     expect(tree.find('.usa-alert').text()).to.contain(
-      'Your saved health care (10-10EZ) application has expired. If you want to apply for health care, please start a new application.',
+      'Your saved health care application (10-10EZ) has expired. If you want to apply for health care, please start a new application.',
     );
     expect(tree.find('withRouter(FormStartControls)').exists()).to.be.true;
   });


### PR DESCRIPTION
## Description
These changes add messages for expired forms on the static pages and on the form introduction pages.

## Testing done
unit tests updated

## Screenshots
Intro page
![image](https://user-images.githubusercontent.com/16051172/46763926-e9d15580-cc8f-11e8-8b94-0e99656b9fb2.png)
![image](https://user-images.githubusercontent.com/16051172/46764627-c8716900-cc91-11e8-930e-7b8d27f5c18c.png)

Static pages
![image](https://user-images.githubusercontent.com/16051172/46763941-f35abd80-cc8f-11e8-8aba-08f5b66be532.png)
![image](https://user-images.githubusercontent.com/16051172/46764637-cf987700-cc91-11e8-9213-c5dd8baba457.png)

## Acceptance criteria
- [x] Display a message to users if their form has expired.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
