### PR TITLE
Fix broken unit test in Announcements

### DIFF
--- a/src/platform/site-wide/announcements/actions/index.js
+++ b/src/platform/site-wide/announcements/actions/index.js
@@ -6,10 +6,12 @@ export const DISMISS_ANNOUNCEMENT = 'DISMISS_ANNOUNCEMENT';
 export const ANNOUNCEMENTS_LOCAL_STORAGE = 'DISMISSED_ANNOUNCEMENTS';
 
 const previouslyDismissedAnnouncements = (() => {
-  let parsed = [];
+  let parsed = null;
 
   return {
     initializeFromLocalStorage() {
+      parsed = [];
+
       const fromLocalStorage = localStorage.getItem(
         ANNOUNCEMENTS_LOCAL_STORAGE,
       );


### PR DESCRIPTION
## Description
This PR fixes an issue with the announcement's unit tests failing depending on the order. 

## Testing done
Ran the unit test locally over and over

## Acceptance criteria
- [ ] Unit test passes consistently

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
