### PR TITLE
Add lastmod to sitemap on new builds

### DIFF
--- a/script/create-sitemaps.js
+++ b/script/create-sitemaps.js
@@ -3,9 +3,11 @@ const metalsmithSitemap = require('metalsmith-sitemap');
 function createSitemaps(BUILD_OPTIONS) {
   const hostname = BUILD_OPTIONS.hostUrl;
 
+  const now = new Date();
   const metalsmithSitemapOptions = {
     hostname,
     omitIndex: true,
+    lastmod: now,
   };
 
   return (files, metalsmith, done) => {


### PR DESCRIPTION
## Description
In order to facilitate indexing and better content presentation, we want to let search engines know when our content was last modified. As per https://www.sitemaps.org/protocol.html, this involves adding a <lastmod> tag to each <url> entry in sitemap-dynamic.xml.

We have an MVP implementation that will blanket all URLs on each build with the current date, so that Search.gov will prioritize these results. 

## Testing done
Build the site locally and ensure each URL in the sitemap contains a `<lastmod>` entry with the current date

## Screenshots


## Acceptance criteria
- [x] Sitemap generates with `<lastmod>`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
