### PR TITLE
Bah 781 508 label bugs

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/incidentUnitAssignment.jsx
+++ b/src/applications/disability-benefits/all-claims/content/incidentUnitAssignment.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 
-export const ptsdAssignmentDescription = (
-  <div>
-    <h5>Your assignment</h5>
-  </div>
-);
+export const ptsdAssignmentDescription = <h5>Your assignment</h5>;
 
 export const ptsdAssignmentDatesDescription = (
   <p>Dates you were assigned to this unit</p>

--- a/src/applications/disability-benefits/all-claims/content/incidentUnitAssignment.jsx
+++ b/src/applications/disability-benefits/all-claims/content/incidentUnitAssignment.jsx
@@ -3,10 +3,6 @@ import React from 'react';
 export const ptsdAssignmentDescription = (
   <div>
     <h5>Your assignment</h5>
-    <p>
-      Name of the unit you were assigned to when this event happened. (This can
-      include your division, wing, battalion, cavalry, ship, etc.)
-    </p>
   </div>
 );
 

--- a/src/applications/disability-benefits/all-claims/pages/additionalRemarks781.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/additionalRemarks781.jsx
@@ -2,26 +2,14 @@ import React from 'react';
 
 import { ptsd781NameTitle } from '../content/ptsdClassification';
 
-const additionalRemarksDescription = (
-  <div>
-    <h3>Additional Remarks</h3>
-    <p>
-      If there is anything else you would like to tell us about the stressful
-      events that contributed to your PTSD, you can provide that information
-      below.
-    </p>
-    <p>
-      If you have any supporting documents or buddy statements to support your
-      claim, you‘ll have a chance to upload those later in the application.
-    </p>
-  </div>
-);
+const additionalRemarksDescription = <h3>Additional Remarks</h3>;
 
 export const uiSchema = {
   'ui:title': ptsd781NameTitle,
   'ui:description': additionalRemarksDescription,
   additionalRemarks781: {
-    'ui:title': ' ',
+    'ui:title':
+      'If there is anything else you would like to tell us about the stressful events that contributed to your PTSD, you can provide that information below. If you have any supporting documents or buddy statements to support your claim, you‘ll have a chance to upload those later in the application.',
     'ui:widget': 'textarea',
     'ui:options': {
       rows: 5,

--- a/src/applications/disability-benefits/all-claims/pages/incidentDescription.js
+++ b/src/applications/disability-benefits/all-claims/pages/incidentDescription.js
@@ -3,16 +3,7 @@ import React from 'react';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { PtsdNameTitle } from '../content/ptsdClassification';
 
-const incidentDescriptionInstructions = (
-  <div>
-    <h3>Event description</h3>
-    <p>
-      Please tell us what happened during the event or situation. Provide the
-      level of detail that you‘re comfortable sharing. You don‘t have to repeat
-      any information that you‘ve already shared.
-    </p>
-  </div>
-);
+const incidentDescriptionInstructions = <h3>Event description</h3>;
 
 const { description } = fullSchema.definitions.ptsdIncident.properties;
 
@@ -23,7 +14,8 @@ export const uiSchema = index => ({
   'ui:description': incidentDescriptionInstructions,
   [`incident${index}`]: {
     description: {
-      'ui:title': ' ',
+      'ui:title':
+        'Please tell us what happened during the event or situation. Provide the level of detail that you‘re comfortable sharing. You don‘t have to repeat any information that you‘ve already shared.',
       'ui:widget': 'textarea',
       'ui:options': {
         rows: 5,

--- a/src/applications/disability-benefits/all-claims/pages/incidentUnitAssignment.js
+++ b/src/applications/disability-benefits/all-claims/pages/incidentUnitAssignment.js
@@ -20,10 +20,6 @@ export const uiSchema = index => ({
     unitAssigned: {
       'ui:title':
         'Name of the unit you were assigned to when this event happened. (This can include your division, wing, battalion, cavalry, ship, etc.)',
-      // hideLabelText: true,
-      'ui:options': {
-        // hideLabelText: true,
-      },
     },
     unitAssignedDates: {
       ...dateRangeUI('From', 'To', 'The date must be after Start date'),

--- a/src/applications/disability-benefits/all-claims/pages/incidentUnitAssignment.js
+++ b/src/applications/disability-benefits/all-claims/pages/incidentUnitAssignment.js
@@ -18,7 +18,12 @@ export const uiSchema = index => ({
   'ui:description': ptsdAssignmentDescription,
   [`incident${index}`]: {
     unitAssigned: {
-      'ui:title': ' ',
+      'ui:title':
+        'Name of the unit you were assigned to when this event happened. (This can include your division, wing, battalion, cavalry, ship, etc.)',
+      // hideLabelText: true,
+      'ui:options': {
+        // hideLabelText: true,
+      },
     },
     unitAssignedDates: {
       ...dateRangeUI('From', 'To', 'The date must be after Start date'),

--- a/src/applications/disability-benefits/all-claims/pages/secondaryIncidentDescription.js
+++ b/src/applications/disability-benefits/all-claims/pages/secondaryIncidentDescription.js
@@ -3,16 +3,7 @@ import React from 'react';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { ptsd781aNameTitle } from '../content/ptsdClassification';
 
-const incidentDescriptionInstructions = (
-  <div>
-    <h3>Event description</h3>
-    <p>
-      Please tell us what happened during the event or situation. Provide the
-      level of detail that you‘re comfortable sharing. You don‘t have to repeat
-      any information that you‘ve already shared.
-    </p>
-  </div>
-);
+const incidentDescriptionInstructions = <h3>Event description</h3>;
 
 const { description } = fullSchema.definitions.secondaryPtsdIncident.properties;
 
@@ -21,7 +12,8 @@ export const uiSchema = index => ({
   'ui:description': incidentDescriptionInstructions,
   [`secondaryIncident${index}`]: {
     description: {
-      'ui:title': ' ',
+      'ui:title':
+        'Please tell us what happened during the event or situation. Provide the level of detail that you‘re comfortable sharing. You don‘t have to repeat any information that you‘ve already shared.',
       'ui:widget': 'textarea',
       'ui:options': {
         rows: 5,

--- a/src/applications/disability-benefits/all-claims/pages/secondaryIncidentUnitAssignment.js
+++ b/src/applications/disability-benefits/all-claims/pages/secondaryIncidentUnitAssignment.js
@@ -18,7 +18,8 @@ export const uiSchema = index => ({
   'ui:description': ptsdAssignmentDescription,
   [`secondaryIncident${index}`]: {
     unitAssigned: {
-      'ui:title': ' ',
+      'ui:title':
+        'Name of the unit you were assigned to when this event happened. (This can include your division, wing, battalion, cavalry, ship, etc.)',
     },
     unitAssignedDates: {
       ...dateRangeUI('From', 'To', 'The date must be after Start date'),


### PR DESCRIPTION
## Description
Adds labels to input fields within 781/781a that had none for 508 accessibility.

## Testing done
- [x] local testing done

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
