### PR TITLE
Fix for local development after vets.gov-to-va.gov redirect implementation

### DIFF
--- a/script/options.js
+++ b/script/options.js
@@ -39,6 +39,16 @@ function gatherFromCommandLine() {
   return options;
 }
 
+function applyDeprecatedBuildtypes(options) {
+  const deprecatedEnvironments = [environments.DEVELOPMENT];
+
+  const isDeprecated = deprecatedEnvironments.includes(options.buildtype);
+  if (isDeprecated) {
+    options['vets-gov-to-va-gov'] = true;
+    options['brand-consolidation-enabled'] = true;
+  }
+}
+
 function applyDefaultOptions(options) {
   const contentRoot = '../content';
 
@@ -72,8 +82,6 @@ function applyEnvironmentOverrides(options) {
 
   switch (options.buildtype) {
     case environments.DEVELOPMENT:
-      options['vets-gov-to-va-gov'] = true;
-      options['brand-consolidation-enabled'] = true;
       break;
 
     case environments.STAGING:
@@ -132,6 +140,7 @@ function applyBrandConsolidationOverrides(options) {
 function getOptions() {
   const options = gatherFromCommandLine();
 
+  applyDeprecatedBuildtypes(options);
   applyDefaultOptions(options);
 
   const isHerokuBuild = !!process.env.HEROKU_APP_NAME;


### PR DESCRIPTION
## Description
Same logic as here, https://github.com/department-of-veterans-affairs/vets-website/pull/9014.

The watch task applies the behavior of `DEVELOPMENT`, but that is now a deprecated Vets.gov environment, causing some conflict during local dev.

## Testing done
`npm run watch`

## Acceptance criteria
- [ ] Watch works again

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
