### PR TITLE
Implement an optional "heading" property for distinguishing between the H1 and the document title

### DIFF
--- a/src/site/includes/detail-page.html
+++ b/src/site/includes/detail-page.html
@@ -16,7 +16,7 @@
     <div class="usa-width-three-fourths">
       {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
       <article class="usa-content">
-        <h1>{{ title }}</h1>
+        <h1>{{ heading }}</h1>
         {{ contents }}
       </article>
       {% if majorlinks != empty %}

--- a/src/site/includes/level2-index.html
+++ b/src/site/includes/level2-index.html
@@ -15,7 +15,7 @@ Used for index pages in top-level paths (e.g. /healthcare/index.html)
       </div>
       <div class="inline hub-main-title">
         <h1>
-          {{ title }}
+          {{ heading }}
         </h1>
       </div>
       {{ contents }}

--- a/src/site/includes/topic-landing.html
+++ b/src/site/includes/topic-landing.html
@@ -15,7 +15,7 @@
     <div class="usa-width-three-fourths">
       {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
       <article class="usa-content">
-        <h1>{{ title }}</h1>
+        <h1>{{ heading }}</h1>
         {{ contents }}
       </article>
       {% if majorlinks != empty %}

--- a/src/site/layouts/page-breadcrumbs.html
+++ b/src/site/layouts/page-breadcrumbs.html
@@ -8,6 +8,10 @@
 
 <div id="content" class="interior {{ id }}">
 
+  {% if !heading %}
+    {% assign heading = title %}
+  {% endif %}
+
   {% case template %}
     {% when 'level2-index' %}
       {% include "src/site/includes/level2-index.html" %}
@@ -17,8 +21,6 @@
 
     {% when 'topic-landing' %}
       {% include "src/site/includes/topic-landing.html" %}
-    {% when 'level2-index' %}
-      {% include "src/site/includes/level2-index.html" %}
   {% else %}
     {{ contents }}
   {% endcase %}


### PR DESCRIPTION
## Description
This pull requests adds a property `heading` into our Metalsmith layouts so that when defined, that property will be used instead of the `title` for rendering the `<h1>` tag on the page. This is useful so that more keywords can be added into the Google search result, while the visible heading on the page is unaffected.

Related ticket, https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15370

## Testing done
- Added a heading property to a page and confirmed that property was rendered
- Removed the heading property and confirmed the old title was rendered in its place

## Acceptance criteria
- [ ] Content editors can distinguish between the document title and visible heading

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
