### PR TITLE
Remove "Community Care" option from Facility Locator in Brand Consolidation

### DIFF
--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -20,7 +20,7 @@ export const api = {
  * existing Facility Locator App.
  */
 export const ccLocatorEnabled = () => {
-  return __BUILDTYPE__ !== 'production';
+  return __BUILDTYPE__ !== 'production' && __BUILDTYPE__ !== 'preview';
 };
 
 /* eslint-disable camelcase */

--- a/src/applications/facility-locator/tests/facility-helpers.js
+++ b/src/applications/facility-locator/tests/facility-helpers.js
@@ -241,7 +241,10 @@ function initApplicationMock(token) {
  * existing Facility Locator App.
  */
 function ccLocatorEnabled() {
-  return process.env.BUILDTYPE !== 'production';
+  return (
+    process.env.BUILDTYPE !== 'production' &&
+    process.env.BUILDTYPE !== 'preview'
+  );
 }
 
 module.exports = {


### PR DESCRIPTION
## Description
Preview is a production environment, but a different build-type than `production`, because that refers to Vets.gov. We need an additional check for Preview to keep the "Community Care" option from appearing on https://preview.va.gov/facilities.

Moves to validate - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14318

## Acceptance criteria
- [x] Community Care option does not exist on https://preview.va.gov/facilities

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
