### PR TITLE
Fix spacing between items on burials & memorials hub page

### DIFF
--- a/va-gov/pages/burials-memorials/index.md
+++ b/va-gov/pages/burials-memorials/index.md
@@ -162,14 +162,17 @@ VA burial benefits can help Servicemembers, Veterans, and their family members p
   <div class="link">
     <a href="https://www.benefits.va.gov/Compensation/current_rates_dic.asp"><b>VA Survivor Benefits Rates (VA DIC)</b></a>
     <p>View current dependency and indemnity compensation rates for surviving spouses and children.</p>
+  </div>
 
   <div class="link">
     <a href="https://www.benefits.va.gov/Pension/current_rates_Parents_DIC_pen.asp"><b>Parents Dependency and Indemnity Compensation (DIC) Rates</b></a>
     <p>View current survivor benefit rates for parents.</p>
+  </div>
 
   <div class="link">
     <a href="https://www.archives.gov/veterans/replace-medals" target="_blank"><b>Replace Medals, Awards, and Decorations</b></a>
     <p>Visit the National Archives website to find out how to request replacement medals, awards, and decorations.</p>
+  </div>
 
   <div class="link">
     <a href="https://www.archives.gov/veterans" target="_blank"><b>Search Historical Military Records (National Archives)</b></a>


### PR DESCRIPTION
## Description
On https://preview.va.gov/burials-memorials/, there should be equal spacing between all of the items on this hub page but it is messed up in this area.

## Testing done
Local testing

## Screenshots
#### Before
![image](https://user-images.githubusercontent.com/7482329/47031182-9bf39c00-d12c-11e8-827c-aa10fe2749c2.png)

#### After
![image](https://user-images.githubusercontent.com/7482329/47031200-a2821380-d12c-11e8-9ea6-cb5f886ad687.png)


## Acceptance criteria
- [x] Fixes spacing between `div`s

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
