### PR TITLE
Bah sprint6 0781 add injury death other

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -543,6 +543,114 @@ const schema = {
         },
       },
     },
+    form4142: {
+      type: 'object',
+      properties: {
+        limitedConsent: {
+          type: 'string',
+        },
+        providerFacility: {
+          type: 'array',
+          required: [
+            'providerFacilityName',
+            'treatmentDateRange',
+            'providerFacilityAddress',
+          ],
+          items: {
+            type: 'object',
+            properties: {
+              providerFacilityName: {
+                type: 'string',
+              },
+              treatmentDateRange: {
+                $ref: '#/definitions/dateRange',
+              },
+              providerFacilityAddress: {
+                $ref: '#/definitions/address',
+              },
+            },
+          },
+        },
+        privacyAgreementAccepted: {
+          $ref: '#/definitions/privacyAgreementAccepted',
+        },
+      },
+    },
+    form0781: {
+      type: 'object',
+      incident: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            personalAssault: {
+              type: 'boolean',
+            },
+            medalsCitations: {
+              type: 'string',
+            },
+            incidentDate: {
+              $ref: '#/definitions/date',
+            },
+            incidentLocation: {
+              type: 'string',
+            },
+            incidentDescription: {
+              type: 'string',
+            },
+            unitAssigned: {
+              type: 'string',
+            },
+            unitAssignedDates: {
+              $ref: '#/definitions/dateRange',
+            },
+            remarks: {
+              type: 'string',
+            },
+            personInvolved: {
+              type: 'array',
+              items: {
+                type: 'object',
+                name: {
+                  $ref: '#/definitions/fullName',
+                },
+                rank: {
+                  type: 'string',
+                },
+                injuryDeath: {
+                  type: 'string',
+                  enum: [
+                    'Killed in Action',
+                    'Killed Non-Battle',
+                    'Wounded in Action',
+                    'Injured Non-Battle',
+                    'Other',
+                  ],
+                },
+                injuryDeathDate: {
+                  $ref: '#/definitions/date',
+                },
+                unitAssigned: {
+                  type: 'string',
+                },
+              },
+            },
+            source: {
+              type: 'array',
+              items: {
+                type: 'object',
+                name: {
+                  $ref: '#/definitions/fullName',
+                },
+                address: {
+                  $ref: '#/definitions/address',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   },
   properties: {
     alternateNames: {

--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -627,6 +627,9 @@ const schema = {
                     'Other',
                   ],
                 },
+                injuryDeathOther: {
+                  type: 'string',
+                },
                 injuryDeathDate: {
                   $ref: '#/definitions/date',
                 },


### PR DESCRIPTION
## Description
Add the 21-4142 schema and 21-0781 schema with the addition of a new injuryDeathOther field for when a user selects 'Other' in the 'injuryDeath' field. Otherwise, this field should be blank.