### PR TITLE
Show AlertBox in case of search errors

### DIFF
--- a/src/applications/search/actions/index.js
+++ b/src/applications/search/actions/index.js
@@ -30,7 +30,7 @@ export function fetchSearchResults(query, page) {
       error =>
         dispatch({
           type: FETCH_SEARCH_RESULTS_FAILURE,
-          error,
+          errors: error.errors,
         }),
     );
   };

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -10,6 +10,7 @@ import recordEvent from '../../../platform/monitoring/record-event';
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 import IconSearch from '@department-of-veterans-affairs/formation/IconSearch';
 import Pagination from '@department-of-veterans-affairs/formation/Pagination';
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
 class SearchApp extends React.Component {
   static propTypes = {
@@ -110,7 +111,7 @@ class SearchApp extends React.Component {
   /* eslint-enable react/no-danger */
 
   renderResults() {
-    const { results, loading } = this.props.search;
+    const { results, loading, errors } = this.props.search;
 
     if (loading) {
       return <LoadingIndicator message="Loading results..." setFocus />;
@@ -121,6 +122,16 @@ class SearchApp extends React.Component {
         <ul className="results-list">
           {results.map(r => this.renderWebResult(r))}
         </ul>
+      );
+    }
+
+    if (errors && errors.length > 0) {
+      return (
+        <AlertBox
+          status="error"
+          headline="Something went wrong"
+          content="We're sorry, that search did not go through successfully. Please try again."
+        />
       );
     }
 

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -186,9 +186,7 @@ class SearchApp extends React.Component {
     /* eslint-disable prettier/prettier */
     return (
       <p>
-        Showing{' '}
-        {totalEntries === 0 ? '0' : `${resultRangeStart}-${resultRangeEnd}`} of{' '}
-        {totalEntries} results
+        Showing {totalEntries === 0 ? '0' : `${resultRangeStart}-${resultRangeEnd}`} of {totalEntries} results
       </p>
     );
     /* eslint-enable prettier/prettier */

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -87,6 +87,101 @@ class SearchApp extends React.Component {
     }
   }
 
+  renderResults() {
+    const { loading, errors } = this.props.search;
+    const hasErrors = !!(errors && errors.length > 0);
+
+    // Reusable search input
+    const searchInput = (
+      <form onSubmit={this.handleSearch} className="va-flex search-box">
+        <input
+          type="text"
+          name="query"
+          value={this.state.userInput}
+          onChange={this.handleInputChange}
+        />
+        <button type="submit">
+          <IconSearch color="#fff" />
+          <span>Search</span>
+        </button>
+      </form>
+    );
+
+    if (hasErrors && !loading) {
+      return (
+        <div className="usa-width-three-fourths medium-8 small-12 columns error">
+          <AlertBox
+            status="error"
+            headline="Something went wrong"
+            content="We're sorry, that search did not go through successfully. Please try again."
+          />
+          {searchInput}
+        </div>
+      );
+    }
+
+    return (
+      <div className="usa-width-three-fourths medium-8 small-12 columns">
+        {searchInput}
+        {this.renderResultsCount()}
+        <hr />
+        {this.renderResultsList()}
+        <hr />
+        {this.renderResultsFooter()}
+      </div>
+    );
+  }
+
+  renderResultsCount() {
+    const {
+      currentPage,
+      perPage,
+      totalPages,
+      totalEntries,
+      loading,
+    } = this.props.search;
+
+    let resultRangeEnd = currentPage * perPage;
+
+    if (currentPage === totalPages) {
+      resultRangeEnd = totalEntries;
+    }
+
+    const resultRangeStart = (currentPage - 1) * perPage + 1;
+
+    if (loading) return null;
+
+    /* eslint-disable prettier/prettier */
+    return (
+      <p>
+        Showing {totalEntries === 0 ? '0' : `${resultRangeStart}-${resultRangeEnd}`} of {totalEntries} results
+      </p>
+    );
+    /* eslint-enable prettier/prettier */
+  }
+
+  renderResultsList() {
+    const { results, loading } = this.props.search;
+
+    if (loading) {
+      return <LoadingIndicator message="Loading results..." setFocus />;
+    }
+
+    if (results && results.length > 0) {
+      return (
+        <ul className="results-list">
+          {results.map(r => this.renderWebResult(r))}
+        </ul>
+      );
+    }
+
+    return (
+      <p>
+        Sorry, no results found. Try again using different (or fewer) words.
+      </p>
+    );
+  }
+
   /* eslint-disable react/no-danger */
   renderWebResult(result) {
     return (
@@ -110,44 +205,8 @@ class SearchApp extends React.Component {
   }
   /* eslint-enable react/no-danger */
 
-  renderResults() {
-    const { results, loading, errors } = this.props.search;
-
-    if (loading) {
-      return <LoadingIndicator message="Loading results..." setFocus />;
-    }
-
-    if (results && results.length > 0) {
-      return (
-        <ul className="results-list">
-          {results.map(r => this.renderWebResult(r))}
-        </ul>
-      );
-    }
-
-    if (errors && errors.length > 0) {
-      return (
-        <AlertBox
-          status="error"
-          headline="Something went wrong"
-          content="We're sorry, that search did not go through successfully. Please try again."
-        />
-      );
-    }
-
-    return (
-      <p>
-        Sorry, no results found. Try again using different (or fewer) words.
-      </p>
-    );
-  }
-
   renderResultsFooter() {
-    const { currentPage, totalPages, errors } = this.props.search;
-
-    if (errors && errors.length > 0) {
-      return null;
-    }
+    const { currentPage, totalPages } = this.props.search;
 
     return (
       <div className="va-flex results-footer">
@@ -163,35 +222,6 @@ class SearchApp extends React.Component {
     );
   }
 
-  renderResultsCount() {
-    const {
-      currentPage,
-      errors,
-      perPage,
-      totalPages,
-      totalEntries,
-      loading,
-    } = this.props.search;
-
-    let resultRangeEnd = currentPage * perPage;
-
-    if (currentPage === totalPages) {
-      resultRangeEnd = totalEntries;
-    }
-
-    const resultRangeStart = (currentPage - 1) * perPage + 1;
-
-    if (loading || (errors && errors.length > 0)) return null;
-
-    /* eslint-disable prettier/prettier */
-    return (
-      <p>
-        Showing {totalEntries === 0 ? '0' : `${resultRangeStart}-${resultRangeEnd}`} of {totalEntries} results
-      </p>
-    );
-    /* eslint-enable prettier/prettier */
-  }
-
   render() {
     return (
       <div className="search-app">
@@ -201,25 +231,7 @@ class SearchApp extends React.Component {
           </div>
         </div>
         <div className="row">
-          <div className="usa-width-three-fourths medium-8 small-12 columns">
-            <form onSubmit={this.handleSearch} className="va-flex search-box">
-              <input
-                type="text"
-                name="query"
-                value={this.state.userInput}
-                onChange={this.handleInputChange}
-              />
-              <button type="submit">
-                <IconSearch color="#fff" />
-                <span>Search</span>
-              </button>
-            </form>
-            {this.renderResultsCount()}
-            <hr />
-            {this.renderResults()}
-            <hr />
-            {this.renderResultsFooter()}
-          </div>
+          {this.renderResults()}
           <div className="usa-width-one-fourth medium-4 small-12 columns sidebar">
             <h4 className="highlight">More VA Search Tools</h4>
             <ul>

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -143,7 +143,11 @@ class SearchApp extends React.Component {
   }
 
   renderResultsFooter() {
-    const { currentPage, totalPages } = this.props.search;
+    const { currentPage, totalPages, errors } = this.props.search;
+
+    if (errors && errors.length > 0) {
+      return null;
+    }
 
     return (
       <div className="va-flex results-footer">
@@ -162,6 +166,7 @@ class SearchApp extends React.Component {
   renderResultsCount() {
     const {
       currentPage,
+      errors,
       perPage,
       totalPages,
       totalEntries,
@@ -176,12 +181,14 @@ class SearchApp extends React.Component {
 
     const resultRangeStart = (currentPage - 1) * perPage + 1;
 
-    if (loading) return null;
+    if (loading || (errors && errors.length > 0)) return null;
 
     /* eslint-disable prettier/prettier */
     return (
       <p>
-        Showing {totalEntries === 0 ? '0' : `${resultRangeStart}-${resultRangeEnd}`} of {totalEntries} results
+        Showing{' '}
+        {totalEntries === 0 ? '0' : `${resultRangeStart}-${resultRangeEnd}`} of{' '}
+        {totalEntries} results
       </p>
     );
     /* eslint-enable prettier/prettier */

--- a/src/applications/search/reducers/index.js
+++ b/src/applications/search/reducers/index.js
@@ -44,7 +44,8 @@ function SearchReducer(state = initialState, action) {
     case FETCH_SEARCH_RESULTS_FAILURE: {
       return {
         ...state,
-        error: action.error,
+        errors: action.errors,
+        results: undefined,
         loading: false,
       };
     }

--- a/src/applications/search/reducers/index.js
+++ b/src/applications/search/reducers/index.js
@@ -37,6 +37,7 @@ function SearchReducer(state = initialState, action) {
         currentPage,
         perPage,
         totalPages,
+        errors: undefined,
         loading: false,
       };
     }

--- a/src/applications/search/styles.scss
+++ b/src/applications/search/styles.scss
@@ -13,6 +13,10 @@
     background: none;
   }
 
+  .usa-width-three-fourths.error {
+    padding-left: 1.5rem;
+  }
+
   ul {
     list-style-type: none;
     padding: 0;
@@ -36,11 +40,14 @@
     }
   }
 
-  .usa-alert-body {
-    padding-left: 1rem;
-
-    .usa-alert-text {
-      margin-top: 1rem;
+  .usa-alert {
+    margin-bottom: 2rem;
+    .usa-alert-body {
+      padding-left: 1rem;
+  
+      .usa-alert-text {
+        margin-top: 1rem;
+      }
     }
   }
 

--- a/src/applications/search/styles.scss
+++ b/src/applications/search/styles.scss
@@ -8,7 +8,8 @@
     margin-top: 0;
   }
 
-  [href^="http"], [rel="external"] {
+  [href^="http"],
+  [rel="external"] {
     background: none;
   }
 
@@ -35,6 +36,14 @@
     }
   }
 
+  .usa-alert-body {
+    padding-left: 1rem;
+
+    .usa-alert-text {
+      margin-top: 1rem;
+    }
+  }
+
   hr {
     border-bottom: none;
   }
@@ -54,7 +63,9 @@
   }
 
   .search-box {
-    input, button {
+
+    input,
+    button {
       margin: 0;
       max-width: none;
     }


### PR DESCRIPTION
## Description

Display an error `AlertBox` if search encounters rate limiting error, or any errors in general.

## Testing done

Mocked redux action using Redux DevTools using the following:

```
{
  type: 'FETCH_SEARCH_RESULTS_FAILURE',
  errors: [
    {
      "title": "Exceeded rate limit",
      "detail": "Exceeded Search.gov rate limit",
      "code": "SEARCH_429",
      "status": "429",
      "source": "Search::Service"
    }
  ]
}
```

## Screenshots

![image](https://user-images.githubusercontent.com/786704/47757170-730df380-dc62-11e8-87f5-8ad1f26749ec.png)


## Acceptance criteria
- [x] `AlertBox` shows when `FETCH_SEARCH_RESULTS_FAILURE` action with an array of errors is dispatched.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
