### PR TITLE
Enable disability redirects

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
+++ b/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
@@ -14,7 +14,7 @@ import startMobileMenuButton from '../../platform/site-wide/mobile-menu-button';
 import startFeedbackWidget from '../../platform/site-wide/feedback';
 // import startAnnouncementWidget from '../../platform/site-wide/announcements';
 import startVAFooter from '../../platform/site-wide/va-footer';
-// import redirectIfNecessary from './redirects';
+import redirectIfNecessary from './redirects';
 import { addFocusBehaviorToCrisisLineModal } from '../../platform/site-wide/accessible-VCL-modal';
 import { addOverlayTriggers } from '../../platform/site-wide/legacy/menu';
 import { proxyRewriteWhitelist } from './proxy-rewrite-whitelist.json';
@@ -148,6 +148,6 @@ if (
   )
 ) {
   // TODO: remove comment and test
-  // redirectIfNecessary(window);
+  redirectIfNecessary(window);
   activateInjectedAssets();
 }

--- a/src/applications/proxy-rewrite/redirects/disabilityRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/disabilityRedirects.json
@@ -1,0 +1,187 @@
+[
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/types-disability.asp",
+    "dest": "/disability/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-postservice-index.asp",
+    "dest": "/disability/eligibility/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-postservice-exposures-index.asp",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-postservice-exposures-environmental_hazards.asp",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/specific-environmental-hazards/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-postservice-agent_orange.asp",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/agentorange-c123.asp",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-postservice-exposures-asbestos.asp",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/asbestos/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-postservice-exposures-mustard.asp",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-postservice-exposures-camp-lejeune-water.asp",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/camp-lejeune-water-contamination/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-postservice-exposures-ionizing_radiation.asp",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-postservice-exposures-radiogenic_diseases.asp",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/ionizing-radiation/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-postservice-exposures-project_112_shad.asp",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/project-112-shad/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-postservice-gulfwar.asp",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/gulf-war-illness-southwest-asia/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-postservice-one_year.asp",
+    "dest": "/disability/eligibility/illnesses-within-one-year-of-discharge/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-special-index.asp",
+    "dest": "/disability/eligibility/special-claims/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-special-auto-allowance.asp",
+    "dest": "/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-special-birth_defects.asp",
+    "dest": "/disability/eligibility/special-claims/birth-defects/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-special-clothing_allowance.asp",
+    "dest": "/disability/eligibility/special-claims/clothing-allowance/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-special-dental.asp",
+    "dest": "/disability/eligibility/special-claims/dental-care/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-special-convalescence.asp",
+    "dest": "/disability/eligibility/special-claims/temporary-increase-after-surgery-or-cast/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-special-hospital_treatment.asp",
+    "dest": "/disability/eligibility/special-claims/temporary-increase-for-time-in-hospital/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-special-prestabilization.asp",
+    "dest": "/disability/eligibility/special-claims/temporary-rating-prestabilization/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-special-1151.asp",
+    "dest": "/disability/eligibility/special-claims/1151-claims-title-38/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claims-special-individual_unemployability.asp",
+    "dest": "/disability/eligibility/special-claims/unemployability/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/apply.asp",
+    "dest": "/disability/how-to-file-claim/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/process.asp",
+    "dest": "/disability/how-to-file-claim/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/types-claims.asp",
+    "dest": "/disability/how-to-file-claim/when-to-file/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/predischarge/index.asp",
+    "dest": "/disability/how-to-file-claim/when-to-file/pre-discharge-claim/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/predischarge",
+    "dest": "/disability/how-to-file-claim/when-to-file/pre-discharge-claim/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/predischarge/claims-pre-discharge-benefits-delivery-at-discharge.asp",
+    "dest": "/disability/how-to-file-claim/when-to-file/pre-discharge-claim/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/predischarge/claims-pre-discharge-overseas-intake-sites.asp",
+    "dest": "/disability/how-to-file-claim/when-to-file/pre-discharge-claim/file-while-overseas/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/evidence.asp",
+    "dest": "/disability/how-to-file-claim/evidence-needed/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/drc.asp",
+    "dest": "/disability/how-to-file-claim/evidence-needed/decision-ready-claims/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/fdc/index.asp",
+    "dest": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/fdc",
+    "dest": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/effective_dates.asp",
+    "dest": "/disability/about-disability-ratings/effective-date/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claimexam.asp",
+    "dest": "/disability/va-claim-exam/"
+  }
+]

--- a/src/applications/proxy-rewrite/redirects/index.js
+++ b/src/applications/proxy-rewrite/redirects/index.js
@@ -1,7 +1,9 @@
 import environment from '../../../platform/utilities/environment';
 // These pages are old va.gov pages that we are redirecting to
 // pages that we control
-import redirects from './otherDomainRedirects.json';
+// import redirects from './otherDomainRedirects.json';
+// Currently we only have approval for disability related ones:
+import redirects from './disabilityRedirects.json';
 
 /*
  * Redirect to a www.va.gov page if we're on a page that's being

--- a/src/applications/proxy-rewrite/redirects/index.js
+++ b/src/applications/proxy-rewrite/redirects/index.js
@@ -12,8 +12,8 @@ import redirects from './disabilityRedirects.json';
 export default function redirectIfNecessary(currentWindow) {
   const matchedRedirect = redirects.find(
     redirect =>
-      redirect.domain.toLowerCase() ===
-        currentWindow.location.host.toLowerCase() &&
+      redirect.domain.replace('www.', '').toLowerCase() ===
+        currentWindow.location.host.replace('www.', '').toLowerCase() &&
       redirect.src.toLowerCase() ===
         currentWindow.location.pathname.toLowerCase(),
   );

--- a/src/applications/proxy-rewrite/tests/redirects/index.unit.spec.js
+++ b/src/applications/proxy-rewrite/tests/redirects/index.unit.spec.js
@@ -7,14 +7,13 @@ describe('Redirect replaced pages', () => {
     const fakeWindow = {
       location: {
         host: 'www.benefits.va.gov',
-        pathname: '/homeloans/',
+        pathname: '/compensation/types-disability.asp',
       },
     };
 
     redirectIfNecessary(fakeWindow);
 
-    expect(fakeWindow.location.href.endsWith('.gov/housing-assistance/')).to.be
-      .true;
+    expect(fakeWindow.location.href.endsWith('.gov/disability/')).to.be.true;
   });
 
   it('should not redirect when there are no matches', () => {


### PR DESCRIPTION
## Description
If we need to, this turns on client side disability redirects

## Testing done
Ran unit tests


## Acceptance criteria
- [x] List of redirects is correct

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
