### PR TITLE
[TeamSite] Fix for "last updated" field of footer in IE

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
+++ b/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
@@ -93,9 +93,9 @@ function renderFooter() {
         </div>
       `;
 
-      document
-        .getElementById(footerElemementId)
-        .parentElement.prepend(lastUpdatedPanel);
+      const footer = document.getElementById(footerElemementId);
+
+      footer.parentElement.insertBefore(lastUpdatedPanel, footer);
     }
   });
 }


### PR DESCRIPTION
## Description
This PR fixes an IE-rendering issue with the "last updated" field of TeamSite footers. We were using `element.prepend`, but that isn't compatible with IE.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15193

## Testing done
- Double-checked that this works in Chrome still and that the functions used are IE-friendly. I couldn't really do much more than that, because Heroku review instances can't test a TeamSite page, and I can't do a manual dev deploy off this commit SHA, because TeamSite Dev still uses the prod bundle. 

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/50600306-aea18580-0e7e-11e9-9d14-bac3f6b2fbda.png)

## Acceptance criteria
- [ ] "last updated' is visible in IE

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
