### PR TITLE
Upgrade USFS

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "reselect": "^2.5.4",
     "text-loader": "^0.0.1",
     "url-search-params": "^0.10.0",
-    "us-forms-system": "https://github.com/usds/us-forms-system.git#f476ed0ff038403d04e531bbbae41f72290e23b5",
+    "us-forms-system": "https://github.com/usds/us-forms-system.git#827b57caf055ec268919c77afbe6a03c2ef59bd0",
     "vanilla-lazyload": "^8.17.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#1067172de60a32f5d268fbfe0a71292e66da3a39",
     "webpack-bundle-analyzer": "^2.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10759,9 +10759,9 @@ url@^0.11.0, url@~0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-"us-forms-system@https://github.com/usds/us-forms-system.git#f476ed0ff038403d04e531bbbae41f72290e23b5":
+"us-forms-system@https://github.com/usds/us-forms-system.git#827b57caf055ec268919c77afbe6a03c2ef59bd0":
   version "1.1.0"
-  resolved "https://github.com/usds/us-forms-system.git#f476ed0ff038403d04e531bbbae41f72290e23b5"
+  resolved "https://github.com/usds/us-forms-system.git#827b57caf055ec268919c77afbe6a03c2ef59bd0"
   dependencies:
     "@department-of-veterans-affairs/react-jsonschema-form" "^1.0.0"
     classnames "^2.2.5"


### PR DESCRIPTION
## Description
I [fixed a thing on USFS](https://github.com/usds/us-forms-system/pull/321). This PR updates our USFS dependency to use that version. Looking at the [commit history](https://github.com/usds/us-forms-system/commits/1.x-stable) on the stable branch that I merged into, the only difference between the new version and what we're currently using is that PR merge.

## Testing done
Ran unit tests; they all work.

## Screenshots
N/A

## Acceptance criteria
- [x] Nothing breaks that I know of

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
