### PR TITLE
[Left Nav] Fix for slide-out menu on zoomed-in Internet Explorer

### DIFF
--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -364,7 +364,7 @@ $medium-phone-screen: 375px;
 
     .va-sidebarnav--opened {
       position: fixed;
-      display: initial;
+      display: block;
     }
     .va-navigation-nextprevious {
       padding-left: 0.9375rem;


### PR DESCRIPTION
## Description
On mobile, on pages two-levels deep, the left navigation on content pages disappears, and a "More In This Section" button is revealed instead. This button is used to toggle a drawer that slides out from the right. On IE, that drawer wasn't rendering, causing the whole page to lock up.

## Testing done
- Remote IE 11 session zoomed in at 300%

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/51211321-20e48200-18e3-11e9-9959-8356c3c79ec3.png)

## Acceptance criteria
- [ ] Slide-out drawer works on zoomed-in IE 11

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
