### PR TITLE
All claims remove unit details mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -724,6 +724,7 @@ const schema = {
         },
         reservesNationalGuardService: {
           type: 'object',
+          required: ['unitName', 'obligationTermOfServiceDateRange'],
           properties: {
             unitName: {
               type: 'string',

--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -724,22 +724,11 @@ const schema = {
         },
         reservesNationalGuardService: {
           type: 'object',
-          required: [
-            'unitName',
-            'obligationTermOfServiceDateRange',
-            'waiveVABenefitsToRetainTrainingPay',
-          ],
           properties: {
             unitName: {
               type: 'string',
               maxLength: 256,
               pattern: "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$",
-            },
-            unitAddress: {
-              $ref: '#/definitions/address',
-            },
-            unitPhone: {
-              $ref: '#/definitions/phone',
             },
             obligationTermOfServiceDateRange: {
               $ref: '#/definitions/dateRangeAllRequired',

--- a/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
@@ -3,9 +3,9 @@ import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import { ReservesGuardDescription } from '../utils';
 
 const {
-  unitName,
-  obligationTermOfServiceDateRange,
-} = fullSchema.properties.serviceInformation.properties.reservesNationalGuardService.properties;
+  properties: { unitName, obligationTermOfServiceDateRange },
+  required,
+} = fullSchema.properties.serviceInformation.properties.reservesNationalGuardService;
 
 export const uiSchema = {
   'ui:title': 'Reserves and National Guard Information',
@@ -32,7 +32,7 @@ export const schema = {
       properties: {
         reservesNationalGuardService: {
           type: 'object',
-          required: ['obligationTermOfServiceDateRange', 'unitName'],
+          required,
           properties: {
             obligationTermOfServiceDateRange,
             unitName,

--- a/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
@@ -1,82 +1,8 @@
-import { get } from 'lodash';
-
 import fullSchema from '../config/schema';
-
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
-import phoneUI from 'us-forms-system/lib/js/definitions/phone';
-
 import { ReservesGuardDescription } from '../utils';
 
-import {
-  MILITARY_CITIES,
-  MILITARY_STATE_LABELS,
-  MILITARY_STATE_VALUES,
-  STATE_LABELS,
-  STATE_VALUES,
-  USA,
-} from '../constants';
-
-function validateMilitaryCity(errors, city, formData) {
-  const isMilitaryState = MILITARY_STATE_VALUES.includes(
-    formData.serviceInformation.reservesNationalGuardService.unitAddress
-      .state || '',
-  );
-  const isMilitaryCity = MILITARY_CITIES.includes(city.trim().toUpperCase());
-  if (isMilitaryState && !isMilitaryCity) {
-    errors.addError(
-      'City must match APO, DPO, or FPO when using a military state code',
-    );
-  }
-}
-
-function validateMilitaryState(errors, state, formData) {
-  const isMilitaryCity = MILITARY_CITIES.includes(
-    formData.serviceInformation.reservesNationalGuardService.unitAddress.city
-      .trim()
-      .toUpperCase(),
-  );
-  const isMilitaryState = MILITARY_STATE_VALUES.includes(state);
-  if (isMilitaryCity && !isMilitaryState) {
-    errors.addError('State must be AA, AE, or AP when using a military city');
-  }
-}
-
-function isValidZIP(value) {
-  if (value !== null) {
-    return /^\d{5}(?:(?:[-\s])?\d{4})?$/.test(value);
-  }
-  return true;
-}
-
-function validateZIP(errors, zip) {
-  if (zip && !isValidZIP(zip)) {
-    errors.addError('Please enter a valid 9 digit ZIP (dashes allowed)');
-  }
-}
-
-const updateStates = form => {
-  const currentCity = get(
-    form,
-    'serviceInformation.reservesNationalGuardService.unitAddress.city',
-    '',
-  )
-    .trim()
-    .toUpperCase();
-  if (MILITARY_CITIES.includes(currentCity)) {
-    return {
-      enum: MILITARY_STATE_VALUES,
-      enumNames: MILITARY_STATE_LABELS,
-    };
-  }
-
-  return {
-    enum: STATE_VALUES,
-    enumNames: STATE_LABELS,
-  };
-};
 const {
-  unitPhone,
-  unitAddress,
   unitName,
   obligationTermOfServiceDateRange,
 } = fullSchema.properties.serviceInformation.properties.reservesNationalGuardService.properties;
@@ -94,81 +20,6 @@ export const uiSchema = {
       unitName: {
         'ui:title': 'Unit name',
       },
-      unitAddress: {
-        'ui:title': 'Unit address',
-        'ui:order': [
-          'country',
-          'addressLine1',
-          'addressLine2',
-          'addressLine3',
-          'city',
-          'state',
-          'zipCode',
-        ],
-        country: {
-          'ui:title': 'Country',
-        },
-        addressLine1: {
-          'ui:title': 'Street address',
-        },
-        addressLine2: {
-          'ui:title': 'Street address (optional)',
-        },
-        addressLine3: {
-          'ui:title': 'Street address (optional)',
-        },
-        city: {
-          'ui:title': 'City',
-          'ui:validations': [validateMilitaryCity],
-        },
-        state: {
-          'ui:title': 'State',
-          'ui:required': formData =>
-            get(
-              formData,
-              'serviceInformation.reservesNationalGuardService.unitAddress.country',
-              USA,
-            ) === USA,
-          'ui:options': {
-            hideIf: formData =>
-              get(
-                formData,
-                'serviceInformation.reservesNationalGuardService.unitAddress.country',
-                USA,
-              ) !== USA,
-            updateSchema: updateStates,
-          },
-          'ui:validations': [
-            {
-              validator: validateMilitaryState,
-            },
-          ],
-        },
-        zipCode: {
-          'ui:title': 'ZIP code',
-          'ui:validations': [validateZIP],
-          'ui:required': formData =>
-            get(
-              formData,
-              'serviceInformation.reservesNationalGuardService.unitAddress.country',
-              USA,
-            ) === USA,
-          'ui:errorMessages': {
-            pattern:
-              'Please enter a valid 5- or 9-digit ZIP code (dashes allowed)',
-          },
-          'ui:options': {
-            widgetClassNames: 'va-input-medium-large',
-            hideIf: formData =>
-              get(
-                formData,
-                'serviceInformation.reservesNationalGuardService.unitAddress.country',
-                USA,
-              ) !== USA,
-          },
-        },
-      },
-      unitPhone: phoneUI('Unit phone number'),
     },
   },
 };
@@ -181,11 +32,10 @@ export const schema = {
       properties: {
         reservesNationalGuardService: {
           type: 'object',
+          required: ['obligationTermOfServiceDateRange', 'unitName'],
           properties: {
             obligationTermOfServiceDateRange,
             unitName,
-            unitAddress,
-            unitPhone,
           },
         },
       },

--- a/src/applications/disability-benefits/all-claims/tests/pages/reservesNationalGuardService.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/reservesNationalGuardService.unit.spec.jsx
@@ -26,8 +26,8 @@ describe('Reserve information', () => {
       />,
     );
 
-    expect(form.find('input').length).to.equal(9);
-    expect(form.find('select').length).to.equal(6);
+    expect(form.find('input').length).to.equal(3);
+    expect(form.find('select').length).to.equal(4);
   });
 
   it('should fail to submit when no data is filled out', () => {
@@ -44,7 +44,7 @@ describe('Reserve information', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(6);
+    expect(form.find('.usa-input-error-message').length).to.equal(3);
     expect(onSubmit.called).to.be.false;
   });
 
@@ -75,31 +75,6 @@ describe('Reserve information', () => {
       form,
       'input#root_serviceInformation_reservesNationalGuardService_unitName',
       'Unit',
-    );
-    fillData(
-      form,
-      'input#root_serviceInformation_reservesNationalGuardService_unitPhone',
-      '5555555555',
-    );
-    fillData(
-      form,
-      'input#root_serviceInformation_reservesNationalGuardService_unitAddress_addressLine1',
-      '123 1st st',
-    );
-    fillData(
-      form,
-      'input#root_serviceInformation_reservesNationalGuardService_unitAddress_city',
-      'boston',
-    );
-    fillData(
-      form,
-      'select#root_serviceInformation_reservesNationalGuardService_unitAddress_state',
-      'MA',
-    );
-    fillData(
-      form,
-      'input#root_serviceInformation_reservesNationalGuardService_unitAddress_zipCode',
-      '33333',
     );
 
     form.find('form').simulate('submit');


### PR DESCRIPTION
## Description
Removes unit address & unit phone from reserves All Claims form page.

## Testing done
- Tested locally
- Updated unit tests

## Screenshots
<img width="729" alt="screen shot 2018-11-08 at 10 17 18 am" src="https://user-images.githubusercontent.com/24251447/48214737-38811680-e346-11e8-8eac-ab54fc4cd838.png">


## Acceptance criteria
- [x] Phone and address removed from reserves page
- [x] obligation dates and unit name required

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
