### PR TITLE
Use common review widget

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -5,6 +5,7 @@ import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 // import dateUI from 'us-forms-system/lib/js/definitions/date';
 import dateRangeUI from 'us-forms-system/lib/js/definitions/dateRange';
 import PhoneNumberWidget from 'us-forms-system/lib/js/widgets/PhoneNumberWidget';
+import PhoneNumberReviewWidget from 'us-forms-system/lib/js/review/PhoneNumberWidget';
 
 import ReviewCardField from '../components/ReviewCardField';
 
@@ -159,6 +160,7 @@ export const uiSchema = {
     primaryPhone: {
       'ui:title': 'Phone number',
       'ui:widget': PhoneNumberWidget,
+      'ui:reviewWidget': PhoneNumberReviewWidget,
       'ui:errorMessages': {
         pattern: 'Phone numbers must be 10 digits (dashes allowed)',
       },


### PR DESCRIPTION
## Description
Fixes issue where phone number is editable by default on the review page. Now, you have to click 'edit' to change it like the rest of the review fields.

## Testing done
- Tested locally

## Screenshots [see ticket for 'before' picture]
Default review view:
![screen shot 2019-01-09 at 11 40 54 am](https://user-images.githubusercontent.com/24251447/50918980-4e26c100-1407-11e9-9d6f-734a9c87712a.png)

-----
Edit view:
![screen shot 2019-01-09 at 11 40 58 am](https://user-images.githubusercontent.com/24251447/50919005-57179280-1407-11e9-883f-a6b28f371ea4.png)


## Acceptance criteria
- [x] Phone number does not show in edit mode by default on the review page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
