### PR TITLE
14366- Fixes pension application links

### DIFF
--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -117,7 +117,7 @@ class IntroductionPage extends React.Component {
                 <strong>What if I need help filling out my application?</strong>{' '}
                 An accredited representative, like a Veterans Service Officer
                 (VSO), can help you fill out your claim.{' '}
-                <a href="/disability-benefits/apply/help/index.html">
+                <a href="/disability/get-help-filing-claim/">
                   Get help filing your claim
                 </a>
                 .

--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -123,7 +123,7 @@ class IntroductionPage extends React.Component {
                 .
               </p>
               <h6>Learn about Veterans pension rates</h6>
-              <a href="/pension/rates/" target="_blank">
+              <a href="/pension/veterans-pension-rates/" target="_blank">
                 Find out how we decide pension rates.
               </a>
             </li>


### PR DESCRIPTION
## Description
There are two link issues on the Pension form intro page:

https://preview.va.gov/pension/application/527EZ/introduction

## Testing done
Local testing

## Screenshots

#### Get help filing your claim

![image](https://user-images.githubusercontent.com/7482329/48018385-f3fb3e00-e0ed-11e8-8650-11aaf2bafd62.png)

#### Learn about pension rates

![image](https://user-images.githubusercontent.com/7482329/48018403-fe1d3c80-e0ed-11e8-9f25-2ce34e682e87.png)


## Acceptance criteria
- [x] "Get help filing your claim" link is redirecting and needs to be updated with this correct URL: `/disability/get-help-filing-claim/`
- [x] "Learn about pension rates" is not redirecting correctly and needs to be updated with this correct URL:  `/pension/veterans-pension-rates/`


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
