### PR TITLE
Fix a bug on single-entry production build

### DIFF
--- a/script/add-asset-hashes.js
+++ b/script/add-asset-hashes.js
@@ -56,7 +56,9 @@ function addAssetHashes() {
     ].forEach(unhashedName => {
       const hashedName = manifest[unhashedName];
 
-      files[`generated/${unhashedName}`] = files[hashedName.substr(1)]; // eslint-disable-line no-param-reassign
+      if (hashedName) {
+        files[`generated/${unhashedName}`] = files[hashedName.substr(1)]; // eslint-disable-line no-param-reassign
+      }
     });
 
     done();

--- a/script/add-asset-hashes.js
+++ b/script/add-asset-hashes.js
@@ -56,6 +56,7 @@ function addAssetHashes() {
     ].forEach(unhashedName => {
       const hashedName = manifest[unhashedName];
 
+      // When an --entry is specified that isn't proxy-rewrite, these files won't be here
       if (hashedName) {
         files[`generated/${unhashedName}`] = files[hashedName.substr(1)]; // eslint-disable-line no-param-reassign
       }


### PR DESCRIPTION
## Description
The build was breaking when I was trying to do a single-entry production build so I could run our bundle analyzer. After debugging a bit, I found this was because when we specify the `--entry` for the build, it doesn't grab the `proxy-rewrite.entry.js` (at least), which threw an error when we tried to run `.substr()` on `undefined`.

I admit this is just fixing symptoms. I don't know why it doesn't grab that file for the build--I also don't know what this proxy-rewrite is for, now that I think about it. :thinking: But it's new as of today, so...there's that, right?