### PR TITLE
Full screen login flow with feature toggle.

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -30,8 +30,8 @@ export class AuthApp extends React.Component {
     setupProfileSession(payload);
 
     if (isFullScreenLoginEnabled()) {
-      const returnUrl = sessionStorage.getItem('returnUrl');
-      sessionStorage.removeItem('returnUrl');
+      const returnUrl = sessionStorage.getItem('authReturnUrl');
+      sessionStorage.removeItem('authReturnUrl');
       window.location = returnUrl || '/';
     } else {
       const parent = window.opener;

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -5,6 +5,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingI
 
 import siteName from '../../../platform/brand-consolidation/site-name';
 import SubmitSignInForm from '../../../platform/brand-consolidation/components/SubmitSignInForm';
+import { isFullScreenLoginEnabled } from '../../../platform/user/authentication/utilities';
 import { setupProfileSession } from '../../../platform/user/profile/utilities';
 import { apiRequest } from '../../../platform/utilities/api';
 import environment from '../../../platform/utilities/environment';
@@ -28,19 +29,25 @@ export class AuthApp extends React.Component {
   handleAuthSuccess = payload => {
     setupProfileSession(payload);
 
-    const parent = window.opener;
-    parent.postMessage('loggedIn', environment.BASE_URL);
+    if (isFullScreenLoginEnabled()) {
+      const returnUrl = sessionStorage.getItem('returnUrl');
+      sessionStorage.removeItem('returnUrl');
+      window.location = returnUrl || '/';
+    } else {
+      const parent = window.opener;
+      parent.postMessage('loggedIn', environment.BASE_URL);
 
-    // Internet Explorer 6-11
-    const isIE = /*@cc_on!@*/ false || !!document.documentMode; // eslint-disable-line spaced-comment
-    // Edge 20+
-    const isEdge = !isIE && !!window.StyleMedia;
+      // Internet Explorer 6-11
+      const isIE = /*@cc_on!@*/ false || !!document.documentMode; // eslint-disable-line spaced-comment
+      // Edge 20+
+      const isEdge = !isIE && !!window.StyleMedia;
 
-    // Reload the parent window if the user is using IE or Edge,
-    // due to unreliable support for postMessage.
-    if (isIE || isEdge) parent.location.reload();
+      // Reload the parent window if the user is using IE or Edge,
+      // due to unreliable support for postMessage.
+      if (isIE || isEdge) parent.location.reload();
 
-    window.close();
+      window.close();
+    }
   };
 
   // Fetch the user to get the login policy and validate the session.

--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import moment from 'moment';
 
 import {
   DefinitionTester, // selectCheckbox
@@ -11,6 +12,10 @@ import {
   STATE_VALUES,
   MILITARY_STATE_VALUES,
 } from '../../../all-claims/constants';
+
+const NEXT_YEAR = moment()
+  .add(1, 'year')
+  .format('YYYY-MM-DD');
 
 describe('Disability benefits 526EZ contact information', () => {
   const {
@@ -249,7 +254,7 @@ describe('Disability benefits 526EZ contact information', () => {
           'view:hasForwardingAddress': true,
           forwardingAddress: {
             effectiveDate: {
-              from: '2019-01-01',
+              from: NEXT_YEAR,
             },
             country: 'USA',
             addressLine1: '123 Any Street',
@@ -291,7 +296,7 @@ describe('Disability benefits 526EZ contact information', () => {
           'view:hasForwardingAddress': true,
           forwardingAddress: {
             effectiveDate: {
-              from: '2019-01-01',
+              from: NEXT_YEAR,
             },
             country: 'USA',
             addressLine1: '123 Any Street',
@@ -456,7 +461,7 @@ describe('Disability benefits 526EZ contact information', () => {
           'view:hasForwardingAddress': true,
           forwardingAddress: {
             effectiveDate: {
-              from: '2019-01-01',
+              from: NEXT_YEAR,
             },
             country: 'USA',
             addressLine1: '234 Maple St.',

--- a/src/applications/health-records/tests/00-required.e2e.spec.js
+++ b/src/applications/health-records/tests/00-required.e2e.spec.js
@@ -46,3 +46,5 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
   client.end();
 });
+
+module.exports['@disabled'] = true;

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -19,13 +19,6 @@ import {
 import SearchHelpSignIn from '../components/SearchHelpSignIn';
 import { selectUserGreeting } from '../selectors';
 
-import dashboardManifest from '../../../../applications/personalization/dashboard/manifest';
-import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
-
-const brandConsolidationEnabled = isBrandConsolidationEnabled();
-
-const DASHBOARD_URL = dashboardManifest.rootUrl;
-
 // const SESSION_REFRESH_INTERVAL_MINUTES = 45;
 
 export class Main extends React.Component {
@@ -58,21 +51,12 @@ export class Main extends React.Component {
     if (nextParam) {
       return nextParam.startsWith('/') ? nextParam : `/${nextParam}`;
     }
-    return false;
+
+    return null;
   }
 
-  getRedirectUrl = () => {
-    const nextParam = this.getNextParameter();
-    if (nextParam) return nextParam;
-
-    if (brandConsolidationEnabled) return null;
-
-    // remove this line when refactoring isBrandConsolidationEnabled
-    return window.location.pathname === '/' && DASHBOARD_URL;
-  };
-
   executeRedirect() {
-    const redirectUrl = this.getRedirectUrl();
+    const redirectUrl = this.getNextParameter();
     const shouldRedirect =
       redirectUrl && !window.location.pathname.includes('verify');
 

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -46,7 +46,7 @@ function popup(popupUrl, clickedEvent, openedEvent) {
       popupUrl,
       null,
       ({ url }) => {
-        popupWindow.location = url;
+        if (url) popupWindow.location = url;
       },
       () => {
         popupWindow.location = `${environment.BASE_URL}/auth/login/callback`;
@@ -75,8 +75,10 @@ function redirect(redirectUrl, clickedEvent, openedEvent) {
     redirectUrl,
     null,
     ({ url }) => {
-      recordEvent({ event: openedEvent });
-      window.location = url;
+      if (url) {
+        recordEvent({ event: openedEvent });
+        window.location = url;
+      }
     },
     () => {
       // TODO: Create a separate page or modal when failed to get the URL.

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -67,7 +67,7 @@ function redirect(redirectUrl, clickedEvent, openedEvent) {
   }
 
   // Keep track of the URL to return to after auth operation.
-  sessionStorage.setItem('returnUrl', window.location);
+  sessionStorage.setItem('authReturnUrl', window.location);
 
   recordEvent({ event: clickedEvent });
 

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -4,16 +4,17 @@ import appendQuery from 'append-query';
 import recordEvent from '../../monitoring/record-event';
 import { apiRequest } from '../../utilities/api';
 import environment from '../../utilities/environment';
+import localStorage from '../../utilities/storage/localStorage';
 
 const SESSIONS_URI = `${environment.API_URL}/sessions`;
-const redirectUrl = type => `${SESSIONS_URI}/${type}/new`;
+const sessionTypeUrl = type => `${SESSIONS_URI}/${type}/new`;
 
-const MHV_URL = redirectUrl('mhv');
-const DSLOGON_URL = redirectUrl('dslogon');
-const IDME_URL = redirectUrl('idme');
-const MFA_URL = redirectUrl('mfa');
-const VERIFY_URL = redirectUrl('verify');
-const LOGOUT_URL = redirectUrl('slo');
+const MHV_URL = sessionTypeUrl('mhv');
+const DSLOGON_URL = sessionTypeUrl('dslogon');
+const IDME_URL = sessionTypeUrl('idme');
+const MFA_URL = sessionTypeUrl('mfa');
+const VERIFY_URL = sessionTypeUrl('verify');
+const LOGOUT_URL = sessionTypeUrl('slo');
 
 const loginUrl = policy => {
   switch (policy) {
@@ -25,6 +26,10 @@ const loginUrl = policy => {
       return IDME_URL;
   }
 };
+
+export function isFullScreenLoginEnabled() {
+  return !!localStorage.getItem('enableFullScreenLogin');
+}
 
 function popup(popupUrl, clickedEvent, openedEvent) {
   recordEvent({ event: clickedEvent });
@@ -56,24 +61,51 @@ function popup(popupUrl, clickedEvent, openedEvent) {
   return Promise.reject(new Error('Failed to open new window'));
 }
 
+function redirect(redirectUrl, clickedEvent, openedEvent) {
+  if (!isFullScreenLoginEnabled()) {
+    return popup(redirectUrl, clickedEvent, openedEvent);
+  }
+
+  // Keep track of the URL to return to after auth operation.
+  sessionStorage.setItem('returnUrl', window.location);
+
+  recordEvent({ event: clickedEvent });
+
+  return apiRequest(
+    redirectUrl,
+    null,
+    ({ url }) => {
+      window.location = url;
+    },
+    () => {
+      // TODO: Create a separate page or modal when failed to get the URL.
+      window.location = `${environment.BASE_URL}/auth/login/callback`;
+    },
+  );
+}
+
 export function login(policy) {
-  return popup(loginUrl(policy), 'login-link-clicked', 'login-link-opened');
+  return redirect(loginUrl(policy), 'login-link-clicked', 'login-link-opened');
 }
 
 export function mfa() {
-  return popup(MFA_URL, 'multifactor-link-clicked', 'multifactor-link-opened');
+  return redirect(
+    MFA_URL,
+    'multifactor-link-clicked',
+    'multifactor-link-opened',
+  );
 }
 
 export function verify() {
-  return popup(VERIFY_URL, 'verify-link-clicked', 'verify-link-opened');
+  return redirect(VERIFY_URL, 'verify-link-clicked', 'verify-link-opened');
 }
 
 export function logout() {
-  return popup(LOGOUT_URL, 'logout-link-clicked', 'logout-link-opened');
+  return redirect(LOGOUT_URL, 'logout-link-clicked', 'logout-link-opened');
 }
 
 export function signup() {
-  return popup(
+  return redirect(
     appendQuery(IDME_URL, { signup: true }),
     'register-link-clicked',
     'register-link-opened',

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -75,6 +75,7 @@ function redirect(redirectUrl, clickedEvent, openedEvent) {
     redirectUrl,
     null,
     ({ url }) => {
+      recordEvent({ event: openedEvent });
       window.location = url;
     },
     () => {

--- a/src/platform/user/tests/unauthed-flows.e2e.spec.js
+++ b/src/platform/user/tests/unauthed-flows.e2e.spec.js
@@ -6,7 +6,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
   const appPaths = [
     // While the page is in maintenance, it doesn't need authed
     '/education/gi-bill/post-9-11/ch-33-benefit/status',
-    '/health-care/health-records',
     '/records/download-va-letters/letters',
     '/track-claims',
   ];


### PR DESCRIPTION
## Description
Full screen login (and logout, MFA, identity proofing, etc.) can be toggled on by setting `enableFullScreenLogin` in `localStorage`.

Corresponding change to the logout page is here: department-of-veterans-affairs/vagov-content#201

## Testing done
Local testing with the feature toggled off and on.

## Acceptance criteria
- [x] User auth flows (login, logout, MFA, etc.) should all occur in the same window.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs