### PR TITLE
[FacilityLocator] Quick "Search" Logic Reversion

### DIFF
--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -309,17 +309,12 @@ class VAMap extends Component {
   };
 
   handleSearch = () => {
-    const { currentQuery, location } = this.props;
-    const { query: prevQuery } = location;
+    const { currentQuery } = this.props;
+    this.updateUrlParams({
+      address: currentQuery.searchString,
+    });
 
-    // Don't recalculate if we didn't change search location
-    if (currentQuery.searchString !== prevQuery.address) {
-      this.updateUrlParams({
-        address: currentQuery.searchString,
-      });
-
-      this.props.genBBoxFromAddress(currentQuery);
-    }
+    this.props.genBBoxFromAddress(currentQuery);
   };
 
   handleBoundsChanged = () => {


### PR DESCRIPTION
## Description
In a previous commit was working to fix some extraneous service calls, but needs more work. So this little PR is to back all that out til everything can be refined as we're trying to push the soft-launch this Friday.

### Some Detail
In `handleSearch` had some logic to prevent calls to recalculate the bounding box and center point if the address hadn't changed. However, missed that part of the success response to those service calls updates the Redux store, which in turn causes the wrapped VAMap to update in response to it's parent (`<Connect(VAMap)>`) updating, and on that update one of the lifecycle methods handles checking if anything significant enough changed in the store to warrant an actual service call to our API.
So, blocking the recalc call was causing some subsequent searches from going through if the user never changed the address on which they were searching.

I've got some work already done to remedy this, however it's not in a place to be ready in the next few days. So, it's faster to revert this initial change first before getting the full search terms dupe-checking logic in place. (May even be better to hold off on this change to go along with a potential rewrite of the logic flow of this component (that's TBD still, tho))