### PR TITLE
Add a slash into Vets.gov-to-VA.gov redirect page

### DIFF
--- a/content/pages/va-gov-onboarding-modal-check.html
+++ b/content/pages/va-gov-onboarding-modal-check.html
@@ -4,7 +4,7 @@ production: false
 <!doctype html>
 <html>
   <head>
-      <meta http-equiv=refresh content="1; url=https://staging.va.gov">
+      <meta http-equiv=refresh content="1; url=https://staging.va.gov/">
       <link rel=canonical href="/">
   </head>
 </html>


### PR DESCRIPTION
## Description
This is a follow-up to https://github.com/department-of-veterans-affairs/vets-website/pull/8948. Previously I forgot the `s` in `https`; this time I forgot the trailing slash, again causing an intermediate redirect and the `document.referrer` to be lost. 

This was difficult to test.

## Testing done
Started Vets.gov locally and visited `http://localhost:3001/va-gov-onboarding-modal-check?vets.gov`. Was redirected to `https://staging.va.gov` and saw the onboarding modal finally.

## Acceptance criteria
- [ ] Vets.gov redirect-page works in Staging

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
