### PR TITLE
All claims fix nonretryable mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -845,7 +845,7 @@ const schema = {
     waiveTrainingPay: {
       type: 'boolean',
     },
-    disabilities: {
+    ratedDisabilities: {
       type: 'array',
       minItems: 1,
       maxItems: 100,
@@ -984,11 +984,17 @@ const schema = {
         }),
       ),
     ),
-    emailAddress: {
-      $ref: '#/definitions/email',
-    },
-    primaryPhone: {
-      $ref: '#/definitions/phone',
+    phoneAndEmail: {
+      type: 'object',
+      required: ['primaryPhone', 'emailAddress'],
+      properties: {
+        primaryPhone: {
+          $ref: '#/definitions/phone',
+        },
+        emailAddress: {
+          $ref: '#/definitions/email',
+        },
+      },
     },
     homelessOrAtRisk: {
       type: 'string',

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -143,14 +143,13 @@ const addressUISchema = (addressType, title) => {
 const {
   mailingAddress,
   forwardingAddress,
-  emailAddress,
-  primaryPhone,
+  phoneAndEmail,
 } = fullSchema.properties;
 
 export const uiSchema = {
   'ui:title': 'Contact information',
   'ui:description': contactInfoDescription,
-  phoneEmailCard: {
+  phoneAndEmail: {
     'ui:title': 'Phone & email',
     'ui:field': ReviewCardField,
     'ui:options': {
@@ -238,14 +237,7 @@ export const uiSchema = {
 export const schema = {
   type: 'object',
   properties: {
-    phoneEmailCard: {
-      type: 'object',
-      required: ['primaryPhone', 'emailAddress'],
-      properties: {
-        primaryPhone,
-        emailAddress,
-      },
-    },
+    phoneAndEmail,
     mailingAddress,
     'view:hasForwardingAddress': {
       type: 'boolean',

--- a/src/applications/disability-benefits/all-claims/pages/ratedDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/ratedDisabilities.js
@@ -5,7 +5,7 @@ import {
   disabilitiesClarification,
 } from '../content/ratedDisabilities';
 
-const { disabilities: disabilitiesSchema } = fullSchema.properties;
+const { ratedDisabilities } = fullSchema.properties;
 
 export const uiSchema = {
   'ui:title': 'Rated Disabilities',
@@ -31,7 +31,7 @@ export const uiSchema = {
 export const schema = {
   type: 'object',
   properties: {
-    ratedDisabilities: disabilitiesSchema,
+    ratedDisabilities,
     'view:disabilitiesClarification': {
       type: 'object',
       properties: {},

--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('Disability benefits 526EZ contact information', () => {
         schema={schema}
         data={{
           mailingAddress: {},
-          phoneEmailCard: {},
+          phoneAndEmail: {},
         }}
         formData={{}}
         uiSchema={uiSchema}
@@ -47,7 +47,7 @@ describe('Disability benefits 526EZ contact information', () => {
           mailingAddress: {
             country: 'USA',
           },
-          phoneEmailCard: {},
+          phoneAndEmail: {},
         }}
         formData={{}}
         uiSchema={uiSchema}
@@ -69,7 +69,7 @@ describe('Disability benefits 526EZ contact information', () => {
           mailingAddress: {
             country: 'Afghanistan',
           },
-          phoneEmailCard: {},
+          phoneAndEmail: {},
         }}
         formData={{}}
         uiSchema={uiSchema}
@@ -92,7 +92,7 @@ describe('Disability benefits 526EZ contact information', () => {
             country: 'USA',
             city: 'APO',
           },
-          phoneEmailCard: {},
+          phoneAndEmail: {},
         }}
         formData={{}}
         uiSchema={uiSchema}
@@ -118,7 +118,7 @@ describe('Disability benefits 526EZ contact information', () => {
             country: 'USA',
             city: 'Detroit',
           },
-          phoneEmailCard: {},
+          phoneAndEmail: {},
         }}
         formData={{}}
         uiSchema={uiSchema}
@@ -139,7 +139,7 @@ describe('Disability benefits 526EZ contact information', () => {
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         data={{
-          phoneEmailCard: {
+          phoneAndEmail: {
             primaryPhone: '1231231231',
             emailAddress: 'a@b.co',
           },
@@ -169,7 +169,7 @@ describe('Disability benefits 526EZ contact information', () => {
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         data={{
-          phoneEmailCard: {
+          phoneAndEmail: {
             primaryPhone: '1231231231',
             emailAddress: 'a@b.co',
           },
@@ -207,7 +207,7 @@ describe('Disability benefits 526EZ contact information', () => {
             country: '',
             addressLine1: '',
           },
-          phoneEmailCard: {},
+          phoneAndEmail: {},
         }}
         formData={{}}
         uiSchema={uiSchema}
@@ -227,7 +227,7 @@ describe('Disability benefits 526EZ contact information', () => {
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         data={{
-          phoneEmailCard: {
+          phoneAndEmail: {
             primaryPhone: '1231231231',
             emailAddress: 'a@b.co',
           },
@@ -268,7 +268,7 @@ describe('Disability benefits 526EZ contact information', () => {
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         data={{
-          phoneEmailCard: {
+          phoneAndEmail: {
             primaryPhone: '1231231231',
             emailAddress: 'a@b.co',
           },
@@ -309,7 +309,7 @@ describe('Disability benefits 526EZ contact information', () => {
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         data={{
-          phoneEmailCard: {
+          phoneAndEmail: {
             primaryPhone: '1231231231',
             emailAddress: 'a@b.co',
           },
@@ -350,7 +350,7 @@ describe('Disability benefits 526EZ contact information', () => {
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         data={{
-          phoneEmailCard: {
+          phoneAndEmail: {
             primaryPhone: '1231231231',
             emailAddress: 'a@b.co',
           },
@@ -392,7 +392,7 @@ describe('Disability benefits 526EZ contact information', () => {
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         data={{
-          phoneEmailCard: {
+          phoneAndEmail: {
             primaryPhone: '',
             emailAddress: '',
           },
@@ -429,7 +429,7 @@ describe('Disability benefits 526EZ contact information', () => {
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         data={{
-          phoneEmailCard: {
+          phoneAndEmail: {
             primaryPhone: '1231231231',
             emailAddress: 'a@b.co',
           },

--- a/src/applications/disability-benefits/all-claims/tests/schema/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/schema/maximal-test.json
@@ -29,7 +29,7 @@
     "bankAccountNumber": "1233",
     "bankRoutingNumber": "123412345",
     "bankName": "BigBank Name",
-    "phoneEmailCard": {
+    "phoneAndEmail": {
       "primaryPhone": "1231231234",
       "emailAddress": "asdf@adsf.asdf"
     },

--- a/src/applications/disability-benefits/all-claims/tests/schema/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/schema/maximal-test.json
@@ -8,7 +8,7 @@
       "separationPayDate": "2019-01-01",
       "separationPayBranch": "Air Force"
     },
-    "view:hasTrainingPay": true,
+    "hasTrainingPay": true,
     "view:waiveTrainingPay": {
       "view:waiveTrainingPayDescription": {},
       "waiveTrainingPay": true

--- a/src/applications/disability-benefits/all-claims/tests/schema/minimal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/schema/minimal-test.json
@@ -4,7 +4,7 @@
     "hasTrainingPay": false,
     "isVAEmployee": false,
     "homelessOrAtRisk": "no",
-    "phoneEmailCard": {
+    "phoneAndEmail": {
       "primaryPhone": "1231231234",
       "emailAddress": "asdf@as.asdf"
     },

--- a/src/applications/disability-benefits/all-claims/tests/schema/transformedData.js
+++ b/src/applications/disability-benefits/all-claims/tests/schema/transformedData.js
@@ -43,6 +43,7 @@ export const transformedMinimalData = {
 
 export const transformedMaximalData = {
   form526: {
+    hasTrainingPay: true,
     standardClaim: false,
     separationPayDate: '2019-01-01',
     separationPayBranch: 'Air Force',

--- a/src/applications/disability-benefits/all-claims/tests/schema/transformedData.js
+++ b/src/applications/disability-benefits/all-claims/tests/schema/transformedData.js
@@ -3,7 +3,7 @@ export const transformedMinimalData = {
     hasTrainingPay: false,
     isVAEmployee: false,
     homelessOrAtRisk: 'no',
-    phoneEmailCard: {
+    phoneAndEmail: {
       primaryPhone: '1231231234',
       emailAddress: 'asdf@as.asdf',
     },
@@ -57,7 +57,7 @@ export const transformedMaximalData = {
     bankAccountNumber: '1233',
     bankRoutingNumber: '123412345',
     bankName: 'BigBank Name',
-    phoneEmailCard: {
+    phoneAndEmail: {
       primaryPhone: '1231231234',
       emailAddress: 'asdf@adsf.asdf',
     },


### PR DESCRIPTION
## Description
Updates a couple little things in the 526 all claims form to enable successful submission to vets-api. Will need corresponding updates to vets-api.
- Renames `disabilities` schema property to `ratedDisabilities`
- Nests phone and email into `phoneAndEmail` property in schema


## Testing done
- Updated unit tests

## Acceptance criteria
- [x] Schema should validate against vets-api

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
