### PR TITLE
Send only the selected conditions

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/schema/transformedData.js
+++ b/src/applications/disability-benefits/all-claims/tests/schema/transformedData.js
@@ -134,26 +134,6 @@ export const transformedMaximalData = {
         ratingPercentage: 100,
         disabilityActionType: 'INCREASE',
       },
-      {
-        name: 'Second Condition',
-        ratedDisabilityId: '1',
-        ratingDecisionId: '63655',
-        diagnosticCode: 5238,
-        decisionCode: 'SVCCONNCTED',
-        decisionText: 'Service Connected',
-        ratingPercentage: 0,
-        disabilityActionType: 'INCREASE',
-      },
-      {
-        name: 'Third Condition',
-        ratedDisabilityId: '1',
-        ratingDecisionId: '63655',
-        diagnosticCode: 5238,
-        decisionCode: 'SVCCONNCTED',
-        decisionText: 'Service Connected',
-        ratingPercentage: 100,
-        disabilityActionType: 'INCREASE',
-      },
     ],
     serviceInformation: {
       reservesNationalGuardService: {

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -276,7 +276,16 @@ export function transform(formConfig, form) {
   // The transformForSubmit's JSON.stringify transformer doesn't remove deeply empty objects, so we call
   //  it here to remove reservesNationalGuardService if it's deeply empty.
   clonedData = removeDeeplyEmptyObjects(
-    JSON.parse(transformForSubmit(formConfig, form, customReplacer)),
+    JSON.parse(
+      transformForSubmit(
+        formConfig,
+        {
+          ...form,
+          data: clonedData,
+        },
+        customReplacer,
+      ),
+    ),
   );
 
   // Transform the related disabilities lists into an array of strings


### PR DESCRIPTION
## Description
The `transformForSubmit` function was being called with the original `form`, so the `form.data` passed to that function didn't use the filtered `ratedDisabilities`. Since we overwrote `clonedData` with the result, it effectively washed out the disability selection filter we did first thing.

## Testing done
Unit test.

## Screenshots
**Expected test failure after the update**
![image](https://user-images.githubusercontent.com/12970166/49602926-92bdc900-f93e-11e8-896b-58bc87c87fe3.png)


## Acceptance criteria
- [x] The `tranform` function removes non-selected conditions

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
