### PR TITLE
[BLOCKED] Removed handling for T&C in health tool CTAs

### DIFF
--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -49,14 +49,18 @@ export class CallToActionWidget extends React.Component {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     if (!this.props.isLoggedIn) return;
 
     if (this.isAccessible()) {
       if (this._hasRedirect && !this._popup) this.goToTool();
     } else if (this._isHealthTool) {
       const { accountState, loading } = this.props.mhvAccount;
-      if (!loading && !accountState) this.props.fetchMHVAccount();
+      const { verified } = this.props.profile;
+      const shouldRefreshMhvAccount =
+        (!loading && !accountState) ||
+        (!prevProps.profile.verified && verified);
+      if (shouldRefreshMhvAccount) this.props.fetchMHVAccount();
     }
   }
 

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import appendQuery from 'append-query';
-import URLSearchParams from 'url-search-params';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 import CallHelpDesk from '../../brand-consolidation/components/CallHelpDesk';
@@ -57,24 +55,8 @@ export class CallToActionWidget extends React.Component {
     if (this.isAccessible()) {
       if (this._hasRedirect && !this._popup) this.goToTool();
     } else if (this._isHealthTool) {
-      const { accountLevel, accountState, loading } = this.props.mhvAccount;
-
-      if (loading) return;
-
-      if (!accountState) {
-        this.props.fetchMHVAccount();
-      } else if (
-        new URLSearchParams(window.location.search).get('tc_accepted')
-      ) {
-        // Since T&C is still required to support the existing account states,
-        // check the existence of a query param that gets appended after
-        // successful T&C acceptance to complete account creation or upgrade.
-        if (!accountLevel && accountState !== 'register_failed') {
-          this.props.createAndUpgradeMHVAccount();
-        } else if (accountLevel && accountState !== 'upgrade_failed') {
-          this.props.upgradeMHVAccount();
-        }
-      }
+      const { accountState, loading } = this.props.mhvAccount;
+      if (!loading && !accountState) this.props.fetchMHVAccount();
     }
   }
 
@@ -342,25 +324,13 @@ export class CallToActionWidget extends React.Component {
 
     const { accountLevel } = this.props.mhvAccount;
 
-    const redirectToTermsAndConditions = () => {
-      const redirectQuery = { tc_redirect: window.location.pathname }; // eslint-disable-line camelcase
-      const termsConditionsUrl = appendQuery(
-        '/health-care/medical-information-terms-conditions/',
-        redirectQuery,
-      );
-      window.location = termsConditionsUrl;
-    };
-
     if (!accountLevel) {
       return {
         heading: `You’ll need to create a My HealtheVet account before you can ${
           this._serviceDescription
         }`,
         buttonText: 'Create a My HealtheVet Account',
-        buttonHandler:
-          accountState === 'needs_terms_acceptance'
-            ? redirectToTermsAndConditions
-            : this.props.createAndUpgradeMHVAccount,
+        buttonHandler: this.props.createAndUpgradeMHVAccount,
         status: 'continue',
       };
     }
@@ -370,10 +340,7 @@ export class CallToActionWidget extends React.Component {
         this._serviceDescription
       }`,
       buttonText: 'Upgrade Your Account',
-      buttonHandler:
-        accountState === 'needs_terms_acceptance'
-          ? redirectToTermsAndConditions
-          : this.props.upgradeMHVAccount,
+      buttonHandler: this.props.upgradeMHVAccount,
       status: 'continue',
     };
   };


### PR DESCRIPTION
## Description
No longer redirect to T&C if the user has not accepted T&C when creating a MHV account.

BE PR: department-of-veterans-affairs/vets-api#2453

**NOTE:** Planning on removing the rest of the obsolete code around the health tools and T&C in a separate PR.

## Testing done
Local testing on user vets.gov.user+1 comparing what happens with and without changes on both BE and FE. Without the changes, clicking the button to create an account will redirect to T&C (due to the account state being `needs_terms_acceptance`). With the changes, clicking it will start a `POST /mhv_account` request (due to the account state being `no_account`).

## Acceptance criteria
- [x] Clicking "Create a My HealtheVet Account" should not prompt for T&C acceptance.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs