### PR TITLE
Remove the submit promise

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -88,8 +88,6 @@ const formConfig = {
   transformForSubmit: transform,
   introduction: IntroductionPage,
   confirmation: ConfirmationPoll,
-  // TODO: Remove this once we've got the api up and running
-  submit: () => Promise.resolve({ attributes: { jobId: '12345' } }),
   // footerContent: FormFooter,
   // getHelp: GetFormHelp,
   defaultDefinitions: {


### PR DESCRIPTION
## Description
Removes the submission promise on the 526 all claims form.

## Testing done
None. :grimacing:

Not sure how to test this, honestly. I mean, it submits to the api without this, right? That's probably enough?

## Screenshots
N/A

## Acceptance criteria
- [x] The all claims form submits to the API

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
