### PR TITLE
BetaGate content change

### DIFF
--- a/src/applications/disability-benefits/526EZ/containers/BetaGate.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/BetaGate.jsx
@@ -40,7 +40,8 @@ export function BetaGate({
               </h3>
               <p>
                 We can accept only a limited number of submissions a day while
-                we’re in beta. Please check back again soon.
+                we’re in beta. We’re sorry for the inconvenience. Please try
+                again tomorrow.
               </p>
             </div>
           }


### PR DESCRIPTION
## Description
I wasn't sure whether we should show the beta signup message or the "try back later" message when both were valid. After some consideration, @goldenmeanie figured the best path forward was to keep the "try back later" one with a tweak to be clear about establishing expectations.

## Testing done
Fired up the form and used the React dev tools to change the props on the BetaGate component to get the message.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/47534914-ffd53d80-d86d-11e8-86a0-5147c6cc6718.png)


## Acceptance criteria
- [x] The new content is displayed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
