### PR TITLE
Fix for the Personalization banner falling behind the footer

### DIFF
--- a/src/platform/site-wide/announcements/sass/style.scss
+++ b/src/platform/site-wide/announcements/sass/style.scss
@@ -2,6 +2,7 @@
 
 .personalization-announcement {
   position: fixed;
+  z-index: $base-layer + 1;
   bottom: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
## Description
This banner inviting users to try their new personalization features falls behind the footer of the website, causing some mysteriousness with how keyboard focus is working.

Related ticket, https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14455

## Testing done
Local testing of the site

## Screenshots

### Problem
This screenshot shows the footer overlapping over the banner -
![image](https://user-images.githubusercontent.com/1915775/49604111-0cfc4680-f95b-11e8-9546-2335036be2af.png)

### Solution
This screenshot shows that adding a z-index value fixes it -
![image](https://user-images.githubusercontent.com/1915775/49604156-361cd700-f95b-11e8-9cd9-1b8054801aec.png)

## Acceptance criteria
- [ ] Personalization banner doesn't get lost behind the footer

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
