### PR TITLE
Disable E2E tests for Health Records

### DIFF
--- a/src/applications/health-records/tests/00-required.e2e.spec.js
+++ b/src/applications/health-records/tests/00-required.e2e.spec.js
@@ -46,3 +46,5 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
   client.end();
 });
+
+module.exports['@disabled'] = true;

--- a/src/platform/user/tests/unauthed-flows.e2e.spec.js
+++ b/src/platform/user/tests/unauthed-flows.e2e.spec.js
@@ -6,7 +6,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
   const appPaths = [
     // While the page is in maintenance, it doesn't need authed
     '/education/gi-bill/post-9-11/ch-33-benefit/status',
-    // '/pension/application/527EZ/',
     '/records/download-va-letters/letters',
     '/track-claims',
   ];

--- a/src/platform/user/tests/unauthed-flows.e2e.spec.js
+++ b/src/platform/user/tests/unauthed-flows.e2e.spec.js
@@ -6,7 +6,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   const appPaths = [
     // While the page is in maintenance, it doesn't need authed
     '/education/gi-bill/post-9-11/ch-33-benefit/status',
-    '/health-care/health-records',
+    // '/pension/application/527EZ/',
     '/records/download-va-letters/letters',
     '/track-claims',
   ];


### PR DESCRIPTION
## Description
This PR here, https://github.com/department-of-veterans-affairs/vagov-content/pull/208, removed the Health Records page, but the E2E tests weren't removed along with it. This PR removes those E2E test references.

## Testing done
Local testing of affected E2E tests

## Acceptance criteria
- [ ] Tests pass again

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
