### PR TITLE
Add display: inline rule so search results are styled

### DIFF
--- a/src/applications/search/styles.scss
+++ b/src/applications/search/styles.scss
@@ -36,6 +36,7 @@
         }
 
         a.result-title {
+          display: block;
           text-decoration: none;
 
           h5 {


### PR DESCRIPTION
## Description
While QA'ing Search V2 we noticed that keyboard users/low visibility users would not see a highlight on tab focusing a given search result.


## Testing done
Visually verified locally that tabbing works as expected and search result links are highlighted.

## Screenshots
![2018-11-02-105607_792x797_scrot](https://user-images.githubusercontent.com/11085141/47926436-8bfaec80-de8e-11e8-8786-e92793682f50.png)


## Acceptance criteria
- [x]  Search results can be tab-selected and are stylistically in line with other links.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
