### PR TITLE
Prevent benefit alerts from coming back when they should not

### DIFF
--- a/src/applications/personalization/preferences/actions/index.js
+++ b/src/applications/personalization/preferences/actions/index.js
@@ -7,7 +7,7 @@ import {
   transformPreferencesForSaving,
   restoreDismissedBenefitAlerts,
   getDismissedBenefitAlerts,
-  // getNewSelections,
+  getNewSelections,
 } from '../helpers';
 
 export const FETCH_ALL_BENEFITS_STARTED = 'FETCH_ALL_BENEFITS_STARTED';
@@ -116,16 +116,10 @@ export function savePreferences(benefitsData) {
           type: SAVE_USER_PREFERENCES_SUCCEEDED,
         });
 
-        // TODO: use getNewSelections helper with staged and saved data
-        // const newBenefitSelections = getNewSelections(
-        //   getState().preferences.savedPreferences,
-        //   benefitsData,
-        // );
-        // TODO: remove this mock newBenefitSelections
-        // This re-enables an alert whenever any relevant benefit is included
-        // not only if it is a new addition to the selected benefits
-        const newBenefitSelections = Object.keys(benefitsData);
-        // Get alert names for new selections
+        const newBenefitSelections = getNewSelections(
+          getState().preferences.savedDashboard,
+          benefitsData,
+        );
 
         const newBenefitAlerts = benefitChoices
           .filter(

--- a/src/applications/personalization/preferences/tests/e2e/emptyPreferences.e2e.spec.js
+++ b/src/applications/personalization/preferences/tests/e2e/emptyPreferences.e2e.spec.js
@@ -21,7 +21,7 @@ function emptyPreferences(browser, token) {
     );
   });
 
-  // verify modal
+  // verify FTUX Find VA Benefits modal
   browser
     .url(`${E2eHelpers.baseUrl}/my-va`)
     .waitForElementVisible('.va-modal-body', Timeouts.slow);

--- a/src/applications/personalization/preferences/tests/e2e/helpers.js
+++ b/src/applications/personalization/preferences/tests/e2e/helpers.js
@@ -91,7 +91,24 @@ export function initChoicesGetMock(token) {
   });
 }
 
-// TODO: add delete all mock and test
+export function initDeleteMock(token) {
+  mock(token, {
+    path: '/v0/user/preferences/benefits/delete_all',
+    verb: 'delete',
+    value: {
+      value: {
+        data: {
+          id: 'string',
+          type: 'string',
+          attributes: {
+            preferenceCode: 'string',
+            userPreferences: [],
+          },
+        },
+      },
+    },
+  });
+}
 
 export function initHealthPostMock(token) {
   mock(token, {
@@ -141,6 +158,40 @@ export function initHealthGetMock(token) {
                 {
                   code: 'health-care',
                   description: 'Get health care coverage',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  });
+}
+
+export function initCareersAndEducationGetMock(token) {
+  mock(token, {
+    path: '/v0/user/preferences',
+    verb: 'get',
+    value: {
+      data: {
+        id: '',
+        type: 'arrays',
+        attributes: {
+          userPreferences: [
+            {
+              code: 'benefits',
+              title:
+                'the benefits a veteran is interested in, so VA.gov can help you apply for them',
+              userPreferences: [
+                {
+                  code: 'careers-employment',
+                  description:
+                    'Find a job, build skills, or get support for my own business',
+                },
+                {
+                  code: 'education-training',
+                  description:
+                    'GI Bill to help pay for college, training, or certification',
                 },
               ],
             },

--- a/src/applications/personalization/preferences/tests/e2e/selectedPreferences.e2e.spec.js
+++ b/src/applications/personalization/preferences/tests/e2e/selectedPreferences.e2e.spec.js
@@ -2,31 +2,65 @@ const E2eHelpers = require('platform/testing/e2e/helpers');
 const Timeouts = require('platform/testing/e2e/timeouts');
 const Auth = require('platform/testing/e2e/auth');
 
-import { initHealthGetMock } from './helpers';
+import {
+  initCareersAndEducationGetMock,
+  initDeleteMock,
+  initHealthPostMock,
+} from './helpers';
 // This would make a great candidate for integration testing
 // given the frequency of interaction between the FE and BE
 
+function removeFirstListedBenefit(browser) {
+  // click the "X REMOVE" button to start removing the benefit
+  browser.click('.preference-item-title .va-button-link');
+
+  // click the confirm button to remove the Education benefit
+  browser.waitForElementPresent(
+    '.usa-alert-warning button.usa-button-primary',
+    Timeouts.normal,
+  );
+  browser.click('.usa-alert-warning button.usa-button-primary');
+  browser.waitForElementNotPresent('.usa-alert-warning', Timeouts.slow);
+  browser.waitForElementPresent('.usa-alert-success', Timeouts.slow);
+}
+
 function selectedPreferences(browser, token) {
-  // Verify homelessness alert
-  initHealthGetMock(token);
+  initCareersAndEducationGetMock(token);
+  initHealthPostMock(token);
+  initDeleteMock(token);
+
+  // go to Dashboard
   browser
     .url(`${E2eHelpers.baseUrl}/my-va/`)
     .waitForElementVisible('.usa-alert-warning', Timeouts.slow);
+
+  // Verify homelessness alert
   browser.assert.containsText(
     '.usa-alert-warning',
     'If you’re homeless or at risk of becoming homeless:',
   );
 
-  // dismiss alert
+  // dismiss homelessness alert
   browser.click('.va-alert-close');
-  browser.waitForElementNotPresent('.usa-alert-warning', 5000);
+  browser.waitForElementNotPresent('.usa-alert-warning', Timeouts.slow);
 
-  // DELETE
-  browser.click('.preference-item-title .va-button-link');
-  browser.waitForElementPresent('.usa-alert-warning', Timeouts.normal);
+  // remove the Education benefit
+  removeFirstListedBenefit(browser);
 
-  // TODO: confirm delete
-  // TODO: check that benefit is gone
+  // confirm that the Homeless Alert does not reappear
+  browser.assert.elementNotPresent('.usa-alert-warning', Timeouts.slow);
+
+  // remove the Careers benefit
+  removeFirstListedBenefit(browser);
+
+  // confirm that the Homeless Alert does not reappear
+  browser.assert.elementNotPresent('.usa-alert-warning', Timeouts.slow);
+
+  // confirm there are no longer any benefits selected
+  browser.assert.containsText(
+    '.user-profile-row div div div p',
+    'You haven’t selected any benefits to learn about.',
+  );
 }
 
 module.exports = E2eHelpers.createE2eTest(browser => {


### PR DESCRIPTION
## Description
This fixes an issue where the previously-dismissed homeless alert would re-appear too aggressively on the My VA Dashboard. The most glaring example of this was as follows:

1. Select multiple benefits
2. Dismiss the homeless alert that appears on the dashboard
3. Delete a single benefit from the dashboard
4. The homeless alert would reappear if the homeless alert was associated with any of the remaining benefits

With this fix, the dismissed alert will only reappear if you _add_ a new benefit that is associated with the alert. We are still erring on the side of showing the alert more often vs. less often, but this is acceptable.

This should resolve department-of-veterans-affairs/vets.gov-team#16016 and resolve department-of-veterans-affairs/vets.gov-team#16076

## Testing done
Local tests, added e2e test

## Acceptance criteria
- [x] A previously-dismissed homeless alert does not come back after simply deleting a benefit from the Dashboard

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs