### PR TITLE
fix checkbox aXe errors

### DIFF
--- a/src/applications/gi/components/Checkbox.jsx
+++ b/src/applications/gi/components/Checkbox.jsx
@@ -73,7 +73,6 @@ class Checkbox extends React.Component {
     return (
       <div className={className}>
         <input
-          autoComplete="false"
           aria-describedby={errorSpanId}
           checked={this.props.checked}
           id={this.inputId}

--- a/src/applications/personalization/preferences/components/PreferenceOption.jsx
+++ b/src/applications/personalization/preferences/components/PreferenceOption.jsx
@@ -13,7 +13,9 @@ export default ({ item, onChange, checked }) => {
         <Checkbox
           name={item.code}
           checked={checked}
-          label=""
+          label={
+            <span className="usa-sr-only">{item.shortTitle || item.title}</span>
+          }
           onChange={() => onChange(item.code, !checked)}
         />
       </div>


### PR DESCRIPTION
## Description
Fix aXe checkbox errors:
1. adds missing `label` contents (resolves department-of-veterans-affairs/vets.gov-team#16092)
2. removes `autocomplete` attribute (resolves department-of-veterans-affairs/vets.gov-team#16091)

## Testing done
Manual

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/50784359-4aa60500-1262-11e9-95d7-f80ab005fcab.png)

The above screenshot shows the updated renderer DOM

## Acceptance criteria
- [ ] passes aXe tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs