### PR TITLE
All claims split training pay mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -32,6 +32,7 @@ import {
   militaryHistory,
   servedInCombatZone,
   separationTrainingPay,
+  trainingPayWaiver,
   reservesNationalGuardService,
   federalOrders,
   prisonerOfWar,
@@ -381,6 +382,14 @@ const formConfig = {
           uiSchema: separationTrainingPay.uiSchema,
           schema: separationTrainingPay.schema,
         },
+        trainingPayWaiver: {
+          title: 'Training pay waiver',
+          path: 'training-pay-waiver',
+          depends: formData => formData.hasTrainingPay,
+          uiSchema: trainingPayWaiver.uiSchema,
+          schema: trainingPayWaiver.schema,
+        },
+
         fullyDevelopedClaim: {
           title: 'Fully developed claim program',
           path: 'fully-developed-claim',

--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -786,6 +786,9 @@ const schema = {
       type: 'string',
       enum: serviceBranches,
     },
+    hasTrainingPay: {
+      type: 'boolean',
+    },
     waiveTrainingPay: {
       type: 'boolean',
     },

--- a/src/applications/disability-benefits/all-claims/content/separationTrainingPay.jsx
+++ b/src/applications/disability-benefits/all-claims/content/separationTrainingPay.jsx
@@ -9,14 +9,3 @@ export const separationPayDetailsDescription = (
     mean that we’ve paid you too much, and you may need to repay the money.
   </p>
 );
-
-export const waiveTrainingPayDescription = (
-  <p>
-    The amount you get for VA compensation may be reduced or withheld if you’re
-    also receiving active or inactive duty training pay. To keep your training
-    pay you must waive VA compensation pay for the same number of days you
-    receive training pay. Getting VA compensation pay and training pay at the
-    same time may mean that we've paid you too much, and you may need to repay
-    the money.
-  </p>
-);

--- a/src/applications/disability-benefits/all-claims/content/trainingPayWaiver.jsx
+++ b/src/applications/disability-benefits/all-claims/content/trainingPayWaiver.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export const waiveTrainingPayDescription = (
+  <p>
+    If you’re eligible for both training pay and VA compensation, you’ll need to
+    decide which one you want to get. You can’t get VA compensation for the same
+    days you get training pay. If you want to keep your training pay, you’ll
+    need to waive (or tell us you don’t want to get) VA compensation pay for the
+    days you receive training pay.
+  </p>
+);

--- a/src/applications/disability-benefits/all-claims/pages/index.js
+++ b/src/applications/disability-benefits/all-claims/pages/index.js
@@ -29,6 +29,11 @@ import {
 } from '../pages/separationTrainingPay';
 
 import {
+  uiSchema as trainingPayWaiverUISchema,
+  schema as trainingPayWaiverSchema,
+} from '../pages/trainingPayWaiver';
+
+import {
   uiSchema as reservesNationalGuardUISchema,
   schema as reservesNationalGuardSchema,
 } from './reservesNationalGuardService';
@@ -176,6 +181,11 @@ export const waiveRetirementPay = {
 export const separationTrainingPay = {
   uiSchema: separationTrainingPayUISchema,
   schema: separationTrainingPaySchema,
+};
+
+export const trainingPayWaiver = {
+  uiSchema: trainingPayWaiverUISchema,
+  schema: trainingPayWaiverSchema,
 };
 
 export const militaryHistory = {

--- a/src/applications/disability-benefits/all-claims/pages/separationTrainingPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/separationTrainingPay.js
@@ -2,15 +2,12 @@ import dateUI from 'us-forms-system/lib/js/definitions/date';
 import fullSchema from '../config/schema';
 import merge from 'lodash/merge';
 import { hasSeparationPay } from '../validations';
-import {
-  waiveTrainingPayDescription,
-  separationPayDetailsDescription,
-} from '../content/separationTrainingPay';
+import { separationPayDetailsDescription } from '../content/separationTrainingPay';
 
 const {
   separationPayDate: separationPayDateSchema,
   separationPayBranch: separationPayBranchSchema,
-  waiveTrainingPay: waiveTrainingPaySchema,
+  hasTrainingPay,
 } = fullSchema.properties;
 
 export const uiSchema = {
@@ -37,28 +34,16 @@ export const uiSchema = {
       'ui:required': hasSeparationPay,
     },
   },
-  'view:hasTrainingPay': {
-    'ui:title': 'Did you receive active or inactive training pay?',
+  hasTrainingPay: {
+    'ui:title':
+      'Do you expect to receive active or inactive duty training pay?',
     'ui:widget': 'yesNo',
-  },
-  'view:waiveTrainingPay': {
-    'ui:options': {
-      expandUnder: 'view:hasTrainingPay',
-    },
-    'view:waiveTrainingPayDescription': {
-      'ui:title': 'Training pay waiver',
-      'ui:description': waiveTrainingPayDescription,
-    },
-    waiveTrainingPay: {
-      'ui:title': `I choose to waive VA compensation pay for the days I receive inactive 
-      duty training pay, so I can keep my inactive duty training pay.`,
-    },
   },
 };
 
 export const schema = {
   type: 'object',
-  required: ['view:hasSeparationPay', 'view:hasTrainingPay'],
+  required: ['view:hasSeparationPay', 'hasTrainingPay'],
   properties: {
     'view:hasSeparationPay': {
       type: 'boolean',
@@ -74,18 +59,6 @@ export const schema = {
         separationPayBranch: separationPayBranchSchema,
       },
     },
-    'view:hasTrainingPay': {
-      type: 'boolean',
-    },
-    'view:waiveTrainingPay': {
-      type: 'object',
-      properties: {
-        'view:waiveTrainingPayDescription': {
-          type: 'object',
-          properties: {},
-        },
-        waiveTrainingPay: waiveTrainingPaySchema,
-      },
-    },
+    hasTrainingPay,
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/trainingPayWaiver.js
+++ b/src/applications/disability-benefits/all-claims/pages/trainingPayWaiver.js
@@ -22,6 +22,7 @@ export const uiSchema = {
 
 export const schema = {
   type: 'object',
+  required: ['waiveTrainingPay'],
   properties: {
     waiveTrainingPay,
   },

--- a/src/applications/disability-benefits/all-claims/pages/trainingPayWaiver.js
+++ b/src/applications/disability-benefits/all-claims/pages/trainingPayWaiver.js
@@ -4,8 +4,9 @@ import { waiveTrainingPayDescription } from '../content/trainingPayWaiver';
 const { waiveTrainingPay } = fullSchema.properties;
 
 export const uiSchema = {
+  'ui:title': 'Training pay waiver',
   waiveTrainingPay: {
-    'ui:title': 'Training pay waiver',
+    'ui:title': ' ',
     'ui:description': waiveTrainingPayDescription,
     'ui:widget': 'yesNo',
     'ui:options': {

--- a/src/applications/disability-benefits/all-claims/pages/trainingPayWaiver.js
+++ b/src/applications/disability-benefits/all-claims/pages/trainingPayWaiver.js
@@ -1,0 +1,27 @@
+import fullSchema from '../config/schema';
+import { waiveTrainingPayDescription } from '../content/trainingPayWaiver';
+
+const { waiveTrainingPay } = fullSchema.properties;
+
+export const uiSchema = {
+  waiveTrainingPay: {
+    'ui:title': 'Training pay waiver',
+    'ui:description': waiveTrainingPayDescription,
+    'ui:widget': 'yesNo',
+    'ui:options': {
+      yesNoReverse: true,
+      labels: {
+        Y:
+          'I don’t want to get VA compensation pay for the days I receive training pay.',
+        N: 'I want to get VA compensation pay instead of training pay.',
+      },
+    },
+  },
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    waiveTrainingPay,
+  },
+};

--- a/src/applications/disability-benefits/all-claims/tests/pages/separationTrainingPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/separationTrainingPay.unit.spec.jsx
@@ -54,7 +54,7 @@ describe('Separation or Training Pay', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
-          'view:hasTrainingPay': false,
+          hasTrainingPay: false,
           'view:hasSeparationPay': false,
         }}
         formData={{}}
@@ -75,7 +75,7 @@ describe('Separation or Training Pay', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
-          'view:hasTrainingPay': true,
+          hasTrainingPay: true,
           'view:hasSeparationPay': true,
         }}
         formData={{}}
@@ -95,7 +95,7 @@ describe('Separation or Training Pay', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
-          'view:hasTrainingPay': true,
+          hasTrainingPay: true,
           'view:hasSeparationPay': true,
         }}
         formData={{}}
@@ -103,7 +103,7 @@ describe('Separation or Training Pay', () => {
     );
 
     expect(form.find('.form-radio-buttons').length).to.equal(2);
-    expect(form.find('input').length).to.equal(6); // 4 radios + year input + checkbox
+    expect(form.find('input').length).to.equal(5); // 4 radios + year input
     expect(form.find('select').length).to.equal(3); // month, day, service branch
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/trainingPayWaiver.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/trainingPayWaiver.unit.spec.jsx
@@ -24,7 +24,7 @@ describe('trainingPayWaiver', () => {
     expect(form.find('input').length).to.equal(2);
   });
 
-  it('should submit without any input from user', () => {
+  it('should not submit when user does not make a selection', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
@@ -32,6 +32,26 @@ describe('trainingPayWaiver', () => {
         uiSchema={uiSchema}
         schema={schema}
         onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should submit when user makes a selection', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={defaultDefinitions}
+        uiSchema={uiSchema}
+        schema={schema}
+        onSubmit={onSubmit}
+        data={{
+          waiveTrainingPay: true,
+        }}
       />,
     );
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/trainingPayWaiver.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/trainingPayWaiver.unit.spec.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils';
+import formConfig from '../../config/form';
+import { ERR_MSG_CSS_CLASS } from '../../constants';
+
+describe('trainingPayWaiver', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.additionalInformation.pages.trainingPayWaiver;
+  const { defaultDefinitions } = formConfig;
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={defaultDefinitions}
+        uiSchema={uiSchema}
+        schema={schema}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(2);
+  });
+
+  it('should submit without any input from user', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={defaultDefinitions}
+        uiSchema={uiSchema}
+        schema={schema}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(0);
+    expect(onSubmit.calledOnce).to.be.true;
+  });
+});


### PR DESCRIPTION
## Description
Splits training pay questions onto two pages:
- First asks if veteran will receive training pay
- Second, conditional page asks whether or not they want to waive training pay to receive VA pay

## Testing done
- Tested locally
- Added unit tests


## Screenshots
First Page:
![screen shot 2018-11-09 at 1 43 43 pm](https://user-images.githubusercontent.com/24251447/48284987-cdf3d780-e426-11e8-991b-ee3bab10ba06.png)

-----

Follow-up page:
![screen shot 2018-11-09 at 1 46 29 pm](https://user-images.githubusercontent.com/24251447/48285007-d9470300-e426-11e8-97a2-86111b10ec27.png)



## Acceptance criteria
- [x] Waive training pay question is on its own page
- [x] Content for questions and descriptions matches latest in ticket
- [x] Veteran must answer waiver question if they indicated they will receive training pay

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
