### PR TITLE
Brand Consolidation - Fix the sidebar-trigger button on non-static pages

### DIFF
--- a/src/applications/discharge-wizard/discharge-wizard-entry.jsx
+++ b/src/applications/discharge-wizard/discharge-wizard-entry.jsx
@@ -1,6 +1,12 @@
 import '../../platform/polyfills';
 import './sass/discharge-wizard.scss';
 
+import brandConsolidation from '../../platform/brand-consolidation';
+
+if (brandConsolidation.isEnabled()) {
+  require('../static-pages/sidebar-navigation');
+}
+
 import startApp from '../../platform/startup';
 
 import routes from './routes';

--- a/src/applications/post-911-gib-status/post-911-gib-status-entry.jsx
+++ b/src/applications/post-911-gib-status/post-911-gib-status-entry.jsx
@@ -1,6 +1,12 @@
 import '../../platform/polyfills';
 import './sass/post-911-gib-status.scss';
 
+import brandConsolidation from '../../platform/brand-consolidation';
+
+if (brandConsolidation.isEnabled()) {
+  require('../static-pages/sidebar-navigation');
+}
+
 import startApp from '../../platform/startup';
 
 import routes from './routes';


### PR DESCRIPTION
## Description
The script for toggling the rights sidebar on mobile is only imported on content pages, and not on React apps. This means that pages that require the sidebar but are also React apps need to import `sidebar-navigation.js` to enable the button behavior.

This PR ultimately enables the "More in this section" button for the Discharge Wizard and Post-9-11 GIBS app.

### Ticket
Moves to validate - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14105

## Testing done
1. Went to `http://localhost:3001/discharge-upgrade-instructions/`
2. Sized browser window down to mobile
3. Clicked the "More in this section" button
4. Repeated for `http://localhost:3001/education/gi-bill/post-9-11/ch-33-benefit/`

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/46752751-023f7100-cc8c-11e8-930a-d74e8642d6ed.png)


## Acceptance criteria
- [ ] Mobile sidebar opens on React apps that contain the sidebar

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
