### PR TITLE
Freeze the version of the selenium/standalone-chrome Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - 3000
     command: ./script/run-docker-nightwatch.sh
   selenium-chrome:
-    image: selenium/standalone-chrome:3.14.0
+    image: selenium/standalone-chrome:3.14.0-francium
     links:
       - vets-website
     shm_size: 2g

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - 3000
     command: ./script/run-docker-nightwatch.sh
   selenium-chrome:
-    image: selenium/standalone-chrome
+    image: selenium/standalone-chrome:3.14.0
     links:
       - vets-website
     shm_size: 2g


### PR DESCRIPTION
## Description
Apparently, our  Selenium/standalone-chrome image is under pretty [active development](https://hub.docker.com/r/selenium/standalone-chrome/tags/), and caused some trouble with `master`. I noticed the first E2E test to fail was here, http://jenkins.vetsgov-internal/blue/organizations/jenkins/testing%2Fvets-website/detail/master/2890/pipeline, but the corresponding commit had nothing that suggested anything problematic.  However, I noticed at the top of the E2E step this output -

```
[vets-website] Running shell script
+ export IMAGE_TAG=jenkins-testing-vets-website-master-2890
+ IMAGE_TAG=jenkins-testing-vets-website-master-2890
+ docker-compose -p e2e up -d
Creating network "e2e_default" with the default driver
Pulling selenium-chrome (selenium/standalone-chrome:latest)...
latest: Pulling from selenium/standalone-chrome
Digest: sha256:8f265a536bb69b89c029bb05024a11eaa71315b89ad51deda05a4e9d6b942cfd
**Status: Downloaded newer image for selenium/standalone-chrome:latest**
Creating e2e_vets-website_1 ... 
Creating e2e_vets-website_1
Creating e2e_vets-website_1 ... done
Creating e2e_selenium-chrome_1 ... 
Creating e2e_selenium-chrome_1
Creating e2e_selenium-chrome_1 ... done
+ docker-compose -p e2e run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=production vets-website --no-color run nightwatch:docker
```

Which seemed very suspicious, because the E2E tests pass on a local machine when running without Docker. I tried a few different versions of the `selenium/standalone-chrome` image, each time running -

```
docker-compose -p e2e up -d && docker-compose -p e2e run --user=node --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=production vets-website --no-color run nightwatch:docker -- src/applications/personalization/profile360/tests/e2e/profile-360.e2e.spec.js && docker-compose -p e2e stop
```

And finally found one that allowed the profile's e2e test to pass.

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/47733972-ca4e9c80-dc3f-11e8-8b26-fb3040ceadd3.png)


## Acceptance criteria
- [x] E2E tests finally pass

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
