### PR TITLE
Implement a link to "#other-options" on the Discharge Wizard

### DIFF
--- a/src/applications/discharge-wizard/components/InstructionsPage.jsx
+++ b/src/applications/discharge-wizard/components/InstructionsPage.jsx
@@ -6,7 +6,11 @@ class InstructionsPage extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {};
+    const defaultOpenFaqItem =
+      document.location.hash && document.location.hash.slice(1);
+    this.state = {
+      [defaultOpenFaqItem]: true,
+    };
   }
 
   componentDidMount() {
@@ -86,12 +90,13 @@ class InstructionsPage extends React.Component {
                         <ul className="usa-unstyled-list">
                           <li itemScope itemType="http://schema.org/Question">
                             <button
+                              id="other-options"
                               className="usa-button-unstyled usa-accordion-button"
                               aria-controls="dbq4"
                               itemProp="name"
-                              aria-expanded={!!this.state.q1}
+                              aria-expanded={!!this.state['other-options']}
                               onClick={this.handleFAQToggle}
-                              name="q1"
+                              name="other-options"
                             >
                               Can I get VA benefits without a discharge upgrade?
                             </button>


### PR DESCRIPTION
## Description
Per this ticket, https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11260, we have a link to `/discharge-upgrade-instructions/#other-options`. This anchor should open an accordion item on the Discharge Wizard intro. This PR implements that by adding a default state, and changing the accordion button's ID to match that of the location hash.

## Testing done
Local testing

## Screenshots
On reload -
![image](https://user-images.githubusercontent.com/1915775/49892776-c8b7ed00-fe17-11e8-8954-59c278d8ccc1.png)

## Acceptance criteria
- [x] The link to `#other-options` works

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
