### PR TITLE
526 MVP Confirmation page content

### DIFF
--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -1,17 +1,14 @@
 import React from 'react';
-import moment from 'moment';
 import Scroll from 'react-scroll';
 
 import { focusElement } from '../../../../platform/utilities/ui';
-import { get4142Selection } from '../helpers';
-import {
-  successMessage,
-  checkLaterMessage,
-  errorMessage,
-} from '../content/confirmation-poll';
 
 import { submissionStatuses } from '../constants';
-import siteName from '../../../../platform/brand-consolidation/site-name';
+import {
+  retryableErrorContent,
+  successfulSubmitContent,
+  submitErrorContent,
+} from '../content/confirmation-page';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
@@ -34,131 +31,15 @@ export default class ConfirmationPage extends React.Component {
   }
 
   render() {
-    const {
-      fullName: { first, middle, last, suffix },
-      disabilities,
-      submittedAt,
-      claimId,
-      jobId,
-      submissionStatus,
-    } = this.props;
-
-    let submissionMessage;
-    switch (submissionStatus) {
+    switch (this.props.submissionStatus) {
       case submissionStatuses.succeeded:
-        submissionMessage = successMessage(claimId);
-        break;
+        return successfulSubmitContent(this.props);
       case submissionStatuses.retry:
       case submissionStatuses.exhausted:
       case submissionStatuses.apiFailure:
-        submissionMessage = checkLaterMessage(jobId);
-        break;
+        return retryableErrorContent(this.props);
       default:
-        submissionMessage = errorMessage();
+        return submitErrorContent(this.props);
     }
-
-    // TODO: Verify we need this
-    const selected4142 = get4142Selection(disabilities || []);
-
-    const privateRecordReleaseContent = (
-      <div>
-        <p>
-          <strong>
-            If you need us to get your private medical records from your doctor,
-          </strong>{' '}
-          you’ll need to fill out an Authorization to Disclose Information to
-          the VA (VA Form 21-4142).
-        </p>
-        <p>
-          <a
-            href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf"
-            target="_blank"
-          >
-            Download VA Form 21-4142
-          </a>
-          .
-        </p>
-        <p>Please print the form, fill it out, and send it to:</p>
-        <p className="va-address-block">
-          Department of Veterans Affairs
-          <br />
-          Claims Intake Center
-          <br />
-          PO Box 4444
-          <br />
-          Janesville, WI 53547-4444
-        </p>
-      </div>
-    );
-
-    return (
-      <div>
-        <h3 className="confirmation-page-title">
-          Your claim has been submitted.
-        </h3>
-        <p>
-          We process applications in the order we receive them. We may contact
-          you if we have questions or need more information. You can print this
-          page for your records.
-        </p>
-        {selected4142 && privateRecordReleaseContent}
-
-        <div className="inset">
-          <h4>
-            Disability Compensation Claim{' '}
-            <span className="additional">(Form 21-526EZ)</span>
-          </h4>
-          <span>
-            For {first} {middle} {last} {suffix}
-          </span>
-          <ul className="claim-list">
-            <strong>Conditions claimed for increase</strong>
-            <br />
-            <ul className="disability-list">
-              {disabilities
-                .filter(item => item['view:selected'])
-                .map((disability, i) => (
-                  <li key={i}>{disability.name}</li>
-                ))}
-            </ul>
-            {submissionMessage}
-            <li>
-              <strong>Date submitted</strong>
-              <br />
-              <span>{moment(submittedAt).format('MMM D, YYYY')}</span>
-            </li>
-          </ul>
-        </div>
-
-        <h4 className="confirmation-guidance-heading">
-          What happens after I apply?
-        </h4>
-        <p className="confirmation-guidance-message">
-          You don’t need to do anything unless we send you a letter asking for
-          more information.
-        </p>
-        <br />
-        <a href="/disability-benefits/after-you-apply/">
-          Learn more about what happens after you file a disability claim.
-        </a>
-        <div className="confirmation-guidance-container">
-          <h4 className="confirmation-guidance-heading">Need help?</h4>
-          <p className="confirmation-guidance-message">
-            If you have questions, please call{' '}
-            <a href="tel:+18772228387">1-877-222-8387</a>, Monday &#8211;
-            Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).
-          </p>
-        </div>
-        <div className="row form-progress-buttons schemaform-back-buttons">
-          <div className="small-6 usa-width-one-half medium-6 columns">
-            <a href="/">
-              <button className="usa-button-primary">
-                Go Back to {siteName}
-              </button>
-            </a>
-          </div>
-        </div>
-      </div>
-    );
   }
 }

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Scroll from 'react-scroll';
 
 import { focusElement } from '../../../../platform/utilities/ui';
@@ -43,3 +44,17 @@ export default class ConfirmationPage extends React.Component {
     }
   }
 }
+
+ConfirmationPage.propTypes = {
+  submissionStatus: PropTypes.oneOf(Object.values(submissionStatuses)),
+  fullName: PropTypes.shape({
+    first: PropTypes.string,
+    last: PropTypes.string,
+    middle: PropTypes.string,
+    suffix: PropTypes.string,
+  }).isRequired,
+  disabilities: PropTypes.array.isRequired,
+  submittedAt: PropTypes.string.isRequired,
+  claimId: PropTypes.string,
+  jobId: PropTypes.string,
+};

--- a/src/applications/disability-benefits/526EZ/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/526EZ/content/confirmation-page.jsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import moment from 'moment';
+
+import siteName from '../../../../platform/brand-consolidation/site-name';
+import {
+  successMessage,
+  checkLaterMessage,
+  errorMessage,
+} from '../content/confirmation-poll';
+import { get4142Selection } from '../helpers';
+
+const privateRecordReleaseContent = (
+  <div>
+    <p>
+      <strong>
+        If you need us to get your private medical records from your doctor,
+      </strong>{' '}
+      you’ll need to fill out an Authorization to Disclose Information to the VA
+      (VA Form 21-4142).
+    </p>
+    <p>
+      <a
+        href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf"
+        target="_blank"
+      >
+        Download VA Form 21-4142
+      </a>
+      .
+    </p>
+    <p>Please print the form, fill it out, and send it to:</p>
+    <p className="va-address-block">
+      Department of Veterans Affairs
+      <br />
+      Claims Intake Center
+      <br />
+      PO Box 4444
+      <br />
+      Janesville, WI 53547-4444
+    </p>
+  </div>
+);
+
+const template = (props, title, content, submissionMessage) => {
+  const { fullName, suffix, disabilities, submittedAt } = props;
+  const { first, last, middle } = fullName;
+
+  const selected4142 = get4142Selection(disabilities || []);
+
+  const renderableContent =
+    typeof content === 'string' ? <p>{content}</p> : content;
+
+  return (
+    <div>
+      <h3 className="confirmation-page-title">{title}</h3>
+      {renderableContent}
+      {selected4142 && privateRecordReleaseContent}
+
+      <div className="inset">
+        <h4>
+          Disability Compensation Claim{' '}
+          <span className="additional">(Form 21-526EZ)</span>
+        </h4>
+        <span>
+          For {first} {middle} {last} {suffix}
+        </span>
+        <ul className="claim-list">
+          <strong>Conditions claimed for increase</strong>
+          <br />
+          <ul className="disability-list">
+            {disabilities
+              .filter(item => item['view:selected'])
+              .map((disability, i) => (
+                <li key={i}>{disability.name}</li>
+              ))}
+          </ul>
+          {submissionMessage}
+          <li>
+            <strong>Date submitted</strong>
+            <br />
+            <span>{moment(submittedAt).format('MMM D, YYYY')}</span>
+          </li>
+        </ul>
+      </div>
+
+      <h4 className="confirmation-guidance-heading">
+        What happens after I apply?
+      </h4>
+      <p className="confirmation-guidance-message">
+        You don’t need to do anything unless we send you a letter asking for
+        more information.
+      </p>
+      <br />
+      <a href="/disability-benefits/after-you-apply/">
+        Learn more about what happens after you file a disability claim.
+      </a>
+      <div className="confirmation-guidance-container">
+        <h4 className="confirmation-guidance-heading">Need help?</h4>
+        <p className="confirmation-guidance-message">
+          If you have questions, please call{' '}
+          <a href="tel:+18772228387">1-877-222-8387</a>, Monday &#8211; Friday,
+          8:00 a.m. &#8211; 8:00 p.m. (ET).
+        </p>
+      </div>
+      <div className="row form-progress-buttons schemaform-back-buttons">
+        <div className="small-6 usa-width-one-half medium-6 columns">
+          <a href="/">
+            <button className="usa-button-primary">
+              Go Back to {siteName}
+            </button>
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const retryableErrorContent = props =>
+  template(
+    props,
+    'Your claim has been submitted.',
+    'We process applications in the order we receive them. We may contact you if we have questions or need more information. You can print this page for your records.',
+    checkLaterMessage(props.jobId),
+  );
+
+export const successfulSubmitContent = props =>
+  template(
+    props,
+    'Your claim has successfully been submitted',
+    'We process applications in the order we receive them. We may contact you if we have questions or need more information. You can print this page for your records.',
+    successMessage(props.claimId),
+  );
+
+export const submitErrorContent = props =>
+  template(
+    props,
+    'We’re sorry. Something went wrong when we tried to submit your claim.',
+    <div>
+      <p>
+        For help submitting your claim, please call Veterans Benefits Assistance
+        at 1-800-827-1000, Monday – Friday, 8:30 a.m. – 4:30 p.m. (ET). Or, you
+        can get in touch with your nearest Veterans Service Officer (VSO).
+      </p>{' '}
+      <a href="/disability-benefits/apply/help/">Contact your nearest VSO.</a>
+    </div>,
+    errorMessage(),
+  );

--- a/src/applications/disability-benefits/526EZ/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/526EZ/content/confirmation-page.jsx
@@ -41,8 +41,8 @@ const privateRecordReleaseContent = (
 );
 
 const template = (props, title, content, submissionMessage) => {
-  const { fullName, suffix, disabilities, submittedAt } = props;
-  const { first, last, middle } = fullName;
+  const { fullName, disabilities, submittedAt } = props;
+  const { first, last, middle, suffix } = fullName;
 
   const selected4142 = get4142Selection(disabilities || []);
 
@@ -125,7 +125,7 @@ export const retryableErrorContent = props =>
 export const successfulSubmitContent = props =>
   template(
     props,
-    'Your claim has successfully been submitted',
+    'Your claim has successfully been submitted.',
     'We process applications in the order we receive them. We may contact you if we have questions or need more information. You can print this page for your records.',
     successMessage(props.claimId),
   );

--- a/src/applications/disability-benefits/526EZ/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -30,7 +30,7 @@ describe('Disability Benefits 526EZ <ConfirmationPage>', () => {
         .find('.confirmation-page-title')
         .render()
         .text(),
-    ).to.equal('Your claim has been submitted.');
+    ).to.equal('Your claim has successfully been submitted.');
     expect(
       tree
         .find('span')


### PR DESCRIPTION
## Description
Not much content actually changed, but I took the opportunity to factor the content out into its own content page.

## Testing done
Manually tested that all three statuses by using submitting a form successfully, then using the React dev tools to change the `submissionStatus` prop on the `ConfirmationPage` component. Getting the proper `submissionStatus` has already been tested in a previous PR.

## Screenshots

### Success
![image](https://user-images.githubusercontent.com/12970166/46772449-ea2c1980-ccac-11e8-8420-92d95fe8f7e9.png)

### Retry
The only part that changed:
![image](https://user-images.githubusercontent.com/12970166/46772469-ffa14380-ccac-11e8-81bd-6c81ea65e663.png)

### Error
The only part that changed:
![image](https://user-images.githubusercontent.com/12970166/46772405-b9e47b00-ccac-11e8-99a4-c6fb5615736f.png)


## Acceptance criteria
- [x] All three messages show for the appropriate submission statuses

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
