### PR TITLE
update links to fonts to pull from generated

### DIFF
--- a/src/platform/site-wide/sass/style-consolidated.scss
+++ b/src/platform/site-wide/sass/style-consolidated.scss
@@ -37,40 +37,40 @@ $modal-layer: 400;
   font-family: "Source Sans Pro";
   font-style: normal;
   font-weight: 300;
-  src: url(/fonts/sourcesanspro-light-webfont.eot?#iefix) format("embedded-opentype"),
-    url(/fonts/sourcesanspro-light-webfont.woff2) format("woff2"),
-    url(/fonts/sourcesanspro-light-webfont.woff) format("woff"),
-    url(/fonts/sourcesanspro-light-webfont.ttf) format("truetype");
+  src: url(/generated/sourcesanspro-light-webfont.eot?#iefix) format("embedded-opentype"),
+    url(/generated/sourcesanspro-light-webfont.woff2) format("woff2"),
+    url(/generated/sourcesanspro-light-webfont.woff) format("woff"),
+    url(/generated/sourcesanspro-light-webfont.ttf) format("truetype");
 }
 
 @font-face {
   font-family: "Source Sans Pro";
   font-style: normal;
   font-weight: 400;
-  src: url(/fonts/sourcesanspro-regular-webfont.eot?#iefix) format("embedded-opentype"),
-    url(/fonts/sourcesanspro-regular-webfont.woff2) format("woff2"),
-    url(/fonts/sourcesanspro-regular-webfont.woff) format("woff"),
-    url(/fonts/sourcesanspro-regular-webfont.ttf) format("truetype");
+  src: url(/generated/sourcesanspro-regular-webfont.eot?#iefix) format("embedded-opentype"),
+    url(/generated/sourcesanspro-regular-webfont.woff2) format("woff2"),
+    url(/generated/sourcesanspro-regular-webfont.woff) format("woff"),
+    url(/generated/sourcesanspro-regular-webfont.ttf) format("truetype");
 }
 
 @font-face {
   font-family: "Source Sans Pro";
   font-style: italic;
   font-weight: 400;
-  src: url(/fonts/sourcesanspro-italic-webfont.eot?#iefix) format("embedded-opentype"),
-    url(/fonts/sourcesanspro-italic-webfont.woff2) format("woff2"),
-    url(/fonts/sourcesanspro-italic-webfont.woff) format("woff"),
-    url(/fonts/sourcesanspro-italic-webfont.ttf) format("truetype");
+  src: url(/generated/sourcesanspro-italic-webfont.eot?#iefix) format("embedded-opentype"),
+    url(/generated/sourcesanspro-italic-webfont.woff2) format("woff2"),
+    url(/generated/sourcesanspro-italic-webfont.woff) format("woff"),
+    url(/generated/sourcesanspro-italic-webfont.ttf) format("truetype");
 }
 
 @font-face {
   font-family: "Source Sans Pro";
   font-style: normal;
   font-weight: 700;
-  src: url(/fonts/sourcesanspro-bold-webfont.eot?#iefix) format("embedded-opentype"),
-    url(/fonts/sourcesanspro-bold-webfont.woff2) format("woff2"),
-    url(/fonts/sourcesanspro-bold-webfont.woff) format("woff"),
-    url(/fonts/sourcesanspro-bold-webfont.ttf) format("truetype");
+  src: url(/generated/sourcesanspro-bold-webfont.eot?#iefix) format("embedded-opentype"),
+    url(/generated/sourcesanspro-bold-webfont.woff2) format("woff2"),
+    url(/generated/sourcesanspro-bold-webfont.woff) format("woff"),
+    url(/generated/sourcesanspro-bold-webfont.ttf) format("truetype");
 }
 
 @font-face {


### PR DESCRIPTION
## Description
these fonts are being pulled from /generated now

## Testing done
verified locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
