### PR TITLE
Add aria-label to search input

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -100,6 +100,7 @@ class SearchApp extends React.Component {
         <input
           type="text"
           name="query"
+          aria-label="Enter the word or phrase you'd like to search for"
           value={this.state.userInput}
           onChange={this.handleInputChange}
         />


### PR DESCRIPTION
## Description

Add `aria-label` to search input for 508 accessibility

## Testing done

Used aXe accessibility extension on Chrome

## Acceptance criteria
- [x] Search input on search results page has `aria` label
- [x] Search input does not come up in accessibility errors when analyzing with aXe

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
