### PR TITLE
Add "www" into OIG link in footer

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -210,7 +210,7 @@
   },
   {
     "column": "bottom_rail",
-    "href": "https://va.gov/oig/",
+    "href": "https://www.va.gov/oig/",
     "order": 2,
     "target": null,
     "title": "Office of Inspector General"


### PR DESCRIPTION
## Description
Not having the "www" on this link causes some issues on the VA network.

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14967

## Acceptance criteria
- [x] The OIG link has "www" in it

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
