### PR TITLE
Fix straight apostrophes

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/recentJobApplications.jsx
+++ b/src/applications/disability-benefits/all-claims/content/recentJobApplications.jsx
@@ -9,17 +9,17 @@ export const recentJobApplicationsDescription = () => (
       since you became too disabled to work?
     </p>
     <p>
-      (Don't include applications to the VA's Compensated Work Therapy Program.)
+      (Don’t include applications to the VA’s Compensated Work Therapy Program.)
     </p>
   </div>
 );
 
 export const substantiallyGainfulEmployment = () => (
-  <AdditionalInfo triggerText="What's substantially gainful employment?">
+  <AdditionalInfo triggerText="What’s substantially gainful employment?">
     <p>Substantially gainful employment means:</p>
     <ul>
       <li>
-        You're employed in a competitive marketplace or job that isn't in a
+        You’re employed in a competitive marketplace or job that isn’t in a
         protected environment, such as a family business or sheltered workshop.
       </li>
       <li>


### PR DESCRIPTION
## Description
I found a few straight apostrophes that were merged into master before I could catch them. This changes them to `’`s

## Testing done
None. :yolo:

## Screenshots
I can capture them if desired, but didn't because that would take me longer than writing the PR itself.

## Acceptance criteria
- [x] The apostrophes are changed to curly quotes

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
