### PR TITLE
Vets-to-VA Redirect - Clean destination before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,6 +235,7 @@
     "eslint-stats": "^1.0.0",
     "fast-levenshtein": "^2.0.6",
     "file-loader": "^1.1.11",
+    "fs-extra": "^7.0.0",
     "js-yaml": "^3.12.0",
     "local-storage-fallback": "^4.1.1",
     "nyc": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
     "metalsmith-permalinks": "^0.5.0",
     "metalsmith-sitemap": "^1.0.0",
     "metalsmith-watch": "^1.0.3",
-    "mkdirp": "^0.5.1",
     "mocha": "^3.5.0",
     "mocha-junit-reporter": "^1.17.0",
     "moment": "^2.15.1",

--- a/script/vets-gov-to-va-gov/index.js
+++ b/script/vets-gov-to-va-gov/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const yaml = require('js-yaml');
 const mkdirp = require('mkdirp');
@@ -29,6 +29,8 @@ function generateRedirectedPages(BUILD_OPTIONS) {
   );
   const mappingsFile = fs.readFileSync(mappingsFileLocation);
   const mappings = yaml.safeLoad(mappingsFile);
+
+  fs.removeSync(destination);
 
   for (const mapping of mappings) {
     const { vets_gov_src: vetsGovSrc, retain_path: retainPath } = mapping;

--- a/script/vets-gov-to-va-gov/index.js
+++ b/script/vets-gov-to-va-gov/index.js
@@ -3,7 +3,6 @@
 const fs = require('fs-extra');
 const path = require('path');
 const yaml = require('js-yaml');
-const mkdirp = require('mkdirp');
 
 const environments = require('../constants/environments');
 const hostnames = require('../constants/hostnames');
@@ -39,7 +38,7 @@ function generateRedirectedPages(BUILD_OPTIONS) {
 
     const htmlDirectory = path.join(destination, vetsGovSrc);
 
-    mkdirp.sync(htmlDirectory);
+    fs.ensureDirSync(htmlDirectory);
 
     const htmlFileName = path.join(htmlDirectory, 'index.html');
     let htmlFileContents = null;

--- a/src/platform/testing/visual-regression/util/get-file-names.js
+++ b/src/platform/testing/visual-regression/util/get-file-names.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const mkdirp = require('mkdirp');
+const fs = require('fs-extra');
 const { baseUrl } = require('../../e2e-puppeteer/helpers');
 const commandLineArgs = require('command-line-args');
 
@@ -38,7 +38,7 @@ function getFileNames(route) {
 async function createDirectoryIfNotExist(filePath) {
   const directory = path.dirname(filePath);
   return new Promise((resolve, reject) => {
-    mkdirp(directory, err => (err ? reject(err) : resolve()));
+    fs.ensureDir(directory, err => (err ? reject(err) : resolve()));
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4206,6 +4206,14 @@ fs-extra@^1.0.0:
     jsonfile "^2.1.0"
     klaw "^1.0.0"
 
+fs-extra@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@~0.26.5:
   version "0.26.7"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
@@ -5936,6 +5944,12 @@ json5@^0.5.0, json5@^0.5.1:
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -10703,6 +10717,10 @@ unique-slug@^2.0.0:
   resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.0.tgz#db6676e7c7cc0629878ff196097c78855ae9f4ab"
   dependencies:
     imurmurhash "^0.1.4"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Description
After a full deployment, I discovered that the catch-all redirect wasn't working and instead, the regular Vets.gov page was being served. I believe this is because we weren't clearing the directory before building the redirect-HTML. This PR fixes that by clearing out the directory.

## Testing done
Local builds

## Acceptance criteria
- [x] Global catch-all redirect to VA.gov works

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
