### PR TITLE
526 empty attachment id mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -42,6 +42,7 @@ const aggregate = (dataArray, property, refPropPath) => {
   dataArray.forEach(item => {
     const itemIsSelected = get(refPropPath, item, true);
     if (item[property] && itemIsSelected) {
+      console.log('item is selected: ', itemIsSelected, 'for:', item);
       item[property].forEach(listItem => masterList.push(listItem));
     }
   });
@@ -133,18 +134,22 @@ export function transform(formConfig, form) {
     ? { servicePeriods, reservesNationalGuardService }
     : { servicePeriods };
 
+  const selectedDisabilities = disabilities.filter(
+    disability => disability['view:selected'],
+  );
+
   const additionalDocuments = aggregate(
-    disabilities,
+    selectedDisabilities,
     'additionalDocuments',
     'view:selectableEvidenceTypes.view:otherEvidence',
   );
   const privateRecords = aggregate(
-    disabilities,
+    selectedDisabilities,
     'privateRecords',
     'view:selectableEvidenceTypes.view:privateMedicalRecords',
   );
   const treatments = aggregate(
-    disabilities,
+    selectedDisabilities,
     'treatments',
     'view:selectableEvidenceTypes.view:vaMedicalRecords',
   );
@@ -152,9 +157,9 @@ export function transform(formConfig, form) {
   const attachments = additionalDocuments.concat(privateRecords);
 
   const transformedData = {
-    disabilities: disabilities
-      .filter(disability => disability['view:selected'] === true)
-      .map(filtered => pick(filtered, disabilityProperties)),
+    disabilities: selectedDisabilities.map(filtered =>
+      pick(filtered, disabilityProperties),
+    ),
     // Pull phone & email out of phoneEmailCard and into veteran property
     veteran: setPhoneEmailPaths(veteran),
     privacyAgreementAccepted,

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -42,7 +42,6 @@ const aggregate = (dataArray, property, refPropPath) => {
   dataArray.forEach(item => {
     const itemIsSelected = get(refPropPath, item, true);
     if (item[property] && itemIsSelected) {
-      console.log('item is selected: ', itemIsSelected, 'for:', item);
       item[property].forEach(listItem => masterList.push(listItem));
     }
   });

--- a/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import _ from 'lodash';
+import _ from '../../../../platform/utilities/data';
 
 import {
   validateDisability,
@@ -21,7 +21,7 @@ describe('526 helpers', () => {
     invalidDisability,
   );
   describe('transform', () => {
-    const formData = maximalData;
+    const formData = _.cloneDeep(maximalData);
     const transformedData = {
       form526: {
         disabilities: [
@@ -141,6 +141,7 @@ describe('526 helpers', () => {
         ],
       },
     };
+
     it('should return stringified, transformed data for submit', () => {
       expect(transform(null, formData)).to.deep.equal(
         JSON.stringify(transformedData),
@@ -148,19 +149,41 @@ describe('526 helpers', () => {
     });
 
     it('should not submit uploads when corresponding evidence type not selected', () => {
-      const noAttachments = _.merge(maximalData, {
-        disabilities: [
-          {
-            'view:selectableEvidenceTypes': {
-              'view:privateMedicalRecords': false,
-              'view:otherEvidence': false,
-            },
+      const noUploadsSelected = _.set(
+        'data.disabilities[0].view:selectableEvidenceTypes',
+        {
+          'view:privateMedicalRecords': false,
+          'view:otherEvidence': false,
+        },
+        _.cloneDeep(formData),
+      );
+
+      expect(JSON.parse(transform(null, noUploadsSelected)).form526.attachments)
+        .to.be.undefined;
+    });
+
+    it('should submit uploads when parent disability is selected', () => {
+      expect(
+        JSON.parse(transform(null, formData)).form526.attachments.length,
+      ).to.equal(transformedData.form526.attachments.length);
+    });
+
+    it('should not submit uploads when parent disability not selected', () => {
+      const noAttachments = _.set(
+        'data.disabilities[0]',
+        {
+          'view:selected': false,
+          'view:selectableEvidenceTypes': {
+            'view:privateMedicalRecords': true,
+            'view:otherEvidence': true,
           },
-        ],
-      });
+        },
+        _.cloneDeep(maximalData),
+      );
 
       const transformedNoAttachments = transform(null, noAttachments);
-      expect(transformedNoAttachments.attachments).to.be.undefined;
+      expect(JSON.parse(transformedNoAttachments).form526.attachments).to.be
+        .undefined;
     });
   });
 
@@ -247,7 +270,7 @@ describe('526 helpers', () => {
     });
     it('should return original data when no disabilities returned', () => {
       const pages = [];
-      const formData = _.omit(initialData, 'disabilities');
+      const formData = _.omit('disabilities', initialData);
       const metadata = {};
 
       expect(prefillTransformer(pages, formData, metadata)).to.deep.equal({
@@ -259,9 +282,11 @@ describe('526 helpers', () => {
     it('should return original data if disabilities is not an array', () => {
       const clonedData = _.cloneDeep(initialData);
       const pages = [];
-      const formData = _.set(clonedData, 'disabilities', {
-        someProperty: 'value',
-      });
+      const formData = _.set(
+        'disabilities',
+        { someProperty: 'value' },
+        clonedData,
+      );
       const metadata = {};
 
       expect(prefillTransformer(pages, formData, metadata)).to.deep.equal({
@@ -273,10 +298,11 @@ describe('526 helpers', () => {
     it('should transform prefilled data when disability name has special chars', () => {
       const newName = '//()';
       const dataClone = _.set(
-        _.cloneDeep(initialData),
         'disabilities[0].name',
         newName,
+        _.cloneDeep(initialData),
       );
+
       const prefill = prefillTransformer([], dataClone, {});
       expect(prefill.formData.disabilities[0].name).to.equal(newName);
     });
@@ -289,7 +315,6 @@ describe('526 helpers', () => {
       const pages = [];
       const metadata = {};
       const formData = _.set(
-        _.cloneDeep(initialData),
         'reservesNationalGuardService',
         {
           obligationTermOfServiceDateRange: {
@@ -297,6 +322,7 @@ describe('526 helpers', () => {
             to: dateRange.to,
           },
         },
+        _.cloneDeep(initialData),
       );
 
       const newData = prefillTransformer(pages, formData, metadata);
@@ -381,7 +407,7 @@ describe('526 helpers', () => {
       };
 
       expect(getReservesGuardData(formData)).to.deep.equal(
-        _.omit(formData, 'view:isTitle10Activated'),
+        _.omit('view:isTitle10Activated', formData),
       );
     });
     it('returns null when some required data is missing', () => {

--- a/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
@@ -155,7 +155,7 @@ describe('526 helpers', () => {
           'view:privateMedicalRecords': false,
           'view:otherEvidence': false,
         },
-        _.cloneDeep(formData),
+        formData,
       );
 
       expect(JSON.parse(transform(null, noUploadsSelected)).form526.attachments)
@@ -178,7 +178,7 @@ describe('526 helpers', () => {
             'view:otherEvidence': true,
           },
         },
-        _.cloneDeep(maximalData),
+        maximalData,
       );
 
       const transformedNoAttachments = transform(null, noAttachments);


### PR DESCRIPTION
## Description
Only attaches . . . attachments to MVP submit payload when their respective evidence type has been selected.

## Testing done
- Tested manually
- Updated unit tests

## Screenshots


## Acceptance criteria
- [x] Presubmit transformer output includes `attachments` property with valid properties when the corresponding evidence type (`view:privateMedicalRecords` or `view:otherEvidence`) is selected
- [x] Presubmit transformer output does not include `attachments` property – even when attachments uploaded – when the corresponding evidence type (`view:privateMedicalRecords` or `view:otherEvidence`) is *not* selected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
