### PR TITLE
Adjust padding margin

### DIFF
--- a/src/applications/personalization/preferences/components/PreferenceItem.jsx
+++ b/src/applications/personalization/preferences/components/PreferenceItem.jsx
@@ -77,7 +77,7 @@ export default function PreferenceItem({
   }
   return (
     <div>
-      <div className="title-container va-nav-linkslist-heading">
+      <div className="title-container preference-item-title">
         <h3>{title}</h3>
         <button
           className="va-button-link"

--- a/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
+++ b/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
@@ -154,34 +154,32 @@ class PreferencesWidget extends React.Component {
     const { savedMessage } = this.state;
 
     return (
-      <div className="row user-profile-row">
-        <div className="small-12 columns">
-          <div className="title-container">
-            <h2>Find VA Benefits</h2>
-            {userBenefitsLoadingStatus !== LOADING_STATES.pending && (
-              <Link
-                className="usa-button usa-button-secondary"
-                to="find-benefits"
-              >
-                Find VA Benefits
-              </Link>
-            )}
-          </div>
-          <ReactCSSTransitionGroup
-            transitionName="form-expanding-group-inner"
-            transitionAppear
-            transitionAppearTimeout={500}
-            transitionEnterTimeout={500}
-            transitionLeaveTimeout={500}
-          >
-            {savedMessage && (
-              <SaveSucceededMessageComponent
-                handleCloseAlert={this.handleCloseAlert}
-              />
-            )}
-          </ReactCSSTransitionGroup>
-          {this.renderContent()}
+      <div>
+        <div className="title-container">
+          <h2>Find VA Benefits</h2>
+          {userBenefitsLoadingStatus !== LOADING_STATES.pending && (
+            <Link
+              className="usa-button usa-button-secondary"
+              to="find-benefits"
+            >
+              Find VA Benefits
+            </Link>
+          )}
         </div>
+        <ReactCSSTransitionGroup
+          transitionName="form-expanding-group-inner"
+          transitionAppear
+          transitionAppearTimeout={500}
+          transitionEnterTimeout={500}
+          transitionLeaveTimeout={500}
+        >
+          {savedMessage && (
+            <SaveSucceededMessageComponent
+              handleCloseAlert={this.handleCloseAlert}
+            />
+          )}
+        </ReactCSSTransitionGroup>
+        {this.renderContent()}
       </div>
     );
   }

--- a/src/applications/personalization/preferences/sass/preferences.scss
+++ b/src/applications/personalization/preferences/sass/preferences.scss
@@ -19,14 +19,17 @@
       .title-container {
         display: flex;
         align-items: center;
+        margin-bottom: 2rem;
         .title-item {
           margin: 0;
+          padding-right: 0.5em;
           &:first-child {
             flex: 1;
           }
         }
         .form-checkbox {
           margin: 0;
+          margin-right: -0.3em;
           flex: 0;
           input[type=checkbox] {
             cursor: pointer;
@@ -36,6 +39,9 @@
           }
         }
       }
+      p {
+        margin: 0.5em 0 0.25em;
+      }
     }
   }
 }
@@ -44,13 +50,22 @@
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  margin-bottom: 2rem;
+  a.usa-button {
+    margin-right: 0;
+  }
   .va-button-link {
     text-decoration: none;
   }
   h2 {
     margin-top: 0.5em;
   }
+  h3 {
+    margin-top: 1em;
+  }
+}
+
+.preference-item-title {
+  border-bottom: 1px solid $color-gray-light;
 }
 
 .form-expanding-group {


### PR DESCRIPTION
## Description
Fixes some whitespace issues to address these comments:
https://github.com/department-of-veterans-affairs/vets-website/pull/9186#issuecomment-445009116
https://github.com/department-of-veterans-affairs/vets-website/pull/9186#issuecomment-445033249

## Testing done
local

## Screenshots
<img width="836" alt="my-va-dashboard-after" src="https://user-images.githubusercontent.com/20728956/50177794-be826c80-02b7-11e9-9227-0707bc1650dc.png">

- Tighten vertical space between Find VA Benefits and content below
- shift Find VA Benefits button to the right

<img width="1089" alt="select-benefits-after" src="https://user-images.githubusercontent.com/20728956/50177796-be826c80-02b7-11e9-8c7f-df159830be00.png">

- Reduce padding on bottom of each grid cell
- Shift checkbox to the right to event out horizontal padding

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs