### PR TITLE
Limited consent bug and tests

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
@@ -29,8 +29,8 @@ export const uiSchema = {
       expandUnder: 'view:limitedConsent',
       expandUnderCondition: true,
     },
-    'ui:required': (formData, index) =>
-      _.get(`disabilities.${index}.view:limitedConsent`, formData),
+    'ui:required': formData =>
+      _.get('view:limitedConsent', formData, '') === true,
   },
   'view:privateRecordsChoiceHelp': {
     'ui:description': limitedConsentDescription,

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
@@ -29,8 +29,7 @@ export const uiSchema = {
       expandUnder: 'view:limitedConsent',
       expandUnderCondition: true,
     },
-    'ui:required': formData =>
-      _.get('view:limitedConsent', formData, '') === true,
+    'ui:required': formData => _.get('view:limitedConsent', formData, false),
   },
   'view:privateRecordsChoiceHelp': {
     'ui:description': limitedConsentDescription,

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
@@ -119,4 +119,30 @@ describe('Disability benefits 4142 provider medical records facility information
     expect(form.find('input').length).to.equal(8);
     form.unmount();
   });
+
+  it('does not submit (and renders error messages) when limited consent option chosen and no fields touched', () => {
+    const submit = sinon.spy();
+
+    const form = mount(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{
+          'view:limitedConsent': true,
+        }}
+        formData={initialData}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(submit.called).to.be.false;
+
+    expect(form.find('.usa-input-error').length).to.equal(8);
+
+    expect(form.find('input').length).to.equal(9);
+    form.unmount();
+  });
 });


### PR DESCRIPTION
## Description
When Adding a provider for form 4142, the user is given the option to check the following checkbox:
"I want to limit my consent for the VA to retrieve only specific information from my private medical provider(s)."
If this checkbox is checked, a text box appears allowing the user to describe the limitation they would like to place on their consent. This field should be required.

http://localhost:3001/disability-benefits/apply/form-526-all-claims/supporting-evidence/private-medical-records-release
This bug has been corrected.

## Testing done
tests/pages/privateMedicalRecordsRelease.unit.spec.jsx

## Screenshots
<img width="551" alt="screen shot 2018-12-19 at 7 09 39 pm" src="https://user-images.githubusercontent.com/41440372/50256001-5c625e00-03c2-11e9-82b4-8fd472a04d89.png">


## Acceptance criteria
- [ ] When user checks the checkbox for "I want to limit my consent for the VA to retrieve only specific information from my private medical provider(s)." A text box appears and is required.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
