### PR TITLE
PaymentView reacts to new data that hasn't been pre-filled

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/PaymentView.jsx
+++ b/src/applications/disability-benefits/all-claims/components/PaymentView.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { isEqual } from 'lodash';
 
+import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
+
 import { accountTitleLabels } from '../constants';
-import { srSubstitute } from '../utils';
+import { srSubstitute, viewifyFields } from '../utils';
 
 const mask = (string, unmaskedLength) => {
   // If no string is given, tell the screen reader users the account or routing number is blank
@@ -24,30 +26,40 @@ const mask = (string, unmaskedLength) => {
   );
 };
 
-export const PaymentView = ({ formData, originalData }) => {
-  const {
-    bankAccountType,
-    bankAccountNumber,
-    bankRoutingNumber,
-    bankName,
-  } = formData;
+const accountsDifferContent = (
+  <p>
+    We’ll add this new bank account to your disability application.{' '}
+    <strong>
+      This new account won’t be updated in all VA systems right away.
+    </strong>{' '}
+    Your current payments will continue to be deposited into the previous
+    account we showed.
+  </p>
+);
 
-  const dataChanged = isEqual(formData, originalData);
+export const PaymentView = ({ formData, originalData = {} }) => {
+  const bankAccountType =
+    formData.bankAccountType || originalData['view:bankAccountType'];
+  const bankAccountNumber =
+    formData.bankAccountNumber || originalData['view:bankAccountNumber'];
+  const bankRoutingNumber =
+    formData.bankRoutingNumber || originalData['view:bankRoutingNumber'];
+  const bankName = formData.bankName || originalData['view:bankName'];
+
+  const dataChanged = !isEqual(
+    viewifyFields({
+      bankAccountType,
+      bankAccountNumber,
+      bankRoutingNumber,
+      bankName,
+    }),
+    originalData,
+  );
 
   return (
     <div>
       {!dataChanged && (
         <p>We’re currently paying your compensation to this account</p>
-      )}
-      {dataChanged && (
-        <p>
-          We’ll add this new bank account to your disability application.{' '}
-          <strong>
-            This new account won’t be updated in all VA systems right away.
-          </strong>{' '}
-          Your current payments will continue to be deposited into the previous
-          account we showed.
-        </p>
       )}
       <div className="blue-bar-block">
         <p>
@@ -59,6 +71,9 @@ export const PaymentView = ({ formData, originalData }) => {
         <p>Bank routing number: {mask(bankRoutingNumber, 4)}</p>
         <p>Bank name: {bankName || srSubstitute('', 'is blank')}</p>
       </div>
+      {dataChanged && (
+        <AlertBox isVisible status="warning" content={accountsDifferContent} />
+      )}
     </div>
   );
 };

--- a/src/applications/disability-benefits/all-claims/components/PaymentView.jsx
+++ b/src/applications/disability-benefits/all-claims/components/PaymentView.jsx
@@ -37,7 +37,7 @@ const accountsDifferContent = (
   </p>
 );
 
-export const PaymentView = ({ formData, originalData = {} }) => {
+export const PaymentView = ({ formData = {}, originalData = {} }) => {
   const bankAccountType =
     formData.bankAccountType || originalData['view:bankAccountType'];
   const bankAccountNumber =

--- a/src/applications/disability-benefits/all-claims/pages/paymentInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/paymentInformation.js
@@ -13,16 +13,13 @@ const {
 export const uiSchema = {
   'view:bankAccount': {
     'ui:title': 'Payment Information',
-    'ui:description':
-      'We’re currently paying your compensation to this account',
     'ui:field': ReviewCardField,
     'ui:options': {
       viewComponent: PaymentView,
       reviewTitle: 'Payment information',
       editTitle: 'Add new bank account',
       itemName: 'account',
-      startInEdit: formData =>
-        Object.keys(formData).every(key => !formData[key]),
+      startInEdit: formData => !formData['view:hasPrefilledBank'],
       volatileData: true,
     },
     bankAccountType: {

--- a/src/applications/disability-benefits/all-claims/tests/components/PaymentView.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/PaymentView.unit.spec.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import { PaymentView } from '../../components/PaymentView';
+
+describe('AllClaims PaymentView', () => {
+  it('should render with no data', () => {
+    const tree = shallow(<PaymentView />);
+    expect(tree.find('.blue-bar-block').length).to.equal(1);
+  });
+
+  it('should render with formData and no originalData', () => {
+    const formData = {
+      bankAccountType: 'Checking',
+      bankAccountNumber: '1231231234',
+      bankRoutingNumber: '123123123',
+      bankName: 'Big Bank',
+    };
+    const tree = shallow(<PaymentView formData={formData} />);
+    const text = tree.text();
+    expect(text).to.contain('Checking Account');
+    expect(text).to.contain('Account number: ●●●●●●ending with1234');
+    expect(text).to.contain('Bank routing number: ●●●●●ending with3123');
+    expect(text).to.contain('Bank name: Big Bank');
+    expect(tree.find('AlertBox').length).to.equal(1);
+  });
+
+  it('should render with originalData only', () => {
+    const originalData = {
+      'view:bankAccountType': 'Checking',
+      'view:bankAccountNumber': '1231231234',
+      'view:bankRoutingNumber': '123123123',
+      'view:bankName': 'Big Bank',
+    };
+    const tree = shallow(<PaymentView originalData={originalData} />);
+    const text = tree.text();
+    expect(text).to.contain(
+      'We’re currently paying your compensation to this account',
+    );
+    expect(text).to.contain('Checking Account');
+    expect(text).to.contain('Account number: ●●●●●●ending with1234');
+    expect(text).to.contain('Bank routing number: ●●●●●ending with3123');
+    expect(text).to.contain('Bank name: Big Bank');
+  });
+
+  it('should render with different formData than originalData', () => {
+    const formData = {
+      bankAccountType: 'Checking',
+      bankAccountNumber: '1231231234',
+      bankRoutingNumber: '123123123',
+      bankName: 'Big Bank',
+    };
+    const originalData = {
+      'view:bankAccountType': 'Checking',
+      'view:bankAccountNumber': '83920405839',
+      'view:bankRoutingNumber': '987654321',
+      'view:bankName': 'Old Bank',
+    };
+    const tree = shallow(
+      <PaymentView formData={formData} originalData={originalData} />,
+    );
+    const text = tree.text();
+    expect(text).to.contain('Checking Account');
+    expect(text).to.contain('Account number: ●●●●●●ending with1234');
+    expect(text).to.contain('Bank routing number: ●●●●●ending with3123');
+    expect(text).to.contain('Bank name: Big Bank');
+    expect(tree.find('AlertBox').length).to.equal(1);
+  });
+});

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -162,6 +162,22 @@ export function transformMVPData(formData) {
   return newFormData;
 }
 
+/**
+ * Returns an object where all the fields are prefixed with `view:` if they aren't already
+ */
+export const viewifyFields = formData => {
+  const newFormData = {};
+  Object.keys(formData).forEach(key => {
+    const viewKey = /^view:/.test(key) ? key : `view:${key}`;
+    // Recurse if necessary
+    newFormData[viewKey] =
+      typeof formData[key] === 'object' && !Array.isArray(formData[key])
+        ? viewifyFields(formData[key])
+        : formData[key];
+  });
+  return newFormData;
+};
+
 export function prefillTransformer(pages, formData, metadata) {
   const { disabilities } = formData;
   if (!disabilities || !Array.isArray(disabilities)) {
@@ -176,6 +192,32 @@ export function prefillTransformer(pages, formData, metadata) {
     transformMVPData(formData),
   );
   delete newFormData.disabilities;
+
+  // Pre-fill hidden bank info for use in the PaymentView
+  const bankAccount = {
+    bankAccountType: newFormData.bankAccountType,
+    bankAccountNumber: newFormData.bankAccountNumber,
+    bankRoutingNumber: newFormData.bankRoutingNumber,
+    bankName: newFormData.bankName,
+  };
+  newFormData['view:originalBankAccount'] = viewifyFields(bankAccount);
+
+  // Let the payment info card start in review mode if we have pre-filled bank information
+  if (
+    Object.values(newFormData['view:originalBankAccount']).some(
+      value => !!value,
+    )
+  ) {
+    newFormData['view:bankAccount'] = {
+      'view:hasPrefilledBank': true,
+    };
+  }
+
+  // Remove bank fields since they're already in view:originalBankAccount
+  delete newFormData.bankAccountType;
+  delete newFormData.bankAccountNumber;
+  delete newFormData.bankRoutingNumber;
+  delete newFormData.bankName;
 
   return {
     metadata,
@@ -418,22 +460,6 @@ export const addCheckboxPerNewDisability = createSelector(
     ),
   }),
 );
-
-/**
- * Returns an object where all the fields are prefixed with `view:` if they aren't already
- */
-export const viewifyFields = formData => {
-  const newFormData = {};
-  Object.keys(formData).forEach(key => {
-    const viewKey = /^view:/.test(key) ? key : `view:${key}`;
-    // Recurse if necessary
-    newFormData[viewKey] =
-      typeof formData[key] === 'object' && !Array.isArray(formData[key])
-        ? viewifyFields(formData[key])
-        : formData[key];
-  });
-  return newFormData;
-};
 
 export const hasVAEvidence = formData =>
   _.get(DATA_PATHS.hasVAEvidence, formData, false);


### PR DESCRIPTION
## Description
Like it says on the tin, this PR makes the payment view react to new data. When the stuff that's entered is different than the pre-filled data (which is stored in `view:`-only properties so it's not sent to the API).

Fun fact: If there's bank data fetched in pre-fill, then a new bank account is added and saved, then _another_ account is added--but with completely blank information--the pre-fill data shows up like it should (because that's what the API will put on the submission to EVSS).

## Testing done
Manually tested that it works.
Wrote unit tests for the same.

## Screenshots
### No bank data was fetched in pre-fill
![image](https://user-images.githubusercontent.com/12970166/49677718-1fe34980-fa35-11e8-8d46-5de09a9374bf.png)

### When the data is fetched in pre-fill
![image](https://user-images.githubusercontent.com/12970166/49677645-c418c080-fa34-11e8-956e-103a8244ba56.png)

### Edit mode
![image](https://user-images.githubusercontent.com/12970166/49677648-d1ce4600-fa34-11e8-9091-456e612cb716.png)

### New information that's been added
![image](https://user-images.githubusercontent.com/12970166/49677676-ead6f700-fa34-11e8-9a1b-ae31b667f6f8.png)


## Acceptance criteria
- [x] The payment information view reacts to new data

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
