### PR TITLE
Removes PIV card link, and re-orders footer links

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -99,29 +99,22 @@
   },
   {
     "column": 2,
-    "href": "https://www.oit.va.gov/programs/piv/",
-    "order": 8,
-    "target": "_blank",
-    "title": "VA Information Technology and PIV Card"
-  },
-  {
-    "column": 2,
     "href": "https://www.va.gov/vso/",
-    "order": 9,
+    "order": 8,
     "target": null,
     "title": "Veterans Service Organizations (VSO)"
   },
   {
     "column": 2,
     "href": "https://www.va.gov/statedva.htm",
-    "order": 10,
+    "order": 9,
     "target": null,
     "title": "State Veterans Affairs Offices"
   },
   {
     "column": 2,
     "href": "/welcome-kit/",
-    "order": 11,
+    "order": 10,
     "target": null,
     "title": "Print Your VA Welcome Kit"
   },


### PR DESCRIPTION
## Description
Remove the VA Information Technology and PIV Card link from the More VA Resources column in the footer. The Footer tab in the TopNav-Hub Links spreadsheet has been updated to reflect the change.

## Testing done
Tested locally after running `yarn watch:devpreview`

## Screenshots
![image](https://user-images.githubusercontent.com/7482329/46980980-9dbd5100-d093-11e8-93cd-ab2fd694efca.png)


## Acceptance criteria
- [x] Removes `VA Information Technology and PIV Card` link from footer

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
