### PR TITLE
All claims 41 effective end date mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -19,6 +19,7 @@ import { genderLabels } from '../../../platform/static-data/labels';
 
 import { DateWidget } from 'us-forms-system/lib/js/review/widgets';
 import { getDisabilityName, transformDisabilities } from '../all-claims/utils';
+import { AddressViewField } from '../all-claims/content/contactInformation';
 
 import { VA_FORM4142_URL } from '../all-claims/constants';
 
@@ -797,3 +798,20 @@ export const validateIfHasEvidence = (
 
 export const title10DatesRequired = formData =>
   get('view:isTitle10Activated', formData, false);
+
+export const ForwardingAddressViewField = ({ formData }) => {
+  const { effectiveDate } = formData;
+  return (
+    <div>
+      <EffectiveDateViewField formData={effectiveDate} />
+      <AddressViewField formData={formData} />
+    </div>
+  );
+};
+
+const EffectiveDateViewField = ({ formData }) => (
+  <p>
+    We will use this address starting on{' '}
+    <DateWidget value={formData} options={{ monthYear: false }} />:
+  </p>
+);

--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -8,10 +8,10 @@ import PhoneNumberWidget from 'us-forms-system/lib/js/widgets/PhoneNumberWidget'
 import PhoneNumberReviewWidget from 'us-forms-system/lib/js/review/PhoneNumberWidget';
 
 import ReviewCardField from '../../all-claims/components/ReviewCardField';
+import { ForwardingAddressViewField } from '../helpers';
 
 import {
   PrimaryAddressViewField,
-  ForwardingAddressViewField,
   contactInfoDescription,
   contactInfoUpdateHelp,
   phoneEmailViewField,

--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -532,6 +532,17 @@ const schema = {
       },
       required: ['from'],
     },
+    dateRange: {
+      type: 'object',
+      properties: {
+        from: {
+          $ref: '#/definitions/date',
+        },
+        to: {
+          $ref: '#/definitions/date',
+        },
+      },
+    },
   },
   properties: {
     alternateNames: {
@@ -776,7 +787,7 @@ const schema = {
     forwardingAddress: _.set(
       'properties.effectiveDate',
       {
-        $ref: '#/definitions/dateRangeFromRequired',
+        $ref: '#/definitions/dateRange',
       },
       _.omit(
         'required',

--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -770,12 +770,13 @@ const schema = {
     // Forwarding address differs from mailing address in a few key ways:
     // 1. Address lines 1-3 are max 35 chars instead of 20
     // 2. The UI is such that requiring fields must be done in the UI schema
-    // 3. There is an effectiveDate property that specifies the date at which
-    //    the forwarding address should start to be used
+    // 3. There is are effectiveStartDate and effectiveEndDate properties that
+    //    specify the date at which the forwarding address should start to be
+    //    used
     forwardingAddress: _.set(
       'properties.effectiveDate',
       {
-        $ref: '#/definitions/date',
+        $ref: '#/definitions/dateRangeFromRequired',
       },
       _.omit(
         'required',

--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -781,7 +781,7 @@ const schema = {
     // Forwarding address differs from mailing address in a few key ways:
     // 1. Address lines 1-3 are max 35 chars instead of 20
     // 2. The UI is such that requiring fields must be done in the UI schema
-    // 3. There is are effectiveStartDate and effectiveEndDate properties that
+    // 3. There are effectiveStartDate and effectiveEndDate properties that
     //    specify the date at which the forwarding address should start to be
     //    used
     forwardingAddress: _.set(

--- a/src/applications/disability-benefits/all-claims/content/contactInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/content/contactInformation.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { DateWidget } from 'us-forms-system/lib/js/review/widgets';
-
+import moment from 'moment';
 import { USA } from '../constants';
 
 export const AddressViewField = ({ formData }) => {
@@ -61,17 +60,15 @@ const EmailViewField = ({ formData, name }) => (
 
 const EffectiveDateViewField = ({ formData }) => {
   const { from, to } = formData;
+  const dateFormat = 'MMM D, YYYY';
+  const fromDateString = moment(from).format(dateFormat);
   return to ? (
     <p>
-      We will use this address starting on{' '}
-      <DateWidget value={from} options={{ monthYear: false }} /> until{' '}
-      <DateWidget value={to} options={{ monthYear: false }} />:
+      We’ll use this address starting on {`${fromDateString} `}
+      until {moment(to).format(dateFormat)}:
     </p>
   ) : (
-    <p>
-      We will use this address starting on{' '}
-      <DateWidget value={from} options={{ monthYear: false }} />:
-    </p>
+    <p>We’ll use this address starting on {fromDateString}:</p>
   );
 };
 

--- a/src/applications/disability-benefits/all-claims/content/contactInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/content/contactInformation.jsx
@@ -3,7 +3,7 @@ import { DateWidget } from 'us-forms-system/lib/js/review/widgets';
 
 import { USA } from '../constants';
 
-const AddressViewField = ({ formData }) => {
+export const AddressViewField = ({ formData }) => {
   const {
     addressLine1,
     addressLine2,
@@ -36,13 +36,6 @@ const AddressViewField = ({ formData }) => {
   );
 };
 
-const EffectiveDateViewField = ({ formData }) => (
-  <p>
-    We will use this address starting on{' '}
-    <DateWidget value={formData} options={{ monthYear: false }} />:
-  </p>
-);
-
 const PhoneViewField = ({ formData: phoneNumber = '', name }) => {
   const midBreakpoint = -7;
   const lastPhoneString = phoneNumber.slice(-4);
@@ -62,6 +55,22 @@ const EmailViewField = ({ formData, name }) => (
     <strong>{name}</strong>: {formData || ''}
   </p>
 );
+
+const EffectiveDateViewField = ({ formData }) => {
+  const { from, to } = formData;
+  return to ? (
+    <p>
+      We will use this address starting on{' '}
+      <DateWidget value={from} options={{ monthYear: false }} /> until{' '}
+      <DateWidget value={to} />:
+    </p>
+  ) : (
+    <p>
+      We will use this address starting on{' '}
+      <DateWidget value={from} options={{ monthYear: false }} />:
+    </p>
+  );
+};
 
 export const PrimaryAddressViewField = ({ formData }) => (
   <AddressViewField formData={formData} />

--- a/src/applications/disability-benefits/all-claims/content/contactInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/content/contactInformation.jsx
@@ -62,7 +62,7 @@ const EffectiveDateViewField = ({ formData }) => {
     <p>
       We will use this address starting on{' '}
       <DateWidget value={from} options={{ monthYear: false }} /> until{' '}
-      <DateWidget value={to} />:
+      <DateWidget value={to} options={{ monthYear: false }} />:
     </p>
   ) : (
     <p>

--- a/src/applications/disability-benefits/all-claims/content/contactInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/content/contactInformation.jsx
@@ -64,8 +64,8 @@ const EffectiveDateViewField = ({ formData }) => {
   const fromDateString = moment(from).format(dateFormat);
   return to ? (
     <p>
-      We’ll use this address starting on {`${fromDateString} `}
-      until {moment(to).format(dateFormat)}:
+      We’ll use this address starting on {fromDateString} until{' '}
+      {moment(to).format(dateFormat)}:
     </p>
   ) : (
     <p>We’ll use this address starting on {fromDateString}:</p>

--- a/src/applications/disability-benefits/all-claims/content/contactInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/content/contactInformation.jsx
@@ -27,12 +27,15 @@ export const AddressViewField = ({ formData }) => {
     lastLine = `${city}, ${country}`;
   }
   return (
-    <div>
-      {addressLine1 && <p>{addressLine1}</p>}
-      {addressLine2 && <p>{addressLine2}</p>}
-      {addressLine3 && <p>{addressLine3}</p>}
-      <p>{lastLine}</p>
-    </div>
+    <p className="blue-bar-block">
+      {addressLine1 && addressLine1}
+      <br />
+      {addressLine2 && addressLine2}
+      {addressLine2 && <br />}
+      {addressLine3 && addressLine3}
+      {addressLine3 && <br />}
+      {lastLine}
+    </p>
   );
 };
 

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -2,7 +2,8 @@
 import _ from 'lodash';
 import merge from 'lodash/merge';
 import fullSchema from '../config/schema';
-import dateUI from 'us-forms-system/lib/js/definitions/date';
+// import dateUI from 'us-forms-system/lib/js/definitions/date';
+import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import PhoneNumberWidget from 'us-forms-system/lib/js/widgets/PhoneNumberWidget';
 
 import ReviewCardField from '../components/ReviewCardField';
@@ -19,6 +20,7 @@ import {
   validateZIP,
   validateMilitaryCity,
   validateMilitaryState,
+  isInFuture,
 } from '../validations';
 
 import { hasForwardingAddress, forwardingCountryIsUSA } from '../utils';
@@ -196,12 +198,19 @@ export const uiSchema = {
         viewComponent: ForwardingAddressViewField,
         expandUnder: 'view:hasForwardingAddress',
       },
-      effectiveDate: {
-        from: merge({}, dateUI('Effective from'), {
-          'ui:required': hasForwardingAddress,
-        }),
-        to: dateUI('Effective to'),
-      },
+      effectiveDate: merge(
+        dateRangeUI(
+          'Effective from',
+          'Effective to',
+          'End date must be after start date',
+        ),
+        {
+          from: {
+            'ui:required': hasForwardingAddress,
+            'ui:validations': [isInFuture],
+          },
+        },
+      ),
       country: {
         'ui:required': hasForwardingAddress,
       },

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -196,9 +196,12 @@ export const uiSchema = {
         viewComponent: ForwardingAddressViewField,
         expandUnder: 'view:hasForwardingAddress',
       },
-      effectiveDate: merge({}, dateUI('Effective date'), {
-        'ui:required': hasForwardingAddress,
-      }),
+      effectiveDate: {
+        from: merge({}, dateUI('Effective from'), {
+          'ui:required': hasForwardingAddress,
+        }),
+        to: dateUI('Effective to'),
+      },
       country: {
         'ui:required': hasForwardingAddress,
       },

--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -12,7 +12,7 @@ import {
   MILITARY_STATE_VALUES,
 } from '../../../all-claims/constants';
 
-describe('Disability benefits 526EZ contact information', () => {
+describe.only('Disability benefits 526EZ contact information', () => {
   const {
     schema,
     uiSchema,
@@ -288,6 +288,89 @@ describe('Disability benefits 526EZ contact information', () => {
             addressLine1: '123 Any Street',
             city: 'Anytown',
             state: 'AA',
+            zipCode: '12345',
+          },
+        }}
+        formData={{}}
+        uiSchema={uiSchema}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('validates that effective date is in the future', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{
+          phoneEmailCard: {
+            primaryPhone: '1231231231',
+            emailAddress: 'a@b.co',
+          },
+          mailingAddress: {
+            country: 'USA',
+            addressLine1: '123 Any Street',
+            city: 'Anytown',
+            state: 'MI',
+            zipCode: '12345',
+          },
+          'view:hasForwardingAddress': true,
+          forwardingAddress: {
+            effectiveDate: {
+              from: '2018-10-12',
+            },
+            country: 'USA',
+            addressLine1: '123 Any Street',
+            city: 'Detroit',
+            state: 'MI',
+            zipCode: '12345',
+          },
+        }}
+        formData={{}}
+        uiSchema={uiSchema}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('validates that effective end date is after start date', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{
+          phoneEmailCard: {
+            primaryPhone: '1231231231',
+            emailAddress: 'a@b.co',
+          },
+          mailingAddress: {
+            country: 'USA',
+            addressLine1: '123 Any Street',
+            city: 'Anytown',
+            state: 'MI',
+            zipCode: '12345',
+          },
+          'view:hasForwardingAddress': true,
+          forwardingAddress: {
+            effectiveDate: {
+              from: '2099-10-12',
+              to: '2099-10-12',
+            },
+            country: 'USA',
+            addressLine1: '123 Any Street',
+            city: 'Detroit',
+            state: 'MI',
             zipCode: '12345',
           },
         }}

--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -12,7 +12,7 @@ import {
   MILITARY_STATE_VALUES,
 } from '../../../all-claims/constants';
 
-describe.only('Disability benefits 526EZ contact information', () => {
+describe('Disability benefits 526EZ contact information', () => {
   const {
     schema,
     uiSchema,

--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -214,10 +214,10 @@ describe('Disability benefits 526EZ contact information', () => {
       />,
     );
 
-    // (2 x country), date month, date day, country
-    expect(form.find('select').length).to.equal(4);
-    // (2 x (street 1, 2, 3, city)), phone, email, fwding address checkbox, date year
-    expect(form.find('input').length).to.equal(12);
+    // (2 x country), 2x date month, 2x date day, country
+    expect(form.find('select').length).to.equal(6);
+    // (2 x (street 1, 2, 3, city)), phone, email, fwding address checkbox, 2x date year
+    expect(form.find('input').length).to.equal(13);
   });
 
   it('validates that forwarding state is military type if forwarding city is military type', () => {
@@ -240,7 +240,9 @@ describe('Disability benefits 526EZ contact information', () => {
           },
           'view:hasForwardingAddress': true,
           forwardingAddress: {
-            effectiveDate: '2019-01-01',
+            effectiveDate: {
+              from: '2019-01-01',
+            },
             country: 'USA',
             addressLine1: '123 Any Street',
             city: 'APO',
@@ -279,7 +281,9 @@ describe('Disability benefits 526EZ contact information', () => {
           },
           'view:hasForwardingAddress': true,
           forwardingAddress: {
-            effectiveDate: '2019-01-01',
+            effectiveDate: {
+              from: '2019-01-01',
+            },
             country: 'USA',
             addressLine1: '123 Any Street',
             city: 'Anytown',
@@ -316,7 +320,9 @@ describe('Disability benefits 526EZ contact information', () => {
           },
           'view:hasForwardingAddress': true,
           forwardingAddress: {
-            effectiveDate: '',
+            effectiveDate: {
+              from: '',
+            },
             country: '',
             addressLine1: '',
             city: '',
@@ -353,7 +359,9 @@ describe('Disability benefits 526EZ contact information', () => {
           },
           'view:hasForwardingAddress': true,
           forwardingAddress: {
-            effectiveDate: '2019-01-01',
+            effectiveDate: {
+              from: '2019-01-01',
+            },
             country: 'USA',
             addressLine1: '234 Maple St.',
             city: 'Detroit',

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -122,3 +122,10 @@ export const validateIfHasEvidence = (
     wrappedValidator(errors, fieldData, formData, schema, messages, index);
   }
 };
+
+export const isInFuture = (err, fieldData) => {
+  const fieldDate = new Date(fieldData);
+  if (fieldDate.getTime() < Date.now()) {
+    err.addError('Start date must be in the future');
+  }
+};


### PR DESCRIPTION
## Description
Adds end date for effecitve dates to the All Claims form
Not sure if this content looks right.

## Testing done
- [x] local testing
- [x] unit tests

## Screenshots
When no end date:
<img width="599" alt="screen shot 2018-10-10 at 10 29 01 pm" src="https://user-images.githubusercontent.com/24251447/46779215-74d83d00-ccdc-11e8-82b6-06c3f8296a9f.png">

-----

When end date:
<img width="572" alt="screen shot 2018-10-10 at 10 28 16 pm" src="https://user-images.githubusercontent.com/24251447/46779216-74d83d00-ccdc-11e8-89db-9d0d424a7b92.png">


## Acceptance criteria
- [x] Forwarding address has an end date
- [x] End date is optional

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
