### PR TITLE
Remove period

### DIFF
--- a/src/applications/personalization/profile360/components/DowntimeBanner.jsx
+++ b/src/applications/personalization/profile360/components/DowntimeBanner.jsx
@@ -14,7 +14,7 @@ function DowntimeBanner({ downtime, section }) {
             We’re sorry. The system that handles {section} information is down
             for maintenance right now. We hope to be finished with our work by{' '}
             {downtime.startTime.format('MMMM Do')},{' '}
-            {downtime.endTime.format('LT')}. Please check back soon.
+            {downtime.endTime.format('LT')} Please check back soon.
           </p>
         </div>
       }


### PR DESCRIPTION
## Description
This PR removes a period that was rendering an additional period after `p.m.` in the downtime banner for the Profile - 

![image](https://user-images.githubusercontent.com/1915775/47579316-9874c780-d919-11e8-984e-c8c714106a14.png)

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14637

## Acceptance criteria
- [x] Double period is gone

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
