### PR TITLE
Fix Summary of Evidence page display message

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
@@ -5,7 +5,11 @@ import { DATA_PATHS } from '../constants';
 export const summaryOfEvidenceDescription = ({ formData }) => {
   const vaEvidence = _.get('vaTreatmentFacilities', formData, []);
   const privateEvidence = _.get('providerFacility', formData, []);
-  const privateEvidenceUploads = _.get('privateMedicalRecords', formData, []);
+  const privateEvidenceUploads = _.get(
+    'privateMedicalRecordAttachments',
+    formData,
+    [],
+  );
   const layEvidenceUploads = _.get('additionalDocuments', formData, []);
   const evidenceLength = !!vaEvidence.concat(
     privateEvidence,

--- a/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
@@ -40,7 +40,7 @@ describe('Summary of Evidence', () => {
     },
   ];
 
-  const privateMedicalRecords = [
+  const privateMedicalRecordAttachments = [
     { name: 'TestFile.png' },
     { name: 'hospital records.pdf' },
   ];
@@ -93,7 +93,7 @@ describe('Summary of Evidence', () => {
         data={{
           'view:hasEvidence': false,
           vaTreatmentFacilities,
-          privateMedicalRecords,
+          privateMedicalRecordAttachments,
           additionalDocuments,
           providerFacility: privateFacilities,
         }}
@@ -122,7 +122,7 @@ describe('Summary of Evidence', () => {
             'view:selectableEvidenceTypes': {},
           },
           vaTreatmentFacilities,
-          privateMedicalRecords,
+          privateMedicalRecordAttachments,
           additionalDocuments,
           providerFacility: privateFacilities,
         }}
@@ -198,7 +198,7 @@ describe('Summary of Evidence', () => {
           'view:uploadPrivateRecordsQualifier': {
             'view:hasPrivateRecordsToUpload': true,
           },
-          privateMedicalRecords,
+          privateMedicalRecordAttachments,
         }}
       />,
     );
@@ -210,13 +210,13 @@ describe('Summary of Evidence', () => {
         .at(0)
         .render()
         .text(),
-    ).to.contain(privateMedicalRecords[0].name);
+    ).to.contain(privateMedicalRecordAttachments[0].name);
     expect(
       list
         .at(1)
         .render()
         .text(),
-    ).to.contain(privateMedicalRecords[1].name);
+    ).to.contain(privateMedicalRecordAttachments[1].name);
     form.unmount();
   });
 
@@ -261,7 +261,7 @@ describe('Summary of Evidence', () => {
           'view:uploadPrivateRecordsQualifier': {
             'view:hasPrivateRecordsToUpload': false,
           },
-          privateMedicalRecords,
+          privateMedicalRecordAttachments,
         }}
       />,
     );


### PR DESCRIPTION
## Description
Summary of Evidence page was displaying 
```
        You haven’t uploaded any evidence. This may delay us processing your
        claim. In addition, we may also schedule a claim exam for you to help us
        decide your claim.
```
still after uploading supporting Evidence on private medical records page(4142). The key was changed on the upload page, but not within the summaryOfEvidence component.

## Screenshots
**Current state after uploading**
![68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3563303766303030333931613666363335376164633433302f62643434353435392d316532642d343136372d616539382d383930323233653264383866](https://user-images.githubusercontent.com/22040793/51329675-01189f80-1a44-11e9-9822-faf5969242b4.png)

**After fixing key and uploading**
![image](https://user-images.githubusercontent.com/22040793/51329640-ee05cf80-1a43-11e9-8acc-74c0a5ee4dbb.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
