### PR TITLE
use absolute urls in images on sign in

### DIFF
--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -9,6 +9,7 @@ import isBrandConsolidationEnabled from '../../../brand-consolidation/feature-fl
 import recordEvent from '../../../monitoring/record-event';
 import { login, signup } from '../../../user/authentication/utilities';
 import { externalServices } from '../../../../platform/monitoring/DowntimeNotification';
+import { replaceWithStagingDomain } from '../../../../platform/utilities/environment/stagingDomains';
 import DowntimeBanner from '../../../../platform/monitoring/DowntimeNotification/components/Banner';
 import siteName from '../../../brand-consolidation/site-name';
 
@@ -21,11 +22,18 @@ const handleDsLogon = loginHandler('dslogon');
 const handleMhv = loginHandler('mhv');
 const handleIdMe = loginHandler('idme');
 
-const logoSrc = `/img/design/logo/${
-  isBrandConsolidationEnabled() ? 'va-logo.png' : 'logo-alt.png'
-}`;
-const faqHref = isBrandConsolidationEnabled() ? '/sign-in-faq/' : '/faq/';
+const logoSrc = replaceWithStagingDomain(
+  isBrandConsolidationEnabled()
+    ? 'https://www.va.gov/img/design/logo/va-logo.png'
+    : '/img/design/logo/logo-alt.png',
+);
+const faqHref = replaceWithStagingDomain(
+  isBrandConsolidationEnabled() ? 'https://www.va.gov/sign-in-faq/' : '/faq/',
+);
 
+const vaGovFullDomain = isBrandConsolidationEnabled()
+  ? replaceWithStagingDomain('https://www.va.gov')
+  : '';
 class SignInModal extends React.Component {
   componentDidUpdate(prevProps) {
     if (!prevProps.visible && this.props.visible) {
@@ -83,27 +91,42 @@ class SignInModal extends React.Component {
             <div className="signin-actions-container">
               <div className="top-banner">
                 <div>
-                  <img alt="ID.me" src="/img/signin/lock-icon.svg" /> Secured &
-                  powered by{' '}
-                  <img alt="ID.me" src="/img/signin/idme-icon-dark.svg" />
+                  <img
+                    alt="ID.me"
+                    src={`${vaGovFullDomain}/img/signin/lock-icon.svg`}
+                  />{' '}
+                  Secured & powered by{' '}
+                  <img
+                    alt="ID.me"
+                    src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
+                  />
                 </div>
               </div>
               <div className="signin-actions">
                 <h5>Sign in with an existing account</h5>
                 <div>
                   <button className="dslogon" onClick={handleDsLogon}>
-                    <img alt="DS Logon" src="/img/signin/dslogon-icon.svg" />
+                    <img
+                      alt="DS Logon"
+                      src={`${vaGovFullDomain}/img/signin/dslogon-icon.svg`}
+                    />
                     <strong> Sign in with DS Logon</strong>
                   </button>
                   <button className="mhv" onClick={handleMhv}>
-                    <img alt="My HealtheVet" src="/img/signin/mhv-icon.svg" />
+                    <img
+                      alt="My HealtheVet"
+                      src={`${vaGovFullDomain}/img/signin/mhv-icon.svg`}
+                    />
                     <strong> Sign in with My HealtheVet</strong>
                   </button>
                   <button
                     className="usa-button-primary va-button-primary"
                     onClick={handleIdMe}
                   >
-                    <img alt="ID.me" src="/img/signin/idme-icon-white.svg" />
+                    <img
+                      alt="ID.me"
+                      src={`${vaGovFullDomain}/img/signin/idme-icon-white.svg`}
+                    />
                     <strong> Sign in with ID.me</strong>
                   </button>
                   <span className="sidelines">OR</span>
@@ -113,7 +136,10 @@ class SignInModal extends React.Component {
                       className="idme-create usa-button usa-button-secondary"
                       onClick={signup}
                     >
-                      <img alt="ID.me" src="/img/signin/idme-icon-dark.svg" />
+                      <img
+                        alt="ID.me"
+                        src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
+                      />
                       <strong> Create an ID.me account</strong>
                     </button>
                     <p>Use your email, Google, or Facebook</p>


### PR DESCRIPTION
## Description
the sign in modal uses relative image links. this adds absolute urls for va.gov staging and production builds and leaves relative paths for dev and vets.gov builds

## Testing done
verified locally

## Screenshots vets.gov
![screen shot 2018-10-23 at 10 42 48](https://user-images.githubusercontent.com/4998130/47376766-b8558280-d6b0-11e8-95ac-04b21c9bf00b.png)


## screenshots va.gov
![screen shot 2018-10-23 at 10 40 24](https://user-images.githubusercontent.com/4998130/47376762-b390ce80-d6b0-11e8-974a-77963a1ade73.png)


## screenshots cem.va.gov
![screen shot 2018-10-23 at 10 37 28](https://user-images.githubusercontent.com/4998130/47376817-dae79b80-d6b0-11e8-97ed-aabd8300b197.png)
![screen shot 2018-10-23 at 10 40 44](https://user-images.githubusercontent.com/4998130/47376897-14200b80-d6b1-11e8-908d-c335a43a9458.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
