### PR TITLE
[WIP] Connected Accounts Management Page

### DIFF
--- a/src/applications/personalization/account/components/AccountMain.jsx
+++ b/src/applications/personalization/account/components/AccountMain.jsx
@@ -125,11 +125,20 @@ class AccountMain extends React.Component {
         )}
         <LoginSettings />
         {verified && <TermsAndConditions mhvAccount={mhvAccount} />}
-        <h3>Have questions about signing in to {propertyName}?</h3>
+
+        <h3>Connected accounts</h3>
         <p>
-          Get answers to frequently asked questions about how to sign in, common
-          issues with verifying your identity, and your privacy and security on{' '}
-          {propertyName}.<br />
+          Manage the sites and applications that you've granted access to your
+          {propertyName} profile data.
+        </p>
+        <a href="/connected-accounts">Manage your connected accounts</a>
+        <div className="feature">
+          <h3>Have questions about signing in to {propertyName}?</h3>
+          <p>
+            Get answers to frequently asked questions about how to sign in,
+            common issues with verifying your identity, and your privacy and
+            security on {propertyName}.
+          </p>
           <a
             href="/faq"
             onClick={() =>
@@ -142,7 +151,7 @@ class AccountMain extends React.Component {
           >
             Go to {propertyName} FAQs
           </a>
-        </p>
+        </div>
       </div>
     );
   }

--- a/src/applications/personalization/connected-accounts/actions/index.js
+++ b/src/applications/personalization/connected-accounts/actions/index.js
@@ -1,0 +1,41 @@
+import { apiRequest } from '../../../../platform/utilities/api';
+
+export * from '../../../../platform/user/profile/actions';
+
+export const LOADING_CONNECTED_ACCOUNTS = 'LOADING_CONNECTED_ACCOUNTS';
+export const FINISHED_CONNECTED_ACCOUNTS = 'FINISHED_CONNECTED_ACCOUNTS';
+export const ERROR_CONNECTED_ACCOUNTS = 'ERROR_CONNECTED_ACCOUNTS';
+export const DELETING_CONNECTED_ACCOUNT = 'DELETING_CONNECTED_ACCOUNT';
+export const ERROR_DELETING_CONNECTED_ACCOUNT =
+  'ERROR_DELETING_CONNECTED_ACCOUNT';
+export const FINISHED_DELETING_CONNECTED_ACCOUNT =
+  'FINISHED_DELETING_CONNECTED_ACCOUNT';
+
+const grantsUrl = '/profile/connected_applications';
+
+export function loadConnectedAccounts() {
+  return async dispatch => {
+    dispatch({ type: 'LOADING_CONNECTED_ACCOUNTS' });
+
+    return apiRequest(
+      grantsUrl,
+      null,
+      ({ data }) => dispatch({ type: FINISHED_CONNECTED_ACCOUNTS, data }),
+      ({ errors }) => dispatch({ type: ERROR_CONNECTED_ACCOUNTS, errors }),
+    );
+  };
+}
+
+export function deleteConnectedAccount(accountId) {
+  return async dispatch => {
+    dispatch({ type: DELETING_CONNECTED_ACCOUNT, accountId });
+
+    return apiRequest(
+      `${grantsUrl}/${accountId}`,
+      { method: 'DELETE' },
+      () => dispatch({ type: FINISHED_DELETING_CONNECTED_ACCOUNT, accountId }),
+      ({ errors }) =>
+        dispatch({ type: ERROR_DELETING_CONNECTED_ACCOUNT, errors }),
+    );
+  };
+}

--- a/src/applications/personalization/connected-accounts/components/AccountModal.jsx
+++ b/src/applications/personalization/connected-accounts/components/AccountModal.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import Modal from '@department-of-veterans-affairs/formation/Modal';
+
+export function AccountModal({
+  appName,
+  modalOpen,
+  onCloseModal,
+  onConfirmDelete,
+  propertyName,
+}) {
+  return (
+    <Modal
+      clickToClose
+      cssClass="va-modal"
+      id="disconnect-alert"
+      onClose={onCloseModal}
+      title={`Are you sure you want to disconnect from ${appName}?`}
+      visible={modalOpen}
+    >
+      <p>
+        {appName} will no longer be able to access your {propertyName} account
+        informaton. You cannot undo this action.
+      </p>
+      <button className="usa-button-primary" onClick={onConfirmDelete}>
+        Confirm
+      </button>
+      <button className="usa-button-secondary" onClick={onCloseModal}>
+        Cancel
+      </button>
+    </Modal>
+  );
+}

--- a/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import moment from 'moment';
+
+import PropTypes from 'prop-types';
+
+import { AccountModal } from './AccountModal';
+
+class ConnectedApp extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { modalOpen: false };
+  }
+
+  closeModal = () => {
+    this.setState({ modalOpen: false });
+  };
+
+  openModal = () => {
+    this.setState({ modalOpen: true });
+  };
+
+  confirmDelete = () => {
+    this.props.confirmDelete(this.props.id);
+  };
+
+  render() {
+    const { href, logo, title, created } = this.props.attributes;
+    return (
+      <tr>
+        <th scope="row">
+          <a href={href} className="no-external-icon">
+            <img src={logo} alt={`${title} logo`} width="100" />
+          </a>
+        </th>
+        <th>
+          <a href={href}>{title}</a> <br />
+          Connected at {moment(created).format('MMMM Do, YYYY')}
+        </th>
+        <th>
+          <button className="usa-button-primary" onClick={this.openModal}>
+            Disconnect
+          </button>
+        </th>
+        <AccountModal
+          appName={title}
+          modalOpen={this.state.modalOpen}
+          onCloseModal={this.closeModal}
+          onConfirmDelete={this.confirmDelete}
+          propertyName={this.props.propertyName}
+        />
+      </tr>
+    );
+  }
+}
+
+ConnectedApp.propTypes = {
+  id: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  attribtues: PropTypes.object.isRequired,
+  confirmDelete: PropTypes.func.isRequired,
+  propertyName: PropTypes.string.isRequired,
+};
+
+export { ConnectedApp };

--- a/src/applications/personalization/connected-accounts/components/ConnectedApps.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApps.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import { ConnectedApp } from './ConnectedApp';
+import recordEvent from '../../../../platform/monitoring/record-event';
+
+export function ConnectedApps({ confirmDelete, propertyName, accounts }) {
+  return (
+    <div className="row va-connected-acct">
+      <div className="usa-width-two-thirds medium-8 small-12 columns">
+        <h1>Your Connected Accounts</h1>
+        <p className="va-introtext">
+          {/* eslint-disable prettier/prettier */}
+          You gave these sites and applications read only access to some of
+          your {propertyName} account data.
+          {/* eslint-enable prettier/prettier */}
+        </p>
+
+        <table className="va-table-connected-acct usa-table-borderless">
+          <tbody>
+            {accounts.map((a, idx) => (
+              <ConnectedApp
+                key={idx}
+                confirmDelete={confirmDelete}
+                propertyName={propertyName}
+                {...a}
+              />
+            ))}
+          </tbody>
+        </table>
+
+        <div className="feature">
+          <h3>Have questions about signing in to {propertyName}?</h3>
+          <p>
+            Get answers to frequently asked questions about how to sign in,
+            common issues with verifying your identity, and your privacy and
+            security on {propertyName}.
+          </p>
+
+          <a
+            href="/faq"
+            onClick={() =>
+              recordEvent({
+                event: 'account-navigation',
+                'account-action': 'view-link',
+                'account-section': 'vets-faqs',
+              })
+            }
+          >
+            Go to {propertyName} FAQs
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/applications/personalization/connected-accounts/components/NoConnectedApps.jsx
+++ b/src/applications/personalization/connected-accounts/components/NoConnectedApps.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import recordEvent from '../../../../platform/monitoring/record-event';
+
+const recordAction = () => {
+  recordEvent({
+    event: 'account-navigation',
+    'account-action': 'view-link',
+    'account-section': 'vets-faqs',
+  });
+};
+
+export function NoConnectedApps({ errors, propertyName }) {
+  let title;
+  if (errors.length > 0) {
+    title = <h3>Something went wrong loading your connected Accounts.</h3>;
+  } else {
+    title = <h3>You do not have any connected accounts.</h3>;
+  }
+
+  return (
+    <div className="row va-connected-acct-null">
+      <div className="usa-width-two-thirds medium-8 small-12 columns">
+        {title}
+        <div className="feature">
+          <h3>Have questions about signing in to {propertyName}?</h3>
+          <p>
+            Get answers to frequently asked questions about how to sign in,
+            common issues with verifying your identity, and your privacy and
+            security on {propertyName}.
+          </p>
+
+          <a href="/faq" onClick={recordAction}>
+            Go to {propertyName} FAQs
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/applications/personalization/connected-accounts/components/index.js
+++ b/src/applications/personalization/connected-accounts/components/index.js
@@ -1,0 +1,2 @@
+export * from './NoConnectedApps.jsx';
+export * from './ConnectedApps.jsx';

--- a/src/applications/personalization/connected-accounts/connected-accounts-entry.jsx
+++ b/src/applications/personalization/connected-accounts/connected-accounts-entry.jsx
@@ -1,0 +1,15 @@
+import '../profile360/sass/profile-360.scss';
+import '../../../platform/polyfills';
+import '../profile360/sass/user-profile.scss';
+
+import startApp from '../../../platform/startup';
+
+import routes from './routes';
+import reducer from './reducers';
+import manifest from './manifest.json';
+
+startApp({
+  url: manifest.rootUrl,
+  reducer,
+  routes,
+});

--- a/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
+++ b/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
@@ -1,27 +1,29 @@
-/* eslint-disable no-use-before-declare */
-/* eslint-disable react/jsx-indent */
-/* eslint-disable prettier/prettier */
-/* eslint-disable arrow-body-style */
-/* eslint-disable react/jsx-closing-bracket-location */
-
 import React from 'react';
 import { connect } from 'react-redux';
+import backendServices from '../../../../platform/user/profile/constants/backendServices';
+import { selectUser } from '../../../../platform/user/selectors';
 
-import Modal from '@department-of-veterans-affairs/formation/Modal';
-
-import recordEvent from '../../../../platform/monitoring/record-event';
+import RequiredLoginView from '../../../../platform/user/authorization/components/RequiredLoginView';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
+
+import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
+
+import { loadConnectedAccounts, deleteConnectedAccount } from '../actions';
+import { NoConnectedApps, ConnectedApps } from '../components';
 
 import '../sass/connected-acct.scss';
 
 const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 class ConnectedAcctApp extends React.Component {
-
   constructor(props) {
     super(props);
     this.state = { modalOpen: false };
   }
+
+  componentDidMount = () => {
+    this.props.loadConnectedAccounts();
+  };
 
   closeModal = () => {
     this.setState({ modalOpen: false });
@@ -31,121 +33,62 @@ class ConnectedAcctApp extends React.Component {
     this.setState({ modalOpen: true });
   };
 
+  confirmDelete = accountId => {
+    this.props.deleteConnectedAccount(accountId);
+  };
+
   render() {
+    let connectedAccountsView;
+    if (this.props.accounts.length > 0) {
+      connectedAccountsView = (
+        <ConnectedApps
+          confirmDelete={this.confirmDelete}
+          accounts={this.props.accounts}
+          propertyName={propertyName}
+        />
+      );
+    } else if (this.props.loading) {
+      connectedAccountsView = (
+        <LoadingIndicator message="Loading your account information..." />
+      );
+    } else {
+      connectedAccountsView = (
+        <NoConnectedApps
+          propertyName={propertyName}
+          errors={this.props.errors}
+        />
+      );
+    }
+
     return (
-      // Below are the styles for when they End User DOES NOT have connected accounts.
-      //
-      // <div className="row va-connected-acct-null">
-      //   <div className="usa-width-two-thirds medium-8 small-12 columns">
-      //     <h3>You do not have any connected accounts.</h3>
-      //       <div className="feature">
-      //       <h3>Have questions about signing in to {propertyName}?</h3>
-      //        <p>
-      //         Get answers to frequently asked questions about how to sign in,
-      //         common issues with verifying your identity, and your privacy and
-      //         security on {propertyName}.
-      //       </p>
-      //
-      //       <a
-      //         href="/faq"
-      //         onClick={() =>
-      //           recordEvent({
-      //             event: 'account-navigation',
-      //             'account-action': 'view-link',
-      //             'account-section': 'vets-faqs',
-      //           })
-      //         }
-      //       >
-      //         Go to {propertyName} FAQs
-      //       </a>
-      //     </div>
-      //   </div>
-      // </div>
-      // Below are the styles for when they End User DOES have connected accounts.
-      <div className="row va-connected-acct">
-        <div className="usa-width-two-thirds medium-8 small-12 columns">
-          <h1>Your Connected Accounts</h1>
-          <p className="va-introtext">
-            You gave these sites and applications read only access to some of
-            your {propertyName} account data.
-          </p>
-
-          <table className="va-table-connected-acct usa-table-borderless">
-            <tbody>
-             <tr>
-               <th scope="row">
-                 <a href="https://usajobs.gov" className="no-external-icon">
-                 <img
-                   src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1f/USAJOBS.gov_logo.svg/2000px-USAJOBS.gov_logo.svg.png"
-                   alt="VA logo"
-                   width="100"
-                   />
-                </a>
-               </th>
-               <th>
-                 <a href="https://usajobs.gov">USAJOBS Profile</a> <br />
-                 Last used within the past 2 days
-               </th>
-               <th>
-                 <button
-                   className="usa-button-primary"
-                   onClick={this.openModal}
-                   >
-                   Disconnect
-                </button>
-               </th>
-             </tr>
-            </tbody>
-          </table>
-
-          <div className="feature">
-            <h3>Have questions about signing in to {propertyName}?</h3>
-            <p>
-              Get answers to frequently asked questions about how to sign in,
-              common issues with verifying your identity, and your privacy and
-              security on {propertyName}.
-            </p>
-
-            <a
-              href="/faq"
-              onClick={() =>
-                recordEvent({
-                  event: 'account-navigation',
-                  'account-action': 'view-link',
-                  'account-section': 'vets-faqs',
-                })
-              }
-            >
-              Go to {propertyName} FAQs
-            </a>
-          </div>
-        </div>
-        <Modal
-          clickToClose
-          cssClass="va-modal"
-          id="disconnect-alert"
-          onClose={this.closeModal}
-          title="Are you sure you want to disconnect from USAJOBS?"
-          visible={this.state.modalOpen}
+      <div>
+        <RequiredLoginView
+          authRequired={1}
+          serviceRequired={backendServices.USER_PROFILE}
+          user={this.props.user}
         >
-          <p>
-            USAJOBS will no longer be able to access your {propertyName} account
-            informaton. You cannot undo this action.
-          </p>
-            <a
-              href="#"
-              className="usa-button-primary"
-            >
-              Confirm
-            </a>
-            <button className="usa-button-secondary" onClick={this.closeModal}>
-              Cancel
-            </button>
-        </Modal>
+          {connectedAccountsView}
+        </RequiredLoginView>
       </div>
     );
   }
 }
 
-export default connect()(ConnectedAcctApp);
+const mapStateToProps = state => {
+  const user = selectUser(state);
+  return {
+    ...state.connectedAccounts,
+    user,
+  };
+};
+
+const mapDispatchToProps = {
+  loadConnectedAccounts,
+  deleteConnectedAccount,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ConnectedAcctApp);
 export { ConnectedAcctApp };

--- a/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
+++ b/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
@@ -74,7 +74,7 @@ class ConnectedAcctApp extends React.Component {
             <tbody>
              <tr>
                <th scope="row">
-                 <a href="https://usajobs.gov">
+                 <a href="https://usajobs.gov" className="no-external-icon">
                  <img
                    src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1f/USAJOBS.gov_logo.svg/2000px-USAJOBS.gov_logo.svg.png"
                    alt="VA logo"

--- a/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
+++ b/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
@@ -1,0 +1,151 @@
+/* eslint-disable no-use-before-declare */
+/* eslint-disable react/jsx-indent */
+/* eslint-disable prettier/prettier */
+/* eslint-disable arrow-body-style */
+/* eslint-disable react/jsx-closing-bracket-location */
+
+import React from 'react';
+import { connect } from 'react-redux';
+
+import Modal from '@department-of-veterans-affairs/formation/Modal';
+
+import recordEvent from '../../../../platform/monitoring/record-event';
+import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
+
+import '../sass/connected-acct.scss';
+
+const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+
+class ConnectedAcctApp extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { modalOpen: false };
+  }
+
+  closeModal = () => {
+    this.setState({ modalOpen: false });
+  };
+
+  openModal = () => {
+    this.setState({ modalOpen: true });
+  };
+
+  render() {
+    return (
+      // Below are the styles for when they End User DOES NOT have connected accounts.
+      //
+      // <div className="row va-connected-acct-null">
+      //   <div className="usa-width-two-thirds medium-8 small-12 columns">
+      //     <h3>You do not have any connected accounts.</h3>
+      //       <div className="feature">
+      //       <h3>Have questions about signing in to {propertyName}?</h3>
+      //        <p>
+      //         Get answers to frequently asked questions about how to sign in,
+      //         common issues with verifying your identity, and your privacy and
+      //         security on {propertyName}.
+      //       </p>
+      //
+      //       <a
+      //         href="/faq"
+      //         onClick={() =>
+      //           recordEvent({
+      //             event: 'account-navigation',
+      //             'account-action': 'view-link',
+      //             'account-section': 'vets-faqs',
+      //           })
+      //         }
+      //       >
+      //         Go to {propertyName} FAQs
+      //       </a>
+      //     </div>
+      //   </div>
+      // </div>
+      // Below are the styles for when they End User DOES have connected accounts.
+      <div className="row va-connected-acct">
+        <div className="usa-width-two-thirds medium-8 small-12 columns">
+          <h1>Your Connected Accounts</h1>
+          <p className="va-introtext">
+            You gave these sites and applications read only access to some of
+            your {propertyName} account data.
+          </p>
+
+          <table className="va-table-connected-acct usa-table-borderless">
+            <tbody>
+             <tr>
+               <th scope="row">
+                 <a href="https://usajobs.gov">
+                 <img
+                   src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1f/USAJOBS.gov_logo.svg/2000px-USAJOBS.gov_logo.svg.png"
+                   alt="VA logo"
+                   width="100"
+                   />
+                </a>
+               </th>
+               <th>
+                 <a href="https://usajobs.gov">USAJOBS Profile</a> <br />
+                 Last used within the past 2 days
+               </th>
+               <th>
+                 <button
+                   className="usa-button-primary"
+                   onClick={this.openModal}
+                   >
+                   Disconnect
+                </button>
+               </th>
+             </tr>
+            </tbody>
+          </table>
+
+          <div className="feature">
+            <h3>Have questions about signing in to {propertyName}?</h3>
+            <p>
+              Get answers to frequently asked questions about how to sign in,
+              common issues with verifying your identity, and your privacy and
+              security on {propertyName}.
+            </p>
+
+            <a
+              href="/faq"
+              onClick={() =>
+                recordEvent({
+                  event: 'account-navigation',
+                  'account-action': 'view-link',
+                  'account-section': 'vets-faqs',
+                })
+              }
+            >
+              Go to {propertyName} FAQs
+            </a>
+          </div>
+        </div>
+        <Modal
+          clickToClose
+          cssClass="va-modal"
+          id="disconnect-alert"
+          onClose={this.closeModal}
+          title="Are you sure you want to disconnect from USAJOBS?"
+          visible={this.state.modalOpen}
+        >
+          <p>
+            USAJOBS will no longer be able to access your {propertyName} account
+            informaton. You cannot undo this action.
+          </p>
+            <a
+              href="#"
+              className="usa-button-primary"
+            >
+              Confirm
+            </a>
+            <button className="usa-button-secondary" onClick={this.closeModal}>
+              Cancel
+            </button>
+        </Modal>
+      </div>
+    );
+  }
+}
+
+export default connect()(ConnectedAcctApp);
+export { ConnectedAcctApp };

--- a/src/applications/personalization/connected-accounts/manifest.json
+++ b/src/applications/personalization/connected-accounts/manifest.json
@@ -1,0 +1,8 @@
+{
+  "appName": "Connected Accounts",
+  "entryFile": "./connected-accounts-entry.jsx",
+  "entryName": "connected-accounts",
+  "rootUrl": "/connected-accounts",
+  "production": true,
+  "contentPage": "connected-accounts/index.md"
+}

--- a/src/applications/personalization/connected-accounts/reducers/index.js
+++ b/src/applications/personalization/connected-accounts/reducers/index.js
@@ -2,4 +2,59 @@
 // leverage this functionality.
 import profileInformation from '../../../../platform/user/profile/reducers';
 
-export default { account: profileInformation };
+import {
+  LOADING_CONNECTED_ACCOUNTS,
+  FINISHED_CONNECTED_ACCOUNTS,
+  ERROR_CONNECTED_ACCOUNTS,
+  DELETING_CONNECTED_ACCOUNT,
+  ERROR_DELETING_CONNECTED_ACCOUNT,
+  FINISHED_DELETING_CONNECTED_ACCOUNT,
+} from '../actions';
+
+const initialState = {
+  accounts: [],
+  loading: false,
+  errors: [],
+};
+
+function connectedAccounts(state = initialState, action) {
+  switch (action.type) {
+    case LOADING_CONNECTED_ACCOUNTS:
+      return { ...state, loading: true };
+    case FINISHED_CONNECTED_ACCOUNTS:
+      return { accounts: action.data, loading: false, errors: [] };
+    case ERROR_CONNECTED_ACCOUNTS:
+      return { ...state, loading: false, errors: action.errors };
+    case DELETING_CONNECTED_ACCOUNT: {
+      const accounts = state.accounts.map(account => {
+        if (account.id === action.accountId) {
+          return { ...account, deleting: true };
+        }
+        return account;
+      });
+      return { ...state, accounts };
+    }
+    case ERROR_DELETING_CONNECTED_ACCOUNT: {
+      const accounts = state.accounts.map(account => {
+        if (account.id === action.accountId) {
+          return { ...account, deleting: false, errors: action.errors };
+        }
+        return account;
+      });
+      return { ...state, accounts };
+    }
+    case FINISHED_DELETING_CONNECTED_ACCOUNT: {
+      const accounts = state.accounts.filter(
+        account => account.id !== action.accountId,
+      );
+      return { ...state, accounts };
+    }
+    default:
+      return state;
+  }
+}
+
+export default {
+  connectedAccounts,
+  account: profileInformation,
+};

--- a/src/applications/personalization/connected-accounts/reducers/index.js
+++ b/src/applications/personalization/connected-accounts/reducers/index.js
@@ -1,0 +1,5 @@
+// Not entirely sure if this is needed. Adding in here just in case we want to
+// leverage this functionality.
+import profileInformation from '../../../../platform/user/profile/reducers';
+
+export default { account: profileInformation };

--- a/src/applications/personalization/connected-accounts/routes.jsx
+++ b/src/applications/personalization/connected-accounts/routes.jsx
@@ -1,0 +1,8 @@
+import ConnectedAcctApp from './containers/ConnectedAcctApp';
+
+const routes = {
+  path: '/',
+  component: ConnectedAcctApp,
+};
+
+export default routes;

--- a/src/applications/personalization/connected-accounts/sass/connected-acct.scss
+++ b/src/applications/personalization/connected-accounts/sass/connected-acct.scss
@@ -1,5 +1,9 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 
+.va-connected-acct {
+   margin-bottom: 6em;
+}
+
 .va-table-connected-acct {
  margin-top: 40px;
  margin-bottom: 100px;

--- a/src/applications/personalization/connected-accounts/sass/connected-acct.scss
+++ b/src/applications/personalization/connected-accounts/sass/connected-acct.scss
@@ -1,0 +1,15 @@
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+
+.va-table-connected-acct {
+ margin-top: 40px;
+ margin-bottom: 100px;
+}
+
+
+.va-connected-acct-null {
+   padding-bottom: 40px;
+
+   .feature {
+     margin-top: 100px;
+   }
+}


### PR DESCRIPTION
## Description

This pull request is for adding a way for an End User(Veteran) to manage the authorized/connected accounts to their VA.gov profile. It is part of the work that the VA API Platform team is doing to add Veteran Verification OAuth as a service to our End Users.

Fixes https://github.com/department-of-veterans-affairs/vets-contrib/issues/178

Supersedes: https://github.com/department-of-veterans-affairs/vets-website/pull/8905 but am making it separate to allow code comparison. 

## Testing done
- [ ] Accessibility testing
- [x] Cross browser testing
- [ ] Write tests 😄 

## Screenshots
![screenshot from 2018-11-01 14-07-40](https://user-images.githubusercontent.com/108177/47871873-86949800-dde3-11e8-9fda-8b1be846638a.png)

See https://github.com/department-of-veterans-affairs/vets-contrib/issues/178#issuecomment-432248738

## Acceptance criteria
- [x] End User is able to view a list of their authorized/connected accounts
- [x] End User is able to revoke access to their authorized connected accounts

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs