### PR TITLE
Add aria attributes to enable screenreading of loading results

### DIFF
--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -61,7 +61,7 @@ class ResultsList extends Component {
 
     if (currentQuery.inProgress) {
       return (
-        <div aria-live="polite" aria-relevant="additions text">
+        <div>
           <LoadingIndicator message="Loading results..." />
         </div>
       );

--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -61,7 +61,7 @@ class ResultsList extends Component {
 
     if (currentQuery.inProgress) {
       return (
-        <div>
+        <div aria-live="polite" aria-relevant="additions text">
           <LoadingIndicator message="Loading results..." />
         </div>
       );

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -380,7 +380,11 @@ class VAMap extends Component {
               <Tab className="small-6 tab">View Map</Tab>
             </TabList>
             <TabPanel>
-              <div className="facility-search-results">
+              <div
+                aria-live="polite"
+                aria-relevant="additions text"
+                className="facility-search-results"
+              >
                 <p>
                   Search Results near <strong>“{currentQuery.context}”</strong>
                 </p>
@@ -443,7 +447,11 @@ class VAMap extends Component {
             style={{ maxHeight: '75vh', overflowY: 'auto' }}
             id="searchResultsContainer"
           >
-            <div className="facility-search-results">
+            <div
+              aria-live="polite"
+              aria-relevant="additions text"
+              className="facility-search-results"
+            >
               <div>
                 <ResultsList
                   facilities={facilities}


### PR DESCRIPTION
## Description
The Facility and Service Locator tool has a dynamic DIV that is populated with results when they are returned from the API. The loading graphic also has the text "Loading results" that is not being read out by screen readers. Non-sighted users are not being made aware when the results are populated.

## Testing done
- Tested (with ChromeVox) that when the `Loading Results...` div is on-screen after a "search" action is initiated, the screen reader reads out "loading results"

## Screenshots


## Acceptance criteria
- [x] As a screenreader user, I want to hear the "Loading results" text read out when I am waiting for results to come back, and to hear the actual results read when they are added to the containing DIV.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
