### PR TITLE
Strip highlight characters for GA event

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -224,6 +224,7 @@ class SearchApp extends React.Component {
 
   /* eslint-disable react/no-danger */
   renderWebResult(result, snippetKey = 'snippet', isBestBet = false) {
+    const strippedTitle = formatResponseString(result.title, true);
     return (
       <li key={result.url} className="result-item">
         <a
@@ -234,14 +235,14 @@ class SearchApp extends React.Component {
               ? () =>
                   recordEvent({
                     event: 'nav-searchresults',
-                    'nav-path': `Recommended Results -> ${result.title}`,
+                    'nav-path': `Recommended Results -> ${strippedTitle}`,
                   })
               : null
           }
         >
           <h5
             dangerouslySetInnerHTML={{
-              __html: formatResponseString(result.title, true),
+              __html: strippedTitle,
             }}
           />
         </a>


### PR DESCRIPTION
## Description
When implementing the solution for [this issue](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14466) I didn't strip the highlighting characters out of the event string. This PR fixes that.

## Testing done
Testing in browser and ensure the result title is used correctly in GA event fire and header.

## Acceptance criteria
- [x] GA Event uses correct string (without highlighting characters)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
