### PR TITLE
Update link text for GI Bill comparison tool in nav

### DIFF
--- a/content/includes/veteran-navigation.html
+++ b/content/includes/veteran-navigation.html
@@ -97,7 +97,7 @@
                   <li><a href="/education/apply/" onClick="reportHeaderNav('Explore Benefits->Education Training');">How to Apply for Education Benefits</a></li>
                   <li><a href="/education/gi-bill/" onClick="reportHeaderNav('Explore Benefits->Education Training');">GI Bill Programs</a></li>
                   <li><a href="/employment/vocational-rehab-and-employment" onClick="reportHeaderNav('Explore Benefits->Vocational Rehab and Employment');">Vocational Rehabilitation &amp; <br>Employment (VR&amp;E)</a></li>
-                  <li><a href="/gi-bill-comparison-tool/" onClick="reportHeaderNav('Explore Benefits->Education Training');">Compare GI Bill Benefits</a></li>
+                  <li><a href="/gi-bill-comparison-tool/" onClick="reportHeaderNav('Explore Benefits->Education Training');">GI Bill&reg; Comparison Tool</a></li>
                   <li><a href="/education/apply/" class="usa-button va-button-primary" onClick="reportHeaderNav('Explore Benefits->Education Training');">Apply Now</a></li>
                 </ul>
               </li>

--- a/va-gov/includes/veteran-navigation.html
+++ b/va-gov/includes/veteran-navigation.html
@@ -68,7 +68,7 @@
                   <li><a href="/education/how-to-apply/" onClick="reportHeaderNav('Explore Benefits->Education Training');">How to Apply for Education Benefits</a></li>
                   <li><a href="/education/about-gi-bill-benefits/" onClick="reportHeaderNav('Explore Benefits->Education Training');">GI Bill Programs</a></li>
                   <li><a href="/employment/vocational-rehab-and-employment" onClick="reportHeaderNav('Explore Benefits->Vocational Rehab and Employment');">Vocational Rehabilitation &amp; <br>Employment (VR&amp;E)</a></li>
-                  <li><a href="/gi-bill-comparison-tool" onClick="reportHeaderNav('Explore Benefits->Education Training');">Compare GI Bill Benefits</a></li>
+                  <li><a href="/gi-bill-comparison-tool" onClick="reportHeaderNav('Explore Benefits->Education Training');">GI Bill&reg; Comparison Tool</a></li>
                   <li><a href="/education/how-to-apply/" class="usa-button va-button-primary" onClick="reportHeaderNav('Explore Benefits->Education Training');">Apply Now</a></li>
                 </ul>
               </li>


### PR DESCRIPTION
## Description

Updated mega-menu link text for GI Bill Comparison Tool

## Testing done

Tested locally on Chrome

## Screenshots

![image](https://user-images.githubusercontent.com/786704/48033752-692c3a80-e111-11e8-83bd-2e131cd26db9.png)


## Acceptance criteria
- [x] Link text has been updated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
