### PR TITLE
Add uppercase health redirects and fix cem redirect

### DIFF
--- a/script/vagovRedirects.json
+++ b/script/vagovRedirects.json
@@ -63,5 +63,70 @@
     "domain": "www.va.gov",
     "src": "/healthbenefits/apply/",
     "dest": "/health-care/how-to-apply/"
+  },
+  {
+    "domain": "www.va.gov",
+    "src": "/HEALTHBENEFITS/index.asp",
+    "dest": "/health-care/"
+  },
+  {
+    "domain": "www.va.gov",
+    "src": "/HEALTHBENEFITS/access/medical_benefits_package.asp",
+    "dest": "/health-care/about-va-health-benefits/"
+  },
+  {
+    "domain": "www.va.gov",
+    "src": "/HEALTHBENEFITS/cost/insurance.asp",
+    "dest": "/health-care/about-va-health-benefits/va-health-care-and-other-insurance/"
+  },
+  {
+    "domain": "www.va.gov",
+    "src": "/HEALTHBENEFITS/access/geriatrics.asp",
+    "dest": "/health-care/about-va-health-benefits/long-term-care/"
+  },
+  {
+    "domain": "www.va.gov",
+    "src": "/HEALTHBENEFITS/access/home_health_care.asp",
+    "dest": "/health-care/about-va-health-benefits/long-term-care/"
+  },
+  {
+    "domain": "www.va.gov",
+    "src": "/HEALTHBENEFITS/apply/veterans.asp",
+    "dest": "/health-care/eligibility/"
+  },
+  {
+    "domain": "www.va.gov",
+    "src": "/HEALTHBENEFITS/apply/index.asp",
+    "dest": "/health-care/how-to-apply/"
+  },
+  {
+    "domain": "www.va.gov",
+    "src": "/HEALTHBENEFITS/apply/application_process.asp",
+    "dest": "/health-care/how-to-apply/"
+  },
+  {
+    "domain": "www.va.gov",
+    "src": "/HEALTHBENEFITS/apply/family_members.asp",
+    "dest": "/health-care/family-caregiver-benefits/"
+  },
+  {
+    "domain": "www.va.gov",
+    "src": "/HEALTHBENEFITS/access/prescriptions.asp",
+    "dest": "/health-care/refill-track-prescriptions/"
+  },
+  {
+    "domain": "www.va.gov",
+    "src": "/HEALTHBENEFITS/apply/women_veterans.asp",
+    "dest": "/health-care/health-needs-conditions/womens-health-needs/"
+  },
+  {
+    "domain": "www.va.gov",
+    "src": "/HEALTHBENEFITS/",
+    "dest": "/health-care/"
+  },
+  {
+    "domain": "www.va.gov",
+    "src": "/HEALTHBENEFITS/apply/",
+    "dest": "/health-care/how-to-apply/"
   }
 ]

--- a/script/vets-gov-to-va-gov/index.js
+++ b/script/vets-gov-to-va-gov/index.js
@@ -42,7 +42,7 @@ function generateRedirectedPages(BUILD_OPTIONS) {
 
     const htmlFileName = path.join(htmlDirectory, 'index.html');
     let htmlFileContents = null;
-    let vaGovFullPath;
+    let vaGovFullPath = vaGovDest;
 
     if (!vaGovDest.startsWith('http'))
       vaGovFullPath = `https://${vaGovHostDestination}/${vaGovDest}`;


### PR DESCRIPTION
## Description
Some VA.gov health pages have an upper case url segment, this adds them to our list because we can't do a case insensitive comparison here

## Testing done
Tested locally

## Acceptance criteria
- [x] Redirects happen correctly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
