### PR TITLE
Adjust help menu spacing

### DIFF
--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -65,7 +65,14 @@
     }
   }
 
-  #helpmenu {
+  .va-helpmenu-contents {
+    > p {
+      line-height: 1.2em;
+      margin-bottom: 0.8em;
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
     a {
       text-decoration: none;
     }

--- a/src/platform/site-wide/user-nav/components/HelpMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/HelpMenu.jsx
@@ -17,7 +17,7 @@ class HelpMenu extends React.Component {
 
     if (isBrandConsolidationEnabled()) {
       dropDownContents = (
-        <div>
+        <div className="va-helpmenu-contents">
           <p>
             <a href={`${FACILITY_LOCATOR_URL}`}>Find a VA Location</a>
           </p>
@@ -25,10 +25,7 @@ class HelpMenu extends React.Component {
             <a href="https://iris.custhelp.va.gov/app/ask">Ask a Question</a>
           </p>
           <p>
-            <b>Call MyVA311:</b>
-          </p>
-          <p>
-            <a href="tel:18446982311">1-844-698-2311</a>
+            <a href="tel:18446982311">Call MyVA311: 1-844-698-2311</a>
           </p>
           <p>TTY: 711</p>
         </div>


### PR DESCRIPTION
## Description

This adjust the help menu spacing to match the requirements in the linked issue.

## Testing done
Tested locally

## Screenshots
![screen shot 2018-10-29 at 1 53 43 pm](https://user-images.githubusercontent.com/634932/47669855-310d8080-db82-11e8-99e9-b8fbab75c9c9.png)
![screen shot 2018-10-29 at 1 52 53 pm](https://user-images.githubusercontent.com/634932/47669859-34a10780-db82-11e8-8d21-1a4463a260b5.png)


## Acceptance criteria
- [x] Menu items have correct spacing

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
