### PR TITLE
13506 Move subheader out of <ul> element for Connect With Us lists

### DIFF
--- a/va-gov/components/merger-social.html
+++ b/va-gov/components/merger-social.html
@@ -25,8 +25,8 @@ See https://help.shopify.com/themes/liquid/tags/theme-tags#include
         {% for subs in group.subsections %}
 
         <section>
+          <h4>{{ subs.subhead }}</h4>
           <ul class="va-nav-linkslist-list social">
-            <h4>{{ subs.subhead }}</h4>
             {% for link in subs.links %}
               {% if link.url != empty %}
                 <li>


### PR DESCRIPTION
## Description
The `Connect With Us` lists on a few pages have an `<h4>` nested inside the `<ul>` and aXe is throwing an error for invalid list formation. Screenshot below.

## Related Issues
* https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13506

## Testing done
- Manually ensured that each page listed below does not have the aXe violation present
- Ensured component styles are unchanged
- Ensured screen reader (ChromeVox) while performing content navigation reads the `<li>`s appropriately. 

## Screenshots

## Acceptance criteria
- [x] As a screenreader user, I want to hear lists announced properly, and be able to navigate by headings on the page.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
