### PR TITLE
Replace existing Dashboard modal with new Find VA Benefits modal on prod

### DIFF
--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -1,11 +1,9 @@
-import DashboardIntro from '../components/DashboardIntro';
 import FindVABenefitsIntro from '../components/FindVABenefitsIntro';
 import Profile360Intro from '../components/Profile360Intro';
 import PersonalizationBanner from '../components/PersonalizationBanner';
 import ClaimIncreaseBanner from '../components/ClaimIncreaseBanner';
 import VAPlusVetsModal from '../components/VAPlusVetsModal';
 import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
-import environment from 'platform/utilities/environment';
 
 const config = {
   announcements: [
@@ -23,17 +21,9 @@ const config = {
       disabled: !WelcomeToNewVAModal.isEnabled(),
     },
     {
-      name: 'dashboard-intro',
-      paths: /^(\/my-va\/)$/,
-      component: DashboardIntro,
-      disabled: !environment.isProduction(),
-      relatedAnnouncements: ['personalization'],
-    },
-    {
       name: 'find-benefits-intro',
       paths: /^(\/my-va\/)$/,
       component: FindVABenefitsIntro,
-      disabled: environment.isProduction(),
       relatedAnnouncements: ['personalization'],
     },
     {


### PR DESCRIPTION
## Description
Now that we are pushing Find VA Benefits live, we need to update the FTUX modal used on the My VA Dashboard page

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs