### PR TITLE
Va gov/feature/14085: Add Options to Housing Left Nav

### DIFF
--- a/va-gov/pages/housing-assistance/home-loans/find-a-va-regional-loan-center.md
+++ b/va-gov/pages/housing-assistance/home-loans/find-a-va-regional-loan-center.md
@@ -1,6 +1,6 @@
 ---
 title: Find a VA Regional Loan Center
 href: https://www.benefits.va.gov/HOMELOANS/contact_rlc_info.asp
-order: 8
+order: 9
 private: true
 ---

--- a/va-gov/pages/housing-assistance/home-loans/find-va-acquired-properties.md
+++ b/va-gov/pages/housing-assistance/home-loans/find-va-acquired-properties.md
@@ -1,0 +1,6 @@
+---
+title: Find VA-Acquired Properties
+href: https://www.benefits.va.gov/homeloans/realtors_property_mgmt.asp
+order: 10
+private: true
+---

--- a/va-gov/pages/housing-assistance/home-loans/guidance-on-natural-disasters.md
+++ b/va-gov/pages/housing-assistance/home-loans/guidance-on-natural-disasters.md
@@ -1,6 +1,6 @@
 ---
 title: Guidance on Natural Disasters
 href: https://www.benefits.va.gov/HOMELOANS/documents/docs/va_policy_regarding_natural_disasters.pdf
-order: 9
+order: 11
 private: true
 ---

--- a/va-gov/pages/housing-assistance/home-loans/home-buying-process.md
+++ b/va-gov/pages/housing-assistance/home-loans/home-buying-process.md
@@ -1,6 +1,6 @@
 ---
 title: Home Buying Process
 href: https://www.benefits.va.gov/homeloans/resources_veteran.asp
-order: 6
+order: 7
 private: true
 ---

--- a/va-gov/pages/housing-assistance/home-loans/va-loan-funding-fee.md
+++ b/va-gov/pages/housing-assistance/home-loans/va-loan-funding-fee.md
@@ -1,6 +1,6 @@
 ---
 title: VA Loan Funding Fee
 href: https://www.benefits.va.gov/homeloans/purchaseco_loan_fee.asp
-order: 7
+order: 8
 private: true
 ---

--- a/va-gov/pages/housing-assistance/home-loans/warning-about-refinancing-offers.md
+++ b/va-gov/pages/housing-assistance/home-loans/warning-about-refinancing-offers.md
@@ -1,0 +1,7 @@
+---
+title: Warning about Refinancing Offers
+href: https://www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/
+order: 6
+target: _blank
+private: true
+---


### PR DESCRIPTION
## Description
The following items need to be added to the left nav per SME request.  
Left nav spreadsheet is updated with this information.

- [x] Per #12913  "Warning about Refinancing Offers" should be placed just below "Trouble Making Payments" and will open in a new tab/window when clicked.  Link to  www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/

- [x] Per #12822 "Find VA-Acquired Properties" should be placed just below "Find a VA Regional Loan Center" and will open in the SAME tab/window.  Link to www.benefits.va.gov/homeloans/realtors_property_mgmt.asp

## Testing done
Local Testing

## Screenshots
<img width="1067" alt="screen shot 2018-10-23 at 7 13 49 pm" src="https://user-images.githubusercontent.com/5377648/47401883-e316f980-d6f7-11e8-8ed1-aa3fd70e2d29.png">

## Acceptance criteria
- [ ] Per #12913  "Warning about Refinancing Offers" should be placed just below "Trouble Making Payments" and will open in a new tab/window when clicked.  Link to  www.blogs.va.gov/VAntage/43234/va-and-the-consumer-financial-protection-bureau-warn-against-home-loan-refinancing-offers-that-sound-too-good-to-be-true/

- [ ] Per #12822 "Find VA-Acquired Properties" should be placed just below "Find a VA Regional Loan Center" and will open in the SAME tab/window.  Link to www.benefits.va.gov/homeloans/realtors_property_mgmt.asp

LeftRailNav spreadsheet:
https://docs.google.com/spreadsheets/d/1SsA5RVkERpMF8DE4Oal7fy4dK617JkdJgMQ2zrRdJXc/edit#gid=1369630563

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
