### PR TITLE
Show Welcome modal: only on homepage, only once

### DIFF
--- a/src/platform/site-wide/announcements/components/WelcomeToNewVAModal.jsx
+++ b/src/platform/site-wide/announcements/components/WelcomeToNewVAModal.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import Modal from '@department-of-veterans-affairs/formation/Modal';
+import brandConsolidation from '../../../brand-consolidation';
+
+export default class WelcomeToNewVAModal extends React.Component {
+  static isEnabled() {
+    if (!brandConsolidation.isEnabled()) return false;
+
+    if (__BUILDTYPE__ === 'preview') return false;
+
+    return true;
+  }
+
+  render() {
+    const { dismiss } = this.props;
+
+    return (
+      <Modal
+        cssClass="va-modal announcement-brand-consolidation"
+        visible
+        onClose={dismiss}
+        id="modal-announcement"
+      >
+        <div className="announcement-heading-brand-consolidation">
+          <img
+            className="announcement-brand-consolidation-logo"
+            src="/img/design/logo/va-plus-vets.png"
+            alt="VA.gov plus Vets.gov"
+          />
+        </div>
+        <h3 className="announcement-title">
+          Welcome to the New VA.gov — Built with Veterans, for Veterans
+        </h3>
+        <p>
+          Our new site offers one place to access all VA benefits and health
+          care services. You can sign in with your My HealtheVet, DS Logon, or
+          ID.me account to track your claims, refill your prescriptions, and
+          more.
+        </p>
+        <button type="button" onClick={dismiss}>
+          Continue to the new VA.gov
+        </button>
+      </Modal>
+    );
+  }
+}

--- a/src/platform/site-wide/announcements/components/WelcomeToNewVAModal.jsx
+++ b/src/platform/site-wide/announcements/components/WelcomeToNewVAModal.jsx
@@ -4,11 +4,7 @@ import brandConsolidation from '../../../brand-consolidation';
 
 export default class WelcomeToNewVAModal extends React.Component {
   static isEnabled() {
-    if (!brandConsolidation.isEnabled()) return false;
-
-    if (__BUILDTYPE__ === 'preview') return false;
-
-    return true;
+    return brandConsolidation.isEnabled();
   }
 
   render() {
@@ -24,8 +20,8 @@ export default class WelcomeToNewVAModal extends React.Component {
         <div className="announcement-heading-brand-consolidation">
           <img
             className="announcement-brand-consolidation-logo"
-            src="/img/design/logo/va-plus-vets.png"
-            alt="VA.gov plus Vets.gov"
+            src="/img/design/logo/va-logo.png"
+            alt="VA.gov"
           />
         </div>
         <h3 className="announcement-title">

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -3,6 +3,7 @@ import Profile360Intro from '../components/Profile360Intro';
 import PersonalizationBanner from '../components/PersonalizationBanner';
 import ClaimIncreaseBanner from '../components/ClaimIncreaseBanner';
 import VAPlusVetsModal from '../components/VAPlusVetsModal';
+import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
 import isBrandConsolidationEnabled from '../../../brand-consolidation/feature-flag';
 
 const config = {
@@ -13,6 +14,12 @@ const config = {
       component: VAPlusVetsModal,
       disabled: !VAPlusVetsModal.isEnabled(),
       showEverytime: true,
+    },
+    {
+      name: 'welcome-to-new-va',
+      paths: /^\/$/,
+      component: WelcomeToNewVAModal,
+      disabled: !WelcomeToNewVAModal.isEnabled(),
     },
     {
       name: 'dashboard-intro',


### PR DESCRIPTION
> I'm still mentally walking through this to make sure this will work as expected in all cases.

## Description
Add a Welcome To The New VA modal that only appears on the homepage and only appears once.

## Testing done
Local testing

## Screenshots
### Updated screenshot
![image](https://user-images.githubusercontent.com/20728956/48072001-74727b00-e190-11e8-8ab2-7f5bdcff4b56.png)

### Old screenshot
![image](https://user-images.githubusercontent.com/20728956/48022081-0a55c980-e0ef-11e8-9b64-bc93ced03d26.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
