### PR TITLE
Use the form526 property

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/schema/schema.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/schema/schema.unit.spec.js
@@ -17,7 +17,7 @@ describe('526 all claims schema tests', () => {
       const submitData = JSON.parse(
         formConfig.transformForSubmit(formConfig, contents),
       );
-      const result = v.validate(submitData, fullSchema);
+      const result = v.validate(submitData.form526, fullSchema);
 
       if (!result.valid) {
         console.log(`Validation errors found in ${file}`); // eslint-disable-line


### PR DESCRIPTION
## Description
We had a bug where the 526 all claims schema test would always pass.

### Why this works
The `transform` function puts the data for submission in a `form526` object. This is because the API requires it. Inside this `form526` object, we need to have valid data according to the schema.

When we were running the validator, we were passing in the root object--the one with only a `form526` property. The validations passed because there was no `form526` schema to validate against.

Arguably, the schema validation should fail if there's data sent that doesn't match up with a schema. The API does it that way. Unfortunately, this JSON schema implementation doesn't.

## Testing done
In `maximal-test.json`, I changed the value for `isVAEmployee` to `"boo"` (string instead of boolean) and ensured that the test failed. Changing it back to `true` succeeded.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/50181238-abc06580-02c0-11e9-9a2c-c20ceb682e09.png)


## Acceptance criteria
- [x] The test fails when the data doesn't match the schema
- [x] The test succeeds when the data does match the schema

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
