### PR TITLE
Itf continue after fail cv

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
@@ -48,7 +48,8 @@ export class ITFWrapper extends React.Component {
       itf.currentITF && itf.currentITF.status === itfStatuses.active;
     const createITFCalled = itf.creationCallState !== requestStates.notCalled;
     if (
-      itf.fetchCallState === requestStates.succeeded &&
+      (itf.fetchCallState === requestStates.succeeded ||
+        itf.fetchCallState === itf.fetchCallState.failed) &&
       !hasActiveITF &&
       !createITFCalled
     ) {

--- a/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
@@ -49,7 +49,7 @@ export class ITFWrapper extends React.Component {
     const createITFCalled = itf.creationCallState !== requestStates.notCalled;
     if (
       (itf.fetchCallState === requestStates.succeeded ||
-        itf.fetchCallState === itf.fetchCallState.failed) &&
+        itf.fetchCallState === requestStates.failed) &&
       !hasActiveITF &&
       !createITFCalled
     ) {

--- a/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
@@ -115,7 +115,7 @@ describe('526 ITFWrapper', () => {
     expect(banner.props().status).to.equal('error');
   });
 
-  it('should not submit a new ITF if the fetch failed', () => {
+  it('should submit a new ITF if the fetch failed', () => {
     const props = merge(defaultProps, {
       itf: {
         fetchCallState: requestStates.pending,
@@ -130,7 +130,7 @@ describe('526 ITFWrapper', () => {
     tree.setProps(
       merge(props, { itf: { fetchCallState: requestStates.failed } }),
     );
-    expect(createITF.called).to.be.false;
+    expect(createITF.called).to.be.true;
   });
 
   it('should submit a new ITF if no active ITF is found', () => {


### PR DESCRIPTION
## Description
Creates a new ITF if the fetch failed.

## Testing done
Unit tests written

## Screenshots
N/A

## Acceptance criteria
- [x] The ITF is created if the fetch failed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
