### PR TITLE
Fix for document.referrer not being passed from Staging Vets.gov to Staging VA.gov

### DIFF
--- a/content/pages/va-gov-onboarding-modal-check.html
+++ b/content/pages/va-gov-onboarding-modal-check.html
@@ -4,7 +4,7 @@ production: false
 <!doctype html>
 <html>
   <head>
-      <meta http-equiv=refresh content="1; url=http://staging.va.gov">
+      <meta http-equiv=refresh content="1; url=https://staging.va.gov">
       <link rel=canonical href="/">
   </head>
 </html>

--- a/src/platform/site-wide/announcements/components/VAPlusVetsModal.jsx
+++ b/src/platform/site-wide/announcements/components/VAPlusVetsModal.jsx
@@ -10,7 +10,7 @@ export default class VAPlusVetsModal extends React.Component {
     let wasRedirectedFromVets = !!referrer && referrer.includes('vets.gov');
 
     // Allow an override on the URL to force the Onboarding Modal to appear for testing purposes.s
-    if (__BUILDTYPE__ !== 'preview') {
+    if (__BUILDTYPE__ !== 'preview' && !wasRedirectedFromVets) {
       wasRedirectedFromVets = window.location.search.includes(
         'onboarding-modal',
       );


### PR DESCRIPTION
## Description
This PR add a missing "s" to the redirect-destination of a page used to verify that the onboarding modal is being triggered properly from Vets.gov to VA.gov environments. The `document.referrer` property was being lost without the "s" in place, because they were first being redirect from the http-site to https.

Moves to validate - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14556

## Testing done
- [x] Visited https://vetsgov-pr-8948.herokuapp.com/va-gov-onboarding-modal-check?vets.gov to verify the `document.referrer` is received okay

## Acceptance criteria
- [x] Redirect works okay

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
