### PR TITLE
Redirect home if session is expired and user tries to log out

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -75,8 +75,10 @@ function redirect(redirectUrl, clickedEvent, openedEvent) {
     redirectUrl,
     null,
     ({ url }) => {
-      recordEvent({ event: openedEvent });
-      window.location = url;
+      if (url) {
+        recordEvent({ event: openedEvent });
+        window.location = url;
+      }
     },
     () => {
       // TODO: Create a separate page or modal when failed to get the URL.

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -63,6 +63,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
           response.status === 401 &&
           !pathname.includes('auth/login/callback') &&
           !isLogout;
+
         if (shouldRedirectToLogin) {
           const loginUrl = appendQuery(environment.BASE_URL, {
             next: pathname,


### PR DESCRIPTION
## Description
Error is being shown when a user's session has expired and they try to log out because API is returning a `401`.

Added logic to redirect user home if they receive a `401` when logging out.  Since this is related to the full screen login, created this PR to merge into `full-screen-login` branch.

## Testing done
Reduced TTL for session in API to 60 sec to test.

## Acceptance criteria
- [ ] Logging out after session expires redirects home and does not display any errors 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
