### PR TITLE
a11y fixes for Find VA Benefits FTUX modal

### DIFF
--- a/src/platform/site-wide/announcements/components/FindVABenefitsIntro.jsx
+++ b/src/platform/site-wide/announcements/components/FindVABenefitsIntro.jsx
@@ -5,9 +5,9 @@ export default function FindVABenefitsIntro({ dismiss }) {
   return (
     <Modal visible onClose={dismiss} id="modal-announcement">
       <div className="announcement-heading">
-        <img alt="form icon" src="/img/dashboard-form.svg" />
+        <img aria-hidden="true" alt="" src="/img/dashboard-form.svg" />
       </div>
-      <h3 className="announcement-title">
+      <h3 className="announcement-title" id="modal-announcement-title">
         We can help you find and apply for benefits.
       </h3>
       <p>

--- a/src/platform/site-wide/announcements/index.jsx
+++ b/src/platform/site-wide/announcements/index.jsx
@@ -9,7 +9,7 @@ import './sass/style.scss';
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import localStorage from '../../../platform/utilities/storage/localStorage';
+import localStorage from 'platform/utilities/storage/localStorage';
 
 import startReactApp from '../../startup/react';
 import Announcement from './containers/Announcement';


### PR DESCRIPTION
Related PR: https://github.com/department-of-veterans-affairs/design-system/pull/223

## Description
Along with https://github.com/department-of-veterans-affairs/design-system/pull/223 this PR addressed the issues in https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/16152, with the exception of adding the `tabindex="0"` to the `div.va-modal-body`, which throws a `jsx-a11y` error.

## Testing done
Local, verified final rendered markup

## Screenshots
<img width="1108" alt="screen shot 2019-01-15 at 10 16 34 am" src="https://user-images.githubusercontent.com/20728956/51200701-14decd00-18af-11e9-85f1-486303f16621.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs