### PR TITLE
Remove body text for redirect

### DIFF
--- a/script/create-redirects.js
+++ b/script/create-redirects.js
@@ -13,7 +13,6 @@ function getRedirectPage(redirectToPath) {
       <title>Page Moved</title>
     </head>
     <body>
-      New location: <a href="${absolutePath}">${absolutePath}</a>
     </body>`;
 }
 


### PR DESCRIPTION
## Description
Remove the body text for redirects so people don't notice the interstitial.

## Acceptance criteria
- [x] Body text is gone

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
