### PR TITLE
Update pre-archive script to check for data-src

### DIFF
--- a/script/pre-archive/link-assets-to-bucket.js
+++ b/script/pre-archive/link-assets-to-bucket.js
@@ -39,6 +39,11 @@ function linkAssetsToBucket(options, fileNames) {
         assetSrc = element.getAttribute(assetSrcProp);
       }
 
+      if (!assetSrc) {
+        assetSrcProp = 'data-src';
+        assetSrc = element.getAttribute(assetSrcProp);
+      }
+
       if (!assetSrc) continue;
       if (assetSrc.startsWith('http')) continue;
 


### PR DESCRIPTION
## Description
This updates the pre-archive script to check for `data-src` so that we can pull lazy loaded images from the s3 bucket like the rest of the assets

## Testing done
Ran a build locally and verified that links were updated.

## Screenshots

(These errors are expected, because AWS won't let me download them)
![screen shot 2018-11-02 at 11 10 23 am](https://user-images.githubusercontent.com/634932/47923552-227bdd80-de90-11e8-8950-0b047dc2e08a.png)

## Acceptance criteria
- [x] Lazy loaded image links are set to the s3 bucket

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
