### PR TITLE
686 dynamic test dates mg

### DIFF
--- a/src/applications/disability-benefits/686/config/form.js
+++ b/src/applications/disability-benefits/686/config/form.js
@@ -969,7 +969,7 @@ const formConfig = {
                     hideIf: (form, index) => {
                       const childAge = calculateChildAge(form, index);
                       if (childAge) {
-                        return childAge > 18;
+                        return childAge >= 18;
                       }
                       return true;
                     },

--- a/src/applications/disability-benefits/686/tests/config/dependentInfo.unit.spec.js
+++ b/src/applications/disability-benefits/686/tests/config/dependentInfo.unit.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
+import moment from 'moment';
 
 import {
   DefinitionTester,
@@ -11,7 +12,7 @@ import {
 } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
-describe('686 dependent info', () => {
+describe.only('686 dependent info', () => {
   const {
     schema,
     uiSchema,
@@ -27,10 +28,14 @@ describe('686 dependent info', () => {
             first: 'Jane',
             last: 'Doe',
           },
-          childDateOfBirth: '2000-01-10',
+          // Child needs to be between 18 & 23
+          childDateOfBirth: moment()
+            .subtract(18, 'years')
+            .format('YYYY-MM-DD'),
         },
       ],
     });
+
   it('should render', () => {
     const form = mount(
       <DefinitionTester
@@ -42,13 +47,16 @@ describe('686 dependent info', () => {
         uiSchema={uiSchema}
       />,
     );
-    expect(form.find('input').length).to.equal(8);
+    expect(form.find('input').length).to.equal(7); // `disabled` question hidden
     form.unmount();
   });
 
-  it('should show disabled if child is less than 18 years old', () => {
+  it('should show disabled question if child is less than 18 years old', () => {
     const props = dependentData();
-    props.dependents[0].childDateOfBirth = '2010-01-10';
+    const underageBirthday = moment()
+      .subtract(17, 'years')
+      .format('YYYY-MM-DD');
+    props.dependents[0].childDateOfBirth = underageBirthday;
     const form = mount(
       <DefinitionTester
         arrayPath={arrayPath}
@@ -59,13 +67,36 @@ describe('686 dependent info', () => {
         uiSchema={uiSchema}
       />,
     );
-    expect(form.find('input').length).to.equal(7);
+    expect(form.find('input').length).to.equal(7); // `inSchool` question hidden
+    form.unmount();
+  });
+
+  it('should not show show disabled question if child is 18 years old', () => {
+    const props = dependentData();
+    const underageBirthday = moment()
+      .subtract(18, 'years')
+      .format('YYYY-MM-DD');
+    props.dependents[0].childDateOfBirth = underageBirthday;
+    const form = mount(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        schema={schema}
+        data={props}
+        definitions={formConfig.defaultDefinitions}
+        uiSchema={uiSchema}
+      />,
+    );
+    expect(form.find('input').length).to.equal(7); // `inSchool` question visible
     form.unmount();
   });
 
   it('should not show disabled or inSchool if child is older than 23', () => {
     const props = dependentData();
-    props.dependents[0].childDateOfBirth = '1986-01-10';
+    const over23Birthday = moment()
+      .subtract(24, 'years')
+      .format('YYYY-MM-DD');
+    props.dependents[0].childDateOfBirth = over23Birthday;
     const form = mount(
       <DefinitionTester
         arrayPath={arrayPath}
@@ -134,26 +165,7 @@ describe('686 dependent info', () => {
     );
 
     selectRadio(form, 'root_childRelationship', 'stepchild');
-    expect(form.find('input').length).to.equal(10);
-    form.unmount();
-  });
-
-  it('should expand info boxes if child is in school and disabled', () => {
-    const form = mount(
-      <DefinitionTester
-        data={dependentData()}
-        arrayPath={arrayPath}
-        pagePerItemIndex={0}
-        schema={schema}
-        definitions={formConfig.defaultDefinitions}
-        uiSchema={uiSchema}
-      />,
-    );
-
-    selectCheckbox(form, 'root_inSchool', true);
-    selectCheckbox(form, 'root_disabled', true);
-
-    expect(form.find('.usa-alert-warning').length).to.equal(2);
+    expect(form.find('input').length).to.equal(9); // `disabled` question hidden
     form.unmount();
   });
 });

--- a/src/applications/disability-benefits/686/tests/config/dependentInfo.unit.spec.js
+++ b/src/applications/disability-benefits/686/tests/config/dependentInfo.unit.spec.js
@@ -8,11 +8,10 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-  selectCheckbox,
 } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
-describe.only('686 dependent info', () => {
+describe('686 dependent info', () => {
   const {
     schema,
     uiSchema,


### PR DESCRIPTION
## Description
- Fixes failing unit tests on master that were due to reliance on static date strings
- Fixes display logic in `uiSchema` to line up with the question title: `disabled` question now only shows when the child's age is _less_ than 18.
- Removes a unit test that tested a condition which shouldn't exist: the 'disabled' and 'inSchool' questions shouldn't show concurrently, because 'disabled' is hidden when child is >=18, and 'inSchool' is hidden when child is < 18

## Testing done
- Unit tests

## Screenshots
NA

## Acceptance criteria
- [x] No unit tests fail

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
