### PR TITLE
Remove Medallia script from Brand Consolidation

### DIFF
--- a/va-gov/includes/survey-tools.html
+++ b/va-gov/includes/survey-tools.html
@@ -1,6 +1,1 @@
-{% assign auth_required_entrynames = 'claims-status, letters, health-records, messaging, rx, profile-360' | split: ', ' %}
-{% if auth_required_entrynames contains entryname  %}
-  <script type="text/javascript" src="/js/foresee/{{ buildtype }}.js"></script>
-{% else %}
-  <script type="text/javascript" src="https://resources.digital-cloud-gov.voice.medallia.com/wdcgov/2/onsite/embed.js" async></script>
-{% endif %}
+<script type="text/javascript" src="/js/foresee/{{ buildtype }}.js"></script>


### PR DESCRIPTION
## Description
This pull request loads the Foresee survey tool on every VA.gov page, instead of conditionally showing Medallia.

Moves to validate - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14282

## Testing done
The Foresee script is configured for the domain, so I can't really test until Staging.
