### PR TITLE
Applies "no-external-icon" class to VCL link and make the connection

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-crisis-line-brand-consolidation.scss
+++ b/src/platform/site-wide/sass/modules/_m-crisis-line-brand-consolidation.scss
@@ -115,15 +115,6 @@ button.va-crisis-line-button {
   }
 }
 
-.no-external-icon {
-  padding-right: 0;
-  background-image: none;
-  &::after {
-    display: none !important;
-    content: none;
-  }
-}
-
 .va-footer-vcl-trigger {
   background: transparent;
   color: inherit;

--- a/va-gov/includes/common-and-popular.html
+++ b/va-gov/includes/common-and-popular.html
@@ -20,7 +20,7 @@
       <li>
         <a href="/gi-bill-comparison-tool">View education benefits available by school</a>
       </li>
-      <li><a target="_blank" href="https://www.veteranscrisisline.net/" class="external">Contact the Veterans Crisis Line</a></li>
+      <li><a target="_blank" href="https://www.veteranscrisisline.net/" class="external no-external-icon">Contact the Veterans Crisis Line</a></li>
     </ul>
   </div>
 </div>

--- a/va-gov/layouts/home.html
+++ b/va-gov/layouts/home.html
@@ -198,7 +198,7 @@
         <div class="homepage-image-wrapper">
           <img class="lazy" width="552" data-src="/img/homepage/home-1.jpg" alt="Four Veterans standing together in front of the United States flag."/>
         </div>
-        <h4 class="homepage-news-story-title"><a href=https://maketheconnection.net/>Make the Connection Website</a></h4>
+        <h4 class="homepage-news-story-title"><a class="no-external-icon" href=https://maketheconnection.net/>Make the Connection Website</a></h4>
         <p class="homepage-news-story-desc">Hear Veterans share their stories of recovery, and find resources near you.</p>
       </div>
 

--- a/va-gov/pages/careers-employment/index.md
+++ b/va-gov/pages/careers-employment/index.md
@@ -98,7 +98,7 @@ We can support you in all stages of your job search—from returning to work wit
         </ul>
         <p><b>Talk with someone right now:</b>
         <p>Whatever you’re struggling with—homelessness, chronic pain, anxiety, depression, trouble sleeping, or anger—we can support you, day or night.</p>
-        <a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Homeless%20Veterans%20Chat">Chat online with a trained VA staff member</a>.</p>
+        <a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Homeless%20Veterans%20Chat" class="no-external-icon" >Chat online with a trained VA staff member</a>.</p>
       </div>
     </div>
   </div>

--- a/va-gov/pages/disability/eligibility/ptsd.md
+++ b/va-gov/pages/disability/eligibility/ptsd.md
@@ -30,7 +30,7 @@ Posttraumatic stress can happen after someone goes through a traumatic event suc
 	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>	  
 	    <ul>
               <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
-	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
+	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/" class="no-external-icon" >Start a confidential Veterans Chat</a>.</li>
   	      <li>Text <a href="sms:838255">838255</a>.</li>
             </ul>
      	    <p><strong>You can also:</strong></p>	  

--- a/va-gov/pages/dummy-placeholder.md
+++ b/va-gov/pages/dummy-placeholder.md
@@ -53,7 +53,7 @@ private: true
     <div class="small-12 usa-width-one-half medium-6 columns">
         <ul class="plain">
           <li><a href="/facilities/">How can I find VA locations?</a></li>
-          <li><a target="_blank" href="https://www.veteranscrisisline.net/" class="external">How do I contact the Veterans Crisis Line?</a></li>
+          <li><a target="_blank" href="https://www.veteranscrisisline.net" class="external no-external-icon">How do I contact the Veterans Crisis Line?</a></li>
         </ul>
     </div>
   </div>

--- a/va-gov/pages/health-care/health-needs-conditions/mental-health.md
+++ b/va-gov/pages/health-care/health-needs-conditions/mental-health.md
@@ -28,7 +28,7 @@ If you qualify for VA health care, you can get high-quality mental health servic
 	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>
 	    <ul>
               <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
-	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
+	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/" class="no-external-icon">Start a confidential Veterans Chat</a>.</li>
   	      <li>Text <a href="sms:838255">838255</a>.</li>
             </ul>
      	    <p><strong>You can also:</strong></p>

--- a/va-gov/pages/health-care/health-needs-conditions/mental-health/depression.md
+++ b/va-gov/pages/health-care/health-needs-conditions/mental-health/depression.md
@@ -41,7 +41,7 @@ Depression is a serious illness, but this common mental health problem is also h
 	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>
 	    <ul>
               <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
-	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
+	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/" class="no-external-icon">Start a confidential Veterans Chat</a>.</li>
   	      <li>Text <a href="sms:838255">838255</a>.</li>
             </ul>
      	    <p><strong>You can also:</strong></p>
@@ -105,8 +105,7 @@ You may still be able to get care:
 [Visit our Depression website](https://www.mentalhealth.va.gov/depression.asp).
 - Visit our Self-Help Resources guide to get links to books, web resources, and mobile applications that have been reviewed and recommended by VA experts. <br>
 [Get self-help resources](https://www.mentalhealth.va.gov/self_help.asp).
-- Go to our Make the Connection website to get resources and watch stories of Veterans who’ve overcome depression and other mental health challenges. <br>
-[Visit Make the Connection](https://maketheconnection.net/).
+- Go to our Make the Connection website to get resources and watch stories of Veterans who’ve overcome depression and other mental health challenges. <br> <a href="https://maketheconnection.net/" class="no-external-icon">Visit Make the Connection</a>
 - Call the VA general information hotline at <a href="tel:+1-800-827-1000">1-800-827-1000</a>.
 
 

--- a/va-gov/pages/health-care/health-needs-conditions/mental-health/ptsd.md
+++ b/va-gov/pages/health-care/health-needs-conditions/mental-health/ptsd.md
@@ -44,7 +44,7 @@ Our National Center for PTSD is the world leader in PTSD research, education, an
 	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>
 	    <ul>
               <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
-	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
+	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/" class="no-external-icon">Start a confidential Veterans Chat</a>.</li>
   	      <li>Text <a href="sms:838255">838255</a>.</li>
             </ul>
      	    <p><strong>You can also:</strong></p>
@@ -125,7 +125,7 @@ If you have symptoms of PTSD and suffered a serious injury, personal trauma, sex
 - See our “Understanding PTSD and PTSD Treatment” booklet for more about PTSD symptoms and treatment. [Read the booklet](http://www.ptsd.va.gov/public/understanding_ptsd/booklet.pdf).
 - Go to our National Center for PTSD website for information about PTSD treatment and support. [Visit the National Center for PTSD](https://www.ptsd.va.gov/public/index.asp).
 - Go to these websites for resources and stories of Veterans who’ve overcome PTSD and other mental health challenges:
-  - [Visit Make the Connection](http://maketheconnection.net/).
+  - <a href="http://maketheconnection.net/" class="no-external-icon">Visit Make the Connection</a>
   - [Visit About Face](https://www.ptsd.va.gov/apps/AboutFace/).
 - Use our PTSD Coach Online to help manage stress. [Visit PTSD Coach Online](https://www.ptsd.va.gov/apps/ptsdcoachonline/default.htm).
 - See our Self-Help Resources guide for books, web resources, and mobile applications recommended by VA experts. [Get self-help resources](https://www.mentalhealth.va.gov/self_help.asp).

--- a/va-gov/pages/health-care/health-needs-conditions/mental-health/suicide-prevention.md
+++ b/va-gov/pages/health-care/health-needs-conditions/mental-health/suicide-prevention.md
@@ -41,7 +41,7 @@ If you’re a Veteran in a mental health crisis and you’re thinking about hurt
 	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>
 	    <ul>
               <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
-	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
+	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/" class="no-external-icon">Start a confidential Veterans Chat</a>.</li>
   	      <li>Text <a href="sms:838255">838255</a>.</li>
             </ul>
      	    <p><strong>You can also:</strong></p>
@@ -68,14 +68,14 @@ If you’re a Veteran in a mental health crisis and you’re thinking about hurt
 
 <br>
 
-[Find these and other resources near you](https://www.veteranscrisisline.net/GetHelp/ResourceLocator.aspx).
+<a href="https://www.veteranscrisisline.net/GetHelp/ResourceLocator.aspx" class="no-external-icon">Find these and other resources near you</a>
 
 <br>
 
 #### You can also find information and support on our websites:
 
 - Get information about suicide prevention and the support we offer. [Visit our suicide prevention website](https://www.mentalhealth.va.gov/MENTALHEALTH/suicide_prevention/index.asp).
-- Go to our Make the Connection website to get resources and watch stories of Veterans who’ve overcome depression and other mental health challenges. [Visit Make the Connection](https://maketheconnection.net/).
+- Go to our Make the Connection website to get resources and watch stories of Veterans who’ve overcome depression and other mental health challenges.<a href="http://maketheconnection.net/" class="no-external-icon">Visit Make the Connection</a>
 
 </div>
 
@@ -96,7 +96,9 @@ They may also change the way they act, and start to:
 - Act violently or take risks (like driving fast or running red lights)
 - Do things to prepare for a suicide (like giving away special personal items, making a will, or seeking access to guns or pills)
 
-[Get the full list of signs that someone may be considering suicide](https://www.veteranscrisisline.net/SignsOfCrisis/Identifying.aspx).
+<a href="https://www.veteranscrisisline.net/SignsOfCrisis/Identifying.aspx" class="no-external-icon">
+Get the full list of signs that someone may be considering suicide
+</a>
 
 Learn about common suicide myths and realities, Veteran-specific suicide risks, and warning signs. [Recognize when to ask for help](https://www.mentalhealth.va.gov/suicide_prevention/whentoaskforhelp.asp).
 

--- a/va-gov/pages/health-care/health-needs-conditions/military-sexual-trauma.md
+++ b/va-gov/pages/health-care/health-needs-conditions/military-sexual-trauma.md
@@ -42,7 +42,7 @@ Military sexual trauma (MST) refers to sexual assault or repeated, threatening s
 	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>
 	    <ul>
               <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
-	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
+	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/" class="no-external-icon">Start a confidential Veterans Chat</a>.</li>
   	      <li>Text <a href="sms:838255">838255</a>.</li>
             </ul>
      	    <p><strong>You can also:</strong></p>
@@ -127,7 +127,7 @@ Or get help applying for disability compensation by:
 - Access more fact sheets, articles, and resources, and learn more about our programs and services on the VA.gov website.<br>
 [Go to the VA.gov MST website](https://www.mentalhealth.va.gov/msthome.asp).
 - Go to our Make the Connection website to hear stories from Veterans about their own experiences with the effects of MST, and find more resources and support.<br>
-[Visit Make the Connection](https://maketheconnection.net/).
+<a href="http://maketheconnection.net/" class="no-external-icon">Visit Make the Connection</a>
 - Go to the Department of Defense (DoD) Safe Helpline website, a crisis support service for members of the DOD community affected by sexual assault. When you contact the Safe Helpline, you can remain anonymous (meaning you don’t have to give your name). You can get 1-on-1 advice, support, and information 24/7—by phone, text, or online chat. You can also connect with a sexual assault response coordinator near your base or installation.<br>
 [Visit SafeHelpline.org](https://www.safehelpline.org/).
 

--- a/va-gov/pages/health-care/health-needs-conditions/substance-use-problems.md
+++ b/va-gov/pages/health-care/health-needs-conditions/substance-use-problems.md
@@ -38,7 +38,7 @@ If you’re struggling with substance use problems, you’re not alone. Many Vet
 	    <p><strong>To connect with a Veterans Crisis Line responder any time day or night:</strong></p>
 	    <ul>
               <li>Call <a href="tel:+1-800-273-8255">1-800-273-8255</a>, then press 1.</li>
-	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
+	      <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/" class="no-external-icon">Start a confidential Veterans Chat</a>.</li>
   	      <li>Text <a href="sms:838255">838255</a>.</li>
             </ul>
      	    <p><strong>You can also:</strong></p>
@@ -120,7 +120,7 @@ You may still be able to get care:
 ### Where can I find more information and support?
 
 - [Download our Guide to VA Mental Health Services](https://www.mentalhealth.va.gov/docs/MHG_English.pdf).
-- Go to our Make the Connection website to hear stories from Veterans about their own experiences with overcoming drug and alcohol problems, and to get access to more resources and support. [Visit Make the Connection](https://maketheconnection.net/).
+- Go to our Make the Connection website to hear stories from Veterans about their own experiences with overcoming drug and alcohol problems, and to get access to more resources and support. <a href="http://maketheconnection.net/" class="no-external-icon">Visit Make the Connection</a>
 - Visit our Self-Help Resources guide to get links to books, web resources, and mobile applications that have been reviewed and recommended by VA experts. [Get self-help resources](https://www.mentalhealth.va.gov/self_help.asp).
 - Visit the resources section of our VA website to find more trusted resources outside VA that can offer information and support. [Find resources](https://www.mentalhealth.va.gov/substanceabuse.asp).
 - Download our Stay Quit Coach mobile app—designed to help Veterans with PTSD quit smoking. We based this app on steps proven to work to help people quit smoking. It includes tools to control cravings and manage smoking triggers, messages to keep you going, medication reminders, and more. [Get the Stay Quit Coach app](https://mobile.va.gov/app/stay-quit-coach).

--- a/va-gov/pages/health-care/index.md
+++ b/va-gov/pages/health-care/index.md
@@ -98,7 +98,9 @@ We offer many programs and services that may help—including free health care a
 **Talk with someone right now:**
 
 Whatever you’re struggling with—homelessness, chronic pain, anxiety, depression, trouble sleeping, or anger—we can support you, day or night.<br>
-[Chat online with a trained VA staff member](https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Homeless%20Veterans%20Chat").
+<a class="no-external-icon" href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Homeless%20Veterans%20Chat">
+Chat online with a trained VA staff member
+</a>
 
    </div>
   </div>

--- a/va-gov/pages/health-care/schedule-view-va-appointments.md
+++ b/va-gov/pages/health-care/schedule-view-va-appointments.md
@@ -46,7 +46,7 @@ With our VA Appointments tools, you can schedule some VA health care appointment
         <p><strong>To connect with a Veterans Crisis Line responder anytime day or night:</strong></p>
         <ul>
              <li>Call <a href="tel:+18002738255">1-800-273-8255</a>, then press 1.</li>
-          <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
+          <li><a class="no-external-icon" href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
            <li>Text <a href="sms:838255">838255</a>.</li>
            <li>Call TTY <a href="tel:+18007994889">1-800-799-4889</a> for support if you have hearing loss. 
            </ul>

--- a/va-gov/pages/health-care/secure-messaging.md
+++ b/va-gov/pages/health-care/secure-messaging.md
@@ -99,7 +99,7 @@ No. You shouldn't use Secure Messaging when you have an urgent need, because it 
 
 To connect with a Veterans Crisis Line responder anytime, day or night:
 - Call <a href="tel:+18002738255">1-800-273-8255</a>, then press 1.
-- [Start a confidential Veterans Chat](https://www.veteranscrisisline.net/get-help/chat).
+- <a class="no-external-icon" href="https://www.veteranscrisisline.net/get-help/chat">Start a confidential Veterans Chat</a>
 - Text <a href="tel:+1838255">838255</a>.
 
 </div>

--- a/va-gov/pages/housing-assistance/index.md
+++ b/va-gov/pages/housing-assistance/index.md
@@ -90,7 +90,9 @@ We offer many programs and services that may help—including free health care a
 **Talk with someone right now:**
 
 Whatever you’re struggling with—homelessness, chronic pain, anxiety, depression, trouble sleeping, or anger—we can support you, day or night.<br>
-[Chat online with a trained VA staff member](https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Homeless%20Veterans%20Chat").
+<a class="no-external-icon" href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Homeless%20Veterans%20Chat">
+Chat online with a trained VA staff member
+</a>
 
    </div>
   </div>

--- a/va-gov/pages/privacy.md
+++ b/va-gov/pages/privacy.md
@@ -180,11 +180,11 @@ The VA Privacy Service works to minimize the impact on Veterans' privacy, partic
  </div> <br>
  
  <div class="link">
-  <a href="https://www.veteranscrisisline.net/about/privacy-and-security"><b>Veterans Crisis Line Privacy and Security</b></a>
+  <a class="no-external-icon" href="https://www.veteranscrisisline.net/about/privacy-and-security"><b>Veterans Crisis Line Privacy and Security</b></a>
  </div> <br>
  
  <div class="link">
-  <a href="https://www.veteranscrisisline.net/get-help/text"><b>Veterans Crisis Line Text Terms of Service</b></a>
+  <a class="no-external-icon" href="https://www.veteranscrisisline.net/get-help/text"><b>Veterans Crisis Line Text Terms of Service</b></a>
  </div> <br>
  
   <span id="links"></span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,8 +3,8 @@
 
 
 "@department-of-veterans-affairs/formation@^1.7.7":
-  version "1.7.7"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.7.7.tgz#e8a46ed0ef7eb742c6171449cf740449c79cd90e"
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.7.8.tgz#6a1b812ca86d4d3b5a64b8045105f0ccee26eea5"
   dependencies:
     classnames "^2.2.5"
     font-awesome "4"


### PR DESCRIPTION
## Description
Applies `no-external-icon` class to special links as specified in this issue https://app.zenhub.com/workspace/o/department-of-veterans-affairs/vets.gov-team/issues/13566

This relies on design system 1.7.8

## Testing done
Local testing and visual regression testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
