### PR TITLE
Link GIB status error page back to GIB page

### DIFF
--- a/src/applications/post-911-gib-status/utils/helpers.jsx
+++ b/src/applications/post-911-gib-status/utils/helpers.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router';
 import { formatDateParsedZoneLong } from '../../../platform/utilities/date';
 import isBrandConsolidationEnabled from '../../../platform/brand-consolidation/feature-flag';
 import CallHRC from '../../../platform/brand-consolidation/components/CallHRC';
@@ -217,9 +218,9 @@ export function backendErrorMessage() {
             through Friday, 8:00 a.m. to 8:00 p.m. (ET).
           </CallHRC>
         </p>
-        <a className="usa-button usa-button-primary">
+        <Link className="usa-button usa-button-primary" to="/">
           Back to Post-9/11 GI Bill
-        </a>
+        </Link>
         <br />
         <br />
         <br />


### PR DESCRIPTION
## Description
The Back to Post-9/11 Bill CTA button on the GIB Error page was not linked to the "home" of the GIBS app

## Testing done
Local testing

## Screenshots
![gibs-link](https://user-images.githubusercontent.com/20728956/48205477-25a81b00-e321-11e8-8c25-c8a8796cd5db.gif)

## Acceptance criteria
- [x] The button is functional and links to the root of the GIBS app.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs