### PR TITLE
[Metalsmith] Add src/site to watch task

### DIFF
--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -39,6 +39,10 @@ function gatherFromCommandLine() {
 function applyDefaultOptions(options) {
   const contentPagesRoot = options['content-directory'];
   const contentRoot = path.join(contentPagesRoot, '../');
+  const siteRoot = path.join(__dirname, '../../');
+  const includes = path.join(siteRoot, 'includes');
+  const components = path.join(siteRoot, 'components');
+  const layouts = path.join(siteRoot, 'layouts');
 
   Object.assign(options, {
     contentRoot,
@@ -60,6 +64,12 @@ function applyDefaultOptions(options) {
     layouts: path.join(__dirname, '../../layouts'),
     collections: require('./data/collections.json'),
     redirects: require('./data/vagovRedirects.json'),
+    watchPaths: {
+      [`${contentPagesRoot}/**/*`]: '**/*.{md,html}',
+      [`${includes}/**/*`]: '**/*.{md,html}',
+      [`${components}/**/*`]: '**/*.{md,html}',
+      [`${layouts}/**/*`]: '**/*.{md,html}',
+    },
   });
 }
 

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -65,7 +65,7 @@ function applyDefaultOptions(options) {
     collections: require('./data/collections.json'),
     redirects: require('./data/vagovRedirects.json'),
     watchPaths: {
-      [`${contentPagesRoot}/**/*`]: '**/*.{md,html}',
+      [`${contentRoot}/**/*`]: '**/*.{md,html}',
       [`${includes}/**/*`]: '**/*.{md,html}',
       [`${components}/**/*`]: '**/*.{md,html}',
       [`${layouts}/**/*`]: '**/*.{md,html}',

--- a/src/site/stages/build/plugins/configure-assets.js
+++ b/src/site/stages/build/plugins/configure-assets.js
@@ -13,14 +13,10 @@ function configureAssets(smith, buildOptions) {
   );
 
   if (buildOptions.watch) {
-    const watchPaths = {
-      [`${buildOptions.contentPagesRoot}/**/*`]: '**/*.{md,html}',
-      'src/site/includes/**/*': '**/*.{md,html}',
-      'src/site/components/**/*': '**/*.{md,html}',
-      'src/site/layouts/**/*': '**/*.{md,html}',
-    };
-
-    const watchMetalSmith = watch({ paths: watchPaths, livereload: true });
+    const watchMetalSmith = watch({
+      paths: buildOptions.watchPaths,
+      livereload: true,
+    });
 
     smith.use(watchMetalSmith);
     smith.use(webpackMetalsmithConnect.watchAssets(buildOptions));

--- a/src/site/stages/build/plugins/configure-assets.js
+++ b/src/site/stages/build/plugins/configure-assets.js
@@ -14,7 +14,6 @@ function configureAssets(smith, buildOptions) {
 
   if (buildOptions.watch) {
     const watchPaths = {
-      [`${buildOptions.contentRoot}/**/*`]: '**/*.{md,html}',
       [`${buildOptions.contentPagesRoot}/**/*`]: '**/*.{md,html}',
       'src/site/includes/**/*': '**/*.{md,html}',
       'src/site/components/**/*': '**/*.{md,html}',

--- a/src/site/stages/build/plugins/configure-assets.js
+++ b/src/site/stages/build/plugins/configure-assets.js
@@ -16,6 +16,9 @@ function configureAssets(smith, buildOptions) {
     const watchPaths = {
       [`${buildOptions.contentRoot}/**/*`]: '**/*.{md,html}',
       [`${buildOptions.contentPagesRoot}/**/*`]: '**/*.{md,html}',
+      'src/site/includes/**/*': '**/*.{md,html}',
+      'src/site/components/**/*': '**/*.{md,html}',
+      'src/site/layouts/**/*': '**/*.{md,html}',
     };
 
     const watchMetalSmith = watch({ paths: watchPaths, livereload: true });


### PR DESCRIPTION
## Description
After moving the Metalsmith templates into `src/site`, I forgot to also update the paths in the Metalsmith watch task. This PR fixes that so that the pages are reloaded after saving one a file in `src/site(includes|components|layouts)`.

## Testing done
Local testing of the watch task

## Acceptance criteria
- [x] Watch task works as expected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
