### PR TITLE
add aria-live wrapper

### DIFF
--- a/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
+++ b/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
@@ -250,7 +250,7 @@ class PreferencesWidget extends React.Component {
             />
           )}
         </ReactCSSTransitionGroup>
-        {this.renderContent()}
+        <div ariaLive="polite">{this.renderContent()}</div>
       </div>
     );
   }


### PR DESCRIPTION
## Description
This is an attempt to fix department-of-veterans-affairs/vets.gov-team#16155. Adding an `aria-live` wrapper `div` that is always rendered by the component, which should resolve any issues with screen readers not reading the conditionally-rendered content.

## Testing done
Local

## Acceptance criteria
- [ ] Homeless Alert is read on page load in Win10/FF/JAWS

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs