### PR TITLE
14853-facility-breadcrumb-url

### DIFF
--- a/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
+++ b/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
@@ -10,6 +10,9 @@ import { ccLocatorEnabled } from '../config';
 import appendQuery from 'append-query';
 
 class FacilityLocatorApp extends React.Component {
+  // TODO: Move this logic into a shared helper so it can be 
+  // reused on VAMap.jsx and other places we want to build
+  // complex URL strings.
   buildSearchString() {
     const {
       currentPage: page,

--- a/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
+++ b/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
@@ -11,14 +11,34 @@ import appendQuery from 'append-query';
 
 class FacilityLocatorApp extends React.Component {
   buildSearchString() {
-    const searchQueryUrl = appendQuery('/', this.props.location.query);
+    const {
+      currentPage: page,
+      context,
+      facilityType,
+      position: location,
+      searchString: address,
+      serviceType,
+      zoomLevel,
+    } = this.props.searchQuery;
+    
+    const searchQuery = {
+      zoomLevel,
+      page,
+      address,
+      location: `${location.latitude},${location.longitude}`,
+      context,
+      facilityType,
+      serviceType,
+    };
+
+    const searchQueryUrl = appendQuery('/', searchQuery);
     return searchQueryUrl;
   }
 
   renderBreadcrumbs(location, selectedResult) {
     const crumbs = [
       <a href="/" key="home">Home</a>,
-      <Link to={this.buildSearchString()}key="facility-locator">Find Facilities & Services</Link>,
+      <Link to={this.buildSearchString()} key="facility-locator">Find Facilities & Services</Link>,
     ];
 
     if (location.pathname.match(/facility\/[a-z]+_\d/) && selectedResult) {
@@ -55,6 +75,7 @@ class FacilityLocatorApp extends React.Component {
 function mapStateToProps(state) {
   return {
     selectedResult: state.searchResult.selectedResult,
+    searchQuery: state.searchQuery,
   };
 }
 

--- a/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
+++ b/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
@@ -1,29 +1,24 @@
 /* eslint-disable prettier/prettier */
 import { connect } from 'react-redux';
-import { Link, browserHistory } from 'react-router';
+import { Link } from 'react-router';
 import React from 'react';
 import DowntimeNotification, {
   externalServices,
 } from '../../../platform/monitoring/DowntimeNotification';
 import Breadcrumbs from '@department-of-veterans-affairs/formation/Breadcrumbs';
 import { ccLocatorEnabled } from '../config';
-
-/**
- * Preserves the search form in the UI & address bar when
- * navigating back to the search/map page.
- *
- * @param {Object} e The click event
- */
-const goBackHistory = (e) => {
-  e.preventDefault();
-  browserHistory.goBack();
-};
+import appendQuery from 'append-query';
 
 class FacilityLocatorApp extends React.Component {
+  buildSearchString() {
+    const searchQueryUrl = appendQuery('/', this.props.location.query);
+    return searchQueryUrl;
+  }
+
   renderBreadcrumbs(location, selectedResult) {
     const crumbs = [
       <a href="/" key="home">Home</a>,
-      <Link onClick={goBackHistory} key="facility-locator">Find Facilities & Services</Link>
+      <Link to={this.buildSearchString()}key="facility-locator">Find Facilities & Services</Link>,
     ];
 
     if (location.pathname.match(/facility\/[a-z]+_\d/) && selectedResult) {


### PR DESCRIPTION
## Description
@mnorthuis Alerted me to this issue, that the Facilities Locator breadcrumb was not working the same as it previously had.

Rewriting the Find Facilities & Services breadcrumb link to remove the History API, and insert a `to` prop on the `<Link />` component. This change is meant to accomplish three things:

1. Remember local state when users click the `Find Facilities & Services` breadcrumb from a detail page
2. Remember the search parameters across route changes
3. Restore the keyboard focusability of the link. Previously the HREF attribute was not being rendered, and thus causing the link to be removed from the tab order and screen reader Links menus.

## Original Issue
* https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14853

## Testing done
1. Ran axe-core current on the `localhost` build to ensure no errors
2. Tested keyboard focus and use with the `ENTER` keypress
3. Verified the browser back button works and remembers local state
4. Ran automated test suites to ensure no breaks
5. Tested with MacOS + Safari + VoiceOver for screen reader usability. Will test with NVDA and JAWS in staging before verifying and closing.

## Screenshots
![screen shot 2018-11-06 at 10 40 20 am](https://user-images.githubusercontent.com/934879/48079259-a09df400-e1b0-11e8-822c-d5753bb6e9de.png)

---
![screen shot 2018-11-06 at 10 40 53 am](https://user-images.githubusercontent.com/934879/48079489-13a76a80-e1b1-11e8-916c-19c538fb0ea8.png)



## Acceptance criteria
- [x] Keyboard access and usability is restored
- [x] Back button works on browser
- [x] Fully qualified URL is remembered across route changes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
