### PR TITLE
Implement global "Preview the New VA.gov" alert banner on Vets.gov

### DIFF
--- a/content/includes/top-nav.html
+++ b/content/includes/top-nav.html
@@ -1,4 +1,15 @@
 <header class="header">
+
+  {% if buildtype != 'production' %}
+    <div id="preview-banner" class="usa-alert usa-alert-info">
+      <div class="usa-alert-body">
+        <h3 class="usa-alert-heading">Preview the New VA.gov—Built with Veterans, for Veterans</h3>
+        <p>We're making some improvements to VA.gov. Our new site offers one place to access all VA benefits and health care services. You can sign in with your My HealtheVet, DS Logon, or ID.me account to track your claims, refill your prescriptions, and more.</p>
+        <a href="https://preview.va.gov" class="usa-button-primary">Preview the New VA.gov</a>
+      </div>
+    </div>
+  {% endif %}
+
   <div class="incompatible-browser-warning">
     <div class="row full">
       <div class="small-12">

--- a/src/platform/site-wide/sass/modules/_m-preview-banner.scss
+++ b/src/platform/site-wide/sass/modules/_m-preview-banner.scss
@@ -1,0 +1,5 @@
+// This file can be removed post-launch, as it only exists on Vets.gov.
+#preview-banner {
+  color: $color-gray-dark;
+  margin-top: 0;
+}

--- a/src/platform/site-wide/sass/style.scss
+++ b/src/platform/site-wide/sass/style.scss
@@ -35,3 +35,6 @@ $image-path: "~uswds/src/img";
 
 // ----- Medallia ----- //
 @import "modules/m-medallia";
+
+// "Preview the New VA.gov" banner
+@import "modules/m-preview-banner";


### PR DESCRIPTION
## Description
This pull request adds a banner to the top of all Vets.gov pages informing users of the Brand Consolidation site.

Currently, this banner is limited to all Vets.gov environments minus production to first confirm analytics and content. Tomorrow (10/17) we'll enable this banner in production as well. 

### Ticket
Moves to validate - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13287

## Testing done
- Surfed the site to confirm it looks okay
- Ran a production build to confirm no prod impact

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/47038883-9314c180-d150-11e8-8fac-40a38b0f9aa7.png)


## Acceptance criteria
- [x] Preview banner is live on every page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
