### PR TITLE
All claims require homelessness poc mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -261,15 +261,9 @@ const formConfig = {
                       pattern:
                         "Full names can only contain letters, numbers, spaces, dashes ('-'), and forward slashes ('/')",
                     },
-                    'ui:required': formData => {
-                      const {
-                        homelessness: homelessOrAtRisk,
-                      } = formData.veteran;
-                      if (homelessOrAtRisk.isHomeless !== true) {
-                        return false;
-                      }
-                      return !!homelessOrAtRisk.pointOfContact.primaryPhone;
-                    },
+                    'ui:required': formData =>
+                      _.get('veteran.homelessness.isHomeless', formData, '') ===
+                      true,
                   },
                   primaryPhone: {
                     'ui:title': 'Phone number',
@@ -282,16 +276,9 @@ const formConfig = {
                       pattern:
                         'Phone numbers must be 10 digits (dashes allowed)',
                     },
-                    'ui:required': formData => {
-                      const {
-                        homelessness: homelessOrAtRisk,
-                      } = formData.veteran;
-                      if (homelessOrAtRisk.isHomeless !== true) {
-                        return false;
-                      }
-                      return !!homelessOrAtRisk.pointOfContact
-                        .pointOfContactName;
-                    },
+                    'ui:required': formData =>
+                      _.get('veteran.homelessness.isHomeless', formData, '') ===
+                      true,
                   },
                 },
               },

--- a/src/applications/disability-benefits/526EZ/tests/config/specialCircumstances.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/specialCircumstances.unit.spec.jsx
@@ -80,13 +80,12 @@ describe('Disability benefits 526EZ special circumstances', () => {
     expect(onSubmit.called).to.be.true;
   });
 
-  it('should submit form when veteran indicates they are homeless but have no POC', () => {
+  it('should not submit form when veteran indicates they are homeless but have no POC', () => {
     const onSubmit = sinon.spy();
     const formData = {
       veteran: {
         homelessness: {
           isHomeless: true,
-          pointOfContact: {},
         },
       },
     };
@@ -103,8 +102,8 @@ describe('Disability benefits 526EZ special circumstances', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error').length).to.equal(0);
-    expect(onSubmit.called).to.be.true;
+    expect(form.find('.usa-input-error').length).to.equal(2);
+    expect(onSubmit.called).to.be.false;
   });
 
   it('should not submit form when veteran indicates only POC name', () => {

--- a/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
+++ b/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
@@ -115,11 +115,11 @@ export const uiSchema = {
     name: {
       'ui:title': 'Name of person we can contact',
       'ui:required': formData =>
-        !!_.get('homelessnessContact.phoneNumber', formData, null),
+        _.get('homelessOrAtRisk', formData, '') === HOMELESSNESS_TYPES.homeless,
     },
     phoneNumber: merge(phoneUI('Phone number'), {
       'ui:required': formData =>
-        !!_.get('homelessnessContact.name', formData, null),
+        _.get('homelessOrAtRisk', formData, '') === HOMELESSNESS_TYPES.homeless,
     }),
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
+++ b/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
@@ -21,6 +21,8 @@ import {
   HOMELESS_HOUSING_TYPES,
 } from '../constants';
 
+import { getHomelessOrAtRisk } from '../utils';
+
 export const uiSchema = {
   homelessOrAtRisk: {
     'ui:title': 'Are you homeless or at risk of becoming homeless?',
@@ -114,12 +116,10 @@ export const uiSchema = {
     },
     name: {
       'ui:title': 'Name of person we can contact',
-      'ui:required': formData =>
-        _.get('homelessOrAtRisk', formData, '') === HOMELESSNESS_TYPES.homeless,
+      'ui:required': getHomelessOrAtRisk,
     },
     phoneNumber: merge(phoneUI('Phone number'), {
-      'ui:required': formData =>
-        _.get('homelessOrAtRisk', formData, '') === HOMELESSNESS_TYPES.homeless,
+      'ui:required': getHomelessOrAtRisk,
     }),
   },
 };

--- a/src/applications/disability-benefits/all-claims/tests/pages/homelessOrAtRisk.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/homelessOrAtRisk.unit.spec.jsx
@@ -9,9 +9,10 @@ import {
   HOMELESSNESS_TYPES,
   AT_RISK_HOUSING_TYPES,
   HOMELESS_HOUSING_TYPES,
+  ERR_MSG_CSS_CLASS,
 } from '../../constants';
 
-describe('Homeless or At Risk Info', () => {
+describe.only('Homeless or At Risk Info', () => {
   const {
     schema,
     uiSchema,
@@ -48,11 +49,11 @@ describe('Homeless or At Risk Info', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(0);
     expect(onSubmit.calledOnce).to.be.true;
   });
 
-  it('should require living situation and needToLeave when homeless', () => {
+  it('should require living situation, needToLeave, and contact name / number when homeless', () => {
     const onSubmit = sinon.spy();
 
     const form = mount(
@@ -69,7 +70,7 @@ describe('Homeless or At Risk Info', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(2);
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(4);
     expect(onSubmit.called).to.be.false;
   });
 
@@ -90,11 +91,11 @@ describe('Homeless or At Risk Info', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(1);
     expect(onSubmit.called).to.be.false;
   });
 
-  it('should require homeless housing input when other selected', () => {
+  it("should require homeless housing input when 'other' selected", () => {
     const onSubmit = sinon.spy();
 
     const form = mount(
@@ -108,6 +109,10 @@ describe('Homeless or At Risk Info', () => {
             homelessHousingSituation: HOMELESS_HOUSING_TYPES.other,
             needToLeaveHousing: true,
           },
+          homelessnessContact: {
+            name: 'John Smith',
+            phoneNumber: '1234567890',
+          },
         }}
         formData={{}}
         onSubmit={onSubmit}
@@ -115,7 +120,7 @@ describe('Homeless or At Risk Info', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(1);
     expect(onSubmit.called).to.be.false;
   });
 
@@ -140,61 +145,7 @@ describe('Homeless or At Risk Info', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-  });
-
-  it('should require contact phone number when contact name filled out', () => {
-    const onSubmit = sinon.spy();
-
-    const form = mount(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{
-          homelessOrAtRisk: HOMELESSNESS_TYPES.atRisk,
-          'view:isAtRisk': {
-            atRiskHousingSituation: AT_RISK_HOUSING_TYPES.losingHousing,
-          },
-          homelessnessContact: {
-            name: 'John Smith',
-          },
-        }}
-        formData={{}}
-        onSubmit={onSubmit}
-      />,
-    );
-
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-  });
-
-  it('should require contact name when phone number filled out', () => {
-    const onSubmit = sinon.spy();
-
-    const form = mount(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{
-          homelessOrAtRisk: HOMELESSNESS_TYPES.atRisk,
-          'view:isAtRisk': {
-            atRiskHousingSituation: AT_RISK_HOUSING_TYPES.losingHousing,
-          },
-          homelessnessContact: {
-            phoneNumber: '1234567890',
-          },
-        }}
-        formData={{}}
-        onSubmit={onSubmit}
-      />,
-    );
-
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(1);
     expect(onSubmit.called).to.be.false;
   });
 
@@ -224,7 +175,7 @@ describe('Homeless or At Risk Info', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(0);
     expect(onSubmit.calledOnce).to.be.true;
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/homelessOrAtRisk.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/homelessOrAtRisk.unit.spec.jsx
@@ -12,7 +12,7 @@ import {
   ERR_MSG_CSS_CLASS,
 } from '../../constants';
 
-describe.only('Homeless or At Risk Info', () => {
+describe('Homeless or At Risk Info', () => {
   const {
     schema,
     uiSchema,
@@ -74,7 +74,7 @@ describe.only('Homeless or At Risk Info', () => {
     expect(onSubmit.called).to.be.false;
   });
 
-  it('should require living situation when at risk', () => {
+  it('should require living situation and contact name / number when at risk', () => {
     const onSubmit = sinon.spy();
 
     const form = mount(
@@ -91,7 +91,7 @@ describe.only('Homeless or At Risk Info', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(1);
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(3);
     expect(onSubmit.called).to.be.false;
   });
 
@@ -124,7 +124,7 @@ describe.only('Homeless or At Risk Info', () => {
     expect(onSubmit.called).to.be.false;
   });
 
-  it('should require at risk housing input when other option selected', () => {
+  it("should require at risk housing input when 'other' option selected", () => {
     const onSubmit = sinon.spy();
 
     const form = mount(
@@ -137,6 +137,10 @@ describe.only('Homeless or At Risk Info', () => {
           'view:isHomeless': {
             homelessHousingSituation: AT_RISK_HOUSING_TYPES.other,
             needToLeaveHousing: true,
+          },
+          homelessnessContact: {
+            name: 'John Smith',
+            phoneNumber: '1234567890',
           },
         }}
         formData={{}}

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -12,6 +12,7 @@ import {
   USA,
   DATA_PATHS,
   NINE_ELEVEN,
+  HOMELESSNESS_TYPES,
 } from './constants';
 /**
  * Show one thing, have a screen reader say another.
@@ -270,3 +271,11 @@ export const needsToEnter781 = formData =>
 
 export const isUploadingPtsdForm = formData =>
   _.get('view:uploadPtsdChoice', formData, '') === 'upload';
+
+export const getHomelessOrAtRisk = formData => {
+  const homelessStatus = _.get('homelessOrAtRisk', formData, '');
+  return (
+    homelessStatus === HOMELESSNESS_TYPES.homeless ||
+    homelessStatus === HOMELESSNESS_TYPES.atRisk
+  );
+};


### PR DESCRIPTION
## Description
Requires POC name and phone number for all veterans who indicate they are homeless or at risk of becoming homeless, on both the MVP and All Claims forms.

## Testing done
- [x] Tested locally
- [x] Unit tests

## Screenshots
Nothing really changes visually, except the 'required' text is added to the POC questions and they have to be filled out.

MVP:
![screen shot 2018-10-31 at 4 41 26 pm](https://user-images.githubusercontent.com/24251447/47821419-a027d800-dd2e-11e8-81cc-45d3394c64f0.png)

-----

All Claims:
![screen shot 2018-10-31 at 5 01 56 pm](https://user-images.githubusercontent.com/24251447/47821481-ce0d1c80-dd2e-11e8-9f1d-b013fece8362.png)


## Acceptance criteria
- [x] Require POC name & phone for homeless veterans
- [x] Require POC name & phone for 'at risk' veterans
- [x] Update these requirements across both MVP & All Claims forms

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
