### PR TITLE
Removed "How to apply for a discharge upgrade" link from dashboard

### DIFF
--- a/src/applications/personalization/dashboard/containers/DashboardApp.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardApp.jsx
@@ -402,21 +402,6 @@ class DashboardApp extends React.Component {
             <ul className="va-nav-linkslist-list">
               <li>
                 <a
-                  href="/discharge-upgrade-instructions/"
-                  onClick={recordDashboardClick('apply-discharge')}
-                >
-                  <h4 className="va-nav-linkslist-title">
-                    How to Apply for a Discharge Upgrade
-                  </h4>
-                  <p className="va-nav-linkslist-description">
-                    Answer a series of questions to get customized step-by-step
-                    instructions on how to apply for a discharge upgrade or
-                    correction.
-                  </p>
-                </a>
-              </li>
-              <li>
-                <a
                   href="/health-care/health-records/"
                   onClick={recordDashboardClick('health-records')}
                 >


### PR DESCRIPTION
## Description

Remove "How to Apply for a Discharge Upgrade" link from Dashboard

## Testing done

Tested locally on desktop and mobile

## Screenshots

![image](https://user-images.githubusercontent.com/786704/47814371-c045a000-dd0a-11e8-9edc-057189604398.png)

## Acceptance criteria
- [x] "How to Apply for a Discharge Upgrade" link no longer on Dashboard

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
