### PR TITLE
Fix master - Remove NSP; Add unmount()

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ ENV NODE_ENV production
 
 RUN apt-get update && apt-get install -y netcat \
   && npm install -g yarn@$YARN_VERSION \
-  && npm install -g nsp \
   && npm install -g s3-cli \
   && npm install -g codeclimate-test-reporter \
   && chmod +x /usr/local/lib/node_modules/yarn/bin/yarn.js

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,13 +121,13 @@ node('vetsgov-general-purpose') {
         },
 
         // Check package.json for known vulnerabilities
-        security: {
-          retry(3) {
-            dockerImage.inside(args) {
-              sh "cd /application && nsp check"
-            }
-          }
-        },
+        // security: {
+        //   retry(3) {
+        //     dockerImage.inside(args) {
+        //       sh "cd /application && nsp check"
+        //     }
+        //   }
+        // },
 
         unit: {
           dockerImage.inside(args) {

--- a/src/applications/disability-benefits/all-claims/tests/pages/medals.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/medals.unit.spec.jsx
@@ -26,6 +26,7 @@ describe('781 medals', () => {
       />,
     );
     expect(form.find('input').length).to.equal(2);
+    form.unmount();
   });
 
   it('should fill in Medal citation', () => {
@@ -47,6 +48,8 @@ describe('781 medals', () => {
 
     expect(form.find('.usa-input-error-message').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
+
+    form.umount();
   });
   it('should allow submission if no medals submitted', () => {
     const onSubmit = sinon.spy();
@@ -65,5 +68,7 @@ describe('781 medals', () => {
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error-message').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
+
+    form.unmount();
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/medals.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/medals.unit.spec.jsx
@@ -49,7 +49,7 @@ describe('781 medals', () => {
     expect(form.find('.usa-input-error-message').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
 
-    form.umount();
+    form.unmount();
   });
   it('should allow submission if no medals submitted', () => {
     const onSubmit = sinon.spy();


### PR DESCRIPTION
## Description
This PR fixes the build errors we're seeing on `master` -

1. Removes NSP, per the discovery here, https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15628
2. Adds `unmount()` to some [unit tests](http://jenkins.vetsgov-internal/blue/organizations/jenkins/testing%2Fvets-website/detail/master/3263/pipeline). These tests were likely branched off of `master` prior to some new linting rules -

```
/application/src/applications/disability-benefits/all-claims/tests/pages/medals.unit.spec.jsx

  18:18  error  mount() has no matching ReactWrapper.unmount()  va-enzyme/unmount

  33:18  error  mount() has no matching ReactWrapper.unmount()  va-enzyme/unmount

  53:18  error  mount() has no matching ReactWrapper.unmount()  va-enzyme/unmount
```

## Testing done
- Ran unit test locally

## Acceptance criteria
- [x] Master builds

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
