### PR TITLE
14841 fix search page num

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -33,6 +33,7 @@ class SearchApp extends React.Component {
 
     this.state = {
       userInput: userInputFromAddress,
+      currentResultsQuery: userInputFromAddress,
       page,
     };
 
@@ -62,15 +63,27 @@ class SearchApp extends React.Component {
 
   handleSearch = e => {
     if (e) e.preventDefault();
-    const { userInput, page } = this.state;
+    const { userInput, currentResultsQuery, page } = this.state;
+
+    const queryChanged = userInput !== currentResultsQuery;
+    const nextPage = queryChanged ? 1 : page;
+
+    // Update URL
     this.props.router.push({
       pathname: '',
       query: {
         query: userInput,
-        page,
+        page: nextPage,
       },
     });
-    this.props.fetchSearchResults(userInput, page);
+
+    // Fetch new results
+    this.props.fetchSearchResults(userInput, nextPage);
+
+    // Update query is necessary
+    if (queryChanged) {
+      this.setState({ currentResultsQuery: userInput });
+    }
   };
 
   handleInputChange = event => {

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -82,7 +82,7 @@ class SearchApp extends React.Component {
 
     // Update query is necessary
     if (queryChanged) {
-      this.setState({ currentResultsQuery: userInput });
+      this.setState({ currentResultsQuery: userInput, page: 1 });
     }
   };
 


### PR DESCRIPTION
## Description

When a user submits a query and navigates to a subsequent page of results, i.e. [this example](https://staging.va.gov/search/?page=2&query=test), then updates the query and resubmits search, they are still on page 2 of the *new* search results. 

Added logic to check if the query has changed. If so, page is reset to 1 for `fetchSearchResults()` which should retrieve the correct page of results.

## Testing done

This is tough to test locally or on dev due to us mocking the search results.  Will need to be tested on staging.

## Acceptance criteria
- [x] Page resets to 1 if user enters a new query into the search box and hits search

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
