### PR TITLE
Inherit hover color attribute in facility result links

### DIFF
--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -85,7 +85,7 @@
 
       &:focus {
         h5 {
-          outline: $color-link-default solid thin;
+          outline: inherit;
         }
       }
 


### PR DESCRIPTION
## Description
The Facility and Service Locator links to detail views do not show the standard yellow halo when they receive keyboard `focus`. Instead they show a thinner blue halo. These haloes are doubly important because these [links do not have underlines](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13638). Screenshots attached below at different zoom levels.

## Issue Type
* Enhancement

## Testing done
Localhost, Chrome on Debian 

Focused each element on Search results object and verified yellow halo appears. 

## Screenshots
![screenshot-localhost-3001-2018 10 17-03-28-47](https://user-images.githubusercontent.com/11085141/47074390-ea9e4600-d1bf-11e8-80ca-d89e3df314c1.png)


## Acceptance criteria
- [x] As a keyboard user, I would like to see the facility detail links show our yellow focus halo like other links for positive link identification. 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
