### PR TITLE
Life Insurance link to Prudential website opens in a popup 

### DIFF
--- a/va-gov/pages/life-insurance/manage-your-policy.md
+++ b/va-gov/pages/life-insurance/manage-your-policy.md
@@ -27,5 +27,7 @@ If you have a VA life insurance policy with a file number that starts with a V, 
 
 **Note:** For Service-Disabled Veterans Life Insurance (S-DVI) and Veterans’ Mortgage Life Insurance (VMLI), the Department of the Treasury requires that all payments be made through an electronic funds transfer, and will no longer send paper checks through the mail. You don’t have to share your bank information when applying for coverage. But, when you apply for an insurance payment (such as a policy loan, cash surrender, or beneficiary claim payment), you’ll be asked for this information. To make the process easier, send a voided check when you apply for your payment.
 
-If you have a Veterans’ Group Life Insurance (VGLI) policy with a VGLI control number, access your policy online through the Office of Servicemembers’ Group Life Insurance at Prudential Insurance Company of America. Prudential works with us to provide SGLI and VGLI benefits to Servicemembers and Veterans. [Find your policy through Prudential Insurance Company of America](https://giosgli.prudential.com/osgli/web/OSGLIMenu.html).
+If you have a Veterans’ Group Life Insurance (VGLI) policy with a VGLI control number, access your policy online through the Office of Servicemembers’ Group Life Insurance at Prudential Insurance Company of America. Prudential works with us to provide SGLI and VGLI benefits to Servicemembers and Veterans. 
+
+<a href="https://giosgli.prudential.com/osgli/web/OSGLIMenu.html" data-popup>Find your policy through Prudential Insurance Company of America</a>
 


### PR DESCRIPTION
## Description

**Steps to reproduce:**
On this page:
https://preview.va.gov/life-insurance/manage-your-policy/
Click on the last link on the page: "Find your policy through Prudential Insurance Company of America." It should open in a pop-up but doesn't. 

**Expected behavior:**
The link should open a pop-up. Here's how the link should be structured to achieve this:
<a data-popup href="https://giosgli.prudential.com/osgli/web/OSGLIMenu.html">Find your policy through Prudential Insurance Company of America</a>

## Testing done
Local testing

## Screenshots
#### With popup

![image](https://user-images.githubusercontent.com/7482329/47454541-b4972e00-d78c-11e8-9147-17645b96b6d1.png)


## Acceptance criteria
- [x] Link opens in a popup

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
