### PR TITLE
Replace link with anchor to support static breadcrumbs

### DIFF
--- a/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
+++ b/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
@@ -153,7 +153,7 @@ class PreferencesWidget extends React.Component {
         return (
           <div>
             <p>You haven’t selected any benefits to learn about.</p>
-            <Link to="find-benefits">Select benefits now.</Link>
+            <a href="/my-va/find-benefits">Select benefits now.</a>
           </div>
         );
       }

--- a/src/applications/personalization/preferences/tests/containers/PreferencesWidget.unit.spec.jsx
+++ b/src/applications/personalization/preferences/tests/containers/PreferencesWidget.unit.spec.jsx
@@ -22,9 +22,9 @@ describe('<PreferencesWidget>', () => {
     props.setDismissedBenefitAlerts = () => true;
     props.preferences.dismissedBenefitAlerts = [];
     const component = shallow(<PreferencesWidget {...props} />);
-    expect(component.find('Link').length).to.equal(1);
-    expect(component.find('Link').html()).to.contain('Select benefits now.');
-    expect(component.find('Link').html()).to.not.contain('Find VA Benefits');
+    expect(component.find('a').length).to.equal(1);
+    expect(component.find('Link').length).to.equal(0);
+    expect(component.find('a').html()).to.contain('Select benefits now.');
     expect(component.html()).to.contain(
       'You haven’t selected any benefits to learn about.',
     );
@@ -37,6 +37,7 @@ describe('<PreferencesWidget>', () => {
     props.preferences.dismissedBenefitAlerts = [];
     const component = shallow(<PreferencesWidget {...props} />);
     expect(component.find('Link').length).to.equal(1);
+    expect(component.find('a').length).to.equal(0);
     expect(component.find('Link').html()).to.contain('Find VA Benefits');
     expect(component.find('Link').html()).to.not.contain(
       'Select benefits now.',


### PR DESCRIPTION
## Description
These changes allow the preferences page to support additional breadcrumbs.


## Testing done
verified locally

## Screenshots
![image](https://user-images.githubusercontent.com/16051172/50575817-0a560b00-0dba-11e9-9d85-ab362d831eea.png)


## Acceptance criteria
- [x] Display Find VA Benefits breadcrumb

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
