### PR TITLE
Add POW to specialIssues array

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -654,6 +654,41 @@ const schema = {
         },
       },
     },
+    specialIssues: {
+      type: 'array',
+      maxItems: 100,
+      items: {
+        type: 'object',
+        required: ['code', 'name'],
+        properties: {
+          name: {
+            type: 'string',
+          },
+          code: {
+            type: 'string',
+            enum: [
+              'ALS',
+              'AOIV',
+              'AOOV',
+              'ASB',
+              'EHCL',
+              'GW',
+              'HEPC',
+              'MG',
+              'POW',
+              'RDN',
+              'SHAD',
+              'TRM',
+              'PTSD/1',
+              'PTSD/2',
+              'PTSD/3',
+              'PTSD/4',
+              'MST',
+            ],
+          },
+        },
+      },
+    },
   },
   properties: {
     alternateNames: {
@@ -798,39 +833,7 @@ const schema = {
             enum: ['NONE', 'NEW', 'SECONDARY', 'INCREASE', 'REOPEN'],
           },
           specialIssues: {
-            type: 'array',
-            maxItems: 100,
-            items: {
-              type: 'object',
-              required: ['code', 'name'],
-              properties: {
-                name: {
-                  type: 'string',
-                },
-                code: {
-                  type: 'string',
-                  enum: [
-                    'ALS',
-                    'AOIV',
-                    'AOOV',
-                    'ASB',
-                    'EHCL',
-                    'GW',
-                    'HEPC',
-                    'MG',
-                    'POW',
-                    'RDN',
-                    'SHAD',
-                    'TRM',
-                    'PTSD/1',
-                    'PTSD/2',
-                    'PTSD/3',
-                    'PTSD/4',
-                    'MST',
-                  ],
-                },
-              },
-            },
+            $ref: '#/definitions/specialIssues',
           },
           ratedDisabilityId: {
             type: 'string',
@@ -859,39 +862,7 @@ const schema = {
                   enum: ['NONE', 'NEW', 'SECONDARY', 'INCREASE', 'REOPEN'],
                 },
                 specialIssues: {
-                  type: 'array',
-                  maxItems: 100,
-                  items: {
-                    type: 'object',
-                    required: ['code', 'name'],
-                    properties: {
-                      name: {
-                        type: 'string',
-                      },
-                      code: {
-                        type: 'string',
-                        enum: [
-                          'ALS',
-                          'AOIV',
-                          'AOOV',
-                          'ASB',
-                          'EHCL',
-                          'GW',
-                          'HEPC',
-                          'MG',
-                          'POW',
-                          'RDN',
-                          'SHAD',
-                          'TRM',
-                          'PTSD/1',
-                          'PTSD/2',
-                          'PTSD/3',
-                          'PTSD/4',
-                          'MST',
-                        ],
-                      },
-                    },
-                  },
+                  $ref: '#/definitions/specialIssues',
                 },
                 ratedDisabilityId: {
                   type: 'string',
@@ -932,6 +903,9 @@ const schema = {
           },
           causedByDisabilityDescription: {
             type: 'string',
+          },
+          specialIssues: {
+            $ref: '#/definitions/specialIssues',
           },
           worsenedDescription: {
             type: 'string',

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -440,8 +440,8 @@ describe('526 helpers', () => {
   describe('transformRelatedDisabilities', () => {
     it('should return an array of strings', () => {
       const claimedConditions = [
-        'Some condition name',
-        'Another condition name',
+        'some condition name',
+        'another condition name',
       ];
       const relatedDisabilities = {
         'Some condition name': true,
@@ -450,10 +450,10 @@ describe('526 helpers', () => {
       };
       expect(
         transformRelatedDisabilities(relatedDisabilities, claimedConditions),
-      ).to.eql(['Some condition name', 'Another condition name']);
+      ).to.eql(['some condition name', 'another condition name']);
     });
     it('should not add conditions if they are not claimed', () => {
-      const claimedConditions = ['Some condition name'];
+      const claimedConditions = ['some condition name'];
       const relatedDisabilities = {
         'Some condition name': true,
         'Another condition name': true,
@@ -461,7 +461,7 @@ describe('526 helpers', () => {
       };
       expect(
         transformRelatedDisabilities(relatedDisabilities, claimedConditions),
-      ).to.eql(['Some condition name']);
+      ).to.eql(['some condition name']);
     });
   });
 });


### PR DESCRIPTION
## Description
In the transform before submit, we'll now take the list of `powDisabilities` as gathered on the POW screen and add an item to the appropriate condition's `specialIssues` array.

## Testing done
Tested the schema test still works.

## Screenshots
N/A

## Acceptance criteria
- [x] The `specialIssues` array is added if needed
- [x] The POW special issue is added to the array if appropriate

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
