### PR TITLE
Use new utility class to remove padding on mobile menu

### DIFF
--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -84,7 +84,7 @@ export default `
     <div id="va-nav-controls"></div>
     <div id="login-root" class="vet-toolbar"></div>
   </div>
-  <div class="usa-grid">
+  <div class="usa-grid padding-h-none">
     <div id="menu-rule" class="usa-one-whole"></div>
     <div id="mega-menu"></div>
   </div>

--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -84,6 +84,9 @@ export default `
     <div id="va-nav-controls"></div>
     <div id="login-root" class="vet-toolbar"></div>
   </div>
+  <!-- HACK: Using padding-h-none class to remove horizontal padding introduced
+  by usa-grid. Should be able to use usa-grid-full to remove padding, but that
+  class now hard-codes the width. -->
   <div class="usa-grid padding-h-none">
     <div id="menu-rule" class="usa-one-whole"></div>
     <div id="mega-menu"></div>

--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -30,6 +30,8 @@
   }
 }
 
+// HACK: Hard-coding the width fixes one issue but prevents us from using this
+// class to remove the horizontal padding introduced by .usa-grid
 .usa-grid-full {
   width: $teamsite-width;
 }
@@ -106,6 +108,9 @@ footer.footer {
   }
 }
 
+// HACK: Added this new utility class to remove horizontal padding from the
+// mobile menu. .usa-grid-full cannot be used for this purpose as its width has
+// now been hard-coded
 .padding-h-none {
   padding-left: 0 !important;
   padding-right: 0 !important;

--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -105,3 +105,8 @@ footer.footer {
     color: $color-white;
   }
 }
+
+.padding-h-none {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}


### PR DESCRIPTION
## Description
Ideally we'd just add the `.usa-grid-full` class to the wrapper div to remove the 15px padding. But `.usa-grid-full` [has been expanded](https://github.com/department-of-veterans-affairs/vets-website/blob/fix-mobile-menu-padding/src/platform/site-wide/sass/consolidated-patches.scss#L33-L35) to fix a previous TeamSite nav styling issue. So I created a new [utility class](https://davidtheclark.com/on-utility-classes/) that removes horizontal padding and am using that instead.

## Testing done
Local testing

## Screenshots
<img width="509" alt="image" src="https://user-images.githubusercontent.com/20728956/47529181-f17e2600-d85b-11e8-92a9-206443a73929.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
