### PR TITLE
Add a meta tag for verifying site-ownership to the Insight App Sec Scanner

### DIFF
--- a/va-gov/includes/header.html
+++ b/va-gov/includes/header.html
@@ -45,6 +45,12 @@
 <meta content="{{ tag }}" property="article:tag">
 {% endfor %}
 {% endif %}
+
+{% if buildtype == 'vagovstaging' %}
+<!-- Verification of site-ownership to the Insight App Sec Scanner -->
+<meta name="insight-app-sec-validation" content="ec59f99e-d869-4e3f-82d2-a61d32c65776">
+{% endif %}
+
 {% if title === 'Home' %}
 <title>VA.gov</title>
 {% else %}


### PR DESCRIPTION
## Description
This PR adds a meta tag into the header of all pages in the Staging.Va.gov environment to verify to the Insight App Sec Scanner that we own the site we're scanning.

## Acceptance criteria
- [x] Meta tag exists on `staging.va.gov`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
