### PR TITLE
Va gov/content wip vets to va updates 2

### DIFF
--- a/va-gov/components/react-loader.html
+++ b/va-gov/components/react-loader.html
@@ -5,7 +5,7 @@
         <div class="csp-inline-patch-page-react">
         <h3>{{ maintenance_line1 }}</h3>
         <h4>{{ maintenance_line2 }}</h4>
-        <a href="/"><button>Go back to Vets.gov</button></a>
+        <a href="/"><button>Go back to VA.gov</button></a>
         </div>
       </div>
     </div>

--- a/va-gov/includes/common-and-popular.html
+++ b/va-gov/includes/common-and-popular.html
@@ -14,7 +14,7 @@
     </ul>
   </div>
   <div class="small-12 usa-width-one-half medium-6 columns">
-    <h3 class="va-h-ruled">Popular on vets.gov</h3>
+    <h3 class="va-h-ruled">Popular on VA.gov</h3>
     <ul class="va-list--plain">
       <li><a href="/facilities/">Find nearby VA locations</a></li>
       <li>

--- a/va-gov/includes/homepage-warning.html
+++ b/va-gov/includes/homepage-warning.html
@@ -1,8 +1,8 @@
 <div id="top-of-page-alert-container">
   <div id="top-of-page-alert" class="usa-alert usa-alert-warning">
       <div class="usa-alert-body">
-          <h4 class="usa-alert-heading">Some Vets.gov tools and features may not be working as expected</h4>
-          <p class="usa-alert-text">We’re sorry. We’re working to fix some problems with DS Logon right now. Please check back later or call the Vets.gov Help Desk for more information at <a href="tel:1-855-574-7286">1-855-574-7286</a>, TTY: <a href="tel:1-800-877-8339">1-800-877-8339</a>.</p>
+          <h4 class="usa-alert-heading">Some VA.gov tools and features may not be working as expected</h4>
+          <p class="usa-alert-text">We’re sorry. We’re working to fix some problems with DS Logon right now. Please check back later or call the VA.gov Help Desk for more information at <a href="tel:1-855-574-7286">1-855-574-7286</a>, TTY: <a href="tel:1-800-877-8339">1-800-877-8339</a>.</p>
       </div>
   </div>
 </div>

--- a/va-gov/pages/404.md
+++ b/va-gov/pages/404.md
@@ -1,7 +1,7 @@
 ---
 layout: home-no-search.html
 body_class: fourohfour
-title: Vets.gov
+title: VA.gov
 majorlinks:
   - url: /disability/
     title: Disability Benefits

--- a/va-gov/pages/account/index.md
+++ b/va-gov/pages/account/index.md
@@ -1,5 +1,5 @@
 ---
-title: Your Vets.gov Account
+title: Your VA.gov Account
 layout: page-react.html
 entryname: account
 ---

--- a/va-gov/pages/analytics-opt-out.md
+++ b/va-gov/pages/analytics-opt-out.md
@@ -13,9 +13,9 @@ private: true
       <div class="small-12 columns">
         <div style="padding: 2em 0;">
         <h3>Analytics Opt-out</h3>
-        <h4>Click the below button to opt out of the vets.gov Google Analytics collection.</h4>
+        <h4>Click the below button to opt out of the VA.gov Google Analytics collection.</h4>
         <p>This opt-out is will endure for this device/browser combination as long as you do not remove/reset your cookies. If you use multiple browsers or devices, you will need to opt out once for each device/browser combination to fully exclude yourself.</p>
-        <p>The intended use case of this opt-out is for Vets.gov team members performing testing or validation in the production environment with their personal devices. Other uses are not recommended. The only way to re-enable Vets.gov Google Analytics collection is to clear the browser cookies. Therefore, this is not recommended for use on any shared devices.</p>
+        <p>The intended use case of this opt-out is for VA.gov team members performing testing or validation in the production environment with their personal devices. Other uses are not recommended. The only way to re-enable VA.gov Google Analytics collection is to clear the browser cookies. Therefore, this is not recommended for use on any shared devices.</p>
         <button class="usa-button-primary" onClick="recordEvent({ event: 'analytics-opt-out', 'internal-user': 'true' }); event.target.classList = ['usa-button-disabled']; event.target.innerText='Opted out'">Opt out</button>
         </div>
       </div>

--- a/va-gov/pages/beta-enrollment/claim-increase.md
+++ b/va-gov/pages/beta-enrollment/claim-increase.md
@@ -23,11 +23,11 @@ We invite you to use our new beta tool—an online application for increased dis
 
 ### What’s a beta tool?
 
-A beta tool is a new tool we’re testing to make sure it works the way it should before we give all Vets.gov users access to it. Your feedback will help us make the tool better for all Veterans.
+A beta tool is a new tool we’re testing to make sure it works the way it should before we give all VA.gov users access to it. Your feedback will help us make the tool better for all Veterans.
 
 ### What will happen when I try the new tool?
 
-When you agree to test out the new tool, you’ll use our online application to file a claim for increased disability compensation. You’ll have the same access to all the other Vets.gov tools and information as you have right now.
+When you agree to test out the new tool, you’ll use our online application to file a claim for increased disability compensation. You’ll have the same access to all the other VA.gov tools and information as you have right now.
 
 You’ll need to be signed in to your verified DS Logon or My HealtheVet account. If you don’t have one of these accounts, you can create an ID.me account to complete the verification process.
 

--- a/va-gov/pages/dummy-placeholder.md
+++ b/va-gov/pages/dummy-placeholder.md
@@ -1,7 +1,7 @@
 ---
 layout: home.html
 body_class: fourohfour
-title: Vets.gov
+title: VA.gov
 permalink: false
 private: true
 ---

--- a/va-gov/pages/faq.md
+++ b/va-gov/pages/faq.md
@@ -1,47 +1,47 @@
 ---
 layout: page.html
 permalink: /faq.html
-title: Frequently Asked Questions about Signing In to Vets.gov
+title: Frequently Asked Questions about Signing In to VA.gov
 display_title: Frequently Asked Questions
 ---
 
 <main itemscope itemtype="http://schema.org/FAQPage">
   <div class="row">
     <article class="usa-content columns faq-page">
-      <h1>Frequently Asked Questions (FAQ) about Signing In to Vets.gov</h1>
+      <h1>Frequently Asked Questions (FAQ) about Signing In to VA.gov</h1>
       <div class="main home signup" role="main">
         <div class="section main-menu">
           <div class="row">
             <div class="small-12 columns">
               <div itemprop="description">
                 <p>
-                  Get answers to common questions about signing in to Vets.gov (a VA website) to manage your benefits and services online. Find out how to sign in with your existing <strong>My HealtheVet</strong> or <strong>DS Logon</strong> account—or how to use ID.me to create your account.
+                  Get answers to common questions about signing in to VA.gov (a VA website) to manage your benefits and services online. Find out how to sign in with your existing <strong>My HealtheVet</strong> or <strong>DS Logon</strong> account—or how to use ID.me to create your account.
                 </p>
               </div>
               <div class="feature">
                 <h4>Need help?</h4>
                 <p>
-                  Please call the Vets.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a> (TTY: <a href="tel:+18008778339"> 1-800-877-8339</a>). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. (<abbr title="eastern time">ET</abbr>).
+                  Please call the VA.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a> (TTY: <a href="tel:+18008778339"> 1-800-877-8339</a>). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. (<abbr title="eastern time">ET</abbr>).
                 </p>
               </div>
             </div>
           </div>
           <div class="row">
             <div class="small-12 columns">
-              <h4>Signing in to Vets.gov</h4>
+              <h4>Signing in to VA.gov</h4>
               <div class="usa-accordion" aria-multiselectable="true">
                 <ul class="usa-unstyled-list">
                   <li markdown="1" itemscope itemtype="http://schema.org/Question">
-                    <button class="usa-button-unstyled usa-accordion-button" aria-controls="faq-vetsgov-0" itemprop="name">How do I sign in to Vets.gov? </button>
+                    <button class="usa-button-unstyled usa-accordion-button" aria-controls="faq-vetsgov-0" itemprop="name">How do I sign in to VA.gov? </button>
                     <div id="faq-vetsgov-0" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
-                        <p><strong>You can sign in to Vets.gov in 1 of 3 ways:</strong></p>
+                        <p><strong>You can sign in to VA.gov in 1 of 3 ways:</strong></p>
                         <ul>
                           <li>With your existing <strong>My HealtheVet</strong> account, <strong>or</strong></li>
                           <li>With your existing <strong>DS Logon</strong> account, <strong>or</strong></li>
                           <li>By creating an account through ID.me (a trusted partner)</li>
                         </ul>
-                        <p><strong>Note:</strong> If you have a premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account, using it to sign in is the easiest way to get access to all Vets.gov tools. Because you already verified your identity when you got your premium account, you won’t need to verify your identity again before doing common tasks on Vets.gov, like checking your claims status or sending a secure message to your health care team.</p>
+                        <p><strong>Note:</strong> If you have a premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account, using it to sign in is the easiest way to get access to all VA.gov tools. Because you already verified your identity when you got your premium account, you won’t need to verify your identity again before doing common tasks on VA.gov, like checking your claims status or sending a secure message to your health care team.</p>
                         <p><a href="/faq/" class="login-required">Sign in now</a>.</p>
                       </div>
                     </div>
@@ -49,14 +49,14 @@ display_title: Frequently Asked Questions
                 </ul>
                 <br/>
                 <a name="verifying-your-identity"></a>
-                <h4>Verifying your identity on Vets.gov</h4>
+                <h4>Verifying your identity on VA.gov</h4>
                 <ul class="usa-unstyled-list">
                   <li markdown="1" itemscope itemtype="http://schema.org/Question">
                     <button class="usa-button-unstyled usa-accordion-button" aria-controls="faq-verify-0" itemprop="name">How do I verify my identity online? </button>
                     <div id="faq-verify-0" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
                         <h4>Fastest way to verify your identity online</h4>
-                        <p>If you have a premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account, you can use your existing account to sign in. Because you already verified your identity when you got your premium account, you won’t need to verify your identity again before doing common tasks on Vets.gov, like checking your claims status or sending a secure message to your health care team.</p>
+                        <p>If you have a premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account, you can use your existing account to sign in. Because you already verified your identity when you got your premium account, you won’t need to verify your identity again before doing common tasks on VA.gov, like checking your claims status or sending a secure message to your health care team.</p>
                         <p><a href="/faq/" class="login-required">Sign in now</a>.</p>
                         <h4>How to verify your identity online if you don’t have an existing premium account</h4>
                         <p>If you don’t have a premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account, we’ll help you verify your identity using ID.me—a trusted partner that provides the strongest identity verification system available to prevent fraud and identity theft.</p>
@@ -80,7 +80,7 @@ display_title: Frequently Asked Questions
                       <div itemprop="text">
                         <p>Yes. You can verify your identity in person at your nearest VA regional office. If you’re a VA patient, you can also verify your identity in person at your local VA health care facility.</p>
                         <h4>Verifying your identity in person at a VA regional office</h4>
-                        <p>You can verify your identity at your nearest VA regional office as part of the process of getting a premium <strong>DS Logon</strong> account. You can then use this account to sign in to Vets.gov without having to verify your identity online.</p>
+                        <p>You can verify your identity at your nearest VA regional office as part of the process of getting a premium <strong>DS Logon</strong> account. You can then use this account to sign in to VA.gov without having to verify your identity online.</p>
                         <p><strong>You’ll need to:</strong></p>
                         <ul>
                           <li>Bring 2 forms of ID that meet the requirements of the U.S. Citizenship and Immigration Services Form I-9. Accepted forms of ID include an unexpired U.S. passport and a current driver’s license.<br/>
@@ -91,7 +91,7 @@ display_title: Frequently Asked Questions
                         <p><a href="/facilities/">Find a VA regional office near you</a>.</p>
                         <p><a href="https://myaccess.dmdc.osd.mil/identitymanagement/consent?continueToUrl=%2Fidentitymanagement%2Fauthenticate.do%3Fexecution%3De4s1">Visit the DS Logon self-service website</a>.
                         <h4>Verifying your identity in person if you’re a VA patient</h4>
-                        <p>If you’re a VA patient, you can verify your identity at your local VA health care facility as part of the process of getting a premium <strong>My HealtheVet</strong> account. You can then use this account to sign in to Vets.gov without having to verify your identity online.</p>
+                        <p>If you’re a VA patient, you can verify your identity at your local VA health care facility as part of the process of getting a premium <strong>My HealtheVet</strong> account. You can then use this account to sign in to VA.gov without having to verify your identity online.</p>
                         <p><strong>You’ll need to bring:</strong></p>
                         <ul>
                           <li><strong>An Individuals’ Request for a Copy of Their Own Health Information (VA Form 10-5345a-MHV).</strong> You can download a PDF copy of this “VA release of information” form now, call ahead to ask the staff to mail you a form, or ask for a form when you get there.<br/>
@@ -108,7 +108,7 @@ display_title: Frequently Asked Questions
                     <button class="usa-button-unstyled usa-accordion-button" aria-controls="faq-verify-2" itemprop="name">Can I verify my identity by phone? </button>
                     <div id="faq-verify-2" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
-                        <p>If you can’t verify your identity online or get to a VA regional office to do it in person, you may be able to verify your identity by phone as part of the process of getting a premium <strong>DS Logon</strong> account. You can then use this account to sign in to Vets.gov without having to verify your identity online.</p>
+                        <p>If you can’t verify your identity online or get to a VA regional office to do it in person, you may be able to verify your identity by phone as part of the process of getting a premium <strong>DS Logon</strong> account. You can then use this account to sign in to VA.gov without having to verify your identity online.</p>
                         <p>You can only use this method to verify your identity if you’ve received a VA direct deposit payment by Electronic Fund Transfer (EFT), like a disability compensation or pension payment.</p>
                         <p>To get started, call us at <a href="tel:+1phonenumber">1-800-827-1000</a>. When you’re prompted to give a reason for your call, say, “eBenefits.”</p>
                         <p><strong>You’ll need to have this information ready:</strong></p>
@@ -130,7 +130,7 @@ display_title: Frequently Asked Questions
                     <button class="usa-button-unstyled usa-accordion-button" aria-controls="faq-trouble-0" itemprop="name">If I can’t or don’t want to verify my identity through ID.me, what are my other options? </button>
                     <div id="faq-trouble-0" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
-                        <p>You can use a premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account to sign in to Vets.gov with a verified account. Because you already verified your identity when you got your premium account, you won’t need to verify your identity again on Vets.gov.</p>
+                        <p>You can use a premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account to sign in to VA.gov with a verified account. Because you already verified your identity when you got your premium account, you won’t need to verify your identity again on VA.gov.</p>
                         <h4>How to get a premium DS Logon account</h4>
                         <p>Follow these 2 steps to sign up for a premium <strong>DS Logon</strong> account.</p>
                         <p><strong>1. First, make sure you’re enrolled in the Defense Enrollment Eligibility Reporting System (DEERS).</strong> This is the database that records all the people who are eligible for military benefits.</p>
@@ -246,11 +246,11 @@ display_title: Frequently Asked Questions
                     <button class="usa-button-unstyled usa-accordion-button" aria-controls="faq-trouble-6" itemprop="name">I don’t want to add 2-factor authentication. Do I have to? </button>
                     <div id="faq-trouble-6" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
-                        <p>It depends on how you sign in to Vets.gov.</p>
+                        <p>It depends on how you sign in to VA.gov.</p>
                         <ul>
-                          <li><strong>If you set up a verified Vets.gov account through ID.me,</strong> you need to set up 2-factor authentication. Authentication gives you an extra layer of security by letting you into your account only after you’ve signed in with a password and a 6-digit code sent directly to your mobile or home phone. This helps to make sure that no one but you can access your account—even if they get your password.</li>
-                          <li><strong>If you sign in to Vets.gov using your existing premium My HealtheVet or premium DS Logon account,</strong> setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your Vets.gov profile page.</li>
-                          <li><strong>If you sign in to Vets.gov using your existing basic or advanced My HealtheVet or basic DS Logon account and don’t want to verify your identity,</strong> you don’t need to add 2-factor authentication. But you won’t be able to use the site’s tools that require you to verify your identity and do common tasks, like checking your claims status or sending a secure message to your health care team.</li>
+                          <li><strong>If you set up a verified VA.gov account through ID.me,</strong> you need to set up 2-factor authentication. Authentication gives you an extra layer of security by letting you into your account only after you’ve signed in with a password and a 6-digit code sent directly to your mobile or home phone. This helps to make sure that no one but you can access your account—even if they get your password.</li>
+                          <li><strong>If you sign in to VA.gov using your existing premium My HealtheVet or premium DS Logon account,</strong> setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your VA.gov profile page.</li>
+                          <li><strong>If you sign in to VA.gov using your existing basic or advanced My HealtheVet or basic DS Logon account and don’t want to verify your identity,</strong> you don’t need to add 2-factor authentication. But you won’t be able to use the site’s tools that require you to verify your identity and do common tasks, like checking your claims status or sending a secure message to your health care team.</li>
                       </div>
                     </div>
                   </li>
@@ -258,22 +258,22 @@ display_title: Frequently Asked Questions
                 <br/>
                 <a name="why-verify"></a>
                 <a name="what-is-idme"></a>
-                <h4>Privacy and security on Vets.gov</h4>
+                <h4>Privacy and security on VA.gov</h4>
                 <ul class="usa-unstyled-list">
                   <li markdown="1" itemscope itemtype="http://schema.org/Question">
-                    <button class="usa-button-unstyled usa-accordion-button" aria-controls="faq-security-0" itemprop="name">Why should I trust Vets.gov? </button>
+                    <button class="usa-button-unstyled usa-accordion-button" aria-controls="faq-security-0" itemprop="name">Why should I trust VA.gov? </button>
                     <div id="faq-security-0" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
-                        <p>Vets.gov is an official, secure VA government website, built and maintained by U.S. Department of Veterans Affairs employees and contractors under the direction of the VA Office of the Secretary. As with all VA websites, we follow strict security policies and practices to make sure that your personal information is safe and protected.</p>
-                        <p>When you sign in to Vets.gov, we’ll protect your personal information by using the strongest identity verification system available to prevent fraud and identity theft. We’ll also give you the option to set up an extra layer of security (called 2-factor authentication) on your account. This helps to make sure that no one but you can access your account—even if they get your password.</p>
-                        <p>We’ve built Vets.gov to help you better access our agency’s vast digital system—so you can easily find, apply for, track, and manage the benefits and services you’ve earned. We test all site content and tools with Veterans and make changes based on their feedback. We welcome your feedback too.</p>
-                          <p><a href="#feedback-tool" onclick="document.getElementById('feedback-tool').click()">Provide feedback on Vets.gov</a>.</p>
+                        <p>VA.gov is an official, secure VA government website, built and maintained by U.S. Department of Veterans Affairs employees and contractors under the direction of the VA Office of the Secretary. As with all VA websites, we follow strict security policies and practices to make sure that your personal information is safe and protected.</p>
+                        <p>When you sign in to VA.gov, we’ll protect your personal information by using the strongest identity verification system available to prevent fraud and identity theft. We’ll also give you the option to set up an extra layer of security (called 2-factor authentication) on your account. This helps to make sure that no one but you can access your account—even if they get your password.</p>
+                        <p>We’ve built VA.gov to help you better access our agency’s vast digital system—so you can easily find, apply for, track, and manage the benefits and services you’ve earned. We test all site content and tools with Veterans and make changes based on their feedback. We welcome your feedback too.</p>
+                          <p><a href="#feedback-tool" onclick="document.getElementById('feedback-tool').click()">Provide feedback on VA.gov</a>.</p>
                       </div>
                     </div>
                   </li>
                   <li markdown="1" itemscope itemtype="http://schema.org/Question">
                     <button class="usa-button-unstyled usa-accordion-button" aria-controls="faq-security-1" itemprop="name">
-                      Why do I need to verify my identity to use advanced tools and services on Vets.gov?
+                      Why do I need to verify my identity to use advanced tools and services on VA.gov?
                     </button>
                     <div id="faq-security-1" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
@@ -297,7 +297,7 @@ display_title: Frequently Asked Questions
                         <p>When you create an account, ID.me will ask you to provide personal information, like your name, date of birth, address, or other details. ID.me will also ask you to either upload a picture of your driver’s license or passport or answer questions based on your public and private data (like your credit report) that only you’d know how to answer. This is to help make sure you're you—and not someone pretending to be you.</p>
                         <p>With your permission, ID.me will share this information with the Department of Veterans Affairs so we can give you access to your VA health records and benefit information. ID.me will never share your information with anyone else without asking for your permission.</p>
                         <p>ID.me protects all sensitive data with AES 256-bit encryption at rest and RSA 2048-bit encryption in transit. Their information security protections are stronger than many financial institutions. To learn more about how your personal information will be kept safe, read our privacy policy and ID.me’s privacy policy.</p>
-                        <p><a href="/privacy/">View the Vets.gov privacy policy</a>.</p>
+                        <p><a href="/privacy/">View the VA.gov privacy policy</a>.</p>
                         <p><a href="https://wallet.id.me/privacy">View the ID.me privacy policy</a>.</p>
                       </div>
                     </div>
@@ -307,8 +307,8 @@ display_title: Frequently Asked Questions
                     <div id="faq-idme-security-4" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
                         <p>This code is part of the 2-factor authentication process.</p>
-                        <p>When you set up a verified Vets.gov account through ID.me, you need to set up 2-factor authentication. Authentication gives you an extra layer of security by letting you into your account only after you’ve signed in with a password and a 6-digit code sent directly to your mobile or home phone. This helps to make sure that no one but you can access your account—even if they get your password.<p>
-                        <p>If you sign in to Vets.gov using your existing basic or advanced <strong>My HealtheVet</strong> or basic <strong>DS Logon</strong> account and don’t want to verify your identity, or if you sign in using your existing premium <strong>My Health <em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your Vets.gov profile page.<p>
+                        <p>When you set up a verified VA.gov account through ID.me, you need to set up 2-factor authentication. Authentication gives you an extra layer of security by letting you into your account only after you’ve signed in with a password and a 6-digit code sent directly to your mobile or home phone. This helps to make sure that no one but you can access your account—even if they get your password.<p>
+                        <p>If you sign in to VA.gov using your existing basic or advanced <strong>My HealtheVet</strong> or basic <strong>DS Logon</strong> account and don’t want to verify your identity, or if you sign in using your existing premium <strong>My Health <em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your VA.gov profile page.<p>
                       </div>
                     </div>
                   </li>

--- a/va-gov/pages/health-beta/index.md
+++ b/va-gov/pages/health-beta/index.md
@@ -1,5 +1,5 @@
 ---
-title: Your Vets.gov Account
+title: Your VA.gov Account
 layout: page-react.html
 entryname: health-beta
 private: true

--- a/va-gov/pages/health-care/after-you-apply.md
+++ b/va-gov/pages/health-care/after-you-apply.md
@@ -86,7 +86,7 @@ Contact your local VA medical center or clinic and ask for:
 
 If you want to know more about your VA health care benefits, your health care team, and where you’ll go for care, we can help. [Learn more about your VA health care coverage](/health-care/about-va-health-benefits/).
 
-If you’re signed up for VA health care, you can manage your VA health and benefits online through Vets.gov: <br />
+If you’re signed up for VA health care, you can manage your VA health and benefits online through VA.gov: <br />
 [Refill your prescriptions](/health-care/refill-track-prescriptions). <br />
 [Send a secure message to your health care team](/health-care/secure-messaging). <br />
 [Check the status of a disability or pension claim](/track-claims/).

--- a/va-gov/pages/health-care/health-needs-conditions.md
+++ b/va-gov/pages/health-care/health-needs-conditions.md
@@ -111,7 +111,7 @@ If you need help accessing services, call our toll-free hotline at 1-877-222-VET
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
 <div itemprop="text">
 
-Yes. If you’re signed up for the VA health care program, you can manage your VA health and benefits online through Vets.gov: <br>
+Yes. If you’re signed up for the VA health care program, you can manage your VA health and benefits online through VA.gov: <br>
 [Refill your prescriptions](/health-care/refill-track-prescriptions). <br>
 [Send a message to your VA health care provider](/health-care/secure-messaging). <br>
 [Check the status of a disability or pension claim](/track-claims/).

--- a/va-gov/pages/health-care/health-needs-conditions/military-sexual-trauma.md
+++ b/va-gov/pages/health-care/health-needs-conditions/military-sexual-trauma.md
@@ -124,8 +124,8 @@ Or get help applying for disability compensation by:
   - [In Spanish](https://www.mentalhealth.va.gov/docs/mst/Strength_Recovery-Men_Overcoming_MST_Spanish_508.pdf)
 - Watch a video about MST, its effects on survivors, and VA services available to Veterans who’ve experienced MST. <br>
 [Watch the video](https://www.youtube.com/watch?v=b9snig5gZfk).
-- Access more fact sheets, articles, and resources, and learn more about our programs and services on the VA.gov website.<br>
-[Go to the VA.gov MST website](https://www.mentalhealth.va.gov/msthome.asp).
+- Access more fact sheets, articles, and resources, and learn more about our programs and services on our mental health website.<br>
+[Go to our mental health website](https://www.mentalhealth.va.gov/msthome.asp).
 - Go to our Make the Connection website to hear stories from Veterans about their own experiences with the effects of MST, and find more resources and support.<br>
 <a href="http://maketheconnection.net/" class="no-external-icon">Visit Make the Connection</a>
 - Go to the Department of Defense (DoD) Safe Helpline website, a crisis support service for members of the DOD community affected by sexual assault. When you contact the Safe Helpline, you can remain anonymous (meaning you don’t have to give your name). You can get 1-on-1 advice, support, and information 24/7—by phone, text, or online chat. You can also connect with a sexual assault response coordinator near your base or installation.<br>

--- a/va-gov/pages/id-card-beta/index.md
+++ b/va-gov/pages/id-card-beta/index.md
@@ -1,5 +1,5 @@
 ---
-title: Your Vets.gov Account
+title: Your VA.gov Account
 layout: page-react.html
 entryname: id-card-beta
 ---

--- a/va-gov/pages/logout.md
+++ b/va-gov/pages/logout.md
@@ -9,7 +9,7 @@ private: true
     <div class="row">
       <div class="small-12 columns">
         <div class="csp-inline-patch-logout">
-        <h3>Signing out of Vets.gov...</h3>
+        <h3>Signing out of VA.gov...</h3>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description
This work is continued from https://github.com/department-of-veterans-affairs/vets-website/pull/8534. That PR's scope was reduced to being only the `va-gov` directory, because `content` belong to Vets.gov-only and `src` must be update by an engineer because it's shared with Vets.gov and changes must be compatible. This PR was generated via find-and-replace for "vets.gov" with "va.gov", then sifting through the results to ensure no side effects.

## Acceptance criteria
- [x] "vets.gov" has been replaced with "va.gov" throughout `va-gov` directory

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
