### PR TITLE
add overrides for teamsite header

### DIFF
--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -15,6 +15,10 @@
   }
 }
 
+.header {
+  text-align: left;
+}
+
 .login .container h1 {
   color: $color-black !important;
 }
@@ -63,6 +67,7 @@ header.merger {
   margin: auto;
 
   .va-crisis-line-container {
+    box-sizing: border-box;
     button.va-crisis-line {
       background-image: none;
 


### PR DESCRIPTION
## Description
- Overrides default behavior for .header to center all text on `https://preview.va.gov/osdbu/calendar.as`: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14746
- Overides box-sizing for VCL elements: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14738

## Testing done
Verified locally 

## Screenshots
![screen shot 2018-11-01 at 09 15 55](https://user-images.githubusercontent.com/4998130/47860799-08220100-ddb7-11e8-9ad5-c85e48bd44b4.png)
![screen shot 2018-11-01 at 09 15 50](https://user-images.githubusercontent.com/4998130/47860800-08ba9780-ddb7-11e8-8be3-dc9b159a5508.png)
![screen shot 2018-10-31 at 15 46 19](https://user-images.githubusercontent.com/4998130/47860801-08ba9780-ddb7-11e8-9236-1969ab1eeb3e.png)
![screen shot 2018-10-31 at 15 46 16](https://user-images.githubusercontent.com/4998130/47860803-08ba9780-ddb7-11e8-9b02-7c546663b7ea.png)
![screen shot 2018-10-31 at 15 46 13](https://user-images.githubusercontent.com/4998130/47860804-08ba9780-ddb7-11e8-8399-220d50c0d3d5.png)




## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
