### PR TITLE
Add an exception for data protocol

### DIFF
--- a/script/pre-archive/link-assets-to-bucket.js
+++ b/script/pre-archive/link-assets-to-bucket.js
@@ -45,7 +45,7 @@ function linkAssetsToBucket(options, fileNames) {
       }
 
       if (!assetSrc) continue;
-      if (assetSrc.startsWith('http')) continue;
+      if (assetSrc.startsWith('http') || assetSrc.startsWith('data:')) continue;
 
       const assetBucketLocation = `${bucketPath}${assetSrc}`;
 


### PR DESCRIPTION
## Description
This PR fixes an error in our pre-archive step that was causing images loaded with the `data:` protocol to also have the bucket prefixed in its URL -

```
<img width="250" alt="Go to VA.gov" src="https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.comdata:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAV4AAABOCAYAAABoin41AAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg
```

This PR adds an exception in the pre-archive step for the data protocol.

## Testing done
Locally ran the pre-archive step against the vagovprod build-type and confirmed the logo URL for 503.html was unchanged.

## Acceptance criteria
- [ ] 503.html's logo loads okay

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
