### PR TITLE
Updated copy for health tools CTA upgrade pages

### DIFF
--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -181,20 +181,20 @@ export const requiredServices = appId => {
 export const serviceDescription = (appId, index) => {
   switch (appId) {
     case frontendApps.HEALTH_RECORDS:
-      return 'use VA Blue Button';
+      return 'view your VA medical records';
 
     case frontendApps.RX:
-      return 'refill VA prescriptions online';
+      return 'refill VA prescriptions';
 
     case frontendApps.MESSAGING:
-      return 'send secure messages to your health care team';
+      return 'send secure messages';
 
     case frontendApps.LAB_AND_TEST_RESULTS:
-      return 'view your VA lab and test results';
+      return 'view your lab and test results';
 
     case frontendApps.APPOINTMENTS:
       return [
-        'view your VA appointments online',
+        'view your appointments online',
         'schedule, reschedule, or cancel a VA appointment online',
       ][index];
 

--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -184,7 +184,7 @@ export const serviceDescription = (appId, index) => {
       return 'view your VA medical records';
 
     case frontendApps.RX:
-      return 'refill VA prescriptions';
+      return 'refill prescriptions';
 
     case frontendApps.MESSAGING:
       return 'send secure messages';
@@ -194,7 +194,7 @@ export const serviceDescription = (appId, index) => {
 
     case frontendApps.APPOINTMENTS:
       return [
-        'view your appointments online',
+        'view your appointments',
         'schedule, reschedule, or cancel a VA appointment online',
       ][index];
 

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -367,10 +367,10 @@ export class CallToActionWidget extends React.Component {
     }
 
     return {
-      heading: `You’ll need to upgrade your account before you can ${
+      heading: `You’ll need to upgrade your My HealtheVet account before you can ${
         this._serviceDescription
-      }`,
-      buttonText: 'Upgrade Your Account',
+      }. It’ll only take us a minute to do this for you, and it’s free.`,
+      buttonText: 'Upgrade Your My HealtheVet Account',
       buttonHandler:
         accountState === 'needs_terms_acceptance'
           ? redirectToTermsAndConditions


### PR DESCRIPTION
## Description

Updated copy for MHV CTA as well as service descriptions in `helpers.js`.

## Testing done

Tested locally on Chrome.

## Screenshots

![image](https://user-images.githubusercontent.com/786704/50552703-e7a6e380-0c4d-11e9-839f-ad136e1dd6ac.png)



## Acceptance criteria
Copy is updated for the following services
- [ ] [Refill prescriptions](https://www.va.gov/health-care/refill-track-prescriptions/)
- [ ] [Secure messages](https://www.va.gov/health-care/secure-messaging/)
- [ ] [Appointments](https://www.va.gov/health-care/schedule-view-va-appointments/)
- [ ] [Labs & test results](https://www.va.gov/health-care/view-test-and-lab-results/)
- [ ] [Medical Records](https://www.va.gov/health-care/get-medical-records/)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
