### PR TITLE
Let local vets.gov dev run normally

### DIFF
--- a/script/options.js
+++ b/script/options.js
@@ -54,6 +54,11 @@ function applyDefaultOptions(options) {
     redirects: [],
   });
 
+  if (options.buildtype === environments.DEVELOPMENT) {
+    options['vets-gov-to-va-gov'] = true;
+    options['brand-consolidation-enabled'] = true;
+  }
+
   if (options.buildtype === environments.LOCALHOST) {
     options.buildtype = environments.DEVELOPMENT;
   } else {
@@ -72,10 +77,6 @@ function applyEnvironmentOverrides(options) {
 
   switch (options.buildtype) {
     case environments.DEVELOPMENT:
-      options['vets-gov-to-va-gov'] = true;
-      options['brand-consolidation-enabled'] = true;
-      break;
-
     case environments.STAGING:
       options.move = [{ source: 'vets-robots.txt', target: 'robots.txt' }];
       options.remove = ['va-robots.txt'];


### PR DESCRIPTION
## Description
The watch task is getting pulled into our redirect build path when it shouldn't.

## Testing done
Ran both build types locally

## Acceptance criteria
- [x] Watch task spins up the vets.gov site locally

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
