### PR TITLE
[FacilityLocator] Provider Locator Address & Map Fixes

### DIFF
--- a/src/applications/facility-locator/api/MockLocatorApi.js
+++ b/src/applications/facility-locator/api/MockLocatorApi.js
@@ -936,6 +936,37 @@ export const facilityData = {
         long: -76.95675965,
       },
     },
+    {
+      id: 'ccp_4',
+      type: 'cc_provider',
+      attributes: {
+        uniqueId: '4',
+        name: 'University of Broken Data',
+        specialty: [
+          {
+            name: 'Bad Data',
+            desc: '...b0rk...',
+          },
+          {
+            name: 'Eyyy Lmao',
+            desc: 'LUL  IceCold...',
+          },
+        ],
+        address: {},
+        email: 'b0rkb0rk@br0k.edu',
+        phone: '240-123-0199',
+        schedPhone: '866-606-8198',
+        fax: '240-123-0198',
+        website: 'http://b0rk.org',
+        prefContact: 'phone',
+        accNewPatients: true,
+        gender: 'Male',
+        distance: 3.65, // in miles
+        network: 'LHASNRM',
+        lat: 38.9857684400001,
+        long: -76.95675965,
+      },
+    },
   ],
   links: {
     self:

--- a/src/applications/facility-locator/components/LocationMap.jsx
+++ b/src/applications/facility-locator/components/LocationMap.jsx
@@ -1,6 +1,7 @@
 import { mapboxToken } from './MapboxClient';
 import environment from '../../../platform/utilities/environment';
 import React, { Component } from 'react';
+import { LocationType, PinNames } from '../constants';
 
 class LocationMap extends Component {
   render() {
@@ -9,21 +10,17 @@ class LocationMap extends Component {
     }
 
     const {
+      type,
       attributes: { lat, long, facilityType },
     } = this.props.info;
 
-    /* eslint-disable camelcase */
-    const pinNames = {
-      va_health_facility: 'health',
-      cc_provider: 'cc-provider',
-      va_cemetery: 'cemetery',
-      va_benefits_facility: 'benefits',
-      vet_center: 'vet-centers',
-    };
-    /* eslint-enable camelcase */
+    const pinName =
+      type === LocationType.CC_PROVIDER
+        ? PinNames[type]
+        : PinNames[facilityType];
 
     const pinURL = encodeURIComponent(
-      `${environment.BASE_URL}/img/icons/${pinNames[facilityType]}-pin.png`,
+      `${environment.BASE_URL}/img/icons/${pinName}-pin.png`,
     );
 
     const mapUrl = `https://api.mapbox.com/v4/mapbox.streets/url-${pinURL}(${long},${lat})/${long},${lat},16/500x300.png?access_token=${mapboxToken}`;

--- a/src/applications/facility-locator/components/search-results/LocationAddress.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationAddress.jsx
@@ -5,6 +5,15 @@ import { buildAddressArray } from '../../utils/facilityAddress';
 const LocationAddress = ({ location }) => {
   const addressArray = buildAddressArray(location);
 
+  if (addressArray.length === 0) {
+    return (
+      <span>
+        <strong>Address: </strong>
+        Contact for Information
+      </span>
+    );
+  }
+
   return (
     <span>
       {[].concat(...addressArray.map(e => [<br key={e} />, e])).slice(1)}

--- a/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
@@ -13,7 +13,8 @@ class LocationDirectionsLink extends Component {
           href={`https://maps.google.com?saddr=Current+Location&daddr=${address}`}
           target="_blank"
         >
-          <i className="fa fa-road" /> Directions
+          <i className="fa fa-road" />
+          Directions
         </a>
       </span>
     );

--- a/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
@@ -19,6 +19,7 @@ class LocationDirectionsLink extends Component {
       <span>
         <a
           href={`https://maps.google.com?saddr=Current+Location&daddr=${address}`}
+          rel="noopener noreferrer"
           target="_blank"
         >
           <i className="fa fa-road" />

--- a/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
@@ -5,7 +5,15 @@ import { buildAddressArray } from '../../utils/facilityAddress';
 class LocationDirectionsLink extends Component {
   render() {
     const { location } = this.props;
-    const address = buildAddressArray(location).join(', ');
+    let address = buildAddressArray(location);
+
+    if (address.length !== 0) {
+      address = address.join(', ');
+    } else {
+      // If we don't have an address fallback on coords
+      const { lat, long } = location.attributes;
+      address = `${lat},${long}`;
+    }
 
     return (
       <span>

--- a/src/applications/facility-locator/constants/index.js
+++ b/src/applications/facility-locator/constants/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { ccLocatorEnabled } from '../config';
 
 /**
@@ -33,8 +32,10 @@ export const FacilityType = {
 };
 
 /**
- *
+ * Enum for map pins.
+ * Location types mapped to the filename prefix for the png/svg.
  */
+/* eslint-disable camelcase */
 export const PinNames = {
   va_health_facility: 'health',
   cc_provider: 'cc-provider',
@@ -42,6 +43,7 @@ export const PinNames = {
   va_benefits_facility: 'benefits',
   vet_center: 'vet-centers',
 };
+/* eslint-enable camelcase */
 
 /**
  * Defines the options available for the Location Type Dropdown

--- a/src/applications/facility-locator/constants/index.js
+++ b/src/applications/facility-locator/constants/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { ccLocatorEnabled } from '../config';
 
 /**
@@ -29,6 +30,17 @@ export const FacilityType = {
   VA_CEMETARY: 'va_cemetery',
   VA_BENEFITS_FACILITY: 'va_benefits_facility',
   VET_CENTER: 'vet_center',
+};
+
+/**
+ *
+ */
+export const PinNames = {
+  va_health_facility: 'health',
+  cc_provider: 'cc-provider',
+  va_cemetery: 'cemetery',
+  va_benefits_facility: 'benefits',
+  vet_center: 'vet-centers',
 };
 
 /**

--- a/src/applications/facility-locator/containers/ProviderDetail.jsx
+++ b/src/applications/facility-locator/containers/ProviderDetail.jsx
@@ -131,7 +131,7 @@ class ProviderDetail extends Component {
 }
 
 ProviderDetail.propTypes = {
-  location: object.isRequired,
+  location: object, // technically req, but comes in off a REST call in didMount
   currentQuery: object.isRequired,
   fetchProviderDetail: func.isRequired,
   params: object.isRequired,

--- a/src/applications/facility-locator/utils/facilityAddress.js
+++ b/src/applications/facility-locator/utils/facilityAddress.js
@@ -1,4 +1,5 @@
-import { compact, isEmpty } from 'lodash';
+import compact from 'lodash/compact';
+import isEmpty from 'lodash/isEmpty';
 import { LocationType } from '../constants';
 
 export function buildAddressArray(location) {

--- a/src/applications/facility-locator/utils/facilityAddress.js
+++ b/src/applications/facility-locator/utils/facilityAddress.js
@@ -1,4 +1,4 @@
-import { compact, isEmpty } from 'lodash/compact';
+import { compact, isEmpty } from 'lodash';
 import { LocationType } from '../constants';
 
 export function buildAddressArray(location) {

--- a/src/applications/facility-locator/utils/facilityAddress.js
+++ b/src/applications/facility-locator/utils/facilityAddress.js
@@ -1,5 +1,4 @@
-import compact from 'lodash/compact';
-import isEmpty from 'lodash/isEmpty';
+import { compact, isEmpty } from 'lodash/compact';
 import { LocationType } from '../constants';
 
 export function buildAddressArray(location) {

--- a/src/applications/facility-locator/utils/facilityAddress.js
+++ b/src/applications/facility-locator/utils/facilityAddress.js
@@ -1,15 +1,19 @@
-import { compact } from 'lodash';
+import { compact, isEmpty } from 'lodash';
 import { LocationType } from '../constants';
 
 export function buildAddressArray(location) {
   if (location.type === LocationType.CC_PROVIDER) {
     const { address } = location.attributes;
 
-    return compact([
-      address.street,
-      address.appt,
-      `${address.city}, ${address.state} ${address.zip}`,
-    ]);
+    if (!isEmpty(address)) {
+      return compact([
+        address.street,
+        address.appt,
+        `${address.city}, ${address.state} ${address.zip}`,
+      ]);
+    }
+
+    return [];
   }
 
   const {


### PR DESCRIPTION
These should remedy the the two big items we discussed this afternoon and will pair with one of @SimonSchama 's PRs going in for the API tonight.
Two items being:
- [Static Map on Details page not generating](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15273)
- `null`s appearing in the address fields for Providers that have bad/missing/malformed data.
- (Also snuck in a couple other fixes we found along the way or were small enough to include)

## Description
Updates/Tweaks/Changes for Address & Details Map
* New mock data for testing empty address fields
* Moved LocationMap's `pinNames` out to `constants/index.js`
* Changed how to check which pin png to use in the Mapbox API call for static maps
* Additional small changes to other files to handle empty address fields, returning appropriate data to indicate to parent components, and formatting text to display to the user
* Fixed tiny visual glitch where Details page had an extra space before "Directions"
* Fixed tiny warning from ProviderDetail where it would warn about `location` not existing while being required
  * Fix was removing the `isRequired` as `location` is something mapped off of props out of the Redux store and that value isn't loaded until a service call is made in the component's `componentWillMount`


(@'s for visibility to @rtluu @ehuntdsva & @brettdt )