### PR TITLE
4192: Document Type dropdown display during upload#15649

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/4192/index.js
+++ b/src/applications/disability-benefits/all-claims/config/4192/index.js
@@ -10,10 +10,15 @@ import {
 import { needsToEnterUnemployability } from '../../utils';
 
 // const showFormTutorial = formData => _.get(formData, 'view:upload4192Choice.view:4192Info', false);
+
 const isDownloading = formData =>
-  _.get(formData, 'view:upload4192Choice.view:download4192', false);
+  _.get(formData, 'view:upload4192Choice.view:download4192', false) &&
+  needsToEnterUnemployability(formData);
+
 const isUploading = formData =>
-  _.get(formData, 'view:upload4192Choice.view:upload4192', false);
+  _.get(formData, 'view:upload4192Choice.view:upload4192', false) &&
+  needsToEnterUnemployability(formData);
+
 // const isExiting = formData => _.get(formData, 'view:upload4192Choice.view:sendRequests', false);
 
 export default function() {
@@ -31,16 +36,14 @@ export default function() {
       // Download
       pastEmploymentFormDownload: {
         path: 'past-employment-download',
-        depends: formData =>
-          isDownloading(formData) && needsToEnterUnemployability(formData),
+        depends: isDownloading,
         uiSchema: pastEmploymentFormDownload.uiSchema,
         schema: pastEmploymentFormDownload.schema,
       },
       // Upload
       pastEmploymentFormUpload: {
         path: 'past-employment-form-upload',
-        depends: formData =>
-          isUploading(formData) && needsToEnterUnemployability(formData),
+        depends: isUploading,
         uiSchema: pastEmploymentFormUpload.uiSchema,
         schema: pastEmploymentFormUpload.schema,
       },

--- a/src/applications/disability-benefits/all-claims/config/4192/index.js
+++ b/src/applications/disability-benefits/all-claims/config/4192/index.js
@@ -4,15 +4,40 @@ import { pastEmploymentFormIntro } from '../../pages';
 
 import { needsToEnterUnemployability } from '../../utils';
 
+// const showFormTutorial = formData => _.get(formData, 'view:upload4192Choice.view:4192Info', false);
+// const isDownloading = formData =>
+// _.get(formData, 'view:upload4192Choice.view:download4192', false);
+// const isUploading = formData =>
+//   _.get(formData, 'view:upload4192Choice.view:upload4192', false);
+// const isExiting = formData => _.get(formData, 'view:upload4192Choice.view:sendRequests', false);
 export default function() {
   let configObj = {};
   if (!environment.isProduction()) {
     configObj = {
       pastEmploymentFormIntro: {
         path: 'past-employment-walkthrough-choice',
+        depends: needsToEnterUnemployability,
         uiSchema: pastEmploymentFormIntro.uiSchema,
         schema: pastEmploymentFormIntro.schema,
       },
+      // Form Tutorial (multiple pages)
+      // Download
+      // Upload
+      pastEmploymentFormUpload: {
+        path: '',
+      },
+      // ***Below page comments for when logic is added in***
+      // Conditional Options (Intro page again if A and not A && B && C)
+      // Form Tutorial (multiple pages)
+      // Download
+      // Upload
+      // Conditional Options (Intro page again if A and not A && B && C)
+      // Form Tutorial (multiple pages)
+      // Download
+      // Upload
+      // Conditional Options (Intro page again if A and not A && B && C)
+      // ***Above page comments for when logic is added in***
+      // Exit
       conclusion4192: {
         title: 'Conclusion 4192',
         path: 'disabilities/conclusion-4192',

--- a/src/applications/disability-benefits/all-claims/config/4192/index.js
+++ b/src/applications/disability-benefits/all-claims/config/4192/index.js
@@ -1,6 +1,6 @@
 import environment from '../../../../../platform/utilities/environment';
 
-import { pastEmploymentFormIntro } from '../../pages';
+import { pastEmploymentFormIntro, pastEmploymentFormUpload } from '../../pages';
 
 import { needsToEnterUnemployability } from '../../utils';
 
@@ -8,8 +8,9 @@ import { needsToEnterUnemployability } from '../../utils';
 // const isDownloading = formData =>
 // _.get(formData, 'view:upload4192Choice.view:download4192', false);
 // const isUploading = formData =>
-//   _.get(formData, 'view:upload4192Choice.view:upload4192', false);
+// _.get(formData, 'view:upload4192Choice.view:upload4192', false);
 // const isExiting = formData => _.get(formData, 'view:upload4192Choice.view:sendRequests', false);
+
 export default function() {
   let configObj = {};
   if (!environment.isProduction()) {
@@ -24,7 +25,11 @@ export default function() {
       // Download
       // Upload
       pastEmploymentFormUpload: {
-        path: '',
+        path: 'past-employment-form-upload',
+        // depends: formData =>
+        // isUploading(formData) && needsToEnterUnemployability(formData),
+        uiSchema: pastEmploymentFormUpload.uiSchema,
+        schema: pastEmploymentFormUpload.schema,
       },
       // ***Below page comments for when logic is added in***
       // Conditional Options (Intro page again if A and not A && B && C)

--- a/src/applications/disability-benefits/all-claims/config/8940/index.js
+++ b/src/applications/disability-benefits/all-claims/config/8940/index.js
@@ -111,7 +111,7 @@ export default function() {
       militaryDutyImpact: {
         title: 'Impact on military duty',
         path: 'military-duty-impact',
-        depends: needsToEnterUnemployability,
+        depends: needsToAnswerUnemployability,
         uiSchema: militaryDutyImpact.uiSchema,
         schema: militaryDutyImpact.schema,
       },

--- a/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
+++ b/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
@@ -20,7 +20,7 @@ export const download4192Notice = (
     {claimsIntakeAddress}
     <p>Or fax them toll-free: 1-844-531-7818</p>
     <p>
-      If you need help completing this form, they can call Veterans Benefits
+      If they need help completing this form, they can call Veterans Benefits
       Assistance at 1-800-827-1000.
     </p>
   </div>

--- a/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
+++ b/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { VA_FORM4142_URL } from '../constants';
+import { VA_FORM4192_URL } from '../constants';
 import { claimsIntakeAddress } from './itfWrapper';
 
 export const download4192Notice = (
   <div>
     <p>
-      <a href={VA_FORM4142_URL} target="_blank">
-        Download VA Form 21-4142
+      <a href={VA_FORM4192_URL} target="_blank">
+        Download VA Form 21-4192
       </a>
     </p>
     <p>

--- a/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
+++ b/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
@@ -5,7 +5,7 @@ import { claimsIntakeAddress } from './itfWrapper';
 export const download4192Notice = (
   <div>
     <p>
-      <a href={VA_FORM4192_URL} target="_blank">
+      <a href={VA_FORM4192_URL} target="_blank" rel="noopener">
         Download VA Form 21-4192
       </a>
     </p>

--- a/src/applications/disability-benefits/all-claims/pages/hospitalizationHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/hospitalizationHistory.js
@@ -42,7 +42,7 @@ export const uiSchema = {
           'ui:title': 'Hospital’s name',
         },
         'view:hospitalAddressTitle': {
-          'ui:title': "Hospital's address",
+          'ui:title': 'Hospital’s address',
         },
         address: addressUI,
         dates: {

--- a/src/applications/disability-benefits/all-claims/pages/hospitalizationHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/hospitalizationHistory.js
@@ -23,7 +23,7 @@ const { addressUI, addressSchema } = generateAddressSchemas(
     addressLine2: 'Street address (optional)',
     city: 'City',
     state: 'State',
-    zipCode: 'ZIP',
+    zipCode: 'Postal Code',
   },
 );
 
@@ -39,7 +39,10 @@ export const uiSchema = {
       },
       items: {
         name: {
-          'ui:title': 'Name of hospital',
+          'ui:title': 'Hospital’s name',
+        },
+        'view:hospitalAddressTitle': {
+          'ui:title': "Hospital's address",
         },
         address: addressUI,
         dates: {
@@ -70,8 +73,13 @@ export const schema = {
           items: {
             type: 'object',
             properties: {
-              ...hospitalProvidedCare.items.properties,
+              name: hospitalProvidedCare.items.properties.name,
+              'view:hospitalAddressTitle': {
+                type: 'object',
+                properties: {},
+              },
               address: addressSchema,
+              dates: hospitalProvidedCare.items.properties.dates,
             },
           },
         },

--- a/src/applications/disability-benefits/all-claims/pages/index.js
+++ b/src/applications/disability-benefits/all-claims/pages/index.js
@@ -84,6 +84,7 @@ import * as vaMedicalRecords from './vaMedicalRecords';
 import * as workBehaviorChanges from './workBehaviorChanges';
 import * as unemployabilityDoctorCare from './unemployabilityDoctorCare';
 import * as pastEmploymentFormIntro from './pastEmploymentFormIntro';
+import * as pastEmploymentFormUpload from './pastEmploymentFormUpload';
 
 export {
   adaptiveBenefits,
@@ -124,6 +125,8 @@ export {
   newDisabilityFollowUp,
   newPTSDFollowUp,
   pastEducationTraining,
+  pastEmploymentFormIntro,
+  pastEmploymentFormUpload,
   paymentInformation,
   physicalHealthChanges,
   prisonerOfWar,
@@ -171,5 +174,4 @@ export {
   vaEmployee,
   vaMedicalRecords,
   workBehaviorChanges,
-  pastEmploymentFormIntro,
 };

--- a/src/applications/disability-benefits/all-claims/pages/pastEmploymentFormIntro.js
+++ b/src/applications/disability-benefits/all-claims/pages/pastEmploymentFormIntro.js
@@ -36,6 +36,7 @@ export const uiSchema = {
 
 export const schema = {
   type: 'object',
+  required: ['view:upload4192Choice'],
   properties: {
     'view:upload4192Choice': {
       type: 'object',

--- a/src/applications/disability-benefits/all-claims/pages/pastEmploymentFormIntro.js
+++ b/src/applications/disability-benefits/all-claims/pages/pastEmploymentFormIntro.js
@@ -26,7 +26,7 @@ export const uiSchema = {
     },
     'view:upload4192': {
       'ui:title':
-        ' want to upload a completed Request for Employment Information (VA Form 21-4192).',
+        'I want to upload a completed Request for Employment Information (VA Form 21-4192).',
     },
     'view:sendRequests': {
       'ui:title': 'I would like you to handle these requests for me.',

--- a/src/applications/disability-benefits/all-claims/pages/pastEmploymentFormUpload.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/pastEmploymentFormUpload.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { UploadDescription } from '../content/fileUploadDescriptions';
+import { ancillaryFormUploadUi } from '../utils';
+import { unemployabilityTitle } from '../content/unemployabilityFormIntro';
+
+const PTSD_4192_ATTACHMENT_ID = 'L115';
+
+export const uiSchema = {
+  'ui:title': unemployabilityTitle,
+  'ui:description': <UploadDescription uploadTitle="Upload VA Form 21-4192" />,
+  uploaded4192: ancillaryFormUploadUi(
+    '',
+    'Individual Unemployability 4192 form documents',
+    {
+      attachmentId: PTSD_4192_ATTACHMENT_ID,
+      customClasses: 'upload-completed-form',
+      isDisabled: true,
+    },
+  ),
+};
+
+export const schema = {
+  type: 'object',
+  required: ['uploaded4192'],
+  properties: {
+    uploaded4192: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+          size: {
+            type: 'integer',
+          },
+          confirmationCode: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormUpload.unit.spec.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+
+import {
+  DefinitionTester, // selectCheckbox
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import formConfig from '../../config/form.js';
+import { ERR_MSG_CSS_CLASS } from '../../constants';
+
+describe('4192 form upload', () => {
+  const page = formConfig.chapters.disabilities.pages.pastEmploymentFormUpload;
+  const { schema, uiSchema, arrayPath } = page;
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{
+          'view:unemployabilityUploadChoice': 'answerQuestions',
+          'view:uploadUnemployabilitySupportingDocumentsChoice': true,
+        }}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(1);
+    form.unmount();
+  });
+
+  it('should submit without required upload', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        onSubmit={onSubmit}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{
+          'view:uploadUnemployabilitySupportingDocumentsChoice': true,
+        }}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should submit with uploaded form', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        onSubmit={onSubmit}
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{
+          unemployabilitySupportingDocuments: [
+            {
+              confirmationCode: 'testing',
+              name: '8940.pdf',
+            },
+          ],
+        }}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+});


### PR DESCRIPTION
## Description

As a va.gov developer I need to filter the display of document types during the upload process so that the user is not overwhelmed with the full list of document types and the document types that are displayed to the user are relevant.


## Testing done
- [x] local testing
- [x] unit testing

## Screenshots
![screen shot 2019-01-15 at 4 25 26 pm](https://user-images.githubusercontent.com/1094999/51210991-31482d00-18e2-11e9-9f78-6de81fc0785e.png)

## Acceptance criteria
- [ ] During the interview if the user specifically selects to **upload a completed** 4192 then the document type list will automatically default to the Form name (_VA 21-4192- Request for Employment Information in Connection with Claim for 
- [x] In the scenario where the Document Type is defaulted to a specific form then it is not editable by the user
- [x]  Document name field will not be editable, it will default to the file name that is uploaded
- [x]  User is able to delete the file if needed
- [x]  User can add another document
- [x]  User can continue to next step in the flow

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
