### PR TITLE
Add bottom margin to alert if unauthenticated

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
@@ -48,8 +48,10 @@ class IntroductionPage extends React.Component {
       saveInProgress: { user },
     } = this.props;
 
+    const isLoggedIn = user && user.login && user.login.currentlyLoggedIn;
+
     const itfAgreement = (
-      <p className="itf-agreement">
+      <p className={`itf-agreement${isLoggedIn ? '' : ' unauthenticated'}`}>
         By clicking the button to start the disability application, you’ll
         declare your intent to file. This will reserve a potential effective
         date for when you could start getting benefits. You have 1 year from the

--- a/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
@@ -165,6 +165,10 @@
   margin-bottom: 2em;
 }
 
+.usa-alert {
+  margin-bottom: 1em;
+}
+
 .itf-agreement {
   margin-top: 0;
   

--- a/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
@@ -165,6 +165,10 @@
   margin-bottom: 2em;
 }
 
+.usa-alert {
+  margin-bottom: 1em;
+}
+
 .itf-agreement {
   margin-top: 0;
 }

--- a/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
@@ -165,10 +165,6 @@
   margin-bottom: 2em;
 }
 
-.usa-alert {
-  margin-bottom: 1em;
-}
-
 .itf-agreement {
   margin-top: 0;
   

--- a/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
@@ -165,12 +165,12 @@
   margin-bottom: 2em;
 }
 
-.usa-alert {
-  margin-bottom: 1em;
-}
-
 .itf-agreement {
   margin-top: 0;
+  
+  &.unauthenticated {
+    margin-top: 1em;
+  }
 }
 
 .private-records-choice-help {


### PR DESCRIPTION
## Description

Add 1em of space to the top of paragraph below alert box on the [File for increased disability compensation page](https://www.va.gov/disability-benefits/apply/form-526-disability-claim) page.

## Testing done

Locally on Chrome

## Screenshots

### Before
![image.png](https://images.zenhubusercontent.com/5b744a5479b04b75031e37c2/e20893b6-fef0-419a-b48b-cdc09b664a5c)

### After
![image](https://user-images.githubusercontent.com/786704/48376759-c62f6f80-e680-11e8-91af-001c17f9c298.png)


## Acceptance criteria
- [x] There is a margin under the alert box if unauthenticated on the [File for increased disability compensation page](https://www.va.gov/disability-benefits/apply/form-526-disability-claim) page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
