### PR TITLE
Removed unwanted margin-top from IAMA select on preview.va.gov/health

### DIFF
--- a/src/platform/site-wide/sass/style-consolidated.scss
+++ b/src/platform/site-wide/sass/style-consolidated.scss
@@ -55,5 +55,12 @@ $teamsite-width: 959px;
 }
 
 .merger #bg-middle-effect {
-    background: url(/va_files/2014/responsive/images/bg-middle-effect.png) repeat-y scroll center -65px $teamsite-light-blue;
+  background: url(/va_files/2014/responsive/images/bg-middle-effect.png) repeat-y scroll center -65px $teamsite-light-blue;
+}
+
+// ----- Patches to elements outside of .consolidated ----- //
+
+// "I am a" select field on /health is having an unwanted margin-top added by @us-forms-system library
+#iama {
+  margin-top: 0;
 }


### PR DESCRIPTION
## Description

Issue: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13906

The brand consolidation injected styling is adding an unwanted margin on the "I am a..." select field on preview.va.gov/health. Added a patch in `style-consolidated.scss` to remove this margin.  

**Note:** This fix was added to `style-consolidated.scss` rather than `consolidated-patches.scss` because the select element falls outside the `.consolidated` element.

## Testing done

Chrome  69.0.3497.100

## Screenshots

### Before fix
![Screen Shot 2018-10-02 at 16.42.02.png](https://images.zenhubusercontent.com/5a5d4c174b5806bc2bc2db50/b7dce542-2cf1-4aef-a8fc-f276d9ffcc9a)

### After fix
![Screen Shot 2018-10-02 at 16.43.15.png](https://images.zenhubusercontent.com/5a5d4c174b5806bc2bc2db50/9141627f-3b8f-4c95-bd6d-b5386b1318d9)

## Acceptance criteria
- [x] No unnecessary margin at top of "I am a..." select
