### PR TITLE
Fix More in this section cutoff

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/DisabilityWizard.jsx
+++ b/src/applications/disability-benefits/526EZ/components/DisabilityWizard.jsx
@@ -209,6 +209,7 @@ class DisabilityWizard extends React.Component {
             )}
             {isChoosingStatus() && (
               <ErrorableRadioButtons
+                additionalFieldsetClass="wizard-fieldset"
                 name="disabilityStatus"
                 label={labelText}
                 id="disabilityStatus"
@@ -222,6 +223,7 @@ class DisabilityWizard extends React.Component {
             )}
             {isChoosingUpdate() && (
               <ErrorableCheckboxGroup
+                additionalFieldsetClass="wizard-fieldset"
                 name="disabilityUpdate"
                 label={labelText}
                 id="disabilityUpdate"

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -87,6 +87,7 @@ export default class EducationWizard extends React.Component {
         <div className={contentClasses} id="wizardOptions">
           <div className="wizard-content-inner">
             <ErrorableRadioButtons
+              additionalFieldsetClass="wizard-fieldset"
               name="newBenefit"
               id="newBenefit"
               options={[
@@ -104,6 +105,7 @@ export default class EducationWizard extends React.Component {
             />
             {newBenefit === 'yes' && (
               <ErrorableRadioButtons
+                additionalFieldsetClass="wizard-fieldset"
                 name="serviceBenefitBasedOn"
                 id="serviceBenefitBasedOn"
                 options={[
@@ -119,6 +121,7 @@ export default class EducationWizard extends React.Component {
             )}
             {newBenefit === 'no' && (
               <ErrorableRadioButtons
+                additionalFieldsetClass="wizard-fieldset"
                 name="transferredEduBenefits"
                 id="transferredEduBenefits"
                 options={[
@@ -142,6 +145,7 @@ export default class EducationWizard extends React.Component {
             )}
             {serviceBenefitBasedOn === 'own' && (
               <ErrorableRadioButtons
+                additionalFieldsetClass="wizard-fieldset"
                 name="nationalCallToService"
                 id="nationalCallToService"
                 options={[
@@ -162,6 +166,7 @@ export default class EducationWizard extends React.Component {
             )}
             {serviceBenefitBasedOn === 'other' && (
               <ErrorableRadioButtons
+                additionalFieldsetClass="wizard-fieldset"
                 name="sponsorDeceasedDisabledMIA"
                 id="sponsorDeceasedDisabledMIA"
                 options={[

--- a/src/applications/static-pages/sass/modules/_m-education-wizard.scss
+++ b/src/applications/static-pages/sass/modules/_m-education-wizard.scss
@@ -44,3 +44,9 @@
 .wizard-alert-heading {
   padding: 0;
 }
+
+.wizard-fieldset {
+  input[type="checkbox"], input[type="radio"] {
+    margin-left: -4rem;
+  }
+}


### PR DESCRIPTION
## Description

The "More in this section" button was being cutoff on some pages when stuck to the top of the page. This is apparently because on certain pages we have a hidden wizard with radio and checkboxes. These are absolutely positioned by USWDS with a negative margin, but the margin offset is not enough when inside our gray box. This widens the page and makes it horizontally scrollable, which for some reason throws off the fixed position of the button. No idea why that is, but fixing the wizard fixes the button.

## Testing done
Tested locally

## Screenshots
![screen shot 2018-10-31 at 10 35 07 am](https://user-images.githubusercontent.com/634932/47795266-a69b5d00-dcf8-11e8-80e2-ad7c90052f99.png)


## Acceptance criteria
- [x] Scrolling doesn't cut off more in this section button on mobile when fixed to top

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
