### PR TITLE
Extend outline offset for <a>..</a> homepage buttons

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-homepage.scss
+++ b/src/platform/site-wide/sass/modules/_m-homepage.scss
@@ -32,7 +32,7 @@
   }
 }
 
-// The !importants here are due to the 
+// The !importants here are due to the
 // usa-grid padding 0 rule
 .homepage-benefits-row {
   padding-bottom: 1.5em;
@@ -95,6 +95,7 @@
     color: $color-white;
     text-decoration: none;
     background-color: $color-primary;
+    outline-offset: 2px;
   }
 
   &.vcl {


### PR DESCRIPTION
## Description
This PR adds a style rule to the `.homepage-button` class which will enforce a 2px offset on `:focus` for `<a>` type buttons on the homepage, for a11y consistency. See [this comment](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13605#issuecomment-428698970).

## Testing done
Manually tested by inspecting elements while focused. 

## Screenshots
Before:

![46760492-d2966600-cc97-11e8-9e83-9af93a94651e](https://user-images.githubusercontent.com/11085141/46788094-13759580-ccff-11e8-8074-d400bbace387.png)

After:

![screenshot-localhost-3001-2018 10 11-02-42-11](https://user-images.githubusercontent.com/11085141/46788216-44ee6100-ccff-11e8-82d3-e480a756fa5b.png)



## Acceptance criteria
- [x] Homepage buttons have consistent outline-offset styles while focused.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
