### PR TITLE
[WIP] Fix integration (Jest/Puppeteer) tests

### DIFF
--- a/config/jest-integration.config.js
+++ b/config/jest-integration.config.js
@@ -104,7 +104,7 @@ module.exports = {
   // restoreMocks: false,
 
   // The root directory that Jest should scan for tests and modules within
-  // rootDir: null,
+  rootDir: '../src',
 
   // A list of paths to directories that Jest should use to search for files in
   // roots: [


### PR DESCRIPTION
## Description
This config was moved into the `config` directory as part of cleaning up the repo root. I thought the config had been updated correctly when doing so, but running it now it looks like it needs another property added.

These tests are run via `npm run test:integration`. At the time, the tests passed, but they weren't incorporated into the CI so have gone unmaintained and now fail when you run them -

```
> jest -c=config/jest-integration.config.js

 FAIL  src/applications/proxy-rewrite/tests/health.integration.spec.js (23.274s)
  Veterans Health Administration page
    ✕ renders full screen size (7067ms)
    ✕ renders tablet screen size (5053ms)
    ✕ renders mobile screen size (4897ms)
    ✕ renders small mobile screen size (4571ms)

  ● Veterans Health Administration page › renders full screen size

    Expected image to match or be a close match to snapshot but was 17.440199577945403% different from snapshot (124297 differing pixels).
    See diff for details: /Users/nicksullivan/Repos/vagov/vets-website/src/applications/proxy-rewrite/tests/__image_snapshots__/__diff_output__/health-integration-spec-js-veterans-health-administration-page-renders-full-screen-size-1-diff.png

      20 |     await page.waitFor(1000);
      21 |     const image = await element.screenshot();
    > 22 |     expect(image).toMatchImageSnapshot();
         |                   ^
      23 |   };
      24 |   beforeAll(async () => {
      25 |     browser = await puppeteer.launch();

      at Object.toMatchImageSnapshot (applications/proxy-rewrite/tests/health.integration.spec.js:22:19)
      at tryCatch (../node_modules/regenerator-runtime/runtime.js:65:40)
      at Generator.invoke [as _invoke] (../node_modules/regenerator-runtime/runtime.js:303:22)
      at Generator.prototype.(anonymous function) [as next] (../node_modules/regenerator-runtime/runtime.js:117:21)
      at step (applications/proxy-rewrite/tests/health.integration.spec.js:3:191)
      at applications/proxy-rewrite/tests/health.integration.spec.js:3:361

  ● Veterans Health Administration page › renders tablet screen size

    Expected image to match or be a close match to snapshot but was 19.924949576938214% different from snapshot (129611 differing pixels).
    See diff for details: /Users/nicksullivan/Repos/vagov/vets-website/src/applications/proxy-rewrite/tests/__image_snapshots__/__diff_output__/health-integration-spec-js-veterans-health-administration-page-renders-tablet-screen-size-1-diff.png

      20 |     await page.waitFor(1000);
      21 |     const image = await element.screenshot();
    > 22 |     expect(image).toMatchImageSnapshot();
         |                   ^
      23 |   };
      24 |   beforeAll(async () => {
      25 |     browser = await puppeteer.launch();

      at Object.toMatchImageSnapshot (applications/proxy-rewrite/tests/health.integration.spec.js:22:19)
      at tryCatch (../node_modules/regenerator-runtime/runtime.js:65:40)
      at Generator.invoke [as _invoke] (../node_modules/regenerator-runtime/runtime.js:303:22)
      at Generator.prototype.(anonymous function) [as next] (../node_modules/regenerator-runtime/runtime.js:117:21)
      at step (applications/proxy-rewrite/tests/health.integration.spec.js:3:191)
      at applications/proxy-rewrite/tests/health.integration.spec.js:3:361

  ● Veterans Health Administration page › renders mobile screen size

    Expected image to match or be a close match to snapshot but was 31.500350877192986% different from snapshot (67332 differing pixels).
    See diff for details: /Users/nicksullivan/Repos/vagov/vets-website/src/applications/proxy-rewrite/tests/__image_snapshots__/__diff_output__/health-integration-spec-js-veterans-health-administration-page-renders-mobile-screen-size-1-diff.png

      20 |     await page.waitFor(1000);
      21 |     const image = await element.screenshot();
    > 22 |     expect(image).toMatchImageSnapshot();
         |                   ^
      23 |   };
      24 |   beforeAll(async () => {
      25 |     browser = await puppeteer.launch();

      at Object.toMatchImageSnapshot (applications/proxy-rewrite/tests/health.integration.spec.js:22:19)
      at tryCatch (../node_modules/regenerator-runtime/runtime.js:65:40)
      at Generator.invoke [as _invoke] (../node_modules/regenerator-runtime/runtime.js:303:22)
      at Generator.prototype.(anonymous function) [as next] (../node_modules/regenerator-runtime/runtime.js:117:21)
      at step (applications/proxy-rewrite/tests/health.integration.spec.js:3:191)
      at applications/proxy-rewrite/tests/health.integration.spec.js:3:361

  ● Veterans Health Administration page › renders small mobile screen size

    Expected image to match or be a close match to snapshot but was 30.774775904218643% different from snapshot (58914 differing pixels).
    See diff for details: /Users/nicksullivan/Repos/vagov/vets-website/src/applications/proxy-rewrite/tests/__image_snapshots__/__diff_output__/health-integration-spec-js-veterans-health-administration-page-renders-small-mobile-screen-size-1-diff.png

      20 |     await page.waitFor(1000);
      21 |     const image = await element.screenshot();
    > 22 |     expect(image).toMatchImageSnapshot();
         |                   ^
      23 |   };
      24 |   beforeAll(async () => {
      25 |     browser = await puppeteer.launch();

      at Object.toMatchImageSnapshot (applications/proxy-rewrite/tests/health.integration.spec.js:22:19)
      at tryCatch (../node_modules/regenerator-runtime/runtime.js:65:40)
      at Generator.invoke [as _invoke] (../node_modules/regenerator-runtime/runtime.js:303:22)
      at Generator.prototype.(anonymous function) [as next] (../node_modules/regenerator-runtime/runtime.js:117:21)
      at step (applications/proxy-rewrite/tests/health.integration.spec.js:3:191)
      at applications/proxy-rewrite/tests/health.integration.spec.js:3:361

 › 4 snapshots failed.
Snapshot Summary
 › 4 snapshots failed from 1 test suite. Inspect your code changes or run `npm run test:integration -- -u` to upd
ate them.

Test Suites: 1 failed, 1 total
Tests:       4 failed, 4 total
Snapshots:   4 failed, 4 total
Time:        24.197s, estimated 30s
Ran all test suites.

```

## Testing done


## Screenshots


## Acceptance criteria
- [ ] Integration tests run

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
