### PR TITLE
All claims disabilities summary fix mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -4,7 +4,9 @@ import { getDisabilityName } from '../utils';
 export const summaryOfDisabilitiesDescription = ({ formData }) => {
   const { ratedDisabilities, newDisabilities } = formData;
   const ratedDisabilityNames = ratedDisabilities
-    ? ratedDisabilities.map(disability => getDisabilityName(disability.name))
+    ? ratedDisabilities
+        .filter(disability => disability['view:selected'])
+        .map(disability => getDisabilityName(disability.name))
     : [];
   const newDisabilityNames = newDisabilities
     ? newDisabilities.map(disability => getDisabilityName(disability.condition))

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { getDisabilityName } from '../utils';
 
-export const summaryOfDisabilitiesDescription = ({ formData }) => {
+export const SummaryOfDisabilitiesDescription = ({ formData }) => {
   const { ratedDisabilities, newDisabilities } = formData;
   const ratedDisabilityNames = ratedDisabilities
     ? ratedDisabilities

--- a/src/applications/disability-benefits/all-claims/pages/summaryOfDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/summaryOfDisabilities.js
@@ -1,8 +1,8 @@
-import { summaryOfDisabilitiesDescription } from '../content/summaryOfDisabilities';
+import { SummaryOfDisabilitiesDescription } from '../content/summaryOfDisabilities';
 
 export const uiSchema = {
   'ui:title': 'Summary of disabilities',
-  'ui:description': summaryOfDisabilitiesDescription,
+  'ui:description': SummaryOfDisabilitiesDescription,
 };
 
 export const schema = {

--- a/src/applications/disability-benefits/all-claims/tests/content/summaryOfDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/summaryOfDisabilities.unit.spec.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { SummaryOfDisabilitiesDescription } from '../../content/summaryOfDisabilities';
+
+describe.only('summaryOfDisabilitiesDescription', () => {
+  it('renders selected rated disabilities', () => {
+    const formData = {
+      ratedDisabilities: [
+        {
+          'view:selected': true,
+          name: 'Condition 1',
+        },
+        {
+          'view:selected': true,
+          name: 'Condition 2',
+        },
+      ],
+    };
+
+    const wrapper = shallow(
+      <SummaryOfDisabilitiesDescription formData={formData} />,
+    );
+
+    expect(wrapper.find('li').length).to.equal(2);
+  });
+
+  it('does not render unselected rated disabilities', () => {
+    const formData = {
+      ratedDisabilities: [
+        {
+          'view:selected': true,
+          name: 'Condition 1',
+        },
+        {
+          'view:selected': false,
+          name: 'Condition 2',
+        },
+      ],
+    };
+
+    const wrapper = shallow(
+      <SummaryOfDisabilitiesDescription formData={formData} />,
+    );
+
+    expect(wrapper.find('li').length).to.equal(1);
+  });
+
+  it('renders new disabilities', () => {
+    const formData = {
+      newDisabilities: [
+        { condition: 'Condition 1' },
+        { condition: 'Condition 2' },
+        { condition: 'Condition 3' },
+      ],
+    };
+
+    const wrapper = shallow(
+      <SummaryOfDisabilitiesDescription formData={formData} />,
+    );
+
+    expect(wrapper.find('li').length).to.equal(3);
+  });
+})

--- a/src/applications/disability-benefits/all-claims/tests/content/summaryOfDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/summaryOfDisabilities.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { SummaryOfDisabilitiesDescription } from '../../content/summaryOfDisabilities';
 
-describe.only('summaryOfDisabilitiesDescription', () => {
+describe('summaryOfDisabilitiesDescription', () => {
   it('renders selected rated disabilities', () => {
     const formData = {
       ratedDisabilities: [

--- a/src/applications/disability-benefits/all-claims/tests/content/summaryOfDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/summaryOfDisabilities.unit.spec.jsx
@@ -61,4 +61,4 @@ describe.only('summaryOfDisabilitiesDescription', () => {
 
     expect(wrapper.find('li').length).to.equal(3);
   });
-})
+});


### PR DESCRIPTION
## Description
Fixes a problem where rated disabilities show on the summary page even when not selected.

## Testing done
- Tested locally
- Added unit tests

## Screenshots


## Acceptance criteria
- [x] Only selected rated disabilities (and all new disabilities) show on summary page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
