### PR TITLE
Manage tab focus properly on claims and appeals tracker

### DIFF
--- a/src/applications/claims-status/containers/AppealInfo.jsx
+++ b/src/applications/claims-status/containers/AppealInfo.jsx
@@ -12,6 +12,7 @@ import { getAppealsV2 } from '../actions/index.jsx';
 import AppealHeader from '../components/appeals-v2/AppealHeader';
 import AppealsV2TabNav from '../components/appeals-v2/AppealsV2TabNav';
 import AppealHelpSidebar from '../components/appeals-v2/AppealHelpSidebar';
+import { setUpPage, scrollToTop } from '../utils/page';
 
 import {
   EVENT_TYPES,
@@ -65,6 +66,11 @@ export class AppealInfo extends React.Component {
   componentDidMount() {
     if (!this.props.appeal) {
       this.props.getAppealsV2();
+    }
+    if (!this.props.appealsLoading) {
+      setUpPage();
+    } else {
+      scrollToTop();
     }
   }
 

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -68,6 +68,7 @@ class YourClaimsPageV2 extends React.Component {
     if (!this.props.loading && prevProps.loading) {
       setPageFocus();
     }
+    setPageFocus();
   }
 
   changePage(page) {
@@ -184,7 +185,6 @@ class YourClaimsPageV2 extends React.Component {
       } else if (!this.props.canAccessClaims && bothRequestsLoaded) {
         content = <NoClaims />;
       }
-
       content = <div className="va-tab-content">{content}</div>;
     }
 

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -64,10 +64,7 @@ class YourClaimsPageV2 extends React.Component {
   // an initial sort needs to happen in componentDidMount
   // }
 
-  componentDidUpdate(prevProps) {
-    if (!this.props.loading && prevProps.loading) {
-      setPageFocus();
-    }
+  componentDidUpdate() {
     setPageFocus();
   }
 


### PR DESCRIPTION
## Description
The Track Claims and Appeals application is doing client-side routing, and is not actively managing focus when new views mount. This leaves keyboard and screen reader users to orient themselves, without a clear understanding of which element has focus on first "load".  See [attached issue](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14488)

**This PR fixes a bug that would reset tab focus to the main `<body>` tag after claims component updated**

## Testing done
- Tested with keyboard that tab focus order works as expected, focusing on the breadcrumb menu. 
- Tested with ChromeVox that content is read to me when loaded. 

## Screenshots
Here's a cast of me navigating via the keyboard

![screencast-localhost-3001-2018 11 07-13-45-23](https://user-images.githubusercontent.com/11085141/48157128-7291e000-e294-11e8-9e00-aef2e158a6a0.gif)


## Acceptance criteria
- [x] As a keyboard user, I want to have a clear understanding of where focus is when the Claims and Appeals pages first load. I want to press TAB once and start tabbing through the breadcrumb menu.
- [x] I want the focus to be set consistently when the application first loads, and when I move through pages, whether that's by clicking links, pressing the Back button, or clicking on the breadcrumb menu links.
- [x] As a screenreader user, I want the same things as the keyboard user, and I want the content to be read to me when it is loaded on the page. This is my primary cue for new content on screen.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
