### PR TITLE
All claims fix rated disabilities mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/schema/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/schema/maximal-test.json
@@ -154,7 +154,8 @@
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",
         "ratingPercentage": 100,
-        "view:selected": true
+        "view:selected": true,
+        "disabilityActionType": "NONE"
       },
       {
         "name": "Second Condition",
@@ -164,7 +165,8 @@
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",
         "ratingPercentage": 0,
-        "view:selected": false
+        "view:selected": false,
+        "disabilityActionType": "NONE"
       },
       {
         "name": "Third Condition",
@@ -173,7 +175,8 @@
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",
-        "ratingPercentage": 100
+        "ratingPercentage": 100,
+        "disabilityActionType": "NONE"
       }
     ],
     "view:disabilitiesClarification": {},

--- a/src/applications/disability-benefits/all-claims/tests/schema/minimal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/schema/minimal-test.json
@@ -29,7 +29,8 @@
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",
         "ratingPercentage": 100,
-        "view:selected": true
+        "view:selected": true,
+        "disabilityActionType": "NONE"
       }
     ],
     "view:disabilitiesClarification": {},

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -51,7 +51,7 @@ import {
   disabilityActionTypes,
 } from '../../all-claims/constants';
 
-describe.only('526 helpers', () => {
+describe('526 helpers', () => {
   describe('addNoneDisabilityActionType', () => {
     const disabilities = [
       { decisionCode: SERVICE_CONNECTION_TYPES.notServiceConnected },

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -32,6 +32,7 @@ import {
   getFlatIncidentKeys,
   getPtsdChangeText,
   hasHospitalCare,
+  addNoneDisabilityActionType,
   filterServiceConnected,
 } from '../utils.jsx';
 
@@ -50,7 +51,36 @@ import {
   disabilityActionTypes,
 } from '../../all-claims/constants';
 
-describe('526 helpers', () => {
+describe.only('526 helpers', () => {
+  describe('addNoneDisabilityActionType', () => {
+    const disabilities = [
+      { decisionCode: SERVICE_CONNECTION_TYPES.notServiceConnected },
+      { decisionCode: SERVICE_CONNECTION_TYPES.serviceConnected },
+      { decisionCode: SERVICE_CONNECTION_TYPES.notServiceConnected },
+      { decisionCode: SERVICE_CONNECTION_TYPES.serviceConnected },
+    ];
+
+    it('should return an array of same length as input', () => {
+      const withActionType = addNoneDisabilityActionType(disabilities);
+      expect(withActionType)
+        .to.be.an('array')
+        .that.has.length(disabilities.length);
+    });
+
+    it('should return an empty array when no input', () => {
+      expect(addNoneDisabilityActionType())
+        .to.be.an('array')
+        .that.has.length(0);
+    });
+
+    it('should set disabilityActionType to NONE for each rated disability', () => {
+      const withActionType = addNoneDisabilityActionType(disabilities);
+      withActionType.forEach(d => {
+        expect(d.disabilityActionType).to.equal(disabilityActionTypes.NONE);
+      });
+    });
+  });
+
   describe('filterServiceConnected', () => {
     it('should filter non-service-connected disabililties', () => {
       const disabilities = [


### PR DESCRIPTION
## Description
- Fixes a bug I introduced earlier today where `disabilityActionType` wasn't getting set for rated disabilities early enough, causing the form to not be able to advance past the rated disabilities selection page
- Bonus: Fixes bug where not having any rated disabilities in prefill causes all of prefill to fail

## Testing done
- Tested locally that prefill works in general, that the user can advance past rated disabilities page, that the form transforms successfully on submit, and that both having some and not having any rated disabilities works
- Added unit tests

## Screenshots
NA

## Acceptance criteria
- [x] Form can be advanced past the rated disabilities page
- [x] Prefill works, including rated disabilities prefill
- [x] No regression in submit transformer functionality

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
