### PR TITLE
Show VA logo in sign-in modal for brand consolidated site.

### DIFF
--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 import Modal from '@department-of-veterans-affairs/formation/Modal';
+
+import isBrandConsolidationEnabled from '../../../brand-consolidation/feature-flag';
 import recordEvent from '../../../monitoring/record-event';
 import { login, signup } from '../../../user/authentication/utilities';
 import { externalServices } from '../../../../platform/monitoring/DowntimeNotification';
@@ -18,23 +20,24 @@ const handleDsLogon = loginHandler('dslogon');
 const handleMhv = loginHandler('mhv');
 const handleIdMe = loginHandler('idme');
 
+const logoSrc = `/img/design/logo/${
+  isBrandConsolidationEnabled() ? 'va-logo.png' : 'logo-alt.png'
+}`;
+
 class SignInModal extends React.Component {
   componentDidUpdate(prevProps) {
     if (!prevProps.visible && this.props.visible) {
       recordEvent({ event: 'login-modal-opened' });
     }
   }
+
   renderModalContent = () => (
     <main className="login">
       <div className="row">
         <div className="columns">
           <div className="logo">
             <a href="/">
-              <img
-                alt={siteName}
-                className="va-header-logo"
-                src="/img/design/logo/logo-alt.png"
-              />
+              <img alt={siteName} className="va-header-logo" src={logoSrc} />
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Description
We should be showing the VA logo (instead of VA | Vets.gov) on the brand consolidated site.

## Testing done
Local testing.

## Screenshots
> <img width="1008" alt="screen shot 2018-10-17 at 1 06 15 pm" src="https://user-images.githubusercontent.com/1067024/47103638-b05b9580-d20d-11e8-9432-028b64e8120b.png">

## Acceptance criteria
- [x] VA.gov should use the corresponding logo in the sign-in modal.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
