### PR TITLE
Implement build task to generate Vets.gov-to-VA.gov redirects

### DIFF
--- a/script/build.js
+++ b/script/build.js
@@ -13,6 +13,7 @@ const moveRemove = require('metalsmith-move-remove');
 const navigation = require('metalsmith-navigation');
 const permalinks = require('metalsmith-permalinks');
 
+const generateRedirectedPages = require('./vets-gov-to-va-gov');
 const createBuildSettings = require('./create-build-settings');
 const createRedirects = require('./create-redirects');
 const createSitemaps = require('./create-sitemaps');
@@ -24,143 +25,155 @@ const checkBrokenLinks = require('./check-broken-links');
 const rewriteVaDomains = require('./rewrite-va-domains');
 const configureAssets = require('./configure-assets');
 const applyFragments = require('./apply-fragments');
-const BUILD_OPTIONS = require('./options');
 
-const smith = Metalsmith(__dirname); // eslint-disable-line new-cap
+function defaultBuild(BUILD_OPTIONS) {
+  const smith = Metalsmith(__dirname); // eslint-disable-line new-cap
 
-// Custom liquid filter(s)
-liquid.filters.humanizeDate = dt => moment(dt).format('MMMM D, YYYY');
+  // Custom liquid filter(s)
+  liquid.filters.humanizeDate = dt => moment(dt).format('MMMM D, YYYY');
 
-// Set up Metalsmith. BE CAREFUL if you change the order of the plugins. Read the comments and
-// add comments about any implicit dependencies you are introducing!!!
-//
-smith.source(`${BUILD_OPTIONS.contentPagesRoot}`);
-smith.destination(BUILD_OPTIONS.destination);
+  // Set up Metalsmith. BE CAREFUL if you change the order of the plugins. Read the comments and
+  // add comments about any implicit dependencies you are introducing!!!
+  //
+  smith.source(`${BUILD_OPTIONS.contentPagesRoot}`);
+  smith.destination(BUILD_OPTIONS.destination);
 
-// This lets us access the {{buildtype}} variable within liquid templates.
-smith.metadata({
-  buildtype: BUILD_OPTIONS.buildtype,
-  hostUrl: BUILD_OPTIONS.hostUrl,
-  mergedbuild: !!BUILD_OPTIONS['brand-consolidation-enabled'], // @deprecated - We use a separate Metalsmith directory for VA.gov. We shouldn't ever need this info in Metalsmith files.
-});
+  // This lets us access the {{buildtype}} variable within liquid templates.
+  smith.metadata({
+    buildtype: BUILD_OPTIONS.buildtype,
+    hostUrl: BUILD_OPTIONS.hostUrl,
+    mergedbuild: !!BUILD_OPTIONS['brand-consolidation-enabled'], // @deprecated - We use a separate Metalsmith directory for VA.gov. We shouldn't ever need this info in Metalsmith files.
+  });
 
-smith.use(createEnvironmentFilter(BUILD_OPTIONS));
+  smith.use(createEnvironmentFilter(BUILD_OPTIONS));
 
-// This adds the filename into the "entry" that is passed to other plugins. Without this errors
-// during templating end up not showing which file they came from. Load it very early in in the
-// plugin chain.
-smith.use(filenames());
+  // This adds the filename into the "entry" that is passed to other plugins. Without this errors
+  // during templating end up not showing which file they came from. Load it very early in in the
+  // plugin chain.
+  smith.use(filenames());
 
-if (BUILD_OPTIONS.contentFragments) {
-  smith.use(applyFragments(BUILD_OPTIONS));
-}
-
-smith.use(collections(BUILD_OPTIONS.collections));
-smith.use(leftRailNavResetLevels());
-smith.use(dateInFilename(true));
-
-smith.use(assets(BUILD_OPTIONS.appAssets));
-if (BUILD_OPTIONS.contentAssets) {
-  smith.use(assets(BUILD_OPTIONS.contentAssets));
-}
-
-// smith.use(cspHash({ pattern: ['js/*.js', 'generated/*.css', 'generated/*.js'] }))
-
-// Liquid substitution must occur before markdown is run otherwise markdown will escape the
-// bits of liquid commands (eg., quotes) and break things.
-//
-// Unfortunately this must come before permalinks and navgation because of limitation in both
-// modules regarding what files they understand. The consequence here is that liquid templates
-// *within* a single file do NOT have access to the final path that they will be rendered under
-// or any other metadata added by the permalinks() and navigation() filters.
-//
-// Thus far this has not been a problem because the only references to such paths are in the
-// includes which are handled by the layout module. The layout module, luckily, can be run
-// near the end of the filter chain and therefore has access to all the metadata.
-//
-// If this becomes a barrier in the future, permalinks should be patched to understand
-// translating .md files which would allow inPlace() and markdown() to be moved under the
-// permalinks() and navigation() filters making the variable stores uniform between inPlace()
-// and layout().
-smith.use(inPlace({ engine: 'liquid', pattern: '*.{md,html}' }));
-smith.use(
-  markdown({
-    typographer: true,
-    html: true,
-  }),
-);
-
-// Responsible for create permalink structure. Most commonly used change foo.md to foo/index.html.
-//
-// This must come before navigation module, otherwise breadcrunmbs will see the wrong URLs.
-//
-// It also must come AFTER the markdown() module because it only recognizes .html files. See
-// comment above the inPlace() module for explanation of effects on the metadata().
-smith.use(
-  permalinks({
-    relative: false,
-    linksets: [
-      {
-        match: { collection: 'posts' },
-        pattern: ':date/:slug',
-      },
-    ],
-  }),
-);
-
-smith.use(
-  navigation({
-    navConfigs: {
-      sortByNameFirst: true,
-      breadcrumbProperty: 'breadcrumb_path',
-      pathProperty: 'nav_path',
-      includeDirs: true,
-    },
-    navSettings: {},
-  }),
-);
-
-smith.use(
-  layouts({
-    engine: 'liquid',
-    directory: `${BUILD_OPTIONS.contentRoot}/layouts/`,
-    // Only apply layouts to markdown and html files.
-    pattern: '**/*.{md,html}',
-  }),
-);
-
-/*
-Add nonce attribute with substition string to all inline script tags
-Convert onclick event handles into nonced script tags
-*/
-smith.use(nonceTransformer);
-
-/*
- * This will replace links in static pages with a staging domain,
- * if it is in the list of domains to replace
- */
-smith.use(rewriteVaDomains(BUILD_OPTIONS));
-
-// Create the data passed from the content build to the assets compiler.
-// On the server, it can be accessed at BUILD_OPTIONS.buildSettings.
-// In the browser, it can be accessed at window.settings.
-smith.use(createBuildSettings(BUILD_OPTIONS));
-
-smith.use(updateExternalLinks(BUILD_OPTIONS));
-smith.use(checkBrokenLinks(BUILD_OPTIONS));
-
-configureAssets(smith, BUILD_OPTIONS);
-
-smith.use(createSitemaps(BUILD_OPTIONS));
-smith.use(createRedirects(BUILD_OPTIONS));
-smith.use(moveRemove(BUILD_OPTIONS));
-
-/* eslint-disable no-console */
-smith.build(err => {
-  if (err) throw err;
-  if (BUILD_OPTIONS.watch) {
-    console.log('Metalsmith build finished!  Starting webpack-dev-server...');
-  } else {
-    console.log('Build finished!');
+  if (BUILD_OPTIONS.contentFragments) {
+    smith.use(applyFragments(BUILD_OPTIONS));
   }
-});
+
+  smith.use(collections(BUILD_OPTIONS.collections));
+  smith.use(leftRailNavResetLevels());
+  smith.use(dateInFilename(true));
+
+  smith.use(assets(BUILD_OPTIONS.appAssets));
+  if (BUILD_OPTIONS.contentAssets) {
+    smith.use(assets(BUILD_OPTIONS.contentAssets));
+  }
+
+  // smith.use(cspHash({ pattern: ['js/*.js', 'generated/*.css', 'generated/*.js'] }))
+
+  // Liquid substitution must occur before markdown is run otherwise markdown will escape the
+  // bits of liquid commands (eg., quotes) and break things.
+  //
+  // Unfortunately this must come before permalinks and navgation because of limitation in both
+  // modules regarding what files they understand. The consequence here is that liquid templates
+  // *within* a single file do NOT have access to the final path that they will be rendered under
+  // or any other metadata added by the permalinks() and navigation() filters.
+  //
+  // Thus far this has not been a problem because the only references to such paths are in the
+  // includes which are handled by the layout module. The layout module, luckily, can be run
+  // near the end of the filter chain and therefore has access to all the metadata.
+  //
+  // If this becomes a barrier in the future, permalinks should be patched to understand
+  // translating .md files which would allow inPlace() and markdown() to be moved under the
+  // permalinks() and navigation() filters making the variable stores uniform between inPlace()
+  // and layout().
+  smith.use(inPlace({ engine: 'liquid', pattern: '*.{md,html}' }));
+  smith.use(
+    markdown({
+      typographer: true,
+      html: true,
+    }),
+  );
+
+  // Responsible for create permalink structure. Most commonly used change foo.md to foo/index.html.
+  //
+  // This must come before navigation module, otherwise breadcrunmbs will see the wrong URLs.
+  //
+  // It also must come AFTER the markdown() module because it only recognizes .html files. See
+  // comment above the inPlace() module for explanation of effects on the metadata().
+  smith.use(
+    permalinks({
+      relative: false,
+      linksets: [
+        {
+          match: { collection: 'posts' },
+          pattern: ':date/:slug',
+        },
+      ],
+    }),
+  );
+
+  smith.use(
+    navigation({
+      navConfigs: {
+        sortByNameFirst: true,
+        breadcrumbProperty: 'breadcrumb_path',
+        pathProperty: 'nav_path',
+        includeDirs: true,
+      },
+      navSettings: {},
+    }),
+  );
+
+  smith.use(
+    layouts({
+      engine: 'liquid',
+      directory: `${BUILD_OPTIONS.contentRoot}/layouts/`,
+      // Only apply layouts to markdown and html files.
+      pattern: '**/*.{md,html}',
+    }),
+  );
+
+  /*
+  Add nonce attribute with substition string to all inline script tags
+  Convert onclick event handles into nonced script tags
+  */
+  smith.use(nonceTransformer);
+
+  /*
+  * This will replace links in static pages with a staging domain,
+  * if it is in the list of domains to replace
+  */
+  smith.use(rewriteVaDomains(BUILD_OPTIONS));
+
+  // Create the data passed from the content build to the assets compiler.
+  // On the server, it can be accessed at BUILD_OPTIONS.buildSettings.
+  // In the browser, it can be accessed at window.settings.
+  smith.use(createBuildSettings(BUILD_OPTIONS));
+
+  smith.use(updateExternalLinks(BUILD_OPTIONS));
+  smith.use(checkBrokenLinks(BUILD_OPTIONS));
+
+  configureAssets(smith, BUILD_OPTIONS);
+
+  smith.use(createSitemaps(BUILD_OPTIONS));
+  smith.use(createRedirects(BUILD_OPTIONS));
+  smith.use(moveRemove(BUILD_OPTIONS));
+
+  /* eslint-disable no-console */
+  smith.build(err => {
+    if (err) throw err;
+    if (BUILD_OPTIONS.watch) {
+      console.log('Metalsmith build finished!  Starting webpack-dev-server...');
+    } else {
+      console.log('Build finished!');
+    }
+  });
+}
+
+function main() {
+  const BUILD_OPTIONS = require('./options');
+  if (BUILD_OPTIONS['vets-gov-to-va-gov']) {
+    generateRedirectedPages(BUILD_OPTIONS);
+  } else {
+    defaultBuild(BUILD_OPTIONS);
+  }
+}
+
+main();

--- a/script/create-redirects.js
+++ b/script/create-redirects.js
@@ -8,7 +8,7 @@ function getRedirectPage(redirectToPath) {
   return `
     <!doctype html>
     <head>
-      <meta http-equiv=refresh content="1; url=${absolutePath}">
+      <meta http-equiv=refresh content="0; url=${absolutePath}">
       <link rel=canonical href="${absolutePath}">
       <title>Page Moved</title>
     </head>

--- a/script/options.js
+++ b/script/options.js
@@ -72,6 +72,10 @@ function applyEnvironmentOverrides(options) {
 
   switch (options.buildtype) {
     case environments.DEVELOPMENT:
+      options['vets-gov-to-va-gov'] = true;
+      options['brand-consolidation-enabled'] = true;
+      break;
+
     case environments.STAGING:
       options.move = [{ source: 'vets-robots.txt', target: 'robots.txt' }];
       options.remove = ['va-robots.txt'];

--- a/script/options.js
+++ b/script/options.js
@@ -24,7 +24,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
     type: String,
     defaultValue: '../../vagov-content/pages',
   },
-
+  { name: 'vets-gov-to-va-gov', type: Boolean, defaultValue: false },
   // Catch-all for bad arguments.
   { name: 'unexpected', type: String, multile: true, defaultOption: true },
 ];

--- a/script/vets-gov-to-va-gov/app-redirect.js
+++ b/script/vets-gov-to-va-gov/app-redirect.js
@@ -1,3 +1,22 @@
-function createAppRedirectHtml(vetsGovSrc, vaGovDest) {}
+function createAppRedirectHtml(vetsGovSrc, vaGovDest, vaGovHost) {
+  return (
+    `` +
+    `<!doctype html>
+<head>
+  <script>
+    var pathname = window.location.pathname; 
+    var newPath = pathname.replace('${vetsGovSrc}', '${vaGovDest}');
+    var fullUrl = '${vaGovHost}' + newPath + window.location.search;
+    document.write('<meta http-equiv=refresh content="0; url=' + fullUrl + '">');
+  </script>
+  <link rel=canonical href="${vaGovDest}">
+  <title>Page Moved</title>
+</head>
+<body>
+  New location: <a href="${vaGovDest}">${vaGovDest}</a>
+</body>
+`
+  );
+}
 
 module.exports = createAppRedirectHtml;

--- a/script/vets-gov-to-va-gov/app-redirect.js
+++ b/script/vets-gov-to-va-gov/app-redirect.js
@@ -4,16 +4,32 @@ function createAppRedirectHtml(vetsGovSrc, vaGovDest, vaGovHost) {
     `<!doctype html>
 <head>
   <script>
+    function requiresSignIn(newPath) {
+      var pathsRequiringSignIn = [
+        '/track-claims',
+        '/my-va',
+        '/download-va-letters',
+        '/profile',
+        '/account',
+        '/get-veteran-id-cards/apply',
+        '/health-care/health-records'
+      ];
+      return pathsRequiringSignIn.some(reactPath => newPath.indexOf(reactPath) >= 0);
+    }
     var pathname = window.location.pathname; 
     var newPath = pathname.replace('${vetsGovSrc}', '${vaGovDest}');
-    var fullUrl = '${vaGovHost}' + newPath + window.location.search;
-    document.write('<meta http-equiv=refresh content="0; url=' + fullUrl + '">');
+    var finalUrl = '${vaGovHost}' + newPath;
+    var redirectUrl = finalUrl + window.location.search;
+
+    if (requiresSignIn(newPath)) {
+      redirectUrl = '${vaGovHost}?next=' + encodeURIComponent(newPath + window.location.search);
+    }
+    document.write('<meta http-equiv=refresh content="0; url=' + redirectUrl + '">');
+    document.write('<link rel=canonical href="' + finalUrl + '">');
   </script>
-  <link rel=canonical href="${vaGovDest}">
   <title>Page Moved</title>
 </head>
 <body>
-  New location: <a href="${vaGovDest}">${vaGovDest}</a>
 </body>
 `
   );

--- a/script/vets-gov-to-va-gov/app-redirect.js
+++ b/script/vets-gov-to-va-gov/app-redirect.js
@@ -3,7 +3,7 @@ function createAppRedirectHtml(vetsGovSrc, vaGovDest, vaGovHost) {
     `` +
     `<!doctype html>
 <head>
-  <script>
+  <script nonce="**CSP_NONCE**">
     function requiresSignIn(newPath) {
       var pathsRequiringSignIn = [
         '/track-claims',

--- a/script/vets-gov-to-va-gov/app-redirect.js
+++ b/script/vets-gov-to-va-gov/app-redirect.js
@@ -1,0 +1,3 @@
+function createAppRedirectHtml(vetsGovSrc, vaGovDest) {}
+
+module.exports = createAppRedirectHtml;

--- a/script/vets-gov-to-va-gov/index.js
+++ b/script/vets-gov-to-va-gov/index.js
@@ -52,8 +52,8 @@ function generateRedirectedPages(BUILD_OPTIONS) {
       htmlFileContents = createStandardRedirectHtml(vaGovFullPath);
     } else {
       htmlFileContents = createAppRedirectHtml(
-        vetsGovSrc,
-        vaGovDest,
+        vetsGovSrc.replace(/\/$/, ''),
+        vaGovDest.replace(/\/$/, ''),
         `https://${vaGovHostDestination}`,
       );
     }

--- a/script/vets-gov-to-va-gov/index.js
+++ b/script/vets-gov-to-va-gov/index.js
@@ -31,14 +31,9 @@ function generateRedirectedPages(BUILD_OPTIONS) {
   const mappings = yaml.safeLoad(mappingsFile);
 
   for (const mapping of mappings) {
-    const {
-      vets_gov_src: vetsGovSrc,
-      retain_path: retainPath,
-    } = mapping;
+    const { vets_gov_src: vetsGovSrc, retain_path: retainPath } = mapping;
 
-    let {
-      va_gov_dest: vaGovDest,
-    } = mapping;
+    const { va_gov_dest: vaGovDest } = mapping;
 
     const htmlDirectory = path.join(destination, vetsGovSrc);
 
@@ -46,20 +41,30 @@ function generateRedirectedPages(BUILD_OPTIONS) {
 
     const htmlFileName = path.join(htmlDirectory, 'index.html');
     let htmlFileContents = null;
+    let vaGovFullPath;
 
     if (!vaGovDest.startsWith('http'))
-      vaGovDest = `https://${vaGovHostDestination}/${vaGovDest}`;
+      vaGovFullPath = `https://${vaGovHostDestination}/${vaGovDest}`;
 
     console.log(`Writing redirect for ${vetsGovSrc} to ${vaGovDest}`);
 
     if (!retainPath) {
-      htmlFileContents = createStandardRedirectHtml(vaGovDest);
+      htmlFileContents = createStandardRedirectHtml(vaGovFullPath);
     } else {
-      // htmlFileContents = createAppRedirectHtml(vetsGovSrc, vaGovDest);
+      htmlFileContents = createAppRedirectHtml(
+        vetsGovSrc,
+        vaGovDest,
+        `https://${vaGovHostDestination}`,
+      );
     }
 
     fs.writeFileSync(htmlFileName, htmlFileContents);
   }
+
+  fs.writeFileSync(
+    path.join(destination, '404.html'),
+    createAppRedirectHtml('', '', `https://${vaGovHostDestination}`),
+  );
 }
 
 module.exports = generateRedirectedPages;

--- a/script/vets-gov-to-va-gov/index.js
+++ b/script/vets-gov-to-va-gov/index.js
@@ -1,0 +1,65 @@
+/* eslint-disable no-console */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const mkdirp = require('mkdirp');
+
+const environments = require('../constants/environments');
+const hostnames = require('../constants/hostnames');
+
+const createStandardRedirectHtml = require('./standard-redirect');
+const createAppRedirectHtml = require('./app-redirect');
+
+const vetsEnvToVaHost = {
+  [environments.DEVELOPMENT]: hostnames[environments.VAGOVDEV],
+  [environments.STAGING]: hostnames[environments.VAGOVSTAGING],
+  [environments.PRODUCTION]: hostnames[environments.VAGOVPROD],
+};
+
+function generateRedirectedPages(BUILD_OPTIONS) {
+  const { destination, contentPagesRoot } = BUILD_OPTIONS;
+
+  const vaGovHostDestination = vetsEnvToVaHost[BUILD_OPTIONS.buildtype];
+  const mappingsFileLocation = path.join(
+    __dirname,
+    '../',
+    contentPagesRoot,
+    '../redirects/vets-gov-to-va-gov.yml',
+  );
+  const mappingsFile = fs.readFileSync(mappingsFileLocation);
+  const mappings = yaml.safeLoad(mappingsFile);
+
+  for (const mapping of mappings) {
+    const {
+      vets_gov_src: vetsGovSrc,
+      retain_path: retainPath,
+    } = mapping;
+
+    let {
+      va_gov_dest: vaGovDest,
+    } = mapping;
+
+    const htmlDirectory = path.join(destination, vetsGovSrc);
+
+    mkdirp.sync(htmlDirectory);
+
+    const htmlFileName = path.join(htmlDirectory, 'index.html');
+    let htmlFileContents = null;
+
+    if (!vaGovDest.startsWith('http'))
+      vaGovDest = `https://${vaGovHostDestination}/${vaGovDest}`;
+
+    console.log(`Writing redirect for ${vetsGovSrc} to ${vaGovDest}`);
+
+    if (!retainPath) {
+      htmlFileContents = createStandardRedirectHtml(vaGovDest);
+    } else {
+      // htmlFileContents = createAppRedirectHtml(vetsGovSrc, vaGovDest);
+    }
+
+    fs.writeFileSync(htmlFileName, htmlFileContents);
+  }
+}
+
+module.exports = generateRedirectedPages;

--- a/script/vets-gov-to-va-gov/standard-redirect.js
+++ b/script/vets-gov-to-va-gov/standard-redirect.js
@@ -3,7 +3,7 @@ function createStandardRedirectHtml(vaGovDest) {
     `` +
     `<!doctype html>
 <head>
-  <meta http-equiv=refresh content="1; url=${vaGovDest}">
+  <meta http-equiv=refresh content="0; url=${vaGovDest}">
   <link rel=canonical href="${vaGovDest}">
   <title>Page Moved</title>
 </head>

--- a/script/vets-gov-to-va-gov/standard-redirect.js
+++ b/script/vets-gov-to-va-gov/standard-redirect.js
@@ -1,0 +1,17 @@
+function createStandardRedirectHtml(vaGovDest) {
+  return (
+    `` +
+    `<!doctype html>
+<head>
+  <meta http-equiv=refresh content="1; url=${vaGovDest}">
+  <link rel=canonical href="${vaGovDest}">
+  <title>Page Moved</title>
+</head>
+<body>
+  New location: <a href="${vaGovDest}">${vaGovDest}</a>
+</body>
+`
+  );
+}
+
+module.exports = createStandardRedirectHtml;

--- a/script/vets-gov-to-va-gov/standard-redirect.js
+++ b/script/vets-gov-to-va-gov/standard-redirect.js
@@ -8,7 +8,6 @@ function createStandardRedirectHtml(vaGovDest) {
   <title>Page Moved</title>
 </head>
 <body>
-  New location: <a href="${vaGovDest}">${vaGovDest}</a>
 </body>
 `
   );


### PR DESCRIPTION
## Description
This pull request consumes the mappings files at https://github.com/department-of-veterans-affairs/vagov-content/pull/101 to generate HTML files of Vets.gov page locations that redirect to their mapped VA.gov page destination.

The redirect version of a Vets.gov build-type is generated via -

```
npm run build -- --buildtype=${buildtype} --vets-gov-to-va-gov --brand-consolidation-enabled
```

TODO
- [x] Write an HTML page that preserves URL parameters for React apps
- [x] Write the 404 "catch-all" that bounces the whole path to VA.gov

## Testing done
- Confirmed file output
- Ran generated site locally

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/47942670-1eb87d00-dec9-11e8-8807-084a0978c4e0.png)


## Acceptance criteria
- [ ] A strategy is in place for redirecting users from Vets.gov to VA.gov

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

## Tickets

### Main
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14768

### Other
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14698
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13928
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12787