### PR TITLE
Catch for null website attribute

### DIFF
--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -34,7 +34,7 @@ class FacilityDetail extends Component {
         <div>
           <LocationPhoneLink location={facility} />
         </div>
-        { website &&
+        { website && website !== 'NULL' &&
           <span>
             <a href={website} target="_blank">
               <i className="fa fa-globe" />Website


### PR DESCRIPTION
## Description

Correctly catches null website attributes in facility locator

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14995

## Testing done
Local testing

## Screenshots


## Acceptance criteria
- [x] Facilities with null website attributes should not show invalid website link

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
