### PR TITLE
Remove noEvidence helper text and related schema

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/evidenceTypes.jsx
+++ b/src/applications/disability-benefits/all-claims/content/evidenceTypes.jsx
@@ -28,22 +28,3 @@ export const evidenceTypeHelp = (
     </p>
   </AdditionalInfo>
 );
-
-export const noEvidenceDescription = (
-  <AlertBox status="info" isVisible>
-    <div>
-      <p>
-        <strong>Please note:</strong> You don’t have to submit evidence for your
-        claim, but we recommend that you do provide some supporting information
-        related to your claimed disability. If you don’t submit any evidence we
-        may schedule a claim exam for you to help us decide your claim.
-      </p>
-      <p>
-        You have up to 1 year from the date we receive your claim to turn in any
-        evidence. If you don’t have supporting evidence right now, you can save
-        your application and return to it later when your evidence is ready to
-        upload.
-      </p>
-    </div>
-  </AlertBox>
-);

--- a/src/applications/disability-benefits/all-claims/content/evidenceTypes.jsx
+++ b/src/applications/disability-benefits/all-claims/content/evidenceTypes.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation/AdditionalInfo';
-import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
 export const evidenceTypeHelp = (
   <AdditionalInfo triggerText="Which evidence type should I choose?">

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
@@ -2,10 +2,7 @@ import { validateBooleanGroup } from 'us-forms-system/lib/js/validation';
 import { validateIfHasEvidence } from '../validations';
 import get from '../../../../platform/utilities/data/get';
 
-import {
-  evidenceTypeHelp,
-  noEvidenceDescription,
-} from '../content/evidenceTypes';
+import { evidenceTypeHelp } from '../content/evidenceTypes';
 
 export const uiSchema = {
   'view:hasEvidence': {
@@ -45,14 +42,6 @@ export const uiSchema = {
       'ui:description': evidenceTypeHelp,
     },
   },
-  'view:noEvidenceFollowUp': {
-    'ui:title': ' ',
-    'ui:description': noEvidenceDescription,
-    'ui:options': {
-      expandUnder: 'view:hasEvidence',
-      expandUnderCondition: false,
-    },
-  },
 };
 
 export const schema = {
@@ -79,10 +68,6 @@ export const schema = {
           properties: {},
         },
       },
-    },
-    'view:noEvidenceFollowUp': {
-      type: 'object',
-      properties: {},
     },
   },
 };


### PR DESCRIPTION
## Description
Removes the helper text that used to show up when a veteran indicated that they don't have evidence to submit with their 526 All Claims form.

## Testing done
- Tested locally
- Passed existing unit tests

## Screenshots
![screen shot 2018-11-07 at 2 45 58 pm](https://user-images.githubusercontent.com/24251447/48161449-2cdb1480-e2a0-11e8-9a14-2a8d451ed303.png)



## Acceptance criteria
- [x] Helper text does not show 'no evidence' option selected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
