### PR TITLE
Fix empty / incorrect contents bug for summaryOfEvidence, beef up tests

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import _ from '../../../../platform/utilities/data';
+import { DATA_PATHS } from '../constants';
 
 export const summaryOfEvidenceDescription = ({ formData }) => {
   const vaEvidence = _.get('vaTreatmentFacilities', formData, []);
-  const privateEvidence = _.get('privateMedicalRecords', formData, []);
-  const layEvidence = _.get('additionalDocuments', formData, []);
-  const evidenceLength = !!vaEvidence.concat(privateEvidence, layEvidence)
-    .length;
+  const privateEvidence = _.get('providerFacility', formData, []);
+  const privateEvidenceUploads = _.get('privateMedicalRecords', formData, []);
+  const layEvidenceUploads = _.get('additionalDocuments', formData, []);
+  const evidenceLength = !!vaEvidence.concat(
+    privateEvidence,
+    privateEvidenceUploads,
+    layEvidenceUploads,
+  ).length;
   const selectedEvidence = _.get('view:hasEvidence', formData, false);
-  const privateFacility = _.get('providerFacility', formData, []);
   // Evidence isn't always properly cleared out from form data if removed so
   // need to also check that 'no evidence' was explicitly selected
-  if ((!evidenceLength || !selectedEvidence) && !privateFacility) {
+  if (!evidenceLength || !selectedEvidence) {
     return (
       <p>
         You haven’t uploaded any evidence. This may delay us processing your
@@ -24,9 +28,27 @@ export const summaryOfEvidenceDescription = ({ formData }) => {
   let vaContent = null;
   let privateContent = null;
   let layContent = null;
-  let privateFacilityContent = null;
+  let privateEvidenceContent = null;
 
-  if (vaEvidence.length) {
+  const vaEvidenceSelected = _.get(DATA_PATHS.hasVAEvidence, formData, false);
+  const privateEvidenceSelected = _.get(
+    DATA_PATHS.hasPrivateEvidence,
+    formData,
+    false,
+  );
+  const uploadPrivateEvidenceSelected = _.get(
+    DATA_PATHS.hasPrivateRecordsToUpload,
+    formData,
+    false,
+  );
+
+  const additionalEvidenceSelected = _.get(
+    DATA_PATHS.hasAdditionalDocuments,
+    formData,
+    false,
+  );
+
+  if (vaEvidence.length && vaEvidenceSelected) {
     const facilitiesList = vaEvidence.map(facility => (
       <li key={facility.treatmentCenterName}>{facility.treatmentCenterName}</li>
     ));
@@ -38,40 +60,48 @@ export const summaryOfEvidenceDescription = ({ formData }) => {
     );
   }
 
-  if (privateEvidence.length) {
-    const privateEvidenceList = privateEvidence.map(upload => (
+  if (
+    privateEvidenceUploads.length &&
+    privateEvidenceSelected &&
+    uploadPrivateEvidenceSelected
+  ) {
+    const privateEvidenceUploadsList = privateEvidenceUploads.map(upload => (
       <li key={upload.name}>{upload.name}</li>
     ));
     privateContent = (
       <div>
         <p>We’ll submit the below private medical records you uploaded:</p>
+        <ul>{privateEvidenceUploadsList}</ul>
+      </div>
+    );
+  }
+
+  if (
+    privateEvidence.length &&
+    privateEvidenceSelected &&
+    !uploadPrivateEvidenceSelected
+  ) {
+    const privateEvidenceList = privateEvidence.map(facility => (
+      <li key={facility.providerFacilityName}>
+        {facility.providerFacilityName}
+      </li>
+    ));
+    privateEvidenceContent = (
+      <div>
+        <p>We'll get your private medical records from:</p>
         <ul>{privateEvidenceList}</ul>
       </div>
     );
   }
 
-  if (layEvidence.length) {
-    const layEvidenceList = layEvidence.map(upload => (
+  if (layEvidenceUploads.length && additionalEvidenceSelected) {
+    const layEvidenceUploadsList = layEvidenceUploads.map(upload => (
       <li key={upload.name}>{upload.name}</li>
     ));
     layContent = (
       <div>
         <p>We’ll submit the below supporting evidence you uploaded:</p>
-        <ul>{layEvidenceList}</ul>
-      </div>
-    );
-  }
-
-  if (privateFacility.length) {
-    const privateFacilityList = privateFacility.map(facility => (
-      <li key={facility.providerFacilityName}>
-        {facility.providerFacilityName}
-      </li>
-    ));
-    privateFacilityContent = (
-      <div>
-        <p>We'll get your private medical records from:</p>
-        <ul>{privateFacilityList}</ul>
+        <ul>{layEvidenceUploadsList}</ul>
       </div>
     );
   }
@@ -80,8 +110,8 @@ export const summaryOfEvidenceDescription = ({ formData }) => {
     <div>
       {vaContent}
       {privateContent}
+      {privateEvidenceContent}
       {layContent}
-      {privateFacilityContent}
     </div>
   );
 };

--- a/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
@@ -88,7 +88,7 @@ export const summaryOfEvidenceDescription = ({ formData }) => {
     ));
     privateEvidenceContent = (
       <div>
-        <p>We'll get your private medical records from:</p>
+        <p>We’ll get your private medical records from:</p>
         <ul>{privateEvidenceList}</ul>
       </div>
     );

--- a/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
@@ -10,6 +10,46 @@ describe('Summary of Evidence', () => {
     uiSchema,
   } = formConfig.chapters.supportingEvidence.pages.summaryOfEvidence;
 
+  const vaTreatmentFacilities = [
+    { treatmentCenterName: 'Sommerset' },
+    { treatmentCenterName: 'Huntsville' },
+  ];
+
+  const privateFacilities = [
+    {
+      providerFacilityName: 'Provider',
+      treatmentDateRange: [{ from: '2010-02-03', to: '2012-03-05' }],
+      providerFacilityAddress: {
+        street: '1234 test rd',
+        city: 'Testville',
+        postalCode: '12345',
+        country: 'USA',
+        state: 'AZ',
+      },
+    },
+    {
+      providerFacilityName: 'Another Provider',
+      treatmentDateRange: [{ from: '2010-03-04', to: '2012-02-03' }],
+      providerFacilityAddress: {
+        street: '1234 test rd',
+        city: 'Testville',
+        country: 'USA',
+        state: 'AZ',
+        postalCode: '12345',
+      },
+    },
+  ];
+
+  const privateMedicalRecords = [
+    { name: 'TestFile.png' },
+    { name: 'hospital records.pdf' },
+  ];
+
+  const additionalDocuments = [
+    { name: 'Test Lay Statement.png' },
+    { name: 'buddy statement.pdf' },
+  ];
+
   it('should render', () => {
     const form = mount(
       <DefinitionTester
@@ -25,7 +65,7 @@ describe('Summary of Evidence', () => {
     form.unmount();
   });
 
-  it("should render private medical facility list when 'no evidence' selected", () => {
+  it("should render 'no evidence' warning when 'no evidence' selected", () => {
     const form = mount(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
@@ -33,37 +73,63 @@ describe('Summary of Evidence', () => {
         uiSchema={uiSchema}
         data={{
           'view:hasEvidence': false,
-          providerFacility: [
-            {
-              providerFacilityName: 'Provider',
-              treatmentDateRange: [{ from: '2010-02-03', to: '2012-03-05' }],
-              providerFacilityAddress: {
-                street: '1234 test rd',
-                city: 'Testville',
-                postalCode: '12345',
-                country: 'USA',
-                state: 'AZ',
-              },
-            },
-            {
-              providerFacilityName: 'Another Provider',
-              treatmentDateRange: [{ from: '2010-03-04', to: '2012-02-03' }],
-              providerFacilityAddress: {
-                street: '1234 test rd',
-                city: 'Testville',
-                country: 'USA',
-                state: 'AZ',
-                postalCode: '12345',
-              },
-            },
-          ],
         }}
       />,
     );
 
-    expect(form.render().text()).to.contain('Provider');
-    expect(form.render().text()).to.contain('Another Provider');
-    expect(form.find('li').length).to.equal(2);
+    expect(form.render().text()).to.contain(
+      'You haven’t uploaded any evidence.',
+    );
+    expect(form.find('li').length).to.equal(0);
+    form.unmount();
+  });
+
+  it("should render 'no evidence' warning when 'no evidence' selected even if evidence present", () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          'view:hasEvidence': false,
+          vaTreatmentFacilities,
+          privateMedicalRecords,
+          additionalDocuments,
+          providerFacility: privateFacilities,
+        }}
+      />,
+    );
+
+    expect(form.render().text()).to.contain(
+      'You haven’t uploaded any evidence.',
+    );
+    expect(form.find('li').length).to.equal(0);
+    form.unmount();
+  });
+
+  it('should not render any evidence whose evidence type was not selected', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          // Note: this isn't technically a valid state, because you are required
+          // to select at least one type if hasEvidence is true, but it lets us
+          // test that unselected evidence types aren't displayed
+          'view:hasEvidence': true,
+          'view:hasEvidenceFollowUp': {
+            'view:selectableEvidenceTypes': {},
+          },
+          vaTreatmentFacilities,
+          privateMedicalRecords,
+          additionalDocuments,
+          providerFacility: privateFacilities,
+        }}
+      />,
+    );
+
+    expect(form.find('li').length).to.equal(0);
     form.unmount();
   });
 
@@ -75,10 +141,12 @@ describe('Summary of Evidence', () => {
         uiSchema={uiSchema}
         data={{
           'view:hasEvidence': true,
-          vaTreatmentFacilities: [
-            { treatmentCenterName: 'Sommerset' },
-            { treatmentCenterName: 'Huntsville' },
-          ],
+          'view:hasEvidenceFollowUp': {
+            'view:selectableEvidenceTypes': {
+              'view:hasVAMedicalRecords': true,
+            },
+          },
+          vaTreatmentFacilities,
         }}
       />,
     );
@@ -87,9 +155,7 @@ describe('Summary of Evidence', () => {
     form.unmount();
   });
 
-  it('should render private evidence list when private evidence submitted', () => {
-    const fileName1 = 'TestFile.png';
-    const fileName2 = 'hospital records.pdf';
+  it('should render private medical facility list when private facilities selected', () => {
     const form = mount(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
@@ -97,7 +163,42 @@ describe('Summary of Evidence', () => {
         uiSchema={uiSchema}
         data={{
           'view:hasEvidence': true,
-          privateMedicalRecords: [{ name: fileName1 }, { name: fileName2 }],
+          'view:hasEvidenceFollowUp': {
+            'view:selectableEvidenceTypes': {
+              'view:hasPrivateMedicalRecords': true,
+            },
+          },
+          'view:uploadPrivateRecordsQualifier': {
+            'view:hasPrivateRecordsToUpload': false,
+          },
+          providerFacility: privateFacilities,
+        }}
+      />,
+    );
+
+    expect(form.render().text()).to.contain('Provider');
+    expect(form.render().text()).to.contain('Another Provider');
+    expect(form.find('li').length).to.equal(2);
+    form.unmount();
+  });
+
+  it('should render private evidence list when private evidence submitted', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          'view:hasEvidence': true,
+          'view:hasEvidenceFollowUp': {
+            'view:selectableEvidenceTypes': {
+              'view:hasPrivateMedicalRecords': true,
+            },
+          },
+          'view:uploadPrivateRecordsQualifier': {
+            'view:hasPrivateRecordsToUpload': true,
+          },
+          privateMedicalRecords,
         }}
       />,
     );
@@ -109,19 +210,67 @@ describe('Summary of Evidence', () => {
         .at(0)
         .render()
         .text(),
-    ).to.contain(fileName1);
+    ).to.contain(privateMedicalRecords[0].name);
     expect(
       list
         .at(1)
         .render()
         .text(),
-    ).to.contain(fileName2);
+    ).to.contain(privateMedicalRecords[1].name);
+    form.unmount();
+  });
+
+  it('should not render private medical facilities even if entered, when upload selected', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          'view:hasEvidence': true,
+          'view:hasEvidenceFollowUp': {
+            'view:selectableEvidenceTypes': {
+              'view:hasPrivateMedicalRecords': true,
+            },
+          },
+          'view:uploadPrivateRecordsQualifier': {
+            'view:hasPrivateRecordsToUpload': true,
+          },
+          providerFacility: privateFacilities,
+        }}
+      />,
+    );
+
+    expect(form.find('li').length).to.equal(0);
+    form.unmount();
+  });
+
+  it('should not render private evidence uploads even if uploaded, when upload not selected', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          'view:hasEvidence': true,
+          'view:hasEvidenceFollowUp': {
+            'view:selectableEvidenceTypes': {
+              'view:hasPrivateMedicalRecords': true,
+            },
+          },
+          'view:uploadPrivateRecordsQualifier': {
+            'view:hasPrivateRecordsToUpload': false,
+          },
+          privateMedicalRecords,
+        }}
+      />,
+    );
+
+    expect(form.find('li').length).to.equal(0);
     form.unmount();
   });
 
   it('should render lay evidence list when lay evidence submitted', () => {
-    const fileName1 = 'Test Lay Statement.png';
-    const fileName2 = 'buddy statement.pdf';
     const form = mount(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
@@ -129,7 +278,12 @@ describe('Summary of Evidence', () => {
         uiSchema={uiSchema}
         data={{
           'view:hasEvidence': true,
-          additionalDocuments: [{ name: fileName1 }, { name: fileName2 }],
+          'view:hasEvidenceFollowUp': {
+            'view:selectableEvidenceTypes': {
+              'view:hasOtherEvidence': true,
+            },
+          },
+          additionalDocuments,
         }}
       />,
     );
@@ -141,13 +295,13 @@ describe('Summary of Evidence', () => {
         .at(0)
         .render()
         .text(),
-    ).to.contain(fileName1);
+    ).to.contain(additionalDocuments[0].name);
     expect(
       list
         .at(1)
         .render()
         .text(),
-    ).to.contain(fileName2);
+    ).to.contain(additionalDocuments[1].name);
     form.unmount();
   });
 });


### PR DESCRIPTION
## Description
Updates conditionals on the evidence summary page to ensure that 
1. Entered -> unselected evidence doesn't show up
2. We get the 'no evidence warning' message in all instances where no evidence should be shown on the page (fixing a bug where the page is empty under certain conditions).

## Testing done
- Local tests
- Updated and wrote some more unit tests

## Screenshots
- No changes


## Acceptance criteria
- [x] Summary page is never completely empty
- [x] Summary page should show only explicitly selected evidence types
- [x] Summary page shouldn't show any evidence that exists in form data unless the corresponding evidence type has been selected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
