### PR TITLE
Render site-name conditionally in files shared between Vets.gov and VA.gov

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -178,7 +178,7 @@ export class AuthApp extends React.Component {
     const view = this.state.error ? (
       this.renderError()
     ) : (
-      <LoadingIndicator message="Signing in to {siteName}..." />
+      <LoadingIndicator message={`Signing in to ${siteName}...`} />
     );
 
     return (

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 
+import siteName from '../../../platform/brand-consolidation/site-name';
 import recordEvent from '../../../platform/monitoring/record-event';
 import { apiRequest } from '../../../platform/utilities/api';
 import environment from '../../../platform/utilities/environment';
@@ -88,9 +89,9 @@ export class AuthApp extends React.Component {
               <p>
                 We’re sorry. It looks like you selected "Deny" on the last page
                 when asked for your permission to share information with
-                Vets.gov, so we couldn’t complete the process. To give you full
-                access to the tools on Vets.gov, we need to be able to share
-                your information with the site.
+                {siteName}, so we couldn’t complete the process. To give you
+                full access to the tools on {siteName}, we need to be able to
+                share your information with the site.
               </p>
               <p>
                 Please try again and click “Accept” on the final page. Or, you
@@ -153,7 +154,7 @@ export class AuthApp extends React.Component {
             <div>
               <p>We’re sorry. Something went wrong on our end.</p>
               <p>
-                Please call the Vets.gov Help Desk at{' '}
+                Please call the {siteName} Help Desk at{' '}
                 <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
                 <a href="tel:18008778339">1-800-877-8339</a>. We’re open Monday
                 &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).
@@ -177,7 +178,7 @@ export class AuthApp extends React.Component {
     const view = this.state.error ? (
       this.renderError()
     ) : (
-      <LoadingIndicator message="Signing in to Vets.gov..." />
+      <LoadingIndicator message="Signing in to {siteName}..." />
     );
 
     return (

--- a/src/applications/health-records/components/ErrorView.jsx
+++ b/src/applications/health-records/components/ErrorView.jsx
@@ -4,6 +4,8 @@ import { isEmpty, some, includes, intersection, concat } from 'lodash';
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 import { errorCodes } from '../config';
 
+import siteName from '../../../platform/brand-consolidation/site-name';
+
 class ErrorView extends React.Component {
   renderErrorMessage() {
     const { errors } = this.props;
@@ -26,7 +28,7 @@ class ErrorView extends React.Component {
           >
             try again
           </a>{' '}
-          in a few minutes. If it still doesn’t work, please call the Vets.gov
+          in a few minutes. If it still doesn’t work, please call the {siteName}
           Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
           <a href="tel:18008778339">1-800-877-8339</a>. We’re here Monday
           &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).

--- a/src/applications/health-records/containers/DownloadPage.jsx
+++ b/src/applications/health-records/containers/DownloadPage.jsx
@@ -11,6 +11,8 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingI
 import DownloadLink from '../components/DownloadLink';
 import { openModal, closeModal } from '../actions/modal';
 
+import siteName from '../../../platform/brand-consolidation/site-name';
+
 export class DownloadPage extends React.Component {
   renderIncompleteMessage = () => {
     const outdatedStatuses = this.props.refresh.statuses.incomplete;
@@ -21,10 +23,10 @@ export class DownloadPage extends React.Component {
           Most of your health record should be up to date. But we’re having
           trouble accessing some of your data right now. Please refresh this
           page or try again later. If you still don’t see your updated
-          information, please call the Vets.gov Help Desk at 855-574-7286 (TTY:
-          800-829-4833). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. (ET). If
-          you need this information right away, please call your VA health care
-          provider.
+          information, please call the {siteName} Help Desk at 855-574-7286
+          (TTY: 800-829-4833). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m.
+          (ET). If you need this information right away, please call your VA
+          health care provider.
         </p>
       ),
     };
@@ -41,7 +43,7 @@ export class DownloadPage extends React.Component {
                 having trouble accessing data for VA radiology reports right
                 now. Please refresh this page or try again later. If you still
                 don’t see your most recent radiology reports, please call the
-                Vets.gov Help Desk at 855-574-7286 (TTY: 800-829-4833). We’re
+                {siteName} Help Desk at 855-574-7286 (TTY: 800-829-4833). We’re
                 here Monday–Friday, 8:00 a.m.–8:00 p.m. (ET). If you need your
                 reports right away, please call your VA health care provider.
               </p>
@@ -57,7 +59,7 @@ export class DownloadPage extends React.Component {
                 having trouble accessing data for VA laboratory results and/or
                 pathology reports right now. Please refresh this page or try
                 again later. If you still don’t see your most recent lab results
-                or pathology reports, please call the Vets.gov Help Desk at
+                or pathology reports, please call the {siteName} Help Desk at
                 855-574-7286 (TTY: 800-829-4833). We’re here Monday–Friday, 8:00
                 a.m.–8:00 p.m. (ET). If you need your reports right away, please
                 call your VA health care provider.
@@ -75,10 +77,10 @@ export class DownloadPage extends React.Component {
                 having trouble accessing your VA electronic health record
                 history right now. Please refresh this page or try again later.
                 If you still don’t see your updated history information, please
-                call the Vets.gov Help Desk at 855-574-7286 (TTY: 800-829-4833).
-                We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. (ET). If you need
-                this information right away, please call your VA health care
-                provider.
+                call the {siteName} Help Desk at 855-574-7286 (TTY:
+                800-829-4833). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m.
+                (ET). If you need this information right away, please call your
+                VA health care provider.
               </p>
             ),
           };
@@ -93,7 +95,7 @@ export class DownloadPage extends React.Component {
                 having trouble accessing your Department of Defense (DoD)
                 information right now. Please refresh this page or try again
                 later. If you still don’t see your updated DoD information,
-                please call the Vets.gov Help Desk at 855-574-7286 (TTY:
+                please call the {siteName} Help Desk at 855-574-7286 (TTY:
                 800-829-4833). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m.
                 (ET). If you need this information right away, please call your
                 VA health care provider.
@@ -118,8 +120,8 @@ export class DownloadPage extends React.Component {
         content: (
           <p>
             Unfortunately, we weren’t able to generate your health records.
-            Please try again later. You can also call the Vets.gov Help Desk at{' '}
-            <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
+            Please try again later. You can also call the {siteName} Help Desk
+            at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
             <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday,
             8:00 a.m. &#8211; 8:00 p.m. (ET).
           </p>

--- a/src/applications/messaging/components/ErrorView.jsx
+++ b/src/applications/messaging/components/ErrorView.jsx
@@ -4,6 +4,7 @@ import { isEmpty, some, includes, intersection, concat } from 'lodash';
 
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 import { mhvAccessError } from '../../../platform/static-data/error-messages';
+import siteName from '../../../platform/brand-consolidation/site-name';
 import { errorCodes } from '../config';
 
 class ErrorView extends React.Component {
@@ -32,7 +33,7 @@ class ErrorView extends React.Component {
           >
             try again
           </a>{' '}
-          in a few minutes. If it still doesn’t work, please call the Vets.gov
+          in a few minutes. If it still doesn’t work, please call the {siteName}
           Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
           <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday,
           8:00 a.m. &#8211; 8:00 p.m. (ET).

--- a/src/applications/messaging/containers/MessagingApp.jsx
+++ b/src/applications/messaging/containers/MessagingApp.jsx
@@ -12,6 +12,7 @@ import RequiredLoginView from '../../../platform/user/authorization/components/R
 import { closeAlert } from '../actions';
 import ButtonSettings from '../components/buttons/ButtonSettings';
 import { isEmpty } from 'lodash';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
 const SERVICE_REQUIRED = backendServices.MESSAGING;
 
@@ -35,7 +36,7 @@ class MessagingApp extends React.Component {
           We’re sorry. It looks like you don’t have a VA health care team linked
           to your account in our system. To begin sending secure messages,
           please contact your health care team, and ask them to add you into the
-          system. If you need more help, please call the Vets.gov Help Desk at{' '}
+          system. If you need more help, please call the {siteName} Help Desk at{' '}
           <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
           <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday,
           8:00 a.m. &#8211; 8:00 p.m. (ET).

--- a/src/applications/personalization/profile360/components/AccountMessage.jsx
+++ b/src/applications/personalization/profile360/components/AccountMessage.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import accountManifest from '../../account/manifest.json';
+import siteName from '../../../../platform/brand-consolidation/site-name';
 
 export default function AccountMessage() {
   return (
     <div>
-      <h3>Want to update the email you use to sign in to Vets.gov?</h3>
+      <h3>Want to update the email you use to sign in to {siteName}?</h3>
       <a href={accountManifest.rootUrl}>Go to your account settings</a>
     </div>
   );

--- a/src/applications/rx/components/ErrorView.jsx
+++ b/src/applications/rx/components/ErrorView.jsx
@@ -4,6 +4,7 @@ import { isEmpty, some, includes, intersection, concat } from 'lodash';
 
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 import { mhvAccessError } from '../../../platform/static-data/error-messages';
+import siteName from '../../../platform/brand-consolidation/site-name';
 import { errorCodes } from '../config';
 
 class ErrorView extends React.Component {
@@ -46,7 +47,8 @@ class ErrorView extends React.Component {
           >
             refresh this page
           </a>{' '}
-          or try again later. If this problem persists, please call the Vets.gov
+          or try again later. If this problem persists, please call the{' '}
+          {siteName}
           Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
           <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday,
           8:00 a.m. &#8211; 8:00 p.m. (ET).
@@ -66,7 +68,7 @@ class ErrorView extends React.Component {
           >
             try again
           </a>{' '}
-          in a few minutes. If it still doesn’t work, please call the Vets.gov
+          in a few minutes. If it still doesn’t work, please call the {siteName}
           Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
           <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday,
           8:00 a.m. &#8211; 8:00 p.m. (ET).

--- a/src/applications/rx/containers/Active.jsx
+++ b/src/applications/rx/containers/Active.jsx
@@ -12,6 +12,7 @@ import Pagination from '@department-of-veterans-affairs/formation/Pagination';
 
 import recordEvent from '../../../platform/monitoring/record-event';
 import { getScrollOptions } from '../../../platform/utilities/ui';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
 import { openGlossaryModal, openRefillModal } from '../actions/modals';
 
@@ -188,7 +189,7 @@ class Active extends React.Component {
       return (
         <p className="rx-tab-explainer rx-loading-error">
           We couldn’t retrieve your prescriptions. Please refresh this page or
-          try again later. If this problem persists, please call the Vets.gov
+          try again later. If this problem persists, please call the {siteName}
           Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
           <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday,
           8:00 a.m. &#8211; 8:00 p.m. (ET).
@@ -202,7 +203,7 @@ class Active extends React.Component {
           It looks like you don’t have any VA prescriptions to refill right now.
           If you think this is a mistake, please contact your VA health care
           team and ask them to check your prescription records. If you need more
-          help, please call the Vets.gov Help Desk at{' '}
+          help, please call the {siteName} Help Desk at{' '}
           <a href="tel:8555747286">1-855-574-7286</a> (TTY:{' '}
           <a href="tel:18008778339">1-800-877-8339</a>
           ). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. (ET).

--- a/src/applications/rx/containers/History.jsx
+++ b/src/applications/rx/containers/History.jsx
@@ -10,6 +10,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingI
 import Pagination from '@department-of-veterans-affairs/formation/Pagination';
 import SortableTable from '@department-of-veterans-affairs/formation/SortableTable';
 
+import siteName from '../../../platform/brand-consolidation/site-name';
 import { getScrollOptions } from '../../../platform/utilities/ui';
 import { loadPrescriptions } from '../actions/prescriptions';
 import { openGlossaryModal } from '../actions/modals';
@@ -103,7 +104,7 @@ class History extends React.Component {
       return (
         <p className="rx-tab-explainer rx-loading-error">
           We couldn’t retrieve your prescriptions. Please refresh this page or
-          try again later. If this problem persists, please call the Vets.gov
+          try again later. If this problem persists, please call the {siteName}
           Help Desk at <a href="tel:8555747286">1-855-574-7286</a>, TTY:{' '}
           <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday,
           8:00 a.m. &#8211; 8:00 p.m. (ET).
@@ -117,7 +118,7 @@ class History extends React.Component {
           It looks like you don’t have any active VA prescriptions. If you’re
           taking a medicine that you don’t see listed here—or if you have any
           questions about your current medicines—please contact your VA health
-          care team. If you need more help, please call the Vets.gov Help Desk
+          care team. If you need more help, please call the {siteName} Help Desk
           at <a href="tel:8555747286">1-855-574-7286</a> (TTY:{' '}
           <a href="tel:18008778339">1-800-877-8339</a>
           ). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. (ET). We’re here

--- a/src/applications/rx/containers/Prescription.jsx
+++ b/src/applications/rx/containers/Prescription.jsx
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
+import siteName from '../../../platform/brand-consolidation/site-name';
 import { closeAlert } from '../actions/alert.js';
 import { loadPrescription } from '../actions/prescriptions';
 import SettingsButton from '../components/SettingsButton';
@@ -50,7 +51,7 @@ export class Prescription extends React.Component {
       content = (
         <p className="rx-loading-error">
           We couldn’t retrieve your prescription. Please refresh this page or
-          try again later. If this problem persists, please call the Vets.gov
+          try again later. If this problem persists, please call the {siteName}
           Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
           <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday,
           8:00 a.m. &#8211; 8:00 p.m. (ET).

--- a/src/applications/terms-and-conditions/containers/MhvTermsAndConditions.jsx
+++ b/src/applications/terms-and-conditions/containers/MhvTermsAndConditions.jsx
@@ -9,6 +9,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingI
 import recordEvent from '../../../platform/monitoring/record-event';
 import conditionalStorage from '../../../platform/utilities/storage/conditionalStorage';
 import { getScrollOptions } from '../../../platform/utilities/ui';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
 import {
   acceptTerms,
@@ -22,9 +23,8 @@ const scroller = Scroll.scroller;
 const TERMS_NAME = 'mhvac';
 
 const unagreedBannerProps = {
-  headline: 'Using Vets.gov Health Tools',
-  content:
-    'Before you can use the health tools on Vets.gov, you’ll need to read and agree to the Terms and Conditions below. This will give us your permission to show you your VA medical information on this site.',
+  headline: `Using ${siteName} Health Tools`,
+  content: `Before you can use the health tools on ${siteName}, you’ll need to read and agree to the Terms and Conditions below. This will give us your permission to show you your VA medical information on this site.`,
   status: 'warning',
 };
 
@@ -113,8 +113,7 @@ export class MhvTermsAndConditions extends React.Component {
 
     if (this.state.showAcceptedMessage) {
       bannerProps = {
-        headline:
-          'You’ve accepted the Terms and Conditions for using Vets.gov health tools',
+        headline: `You’ve accepted the Terms and Conditions for using ${siteName} health tools`,
         content: '',
         status: 'success',
       };

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -7,6 +7,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingI
 import recordEvent from '../../../platform/monitoring/record-event';
 import { verify } from '../../../platform/user/authentication/utilities';
 import conditionalStorage from '../../../platform/utilities/storage/conditionalStorage';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
 export class VerifyApp extends React.Component {
   componentDidMount() {
@@ -61,7 +62,7 @@ export class VerifyApp extends React.Component {
                   access and manage your benefits.
                   <br />
                   <a href="/faq/#why-verify" target="_blank">
-                    Why does Vets.gov verify identity?
+                    Why does {siteName} verify identity?
                   </a>
                 </p>
                 <p>
@@ -88,7 +89,7 @@ export class VerifyApp extends React.Component {
                   </a>
                 </p>
                 <p>
-                  Call the Vets.gov Help Desk at{' '}
+                  Call the {siteName} Help Desk at{' '}
                   <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
                   <a href="tel:18008778339">1-800-877-8339</a>
                   <br />

--- a/src/applications/veteran-id-card/containers/Main.jsx
+++ b/src/applications/veteran-id-card/containers/Main.jsx
@@ -4,6 +4,7 @@ import { has, head } from 'lodash';
 import { initiateIdRequest, timeoutRedirect } from '../actions';
 import config from '../config';
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
 class Main extends React.Component {
   constructor(props) {
@@ -69,7 +70,7 @@ class Main extends React.Component {
     const content = (
       <p>
         Please refresh the page or try again later. You can also call the
-        Vets.gov Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>,
+        {siteName} Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>,
         TTY: <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211;
         Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).
       </p>

--- a/src/applications/vic-v2/containers/ConfirmationPage.jsx
+++ b/src/applications/vic-v2/containers/ConfirmationPage.jsx
@@ -4,6 +4,7 @@ import Scroll from 'react-scroll';
 import moment from 'moment';
 
 import { focusElement } from '../../../platform/utilities/ui';
+import siteName from '../../../platform/brand-consolidation/site-name';
 
 import VeteranIDCard from '../components/VeteranIDCard';
 
@@ -156,7 +157,7 @@ class ConfirmationPage extends React.Component {
           <div className="small-6 usa-width-one-half medium-6 columns">
             <a href="/">
               <button className="usa-button-primary">
-                Go Back to Vets.gov
+                Go Back to {siteName}
               </button>
             </a>
           </div>

--- a/src/applications/vic-v2/containers/IntroductionPage.jsx
+++ b/src/applications/vic-v2/containers/IntroductionPage.jsx
@@ -12,6 +12,8 @@ import SaveInProgressIntro, {
 } from '../../../platform/forms/save-in-progress/SaveInProgressIntro';
 import { hasSavedForm } from '../helpers';
 
+import siteName from '../../../platform/brand-consolidation/site-name';
+
 const { animateScroll: scroll } = Scroll;
 
 class IntroductionPage extends React.Component {
@@ -174,15 +176,17 @@ class IntroductionPage extends React.Component {
                   <h5>Sign In and Verify Your Identity</h5>
                 </div>
                 <p>You have a choice for how you complete this application.</p>
-                <h6>Choice 1: Sign in to Vets.gov and verify your identity</h6>
+                <h6>
+                  Choice 1: Sign in to {siteName} and verify your identity
+                </h6>
                 <p>
-                  Sign in to Vets.gov with either your existing My Health
+                  Sign in to {siteName} with either your existing My Health
                   <em>e</em>
                   Vet or DS Logon account (the same one you use for eBenefits or
                   MilConnect) or an ID.me account.
                 </p>
                 <p>
-                  If you don’t have an account on Vets.gov, you can create one
+                  If you don’t have an account on {siteName}, you can create one
                   using ID.me, our Veteran-owned, trusted technology partner
                   that provides the strongest identity verification system
                   available.
@@ -234,7 +238,7 @@ class IntroductionPage extends React.Component {
                     If you signed in using your My Health
                     <em>e</em>
                     Vet or DS Logon account, we’ll connect your account to
-                    Vets.gov through ID.me. To verify your identity through
+                    {siteName} through ID.me. To verify your identity through
                     ID.me, you’ll need:
                   </p>
                   {idProofingReqs}
@@ -347,11 +351,13 @@ class IntroductionPage extends React.Component {
         />
         {(!signedIn || !idProofed) && (
           <p>
-            <a href="/faq">Get more information about signing in to Vets.gov</a>
+            <a href="/faq">
+              Get more information about signing in to {siteName}
+            </a>
             .
           </p>
         )}
-        <a href="/privacy">Read the Vets.gov Privacy Policy</a>
+        <a href="/privacy">Read the {siteName} Privacy Policy</a>
       </div>
     );
   }

--- a/src/applications/vre/chapter31/containers/ConfirmationPage.jsx
+++ b/src/applications/vre/chapter31/containers/ConfirmationPage.jsx
@@ -5,6 +5,7 @@ import moment from 'moment';
 
 import { focusElement } from '../../../../platform/utilities/ui';
 import AskVAQuestions from '../../../../platform/forms/components/AskVAQuestions';
+import siteName from '../../../../platform/brand-consolidation/site-name';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
@@ -100,7 +101,7 @@ class ConfirmationPage extends React.Component {
           <div className="small-6 usa-width-one-half medium-6 columns">
             <a href="/">
               <button className="usa-button-primary">
-                Go Back to Vets.gov
+                Go Back to {siteName}
               </button>
             </a>
           </div>

--- a/src/applications/vre/chapter36/containers/ConfirmationPage.jsx
+++ b/src/applications/vre/chapter36/containers/ConfirmationPage.jsx
@@ -4,6 +4,7 @@ import Scroll from 'react-scroll';
 import moment from 'moment';
 
 import { focusElement } from '../../../../platform/utilities/ui';
+import siteName from '../../../../platform/brand-consolidation/site-name';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
@@ -104,7 +105,7 @@ class ConfirmationPage extends React.Component {
           <div className="small-6 usa-width-one-half medium-6 columns">
             <a href="/">
               <button className="usa-button-primary">
-                Go Back to Vets.gov
+                Go Back to {siteName}
               </button>
             </a>
           </div>

--- a/src/platform/site-wide/announcements/components/ProfileIntro.jsx
+++ b/src/platform/site-wide/announcements/components/ProfileIntro.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Modal from '@department-of-veterans-affairs/formation/Modal';
+import siteName from '../../../brand-consolidation/site-name';
 
 export default function ProfileIntro({ dismiss, profile }) {
   if (profile.loading) return <div />;
@@ -11,7 +12,7 @@ export default function ProfileIntro({ dismiss, profile }) {
         <img alt="profile icon" src="/img/profile-announcement.svg" />
       </div>
       <h3 className="announcement-title">
-        Welcome to your new Vets.gov profile
+        Welcome to your new {siteName} profile
       </h3>
       <p>
         Review your contact, personal, and military service information—and find

--- a/src/platform/static-data/error-messages.jsx
+++ b/src/platform/static-data/error-messages.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import React from 'react';
+import siteName from '../brand-consolidation/site-name';
 
 export const systemDownMessage = (
   <div className="row" id="systemDownMessage">
@@ -10,7 +11,7 @@ export const systemDownMessage = (
           Please try again later.
         </h3>
         <a href="/" className="usa-button-primary">
-          Go Back to Vets.gov
+          Go Back to {siteName}
         </a>
       </div>
     </div>
@@ -73,7 +74,7 @@ export const mhvAccessError = (
             </li>
           </ol>
           <p>
-            If none of these reasons applies to you, please call the Vets.gov
+            If none of these reasons applies to you, please call the {siteName}
             Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We're here Monday
             – Friday, 8:00 a.m. – 8:00 p.m. (ET).
           </p>

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -7,6 +7,7 @@ import recordEvent from '../../../monitoring/record-event';
 import { login, signup } from '../../../user/authentication/utilities';
 import { externalServices } from '../../../../platform/monitoring/DowntimeNotification';
 import DowntimeBanner from '../../../../platform/monitoring/DowntimeNotification/components/Banner';
+import siteName from '../../../brand-consolidation/site-name';
 
 const loginHandler = loginType => () => {
   recordEvent({ event: `login-attempted-${loginType}` });
@@ -30,7 +31,7 @@ class SignInModal extends React.Component {
           <div className="logo">
             <a href="/">
               <img
-                alt="vets.gov"
+                alt={siteName}
                 className="va-header-logo"
                 src="/img/design/logo/logo-alt.png"
               />
@@ -41,7 +42,7 @@ class SignInModal extends React.Component {
       <div className="container">
         <div className="row">
           <div className="columns small-12">
-            <h1>Sign in to Vets.gov</h1>
+            <h1>Sign in to {siteName}</h1>
           </div>
         </div>
         <div className="row hide-for-medium-up mobile-explanation">
@@ -56,8 +57,8 @@ class SignInModal extends React.Component {
             <div className="columns small-12">
               <div className="form-warning-banner">
                 <AlertBox
-                  headline="Some Vets.gov tools and features may not be working as expected"
-                  content="We’re sorry. We’re working to fix some problems with DS Logon right now. Please check back later or call the Vets.gov Help Desk for more information at 1-855-574-7286, TTY: 1-800-877-8339."
+                  headline={`Some ${siteName} tools and features may not be working as expected`}
+                  content={`We’re sorry. We’re working to fix some problems with DS Logon right now. Please check back later or call the ${siteName} Help Desk for more information at 1-855-574-7286, TTY: 1-800-877-8339.`}
                   isVisible
                   status="warning"
                 />
@@ -117,7 +118,7 @@ class SignInModal extends React.Component {
                 fingertips.
               </div>
               <p>
-                You spoke. We listened. Vets.gov is the direct result of what
+                You spoke. We listened. {siteName} is the direct result of what
                 you said you wanted most—one easy-to-use place to:
               </p>
               <ul>
@@ -159,7 +160,7 @@ class SignInModal extends React.Component {
                 </a>
               </p>
               <p>
-                Call the Vets.gov Help Desk at{' '}
+                Call the {siteName} Help Desk at{' '}
                 <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
                 <a href="tel:18008778339">1-800-877-8339</a>
                 <br />
@@ -169,7 +170,7 @@ class SignInModal extends React.Component {
             <hr />
             <div className="fed-warning">
               <p>
-                <strong>Please note:</strong> When you sign in to Vets.gov,
+                <strong>Please note:</strong> When you sign in to {siteName},
                 you're accessing a United States Federal Government information
                 system.
               </p>
@@ -203,7 +204,7 @@ class SignInModal extends React.Component {
         focusSelector="button"
         onClose={this.props.onClose}
         id="signin-signup-modal"
-        title="Sign in to Vets.gov"
+        title={`Sign in to ${siteName}`}
       >
         {this.renderModalContent()}
       </Modal>

--- a/src/platform/user/authorization/components/RequiredLoginView.jsx
+++ b/src/platform/user/authorization/components/RequiredLoginView.jsx
@@ -8,6 +8,7 @@ import SystemDownView from '@department-of-veterans-affairs/formation/SystemDown
 
 import conditionalStorage from '../../../utilities/storage/conditionalStorage';
 import backendServices from '../../profile/constants/backendServices';
+import siteName from '../../../brand-consolidation/site-name';
 
 const nextQuery = { next: window.location.pathname };
 const signInUrl = appendQuery('/', nextQuery);
@@ -86,7 +87,7 @@ class RequiredLoginView extends React.Component {
       return (
         <SystemDownView
           messageLine1="We couldn’t find your records with that information."
-          messageLine2="Please call the Vets.gov Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We're open Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)."
+          messageLine2={`Please call the ${siteName} Help Desk at 1-855-574-7286, TTY: 1-800-877-8339. We're open Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).`}
         />
       );
     }

--- a/src/platform/user/authorization/containers/MHVApp.jsx
+++ b/src/platform/user/authorization/containers/MHVApp.jsx
@@ -9,6 +9,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingI
 import { mhvAccessError } from '../../../static-data/error-messages';
 import backendServices from '../../profile/constants/backendServices';
 import { selectProfile } from '../../selectors';
+import siteName from '../../../brand-consolidation/site-name';
 
 import {
   createMHVAccount,
@@ -19,12 +20,12 @@ import {
 /* eslint-disable camelcase */
 const INELIGIBLE_MESSAGES = {
   needs_ssn_resolution: {
-    headline: 'We can’t give you access to the Vets.gov health tools',
+    headline: `We can’t give you access to the ${siteName} health tools`,
     content: (
       <div>
         <p>
           We’re sorry. We can’t match your Social Security number to our Veteran
-          records. We won’t be able to give you access to the Vets.gov health
+          records. We won’t be able to give you access to the {siteName} health
           tools until we can match your information to verify your identity.
         </p>
         <p>
@@ -41,11 +42,11 @@ const INELIGIBLE_MESSAGES = {
   },
 
   needs_va_patient: {
-    headline: 'We can’t give you access to the Vets.gov health tools',
+    headline: `We can’t give you access to the ${siteName} health tools`,
     content: (
       <div>
         <p>
-          We’re sorry. We can’t give you access to the Vets.gov health tools
+          We’re sorry. We can’t give you access to the {siteName} health tools
           because we can’t verify that you’re a VA patient. Only patients who’ve
           received care at a VA health facility can use these tools.
         </p>
@@ -68,7 +69,7 @@ const INELIGIBLE_MESSAGES = {
     content: (
       <div>
         <p>
-          We’re sorry. We can’t give you access to the Vets.gov health tools
+          We’re sorry. We can’t give you access to the {siteName} health tools
           because it looks like you already have a My Health
           <em>e</em>
           Vet account that’s been disabled.
@@ -94,7 +95,7 @@ const INELIGIBLE_MESSAGES = {
     content: (
       <div>
         <p>
-          We’re sorry. We can’t give you access to the Vets.gov health tools
+          We’re sorry. We can’t give you access to the {siteName} health tools
           because we’ve found more than one active account for you in the My
           Health
           <em>e</em>
@@ -191,9 +192,8 @@ export class MHVApp extends React.Component {
     }
 
     const alertProps = {
-      headline:
-        'Thank you for accepting the Terms and Conditions for using Vets.gov health tools',
-      content: <p>You can now access health tools on Vets.gov.</p>,
+      headline: `Thank you for accepting the Terms and Conditions for using ${siteName} health tools`,
+      content: <p>You can now access health tools on {siteName}.</p>,
       onCloseAlert: this.closeTcAcceptanceMessage,
     };
 
@@ -219,7 +219,8 @@ export class MHVApp extends React.Component {
           >
             refresh this page
           </a>{' '}
-          or try again later. If this problem persists, please call the Vets.gov
+          or try again later. If this problem persists, please call the{' '}
+          {siteName}
           Help Desk at <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
           <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211; Friday,
           8:00 a.m. &#8211; 8:00 p.m. (ET).
@@ -262,7 +263,7 @@ export class MHVApp extends React.Component {
           Health
           <em>e</em>
           Vet account level right now. You can use most of the tools on
-          Vets.gov, but you won’t be able to send secure messages or refill
+          {siteName}, but you won’t be able to send secure messages or refill
           prescriptions at this time. We’re working to fix this. Please check
           back later.
         </p>
@@ -274,7 +275,7 @@ export class MHVApp extends React.Component {
 
   renderRegisterFailedMessage() {
     const alertProps = {
-      headline: 'We can’t give you access to Vets.gov health tools right now',
+      headline: `We can’t give you access to ${siteName} health tools right now`,
       content: (
         <p>
           We’re sorry. Something went wrong on our end that’s preventing you
@@ -290,12 +291,12 @@ export class MHVApp extends React.Component {
 
   renderUpgradeFailedMessage() {
     const alertProps = {
-      headline: 'We can’t give you access to Vets.gov health tools right now',
+      headline: `We can’t give you access to ${siteName} health tools right now`,
       content: (
         <p>
           We’re sorry. We started the process of creating the MyHealth
           <em>e</em>
-          Vet account you’ll need to access the Vets.gov health tools, but
+          Vet account you’ll need to access the {siteName} health tools, but
           something went wrong on our end before we could complete it. We’ve
           created your MyHealth
           <em>e</em>


### PR DESCRIPTION
## Description
In files that are shared between Vets.gov and VA.gov, we need to render the site name conditionally. 

### Tickets
Moves to validate - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14141

## Testing done
- Unit tests, many of which use the hardcoded "Vets.gov" string and would fail if "VA.gov" were rendered instead
- Checked the site manually

## Screenshots
Ignore the top title - that's an image and will have to be updated separately.

### Vets.gov
![image](https://user-images.githubusercontent.com/1915775/46878510-7e16f600-ce11-11e8-8c9c-e7f706aa12d7.png)

### VA.gov
![image](https://user-images.githubusercontent.com/1915775/46878589-ae5e9480-ce11-11e8-8b65-fa07c2fed562.png)

## Acceptance criteria
- [x] "VA.gov" is rendered as the site name in shared assets when running under a VA.gov domain
- [x] "Vets.gov" is rendered as the site name in shared assets when running under a Vets.gov domain

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
