### PR TITLE
Update preferences alert content

### DIFF
--- a/src/applications/personalization/preferences/helpers.jsx
+++ b/src/applications/personalization/preferences/helpers.jsx
@@ -280,6 +280,10 @@ export const SaveFailedMessageComponent = (
   </AlertBox>
 );
 
-export const SaveSucceededMessageComponent = (
-  <AlertBox status="success" headline="We’ve saved your preferences." />
+export const SaveSucceededMessageComponent = handleCloseAlert => (
+  <AlertBox
+    onCloseAlert={handleCloseAlert}
+    status="success"
+    headline="We’ve saved your preferences."
+  />
 );

--- a/src/applications/personalization/preferences/helpers.jsx
+++ b/src/applications/personalization/preferences/helpers.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router';
 
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
@@ -245,3 +246,40 @@ export const benefitChoices = [
     faqComponent: healthFAQ,
   },
 ];
+
+export const RetrieveFailedMessageComponent = ({ showLink }) => (
+  <AlertBox
+    status="error"
+    className="preferences-alert"
+    headline="We can’t show your selected benefit information right now."
+  >
+    <div>
+      <p>
+        We’re sorry. Something went wrong on our end, and we can’t show you
+        information about the benefits you chose. Please check back later.
+      </p>
+      {showLink && <Link to="/">Go back to my VA</Link>}
+    </div>
+  </AlertBox>
+);
+
+export const SaveFailedMessageComponent = (
+  <AlertBox
+    status="error"
+    className="preferences-alert"
+    headline="We couldn’t save your update"
+  >
+    <div>
+      <span>
+        We’re sorry. Something went wrong on our end, and we couldn’t save your
+        update.
+      </span>
+      <br />
+      <span>Please try again or check back later.</span>
+    </div>
+  </AlertBox>
+);
+
+export const SaveSucceededMessageComponent = (
+  <AlertBox status="success" headline="We’ve saved your preferences." />
+);

--- a/src/applications/personalization/preferences/sass/preferences.scss
+++ b/src/applications/personalization/preferences/sass/preferences.scss
@@ -53,3 +53,8 @@
 .form-expanding-group {
   margin-bottom: 2rem;
 }
+
+.preferences-alert {
+  max-width: 77rem;
+  margin-bottom: 1.5em;
+}


### PR DESCRIPTION
## Description
These changes update the preferences alert content (https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15526). 

## Testing done
-verified locally

## Screenshots
Save succeeded
![screen shot 2018-12-11 at 10 25 56 am](https://user-images.githubusercontent.com/16051172/49826433-cbddab00-fd3b-11e8-96ca-5e9d1aa31b8c.png)

Save failed
![screen shot 2018-12-11 at 10 24 45 am](https://user-images.githubusercontent.com/16051172/49826468-dd26b780-fd3b-11e8-87a5-53f3afd32494.png)

Retrieve failed
![screen shot 2018-12-11 at 11 26 09 am](https://user-images.githubusercontent.com/16051172/49826421-c4b69d00-fd3b-11e8-856a-6a54ddade8e8.png)

Save failed
![screen shot 2018-12-11 at 11 31 50 am](https://user-images.githubusercontent.com/16051172/49826392-b4062700-fd3b-11e8-87c7-647ca7c21d1d.png)

## Acceptance criteria
- [x] Update the preferences alert content.

## Definition of done
~- [ ] Events are logged appropriately~
~- [ ] Documentation has been updated, if applicable~
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
