### PR TITLE
pull @font-face declarations out of .consolidated

### DIFF
--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -1055,7 +1055,7 @@ $marker-text-width: 9rem;
   }
 
   .appeals-ahead {
-    font-family: Source Sans Pro, sans serif;
+    font-family: "Source Sans Pro", sans-serif;
     font-size: 26px;
     font-weight: bold;
     line-height: 1;

--- a/src/platform/site-wide/sass/style-consolidated.scss
+++ b/src/platform/site-wide/sass/style-consolidated.scss
@@ -13,6 +13,70 @@ $teamsite-width: 959px;
   font-style: normal;
 }
 
+@font-face {
+  font-family: "Source Sans Pro";
+  font-style: normal;
+  font-weight: 300;
+  src: url(/fonts/sourcesanspro-light-webfont.eot?#iefix) format("embedded-opentype"),
+    url(/fonts/sourcesanspro-light-webfont.woff2) format("woff2"),
+    url(/fonts/sourcesanspro-light-webfont.woff) format("woff"),
+    url(/fonts/sourcesanspro-light-webfont.ttf) format("truetype");
+}
+
+@font-face {
+  font-family: "Source Sans Pro";
+  font-style: normal;
+  font-weight: 400;
+  src: url(/fonts/sourcesanspro-regular-webfont.eot?#iefix) format("embedded-opentype"),
+    url(/fonts/sourcesanspro-regular-webfont.woff2) format("woff2"),
+    url(/fonts/sourcesanspro-regular-webfont.woff) format("woff"),
+    url(/fonts/sourcesanspro-regular-webfont.ttf) format("truetype");
+}
+
+@font-face {
+  font-family: "Source Sans Pro";
+  font-style: italic;
+  font-weight: 400;
+  src: url(/fonts/sourcesanspro-italic-webfont.eot?#iefix) format("embedded-opentype"),
+    url(/fonts/sourcesanspro-italic-webfont.woff2) format("woff2"),
+    url(/fonts/sourcesanspro-italic-webfont.woff) format("woff"),
+    url(/fonts/sourcesanspro-italic-webfont.ttf) format("truetype");
+}
+
+@font-face {
+  font-family: "Source Sans Pro";
+  font-style: normal;
+  font-weight: 700;
+  src: url(/fonts/sourcesanspro-bold-webfont.eot?#iefix) format("embedded-opentype"),
+    url(/fonts/sourcesanspro-bold-webfont.woff2) format("woff2"),
+    url(/fonts/sourcesanspro-bold-webfont.woff) format("woff"),
+    url(/fonts/sourcesanspro-bold-webfont.ttf) format("truetype");
+}
+
+@font-face {
+  font-family: "Bitter";
+  font-style: normal;
+  font-weight: 400;
+  src:
+    local("Bitter Regular"),
+    local("Bitter-Regular"),
+    url(/fonts/bitter-regular.woff2) format("woff2"),
+    url(/fonts/bitter-regular.ttf) format("truetype");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215;
+}
+
+@font-face {
+  font-family: "Bitter";
+  font-style: normal;
+  font-weight: 700;
+  src:
+    local("Bitter Bold"),
+    local("Bitter-Bold"),
+    url(/fonts/bitter-bold.woff2) format("woff2"),
+    url(/fonts/bitter-bold.ttf) format("truetype");
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215;
+}
+
 .consolidated {
   font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
   @import "~@department-of-veterans-affairs/formation/sass/core";


### PR DESCRIPTION
## Description
Current imported `@font-face` declarations are not working because they are nested in a `.consolidated` class. Pulling the declarations up to the top level alongside the FontAwesome declaration makes the web fonts work.

## Testing done
Testing locally

## Screenshots
**BEFORE** on left, **AFTER** on right
<img width="1440" alt="screen shot 2018-10-23 at 2 48 09 pm" src="https://user-images.githubusercontent.com/20728956/47393313-f87a2c80-d6d3-11e8-9ce4-d8caf3364c30.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
