### PR TITLE
Open eBenefits button in new tab

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
@@ -59,6 +59,7 @@ export default function ButtonContainer(props) {
         <a
           className="usa-button-primary"
           href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation"
+          target="_blank"
         >
           Go to eBenefits
           <span className="button-icon"> »</span>

--- a/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
@@ -59,6 +59,7 @@ export default function ButtonContainer(props) {
         <a
           className="usa-button-primary"
           href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation"
+          rel="noopener"
           target="_blank"
         >
           Go to eBenefits


### PR DESCRIPTION
## Description
Links to eBenefits should open in a new tab. The following two links/buttons are not opening a new tab:

https://preview.va.gov/disability/how-to-file-claim/
[Go to eBenefits] button

https://preview.va.gov/disability/add-remove-dependent/
[Go to eBenefits to Add a Dependent Child or Spouse] button

## Testing done
Verified that wizard buttons to eBenefits link in a new tab

## Acceptance criteria
- [x] eBenefits links open in a new tab

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
