### PR TITLE
Adding a language attribute to the 503 page.

### DIFF
--- a/va-gov/pages/503.html
+++ b/va-gov/pages/503.html
@@ -3,7 +3,7 @@ permalink: false
 private: true
 ---
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <meta http-equiv="Content-type" content="text/html; charset=utf-8">


### PR DESCRIPTION
## Description
Added a `lang="en"` to the `<html>` tag on our 503.html page. Zenhub issue here: https://app.zenhub.com/workspace/o/department-of-veterans-affairs/vets.gov-team/issues/14264


## Testing done
* Verified the axe-core error was no longer appearing. Checked the page in OSX browsers Chrome, Safari, Firefox. Did not check in Windows as I"m on the road, but do not anticipate any visual changes, since it's an attribute only.

## Acceptance criteria
- [x] axe-core error is no longer appearing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
