### PR TITLE
un-italicizing e from My HealtheVet

### DIFF
--- a/content/pages/faq.md
+++ b/content/pages/faq.md
@@ -308,7 +308,7 @@ display_title: Frequently Asked Questions
                       <div itemprop="text">
                         <p>This code is part of the 2-factor authentication process.</p>
                         <p>When you set up a verified Vets.gov account through ID.me, you need to set up 2-factor authentication. Authentication gives you an extra layer of security by letting you into your account only after you’ve signed in with a password and a 6-digit code sent directly to your mobile or home phone. This helps to make sure that no one but you can access your account—even if they get your password.<p>                        
-                        <p>If you sign in to Vets.gov using your existing basic or advanced <strong>My HealtheVet</strong> or basic <strong>DS Logon</strong> account and don’t want to verify your identity, or if you sign in using your existing premium <strong>My Health <em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your Vets.gov profile page.<p>          
+                        <p>If you sign in to Vets.gov using your existing basic or advanced <strong>My HealtheVet</strong> or basic <strong>DS Logon</strong> account and don’t want to verify your identity, or if you sign in using your existing premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account, setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your Vets.gov profile page.<p>          
                       </div>
                     </div>
                   </li>

--- a/content/pages/faq.md
+++ b/content/pages/faq.md
@@ -15,7 +15,7 @@ display_title: Frequently Asked Questions
             <div class="small-12 columns">
               <div itemprop="description">
                 <p>
-                  Get answers to common questions about signing in to Vets.gov (a VA website) to manage your benefits and services online. Find out how to sign in with your existing <strong>My Health<em>e</em>Vet</strong> or <strong>DS Logon</strong> account—or how to use ID.me to create your account.
+                  Get answers to common questions about signing in to Vets.gov (a VA website) to manage your benefits and services online. Find out how to sign in with your existing <strong>My HealtheVet</strong> or <strong>DS Logon</strong> account—or how to use ID.me to create your account.
                 </p>
               </div>
               <div class="feature">
@@ -37,11 +37,11 @@ display_title: Frequently Asked Questions
                       <div itemprop="text">
                         <p><strong>You can sign in to Vets.gov in 1 of 3 ways:</strong></p>
                         <ul>
-                          <li>With your existing <strong>My Health<em>e</em>Vet</strong> account, <strong>or</strong></li>
+                          <li>With your existing <strong>My HealtheVet</strong> account, <strong>or</strong></li>
                           <li>With your existing <strong>DS Logon</strong> account, <strong>or</strong></li>
                           <li>By creating an account through ID.me (a trusted partner)</li>
                         </ul>
-                        <p><strong>Note:</strong> If you have a premium <strong>My Health<em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, using it to sign in is the easiest way to get access to all Vets.gov tools. Because you already verified your identity when you got your premium account, you won’t need to verify your identity again before doing common tasks on Vets.gov, like checking your claims status or sending a secure message to your health care team.</p>
+                        <p><strong>Note:</strong> If you have a premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account, using it to sign in is the easiest way to get access to all Vets.gov tools. Because you already verified your identity when you got your premium account, you won’t need to verify your identity again before doing common tasks on Vets.gov, like checking your claims status or sending a secure message to your health care team.</p>
                         <p><a href="/faq/" class="login-required">Sign in now</a>.</p>
                       </div>
                     </div>
@@ -56,10 +56,10 @@ display_title: Frequently Asked Questions
                     <div id="faq-verify-0" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
                         <h4>Fastest way to verify your identity online</h4>
-                        <p>If you have a premium <strong>My Health<em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, you can use your existing account to sign in. Because you already verified your identity when you got your premium account, you won’t need to verify your identity again before doing common tasks on Vets.gov, like checking your claims status or sending a secure message to your health care team.</p>
+                        <p>If you have a premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account, you can use your existing account to sign in. Because you already verified your identity when you got your premium account, you won’t need to verify your identity again before doing common tasks on Vets.gov, like checking your claims status or sending a secure message to your health care team.</p>
                         <p><a href="/faq/" class="login-required">Sign in now</a>.</p>
                         <h4>How to verify your identity online if you don’t have an existing premium account</h4>
-                        <p>If you don’t have a premium <strong>My Health<em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, we’ll help you verify your identity using ID.me—a trusted partner that provides the strongest identity verification system available to prevent fraud and identity theft.</p>
+                        <p>If you don’t have a premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account, we’ll help you verify your identity using ID.me—a trusted partner that provides the strongest identity verification system available to prevent fraud and identity theft.</p>
                         <p><strong>To go through the ID.me identity-proofing process, you’ll need:</strong></p>
                         <ul>
                           <li>A smartphone (or a landline or mobile phone and a computer with an Internet connection), <strong>and</strong></li>
@@ -91,7 +91,7 @@ display_title: Frequently Asked Questions
                         <p><a href="/facilities/">Find a VA regional office near you</a>.</p>
                         <p><a href="https://myaccess.dmdc.osd.mil/identitymanagement/consent?continueToUrl=%2Fidentitymanagement%2Fauthenticate.do%3Fexecution%3De4s1">Visit the DS Logon self-service website</a>.               
                         <h4>Verifying your identity in person if you’re a VA patient</h4>
-                        <p>If you’re a VA patient, you can verify your identity at your local VA health care facility as part of the process of getting a premium <strong>My Health<em>e</em>Vet</strong> account. You can then use this account to sign in to Vets.gov without having to verify your identity online.</p>
+                        <p>If you’re a VA patient, you can verify your identity at your local VA health care facility as part of the process of getting a premium <strong>My HealtheVet</strong> account. You can then use this account to sign in to Vets.gov without having to verify your identity online.</p>
                         <p><strong>You’ll need to bring:</strong></p>
                         <ul>
                           <li><strong>An Individuals’ Request for a Copy of Their Own Health Information (VA Form 10-5345a-MHV).</strong> You can download a PDF copy of this “VA release of information” form now, call ahead to ask the staff to mail you a form, or ask for a form when you get there.<br/>
@@ -99,7 +99,7 @@ display_title: Frequently Asked Questions
                             <a href="/facilities/">Find the phone number for your nearest VA health care facility</a>.</li>
                           <li><strong>A government-issued photo ID.</strong> This can be either your Veteran Health Identification Card or a valid driver’s license.</li>
                         </ul>
-                        <p>A VA staff member will verify your identity. Then they’ll record your information in the <strong>My Health<em>e</em>Vet</strong> system and confirm that you’re eligible for a premium account. A copy of your VA Form 10-5345a-MHV will be added to your VA medical record, and your original paper copy will be shredded to protect your privacy.</p>                        
+                        <p>A VA staff member will verify your identity. Then they’ll record your information in the <strong>My HealtheVet</strong> system and confirm that you’re eligible for a premium account. A copy of your VA Form 10-5345a-MHV will be added to your VA medical record, and your original paper copy will be shredded to protect your privacy.</p>                        
                         <p><strong>Note:</strong> When you open or download a PDF file, you create a temporary file on your computer. Other people may be able to see this file—and any personal health information you fill in—especially if you’re using a public or shared computer.</p>
                       </div>
                     </div>
@@ -130,7 +130,7 @@ display_title: Frequently Asked Questions
                     <button class="usa-button-unstyled usa-accordion-button" aria-controls="faq-trouble-0" itemprop="name">If I can’t or don’t want to verify my identity through ID.me, what are my other options? </button>
                     <div id="faq-trouble-0" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
-                        <p>You can use a premium <strong>My Health<em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account to sign in to Vets.gov with a verified account. Because you already verified your identity when you got your premium account, you won’t need to verify your identity again on Vets.gov.</p>
+                        <p>You can use a premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account to sign in to Vets.gov with a verified account. Because you already verified your identity when you got your premium account, you won’t need to verify your identity again on Vets.gov.</p>
                         <h4>How to get a premium DS Logon account</h4>                      
                         <p>Follow these 2 steps to sign up for a premium <strong>DS Logon</strong> account.</p>
                         <p><strong>1. First, make sure you’re enrolled in the Defense Enrollment Eligibility Reporting System (DEERS).</strong> This is the database that records all the people who are eligible for military benefits.</p>
@@ -149,18 +149,18 @@ display_title: Frequently Asked Questions
                            <p>The registration tool will walk you through the sign-up process for your account and will prompt you to upgrade to a premium account through an online proofing process. Through this process, you’ll be asked a series of questions to prove you’re you—and not someone pretending to be you—to help protect the personal information you’ll have access to with a premium account.</p>                        
                            <p><a href="https://myaccess.dmdc.osd.mil/">Go to the DS Logon self-service website</a>.</p>
                         <p><strong>Note:</strong> If you’d rather verify your identity and upgrade to a premium <strong>DS Logon</strong> account in person or by phone, read the instructions in the section above on verifying your identity.</p>
-                        <h4>How to get a premium My Health<em>e</em>Vet account if you’re a VA patient</h4>  
-                        <p>Follow these 2 steps to sign up for a premium <strong>My Health<em>e</em>Vet</strong> account.</p>
-                        <p><strong>1. First, sign up for an account on the My Health<em>e</em>Vet website.</strong> You’ll need to have your Social Security number on hand. Be sure to choose <strong>VA Patient</strong> on the registration form. This will automatically upgrade your account to an advanced account, and then you can upgrade to a premium account.</p>
-                        <p><a href="https://www.myhealth.va.gov/mhv-portal-web/user-registration/">Sign up for a My Health<em>e</em>Vet account</a>.</p>
-                        <p><strong>Note:</strong> If you have a premium <strong>DS Logon</strong> or ID.me account, you can skip step 1 above, and go right to step 2 to sign in to <strong>My Health<em>e</em>Vet</strong> with either of these accounts.
+                        <h4>How to get a premium My HealtheVet account if you’re a VA patient</h4>  
+                        <p>Follow these 2 steps to sign up for a premium <strong>My HealtheVet</strong> account.</p>
+                        <p><strong>1. First, sign up for an account on the My HealtheVet website.</strong> You’ll need to have your Social Security number on hand. Be sure to choose <strong>VA Patient</strong> on the registration form. This will automatically upgrade your account to an advanced account, and then you can upgrade to a premium account.</p>
+                        <p><a href="https://www.myhealth.va.gov/mhv-portal-web/user-registration/">Sign up for a My HealtheVet account</a>.</p>
+                        <p><strong>Note:</strong> If you have a premium <strong>DS Logon</strong> or ID.me account, you can skip step 1 above, and go right to step 2 to sign in to <strong>My HealtheVet</strong> with either of these accounts.
                         <p><strong>2. Then, upgrade to a premium account.</strong></p>
                         <p>You can do this in 1 of 2 ways.</p>
                         <h5>Upgrade your acount using your premium DS Logon or ID.me user ID and password</h5>
-                        <p>To do this, sign in to <strong>My Health<em>e</em>Vet</strong> using your premium <strong>DS Logon</strong> or ID.me user ID and password.</p>
+                        <p>To do this, sign in to <strong>My HealtheVet</strong> using your premium <strong>DS Logon</strong> or ID.me user ID and password.</p>
                         <p>Once signed in, select the <strong>Upgrade Now</strong> button at the top left side of the screen. Then, on the account upgrade page, check the box certifying that you’re the owner of the account and approve the request, and click <strong>Continue</strong>.</p>
                         <p>The system will upgrade you to a premium account.</p>
-                        <p><a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/user-login?redirect=/mhv-portal-web/user-registration/user-login">Sign in to to My Health<em>e</em>Vet</a>.  
+                        <p><a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/user-login?redirect=/mhv-portal-web/user-registration/user-login">Sign in to to My HealtheVet</a>.  
                         <h5>Upgrade your account in person at a VA health facility</h5>
                         <p><strong>You’ll need to have:</strong></p>
                         <ul>
@@ -169,7 +169,7 @@ display_title: Frequently Asked Questions
                             <a href="/facilities/">Find the phone number for your nearest VA health care facility</a>.</li>
                           <li><strong>A government-issued photo ID.</strong> This can be either your Veteran Health Identification Card or a valid driver’s license.</li>
                         </ul>
-                        <p>A VA staff member will verify your identity. Then they’ll record your information in the <strong>My Health<em>e</em>Vet</strong> system and confirm you’re eligible for a premium account. A copy of your VA Form 10-5345a-MHV will be added to your VA medical record, and the original paper copy will be shredded to protect your privacy.</p>                        
+                        <p>A VA staff member will verify your identity. Then they’ll record your information in the <strong>My HealtheVet</strong> system and confirm you’re eligible for a premium account. A copy of your VA Form 10-5345a-MHV will be added to your VA medical record, and the original paper copy will be shredded to protect your privacy.</p>                        
                         <p><strong>Note:</strong> When you open or download a PDF file, you create a temporary file on your computer. Other people may be able to see this file—and any personal health information you fill in—especially if you’re using a public or shared computer.</p>
                      </div>
                     </div>
@@ -212,7 +212,7 @@ display_title: Frequently Asked Questions
                     <button class="usa-button-unstyled usa-accordion-button" aria-controls="faq-trouble-3" itemprop="name">What address should I use to verify my identity if I live overseas? </button>
                     <div id="faq-trouble-3" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
-                        <p><strong>If you have a premium My Health<em>e</em>Vet or DS Logon account,</strong> you can sign in using those credentials and you won’t need to verify your identity.</p>
+                        <p><strong>If you have a premium My HealtheVet or DS Logon account,</strong> you can sign in using those credentials and you won’t need to verify your identity.</p>
                         <p><strong>If you’re signing in through your ID.me account,</strong> you’ll need to use your most recent official stateside address and phone number (the information that’ll match records like your credit history)—even if it’s not your current contact information.</p>                        
                       </div>
                     </div>
@@ -238,7 +238,7 @@ display_title: Frequently Asked Questions
                     <div id="faq-trouble-5" class="usa-accordion-content" itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
                       <div itemprop="text">
                         <p><strong>You can try using your driver’s license or passport to verify your identity.</strong> Be sure to follow the image guidelines provided when you upload a copy of your driver’s license or passport.</p>
-                        <p><strong>Note:</strong> If you have a premium <strong>My Health<em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, you can sign in using those credentials and you won’t need to verify your identity. If you don’t have an existing premium account, you can find out how to get one by reading the question above about other options for verifying your identity.</p>                          
+                        <p><strong>Note:</strong> If you have a premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account, you can sign in using those credentials and you won’t need to verify your identity. If you don’t have an existing premium account, you can find out how to get one by reading the question above about other options for verifying your identity.</p>                          
                       </div>
                     </div>
                   </li>
@@ -249,8 +249,8 @@ display_title: Frequently Asked Questions
                         <p>It depends on how you sign in to Vets.gov.</p>
                         <ul>
                           <li><strong>If you set up a verified Vets.gov account through ID.me,</strong> you need to set up 2-factor authentication. Authentication gives you an extra layer of security by letting you into your account only after you’ve signed in with a password and a 6-digit code sent directly to your mobile or home phone. This helps to make sure that no one but you can access your account—even if they get your password.</li>
-                          <li><strong>If you sign in to Vets.gov using your existing premium My Health<em>e</em>Vet or premium DS Logon account,</strong> setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your Vets.gov profile page.</li>
-                          <li><strong>If you sign in to Vets.gov using your existing basic or advanced My Health<em>e</em>Vet or basic DS Logon account and don’t want to verify your identity,</strong> you don’t need to add 2-factor authentication. But you won’t be able to use the site’s tools that require you to verify your identity and do common tasks, like checking your claims status or sending a secure message to your health care team.</li>
+                          <li><strong>If you sign in to Vets.gov using your existing premium My HealtheVet or premium DS Logon account,</strong> setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your Vets.gov profile page.</li>
+                          <li><strong>If you sign in to Vets.gov using your existing basic or advanced My HealtheVet or basic DS Logon account and don’t want to verify your identity,</strong> you don’t need to add 2-factor authentication. But you won’t be able to use the site’s tools that require you to verify your identity and do common tasks, like checking your claims status or sending a secure message to your health care team.</li>
                       </div>
                     </div>
                   </li>                          
@@ -308,7 +308,7 @@ display_title: Frequently Asked Questions
                       <div itemprop="text">
                         <p>This code is part of the 2-factor authentication process.</p>
                         <p>When you set up a verified Vets.gov account through ID.me, you need to set up 2-factor authentication. Authentication gives you an extra layer of security by letting you into your account only after you’ve signed in with a password and a 6-digit code sent directly to your mobile or home phone. This helps to make sure that no one but you can access your account—even if they get your password.<p>                        
-                        <p>If you sign in to Vets.gov using your existing basic or advanced <strong>My Health<em>e</em>Vet</strong> or basic <strong>DS Logon</strong> account and don’t want to verify your identity, or if you sign in using your existing premium <strong>My Health <em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your Vets.gov profile page.<p>          
+                        <p>If you sign in to Vets.gov using your existing basic or advanced <strong>My HealtheVet</strong> or basic <strong>DS Logon</strong> account and don’t want to verify your identity, or if you sign in using your existing premium <strong>My Health <em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your Vets.gov profile page.<p>          
                       </div>
                     </div>
                   </li>

--- a/content/pages/health-care/about-va-health-care/your-care-team.md
+++ b/content/pages/health-care/about-va-health-care/your-care-team.md
@@ -71,8 +71,8 @@ Your team’s goal is to plan for all the care you need to help you stay healthy
 
 - **Provide or arrange for preventive care,** such as immunizations (like flu shots) to prevent illness and screenings to help find diseases like cancer in their earliest stages—when treatment is most likely to be successful.
 
-- **Help you get care in the ways that work best for you.** This may include personal visits with your primary care provider, group clinics, and 24/7 telephone care. You can also get online educational information and secure messaging with your health care team through the My Health***e***Vet portal.<br>
-[Visit My Health***e***Vet](https://www.myhealth.va.gov/).
+- **Help you get care in the ways that work best for you.** This may include personal visits with your primary care provider, group clinics, and 24/7 telephone care. You can also get online educational information and secure messaging with your health care team through the My HealtheVet portal.<br>
+[Visit My HealtheVet](https://www.myhealth.va.gov/).
 
 - **Coordinate your care.** Team members will meet often to talk with you—and each other—about your progress and goals. And they’ll coordinate any care you may need from specialists outside the team.
 
@@ -111,7 +111,7 @@ Your health care team will have a plan in place if your primary care provider is
 
 #### Can I see a local community care provider, paid for by VA?
 
-It depends. If we can't provide the care you need, we may refer you to a community provider. Your eligibility for community care will be based on your specific needs and circumstances. 
+It depends. If we can't provide the care you need, we may refer you to a community provider. Your eligibility for community care will be based on your specific needs and circumstances.
 
 **We may refer you to a community provider if any one of these is true for you:**
 - We can’t provide the services you need, **or**

--- a/content/pages/health-care/schedule-an-appointment.md
+++ b/content/pages/health-care/schedule-an-appointment.md
@@ -86,7 +86,7 @@ If you have VA health care benefits, you can schedule a VA primary care appointm
 
 **And, you must have one of these free accounts:**
 - A premium My HealtheVet account <br>
-[Sign up for a My Health*e*Vet account](https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/upgrading-your-my-healthevet-account-through-in-person-or-online-authentication). <br>
+[Sign up for a My HealtheVet account](https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/upgrading-your-my-healthevet-account-through-in-person-or-online-authentication). <br>
 - Or, a premium DS Logon account (used for eBenefits and milConnect) <br>
 [Sign up for a DS Logon account](https://mobile.va.gov/dslogon).
 
@@ -102,11 +102,11 @@ If you have VA health care benefits, you can schedule a VA primary care appointm
 
 <div itemprop="itemListElement">
 
-If you have a Vets.gov account or a My Health*e*Vet Premium account, you can send secure messages to your health care team about non-urgent, health-related questions like scheduling and canceling appointments.
+If you have a Vets.gov account or a My HealtheVet Premium account, you can send secure messages to your health care team about non-urgent, health-related questions like scheduling and canceling appointments.
 
 **Send a secure message or sign up now through:**
 - [Vets.gov](/?next=%2Fhealth-care%2Fmessaging), **or** <br>
-- [My Health*e*Vet Premium](https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/upgrading-your-my-healthevet-account-through-in-person-or-online-authentication)
+- [My HealtheVet Premium](https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/upgrading-your-my-healthevet-account-through-in-person-or-online-authentication)
 
 **Please note:** These online tools allow you to schedule only VA appointments. If you have appointments with non-VA facilities through the Community Care Program, please contact that health care facility directly.<br>
 [Learn how the Community Care Program works](https://www.va.gov/COMMUNITYCARE/index.asp).

--- a/content/pages/health-care/schedule-an-appointment.md
+++ b/content/pages/health-care/schedule-an-appointment.md
@@ -85,7 +85,7 @@ If you have VA health care benefits, you can schedule a VA primary care appointm
 - You've had an appointment at that VA medical facility within the last 2 years
 
 **And, you must have one of these free accounts:**
-- A premium My Health<em>e</em>Vet account <br>
+- A premium My HealtheVet account <br>
 [Sign up for a My Health*e*Vet account](https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/upgrading-your-my-healthevet-account-through-in-person-or-online-authentication). <br>
 - Or, a premium DS Logon account (used for eBenefits and milConnect) <br>
 [Sign up for a DS Logon account](https://mobile.va.gov/dslogon).

--- a/content/pages/veteran-id-card/how-to-get.md
+++ b/content/pages/veteran-id-card/how-to-get.md
@@ -46,7 +46,7 @@ You’ll need to apply online.
 
 ### Do I need to sign in to Vets.gov to apply for a Veteran ID Card?
 
-No. You can complete the application without signing in, but it’ll take us longer to verify your identity. This will delay a decision on your application. The fastest way to get your application processed is to sign in with a My Health<em>e</em>Vet or DS Logon account (the same one you use for eBenefits or MilConnect) or an ID.me account.
+No. You can complete the application without signing in, but it’ll take us longer to verify your identity. This will delay a decision on your application. The fastest way to get your application processed is to sign in with a My HealtheVet or DS Logon account (the same one you use for eBenefits or MilConnect) or an ID.me account.
 
 **When you sign in to Vets.gov and verify your identity, you’ll:**
 
@@ -64,7 +64,7 @@ It depends. We process applications in the order we receive them. If your applic
 
 When you sign in to Vets.gov, we need to verify your identity to make sure you’re you—and not someone pretending to be you—before we can give you access to your personal information. This helps to keep your information safe and prevent fraud and identity theft.
 
-You can sign in with your My Health<em>e</em>Vet or DS Logon account, and we’ll connect your account to Vets.gov through ID.me. If you have a basic or advanced (non-premium) account, you’ll need to verify your identity through ID.me. We can also help you use ID.me to add an extra layer of security to your account. If you don’t have an account on Vets.gov, you can create one using ID.me.
+You can sign in with your My HealtheVet or DS Logon account, and we’ll connect your account to Vets.gov through ID.me. If you have a basic or advanced (non-premium) account, you’ll need to verify your identity through ID.me. We can also help you use ID.me to add an extra layer of security to your account. If you don’t have an account on Vets.gov, you can create one using ID.me.
 
 ID.me is our trusted technology partner that provides the strongest identity verification system available. ID.me is 1 of 4 Single Sign-On providers that meet the U.S. government’s most rigorous requirements for online identity proofing and authentication.<br>
 

--- a/src/applications/post-911-gib-status/containers/IntroPageSummary.jsx
+++ b/src/applications/post-911-gib-status/containers/IntroPageSummary.jsx
@@ -102,13 +102,8 @@ export default function BrandConsolidationSummary() {
           </p>
           <ul>
             <li>
-              A premium{' '}
-              <strong>
-                My Health
-                <em>e</em>
-                Vet
-              </strong>{' '}
-              account, <strong>or</strong>
+              A premium <strong>My HealtheVet</strong> account,
+              <strong>or</strong>
             </li>
             <li>
               A <strong>DS Logon</strong> account (used for eBenefits and

--- a/src/applications/vic-v2/containers/IntroductionPage.jsx
+++ b/src/applications/vic-v2/containers/IntroductionPage.jsx
@@ -180,9 +180,8 @@ class IntroductionPage extends React.Component {
                   Choice 1: Sign in to {siteName} and verify your identity
                 </h6>
                 <p>
-                  Sign in to {siteName} with either your existing My Health
-                  <em>e</em>
-                  Vet or DS Logon account (the same one you use for eBenefits or
+                  Sign in to {siteName} with either your existing My HealtheVet
+                  or DS Logon account (the same one you use for eBenefits or
                   MilConnect) or an ID.me account.
                 </p>
                 <p>
@@ -214,9 +213,8 @@ class IntroductionPage extends React.Component {
                   You can complete the application without signing in, but it’ll
                   take us longer to verify your identity. This will delay a
                   decision on your application. The fastest way to get your
-                  application processed is to sign in with a My Health
-                  <em>e</em>
-                  Vet, DS Logon, or ID.me account.
+                  application processed is to sign in with a My HealtheVet, DS
+                  Logon, or ID.me account.
                 </p>
               </li>
             )}
@@ -235,11 +233,9 @@ class IntroductionPage extends React.Component {
                     verification system available.
                   </p>
                   <p>
-                    If you signed in using your My Health
-                    <em>e</em>
-                    Vet or DS Logon account, we’ll connect your account to
-                    {siteName} through ID.me. To verify your identity through
-                    ID.me, you’ll need:
+                    If you signed in using your My HealtheVet or DS Logon
+                    account, we’ll connect your account to {siteName} through
+                    ID.me. To verify your identity through ID.me, you’ll need:
                   </p>
                   {idProofingReqs}
                   <p>

--- a/src/platform/static-data/error-messages.jsx
+++ b/src/platform/static-data/error-messages.jsx
@@ -51,9 +51,7 @@ export const mhvAccessError = (
             </li>
             <li>
               <strong>
-                Do you need a different My Health
-                <em>e</em>
-                Vet account type?
+                Do you need a different My HealtheVet account type?
               </strong>{' '}
               You may need a higher level of access to use this tool. Learn
               about the different account types on the{' '}
@@ -61,20 +59,15 @@ export const mhvAccessError = (
                 href="https://www.myhealth.va.gov/mhv-portal-web/upgrading-your-my-healthevet-account-through-in-person-or-online-authentication"
                 target="_blank"
               >
-                My Health
-                <em>e</em>
-                Vet website.
+                My HealtheVet website.
               </a>
             </li>
             <li>
               <strong>
-                Did you forget to accept My Health
-                <em>e</em>
-                Vet's terms and conditions?
+                Did you forget to accept My HealtheVet's terms and conditions?
               </strong>{' '}
-              You need to log in to My Health
-              <em>e</em>
-              Vet and accept their terms and conditions.
+              You need to log in to My HealtheVet and accept their terms and
+              conditions.
             </li>
           </ol>
           <p>

--- a/src/platform/user/authorization/containers/MHVApp.jsx
+++ b/src/platform/user/authorization/containers/MHVApp.jsx
@@ -61,25 +61,19 @@ const INELIGIBLE_MESSAGES = {
 
   has_deactivated_mhv_ids: {
     headline: (
-      <span>
-        It looks like you’ve disabled your My Health
-        <em>e</em>
-        Vet account
-      </span>
+      <span>It looks like you’ve disabled your My HealtheVet account</span>
     ),
     content: (
       <div>
         <p>
           We’re sorry. We can’t give you access to the {siteName} health tools
-          because it looks like you already have a My Health
-          <em>e</em>
-          Vet account that’s been disabled.
+          because it looks like you already have a My HealtheVet account that’s
+          been disabled.
         </p>
         <p>
-          Please call the My Health
-          <em>e</em>
-          Vet Help Desk at 1-877-327-0022 (TTY: 1-800-877-8339), 7:00 a.m. -
-          7:00 p.m. (CT), and ask for help to activate your disabled account.
+          Please call the My HealtheVet Help Desk at 1-877-327-0022 (TTY:
+          1-800-877-8339), 7:00 a.m. - 7:00 p.m. (CT), and ask for help to
+          activate your disabled account.
         </p>
       </div>
     ),
@@ -87,27 +81,19 @@ const INELIGIBLE_MESSAGES = {
 
   has_multiple_active_mhv_ids: {
     headline: (
-      <span>
-        It looks like you have more than one My Health
-        <em>e</em>
-        Vet account
-      </span>
+      <span>It looks like you have more than one My HealtheVet account</span>
     ),
     content: (
       <div>
         <p>
           We’re sorry. We can’t give you access to the {siteName} health tools
           because we’ve found more than one active account for you in the My
-          Health
-          <em>e</em>
-          Vet system.
+          HealtheVet system.
         </p>
         <p>
-          Please call the My Health
-          <em>e</em>
-          Vet Help Desk at 1-877-327-0022 (TTY: 1-800-877-8339), 7:00 a.m. -
-          7:00 p.m. (CT), and ask for help to delete any extra accounts in the
-          system.
+          Please call the My HealtheVet Help Desk at 1-877-327-0022 (TTY:
+          1-800-877-8339), 7:00 a.m. - 7:00 p.m. (CT), and ask for help to
+          delete any extra accounts in the system.
         </p>
       </div>
     ),
@@ -204,11 +190,7 @@ export class MHVApp extends React.Component {
   renderPlaceholderErrorMessage() {
     const alertProps = {
       headline: (
-        <span>
-          We’re not able to process your My Health
-          <em>e</em>
-          Vet account
-        </span>
+        <span>We’re not able to process your My HealtheVet account</span>
       ),
       content: (
         <p>
@@ -253,19 +235,11 @@ export class MHVApp extends React.Component {
 
   renderAccountUnknownMessage() {
     const alertProps = {
-      headline: (
-        <span>
-          We can’t confirm your My Health
-          <em>e</em>
-          Vet account level
-        </span>
-      ),
+      headline: <span>We can’t confirm your My HealtheVet account level</span>,
       content: (
         <p>
           We’re sorry. Something went wrong on our end. We can’t confirm your My
-          Health
-          <em>e</em>
-          Vet account level right now. You can use most of the tools on
+          HealtheVet account level right now. You can use most of the tools on
           {siteName}, but you won’t be able to send secure messages or refill
           prescriptions at this time. We’re working to fix this. Please check
           back later.
@@ -297,16 +271,13 @@ export class MHVApp extends React.Component {
       headline: `We can’t give you access to ${siteName} health tools right now`,
       content: (
         <p>
-          We’re sorry. We started the process of creating the MyHealth
-          <em>e</em>
-          Vet account you’ll need to access the {siteName} health tools, but
+          We’re sorry. We started the process of creating the MyHealtheVet
+          account you’ll need to access the {siteName} health tools, but
           something went wrong on our end before we could complete it. We’ve
-          created your MyHealth
-          <em>e</em>
-          Vet account, but we still need to upgrade it to the security level
-          needed to use tools that access your health-related information. We’re
-          working to fix this so you can use the tools as soon as possible.
-          Please try signing in again later.
+          created your MyHealtheVet account, but we still need to upgrade it to
+          the security level needed to use tools that access your health-related
+          information. We’re working to fix this so you can use the tools as
+          soon as possible. Please try signing in again later.
         </p>
       ),
     };

--- a/va-gov/pages/health-care/about-va-health-benefits/your-care-team.md
+++ b/va-gov/pages/health-care/about-va-health-benefits/your-care-team.md
@@ -73,8 +73,8 @@ Your team’s goal is to plan for all the care you need to help you stay healthy
 
 - **Provide or arrange for preventive care,** such as immunizations (like flu shots) to prevent illness and screenings to help find diseases like cancer in their earliest stages—when treatment is most likely to be successful.
 
-- **Help you get care in the ways that work best for you.** This may include personal visits with your primary care provider, group clinics, and 24/7 telephone care. You can also get online educational information and secure messaging with your health care team through the My Health***e***Vet portal.<br>
-[Visit My Health***e***Vet](https://www.myhealth.va.gov/).
+- **Help you get care in the ways that work best for you.** This may include personal visits with your primary care provider, group clinics, and 24/7 telephone care. You can also get online educational information and secure messaging with your health care team through the My HealtheVet portal.<br>
+[Visit My HealtheVet](https://www.myhealth.va.gov/).
 
 - **Coordinate your care.** Team members will meet often to talk with you—and each other—about your progress and goals. And they’ll coordinate any care you may need from specialists outside the team.
 

--- a/va-gov/pages/sign-in-faq.md
+++ b/va-gov/pages/sign-in-faq.md
@@ -3,7 +3,7 @@ layout: page.html
 permalink: /sign-in-faq.html
 title: Frequently Asked Questions about Signing In to VA.gov
 display_title: Frequently Asked Questions
-aliases: 
+aliases:
   - /faq/
 ---
 
@@ -310,7 +310,7 @@ aliases:
                       <div itemprop="text">
                         <p>This code is part of the 2-factor authentication process.</p>
                         <p>When you set up a verified VA.gov account through ID.me, you need to set up 2-factor authentication. Authentication gives you an extra layer of security by letting you into your account only after you’ve signed in with a password and a 6-digit code sent directly to your mobile or home phone. This helps to make sure that no one but you can access your account—even if they get your password.<p>
-                        <p>If you sign in to VA.gov using your existing basic or advanced <strong>My HealtheVet</strong> or basic <strong>DS Logon</strong> account and don’t want to verify your identity, or if you sign in using your existing premium <strong>My Health <em>e</em>Vet</strong> or premium <strong>DS Logon</strong> account, setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your VA.gov profile page.<p>
+                        <p>If you sign in to VA.gov using your existing basic or advanced <strong>My HealtheVet</strong> or basic <strong>DS Logon</strong> account and don’t want to verify your identity, or if you sign in using your existing premium <strong>My HealtheVet</strong> or premium <strong>DS Logon</strong> account, setting up 2-factor authentication is optional. You can set it up during the sign-in process or any time from your VA.gov profile page.<p>
                       </div>
                     </div>
                   </li>


### PR DESCRIPTION
## Description
un-italicizing e from My HealtheVet

## Testing done
Local Testing

## Acceptance criteria
- [ ] all <e> tags from removed My HealtheVet

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
