### PR TITLE
Add analytics layers to personalization dropdown links

### DIFF
--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -45,12 +45,31 @@ class PersonalizationDropdown extends React.Component {
       <ul>
         {brandConsolidationEnabled && (
           <li>
-            <a href="/my-va/">My VA</a>
+            <a
+              href="/my-va/"
+              onClick={() => {
+                recordEvent({
+                  event: 'nav-user',
+                  'nav-user-section': 'my-va',
+                });
+              }}
+            >
+              My VA
+            </a>
           </li>
         )}
         {brandConsolidationEnabled && (
           <li>
-            <a href={`${mhvBaseUrl()}/mhv-portal-web/home`} target="_blank">
+            <a
+              href={`${mhvBaseUrl()}/mhv-portal-web/home`}
+              target="_blank"
+              onClick={() => {
+                recordEvent({
+                  event: 'nav-user',
+                  'nav-user-section': 'my-health',
+                });
+              }}
+            >
               My Health
             </a>
           </li>


### PR DESCRIPTION
## Description
Updates the Personalization drop down links to include GA datalayer `onClick` events

## Testing done


## Screenshots


## Acceptance criteria
- [x]  datalayers are present for 'My VA' and 'My Health' in user dropdown

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
