### PR TITLE
Disable the Content Deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,7 +131,7 @@ node('vetsgov-general-purpose') {
 
       dir("vets-website") {
         ref = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
-        isCMSDeploy = getIsCMSDeploy(ref)
+        isCMSDeploy = false // getIsCMSDeploy(ref)
         envNames = getEnvNames(isCMSDeploy)
 
         sh "mkdir -p build"


### PR DESCRIPTION
## Description
There was a conflict with our Content Deployment and the way it builds archives based on commit SHA.

## Acceptance criteria
- [x] Content Deployment is disabled (until we have a better archiving scheme for content deployments)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
