### PR TITLE
Updates military info help content

### DIFF
--- a/src/applications/personalization/profile360/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile360/components/MilitaryInformation.jsx
@@ -99,7 +99,7 @@ class MilitaryInformationContent extends React.Component {
     return (
       <div>
         <AdditionalInfo
-          triggerText="How do I update my military service information?"
+          triggerText="What if my military service information doesn't look right?"
           onClick={() => {
             recordEvent({
               event: 'profile-navigation',
@@ -109,12 +109,10 @@ class MilitaryInformationContent extends React.Component {
           }}
         >
           <p>
-            You'll need to file a request to change or correct your DD214 or
-            other military records.
-            <br />
-            <a href="https://iris.custhelp.va.gov/app/answers/detail/a_id/478/~/amend-or-change-dd-214-or-other-military-records">
-              Find out how to request a change to your military records
-            </a>
+            Some Veterans have reported seeing military service information that
+            doesn't seem right. We're aware of this problem, and we're working
+            to fix it as soon as possible. Thank you for your patience, and we
+            apologize for this issue.
           </p>
         </AdditionalInfo>
         <LoadingSection


### PR DESCRIPTION
## Description

Right now, we are sending veterans to a link to fix military info, and call a phone number that has been, gulp, disconnected. We need to remove the broken link to iris, and put helper content in below:

This PR updates the message with the new content provided in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14889

## Testing done

Local testing

## Screenshots

#### After fix

![image](https://user-images.githubusercontent.com/7482329/48096738-3c415b80-e1d5-11e8-8426-d753a8671fa9.png)


## Acceptance criteria
- [x] Updates content (add new content under dropdown and remove IRIS link)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
