### PR TITLE
whitelist all pages under www.va.gov

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -6,7 +6,7 @@
         "cookieOnly": true
     },
     {
-        "hostname": "prebenefits.va.gov",
+        "hostname": "benefits.va.gov",
         "pathnameBeginning": "/",
         "cookieOnly": true
     },

--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -1,6 +1,11 @@
 {
     "proxyRewriteWhitelist": [
     {
+        "hostname": "www.choose.va.gov",
+        "pathnameBeginning": "/",
+        "cookieOnly": true
+    },
+    {
         "hostname": "prebenefits.va.gov",
         "pathnameBeginning": "/",
         "cookieOnly": true

--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -12,22 +12,22 @@
     },
     {
         "hostname": "dev.va.gov",
-        "pathnameBeginning": "/health/",
+        "pathnameBeginning": "/",
         "cookieOnly": false
     },
     {
         "hostname": "localhost",
-        "pathnameBeginning": "/health/",
+        "pathnameBeginning": "/",
         "cookieOnly": false
     },
     {
         "hostname": "staging.va.gov",
-        "pathnameBeginning": "/health/",
+        "pathnameBeginning": "/",
         "cookieOnly": false
     },
     {
         "hostname": "preview.va.gov",
-        "pathnameBeginning": "/health/",
+        "pathnameBeginning": "/",
         "cookieOnly": false
     },
     {


### PR DESCRIPTION
## Description
edited whitelist behavior to show header for any teamsite page that goes through the reverse proxy 

## Testing done
verified locally on 
https://staging.va.gov/health/ 
https://staging.va.gov/opa/bios/index.asp
https://staging.va.gov/landing_organizations.htm 
https://staging.va.gov/OPA/index.asp
https://staging.va.gov/oca/index.asp
https://staging.va.gov/COMMUNITYCARE/programs/veterans/VCP/index.asp 
https://staging.va.gov/VETDATA/index.asp
https://staging.va.gov/recovery/ 
https://staging.va.gov/ABOUT_VA/index.asp
https://staging.va.gov/about_va/vahistory.asp
https://staging.va.gov/performance/ 
https://staging.va.gov/homeless/nationalcallcenter.asp 
https://staging.va.gov/404

## Screenshots
![screen shot 2018-10-26 at 14 43 52](https://user-images.githubusercontent.com/4998130/47591631-97e62c00-d92d-11e8-83c9-6cde13767d0e.png)
![screen shot 2018-10-26 at 14 43 50](https://user-images.githubusercontent.com/4998130/47591633-987ec280-d92d-11e8-836a-39509b45d9cf.png)
![screen shot 2018-10-26 at 14 43 48](https://user-images.githubusercontent.com/4998130/47591634-987ec280-d92d-11e8-8be2-e47fcdd38cf6.png)
![screen shot 2018-10-26 at 14 43 45](https://user-images.githubusercontent.com/4998130/47591635-987ec280-d92d-11e8-94d2-8568721bb428.png)
![screen shot 2018-10-26 at 14 43 43](https://user-images.githubusercontent.com/4998130/47591636-987ec280-d92d-11e8-891c-3350a7bd124d.png)
![screen shot 2018-10-26 at 14 43 40](https://user-images.githubusercontent.com/4998130/47591637-987ec280-d92d-11e8-8514-c418f7a48bb2.png)
![screen shot 2018-10-26 at 14 43 35](https://user-images.githubusercontent.com/4998130/47591638-987ec280-d92d-11e8-9334-c302ff5034f1.png)
![screen shot 2018-10-26 at 14 43 32](https://user-images.githubusercontent.com/4998130/47591639-99175900-d92d-11e8-969f-eb3375b23cc1.png)
![screen shot 2018-10-26 at 14 43 30](https://user-images.githubusercontent.com/4998130/47591640-99175900-d92d-11e8-927e-a8e485b942be.png)
![screen shot 2018-10-26 at 14 43 27](https://user-images.githubusercontent.com/4998130/47591641-99175900-d92d-11e8-9da6-6240b1d6e55c.png)
![screen shot 2018-10-26 at 14 43 24](https://user-images.githubusercontent.com/4998130/47591642-99175900-d92d-11e8-9d4c-e34a8e1a4b8b.png)
![screen shot 2018-10-26 at 14 43 17](https://user-images.githubusercontent.com/4998130/47591643-99175900-d92d-11e8-8c5c-ccd35e12f2ae.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
