### PR TITLE
Update confirmation page to show new disabilities

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
@@ -110,7 +110,7 @@ export class ConfirmationPoll extends React.Component {
   }
 }
 
-export const disabilitiesSelector = createSelector(
+export const selectAllDisabilityNames = createSelector(
   state => state.form.data.ratedDisabilities,
   state => state.form.data.newDisabilities,
   (ratedDisabilities = [], newDisabilities = []) =>
@@ -123,7 +123,7 @@ export const disabilitiesSelector = createSelector(
 function mapStateToProps(state) {
   return {
     fullName: state.user.profile.userFullName,
-    disabilities: disabilitiesSelector(state),
+    disabilities: selectAllDisabilityNames(state),
     submittedAt: state.form.submission.submittedAt,
     jobId: state.form.submission.response.attributes.jobId,
   };

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
 
 import get from '../../../../platform/utilities/data/get';
 import { apiRequest } from '../../../../platform/utilities/api';
@@ -109,10 +110,20 @@ export class ConfirmationPoll extends React.Component {
   }
 }
 
+export const disabilitiesSelector = createSelector(
+  state => state.form.data.ratedDisabilities,
+  state => state.form.data.newDisabilities,
+  (ratedDisabilities = [], newDisabilities = []) =>
+    ratedDisabilities
+      .filter(disability => disability['view:selected'])
+      .concat(newDisabilities)
+      .map(disability => disability.name || disability.condition),
+);
+
 function mapStateToProps(state) {
   return {
     fullName: state.user.profile.userFullName,
-    disabilities: state.form.data.ratedDisabilities,
+    disabilities: disabilitiesSelector(state),
     submittedAt: state.form.submission.submittedAt,
     jobId: state.form.submission.response.attributes.jobId,
   };

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -32,11 +32,9 @@ const template = (props, title, content, submissionMessage) => {
           <strong>Conditions claimed</strong>
           <br />
           <ul className="disability-list">
-            {disabilities
-              .filter(item => item['view:selected'])
-              .map((disability, i) => (
-                <li key={i}>{disability.name}</li>
-              ))}
+            {disabilities.map((disability, i) => (
+              <li key={i}>{disability}</li>
+            ))}
           </ul>
           {submissionMessage}
           <li>

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment';
 
 import siteName from '../../../../platform/brand-consolidation/site-name';
+import { getDisabilityName } from '../utils';
 import {
   successMessage,
   checkLaterMessage,
@@ -33,7 +34,7 @@ const template = (props, title, content, submissionMessage) => {
           <br />
           <ul className="disability-list">
             {disabilities.map((disability, i) => (
-              <li key={i}>{disability}</li>
+              <li key={i}>{getDisabilityName(disability)}</li>
             ))}
           </ul>
           {submissionMessage}

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -9,7 +9,7 @@ import {
 
 import {
   ConfirmationPoll,
-  disabilitiesSelector,
+  selectAllDisabilityNames,
 } from '../../components/ConfirmationPoll';
 import { submissionStatuses } from '../../constants';
 
@@ -106,7 +106,7 @@ describe('ConfirmationPoll', () => {
     }, 500);
   });
 
-  describe('disabilitiesSelector', () => {
+  describe('selectAllDisabilityNames', () => {
     it('should return selected rated disability names', () => {
       const state = {
         form: {
@@ -133,7 +133,7 @@ describe('ConfirmationPoll', () => {
         },
       };
 
-      const selectedDisabilities = disabilitiesSelector(state);
+      const selectedDisabilities = selectAllDisabilityNames(state);
       const { ratedDisabilities } = state.form.data;
 
       expect(selectedDisabilities.length).to.equal(2);
@@ -159,7 +159,7 @@ describe('ConfirmationPoll', () => {
         },
       };
 
-      const selectedDisabilities = disabilitiesSelector(state);
+      const selectedDisabilities = selectAllDisabilityNames(state);
       const { newDisabilities } = state.form.data;
 
       expect(selectedDisabilities.length).to.equal(2);
@@ -203,7 +203,7 @@ describe('ConfirmationPoll', () => {
         },
       };
 
-      const selectedDisabilities = disabilitiesSelector(state);
+      const selectedDisabilities = selectAllDisabilityNames(state);
       const { newDisabilities, ratedDisabilities } = state.form.data;
 
       expect(selectedDisabilities.length).to.equal(4);

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -136,7 +136,6 @@ describe('ConfirmationPoll', () => {
       const selectedDisabilities = selectAllDisabilityNames(state);
       const { ratedDisabilities } = state.form.data;
 
-      expect(selectedDisabilities.length).to.equal(2);
       expect(selectedDisabilities).to.deep.equal([
         ratedDisabilities[0].name,
         ratedDisabilities[2].name,
@@ -162,7 +161,6 @@ describe('ConfirmationPoll', () => {
       const selectedDisabilities = selectAllDisabilityNames(state);
       const { newDisabilities } = state.form.data;
 
-      expect(selectedDisabilities.length).to.equal(2);
       expect(selectedDisabilities).to.deep.equal([
         newDisabilities[0].condition,
         newDisabilities[1].condition,
@@ -206,7 +204,6 @@ describe('ConfirmationPoll', () => {
       const selectedDisabilities = selectAllDisabilityNames(state);
       const { newDisabilities, ratedDisabilities } = state.form.data;
 
-      expect(selectedDisabilities.length).to.equal(4);
       expect(selectedDisabilities).to.deep.equal([
         ratedDisabilities[0].name,
         ratedDisabilities[2].name,

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -7,7 +7,10 @@ import {
   mockMultipleApiRequests,
 } from '../../../../../platform/testing/unit/helpers';
 
-import { ConfirmationPoll } from '../../components/ConfirmationPoll';
+import {
+  ConfirmationPoll,
+  disabilitiesSelector,
+} from '../../components/ConfirmationPoll';
 import { submissionStatuses } from '../../constants';
 
 const originalFetch = global.fetch;
@@ -101,5 +104,115 @@ describe('ConfirmationPoll', () => {
       tree.unmount();
       done();
     }, 500);
+  });
+
+  describe('disabilitiesSelector', () => {
+    it('should return selected rated disability names', () => {
+      const state = {
+        form: {
+          data: {
+            ratedDisabilities: [
+              {
+                'view:selected': true,
+                name: 'first rated disability',
+              },
+              {
+                'view:selected': false,
+                name: 'second rated disability',
+              },
+              {
+                'view:selected': true,
+                name: 'third rated disability',
+              },
+              {
+                'view:selected': false,
+                name: 'fourth rated disability',
+              },
+            ],
+          },
+        },
+      };
+
+      const selectedDisabilities = disabilitiesSelector(state);
+      const { ratedDisabilities } = state.form.data;
+
+      expect(selectedDisabilities.length).to.equal(2);
+      expect(selectedDisabilities).to.deep.equal([
+        ratedDisabilities[0].name,
+        ratedDisabilities[2].name,
+      ]);
+    });
+
+    it('should return new disability names', () => {
+      const state = {
+        form: {
+          data: {
+            newDisabilities: [
+              {
+                condition: 'first new disability',
+              },
+              {
+                condition: 'second new disability',
+              },
+            ],
+          },
+        },
+      };
+
+      const selectedDisabilities = disabilitiesSelector(state);
+      const { newDisabilities } = state.form.data;
+
+      expect(selectedDisabilities.length).to.equal(2);
+      expect(selectedDisabilities).to.deep.equal([
+        newDisabilities[0].condition,
+        newDisabilities[1].condition,
+      ]);
+    });
+
+    it('should return both rated and new disabilities', () => {
+      const state = {
+        form: {
+          data: {
+            newDisabilities: [
+              {
+                condition: 'first new disability',
+              },
+              {
+                condition: 'second new disability',
+              },
+            ],
+            ratedDisabilities: [
+              {
+                'view:selected': true,
+                name: 'first rated disability',
+              },
+              {
+                'view:selected': false,
+                name: 'second rated disability',
+              },
+              {
+                'view:selected': true,
+                name: 'third rated disability',
+              },
+              {
+                'view:selected': false,
+                name: 'fourth rated disability',
+              },
+            ],
+          },
+        },
+      };
+
+      const selectedDisabilities = disabilitiesSelector(state);
+      const { newDisabilities, ratedDisabilities } = state.form.data;
+
+      expect(selectedDisabilities.length).to.equal(4);
+      expect(selectedDisabilities).to.deep.equal([
+        ratedDisabilities[0].name,
+        ratedDisabilities[2].name,
+        newDisabilities[0].condition,
+        newDisabilities[1].condition,
+      ]);
+    });
   });
 });


### PR DESCRIPTION
## Description
Adds new disabilities to the confirmation page
*Note:* Need to split new primary and new secondary disabilities out after https://github.com/department-of-veterans-affairs/vets-website/pull/9294 is merged

## Testing done
- Tested locally
- Unit tests

## Screenshots
![screen shot 2018-12-19 at 11 31 16 am](https://user-images.githubusercontent.com/24251447/50246981-5a85a400-039c-11e9-874c-c2d5e851b7b7.png)


## Acceptance criteria
- [x] Confirmation page shows new disabilities from the application
- [x] Confirmation page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
