### PR TITLE
Va gov/content-WIP-GIBS-crosslinks

### DIFF
--- a/va-gov/pages/education/about-gi-bill-benefits.md
+++ b/va-gov/pages/education/about-gi-bill-benefits.md
@@ -66,7 +66,7 @@ aliases:
 
 Since 1944, the GI Bill has helped millions of Veterans pay for college, graduate school, and training programs. Under this bill, qualifying Veterans and their family members can get money to cover all or some of the costs for school or training. Learn more about these benefits below—and how to apply for them.
 
-If you served on active duty after September 10, 2001, you may qualify for Post-9/11 GI Bill education benefits. You can check to see if you have Post-9/11 GI Bill benefits. [View and print your benefits summary](/education/gi-bill/post-9-11/ch-33-benefit).
+If you applied for and were awarded Post-9/11 GI Bill education benefits, your GI Bill Statement of Benefits will show you how much of your benefits you’ve used and how much you have left to use. [View your GI Bill Statement of Benefits](/education/gi-bill/post-9-11/ch-33-benefit).
 
 The GI Bill Comparison Tool and Veterans Service Organizations can help you explore options and find out what benefits you can get. [Find a Veterans Service Organization](https://www.va.gov/vso/).
 

--- a/va-gov/pages/education/about-gi-bill-benefits/post-9-11.md
+++ b/va-gov/pages/education/about-gi-bill-benefits/post-9-11.md
@@ -118,6 +118,7 @@ The benefit amount depends on which school you go to, how much active-duty servi
  <h3 itemprop="name">How do I know how much of my Post-9/11 GI Bill benefits are left?</h3>
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
 <div itemprop="text">
+  
 If you already applied for and were awarded Post-9/11 GI Bill education benefits, your GI Bill Statement of Benefits will show you how much of your benefits you’ve used and how much you have left to use. <br>
 [View your GI Bill Statement of Benefits](/education/gi-bill/post-9-11/ch-33-benefit). 
 

--- a/va-gov/pages/education/about-gi-bill-benefits/post-9-11.md
+++ b/va-gov/pages/education/about-gi-bill-benefits/post-9-11.md
@@ -79,18 +79,6 @@ Post-9/11 GI Bill benefits expire 15 years after your last separation date from 
 </div>
 </div>
 
-<div itemscope itemtype="http://schema.org/Question">
-
-<h3 itemprop="name">Do I have Post-9/11 GI Bill benefits?</h3>
-<div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
-<div itemprop="text">
-
-You can check to see if you have Post-9/11 GI Bill benefits. <br>
-[View and print your statement of benefits](/education/gi-bill/post-9-11/ch-33-benefit).
-
-</div>
-</div>
-</div>
 
 -------
 
@@ -126,6 +114,16 @@ The benefit amount depends on which school you go to, how much active-duty servi
 </div>
 </div>
 
+<div itemscope itemtype="http://schema.org/Question">
+ <h3 itemprop="name">How do I know how much of my Post-9/11 GI Bill benefits are left?</h3>
+<div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
+<div itemprop="text">
+If you already applied for and were awarded Post-9/11 GI Bill education benefits, your GI Bill Statement of Benefits will show you how much of your benefits you’ve used and how much you have left to use. <br>
+[View your GI Bill Statement of Benefits](/education/gi-bill/post-9-11/ch-33-benefit). 
+
+</div>
+</div>
+</div>
 
 <div itemscope itemtype="http://schema.org/Question">
 

--- a/va-gov/pages/education/eligibility.md
+++ b/va-gov/pages/education/eligibility.md
@@ -31,9 +31,6 @@ You may be able to get benefits through the Post-9/11 GI Bill if you've served o
 [Learn more about the Post-9/11 GI Bill](/education/about-gi-bill-benefits/post-9-11/).
 <br>
 
-You can check to see if you have Post-9/11 GI Bill benefits. <br>
-[View and print your statement of benefits](/education/gi-bill/post-9-11/ch-33-benefit).
-
 </div>
 </div>
 


### PR DESCRIPTION
## Description
Update the crosslinks to the GIBS static page to make them more clear that a GIBS statement of benefits will only be available for a user if they've been rewarded education benefits.

 - [x] Remove crosslink on the eligibility page (https://www.vets.gov/education/eligibility/)
- [x] Update crosslink on https://www.vets.gov/education/gi-bill/  TO:
If you applied for and were awarded Post-9/11 GI Bill education benefits, your GI Bill Statement of Benefits will show you how much of your benefits you’ve used and how much you have left to use. 
[View your GI Bill Statement of Benefits](/education/gi-bill/post-9-11/ch-33-benefit/).
- [x] Move crosslink lower on https://www.vets.gov/education/gi-bill/post-9-11/ to below "What benefits does the Post-9/11 GI Bill include?" 
And update content to: 
**How do I know how much of my Post-9/11 GI Bill benefits are left?**
If you already applied for and were awarded Post-9/11 GI Bill education benefits, your GI Bill Statement of Benefits will show you how much of your benefits you’ve used and how much you have left to use. 
[View your GI Bill Statement of Benefits](/education/gi-bill/post-9-11/ch-33-benefit/).


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
