### PR TITLE
Missing "or" on authorities field name

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/secondaryIncidentAuthorities.js
+++ b/src/applications/disability-benefits/all-claims/pages/secondaryIncidentAuthorities.js
@@ -20,7 +20,7 @@ export const uiSchema = index => ({
       },
       items: {
         name: {
-          'ui:title': 'Name of official authority',
+          'ui:title': 'Name of official or authority',
         },
         address: merge(addressUI(''), {
           'ui:order': [


### PR DESCRIPTION
## Description
Missing "or" on authorities field name

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
