### PR TITLE
Hardcode health care redirect

### DIFF
--- a/script/vets-gov-to-va-gov/app-redirect.js
+++ b/script/vets-gov-to-va-gov/app-redirect.js
@@ -23,7 +23,7 @@ function createAppRedirectHtml(vetsGovSrc, vaGovDest, vaGovHost) {
     var pathname = window.location.pathname;
     var newPath;
 
-    if (pathname.indexOf('/healthcare')) {
+    if (pathname.indexOf('/healthcare') >= 0) {
       newPath = pathname.replace('healthcare', 'health-care');
     } else {
       newPath = pathname.replace('${vetsGovSrc}', '${vaGovDest}');

--- a/script/vets-gov-to-va-gov/app-redirect.js
+++ b/script/vets-gov-to-va-gov/app-redirect.js
@@ -21,7 +21,14 @@ function createAppRedirectHtml(vetsGovSrc, vaGovDest, vaGovHost) {
       }
     }
     var pathname = window.location.pathname;
-    var newPath = pathname.replace('${vetsGovSrc}', '${vaGovDest}');
+    var newPath;
+
+    if (pathname.indexOf('/healthcare')) {
+      newPath = pathname.replace('healthcare', 'health-care');
+    } else {
+      newPath = pathname.replace('${vetsGovSrc}', '${vaGovDest}');
+    }
+
     var finalUrl = '${vaGovHost}' + newPath;
     var redirectUrl = finalUrl + window.location.search;
 


### PR DESCRIPTION
## Description
We need to redirect all /healthcare vets.gov pages to /health-care, but we can't do that like we do for the React apps in our redirect code. This does a sort of hackish fix to detect the path in our 404 page and rewrite it.

## Testing done
None yet, need to try it on dev.vets.gov

## Acceptance criteria
- [x] Redirects correctly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
