### PR TITLE
21-0781a Form Other Sources of Information Checkbox are not clearing when User changes their answer from yes to no#15926

### DIFF
--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -678,11 +678,15 @@ export const wantsHelpWithPrivateRecordsSecondary = index => formData =>
     `incident${index}.otherSourcesHelp.view:helpPrivateMedicalTreatment`,
     formData,
     '',
-  ) && isAnswering781aQuestions(index)(formData);
+  ) &&
+  isAnswering781aQuestions(index)(formData) &&
+  wantsHelpWithOtherSourcesSecondary(index)(formData);
 
 export const wantsHelpRequestingStatementsSecondary = index => formData =>
   _.get(
     `incident${index}.otherSourcesHelp.view:helpRequestingStatements`,
     formData,
     '',
-  ) && isAnswering781aQuestions(index)(formData);
+  ) &&
+  isAnswering781aQuestions(index)(formData) &&
+  wantsHelpWithOtherSourcesSecondary(index)(formData);


### PR DESCRIPTION
## Description
When filling out a 781a from, a user is asked if they need help gathering supporting evidence for their claim. If the user selects yes, they are presented with two checkboxes. If the user selects one or both of these checkboxes, they are presented with the "permission to request private medical records" page or the "reports from authorities" page, or both. If the user goes back to the help question and changes their answer to no, these pages should not appear.

## Testing done
- [x] local testing

## Screenshots
n/a

## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
