### PR TITLE
Updated sign in link on mobile nav

### DIFF
--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -543,8 +543,10 @@ $medium-phone-screen: 375px;
     // very tricky to write and maintain
     @media (max-width: $medium-large-screen - 1) {
       @include button-link;
+      font-weight: 600;
       color: $color-white !important;
       text-decoration: none;
+      -webkit-font-smoothing: antialiased;
     }
   }
 }


### PR DESCRIPTION
## Description
Adjusted font-weight of Sign In link on mobile nav

## Testing done
Viewed changes on mobile-sized chrome browser window

## Screenshots
![screen shot 2019-01-03 at 5 43 36 pm](https://user-images.githubusercontent.com/11021491/50665570-235be900-0f7f-11e9-82ed-7f69210cf7b9.png)

## Acceptance criteria
- [X] Font-weight of 'Sign In' nav bar is consistent with 'Search' and 'Contact Us'.

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
