### PR TITLE
Messages for Vets.gov users about health tools moving to MHV

### DIFF
--- a/content/pages/health-care/schedule-an-appointment.md
+++ b/content/pages/health-care/schedule-an-appointment.md
@@ -54,6 +54,17 @@ If you're a Veteran with VA health care benefits, you can make health care appoi
  </div>
 </div>
 
+<div class="usa-alert usa-alert-info">
+<div class="usa-alert-body">
+<h4 class="usa-alert-heading">Vets.gov health tools will be moving to My HealtheVet soon</h4>
+<div class="usa-alert-text">
+
+When our tools move, we’ll show you how to get to My HealtheVet from here. You’ll be able to refill prescriptions, schedule or cancel VA health care appointments, and send secure messages to your health care team. For now, you can keep managing your health care using these tools on Vets.gov.
+
+</div>
+</div>
+</div>
+
 <br>
 
 <div itemprop="steps" itemscope itemtype ="http://schema.org/HowToSection">

--- a/src/applications/health-records/containers/Main.jsx
+++ b/src/applications/health-records/containers/Main.jsx
@@ -10,6 +10,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingI
 import ErrorableCheckbox from '@department-of-veterans-affairs/formation/ErrorableCheckbox';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation/ErrorableRadioButtons';
 
+import HealthToolsMovingMessage from '../../../platform/static-data/HealthToolsMovingMessage';
 import ErrorView from '../components/ErrorView';
 import { reportTypes as reportTypesConfig } from '../config';
 import {
@@ -346,6 +347,7 @@ export class Main extends React.Component {
             <h1>Get Your VA Health Records</h1>
             <span className="blue-button-logo" />
           </div>
+          <HealthToolsMovingMessage />
           <form>
             {this.renderDateOptions()}
             <div>

--- a/src/applications/messaging/containers/MessagingApp.jsx
+++ b/src/applications/messaging/containers/MessagingApp.jsx
@@ -2,12 +2,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
 import backendServices from '../../../platform/user/profile/constants/backendServices';
 import DowntimeNotification, {
   externalServices,
 } from '../../../platform/monitoring/DowntimeNotification';
+import HealthToolsMovingMessage from '../../../platform/static-data/HealthToolsMovingMessage';
 import MHVApp from '../../../platform/user/authorization/containers/MHVApp';
-import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 import RequiredLoginView from '../../../platform/user/authorization/components/RequiredLoginView';
 import { closeAlert } from '../actions';
 import ButtonSettings from '../components/buttons/ButtonSettings';
@@ -87,6 +89,7 @@ class MessagingApp extends React.Component {
                   <h1>Message your health care team</h1>
                   <ButtonSettings />
                 </div>
+                <HealthToolsMovingMessage />
                 {this.renderWarningBanner()}
               </div>
               {this.props.children}

--- a/src/applications/rx/containers/Active.jsx
+++ b/src/applications/rx/containers/Active.jsx
@@ -270,7 +270,7 @@ class Active extends React.Component {
 
   render() {
     return (
-      <ScrollElement id="rx-active" name="active" className="va-tab-content">
+      <ScrollElement id="rx-active" name="active">
         {this.renderContent()}
       </ScrollElement>
     );

--- a/src/applications/rx/containers/History.jsx
+++ b/src/applications/rx/containers/History.jsx
@@ -207,7 +207,7 @@ class History extends React.Component {
 
   render() {
     return (
-      <ScrollElement id="rx-history" name="history" className="va-tab-content">
+      <ScrollElement id="rx-history" name="history">
         {this.renderContent()}
       </ScrollElement>
     );

--- a/src/applications/rx/containers/Main.jsx
+++ b/src/applications/rx/containers/Main.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
+import HealthToolsMovingMessage from '../../../platform/static-data/HealthToolsMovingMessage';
 import { closeDisclaimer } from '../actions/disclaimer';
 import { closeAlert } from '../actions/alert.js';
 import Disclaimer from '../components/Disclaimer';
@@ -29,7 +31,10 @@ class Main extends React.Component {
           <SettingsButton />
         </div>
         <TabNav />
-        {this.props.children}
+        <div className="va-tab-content">
+          <HealthToolsMovingMessage />
+          {this.props.children}
+        </div>
       </ErrorView>
     );
   }

--- a/src/platform/static-data/HealthToolsMovingMessage.jsx
+++ b/src/platform/static-data/HealthToolsMovingMessage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
+export default function() {
+  return (
+    <AlertBox
+      headline="Vets.gov health tools will be moving to My HealtheVet soon"
+      content="When our tools move, we’ll show you how to get to My HealtheVet from here. You’ll be able to refill prescriptions, schedule or cancel VA health care appointments, and send secure messages to your health care team. For now, you can keep managing your health care using these tools on Vets.gov."
+      status="info"
+    />
+  );
+}


### PR DESCRIPTION
## Description
Added alerts to individual health tools about them moving to MHV.

## Testing done
Verified locally that the messages are rendering properly.

## Screenshots
### Rx
> <img width="941" alt="screen shot 2018-11-02 at 12 42 23 am" src="https://user-images.githubusercontent.com/1067024/47894542-d7cf7680-de39-11e8-8830-2e8297d2bcab.png">

### Secure Messaging
> <img width="927" alt="screen shot 2018-11-02 at 12 45 55 am" src="https://user-images.githubusercontent.com/1067024/47894548-def68480-de39-11e8-8bde-1e355385a326.png">

### Health Records
> <img width="907" alt="screen shot 2018-11-02 at 12 48 30 am" src="https://user-images.githubusercontent.com/1067024/47894553-e584fc00-de39-11e8-85c1-592210f1e1df.png">

### Appointments
> <img width="699" alt="screen shot 2018-11-02 at 12 05 55 am" src="https://user-images.githubusercontent.com/1067024/47894559-ec137380-de39-11e8-9c27-6f795e33d880.png">


## Acceptance criteria
- [x] Health tools on Vets.gov should have messages about moving to MHV soon.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs