### PR TITLE
Update link to Jenkins job to build master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VA.gov [![Build Status](https://dev.vets.gov/jenkins/buildStatus/icon?job=testing/vets-website/master)](http://jenkins.vetsgov-internal/job/department-of-veterans-affairs/job/vets-website/job/master/)
+# VA.gov [![Build Status](https://dev.vets.gov/jenkins/buildStatus/icon?job=testing/vets-website/master)](http://jenkins.vetsgov-internal/job/testing/job/vets-website/job/master/)
 
 ## What is this?
 


### PR DESCRIPTION
## Description
Clicking the image for the build status in the README renders a 404. This PR updates that link to go to the Jenkins master job.

## Acceptance criteria
- [ ] Image links to proper build job

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
