### PR TITLE
Update Formation to pull in mega menu changes

### DIFF
--- a/src/platform/site-wide/mega-menu/actions/index.js
+++ b/src/platform/site-wide/mega-menu/actions/index.js
@@ -2,6 +2,8 @@ export const UPDATE_CURRENT_SECTION = 'UPDATE_CURRENT_SECTION';
 export const TOGGLE_PANEL_OPEN = 'TOGGLE_PANEL_OPEN';
 export const TOGGLE_DISPLAY_HIDDEN = 'TOGGLE_DISPLAY_HIDDEN';
 
+const tabletMediaQuery = window.matchMedia('(min-width: 768px)');
+
 export const togglePanel = megaMenu => ({
   type: 'TOGGLE_PANEL_OPEN',
   megaMenu,
@@ -22,7 +24,7 @@ export function updateCurrentSection(currentSection) {
 export const toggleMobileDisplayHidden = hidden => (dispatch, getState) => {
   const state = getState();
 
-  if (document.body.clientWidth >= 768) {
+  if (tabletMediaQuery.matches) {
     dispatch(toggleDisplayHidden({}));
   } else if (hidden) {
     dispatch(toggleDisplayHidden({ hidden: true }));

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -55,6 +55,9 @@ export default function setupJSDom() {
   win.scrollTo = () => {};
   win.sessionStorage = {};
   win.requestAnimationFrame = func => func();
+  win.matchMedia = () => ({
+    matches: false,
+  });
 
   global.Blob = window.Blob;
 

--- a/va-gov/components/navigation-sidebar-trigger.html
+++ b/va-gov/components/navigation-sidebar-trigger.html
@@ -17,21 +17,22 @@ Used to open or close the side bar navigation bar on mobile screens. Must be use
 
 
 <script type="text/javascript">
+    var mobileMediaQuery = window.matchMedia('(max-width: 767px)');
     var element = document.getElementsByClassName("va-btn-sidebarnav-trigger")[0];
     var offset;
 
-    if (document.body.clientWidth < 768) {
+    if (mobileMediaQuery.matches) {
       offset = element.offsetTop;
     }
 
     window.addEventListener("resize", function() {
-      if (document.body.clientWidth < 768) {
+      if (mobileMediaQuery.matches) {
         offset = element.offsetTop;
       }
     }, false);
 
     window.addEventListener("scroll", function() {
-      if (document.body.clientWidth < 768) {
+      if (mobileMediaQuery.matches) {
         if (offset < window.pageYOffset) {
           element.classList.add("fixed-trigger");
         } else {

--- a/va-gov/includes/social-accordion.html
+++ b/va-gov/includes/social-accordion.html
@@ -9,8 +9,9 @@
 	  button.setAttribute('aria-expanded', `${!buttonOpen}`);
 	  content.setAttribute('aria-hidden', `${!contentHidden}`);
 	};
+  var mobileMediaQuery = window.matchMedia('(max-width: 767px)');
 	document.addEventListener('DOMContentLoaded', function() {
-	  if (document.body.clientWidth < 768) { // is Mobile
+	  if (mobileMediaQuery.matches) {
 	    toggleAccordion();
 	  }
 	});

--- a/va-gov/includes/social-accordion.html
+++ b/va-gov/includes/social-accordion.html
@@ -1,19 +1,19 @@
 <script>
 (function() {
-	function toggleAccordion(){
-	  var node = document.querySelector('.usa-accordion-bordered');
-	  var button = node.querySelector('button.usa-accordion-button-dark');
-	  var content = node.querySelector('.usa-accordion-content');
-	  var buttonOpen = button.getAttribute('aria-expanded') === 'true';
-	  var contentHidden = content.getAttribute('aria-hidden') === 'true';
-	  button.setAttribute('aria-expanded', `${!buttonOpen}`);
-	  content.setAttribute('aria-hidden', `${!contentHidden}`);
-	};
+  function toggleAccordion(){
+    var node = document.querySelector('.usa-accordion-bordered');
+    var button = node.querySelector('button.usa-accordion-button-dark');
+    var content = node.querySelector('.usa-accordion-content');
+    var buttonOpen = button.getAttribute('aria-expanded') === 'true';
+    var contentHidden = content.getAttribute('aria-hidden') === 'true';
+    button.setAttribute('aria-expanded', `${!buttonOpen}`);
+    content.setAttribute('aria-hidden', `${!contentHidden}`);
+  };
   var mobileMediaQuery = window.matchMedia('(max-width: 767px)');
-	document.addEventListener('DOMContentLoaded', function() {
-	  if (mobileMediaQuery.matches) {
-	    toggleAccordion();
-	  }
-	});
+  document.addEventListener('DOMContentLoaded', function() {
+  if (mobileMediaQuery.matches) {
+    toggleAccordion();
+  }
+});
 })()
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,8 +17,8 @@
     js-tokens "^4.0.0"
 
 "@department-of-veterans-affairs/formation@^1.10.3":
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.10.3.tgz#8f5032f570fc530f585782d744ef5227818db44a"
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.10.4.tgz#62a19c1d57624a4581a01b205efe62a175f50f19"
   dependencies:
     classnames "^2.2.5"
     font-awesome "4"


### PR DESCRIPTION
## Description
This pulls in the changes that keep the mega menu from disappearing at certain screen sizes. I've also updated most of the `clientWidth` instances to use `matchMedia`.

## Testing done
Tested locally, on iPad, on Browserstack

## Screenshots
![screen shot 2018-10-31 at 2 24 38 pm](https://user-images.githubusercontent.com/634932/47863308-580bc280-ddcd-11e8-9076-3ae32768cf2a.png)

## Acceptance criteria
- [x] Menu shows up between 768 and 782 widths

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
