### PR TITLE
Fix help text on 526 footer

### DIFF
--- a/src/applications/disability-benefits/components/GetFormHelp.jsx
+++ b/src/applications/disability-benefits/components/GetFormHelp.jsx
@@ -4,20 +4,9 @@ import CallVBACenter from '../../../platform/brand-consolidation/components/Call
 function GetFormHelp() {
   return (
     <div>
-      <p className="help-talk">For help filling out this form, please call:</p>
-      <p className="help-phone-number">
-        <a className="help-phone-number-link" href="tel:+1-877-222-8387">
-          1-877-222-VETS
-        </a>{' '}
-        (
-        <a className="help-phone-number-link" href="tel:+1-877-222-8387">
-          1-877-222-8387
-        </a>
-        )<br />
-        Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET)
-      </p>
       <p className="help-talk">
-        If this form isn't working right for you, please <CallVBACenter />
+        For help filling out this form, or if the form isn’t working right,
+        please <CallVBACenter />
       </p>
     </div>
   );


### PR DESCRIPTION
## Description
The help info is wrong in the 526 form footer

## Testing done
Checked locally

## Screenshots
![screen shot 2018-11-28 at 4 17 09 pm](https://user-images.githubusercontent.com/634932/49182792-326ccd00-f329-11e8-9243-a05e3826cfd5.png)

## Acceptance criteria
- [x] Help information is correct

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
