### PR TITLE
Add alert about busy spring enrollment season into Education forms

### DIFF
--- a/src/applications/edu-benefits/1990/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/1990/containers/ConfirmationPage.jsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
+import BusyEnrollmentAlert from '../../components/BusyEnrollmentAlert';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 import { focusElement } from '../../../../platform/utilities/ui';
 
@@ -99,6 +100,7 @@ class ConfirmationPage extends React.Component {
         <p>
           We usually process claims within <strong>30 days</strong>.
         </p>
+        <BusyEnrollmentAlert />
         <p>
           We may contact you for more information or documents.
           <br />

--- a/src/applications/edu-benefits/1990/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/1990/containers/ConfirmationPage.jsx
@@ -4,10 +4,10 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import BusyEnrollmentAlert from '../../components/BusyEnrollmentAlert';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 import { focusElement } from '../../../../platform/utilities/ui';
 
+import BusyEnrollmentAlert from '../../components/BusyEnrollmentAlert';
 import { getListOfBenefits } from '../../utils/helpers';
 import { benefitsRelinquishmentLabels } from '../helpers';
 

--- a/src/applications/edu-benefits/1990/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/1990/containers/ConfirmationPage.jsx
@@ -96,11 +96,11 @@ class ConfirmationPage extends React.Component {
 
     return (
       <div>
+        <BusyEnrollmentAlert />
         <h3 className="confirmation-page-title">Claim received</h3>
         <p>
           We usually process claims within <strong>30 days</strong>.
         </p>
-        <BusyEnrollmentAlert />
         <p>
           We may contact you for more information or documents.
           <br />

--- a/src/applications/edu-benefits/1990e/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/1990e/containers/ConfirmationPage.jsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
+import BusyEnrollmentAlert from '../../components/BusyEnrollmentAlert';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 import { focusElement } from '../../../../platform/utilities/ui';
 
@@ -45,6 +46,7 @@ class ConfirmationPage extends React.Component {
 
     return (
       <div>
+        <BusyEnrollmentAlert />
         <h3 className="confirmation-page-title">Claim received</h3>
         <p>
           We usually process claims within <strong>30 days</strong>.

--- a/src/applications/edu-benefits/1990e/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/1990e/containers/ConfirmationPage.jsx
@@ -3,10 +3,10 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import BusyEnrollmentAlert from '../../components/BusyEnrollmentAlert';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 import { focusElement } from '../../../../platform/utilities/ui';
 
+import BusyEnrollmentAlert from '../../components/BusyEnrollmentAlert';
 import { benefitsLabels } from '../../utils/labels';
 
 const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';

--- a/src/applications/edu-benefits/1990n/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/1990n/containers/ConfirmationPage.jsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
+import BusyEnrollmentAlert from '../../components/BusyEnrollmentAlert';
 import { focusElement } from '../../../../platform/utilities/ui';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 
@@ -57,6 +58,7 @@ class ConfirmationPage extends React.Component {
 
     return (
       <div>
+        <BusyEnrollmentAlert />
         <h3 className="confirmation-page-title">Claim received</h3>
         <p>
           We usually process claims within <strong>30 days</strong>.

--- a/src/applications/edu-benefits/1990n/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/1990n/containers/ConfirmationPage.jsx
@@ -3,9 +3,10 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import BusyEnrollmentAlert from '../../components/BusyEnrollmentAlert';
 import { focusElement } from '../../../../platform/utilities/ui';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
+
+import BusyEnrollmentAlert from '../../components/BusyEnrollmentAlert';
 
 const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 const scroller = Scroll.scroller;

--- a/src/applications/edu-benefits/1995/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/1995/containers/ConfirmationPage.jsx
@@ -6,6 +6,7 @@ import Scroll from 'react-scroll';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 import { focusElement } from '../../../../platform/utilities/ui';
 
+import BusyEnrollmentAlert from '../../components/BusyEnrollmentAlert';
 import { benefitsLabels } from '../../utils/labels';
 
 const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
@@ -64,6 +65,7 @@ class ConfirmationPage extends React.Component {
 
     return (
       <div>
+        <BusyEnrollmentAlert />
         <h3 className="confirmation-page-title">Claim received</h3>
         <p>
           We usually process claims within <strong>30 days</strong>.

--- a/src/applications/edu-benefits/5490/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/5490/containers/ConfirmationPage.jsx
@@ -6,6 +6,7 @@ import Scroll from 'react-scroll';
 import { focusElement } from '../../../../platform/utilities/ui';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 
+import BusyEnrollmentAlert from '../../components/BusyEnrollmentAlert';
 import { survivorBenefitsLabels } from '../../utils/labels';
 
 const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
@@ -45,6 +46,7 @@ class ConfirmationPage extends React.Component {
 
     return (
       <div>
+        <BusyEnrollmentAlert />
         <h3 className="confirmation-page-title">Claim received</h3>
         <p>
           We usually process claims within <strong>30 days</strong>.

--- a/src/applications/edu-benefits/5495/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/5495/containers/ConfirmationPage.jsx
@@ -6,6 +6,7 @@ import Scroll from 'react-scroll';
 import { focusElement } from '../../../../platform/utilities/ui';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 
+import BusyEnrollmentAlert from '../../components/BusyEnrollmentAlert';
 import { survivorBenefitsLabels } from '../../utils/labels';
 
 const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
@@ -39,6 +40,7 @@ class ConfirmationPage extends React.Component {
 
     return (
       <div>
+        <BusyEnrollmentAlert />
         <h3 className="confirmation-page-title">Claim received</h3>
         <p>
           We usually process claims within <strong>30 days</strong>.

--- a/src/applications/edu-benefits/components/BusyEnrollmentAlert.jsx
+++ b/src/applications/edu-benefits/components/BusyEnrollmentAlert.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
+export default function() {
+  return (
+    <AlertBox
+      isVisible
+      status="info"
+      headline="We've started our busy spring enrollment season"
+      content={
+        <span>
+          We process more GI Bill payments during this busy time of year, and we
+          expect to keep up with the increase. But if your monthly payment is
+          delayed, and you’re having trouble paying your bills or meeting your
+          basic needs, please call us at{' '}
+          <a href="tel:+18884424551">1-888-442-4551</a>. We're here Monday
+          through Friday, 7:00 a.m. - 6:00 p.m. (CT).
+        </span>
+      }
+    />
+  );
+}


### PR DESCRIPTION
## Description
This pull request is being worked on in parallel to https://github.com/department-of-veterans-affairs/vagov-content/pull/179. The work here adds an alert banner into each education form.

## Testing done
Viewed the Education forms locally

## Screenshots

### 1990
![image](https://user-images.githubusercontent.com/1915775/49550089-a1fa3380-f8b8-11e8-91b1-b06581a998ec.png)

### 1990e
![image](https://user-images.githubusercontent.com/1915775/49600584-88f19100-f951-11e8-8287-586b47af44b5.png)


### 1990n
![image](https://user-images.githubusercontent.com/1915775/49600667-bf2f1080-f951-11e8-9e92-07e6a65f064f.png)


### 1995
![image](https://user-images.githubusercontent.com/1915775/49600773-f998ad80-f951-11e8-882b-16770fc6bf1d.png)


### 5490
![image](https://user-images.githubusercontent.com/1915775/49600864-43819380-f952-11e8-8c95-abcb04e26e37.png)


### 5495
![image](https://user-images.githubusercontent.com/1915775/49600928-74fa5f00-f952-11e8-8f11-ec5fd78ed4a3.png)


## Acceptance criteria
- [x] Alert banner is visible on the confirmation page of each education form

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
