### PR TITLE
Add additional hidden text for screen readers in search results

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -179,6 +179,9 @@ class SearchApp extends React.Component {
     return (
       <p>
         Showing {totalEntries === 0 ? '0' : `${resultRangeStart}-${resultRangeEnd}`} of {totalEntries} results
+        <span className="usa-sr-only">
+          {' '}for "{this.props.router.location.query.query}"
+        </span>
       </p>
     );
     /* eslint-enable prettier/prettier */


### PR DESCRIPTION
## Description

Add hidden `span` with additional context for screen readers

## Testing done

Tested locally on Chrome

## Acceptance criteria
- [x] `span` with class `.usa-sr-only` containing "for {search query}" has been added after "Showing x of x results" text on Search page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
