### PR TITLE
Vagov teamsite fixes

### DIFF
--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -28,7 +28,6 @@
 
 header.merger {
   width: 100%;
-  border: 1px solid #01133F;
   margin: auto;
 
   .va-crisis-line {

--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -37,10 +37,6 @@ header.merger {
     button.va-crisis-line-button {
       background-image: none;
     }
-    .va-crisis-line-arrow {
-      height: 10px;
-      margin-top: 8px;
-    }
   }
   @media (min-width: $medium-screen) {
     .va-notice--banner-inner {

--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -16,7 +16,10 @@
 
 .usa-grid {
   width: $teamsite-width;
-  padding-left: 1px;
+  @media (min-width: $medium-screen) {
+    padding-left: 1px;
+    padding-right: 1px;
+  }
 }
 
 .usa-grid-full {

--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -35,10 +35,19 @@ header.merger {
     button.va-crisis-line-button {
       background-image: none;
     }
+    .va-crisis-line-arrow {
+      height: 10px;
+      margin-top: 8px;
+    }
   }
-  .va-notice--banner-inner {
-    width: $teamsite-width;
-    padding-left: 1rem;
+  @media (min-width: $medium-screen) {
+    .va-notice--banner-inner {
+      width: $teamsite-width;
+      padding-left: 1rem;
+    }
+    #mega-menu .panel-bottom-link {
+      width: 468px;
+    }
   }
   @media (min-width: $large-screen) {
     #mega-menu .vetnav-panel {

--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -48,6 +48,9 @@ header.merger {
     #mega-menu .column-three {
       left: 487px;
     }    
+    #mega-menu .panel-bottom-link {
+      width: 657px;
+    }
   }
   @media (max-width: $large-screen - 1) {
     #vetnav-va-benefits-and-health-care, #vetnav-about-va {

--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -1,5 +1,7 @@
 .usa-banner-inner {
   p {
+    font-size: 1.2rem;
+    font-family: inherit;
     padding: 0;
   }
 }


### PR DESCRIPTION
## Description
These changes address the following:
- [Teamsite: Line sticks outside of menu](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14305)
- [Teamsite: Different Font and/or Font Size of `Official US Gov` banner making it slightly too big](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14304) 
- [Teamsite: Inconsistent separation line in header](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14302)
- [Teamsite: Remove line on top of webpage](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14299)
- [Teamsite: Unwanted Header Padding - mobile/tablet media queries](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14317)

## Testing done
verified locally

## Screenshots

### Line sticks outside of menu: tablet width
![screen shot 2018-10-18 at 1 50 17 pm](https://user-images.githubusercontent.com/16051172/47191198-c7c47c80-d2fa-11e8-8cf7-425a07ea4849.png)

### Line sticks outside of menu: large width
![screen shot 2018-10-18 at 1 11 09 pm](https://user-images.githubusercontent.com/16051172/47191222-df9c0080-d2fa-11e8-9a8d-38b4e857f372.png)

### Different Font and/or Font Size of `Official US Gov` banner making it slightly too big
![image](https://user-images.githubusercontent.com/16051172/47191301-5507d100-d2fb-11e8-95ce-ceb6231ced98.png)

### Inconsistent separation line in header & Remove line on top of webpage
![image](https://user-images.githubusercontent.com/16051172/47191262-34d81200-d2fb-11e8-9ce8-d797e0ab0259.png)

### Teamsite: Unwanted Header Padding - mobile/tablet media queries
![image](https://user-images.githubusercontent.com/16051172/47232138-bbd0cd00-d383-11e8-897c-a141638d89bd.png)

## Acceptance criteria
- [x] Fix: Line sticks outside of menu
- [x] Fix: Different Font and/or Font Size of `Official US Gov` banner making it slightly too big
- [x] Fix: Inconsistent separation line in header
- [x] Fix: Remove line on top of webpage
- [x] Unwanted Header Padding - mobile/tablet media queries

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
