### PR TITLE
keep a backup of the user-selected preferences

### DIFF
--- a/src/applications/personalization/preferences/actions/index.js
+++ b/src/applications/personalization/preferences/actions/index.js
@@ -115,3 +115,8 @@ export function savePreferences(benefitsData) {
     );
   };
 }
+
+export function deletePreferences() {
+  // TODO: flesh out with a call to the DELETE
+  // /v0/user/preferences/:code/delete_all endpoint
+}

--- a/src/applications/personalization/preferences/containers/SetPreferences.jsx
+++ b/src/applications/personalization/preferences/containers/SetPreferences.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link, withRouter } from 'react-router';
 import { connect } from 'react-redux';
+import { isEqual } from 'lodash';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
 
@@ -71,6 +72,15 @@ class SetPreferences extends React.Component {
     this.props.setPreference(code, !this.props.preferences.dashboard[code]);
   };
 
+  // checks to see if the current state of the dashboard (ie preferences
+  // selected by the user) is different from how they were when they were pulled
+  // from the server
+  userHasNotMadeChange = () =>
+    isEqual(
+      this.props.preferences.dashboard,
+      this.props.preferences.dashboardBackup,
+    );
+
   // hydrate benefit options from the backend with data from the benefitChoices
   // helper array. We are storing user-facing info in the benefitChoices array
   // so that user-facing info can be updated by the frontend devs rather than
@@ -122,6 +132,7 @@ class SetPreferences extends React.Component {
             <LoadingButton
               isLoading={saveStatus === LOADING_STATES.pending}
               onClick={this.handleSave}
+              disabled={this.userHasNotMadeChange()}
             >
               <span>Save Preferences</span>
             </LoadingButton>

--- a/src/applications/personalization/preferences/reducers/index.js
+++ b/src/applications/personalization/preferences/reducers/index.js
@@ -48,7 +48,7 @@ export default function preferences(state = initialState, action) {
       return {
         ...state,
         dashboard: { ...selectedBenefits },
-        dashboardBackup: { ...selectedBenefits },
+        savedDashboard: { ...selectedBenefits },
         userBenefitsLoadingStatus: LOADING_STATES.loaded,
       };
     }

--- a/src/applications/personalization/preferences/reducers/index.js
+++ b/src/applications/personalization/preferences/reducers/index.js
@@ -47,12 +47,19 @@ export default function preferences(state = initialState, action) {
 
       return {
         ...state,
-        dashboard: selectedBenefits,
+        dashboard: { ...selectedBenefits },
+        dashboardBackup: { ...selectedBenefits },
         userBenefitsLoadingStatus: LOADING_STATES.loaded,
       };
     }
     case SET_DASHBOARD_PREFERENCE: {
-      return _.set(`dashboard.${action.code}`, action.value, state);
+      const newState = { ...state };
+      if (action.value) {
+        newState.dashboard[action.code] = true;
+      } else {
+        delete newState.dashboard[action.code];
+      }
+      return newState;
     }
     case SAVED_DASHBOARD_PREFERENCES: {
       return _.set('savedAt', Date.now(), state);

--- a/src/applications/personalization/preferences/tests/reducers/index.unit.spec.js
+++ b/src/applications/personalization/preferences/tests/reducers/index.unit.spec.js
@@ -111,10 +111,10 @@ describe('preferencesReducer', () => {
       const newState = reducer(state, action);
       expect(newState.dashboard).to.be.deep.equal({ pref2: true });
     });
-    it('does not touch the dashboardBackup when updating the dashboard', () => {
+    it('does not touch the savedDashboard when updating the dashboard', () => {
       state = {
         dashboard: { pref1: true, pref2: true },
-        dashboardBackup: { pref1: true, pref2: true },
+        savedDashboard: { pref1: true, pref2: true },
       };
       action = {
         type: preferencesActions.SET_DASHBOARD_PREFERENCE,
@@ -122,7 +122,7 @@ describe('preferencesReducer', () => {
         value: false,
       };
       const newState = reducer(state, action);
-      expect(newState.dashboardBackup).to.be.deep.equal({
+      expect(newState.savedDashboard).to.be.deep.equal({
         pref1: true,
         pref2: true,
       });
@@ -168,7 +168,7 @@ describe('preferencesReducer', () => {
       expect(newState.dashboard).to.be.deep.equal({
         'education-training': true,
       });
-      expect(newState.dashboardBackup).to.be.deep.equal({
+      expect(newState.savedDashboard).to.be.deep.equal({
         'education-training': true,
       });
       expect(newState.userBenefitsLoadingStatus).to.eql('loaded');
@@ -195,7 +195,7 @@ describe('preferencesReducer', () => {
       };
       const newState = reducer(state, action);
       expect(newState.dashboard).to.be.deep.equal({});
-      expect(newState.dashboardBackup).to.be.deep.equal({});
+      expect(newState.savedDashboard).to.be.deep.equal({});
       expect(newState.userBenefitsLoadingStatus).to.eql('loaded');
     });
   });

--- a/src/applications/personalization/preferences/tests/reducers/index.unit.spec.js
+++ b/src/applications/personalization/preferences/tests/reducers/index.unit.spec.js
@@ -86,6 +86,49 @@ describe('preferencesReducer', () => {
     dateNowStub.restore();
   });
 
+  describe('SET_DASHBOARD_PREFERENCE', () => {
+    it('adds new prefs to dashboard with a value of `true`', () => {
+      state = {
+        dashboard: {},
+      };
+      action = {
+        type: preferencesActions.SET_DASHBOARD_PREFERENCE,
+        code: 'pref1',
+        value: true,
+      };
+      const newState = reducer(state, action);
+      expect(newState.dashboard).to.be.deep.equal({ pref1: true });
+    });
+    it('completely removes prefs from dashboard when their new value is `false`', () => {
+      state = {
+        dashboard: { pref1: true, pref2: true },
+      };
+      action = {
+        type: preferencesActions.SET_DASHBOARD_PREFERENCE,
+        code: 'pref1',
+        value: false,
+      };
+      const newState = reducer(state, action);
+      expect(newState.dashboard).to.be.deep.equal({ pref2: true });
+    });
+    it('does not touch the dashboardBackup when updating the dashboard', () => {
+      state = {
+        dashboard: { pref1: true, pref2: true },
+        dashboardBackup: { pref1: true, pref2: true },
+      };
+      action = {
+        type: preferencesActions.SET_DASHBOARD_PREFERENCE,
+        code: 'pref1',
+        value: false,
+      };
+      const newState = reducer(state, action);
+      expect(newState.dashboardBackup).to.be.deep.equal({
+        pref1: true,
+        pref2: true,
+      });
+    });
+  });
+
   describe('SET_DASHBOARD_USER_PREFERENCES', () => {
     let userPreferencesResponse;
 
@@ -125,6 +168,9 @@ describe('preferencesReducer', () => {
       expect(newState.dashboard).to.be.deep.equal({
         'education-training': true,
       });
+      expect(newState.dashboardBackup).to.be.deep.equal({
+        'education-training': true,
+      });
       expect(newState.userBenefitsLoadingStatus).to.eql('loaded');
     });
     it('correctly parses the server payload and updates the state when the user has not set preferences', () => {
@@ -149,6 +195,7 @@ describe('preferencesReducer', () => {
       };
       const newState = reducer(state, action);
       expect(newState.dashboard).to.be.deep.equal({});
+      expect(newState.dashboardBackup).to.be.deep.equal({});
       expect(newState.userBenefitsLoadingStatus).to.eql('loaded');
     });
   });

--- a/src/applications/personalization/profile360/vet360/components/base/LoadingButton.jsx
+++ b/src/applications/personalization/profile360/vet360/components/base/LoadingButton.jsx
@@ -4,6 +4,7 @@ export default function LoadingButton({
   isLoading,
   children,
   onClick,
+  disabled,
   ...props
 }) {
   const contents = isLoading ? (
@@ -14,7 +15,7 @@ export default function LoadingButton({
   return (
     <button
       {...props}
-      disabled={isLoading}
+      disabled={isLoading || disabled}
       onClick={onClick}
       className="usa-button"
     >


### PR DESCRIPTION
## Description
Keep a backup version of the user-selected benefits that reflects the state of things as pulled from the server. This way it can be compared to the working-copy version to see if the user has made changes and we can also restore the working-copy to the last saved version when needed.

This change also disables the SAVE button on the Find VA Benefits page if the user has not actually made any changes to their preferences.

## Testing done
Local, added/updated unit tests

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs