### PR TITLE
Styling fixes for search pagination

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -126,7 +126,7 @@ class SearchApp extends React.Component {
         {this.renderResultsCount()}
         <hr />
         {this.renderResultsList()}
-        <hr />
+        <hr id="hr-search-bottom" />
         {this.renderResultsFooter()}
       </div>
     );

--- a/src/applications/search/styles.scss
+++ b/src/applications/search/styles.scss
@@ -68,7 +68,7 @@
       width: unset;
       border-top: none;
 
-      @media (min-width: 1201px) {
+      @include media($large-screen) {
         .va-pagination-inner {
           width: unset;
         }

--- a/src/applications/search/styles.scss
+++ b/src/applications/search/styles.scss
@@ -42,9 +42,10 @@
 
   .usa-alert {
     margin-bottom: 2rem;
+
     .usa-alert-body {
       padding-left: 1rem;
-  
+
       .usa-alert-text {
         margin-top: 1rem;
       }
@@ -53,10 +54,26 @@
 
   hr {
     border-bottom: none;
+
+    &#hr-search-bottom {
+      margin-bottom: 1.5rem;
+    }
   }
 
   .results-footer {
     justify-content: space-between;
+    align-items: center;
+
+    .va-pagination {
+      width: unset;
+      border-top: none;
+
+      @media (min-width: 1201px) {
+        .va-pagination-inner {
+          width: unset;
+        }
+      }
+    }
 
     .simple-pagination {
       span.current-page {


### PR DESCRIPTION
## Description

Update layout and spacing of pagination to be more inline with mockup

## Testing done

Tested locally on desktop and mobile sizes

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/786704/47813847-6c868700-dd09-11e8-8c72-c7b55b559ab6.png)


### After
![image](https://user-images.githubusercontent.com/786704/47813692-0699ff80-dd09-11e8-89dd-d8f3dc3a5bf8.png)


## Acceptance criteria
- [x] "Powered by Search.gov" should not wrap
- [x] Space between Prev/Next butts and page numbers should be reduced

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
