### PR TITLE
Removes typo in account settings

### DIFF
--- a/src/applications/personalization/account/components/AccountMain.jsx
+++ b/src/applications/personalization/account/components/AccountMain.jsx
@@ -103,7 +103,7 @@ class AccountMain extends React.Component {
               <p>
                 You can update the email or password you use to sign in to
                 VA.gov. Just go to the account you use to sign in (DS Logon, My
-                My HealtheVet, or ID.me) and manage your settings.
+                HealtheVet, or ID.me) and manage your settings.
               </p>
             </div>
             <div>


### PR DESCRIPTION
## Description

The word ‘My’ was present twice in a row.

## Testing done

Local testing

## Screenshots

#### Before

![image](https://user-images.githubusercontent.com/7482329/47880945-5d2b3a80-ddea-11e8-9ab4-b2a7b42f85cb.png)

#### After

![image](https://user-images.githubusercontent.com/7482329/47880955-661c0c00-ddea-11e8-93bf-f672a8d141dd.png)


## Acceptance criteria
- [x] Removes typo

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
