### PR TITLE
Set external icons to be white in footer

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-footer-brand-consolidation.scss
+++ b/src/platform/site-wide/sass/modules/_m-footer-brand-consolidation.scss
@@ -17,6 +17,9 @@
       flex-wrap: nowrap;
     }
   }
+  a[href^="http"]:not([href*="va.gov"]):not([href*="vets.gov"]):not(.no-external-icon) {
+    background-image: url(/img/icons/exit-icon-white.png);
+  }
 }
 
 .footer-inner {


### PR DESCRIPTION
## Description

We want to have external icons for external links, but the footer has a dark background.

## Testing done
Local testing

## Screenshots
![screen shot 2018-10-19 at 4 40 16 pm](https://user-images.githubusercontent.com/634932/47243767-23f1d400-d3c1-11e8-9bff-05c6ac3d7af2.png)

## Acceptance criteria
- [x] External link icons are appropriately visible

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
