### PR TITLE
Update text in 526 button header

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/createDisabilityIncreaseApplicationStatus.jsx
+++ b/src/applications/disability-benefits/526EZ/components/createDisabilityIncreaseApplicationStatus.jsx
@@ -21,7 +21,7 @@ export default function createDisabilityIncreaseApplicationStatus(store) {
             stayAfterDelete
             applyRender={() => (
               <div itemScope itemType="http://schema.org/Question">
-                <h3 itemProp="name">How do I apply?</h3>
+                <h3 itemProp="name">How do I file my claim?</h3>
                 <div
                   itemProp="acceptedAnswer"
                   itemScope


### PR DESCRIPTION
## Description
There's a content change in the header text for the 526 wizard, this adds it

## Testing done
Checked locally

## Screenshots
![screen shot 2018-11-02 at 1 16 33 pm](https://user-images.githubusercontent.com/634932/47930214-a38fa080-dea1-11e8-95d9-43dbc6859396.png)


## Acceptance criteria
- [x] Text is updated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
