### PR TITLE
Fix benefits link for patient acknowledgement 4142 form

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -112,6 +112,7 @@ export const patientAcknowledgmentText = (
           href="https://www.benefits.va.gov/privateproviders/"
           target="_blank"
           className="text-overflow-wrap"
+          rel="noopener"
         >
           https://www.benefits.va.gov/privateproviders/
         </a>

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -108,7 +108,11 @@ export const patientAcknowledgmentText = (
       <p>
         NOTE: For additional information regarding VA Form 21-4142, refer to the
         following website:
-        <a href="https://www.benefits.va.gov/privateproviders/" target="_blank">
+        <a
+          href="https://www.benefits.va.gov/privateproviders/"
+          target="_blank"
+          className="text-overflow-wrap"
+        >
           https://www.benefits.va.gov/privateproviders/
         </a>
         .

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -149,3 +149,7 @@ ul.original-disability-list {
   height: auto;
   white-space: pre-wrap;
 }
+
+.text-overflow-wrap {
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
## Description
The benefits link is being cutoff on mobile. Added helper class to wrap over flow text.

## Testing done
- [x] manual testing done

## Screenshots
![image](https://user-images.githubusercontent.com/22040793/51337642-abe58980-1a55-11e9-9864-eafc1ece4769.png)

**With helper class**
![image](https://user-images.githubusercontent.com/22040793/51337680-c586d100-1a55-11e9-92b9-c0ccb8acdef8.png)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
