### PR TITLE
update jenkinsfile to pull down sibling repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update && apt-get install -y netcat \
   && chmod +x /usr/local/lib/node_modules/yarn/bin/yarn.js
 
 RUN mkdir -p /application
-RUN git clone --depth 1 -b master https://github.com/department-of-veterans-affairs/vagov-content /vagov-content
 
 WORKDIR /application
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,7 +148,9 @@ node('vetsgov-general-purpose') {
       notify()
       throw error
     } finally {
-      step([$class: 'JUnitResultArchiver', testResults: 'test-results.xml'])
+      dir("vets-website") {
+        step([$class: 'JUnitResultArchiver', testResults: 'test-results.xml'])
+      }
     }
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,21 +87,27 @@ node('vetsgov-general-purpose') {
 
   stage('Setup') {
     try {
-      checkout scm
 
-      ref = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+      checkout([$class: 'GitSCM', branches: scm.branches, doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations, extensions: scm.extensions + [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'vets-website']], userRemoteConfigs: scm.userRemoteConfigs])
 
-      sh "mkdir -p build"
-      sh "mkdir -p logs/selenium"
-      sh "mkdir -p coverage"
+      // clone vagov-content
+      checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', noTags: true, reference: '', shallow: true], [$class: 'RelativeTargetDirectory', relativeTargetDir: 'vagov-content']], submoduleCfg: [], userRemoteConfigs: [[url: 'git@github.com:department-of-veterans-affairs/vagov-content.git']]]
 
-      imageTag = java.net.URLDecoder.decode(env.BUILD_TAG).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
-
-      dockerImage = docker.build("vets-website:${imageTag}")
-      args = "-v ${pwd()}:/application"
-      retry(5) {
-        dockerImage.inside(args) {
-          sh "cd /application && yarn install --production=false"
+      dir("vets-website") {
+        ref = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+  
+        sh "mkdir -p build"
+        sh "mkdir -p logs/selenium"
+        sh "mkdir -p coverage"
+  
+        imageTag = java.net.URLDecoder.decode(env.BUILD_TAG).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
+  
+        dockerImage = docker.build("vets-website:${imageTag}")
+        args = "-v ${pwd()}/vets-website:/application -v ${pwd()}/vagov-content:/vagov-content"
+        retry(5) {
+          dockerImage.inside(args) {
+            sh "cd /application && yarn install --production=false"
+          }
         }
       }
     } catch (error) {
@@ -177,27 +183,27 @@ node('vetsgov-general-purpose') {
   // Run E2E and accessibility tests
   stage('Integration') {
     if (shouldBail()) { return }
+    dir("vets-website") {
+      try {
+        parallel (
+          e2e: {
+            sh "export IMAGE_TAG=${imageTag} && docker-compose -p e2e up -d && docker-compose -p e2e run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=production vets-website --no-color run nightwatch:docker"
+          },
 
-    try {
-      parallel (
-        e2e: {
-          sh "export IMAGE_TAG=${imageTag} && docker-compose -p e2e up -d && docker-compose -p e2e run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=production vets-website --no-color run nightwatch:docker"
-        },
-
-        accessibility: {
-          sh "export IMAGE_TAG=${imageTag} && docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=production vets-website --no-color run nightwatch:docker -- --env=accessibility"
-        }
-      )
-    } catch (error) {
-      notify()
-      throw error
-    } finally {
-      sh "docker-compose -p e2e down --remove-orphans"
-      sh "docker-compose -p accessibility down --remove-orphans"
-      step([$class: 'JUnitResultArchiver', testResults: 'logs/nightwatch/**/*.xml'])
+          accessibility: {
+            sh "export IMAGE_TAG=${imageTag} && docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=production vets-website --no-color run nightwatch:docker -- --env=accessibility"
+          }
+        )
+      } catch (error) {
+        notify()
+        throw error
+      } finally {
+        sh "docker-compose -p e2e down --remove-orphans"
+        sh "docker-compose -p accessibility down --remove-orphans"
+        step([$class: 'JUnitResultArchiver', testResults: 'logs/nightwatch/**/*.xml'])
+      }
     }
   }
-
   stage('Archive') {
     if (shouldBail()) { return }
 
@@ -244,8 +250,10 @@ node('vetsgov-general-purpose') {
       if (!isDeployable()) {
         return
       }
-      script {
-        commit = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+      dir("vets-website") {
+        script {
+          commit = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+        }
       }
       if (env.BRANCH_NAME == devBranch) {
         build job: 'deploys/vets-website-dev', parameters: [


### PR DESCRIPTION
This turned out to be more changes than I anticipated. Maybe I am going about this the wrong way? 

Since the vets-website directory needs to have the vagov-content repo as a sibling directory we need to move vets-website somehow. So instead of the normal behavior of checking out the repo in the current directory, I have configured it to have two directories in the workspace: vets-website and vagov-content.