### PR TITLE
Bump version of selenium-server-standalone in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ the test requries features that jsdom does not provide, putting them into a
 #### E2E Troubleshooting
 Try running your `selenium` server manually:
 ```
-$ java -jar <path to GitHub>/vets-website/node_modules/selenium-server/lib/runner/selenium-server-standalone-3.1.0.jar
+$ java -jar <path to GitHub>/vets-website/node_modules/selenium-server/lib/runner/selenium-server-standalone-3.4.0.jar
 ```
 and you should see:
 ```


### PR DESCRIPTION
selenium-server is currently 3.4.0 (https://github.com/department-of-veterans-affairs/vets-website/blob/master/yarn.lock#L8451), so I updated the readme to reflect that.