### PR TITLE
Reduce .column-one width to fix wrapping, consolidate stylings

### DIFF
--- a/src/platform/site-wide/sass/consolidated-patches.scss
+++ b/src/platform/site-wide/sass/consolidated-patches.scss
@@ -95,20 +95,28 @@ header.merger {
   }
 
   @media (min-width: $large-screen) {
-    #mega-menu .vetnav-panel {
-      width: 487px;
-    }
+    #mega-menu  {
+      .vetnav-panel {
+        width: 487px;
 
-    #mega-menu .column-two {
-      left: 240px;
-    }
+        &.column-one {
+          .mm-link-container {
+            width: 200px;
+          }
+        }
 
-    #mega-menu .column-three {
-      left: 487px;
-    }
+        &.column-two {
+          left: 240px;
+        }
 
-    #mega-menu .panel-bottom-link {
-      width: 657px;
+        &.column-three {
+          left: 487px;
+        }
+      }
+
+      .panel-bottom-link {
+        width: 657px;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Fix cut off text in `.column-one` of mega menu on [benefits.va.gov](https://benefits.va.gov) by reducing width of links to `200px`.  Also consolidated some of the styles under `#mega-menu`.

## Testing done
Tested locally on Chrome

## Screenshots

### Before
![](https://camo.githubusercontent.com/8bcc67da18a442a12a41b4a3da1773c466ae3ecc/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3539393735643862386636326463373739386333353139392f30616165306661652d383737642d343066362d396661322d376464363063613762383833)

### After
![screen shot 2018-11-12 at 11 30 04 am](https://user-images.githubusercontent.com/786704/48370512-6d56db80-e66e-11e8-94b8-5208d9588d21.png)



## Acceptance criteria
- [x] "Family and Caregiver Health Benefits" text is not cut off in mega menu

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
