### PR TITLE
Fix path error

### DIFF
--- a/script/apply-fragments.js
+++ b/script/apply-fragments.js
@@ -39,9 +39,9 @@ const path = require('path');
 const yaml = require('js-yaml');
 
 function applyFragments(buildOptions) {
-  const fragmentsRoot = buildOptions.contentFragments;
-
   return (files, smith, done) => {
+    const fragmentsRoot = smith.path(buildOptions.contentFragments);
+
     for (const fileName of Object.keys(files)) {
       const file = files[fileName];
 

--- a/script/apply-fragments.js
+++ b/script/apply-fragments.js
@@ -39,7 +39,7 @@ const path = require('path');
 const yaml = require('js-yaml');
 
 function applyFragments(buildOptions) {
-  const fragmentsRoot = path.join(__dirname, buildOptions.contentFragments);
+  const fragmentsRoot = buildOptions.contentFragments;
 
   return (files, smith, done) => {
     for (const fileName of Object.keys(files)) {


### PR DESCRIPTION
## Description
This PR is a follow-up to https://github.com/department-of-veterans-affairs/vets-website/pull/8939, which was found to have an error when plugging into the Heroku review instance at https://github.com/department-of-veterans-affairs/vagov-content/pull/64. There was an inconsistency with deriving the correct directory path between local and on Heroku.

Could have sworn I tested this several times, but must have overlooked something.

## Testing done
- Confirmed review instance deploys okay at https://github.com/department-of-veterans-affairs/vagov-content/pull/64.
- Confirmed local setup works okay

## Acceptance criteria
- [ ] Review instances work over at `vagov-content`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
