### PR TITLE
All claims fdc mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -49,9 +49,6 @@ import {
   authorizationToDisclose,
   evidenceSummaryView,
   GetFormHelp,
-  FDCDescription,
-  FDCWarning,
-  noFDCWarning,
   getEvidenceTypesDescription,
   veteranInfoDescription,
   editNote,
@@ -73,6 +70,12 @@ import {
   privateRecordsChoiceHelp,
   documentDescription,
 } from '../../all-claims/content/privateMedicalRecords';
+
+import {
+  FDCDescription,
+  FDCWarning,
+  noFDCWarning,
+} from '../../all-claims/content/fullyDevelopedClaim';
 
 import { FIFTY_MB } from '../../all-claims/constants';
 

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -668,64 +668,6 @@ export const VAFileNumberDescription = (
   </div>
 );
 
-export const FDCDescription = (
-  <div>
-    <h5>Fully developed claim program</h5>
-    <p>
-      You can apply using the Fully Developed Claim (FDC) program if you’ve
-      uploaded all the supporting documents or supplemental forms needed to
-      support your claim.
-    </p>
-    <a href="/pension/apply/fully-developed-claim/" target="_blank">
-      Learn more about the FDC program
-    </a>
-    .
-  </div>
-);
-
-export const FDCWarning = (
-  <div className="usa-alert usa-alert-info no-background-image">
-    <div className="usa-alert-body">
-      <div className="usa-alert-text">
-        Since you’ve uploaded all your supporting documents, your claim will be
-        submitted as a fully developed claim.
-      </div>
-    </div>
-  </div>
-);
-
-export const noFDCWarning = (
-  <div className="usa-alert usa-alert-info no-background-image">
-    <div className="usa-alert-body">
-      <div className="usa-alert-text">
-        <p>
-          Since you’ll be sending in additional documents later, your
-          application doesn’t qualify for the Fully Developed Claim program.
-          We’ll review your claim through the standard claim process. With the
-          standard claim process, you have up to 1 year from the date we receive
-          your claim to turn in any information and evidence.
-        </p>
-        <p>You can turn in your evidence 1 of 3 ways:</p>
-        <ul>
-          <li>
-            Visit the Claim Status tool and upload your documents under the File
-            tab. <a href="/track-claims">Track the status of your claims.</a>
-          </li>
-          <li>
-            Call Veterans Benefits Assistance at{' '}
-            <a href="tel:1-800-827-1000">1-800-827-1000</a>, Monday – Friday,
-            8:30 a.m. – 4:30 p.m. (ET).
-          </li>
-          <li>
-            Save your application and return to it later when you have your
-            evidence ready to upload.
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
-);
-
 const evidenceTypesDescription = disabilityName => (
   <p>
     What supporting evidence will you turn in that shows your {disabilityName}{' '}

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -48,6 +48,7 @@ import {
   homelessOrAtRisk,
   vaEmployee,
   summaryOfEvidence,
+  fullyDevelopedClaim,
 } from '../pages';
 
 import { PTSD } from '../constants';
@@ -318,6 +319,12 @@ const formConfig = {
           path: 'va-employee',
           uiSchema: vaEmployee.uiSchema,
           schema: vaEmployee.schema,
+        },
+        fullyDevelopedClaim: {
+          title: 'Fully developed claim program',
+          path: 'fully-developed-claim',
+          uiSchema: fullyDevelopedClaim.uiSchema,
+          schema: fullyDevelopedClaim.schema,
         },
       },
     },

--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -912,6 +912,10 @@ const schema = {
     isVAEmployee: {
       type: 'boolean',
     },
+    standardClaim: {
+      type: 'boolean',
+      default: false,
+    },
   },
 };
 

--- a/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+export const FDCDescription = (
+  <div>
+    <h5>Fully developed claim program</h5>
+    <p>
+      You can apply using the Fully Developed Claim (FDC) program if you’ve
+      uploaded all the supporting documents or supplemental forms needed to
+      support your claim.
+    </p>
+    <a href="/pension/apply/fully-developed-claim/" target="_blank">
+      Learn more about the FDC program
+    </a>
+    .
+  </div>
+);
+
+export const FDCWarning = (
+  <div className="usa-alert usa-alert-info no-background-image">
+    <div className="usa-alert-body">
+      <div className="usa-alert-text">
+        Since you’ve uploaded all your supporting documents, your claim will be
+        submitted as a fully developed claim.
+      </div>
+    </div>
+  </div>
+);
+
+export const noFDCWarning = (
+  <div className="usa-alert usa-alert-info no-background-image">
+    <div className="usa-alert-body">
+      <div className="usa-alert-text">
+        <p>
+          Since you’ll be sending in additional documents later, your
+          application doesn’t qualify for the Fully Developed Claim program.
+          We’ll review your claim through the standard claim process. With the
+          standard claim process, you have up to 1 year from the date we receive
+          your claim to turn in any information and evidence.
+        </p>
+        <p>You can turn in your evidence 1 of 3 ways:</p>
+        <ul>
+          <li>
+            Visit the Claim Status tool and upload your documents under the File
+            tab. <a href="/track-claims">Track the status of your claims.</a>
+          </li>
+          <li>
+            Call Veterans Benefits Assistance at{' '}
+            <a href="tel:1-800-827-1000">1-800-827-1000</a>, Monday – Friday,
+            8:30 a.m. – 4:30 p.m. (ET).
+          </li>
+          <li>
+            Save your application and return to it later when you have your
+            evidence ready to upload.
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+);

--- a/src/applications/disability-benefits/all-claims/pages/fullyDevelopedClaim.js
+++ b/src/applications/disability-benefits/all-claims/pages/fullyDevelopedClaim.js
@@ -1,0 +1,52 @@
+import fullSchema from '../config/schema';
+import get from '../../../../platform/utilities/data/get';
+import {
+  FDCDescription,
+  FDCWarning,
+  noFDCWarning,
+} from '../content/fullyDevelopedClaim';
+
+const standardClaim = fullSchema.properties.standardClaim;
+
+export const uiSchema = {
+  'ui:description': FDCDescription,
+  standardClaim: {
+    'ui:title': 'Do you want to apply using the Fully Developed Claim program?',
+    'ui:widget': 'yesNo',
+    'ui:options': {
+      yesNoReverse: true,
+      labels: {
+        Y: 'Yes, I have uploaded all my supporting documents.',
+        N: 'No, I have some extra information that I’ll submit to VA later.',
+      },
+    },
+  },
+  'view:fdcWarning': {
+    'ui:description': FDCWarning,
+    'ui:options': {
+      hideIf: formData => get('standardClaim', formData),
+    },
+  },
+  'view:noFDCWarning': {
+    'ui:description': noFDCWarning,
+    'ui:options': {
+      hideIf: formData => !get('standardClaim', formData),
+    },
+  },
+};
+
+export const schema = {
+  type: 'object',
+  required: ['standardClaim'],
+  properties: {
+    standardClaim,
+    'view:fdcWarning': {
+      type: 'object',
+      properties: {},
+    },
+    'view:noFDCWarning': {
+      type: 'object',
+      properties: {},
+    },
+  },
+};

--- a/src/applications/disability-benefits/all-claims/pages/index.js
+++ b/src/applications/disability-benefits/all-claims/pages/index.js
@@ -123,6 +123,11 @@ import {
   schema as vaEmployeeSchema,
 } from './vaEmployee';
 
+import {
+  uiSchema as fullyDevelopedClaimUiSchema,
+  schema as fullyDevelopedClaimSchema,
+} from './fullyDevelopedClaim';
+
 export const alternateNames = {
   uiSchema: alternateNamesUISchema,
   schema: alternateNamesSchema,
@@ -246,4 +251,9 @@ export const homelessOrAtRisk = {
 export const vaEmployee = {
   uiSchema: vaEmployeeUISchema,
   schema: vaEmployeeSchema,
+};
+
+export const fullyDevelopedClaim = {
+  uiSchema: fullyDevelopedClaimUiSchema,
+  schema: fullyDevelopedClaimSchema,
 };

--- a/src/applications/disability-benefits/all-claims/tests/pages/fullyDevelopedClaim.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/fullyDevelopedClaim.unit.spec.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { mount } from 'enzyme';
+import formConfig from '../../config/form';
+import { ERR_MSG_CSS_CLASS } from '../../constants';
+
+describe('Fully Developed Claim', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.additionalInformation.pages.fullyDevelopedClaim;
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        uiSchema={uiSchema}
+        schema={schema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(2);
+  });
+
+  // Value should default `false`; form should submit without any user input
+  it('should submit with required data', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        uiSchema={uiSchema}
+        schema={schema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(0);
+  });
+});


### PR DESCRIPTION
## Description
Adds FDC page to the All Claims form
Mimics FDC page in MVP
Moves MVP content to All Claims directory

## Testing done
- Tested locally
- Unit tests


## Screenshots
Default view:
![screen shot 2018-10-24 at 12 13 54 pm](https://user-images.githubusercontent.com/24251447/47450054-d9d66d00-d789-11e8-8339-fde143d79d70.png)

-----

If they don't want rapid processing:
![screen shot 2018-10-24 at 12 14 06 pm](https://user-images.githubusercontent.com/24251447/47450086-e78bf280-d789-11e8-932f-0df4303fdb9a.png)


## Acceptance criteria
- [x] Add FDC page before review page
- [x] FDC page should mimic MVP FDC page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
