### PR TITLE
Remove extraneous query params from search dropdown

### DIFF
--- a/content/pages/404.md
+++ b/content/pages/404.md
@@ -28,7 +28,7 @@ private: true
               <div class="va-flex va-flex--top va-flex--jctr">
                 <label for="mobile-query">Search:</label>
                 <input autocomplete="off" class="usagov-search-autocomplete full-width" id="mobile-query" name="query" type="text" />
-                <input name="commit" type="submit" value="Search">
+                <input type="submit" value="Search">
               </div>
             </form>
           </div>

--- a/content/pages/404.md
+++ b/content/pages/404.md
@@ -25,14 +25,10 @@ private: true
           </p>
           <div class="feature va-flex va-flex--ctr">
             <form accept-charset="UTF-8" action="/search/" id="search_form" class="full-width" method="get">
-              <div class="csp-inline-patch-404">
-                <input name="utf8" type="hidden" value="&#x2713;" />
-              </div>
               <div class="va-flex va-flex--top va-flex--jctr">
-                <input id="affiliate" name="affiliate" type="hidden" value="vets.gov_search" />
-                  <label for="mobile-query">Search:</label>
-                  <input autocomplete="off" class="usagov-search-autocomplete full-width" id="mobile-query" name="query" type="text" />
-                  <input name="commit" type="submit" value="Search">
+                <label for="mobile-query">Search:</label>
+                <input autocomplete="off" class="usagov-search-autocomplete full-width" id="mobile-query" name="query" type="text" />
+                <input name="commit" type="submit" value="Search">
               </div>
             </form>
           </div>

--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 
 import IconSearch from '@department-of-veterans-affairs/formation/IconSearch';
 import DropDownPanel from '@department-of-veterans-affairs/formation/DropDownPanel';
-import isBrandConsolidationEnabled from '../../../brand-consolidation/feature-flag';
 
 class SearchMenu extends React.Component {
   constructor(props) {
@@ -13,7 +12,6 @@ class SearchMenu extends React.Component {
     this.toggleSearchForm = this.toggleSearchForm.bind(this);
     this.state = {
       searchAction: '/search/',
-      searchAffiliate: isBrandConsolidationEnabled() ? 'va' : 'vets.gov_search',
       userInput: '',
     };
   }
@@ -44,15 +42,6 @@ class SearchMenu extends React.Component {
         id="search"
         method="get"
       >
-        <div className="csp-inline-patch-header">
-          <input name="utf8" type="hidden" value="&#x2713;" />
-        </div>
-        <input
-          id="affiliate"
-          name="affiliate"
-          type="hidden"
-          value={this.state.searchAffiliate}
-        />
         <label htmlFor="query" className="usa-sr-only">
           Search:
         </label>

--- a/va-gov/pages/404.md
+++ b/va-gov/pages/404.md
@@ -28,7 +28,7 @@ private: true
               <div class="va-flex va-flex--top va-flex--jctr">
                 <label for="mobile-query">Search:</label>
                 <input autocomplete="off" class="usagov-search-autocomplete full-width" id="mobile-query" name="query" type="text" />
-                <input name="commit" type="submit" value="Search">
+                <input type="submit" value="Search">
               </div>
             </form>
           </div>

--- a/va-gov/pages/404.md
+++ b/va-gov/pages/404.md
@@ -25,14 +25,10 @@ private: true
           </p>
           <div class="feature va-flex va-flex--ctr">
             <form accept-charset="UTF-8" action="/search/" id="search_form" class="full-width" method="get">
-              <div class="csp-inline-patch-404">
-                <input name="utf8" type="hidden" value="&#x2713;" />
-              </div>
               <div class="va-flex va-flex--top va-flex--jctr">
-                <input id="affiliate" name="affiliate" type="hidden" value="va" />
-                  <label for="mobile-query">Search:</label>
-                  <input autocomplete="off" class="usagov-search-autocomplete full-width" id="mobile-query" name="query" type="text" />
-                  <input name="commit" type="submit" value="Search">
+                <label for="mobile-query">Search:</label>
+                <input autocomplete="off" class="usagov-search-autocomplete full-width" id="mobile-query" name="query" type="text" />
+                <input name="commit" type="submit" value="Search">
               </div>
             </form>
           </div>


### PR DESCRIPTION
## Description
When using search.gov's hosted pages, we were passing &utf8=✓&affiliate=va into the URL as required by their docs. We can safely remove these now that we're using a vets-api based approach.

See sibling pr in vagov-content [here](https://github.com/department-of-veterans-affairs/vagov-content/pull/91)

## Testing done
Verified locally that when submitting a search the params are not including in the URL. 

## Acceptance criteria
- [x] When using the dropdown search or 404 page search, when executing a query, the URL does not include &utf= or &affiliate= query params.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
