### PR TITLE
Update missed VIC text in Mega Menu

### DIFF
--- a/src/platform/site-wide/mega-menu/mega-menu-link-data.json
+++ b/src/platform/site-wide/mega-menu/mega-menu-link-data.json
@@ -517,7 +517,7 @@
                                 "href": "/housing-assistance/home-loans/how-to-apply/"
                             },
                             {
-                                "text": "Learn About Veteran ID Cards",
+                                "text": "Get Veteran ID Cards",
                                 "href": "/records/get-veteran-id-cards/"
                             },
                             {

--- a/src/platform/site-wide/mega-menu/mega-menu-link-data.json
+++ b/src/platform/site-wide/mega-menu/mega-menu-link-data.json
@@ -519,10 +519,6 @@
                             {
                                 "text": "Get Veteran ID Cards",
                                 "href": "/records/get-veteran-id-cards/"
-                            },
-                            {
-                                "text": "Get Veteran ID Cards",
-                                "href": "/records/get-veteran-id-cards/vic/"
                             }
                         ]
                     },


### PR DESCRIPTION
## Description
Changes "Learn about Veteran ID Cards" to "get Veteran ID Cards" in the megamenu.

Moves to validate - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13908

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/47244710-7da7cd80-d3c4-11e8-94b8-235ce04e31d1.png)


## Acceptance criteria
- [x] VIC text is updated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
