### PR TITLE
[HOLD] Build Vets.gov Prod as redirects to VA.gov

### DIFF
--- a/script/options.js
+++ b/script/options.js
@@ -40,9 +40,14 @@ function gatherFromCommandLine() {
 }
 
 function applyDeprecatedBuildtypes(options) {
-  const deprecatedEnvironments = [environments.DEVELOPMENT];
+  // All Vets.gov environments generate redirects to VA.gov
+  const deprecatedEnvironments = new Set([
+    environments.DEVELOPMENT,
+    environments.STAGING,
+    environments.PRODUCTION,
+  ]);
 
-  const isDeprecated = deprecatedEnvironments.includes(options.buildtype);
+  const isDeprecated = deprecatedEnvironments.has(options.buildtype);
   if (isDeprecated) {
     options['vets-gov-to-va-gov'] = true;
     options['brand-consolidation-enabled'] = true;


### PR DESCRIPTION
## Description
This pull request builds all Vets.gov environments as redirects to the Brand-Consolidated VA.gov. This is on hold until launch day, November 7th.

Per our [launch checklist](https://github.com/department-of-veterans-affairs/va.gov-team/blob/7497cf15050a21bbc6e231c455d303967c28926e/Rollout/launch%20checklist.md#500-pm-et-launch-initiated), this will be merged by @wyattwalter at 5:00 PM ET.

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14871

## Testing done
- `NODE_ENV=production npm run build -- --buildtype=production`
- `node_modules/http-server/bin/http-server build/production`
- Navigated to `localhost:8080` and confirmed I'm redirected to `www.va.gov`.

## Acceptance criteria
- [ ] Vets.gov prod builds as redirects to VA.gov

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
