### PR TITLE
Default evidence selection to true

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
@@ -61,6 +61,7 @@ export const schema = {
   properties: {
     'view:hasEvidence': {
       type: 'boolean',
+      default: true,
     },
     'view:hasEvidenceFollowUp': {
       type: 'object',

--- a/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypes.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypes.unit.spec.jsx
@@ -25,24 +25,6 @@ describe('evidenceTypes', () => {
     expect(form.find('input').length).to.equal(2);
   });
 
-  it('should require selecting an evidence option', () => {
-    const onSubmit = sinon.spy();
-    const form = mount(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{}}
-        formData={{}}
-        onSubmit={onSubmit}
-      />,
-    );
-
-    form.find('form').simulate('submit');
-    expect(onSubmit.called).to.be.false;
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
-  });
-
   it('should submit when no evidence selected', () => {
     const onSubmit = sinon.spy();
     const form = mount(


### PR DESCRIPTION
## Description
Just like it says on the tin, the evidence selection defaults to true.

## Testing done
Tested manually that the default works.

## Screenshots
N/A

## Acceptance criteria
- [x] The "do you have evidence" question defaults to true

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
