### PR TITLE
Capitalizes words preceded by special characters

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -168,6 +168,9 @@ describe('526 helpers', () => {
       expect(capitalizeEachWord('some disability - some detail')).to.equal(
         'Some Disability - Some Detail',
       );
+      expect(capitalizeEachWord('some disability (some detail)')).to.equal(
+        'Some Disability (Some Detail)',
+      );
     });
     it('should return Unknown Condition with undefined name', () => {
       expect(capitalizeEachWord()).to.equal('Unknown Condition');

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -165,18 +165,15 @@ describe('526 helpers', () => {
 
   describe('capitalizeEachWord', () => {
     it('should return string with each word capitalized when name supplied', () => {
-      expect(capitalizeEachWord('some disability - some detail')).to.equal(
-        'Some Disability - Some Detail',
-      );
-      expect(capitalizeEachWord('some disability (some detail)')).to.equal(
-        'Some Disability (Some Detail)',
-      );
-      expect(
-        capitalizeEachWord('some disability with hyphenated-words'),
-      ).to.equal('Some Disability With Hyphenated-Words');
-      expect(capitalizeEachWord('some "quote" disability')).to.equal(
-        'Some "Quote" Disability',
-      );
+      [
+        ['some disability - some detail', 'Some Disability - Some Detail'],
+        ['some disability (some detail)', 'Some Disability (Some Detail)'],
+        [
+          'some disability with hyphenated-words',
+          'Some Disability With Hyphenated-Words',
+        ],
+        ['some "quote" disability', 'Some "Quote" Disability'],
+      ].forEach(pair => expect(capitalizeEachWord(pair[0])).to.equal(pair[1]));
     });
     it('should return Unknown Condition with undefined name', () => {
       expect(capitalizeEachWord()).to.equal('Unknown Condition');

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -171,6 +171,12 @@ describe('526 helpers', () => {
       expect(capitalizeEachWord('some disability (some detail)')).to.equal(
         'Some Disability (Some Detail)',
       );
+      expect(
+        capitalizeEachWord('some disability with hyphenated-words'),
+      ).to.equal('Some Disability With Hyphenated-Words');
+      expect(capitalizeEachWord('some "quote" disability')).to.equal(
+        'Some "Quote" Disability',
+      );
     });
     it('should return Unknown Condition with undefined name', () => {
       expect(capitalizeEachWord()).to.equal('Unknown Condition');

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -125,10 +125,7 @@ const capitalizeWord = word => {
  */
 export const capitalizeEachWord = name => {
   if (name && typeof name === 'string') {
-    return name
-      .split(/ +/)
-      .map(capitalizeWord)
-      .join(' ');
+    return name.replace(/\w+/g, capitalizeWord);
   }
 
   Raven.captureMessage(


### PR DESCRIPTION
## Description
I was looking through the PRs that got merged while I was out when I found a little fix that I could whip out quickly.

Previously, we'd have condition names like `PTSD (post Traumatic Stress Disorder)`, but now that `post` will be properly capitalized: `PTSD (Post Traumatic Stress Disorder)`.

## Testing done
Unit test written.

## Screenshots
Gonna be honest here: I was too lazy to grab one.

## Acceptance criteria
- [x] The capitalize function capitalizes words a blatant disregard to special characters

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
