### PR TITLE
Include uswds in bundle, load conditionally

### DIFF
--- a/src/platform/site-wide/index.js
+++ b/src/platform/site-wide/index.js
@@ -22,6 +22,10 @@ if (!brandConsolidation.isEnabled()) {
   require('./usa-banner-toggle');
 }
 
+if (brandConsolidation.isEnabled()) {
+  import(/* webpackChunkName: "uswds" */ 'uswds');
+}
+
 /**
  * Start up the site-wide components that live on every page, like
  * the login widget, the header menus, and the feedback widget.

--- a/va-gov/includes/footer.html
+++ b/va-gov/includes/footer.html
@@ -57,7 +57,5 @@
 
 {% include "va-gov/includes/survey-tools.html" %}
 
-<script type="text/javascript" src="/js/vendor/uswds.min.js"></script>
-
 </body>
 </html>


### PR DESCRIPTION
## Description

We decided to start include the USWDS JS everywhere, as a separate script tag, which is confusing. Including it as a conditional import in our bundles is less confusing (still would be better not to have it on every page).

## Testing done
Opened locally, checked that accordions still work

## Acceptance criteria
- [x] Accordions still work outside of React apps

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
