### PR TITLE
fix postal code error message on 781a Reports from authorities

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/secondaryIncidentAuthorities.js
+++ b/src/applications/disability-benefits/all-claims/pages/secondaryIncidentAuthorities.js
@@ -40,6 +40,10 @@ export const uiSchema = index => ({
           zipCode: {
             'ui:title': 'Postal Code',
             'ui:validations': [validateZIP],
+            'ui:errorMessages': {
+              pattern:
+                'Please enter a valid 5- or 9-digit Postal code (dashes allowed)',
+            },
           },
         }),
       },


### PR DESCRIPTION
## Description
781a reports from authorities information page was displaying an unreadable error message for the zip/postal code. Updated error message

## Screenshots
![image](https://user-images.githubusercontent.com/22040793/51051450-cc1ecf80-15a1-11e9-9bb5-d0c5be1fa300.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
