### PR TITLE
Make sure we have one main element on a page

### DIFF
--- a/src/applications/discharge-wizard/components/InstructionsPage.jsx
+++ b/src/applications/discharge-wizard/components/InstructionsPage.jsx
@@ -26,7 +26,7 @@ class InstructionsPage extends React.Component {
     return (
       <div className="dw-instructions">
         <h1>How to Apply for a Discharge Upgrade</h1>
-        <main itemScope itemType="http://schema.org/FAQPage">
+        <div itemScope itemType="http://schema.org/FAQPage">
           <div className="row">
             <article className="usa-content columns">
               <div className="va-introtext">
@@ -370,7 +370,7 @@ class InstructionsPage extends React.Component {
               </div>
             </article>
           </div>
-        </main>
+        </div>
       </div>
     );
   }

--- a/va-gov/layouts/page-react.html
+++ b/va-gov/layouts/page-react.html
@@ -5,8 +5,8 @@
 {% endif %}
 
 <div id="content">
-  <div id="main" class="main" role="main">
+  <main id="main" class="main" role="main">
     {% include "va-gov/components/react-loader.html" %}
-  </div>
+  </main>
 </div>
 {% include "va-gov/includes/footer.html" %}

--- a/va-gov/layouts/page-react.html
+++ b/va-gov/layouts/page-react.html
@@ -5,7 +5,7 @@
 {% endif %}
 
 <div id="content">
-  <main id="main" class="main" role="main">
+  <main id="main" class="main">
     {% include "va-gov/components/react-loader.html" %}
   </main>
 </div>

--- a/va-gov/pages/faq.md
+++ b/va-gov/pages/faq.md
@@ -5,7 +5,7 @@ title: Frequently Asked Questions about Signing In to Vets.gov
 display_title: Frequently Asked Questions
 ---
 
-<main itemscope itemtype="http://schema.org/FAQPage">
+<div itemscope itemtype="http://schema.org/FAQPage">
   <div class="row">
     <article class="usa-content columns faq-page">
       <h1>Frequently Asked Questions (FAQ) about Signing In to Vets.gov</h1>
@@ -320,7 +320,7 @@ display_title: Frequently Asked Questions
       </div>
     </article>
   </div>
-</main>
+</div>
 
 <script type="text/javascript">
 (function() {


### PR DESCRIPTION
## Description

This fixes some pages to make sure we have one main landmark on our pages.

## Testing done
Checked locally, looked for styles that use main role.

## Acceptance criteria
- [x] Only one main landmark on pages changes
- [x] Site doesn't look broken

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
