### PR TITLE
Search: Replace Prod domain with Staging for searches on Staging environment

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { fetchSearchResults } from '../actions';
 import { formatResponseString } from '../utils';
 import recordEvent from '../../../platform/monitoring/record-event';
+import { replaceWithStagingDomain } from '../../../platform/utilities/environment/stagingDomains';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 import IconSearch from '@department-of-veterans-affairs/formation/IconSearch';
@@ -229,7 +230,7 @@ class SearchApp extends React.Component {
       <li key={result.url} className="result-item">
         <a
           className="result-title"
-          href={result.url}
+          href={replaceWithStagingDomain(result.url)}
           onClick={
             isBestBet
               ? () =>
@@ -246,7 +247,7 @@ class SearchApp extends React.Component {
             }}
           />
         </a>
-        <p className="result-url">{result.url}</p>
+        <p className="result-url">{replaceWithStagingDomain(result.url)}</p>
         <p
           className="result-desc"
           dangerouslySetInnerHTML={{

--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
+import { replaceWithStagingDomain } from '../../../utilities/environment/stagingDomains';
 import IconSearch from '@department-of-veterans-affairs/formation/IconSearch';
 import DropDownPanel from '@department-of-veterans-affairs/formation/DropDownPanel';
 
@@ -12,7 +13,7 @@ class SearchMenu extends React.Component {
     this.makeForm = this.makeForm.bind(this);
     this.toggleSearchForm = this.toggleSearchForm.bind(this);
     this.state = {
-      searchAction: 'https://www.va.gov/search/',
+      searchAction: replaceWithStagingDomain('https://www.va.gov/search/'),
       userInput: '',
     };
   }

--- a/src/platform/utilities/environment/stagingDomains.js
+++ b/src/platform/utilities/environment/stagingDomains.js
@@ -1,22 +1,9 @@
 import { mhvBaseUrl } from '../../site-wide/cta-widget/helpers';
 import environment from '.';
 
-let currentEnv = 'dev';
-if (environment.isStaging()) {
-  currentEnv = 'staging';
-}
-
-if (environment.isProduction()) {
-  currentEnv = 'www';
-}
-
 // This list also exists in script/options.js
 const domainReplacements = [
-  {
-    from: 'https://www\\.va\\.gov',
-    // use relative links on dev to accomodate localhost
-    to: currentEnv === 'dev' ? '' : `https://${currentEnv}.va.gov`,
-  },
+  { from: 'https://www\\.va\\.gov', to: environment.BASE_URL },
   { from: 'https://www\\.myhealth\\.va\\.gov', to: mhvBaseUrl() },
 ];
 

--- a/src/platform/utilities/tests/environment/stagingDomains.unit.spec.js
+++ b/src/platform/utilities/tests/environment/stagingDomains.unit.spec.js
@@ -1,15 +1,9 @@
 import { expect } from 'chai';
 
 import { replaceDomainsInData } from '../../environment/stagingDomains';
-import ENVIRONMENT from '../../../../site/constants/environments';
+import HOSTNAME from '../../../../site/constants/hostnames';
 
-let currentEnv = '';
-if (global.__BUILDTYPE__ === ENVIRONMENT.VAGOVSTAGING) {
-  currentEnv = 'https://staging.va.gov';
-}
-if (global.__BUILDTYPE__ === ENVIRONMENT.VAGOVPROD) {
-  currentEnv = 'https://www.va.gov';
-}
+const currentEnv = `https://${HOSTNAME[global.__BUILDTYPE__]}`;
 
 describe('Staging va.gov domain replacement', () => {
   describe('replaceDomainsInData', () => {

--- a/src/platform/utilities/tests/environment/stagingDomains.unit.spec.js
+++ b/src/platform/utilities/tests/environment/stagingDomains.unit.spec.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 
 import { replaceDomainsInData } from '../../environment/stagingDomains';
-import HOSTNAME from '../../../../site/constants/hostnames';
+import HOSTNAMES from '../../../../site/constants/hostnames';
 
-const currentEnv = `https://${HOSTNAME[global.__BUILDTYPE__]}`;
+const currentEnv = `https://${HOSTNAMES[global.__BUILDTYPE__]}`;
 
 describe('Staging va.gov domain replacement', () => {
   describe('replaceDomainsInData', () => {


### PR DESCRIPTION
## Description
This PR changes `www` to `staging` for the Search application so that a query in the Staging environment renders its results page with links to pages also in the Staging environment.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15500

## Testing done
- Local testing, but this is difficult because the helper for switching the domain based on environment is powered by the domain it's running under. 
- Did a manual deploy to Staging using the Git SHA and confirmed this is working.

## Acceptance criteria
- [x] Search result links in Staging point to other Staging VA sites

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
