### PR TITLE
Fix front matter on /records/get-veteran-id-cards

### DIFF
--- a/script/collections/brand-consolidation.json
+++ b/script/collections/brand-consolidation.json
@@ -512,5 +512,14 @@
       "name": "Records",
       "spokes": ["Get Records"]
     }
+  },
+  "veteranIdCards": {
+    "pattern": "records/get-veteran-id-cards/*.md",
+    "sortBy": "order",
+    "metadata": {
+      "icon": "fa-id-card hub-background-records",
+      "name": "Records",
+      "spokes": ["Get Records"]
+    }
   }
 }

--- a/va-gov/pages/records/get-veteran-id-cards.md
+++ b/va-gov/pages/records/get-veteran-id-cards.md
@@ -8,7 +8,8 @@ order: 3
 spoke: Get Records
 plainlanguage:
 template: detail-page
-collection: types-of-veteran-ID-cards
+collection: records
+children: veteranIdCards
 production: false
 relatedlinks:
  - heading:

--- a/va-gov/pages/records/get-veteran-id-cards.md
+++ b/va-gov/pages/records/get-veteran-id-cards.md
@@ -8,7 +8,6 @@ order: 3
 spoke: Get Records
 plainlanguage:
 template: detail-page
-order:
 collection: types-of-veteran-ID-cards
 production: false
 relatedlinks:

--- a/va-gov/pages/records/get-veteran-id-cards/vic.md
+++ b/va-gov/pages/records/get-veteran-id-cards/vic.md
@@ -5,7 +5,7 @@ title: How to Apply for a Veteran ID Card
 display_title: Veteran ID Card
 description: Find out if you're eligible for a printed Veteran ID Card--and how to apply.
 plainlanguage:
-collection: types-of-veteran-ID-cards
+collection: veteranIdCards
 order: 1
 production: false
 ---


### PR DESCRIPTION
## Description
This pull request configures the side navigation and removes a duplicate `order` property from the front matter of the `records/get-veteran-id-cards` section. 

## Testing done
Confirmed the appearance and side navigation of -

- `/records/get-veteran-id-cards/`
- `/records/get-veteran-id-cards/vic/`

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/1915775/47101117-32948b80-d207-11e8-8be1-de899f4617c6.png)


### After
![image](https://user-images.githubusercontent.com/1915775/47101079-1b559e00-d207-11e8-9856-1852b34d9440.png)

![image](https://user-images.githubusercontent.com/1915775/47101103-27416000-d207-11e8-8dca-b3b63ef60d4b.png)


## Acceptance criteria
- [x] Pages render properly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
