### PR TITLE
Map the Facility Locator over to /find-locations/ in VA.gov

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -11,6 +11,8 @@ import { apiRequest } from '../../../platform/utilities/api';
 import environment from '../../../platform/utilities/environment';
 import localStorage from '../../../platform/utilities/storage/localStorage';
 
+import facilityLocator from '../../facility-locator/manifest';
+
 export class AuthApp extends React.Component {
   constructor(props) {
     super(props);
@@ -138,7 +140,11 @@ export class AuthApp extends React.Component {
                 you with the right person who can help.
               </p>
               <p>
-                <a href="/facilities/?facilityType=health&page=1&zoomLevel=7">
+                <a
+                  href={`${
+                    facilityLocator.rootUrl
+                  }/?facilityType=health&page=1&zoomLevel=7`}
+                >
                   Find your nearest VA medical center.
                 </a>
               </p>

--- a/src/applications/burials/components/IntroductionPage.jsx
+++ b/src/applications/burials/components/IntroductionPage.jsx
@@ -10,6 +10,8 @@ import SaveInProgressIntro, {
   introSelector,
 } from '../../../platform/forms/save-in-progress/SaveInProgressIntro';
 
+import facilityLocator from '../../facility-locator/manifest';
+
 class IntroductionPage extends React.Component {
   componentDidMount() {
     focusElement('.va-nav-breadcrumbs-list');
@@ -108,7 +110,7 @@ class IntroductionPage extends React.Component {
                 Mail the application and other paperwork to your local regional
                 benefit office.
                 <br />
-                <a href="/facilities">
+                <a href={facilityLocator.rootUrl}>
                   Find your local regional benefit office
                 </a>
                 .

--- a/src/applications/facility-locator/facility-locator-entry.jsx
+++ b/src/applications/facility-locator/facility-locator-entry.jsx
@@ -5,7 +5,7 @@ import startApp from '../../platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';
-import manifest from './manifest.json';
+import manifest from './manifest';
 
 startApp({
   url: manifest.rootUrl,

--- a/src/applications/facility-locator/manifest.js
+++ b/src/applications/facility-locator/manifest.js
@@ -1,0 +1,9 @@
+module.exports = {
+  appName: 'Facility Locator',
+  entryFile: './facility-locator-entry.jsx',
+  entryName: 'facilities',
+  rootUrl: '/facilities',
+  receiveContentProps({ path: rootUrl }) {
+    this.rootUrl = rootUrl;
+  },
+};

--- a/src/applications/facility-locator/manifest.js
+++ b/src/applications/facility-locator/manifest.js
@@ -2,8 +2,7 @@ module.exports = {
   appName: 'Facility Locator',
   entryFile: './facility-locator-entry.jsx',
   entryName: 'facilities',
-  rootUrl: '/facilities',
   receiveContentProps({ path: rootUrl }) {
-    this.rootUrl = rootUrl;
+    this.rootUrl = `/${rootUrl}`;
   },
 };

--- a/src/applications/facility-locator/manifest.json
+++ b/src/applications/facility-locator/manifest.json
@@ -1,7 +1,0 @@
-{
-  "appName": "Facility Locator",
-  "entryFile": "./facility-locator-entry.jsx",
-  "entryName": "facilities",
-  "rootUrl": "/facilities",
-  "production": true
-}

--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -14,6 +14,8 @@ import {
 import { getInactivePages } from '../../platform/forms/helpers';
 import { isValidDate } from '../../platform/forms/validations';
 
+import facilityLocator from '../facility-locator/manifest';
+
 export function transform(formConfig, form) {
   const expandedPages = expandArrayPages(
     createFormPageList(formConfig),
@@ -62,7 +64,7 @@ export const facilityHelp = (
   <div>
     <div>
       OR{' '}
-      <a href="/facilities" target="_blank">
+      <a href={facilityLocator.rootUrl} target="_blank">
         Find locations with the VA Facility Locator
       </a>
     </div>

--- a/src/applications/personalization/account/components/AccountMain.jsx
+++ b/src/applications/personalization/account/components/AccountMain.jsx
@@ -11,6 +11,7 @@ import LoginSettings from './LoginSettings';
 import MultifactorMessage from './MultifactorMessage';
 import TermsAndConditions from './TermsAndConditions';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
+import facilityLocator from '../../../facility-locator/manifest';
 
 const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
@@ -64,7 +65,9 @@ class AccountMain extends React.Component {
               person who can help.
             </p>
             <p>
-              <a href="/facilities">Find your nearest VA Medical Center</a>
+              <a href={facilityLocator.rootUrl}>
+                Find your nearest VA Medical Center
+              </a>
             </p>
           </div>
         }

--- a/src/applications/personalization/dashboard/containers/DashboardApp.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardApp.jsx
@@ -23,6 +23,7 @@ import profileManifest from '../../profile360/manifest.json';
 import accountManifest from '../../account/manifest.json';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 import lettersManifest from '../../../letters/manifest.js';
+import facilityLocator from '../../../facility-locator/manifest';
 
 const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
@@ -283,7 +284,7 @@ class DashboardApp extends React.Component {
             </p>
             <p>
               <a
-                href="/facilities"
+                href={facilityLocator.rootUrl}
                 onClick={() => {
                   recordEvent({
                     event: 'dashboard-navigation',

--- a/src/applications/personalization/profile360/components/ContactInformationExplanation.jsx
+++ b/src/applications/personalization/profile360/components/ContactInformationExplanation.jsx
@@ -4,6 +4,7 @@ import AdditionalInfo from '@department-of-veterans-affairs/formation/Additional
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 
 import recordEvent from '../../../../platform/monitoring/record-event';
+import facilityLocator from '../../../facility-locator/manifest';
 
 export default function ContactInformationExplanation() {
   return (
@@ -75,7 +76,10 @@ export default function ContactInformationExplanation() {
             your nearest VA medical center.
           </li>
         </ul>
-        <a href="/facilities/">Find your nearest VA medical center</a>.
+        <a href={facilityLocator.rootUrl}>
+          Find your nearest VA medical center
+        </a>
+        .
       </AdditionalInfo>
     </div>
   );

--- a/src/applications/personalization/profile360/components/MVIError.jsx
+++ b/src/applications/personalization/profile360/components/MVIError.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
+import facilityLocator from '../../../facility-locator/manifest';
 
 const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
@@ -24,7 +25,7 @@ export default function MVIError({ facilitiesClick }) {
       </p>
 
       <p>
-        <a href="/facilities/" onClick={facilitiesClick}>
+        <a href={facilityLocator} onClick={facilitiesClick}>
           Find your nearest VA Medical Center
         </a>
         .

--- a/src/applications/personalization/profile360/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile360/components/MilitaryInformation.jsx
@@ -12,6 +12,7 @@ import AdditionalInfo from '@department-of-veterans-affairs/formation/Additional
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
 import recordEvent from '../../../../platform/monitoring/record-event';
+import facilityLocator from '../../../facility-locator/manifest';
 
 class MilitaryInformationContent extends React.Component {
   componentDidMount() {
@@ -38,7 +39,7 @@ class MilitaryInformationContent extends React.Component {
                   regional benefit office and request to be added to the Defense
                   Enrollment Eligibility Reporting System (DEERS).
                 </p>
-                <a href="/facilities">
+                <a href={facilityLocator.rootUrl}>
                   Find your nearest VA regional benefit office
                 </a>
                 .

--- a/src/applications/personalization/profile360/components/PersonalInformation.jsx
+++ b/src/applications/personalization/profile360/components/PersonalInformation.jsx
@@ -9,6 +9,7 @@ import { handleDowntimeForSection } from './DowntimeBanner';
 import AdditionalInfo from '@department-of-veterans-affairs/formation/AdditionalInfo';
 
 import recordEvent from '../../../../platform/monitoring/record-event';
+import facilityLocator from '../../../facility-locator/manifest';
 
 function Gender({ gender }) {
   let content = 'This information is not available right now.';
@@ -66,7 +67,7 @@ class PersonalInformationContent extends React.Component {
             Please contact your nearest VA medical center to update your
             personal information.
             <br />
-            <a href="/facilities/?facilityType=health">
+            <a href={`${facilityLocator.rootUrl}/?facilityType=health`}>
               Find your nearest VA medical center
             </a>
           </p>
@@ -78,7 +79,7 @@ class PersonalInformationContent extends React.Component {
             Please contact your nearest VA regional benefit office to update
             your personal information.
             <br />
-            <a href="/facilities/?facilityType=benefits">
+            <a href={`${facilityLocator.rootUrl}/?facilityType=benefits`}>
               Find your nearest VA regional benefit office
             </a>
           </p>

--- a/src/applications/personalization/profile360/vet360/components/base/EditModalErrorMessage.jsx
+++ b/src/applications/personalization/profile360/vet360/components/base/EditModalErrorMessage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+import facilityLocator from '../../../../../facility-locator/manifest';
 
 import {
   LOW_CONFIDENCE_ADDRESS_ERROR_CODES,
@@ -35,7 +36,9 @@ export default function Vet360EditModalErrorMessage({
             deceased. If this isn’t true, please contact your nearest VA medical
             center.
           </p>
-          <a href="/facilities/">Find your nearest VA medical center</a>
+          <a href={facilityLocator.rootUrl}>
+            Find your nearest VA medical center
+          </a>
         </div>
       );
       break;

--- a/src/applications/personalization/profile360/vet360/components/base/TransactionErrorBanner.jsx
+++ b/src/applications/personalization/profile360/vet360/components/base/TransactionErrorBanner.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+import facilityLocator from '../../../../../facility-locator/manifest';
 
 import {
   hasGenericUpdateError,
@@ -41,7 +42,9 @@ export function MVILookupFailError(props) {
             Veteran records, so we can’t give you access to tools for managing
             your health and benefits.
           </p>
-          <a href="/facilities/">Find your nearest VA medical center</a>
+          <a href={facilityLocator.rootUrl}>
+            Find your nearest VA medical center
+          </a>
         </div>
       }
     />

--- a/src/applications/pre-need/components/IntroductionPage.jsx
+++ b/src/applications/pre-need/components/IntroductionPage.jsx
@@ -10,6 +10,8 @@ import SaveInProgressIntro, {
   introSelector,
 } from '../../../platform/forms/save-in-progress/SaveInProgressIntro';
 
+import facilityLocator from '../../facility-locator/manifest';
+
 class IntroductionPage extends React.Component {
   componentDidMount() {
     focusElement('.va-nav-breadcrumbs-list');
@@ -45,7 +47,10 @@ class IntroductionPage extends React.Component {
                   The name of the VA national cemetery where you’d prefer to be
                   buried.
                   <br />
-                  <a href="/facilities/">Find a VA national cemetery</a>.
+                  <a href={facilityLocator.rootUrl}>
+                    Find a VA national cemetery
+                  </a>
+                  .
                 </li>
                 <li>
                   Service history or the service history of the Servicemember or

--- a/src/applications/vre/chapter31/helpers.jsx
+++ b/src/applications/vre/chapter31/helpers.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import facilityLocator from '../../facility-locator/manifest';
 
 export const facilityLocatorLink = (
   <span>
-    <a href="/facilities" target="_blank">
+    <a href={facilityLocator.rootUrl} target="_blank">
       Look up VA facilities
     </a>
     .

--- a/src/platform/site-wide/mega-menu/mega-menu-link-data.json
+++ b/src/platform/site-wide/mega-menu/mega-menu-link-data.json
@@ -689,6 +689,6 @@
     },
     {
         "title": "Find a VA Location",
-        "href": "https://www.va.gov/facilities/"
+        "href": "https://www.va.gov/find-locations/"
     }
 ]

--- a/src/platform/site-wide/user-nav/components/HelpMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/HelpMenu.jsx
@@ -5,7 +5,7 @@ import DropDownPanel from '@department-of-veterans-affairs/formation/DropDownPan
 import IconHelp from '@department-of-veterans-affairs/formation/IconHelp';
 import isBrandConsolidationEnabled from '../../../brand-consolidation/feature-flag';
 
-import facilityLocatorManifest from '../../../../applications/facility-locator/manifest.json';
+import facilityLocatorManifest from '../../../../applications/facility-locator/manifest';
 
 const FACILITY_LOCATOR_URL = facilityLocatorManifest.rootUrl;
 

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -176,7 +176,7 @@
   },
   {
     "column": 4,
-    "href": "/facilities",
+    "href": "/find-locations/",
     "order": 1,
     "target": null,
     "title": "Find a VA Location"

--- a/va-gov/includes/common-and-popular.html
+++ b/va-gov/includes/common-and-popular.html
@@ -16,7 +16,7 @@
   <div class="small-12 usa-width-one-half medium-6 columns">
     <h3 class="va-h-ruled">Popular on VA.gov</h3>
     <ul class="va-list--plain">
-      <li><a href="/facilities/">Find nearby VA locations</a></li>
+      <li><a href="/find-locations/">Find nearby VA locations</a></li>
       <li>
         <a href="/gi-bill-comparison-tool">View education benefits available by school</a>
       </li>

--- a/va-gov/layouts/home.html
+++ b/va-gov/layouts/home.html
@@ -54,7 +54,7 @@
     <section id="homepage-popular">
       <div class="usa-grid usa-grid-full">
         <div class="usa-width-one-third">
-          <a href="/facilities" onclick="recordEvent({ event: 'nav-main-health' });" class="homepage-button">
+          <a href="/find-locations/" onclick="recordEvent({ event: 'nav-main-health' });" class="homepage-button">
             <div class="icon-wrapper">
               <i class="fa fa-map-marker homepage-button-icon"></i>
             </div>


### PR DESCRIPTION
## Description
This pull requests updates the Facility Locator to use a derived `rootUrl` via a `manifest.js` so that the application can live at `/find-locations/` on Brand Consolidation builds. It also updates all VA.gov-only pages/data to use the new URL, and uses the `manifest.js` for application links. This goes hand-in-hand with https://github.com/department-of-veterans-affairs/vagov-content/pull/93, which needs to be merged first because the link-checker will continue to fail this PR until then.

Moves to validate - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14672

## Testing done
Tested the application locally 

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/47888499-36d1c300-de1b-11e8-8fac-240a2650815a.png)

## Acceptance criteria
- [x] The new URL works and does not negatively impact the Facility Locator

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
