### PR TITLE
[Facility Locator] Upgrade peer dependency for react-leaflet

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6166,8 +6166,9 @@ leaflet-control-geocoder@^1.5.1:
   resolved "https://registry.yarnpkg.com/leaflet-control-geocoder/-/leaflet-control-geocoder-1.5.4.tgz#8f977dba9da0cbbebfa19659cbf0f49f6e268620"
 
 leaflet@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.0.3.tgz#1f401b98b45c8192134c6c8d69686253805007c8"
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.3.4.tgz#7f006ea5832603b53d7269ef5c595fd773060a40"
+  integrity sha512-FYL1LGFdj6v+2Ifpw+AcFIuIOqjNggfoLUwuwQv6+3sS21Za7Wvapq+LhbSE4NDXrEj6eYnW3y7LsaBICpyXtw==
 
 left-pad@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
## Description
This PR is a follow-up to https://github.com/department-of-veterans-affairs/vets-website/pull/9259. That PR updated `react-leaflet`, and this PR updates its peer dependency via  `yarn upgrade leaflet`.

## Testing done
Ran the site locally

## Acceptance criteria
- [x] Module is updated, and the warning below is removed

```
"react-leaflet@1.9.1" has incorrect peer dependency "leaflet@^1.3.0"
```

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
