### PR TITLE
526 no payment notification mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/PaymentView.jsx
+++ b/src/applications/disability-benefits/526EZ/components/PaymentView.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { srSubstitute } from '../../all-claims/utils';
-import { NOBANK, accountTitleLabels } from '../constants';
+import { accountTitleLabels } from '../constants';
 import { PaymentDescription, editNote } from '../helpers';
 
 const PaymentView = response => {
@@ -10,9 +10,6 @@ const PaymentView = response => {
     financialInstitutionRoutingNumber: routingNumber = '',
     financialInstitutionName: bankName = '',
   } = response;
-  let accountNumberString;
-  let routingNumberString;
-  let bankNameString;
 
   const mask = (string, unmaskedLength) => {
     // If no string is given, tell the screen reader users the account or routing number is blank
@@ -33,13 +30,56 @@ const PaymentView = response => {
     );
   };
 
-  if (accountType !== NOBANK) {
-    accountNumberString = <p>Account number: {mask(accountNumber, 4)}</p>;
-    routingNumberString = <p>Bank routing number: {mask(routingNumber, 4)}</p>;
-    bankNameString = (
-      <p>Bank name: {bankName || srSubstitute('', 'is blank')}</p>
+  if (!accountType || !accountNumber || !routingNumber) {
+    // should we also check bankName?
+    return (
+      <div>
+        <PaymentDescription />
+        <div className="blue-bar-block">
+          <p>
+            <strong>
+              We don’t have any bank account information for you in our system.
+            </strong>
+            <br />
+            You can still complete this form, but we'll need your payment
+            information in order to pay you compensation.
+          </p>
+          <p>
+            <strong>You can update your payment information a few ways:</strong>
+          </p>
+          <ul>
+            <li>
+              Fill out and send us a Direct Deposit Enrollment form (VA Form
+              24-0296).{' '}
+              <a
+                href="https://www.vba.va.gov/pubs/forms/vba-24-0296-are.pdf"
+                target="_blank"
+              >
+                Download VA Form 24-0296
+              </a>
+              , <strong>or</strong>
+            </li>
+            <li>
+              Go to eBenefits to add your payment information to your account.{' '}
+              <a
+                href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information"
+                target="_blank"
+              >
+                Go to eBenefits
+              </a>
+              , <strong>or</strong>
+            </li>
+            <li>
+              Call Veterans Benefits Assistance at{' '}
+              <a href="tel:1-800-827-1000">1-800-827-1000</a>, Monday -- Friday,
+              8:00 a.m. -- 9:00 p.m. (ET).
+            </li>
+          </ul>
+        </div>
+      </div>
     );
   }
+
   return (
     <div>
       <PaymentDescription />
@@ -47,9 +87,9 @@ const PaymentView = response => {
         <p>
           <strong>{accountTitleLabels[accountType.toUpperCase()]}</strong>
         </p>
-        {accountNumberString}
-        {routingNumberString}
-        {bankNameString}
+        <p>Account number: {mask(accountNumber, 4)}</p>
+        <p>Bank routing number: {mask(routingNumber, 4)}</p>
+        <p>Bank name: {bankName || srSubstitute('', 'is blank')}</p>
       </div>
       {editNote('bank information')}
     </div>

--- a/src/applications/disability-benefits/526EZ/components/PaymentView.jsx
+++ b/src/applications/disability-benefits/526EZ/components/PaymentView.jsx
@@ -42,7 +42,7 @@ const PaymentView = response => {
             </strong>
             <br />
             You can still complete this form, but we’ll need your payment
-            information in order to pay you compensation.
+            information before we can pay you any compensation.
           </p>
           <p>
             <strong>You can update your payment information a few ways:</strong>

--- a/src/applications/disability-benefits/526EZ/components/PaymentView.jsx
+++ b/src/applications/disability-benefits/526EZ/components/PaymentView.jsx
@@ -34,48 +34,45 @@ const PaymentView = response => {
     // should we also check bankName?
     return (
       <div>
-        <PaymentDescription />
-        <div className="blue-bar-block">
-          <p>
-            <strong>
-              We don’t have any bank account information for you in our system.
-            </strong>
-            <br />
-            You can still complete this form, but we’ll need your payment
-            information before we can pay you any compensation.
-          </p>
-          <p>
-            <strong>You can update your payment information a few ways:</strong>
-          </p>
-          <ul>
-            <li>
-              Fill out and send us a Direct Deposit Enrollment form (VA Form
-              24-0296).{' '}
-              <a
-                href="https://www.vba.va.gov/pubs/forms/vba-24-0296-are.pdf"
-                target="_blank"
-              >
-                Download VA Form 24-0296
-              </a>
-              , <strong>or</strong>
-            </li>
-            <li>
-              Go to eBenefits to add your payment information to your account.{' '}
-              <a
-                href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information"
-                target="_blank"
-              >
-                Go to eBenefits
-              </a>
-              , <strong>or</strong>
-            </li>
-            <li>
-              Call Veterans Benefits Assistance at{' '}
-              <a href="tel:1-800-827-1000">1-800-827-1000</a>, Monday – Friday,
-              8:00 a.m. – 9:00 p.m. (ET).
-            </li>
-          </ul>
-        </div>
+        <p>
+          <strong>
+            We don’t have any bank account information for you in our system.
+          </strong>
+          <br />
+          You can still complete this form, but we’ll need your payment
+          information before we can pay you any compensation.
+        </p>
+        <p>
+          <strong>You can update your payment information a few ways:</strong>
+        </p>
+        <ul>
+          <li>
+            Fill out and send us a Direct Deposit Enrollment form (VA Form
+            24-0296).{' '}
+            <a
+              href="https://www.vba.va.gov/pubs/forms/vba-24-0296-are.pdf"
+              target="_blank"
+            >
+              Download VA Form 24-0296
+            </a>
+            , <strong>or</strong>
+          </li>
+          <li>
+            Go to eBenefits to add your payment information to your account.{' '}
+            <a
+              href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information"
+              target="_blank"
+            >
+              Go to eBenefits
+            </a>
+            , <strong>or</strong>
+          </li>
+          <li>
+            Call Veterans Benefits Assistance at{' '}
+            <a href="tel:1-800-827-1000">1-800-827-1000</a>, Monday – Friday,
+            8:00 a.m. – 9:00 p.m. (ET).
+          </li>
+        </ul>
       </div>
     );
   }

--- a/src/applications/disability-benefits/526EZ/components/PaymentView.jsx
+++ b/src/applications/disability-benefits/526EZ/components/PaymentView.jsx
@@ -41,7 +41,7 @@ const PaymentView = response => {
               We don’t have any bank account information for you in our system.
             </strong>
             <br />
-            You can still complete this form, but we'll need your payment
+            You can still complete this form, but we’ll need your payment
             information in order to pay you compensation.
           </p>
           <p>
@@ -71,8 +71,8 @@ const PaymentView = response => {
             </li>
             <li>
               Call Veterans Benefits Assistance at{' '}
-              <a href="tel:1-800-827-1000">1-800-827-1000</a>, Monday -- Friday,
-              8:00 a.m. -- 9:00 p.m. (ET).
+              <a href="tel:1-800-827-1000">1-800-827-1000</a>, Monday – Friday,
+              8:00 a.m. – 9:00 p.m. (ET).
             </li>
           </ul>
         </div>

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -144,7 +144,7 @@ const formConfig = {
     dateRangeAllRequired,
     disabilities,
   },
-  title: 'Apply for increased disability compensation',
+  title: 'File for increased disability compensation',
   subTitle: 'Form 21-526EZ',
   preSubmitInfo,
   // getHelp: GetFormHelp, // TODO: May need updated form help content

--- a/src/applications/disability-benefits/526EZ/constants.js
+++ b/src/applications/disability-benefits/526EZ/constants.js
@@ -37,8 +37,6 @@ export const accountTitleLabels = {
   NOBANK: 'No Bank Account',
 };
 
-export const NOBANK = 'NOBANK';
-
 export const PENDING = 'PENDING';
 export const RESOLVED = 'RESOLVED';
 export const REJECTED = 'REJECTED';

--- a/src/applications/disability-benefits/526EZ/tests/components/PaymentView.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/PaymentView.unit.spec.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import PaymentView from '../../components/PaymentView';
+
+describe('Disability benefits 526EZ primary address', () => {
+  const defaultProps = {
+    accountType: 'Checking',
+    accountNumber: '123456789',
+    financialInstitutionRoutingNumber: '234567890',
+    financialInstitutionName: 'Comerica',
+  };
+
+  it('should render payment info when available', () => {
+    const wrapper = shallow(<PaymentView />);
+    expect(wrapper.type()).to.equal('div');
+  });
+
+  it('should render payment info when provided', () => {
+    const wrapper = shallow(<PaymentView {...defaultProps} />);
+    expect(wrapper.render().text()).to.contain(
+      // Looks a little different in the UI, but this is how its read by the screen reader
+      'Account number: ●●●●●ending with6789',
+    );
+  });
+
+  it('should render help when no payment info provided', () => {
+    const wrapper = shallow(<PaymentView />);
+    expect(wrapper.render().text()).to.contain(
+      'You can update your payment information a few ways:',
+    );
+  });
+});


### PR DESCRIPTION
## Description
Adds some help text when we don't find any payment information for a veteran
- No change to UI when payment info found
- No change to UI when there's an error retrieving the payment info

## Testing done
- Unit tests
- Tested locally

## Screenshots
Payment Info (no change):
![screen shot 2018-10-22 at 8 57 17 pm](https://user-images.githubusercontent.com/24251447/47333340-21ed7680-d648-11e8-9ae4-2bb15cd10277.png)

-----

No Payment Info:
![screen shot 2018-10-22 at 9 25 51 pm](https://user-images.githubusercontent.com/24251447/47333354-329dec80-d648-11e8-9941-dfb264e1baec.png)


## Acceptance criteria
- [x] Implement notice to veterans if they don't have any payment info in our system.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
