### PR TITLE
Change specialIssue to specialIssues (Array<String>)

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -569,7 +569,7 @@ const schema = {
               treatmentDateRange: {
                 $ref: '#/definitions/dateRangeAllRequired',
               },
-              /* 
+              /*
                * Back end expects the following structure:
                * "providerFacilityAddress": {
                *  "street": "123 Main Street",
@@ -578,7 +578,7 @@ const schema = {
                *   "state": "MD",
                *   "country": "USA",
                *   "postalCode": "21200-1111"
-               *  } 
+               *  }
               */
               providerFacilityAddress: {
                 type: 'object',
@@ -698,18 +698,21 @@ const schema = {
         },
       },
     },
-    specialIssue: {
-      type: 'string',
-      enum: [
-        'ALS',
-        'HEPC',
-        'POW',
-        'PTSD/1',
-        'PTSD/2',
-        'PTSD/3',
-        'PTSD/4',
-        'MST',
-      ],
+    specialIssues: {
+      type: 'array',
+      items: {
+        type: 'string',
+        enum: [
+          'ALS',
+          'HEPC',
+          'POW',
+          'PTSD/1',
+          'PTSD/2',
+          'PTSD/3',
+          'PTSD/4',
+          'MST',
+        ],
+      },
     },
   },
   properties: {
@@ -854,8 +857,8 @@ const schema = {
             type: 'string',
             enum: ['NONE', 'NEW', 'SECONDARY', 'INCREASE', 'REOPEN'],
           },
-          specialIssue: {
-            $ref: '#/definitions/specialIssue',
+          specialIssues: {
+            $ref: '#/definitions/specialIssues',
           },
           ratedDisabilityId: {
             type: 'string',
@@ -883,8 +886,8 @@ const schema = {
                   type: 'string',
                   enum: ['NONE', 'NEW', 'SECONDARY', 'INCREASE', 'REOPEN'],
                 },
-                specialIssue: {
-                  $ref: '#/definitions/specialIssue',
+                specialIssues: {
+                  $ref: '#/definitions/specialIssues',
                 },
                 ratedDisabilityId: {
                   type: 'string',
@@ -926,8 +929,8 @@ const schema = {
           causedByDisabilityDescription: {
             type: 'string',
           },
-          specialIssue: {
-            $ref: '#/definitions/specialIssue',
+          specialIssues: {
+            $ref: '#/definitions/specialIssues',
           },
           worsenedDescription: {
             type: 'string',

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -240,7 +240,7 @@ export function transform(formConfig, form) {
       if (powDisabilities.includes(d.condition.toLowerCase())) {
         const newSpecialIssues = (d.specialIssues || []).slice();
         // TODO: Make a constant with all the possibilities and use it here
-        newSpecialIssues.push({ code: 'POW', name: '' });
+        newSpecialIssues.push('POW');
         return _.set('specialIssues', newSpecialIssues, d);
       }
       return d;


### PR DESCRIPTION
## Description
I'm _told_ that the `specialIssue` in EVSS' latest swagger doc is changing to accept an array of strings. I can't prove it, however. This PR changes it to an array of strings and hopes for the best.

## Testing done
No new tests were written, but I did ensure that the `schema.unit.spec.js` test failed without updating the transformer.

## Screenshots
N/A

## Acceptance criteria
- [x] The `specialIssues` properties are being sent to the api as arrays of strings

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
