### PR TITLE
Disable the Claims Increase announcement banner from Brand Consolidation

### DIFF
--- a/src/platform/site-wide/announcements/components/ClaimIncreaseBanner.jsx
+++ b/src/platform/site-wide/announcements/components/ClaimIncreaseBanner.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import backendServices from '../../../../platform/user/profile/constants/backendServices';
+import brandConsolidation from '../../../brand-consolidation';
 
 export default function ClaimIncreaseBanner({ dismiss, isLoggedIn, profile }) {
-  if (profile.loading) return <div />;
+  if (brandConsolidation.isEnabled()) return null;
+
+  if (profile.loading) return null;
   if (
     isLoggedIn &&
     !profile.services.includes(backendServices.CLAIM_INCREASE_AVAILABLE)
   )
-    return <div />;
+    return null;
 
   return (
     <div className="personalization-announcement">


### PR DESCRIPTION
## Description
This PR removes the green banner on the bottom of the site on Brand Consolidation -

![image](https://user-images.githubusercontent.com/1915775/47101684-c87ce600-d208-11e8-9472-c75bfe308a3b.png)

Move to validate https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14261

## Testing done
1. Cleared local storage
2. Checked homepage to confirm no banner

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/47101715-dc284c80-d208-11e8-970d-8f3ab8544394.png)


## Acceptance criteria
- [ ] Banner is removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
