### PR TITLE
781 individuals involved 2nd support screen

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/781/index.js
+++ b/src/applications/disability-benefits/all-claims/config/781/index.js
@@ -117,6 +117,13 @@ export function createFormConfig781(iterations) {
         uiSchema: individualsInvolvedFollowUp.uiSchema(index),
         schema: individualsInvolvedFollowUp.schema(index),
       },
+      [`incidentSupport2${index}`]: {
+        title: setReviewTitle('PTSD incident support', index, formType),
+        path: `disabilities/ptsd-incident-support2-${index}`,
+        depends: isAnswering781Questions(index),
+        uiSchema: incidentSupport.uiSchema('781'),
+        schema: incidentSupport.schema,
+      },
       [`incidentDescription${index}`]: {
         title: setReviewTitle('PTSD Event Description', index, formType),
         path: `disabilities/ptsd-incident-description-${index}`,

--- a/src/applications/disability-benefits/all-claims/config/781/index.js
+++ b/src/applications/disability-benefits/all-claims/config/781/index.js
@@ -123,7 +123,7 @@ export function createFormConfig781(iterations) {
           index,
           formType,
         ),
-        path: `disabilities/ptsd-incident-support2-${index}`,
+        path: `disabilities/ptsd-incident-support-additional-break-${index}`,
         depends: isAnswering781Questions(index),
         uiSchema: incidentSupport.uiSchema('781'),
         schema: incidentSupport.schema,

--- a/src/applications/disability-benefits/all-claims/config/781/index.js
+++ b/src/applications/disability-benefits/all-claims/config/781/index.js
@@ -117,8 +117,12 @@ export function createFormConfig781(iterations) {
         uiSchema: individualsInvolvedFollowUp.uiSchema(index),
         schema: individualsInvolvedFollowUp.schema(index),
       },
-      [`incidentSupport2${index}`]: {
-        title: setReviewTitle('PTSD incident support', index, formType),
+      [`incidentSupportAdditional${index}`]: {
+        title: setReviewTitle(
+          'PTSD incident support additional break',
+          index,
+          formType,
+        ),
         path: `disabilities/ptsd-incident-support2-${index}`,
         depends: isAnswering781Questions(index),
         uiSchema: incidentSupport.uiSchema('781'),

--- a/src/applications/disability-benefits/all-claims/pages/individualsInvolved.js
+++ b/src/applications/disability-benefits/all-claims/pages/individualsInvolved.js
@@ -7,11 +7,6 @@ export const uiSchema = index => ({
   [`view:individualsInvolved${index}`]: {
     'ui:title': 'Was any other person injured or killed during this event?',
     'ui:widget': 'yesNo',
-    'ui:options': {
-      labels: {
-        N: 'No, nobody else was injured or killed.',
-      },
-    },
   },
 });
 

--- a/src/applications/disability-benefits/all-claims/pages/individualsInvolved.js
+++ b/src/applications/disability-benefits/all-claims/pages/individualsInvolved.js
@@ -5,8 +5,7 @@ export const uiSchema = index => ({
   'ui:title': ptsd781NameTitle,
   'ui:description': individualsInvolved,
   [`view:individualsInvolved${index}`]: {
-    'ui:title':
-      'Was anyone killed or injured, not including yourself, during this event?',
+    'ui:title': 'Was any other person injured or killed during this event?',
     'ui:widget': 'yesNo',
     'ui:options': {
       labels: {

--- a/src/applications/disability-benefits/all-claims/pages/individualsInvolvedFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/individualsInvolvedFollowUp.js
@@ -120,8 +120,8 @@ export const schema = index => ({
                 type: 'string',
                 enum: [
                   'Killed in action',
-                  'Killed non-battle',
                   'Wounded in action',
+                  'Killed non-battle',
                   'Injured non-battle',
                   'Other',
                 ],


### PR DESCRIPTION
## Description
When user answers questions about individuals involved in 781 flow, a second support screen appears with Veterans Crisis Line numbers.
http://localhost:3001/disability-benefits/apply/form-526-all-claims/disabilities/ptsd-incident-support2-2

## Testing done
No testing done.

## Screenshots

![screen shot 2018-12-16 at 12 09 50 pm](https://user-images.githubusercontent.com/41440372/50056607-55222280-012c-11e9-9744-6f8d9af01e05.png)

## Acceptance criteria
- [ ] When user answers questions about individuals involved in 781 flow, a second support screen appears with Veterans Crisis Line numbers.
- [ ] The second support screen appears in all 3 incident loops. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
