### PR TITLE
Add #mega-menu .current-page bottom border override class to merger.scss

### DIFF
--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -943,3 +943,19 @@ img[data-srcset] {
 .profile-nav {
   margin-top: 6px;
 }
+
+#mega-menu {
+  // @see @department-of-veterans-affairs/formation/sass/modules/_m-megamenu.scss#L266
+  @include media($medium-large-screen) {
+    .current-page {
+      border-bottom: 0px;
+      border-color: $color-blue;
+      box-shadow: inset 0 -5px 0 $color-blue;
+      margin-left: 1.6rem;
+      margin-right: 1.6rem;
+      a {
+        padding: 1.6rem 0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
Header has an extra 5px space that is not supposed to be there. This PR adds a class to override the formation `.current-page` class and reset the border, in favor of a `box-shadow: inset`

## Testing done
Visual acceptance tests in Chrome browser on Linux environment in responsive browser mode sizes 769px and up.

## Screenshots
Here is a screenshot of how it currently looks:
![Screen Shot 2018-09-28 at 1.43.26 PM.png](https://images.zenhubusercontent.com/5b0577164b5806bc2bd4524c/b0b1348c-8845-4d08-9890-996ada5d9a50)

Here is how this PR makes it look: 
![screenshot-localhost-3001-2018 10 18-06-04-11](https://user-images.githubusercontent.com/11085141/47150246-a8e2cd80-d29b-11e8-8ec5-7e824fd3e182.png)

## Acceptance criteria
- [X] Looks as though described in [originating issue](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13772)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
