### PR TITLE
Add a build arg for the API location

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -184,6 +184,7 @@ const configGenerator = (buildOptions, apps) => {
     plugins: [
       new webpack.DefinePlugin({
         __BUILDTYPE__: JSON.stringify(buildOptions.buildtype),
+        __API__: JSON.stringify(buildOptions.api),
       }),
 
       new ExtractTextPlugin({

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -13,6 +13,7 @@ import ENVIRONMENTS from '../../../site/constants/environments';
 // import sinon from 'sinon'
 
 global.__BUILDTYPE__ = process.env.BUILDTYPE || ENVIRONMENTS.VAGOVDEV;
+global.__API__ = null;
 
 chai.use(chaiAsPromised);
 

--- a/src/platform/utilities/environment/index.js
+++ b/src/platform/utilities/environment/index.js
@@ -59,13 +59,9 @@ if (environment.BUILDTYPE === ENVIRONMENTS.LOCALHOST) {
   // __API__ is defined the same way as __BUILDTYPE__, and is used to indicate the URL of the VA API. The main use
   // case for this at the moment is for internal review instances to pass configuration during the build.
 
-  try {
-    // eslint-disable-next-line no-undef
-    const CUSTOM_API = __API__;
-    if (CUSTOM_API) environment.API_URL = CUSTOM_API;
-  } catch (err) {
-    // Nothing to be done - continue using the default localhost API
-  }
+  // eslint-disable-next-line no-undef
+  const CUSTOM_API = __API__;
+  if (CUSTOM_API) environment.API_URL = CUSTOM_API;
 }
 
 export default Object.freeze({

--- a/src/platform/utilities/environment/index.js
+++ b/src/platform/utilities/environment/index.js
@@ -13,6 +13,13 @@ import ENVIRONMENTS from '../../../site/constants/environments';
 // eslint-disable-next-line no-undef
 const BUILDTYPE = __BUILDTYPE__;
 
+// __API__ is defined the same way, and is used to indicate the URL of the VA API. The main use
+// case for this at the moment is for internal review instances to pass configuration during the build.
+// This is only applicable during localhost builds.
+
+// eslint-disable-next-line no-undef
+const CUSTOM_API = __API__;
+
 const ENVIRONMENT_CONFIGURATIONS = {
   [ENVIRONMENTS.VAGOVPROD]: {
     BUILDTYPE: ENVIRONMENTS.VAGOVPROD,
@@ -37,7 +44,7 @@ const ENVIRONMENT_CONFIGURATIONS = {
     BASE_URL: `http://${location.hostname}${
       location.port ? `:${location.port}` : ''
     }`,
-    API_URL: `http://${location.hostname}:3000`,
+    API_URL: CUSTOM_API || `http://${location.hostname}:3000`,
   },
 };
 

--- a/src/platform/utilities/environment/index.js
+++ b/src/platform/utilities/environment/index.js
@@ -13,13 +13,6 @@ import ENVIRONMENTS from '../../../site/constants/environments';
 // eslint-disable-next-line no-undef
 const BUILDTYPE = __BUILDTYPE__;
 
-// __API__ is defined the same way, and is used to indicate the URL of the VA API. The main use
-// case for this at the moment is for internal review instances to pass configuration during the build.
-// This is only applicable during localhost builds.
-
-// eslint-disable-next-line no-undef
-const CUSTOM_API = __API__;
-
 const ENVIRONMENT_CONFIGURATIONS = {
   [ENVIRONMENTS.VAGOVPROD]: {
     BUILDTYPE: ENVIRONMENTS.VAGOVPROD,
@@ -44,7 +37,7 @@ const ENVIRONMENT_CONFIGURATIONS = {
     BASE_URL: `http://${location.hostname}${
       location.port ? `:${location.port}` : ''
     }`,
-    API_URL: CUSTOM_API || `http://${location.hostname}:3000`,
+    API_URL: `http://${location.hostname}:3000`,
   },
 };
 
@@ -60,6 +53,19 @@ if (!isPort80) {
   const LOCALHOST_ENV = ENVIRONMENT_CONFIGURATIONS[ENVIRONMENTS.LOCALHOST];
   environment.API_URL = LOCALHOST_ENV.API_URL;
   environment.BASE_URL = LOCALHOST_ENV.BASE_URL;
+}
+
+if (environment.BUILDTYPE === ENVIRONMENTS.LOCALHOST) {
+  // __API__ is defined the same way as __BUILDTYPE__, and is used to indicate the URL of the VA API. The main use
+  // case for this at the moment is for internal review instances to pass configuration during the build.
+
+  try {
+    // eslint-disable-next-line no-undef
+    const CUSTOM_API = __API__;
+    if (CUSTOM_API) environment.API_URL = CUSTOM_API;
+  } catch (err) {
+    // Nothing to be done - continue using the default localhost API
+  }
 }
 
 export default Object.freeze({

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -14,6 +14,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'buildtype', type: String, defaultValue: defaultBuildtype },
   { name: 'host', type: String, defaultValue: defaultHost },
   { name: 'port', type: Number, defaultValue: 3001 },
+  { name: 'api', type: String, defaultValue: null },
   { name: 'watch', type: Boolean, defaultValue: false },
   { name: 'entry', type: String, defaultValue: null },
   { name: 'analyzer', type: Boolean, defaultValue: false },


### PR DESCRIPTION
## Description
This PR adds a build arg, `api`, into the FE build so that internal review instances can pass over that configuration. This was formerly an environment variable, but was removed during a refactor on the FE because it seemed to be an unused special case.

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16097

## Testing done
- Ran a local build without `api` arg to confirm the default API is still `http://localhost:3000`
- Ran a local build with `api` to confirm that the API arg is passed properly

## Acceptance criteria
- [x] Internal review instances can pass API location

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
