### PR TITLE
Pass setFocus in when defining cta widgets on content pages

### DIFF
--- a/src/applications/static-pages/createCallToActionWidget.js
+++ b/src/applications/static-pages/createCallToActionWidget.js
@@ -10,10 +10,15 @@ export default async function createCallToActionWidget(store) {
       default: CallToActionWidget,
     } = await import(/* webpackChunkName: "cta-widget" */ '../../platform/site-wide/cta-widget');
 
+    // since these widgets are on content pages, we don't want to focus on them
     widgets.forEach((el, index) => {
       ReactDOM.render(
         <Provider store={store}>
-          <CallToActionWidget appId={el.dataset.appId} index={index} />
+          <CallToActionWidget
+            appId={el.dataset.appId}
+            index={index}
+            setFocus={false}
+          />
         </Provider>,
         el,
       );

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -414,9 +414,13 @@ export class CallToActionWidget extends React.Component {
   };
 
   render() {
+    const { setFocus } = this.props;
     if (this.props.profile.loading || this.props.mhvAccount.loading) {
       return (
-        <LoadingIndicator setFocus message="Loading your information..." />
+        <LoadingIndicator
+          setFocus={setFocus}
+          message="Loading your information..."
+        />
       );
     }
 
@@ -439,6 +443,9 @@ export class CallToActionWidget extends React.Component {
     );
   }
 }
+CallToActionWidget.defaultProps = {
+  setFocus: true,
+};
 
 const mapStateToProps = state => {
   const profile = selectProfile(state);


### PR DESCRIPTION
## Description
Content pages that were loading cta widgets would often have them well before the fold, when that page loaded, it would jump down and create a jarring user experience, this makes it so that the loading indicator is not focused on page load and clears a myriad of tickets.

Besides the linked zenhub one, also closes: https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/14321

## Testing done
Local testing

## Screenshots
n/a

## Acceptance criteria
- [ ] pages dont' jump, old tools still focus properly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
