### PR TITLE
Specify format to avoid Moment warning

### DIFF
--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -29,7 +29,8 @@ function defaultBuild(BUILD_OPTIONS) {
   const smith = Metalsmith(__dirname); // eslint-disable-line new-cap
 
   // Custom liquid filter(s)
-  liquid.filters.humanizeDate = dt => moment(dt).format('MMMM D, YYYY');
+  liquid.filters.humanizeDate = dt =>
+    moment(dt, 'YYYY-MM-DD').format('MMMM D, YYYY');
 
   // Set up Metalsmith. BE CAREFUL if you change the order of the plugins. Read the comments and
   // add comments about any implicit dependencies you are introducing!!!


### PR DESCRIPTION
## Description

Our watch/build output has a Moment warning about formatting, this adds a format to our humanizeDate filter to avoid that warning.

## Testing done
Checked locally

## Acceptance criteria
- [x] Build still works, warning is gone

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
