### PR TITLE
Update help desk CTA with MyVA311

### DIFF
--- a/va-gov/pages/faq.md
+++ b/va-gov/pages/faq.md
@@ -21,7 +21,7 @@ display_title: Frequently Asked Questions
               <div class="feature">
                 <h4>Need help?</h4>
                 <p>
-                  Please call the VA.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a> (TTY: <a href="tel:+18008778339"> 1-800-877-8339</a>). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. (<abbr title="eastern time">ET</abbr>).
+                  Call MyVA311 for help: <a href="tel:+18446982311">1-844-698-2311"</a>. If you have hearing loss, call TTY: 711.               
                 </p>
               </div>
             </div>

--- a/va-gov/pages/faq.md
+++ b/va-gov/pages/faq.md
@@ -21,7 +21,7 @@ display_title: Frequently Asked Questions
               <div class="feature">
                 <h4>Need help?</h4>
                 <p>
-                  Call MyVA311 for help: <a href="tel:+18446982311">1-844-698-2311"</a>. If you have hearing loss, call TTY: 711.               
+                  Call MyVA311 for help: <a href="tel:+18446982311">1-844-698-2311</a>. If you have hearing loss, call TTY: 711.               
                 </p>
               </div>
             </div>

--- a/va-gov/pages/records/download-va-letters.md
+++ b/va-gov/pages/records/download-va-letters.md
@@ -61,8 +61,7 @@ Yes. If you're totally and permanently disabled because of your service-connecte
 
 ### What if I have trouble downloading a VA letter?
 
-Call the VA.gov Help Desk at <a href="tel:+18555747286">1-855-574-7286</a> (TTY: <a href="tel:+18008778339">1-800-877-8339</a>).
-We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. (<abbr title="eastern time">ET</abbr>).
+Call MyVA311 for help: <a href="tel:+18446982311">1-844-698-2311</a> If you have hearing loss, call TTY: 711.
 
 </section>
 </div>

--- a/va-gov/pages/records/download-va-letters.md
+++ b/va-gov/pages/records/download-va-letters.md
@@ -61,7 +61,7 @@ Yes. If you're totally and permanently disabled because of your service-connecte
 
 ### What if I have trouble downloading a VA letter?
 
-Call MyVA311 for help: <a href="tel:+18446982311">1-844-698-2311.</a> If you have hearing loss, call TTY: 711.
+Call MyVA311 for help: <a href="tel:+18446982311">1-844-698-2311</a>. If you have hearing loss, call TTY: 711.
 
 </section>
 </div>

--- a/va-gov/pages/records/download-va-letters.md
+++ b/va-gov/pages/records/download-va-letters.md
@@ -61,7 +61,7 @@ Yes. If you're totally and permanently disabled because of your service-connecte
 
 ### What if I have trouble downloading a VA letter?
 
-Call MyVA311 for help: <a href="tel:+18446982311">1-844-698-2311</a> If you have hearing loss, call TTY: 711.
+Call MyVA311 for help: <a href="tel:+18446982311">1-844-698-2311.</a> If you have hearing loss, call TTY: 711.
 
 </section>
 </div>


### PR DESCRIPTION
Problem Statement:
The Content Team is unable to complete Vets.gov to VA.gov branding work without answering the following questions.

Is there a single VA.gov Help Desk phone number we refer people to?
Currently we have references like these on Vets.gov
Please call the Vets.gov Help Desk at 1-855-574-7286 (TTY: 1-800-829-4833). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. (ET).

If there will be multiple contact numbers replacing the single Help Desk number, who is the POC to work with for content strategy?

Is there a different contact number for the technical help desk?
E.g.
src/platform/forms/components/AskVAQuestions.jsx

Risk if not complete:
Users call current help desk number and Vets.gov branding, Call Center experiences higher volume of calls
