### PR TITLE
Updates FAQ Links on Login Modal

### DIFF
--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -24,6 +24,7 @@ const handleIdMe = loginHandler('idme');
 const logoSrc = `/img/design/logo/${
   isBrandConsolidationEnabled() ? 'va-logo.png' : 'logo-alt.png'
 }`;
+const faqHref = isBrandConsolidationEnabled() ? '/sign-in-faq/' : '/faq/';
 
 class SignInModal extends React.Component {
   componentDidUpdate(prevProps) {
@@ -153,7 +154,7 @@ class SignInModal extends React.Component {
                 information.
               </p>
               <p>
-                <a href="/sign-in-faq/#what-is-idme" target="_blank">
+                <a href={`${faqHref}#what-is-idme`} target="_blank">
                   Learn more about ID.me
                 </a>
               </p>
@@ -165,7 +166,7 @@ class SignInModal extends React.Component {
             <div className="help-info">
               <h4>Having trouble signing in?</h4>
               <p>
-                <a href="/sign-in-faq/" target="_blank">
+                <a href={faqHref} target="_blank">
                   Get answers to Frequently Asked Questions
                 </a>
               </p>

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -153,7 +153,7 @@ class SignInModal extends React.Component {
                 information.
               </p>
               <p>
-                <a href="/faq/#what-is-idme" target="_blank">
+                <a href="/sign-in-faq/#what-is-idme" target="_blank">
                   Learn more about ID.me
                 </a>
               </p>
@@ -165,7 +165,7 @@ class SignInModal extends React.Component {
             <div className="help-info">
               <h4>Having trouble signing in?</h4>
               <p>
-                <a href="/faq/" target="_blank">
+                <a href="/sign-in-faq/" target="_blank">
                   Get answers to Frequently Asked Questions
                 </a>
               </p>


### PR DESCRIPTION
## Description
Recent updates were made to rename /faq to /sign-in-faq in this PR: department-of-veterans-affairs/vets-website#8788. Redirects are in place but we'd like to update two instances that appear on the login modal so it's a directly link.

## Testing done
Local testing 

## Screenshots
#### Get answers screenshot

![image](https://user-images.githubusercontent.com/7482329/47307532-782ccc00-d5ec-11e8-9e8c-a9bee623ae47.png)

#### Learn more screenshot

![image](https://user-images.githubusercontent.com/7482329/47307541-81b63400-d5ec-11e8-9756-d1f6bafb58b2.png)


## Acceptance criteria
- [x] Update 'Get answers to Frequently Asked Questions' link to => /sign-in-faq
- [x] Update 'Learn more about ID.me' link to => /sign-in-faq/#what-is-idme

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
