### PR TITLE
Va gov/13889 my healthevet two words

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -95,8 +95,8 @@ export class AuthApp extends React.Component {
               </p>
               <p>
                 Please try again and click “Accept” on the final page. Or, you
-                can try signing in with your premium DS Logon or premium
-                My HealtheVet account instead of identity proofing with ID.me.
+                can try signing in with your premium DS Logon or premium My
+                HealtheVet account instead of identity proofing with ID.me.
               </p>
             </div>
           ),

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -96,7 +96,7 @@ export class AuthApp extends React.Component {
               <p>
                 Please try again and click “Accept” on the final page. Or, you
                 can try signing in with your premium DS Logon or premium
-                MyHealtheVet account instead of identity proofing with ID.me.
+                My HealtheVet account instead of identity proofing with ID.me.
               </p>
             </div>
           ),

--- a/src/applications/personalization/account/components/AccountMain.jsx
+++ b/src/applications/personalization/account/components/AccountMain.jsx
@@ -102,7 +102,7 @@ class AccountMain extends React.Component {
               <h3>Sign in settings</h3>
               <p>
                 You can update the email or password you use to sign in to
-                VA.gov. Just go to the account you use to sign in (DS Logon,
+                VA.gov. Just go to the account you use to sign in (DS Logon, My
                 My HealtheVet, or ID.me) and manage your settings.
               </p>
             </div>

--- a/src/applications/personalization/account/components/AccountMain.jsx
+++ b/src/applications/personalization/account/components/AccountMain.jsx
@@ -103,7 +103,7 @@ class AccountMain extends React.Component {
               <p>
                 You can update the email or password you use to sign in to
                 VA.gov. Just go to the account you use to sign in (DS Logon,
-                MyHealtheVet, or ID.me) and manage your settings.
+                My HealtheVet, or ID.me) and manage your settings.
               </p>
             </div>
             <div>
@@ -116,9 +116,9 @@ class AccountMain extends React.Component {
               </a>
             </div>
             <div>
-              <h5>MyHealtheVet</h5>
+              <h5>My HealtheVet</h5>
               <a href="https://www.myhealth.va.gov" target="_blank">
-                Manage your MyHealtheVet account
+                Manage your My HealtheVet account
               </a>
             </div>
           </div>

--- a/src/applications/personalization/account/components/LoginSettings.jsx
+++ b/src/applications/personalization/account/components/LoginSettings.jsx
@@ -12,7 +12,7 @@ export default function LoginSettings() {
       the strongest identity verification system available to prevent fraud and
       identity theft. We use ID.me to help you create a verified account on{' '}
       {propertyName}
-      -or to connect your premium MyHealtheVet or DS Logon account to our
+      -or to connect your premium My HealtheVet or DS Logon account to our
       site-as well as to add an extra layer of security to your account.
       <br />
       <a

--- a/src/applications/rx/components/ErrorView.jsx
+++ b/src/applications/rx/components/ErrorView.jsx
@@ -27,10 +27,10 @@ class ErrorView extends React.Component {
           Please call support at <a href="tel:855-574-7286">1-855-574-7286</a>,
           TTY: <a href="tel:18008778339">1-800-877-8339</a>, Monday &#8211;
           Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET). To refill prescriptions, you
-          need to be registered as a VA patient through MyHealtheVet. To
+          need to be registered as a VA patient through My HealtheVet. To
           register,{' '}
           <a href="https://www.myhealth.va.gov/web/myhealthevet/user-registration">
-            visit MyHealtheVet
+            visit My HealtheVet
           </a>
         </p>
       );

--- a/src/platform/monitoring/DowntimeNotification/config/externalServices.js
+++ b/src/platform/monitoring/DowntimeNotification/config/externalServices.js
@@ -14,7 +14,7 @@ export default {
   idme: 'idme',
   // Master Veteran Index (source of veteran profile info)
   mvi: 'mvi',
-  // MyHealtheVet
+  // My HealtheVet
   mhv: 'mhv',
   // The Image Management System (education forms)
   tims: 'tims',

--- a/va-gov/pages/records/index.md
+++ b/va-gov/pages/records/index.md
@@ -26,7 +26,7 @@ social:
           title: "VA Benefits Hotline:"
         - url: tel:1-877-327-0022
           number: 1-877-327-0022
-          title: "MyHealtheVet Help Desk:"
+          title: "My HealtheVet Help Desk:"
         - url: tel:1-800-983-0937
           number: 1-800-983-0937
           title: "eBenefits Technical Support:"


### PR DESCRIPTION
## Description
Per Danielle Thierry, the "e" in MyHealtheVet is no longer being italicized on digital platforms AND My HealtheVet is now two words (MyHealtheVet --> My HealtheVet).

There are a few instances of this in Account Settings so we need to fix this.

## Testing done
Verified on local dev

## Acceptance criteria
- [x] Replaces `MyHealtheVet` with `My HealtheVet` in any remaining files 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
