### PR TITLE
Unset footer width for mobile and tablet to fix missing plus icons

### DIFF
--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -41,7 +41,7 @@ header.merger {
 
   @media (min-width: $medium-screen) {
 
-    va-notice--banner-inner,
+    .va-notice--banner-inner,
     .va-crisis-line-container {
       width: $teamsite-width;
       padding-left: 1rem;

--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -38,42 +38,61 @@ header.merger {
       background-image: none;
     }
   }
+
   @media (min-width: $medium-screen) {
-    va-notice--banner-inner, .va-crisis-line-container {
+
+    va-notice--banner-inner,
+    .va-crisis-line-container {
       width: $teamsite-width;
       padding-left: 1rem;
     }
+
     #mega-menu .panel-bottom-link {
       width: 468px;
     }
   }
+
   @media (min-width: $large-screen) {
     #mega-menu .vetnav-panel {
       width: 487px;
     }
+
     #mega-menu .column-two {
       left: 240px;
     }
+
     #mega-menu .column-three {
       left: 487px;
-    }    
+    }
+
     #mega-menu .panel-bottom-link {
       width: 657px;
     }
   }
+
   @media (max-width: $large-screen - 1) {
-    #vetnav-va-benefits-and-health-care, #vetnav-about-va {
+
+    #vetnav-va-benefits-and-health-care,
+    #vetnav-about-va {
       width: 100%;
     }
+
     #mega-menu .column-three {
       display: none;
-    }    
+    }
   }
 }
 
 footer.footer {
   font-size: 16px;
   width: 100%;
+
+  @media (max-width: $medium-screen) {
+
+    .usa-grid-flex-mobile {
+      width: auto;
+    }
+  }
 }
 
 .sign-in-nav {


### PR DESCRIPTION
## Description

Issue: https://app.zenhub.com/workspace/o/department-of-veterans-affairs/vets.gov-team/issues/14320

Fix missing expand icons on mobile/tablet footer.  Footer width is being set to 959px, even in mobile/tablet displays.  Added media query to unset footer width.  

**Note:** Footer accordion is still broken on mobile and being addressed in a separate card: [14500](https://app.zenhub.com/workspace/o/department-of-veterans-affairs/vets.gov-team/issues/14500)

## Testing done

Tested in Chrome and mobile safari

## Screenshots

![screen shot 2018-10-23 at 2 43 42 pm](https://user-images.githubusercontent.com/786704/47393135-86094c80-d6d3-11e8-97a7-8d49bc1ced5d.png)


## Acceptance criteria
- [ ] Expand icons are visible on mobile and tablet
- [ ] Width of `.footer .usa-grid-flex-mobile` remains at 959px on desktop