### PR TITLE
Update 526 intro page content

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
@@ -112,12 +112,12 @@ class IntroductionPage extends React.Component {
               </div>
               <ul>
                 <li>
-                  VA medical and hospital records you may have that show your
-                  rated disability has gotten worse
+                  VA medical and hospital records that show your rated
+                  disability has gotten worse
                 </li>
                 <li>
-                  Private medical and hospital records you may have that show
-                  your rated disability has gotten worse
+                  Private medical and hospital records that show your rated
+                  disability has gotten worse
                 </li>
                 <li>
                   Supporting or lay statements from family, friends, or


### PR DESCRIPTION
## Description
Removes "you may have" from the 526 MVP intro page.

## Testing done
Manually checked that the content changed appropriately.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/48035438-be1f7f00-e118-11e8-9a2c-bf44703e731a.png)


## Acceptance criteria
- [x] The content is updated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
