### PR TITLE
Fixed error in reporting login-success-idme.

### DIFF
--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -74,7 +74,8 @@ export const hasSession = () => localStorage.getItem('hasSession');
 export function setupProfileSession(payload) {
   localStorage.setItem('hasSession', true);
   const userData = get('data.attributes.profile', payload, {});
-  const { firstName, authnContext: loginPolicy = 'idme', loa } = userData;
+  const { firstName, authnContext, loa } = userData;
+  const loginPolicy = authnContext || 'idme';
 
   // Since localStorage coerces everything into String,
   // this avoids setting the first name to the string 'null'.


### PR DESCRIPTION
## Description
We were reporting `login-success-null` to GA due to the way destructuring works with default values.

Apparently when destructuring objects, if a key already exists with value of `null` or any falsy value, it doesn't get assigned the default value if you try to set it through destructuring.

```
const obj = { originalKey: null };
const { originalKey: newKey = 'defaultValue' } = obj;
```

In this example, `newKey` would get assigned the falsy value of `null` instead of `'defaultValue'`.

## Testing done
Experimented with destructuring in a Node console.

## Acceptance criteria
- [x] A successful ID.me login should report `login-success-idme` to GA.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
