### PR TITLE
Remove list style from footer links

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-footer-brand-consolidation.scss
+++ b/src/platform/site-wide/sass/modules/_m-footer-brand-consolidation.scss
@@ -95,6 +95,7 @@
 .va-footer-accordion-content {
   background: transparent;
   > .va-footer-links {
+    list-style: none;
     > li {
       margin-bottom: 0.5em;
       > a {


### PR DESCRIPTION
## Description

They're very hard to see, but the footer links in accordions have a list bullet.

## Testing done

Viewed locally

## Screenshots

![screen shot 2018-10-19 at 9 29 32 am](https://user-images.githubusercontent.com/634932/47221190-becabe00-d381-11e8-9643-cf46848d9295.png)


## Acceptance criteria
- [ ] Bullets are gone

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
