### PR TITLE
Upgrade yarn and add security check based on yarn audit

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,6 +1,6 @@
 {
   "exceptions": [
-    "https://nodesecurity.io/advisories/577",
-    "https://nodesecurity.io/advisories/157"
+    "https://npmjs.com/advisories/577",
+    "https://npmjs.com/advisories/157"
   ]
 }

--- a/.nsprc
+++ b/.nsprc
@@ -1,6 +1,0 @@
-{
-  "exceptions": [
-    "https://npmjs.com/advisories/577",
-    "https://npmjs.com/advisories/157"
-  ]
-}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM node:8
 RUN groupadd --gid 504 jenkins \
   && useradd --uid 504 --gid jenkins --shell /bin/bash --create-home jenkins
 
-ENV YARN_VERSION 1.5.1
+ENV YARN_VERSION 1.12.3
 ENV NODE_ENV production
 
 RUN apt-get update && apt-get install -y netcat \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,13 +121,13 @@ node('vetsgov-general-purpose') {
         },
 
         // Check package.json for known vulnerabilities
-        // security: {
-        //   retry(3) {
-        //     dockerImage.inside(args) {
-        //       sh "cd /application && nsp check"
-        //     }
-        //   }
-        // },
+        security: {
+          retry(3) {
+            dockerImage.inside(args) {
+              sh "cd /application && npm run security-check"
+            }
+          }
+        },
 
         unit: {
           dockerImage.inside(args) {

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Inside the `src` directory, we have two folders `applications` and `platform`. `
 
 Users with government furnished equipment may not have admin account access. [These instructions might help](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Design/run_vets.gov_locally_for_designers.md).
 
-The requirements for running this application are Node.js 8.10.0 and yarn 1.5.1
+The requirements for running this application are Node.js 8.10.0 and yarn 1.12.3
 
 Once you have nvm installed you should now install node.js version 8.10.0 by running:
 
@@ -94,13 +94,13 @@ nvm alias default 8.10.0
 
 Next install Yarn:
 ```bash
-npm i -g yarn@1.5.1
+npm i -g yarn@1.12.3
 ```
 ### Verify your local requirements are set
 
 ```bash
 node --version // 8.10.0
-yarn --version // 1.5.1
+yarn --version // 1.12.3
 ```
 
 Once you use one of the correct commands above (like `npm run watch`), the site will be available locally by typing `localhost:3001` into your browser. If you get weird errors, try `yarn install` as your first step.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "nightwatch-visual": "node src/platform/testing/visual-regression/index.js",
     "postinstall": "npm rebuild node-sass",
     "reset:env": "./script/reset-environment.sh",
+    "security-check": "node ./script/security-check.js",
     "test": "npm run test:unit && npm run test:e2e",
     "test:e2e": "./script/run-nightwatch.sh",
     "test:e2e:headless": "./script/run-nightwatch.sh --env headless",
@@ -218,7 +219,7 @@
   },
   "engines": {
     "node": "8.10.0",
-    "yarn": "1.5.1"
+    "yarn": "1.12.3"
   },
   "private": true,
   "dependencies": {

--- a/script/reset-environment.sh
+++ b/script/reset-environment.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 if ! [ -x "$(command -v yarn)" ]; then
     echo "Installing yarn..."
-    npm i -g yarn@1.5.1
+    npm i -g yarn@1.12.3
     if [ $? -eq 0 ]; then
         echo "Yarn successfulling installed globally."
     else 
@@ -10,12 +10,12 @@ if ! [ -x "$(command -v yarn)" ]; then
     fi
 else
     yarn_version=$(yarn --version)
-    if [ "$yarn_version" != "1.5.1" ]; then
-        echo "Install yarn version 1.5.1 [y/N]: "
+    if [ "$yarn_version" != "1.12.3" ]; then
+        echo "Install yarn version 1.12.3 [y/N]: "
         read input
         case "$input" in 
             y|Y|yes|Yes)
-                npm i -g yarn@1.5.1
+                npm i -g yarn@1.12.3
                 ;;
             *)
                 ;;

--- a/script/security-check.js
+++ b/script/security-check.js
@@ -1,4 +1,9 @@
 /* eslint-disable no-console */
+/*
+ * This script parses the yarn audit JSON results to find security advisories
+ * that affect modules in our dependencies list that are moderate or higher
+ * and aren't in our exceptions list
+ */
 const fs = require('fs');
 const path = require('path');
 const { spawn } = require('child_process');
@@ -48,6 +53,10 @@ Security advisory:
   Details: ${adv.data.advisory.url}
       `);
     });
+  } else {
+    console.log(
+      'No security advisories rated moderate or higher found for non-dev dependencies.',
+    );
   }
 
   process.exit(validAdvisories.length);

--- a/script/security-check.js
+++ b/script/security-check.js
@@ -16,7 +16,7 @@ const exceptions = JSON.parse(
 
 const dependencySet = new Set(Object.keys(packageJSON.dependencies));
 const exceptionSet = new Set(exceptions);
-const severitySet = new Set(['high', 'critical', 'moderate']);
+const severitySet = new Set(['high', 'critical', 'moderate', 'low']);
 
 function getAffectedModule(data) {
   return data.resolution.path.split('>')[0];

--- a/script/security-check.js
+++ b/script/security-check.js
@@ -1,0 +1,71 @@
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const packageJSON = require('../package.json');
+
+const exceptions = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../.nsprc'), 'utf8'),
+).exceptions;
+
+const dependencySet = new Set(Object.keys(packageJSON.dependencies));
+const exceptionSet = new Set(exceptions);
+const severitySet = new Set(['high', 'critical', 'moderate']);
+
+function getAffectedModule(data) {
+  return data.resolution.path.split('>')[0];
+}
+
+function processAuditResults(audit) {
+  const advisories = audit
+    .trim()
+    .split('\n')
+    .map(a => JSON.parse(a));
+
+  const validAdvisories = advisories.filter(adv => {
+    if (adv.type === 'auditAdvisory') {
+      const advisoryData = adv.data.advisory;
+      const affectedModule = getAffectedModule(adv.data);
+      return (
+        !exceptionSet.has(advisoryData.url) &&
+        severitySet.has(advisoryData.severity) &&
+        dependencySet.has(affectedModule)
+      );
+    }
+
+    return false;
+  });
+
+  if (validAdvisories.length) {
+    validAdvisories.forEach(adv => {
+      console.log(`
+Security advisory:
+  Title: ${adv.data.advisory.title}
+  Module name: ${adv.data.advisory.module_name}
+  Dependency: ${getAffectedModule(adv.data)}
+  Severity: ${adv.data.advisory.severity}
+  Details: ${adv.data.advisory.url}
+      `);
+    });
+  }
+
+  process.exit(validAdvisories.length);
+}
+
+const child = spawn('yarn', ['audit', '--json']);
+let auditOutput = '';
+
+child.stdout.setEncoding('utf8');
+
+child.stdout.on('data', data => {
+  auditOutput += data;
+});
+
+child.stderr.on('data', data => {
+  console.error(data);
+});
+
+child.on('close', () => {
+  processAuditResults(auditOutput);
+});

--- a/script/security-check.js
+++ b/script/security-check.js
@@ -4,19 +4,18 @@
  * that affect modules in our dependencies list that are moderate or higher
  * and aren't in our exceptions list
  */
-const fs = require('fs');
-const path = require('path');
 const { spawn } = require('child_process');
 
 const packageJSON = require('../package.json');
 
-const exceptions = JSON.parse(
-  fs.readFileSync(path.join(__dirname, '../.nsprc'), 'utf8'),
-).exceptions;
+const exceptionSet = new Set([
+  'https://npmjs.com/advisories/577',
+  'https://npmjs.com/advisories/157',
+]);
+
+const severitySet = new Set(['high', 'critical', 'moderate']);
 
 const dependencySet = new Set(Object.keys(packageJSON.dependencies));
-const exceptionSet = new Set(exceptions);
-const severitySet = new Set(['high', 'critical', 'moderate']);
 
 function getAffectedModule(data) {
   return data.resolution.path.split('>')[0];

--- a/script/security-check.js
+++ b/script/security-check.js
@@ -16,7 +16,7 @@ const exceptions = JSON.parse(
 
 const dependencySet = new Set(Object.keys(packageJSON.dependencies));
 const exceptionSet = new Set(exceptions);
-const severitySet = new Set(['high', 'critical', 'moderate', 'low']);
+const severitySet = new Set(['high', 'critical', 'moderate']);
 
 function getAffectedModule(data) {
   return data.resolution.path.split('>')[0];

--- a/script/security-check.js
+++ b/script/security-check.js
@@ -62,19 +62,23 @@ Security advisory:
   process.exit(validAdvisories.length);
 }
 
-const child = spawn('yarn', ['audit', '--json']);
-let auditOutput = '';
+function runAudit() {
+  const child = spawn('yarn', ['audit', '--json']);
+  let auditOutput = '';
 
-child.stdout.setEncoding('utf8');
+  child.stdout.setEncoding('utf8');
 
-child.stdout.on('data', data => {
-  auditOutput += data;
-});
+  child.stdout.on('data', data => {
+    auditOutput += data;
+  });
 
-child.stderr.on('data', data => {
-  console.error(data);
-});
+  child.stderr.on('data', data => {
+    console.error(data);
+  });
 
-child.on('close', () => {
-  processAuditResults(auditOutput);
-});
+  child.on('close', () => {
+    processAuditResults(auditOutput);
+  });
+}
+
+runAudit();

--- a/script/security-check.js
+++ b/script/security-check.js
@@ -23,6 +23,8 @@ function getAffectedModule(data) {
 }
 
 function processAuditResults(audit) {
+  // The output isn't valid JSON, it's a list of JSON
+  // objects separated by newlines
   const advisories = audit
     .trim()
     .split('\n')


### PR DESCRIPTION
## Description

This PR upgrades Yarn so that we can use `yarn audit` and it uses the output of that command to find valid issues for us, similar to what NSP was doing previously.

## Testing done
Ran locally

## Acceptance criteria
- [x] Security check works
- [x] Build fails when security check fails

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
