### PR TITLE
Pages were added back in that don't need to be in left nav

### DIFF
--- a/va-gov/pages/disability-benefits/apply/dependents.md
+++ b/va-gov/pages/disability-benefits/apply/dependents.md
@@ -3,9 +3,6 @@ title: Declaration of status of dependents
 display_title: Add or Remove a Dependent
 entryname: 686-dependent-status
 layout: page-react.html
-collection: disability
-spoke: Manage Benefits
-order: 4
 ---
 <nav class="va-nav-breadcrumbs">
   <ul class="row va-nav-breadcrumbs-list columns" role="menubar" aria-label="Primary">

--- a/va-gov/pages/disability-benefits/apply/form-526-disability-claim.md
+++ b/va-gov/pages/disability-benefits/apply/form-526-disability-claim.md
@@ -4,9 +4,6 @@ display_title: File for Increased Disability
 entryname: 526EZ-claims-increase
 layout: page-react.html
 description: Learn how to apply online for increased disability compensation.
-collection: disability
-spoke: Manage Benefits
-order: 2
 ---
 <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
 id="va-breadcrumbs">


### PR DESCRIPTION
## Description
Removing the spoke and collection properties allows these pages to exist, but to keep them out of the sidenav

## Testing done
Local testing

## Screenshots
<img width="1147" alt="screenshot 2018-10-17 19 18 48" src="https://user-images.githubusercontent.com/1959628/47127445-f9c5d800-d241-11e8-8949-8d3cc021a208.png">


## Acceptance criteria
- [ ] Links are accurate on side nav @mnorthuis 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
