### PR TITLE
Fix bad vic link

### DIFF
--- a/src/applications/personalization/dashboard/components/AuthApplicationSection.jsx
+++ b/src/applications/personalization/dashboard/components/AuthApplicationSection.jsx
@@ -36,7 +36,9 @@ class AuthApplicationSection extends React.Component {
               </a>
             </p>
             <p key="vic">
-              <a href="/veteran-id-card">Apply for a Veteran ID Card</a>
+              <a href="/records/get-veteran-id-cards">
+                Apply for a Veteran ID Card
+              </a>
             </p>
             <p>
               <strong>Have a less than honorable discharge?</strong>


### PR DESCRIPTION
## Description
We appear to have missed this in our aliases, but rather than add it there, I'm just going to fix on the one bad link we have.

## Acceptance criteria
- [x] Uses vic url from mapping sheet

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
