### PR TITLE
Hide VIC  content page form sidenav

### DIFF
--- a/va-gov/pages/records/get-veteran-id-cards/vic.md
+++ b/va-gov/pages/records/get-veteran-id-cards/vic.md
@@ -6,6 +6,7 @@ display_title: Veteran ID Card
 description: Find out if you're eligible for a printed Veteran ID Card--and how to apply.
 plainlanguage:
 collection: veteranIdCards
+hideFromSidebar: true
 order: 1
 production: false
 ---

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,7 +1070,7 @@ babel-polyfill@^6.13.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-env@^1.4.0:
+babel-preset-env@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
   dependencies:


### PR DESCRIPTION
## Description
VIC child page was showing up in the child nav and didnt need to be.

## Testing done
Local testing

## Screenshots
![screenshot_2018-10-23 types of veteran id cards](https://user-images.githubusercontent.com/1959628/47396435-9cb5a080-d6df-11e8-94e3-5f5eb805c7a6.png)


## Acceptance criteria
- [ ] Page is not in sidenav

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
