### PR TITLE
Mega menu - Change link to VA Transition Assistance

### DIFF
--- a/src/platform/site-wide/mega-menu/mega-menu-link-data.json
+++ b/src/platform/site-wide/mega-menu/mega-menu-link-data.json
@@ -220,8 +220,8 @@
                         "title": "Manage Your Career",
                         "links": [
                             {
-                                "text": "Transitioning to Civilian Employment",
-                                "href": "https://www.benefits.va.gov/vocrehab/transitioning_from_service.asp"
+                                "text": "VA Transition Assistance",
+                                "href": "https://www.benefits.va.gov/tap/"
                             },
                             {
                                 "text": "CareerScope Assessment",


### PR DESCRIPTION
## Description
Per @DanielleSoCompany at https://github.com/department-of-veterans-affairs/vagov-content/pull/18#issuecomment-433105144 -

> "Transitioning to Civilian Employment" changes to "VA Transition Assistance" and the link becomes: https://www.benefits.va.gov/tap/

## Screenshots
todo

## Acceptance criteria
- [x] Link is updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
