### PR TITLE
Fix 781 pages showing on summary page after changing/removing PTSD from new disabilities

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -10,11 +10,7 @@ import ConfirmationPoll from '../components/ConfirmationPoll';
 import GetFormHelp from '../../components/GetFormHelp';
 import ErrorText from '../../components/ErrorText';
 
-import {
-  hasMilitaryRetiredPay,
-  hasRatedDisabilities,
-  hasNewPtsdDisability,
-} from '../validations';
+import { hasMilitaryRetiredPay, hasRatedDisabilities } from '../validations';
 
 import {
   hasGuardOrReservePeriod,
@@ -33,6 +29,7 @@ import {
   isNotUploadingPrivateMedical,
   showPtsdCombatConclusion,
   showPtsdAssaultConclusion,
+  hasNewPtsdDisability,
 } from '../utils';
 
 import { transform } from '../submit-transformer';

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -27,8 +27,6 @@ import {
   isUploading781aForm,
   servedAfter911,
   isNotUploadingPrivateMedical,
-  showPtsdCombatConclusion,
-  showPtsdAssaultConclusion,
   hasNewPtsdDisability,
 } from '../utils';
 
@@ -308,9 +306,7 @@ const formConfig = {
           title: 'Upload PTSD Documents - 781',
           path: 'new-disabilities/ptsd-781-upload',
           depends: formData =>
-            hasNewPtsdDisability(formData) &&
-            needsToEnter781(formData) &&
-            isUploading781Form(formData),
+            needsToEnter781(formData) && isUploading781Form(formData),
           uiSchema: uploadPtsdDocuments.uiSchema,
           schema: uploadPtsdDocuments.schema,
         },
@@ -334,7 +330,7 @@ const formConfig = {
         conclusionCombat: {
           path: 'ptsd-conclusion-combat',
           title: 'PTSD combat conclusion',
-          depends: showPtsdCombatConclusion,
+          depends: needsToEnter781,
           uiSchema: conclusionCombat.uiSchema,
           schema: conclusionCombat.schema,
         },
@@ -343,8 +339,7 @@ const formConfig = {
         ptsdWalkthroughChoice781a: {
           title: 'Answer online questions or upload paper 21-0781A?',
           path: 'new-disabilities/walkthrough-781a-choice',
-          depends: formData =>
-            hasNewPtsdDisability(formData) && needsToEnter781a(formData),
+          depends: needsToEnter781a,
           uiSchema: ptsdWalkthroughChoice781a.uiSchema,
           schema: ptsdWalkthroughChoice781a.schema,
         },
@@ -355,9 +350,7 @@ const formConfig = {
           title: 'Upload PTSD Documents - 781a',
           path: 'new-disabilities/ptsd-781a-upload',
           depends: formData =>
-            hasNewPtsdDisability(formData) &&
-            needsToEnter781a(formData) &&
-            isUploading781aForm(formData),
+            needsToEnter781a(formData) && isUploading781aForm(formData),
           uiSchema: uploadPersonalPtsdDocuments.uiSchema,
           schema: uploadPersonalPtsdDocuments.schema,
         },
@@ -413,7 +406,7 @@ const formConfig = {
         conclusionAssault: {
           path: 'ptsd-conclusion-assault',
           title: 'PTSD assault conclusion',
-          depends: showPtsdAssaultConclusion,
+          depends: needsToEnter781a,
           uiSchema: conclusionAssault.uiSchema,
           schema: conclusionAssault.schema,
         },

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { capitalizeEachWord, hasNewPtsdDisability } from '../utils';
+import { capitalizeEachWord, isDisabilityPtsd } from '../utils';
 import { ptsdTypeEnum } from './ptsdTypeInfo';
 
 const mapDisabilityName = (disabilityName, formData, index) => {
-  if (hasNewPtsdDisability(formData)) {
+  if (isDisabilityPtsd(disabilityName)) {
     const selectablePtsdTypes = formData['view:selectablePtsdTypes'];
     if (selectablePtsdTypes) {
       const selectedPtsdTypes = Object.keys(selectablePtsdTypes)

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { capitalizeEachWord } from '../utils';
-import { isDisabilityPtsd } from '../validations';
+import { capitalizeEachWord, isDisabilityPtsd } from '../utils';
 import { ptsdTypeEnum } from './ptsdTypeInfo';
 
 const mapDisabilityName = (disabilityName, formData, index) => {

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -31,11 +31,12 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
         .filter(disability => disability['view:selected'])
         .map(disability => capitalizeEachWord(disability.name))
     : [];
-  const newDisabilityNames = newDisabilities
-    ? newDisabilities.map(disability =>
-        capitalizeEachWord(disability.condition),
-      )
-    : [];
+  const newDisabilityNames =
+    newDisabilities && formData['view:newDisablities']
+      ? newDisabilities.map(disability =>
+          capitalizeEachWord(disability.condition),
+        )
+      : [];
   const selectedDisabilitiesList = ratedDisabilityNames
     .concat(newDisabilityNames)
     .map((name, i) => mapDisabilityName(name, formData, i));

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { capitalizeEachWord, isDisabilityPtsd } from '../utils';
+import { capitalizeEachWord, hasNewPtsdDisability } from '../utils';
 import { ptsdTypeEnum } from './ptsdTypeInfo';
 
 const mapDisabilityName = (disabilityName, formData, index) => {
-  if (isDisabilityPtsd(disabilityName)) {
+  if (hasNewPtsdDisability(formData)) {
     const selectablePtsdTypes = formData['view:selectablePtsdTypes'];
     if (selectablePtsdTypes) {
       const selectedPtsdTypes = Object.keys(selectablePtsdTypes)

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -32,7 +32,7 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
         .map(disability => capitalizeEachWord(disability.name))
     : [];
   const newDisabilityNames =
-    newDisabilities && formData['view:newDisablities']
+    newDisabilities && formData['view:newDisabilities']
       ? newDisabilities.map(disability =>
           capitalizeEachWord(disability.condition),
         )

--- a/src/applications/disability-benefits/all-claims/tests/content/summaryOfDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/summaryOfDisabilities.unit.spec.jsx
@@ -50,6 +50,7 @@ describe('summaryOfDisabilitiesDescription', () => {
 
   it('renders new disabilities', () => {
     const formData = {
+      'view:newDisabilities': true,
       newDisabilities: [
         { condition: 'Condition 1' },
         { condition: 'Condition 2' },

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -719,7 +719,7 @@ describe('isAnswering781aQuestions', () => {
   });
 
   describe('isUploading781aSupportingDocuments', () => {
-    it('should return true when a use selects yes to upload sources', () => {
+    it('should return true when a user selects yes to upload sources', () => {
       const formData = {
         'view:newDisabilities': true,
         newDisabilities: [

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -423,6 +423,12 @@ describe('526 helpers', () => {
   describe('needsToEnter781', () => {
     it('should return true if user has selected Combat PTSD types', () => {
       const formData = {
+        'view:newDisabilities': true,
+        newDisabilities: [
+          {
+            condition: 'Ptsd personal trauma',
+          },
+        ],
         'view:selectablePtsdTypes': {
           'view:combatPtsdType': true,
         },
@@ -432,6 +438,12 @@ describe('526 helpers', () => {
 
     it('should return true if user has selected Non-combat PTSD types', () => {
       const formData = {
+        'view:newDisabilities': true,
+        newDisabilities: [
+          {
+            condition: 'Ptsd personal trauma',
+          },
+        ],
         'view:selectablePtsdTypes': {
           'view:nonCombatPtsdType': true,
         },
@@ -448,6 +460,12 @@ describe('526 helpers', () => {
   describe('needsToEnter781a', () => {
     it('should return true if user has selected MST PTSD types', () => {
       const formData = {
+        'view:newDisabilities': true,
+        newDisabilities: [
+          {
+            condition: 'Ptsd personal trauma',
+          },
+        ],
         'view:selectablePtsdTypes': {
           'view:mstPtsdType': true,
         },
@@ -457,6 +475,12 @@ describe('526 helpers', () => {
 
     it('should return true if user has selected Assault PTSD types', () => {
       const formData = {
+        'view:newDisabilities': true,
+        newDisabilities: [
+          {
+            condition: 'Ptsd personal trauma',
+          },
+        ],
         'view:selectablePtsdTypes': {
           'view:assaultPtsdType': true,
         },
@@ -487,6 +511,12 @@ describe('526 helpers', () => {
   describe('isUploading781aForm', () => {
     it('should return true if user has chosen to upload 781a', () => {
       const formData = {
+        'view:newDisabilities': true,
+        newDisabilities: [
+          {
+            condition: 'Ptsd personal trauma',
+          },
+        ],
         'view:upload781aChoice': 'upload',
       };
       expect(isUploading781aForm(formData)).to.be.true;
@@ -526,16 +556,15 @@ describe('526 helpers', () => {
   });
 });
 
-describe('isAnsweringPtsdForm', () => {
-  it('should return false if user has chosen to not answer questions', () => {
-    const formData = {};
-    expect(needsToEnter781(formData)).to.be.false;
-  });
-});
-
 describe('isAnswering781Questions', () => {
   it('should return true if user is answering first set of 781 incident questions', () => {
     const formData = {
+      'view:newDisabilities': true,
+      newDisabilities: [
+        {
+          condition: 'Ptsd personal trauma',
+        },
+      ],
       'view:selectablePtsdTypes': {
         'view:combatPtsdType': true,
       },
@@ -545,6 +574,12 @@ describe('isAnswering781Questions', () => {
   });
   it('should return true if user has chosen to answer questions for a 781 PTSD incident', () => {
     const formData = {
+      'view:newDisabilities': true,
+      newDisabilities: [
+        {
+          condition: 'Ptsd personal trauma',
+        },
+      ],
       'view:selectablePtsdTypes': {
         'view:combatPtsdType': true,
       },
@@ -593,6 +628,12 @@ describe('transformMVPData', () => {
 describe('isAnswering781Questions', () => {
   it('should return true if user is answering first set of 781 incident questions', () => {
     const formData = {
+      'view:newDisabilities': true,
+      newDisabilities: [
+        {
+          condition: 'Ptsd personal trauma',
+        },
+      ],
       'view:selectablePtsdTypes': {
         'view:combatPtsdType': true,
       },
@@ -602,6 +643,12 @@ describe('isAnswering781Questions', () => {
   });
   it('should return true if user has chosen to answer questions for a 781 PTSD incident', () => {
     const formData = {
+      'view:newDisabilities': true,
+      newDisabilities: [
+        {
+          condition: 'Ptsd personal trauma',
+        },
+      ],
       'view:selectablePtsdTypes': {
         'view:combatPtsdType': true,
       },
@@ -625,6 +672,12 @@ describe('isAnswering781Questions', () => {
 describe('isAnswering781aQuestions', () => {
   it('should return true if user is answering first set of 781a incident questions', () => {
     const formData = {
+      'view:newDisabilities': true,
+      newDisabilities: [
+        {
+          condition: 'Ptsd personal trauma',
+        },
+      ],
       'view:selectablePtsdTypes': {
         'view:assaultPtsdType': true,
       },
@@ -634,6 +687,12 @@ describe('isAnswering781aQuestions', () => {
   });
   it('should return true if user has chosen to answer questions for a 781a PTSD incident', () => {
     const formData = {
+      'view:newDisabilities': true,
+      newDisabilities: [
+        {
+          condition: 'Ptsd personal trauma',
+        },
+      ],
       'view:selectablePtsdTypes': {
         'view:assaultPtsdType': true,
       },
@@ -644,6 +703,12 @@ describe('isAnswering781aQuestions', () => {
   });
   it('should return false if user has chosen not to enter another incident', () => {
     const formData = {
+      'view:newDisabilities': true,
+      newDisabilities: [
+        {
+          condition: 'Ptsd personal trauma',
+        },
+      ],
       'view:selectablePtsdTypes': {
         'view:assaultPtsdType': true,
       },
@@ -656,6 +721,12 @@ describe('isAnswering781aQuestions', () => {
   describe('isUploading781aSupportingDocuments', () => {
     it('', () => {
       const formData = {
+        'view:newDisabilities': true,
+        newDisabilities: [
+          {
+            condition: 'Ptsd personal trauma',
+          },
+        ],
         'view:selectablePtsdTypes': {
           'view:assaultPtsdType': true,
         },

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -719,7 +719,7 @@ describe('isAnswering781aQuestions', () => {
   });
 
   describe('isUploading781aSupportingDocuments', () => {
-    it('', () => {
+    it('should return true when a use selects yes to upload sources', () => {
       const formData = {
         'view:newDisabilities': true,
         newDisabilities: [
@@ -730,6 +730,7 @@ describe('isAnswering781aQuestions', () => {
         'view:selectablePtsdTypes': {
           'view:assaultPtsdType': true,
         },
+        'view:upload781aChoice': 'answerQuestions',
         secondaryIncident0: {
           'view:uploadSources': true,
         },

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -459,11 +459,14 @@ const post911Periods = createSelector(
 
 export const servedAfter911 = formData => !!post911Periods(formData).length;
 
-export const isDisabilityPtsd = disability => lowerCase(disability).includes(PTSD)
+export const isDisabilityPtsd = disability =>
+  lowerCase(disability).includes(PTSD);
 
 export const hasNewPtsdDisability = formData =>
   _.get('view:newDisabilities', formData, false) &&
-  some(_.get('newDisabilities', formData, []), item => isDisabilityPtsd(item.condition)
+  some(_.get('newDisabilities', formData, []), item =>
+    isDisabilityPtsd(item.condition),
+  );
 
 export const needsToEnter781 = formData =>
   hasNewPtsdDisability(formData) &&

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -459,12 +459,15 @@ const post911Periods = createSelector(
 
 export const servedAfter911 = formData => !!post911Periods(formData).length;
 
+export const isDisabilityPtsd = disability =>
+  disability.toLowerCase().includes(PTSD);
+
 export const hasNewPtsdDisability = formData =>
   _.get('view:newDisabilities', formData, false) &&
   some(_.get('newDisabilities', formData, []), item => {
     let hasPtsd = false;
     if (item && typeof item.condition === 'string') {
-      hasPtsd = item.condition.toLowerCase().includes(PTSD);
+      hasPtsd = isDisabilityPtsd(item.condition);
     }
     return hasPtsd;
   });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -394,15 +394,12 @@ const post911Periods = createSelector(
 
 export const servedAfter911 = formData => !!post911Periods(formData).length;
 
-export const isDisabilityPtsd = disability =>
-  disability.toLowerCase().includes(PTSD);
-
 export const hasNewPtsdDisability = formData =>
   _.get('view:newDisabilities', formData, false) &&
   some(_.get('newDisabilities', formData, []), item => {
     let hasPtsd = false;
     if (item && typeof item.condition === 'string') {
-      hasPtsd = isDisabilityPtsd(item.condition);
+      hasPtsd = item.condition.toLowerCase().includes(PTSD);
     }
     return hasPtsd;
   });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import Raven from 'raven-js';
 import appendQuery from 'append-query';
 import { createSelector } from 'reselect';
-import { omit, some } from 'lodash';
+import { omit, some, lowerCase } from 'lodash';
 import { apiRequest } from '../../../platform/utilities/api';
 import environment from '../../../platform/utilities/environment';
 import _ from '../../../platform/utilities/data';
@@ -459,18 +459,11 @@ const post911Periods = createSelector(
 
 export const servedAfter911 = formData => !!post911Periods(formData).length;
 
-export const isDisabilityPtsd = disability =>
-  disability.toLowerCase().includes(PTSD);
+export const isDisabilityPtsd = disability => lowerCase(disability).includes(PTSD)
 
 export const hasNewPtsdDisability = formData =>
   _.get('view:newDisabilities', formData, false) &&
-  some(_.get('newDisabilities', formData, []), item => {
-    let hasPtsd = false;
-    if (item && typeof item.condition === 'string') {
-      hasPtsd = isDisabilityPtsd(item.condition);
-    }
-    return hasPtsd;
-  });
+  some(_.get('newDisabilities', formData, []), item => isDisabilityPtsd(item.condition)
 
 export const needsToEnter781 = formData =>
   hasNewPtsdDisability(formData) &&

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -397,28 +397,25 @@ export const servedAfter911 = formData => !!post911Periods(formData).length;
 export const isDisabilityPtsd = disability =>
   disability.toLowerCase().includes(PTSD);
 
-export const hasNewPtsdDisability = formData => {
-  if (!_.get('view:newDisabilities', formData, false)) {
-    return false;
-  }
-  return some(_.get('newDisabilities', formData, []), item => {
+export const hasNewPtsdDisability = formData =>
+  _.get('view:newDisabilities', formData, false) &&
+  some(_.get('newDisabilities', formData, []), item => {
     let hasPtsd = false;
     if (item && typeof item.condition === 'string') {
       hasPtsd = isDisabilityPtsd(item.condition);
     }
     return hasPtsd;
   });
-};
 
 export const needsToEnter781 = formData =>
-  (hasNewPtsdDisability(formData) &&
-    _.get('view:selectablePtsdTypes.view:combatPtsdType', formData, false)) ||
-  _.get('view:selectablePtsdTypes.view:nonCombatPtsdType', formData, false);
+  hasNewPtsdDisability(formData) &&
+  (_.get('view:selectablePtsdTypes.view:combatPtsdType', formData, false) ||
+    _.get('view:selectablePtsdTypes.view:nonCombatPtsdType', formData, false));
 
 export const needsToEnter781a = formData =>
-  (hasNewPtsdDisability(formData) &&
-    _.get('view:selectablePtsdTypes.view:mstPtsdType', formData, false)) ||
-  _.get('view:selectablePtsdTypes.view:assaultPtsdType', formData, false);
+  hasNewPtsdDisability(formData) &&
+  (_.get('view:selectablePtsdTypes.view:mstPtsdType', formData, false) ||
+    _.get('view:selectablePtsdTypes.view:assaultPtsdType', formData, false));
 
 export const isUploading781Form = formData =>
   _.get('view:upload781Choice', formData, '') === 'upload';
@@ -427,23 +424,19 @@ export const isUploading781aForm = formData =>
   _.get('view:upload781aChoice', formData, '') === 'upload';
 
 export const isAnswering781Questions = index => formData =>
+  needsToEnter781(formData) &&
   _.get('view:upload781Choice', formData, '') === 'answerQuestions' &&
-  (index === 0 ||
-    _.get(`view:enterAdditionalEvents${index - 1}`, formData, false)) &&
-  needsToEnter781(formData);
+  (_.get(`view:enterAdditionalEvents${index - 1}`, formData, false) ||
+    index === 0);
 
 export const isAnswering781aQuestions = index => formData =>
+  needsToEnter781a(formData) &&
   _.get('view:upload781aChoice', formData, '') === 'answerQuestions' &&
-  (index === 0 ||
-    _.get(
-      `view:enterAdditionalSecondaryEvents${index - 1}`,
-      formData,
-      false,
-    )) &&
-  needsToEnter781a(formData);
+  (_.get(`view:enterAdditionalSecondaryEvents${index - 1}`, formData, false) ||
+    index === 0);
 
 export const isUploading781aSupportingDocuments = index => formData =>
-  isAnswering781aQuestions(formData) &&
+  isAnswering781aQuestions(index)(formData) &&
   _.get(`secondaryIncident${index}.view:uploadSources`, formData, false);
 
 export const isAddingIndividuals = index => formData =>
@@ -460,16 +453,6 @@ export const getHomelessOrAtRisk = formData => {
 
 export const isNotUploadingPrivateMedical = formData =>
   _.get(DATA_PATHS.hasPrivateRecordsToUpload, formData) === false;
-
-export const showPtsdCombatConclusion = formData =>
-  (needsToEnter781(formData) &&
-    _.get('view:selectablePtsdTypes.view:combatPtsdType', formData, false)) ||
-  _.get('view:selectablePtsdTypes.view:nonCombatPtsdType', formData, false);
-
-export const showPtsdAssaultConclusion = formData =>
-  (needsToEnter781a(formData) &&
-    _.get('view:selectablePtsdTypes.view:mstPtsdType', formData, false)) ||
-  _.get('view:selectablePtsdTypes.view:assaultPtsdType', formData, false);
 
 export const needsToEnterUnemployability = formData =>
   _.get('view:unemployable', formData, false);

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -426,9 +426,6 @@ export const isUploading781Form = formData =>
 export const isUploading781aForm = formData =>
   _.get('view:upload781aChoice', formData, '') === 'upload';
 
-export const isUploading781aSupportingDocuments = index => formData =>
-  _.get(`secondaryIncident${index}.view:uploadSources`, formData, false);
-
 export const isAnswering781Questions = index => formData =>
   _.get('view:upload781Choice', formData, '') === 'answerQuestions' &&
   (index === 0 ||
@@ -444,6 +441,10 @@ export const isAnswering781aQuestions = index => formData =>
       false,
     )) &&
   needsToEnter781a(formData);
+
+export const isUploading781aSupportingDocuments = index => formData =>
+  isAnswering781aQuestions(formData) &&
+  _.get(`secondaryIncident${index}.view:uploadSources`, formData, false);
 
 export const isAddingIndividuals = index => formData =>
   isAnswering781Questions(index)(formData) &&

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -1,7 +1,7 @@
 import _ from '../../../platform/utilities/data';
 import some from 'lodash/some';
 import moment from 'moment';
-import { MILITARY_CITIES, MILITARY_STATE_VALUES, PTSD } from './constants';
+import { MILITARY_CITIES, MILITARY_STATE_VALUES } from './constants';
 
 export const hasMilitaryRetiredPay = data =>
   _.get('view:hasMilitaryRetiredPay', data, false);
@@ -148,22 +148,6 @@ export const oneDisabilityRequired = disabilityList => (
         : 'Please select at least one disability from the lists below.';
     errors.addError(errMsg);
   }
-};
-
-export const isDisabilityPtsd = disability =>
-  disability.toLowerCase().includes(PTSD);
-
-export const hasNewPtsdDisability = formData => {
-  if (!_.get('view:newDisabilities', formData, false)) {
-    return false;
-  }
-  return some(_.get('newDisabilities', formData, []), item => {
-    let hasPtsd = false;
-    if (item && typeof item.condition === 'string') {
-      hasPtsd = isDisabilityPtsd(item.condition);
-    }
-    return hasPtsd;
-  });
 };
 
 export const isInFuture = (err, fieldData) => {


### PR DESCRIPTION
## Description
Updated 781 depends functions to check for newDisabilities to contain a PTSD/be checked.

See issues:
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/16164
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/16191

## Testing done
- [x] manual testing
- [x] unit tests updated

## Screenshots

**Current state of summary page**
![image](https://user-images.githubusercontent.com/22040793/51123339-dfbc7700-17e9-11e9-991d-ce21a1fd969f.png)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
