### PR TITLE
Update search URL on 404 page

### DIFF
--- a/va-gov/pages/404.md
+++ b/va-gov/pages/404.md
@@ -24,12 +24,12 @@ private: true
             Try the search box or one of the common questions below.
           </p>
           <div class="feature va-flex va-flex--ctr">
-            <form accept-charset="UTF-8" action="https://search.vets.gov/search" id="search_form" class="full-width" method="get">
+            <form accept-charset="UTF-8" action="https://search.usa.gov/search" id="search_form" class="full-width" method="get">
               <div class="csp-inline-patch-404">
                 <input name="utf8" type="hidden" value="&#x2713;" />
               </div>
               <div class="va-flex va-flex--top va-flex--jctr">
-                <input id="affiliate-1" name="affiliate-1" type="hidden" value="vets.gov_search" />
+                <input id="affiliate" name="affiliate" type="hidden" value="va" />
                   <label for="mobile-query">Search:</label>
                   <input autocomplete="off" class="usagov-search-autocomplete full-width" id="mobile-query" name="query" type="text" />
                   <input name="commit" type="submit" value="Search">


### PR DESCRIPTION
## Description
404 pages on va.gov pages should use the correct search box

## Testing done
Local testing

## Screenshots


## Acceptance criteria
- [x] Search box on 404 pages should have correct form URL

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs


Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14567