### PR TITLE
Use semver for vets-json-schema dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#f476ed0ff038403d04e531bbbae41f72290e23b5",
     "vanilla-lazyload": "^8.17.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#92816fb3a3d5166dba1404e14c2e12739ba3b3b2",
+    "vets-json-schema": "department-of-veterans-affairs/vets-json-schema.git#v3.119.0",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "url-search-params": "^0.10.0",
     "us-forms-system": "https://github.com/usds/us-forms-system.git#f476ed0ff038403d04e531bbbae41f72290e23b5",
     "vanilla-lazyload": "^8.17.0",
-    "vets-json-schema": "department-of-veterans-affairs/vets-json-schema.git#v3.119.0",
+    "vets-json-schema": "department-of-veterans-affairs/vets-json-schema#v3.119.0",
     "webpack-bundle-analyzer": "^2.11.1"
   }
 }

--- a/script/update-json-schema.sh
+++ b/script/update-json-schema.sh
@@ -2,7 +2,7 @@
 
 # Find the versions
 NEW_VERSION=$(git ls-remote --tags git://github.com/department-of-veterans-affairs/vets-json-schema/ | awk -F / '{ print $3 }' | sort -V -r | head -n 1)
-OLD_VERSION=$(grep -oP '(?<=department-of-veterans-affairs/vets-json-schema#)(.*)(?=",$)' package.json)
+OLD_VERSION=$(grep -o -e 'department-of-veterans-affairs\/vets-json-schema#\(.*\)",\?$' package.json | awk -F '[#"]' '{ print $2 }')
 
 # Set up color output
 GREEN='\033[0;32m'

--- a/yarn.lock
+++ b/yarn.lock
@@ -10869,9 +10869,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#92816fb3a3d5166dba1404e14c2e12739ba3b3b2":
-  version "3.118.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#92816fb3a3d5166dba1404e14c2e12739ba3b3b2"
+vets-json-schema@department-of-veterans-affairs/vets-json-schema.git#v3.119.0:
+  version "3.119.0"
+  resolved "https://codeload.github.com/department-of-veterans-affairs/vets-json-schema/tar.gz/1067172de60a32f5d268fbfe0a71292e66da3a39"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10869,7 +10869,7 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-vets-json-schema@department-of-veterans-affairs/vets-json-schema.git#v3.119.0:
+vets-json-schema@department-of-veterans-affairs/vets-json-schema#v3.119.0:
   version "3.119.0"
   resolved "https://codeload.github.com/department-of-veterans-affairs/vets-json-schema/tar.gz/1067172de60a32f5d268fbfe0a71292e66da3a39"
 


### PR DESCRIPTION
## Description
I made a little test to see if we could use semver to keep track of our `vets-json-schema` dependency. This is part of an [open RFC](https://github.com/department-of-veterans-affairs/vets.gov-team/pull/15646).

## Testing done
I made sure it works by breaking it:
1) Changed the dependency to a [GitHub URL](https://docs.npmjs.com/files/package.json#github-urls) with a valid semver `<commit-ish>`
2) Tested that it work
3) Changed the semver to one that isn't a release
4) Tested that it didn't work

## Screenshots
N/A

## Acceptance criteria
- [x] The dependency is fetched properly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
