### PR TITLE
Update style right rail hub pages

### DIFF
--- a/src/platform/site-wide/sass/right-rail.scss
+++ b/src/platform/site-wide/sass/right-rail.scss
@@ -16,7 +16,7 @@
     margin-bottom: 3em !important;
   }
 
-  &:first-child {
+  &.hub-promo {
     background-color: $mm-gray;
     border: none;
 

--- a/src/platform/site-wide/sass/right-rail.scss
+++ b/src/platform/site-wide/sass/right-rail.scss
@@ -17,12 +17,13 @@
   }
 
   &:first-child {
-    background-color: $color-primary-lightest;
-    padding: 1em;
+    background-color: $mm-gray;
     border: none;
 
     img {
-      margin-bottom: 1em;
+    }
+    section {
+      padding: 1em;
     }
   }
 

--- a/src/platform/site-wide/sass/right-rail.scss
+++ b/src/platform/site-wide/sass/right-rail.scss
@@ -20,11 +20,9 @@
     background-color: $mm-gray;
     border: none;
 
-    img {
-    }
-    section {
-      padding: 1em;
-    }
+  }
+  .hub-promo-text {
+    padding: 1em;
   }
 
   a {

--- a/src/site/components/merger-promo.html
+++ b/src/site/components/merger-promo.html
@@ -21,7 +21,7 @@ See https://help.shopify.com/themes/liquid/tags/theme-tags#include
     {% endif %}
 
     {% if group.heading != empty %}
-      <section>
+      <section class="hub-promo-text">
         <h4 class="heading"><a href="{{group.url}}">{{ group.heading }}</a></h4>
     {% endif %}
 

--- a/src/site/components/merger-promo.html
+++ b/src/site/components/merger-promo.html
@@ -6,7 +6,7 @@ Right-rail promo + illo
 See https://help.shopify.com/themes/liquid/tags/theme-tags#include
 {% endcomment %}
 
-<div class="merger-r-rail" id="promo">
+<div class="merger-r-rail hub-promo" id="promo">
 
   {% for group in promo %}
 


### PR DESCRIPTION
## Description
Updated background color and padding for benefit hub right rail promo spot.

## Testing done
Visual inspection

## Screenshots
Before:
![screen shot 2018-12-19 at 4 49 56 pm](https://user-images.githubusercontent.com/11021491/50250247-464aa280-03ae-11e9-95bd-d6057941bf28.png)

After:
![screen shot 2018-12-19 at 4 50 06 pm](https://user-images.githubusercontent.com/11021491/50250266-4f3b7400-03ae-11e9-9921-37304f8243c2.png)


## Acceptance criteria
- [ ]

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
