### PR TITLE
Add left nav to buy-up page

### DIFF
--- a/script/collections/brand-consolidation.json
+++ b/script/collections/brand-consolidation.json
@@ -208,6 +208,14 @@
       "icon": "fa-book hub-background-education"
     }
   },
+  "educationMontgomeryActiveDuty": {
+    "pattern": "education/about-gi-bill-benefits/montgomery-active-duty/*.md",
+    "sortBy": "order",
+    "metadata": {
+      "name": "GI Bill",
+      "icon": "fa-book hub-background-education"
+    }
+  },
   "educationGIBillSurvivors": {
     "pattern": "education/survivor-dependent-benefits/*.md",
     "sortBy": "order",

--- a/va-gov/pages/education/about-gi-bill-benefits/montgomery-active-duty.md
+++ b/va-gov/pages/education/about-gi-bill-benefits/montgomery-active-duty.md
@@ -5,6 +5,7 @@ title: Montgomery GI Bill Active Duty (MGIB-AD)
 display_title: Montgomery GI Bill Active Duty
 plainlanguage: 11-29-16 certified in compliance with the Plain Writing Act
 concurrence: incomplete
+children: educationMontgomeryActiveDuty
 order: 2
 aliases:
   - /education/gi-bill/montgomery-active-duty/

--- a/va-gov/pages/education/about-gi-bill-benefits/montgomery-active-duty/buy-up.md
+++ b/va-gov/pages/education/about-gi-bill-benefits/montgomery-active-duty/buy-up.md
@@ -5,6 +5,7 @@ title: $600 Buy-Up Program
 plainlanguage: 12-07-16 certified in compliance with the Plain Writing Act
 concurrence: incomplete
 order: 11
+collection: educationMontgomeryActiveDuty
 aliases:
   - /education/gi-bill/buy-up-program/
 ---
@@ -15,10 +16,10 @@ If you take part in the $600 Montgomery GI Bill Buy-Up program, you’ll get mor
 
 </div>
 
-### How do I get this benefit? 
+### How do I get this benefit?
 
-- Decide how much extra you want to contribute. With a $600 contribution, you can get up to $5,400 more in GI Bill benefits. [View the rate table](https://www.benefits.va.gov/gibill/resources/benefits_resources/rates/600_buyup.asp). 
+- Decide how much extra you want to contribute. With a $600 contribution, you can get up to $5,400 more in GI Bill benefits. [View the rate table](https://www.benefits.va.gov/gibill/resources/benefits_resources/rates/600_buyup.asp).
 - Fill out a form called Montgomery GI Bill Act of 1984 Basic Enrollment (DD Form 2366) and take it to your payroll or personnel office. [Get DD Form 2366](http://www.esd.whs.mil/Portals/54/Documents/DD/forms/dd/dd2366.pdf).
-- Keep copies of the form and any other paperwork that shows you made the payment. 
+- Keep copies of the form and any other paperwork that shows you made the payment.
 
 **Note:** This program can’t be used with the Post 9/11 GI Bill.


### PR DESCRIPTION
## Description
The left-rail nav bar is missing on https://preview.va.gov/education/about-gi-bill-benefits/montgomery-active-duty/buy-up/

## Testing done
Manually tested that page and parent pages show the correct breadcrumb, link, and nav structure. 
Manually tested that nav bar is present on buy-up page.

## Screenshots
![screenshot-localhost-3001-2018 10 18-13-44-22](https://user-images.githubusercontent.com/11085141/47176981-ace30f80-d2dc-11e8-899e-501759a6f860.png)


![screenshot-localhost-3001-2018 10 18-13-44-08](https://user-images.githubusercontent.com/11085141/47176987-b4a2b400-d2dc-11e8-9d20-6afc9e6851da.png)


## Acceptance criteria
- [x] Left nav is shown on buy-up page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
