### PR TITLE
All claims fix waive retirement mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
@@ -12,7 +12,6 @@ export const uiSchema = {
     'ui:title': 'What type of pay you would like to receive?',
     'ui:widget': 'yesNo',
     'ui:options': {
-      yesNoReverse: true, // If veteran elects to not receive VA pay, they waive their VA pay
       labels: {
         Y: 'I want to receive VA compensation pay.',
         N: ' I don’t want to receive tax-free VA compensation pay.', // waiveRetirementPay = true because yesNoReverse

--- a/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
@@ -14,7 +14,7 @@ export const uiSchema = {
     'ui:options': {
       labels: {
         Y: 'I want to receive VA compensation pay.',
-        N: ' I don’t want to receive tax-free VA compensation pay.', // waiveRetirementPay = true because yesNoReverse
+        N: ' I don’t want to receive tax-free VA compensation pay.',
       },
     },
   },

--- a/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/waiveRetirementPay.js
@@ -14,7 +14,7 @@ export const uiSchema = {
     'ui:options': {
       labels: {
         Y: 'I want to receive VA compensation pay.',
-        N: ' I don’t want to receive tax-free VA compensation pay.',
+        N: 'I don’t want to receive tax-free VA compensation pay.',
       },
     },
   },


### PR DESCRIPTION
## Description
Removes `yesNoReverse` from `waiveRetirementPay`, because the question's wording has changed and this isn't needed anymore.

#### Before
'I want to receive VA compensation pay' => `waiveRetirementPay: false`
'I don't want to receive tax-free VA compensation pay' => `waiveRetirementPay: true`

#### Now:
'I want to receive VA Compensation pay' => `waiveRetirementPay: true`
'I don't want to receive tax-free VA compensation pay' => `waiveRetirementPay: false`

## Testing done
Tested locally

## Screenshots
No changes

## Acceptance criteria
- [x] `waiveRetirementPay` is true when veteran elects VA pay over military retired pay, false otherwise

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
