### PR TITLE
need cookie for new header on www.va.gov for now

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -58,7 +58,7 @@
     {
         "hostname": "www.va.gov",
         "pathnameBeginning": "/",
-        "cookieOnly": false
+        "cookieOnly": true
     },
     {
         "hostname": "www.cem.va.gov",


### PR DESCRIPTION
## Description
This would've enabled the header on the current www.va.gov subsites without the cookie as they are loading the JS.

## Testing done


## Screenshots


## Acceptance criteria

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

ref: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14786