### PR TITLE
Update encoding pattern in search app

### DIFF
--- a/src/applications/search/actions/index.js
+++ b/src/applications/search/actions/index.js
@@ -12,7 +12,7 @@ export function fetchSearchResults(query, page) {
       method: 'GET',
     };
 
-    let queryString = `/search?query=${query}`;
+    let queryString = `/search?query=${encodeURIComponent(query)}`;
 
     if (page) {
       queryString = queryString.concat(`&page=${page}`);

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -66,7 +66,7 @@ class SearchApp extends React.Component {
     this.props.router.push({
       pathname: '',
       query: {
-        query: encodeURIComponent(userInput),
+        query: userInput,
         page,
       },
     });


### PR DESCRIPTION
## Description
We're seeing a few searches in sentry that error because '%' was used in the search terms.

## Testing done
Manually confirmed in network tab that queries are encoded as expected
Manually confirmed API  receives expected query

## Screenshots


## Acceptance criteria
- [x] Queries containing `%` are encoded properly and do not return an error.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
