### PR TITLE
Re-fixed 781a behavior change fix and test

### DIFF
--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -169,7 +169,7 @@ export function concatIncidentLocationString(incidentLocation) {
     .join(', ');
 }
 
-export function getPtsdChangeText(changeFields) {
+export function getPtsdChangeText(changeFields = {}) {
   return Object.keys(changeFields)
     .filter(
       key =>

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -158,6 +158,11 @@ describe('getPtsdChangeText', () => {
 
     expect(fieldTitles.length).to.eql(2);
   });
+
+  it('should correctly handle undefined ptsd changes', () => {
+    const fieldTitles = getPtsdChangeText(undefined);
+    expect(fieldTitles.length).to.eql(0);
+  });
 });
 
 describe('setActionTypes', () => {


### PR DESCRIPTION
## Description
Adds a null check for PTSD behavior changes.

Related to https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/16098

## Testing done

- [x] Can correctly submit all claims flow without a rated disability .
- [x] Can submit all claims flow without PTSD behavior changes.

## Screenshots
N/A

## Acceptance criteria
- [x] Can submit all claims flow without errors

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs