### PR TITLE
Open eBenefits link in new tab

### DIFF
--- a/va-gov/pages/housing-assistance/home-loans/how-to-apply.md
+++ b/va-gov/pages/housing-assistance/home-loans/how-to-apply.md
@@ -144,7 +144,7 @@ If you’re a **surviving spouse** who qualifies for home loan benefits, you’l
 
 You can apply online right now.
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=cert-of-eligibility-home-loan">Go to eBenefits to Apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=cert-of-eligibility-home-loan" target="_blank">Go to eBenefits to Apply</a>
 
 #### You can also apply:
 
@@ -164,5 +164,5 @@ To apply by mail, fill out a Request for a Certificate of Eligibility (VA Form 2
 
 Applying for your COE is only one part of the process for getting a VA direct or VA-backed home loan. Your next steps will depend on the type of loan you’re looking to get—and on your lender (for most loans, the lender will be a private bank or mortgage company; for the Native American Direct Loan, we’ll be your lender).
 
- 
+
 


### PR DESCRIPTION
## Description
This PR changes the behavior of the "How To Apply" eBenefits link to open in a new tab.

## Testing done
Manually verified

## Screenshots


## Acceptance criteria
- [x] eBenefits link opens in a new tab

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
