### PR TITLE
Fix sign in button hover state

### DIFF
--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -872,6 +872,31 @@
       }
     }
   }
+
+  // These next two rules override some styles in user-nav.scss, should be moved there
+  // after WBC is live
+  .sign-in-links {
+    flex-shrink: 0;
+  }
+
+  .sign-in-link {
+    margin: 0;
+    @include media($medium-large-screen) {
+      &:hover, &:active {
+        background-color: $color-primary;
+        color: inherit !important;
+      }
+    }
+    // This is backwards from the mobile first approach we should be taking
+    // but the amount of overrides we would need if we did that way would be
+    // very tricky to write and maintain
+    @media (max-width: $medium-large-screen - 1) {
+      @include button-link;
+      color: $color-white !important;
+      text-decoration: none;
+    }
+  }
+
 }
 
 .usa-accordion-bordered {
@@ -911,22 +936,8 @@ img[data-srcset] {
   min-height: 1px;
 }
 
-.sign-in-links {
-  flex-shrink: 0;
-}
-
 .vet-toolbar .va-dropdown {
   margin-left: 0;
-}
-
-.sign-in-link {
-  margin: 0;
-  // This is backwards from the mobile first approach we should be taking
-  // but the amount of overrides we would need if we did that way would be
-  // very tricky to write and maintain
-  @media (max-width: $medium-large-screen - 1) {
-    @include button-link;
-  }
 }
 
 .profile-nav {


### PR DESCRIPTION
## Description

The hover state for the sign in button was updated to look more like our normal buttons, but this looks weird in the header.

## Screenshots

Was:

![screen shot 2018-10-17 at 10 01 13 am](https://user-images.githubusercontent.com/634932/47091851-b3498c80-d1f3-11e8-866b-023d7fb5df58.png)

Is now:

![screen shot 2018-10-17 at 10 02 15 am](https://user-images.githubusercontent.com/634932/47091870-bd6b8b00-d1f3-11e8-8aba-f25c8a1a8b19.png)

## Acceptance criteria
- [x] Sign in button looks good on hover

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
