### PR TITLE
All claims migrate json schema mg

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#f476ed0ff038403d04e531bbbae41f72290e23b5",
     "vanilla-lazyload": "^8.17.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#c30b03763019fc71b3ae6ee2907ff2ee2cbf1bad",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#92816fb3a3d5166dba1404e14c2e12739ba3b3b2",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -96,7 +96,7 @@ import { createFormConfig781, createFormConfig781a } from './781';
 
 import { PTSD, PTSD_INCIDENT_ITERATION } from '../constants';
 
-import fullSchema from './schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 const formConfig = {
   urlPrefix: '/',

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -3,7 +3,7 @@ import disabilityLabels from '../content/disabilityLabels';
 import { uiDescription } from '../content/addDisabilities';
 import NewDisability from '../components/NewDisability';
 
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 
 const { condition } = fullSchema.properties.newDisabilities.items.properties;
 

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -3,7 +3,7 @@ import disabilityLabels from '../content/disabilityLabels';
 import { uiDescription } from '../content/addDisabilities';
 import NewDisability from '../components/NewDisability';
 
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 const { condition } = fullSchema.properties.newDisabilities.items.properties;
 

--- a/src/applications/disability-benefits/all-claims/pages/alternateNames.js
+++ b/src/applications/disability-benefits/all-claims/pages/alternateNames.js
@@ -1,5 +1,5 @@
 import FullNameField from 'us-forms-system/lib/js/fields/FullNameField';
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 
 const { alternateNames: alternateNamesSchema } = fullSchema.properties;
 

--- a/src/applications/disability-benefits/all-claims/pages/alternateNames.js
+++ b/src/applications/disability-benefits/all-claims/pages/alternateNames.js
@@ -1,5 +1,5 @@
 import FullNameField from 'us-forms-system/lib/js/fields/FullNameField';
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 const { alternateNames: alternateNamesSchema } = fullSchema.properties;
 

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -1,7 +1,7 @@
 // import _ from '../../../../platform/utilities/data';
 import _ from 'lodash';
 import merge from 'lodash/merge';
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 // import dateUI from 'us-forms-system/lib/js/definitions/date';
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import PhoneNumberWidget from 'us-forms-system/lib/js/widgets/PhoneNumberWidget';

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -1,7 +1,7 @@
 // import _ from '../../../../platform/utilities/data';
 import _ from 'lodash';
 import merge from 'lodash/merge';
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 // import dateUI from 'us-forms-system/lib/js/definitions/date';
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import PhoneNumberWidget from 'us-forms-system/lib/js/widgets/PhoneNumberWidget';

--- a/src/applications/disability-benefits/all-claims/pages/federalOrders.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/federalOrders.jsx
@@ -1,4 +1,4 @@
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import _ from 'lodash/fp';
 
 import dateUI from 'us-forms-system/lib/js/definitions/date';

--- a/src/applications/disability-benefits/all-claims/pages/federalOrders.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/federalOrders.jsx
@@ -1,4 +1,4 @@
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import _ from 'lodash/fp';
 
 import dateUI from 'us-forms-system/lib/js/definitions/date';

--- a/src/applications/disability-benefits/all-claims/pages/fullyDevelopedClaim.js
+++ b/src/applications/disability-benefits/all-claims/pages/fullyDevelopedClaim.js
@@ -1,4 +1,4 @@
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import get from '../../../../platform/utilities/data/get';
 import {
   FDCDescription,

--- a/src/applications/disability-benefits/all-claims/pages/fullyDevelopedClaim.js
+++ b/src/applications/disability-benefits/all-claims/pages/fullyDevelopedClaim.js
@@ -1,4 +1,4 @@
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import get from '../../../../platform/utilities/data/get';
 import {
   FDCDescription,

--- a/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
+++ b/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
@@ -1,5 +1,5 @@
 import _ from '../../../../platform/utilities/data';
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import merge from 'lodash/fp/merge';
 import phoneUI from 'us-forms-system/lib/js/definitions/phone';
 

--- a/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
+++ b/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
@@ -1,5 +1,5 @@
 import _ from '../../../../platform/utilities/data';
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import merge from 'lodash/fp/merge';
 import phoneUI from 'us-forms-system/lib/js/definitions/phone';
 

--- a/src/applications/disability-benefits/all-claims/pages/hospitalizationHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/hospitalizationHistory.js
@@ -2,7 +2,7 @@ import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 
 import HospitalizationPeriodView from '../components/HospitalizationPeriodView';
 
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 
 const { hospitalizationHistory } = fullSchema.properties;
 

--- a/src/applications/disability-benefits/all-claims/pages/hospitalizationHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/hospitalizationHistory.js
@@ -2,7 +2,7 @@ import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 
 import HospitalizationPeriodView from '../components/HospitalizationPeriodView';
 
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 const { hospitalizationHistory } = fullSchema.properties;
 

--- a/src/applications/disability-benefits/all-claims/pages/incidentDate.js
+++ b/src/applications/disability-benefits/all-claims/pages/incidentDate.js
@@ -2,15 +2,15 @@ import currentOrPastDateUI from 'us-forms-system/lib/js/definitions/currentOrPas
 
 import { ptsd781NameTitle } from '../content/ptsdClassification';
 import { ptsdDateDescription } from '../content/incidentDate';
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
-const { date } = fullSchema.definitions.ptsdIncident.properties;
+const { incidentDate } = fullSchema.definitions.ptsdIncident.properties;
 
 export const uiSchema = index => ({
   'ui:title': ptsd781NameTitle,
   [`incident${index}`]: {
     'ui:description': ptsdDateDescription,
-    date: currentOrPastDateUI(' '),
+    incidentDate: currentOrPastDateUI(' '),
   },
 });
 
@@ -19,7 +19,7 @@ export const schema = index => ({
   properties: {
     [`incident${index}`]: {
       type: 'object',
-      properties: { date },
+      properties: { incidentDate },
     },
   },
 });

--- a/src/applications/disability-benefits/all-claims/pages/incidentDescription.js
+++ b/src/applications/disability-benefits/all-claims/pages/incidentDescription.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import { PtsdNameTitle } from '../content/ptsdClassification';
 
 const incidentDescriptionInstructions = (

--- a/src/applications/disability-benefits/all-claims/pages/incidentDescription.js
+++ b/src/applications/disability-benefits/all-claims/pages/incidentDescription.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { PtsdNameTitle } from '../content/ptsdClassification';
 
 const incidentDescriptionInstructions = (

--- a/src/applications/disability-benefits/all-claims/pages/incidentUnitAssignment.js
+++ b/src/applications/disability-benefits/all-claims/pages/incidentUnitAssignment.js
@@ -1,6 +1,6 @@
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 import {
   ptsdAssignmentDescription,

--- a/src/applications/disability-benefits/all-claims/pages/incidentUnitAssignment.js
+++ b/src/applications/disability-benefits/all-claims/pages/incidentUnitAssignment.js
@@ -1,6 +1,6 @@
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 
 import {
   ptsdAssignmentDescription,

--- a/src/applications/disability-benefits/all-claims/pages/mentalHealthChanges.js
+++ b/src/applications/disability-benefits/all-claims/pages/mentalHealthChanges.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 
 import { PtsdNameTitle } from '../content/ptsdClassification';
 

--- a/src/applications/disability-benefits/all-claims/pages/mentalHealthChanges.js
+++ b/src/applications/disability-benefits/all-claims/pages/mentalHealthChanges.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 import { PtsdNameTitle } from '../content/ptsdClassification';
 

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -1,7 +1,7 @@
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import ServicePeriodView from '../../../../platform/forms/components/ServicePeriodView';
 
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 export const uiSchema = {
   serviceInformation: {

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -1,7 +1,7 @@
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import ServicePeriodView from '../../../../platform/forms/components/ServicePeriodView';
 
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 
 export const uiSchema = {
   serviceInformation: {

--- a/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
@@ -4,7 +4,7 @@ import { createSelector } from 'reselect';
 import { getDisabilityName } from '../utils';
 import disabilityLabels from '../content/disabilityLabels';
 
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import {
   CauseTitle,
   disabilityNameTitle,

--- a/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
@@ -4,7 +4,7 @@ import { createSelector } from 'reselect';
 import { getDisabilityName } from '../utils';
 import disabilityLabels from '../content/disabilityLabels';
 
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import {
   CauseTitle,
   disabilityNameTitle,

--- a/src/applications/disability-benefits/all-claims/pages/paymentInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/paymentInformation.js
@@ -1,4 +1,4 @@
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { bankFieldsHaveInput } from '../utils';
 import ReviewCardField from '../components/ReviewCardField';
 import PaymentView from '../components/PaymentView';

--- a/src/applications/disability-benefits/all-claims/pages/paymentInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/paymentInformation.js
@@ -1,4 +1,4 @@
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import { bankFieldsHaveInput } from '../utils';
 import ReviewCardField from '../components/ReviewCardField';
 import PaymentView from '../components/PaymentView';

--- a/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
+++ b/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
@@ -1,4 +1,4 @@
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import PeriodOfConfinement from '../components/PeriodOfConfinement';
 import { addCheckboxPerNewDisability } from '../utils';

--- a/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
+++ b/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
@@ -1,4 +1,4 @@
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import PeriodOfConfinement from '../components/PeriodOfConfinement';
 import { addCheckboxPerNewDisability } from '../utils';

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -6,7 +6,7 @@ import { uploadDescription } from '../content/fileUploadDescriptions';
 import fileUploadUI from 'us-forms-system/lib/js/definitions/file';
 import environment from '../../../../platform/utilities/environment';
 import _ from '../../../../platform/utilities/data';
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { FIFTY_MB, DATA_PATHS } from '../constants';
 
 const { attachments } = fullSchema.properties;

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -6,7 +6,7 @@ import { uploadDescription } from '../content/fileUploadDescriptions';
 import fileUploadUI from 'us-forms-system/lib/js/definitions/file';
 import environment from '../../../../platform/utilities/environment';
 import _ from '../../../../platform/utilities/data';
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import { FIFTY_MB, DATA_PATHS } from '../constants';
 
 const { attachments } = fullSchema.properties;

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
@@ -1,5 +1,5 @@
 import _ from '../../../../platform/utilities/data';
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import {
   recordReleaseDescription,

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
@@ -1,5 +1,5 @@
 import _ from '../../../../platform/utilities/data';
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import {
   recordReleaseDescription,

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
@@ -11,7 +11,7 @@ import {
 import PrivateProviderTreatmentView from '../components/PrivateProviderTreatmentView';
 import { validateDate } from 'us-forms-system/lib/js/validation';
 
-const { form4142 } = fullSchema.definitions;
+const { form4142 } = fullSchema.properties;
 
 const providerFacilities = form4142.properties.providerFacility;
 const limitedConsent = form4142.properties.limitedConsent;

--- a/src/applications/disability-benefits/all-claims/pages/ratedDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/ratedDisabilities.js
@@ -1,4 +1,4 @@
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import SelectArrayItemsWidget from '../components/SelectArrayItemsWidget';
 import {
   disabilityOption,

--- a/src/applications/disability-benefits/all-claims/pages/ratedDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/ratedDisabilities.js
@@ -1,4 +1,4 @@
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import SelectArrayItemsWidget from '../components/SelectArrayItemsWidget';
 import {
   disabilityOption,

--- a/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
@@ -1,4 +1,4 @@
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import { ReservesGuardDescription } from '../utils';
 

--- a/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
@@ -1,4 +1,4 @@
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import { ReservesGuardDescription } from '../utils';
 

--- a/src/applications/disability-benefits/all-claims/pages/secondaryIncidentAuthorities.js
+++ b/src/applications/disability-benefits/all-claims/pages/secondaryIncidentAuthorities.js
@@ -1,6 +1,6 @@
 import { merge } from 'lodash';
 
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import AuthorityField from '../components/AuthorityField';
 import { ptsd781aNameTitle } from '../content/ptsdClassification';
 import { PtsdAssaultAuthoritiesDescription } from '../content/ptsdAssaultAuthorities';

--- a/src/applications/disability-benefits/all-claims/pages/secondaryIncidentAuthorities.js
+++ b/src/applications/disability-benefits/all-claims/pages/secondaryIncidentAuthorities.js
@@ -1,6 +1,6 @@
 import { merge } from 'lodash';
 
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import AuthorityField from '../components/AuthorityField';
 import { ptsd781aNameTitle } from '../content/ptsdClassification';
 import { PtsdAssaultAuthoritiesDescription } from '../content/ptsdAssaultAuthorities';

--- a/src/applications/disability-benefits/all-claims/pages/secondaryIncidentDate.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/secondaryIncidentDate.jsx
@@ -3,9 +3,11 @@ import currentOrPastDateUI from 'us-forms-system/lib/js/definitions/currentOrPas
 
 import { ptsd781aNameTitle } from '../content/ptsdClassification';
 import { SecondaryDateDescription } from '../content/incidentDate';
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
-const { date } = fullSchema.definitions.secondaryPtsdIncident.properties;
+const {
+  incidentDate,
+} = fullSchema.definitions.secondaryPtsdIncident.properties;
 
 export const uiSchema = index => ({
   'ui:title': ptsd781aNameTitle,
@@ -13,7 +15,7 @@ export const uiSchema = index => ({
     <SecondaryDateDescription formData={formData} index={index} />
   ),
   [`secondaryIncident${index}`]: {
-    date: currentOrPastDateUI(' '),
+    incidentDate: currentOrPastDateUI(' '),
   },
 });
 
@@ -22,7 +24,7 @@ export const schema = index => ({
   properties: {
     [`secondaryIncident${index}`]: {
       type: 'object',
-      properties: { date },
+      properties: { incidentDate },
     },
   },
 });

--- a/src/applications/disability-benefits/all-claims/pages/secondaryIncidentDescription.js
+++ b/src/applications/disability-benefits/all-claims/pages/secondaryIncidentDescription.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { ptsd781aNameTitle } from '../content/ptsdClassification';
 
 const incidentDescriptionInstructions = (

--- a/src/applications/disability-benefits/all-claims/pages/secondaryIncidentDescription.js
+++ b/src/applications/disability-benefits/all-claims/pages/secondaryIncidentDescription.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import { ptsd781aNameTitle } from '../content/ptsdClassification';
 
 const incidentDescriptionInstructions = (

--- a/src/applications/disability-benefits/all-claims/pages/secondaryIncidentUnitAssignment.js
+++ b/src/applications/disability-benefits/all-claims/pages/secondaryIncidentUnitAssignment.js
@@ -1,6 +1,6 @@
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 import {
   ptsdAssignmentDescription,

--- a/src/applications/disability-benefits/all-claims/pages/secondaryIncidentUnitAssignment.js
+++ b/src/applications/disability-benefits/all-claims/pages/secondaryIncidentUnitAssignment.js
@@ -1,6 +1,6 @@
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 
 import {
   ptsdAssignmentDescription,

--- a/src/applications/disability-benefits/all-claims/pages/separationTrainingPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/separationTrainingPay.js
@@ -1,4 +1,4 @@
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import { hasSeparationPay, isValidYear } from '../validations';
 import { separationPayDetailsDescription } from '../content/separationTrainingPay';
 

--- a/src/applications/disability-benefits/all-claims/pages/separationTrainingPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/separationTrainingPay.js
@@ -1,4 +1,4 @@
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { hasSeparationPay, isValidYear } from '../validations';
 import { separationPayDetailsDescription } from '../content/separationTrainingPay';
 

--- a/src/applications/disability-benefits/all-claims/pages/servedInCombatZone.js
+++ b/src/applications/disability-benefits/all-claims/pages/servedInCombatZone.js
@@ -1,4 +1,4 @@
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 const { servedInCombatZonePost911 } = fullSchema.properties;
 

--- a/src/applications/disability-benefits/all-claims/pages/servedInCombatZone.js
+++ b/src/applications/disability-benefits/all-claims/pages/servedInCombatZone.js
@@ -1,4 +1,4 @@
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 
 const { servedInCombatZonePost911 } = fullSchema.properties;
 

--- a/src/applications/disability-benefits/all-claims/pages/servicePay.js
+++ b/src/applications/disability-benefits/all-claims/pages/servicePay.js
@@ -1,4 +1,4 @@
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { hasMilitaryRetiredPay } from '../validations';
 
 const {

--- a/src/applications/disability-benefits/all-claims/pages/servicePay.js
+++ b/src/applications/disability-benefits/all-claims/pages/servicePay.js
@@ -1,4 +1,4 @@
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import { hasMilitaryRetiredPay } from '../validations';
 
 const {

--- a/src/applications/disability-benefits/all-claims/pages/trainingPayWaiver.js
+++ b/src/applications/disability-benefits/all-claims/pages/trainingPayWaiver.js
@@ -1,4 +1,4 @@
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import { waiveTrainingPayDescription } from '../content/trainingPayWaiver';
 
 const { waiveTrainingPay } = fullSchema.properties;

--- a/src/applications/disability-benefits/all-claims/pages/trainingPayWaiver.js
+++ b/src/applications/disability-benefits/all-claims/pages/trainingPayWaiver.js
@@ -1,4 +1,4 @@
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { waiveTrainingPayDescription } from '../content/trainingPayWaiver';
 
 const { waiveTrainingPay } = fullSchema.properties;

--- a/src/applications/disability-benefits/all-claims/pages/vaEmployee.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaEmployee.js
@@ -1,4 +1,4 @@
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 
 const { isVAEmployee } = fullSchema.properties;
 export const uiSchema = {

--- a/src/applications/disability-benefits/all-claims/pages/vaEmployee.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaEmployee.js
@@ -1,4 +1,4 @@
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 const { isVAEmployee } = fullSchema.properties;
 export const uiSchema = {

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -1,5 +1,5 @@
 import merge from 'lodash/merge';
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import { uiSchema as autoSuggestUiSchema } from 'us-forms-system/lib/js/definitions/autosuggest';
 import dateRangeUI from 'us-forms-system/lib/js/definitions/monthYearRange';
 import { treatmentView } from '../content/vaMedicalRecords';

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -1,5 +1,5 @@
 import merge from 'lodash/merge';
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { uiSchema as autoSuggestUiSchema } from 'us-forms-system/lib/js/definitions/autosuggest';
 import dateRangeUI from 'us-forms-system/lib/js/definitions/monthYearRange';
 import { treatmentView } from '../content/vaMedicalRecords';

--- a/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
@@ -1,4 +1,4 @@
-import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { waiveRetirementPayDescription } from '../content/waiveRetirementPay';
 
 const { waiveRetirementPay: waiveRetirementPaySchema } = fullSchema.properties;

--- a/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
@@ -1,4 +1,4 @@
-import fullSchema from '../config/schema';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json'
 import { waiveRetirementPayDescription } from '../content/waiveRetirementPay';
 
 const { waiveRetirementPay: waiveRetirementPaySchema } = fullSchema.properties;

--- a/src/applications/disability-benefits/all-claims/tests/pages/incidentDate.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/incidentDate.unit.spec.jsx
@@ -42,7 +42,7 @@ describe('781 Incident Date', () => {
       />,
     );
 
-    fillDate(form, 'root_incident0_date', '2016-07-10');
+    fillDate(form, 'root_incident0_incidentDate', '2016-07-10');
     form.find('form').simulate('submit');
 
     expect(form.find('.usa-input-error-message').length).to.equal(0);
@@ -62,7 +62,7 @@ describe('781 Incident Date', () => {
       />,
     );
 
-    fillDate(form, 'root_incident0_date', '2016-07-XX');
+    fillDate(form, 'root_incident0_incidentDate', '2016-07-XX');
     form.find('form').simulate('submit');
 
     expect(form.find('.usa-input-error-message').length).to.equal(0);

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentDate.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentDate.unit.spec.jsx
@@ -43,7 +43,7 @@ describe('781a Incident Date', () => {
       />,
     );
 
-    fillDate(form, 'root_secondaryIncident0_date', '2016-07-10');
+    fillDate(form, 'root_secondaryIncident0_incidentDate', '2016-07-10');
     form.find('form').simulate('submit');
 
     expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10866,9 +10866,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#c30b03763019fc71b3ae6ee2907ff2ee2cbf1bad":
-  version "3.117.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#c30b03763019fc71b3ae6ee2907ff2ee2cbf1bad"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#92816fb3a3d5166dba1404e14c2e12739ba3b3b2":
+  version "3.118.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#92816fb3a3d5166dba1404e14c2e12739ba3b3b2"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
## Description
- Moves schema to vets-json-schema wherever we were getting it from the vets-website schema
- Updates test for the date => incidentDate revert
- Updates page-level schema and uiSchema for incident / secondary incident date pages to revert `date` property to `incidentDate`
- Updates 4142 page to pull from properties instead of definitions

## Testing done
- Local testing
- Unit tests

## Screenshots


## Acceptance criteria
- [x] Form works without regressions

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
