### PR TITLE
[HOLD] Deploy Preview banner to Vets.gov Production

### DIFF
--- a/script/create-build-settings.js
+++ b/script/create-build-settings.js
@@ -18,7 +18,7 @@ function getBuildSettings(options) {
     // This setting is for a global top-level banner to invite Vets.gov users to try the brand-consolidated VA.gov.
     // It can be removed post-launch.
     previewTheNewVaBanner: {
-      allowTrafficToPreview: false,
+      allowTrafficToPreview: true,
     },
   };
 }


### PR DESCRIPTION
## Description
We recently merged a banner to Vets.gov directing traffic to a Vets.gov page describing the new VA.gov. This banner invites users to actually see it at https://preview.va.gov.

This is a continuation of https://github.com/department-of-veterans-affairs/vets-website/pull/8807.

Move to validate - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14255

## Testing done
Confirmed banner looks okay

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/47394104-a21ae700-d6ef-11e8-94bb-657495bd4602.png)


## Acceptance criteria
- [ ] Preview banner is deployed with link to Preview site

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
