### PR TITLE
Ensure we close the modal after deleting

### DIFF
--- a/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
@@ -21,6 +21,7 @@ class ConnectedApp extends React.Component {
 
   confirmDelete = () => {
     this.props.confirmDelete(this.props.id);
+    this.closeModal();
   };
 
   toggleDetails = () => {


### PR DESCRIPTION
## Description
During a screen recording for @juliaelman, I discovered after disconnecting the modal for confirmation wasn't being closed.

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/846

## Testing done
- local

## Screenshots
- Hard to screen shot behavior

## Acceptance criteria
- [x] modal closes after disconnecting

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
