### PR TITLE
Fix top-level nav button width

### DIFF
--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -73,8 +73,14 @@ header.merger {
     }
   }
 
-  @media (min-width: $medium-screen) {
+  #vetnav-menu {
+    // HACK: To override `content-box` on benefits site
+    button.vetnav-level1 {
+      box-sizing: border-box;
+    }
+  }
 
+  @media (min-width: $medium-screen) {
     .va-notice--banner-inner,
     .va-crisis-line-container {
       width: $teamsite-width;
@@ -105,7 +111,6 @@ header.merger {
   }
 
   @media (max-width: $large-screen - 1) {
-
     #vetnav-va-benefits-and-health-care,
     #vetnav-about-va {
       width: 100%;


### PR DESCRIPTION
## Description
Force the box-sizing to `border-box` for top-level nav buttons. Rules used on the Benefits site set this to `content-box`, resulting in the buttons that render too wide.

## Testing done
Local

## Acceptance criteria
- [ ]

## Definition of done
~~- [ ] Events are logged appropriately~~
~~- [ ] Documentation has been updated, if applicable~~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
