### PR TITLE
Remove external link icons from hub pages

### DIFF
--- a/va-gov/components/hub-page-link-list.html
+++ b/va-gov/components/hub-page-link-list.html
@@ -24,14 +24,10 @@ each link
   <ul id="{{ hublink.id }}" class="hub-page-link-list">
   {% for link in hublink.links %}
     <li class="hub-page-link-list__item">
-        <a href="{{ link.url }}" {% if link.external %} class="no-external-icon" {% endif %} {% if link.target %} target="{{ link.target }}" {% endif %} />
+        <a href="{{ link.url }}" class="no-external-icon" {% if link.target %} target="{{ link.target }}" {% endif %} />
         <span class="hub-page-link-list__header">
          {{ link.label }}
-          {% if link.external %}
-            <i class="external-link-icon-black"></i>
-          {% else %}
-            <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow" /> 
-          {% endif %}
+          <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow" />
         </span>
         <p class="hub-page-link-list__description">
         {{ link.description }}


### PR DESCRIPTION
## Description
Found external link icons on hub pages, edited the template to get them all in line

## Testing done
Local testing, VRT

## Screenshots