### PR TITLE
Copy MVP confirmation page and logic

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import get from '../../../../platform/utilities/data/get';
+import { apiRequest } from '../../../../platform/utilities/api';
+
+import ConfirmationPage from '../containers/ConfirmationPage';
+import { pendingMessage } from '../content/confirmation-poll';
+
+import { submissionStatuses, terminalStatuses } from '../constants';
+
+export class ConfirmationPoll extends React.Component {
+  // Using it as a prop for easy testing
+  static defaultProps = {
+    pollRate: 5000,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      submissionStatus: submissionStatuses.pending,
+      claimId: null,
+      failureCode: null,
+      longWait: false,
+    };
+  }
+
+  componentDidMount() {
+    // Using __ because it fails the unit test without it; something about enzyme using that property, I'm sure
+    this.__isMounted = true;
+    this.startTime = Date.now();
+    this.poll();
+  }
+
+  componentWillUnmount() {
+    this.__isMounted = false;
+  }
+
+  poll = () => {
+    // Don't continue to request after the component is unmounted
+    if (!this.__isMounted) {
+      return;
+    }
+
+    apiRequest(
+      `/disability_compensation_form/submission_status/${this.props.jobId}`,
+      {},
+      response => {
+        // Don't process the request once it comes back if the component is no longer mounted
+        if (!this.__isMounted) {
+          return;
+        }
+
+        // Check status
+        const status = response.data.attributes.transactionStatus;
+        if (terminalStatuses.has(status)) {
+          this.setState({
+            submissionStatus: status,
+            claimId: get('data.attributes.metadata.claimId', response) || null,
+          });
+        } else {
+          // Wait for a bit and recurse
+          const waitTime =
+            status === submissionStatuses.pending
+              ? this.props.pollRate
+              : this.props.pollRate * 2; // Seems like we don't need to poll as frequently when we get here
+
+          // Force a re-render to update the pending message if necessary
+          if (Date.now() - this.startTime >= 30000) {
+            this.setState({ longWait: true });
+          }
+          setTimeout(this.poll, waitTime);
+        }
+      },
+      response => {
+        // Don't process the request once it comes back if the component is no longer mounted
+        if (!this.__isMounted) {
+          return;
+        }
+
+        this.setState({
+          submissionStatus: submissionStatuses.apiFailure,
+          // NOTE: I don't know that it'll always take this shape.
+          failureCode: get('errors[0].status', response),
+        });
+      },
+    );
+  };
+
+  render() {
+    const { submissionStatus, claimId } = this.state;
+    if (submissionStatus === submissionStatuses.pending) {
+      return pendingMessage(this.state.longWait);
+    }
+
+    const { fullName, disabilities, submittedAt, jobId } = this.props;
+
+    return (
+      <ConfirmationPage
+        submissionStatus={submissionStatus}
+        claimId={claimId}
+        jobId={jobId}
+        fullName={fullName}
+        disabilities={disabilities}
+        submittedAt={submittedAt}
+      />
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    fullName: state.user.profile.userFullName,
+    disabilities: state.form.data.ratedDisabilities,
+    submittedAt: state.form.submission.submittedAt,
+    jobId: state.form.submission.response.attributes.jobId,
+  };
+}
+
+export default connect(mapStateToProps)(ConfirmationPoll);

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -2,7 +2,7 @@ import environment from '../../../../platform/utilities/environment';
 
 import preSubmitInfo from '../../../../platform/forms/preSubmitInfo';
 import IntroductionPage from '../components/IntroductionPage';
-import ConfirmationPage from '../containers/ConfirmationPage';
+import ConfirmationPoll from '../components/ConfirmationPoll';
 import {
   hasMilitaryRetiredPay,
   hasRatedDisabilities,
@@ -73,7 +73,9 @@ const formConfig = {
   },
   // transformForSubmit: transform,
   introduction: IntroductionPage,
-  confirmation: ConfirmationPage,
+  confirmation: ConfirmationPoll,
+  // TODO: Remove this once we've got the api up and running
+  submit: () => Promise.resolve({ attributes: { jobId: '12345' } }),
   // footerContent: FormFooter,
   // getHelp: GetFormHelp,
   defaultDefinitions: {

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -141,3 +141,21 @@ export const PTSD = 'ptsd';
 export const NINE_ELEVEN = '2001-09-11';
 
 export const ERR_MSG_CSS_CLASS = '.usa-input-error-message';
+
+export const submissionStatuses = {
+  // Statuses returned by the API
+  pending: 'submitted', // Submitted to EVSS, waiting response
+  retry: 'retrying',
+  succeeded: 'received', // Submitted to EVSS, received response
+  exhausted: 'exhausted', // EVSS is down or something; ran out of retries
+  failed: 'non_retryable_error', // EVSS responded with some error
+  // When the api serves a failure
+  apiFailure: 'apiFailure',
+};
+
+export const terminalStatuses = new Set([
+  submissionStatuses.succeeded,
+  submissionStatuses.exhausted,
+  submissionStatuses.retry,
+  submissionStatuses.failed,
+]);

--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import moment from 'moment';
-import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import Scroll from 'react-scroll';
 
 import { focusElement } from '../../../../platform/utilities/ui';
-import siteName from '../../../../platform/brand-consolidation/site-name';
+
+import { submissionStatuses } from '../constants';
+import {
+  retryableErrorContent,
+  successfulSubmitContent,
+  submitErrorContent,
+} from '../content/confirmation-page';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
@@ -15,7 +20,7 @@ const scrollToTop = () => {
   });
 };
 
-class ConfirmationPage extends React.Component {
+export default class ConfirmationPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = { isExpanded: false };
@@ -27,100 +32,29 @@ class ConfirmationPage extends React.Component {
   }
 
   render() {
-    const {
-      fullName: { first, middle, last, suffix },
-      disabilities,
-      claimId,
-      submittedAt,
-    } = this.props;
-
-    return (
-      <div>
-        <h3 className="confirmation-page-title">
-          Your claim has been submitted.
-        </h3>
-        <p>
-          We usually process claims within <strong>99 days</strong>.
-        </p>
-        <p>
-          We may contact you if we have questions or need more information. You
-          can print this page for your records.
-        </p>
-        <h4 className="confirmation-guidance-heading">
-          What happens after I apply?
-        </h4>
-        <p className="confirmation-guidance-message">
-          You don’t need to do anything unless we send you a letter asking for
-          more information. You can check the status of your claim online. The
-          time frame you see may vary based on how complex your claim is.
-        </p>
-        <a href="/disability-benefits/track-claims">
-          Check the status of your disability claim.
-        </a>
-        <br />
-        <a href="/disability-benefits/after-you-apply/">
-          Learn more about what happens after you file a disability claim.
-        </a>
-        <div className="inset">
-          <h4>
-            Disability Compensation Claim for Increase{' '}
-            <span className="additional">(Form 21-526EZ)</span>
-          </h4>
-          <span>
-            For {first} {middle} {last} {suffix}
-          </span>
-          <ul className="claim-list">
-            <strong>Conditions claimed</strong>
-            <br />
-            <ul className="disability-list">
-              {disabilities
-                .filter(item => item['view:selected'])
-                .map((disability, i) => (
-                  <li key={i}>{disability.name}</li>
-                ))}
-            </ul>
-            <li>
-              <strong>Confirmation number</strong>
-              <br />
-              <span>{claimId}</span>
-            </li>
-            <li>
-              <strong>Date submitted</strong>
-              <br />
-              <span>{moment(submittedAt).format('MMM D, YYYY')}</span>
-            </li>
-          </ul>
-        </div>
-        <div className="confirmation-guidance-container">
-          <h4 className="confirmation-guidance-heading">Need help?</h4>
-          <p className="confirmation-guidance-message">
-            If you have questions, please call{' '}
-            <a href="tel:+18772228387">1-877-222-8387</a>, Monday &#8211;
-            Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).
-          </p>
-        </div>
-        <div className="row form-progress-buttons schemaform-back-buttons">
-          <div className="small-6 usa-width-one-half medium-6 columns">
-            <a href="/">
-              <button className="usa-button-primary">
-                Go Back to {siteName}
-              </button>
-            </a>
-          </div>
-        </div>
-      </div>
-    );
+    switch (this.props.submissionStatus) {
+      case submissionStatuses.succeeded:
+        return successfulSubmitContent(this.props);
+      case submissionStatuses.retry:
+      case submissionStatuses.exhausted:
+      case submissionStatuses.apiFailure:
+        return retryableErrorContent(this.props);
+      default:
+        return submitErrorContent(this.props);
+    }
   }
 }
 
-function mapStateToProps(state) {
-  return {
-    fullName: state.user.profile.userFullName,
-    disabilities: state.form.data.disabilities,
-    claimId: state.form.submission.response.attributes.claimId,
-    submittedAt: state.form.submission.submittedAt,
-  };
-}
-
-export default connect(mapStateToProps)(ConfirmationPage);
-export { ConfirmationPage };
+ConfirmationPage.propTypes = {
+  submissionStatus: PropTypes.oneOf(Object.values(submissionStatuses)),
+  fullName: PropTypes.shape({
+    first: PropTypes.string,
+    last: PropTypes.string,
+    middle: PropTypes.string,
+    suffix: PropTypes.string,
+  }).isRequired,
+  disabilities: PropTypes.array.isRequired,
+  submittedAt: PropTypes.string.isRequired,
+  claimId: PropTypes.string,
+  jobId: PropTypes.string,
+};

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import moment from 'moment';
+
+import siteName from '../../../../platform/brand-consolidation/site-name';
+import {
+  successMessage,
+  checkLaterMessage,
+  errorMessage,
+} from '../content/confirmation-poll';
+
+const template = (props, title, content, submissionMessage) => {
+  const { fullName, disabilities, submittedAt } = props;
+  const { first, last, middle, suffix } = fullName;
+
+  const renderableContent =
+    typeof content === 'string' ? <p>{content}</p> : content;
+
+  return (
+    <div>
+      <h3 className="confirmation-page-title">{title}</h3>
+      {renderableContent}
+
+      <div className="inset">
+        <h4>
+          Disability Compensation Claim{' '}
+          <span className="additional">(Form 21-526EZ)</span>
+        </h4>
+        <span>
+          For {first} {middle} {last} {suffix}
+        </span>
+        <ul className="claim-list">
+          <strong>Conditions claimed for increase</strong>
+          <br />
+          <ul className="disability-list">
+            {disabilities
+              .filter(item => item['view:selected'])
+              .map((disability, i) => (
+                <li key={i}>{disability.name}</li>
+              ))}
+          </ul>
+          {submissionMessage}
+          <li>
+            <strong>Date submitted</strong>
+            <br />
+            <span>{moment(submittedAt).format('MMM D, YYYY')}</span>
+          </li>
+        </ul>
+      </div>
+
+      <h4 className="confirmation-guidance-heading">
+        What happens after I apply?
+      </h4>
+      <p className="confirmation-guidance-message">
+        You don’t need to do anything unless we send you a letter asking for
+        more information.
+      </p>
+      <br />
+      <a href="/disability-benefits/after-you-apply/">
+        Learn more about what happens after you file a disability claim.
+      </a>
+      <div className="confirmation-guidance-container">
+        <h4 className="confirmation-guidance-heading">Need help?</h4>
+        <p className="confirmation-guidance-message">
+          If you have questions, please call{' '}
+          <a href="tel:+18772228387">1-877-222-8387</a>, Monday &#8211; Friday,
+          8:00 a.m. &#8211; 8:00 p.m. (ET).
+        </p>
+      </div>
+      <div className="row form-progress-buttons schemaform-back-buttons">
+        <div className="small-6 usa-width-one-half medium-6 columns">
+          <a href="/">
+            <button className="usa-button-primary">
+              Go Back to {siteName}
+            </button>
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const retryableErrorContent = props =>
+  template(
+    props,
+    'Your claim has been submitted.',
+    'We process applications in the order we receive them. We may contact you if we have questions or need more information. You can print this page for your records.',
+    checkLaterMessage(props.jobId),
+  );
+
+export const successfulSubmitContent = props =>
+  template(
+    props,
+    'Your claim has successfully been submitted.',
+    'We process applications in the order we receive them. We may contact you if we have questions or need more information. You can print this page for your records.',
+    successMessage(props.claimId),
+  );
+
+export const submitErrorContent = props =>
+  template(
+    props,
+    'We’re sorry. Something went wrong when we tried to submit your claim.',
+    <div>
+      <p>
+        For help submitting your claim, please call Veterans Benefits Assistance
+        at 1-800-827-1000, Monday – Friday, 8:30 a.m. – 4:30 p.m. (ET). Or, you
+        can get in touch with your nearest Veterans Service Officer (VSO).
+      </p>{' '}
+      <a href="/disability-benefits/apply/help/">Contact your nearest VSO.</a>
+    </div>,
+    errorMessage(),
+  );

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -29,7 +29,7 @@ const template = (props, title, content, submissionMessage) => {
           For {first} {middle} {last} {suffix}
         </span>
         <ul className="claim-list">
-          <strong>Conditions claimed for increase</strong>
+          <strong>Conditions claimed</strong>
           <br />
           <ul className="disability-list">
             {disabilities

--- a/src/applications/disability-benefits/all-claims/content/confirmation-poll.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-poll.jsx
@@ -5,19 +5,19 @@ import CallHelpDesk from '../../../../platform/brand-consolidation/components/Ca
 
 export const successMessage = claimId => (
   <div>
-    <p>Thank you for filing a claim for increased disability compensation.</p>
+    <p>Thank you for filing a claim for disability compensation.</p>
     <strong>Claim ID number</strong>
     <div>{claimId}</div>
     <p>
       You can check the status of your claim online. Please allow 24 hours for
-      your increased disability claim to show up there.
+      your disability claim to show up there.
     </p>
     <p>
       <a href="/track-claims">Check the status of your claim.</a>
     </p>
     <p>
-      If you don’t see your increased disability claim online after 24 hours,
-      please call Veterans Benefits Assistance at{' '}
+      If you don’t see your disability claim online after 24 hours, please call
+      Veterans Benefits Assistance at{' '}
       <a href="tel:+18008271000">1-800-827-1000</a>, Monday – Friday, 8:00 a.m.
       – 9:00 a.m. (ET).
     </p>
@@ -26,19 +26,18 @@ export const successMessage = claimId => (
 
 export const checkLaterMessage = jobId => (
   <div>
-    <p>Thank you for filing a claim for increased disability compensation.</p>
+    <p>Thank you for filing a claim for disability compensation.</p>
     <strong>Confirmation number</strong>
     <div>{jobId}</div>
     <p>
       You can check the status of your claim online. Please allow 24 hours for
-      your increased disability claim to show up there.
+      your disability claim to show up there.
     </p>
     <p>
       <a href="/track-claims">Check the status of your claim.</a>
     </p>
     <p>
-      If you don’t see your increased disability claim online after 24 hours,
-      please{' '}
+      If you don’t see your disability claim online after 24 hours, please{' '}
       <CallHelpDesk>
         call {siteName} Help Desk at{' '}
         <a href="tel:+18555747286">1-855-574-7286</a>, Monday – Friday, 8:00

--- a/src/applications/disability-benefits/all-claims/content/confirmation-poll.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-poll.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
+import siteName from '../../../../platform/brand-consolidation/site-name';
+import CallHelpDesk from '../../../../platform/brand-consolidation/components/CallHelpDesk';
+
+export const successMessage = claimId => (
+  <div>
+    <p>Thank you for filing a claim for increased disability compensation.</p>
+    <strong>Claim ID number</strong>
+    <div>{claimId}</div>
+    <p>
+      You can check the status of your claim online. Please allow 24 hours for
+      your increased disability claim to show up there.
+    </p>
+    <p>
+      <a href="/track-claims">Check the status of your claim.</a>
+    </p>
+    <p>
+      If you don’t see your increased disability claim online after 24 hours,
+      please call Veterans Benefits Assistance at{' '}
+      <a href="tel:+18008271000">1-800-827-1000</a>, Monday – Friday, 8:00 a.m.
+      – 9:00 a.m. (ET).
+    </p>
+  </div>
+);
+
+export const checkLaterMessage = jobId => (
+  <div>
+    <p>Thank you for filing a claim for increased disability compensation.</p>
+    <strong>Confirmation number</strong>
+    <div>{jobId}</div>
+    <p>
+      You can check the status of your claim online. Please allow 24 hours for
+      your increased disability claim to show up there.
+    </p>
+    <p>
+      <a href="/track-claims">Check the status of your claim.</a>
+    </p>
+    <p>
+      If you don’t see your increased disability claim online after 24 hours,
+      please{' '}
+      <CallHelpDesk>
+        call {siteName} Help Desk at{' '}
+        <a href="tel:+18555747286">1-855-574-7286</a>, Monday – Friday, 8:00
+        a.m. – 9:00 a.m. (ET).
+      </CallHelpDesk>
+    </p>
+  </div>
+);
+
+export const errorMessage = () => (
+  <div>
+    <p>
+      We're sorry. Something went wrong on our end when we tried to submit your
+      application. For help submitting your claim, please call Veterans Benefits
+      Assistance at <a href="tel:18008271000">1-800-827-1000</a>, Monday –
+      Friday, 8:30 a.m. – 4:30 p.m. (ET). Or, you can get in touch with your
+      nearest Veterans Service Officer (VSO).
+    </p>
+    <p>
+      <a href="/disability-benefits/apply/help/">Contact your nearest VSO.</a>
+    </p>
+  </div>
+);
+
+export const pendingMessage = longWait => {
+  const message = !longWait
+    ? 'Please wait while we submit your application and give you a confirmation number.'
+    : 'We’re sorry. It’s taking us longer than expected to submit your application. Thank you for your patience.';
+  return <LoadingIndicator message={message} />;
+};

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { expect } from 'chai';
+
+import {
+  mockApiRequest,
+  mockMultipleApiRequests,
+} from '../../../../../platform/testing/unit/helpers';
+
+import { ConfirmationPoll } from '../../components/ConfirmationPoll';
+import { submissionStatuses } from '../../constants';
+
+const originalFetch = global.fetch;
+
+const pendingResponse = {
+  shouldResolve: true,
+  response: {
+    data: {
+      attributes: {
+        transactionStatus: submissionStatuses.pending,
+      },
+    },
+  },
+};
+
+const successResponse = {
+  shouldResolve: true,
+  response: {
+    data: {
+      attributes: {
+        transactionStatus: submissionStatuses.succeeded,
+        metadata: {
+          claimId: '123abc',
+        },
+      },
+    },
+  },
+};
+
+const failureResponse = {
+  shouldResolve: true,
+  response: {
+    data: {
+      attributes: {
+        transactionStatus: submissionStatuses.failed,
+      },
+    },
+  },
+};
+
+describe('ConfirmationPoll', () => {
+  const defaultProps = {
+    jobId: '12345',
+    fullName: { first: 'asdf', last: 'fdsa' },
+    disabilities: [],
+    submittedAt: Date.now(),
+  };
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('should make an api call after mounting', () => {
+    mockApiRequest(successResponse.response);
+    shallow(<ConfirmationPoll />);
+    expect(global.fetch.calledOnce).to.be.true;
+  });
+
+  it('should continue to make api calls until the response is not pending', done => {
+    mockMultipleApiRequests([
+      pendingResponse,
+      pendingResponse,
+      successResponse,
+      failureResponse,
+    ]);
+    // TODO: Figure out why this is causing an error in the console even though the test passes
+    //  It may have something to do with unmounting the component before a `setState` goes through
+    mount(<ConfirmationPoll pollRate={10} />);
+    // Should stop after the first success
+    setTimeout(() => {
+      expect(global.fetch.callCount).to.equal(3);
+      done();
+    }, 50);
+  });
+
+  it('should render the confirmation page', done => {
+    mockApiRequest(successResponse.response);
+    const tree = shallow(<ConfirmationPoll {...defaultProps} pollRate={10} />);
+    setTimeout(() => {
+      // Without this update, it wasn't catching the last render even though the function was running first
+      tree.update();
+      const confirmationPage = tree.find('ConfirmationPage');
+      expect(confirmationPage.length).to.equal(1);
+      expect(confirmationPage.first().props()).to.eql({
+        submissionStatus: submissionStatuses.succeeded,
+        claimId: '123abc',
+        jobId: defaultProps.jobId,
+        fullName: defaultProps.fullName,
+        disabilities: defaultProps.disabilities,
+        submittedAt: defaultProps.submittedAt,
+      });
+      done();
+    }, 500);
+  });
+});


### PR DESCRIPTION
## Description
This copies over the logic and content from the MVP minus the wording for "increased" conditions. I also removed the 4142 content since we'll be integrating that form right into the middle of this one.

## Testing done
Manually tested and copied the unit tests.

## Screenshots

### Scenario 1: Successfully submitted to EVSS
![image](https://user-images.githubusercontent.com/12970166/47392400-63763400-d6d1-11e8-8771-133315e01001.png)
Because I couldn't get a successful submission yet, I had to mock this out. Act like there's a confirmation number where it says there should be. The code is there, I promise.

### Scenario 2: Check back later
![image](https://user-images.githubusercontent.com/12970166/47392313-1f832f00-d6d1-11e8-9953-c9920f9b8fd4.png)

### Scenario 3: Non-retryable error
![image](https://user-images.githubusercontent.com/12970166/47392473-93253c00-d6d1-11e8-921a-f31f9e082bb8.png)

## Acceptance criteria
- [x] All three scenarios show up under the right circumstances

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
