### PR TITLE
Refactor claim timeline phase header to be a11y friendly

### DIFF
--- a/src/applications/claims-status/components/ClaimPhase.jsx
+++ b/src/applications/claims-status/components/ClaimPhase.jsx
@@ -169,6 +169,7 @@ export default class ClaimPhase extends React.Component {
     const expandCollapseIcon =
       phase <= current && phase !== COMPLETE_PHASE ? (
         <i
+          aria-hidden="true"
           className={
             this.state.open
               ? 'fa fa-minus claim-timeline-icon'
@@ -184,7 +185,11 @@ export default class ClaimPhase extends React.Component {
         className={`${getClasses(phase, current)}`}
       >
         {expandCollapseIcon}
-        <h5 className="section-header">{getUserPhaseDescription(phase)}</h5>
+        <h5 className="section-header">
+          <button aria-expanded={this.state.open}>
+            {getUserPhaseDescription(phase)}
+          </button>
+        </h5>
         {this.state.open || phase === COMPLETE_PHASE ? (
           <div>
             {children}

--- a/src/applications/claims-status/components/ClaimPhase.jsx
+++ b/src/applications/claims-status/components/ClaimPhase.jsx
@@ -186,7 +186,10 @@ export default class ClaimPhase extends React.Component {
       >
         {expandCollapseIcon}
         <h5 className="section-header">
-          <button aria-expanded={this.state.open}>
+          <button
+            className="section-header-button"
+            aria-expanded={this.state.open}
+          >
             {getUserPhaseDescription(phase)}
           </button>
         </h5>

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -569,7 +569,6 @@ h1:focus {
     margin: inherit;
     padding: inherit;
     z-index: inherit;
-
   }
 
   .section-header-button:focus {
@@ -603,7 +602,6 @@ h1:focus {
   > .section-complete:not(.last) {
     cursor: pointer;
   }
-
 }
 
 .usa-alert {

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -556,7 +556,7 @@ h1:focus {
 .claim-timeline {
   padding-top: 0;
 
-  h5 button {
+  .section-header-button {
     background: inherit;
     border: inherit;
     color: inherit;

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -569,9 +569,10 @@ h1:focus {
     margin: inherit;
     padding: inherit;
     z-index: inherit;
+
   }
 
-  h5 button:focus {
+  .section-header-button:focus {
     outline: 2px solid;
     outline-color: $color-gold-light;
     outline-offset: 0;

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -557,7 +557,18 @@ h1:focus {
   padding-top: 0;
 
   h5 button {
-    all: inherit;
+    background: inherit;
+    border: inherit;
+    color: inherit;
+    font-family: inherit;
+    font-size: inherit;
+    font-size-adjust: inherit;
+    font-style: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    margin: inherit;
+    padding: inherit;
+    z-index: inherit;
   }
 
   h5 button:focus {

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -556,6 +556,16 @@ h1:focus {
 .claim-timeline {
   padding-top: 0;
 
+  h5 button {
+    all: inherit;
+  }
+
+  h5 button:focus {
+    outline: 2px solid;
+    outline-color: $color-gold-light;
+    outline-offset: 0;
+  }
+
   .section-current > .section-header {
     color: $color-primary;
   }
@@ -581,6 +591,7 @@ h1:focus {
   > .section-complete:not(.last) {
     cursor: pointer;
   }
+
 }
 
 .usa-alert {

--- a/src/applications/claims-status/tests/components/ClaimPhase.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimPhase.unit.spec.jsx
@@ -109,7 +109,7 @@ describe('<ClaimPhase>', () => {
     const tree = SkinDeep.shallowRender(
       <ClaimPhase id="2" current={1} phase={1} activity={activity} />,
     );
-    expect(tree.everySubTree('button').length).to.equal(1);
+    expect(tree.everySubTree('button').length).to.equal(2);
   });
   describe('event descriptions', () => {
     const activity = {


### PR DESCRIPTION
## Description
The Status tab on Your Compensation Claims view has several expand/collapse accordions that are not keyboard focusable. The trigger elements are `<h5>`, instead of `<button>` and cannot receive keyboard focus as a result. See [issue](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14495) for screenshots/more details.

## Testing done
Manually verified navigation through the page works. 

Verified screenreader (ChromeVox on Chrome/Debian Linux) reads as expected. 

## Screenshots
This is a cast of me navigating through the status timeline page with keyboard, and using both `space` and `enter` keys to toggle the phase sections.

![screencast-localhost-3001-2018 11 08-12-01-02](https://user-images.githubusercontent.com/11085141/48217987-71bd8480-e34e-11e8-805f-e0510d0dc368.gif)

## Acceptance criteria
- [x] As a keyboard user, I want the expand/collapse + sign to be able to receive keyboard focus. This means it should be a <button> element.
- [x] I also want the trigger element to show the yellow :focus halo when it is the active element. A quick console document.activeElement should suffice to test for validity.
- [x] The trigger should toggle open and closed when I press SPACE or ENTER on the keyboard


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
