### PR TITLE
Lowercase the "n" in Pre-need

### DIFF
--- a/src/platform/site-wide/mega-menu/mega-menu-link-data.json
+++ b/src/platform/site-wide/mega-menu/mega-menu-link-data.json
@@ -451,7 +451,7 @@
                                 "href": "https://www.va.gov/burials-memorials/eligibility/"
                             },
                             {
-                                "text": "Pre-Need Burial Eligibility Determination",
+                                "text": "Pre-need Burial Eligibility Determination",
                                 "href": "https://www.va.gov/burials-memorials/pre-need-eligibility/"
                             },
                             {


### PR DESCRIPTION
## Description
This PR lowercases the "n" in "Pre-Need" of the mega menu.

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14717

## Acceptance criteria
- [x] "Pre-need" looks okay

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
