### PR TITLE
add va employee page

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -39,6 +39,7 @@ import {
   evidenceTypes,
   claimExamsInfo,
   homelessOrAtRisk,
+  vaEmployee,
   summaryOfEvidence,
 } from '../pages';
 
@@ -293,6 +294,12 @@ const formConfig = {
           path: 'housing-situation',
           uiSchema: homelessOrAtRisk.uiSchema,
           schema: homelessOrAtRisk.schema,
+        },
+        vaEmployee: {
+          title: 'VA employee',
+          path: 'va-employee',
+          uiSchema: vaEmployee.uiSchema,
+          schema: vaEmployee.schema,
         },
       },
     },

--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -877,6 +877,9 @@ const schema = {
         },
       },
     },
+    isVAEmployee: {
+      type: 'boolean',
+    },
   },
 };
 

--- a/src/applications/disability-benefits/all-claims/pages/index.js
+++ b/src/applications/disability-benefits/all-claims/pages/index.js
@@ -108,6 +108,11 @@ import {
   schema as homelessOrAtRiskSchema,
 } from './homelessOrAtRisk';
 
+import {
+  uiSchema as vaEmployeeUISchema,
+  schema as vaEmployeeSchema,
+} from './vaEmployee';
+
 export const alternateNames = {
   uiSchema: alternateNamesUISchema,
   schema: alternateNamesSchema,
@@ -216,4 +221,9 @@ export const claimExamsInfo = {
 export const homelessOrAtRisk = {
   uiSchema: homelessOrAtRiskUISchema,
   schema: homelessOrAtRiskSchema,
+};
+
+export const vaEmployee = {
+  uiSchema: vaEmployeeUISchema,
+  schema: vaEmployeeSchema,
 };

--- a/src/applications/disability-benefits/all-claims/pages/vaEmployee.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaEmployee.js
@@ -1,0 +1,15 @@
+import fullSchema from '../config/schema';
+
+const { isVAEmployee } = fullSchema.properties;
+export const uiSchema = {
+  isVAEmployee: {
+    'ui:title': 'Are you currently a VA employee?',
+    'ui:widget': 'yesNo',
+  },
+};
+
+export const schema = {
+  type: 'object',
+  required: ['isVAEmployee'],
+  properties: { isVAEmployee },
+};

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaEmployee.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaEmployee.unit.spec.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+import formConfig from '../../config/form';
+
+describe('526 vaEmployee', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.additionalInformation.pages.vaEmployee;
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(2);
+  });
+});


### PR DESCRIPTION
## Description
Adds a question to all claims asking whether veteran is a current va employee.

## Testing done
- tested locally
- made a simple unit test

## Screenshots
<img width="689" alt="screen shot 2018-10-11 at 11 45 55 am" src="https://user-images.githubusercontent.com/24251447/46820209-42195d80-cd4b-11e8-956c-c9f245ff6ae3.png">


## Acceptance criteria
- [x] Add yes / no question asking whether veteran is VA employee

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
