### PR TITLE
Add disabled property to preferences modal

### DIFF
--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -4,6 +4,7 @@ import PersonalizationBanner from '../components/PersonalizationBanner';
 import ClaimIncreaseBanner from '../components/ClaimIncreaseBanner';
 import VAPlusVetsModal from '../components/VAPlusVetsModal';
 import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
+import environment from 'platform/utilities/environment';
 
 const config = {
   announcements: [
@@ -24,6 +25,7 @@ const config = {
       name: 'find-va-benefits-intro',
       paths: /^(\/my-va\/)$/,
       component: FindVABenefitsIntro,
+      disabled: environment.isProduction(),
     },
     {
       name: 'profile-360-intro',


### PR DESCRIPTION
## Description
These changes disable the FindVABenefits modal in production.

## Testing done
verified locally

## Acceptance criteria
- [x] Add a disabled property to the FindVABenefits modal.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
