### PR TITLE
Update mistreatment content and date schema

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -884,7 +884,6 @@ const schema = {
           },
           VAMistreatmentDate: {
             type: 'string',
-            format: 'date',
           },
         },
       },

--- a/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import { createSelector } from 'reselect';
-import dateUI from 'us-forms-system/lib/js/definitions/date';
-import merge from 'lodash/merge';
 
 import { getDisabilityName } from '../utils';
 import disabilityLabels from '../content/disabilityLabels';
@@ -151,20 +149,18 @@ export const uiSchema = {
             getDisabilitiesList(formData, index).length > 0,
         },
         VAMistreatmentLocation: {
-          'ui:title': 'Location',
+          'ui:title': 'Please tell us where this happened',
           'ui:required': (formData, index) =>
             formData.newDisabilities[index].cause === 'VA' &&
             getDisabilitiesList(formData, index).length > 0,
         },
-        VAMistreatmentDate: merge(
-          {},
-          dateUI('Date (This date doesn’t have to be exact.)'),
-          {
-            'ui:required': (formData, index) =>
-              formData.newDisabilities[index].cause === 'VA' &&
-              getDisabilitiesList(formData, index).length > 0,
-          },
-        ),
+        VAMistreatmentDate: {
+          'ui:title':
+            'Please tell us when this happened (If you’re having trouble remembering the exact date you can provide a year.)',
+          'ui:required': (formData, index) =>
+            formData.newDisabilities[index].cause === 'VA' &&
+            getDisabilitiesList(formData, index).length > 0,
+        },
       },
     },
   },

--- a/src/applications/disability-benefits/all-claims/tests/pages/newDisabilitiesFollowUp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/newDisabilitiesFollowUp.unit.spec.jsx
@@ -162,7 +162,6 @@ describe('New disabilities follow up info', () => {
 
     expect(form.find('input').length).to.equal(6);
     expect(form.find('textarea').length).to.equal(1);
-    expect(form.find('select').length).to.equal(2);
   });
 
   it('should not submit when data not filled in', () => {


### PR DESCRIPTION
## Description
Updates the content and input type per the connected ticket.

## Testing done
Manually tested that it shows up as expected.
Updated unit test to not expect the month and day dropdowns.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/48032719-9545bc80-e10d-11e8-952d-e4df99e9d5c1.png)


## Acceptance criteria
- [x] The content is updated
- [x] The date input is a text input, not a date selector

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
