### PR TITLE
Move nav-wrap styles outside of consolidated class

### DIFF
--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -64,7 +64,7 @@ header.merger {
 
   .va-crisis-line-container {
     button.va-crisis-line {
-      background-image: none;  
+      background-image: none;
 
       // HACK: override rules from benefits.va.gov
       .va-crisis-line-text {

--- a/src/platform/site-wide/sass/modules/_m-layers.scss
+++ b/src/platform/site-wide/sass/modules/_m-layers.scss
@@ -2,9 +2,6 @@
 // TODO: bring these layers back into their specific modules
 
 // teamsite
-#nav-wrap {
-  z-index: $top-layer;
-}
 .va-modal {
   z-index: $modal-layer !important;
 }

--- a/src/platform/site-wide/sass/style-consolidated.scss
+++ b/src/platform/site-wide/sass/style-consolidated.scss
@@ -152,3 +152,8 @@ $modal-layer: 400;
 #iama {
   margin-top: 0;
 }
+
+// Place teamsite mobile menu on top of other elements
+.merger #nav-wrap {
+  z-index: $top-layer;
+}


### PR DESCRIPTION
## Description
The CSS for the `#nav-wrap` ID was not being applied because the TeamSite `#nav-wrap` element does not actually live within the `.consolidated` class.

## Testing done
Local

## Screenshots
<img width="420" alt="screen shot 2018-10-31 at 7 11 51 am" src="https://user-images.githubusercontent.com/20728956/47795029-e6ede180-dcde-11e8-9fde-cec38cc14e1a.png">


## Acceptance criteria
- [X] The TeamSite mobile menu does not appear behind main navbar items

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
