### PR TITLE
use physical address when present on search and detailed views

### DIFF
--- a/src/applications/gi/reducers/profile.js
+++ b/src/applications/gi/reducers/profile.js
@@ -17,9 +17,8 @@ function normalizedAttributes(attributes) {
   const name = attributes.name
     ? attributes.name.toUpperCase()
     : attributes.name;
-  const city = attributes.city
-    ? attributes.city.toUpperCase()
-    : attributes.city;
+  let city = attributes.physicalCity || attributes.city;
+  city = city ? city.toUpperCase() : city;
   const state = attributes.state
     ? attributes.state.toUpperCase()
     : attributes.state;

--- a/src/applications/gi/reducers/search.js
+++ b/src/applications/gi/reducers/search.js
@@ -37,9 +37,8 @@ function normalizedAttributes(attributes) {
   const name = attributes.name
     ? attributes.name.toUpperCase()
     : attributes.name;
-  const city = attributes.city
-    ? attributes.city.toUpperCase()
-    : attributes.city;
+  let city = attributes.physicalCity || attributes.city;
+  city = city ? city.toUpperCase() : city;
   const state = attributes.state
     ? attributes.state.toUpperCase()
     : attributes.state;


### PR DESCRIPTION
## Description
display physical city when available 

## Testing done
verified locally- couldn't find an example where these attributes differed but I verified with some test strings this was the place the value is normalized.

## Screenshots
![screen shot 2018-11-14 at 12 24 32](https://user-images.githubusercontent.com/4998130/48507997-a4fa8a80-e80a-11e8-9a40-99551a68eb17.png)
![screen shot 2018-11-14 at 12 24 44](https://user-images.githubusercontent.com/4998130/48507998-a4fa8a80-e80a-11e8-843c-1e80327c642d.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
