### PR TITLE
Convert links without hrefs to buttons in GIBCT

### DIFF
--- a/src/applications/gi/components/heading/GiBillBreadcrumbs.jsx
+++ b/src/applications/gi/components/heading/GiBillBreadcrumbs.jsx
@@ -36,9 +36,13 @@ class GiBillBreadcrumbs extends React.Component {
     if (pathname.match(/profile/)) {
       if (this.props.includeSearch) {
         crumbs.push(
-          <a onClick={browserHistory.goBack} key="search-results">
+          <button
+            className="va-button-link learn-more-button"
+            onClick={browserHistory.goBack}
+            key="search-results"
+          >
             Search Results
-          </a>,
+          </button>,
         );
       }
       crumbs.push(

--- a/src/applications/gi/components/heading/GiBillBreadcrumbs.jsx
+++ b/src/applications/gi/components/heading/GiBillBreadcrumbs.jsx
@@ -37,6 +37,7 @@ class GiBillBreadcrumbs extends React.Component {
       if (this.props.includeSearch) {
         crumbs.push(
           <button
+            type="button"
             className="va-button-link learn-more-button"
             onClick={browserHistory.goBack}
             key="search-results"

--- a/src/applications/gi/components/heading/PreviewBanner.jsx
+++ b/src/applications/gi/components/heading/PreviewBanner.jsx
@@ -17,7 +17,12 @@ class PreviewBanner extends React.Component {
               This is what the version of this data from {when} will look
               like.&nbsp;
               <span className="actions">
-                <a onClick={this.props.onViewLiveVersion}>View live version</a>
+                <button
+                  className="va-button-link learn-more-button"
+                  onClick={this.props.onViewLiveVersion}
+                >
+                  View live version
+                </button>
                 &nbsp;&nbsp;|&nbsp;&nbsp;
                 <a href={this.props.toolUrl}>Go back to the data tool</a>
               </span>

--- a/src/applications/gi/components/heading/PreviewBanner.jsx
+++ b/src/applications/gi/components/heading/PreviewBanner.jsx
@@ -18,6 +18,7 @@ class PreviewBanner extends React.Component {
               like.&nbsp;
               <span className="actions">
                 <button
+                  type="button"
                   className="va-button-link learn-more-button"
                   onClick={this.props.onViewLiveVersion}
                 >

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -12,9 +12,12 @@ export class AdditionalInformation extends React.Component {
       it.accreditationType && (
         <div>
           <strong>
-            <a onClick={this.props.onShowModal.bind(this, 'typeAccredited')}>
+            <button
+              className="va-button-link learn-more-button"
+              onClick={this.props.onShowModal.bind(this, 'typeAccredited')}
+            >
               Type of accreditation:
-            </a>
+            </button>
           </strong>
           &nbsp;
           {it.accreditationType.toUpperCase()}
@@ -25,9 +28,13 @@ export class AdditionalInformation extends React.Component {
       <div>
         <strong>Veterans tuition policy:</strong>
         &nbsp;
-        <a href={it.vetWebsiteLink} target="_blank">
+        <button
+          className="va-button-link learn-more-button"
+          href={it.vetWebsiteLink}
+          target="_blank"
+        >
           View policy
-        </a>
+        </button>
       </div>
     );
 
@@ -36,22 +43,26 @@ export class AdditionalInformation extends React.Component {
         <h3>Institution summary</h3>
         <div>
           <strong>
-            <a onClick={this.props.onShowModal.bind(this, 'accredited')}>
+            <button
+              className="va-button-link learn-more-button"
+              onClick={this.props.onShowModal.bind(this, 'accredited')}
+            >
               Accredited:
-            </a>
+            </button>
           </strong>
           &nbsp;
           {it.accredited ? (
             <span>
               Yes (
-              <a
+              <button
+                className="va-button-link learn-more-button"
                 href={`http://nces.ed.gov/collegenavigator/?id=${
                   it.cross
                 }#accred`}
                 target="_blank"
               >
                 See accreditors
-              </a>
+              </button>
               )
             </span>
           ) : (
@@ -62,36 +73,48 @@ export class AdditionalInformation extends React.Component {
         {vetTuitionPolicy}
         <div>
           <strong>
-            <a onClick={this.props.onShowModal.bind(this, 'singleContact')}>
+            <button
+              className="va-button-link learn-more-button"
+              onClick={this.props.onShowModal.bind(this, 'singleContact')}
+            >
               Single point of contact for veterans:
-            </a>
+            </button>
           </strong>
           &nbsp;
           {it.vetPoc ? 'Yes' : 'No'}
         </div>
         <div>
           <strong>
-            <a onClick={this.props.onShowModal.bind(this, 'creditTraining')}>
+            <button
+              className="va-button-link learn-more-button"
+              onClick={this.props.onShowModal.bind(this, 'creditTraining')}
+            >
               Credit for military training:
-            </a>
+            </button>
           </strong>
           &nbsp;
           {it.creditForMilTraining ? 'Yes' : 'No'}
         </div>
         <div>
           <strong>
-            <a onClick={this.props.onShowModal.bind(this, 'iStudy')}>
+            <button
+              className="va-button-link learn-more-button"
+              onClick={this.props.onShowModal.bind(this, 'iStudy')}
+            >
               Independent study:
-            </a>
+            </button>
           </strong>
           &nbsp;
           {it.independentStudy ? 'Yes' : 'No'}
         </div>
         <div>
           <strong>
-            <a onClick={this.props.onShowModal.bind(this, 'stemOffered')}>
+            <button
+              className="va-button-link learn-more-button"
+              onClick={this.props.onShowModal.bind(this, 'stemOffered')}
+            >
               STEM (Science, Technology, Engineering, and Math):
-            </a>
+            </button>
           </strong>
           &nbsp;
           {it.stemOffered ? 'Yes' : 'No'}
@@ -164,27 +187,36 @@ export class AdditionalInformation extends React.Component {
             <h3>Institution codes</h3>
             <div>
               <strong>
-                <a onClick={this.props.onShowModal.bind(this, 'facilityCode')}>
+                <button
+                  className="va-button-link learn-more-button"
+                  onClick={this.props.onShowModal.bind(this, 'facilityCode')}
+                >
                   VA facility code:
-                </a>
+                </button>
                 &nbsp;
               </strong>
               {it.facilityCode || 'N/A'}
             </div>
             <div>
               <strong>
-                <a onClick={this.props.onShowModal.bind(this, 'ipedsCode')}>
+                <button
+                  className="va-button-link learn-more-button"
+                  onClick={this.props.onShowModal.bind(this, 'ipedsCode')}
+                >
                   ED IPEDS code:
-                </a>
+                </button>
                 &nbsp;
               </strong>
               {it.cross || 'N/A'}
             </div>
             <div>
               <strong>
-                <a onClick={this.props.onShowModal.bind(this, 'opeCode')}>
+                <button
+                  className="va-button-link learn-more-button"
+                  onClick={this.props.onShowModal.bind(this, 'opeCode')}
+                >
                   ED OPE code:
-                </a>
+                </button>
                 &nbsp;
               </strong>
               {it.ope || 'N/A'}

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -13,6 +13,7 @@ export class AdditionalInformation extends React.Component {
         <div>
           <strong>
             <button
+              type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'typeAccredited')}
             >
@@ -28,13 +29,9 @@ export class AdditionalInformation extends React.Component {
       <div>
         <strong>Veterans tuition policy:</strong>
         &nbsp;
-        <button
-          className="va-button-link learn-more-button"
-          href={it.vetWebsiteLink}
-          target="_blank"
-        >
+        <a href={it.vetWebsiteLink} target="_blank" rel="noopener">
           View policy
-        </button>
+        </a>
       </div>
     );
 
@@ -44,6 +41,7 @@ export class AdditionalInformation extends React.Component {
         <div>
           <strong>
             <button
+              type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'accredited')}
             >
@@ -54,15 +52,15 @@ export class AdditionalInformation extends React.Component {
           {it.accredited ? (
             <span>
               Yes (
-              <button
-                className="va-button-link learn-more-button"
+              <a
                 href={`http://nces.ed.gov/collegenavigator/?id=${
                   it.cross
                 }#accred`}
                 target="_blank"
+                rel="noopener"
               >
                 See accreditors
-              </button>
+              </a>
               )
             </span>
           ) : (
@@ -74,6 +72,7 @@ export class AdditionalInformation extends React.Component {
         <div>
           <strong>
             <button
+              type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'singleContact')}
             >
@@ -86,6 +85,7 @@ export class AdditionalInformation extends React.Component {
         <div>
           <strong>
             <button
+              type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'creditTraining')}
             >
@@ -98,6 +98,7 @@ export class AdditionalInformation extends React.Component {
         <div>
           <strong>
             <button
+              type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'iStudy')}
             >
@@ -110,6 +111,7 @@ export class AdditionalInformation extends React.Component {
         <div>
           <strong>
             <button
+              type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'stemOffered')}
             >
@@ -188,6 +190,7 @@ export class AdditionalInformation extends React.Component {
             <div>
               <strong>
                 <button
+                  type="button"
                   className="va-button-link learn-more-button"
                   onClick={this.props.onShowModal.bind(this, 'facilityCode')}
                 >
@@ -200,6 +203,7 @@ export class AdditionalInformation extends React.Component {
             <div>
               <strong>
                 <button
+                  type="button"
                   className="va-button-link learn-more-button"
                   onClick={this.props.onShowModal.bind(this, 'ipedsCode')}
                 >
@@ -212,6 +216,7 @@ export class AdditionalInformation extends React.Component {
             <div>
               <strong>
                 <button
+                  type="button"
                   className="va-button-link learn-more-button"
                   onClick={this.props.onShowModal.bind(this, 'opeCode')}
                 >

--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -114,7 +114,7 @@ export class Calculator extends React.Component {
           <div className="link-header">
             <h5>{title}</h5>
             &nbsp;(
-            <a href={learnMoreLink} target="_blank">
+            <a href={learnMoreLink} target="_blank" rel="noopener">
               Learn more
             </a>
             )

--- a/src/applications/gi/components/profile/CalculatorForm.jsx
+++ b/src/applications/gi/components/profile/CalculatorForm.jsx
@@ -51,7 +51,13 @@ class CalculatorForm extends React.Component {
     return (
       <span>
         {text} (
-        <a onClick={this.props.onShowModal.bind(this, modal)}>Learn more</a>)
+        <button
+          className="va-button-link learn-more-button"
+          onClick={this.props.onShowModal.bind(this, modal)}
+        >
+          Learn more
+        </button>
+        )
       </span>
     );
   }

--- a/src/applications/gi/components/profile/CalculatorForm.jsx
+++ b/src/applications/gi/components/profile/CalculatorForm.jsx
@@ -52,6 +52,7 @@ class CalculatorForm extends React.Component {
       <span>
         {text} (
         <button
+          type="button"
           className="va-button-link learn-more-button"
           onClick={this.props.onShowModal.bind(this, modal)}
         >

--- a/src/applications/gi/components/profile/CautionaryInformation.jsx
+++ b/src/applications/gi/components/profile/CautionaryInformation.jsx
@@ -58,6 +58,7 @@ export class CautionaryInformation extends React.Component {
         </p>
         <p>
           <button
+            type="button"
             className="va-button-link learn-more-button"
             onClick={this.props.onShowModal.bind(this, 'cautionInfo')}
           >

--- a/src/applications/gi/components/profile/CautionaryInformation.jsx
+++ b/src/applications/gi/components/profile/CautionaryInformation.jsx
@@ -45,6 +45,7 @@ export class CautionaryInformation extends React.Component {
       <a
         href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#AshfordSAA"
         target="_blank"
+        rel="noopener"
       >
         More information on Ashford University
       </a>
@@ -56,9 +57,12 @@ export class CautionaryInformation extends React.Component {
           {it.cautionFlagReason} {schoolSpecificLink}
         </p>
         <p>
-          <a onClick={this.props.onShowModal.bind(this, 'cautionInfo')}>
+          <button
+            className="va-button-link learn-more-button"
+            onClick={this.props.onShowModal.bind(this, 'cautionInfo')}
+          >
             Learn more about these warnings
-          </a>
+          </button>
         </p>
       </div>
     );
@@ -67,6 +71,7 @@ export class CautionaryInformation extends React.Component {
       <a
         href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses"
         target="_blank"
+        rel="noopener"
       >
         All campuses
       </a>
@@ -133,6 +138,7 @@ export class CautionaryInformation extends React.Component {
               <a
                 href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints"
                 target="_blank"
+                rel="noopener"
               >
                 student complaints
               </a>
@@ -142,6 +148,7 @@ export class CautionaryInformation extends React.Component {
               <a
                 href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#sourcedata"
                 target="_blank"
+                rel="noopener"
               >
                 Source
               </a>

--- a/src/applications/gi/components/profile/HeadingSummary.jsx
+++ b/src/applications/gi/components/profile/HeadingSummary.jsx
@@ -70,6 +70,7 @@ class HeadingSummary extends React.Component {
               <strong>{formatNumber(it.studentCount)}</strong> GI Bill students
               (
               <button
+                type="button"
                 className="va-button-link learn-more-button"
                 onClick={this.props.onLearnMore}
               >

--- a/src/applications/gi/components/profile/HeadingSummary.jsx
+++ b/src/applications/gi/components/profile/HeadingSummary.jsx
@@ -42,6 +42,7 @@ class HeadingSummary extends React.Component {
                 Are you enrolled in this school?{' '}
                 <a
                   href="https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp"
+                  rel="noopener"
                   target="_blank"
                 >
                   Find out if you qualify to have your benefits restored.
@@ -67,7 +68,14 @@ class HeadingSummary extends React.Component {
           <div className="column">
             <p>
               <strong>{formatNumber(it.studentCount)}</strong> GI Bill students
-              (<a onClick={this.props.onLearnMore}>Learn more</a>)
+              (
+              <button
+                className="va-button-link learn-more-button"
+                onClick={this.props.onLearnMore}
+              >
+                Learn more
+              </button>
+              )
             </p>
           </div>
           <div>

--- a/src/applications/gi/components/profile/Outcomes.jsx
+++ b/src/applications/gi/components/profile/Outcomes.jsx
@@ -34,9 +34,12 @@ class Outcomes extends React.Component {
           <div className="link-header">
             <h3>Retention rate</h3>
             &nbsp;(
-            <a onClick={this.props.onShowModal.bind(this, 'retention')}>
+            <button
+              className="va-button-link learn-more-button"
+              onClick={this.props.onShowModal.bind(this, 'retention')}
+            >
               Learn more
-            </a>
+            </button>
             )
           </div>
           <Graph
@@ -51,9 +54,12 @@ class Outcomes extends React.Component {
           <div className="link-header">
             <h3>Graduation rate</h3>
             &nbsp;(
-            <a onClick={this.props.onShowModal.bind(this, 'gradrates')}>
+            <button
+              className="va-button-link learn-more-button"
+              onClick={this.props.onShowModal.bind(this, 'gradrates')}
+            >
               Learn more
-            </a>
+            </button>
             )
           </div>
           <Graph
@@ -68,9 +74,12 @@ class Outcomes extends React.Component {
           <div className="link-header">
             <h3>Average salaries</h3>
             &nbsp;(
-            <a onClick={this.props.onShowModal.bind(this, 'salaries')}>
+            <button
+              className="va-button-link learn-more-button"
+              onClick={this.props.onShowModal.bind(this, 'salaries')}
+            >
               Learn more
-            </a>
+            </button>
             )
           </div>
           <Graph
@@ -85,9 +94,12 @@ class Outcomes extends React.Component {
           <div className="link-header">
             <h3>Repayment rate</h3>
             &nbsp;(
-            <a onClick={this.props.onShowModal.bind(this, 'repayment')}>
+            <button
+              className="va-button-link learn-more-button"
+              onClick={this.props.onShowModal.bind(this, 'repayment')}
+            >
               Learn more
-            </a>
+            </button>
             )
           </div>
           <Graph
@@ -105,6 +117,7 @@ class Outcomes extends React.Component {
             <a
               title="Veteran Outcome Measures"
               href={download.link}
+              rel="noopener"
               target="_blank"
             >
               Veteran Outcome Measures ({download.info})

--- a/src/applications/gi/components/profile/Outcomes.jsx
+++ b/src/applications/gi/components/profile/Outcomes.jsx
@@ -35,6 +35,7 @@ class Outcomes extends React.Component {
             <h3>Retention rate</h3>
             &nbsp;(
             <button
+              type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'retention')}
             >
@@ -55,6 +56,7 @@ class Outcomes extends React.Component {
             <h3>Graduation rate</h3>
             &nbsp;(
             <button
+              type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'gradrates')}
             >
@@ -75,6 +77,7 @@ class Outcomes extends React.Component {
             <h3>Average salaries</h3>
             &nbsp;(
             <button
+              type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'salaries')}
             >
@@ -95,6 +98,7 @@ class Outcomes extends React.Component {
             <h3>Repayment rate</h3>
             &nbsp;(
             <button
+              type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'repayment')}
             >

--- a/src/applications/gi/components/profile/Programs.jsx
+++ b/src/applications/gi/components/profile/Programs.jsx
@@ -92,6 +92,7 @@ export class Programs extends React.Component {
 
     const label = program.modal ? (
       <button
+        type="button"
         className="va-button-link learn-more-button"
         onClick={this.props.onShowModal.bind(this, program.modal)}
       >

--- a/src/applications/gi/components/profile/Programs.jsx
+++ b/src/applications/gi/components/profile/Programs.jsx
@@ -91,9 +91,12 @@ export class Programs extends React.Component {
       '';
 
     const label = program.modal ? (
-      <a onClick={this.props.onShowModal.bind(this, program.modal)}>
+      <button
+        className="va-button-link learn-more-button"
+        onClick={this.props.onShowModal.bind(this, program.modal)}
+      >
         {program.text}
-      </a>
+      </button>
     ) : (
       program.text
     );

--- a/src/applications/gi/components/search/EligibilityForm.jsx
+++ b/src/applications/gi/components/search/EligibilityForm.jsx
@@ -16,7 +16,13 @@ export class EligibilityForm extends React.Component {
     return (
       <span>
         {text} (
-        <a onClick={this.props.showModal.bind(this, modal)}>Learn more</a>)
+        <button
+          className="va-button-link learn-more-button"
+          onClick={this.props.showModal.bind(this, modal)}
+        >
+          Learn more
+        </button>
+        )
       </span>
     );
   }

--- a/src/applications/gi/components/search/EligibilityForm.jsx
+++ b/src/applications/gi/components/search/EligibilityForm.jsx
@@ -17,6 +17,7 @@ export class EligibilityForm extends React.Component {
       <span>
         {text} (
         <button
+          type="button"
           className="va-button-link learn-more-button"
           onClick={this.props.showModal.bind(this, modal)}
         >

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -345,6 +345,7 @@ export class Modals extends React.Component {
             <a
               href="http://www.benefits.va.gov/vocrehab/vsocfactsheet.asp"
               target="_blank"
+              rel="noopener"
             >
               Download the VSOC fact sheet.
             </a>
@@ -353,6 +354,7 @@ export class Modals extends React.Component {
             <a
               href="http://www.benefits.va.gov/vocrehab/vsoc.asp"
               target="_blank"
+              rel="noopener"
             >
               Learn more about the VSOC program.
             </a>
@@ -545,17 +547,26 @@ export class Modals extends React.Component {
             <a
               href="https://studentaid.ed.gov/sa/about/data-center/school/hcm"
               target="_blank"
+              rel="noopener"
             >
               Heightened Cash Monitoring
             </a>
           </p>
           <p>
-            <a href="http://ope.ed.gov/accreditation/" target="_blank">
+            <a
+              href="http://ope.ed.gov/accreditation/"
+              target="_blank"
+              rel="noopener"
+            >
               Accreditation
             </a>
           </p>
           <p>
-            <a href="https://www.dodmou.com/Home/Faq" target="_blank">
+            <a
+              href="https://www.dodmou.com/Home/Faq"
+              target="_blank"
+              rel="noopener"
+            >
               DoD Probation For Military Tuition Assistance
             </a>
           </p>
@@ -563,6 +574,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.ftc.gov/news-events/press-releases/2016/01/ftc-brings-enforcement-action-against-devry-university"
               target="_blank"
+              rel="noopener"
             >
               Federal Trade Commission Filed Suit for Deceptive Advertising
             </a>
@@ -571,6 +583,7 @@ export class Modals extends React.Component {
             <a
               href="http://www.justice.gov/opa/pr/profit-college-company-pay-955-million-settle-claims-illegal-recruiting-consumer-fraud-and"
               target="_blank"
+              rel="noopener"
             >
               Settlement reached with the Federal Trade Commission (FTC)
             </a>
@@ -579,6 +592,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#caution"
               target="_blank"
+              rel="noopener"
             >
               Suspended for 85/15 violation – Flight Program
             </a>
@@ -587,6 +601,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#caution"
               target="_blank"
+              rel="noopener"
             >
               Denial of Recertification Application to Participate in the
               Federal Student Financial Assistance Programs
@@ -596,6 +611,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#ACICS"
               target="_blank"
+              rel="noopener"
             >
               School operating under provisional accreditation (previously
               accredited by ACICS)
@@ -606,6 +622,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#caution"
               target="_blank"
+              rel="noopener"
             >
               "About this Tool"
             </a>{' '}
@@ -636,6 +653,7 @@ export class Modals extends React.Component {
               href="http://nces.ed.gov/ipeds/datacenter/"
               id="anch_442"
               target="blank"
+              rel="noopener"
             >
               IPEDS
             </a>
@@ -644,6 +662,7 @@ export class Modals extends React.Component {
               href="http://nces.ed.gov/collegenavigator/"
               id="anch_443"
               target="blank"
+              rel="noopener"
             >
               College Navigator
             </a>
@@ -656,6 +675,7 @@ export class Modals extends React.Component {
                 'http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#yellow_ribbon_from_school'
               }
               target="_blank"
+              rel="noopener"
             >
               About This Tool
             </a>
@@ -685,6 +705,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/resources/benefits_resources/rate_tables.asp#ch33#TUITION"
               target="_blank"
+              rel="noopener"
             >
               Click here for more information.
             </a>
@@ -710,6 +731,7 @@ export class Modals extends React.Component {
               title="Click here for FAQs about the Yellow Ribbon Program"
               href="http://www.benefits.va.gov/gibill/docs/factsheets/2012_Yellow_Ribbon_Student_FAQs.pdf"
               target="_blank"
+              rel="noopener"
             >
               this page.
             </a>
@@ -804,6 +826,7 @@ export class Modals extends React.Component {
               title="For more information about MHA increases or decreases click here"
               href="https://gibill.custhelp.com/app/answers/detail/a_id/1412"
               target="_blank"
+              rel="noopener"
             >
               this page
             </a>
@@ -836,6 +859,7 @@ export class Modals extends React.Component {
             <a
               href="https://gibill.custhelp.com/app/answers/detail/a_id/97"
               target="_blank"
+              rel="noopener"
             >
               this page
             </a>
@@ -916,6 +940,7 @@ export class Modals extends React.Component {
             <a
               href="http://www.benefits.va.gov/gibill/comparison_tool.asp"
               target="_blank"
+              rel="noopener"
             >
               this page
             </a>
@@ -948,6 +973,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#cumulativeservice"
               target="_blank"
+              rel="noopener"
             >
               this page
             </a>
@@ -973,6 +999,7 @@ export class Modals extends React.Component {
               href="http://www.benefits.va.gov/gibill/mgib_ad.asp"
               id="anch_399"
               target="_blank"
+              rel="noopener"
             >
               http://www.benefits.va.gov/gibill/mgib_ad.asp
             </a>
@@ -997,6 +1024,7 @@ export class Modals extends React.Component {
               href="https://www.benefits.va.gov/gibill/reap.asp"
               id="anch_403"
               target="_blank"
+              rel="noopener"
             >
               https://www.benefits.va.gov/gibill/reap.asp
             </a>

--- a/src/applications/gi/sass/gi.scss
+++ b/src/applications/gi/sass/gi.scss
@@ -79,3 +79,8 @@
    }
   }
 }
+
+.learn-more-button {
+  background-image: none !important;
+  font-weight: inherit !important;
+}

--- a/src/applications/gi/sass/gi.scss
+++ b/src/applications/gi/sass/gi.scss
@@ -80,6 +80,9 @@
   }
 }
 
+/* 
+ * These styles override our overly broad accordion styles
+ */
 .learn-more-button {
   background-image: none !important;
   font-weight: inherit !important;


### PR DESCRIPTION
## Description

There are a bunch of actions in GIBCT that are coded as links and open a modal. Since these are not changing page location, they should be coded as buttons and styled as links.

I also updated some links that open a new tab to use `rel="noopener"`.

## Testing done
Tested a few locally

## Acceptance criteria
- [x] Actions still work and look the same

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
