### PR TITLE
Disable interactivity in messaging and Rx cards

### DIFF
--- a/src/applications/messaging/sass/partials/_messaging-folder.scss
+++ b/src/applications/messaging/sass/partials/_messaging-folder.scss
@@ -73,6 +73,8 @@
     &:visited {
       color: $color-black;
     }
+
+    cursor: default;
   }
 
   td {

--- a/src/applications/personalization/dashboard/components/PrescriptionCard.jsx
+++ b/src/applications/personalization/dashboard/components/PrescriptionCard.jsx
@@ -1,19 +1,21 @@
-import { Link } from 'react-router';
+// import { Link } from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import recordEvent from '../../../../platform/monitoring/record-event';
+// import recordEvent from '../../../../platform/monitoring/record-event';
 import { formatDate } from '../../../rx/utils/helpers';
 
-function recordDashboardClick(product) {
-  return () => {
-    recordEvent({
-      event: 'dashboard-navigation',
-      'dashboard-action': 'view-button',
-      'dashboard-product': product,
-    });
-  };
-}
+// Disabling interactivity.
+// See: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14499
+// function recordDashboardClick(product) {
+//   return () => {
+//     recordEvent({
+//       event: 'dashboard-navigation',
+//       'dashboard-action': 'view-button',
+//       'dashboard-product': product,
+//     });
+//   };
+// }
 
 export default function PrescriptionCard({ prescription }) {
   const {
@@ -39,25 +41,29 @@ export default function PrescriptionCard({ prescription }) {
         })}
       </p>
       <p>
-        {isTrackable ? (
-          <Link
-            key={`rx-${prescription.id}-track`}
-            className="rx-track-package-link usa-button"
-            href={`/health-care/prescriptions/${prescription.id}/track`}
-            onClick={recordDashboardClick('track-your-package')}
-          >
-            Track Your Package
-          </Link>
-        ) : (
-          <Link
-            className="usa-button usa-button-primary"
-            href={`/health-care/prescriptions/${prescription.id}`}
-            onClick={recordDashboardClick('view-your-prescription')}
-          >
-            View Your Prescription
-            <i className="fa fa-chevron-right" />
-          </Link>
-        )}
+        {
+          // Disabling interactivity.
+          // See: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14499
+          //   isTrackable ? (
+          //   <Link
+          //     key={`rx-${prescription.id}-track`}
+          //     className="rx-track-package-link usa-button"
+          //     href={`/health-care/prescriptions/${prescription.id}/track`}
+          //     onClick={recordDashboardClick('track-your-package')}
+          //   >
+          //     Track Your Package
+          //   </Link>
+          // ) : (
+          //   <Link
+          //     className="usa-button usa-button-primary"
+          //     href={`/health-care/prescriptions/${prescription.id}`}
+          //     onClick={recordDashboardClick('view-your-prescription')}
+          //   >
+          //     View Your Prescription
+          //     <i className="fa fa-chevron-right" />
+          //   </Link>
+          //   )
+        }
       </p>
     </div>
   );

--- a/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
@@ -38,8 +38,12 @@ class MessagingWidget extends React.Component {
       { label: 'Date', value: 'sentDate', nonSortable: true },
     ];
 
+    // eslint-disable-next-line
     const makeMessageLink = (content, id) => (
-      <Link href={`/health-care/messaging/inbox/${id}`}>{content}</Link>
+      // Messaging temporarily disabled.
+      // See: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14499
+      // <Link href={`/health-care/messaging/inbox/${id}`}>{content}</Link>
+      <Link>{content}</Link>
     );
 
     let { messages } = this.props;


### PR DESCRIPTION
## Description
Removed interactive elements from the MessagingWidget and PrescriptionCard components, as they are linking to MHV in an unexpected manner, and this work is out of scope for WBC. See [#14499](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14499) and [#13839](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13839) for more context, as well as [this DSVA slack thread](https://dsva.slack.com/archives/C909ZG2BB/p1540314756000100)

## Testing done
Manual testing

## Screenshots
![screencast-localhost-3001-2018 10 24-07-18-06](https://user-images.githubusercontent.com/11085141/47430344-a4685a00-d75e-11e8-8b6a-40364f82719a.gif)


## Acceptance criteria
- [x] Remove all clickable actions (including hiding buttons) on the prescriptions health widget other than leaving the "View all.." link as is
- [x] Remove all clickable actions on the secure messages health widget other than leaving the "View all.." link as is

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
