### PR TITLE
use empty object instead of empty array

### DIFF
--- a/src/applications/personalization/preferences/actions/index.js
+++ b/src/applications/personalization/preferences/actions/index.js
@@ -25,7 +25,7 @@ export function fetchUserSelectedBenefits() {
       '/user/preferences',
       null,
       response => {
-        // We just want to get an array of Benefits preferences);
+        // We just want to get an array of Benefits preferences
         let selectedBenefits = response.data.attributes.userPreferences;
         if (selectedBenefits.length) {
           selectedBenefits = selectedBenefits
@@ -38,7 +38,7 @@ export function fetchUserSelectedBenefits() {
               return acc;
             }, {});
         } else {
-          selectedBenefits = [];
+          selectedBenefits = {};
         }
 
         dispatch({


### PR DESCRIPTION
## Description
Revert a stupid change Erik had made in a previous PR. Defaulting to an empty array instead of empty object made it impossible for users to select more than one benefit they were interested in.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs