### PR TITLE
Let redirects count as links for blc

### DIFF
--- a/script/build.js
+++ b/script/build.js
@@ -148,12 +148,12 @@ function defaultBuild(BUILD_OPTIONS) {
   smith.use(createBuildSettings(BUILD_OPTIONS));
 
   smith.use(updateExternalLinks(BUILD_OPTIONS));
-  smith.use(checkBrokenLinks(BUILD_OPTIONS));
 
   configureAssets(smith, BUILD_OPTIONS);
 
   smith.use(createSitemaps(BUILD_OPTIONS));
   smith.use(createRedirects(BUILD_OPTIONS));
+  smith.use(checkBrokenLinks(BUILD_OPTIONS));
   smith.use(moveRemove(BUILD_OPTIONS));
 
   /* eslint-disable no-console */

--- a/script/create-redirects.js
+++ b/script/create-redirects.js
@@ -52,13 +52,16 @@ function createRedirects(options) {
       };
 
       for (const alias of aliases) {
-        let absolutePath = path.join(options.destination, alias);
-        if (!path.extname(absolutePath))
-          absolutePath = path.join(absolutePath, 'index.html');
+        let finalPath;
+        if (alias.startsWith('/')) {
+          finalPath = alias.slice(1);
+        }
+        if (!path.extname(finalPath))
+          finalPath = path.join(finalPath, 'index.html');
 
-        files[absolutePath] = {
+        files[finalPath] = {
           ...redirectPage,
-          path: absolutePath,
+          path: finalPath,
         };
       }
     }


### PR DESCRIPTION
## Description
We currently do our broken link checking before we create redirects, but this means that we might flag links that are missing in our content directory but are being redirected through aliases. Updating this will let us remove some pages that shouldn't exist in vagov-content in favor of aliases and let me continue making updates with the goal of getting the accesssibility checker back up.

## Testing done
Checked some redirects locally

## Acceptance criteria
- [x] Redirects still work and there are no broken links flagged

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
