### PR TITLE
Use a regex to test the referrer before showing the onboarding modal

### DIFF
--- a/src/platform/site-wide/announcements/components/VAPlusVetsModal.jsx
+++ b/src/platform/site-wide/announcements/components/VAPlusVetsModal.jsx
@@ -6,8 +6,12 @@ export default class VAPlusVetsModal extends React.Component {
   static isEnabled() {
     if (!brandConsolidation.isEnabled()) return false;
 
-    const referrer = document.referrer;
-    let wasRedirectedFromVets = !!referrer && referrer.includes('vets.gov');
+    // Remove before launch
+    if (__BUILDTYPE__ === 'preview') return false;
+
+    let wasRedirectedFromVets = /^https:\/\/((dev|staging|www)\.)?vets\.gov/.test(
+      document.referrer,
+    );
 
     // Allow an override on the URL to force the Onboarding Modal to appear for testing purposes.s
     if (__BUILDTYPE__ !== 'preview' && !wasRedirectedFromVets) {


### PR DESCRIPTION
## Description
Previously, the onboarding modal was just checking for "vets.gov" in the referrer to determine whether we came from a Vets.gov environment. This caused some confusion, because our Zenhub board has "vets.gov" in its name ("vets.gov-team") and there are many links to preview. This triggers the onboarding modal. To fix this, this PR -

- Uses a regex to test the referrer domain
- Feature flags the onboarding modal to keep from entering prod

This came from a Slack discussion, https://dsva.slack.com/archives/GAR64HV6V/p1541109062488200.

This should be merged before/with https://github.com/department-of-veterans-affairs/devops/pull/3547#event-1941816043.

## Testing done
Local testing

## Acceptance criteria
- [x] Zenhub links no longer trigger the onboarding modal

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
