### PR TITLE
Internal PDFs should not open as popups

### DIFF
--- a/va-gov/pages/life-insurance/file-appeal-for-tsgli.md
+++ b/va-gov/pages/life-insurance/file-appeal-for-tsgli.md
@@ -103,7 +103,7 @@ Send your appeal to your branch of service by mail, fax, or email. You’ll find
 <div itemprop="text">
 
 You’ll need to complete an Application for TSGLI Benefits (SGLV-8600).<br>
-<a data-popup href="https://www.benefits.va.gov/INSURANCE/forms/TSGLIForm.htm">Download Form SGLV-8600</a>.
+<a href="https://www.benefits.va.gov/INSURANCE/forms/TSGLIForm.htm">Download Form SGLV-8600</a>.
 
 </div>
 </div>


### PR DESCRIPTION
## Description
Per @bethpotts 
> @ncksllvn For your awareness, contrary to the title of this issue, we will only use pop-ups for linking to pages off the site. We won't use pop-ups for pdfs (which we're considering "internal" pages after merger happens since they live on va.gov). So could you revert the above example file you added that code to? I'd rather you do it so I don't mess up the code!

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3384#issuecomment-428763474

## Acceptance criteria
- [ ] Link does not open as a popup
