### PR TITLE
Fix bad schema merge

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -1,4 +1,4 @@
-import merge from 'lodash/merge';
+import set from '../../../../platform/utilities/data/set';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { uiSchema as autoSuggestUiSchema } from 'us-forms-system/lib/js/definitions/autosuggest';
 import dateRangeUI from 'us-forms-system/lib/js/definitions/monthYearRange';
@@ -91,15 +91,13 @@ export const schema = {
       type: 'object',
       properties: {},
     },
-    vaTreatmentFacilities: merge({}, vaTreatmentFacilities, {
-      items: {
-        properties: {
-          treatedDisabilityNames: {
-            type: 'object',
-            properties: {},
-          },
-        },
+    vaTreatmentFacilities: set(
+      'items.properties.treatedDisabilityNames',
+      {
+        type: 'object',
+        properties: {},
       },
-    }),
+      vaTreatmentFacilities,
+    ),
   },
 };


### PR DESCRIPTION
## Description
Disabilities were sometimes unselectable in the UI, due to a missing id property, which happened because the property's schema was a mishmash of two different types of schemas resulting from a bad usage of lodash merge:

<img width="821" alt="screen shot 2018-12-14 at 11 14 59 am" src="https://user-images.githubusercontent.com/24251447/50019632-07c17c00-ff99-11e8-957d-9e1bc5e262c8.png">


Using `set` on the right property fixes the problem.

## Testing done
- Tested locally

## Screenshots
NA

## Acceptance criteria
- [x] Disabilities are selectable on the VA Treatments page, before and after entering in a facility name

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
