### PR TITLE
Fixed pagination styling on mobile

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -234,7 +234,7 @@ class SearchApp extends React.Component {
 
     return (
       <div className="va-flex results-footer">
-        <strong>Powered by Search.gov</strong>
+        <span className="powered-by">Powered by Search.gov</span>
         <Pagination
           onPageSelect={this.handlePageChange}
           page={currentPage}

--- a/src/applications/search/styles.scss
+++ b/src/applications/search/styles.scss
@@ -74,12 +74,29 @@
 
     &#hr-search-bottom {
       margin-bottom: 1.5rem;
+
+      @media (max-width: $medium-screen - 1) {
+        margin-bottom: 0;
+      }
     }
   }
 
   .results-footer {
     justify-content: space-between;
     align-items: center;
+
+
+    @media (max-width: $medium-screen - 1) {
+      flex-direction: column-reverse;
+    }
+
+    .powered-by {
+      font-weight: bold;
+
+      @media (max-width: $medium-screen - 1) {
+        margin: 1rem 0 3rem;
+      }
+    }
 
     .va-pagination {
       width: unset;
@@ -89,6 +106,10 @@
         .va-pagination-inner {
           width: unset;
         }
+      }
+
+      @media (max-width: $medium-screen - 1) {
+        width: 100%;
       }
     }
 

--- a/src/applications/search/styles.scss
+++ b/src/applications/search/styles.scss
@@ -73,28 +73,30 @@
     border-bottom: none;
 
     &#hr-search-bottom {
-      margin-bottom: 1.5rem;
+      margin-bottom: 0;
 
-      @media (max-width: $medium-screen - 1) {
-        margin-bottom: 0;
+      @include media($small-screen) {
+        margin-bottom: 1.5rem;
       }
     }
   }
 
   .results-footer {
+    flex-direction: column-reverse;
     justify-content: space-between;
     align-items: center;
     margin-bottom: 4rem;
 
-    @media (max-width: $medium-screen - 1) {
-      flex-direction: column-reverse;
+    @include media($small-screen) {
+      flex-direction: row;
     }
 
     .powered-by {
       font-weight: bold;
+      margin: 1rem 0 3rem;
 
-      @media (max-width: $medium-screen - 1) {
-        margin: 1rem 0 3rem;
+      @include media($small-screen) {
+        margin: unset;
       }
     }
 

--- a/src/applications/search/styles.scss
+++ b/src/applications/search/styles.scss
@@ -84,7 +84,7 @@
   .results-footer {
     justify-content: space-between;
     align-items: center;
-
+    margin-bottom: 4rem;
 
     @media (max-width: $medium-screen - 1) {
       flex-direction: column-reverse;
@@ -99,7 +99,6 @@
     }
 
     .va-pagination {
-      width: unset;
       border-top: none;
 
       @include media($large-screen) {
@@ -108,8 +107,8 @@
         }
       }
 
-      @media (max-width: $medium-screen - 1) {
-        width: 100%;
+      @include media($small-screen) {
+        width: unset;
       }
     }
 


### PR DESCRIPTION
## Description

Fix bug where pagination was being cut off on mobile search.

## Testing done

Tested locally on Chrome and iOS Simulator

## Screenshots

### Before
<img width="526" alt="screen shot 2018-11-01 at 1 10 09 pm" src="https://user-images.githubusercontent.com/786704/47876887-aa51e100-ddd7-11e8-9184-330633cc6a60.png">

### After
<img width="526" alt="screen shot 2018-11-01 at 1 09 41 pm" src="https://user-images.githubusercontent.com/786704/47876862-9a3a0180-ddd7-11e8-9424-7b6bc46f8db9.png">


## Acceptance criteria
- [x] Pagination is not cut off on mobile

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
