### PR TITLE
Provide link to older tools on Facility Locator.

### DIFF
--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -28,6 +28,10 @@ import { facilityTypes } from '../config';
 import { LocationType, FacilityType, BOUNDING_RADIUS } from '../constants';
 import { areGeocodeEqual } from '../utils/helpers';
 
+const otherToolsLink = (<p>
+  Can’t find what you’re looking for? <a href="https://www.va.gov/directory/guide/home.asp">Try using our other tools to search.</a>
+</p>);
+
 // This isn't valid JSX 2.x, better to get used to it now
 /* eslint-disable react/jsx-boolean-value */
 class VAMap extends Component {
@@ -160,7 +164,7 @@ class VAMap extends Component {
    * Presumably handles the case if a user manually makes a change to the
    * address bar and thereby updates the location as tracked by ReactRouter?
    * (i.e. route changes not handled through the Router)
-   * 
+   *
    * @param {Object} location ReactRouter location object
    */
   syncStateWithLocation = (location) => {
@@ -178,8 +182,8 @@ class VAMap extends Component {
 
   /**
    * Regenerates the URL based on the given parameters so that
-   * the map link stays useful for sharing. 
-   * 
+   * the map link stays useful for sharing.
+   *
    * @param {Object} params Object containing the current search fields
    */
   updateUrlParams = (params) => {
@@ -203,7 +207,7 @@ class VAMap extends Component {
 
   /**
    * Generates a bounding box from a lat/long geocoordinate.
-   * 
+   *
    *  @param position Has shape: `{latitude: x, longitude: y}`
    */
   genBBoxFromCoords = (position) => {
@@ -400,9 +404,11 @@ class VAMap extends Component {
               <div aria-live="polite" aria-relevant="additions text" className="facility-search-results">
                 <ResultsList results={results} pagination={pagination} isMobile
                   currentQuery={currentQuery} updateUrlParams={this.updateUrlParams} />
+                {otherToolsLink}
               </div>
             </TabPanel>
             <TabPanel>
+              {otherToolsLink}
               <Map ref="map" center={position} zoom={parseInt(currentQuery.zoomLevel, 10)}
                 style={{ width: '100%', maxHeight: '55vh' }} scrollWheelZoom={false}
                 zoomSnap={0.5} zoomDelta={0.5} onMoveEnd={this.handleBoundsChanged}
@@ -454,6 +460,7 @@ class VAMap extends Component {
             </div>
           </div>
           <div className="columns usa-width-two-thirds medium-8 small-12" style={{ minHeight: '75vh' }}>
+            {otherToolsLink}
             <Map ref="map" center={position} zoomSnap={0.5} zoomDelta={0.5}
               zoom={parseInt(currentQuery.zoomLevel, 10)} style={{ minHeight: '75vh', width: '100%' }}
               scrollWheelZoom={false} onMoveEnd={this.handleBoundsChanged}>


### PR DESCRIPTION
## Description
Added link to old VA.gov Locations tool in a few places. Facility Locator doesn't have full parity with the old tools, so just providing a low-key option to use the old tools instead.

## Testing done
Local manual testing.

## Screenshots
### Desktop
> <img width="486" alt="screen shot 2018-10-31 at 1 49 35 pm" src="https://user-images.githubusercontent.com/1067024/47809773-12d98900-dd18-11e8-9350-07855f463c39.png">

### Mobile Search Results Tab
> <img width="369" alt="screen shot 2018-10-31 at 1 43 33 pm" src="https://user-images.githubusercontent.com/1067024/47809805-24229580-dd18-11e8-94bf-53a56bb0c0f0.png">

### Mobile Map Tab
> <img width="360" alt="screen shot 2018-10-31 at 2 08 36 pm" src="https://user-images.githubusercontent.com/1067024/47809816-2b49a380-dd18-11e8-974a-e517c1ad215c.png">

## Acceptance criteria
- [x] Users should have access to VA.gov Locations tool on the desktop view of Facility Locator.
- [x] Users should have access to VA.gov Locations tool on the mobile view of Facility Locator (in both search results and map tabs).

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs