### PR TITLE
Dismiss modal when clicking on link

### DIFF
--- a/src/platform/site-wide/announcements/components/FindVABenefitsIntro.jsx
+++ b/src/platform/site-wide/announcements/components/FindVABenefitsIntro.jsx
@@ -15,7 +15,7 @@ export default function FindVABenefitsIntro({ dismiss }) {
         benefits you may be eligible for, and how to apply. Get started by
         clicking on the “Find VA Benefits Now” button below.
       </p>
-      <a className="usa-button" href="preferences/">
+      <a onClick={dismiss} className="usa-button" href="preferences/">
         Find VA Benefits Now
       </a>
       <button


### PR DESCRIPTION
## Description
This change extends the dismiss behavior to the preferences announcement on link click.

## Testing done
verified locally

## Acceptance criteria
- [x] Extend dismiss behavior to link click

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
