### PR TITLE
Add Firefox support when checking for PaintTiming

### DIFF
--- a/src/platform/monitoring/frontend-metrics/metrics.js
+++ b/src/platform/monitoring/frontend-metrics/metrics.js
@@ -18,7 +18,10 @@ import { whitelistedPaths } from './whitelisted-paths';
  */
 function contentfulPaintEntry() {
   const paintEntries = performance.getEntriesByName('first-contentful-paint');
-  if (typeof paintEntries === 'undefined') {
+  if (
+    typeof paintEntries === 'undefined' ||
+    (Array.isArray(paintEntries) && !paintEntries.length)
+  ) {
     return false;
   }
   return paintEntries[0].startTime;


### PR DESCRIPTION
## Description

We have a util called `metrics.js` that checks for certain browser features. Chrome and Firefox handle the `performance` interface differently. Our check for `PaintTiming` is not working properly on Firefox, resulting in a [Sentry error](http://sentry.vetsgov-internal/vets-gov/website-production/issues/49553/).  Updated the check to work on Firefox as well. 

## Testing done

Tested locally


## Acceptance criteria
- [ ] Code has been updated to return `false` if performance check results in empty array

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
