### PR TITLE
Teamsite: Remove Header padding below menu dropdowns

### DIFF
--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -7,6 +7,8 @@
 }
 
 .login-container {
+  line-height: 0;
+
   div.row:first-child {
     display: inline-block;
   }


### PR DESCRIPTION
## Description

Remove gap between nav and body.  Unwanted gap was being caused by line-height set by bootstrap on `.login-container`.

## Testing done

Tested in chrome at multiple window sizes

## Screenshots

### Before:

![screen shot 2018-10-23 at 4 25 18 pm](https://user-images.githubusercontent.com/786704/47397100-8bba5e80-d6e2-11e8-9dae-f850fc8a5b4c.png)

### After:

![screen shot 2018-10-23 at 4 24 19 pm](https://user-images.githubusercontent.com/786704/47397107-94ab3000-d6e2-11e8-9e19-141852519bec.png)


## Acceptance criteria
- [ ] Gap no longer exists

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
