### PR TITLE
Summary page shows PTSD type selected during "New Condition" question. NOT the ones selected from the checkboxes#15748

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/ptsdClassification.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ptsdClassification.jsx
@@ -8,7 +8,7 @@ export const getPtsdClassification = (formData, formType) => {
     false,
   );
   const isNonCombat = _.get(
-    'view:selectablePtsdTypes.view:noncombatPtsdType',
+    'view:selectablePtsdTypes.view:nonCombatPtsdType',
     formData,
     false,
   );

--- a/src/applications/disability-benefits/all-claims/content/ptsdTypeInfo.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ptsdTypeInfo.jsx
@@ -1,10 +1,25 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation/AdditionalInfo';
 
-export const nonCombatPtsdType = (
+const combatPtsdType = 'Combat';
+
+const mstPtsdType = 'Sexual trauma';
+
+const assaultPtsdType = 'Personal assault';
+
+const nonCombatPtsdType = 'Non-combat PTSD';
+
+export const ptsdTypeEnum = {
+  combatPtsdType,
+  mstPtsdType,
+  assaultPtsdType,
+  nonCombatPtsdType,
+};
+
+export const nonCombatPtsdTypeLong = (
   <span>
-    Non-combat PTSD <strong>other than</strong> Military sexual trauma or
-    Personal assault
+    {nonCombatPtsdType} <strong>other than</strong> sexual trauma or personal
+    assault
   </span>
 );
 

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -1,5 +1,29 @@
 import React from 'react';
 import { getDisabilityName } from '../utils';
+import { isDisabilityPtsd } from '../validations';
+import { ptsdTypeEnum } from './ptsdTypeInfo';
+
+const mapDisabilityName = (disabilityName, formData, index) => {
+  if (isDisabilityPtsd(disabilityName)) {
+    const selectablePtsdTypes = formData['view:selectablePtsdTypes'];
+    if (selectablePtsdTypes) {
+      const selectedPtsdTypes = Object.keys(selectablePtsdTypes)
+        .filter(ptsdType => selectablePtsdTypes[ptsdType])
+        .map((ptsdType, i) => {
+          const ptsdTypeEnumKey = ptsdType.replace('view:', '');
+          const ptsdTypeTitle = ptsdTypeEnum[ptsdTypeEnumKey];
+          return <li key={`"${ptsdTypeEnumKey}-${i}"`}>{ptsdTypeTitle}</li>;
+        });
+      return (
+        <li key={`"${disabilityName}-${index}"`}>
+          {disabilityName}
+          <ul>{selectedPtsdTypes}</ul>
+        </li>
+      );
+    }
+  }
+  return <li key={`"${disabilityName}-${index}"`}>{disabilityName}</li>;
+};
 
 export const SummaryOfDisabilitiesDescription = ({ formData }) => {
   const { ratedDisabilities, newDisabilities } = formData;
@@ -13,7 +37,7 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
     : [];
   const selectedDisabilitiesList = ratedDisabilityNames
     .concat(newDisabilityNames)
-    .map((name, i) => <li key={`"${name}-${i}"`}>{name}</li>);
+    .map((name, i) => mapDisabilityName(name, formData, i));
   return (
     <div>
       <p>

--- a/src/applications/disability-benefits/all-claims/pages/choosePtsdType.js
+++ b/src/applications/disability-benefits/all-claims/pages/choosePtsdType.js
@@ -3,7 +3,8 @@ import { validateBooleanGroup } from 'us-forms-system/lib/js/validation';
 import {
   ptsdTypeDescription,
   ptsdTypeHelp,
-  nonCombatPtsdType,
+  ptsdTypeEnum,
+  nonCombatPtsdTypeLong,
 } from '../content/ptsdTypeInfo';
 
 import { disabilityNameTitle } from '../content/newPTSDFollowUp';
@@ -24,16 +25,16 @@ export const uiSchema = {
       atLeastOne: 'Please select at least one event type',
     },
     'view:combatPtsdType': {
-      'ui:title': 'Combat',
+      'ui:title': ptsdTypeEnum.combatPtsdType,
     },
     'view:mstPtsdType': {
-      'ui:title': 'Military sexual trauma',
+      'ui:title': ptsdTypeEnum.mstPtsdType,
     },
     'view:assaultPtsdType': {
-      'ui:title': 'Personal assault',
+      'ui:title': ptsdTypeEnum.assaultPtsdType,
     },
-    'view:noncombatPtsdType': {
-      'ui:title': nonCombatPtsdType,
+    'view:nonCombatPtsdType': {
+      'ui:title': nonCombatPtsdTypeLong,
     },
   },
   'view:ptsdTypeHelp': {
@@ -57,7 +58,7 @@ export const schema = {
         'view:assaultPtsdType': {
           type: 'boolean',
         },
-        'view:noncombatPtsdType': {
+        'view:nonCombatPtsdType': {
           type: 'boolean',
         },
       },

--- a/src/applications/disability-benefits/all-claims/tests/content/ptsdClassification.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/ptsdClassification.unit.spec.jsx
@@ -26,7 +26,7 @@ describe('781 getPtsdClassification', () => {
   it('Non-combat classification content is correct', () => {
     const formData = {
       'view:selectablePtsdTypes': {
-        'view:noncombatPtsdType': true,
+        'view:nonCombatPtsdType': true,
       },
     };
 
@@ -42,7 +42,7 @@ describe('781 getPtsdClassification', () => {
     const formData = {
       'view:selectablePtsdTypes': {
         'view:combatPtsdType': true,
-        'view:noncombatPtsdType': true,
+        'view:nonCombatPtsdType': true,
       },
     };
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/choosePtsdType.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/choosePtsdType.unit.spec.jsx
@@ -80,7 +80,7 @@ describe('Disability benefits 718 PTSD type', () => {
     );
     selectCheckbox(
       form,
-      'root_view:selectablePtsdTypes_view:noncombatPtsdType',
+      'root_view:selectablePtsdTypes_view:nonCombatPtsdType',
       true,
     );
 

--- a/src/applications/disability-benefits/all-claims/tests/schema/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/schema/maximal-test.json
@@ -119,7 +119,7 @@
       "view:combatPtsdType": true,
       "view:mstPtsdType": true,
       "view:assaultPtsdType": true,
-      "view:noncombatPtsdType": true
+      "view:nonCombatPtsdType": true
     },
     "view:ptsdTypeHelp": {},
     "view:newDisabilities": true,

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -406,7 +406,7 @@ describe('526 helpers', () => {
     it('should return true if user has selected Non-combat PTSD types', () => {
       const formData = {
         'view:selectablePtsdTypes': {
-          'view:noncombatPtsdType': true,
+          'view:nonCombatPtsdType': true,
         },
       };
       expect(needsToEnter781(formData)).to.be.true;

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -554,7 +554,7 @@ export const servedAfter911 = formData => !!post911Periods(formData).length;
 
 export const needsToEnter781 = formData =>
   _.get('view:selectablePtsdTypes.view:combatPtsdType', formData, false) ||
-  _.get('view:selectablePtsdTypes.view:noncombatPtsdType', formData, false);
+  _.get('view:selectablePtsdTypes.view:nonCombatPtsdType', formData, false);
 
 export const needsToEnter781a = formData =>
   _.get('view:selectablePtsdTypes.view:mstPtsdType', formData, false) ||
@@ -602,7 +602,7 @@ export const isNotUploadingPrivateMedical = formData =>
 
 export const showPtsdCombatConclusion = form =>
   _.get('view:selectablePtsdTypes.view:combatPtsdType', form, false) ||
-  _.get('view:selectablePtsdTypes.view:noncombatPtsdType', form, false);
+  _.get('view:selectablePtsdTypes.view:nonCombatPtsdType', form, false);
 
 export const showPtsdAssaultConclusion = form =>
   _.get('view:selectablePtsdTypes.view:mstPtsdType', form, false) ||

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -126,6 +126,9 @@ export const validateIfHasEvidence = (
   }
 };
 
+export const isDisabilityPtsd = disability =>
+  disability.toLowerCase().includes(PTSD);
+
 export const hasNewPtsdDisability = formData => {
   if (!_.get('view:newDisabilities', formData, false)) {
     return false;
@@ -133,7 +136,7 @@ export const hasNewPtsdDisability = formData => {
   return some(_.get('newDisabilities', formData, []), item => {
     let hasPtsd = false;
     if (item && typeof item.condition === 'string') {
-      hasPtsd = item.condition.toLowerCase().includes(PTSD);
+      hasPtsd = isDisabilityPtsd(item.condition);
     }
     return hasPtsd;
   });


### PR DESCRIPTION
## Description

Steps to reproduce:

Start the application on the all claims flow and select "YES" when asked about a new condition. Continue
On the text box type PTSD, and select "PTSD: Personal trauma" from the suggestions. Continue
From the 4 PTSD types, choose any that is NOT Personal Assault, ex: Combat. and continue all the way until you get to the summary page.
--> Notice the Summary page does not show the PTSD selected from the 4 checkbox options but the one chosen at the beginning from the suggested results.

Includes content updates for "Choose PTSD Type page".

## Testing done
- [x] local testing

## Screenshots
![screen shot 2018-12-19 at 3 57 58 pm](https://user-images.githubusercontent.com/1094999/50247969-64f96b00-03a7-11e9-9a37-2802f36c331f.png)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
