### PR TITLE
remove woff2 fonts

### DIFF
--- a/src/platform/site-wide/sass/style-consolidated.scss
+++ b/src/platform/site-wide/sass/style-consolidated.scss
@@ -48,7 +48,6 @@ $modal-layer: 400;
   font-style: normal;
   font-weight: 400;
   src: url(/generated/sourcesanspro-regular-webfont.eot?#iefix) format("embedded-opentype"),
-    url(/generated/sourcesanspro-regular-webfont.woff2) format("woff2"),
     url(/generated/sourcesanspro-regular-webfont.woff) format("woff"),
     url(/generated/sourcesanspro-regular-webfont.ttf) format("truetype");
 }
@@ -68,7 +67,6 @@ $modal-layer: 400;
   font-style: normal;
   font-weight: 700;
   src: url(/generated/sourcesanspro-bold-webfont.eot?#iefix) format("embedded-opentype"),
-    url(/generated/sourcesanspro-bold-webfont.woff2) format("woff2"),
     url(/generated/sourcesanspro-bold-webfont.woff) format("woff"),
     url(/generated/sourcesanspro-bold-webfont.ttf) format("truetype");
 }


### PR DESCRIPTION
## Description
these two woff2 fonts are not included as part of the core site's build 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
