### PR TITLE
Remove banner role inside header

### DIFF
--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -61,7 +61,7 @@ export default `
   <!-- /header alert box -->
 
   <div class="row va-flex usa-grid" id="va-header-logo-menu">
-    <div role="banner" class="va-header-logo-wrapper">
+    <div class="va-header-logo-wrapper">
       <a href="/" class="va-header-logo" title="Go to VA.gov">
       <img src="/img/header-logo.png"/>
       </a>

--- a/va-gov/includes/top-nav.html
+++ b/va-gov/includes/top-nav.html
@@ -26,7 +26,7 @@
   <!-- /header alert box -->
 
   <div class="row va-flex usa-grid usa-grid-full" id="va-header-logo-menu">
-    <div role="banner" class="va-header-logo-wrapper">
+    <div class="va-header-logo-wrapper">
       <a href="/" class="va-header-logo">
       <img src="/img/header-logo.png" alt="Go to VA.gov"/>
       </a>


### PR DESCRIPTION
## Description

We shouldn't have both a `header` element and an element with the role of `banner`. This removes the banner role from the div it was on.

## Testing done
Checked that site looks ok, searched for styles referencing banner.

## Acceptance criteria
- [x] Site looks fine
- [x] Only one banner landmark

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
