### PR TITLE
Add Office of Inspector General to footer

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -210,22 +210,29 @@
   },
   {
     "column": "bottom_rail",
-    "href": "/opa/Plain_Language.asp",
+    "href": "https://va.gov/oig/",
     "order": 2,
+    "target": null,
+    "title": "Office of Inspector General"
+  },
+  {
+    "column": "bottom_rail",
+    "href": "/opa/Plain_Language.asp",
+    "order": 3,
     "target": null,
     "title": "Plain Language"
   },
   {
     "column": "bottom_rail",
     "href": "/privacy/",
-    "order": 3,
+    "order": 4,
     "target": null,
     "title": "Privacy, Policies, and Legal Information"
   },
   {
     "column": "bottom_rail",
     "href": "/scorecard/",
-    "order": 4,
+    "order": 5,
     "target": null,
     "title": "VA.gov Scorecard"
   }


### PR DESCRIPTION
## Description
This PR adds a federally-required link to the footer.

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14793

## Screenshots
todo

## Acceptance criteria
- [ ] link is added

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
