### PR TITLE
Add homepage banner for Hurricane Michael

### DIFF
--- a/content/includes/homepage-warning.html
+++ b/content/includes/homepage-warning.html
@@ -1,11 +1,10 @@
 <div id="top-of-page-alert-container">
   <div id="top-of-page-alert" class="usa-alert usa-alert-warning">
     <div class="usa-alert-body">
-      <p><strong>Some VA services in the Mid-Atlantic region may be affected by storms</strong></p>
+      <h4 class="usa-alert-title">Some VA services in Florida and the Gulf Coast region may be affected by Hurricane Michael</h4>
       <p>If your usual VA facility is affected, you can contact another VA facility for help.</p>
-      <p>Veterans in the Mid-Atlantic region affected by Hurricane Florence can get updates on VA medical center closures and evacuations at the VA Office of Public and Intergovernmental Affairs website.<br>
-        <a href="https://www.va.gov/opa/alerts/florence.asp" rel="nofollow">Get updates on affected VA services and facilities
-          in the Mid-Atlantic region.</a>
+      <p>Veterans affected by Hurricane Michael can get updates on VA medical center closures and evacuations at the Office of Public and Intergovernmental Affairs website.<br>
+        <a href="https://www.va.gov/opa/alerts/hurricane-michael.asp" rel="nofollow">Get updates on affected VA services and facilities in Florida and the Gulf Coast</a>.</p>
       <p>Or you can call the Veterans Disaster Response Line at 1-800-507-4571.</p>
     </div>
   </div>

--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -3,7 +3,7 @@ layout: home.html
 body_class: home
 title: Home
 plainlanguage: 11-1-16 Ready for Beth review
-enablewarning: false
+enablewarning: true
 description: Apply for and manage the VA benefits and services you’ve earned as a Veteran, Servicemember, or family member—like health care, disability, education, and more.
 majorlinks:
   - heading:


### PR DESCRIPTION
## Description
This pull request adds the banner to the homepage for Hurricane Michael.

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/pull/14089

## Testing done
Checked the homepage

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/46761143-c44d4780-cca1-11e8-816c-280a430e0e03.png)

## Acceptance criteria
- [x] Homepage warning banner is up

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
