### PR TITLE
Fix issue with december wrapping to jan

### DIFF
--- a/src/platform/forms/tests/validations.unit.spec.js
+++ b/src/platform/forms/tests/validations.unit.spec.js
@@ -479,12 +479,11 @@ describe('Validations unit tests', () => {
       expect(isValidPartialMonthYearInPast('2', '2001')).to.be.true;
     });
     it('should validate month and year that is current', () => {
+      const currentMonthIndexedAtOne = moment().month() + 1;
+
       expect(
         isValidPartialMonthYearInPast(
-          moment()
-            .add(1, 'month')
-            .month()
-            .toString(),
+          currentMonthIndexedAtOne.toString(),
           moment()
             .year()
             .toString(),


### PR DESCRIPTION
## Description
This fixes an issue with a unit tests -

```
Validations unit tests isValidPartialMonthYearInPast should validate month and year that is current – should validate month and year that is current
<1s
Stacktrace
AssertionError: expected false to be true
at Context.<anonymous> (src/platform/forms/tests/validations.unit.spec.js:482:7)
```

This was failing because we have a date function expecting the month expressed as an integer indexed starting at 1. The unit test was adding 1 to account for this index change, but we are now in December, so adding 1 to the current month circles back around to January. This broke the test.

## Acceptance criteria
- [x] We can deploy again

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
