### PR TITLE
encode right single quote on headeer

### DIFF
--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -24,7 +24,7 @@ export default `
             )}" alt="U.S. flag">
             <p>An official website of the United States government</p>
             <button id="usa-banner-toggle" class="usa-accordion-button usa-banner-button" aria-expanded="false" aria-controls="gov-banner">
-              <span class="usa-banner-button-text">Here’s how you know</span>
+              <span class="usa-banner-button-text">Here&rsquo;s how you know</span>
             </button>
             </div>
           </div>
@@ -35,7 +35,7 @@ export default `
               )}" alt="Dot gov">
               <div class="usa-media_block-body">
                 <p>
-                  <strong>The .gov means it’s official.</strong>
+                  <strong>The .gov means it&rsquo;s official.</strong>
                   <br>
                   Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site.
                 </p>


### PR DESCRIPTION
## Description
https://staging.va.gov/webpolicylinks.asp doesn't have a utf-8 metatag.

![screen shot 2018-11-05 at 15 54 47](https://user-images.githubusercontent.com/4998130/48032568-5ddb0e00-e115-11e8-9358-602fa6f10a67.png)


## Testing done
verified locally 

## Screenshots
![screen shot 2018-11-05 at 16 09 20](https://user-images.githubusercontent.com/4998130/48032561-59aef080-e115-11e8-8ff2-254edc674074.png)
![screen shot 2018-11-05 at 16 09 05](https://user-images.githubusercontent.com/4998130/48032563-59aef080-e115-11e8-9106-0419de6d2618.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
