### PR TITLE
Add FTUX announcement and update find benefits announcement name

### DIFF
--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -1,3 +1,4 @@
+import DashboardIntro from '../components/DashboardIntro';
 import FindVABenefitsIntro from '../components/FindVABenefitsIntro';
 import Profile360Intro from '../components/Profile360Intro';
 import PersonalizationBanner from '../components/PersonalizationBanner';
@@ -22,10 +23,18 @@ const config = {
       disabled: !WelcomeToNewVAModal.isEnabled(),
     },
     {
-      name: 'find-va-benefits-intro',
+      name: 'dashboard-intro',
+      paths: /^(\/my-va\/)$/,
+      component: DashboardIntro,
+      disabled: !environment.isProduction(),
+      relatedAnnouncements: ['personalization'],
+    },
+    {
+      name: 'find-benefits-intro',
       paths: /^(\/my-va\/)$/,
       component: FindVABenefitsIntro,
       disabled: environment.isProduction(),
+      relatedAnnouncements: ['personalization'],
     },
     {
       name: 'profile-360-intro',


### PR DESCRIPTION
## Description
These changes add the dashboard intro modal, and rename the find benefits modal name.

## Testing done
- verified locally

## Screenshots
![image](https://user-images.githubusercontent.com/16051172/49974667-3aaf3580-feef-11e8-801d-239798844a3b.png)


## Acceptance criteria
- [x] add the dashboard intro modal
- [x] rename the find benefits modal name.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
