### PR TITLE
526 severance date change cv

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/separationTrainingPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/separationTrainingPay.js
@@ -1,5 +1,5 @@
 import fullSchema from '../config/schema';
-import { hasSeparationPay } from '../validations';
+import { hasSeparationPay, isValidYear } from '../validations';
 import {
   waiveTrainingPayDescription,
   separationPayDetailsDescription,
@@ -26,9 +26,8 @@ export const uiSchema = {
     },
     separationPayDate: {
       'ui:title': 'Please tell us the year you received a payment',
-      // TODO: Validate that it's a proper year (a number between 1900 and 3000).
-      'ui:field': 'NumberField',
-      'ui:validations': [],
+      // TODO: Change this to a number field to mimic the regular date field
+      'ui:validations': [isValidYear],
       'ui:errorMessages': {
         pattern: 'Please provide a valid year',
       },

--- a/src/applications/disability-benefits/all-claims/pages/separationTrainingPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/separationTrainingPay.js
@@ -1,6 +1,4 @@
-import dateUI from 'us-forms-system/lib/js/definitions/date';
 import fullSchema from '../config/schema';
-import merge from 'lodash/merge';
 import { hasSeparationPay } from '../validations';
 import {
   waiveTrainingPayDescription,
@@ -26,11 +24,19 @@ export const uiSchema = {
       'ui:title': 'Separation or Severance Pay',
       'ui:description': separationPayDetailsDescription,
     },
-    separationPayDate: merge(
-      {},
-      dateUI('When did you get a separation or severance payment?'),
-      { 'ui:required': hasSeparationPay },
-    ),
+    separationPayDate: {
+      'ui:title': 'Please tell us the year you received a payment',
+      // TODO: Validate that it's a proper year (a number between 1900 and 3000).
+      'ui:field': 'NumberField',
+      'ui:validations': [],
+      'ui:errorMessages': {
+        pattern: 'Please provide a valid year',
+      },
+      'ui:options': {
+        widgetClassNames: 'year-input',
+      },
+      'ui:required': hasSeparationPay,
+    },
     separationPayBranch: {
       'ui:title':
         'Please choose the branch of service that gave you separation or severance pay',
@@ -50,7 +56,7 @@ export const uiSchema = {
       'ui:description': waiveTrainingPayDescription,
     },
     waiveTrainingPay: {
-      'ui:title': `I choose to waive VA compensation pay for the days I receive inactive 
+      'ui:title': `I choose to waive VA compensation pay for the days I receive inactive
       duty training pay, so I can keep my inactive duty training pay.`,
     },
   },

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -115,3 +115,9 @@ ul.original-disability-list {
     }
   }
 }
+
+// Mimics usa-form-group-year minus the float and sets the max width so the
+//  error formatting doesn't increase the size
+.year-input {
+  max-width: 7rem;
+}

--- a/src/applications/disability-benefits/all-claims/tests/pages/separationTrainingPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/separationTrainingPay.unit.spec.jsx
@@ -104,6 +104,6 @@ describe('Separation or Training Pay', () => {
 
     expect(form.find('.form-radio-buttons').length).to.equal(2);
     expect(form.find('input').length).to.equal(6); // 4 radios + year input + checkbox
-    expect(form.find('select').length).to.equal(3); // month, day, service branch
+    expect(form.find('select').length).to.equal(1); // service branch
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -1,0 +1,48 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+
+import { isValidYear } from '../validations';
+
+describe('526 All Claims validations', () => {
+  describe('isValidYear', () => {
+    it('should add an error if the year is not a number', () => {
+      const err = {
+        addError: sinon.spy(),
+      };
+      isValidYear(err, 'asdf');
+      expect(err.addError.called).to.be.true;
+    });
+
+    it('should add an error if the year contains more than just four digits', () => {
+      const err = {
+        addError: sinon.spy(),
+      };
+      isValidYear(err, '1990asdf');
+      expect(err.addError.called).to.be.true;
+    });
+
+    it('should add an error if the year is less than 1900', () => {
+      const err = {
+        addError: sinon.spy(),
+      };
+      isValidYear(err, '1899');
+      expect(err.addError.called).to.be.true;
+    });
+
+    it('should add an error if the year is more than 3000', () => {
+      const err = {
+        addError: sinon.spy(),
+      };
+      isValidYear(err, '3001');
+      expect(err.addError.called).to.be.true;
+    });
+
+    it('should not add an error if the year is between 1900 and 3000', () => {
+      const err = {
+        addError: sinon.spy(),
+      };
+      isValidYear(err, '2010');
+      expect(err.addError.called).to.be.false;
+    });
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -44,5 +44,13 @@ describe('526 All Claims validations', () => {
       isValidYear(err, '2010');
       expect(err.addError.called).to.be.false;
     });
+
+    it('should add an error if the year is in the future', () => {
+      const err = {
+        addError: sinon.spy(),
+      };
+      isValidYear(err, '2999');
+      expect(err.addError.called).to.be.true;
+    });
   });
 });

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -143,3 +143,11 @@ export const isInFuture = (err, fieldData) => {
     err.addError('Start date must be in the future');
   }
 };
+
+export const isValidYear = (err, fieldData) => {
+  const parsedInt = Number.parseInt(fieldData, 10);
+
+  if (!/\d{4}/.test(fieldData) || parsedInt < 1900 || parsedInt > 3000) {
+    err.addError('Please provide a valid year');
+  }
+};

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -152,6 +152,6 @@ export const isValidYear = (err, fieldData) => {
   }
 
   if (parsedInt > new Date().getFullYear()) {
-    err.addError('The year cannot be in the future');
+    err.addError('The year can’t be in the future');
   }
 };

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -147,7 +147,7 @@ export const isInFuture = (err, fieldData) => {
 export const isValidYear = (err, fieldData) => {
   const parsedInt = Number.parseInt(fieldData, 10);
 
-  if (!/\d{4}/.test(fieldData) || parsedInt < 1900 || parsedInt > 3000) {
+  if (!/^\d{4}$/.test(fieldData) || parsedInt < 1900 || parsedInt > 3000) {
     err.addError('Please provide a valid year');
   }
 };

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -150,4 +150,8 @@ export const isValidYear = (err, fieldData) => {
   if (!/^\d{4}$/.test(fieldData) || parsedInt < 1900 || parsedInt > 3000) {
     err.addError('Please provide a valid year');
   }
+
+  if (parsedInt > new Date().getFullYear()) {
+    err.addError('The year cannot be in the future');
+  }
 };


### PR DESCRIPTION
## Description
This PR changes the separation / severance pay date to capture just the year.

## Testing done
Manually tested.
Unit tests written and updated.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/47946411-91752880-dec8-11e8-95be-ce562fbe1a98.png)

![image](https://user-images.githubusercontent.com/12970166/47946415-989c3680-dec8-11e8-83fc-792462297302.png)

![image](https://user-images.githubusercontent.com/12970166/47946418-a0f47180-dec8-11e8-95a8-c44d81897b04.png)


## Acceptance criteria
- [x] The separation or severance pay date captures only a year
- [x] The field rejects invalid responses

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
