### PR TITLE
Call the production check function

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -13,7 +13,7 @@ import { uiSchema as autoSuggestUiSchema } from 'us-forms-system/lib/js/definiti
 import FormFooter from '../../../../platform/forms/components/FormFooter';
 import environment from '../../../../platform/utilities/environment';
 import preSubmitInfo from '../../../../platform/forms/preSubmitInfo';
-import isProd from '../../../../platform/utilities/environment/isProduction';
+import productionCheck from '../../../../platform/utilities/environment/isProduction';
 
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPoll from '../components/ConfirmationPoll';
@@ -117,6 +117,8 @@ const {
   disabilities,
   vaTreatmentCenterAddress,
 } = fullSchema526EZ.definitions;
+
+const isProd = productionCheck();
 
 const formConfig = {
   urlPrefix: '/',


### PR DESCRIPTION
## Description
The way the previous `isProd` flag was used in the 526 was as a boolean not a function, so this was erroneously putting the form down the production path even on non-production environments since `isProd` was a function which, of course, is truthy. :stuck_out_tongue: 

## Testing done
Manually tested that the form goes down the expected path in development.

## Screenshots
N/A

## Acceptance criteria
- [x] The form takes the right path in development

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
