### PR TITLE
All claims on VA.gov

### DIFF
--- a/va-gov/pages/disability-benefits/apply/form-526-all-claims.md
+++ b/va-gov/pages/disability-benefits/apply/form-526-all-claims.md
@@ -1,0 +1,18 @@
+---
+title: Apply for disability benefits
+entryname: 526EZ-all-claims
+layout: page-react.html
+description: Learn how to apply online for disability compensation.
+hideFromSidebar: true
+production: false
+---
+<div id="main">
+  <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+  id="va-breadcrumbs">
+    <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+      <li><a href="/">Home</a></li>
+      <li><a href="/disability-benefits/">Disability Benefits</a></li>
+      <li><a aria-current="page" href="/disability-benefits/apply/form-526-all-claims/">Apply for Disability Benefits</a></li>
+    </ul>
+  </nav>
+</div>

--- a/va-gov/pages/disability-benefits/apply/form-526-all-claims.md
+++ b/va-gov/pages/disability-benefits/apply/form-526-all-claims.md
@@ -11,7 +11,7 @@ production: false
   id="va-breadcrumbs">
     <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
       <li><a href="/">Home</a></li>
-      <li><a href="/disability-benefits/">Disability Benefits</a></li>
+      <li><a href="/disability/">Disability Benefits</a></li>
       <li><a aria-current="page" href="/disability-benefits/apply/form-526-all-claims/">Apply for Disability Benefits</a></li>
     </ul>
   </nav>

--- a/va-gov/pages/disability-benefits/apply/form-526-all-claims.md
+++ b/va-gov/pages/disability-benefits/apply/form-526-all-claims.md
@@ -5,6 +5,7 @@ layout: page-react.html
 description: Learn how to apply online for disability compensation.
 hideFromSidebar: true
 production: false
+preview: false
 ---
 <div id="main">
   <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"


### PR DESCRIPTION
## Description
Copies the all claims entry to `va-gov` content directory.

~**Note:** I don't know how to hide this from production off the top of my head, so if this gets merged in as-is, I'm pretty sure it'll make it to preview.va.gov.~

:point_up: Question answered in the comments. Thanks, @ncksllvn!

## Testing done
Checked that it worked with `yarn watch --brand-consolidation-enabled` and `yarn build --brand-consolidation-enabled --buildtype=preview` and serving it from the `build/preview/` directory with `python -m SimpleHTTPServer 3001`.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/47400279-6254ff00-d6f1-11e8-8aff-37827005f742.png)


## Acceptance criteria
- [x] The form is live in staging.va.gov

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
