### PR TITLE
Update Yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,7 +1070,7 @@ babel-polyfill@^6.13.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-env@^1.4.0:
+babel-preset-env@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
   dependencies:


### PR DESCRIPTION
## Description
Seeing some errors in the Heroku instances about an outdated Yarn.lock. This PR updates that by runniing `yarn install`.