### PR TITLE
Process the proxy-rewrite bundle during pre-archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,3 +337,4 @@ disabled by the feature flag.
   - [Schemaform Walkthrough](docs/schemaform/walkthrough.md)
   - [Form Config](docs/schemaform/form-config.md)
 
+ This is just a test

--- a/README.md
+++ b/README.md
@@ -337,4 +337,3 @@ disabled by the feature flag.
   - [Schemaform Walkthrough](docs/schemaform/walkthrough.md)
   - [Form Config](docs/schemaform/form-config.md)
 
- This is just a test

--- a/script/pre-archive/link-assets-to-bucket.js
+++ b/script/pre-archive/link-assets-to-bucket.js
@@ -62,7 +62,7 @@ function linkAssetsToBucket(options, fileNames) {
   }
 
   const cssFileNames = fileNames.filter(file => path.extname(file) === '.css');
-  const cssUrlRegex = new RegExp(/url\(\//, 'g');
+  const cssUrlRegex = new RegExp(/url\(\/(?!(va_files))/, 'g');
   const cssUrlBucket = `url(${bucketPath}/`;
 
   for (const cssFileName of cssFileNames) {

--- a/script/pre-archive/link-assets-to-bucket.js
+++ b/script/pre-archive/link-assets-to-bucket.js
@@ -12,6 +12,8 @@ const jsdom = require('jsdom');
 const path = require('path');
 const buckets = require('../constants/buckets');
 
+const TEAMSITE_PATH = 'va_files';
+
 function linkAssetsToBucket(options, fileNames) {
   const bucketPath = buckets[options.buildtype];
 
@@ -46,7 +48,7 @@ function linkAssetsToBucket(options, fileNames) {
 
       if (!assetSrc) continue;
       if (assetSrc.startsWith('http') || assetSrc.startsWith('data:')) continue;
-      if (assetSrc.includes('va_files')) continue;
+      if (assetSrc.includes(TEAMSITE_PATH)) continue;
 
       const assetBucketLocation = `${bucketPath}${assetSrc}`;
 

--- a/script/pre-archive/link-assets-to-bucket.js
+++ b/script/pre-archive/link-assets-to-bucket.js
@@ -12,7 +12,7 @@ const jsdom = require('jsdom');
 const path = require('path');
 const buckets = require('../constants/buckets');
 
-const TEAMSITE_PATH = 'va_files';
+const TEAMSITE_ASSETS = 'va_files';
 
 function linkAssetsToBucket(options, fileNames) {
   const bucketPath = buckets[options.buildtype];
@@ -48,7 +48,7 @@ function linkAssetsToBucket(options, fileNames) {
 
       if (!assetSrc) continue;
       if (assetSrc.startsWith('http') || assetSrc.startsWith('data:')) continue;
-      if (assetSrc.includes(TEAMSITE_PATH)) continue;
+      if (assetSrc.includes(TEAMSITE_ASSETS)) continue;
 
       const assetBucketLocation = `${bucketPath}${assetSrc}`;
 

--- a/script/pre-archive/link-assets-to-bucket.js
+++ b/script/pre-archive/link-assets-to-bucket.js
@@ -46,6 +46,7 @@ function linkAssetsToBucket(options, fileNames) {
 
       if (!assetSrc) continue;
       if (assetSrc.startsWith('http') || assetSrc.startsWith('data:')) continue;
+      if (assetSrc.includes('va_files')) continue;
 
       const assetBucketLocation = `${bucketPath}${assetSrc}`;
 
@@ -70,6 +71,17 @@ function linkAssetsToBucket(options, fileNames) {
 
     fs.writeFileSync(cssFileName, newCss);
   }
+
+  // The proxy-rewrite is a special case.
+  const proxyRewriteFileName = fileNames.find(file =>
+    file.endsWith('proxy-rewrite.entry.js'),
+  );
+  const proxyRewriteContents = fs.readFileSync(proxyRewriteFileName);
+  const newProxyRewriteContents = proxyRewriteContents
+    .toString()
+    .replace(/https:\/\/www\.va\.gov\/img/g, `${bucketPath}/img`);
+
+  fs.writeFileSync(proxyRewriteFileName, newProxyRewriteContents);
 }
 
 module.exports = linkAssetsToBucket;


### PR DESCRIPTION
## Description
The `proxy-rewrite.js` includes hardcoded references to `www.va.gov`, because it's executed other different subdomains, and therefore needs the absolute path to certain assets. This addition to the pre-archive build step includes converts any of its references to `https://www.va.gov/img` to the S3 bucket of the corresponding build-type.

This PR also adds a filter to exclude TeamSite assets.

## Testing done
- `npm run build -- buildtype=vagovprod`
- `node script/pre-archive/index.js --buildtype=vagovprod`
- Checked the `build/vagovprod/generated/proxy-rewrite.entry.js`

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/48094734-ea063780-e1e0-11e8-8720-1ec77e331763.png)


## Acceptance criteria
- [ ] The proxy-rewrite loads assets out of the bucket, instead of under the domain.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
