### PR TITLE
Fix for Claims announcement resulting in 404

### DIFF
--- a/va-gov/components/react-loader.html
+++ b/va-gov/components/react-loader.html
@@ -9,7 +9,7 @@
         </div>
       </div>
     </div>
-{% else %}
+{% elsif custom_react_root != true %}
   {{ contents }}
   <div class="section">
     <div id="react-root">
@@ -20,4 +20,6 @@
       </div>
     </div>
   </div>
+{% else %}
+  {{ contents }}
 {% endif %}

--- a/va-gov/pages/beta-enrollment/claim-increase.md
+++ b/va-gov/pages/beta-enrollment/claim-increase.md
@@ -1,0 +1,42 @@
+---
+title: Try Our New Beta Tools
+layout: page-react.html
+custom_react_root: true
+entryname: beta-enrollment
+---
+  <nav class="va-nav-breadcrumbs">
+    <ul class="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
+      <li><a href="/">Home</a></li>
+    </ul>
+  </nav>
+
+<div class="row">
+<div class="columns usa-width-two-thirds medium-8">
+
+# Try Our New Tool to File a Claim for Increased Disability Compensation
+
+<div itemprop="description"  class="va-introtext">
+
+We invite you to use our new beta tool—an online application for increased disability compensation.
+
+</div>
+
+### What’s a beta tool?
+
+A beta tool is a new tool we’re testing to make sure it works the way it should before we give all Vets.gov users access to it. Your feedback will help us make the tool better for all Veterans.
+
+### What will happen when I try the new tool?
+
+When you agree to test out the new tool, you’ll use our online application to file a claim for increased disability compensation. You’ll have the same access to all the other Vets.gov tools and information as you have right now.
+
+You’ll need to be signed in to your verified DS Logon or My HealtheVet account. If you don’t have one of these accounts, you can create an ID.me account to complete the verification process.
+
+Use the beta tool to file a claim for increased disability compensation.
+<br>
+
+<div id="react-root"></div>
+
+<br>
+
+</div>
+</div>


### PR DESCRIPTION
## Description
When a user clicks the banner along the homepage, they see a 404 instead of the beta-enrollment page. The problem was that the page was never mapped over to the `va-gov` directory. 

![image.png](https://images.zenhubusercontent.com/59cb9de1b0222d5de47953d8/62e95b71-8b27-45ff-bd64-a80c71c3bb48)

This PR -
- Copies over the `beta-enrollment` directory from `content` to `va-gov`
- Updates the `va-gov/includes/react-loader.html` to grab some of the missed updates for Vets.gov. Specifically, the `custom_react_root` property.

### Ticket
Moves to validate - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14113

## Testing done
- Cleared localStorage
- Clicked the announcement link
- Confirmed no extra React-spinner was rendering
- Signed up for beta
- Logged in
- Came back
- Claims tool was down, but that was by design.

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/46751489-be973800-cc88-11e8-8ff7-d26f1e12fecf.png)


## Acceptance criteria
- [x] No 404 on the beta page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
