### PR TITLE
Prevent unrelated user actions from causing health tool CTAs to open MHV in a new tab.

### DIFF
--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -387,6 +387,11 @@ export class CallToActionWidget extends React.Component {
     } else {
       this._popup = window.open(url, 'cta-popup');
       if (this._popup) this._popup.focus();
+      else {
+        // Indicate an attempted pop-up to avoid automatically showing a
+        // pop-up later on a component update triggered by a state change.
+        this._popup = true;
+      }
     }
   };
 


### PR DESCRIPTION
## Description
When a pop-up blocker prevented the initial automatic pop-up, any component updates would've seen that this pop-up didn't exist yet and should be opened. The menu clicks described in the issue bypass the pop-up blocker presumably because the browser has detected them as user initiated actions.

The fix is to just making sure the update lifecycle hook recognizes that the pop-up attempt has been made and shouldn't try to open another tab even if it doesn't exist yet.

## Testing done
Local testing.

## Acceptance criteria
- [x] When pop-up blockers prevent the automatic redirect on health tool CTAs, subsequently user actions shouldn't trigger a pop-up.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs