### PR TITLE
Next Button Bug Fix

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
@@ -67,7 +67,7 @@ export default function ButtonContainer(props) {
         </a>
       )}
       {!atGuidance() && (
-        <div
+        <a
           className="usa-button-primary"
           role="button"
           tabIndex="0"
@@ -76,7 +76,7 @@ export default function ButtonContainer(props) {
         >
           Next
           <span className="button-icon"> »</span>
-        </div>
+        </a>
       )}
     </div>
   );

--- a/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
@@ -67,16 +67,15 @@ export default function ButtonContainer(props) {
         </a>
       )}
       {!atGuidance() && (
-        <a
+        <button
           className="usa-button-primary"
-          role="button"
           tabIndex="0"
           onClick={goForward}
           onKeyPress={handleKeyPress}
         >
           Next
           <span className="button-icon"> »</span>
-        </a>
+        </button>
       )}
     </div>
   );

--- a/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
@@ -11,6 +11,7 @@ export default function ButtonContainer(props) {
     authenticate,
     isVerified,
     isLoggedIn,
+    handleKeyPress,
   } = props;
   const { atIncreaseGuidance, atEbenefitsGuidance } = checkGuidanceStatus();
 
@@ -66,10 +67,16 @@ export default function ButtonContainer(props) {
         </a>
       )}
       {!atGuidance() && (
-        <a className="usa-button-primary" onClick={goForward}>
+        <div
+          className="usa-button-primary"
+          role="button"
+          tabIndex="0"
+          onClick={goForward}
+          onKeyPress={handleKeyPress}
+        >
           Next
           <span className="button-icon"> »</span>
-        </a>
+        </div>
       )}
     </div>
   );

--- a/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
@@ -69,7 +69,6 @@ export default function ButtonContainer(props) {
       {!atGuidance() && (
         <button
           className="usa-button-primary"
-          tabIndex="0"
           onClick={goForward}
           onKeyPress={handleKeyPress}
         >

--- a/src/applications/disability-benefits/526EZ/components/DisabilityWizard.jsx
+++ b/src/applications/disability-benefits/526EZ/components/DisabilityWizard.jsx
@@ -136,6 +136,12 @@ class DisabilityWizard extends React.Component {
     this.setState({ currentLayout: nextLayout, errorMessage: '' });
   };
 
+  handleKeyPress = e => {
+    if (e.key === 'Enter') {
+      this.goToNextPage();
+    }
+  };
+
   goBack = () => {
     let nextLayout = chooseStatus;
     const { atGuidance } = this;
@@ -250,6 +256,7 @@ class DisabilityWizard extends React.Component {
                 goBack={this.goBack}
                 goForward={this.goForward}
                 authenticate={this.authenticate}
+                handleKeyPress={this.handleKeyPress}
               />
             }
           </div>

--- a/src/applications/disability-benefits/526EZ/tests/components/DisabilityWizard.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/DisabilityWizard.unit.spec.jsx
@@ -31,8 +31,11 @@ describe('<DisabilityWizard>', () => {
   });
   it('should validate status page on submit', () => {
     const tree = mount(<DisabilityWizard {...defaultProps} />);
+    tree
+      .find('ButtonContainer')
+      .find('button')
+      .simulate('click');
 
-    tree.find('a').simulate('click');
     expect(tree.find('.usa-input-error-message').exists()).to.equal(true);
     tree.unmount();
   });
@@ -48,7 +51,10 @@ describe('<DisabilityWizard>', () => {
     const tree = mount(<DisabilityWizard {...defaultProps} />);
 
     tree.setState({ disabilityStatus: 'update', currentLayout: chooseUpdate });
-    tree.find('a').simulate('click');
+    tree
+      .find('ButtonContainer')
+      .find('.usa-button-primary')
+      .simulate('click');
     expect(tree.find('.usa-input-error-message').exists()).to.equal(true);
     tree.unmount();
   });


### PR DESCRIPTION
## Description
Fix for bug where user cannot select NEXT with TAB button on intro page.
On the introduction page click "Find your disability claim form", hit the TAB button until you see the first bullet highlighted.
Press the DOWN arrow on your keyboard to select the second bullet.
Press the TAB key to go to the next selection which should be the NEXT button
--> Notice the highlight jumped to the link below the Next button completely skipping the button.
User has no way to continue. Same thing happens on the next page. After the user tabs from the "Back" button, it should go to "Next" but instead goes to the links below it.

http://localhost:3001/disability-benefits/apply/form-526-all-claims/introduction

## Testing done
No testing done.

## Screenshots
![screen shot 2018-12-13 at 12 04 16 pm](https://user-images.githubusercontent.com/41440372/49958082-bdc49180-fed7-11e8-8b65-e9faa54d62c8.png)
![screen shot 2018-12-13 at 12 03 44 pm](https://user-images.githubusercontent.com/41440372/49958083-bdc49180-fed7-11e8-89b2-3611d71852c9.png)


## Acceptance criteria
- [ ] User able to select NEXT with TAB Button and pressing ENTER.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
