### PR TITLE
Uptick FE metrics sample rate to 20 percent

### DIFF
--- a/src/platform/monitoring/frontend-metrics/sample-rate.js
+++ b/src/platform/monitoring/frontend-metrics/sample-rate.js
@@ -7,7 +7,7 @@
  */
 export default function withinMetricsSample() {
   // Update this constant to an integer fromn 0 to 100 to alter the sample rate.
-  const sampleRate = 3;
+  const sampleRate = 20;
 
   const randomizer = Math.floor(Math.random() * 100) + 1;
   return randomizer < sampleRate;


### PR DESCRIPTION
## Description
Our [grafana boards](http://grafana.vetsgov-internal/dashboard/db/fe-metrics?orgId=1&var-data_source=Prometheus%20(Production)&var-quantile=0.5&from=now-24h&to=now) are pretty barren. We conservatively set this at 3% but now will uptick to ~ 20% so we have more data :)

See: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14115

## Acceptance criteria
- [x] Data is pulled at 20%

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
