### PR TITLE
axe.js WCAG 2 A and AA rules added to e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "devDependencies": {
     "ajv": "^4.7.1",
     "append-query": "2.0.1",
-    "axe-core": "2.6.1",
+    "axe-core": "^2.6.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^7.2.3",
     "babel-jest": "^23.6.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "devDependencies": {
     "ajv": "^4.7.1",
     "append-query": "2.0.1",
-    "axe-core": "^2.3.1",
+    "axe-core": "2.6.1",
     "babel-core": "^6.26.3",
     "babel-eslint": "^7.2.3",
     "babel-jest": "^23.6.0",

--- a/src/applications/facility-locator/tests/00-required.e2e.spec.js
+++ b/src/applications/facility-locator/tests/00-required.e2e.spec.js
@@ -12,7 +12,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.facility-locator', Timeouts.slow)
     // do not run 'wcag2a' rules because of open aXe bug https://github.com/dequelabs/axe-core/issues/214
-    .axeCheck('.main', { rules: ['section508'] });
+    .axeCheck('.main', { rules: ['section508', 'wcag2a'] });
 
   client
     .clearValue('input[name="street-city-state-zip"]')
@@ -22,7 +22,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .click('input[type="submit"]')
     .waitForElementVisible('.facility-result', Timeouts.normal)
     // do not run 'wcag2a' rules because of open aXe bug https://github.com/dequelabs/axe-core/issues/214
-    .axeCheck('.main', { rules: ['section508'] });
+    .axeCheck('.main', { rules: ['section508', 'wcag2a'] });
 
   // check detail pages
   client

--- a/src/applications/facility-locator/tests/00-required.e2e.spec.js
+++ b/src/applications/facility-locator/tests/00-required.e2e.spec.js
@@ -11,8 +11,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.facility-locator', Timeouts.slow)
-    // do not run 'wcag2a' rules because of open aXe bug https://github.com/dequelabs/axe-core/issues/214
-    .axeCheck('.main', { rules: ['section508', 'wcag2a'] });
+    .axeCheck('.main');
 
   client
     .clearValue('input[name="street-city-state-zip"]')
@@ -21,8 +20,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client
     .click('input[type="submit"]')
     .waitForElementVisible('.facility-result', Timeouts.normal)
-    // do not run 'wcag2a' rules because of open aXe bug https://github.com/dequelabs/axe-core/issues/214
-    .axeCheck('.main', { rules: ['section508', 'wcag2a'] });
+    .axeCheck('.main');
 
   // check detail pages
   client

--- a/src/applications/facility-locator/tests/01-accessibility.e2e.spec.js
+++ b/src/applications/facility-locator/tests/01-accessibility.e2e.spec.js
@@ -11,8 +11,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.facility-locator', Timeouts.slow)
-    // do not run 'wcag2a' rules because of open aXe bug https://github.com/dequelabs/axe-core/issues/214
-    .axeCheck('.main', { rules: ['section508'] });
+    .axeCheck('.main');
 
   // Traverse form controls via keyboard input
   client

--- a/src/applications/gi/tests/00-required.e2e.spec.js
+++ b/src/applications/gi/tests/00-required.e2e.spec.js
@@ -13,8 +13,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.gi-app', Timeouts.slow)
-    // do not run 'wcag2a' rules because of open aXe bug https://github.com/dequelabs/axe-core/issues/214
-    .axeCheck('.main', { rules: ['section508'] });
+    .axeCheck('.main');
 
   client
     .waitForElementVisible(
@@ -27,9 +26,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client
     .click('#search-button')
     .waitForElementVisible('.search-page', Timeouts.normal)
-    // do not run 'wcag2a' rules because of open aXe bug https://github.com/dequelabs/axe-core/issues/214
-    .axeCheck('.main', { rules: ['section508'] });
-
+    .axeCheck('.main');
   client
     .waitForElementVisible('.search-result a', Timeouts.normal)
     .click('.search-result a')

--- a/src/applications/pre-need/tests/00-all-fields.e2e.spec.js
+++ b/src/applications/pre-need/tests/00-all-fields.e2e.spec.js
@@ -63,9 +63,7 @@ const runTest = E2eHelpers.createE2eTest(client => {
     '.progress-bar-segmented div.progress-segment:nth-child(3)',
     'progress-segment-complete',
   );
-  client
-    .axeCheck('.main', { rules: ['section508'] })
-    .click('.form-panel .usa-button-primary');
+  client.axeCheck('.main').click('.form-panel .usa-button-primary');
   E2eHelpers.expectNavigateAwayFrom(client, '/sponsor-military-history');
 
   // Previous Names page
@@ -88,10 +86,7 @@ const runTest = E2eHelpers.createE2eTest(client => {
     'progress-segment-complete',
   );
   PageHelpers.completeBenefitSelection(client, testData.data.application);
-  // do not run 'wcag2a' rules because of open aXe bug https://github.com/dequelabs/axe-core/issues/214
-  client
-    .axeCheck('.main', { rules: ['section508'] })
-    .click('.form-panel .usa-button-primary');
+  client.axeCheck().click('.form-panel .usa-button-primary');
   E2eHelpers.expectNavigateAwayFrom(client, '/burial-benefits');
 
   // Supporting Documents page

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,9 +627,10 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
-axe-core@^2.3.1:
+axe-core@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.6.1.tgz#28772c4f76966d373acda35b9a409299dc00d1b5"
+  integrity sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==
 
 axobject-query@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,7 +627,7 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
-axe-core@2.6.1:
+axe-core@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.6.1.tgz#28772c4f76966d373acda35b9a409299dc00d1b5"
   integrity sha512-QFfI3d+x/v92HJWGBaNfgrxdfon9/xXzd04YYfm5w5NJQOLex8qkJCctOt7+ky6e1l9zcQ5E7jsvbnTgQzyfTw==


### PR DESCRIPTION
## Description
Several of our e2e tests had limited `axeCheck` calls, focused only on the Section 508 tests. This left a few spots where we were not running WCAG 2 A or AA level tests because of an axe.js error. That error was fixed, and so I bumped our version of axe.js to latest 2.6.1 and added those tests back.

## Original Issue
* [#15698](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15698)

## Testing done
All automated e2e tests run headless and with GUI to ensure they passed as expected.

## Acceptance criteria
- [x] All axe tests pass in e2e suites

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
