### PR TITLE
Update pre-archive for picture element

### DIFF
--- a/script/pre-archive/link-assets-to-bucket.js
+++ b/script/pre-archive/link-assets-to-bucket.js
@@ -27,21 +27,21 @@ function linkAssetsToBucket(options, fileNames) {
     const dom = new jsdom.JSDOM(htmlFile.toString());
 
     const assetLinkElements = Array.from(
-      dom.window.document.querySelectorAll('script, img, link'),
+      dom.window.document.querySelectorAll(
+        'script, img, link, picture > source',
+      ),
     );
 
+    const possibleSrcProps = ['src', 'href', 'data-src', 'srcset'];
+
     for (const element of assetLinkElements) {
-      let assetSrcProp = 'src';
-      let assetSrc = element.getAttribute(assetSrcProp);
+      let assetSrcProp = null;
+      let assetSrc = null;
 
-      if (!assetSrc) {
-        assetSrcProp = 'href';
+      for (const prop of possibleSrcProps) {
+        assetSrcProp = prop;
         assetSrc = element.getAttribute(assetSrcProp);
-      }
-
-      if (!assetSrc) {
-        assetSrcProp = 'data-src';
-        assetSrc = element.getAttribute(assetSrcProp);
+        if (assetSrc) break;
       }
 
       if (!assetSrc) continue;


### PR DESCRIPTION
## Description
Now that the veteran banner uses a `<picture/>` element to handle the different breakpoint, we need to add that to the pre-archive build step to also load those images out of the S3 bucket directly.

## Testing done
- `npm run build -- --buildtype=vagovstaging`
- `node script/pre-archive/index.js --buildtype=vagovstaging`
- Checked files to confirm source looks okay

## Acceptance criteria
- [x] Picture element sources are loaded from S3 bucket

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
