### PR TITLE
Form 781a Pages out of order: Changes in Social Behavior#15891

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -351,14 +351,6 @@ const formConfig = {
           schema: physicalHealthChanges.schema,
         },
         // 781a - 13. BEHAVIOR CHANGES: MENTAL/SUBSTANCE ABUSE
-        socialBehaviorChanges: {
-          title: 'Additional changes in behavior - social',
-          path: 'new-disabilities/ptsd-781a-social-changes',
-          depends: isAnswering781aQuestions(0),
-          uiSchema: socialBehaviorChanges.uiSchema,
-          schema: socialBehaviorChanges.schema,
-        },
-        // 781a - 14. BEHAVIOR CHANGES: AT WORK
         mentalHealthChanges: {
           title: 'Additional changes in behavior - mental/substance abuse',
           path: 'new-disabilities/ptsd-781a-mental-changes',
@@ -366,13 +358,21 @@ const formConfig = {
           uiSchema: mentalHealthChanges.uiSchema,
           schema: mentalHealthChanges.schema,
         },
-        // 781a - 15. BEHAVIOR CHANGES: SOCIAL
+        // 781a - 14. BEHAVIOR CHANGES: AT WORK
         workBehaviorChanges: {
           title: 'Additional changes in behavior - work',
           path: 'new-disabilities/ptsd-781a-work-changes',
           depends: isAnswering781aQuestions(0),
           uiSchema: workBehaviorChanges.uiSchema,
           schema: workBehaviorChanges.schema,
+        },
+        // 781a - 15. BEHAVIOR CHANGES: SOCIAL
+        socialBehaviorChanges: {
+          title: 'Additional changes in behavior - social',
+          path: 'new-disabilities/ptsd-781a-social-changes',
+          depends: isAnswering781aQuestions(0),
+          uiSchema: socialBehaviorChanges.uiSchema,
+          schema: socialBehaviorChanges.schema,
         },
         // 781a - 16. BEHAVIOR CHANGES: ADDITIONAL INFORMATION
         additionalBehaviorChanges: {


### PR DESCRIPTION
## Description

When stepping through the 781a Form pages, the Changes in Social Behavior page it show before it should be. It should show after the "work" page, but currently shows after the "physical health" page.

## Testing done
- [x] local testing

## Screenshots
[Apply for disability benefits_ VA.gov.pdf](https://github.com/department-of-veterans-affairs/vets-website/files/2700492/Apply.for.disability.benefits_.VA.gov.pdf)


## Acceptance criteria
- [x] Changes in Social Behavior page should show after the Changes in Work Behavior page and before the "Changes in behavior: additional Information" page


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
