### PR TITLE
526 empty supporting evidence mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -600,7 +600,7 @@ const formConfig = {
                   'ui:options': {
                     labels: {
                       yes: 'Yes',
-                      no: 'No, my doctor has my medical records',
+                      no: 'No, please get my records from my doctor.',
                     },
                   },
                 },

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -465,6 +465,7 @@ export const evidenceSummaryView = ({ formContext, formData }) => {
       'view:privateMedicalRecords': privateRecordsSelected,
       'view:otherEvidence': otherEvidenceSelected,
     },
+    'view:uploadPrivateRecords': uploadPrivateRecords,
   } = formData;
 
   return (
@@ -484,14 +485,15 @@ export const evidenceSummaryView = ({ formContext, formData }) => {
             </li>
           )}
         {privateRecords &&
-          privateRecordsSelected && (
+          privateRecordsSelected &&
+          uploadPrivateRecords === 'yes' && (
             <li>
               We have received the private medical records you uploaded:
               {listDocuments(privateRecords)}
             </li>
           )}
-        {!privateRecords &&
-          privateRecordsSelected && (
+        {privateRecordsSelected &&
+          uploadPrivateRecords === 'no' && (
             <li>
               You asked us to get your private medical records from your doctor,
               so you’ll need to fill out an Authorization to Disclose

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -490,6 +490,15 @@ export const evidenceSummaryView = ({ formContext, formData }) => {
               {listDocuments(privateRecords)}
             </li>
           )}
+        {!privateRecords &&
+          privateRecordsSelected && (
+            <li>
+              You asked us to get your private medical records from your doctor,
+              so you’ll need to fill out an Authorization to Disclose
+              Information to the VA (VA Form 21-4142). We’ll provide a link to
+              the 21-4142 after you submit your form.
+            </li>
+          )}
         {additionalDocuments &&
           otherEvidenceSelected && (
             <li>

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -27,7 +27,7 @@ export const uiSchema = {
       'ui:options': {
         labels: {
           Y: 'Yes',
-          N: 'No, my doctor has my medical records.',
+          N: 'No, please get my records from my doctor.',
         },
       },
     },


### PR DESCRIPTION
## Description
- Fixes an issue on MVP where it's possible to see a blank 'summary of evidence' screen when veteran selects PMR -> 'no, my doctor has my records' in the form flow (and no other evidence).
- Fixes PMR selection content for both MVP and All Claims (per attached ticket, they should match).
- Fixes a small bug where it's possible to see PMR uploads in 'summary of evidence' even though the veteran went back and changed their selection to 'No, my doctor has my records' because the upload data doesn't get cleared out and we didn't check their answer to this question explicitly.

## Testing done
- Tested locally

## Screenshots
New content for PMR answer:
<img width="601" alt="screen shot 2018-11-13 at 2 33 52 pm" src="https://user-images.githubusercontent.com/24251447/48442399-c9476000-e753-11e8-96dc-d99a5557e10b.png">

-----

Summary of Evidence with multiple evidence types:
<img width="595" alt="screen shot 2018-11-13 at 2 34 21 pm" src="https://user-images.githubusercontent.com/24251447/48442440-de23f380-e753-11e8-890f-3ec90e17a99f.png">

-----

Summary of Evidence with only PMR -> No Uploads
<img width="597" alt="screen shot 2018-11-13 at 2 34 39 pm" src="https://user-images.githubusercontent.com/24251447/48442459-ec720f80-e753-11e8-9867-f90efc40efe1.png">


## Acceptance criteria
- [x] Update content per ticket
- [x] List of PMR uploads should only show in summary of evidence when PMR selected as evidence type, 'upload PMR' selected on the follow-up page, and list of PMR exists in formData
- [x] New content should be shown when PMR selected but 'No, my doctor has my records' selected from the follow-up page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
