### PR TITLE
Remove close button for loa alert on dashboard

### DIFF
--- a/src/applications/personalization/dashboard/containers/DashboardApp.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardApp.jsx
@@ -244,7 +244,6 @@ class DashboardApp extends React.Component {
             </p>
           </div>
         }
-        onCloseAlert={this.dismissAlertBox('loa')}
         isVisible={
           this.state['show-loa-alert'] &&
           !localStorage.getItem('hide-loa-alert')


### PR DESCRIPTION
## Description
We do not want the user to be able to close the alert box for LOA id verification, based on [this conversation](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14434)/.

This PR removes the "close" icon, disallowing the user from closing the modal until the user is verified. 

## Testing done
Logged in with a new ID.me account and ensured this alert box does not have close icon. 
Logged in with verified ID.me account and ensured the alert box still does not show. 

## Screenshots
![2018-11-08-135009_844x722_scrot](https://user-images.githubusercontent.com/11085141/48223737-75a4d300-e35d-11e8-8f92-4150b8bd79d0.png)

## Acceptance criteria
- [x] As a user, I cannot remove the alert box until ID is verified.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
