### PR TITLE
Add GA layer event for best bets

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -145,7 +145,7 @@ class SearchApp extends React.Component {
           <h4>Our Top Recommendations for You</h4>
           <ul className="results-list">
             {recommendedResults.map(r =>
-              this.renderWebResult(r, 'description'),
+              this.renderWebResult(r, 'description', true),
             )}
           </ul>
           <hr />
@@ -207,7 +207,36 @@ class SearchApp extends React.Component {
   }
 
   /* eslint-disable react/no-danger */
-  renderWebResult(result, snippetKey = 'snippet') {
+  renderWebResult(result, snippetKey = 'snippet', isBestBet = false) {
+    if (isBestBet) {
+      return (
+        <li key={result.url} className="result-item">
+          <a
+            className="result-title"
+            href={result.url}
+            onClick={() =>
+              recordEvent({
+                event: 'nav-searchresults',
+                'nav-path': `Recommended Results -> ${result.title}`,
+              })
+            }
+          >
+            <h5
+              dangerouslySetInnerHTML={{
+                __html: formatResponseString(result.title, true),
+              }}
+            />
+          </a>
+          <p className="result-url">{result.url}</p>
+          <p
+            className="result-desc"
+            dangerouslySetInnerHTML={{
+              __html: formatResponseString(result[snippetKey]),
+            }}
+          />
+        </li>
+      );
+    }
     return (
       <li key={result.url} className="result-item">
         <a className="result-title" href={result.url}>

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -208,38 +208,21 @@ class SearchApp extends React.Component {
 
   /* eslint-disable react/no-danger */
   renderWebResult(result, snippetKey = 'snippet', isBestBet = false) {
-    if (isBestBet) {
-      return (
-        <li key={result.url} className="result-item">
-          <a
-            className="result-title"
-            href={result.url}
-            onClick={() =>
-              recordEvent({
-                event: 'nav-searchresults',
-                'nav-path': `Recommended Results -> ${result.title}`,
-              })
-            }
-          >
-            <h5
-              dangerouslySetInnerHTML={{
-                __html: formatResponseString(result.title, true),
-              }}
-            />
-          </a>
-          <p className="result-url">{result.url}</p>
-          <p
-            className="result-desc"
-            dangerouslySetInnerHTML={{
-              __html: formatResponseString(result[snippetKey]),
-            }}
-          />
-        </li>
-      );
-    }
     return (
       <li key={result.url} className="result-item">
-        <a className="result-title" href={result.url}>
+        <a
+          className="result-title"
+          href={result.url}
+          onClick={
+            isBestBet
+              ? () =>
+                  recordEvent({
+                    event: 'nav-searchresults',
+                    'nav-path': `Recommended Results -> ${result.title}`,
+                  })
+              : null
+          }
+        >
           <h5
             dangerouslySetInnerHTML={{
               __html: formatResponseString(result.title, true),


### PR DESCRIPTION
## Description
This PR adds a `recordEvent()` call to best bet results on search app.

## Testing done
Verified that a best-bet result has the onClick event fired. 

## Acceptance criteria
- [x] Best bet results have proper GA tag with correct title

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
