### PR TITLE
526 service end date mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -79,7 +79,7 @@ import { FIFTY_MB } from '../../all-claims/constants';
 import { treatmentView } from '../../all-claims/content/vaMedicalRecords';
 import { evidenceTypeHelp } from '../../all-claims/content/evidenceTypes';
 import { additionalDocumentDescription } from '../../all-claims/content/additionalDocuments';
-import { requireOneSelected } from '../validations';
+import { requireOneSelected, isInPast } from '../validations';
 
 import { validateBooleanGroup } from 'us-forms-system/lib/js/validation';
 import PhoneNumberWidget from 'us-forms-system/lib/js/widgets/PhoneNumberWidget';
@@ -185,7 +185,7 @@ const formConfig = {
                 serviceBranch: {
                   'ui:title': 'Branch of service',
                 },
-                dateRange: _.merge(
+                dateRange: merge(
                   dateRangeUI(
                     'Service start date',
                     'Service end date',
@@ -193,7 +193,7 @@ const formConfig = {
                   ),
                   {
                     to: {
-                      'ui:validations': [],
+                      'ui:validations': [isInPast],
                     },
                   },
                 ),

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -1,4 +1,5 @@
 import _ from '../../../../platform/utilities/data';
+import merge from 'lodash/merge';
 
 import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
 // NOTE: Easier to run schema locally with hot reload for dev
@@ -184,10 +185,17 @@ const formConfig = {
                 serviceBranch: {
                   'ui:title': 'Branch of service',
                 },
-                dateRange: dateRangeUI(
-                  'Service start date',
-                  'Service end date',
-                  'End of service must be after start of service',
+                dateRange: _.merge(
+                  dateRangeUI(
+                    'Service start date',
+                    'Service end date',
+                    'End of service must be after start of service',
+                  ),
+                  {
+                    to: {
+                      'ui:validations': [],
+                    },
+                  },
                 ),
               },
             },

--- a/src/applications/disability-benefits/526EZ/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/526EZ/tests/validations.unit.spec.js
@@ -3,7 +3,7 @@ import { isInPast } from '../validations';
 import sinon from 'sinon';
 
 describe('526 Increase validations', () => {
-  describe.only('isInPast', () => {
+  describe('isInPast', () => {
     it('should not add error when no date present', () => {
       const addError = sinon.spy();
       const errors = { addError };

--- a/src/applications/disability-benefits/526EZ/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/526EZ/tests/validations.unit.spec.js
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import { isInPast } from '../validations';
+import sinon from 'sinon';
+
+describe('526 Increase validations', () => {
+  describe.only('isInPast', () => {
+    it('should not add error when no date present', () => {
+      const addError = sinon.spy();
+      const errors = { addError };
+
+      isInPast(errors);
+      expect(addError.called).to.be.false;
+    });
+
+    it('should not add error when end date is in past', () => {
+      const addError = sinon.spy();
+      const errors = { addError };
+
+      isInPast(errors, '2010-12-31');
+      expect(addError.called).to.be.false;
+    });
+
+    it('should add error when end date is in past', () => {
+      const addError = sinon.spy();
+      const errors = { addError };
+
+      isInPast(errors, '2099-01-01');
+      expect(addError.calledOnce).to.be.true;
+    });
+  });
+});

--- a/src/applications/disability-benefits/526EZ/validations.js
+++ b/src/applications/disability-benefits/526EZ/validations.js
@@ -21,5 +21,8 @@ export function requireOneSelected(
 }
 
 export function isInPast(errors, fieldData) {
-  const today = new Date();
+  const fieldDate = new Date(fieldData);
+  if (fieldDate.getTime() > Date().now()) {
+    errors.addError('Service end date must be in the past');
+  }
 }

--- a/src/applications/disability-benefits/526EZ/validations.js
+++ b/src/applications/disability-benefits/526EZ/validations.js
@@ -19,3 +19,7 @@ export function requireOneSelected(
     );
   }
 }
+
+export function isInPast(errors, fieldData) {
+  const today = new Date();
+}

--- a/src/applications/disability-benefits/526EZ/validations.js
+++ b/src/applications/disability-benefits/526EZ/validations.js
@@ -22,7 +22,7 @@ export function requireOneSelected(
 
 export function isInPast(errors, fieldData) {
   const fieldDate = new Date(fieldData);
-  if (fieldDate.getTime() > Date().now()) {
+  if (fieldDate.getTime() > Date.now()) {
     errors.addError('Service end date must be in the past');
   }
 }


### PR DESCRIPTION
## Description
Adds a validation for ensuring that service end dates are in the past

## Testing done
- Tested locally
- Unit tests for the validator

## Screenshots
![screen shot 2018-10-19 at 10 56 20 am](https://user-images.githubusercontent.com/24251447/47231091-9a76dd80-d391-11e8-90de-7660d7fb5713.png)


## Acceptance criteria
- [x] Military service history must be in the past

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
