### PR TITLE
Remove additional va-crisis-line top

### DIFF
--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -18,7 +18,6 @@ header.merger {
   z-index: 300;
 
   .va-crisis-line {
-    top: 20px;
 
     button.va-crisis-line-button {
       background-image: none;


### PR DESCRIPTION
## Description
These changes remove an additional `top` for `va-crisis-line`.

## Testing done
- verified locally via proxy

## Screenshots
![image](https://user-images.githubusercontent.com/16051172/46889591-051b9c80-ce19-11e8-91b3-7f833f08ead7.png)


## Acceptance criteria
- [x] Make VA crisis line placement on `preview.va.gov/health` consistent.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
