### PR TITLE
Remove eBenefits button

### DIFF
--- a/va-gov/pages/disability/how-to-file-claim.md
+++ b/va-gov/pages/disability/how-to-file-claim.md
@@ -73,18 +73,6 @@ Depending on the type of claim you file, you may gather supporting documents you
 </div>
 
 
-<div itemprop="steps" itemscope itemtype ="http://schema.org/HowToSection">
-
-<h3 itemprop="name">How do I file?</h3>
-<div itemprop="itemListElement">
-
-You can file your claim right now.
-
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation">Go to eBenefits to Apply</a>
-
-</div>
-</div>
-
 <div id="react-applicationStatus"></div>
 
 <div itemprop="steps" itemscope itemtype ="http://schema.org/HowToSection">


### PR DESCRIPTION
## Description
This already happened, but because of a merge conflict, the button got added back in. The original PR can be found [here](https://github.com/department-of-veterans-affairs/vets-website/pull/8692/files). I made sure all the changes from that one are still in effect and they are, though the home page got changed up a bit to use a `cards` front matter variable.

## Testing done
Manually tested.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/47449994-e7372b80-d778-11e8-90ad-0245b43ffa84.png)


## Acceptance criteria
- [x] The eBenefits button is removed from VA.gov

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
