### PR TITLE
Bump formation version to fix heading sizing

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,15 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/runtime@^7.1.2":
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.5.tgz#4170907641cf1f61508f563ece3725150cc6fe39"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@department-of-veterans-affairs/formation@^1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.11.0.tgz#37719103c198e3ac6c4e63cafcc37baa5221f982"
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-1.12.0.tgz#a6fd1a424b36c50a8c0ad1062b30f841f6ca598c"
   dependencies:
     classnames "^2.2.5"
     font-awesome "4"
@@ -2931,8 +2937,10 @@ doctrine@^2.0.0:
     isarray "^1.0.0"
 
 dom-helpers@^3.2.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
+  dependencies:
+    "@babel/runtime" "^7.1.2"
 
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
@@ -9012,6 +9020,10 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
 regenerator-runtime@~0.9.5:
   version "0.9.6"


### PR DESCRIPTION
## Description
I bumped up our heading levels in a previous PR, but neglected to update yarn.lock with the new version of Formation that included the styles for them.

## Testing done
Checked locally

## Screenshots
![screen shot 2018-11-16 at 3 10 50 pm](https://user-images.githubusercontent.com/634932/48644823-d2356d00-e9b1-11e8-8299-f03fde0e3132.png)

## Acceptance criteria
- [x] Homepage looks correct again

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
