### PR TITLE
Scope teamsite usa-grid width to medium screens

### DIFF
--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -17,8 +17,8 @@
 }
 
 .usa-grid {
-  width: $teamsite-width;
   @media (min-width: $medium-screen) {
+    width: $teamsite-width;
     padding-left: 1px;
     padding-right: 1px;
   }


### PR DESCRIPTION
## Description
This change scopes `.usa-grid` width to medium screens for Teamsite pages

## Testing done
Verified locally

## Screenshots
![image](https://user-images.githubusercontent.com/16051172/47335165-c10d7080-d63e-11e8-94c3-c01ff70af6f8.png)


## Acceptance criteria
- [ ] Ensure menu is visible on mobile screens

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
