### PR TITLE
781 medals page and tests update

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/medals.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/medals.jsx
@@ -1,24 +1,12 @@
-import React from 'react';
-
 import { ptsd781NameTitle } from '../content/ptsdClassification';
-import { MedalsDescription } from '../content/medals';
 
 export const uiSchema = index => ({
   'ui:title': ptsd781NameTitle,
-  'ui:description': ({ formData }) => (
-    <MedalsDescription formData={formData} index={index} />
-  ),
+  'ui:description':
+    'To help us research your claim, please let us know the names of any medals or citations you received for the event.',
   [`incident${index}`]: {
-    'view:medals': {
-      'ui:title': ' ',
-      'ui:widget': 'yesNo',
-    },
     medalsCitations: {
-      'ui:title': 'Please tell us what medal or citation you received. ',
-      'ui:options': {
-        expandUnder: 'view:medals',
-        expandUnderCondition: true,
-      },
+      'ui:title': 'Medals or citations you received for this event',
     },
   },
 });
@@ -29,10 +17,6 @@ export const schema = index => ({
     [`incident${index}`]: {
       type: 'object',
       properties: {
-        'view:medals': {
-          type: 'boolean',
-          properties: {},
-        },
         medalsCitations: {
           type: 'string',
         },

--- a/src/applications/disability-benefits/all-claims/tests/pages/medals.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/medals.unit.spec.jsx
@@ -6,7 +6,6 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-  selectRadio,
 } from '../../../../../platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
@@ -25,7 +24,7 @@ describe('781 medals', () => {
         uiSchema={uiSchema}
       />,
     );
-    expect(form.find('input').length).to.equal(2);
+    expect(form.find('input').length).to.equal(1);
     form.unmount();
   });
 
@@ -41,7 +40,6 @@ describe('781 medals', () => {
         uiSchema={uiSchema}
       />,
     );
-    selectRadio(form, 'root_incident0_view:medals', 'Y');
     fillData(form, 'input#root_incident0_medalsCitations', 'Medal Of Honor');
 
     form.find('form').simulate('submit');


### PR DESCRIPTION
## Description
Content changes to medals page

## Testing done
tests/pages/medals.unit.spec.jsx

## Screenshots

<img width="538" alt="screen shot 2018-12-18 at 6 23 58 am" src="https://user-images.githubusercontent.com/41440372/50151171-1ad09680-028e-11e9-8a50-a95e5e4eb0b1.png">

## Acceptance criteria
- [ ] "To help us research your claim, please let us know the names of any medals or citations you received for the event."
- [ ] Remove the Yes/No question and Conditional Logic
- [ ] User is able to enter free text for the medal/citation received
- [ ] User is able to proceed to the next step in the process

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
