### PR TITLE
Fix /va-payment-history/ in Records sidebar

### DIFF
--- a/va-gov/pages/records/va-payment-history.md
+++ b/va-gov/pages/records/va-payment-history.md
@@ -1,8 +1,0 @@
----
-layout: page-breadcrumbs.html
-template: detail-page 
-title: View VA Payment History
-display_title: View VA Payment History
-order: 7
-spoke: Get Records
----

--- a/va-gov/pages/va-payment-history.md
+++ b/va-gov/pages/va-payment-history.md
@@ -3,7 +3,9 @@ layout: page-breadcrumbs.html
 template: level2-index
 title: View Your VA Payment History
 display_title: View VA Payment History
-lastupdate:
+collection: records
+order: 7
+spoke: Get Records
 ---
 
 <div itemscope itemtype="http://schema.org/FAQPage">


### PR DESCRIPTION
## Description
Per @minafarzad's comment -

> the URL for View VA Payment History is preview/va-payment-history/ not /records/va-payment-history

Moves to validate - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13418

## Testing done
Confirmed side bar works and looks okay on `http://localhost:3001/records/download-va-letters/`

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/47103302-f6fcc000-d20c-11e8-95d5-f5379cbe9b86.png)


## Acceptance criteria
- [x] Side bar looks okay

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
