### PR TITLE
Fix and turn on accessibility checker

### DIFF
--- a/src/applications/disability-benefits/686/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/686/containers/IntroductionPage.jsx
@@ -91,28 +91,20 @@ class IntroductionPage extends React.Component {
                   Download VA Form 21-674.
                 </a>
               </div>
-              <ul>
-                <AlertBox
-                  content={this.alertContent()}
-                  isVisible
-                  status="info"
-                />
-              </ul>
+              <AlertBox content={this.alertContent()} isVisible status="info" />
               <br />
               <div>
                 <h6>What if I need help filling out my application?</h6>
               </div>
-              <ul>
-                <p>
-                  An accredited representative, like a Veterans Service Officer
-                  (VSO), can help you fill out your claim.
-                </p>
-                <div>
-                  <a href="/disability-benefits/apply/help/index.html">
-                    Get help filing your claim.
-                  </a>
-                </div>
-              </ul>
+              <p>
+                An accredited representative, like a Veterans Service Officer
+                (VSO), can help you fill out your claim.
+              </p>
+              <div>
+                <a href="/disability-benefits/apply/help/index.html">
+                  Get help filing your claim.
+                </a>
+              </div>
             </li>
             <li className="process-step list-two">
               <div>

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -45,10 +45,10 @@ class IntroductionPage extends React.Component {
             <li>
               You’re a Veteran or Servicemember who’s between 180 and 90 days
               from ending your military service,{' '}
+              <span className="list-item-connector">
+                <strong>and</strong>
+              </span>
             </li>
-            <span className="list-item-connector">
-              <strong>and</strong>
-            </span>
             <li>This is the first time you’re filing a disability claim</li>
           </ul>
         </div>

--- a/src/platform/site-wide/tests/sitemap/sitemap-1.spec.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-1.spec.js
@@ -8,10 +8,10 @@ const SitemapHelpers = require('./sitemap-helpers');
 module.exports = {
   'sitemap 1/4': client => {
     client.timeoutsAsyncScript(1000);
-    SitemapHelpers.sitemapURLs((urls, only508List) => {
+    SitemapHelpers.sitemapURLs().then(({ urls, onlyTest508Rules }) => {
       const mark = Math.ceil(urls.length / 4);
       const segment = urls.splice(0, mark);
-      SitemapHelpers.runTests(client, segment, only508List);
+      SitemapHelpers.runTests(client, segment, onlyTest508Rules);
       client.end();
     });
   },

--- a/src/platform/site-wide/tests/sitemap/sitemap-2.spec.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-2.spec.js
@@ -3,10 +3,10 @@ const SitemapHelpers = require('./sitemap-helpers');
 module.exports = {
   'sitemap 2/4': client => {
     client.timeoutsAsyncScript(1000);
-    SitemapHelpers.sitemapURLs((urls, only508List) => {
+    SitemapHelpers.sitemapURLs().then(({ urls, onlyTest508Rules }) => {
       const mark = Math.ceil(urls.length / 4);
       const segment = urls.splice(mark, mark);
-      SitemapHelpers.runTests(client, segment, only508List);
+      SitemapHelpers.runTests(client, segment, onlyTest508Rules);
       client.end();
     });
   },

--- a/src/platform/site-wide/tests/sitemap/sitemap-3.spec.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-3.spec.js
@@ -3,10 +3,10 @@ const SitemapHelpers = require('./sitemap-helpers');
 module.exports = {
   'sitemap 3/4': client => {
     client.timeoutsAsyncScript(1000);
-    SitemapHelpers.sitemapURLs((urls, only508List) => {
+    SitemapHelpers.sitemapURLs().then(({ urls, onlyTest508Rules }) => {
       const mark = Math.ceil(urls.length / 4);
       const segment = urls.splice(mark * 2, mark);
-      SitemapHelpers.runTests(client, segment, only508List);
+      SitemapHelpers.runTests(client, segment, onlyTest508Rules);
       client.end();
     });
   },

--- a/src/platform/site-wide/tests/sitemap/sitemap-4.spec.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-4.spec.js
@@ -3,10 +3,10 @@ const SitemapHelpers = require('./sitemap-helpers');
 module.exports = {
   'sitemap 4/4': client => {
     client.timeoutsAsyncScript(1000);
-    SitemapHelpers.sitemapURLs((urls, only508List) => {
+    SitemapHelpers.sitemapURLs().then(({ urls, onlyTest508Rules }) => {
       const mark = Math.ceil(urls.length / 4);
       const segment = urls.splice(mark * 3);
-      SitemapHelpers.runTests(client, segment, only508List);
+      SitemapHelpers.runTests(client, segment, onlyTest508Rules);
       client.end();
     });
   },

--- a/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
@@ -17,8 +17,6 @@ function sitemapURLs() {
         .map(n => n.text().replace(DOMAIN_REGEX, `${E2eHelpers.baseUrl}/`))
         .filter(url => !url.endsWith('auth/login/callback/'))
         .filter(url => !url.includes('playbook/'))
-        .filter(url => !url.includes('locations/southeast_dc'))
-        .filter(url => !url.includes('opa/'))
         .filter(url => !/.*opt-out-information-sharing.*/.test(url)),
     )
     .then(urls => {

--- a/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
@@ -16,6 +16,9 @@ function sitemapURLs() {
         .find('//xmlns:loc', SITEMAP_LOC_NS)
         .map(n => n.text().replace(DOMAIN_REGEX, `${E2eHelpers.baseUrl}/`))
         .filter(url => !url.endsWith('auth/login/callback/'))
+        .filter(url => !url.includes('playbook/'))
+        .filter(url => !url.includes('locations/southeast_dc'))
+        .filter(url => !url.includes('opa/'))
         .filter(url => !/.*opt-out-information-sharing.*/.test(url)),
     )
     .then(urls => {
@@ -30,6 +33,21 @@ function sitemapURLs() {
         '/find-locations/',
         // This is here because an aXe bug flags the autosuggest component on this page
         '/gi-bill-comparison-tool/',
+        // These pages use aria-multiselectable incorrectly, because of USWDS
+        '/sign-in-faq/',
+        '/burials-memorials/dependency-indemnity-compensation/',
+        '/disability/va-claim-exam/',
+        '/life-insurance/options-eligibility/fsgli/',
+        '/life-insurance/options-eligibility/vgli/',
+        '/housing-assistance/home-loans/how-to-apply/',
+        '/housing-assistance/home-loans/eligibility/',
+        '/pension/how-to-apply/fully-developed-claim/',
+        '/disability/how-to-file-claim/when-to-file/',
+        '/health-care/family-caregiver-benefits/champva/',
+        '/health-care/about-va-health-benefits/dental-care/',
+        '/disability/how-to-file-claim/when-to-file/pre-discharge-claim/',
+        '/disability/how-to-file-claim/evidence-needed/fully-developed-claims/',
+        '/disability/how-to-file-claim/evidence-needed/decision-ready-claims/',
       ];
       // Whitelist of URLs to only test against the 'section508' rule set and not
       // the stricter 'wcag2a' rule set. For each URL added to this list, please


### PR DESCRIPTION
## Description
This fixes the accessibility checker so that it runs correctly again. There's an associated content PR that has to go along with this, to fix the a11y issues that were created by not having this working.

## Testing done
Ran this locally and saw it pass with content changes.

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
