### PR TITLE
Fix Dashboard focus bug

### DIFF
--- a/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
@@ -4,27 +4,27 @@ import moment from 'moment';
 import React from 'react';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation/LoadingIndicator';
-import backendServices from '../../../../platform/user/profile/constants/backendServices';
+import backendServices from 'platform/user/profile/constants/backendServices';
 import {
   APPEAL_V2_TYPE,
   claimsAvailability,
   appealsAvailability,
-} from '../../../claims-status/utils/appeals-v2-helpers';
+} from 'applications/claims-status/utils/appeals-v2-helpers';
 
 import {
   getAppealsV2,
   getClaimsV2,
-} from '../../../claims-status/actions/index.jsx';
-import { scrollToTop } from '../../../claims-status/utils/page';
-import recordEvent from '../../../../platform/monitoring/record-event';
+} from 'applications/claims-status/actions/index.jsx';
+import { scrollToTop } from 'applications/claims-status/utils/page';
+import recordEvent from 'platform/monitoring/record-event';
 
-import ClaimsUnavailable from '../../../claims-status/components/ClaimsUnavailable';
-import AppealsUnavailable from '../../../claims-status/components/AppealsUnavailable';
-import ClaimsAppealsUnavailable from '../../../claims-status/components/ClaimsAppealsUnavailable';
+import ClaimsUnavailable from 'applications/claims-status/components/ClaimsUnavailable';
+import AppealsUnavailable from 'applications/claims-status/components/AppealsUnavailable';
+import ClaimsAppealsUnavailable from 'applications/claims-status/components/ClaimsAppealsUnavailable';
 
 import DowntimeNotification, {
   externalServices,
-} from '../../../../platform/monitoring/DowntimeNotification';
+} from 'platform/monitoring/DowntimeNotification';
 import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 
 import ClaimsListItem from '../components/ClaimsListItem';
@@ -149,10 +149,7 @@ class ClaimsAppealsWidget extends React.Component {
 
     if (bothRequestsLoading || (atLeastOneRequestLoading && emptyList)) {
       content = (
-        <LoadingIndicator
-          message="Loading your claims and appeals..."
-          setFocus
-        />
+        <LoadingIndicator message="Loading your claims and appeals..." />
       );
     } else if (!emptyList) {
       content = (


### PR DESCRIPTION
## Description
Prevent the Claims and Appeals widget's loading spinner from hijacking
the focus when it appears.

## Testing done
Local testing with user+0 to confirm content no longer scrolls to the widget when its loading spinner appears

## Acceptance criteria
- [ ] Trevor is happy

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs