### PR TITLE
Remove connected accounts copy from main account page

### DIFF
--- a/src/applications/personalization/account/components/AccountMain.jsx
+++ b/src/applications/personalization/account/components/AccountMain.jsx
@@ -129,12 +129,6 @@ class AccountMain extends React.Component {
         <LoginSettings />
         {verified && <TermsAndConditions mhvAccount={mhvAccount} />}
 
-        <h3>Connected accounts</h3>
-        <p>
-          Manage the sites and applications that you've granted access to your
-          {propertyName} profile data.
-        </p>
-        <a href="/account/connected-accounts">Manage your connected accounts</a>
         <div className="feature">
           <h3>Have questions about signing in to {propertyName}?</h3>
           <p>


### PR DESCRIPTION
## Description

The connected account feature is not live yet, but the copy is currently appearing in production on the main account page, see screenshot below.

## Screenshots

![image](https://user-images.githubusercontent.com/955558/51186130-dc3af580-18a6-11e9-9b16-325227efcc26.png)

## Acceptance criteria
- [x] Connected accounts page no longer appears in production.

Refs https://github.com/department-of-veterans-affairs/vets-contrib/issues/1006
