### PR TITLE
Footer - Add scorecard link; change privacy title

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -228,6 +228,13 @@
     "href": "/privacy/",
     "order": 3,
     "target": null,
-    "title": "Privacy Policy"
+    "title": "Privacy, Policies, and Legal Information"
+  },
+  {
+    "column": "bottom_rail",
+    "href": "/scorecard/",
+    "order": 4,
+    "target": null,
+    "title": "VA.gov Scorecard"
   }
 ]


### PR DESCRIPTION
## Description
This PR updates the footer links to match the privacy page title and add the scorecard.

Moves to validate - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13937

## Testing done
Looked at the footer 🙂 

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/46886874-1de07e00-ce2a-11e8-8b27-39cd3d0caca2.png)


## Acceptance criteria
- [x] Footer is updated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
