### PR TITLE
[Bug] User is being shown an error if they try to log out after their session has expired

### DIFF
--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -57,22 +57,20 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
         ? response.json()
         : Promise.resolve(response);
 
-      if (!response.ok && response.status === 401) {
-        const { pathname } = window.location;
-        const shouldRedirectToLogin =
-          !pathname.includes('auth/login/callback') && !isLogout;
+      if (!response.ok) {
+        if (response.status === 401) {
+          const { pathname } = window.location;
 
-        if (shouldRedirectToLogin) {
-          const loginUrl = appendQuery(environment.BASE_URL, {
-            next: pathname,
-          });
-          window.location.href = loginUrl;
-        }
-
-        // If session has expired and user tries to log out, API will still return a 401.
-        // In this case, redirect the user home instead of displaying an error
-        if (isLogout) {
-          window.location.href = '/';
+          // If the user receives a 401 when trying to log out, it means their session
+          // has expired.  Redirect them home.  In all other cases, redirect to login
+          if (isLogout) {
+            window.location.href = '/';
+          } else if (!pathname.includes('auth/login/callback')) {
+            const loginUrl = appendQuery(environment.BASE_URL, {
+              next: pathname,
+            });
+            window.location.href = loginUrl;
+          }
         } else {
           return data.then(Promise.reject.bind(Promise));
         }

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -23,6 +23,7 @@ function isJson(response) {
 export function apiRequest(resource, optionalSettings = {}, success, error) {
   const baseUrl = `${environment.API_URL}/v0`;
   const url = resource[0] === '/' ? [baseUrl, resource].join('') : resource;
+  const isLogout = resource.endsWith('/slo/new');
 
   const defaultSettings = {
     method: 'GET',
@@ -40,6 +41,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
 
   const settings = Object.assign({}, defaultSettings, optionalSettings);
   settings.headers = newHeaders;
+
   return fetch(url, settings)
     .catch(err => {
       Raven.captureMessage(`vets_client_error: ${err.message}`, {
@@ -55,10 +57,10 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
         ? response.json()
         : Promise.resolve(response);
 
-      if (!response.ok) {
+      if (!response.ok && response.status === 401) {
         const { pathname } = window.location;
         const shouldRedirectToLogin =
-          response.status === 401 && !pathname.includes('auth/login/callback');
+          !pathname.includes('auth/login/callback') && !isLogout;
 
         if (shouldRedirectToLogin) {
           const loginUrl = appendQuery(environment.BASE_URL, {
@@ -67,7 +69,13 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
           window.location.href = loginUrl;
         }
 
-        return data.then(Promise.reject.bind(Promise));
+        // If session has expired and user tries to log out, API will still return a 401.
+        // In this case, redirect the user home instead of displaying an error
+        if (isLogout) {
+          window.location.href = '/';
+        } else {
+          return data.then(Promise.reject.bind(Promise));
+        }
       }
 
       return data;


### PR DESCRIPTION
## Description
Error is being shown when a user's session has expired and they try to log out because API is returning a `401`.

Added logic to redirect user home if they receive a `401` when logging out.

## Testing done
Reduced TTL for session in API to 60 sec to test.

## Acceptance criteria
- [ ] Logging out after session expires redirects home and does not display any errors 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
