### PR TITLE
Enable source maps for SCSS

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -98,9 +98,13 @@ const configGenerator = (buildOptions, apps) => {
                 loader: 'css-loader',
                 options: {
                   minimize: isOptimizedBuild,
+                  sourceMap: !isOptimizedBuild,
                 },
               },
-              { loader: 'sass-loader' },
+              {
+                loader: 'sass-loader',
+                options: { sourceMap: !isOptimizedBuild },
+              },
             ],
           }),
         },
@@ -195,19 +199,18 @@ const configGenerator = (buildOptions, apps) => {
   };
 
   if (isOptimizedBuild) {
-    const bucket = BUCKETS[buildOptions.buildtype];
+    baseConfig.plugins.push(new webpack.HashedModuleIdsPlugin());
+    baseConfig.mode = 'production';
+  } else {
+    const bucket = BUCKETS[buildOptions.buildtype] || '';
 
+    baseConfig.devtool = '#eval-source-map';
     baseConfig.plugins.push(
       new webpack.SourceMapDevToolPlugin({
         append: `\n//# sourceMappingURL=${bucket}/generated/[url]`,
         filename: '[file].map',
       }),
     );
-
-    baseConfig.plugins.push(new webpack.HashedModuleIdsPlugin());
-    baseConfig.mode = 'production';
-  } else {
-    baseConfig.devtool = '#eval-source-map';
   }
 
   if (buildOptions.analyzer) {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -38,7 +38,6 @@ const globalEntryFiles = {
 
 const configGenerator = (buildOptions, apps) => {
   const entryFiles = Object.assign({}, apps, globalEntryFiles);
-  const bucket = BUCKETS[buildOptions.buildtype];
   const isOptimizedBuild = [
     ENVIRONMENTS.VAGOVSTAGING,
     ENVIRONMENTS.VAGOVPROD,
@@ -196,20 +195,23 @@ const configGenerator = (buildOptions, apps) => {
       new ManifestPlugin({
         fileName: 'file-manifest.json',
       }),
-      new webpack.SourceMapDevToolPlugin(
-        isOptimizedBuild
-          ? {
-              append: `\n//# sourceMappingURL=${bucket}/generated/[url]`,
-              filename: '[file].map',
-            }
-          : {},
-      ),
     ],
   };
 
   if (isOptimizedBuild) {
+    const bucket = BUCKETS[buildOptions.buildtype];
+
+    baseConfig.plugins.push(
+      new webpack.SourceMapDevToolPlugin({
+        append: `\n//# sourceMappingURL=${bucket}/generated/[url]`,
+        filename: '[file].map',
+      }),
+    );
+
     baseConfig.plugins.push(new webpack.HashedModuleIdsPlugin());
     baseConfig.mode = 'production';
+  } else {
+    baseConfig.devtool = '#inline-cheap-module-source-map';
   }
 
   if (buildOptions.analyzer) {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -195,6 +195,9 @@ const configGenerator = (buildOptions, apps) => {
       new ManifestPlugin({
         fileName: 'file-manifest.json',
       }),
+      new webpack.SourceMapDevToolPlugin({
+        test: /\.css$/,
+      }),
     ],
   };
 
@@ -211,7 +214,7 @@ const configGenerator = (buildOptions, apps) => {
     baseConfig.plugins.push(new webpack.HashedModuleIdsPlugin());
     baseConfig.mode = 'production';
   } else {
-    baseConfig.devtool = '#inline-cheap-module-source-map';
+    baseConfig.devtool = '#eval-source-map';
   }
 
   if (buildOptions.analyzer) {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -195,9 +195,6 @@ const configGenerator = (buildOptions, apps) => {
       new ManifestPlugin({
         fileName: 'file-manifest.json',
       }),
-      new webpack.SourceMapDevToolPlugin({
-        test: /\.css$/,
-      }),
     ],
   };
 
@@ -215,6 +212,14 @@ const configGenerator = (buildOptions, apps) => {
     baseConfig.mode = 'production';
   } else {
     baseConfig.devtool = '#eval-source-map';
+
+    // The eval-source-map devtool doesn't seem to work for CSS, so we
+    // add a separate plugin for CSS source maps.
+    baseConfig.plugins.push(
+      new webpack.SourceMapDevToolPlugin({
+        test: /\.css$/,
+      }),
+    );
   }
 
   if (buildOptions.analyzer) {


### PR DESCRIPTION
## Description
This PR enables source maps for SCSS files, so it's easier to trace where a CSS rule originates.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16046

## Testing done
Local testing

## Screenshots
In the screenshot below, you can see that the inspector indicates which SCSS file the CSS rule came from. In this case, the `_m-alert.scss`.

![image](https://user-images.githubusercontent.com/1915775/50666174-7a62bd80-0f81-11e9-951d-737b2a54770c.png)

### Dev build (localhost)
#### Inline source map
![image](https://user-images.githubusercontent.com/1915775/50696391-5056dd00-100d-11e9-8451-38c4a1929c94.png)

#### Optimized build (local build of vagovstaging)
![image](https://user-images.githubusercontent.com/1915775/50696503-a0ce3a80-100d-11e9-9211-b55227ebfdf0.png)

## Acceptance criteria
- [x] SCSS source maps are enabled
- [x] Dev builds (localhost, vagovdev) have inline source maps
- [x] Optimized builds (vagovstaging, vagovprod) have source maps in an external file

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
