### PR TITLE
Clean up unit test output

### DIFF
--- a/src/applications/claims-status/tests/components/RequestedFilesInfo.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/RequestedFilesInfo.unit.spec.jsx
@@ -21,6 +21,7 @@ describe('<RequestedFilesInfo>', () => {
   it('should display requested items', () => {
     const filesNeeded = [
       {
+        trackedItemId: 1,
         type: 'still_need_from_you_list',
         displayName: 'Request 1',
         description: 'Some description',
@@ -51,6 +52,7 @@ describe('<RequestedFilesInfo>', () => {
   it('should display optional files', () => {
     const optionalFiles = [
       {
+        trackedItemId: 1,
         type: 'still_need_from_others_list',
         status: 'NEEDED',
       },

--- a/src/applications/disability-benefits/526EZ/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -71,9 +71,8 @@ describe('ConfirmationPoll', () => {
       successResponse,
       failureResponse,
     ]);
-    // TODO: Figure out why this is causing an error in the console even though the test passes
-    //  It may have something to do with unmounting the component before a `setState` goes through
-    mount(<ConfirmationPoll pollRate={10} />);
+
+    mount(<ConfirmationPoll {...defaultProps} pollRate={10} />);
     // Should stop after the first success
     setTimeout(() => {
       expect(global.fetch.callCount).to.equal(3);

--- a/src/applications/disability-benefits/526EZ/tests/components/PaymentView.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/PaymentView.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import PaymentView from '../../components/PaymentView';
 
-describe('Disability benefits 526EZ primary address', () => {
+describe('Disability benefits 526EZ payment view', () => {
   const defaultProps = {
     accountType: 'Checking',
     accountNumber: '123456789',

--- a/src/applications/disability-benefits/686/tests/config/dependentInfo.unit.spec.js
+++ b/src/applications/disability-benefits/686/tests/config/dependentInfo.unit.spec.js
@@ -27,7 +27,7 @@ describe('686 dependent info', () => {
             first: 'Jane',
             last: 'Doe',
           },
-          childDateOfBirth: '1-10-2000',
+          childDateOfBirth: '2000-01-10',
         },
       ],
     });
@@ -47,7 +47,7 @@ describe('686 dependent info', () => {
 
   it('should show disabled if child is less than 18 years old', () => {
     const props = dependentData();
-    props.dependents[0].childDateOfBirth = '1-10-2010';
+    props.dependents[0].childDateOfBirth = '2010-01-10';
     const form = mount(
       <DefinitionTester
         arrayPath={arrayPath}
@@ -63,7 +63,7 @@ describe('686 dependent info', () => {
 
   it('should not show disabled or inSchool if child is older than 23', () => {
     const props = dependentData();
-    props.dependents[0].childDateOfBirth = '1-10-1986';
+    props.dependents[0].childDateOfBirth = '1986-01-10';
     const form = mount(
       <DefinitionTester
         arrayPath={arrayPath}

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -73,9 +73,8 @@ describe('ConfirmationPoll', () => {
       successResponse,
       failureResponse,
     ]);
-    // TODO: Figure out why this is causing an error in the console even though the test passes
-    //  It may have something to do with unmounting the component before a `setState` goes through
-    mount(<ConfirmationPoll pollRate={10} />);
+
+    mount(<ConfirmationPoll {...defaultProps} pollRate={10} />);
     // Should stop after the first success
     setTimeout(() => {
       expect(global.fetch.callCount).to.equal(3);

--- a/src/applications/disability-benefits/all-claims/tests/components/ReviewCardField.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ReviewCardField.unit.spec.jsx
@@ -27,21 +27,25 @@ describe('Schemaform: ReviewCardField', () => {
       'ui:field': ReviewCardField,
       'ui:options': { viewComponent },
     },
-    // This isn't actually fixing the failed prop types warnings...
-    idSchema: { $id: 'something' },
+    idSchema: {
+      $id: 'something',
+      field1: { $id: 'field1' },
+      field2: { $id: 'field2' },
+    },
     errorSchema: {
       field1: { __errors: [] },
       field2: { __errors: [] },
     },
     formContext: {
       onError: () => {},
-      // This isn't actually fixing the failed prop types warnings...
-      onBlur: () => {},
     },
+    // This isn't actually fixing the failed prop types warnings...
+    onBlur: () => {},
+    onChange: () => {},
     formData: {},
   };
 
-  it('sould render', () => {
+  it('should render', () => {
     const wrapper = shallow(<ReviewCardField {...defaultProps} />);
     expect(wrapper.type()).to.equal('div');
   });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -18,17 +18,16 @@ import {
 } from './constants';
 /**
  * Show one thing, have a screen reader say another.
- * NOTE: This will cause React to get angry if used in a <p> because the DOM is "invalid."
  *
  * @param {ReactElement|ReactComponent|String} srIgnored -- Thing to be displayed visually,
  *                                                           but ignored by screen readers
  * @param {String} substitutionText -- Text for screen readers to say instead of srIgnored
  */
 export const srSubstitute = (srIgnored, substitutionText) => (
-  <div style={{ display: 'inline' }}>
+  <span>
     <span aria-hidden>{srIgnored}</span>
     <span className="sr-only">{substitutionText}</span>
-  </div>
+  </span>
 );
 
 export const hasGuardOrReservePeriod = formData => {

--- a/src/applications/hca/tests/components/DemographicField.unit.spec.jsx
+++ b/src/applications/hca/tests/components/DemographicField.unit.spec.jsx
@@ -9,30 +9,41 @@ import formConfig from '../../config/form';
 
 describe('hca <DemographicField>', () => {
   it('should render ObjectField', () => {
+    const formContext = {
+      reviewMode: false,
+    };
     const registry = {
       fields: {
         ObjectField,
       },
-    };
-    const formContext = {
-      reviewMode: false,
+      definitions: {},
+      widgets: {},
+      formContext,
     };
 
     const tree = SkinDeep.shallowRender(
-      <DemographicField formContext={formContext} registry={registry} />,
+      <DemographicField
+        formContext={formContext}
+        onChange={f => f}
+        registry={registry}
+        schema={{}}
+      />,
     );
 
     expect(tree.subTree('ObjectField')).not.to.be.false;
     expect(tree.subTree('ObjectField').props.formContext).to.equal(formContext);
   });
   it('should render review version', () => {
+    const formContext = {
+      reviewMode: true,
+    };
     const registry = {
       fields: {
         ObjectField,
       },
-    };
-    const formContext = {
-      reviewMode: true,
+      definitions: {},
+      widgets: {},
+      formContext,
     };
     const demographicInformation =
       formConfig.chapters.veteranInformation.pages.demographicInformation;
@@ -40,6 +51,7 @@ describe('hca <DemographicField>', () => {
     const tree = SkinDeep.shallowRender(
       <DemographicField
         formContext={formContext}
+        onChange={f => f}
         schema={
           demographicInformation.schema.properties['view:demographicCategories']
         }

--- a/src/applications/health-records/tests/containers/Main.unit.spec.jsx
+++ b/src/applications/health-records/tests/containers/Main.unit.spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
-import { wrapWithRouterContext } from '../../../../platform/testing/unit/helpers';
 
 import { Main } from '../../containers/Main';
 
@@ -18,20 +17,18 @@ const props = {
   },
 };
 
+const context = { router: {} };
+
 describe('<Main>', () => {
   it('should render', () => {
-    const tree = SkinDeep.shallowRender(
-      wrapWithRouterContext(<Main {...props} />),
-    );
+    const tree = SkinDeep.shallowRender(<Main {...props} />, context);
     const vdom = tree.getRenderOutput();
     expect(vdom).to.exist;
   });
 
   it('submit button should be enabled if form is valid', () => {
-    const tree = SkinDeep.shallowRender(
-      wrapWithRouterContext(<Main {...props} />),
-    );
-    const submitButton = tree.dive(['Main', 'button']);
+    const tree = SkinDeep.shallowRender(<Main {...props} />, context);
+    const submitButton = tree.dive(['button']);
     expect(submitButton.props.disabled).to.not.be.ok;
   });
 });

--- a/src/applications/messaging/tests/components/ComposeButton.unit.spec.jsx
+++ b/src/applications/messaging/tests/components/ComposeButton.unit.spec.jsx
@@ -4,15 +4,17 @@ import { expect } from 'chai';
 
 import ComposeButton from '../../components/ComposeButton';
 
+const context = { router: {} };
+
 describe('<ComposeButton>', () => {
   it('should render correctly', () => {
-    const tree = SkinDeep.shallowRender(<ComposeButton />);
+    const tree = SkinDeep.shallowRender(<ComposeButton />, context);
 
     expect(tree.getRenderOutput()).to.exist;
   });
 
   it('should have the expected default classname', () => {
-    const tree = SkinDeep.shallowRender(<ComposeButton />);
+    const tree = SkinDeep.shallowRender(<ComposeButton />, context);
 
     expect(tree.props.className).to.equal(
       'messaging-compose-button va-button-primary',
@@ -20,7 +22,7 @@ describe('<ComposeButton>', () => {
   });
 
   it('should have the expected classname when disabled', () => {
-    const tree = SkinDeep.shallowRender(<ComposeButton disabled />);
+    const tree = SkinDeep.shallowRender(<ComposeButton disabled />, context);
 
     expect(tree.props.className).to.equal(
       'messaging-compose-button usa-button-disabled',
@@ -28,7 +30,7 @@ describe('<ComposeButton>', () => {
   });
 
   it('should render disabled button when disabled', () => {
-    const tree = SkinDeep.shallowRender(<ComposeButton disabled />);
+    const tree = SkinDeep.shallowRender(<ComposeButton disabled />, context);
 
     expect(tree.subTree('button').props.disabled).to.equal(true);
   });

--- a/src/applications/messaging/tests/components/buttons/ButtonBack.unit.spec.jsx
+++ b/src/applications/messaging/tests/components/buttons/ButtonBack.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import SkinDeep from 'skin-deep';
+import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
 import ButtonBack from '../../../components/buttons/ButtonBack';
@@ -8,16 +8,14 @@ const props = {
   url: 'www.vets.gov',
 };
 
+const context = {
+  router: {},
+};
+
 describe('<ButtonBack>', () => {
   it('should render correctly', () => {
-    const tree = SkinDeep.shallowRender(<ButtonBack {...props} />);
+    const tree = shallow(<ButtonBack {...props} />, { context });
 
-    expect(tree.getRenderOutput()).to.exist;
-  });
-
-  it('should have the expected classname', () => {
-    const tree = SkinDeep.shallowRender(<ButtonBack {...props} />);
-
-    expect(tree.props.className).to.equal('msg-btn-back');
+    expect(tree.find('.msg-btn-back').exists()).to.be.true;
   });
 });

--- a/src/applications/messaging/tests/containers/Compose.unit.spec.jsx
+++ b/src/applications/messaging/tests/containers/Compose.unit.spec.jsx
@@ -30,8 +30,10 @@ const props = {
   router: {},
 };
 
+const context = { router: {} };
+
 describe('Compose', () => {
-  const tree = SkinDeep.shallowRender(<Compose {...props} />);
+  const tree = SkinDeep.shallowRender(<Compose {...props} />, context);
 
   it('should render', () => {
     const vdom = tree.getRenderOutput();

--- a/src/applications/messaging/tests/containers/Folder.unit.spec.jsx
+++ b/src/applications/messaging/tests/containers/Folder.unit.spec.jsx
@@ -55,9 +55,11 @@ const props = {
   router: () => {},
 };
 
+const context = { router: {} };
+
 describe('Folder', () => {
   it('should render', () => {
-    const tree = SkinDeep.shallowRender(<Folder {...props} />);
+    const tree = SkinDeep.shallowRender(<Folder {...props} />, context);
     const vdom = tree.getRenderOutput();
     expect(vdom).to.not.be.undefined;
   });
@@ -65,6 +67,7 @@ describe('Folder', () => {
   it('should show a loading screen', () => {
     const tree = SkinDeep.shallowRender(
       <Folder {...props} loading={{ folder: true }} />,
+      context,
     );
     expect(tree.subTree('LoadingIndicator')).to.not.be.false;
     expect(tree.subTree('MessageSearch')).to.be.false;
@@ -73,7 +76,10 @@ describe('Folder', () => {
   });
 
   it('should show an error message without a reload', () => {
-    const tree = SkinDeep.shallowRender(<Folder {...props} attributes={{}} />);
+    const tree = SkinDeep.shallowRender(
+      <Folder {...props} attributes={{}} />,
+      context,
+    );
     expect(tree.subTree('.msg-loading-error')).to.not.be.false;
     expect(tree.subTree('.msg-reload')).to.be.false;
     expect(tree.subTree('MessageSearch')).to.be.false;
@@ -88,6 +94,7 @@ describe('Folder', () => {
         attributes={{}}
         lastRequestedFolder={{ id: 0, query: {} }}
       />,
+      context,
     );
     expect(tree.subTree('.msg-loading-error')).to.not.be.false;
     expect(tree.subTree('.msg-reload')).to.be.not.be.false;
@@ -109,6 +116,7 @@ describe('Folder', () => {
           totalEntries: 0,
         }}
       />,
+      context,
     );
     expect(tree.dive(['h3']).text()).to.equal('Inbox');
     expect(tree.subTree('.msg-nomessages')).to.not.be.false;
@@ -130,6 +138,7 @@ describe('Folder', () => {
           totalEntries: 0,
         }}
       />,
+      context,
     );
     expect(tree.dive(['h3']).text()).to.equal('Inbox');
     expect(tree.subTree('.msg-nomessages')).to.not.be.false;
@@ -139,7 +148,7 @@ describe('Folder', () => {
   });
 
   it('should show folder controls and messages', () => {
-    const tree = SkinDeep.shallowRender(<Folder {...props} />);
+    const tree = SkinDeep.shallowRender(<Folder {...props} />, context);
     expect(tree.dive(['h3']).text()).to.equal('Inbox');
     expect(tree.subTree('ComposeButton')).to.not.be.false;
     expect(tree.subTree('MessageSearch')).to.not.be.false;
@@ -161,6 +170,7 @@ describe('Folder', () => {
           totalEntries: 2,
         }}
       />,
+      context,
     );
     expect(tree.dive(['h3']).text()).to.equal('Inbox');
     expect(tree.subTree('ComposeButton')).to.not.be.false;

--- a/src/applications/messaging/tests/containers/Thread.unit.spec.jsx
+++ b/src/applications/messaging/tests/containers/Thread.unit.spec.jsx
@@ -41,8 +41,10 @@ const props = {
   dispatch: () => {},
 };
 
+const context = { router: {} };
+
 describe('Thread', () => {
-  const tree = SkinDeep.shallowRender(<Thread {...props} />);
+  const tree = SkinDeep.shallowRender(<Thread {...props} />, context);
 
   it('should render', () => {
     const vdom = tree.getRenderOutput();

--- a/src/applications/pensions/tests/config/childrenInformation.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/childrenInformation.unit.spec.jsx
@@ -116,7 +116,7 @@ describe('Child information page', () => {
     const data = Object.assign({}, dependentData());
     data.dependents[0].childDateOfBirth = moment()
       .subtract(19, 'years')
-      .toString();
+      .toISOString();
 
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
@@ -139,7 +139,7 @@ describe('Child information page', () => {
     const data = Object.assign({}, dependentData());
     data.dependents[0].childDateOfBirth = moment()
       .subtract(19, 'years')
-      .toString();
+      .toISOString();
 
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(

--- a/src/applications/personalization/account/components/LoginSettings.jsx
+++ b/src/applications/personalization/account/components/LoginSettings.jsx
@@ -32,28 +32,16 @@ export default function LoginSettings() {
   return (
     <div>
       <h5>ID.me settings</h5>
-      {isBrandConsolidationEnabled() ? (
-        <div>
-          <p>
-            <a href="https://wallet.id.me/settings" target="_blank">
-              Manage your ID.me account.
-            </a>
-          </p>
-          <AdditionalInfo triggerText="What is ID.me?">
-            {idMeAnswer}
-          </AdditionalInfo>
-        </div>
-      ) : (
+      <div>
         <p>
-          Want to change the email you use to sign in to ID.me, or update your
-          ID.me password or other account settings?
-          <br />
           <a href="https://wallet.id.me/settings" target="_blank">
-            Go to ID.me to manage your account
+            Manage your ID.me account.
           </a>
-          {idMeAnswer}
         </p>
-      )}
+        <AdditionalInfo triggerText="What is ID.me?">
+          {idMeAnswer}
+        </AdditionalInfo>
+      </div>
     </div>
   );
 }

--- a/src/applications/post-911-gib-status/components/EducationWizard.jsx
+++ b/src/applications/post-911-gib-status/components/EducationWizard.jsx
@@ -77,6 +77,7 @@ export default class EducationWizard extends React.Component {
                       additionalFieldsetClass="wizard-fieldset"
                       name={type}
                       id={type}
+                      key={type}
                       options={options}
                       onValueChange={({ value }) =>
                         this.answerQuestion(type, value)

--- a/src/applications/post-911-gib-status/components/EducationWizard.jsx
+++ b/src/applications/post-911-gib-status/components/EducationWizard.jsx
@@ -87,7 +87,7 @@ export default class EducationWizard extends React.Component {
                     />
                   );
                 }
-                return <Component />;
+                return <Component key={type} />;
               }
             })}
           </div>

--- a/src/applications/post-911-gib-status/containers/IntroPageSummary.jsx
+++ b/src/applications/post-911-gib-status/containers/IntroPageSummary.jsx
@@ -165,15 +165,13 @@ export default function BrandConsolidationSummary() {
       >
         {!isProduction() && (
           <div itemProp="text">
-            <p>
-              There are a few situations where your Post-9/11 GI Bill Statement
-              of Benefits might not be available. Answer a few questions and
-              we’ll help you find out why:
-              <EducationWizard
-                config={wizardConfig}
-                toggleText="Troubleshoot My GI Bill Benefits"
-              />
-            </p>
+            There are a few situations where your Post-9/11 GI Bill Statement of
+            Benefits might not be available. Answer a few questions and we’ll
+            help you find out why:
+            <EducationWizard
+              config={wizardConfig}
+              toggleText="Troubleshoot My GI Bill Benefits"
+            />
           </div>
         )}
         {isProduction() && (

--- a/src/applications/post-911-gib-status/containers/IntroPageSummary.jsx
+++ b/src/applications/post-911-gib-status/containers/IntroPageSummary.jsx
@@ -164,7 +164,7 @@ export default function BrandConsolidationSummary() {
         itemType="http://schema.org/Answer"
       >
         {!isProduction() && (
-          <div itemProp="text">
+          <div className="intro-wizard" itemProp="text">
             There are a few situations where your Post-9/11 GI Bill Statement of
             Benefits might not be available. Answer a few questions and we’ll
             help you find out why:

--- a/src/applications/post-911-gib-status/sass/post-911-gib-status.scss
+++ b/src/applications/post-911-gib-status/sass/post-911-gib-status.scss
@@ -123,3 +123,7 @@
   margin-top: 1em;
   margin-bottom: 1em;
 }
+
+.intro-wizard {
+  margin-bottom: 1em;
+}

--- a/src/applications/post-911-gib-status/tests/components/EducationWizard.unit.spec.jsx
+++ b/src/applications/post-911-gib-status/tests/components/EducationWizard.unit.spec.jsx
@@ -15,7 +15,7 @@ function answerQuestion(tree, name, value) {
   getQuestion(tree, name).props.onValueChange({ value });
 }
 
-describe('<EducationWizard>', () => {
+describe.only('<EducationWizard>', () => {
   it('should show button and no questions', () => {
     const tree = SkinDeep.shallowRender(
       <EducationWizard

--- a/src/applications/post-911-gib-status/tests/components/EducationWizard.unit.spec.jsx
+++ b/src/applications/post-911-gib-status/tests/components/EducationWizard.unit.spec.jsx
@@ -15,7 +15,7 @@ function answerQuestion(tree, name, value) {
   getQuestion(tree, name).props.onValueChange({ value });
 }
 
-describe.only('<EducationWizard>', () => {
+describe('<EducationWizard>', () => {
   it('should show button and no questions', () => {
     const tree = SkinDeep.shallowRender(
       <EducationWizard

--- a/src/platform/testing/unit/mocha.opts
+++ b/src/platform/testing/unit/mocha.opts
@@ -5,5 +5,4 @@
 --require blob-polyfill
 --compilers js:babel-register,jsx:babel-register
 --prof
---reporter dot
 --timeout 5000

--- a/src/platform/testing/unit/mocha.opts
+++ b/src/platform/testing/unit/mocha.opts
@@ -5,4 +5,5 @@
 --require blob-polyfill
 --compilers js:babel-register,jsx:babel-register
 --prof
+--reporter dot
 --timeout 5000

--- a/src/platform/user/tests/authorization/containers/MHVApp.unit.spec.jsx
+++ b/src/platform/user/tests/authorization/containers/MHVApp.unit.spec.jsx
@@ -36,6 +36,8 @@ describe('<MHVApp>', () => {
     props.upgradeMHVAccount.reset();
   };
 
+  const context = { router: {} };
+
   const expectAlert = (wrapper, expectedStatus, expectedHeadline) => {
     const alertBox = wrapper.find('AlertBox');
     const headlineProp = alertBox.prop('headline');
@@ -51,19 +53,19 @@ describe('<MHVApp>', () => {
 
   it('should show a loading indicator when fetching an account', () => {
     const newProps = set('mhvAccount.loading', true, props);
-    const wrapper = shallow(<MHVApp {...newProps} />);
+    const wrapper = shallow(<MHVApp {...newProps} />, { context });
     expect(wrapper.find('LoadingIndicator').exists()).to.be.true;
   });
 
   it('should create an account if the user does not have an account but is eligible', () => {
-    const wrapper = shallow(<MHVApp {...props} />);
+    const wrapper = shallow(<MHVApp {...props} />, { context });
     const mhvAccount = set('accountState', 'no_account', props.mhvAccount);
     wrapper.setProps({ mhvAccount });
     expect(props.createMHVAccount.calledOnce).to.be.true;
   });
 
   it('should redirect if the user needs to accepts T&C', () => {
-    const wrapper = shallow(<MHVApp {...props} />);
+    const wrapper = shallow(<MHVApp {...props} />, { context });
     const mhvAccount = set(
       'accountState',
       'needs_terms_acceptance',
@@ -74,14 +76,14 @@ describe('<MHVApp>', () => {
   });
 
   it('should invoke upgrade if the user is only registered', () => {
-    const wrapper = shallow(<MHVApp {...props} />);
+    const wrapper = shallow(<MHVApp {...props} />, { context });
     const mhvAccount = set('accountState', 'registered', props.mhvAccount);
     wrapper.setProps({ mhvAccount });
     expect(props.upgradeMHVAccount.calledOnce).to.be.true;
   });
 
   it('should invoke upgrade if the user is existing without access to the service', () => {
-    const wrapper = shallow(<MHVApp {...props} />);
+    const wrapper = shallow(<MHVApp {...props} />, { context });
     const mhvAccount = set('accountState', 'existing', props.mhvAccount);
     wrapper.setProps({ mhvAccount });
     expect(props.upgradeMHVAccount.calledOnce).to.be.true;
@@ -93,7 +95,7 @@ describe('<MHVApp>', () => {
       location: { ...props.location, query: { tc_accepted: true } }, // eslint-disable-line camelcase
       availableServices: ['rx'],
     });
-    const wrapper = shallow(<MHVApp {...newProps} />);
+    const wrapper = shallow(<MHVApp {...newProps} />, { context });
     expectAlert(
       wrapper,
       'success',
@@ -102,13 +104,13 @@ describe('<MHVApp>', () => {
   });
 
   it('should show MHV access error if nothing is loading or processing', () => {
-    const wrapper = shallow(<MHVApp {...props} />);
+    const wrapper = shallow(<MHVApp {...props} />, { context });
     expect(wrapper.find('#mhv-access-error').exists()).to.be.true;
   });
 
   it('should show MHV access error if user has an account but not the required service', () => {
     const newProps = set('mhvAccount.accountState', 'existing', props);
-    const wrapper = shallow(<MHVApp {...newProps} />);
+    const wrapper = shallow(<MHVApp {...newProps} />, { context });
     expect(wrapper.find('#mhv-access-error').exists()).to.be.true;
   });
 
@@ -121,6 +123,7 @@ describe('<MHVApp>', () => {
       <MHVApp {...newProps}>
         <div id="test" />
       </MHVApp>,
+      { context },
     );
     expect(wrapper.find('#test').exists()).to.be.true;
   });
@@ -134,6 +137,7 @@ describe('<MHVApp>', () => {
       <MHVApp {...newProps}>
         <div id="test" />
       </MHVApp>,
+      { context },
     );
     expect(wrapper.find('#test').exists()).to.be.true;
   });
@@ -149,7 +153,7 @@ describe('<MHVApp>', () => {
     ];
 
     const newProps = set('mhvAccount.errors', errors, props);
-    const wrapper = shallow(<MHVApp {...newProps} />);
+    const wrapper = shallow(<MHVApp {...newProps} />, { context });
     expectAlert(
       wrapper,
       'error',
@@ -159,7 +163,7 @@ describe('<MHVApp>', () => {
 
   it('should show error if unable to determine MHV account level', () => {
     const newProps = set('mhvAccount.accountLevel', 'Unknown', props);
-    const wrapper = shallow(<MHVApp {...newProps} />);
+    const wrapper = shallow(<MHVApp {...newProps} />, { context });
     expectAlert(
       wrapper,
       'error',
@@ -169,7 +173,7 @@ describe('<MHVApp>', () => {
 
   it('should show error if failed to register MHV account', () => {
     const newProps = set('mhvAccount.accountState', 'register_failed', props);
-    const wrapper = shallow(<MHVApp {...newProps} />);
+    const wrapper = shallow(<MHVApp {...newProps} />, { context });
     expectAlert(
       wrapper,
       'error',
@@ -179,7 +183,7 @@ describe('<MHVApp>', () => {
 
   it('should show error if failed to upgrade MHV account', () => {
     const newProps = set('mhvAccount.accountState', 'upgrade_failed', props);
-    const wrapper = shallow(<MHVApp {...newProps} />);
+    const wrapper = shallow(<MHVApp {...newProps} />, { context });
     expectAlert(
       wrapper,
       'error',
@@ -193,7 +197,7 @@ describe('<MHVApp>', () => {
       'needs_ssn_resolution',
       props,
     );
-    const wrapper = shallow(<MHVApp {...newProps} />);
+    const wrapper = shallow(<MHVApp {...newProps} />, { context });
     expectAlert(
       wrapper,
       'error',
@@ -203,7 +207,7 @@ describe('<MHVApp>', () => {
 
   it('should show error if the user is not a VA patient', () => {
     const newProps = set('mhvAccount.accountState', 'needs_va_patient', props);
-    const wrapper = shallow(<MHVApp {...newProps} />);
+    const wrapper = shallow(<MHVApp {...newProps} />, { context });
     expectAlert(
       wrapper,
       'error',
@@ -217,7 +221,7 @@ describe('<MHVApp>', () => {
       'has_deactivated_mhv_ids',
       props,
     );
-    const wrapper = shallow(<MHVApp {...newProps} />);
+    const wrapper = shallow(<MHVApp {...newProps} />, { context });
     expectAlert(
       wrapper,
       'error',
@@ -231,7 +235,7 @@ describe('<MHVApp>', () => {
       'has_multiple_active_mhv_ids',
       props,
     );
-    const wrapper = shallow(<MHVApp {...newProps} />);
+    const wrapper = shallow(<MHVApp {...newProps} />, { context });
     expectAlert(
       wrapper,
       'error',


### PR DESCRIPTION
## Description
This PR cleans up some warnings in our unit test output. It doesn't get everything. The things that are left:

1. React-scroll warnings that hardcoded in the react-scroll module. Fixing our tests here is really time consuming
2. Some USFS prop type warnings that are expected with one of our widgets
3. One USFS prop type warning I can't figure out (in vaMedicalRecords for all claims)
4. Some createClass and propTypes React deprecation warnings that will go away when we upgrade some dependencies for React 16.

## Testing done
Ran unit tests

## Acceptance criteria
- [x] Unit tests pass

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
