### PR TITLE
Updated top-nav 'browser out of date' broken link

### DIFF
--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -5,7 +5,7 @@ export default `
   <div class="incompatible-browser-warning">
     <div class="row full">
       <div class="small-12">
-        Your browser is out of date. To use this website, please <a href="https://whatbrowser.org/">update your browser</a> or use a different device.
+        Your browser is out of date. To use this website, please <a href="https://browsehappy.com/">update your browser</a> or use a different device.
       </div>
     </div>
   </div>

--- a/src/site/includes/top-nav.html
+++ b/src/site/includes/top-nav.html
@@ -2,7 +2,7 @@
   <div class="incompatible-browser-warning">
     <div class="row full">
       <div class="small-12">
-        Your browser is out of date. To use this website, please <a href="https://whatbrowser.org/">update your browser</a> or use a different device.
+        Your browser is out of date. To use this website, please <a href="https://browsehappy.com/">update your browser</a> or use a different device.
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description
Fixed the broken link in top-nav when incompatible browser warning is shown. 

## Testing done
Visual testing on Saucelabs.com using IE10

## Screenshots
![screen shot 2019-01-04 at 2 35 04 pm](https://user-images.githubusercontent.com/11021491/50707156-f4508080-102d-11e9-9418-5847d4415695.png)


## Acceptance criteria
- [X] 'update your browser' link does not return a 404

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
