### PR TITLE
Added "File for Increased Disability" link to sidebar in disability

### DIFF
--- a/va-gov/pages/disability/file-for-increased.md
+++ b/va-gov/pages/disability/file-for-increased.md
@@ -1,0 +1,7 @@
+---
+title: File for Increased Disability
+href: /disability-benefits/apply/form-526-disability-claim/introduction
+order: 2
+spoke: Manage Benefits
+private: true
+---


### PR DESCRIPTION
## Description

Added "File for Increased Disability"  as second option in the left nav, just below Check Claim or Appeal Status.  

It should link to: https://preview.va.gov/disability-benefits/apply/form-526-disability-claim/introduction

![image.png](https://images.zenhubusercontent.com/59ca6a73b0222d5de4792f1d/8c0e31ec-f17b-4076-853b-0db4c79490e8)

## Testing done

Tested locally on Chrome

## Screenshots

![image](https://user-images.githubusercontent.com/786704/48152352-7e6fa900-e278-11e8-82ff-4e1a2fe41ca7.png)

## Acceptance criteria
- [x] "File for Increased Disability"  should be second option in the left nav, just below Check Claim or Appeal Status.  

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
