### PR TITLE
Implement basic Content Deployment

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -193,6 +193,9 @@ const configGenerator = (options, apps) => {
           : `[name].[contenthash]-${timestamp}.css`,
       }),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+      new ManifestPlugin({
+        fileName: 'file-manifest.json',
+      }),
     ],
   };
 
@@ -229,11 +232,6 @@ const configGenerator = (options, apps) => {
     );
 
     baseConfig.plugins.push(new webpack.HashedModuleIdsPlugin());
-    baseConfig.plugins.push(
-      new ManifestPlugin({
-        fileName: 'file-manifest.json',
-      }),
-    );
     baseConfig.mode = 'production';
   } else {
     baseConfig.devtool = '#eval-source-map';

--- a/script/add-asset-hashes.js
+++ b/script/add-asset-hashes.js
@@ -1,0 +1,66 @@
+function addAssetHashes() {
+  // In non-development modes, we add hashes to the names of asset files in order to support
+  // cache busting. That is done via WebPack, but WebPack doesn't know anything about our HTML
+  // files, so we have to replace the references to those files in HTML and CSS files after the
+  // rest of the build has completed. This is done by reading in a manifest file created by
+  // WebPack that maps the original file names to their hashed versions. Metalsmith actions
+  // are passed a list of files that are included in the build. Those files are not yet written
+  // to disk, but the contents are held in memory.
+
+  return (files, metalsmith, done) => {
+    // Read in the data from the manifest file.
+    const manifestKey = Object.keys(files).find(
+      filename => filename.match(/file-manifest.json$/) !== null,
+    );
+
+    const originalManifest = JSON.parse(files[manifestKey].contents.toString());
+
+    // The manifest contains the original filenames without the addition of .entry
+    // on the JS files. This finds all of those and modifies them to add .entry.
+    const manifest = {};
+    Object.keys(originalManifest).forEach(originalManifestKey => {
+      const matchData = originalManifestKey.match(/(.*)\.js$/);
+      if (matchData !== null) {
+        const newKey = `${matchData[1]}.entry.js`;
+        manifest[newKey] = originalManifest[originalManifestKey];
+      } else {
+        manifest[originalManifestKey] = originalManifest[originalManifestKey];
+      }
+    });
+
+    // For each file in the build, if it is a HTML or CSS file, loop over all
+    // the keys in the manifest object and do a search and replace for the
+    // key with the value.
+    Object.keys(files).forEach(filename => {
+      if (filename.match(/\.(html|css)$/) !== null) {
+        Object.keys(manifest).forEach(originalAssetFilename => {
+          const newAssetFilename = manifest[originalAssetFilename].replace(
+            '/generated/',
+            '',
+          );
+          const file = files[filename];
+          const contents = file.contents.toString();
+          const regex = new RegExp(originalAssetFilename, 'g');
+          file.contents = new Buffer(contents.replace(regex, newAssetFilename));
+        });
+      }
+    });
+
+    // Create a copy of the proxy-write files without cache-bust hashes
+    [
+      'proxy-rewrite.entry.js',
+      'styleConsolidated.css',
+      'static-pages.css',
+      'vendor.entry.js',
+      'polyfills.entry.js',
+    ].forEach(unhashedName => {
+      const hashedName = manifest[unhashedName];
+
+      files[`generated/${unhashedName}`] = files[hashedName.substr(1)]; // eslint-disable-line no-param-reassign
+    });
+
+    done();
+  };
+}
+
+module.exports = addAssetHashes;

--- a/script/build.js
+++ b/script/build.js
@@ -136,10 +136,10 @@ smith.use(rewriteVaDomains(BUILD_OPTIONS));
 // On the server, it can be accessed at BUILD_OPTIONS.buildSettings.
 // In the browser, it can be accessed at window.settings.
 smith.use(createBuildSettings(BUILD_OPTIONS));
+smith.use(checkBrokenLinks(BUILD_OPTIONS));
 
 configureAssets(smith, BUILD_OPTIONS);
 
-smith.use(checkBrokenLinks(BUILD_OPTIONS));
 smith.use(createSitemaps(BUILD_OPTIONS));
 smith.use(createRedirects(BUILD_OPTIONS));
 smith.use(moveRemove(BUILD_OPTIONS));

--- a/script/build.js
+++ b/script/build.js
@@ -137,7 +137,8 @@ smith.use(rewriteVaDomains(BUILD_OPTIONS));
 // In the browser, it can be accessed at window.settings.
 smith.use(createBuildSettings(BUILD_OPTIONS));
 
-smith.use(configureAssets(BUILD_OPTIONS));
+configureAssets(smith, BUILD_OPTIONS);
+
 smith.use(checkBrokenLinks(BUILD_OPTIONS));
 smith.use(createSitemaps(BUILD_OPTIONS));
 smith.use(createRedirects(BUILD_OPTIONS));

--- a/script/build.js
+++ b/script/build.js
@@ -12,19 +12,16 @@ const moment = require('moment');
 const moveRemove = require('metalsmith-move-remove');
 const navigation = require('metalsmith-navigation');
 const permalinks = require('metalsmith-permalinks');
-const watch = require('metalsmith-watch');
 
-const webpackMetalsmithConnect = require('../config/webpack-metalsmith-connect');
-const environments = require('./constants/environments');
 const createBuildSettings = require('./create-build-settings');
 const createRedirects = require('./create-redirects');
 const createSitemaps = require('./create-sitemaps');
-const checkBrokenLinks = require('./check-broken-links');
 const createEnvironmentFilter = require('./create-environment-filter');
 const nonceTransformer = require('./metalsmith/nonceTransformer');
 const leftRailNavResetLevels = require('./left-rail-nav-reset-levels');
-const addAssetHashes = require('./configure-assets');
+const checkBrokenLinks = require('./check-broken-links');
 const rewriteVaDomains = require('./rewrite-va-domains');
+const configureAssets = require('./configure-assets');
 const BUILD_OPTIONS = require('./options');
 
 const smith = Metalsmith(__dirname); // eslint-disable-line new-cap
@@ -140,36 +137,12 @@ smith.use(rewriteVaDomains(BUILD_OPTIONS));
 // In the browser, it can be accessed at window.settings.
 smith.use(createBuildSettings(BUILD_OPTIONS));
 
-if (BUILD_OPTIONS.watch) {
-  const watchPaths = {
-    [`${BUILD_OPTIONS.contentRoot}/**/*`]: '**/*.{md,html}',
-    [`${BUILD_OPTIONS.contentPagesRoot}/**/*`]: '**/*.{md,html}',
-  };
-  const watchMetalSmith = watch({ paths: watchPaths, livereload: true });
-  smith.use(watchMetalSmith);
-  smith.use(webpackMetalsmithConnect.watchAssets(BUILD_OPTIONS));
-} else {
-  smith.use(webpackMetalsmithConnect.compileAssets(BUILD_OPTIONS));
-
-  const isDevBuild = [environments.DEVELOPMENT, environments.VAGOVDEV].includes(
-    BUILD_OPTIONS.buildtype,
-  );
-  if (!isDevBuild) {
-    smith.use(addAssetHashes(BUILD_OPTIONS));
-  }
-
-  if (process.env.CHECK_BROKEN_LINKS !== 'no') {
-    smith.use(checkBrokenLinks(BUILD_OPTIONS));
-  }
-}
-
+smith.use(configureAssets(BUILD_OPTIONS));
+smith.use(checkBrokenLinks(BUILD_OPTIONS));
 smith.use(createSitemaps(BUILD_OPTIONS));
-
-// Pages can contain an "alias" property in their metadata, which is processed into
-// separate pages that will each redirect to the original page.
 smith.use(createRedirects(BUILD_OPTIONS));
-
 smith.use(moveRemove(BUILD_OPTIONS));
+
 /* eslint-disable no-console */
 smith.build(err => {
   if (err) throw err;

--- a/script/configure-assets.js
+++ b/script/configure-assets.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+/* eslint-disable no-console */
 
 const fetch = require('node-fetch');
 const watch = require('metalsmith-watch');
@@ -28,7 +29,13 @@ function downloadAssets(buildOptions) {
 
     const downloads = entryNames.map(async entryName => {
       let bundleFileName = fileManifest[entryName];
-      const bundleRequest = await fetch(`${bucket}${bundleFileName}`);
+      const bundleUrl = `${bucket}${bundleFileName}`;
+      const bundleRequest = await fetch(bundleUrl);
+
+      if (!bundleRequest.ok) {
+        console.error(`Failed to download asset: ${bundleUrl}`);
+        return;
+      }
 
       if (bundleFileName.startsWith('/'))
         bundleFileName = bundleFileName.slice(1);
@@ -36,6 +43,8 @@ function downloadAssets(buildOptions) {
       files[bundleFileName] = {
         contents: await bundleRequest.arrayBuffer(),
       };
+
+      console.log(`Successfully downloaded asset: ${bundleUrl}`);
     });
 
     await downloads;

--- a/script/configure-assets.js
+++ b/script/configure-assets.js
@@ -1,95 +1,38 @@
 /* eslint-disable no-param-reassign */
-/* eslint-disable no-console */
 
-const fetch = require('node-fetch');
 const watch = require('metalsmith-watch');
 const environments = require('./constants/environments');
-const buckets = require('./constants/buckets');
 const webpackMetalsmithConnect = require('../config/webpack-metalsmith-connect');
+const downloadAssets = require('./download-assets');
 const addAssetHashes = require('./add-asset-hashes');
 
-function downloadAssets(buildOptions) {
-  return async (files, smith, done) => {
-    const bucket = buckets[buildOptions.buildtype];
-    const fileManifestPath = 'generated/file-manifest.json';
-    const fileManifestRequest = await fetch(`${bucket}/${fileManifestPath}`);
-    const fileManifest = await fileManifestRequest.json();
+function configureAssets(smith, buildOptions) {
+  const isContentDeployment = buildOptions['content-deployment'];
+  const isDevBuild = [environments.DEVELOPMENT, environments.VAGOVDEV].includes(
+    buildOptions.buildtype,
+  );
 
-    files[fileManifestPath] = {
-      contents: new Buffer(fileManifest),
+  if (buildOptions.watch) {
+    const watchPaths = {
+      [`${buildOptions.contentRoot}/**/*`]: '**/*.{md,html}',
+      [`${buildOptions.contentPagesRoot}/**/*`]: '**/*.{md,html}',
     };
 
-    let entryNames = Object.keys(fileManifest);
-    if (buildOptions.entry) {
-      const designatedEntries = buildOptions.entry;
-      entryNames = entryNames.filter(entryName =>
-        designatedEntries.includes(entryName),
-      );
-    }
+    const watchMetalSmith = watch({ paths: watchPaths, livereload: true });
 
-    const downloads = entryNames.map(async entryName => {
-      let bundleFileName = fileManifest[entryName];
-      const bundleUrl = `${bucket}${bundleFileName}`;
-      const bundleRequest = await fetch(bundleUrl);
-
-      if (!bundleRequest.ok) {
-        console.error(`Failed to download asset: ${bundleUrl}`);
-        return;
-      }
-
-      if (bundleFileName.startsWith('/'))
-        bundleFileName = bundleFileName.slice(1);
-
-      files[bundleFileName] = {
-        contents: await bundleRequest.arrayBuffer(),
-      };
-
-      console.log(`Successfully downloaded asset: ${bundleUrl}`);
-    });
-
-    await downloads;
-    done();
-  };
-}
-
-function configureAssets(buildOptions) {
-  let alreadyRegistered = false;
-
-  return (files, smith, done) => {
-    if (alreadyRegistered) {
-      done();
-      return;
-    }
-
-    const isContentDeployment = buildOptions['content-deployment'];
-    const isDevBuild = [
-      environments.DEVELOPMENT,
-      environments.VAGOVDEV,
-    ].includes(buildOptions.buildtype);
-
-    if (buildOptions.watch) {
-      const watchPaths = {
-        [`${buildOptions.contentRoot}/**/*`]: '**/*.{md,html}',
-        [`${buildOptions.contentPagesRoot}/**/*`]: '**/*.{md,html}',
-      };
-
-      const watchMetalSmith = watch({ paths: watchPaths, livereload: true });
-
-      smith.use(watchMetalSmith);
-      smith.use(webpackMetalsmithConnect.watchAssets(buildOptions));
+    smith.use(watchMetalSmith);
+    smith.use(webpackMetalsmithConnect.watchAssets(buildOptions));
+  } else {
+    if (isContentDeployment) {
+      smith.use(downloadAssets(buildOptions));
     } else {
-      if (isContentDeployment) {
-        smith.use(downloadAssets(buildOptions));
-      } else {
-        smith.use(webpackMetalsmithConnect.compileAssets(buildOptions));
-      }
-
-      if (!isDevBuild) smith.use(addAssetHashes(buildOptions));
+      smith.use(webpackMetalsmithConnect.compileAssets(buildOptions));
     }
 
-    alreadyRegistered = true;
-    done();
-  };
+    if (!isDevBuild) {
+      smith.use(addAssetHashes(buildOptions));
+    }
+  }
 }
 
 module.exports = configureAssets;

--- a/script/configure-assets.js
+++ b/script/configure-assets.js
@@ -18,7 +18,15 @@ function downloadAssets(buildOptions) {
       contents: new Buffer(fileManifest),
     };
 
-    const downloads = Object.keys(fileManifest).map(async entryName => {
+    let entryNames = Object.keys(fileManifest);
+    if (buildOptions.entry) {
+      const designatedEntries = buildOptions.entry;
+      entryNames = entryNames.filter(entryName =>
+        designatedEntries.includes(entryName),
+      );
+    }
+
+    const downloads = entryNames.map(async entryName => {
       let bundleFileName = fileManifest[entryName];
       const bundleRequest = await fetch(`${bucket}${bundleFileName}`);
 

--- a/script/constants/buckets.js
+++ b/script/constants/buckets.js
@@ -1,0 +1,21 @@
+const {
+  DEVELOPMENT,
+  PREVIEW,
+  PRODUCTION,
+  STAGING,
+  VAGOVDEV,
+  VAGOVSTAGING,
+} = require('./environments');
+
+const hostnames = require('./hostnames');
+
+const bucket = 'https://s3-us-gov-west-1.amazonaws.com';
+
+module.exports = {
+  [DEVELOPMENT]: `${bucket}/${hostnames[DEVELOPMENT]}`,
+  [PREVIEW]: `${bucket}/${hostnames[PREVIEW]}`,
+  [PRODUCTION]: `${bucket}/${hostnames[PRODUCTION]}`,
+  [STAGING]: `${bucket}/${hostnames[STAGING]}`,
+  [VAGOVDEV]: 'https://dev-va-gov-assets.s3-us-gov-west-1.amazonaws.com',
+  [VAGOVSTAGING]: `${bucket}/${hostnames[VAGOVSTAGING]}`,
+};

--- a/script/download-assets.js
+++ b/script/download-assets.js
@@ -1,0 +1,49 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable no-console */
+
+require('isomorphic-fetch');
+const buckets = require('./constants/buckets');
+
+function downloadAssets(buildOptions) {
+  return async (files, smith, done) => {
+    const bucket = buckets[buildOptions.buildtype];
+    const fileManifestPath = 'generated/file-manifest.json';
+
+    console.log(`Downloading assets from ${bucket}...`);
+
+    const fileManifestRequest = await fetch(`${bucket}/${fileManifestPath}`);
+    const fileManifest = await fileManifestRequest.json();
+
+    files[fileManifestPath] = {
+      path: fileManifestPath,
+      contents: new Buffer(JSON.stringify(fileManifest)),
+    };
+
+    const entryNames = Object.keys(fileManifest);
+
+    const downloads = entryNames.map(async entryName => {
+      let bundleFileName = fileManifest[entryName];
+      const bundleUrl = `${bucket}${bundleFileName}`;
+      const bundleResponse = await fetch(bundleUrl);
+
+      if (!bundleResponse.ok) {
+        throw new Error(`Failed to download asset: ${bundleUrl}`);
+      }
+
+      if (bundleFileName.startsWith('/'))
+        bundleFileName = bundleFileName.slice(1);
+
+      files[bundleFileName] = {
+        path: bundleFileName,
+        contents: await bundleResponse.buffer(),
+      };
+
+      console.log(`Successfully downloaded asset: ${bundleUrl}`);
+    });
+
+    await Promise.all(downloads);
+    done();
+  };
+}
+
+module.exports = downloadAssets;

--- a/script/options.js
+++ b/script/options.js
@@ -18,6 +18,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'protocol', type: String, defaultValue: 'http' },
   { name: 'public', type: String, defaultValue: null },
   { name: 'destination', type: String, defaultValue: null },
+  { name: 'content-deployment', type: Boolean, defaultValue: false },
   {
     name: 'content-directory',
     type: String,


### PR DESCRIPTION
## Description
This is an implementation of a content deployments in our build script. It is very unoptimized and begging for some improvements, but it's already a large amount of changes and it's blocking other work.

It works by -

1. Registers a `content-deployment` command arg
2. When that arg is passed, it skips Webpack compilation
3. Instead, it issues an HTTP request to the [`file-manifest.json`](https://staging.va.gov/generated/file-manifest.json) of the S3 bucket of the corresponding environment
4. All of the entries in the `file-manifest.json` are downloaded and registered in the Metalsmith pipeline
    - Super unoptimized ⚠️ But we have to lay the foundation.

Other things -
- I moved the link-checker to above the asset compilation. It was annoying when a build would fail after waiting several minutes for Webpack to run. I also removed the flag to turn the link checker off on Heroku instances, because we need it to execute over at `vagov-content`.
- I had to move the manifest plugin for Webpack to be registered for every build type.
- I worked on this hand-in-hand with https://github.com/department-of-veterans-affairs/vagov-content/pull/52.

## Testing done
- Local builds of different environments
- Worked hand-in-hand with 

## Screenshots
`npm  run build -- --content-deployment  --brand-consolidation-enabled --buildtype=vagovstaging`

![image](https://user-images.githubusercontent.com/1915775/47690730-8a4ad380-dbc5-11e8-8087-682dea372bd0.png)

## Acceptance criteria
- [x] We have a basic implementation of a content deployment
- [x] Has no side effects on `vets-website`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
