### PR TITLE
All claims combat zone mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -12,6 +12,7 @@ import {
   hasVAEvidence,
   hasPrivateEvidence,
   hasOtherEvidence,
+  servedAfter911,
 } from '../utils';
 
 import { veteranInfoDescription } from '../content/veteranDetails';
@@ -22,6 +23,7 @@ import {
   servicePay,
   waiveRetirementPay,
   militaryHistory,
+  servedInCombatZone,
   separationTrainingPay,
   reservesNationalGuardService,
   federalOrders,
@@ -114,6 +116,13 @@ const formConfig = {
           path: 'review-veteran-details/military-service-history',
           uiSchema: militaryHistory.uiSchema,
           schema: militaryHistory.schema,
+        },
+        servedInCombatZone: {
+          title: 'Combat status',
+          path: 'review-veteran-details/combat-status',
+          depends: servedAfter911,
+          uiSchema: servedInCombatZone.uiSchema,
+          schema: servedInCombatZone.schema,
         },
         reservesNationalGuardService: {
           title: 'Reserves and National Guard Service',

--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -640,6 +640,9 @@ const schema = {
         },
       },
     },
+    servedInCombatZonePost911: {
+      type: 'boolean',
+    },
     confinements: {
       type: 'array',
       minItems: 1,

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -149,3 +149,5 @@ export const VA_FORM4142_URL =
 export const FIFTY_MB = 52428800;
 
 export const PTSD = 'ptsd';
+
+export const NINE_ELEVEN = '2001-09-11';

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -151,3 +151,5 @@ export const FIFTY_MB = 52428800;
 export const PTSD = 'ptsd';
 
 export const NINE_ELEVEN = '2001-09-11';
+
+export const ERR_MSG_CSS_CLASS = '.usa-input-error-message';

--- a/src/applications/disability-benefits/all-claims/pages/index.js
+++ b/src/applications/disability-benefits/all-claims/pages/index.js
@@ -19,6 +19,11 @@ import {
 } from './militaryHistory';
 
 import {
+  uiSchema as servedInCombatZoneUISchema,
+  schema as servedInCombatZoneSchema,
+} from './servedInCombatZone';
+
+import {
   uiSchema as separationTrainingPayUISchema,
   schema as separationTrainingPaySchema,
 } from '../pages/separationTrainingPay';
@@ -131,6 +136,11 @@ export const separationTrainingPay = {
 export const militaryHistory = {
   uiSchema: militaryHistoryUISchema,
   schema: militaryHistorySchema,
+};
+
+export const servedInCombatZone = {
+  uiSchema: servedInCombatZoneUISchema,
+  schema: servedInCombatZoneSchema,
 };
 
 export const reservesNationalGuardService = {

--- a/src/applications/disability-benefits/all-claims/pages/servedInCombatZone.js
+++ b/src/applications/disability-benefits/all-claims/pages/servedInCombatZone.js
@@ -4,7 +4,7 @@ const { servedInCombatZonePost911 } = fullSchema.properties;
 
 export const uiSchema = {
   servedInCombatZonePost911: {
-    'ui:title': 'Did you serve in a combat zone after 9/11/2001?',
+    'ui:title': 'Did you serve in a combat zone after Sept. 11, 2001?',
     'ui:widget': 'yesNo',
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/servedInCombatZone.js
+++ b/src/applications/disability-benefits/all-claims/pages/servedInCombatZone.js
@@ -1,0 +1,18 @@
+import fullSchema from '../config/schema';
+
+const { servedInCombatZonePost911 } = fullSchema.properties;
+
+export const uiSchema = {
+  servedInCombatZonePost911: {
+    'ui:title': 'Did you serve in a combat zone after 9/11/2001?',
+    'ui:widget': 'yesNo',
+  },
+};
+
+export const schema = {
+  type: 'object',
+  required: ['servedInCombatZonePost911'],
+  properties: {
+    servedInCombatZonePost911,
+  },
+};

--- a/src/applications/disability-benefits/all-claims/tests/pages/servedInCombatZone.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/servedInCombatZone.unit.spec.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  DefinitionTester,
+  selectRadio,
+} from '../../../../../platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+import { ERR_MSG_CSS_CLASS } from '../../constants';
+
+describe('servedInCombatZone', () => {
+  const {
+    uiSchema,
+    schema,
+  } = formConfig.chapters.veteranDetails.pages.servedInCombatZone;
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        uiSchema={uiSchema}
+        schema={schema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(2);
+  });
+
+  it('should not submit without required info', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        uiSchema={uiSchema}
+        schema={schema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(onSubmit.called).to.be.false;
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(1);
+  });
+
+  it('should submit with required info', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        uiSchema={uiSchema}
+        schema={schema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    selectRadio(form, 'root_servedInCombatZonePost911', 'N');
+    form.find('form').simulate('submit');
+    expect(onSubmit.calledOnce).to.be.true;
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(0);
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -11,6 +11,7 @@ import {
   transformDisabilities,
   queryForFacilities,
   hasOtherEvidence,
+  servedAfter911,
 } from '../utils.jsx';
 
 import initialData from './initialData';
@@ -260,6 +261,82 @@ describe('526 helpers', () => {
         },
       };
       expect(hasOtherEvidence(formData)).to.equal(true);
+    });
+  });
+
+  describe.only('servedAfter911', () => {
+    it('should return false if no serviceInformation', () => {
+      expect(servedAfter911({})).to.be.false;
+    });
+
+    it('should return false if no servicePeriods', () => {
+      expect(servedAfter911({ serviceInformation: {} })).to.be.false;
+    });
+
+    it('should return false if no dateRange', () => {
+      const formData = {
+        serviceInformation: {
+          servicePeriods: [{}],
+        },
+      };
+      expect(servedAfter911(formData)).to.be.false;
+    });
+
+    it('should return false if no `to` date', () => {
+      const formData = {
+        serviceInformation: {
+          servicePeriods: [
+            {
+              dateRange: {},
+            },
+          ],
+        },
+      };
+      expect(servedAfter911(formData)).to.be.false;
+    });
+
+    it('should return false if `to` date is on or before 9/11/01', () => {
+      const formData = {
+        serviceInformation: {
+          servicePeriods: [
+            {
+              dateRange: {
+                to: '2001-09-11',
+              },
+            },
+          ],
+        },
+      };
+      expect(servedAfter911(formData)).to.be.false;
+    });
+
+    it('should return true if `to` date is after 9/11/01', () => {
+      const formData = {
+        serviceInformation: {
+          servicePeriods: [
+            {
+              dateRange: {
+                to: '2001-09-12',
+              },
+            },
+          ],
+        },
+      };
+      expect(servedAfter911(formData)).to.be.true;
+    });
+
+    it('should return true if any `to` date is after 9/11/01', () => {
+      const formData = {
+        serviceInformation: {
+          servicePeriods: [
+            { dateRange: { to: '1980-09-11' } },
+            { dateRange: { to: '1999-09-12' } },
+            { dateRange: { to: '2014-09-12' } },
+            { dateRange: { to: '1975-09-12' } },
+          ],
+        },
+      };
+      expect(servedAfter911(formData)).to.be.true;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -264,7 +264,7 @@ describe('526 helpers', () => {
     });
   });
 
-  describe.only('servedAfter911', () => {
+  describe('servedAfter911', () => {
     it('should return false if no serviceInformation', () => {
       expect(servedAfter911({})).to.be.false;
     });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import Raven from 'raven-js';
 import appendQuery from 'append-query';
+import { createSelector } from 'reselect';
 import { apiRequest } from '../../../platform/utilities/api';
 import _ from '../../../platform/utilities/data';
 
@@ -243,9 +244,10 @@ export const hasOtherEvidence = formData =>
 export const hasPrivateEvidence = formData =>
   _.get(DATA_PATHS.hasPrivateEvidence, formData, false);
 
-export const servedAfter911 = formData =>
-  !!_.get('serviceInformation.servicePeriods', formData, []).filter(
-    ({ dateRange }) => {
+const post911Periods = createSelector(
+  data => _.get('serviceInformation.servicePeriods', data, []),
+  periods =>
+    periods.filter(({ dateRange }) => {
       if (!(dateRange && dateRange.to)) {
         return false;
       }
@@ -253,5 +255,7 @@ export const servedAfter911 = formData =>
       const toDate = new Date(dateRange.to);
       const cutOff = new Date(NINE_ELEVEN);
       return toDate.getTime() > cutOff.getTime();
-    },
-  ).length;
+    }),
+);
+
+export const servedAfter911 = formData => !!post911Periods(formData).length;

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -244,7 +244,7 @@ export const hasPrivateEvidence = formData =>
   _.get(DATA_PATHS.hasPrivateEvidence, formData, false);
 
 export const servedAfter911 = formData =>
-  _.get('serviceInformation.servicePeriods', formData, []).filter(
+  !!_.get('serviceInformation.servicePeriods', formData, []).filter(
     ({ dateRange }) => {
       if (!(dateRange && dateRange.to)) {
         return false;

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -252,6 +252,6 @@ export const servedAfter911 = formData =>
 
       const toDate = new Date(dateRange.to);
       const cutOff = new Date(NINE_ELEVEN);
-      return toDate.getTime() > cutOff;
+      return toDate.getTime() > cutOff.getTime();
     },
   ).length;

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -10,6 +10,7 @@ import {
   SERVICE_CONNECTION_TYPES,
   USA,
   DATA_PATHS,
+  NINE_ELEVEN,
 } from './constants';
 /**
  * Show one thing, have a screen reader say another.
@@ -241,3 +242,19 @@ export const hasOtherEvidence = formData =>
   _.get(DATA_PATHS.hasAdditionalDocuments, formData, false);
 export const hasPrivateEvidence = formData =>
   _.get(DATA_PATHS.hasPrivateEvidence, formData, false);
+
+export const servedAfter911 = formData => {
+  return _.get('serviceInformation.servicePeriods', formData, []).filter(
+    ({ dateRange }) => {
+      if (!(dateRange && dateRange.from && dateRange.to)) {
+        return false;
+      }
+
+      const { from, to } = dateRange;
+      const fromDate = new Date(from);
+      const toDate = new Date(to);
+      const cutOff = new Date(NINE_ELEVEN);
+      return fromDate.getTime() > cutOff.getTime() || toDate.getTime() > cutOff;
+    },
+  ).length;
+};

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -243,18 +243,15 @@ export const hasOtherEvidence = formData =>
 export const hasPrivateEvidence = formData =>
   _.get(DATA_PATHS.hasPrivateEvidence, formData, false);
 
-export const servedAfter911 = formData => {
-  return _.get('serviceInformation.servicePeriods', formData, []).filter(
+export const servedAfter911 = formData =>
+  _.get('serviceInformation.servicePeriods', formData, []).filter(
     ({ dateRange }) => {
-      if (!(dateRange && dateRange.from && dateRange.to)) {
+      if (!(dateRange && dateRange.to)) {
         return false;
       }
 
-      const { from, to } = dateRange;
-      const fromDate = new Date(from);
-      const toDate = new Date(to);
+      const toDate = new Date(dateRange.to);
       const cutOff = new Date(NINE_ELEVEN);
-      return fromDate.getTime() > cutOff.getTime() || toDate.getTime() > cutOff;
+      return toDate.getTime() > cutOff;
     },
   ).length;
-};


### PR DESCRIPTION
## Description
Adds a post-911 combat zone question page that shows when any service period ends after 9/11.

## Testing done
- Tested locally
- Extensive unit tests

## Screenshots
![screen shot 2018-10-11 at 3 18 36 pm](https://user-images.githubusercontent.com/24251447/46834870-3725f380-cd72-11e8-88c9-f5e194cc6a76.png)


## Acceptance criteria
- [x] New page shows up after service history if any service period is > 9/11/01
- [x] New page asks users if they've served in a combat zone after 9/11 via a yes / no radio widget

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
