### PR TITLE
All claims fix alternate name mg

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#f476ed0ff038403d04e531bbbae41f72290e23b5",
     "vanilla-lazyload": "^8.17.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#92816fb3a3d5166dba1404e14c2e12739ba3b3b2",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#1067172de60a32f5d268fbfe0a71292e66da3a39",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/src/applications/disability-benefits/all-claims/pages/alternateNames.js
+++ b/src/applications/disability-benefits/all-claims/pages/alternateNames.js
@@ -1,7 +1,11 @@
 import FullNameField from 'us-forms-system/lib/js/fields/FullNameField';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
+import get from '../../../../platform/utilities/data/get';
 
 const { alternateNames: alternateNamesSchema } = fullSchema.properties;
+
+const hasAlternateName = formData =>
+  get('view:hasAlternateName', formData, true);
 
 export const uiSchema = {
   'view:hasAlternateName': {
@@ -19,12 +23,14 @@ export const uiSchema = {
     items: {
       first: {
         'ui:title': 'First name',
+        'ui:required': hasAlternateName,
       },
       middle: {
         'ui:title': 'Middle name',
       },
       last: {
         'ui:title': 'Last name',
+        'ui:required': hasAlternateName,
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10869,9 +10869,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#92816fb3a3d5166dba1404e14c2e12739ba3b3b2":
-  version "3.118.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#92816fb3a3d5166dba1404e14c2e12739ba3b3b2"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#1067172de60a32f5d268fbfe0a71292e66da3a39":
+  version "3.119.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#1067172de60a32f5d268fbfe0a71292e66da3a39"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
## Description
Fixes a silent validation issue for alternate names, where clicking 'yes' then 'no' would trigger a silent validation error.

## Testing done
- Local testing
- Unit tests

## Screenshots
No changes

## Acceptance criteria
- [x] Alternate names page doesn't trigger silent validation error when 'yes' selected, then 'no'
- [x] Alternate names page requires at least one first & last name when 'yes' selected
- [x] Alternate names page doesn't require anything when 'no' selected
- [x] Alternate names page can be skipped entirely (without answering 'yes' or 'no')

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
