### PR TITLE
Use Redux to cache preference data

### DIFF
--- a/src/applications/personalization/preferences/actions/index.js
+++ b/src/applications/personalization/preferences/actions/index.js
@@ -29,7 +29,10 @@ export const SET_DISMISSED_DASHBOARD_PREFERENCE_BENEFIT_ALERTS =
 
 // load the benefits the user has picked to learn more about
 export function fetchUserSelectedBenefits() {
-  return dispatch => {
+  return (dispatch, getState) => {
+    if (getState().preferences.selectedBenefitsCached) {
+      return null;
+    }
     dispatch({
       type: FETCH_USER_PREFERENCES_STARTED,
     });
@@ -53,7 +56,10 @@ export function fetchUserSelectedBenefits() {
 
 // load all available benefits
 export function fetchAvailableBenefits() {
-  return dispatch => {
+  return (dispatch, getState) => {
+    if (getState().preferences.availableBenefitsCached) {
+      return null;
+    }
     dispatch({
       type: FETCH_ALL_BENEFITS_STARTED,
     });

--- a/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
+++ b/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
@@ -158,8 +158,8 @@ class PreferencesWidget extends React.Component {
         return (
           <div>
             <p>You haven’t selected any benefits to learn about.</p>
-            <a
-              href="/my-va/find-benefits"
+            <Link
+              to="find-benefits"
               onClick={() =>
                 recordEvent({
                   event: 'dashboard-navigation',
@@ -169,7 +169,7 @@ class PreferencesWidget extends React.Component {
               }
             >
               Select benefits now.
-            </a>
+            </Link>
           </div>
         );
       }

--- a/src/applications/personalization/preferences/reducers/index.js
+++ b/src/applications/personalization/preferences/reducers/index.js
@@ -18,6 +18,8 @@ import {
 } from '../actions';
 
 const initialState = {
+  selectedBenefitsCached: false,
+  availableBenefitsCached: false,
   dashboard: {},
   availableBenefits: [],
   dismissedBenefitAlerts: [],
@@ -53,6 +55,7 @@ export default function preferences(state = initialState, action) {
         ...state,
         dashboard: { ...selectedBenefits },
         savedDashboard: { ...selectedBenefits },
+        selectedBenefitsCached: true,
         userBenefitsLoadingStatus: LOADING_STATES.loaded,
       };
     }
@@ -77,6 +80,7 @@ export default function preferences(state = initialState, action) {
       return {
         ...state,
         availableBenefits,
+        availableBenefitsCached: true,
         allBenefitsLoadingStatus: LOADING_STATES.loaded,
       };
     }
@@ -95,6 +99,7 @@ export default function preferences(state = initialState, action) {
     case SAVE_USER_PREFERENCES_SUCCEEDED: {
       return {
         ...state,
+        savedDashboard: { ...state.dashboard },
         saveStatus: LOADING_STATES.loaded,
         savedAt: Date.now(),
       };

--- a/src/applications/personalization/preferences/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/preferences/tests/actions/index.unit.spec.js
@@ -50,86 +50,105 @@ describe('preferences actions', () => {
     afterEach(() => {
       resetFetch();
     });
-    it(`should dispatch the FETCH_USER_PREFERENCES_STARTED action immediately`, done => {
-      const dispatch = sinon.spy();
+    let dispatch;
+    let getState;
 
-      fetchUserSelectedBenefits()(dispatch);
-
-      expect(
-        dispatch.firstCall.calledWith({
-          type: FETCH_USER_PREFERENCES_STARTED,
-        }),
-      ).to.be.true;
-      done();
-    });
-
-    it(`should call the API`, done => {
-      const dispatch = sinon.spy();
-
-      fetchUserSelectedBenefits()(dispatch);
-
-      setTimeout(() => {
-        expect(global.fetch.firstCall.args[0]).to.contain(
-          '/v0/user/preferences',
-        );
-        expect(global.fetch.firstCall.args[1].method).to.eql('GET');
+    describe('when use selections have been cached', () => {
+      it(`should do nothing and its thunk should return null`, done => {
+        dispatch = sinon.spy();
+        getState = sinon.stub().returns({
+          preferences: {
+            selectedBenefitsCached: true,
+          },
+        });
+        const value = fetchUserSelectedBenefits()(dispatch, getState);
+        expect(value).to.be.null;
+        expect(dispatch.notCalled).to.be.true;
         done();
-      }, 0);
+      });
     });
+    describe('when user selections have not been cached', () => {
+      beforeEach(() => {
+        dispatch = sinon.spy();
+        getState = sinon.stub().returns({
+          preferences: {
+            selectedBenefitsCached: false,
+          },
+        });
+      });
+      it(`should dispatch the FETCH_USER_PREFERENCES_STARTED action immediately`, done => {
+        fetchUserSelectedBenefits()(dispatch, getState);
 
-    it(`should dispatch the FETCH_USER_PREFERENCES_FAILED action on request failure`, done => {
-      const error = { test: 'test' };
-      setFetchFailure(global.fetch.onFirstCall(), error);
-
-      const dispatch = sinon.spy();
-
-      fetchUserSelectedBenefits()(dispatch);
-
-      setTimeout(() => {
         expect(
-          dispatch.secondCall.calledWith({
-            type: FETCH_USER_PREFERENCES_FAILED,
+          dispatch.firstCall.calledWith({
+            type: FETCH_USER_PREFERENCES_STARTED,
           }),
         ).to.be.true;
         done();
-      }, 0);
-    });
+      });
 
-    it(`should dispatch the FETCH_USER_PREFERENCES_SUCCEEDED action on request success`, done => {
-      const response = {
-        data: {
-          attributes: {
-            userPreferences: [
-              {
-                code: 'benefits',
-                userPreferences: [
-                  {
-                    code: 'pensions',
-                    description: 'pension benefits',
-                  },
-                  {
-                    code: 'health-care',
-                    description: 'health care benefits',
-                  },
-                ],
-              },
-            ],
+      it(`should call the API`, done => {
+        fetchUserSelectedBenefits()(dispatch, getState);
+
+        setTimeout(() => {
+          expect(global.fetch.firstCall.args[0]).to.contain(
+            '/v0/user/preferences',
+          );
+          expect(global.fetch.firstCall.args[1].method).to.eql('GET');
+          done();
+        }, 0);
+      });
+
+      it(`should dispatch the FETCH_USER_PREFERENCES_FAILED action on request failure`, done => {
+        const error = { test: 'test' };
+        setFetchFailure(global.fetch.onFirstCall(), error);
+
+        fetchUserSelectedBenefits()(dispatch, getState);
+
+        setTimeout(() => {
+          expect(
+            dispatch.secondCall.calledWith({
+              type: FETCH_USER_PREFERENCES_FAILED,
+            }),
+          ).to.be.true;
+          done();
+        }, 0);
+      });
+
+      it(`should dispatch the FETCH_USER_PREFERENCES_SUCCEEDED action on request success`, done => {
+        const response = {
+          data: {
+            attributes: {
+              userPreferences: [
+                {
+                  code: 'benefits',
+                  userPreferences: [
+                    {
+                      code: 'pensions',
+                      description: 'pension benefits',
+                    },
+                    {
+                      code: 'health-care',
+                      description: 'health care benefits',
+                    },
+                  ],
+                },
+              ],
+            },
           },
-        },
-      };
-      setFetchResponse(global.fetch.onFirstCall(), response);
+        };
+        setFetchResponse(global.fetch.onFirstCall(), response);
 
-      const dispatch = sinon.spy();
+        fetchUserSelectedBenefits()(dispatch, getState);
 
-      fetchUserSelectedBenefits()(dispatch);
-
-      setTimeout(() => {
-        expect(dispatch.secondCall.args[0]).to.eql({
-          type: FETCH_USER_PREFERENCES_SUCCEEDED,
-          payload: response,
-        });
-        done();
-      }, 0);
+        setTimeout(() => {
+          expect(dispatch.secondCall.args[0]).to.eql({
+            type: FETCH_USER_PREFERENCES_SUCCEEDED,
+            payload: response,
+          });
+          done();
+        }, 0);
+      });
     });
   });
   describe('fetchAvailableBenefits', () => {
@@ -139,80 +158,100 @@ describe('preferences actions', () => {
     afterEach(() => {
       resetFetch();
     });
-    it(`should immediately dispatch the FETCH_ALL_BENEFITS_STARTED action`, done => {
-      const dispatch = sinon.spy();
+    let dispatch;
+    let getState;
 
-      fetchAvailableBenefits()(dispatch);
-
-      expect(
-        dispatch.firstCall.calledWith({
-          type: FETCH_ALL_BENEFITS_STARTED,
-        }),
-      ).to.be.true;
-
-      done();
-    });
-
-    it(`should call the API`, done => {
-      const dispatch = sinon.spy();
-
-      fetchAvailableBenefits()(dispatch);
-
-      setTimeout(() => {
-        expect(global.fetch.firstCall.args[0]).to.contain(
-          '/v0/user/preferences/choices/benefits',
-        );
-        expect(global.fetch.firstCall.args[1].method).to.eql('GET');
+    describe('when available preferences have been cached', () => {
+      it(`should do nothing and its thunk should return null`, done => {
+        dispatch = sinon.spy();
+        getState = sinon.stub().returns({
+          preferences: {
+            availableBenefitsCached: true,
+          },
+        });
+        const value = fetchAvailableBenefits()(dispatch, getState);
+        expect(value).to.be.null;
+        expect(dispatch.notCalled).to.be.true;
         done();
-      }, 0);
+      });
     });
 
-    it(`should dispatch the FETCH_ALL_BENEFITS_FAILED on request failure`, done => {
-      const error = { test: 'test' };
-      setFetchFailure(global.fetch.onFirstCall(), error);
+    describe('when available preferences have not been cached', () => {
+      beforeEach(() => {
+        dispatch = sinon.spy();
+        getState = sinon.stub().returns({
+          preferences: {
+            availableBenefitsCached: false,
+          },
+        });
+      });
+      it(`should immediately dispatch the FETCH_ALL_BENEFITS_STARTED action`, done => {
+        fetchAvailableBenefits()(dispatch, getState);
 
-      const dispatch = sinon.spy();
-
-      fetchAvailableBenefits()(dispatch);
-
-      setTimeout(() => {
         expect(
-          dispatch.secondCall.calledWith({
-            type: FETCH_ALL_BENEFITS_FAILED,
+          dispatch.firstCall.calledWith({
+            type: FETCH_ALL_BENEFITS_STARTED,
           }),
         ).to.be.true;
-        done();
-      }, 0);
-    });
 
-    it(`should dispatch the FETCH_ALL_BENEFITS_SUCCEEDED action on request success`, done => {
-      const response = {
-        data: {
-          attributes: {
-            code: 'benefits',
-            title: 'Available Benefits',
-            preferenceChoices: [
-              {
-                code: 'pensions',
-                description: 'pension benefits',
-              },
-            ],
+        done();
+      });
+
+      it(`should call the API`, done => {
+        fetchAvailableBenefits()(dispatch, getState);
+
+        setTimeout(() => {
+          expect(global.fetch.firstCall.args[0]).to.contain(
+            '/v0/user/preferences/choices/benefits',
+          );
+          expect(global.fetch.firstCall.args[1].method).to.eql('GET');
+          done();
+        }, 0);
+      });
+
+      it(`should dispatch the FETCH_ALL_BENEFITS_FAILED on request failure`, done => {
+        const error = { test: 'test' };
+        setFetchFailure(global.fetch.onFirstCall(), error);
+
+        fetchAvailableBenefits()(dispatch, getState);
+
+        setTimeout(() => {
+          expect(
+            dispatch.secondCall.calledWith({
+              type: FETCH_ALL_BENEFITS_FAILED,
+            }),
+          ).to.be.true;
+          done();
+        }, 0);
+      });
+
+      it(`should dispatch the FETCH_ALL_BENEFITS_SUCCEEDED action on request success`, done => {
+        const response = {
+          data: {
+            attributes: {
+              code: 'benefits',
+              title: 'Available Benefits',
+              preferenceChoices: [
+                {
+                  code: 'pensions',
+                  description: 'pension benefits',
+                },
+              ],
+            },
           },
-        },
-      };
-      setFetchResponse(global.fetch.onFirstCall(), response);
+        };
+        setFetchResponse(global.fetch.onFirstCall(), response);
 
-      const dispatch = sinon.spy();
+        fetchAvailableBenefits()(dispatch, getState);
 
-      fetchAvailableBenefits()(dispatch);
-
-      setTimeout(() => {
-        expect(dispatch.secondCall.args[0]).to.eql({
-          type: FETCH_ALL_BENEFITS_SUCCEEDED,
-          payload: response,
-        });
-        done();
-      }, 0);
+        setTimeout(() => {
+          expect(dispatch.secondCall.args[0]).to.eql({
+            type: FETCH_ALL_BENEFITS_SUCCEEDED,
+            payload: response,
+          });
+          done();
+        }, 0);
+      });
     });
   });
   describe('setPreference', () => {

--- a/src/applications/personalization/preferences/tests/containers/PreferencesWidget.unit.spec.jsx
+++ b/src/applications/personalization/preferences/tests/containers/PreferencesWidget.unit.spec.jsx
@@ -22,9 +22,9 @@ describe('<PreferencesWidget>', () => {
     props.setDismissedBenefitAlerts = () => true;
     props.preferences.dismissedBenefitAlerts = [];
     const component = shallow(<PreferencesWidget {...props} />);
-    expect(component.find('a').length).to.equal(1);
-    expect(component.find('Link').length).to.equal(0);
-    expect(component.find('a').html()).to.contain('Select benefits now.');
+    expect(component.find('Link').length).to.equal(1);
+    expect(component.find('Link').html()).to.contain('Select benefits now.');
+    expect(component.find('Link').html()).to.not.contain('Find VA Benefits');
     expect(component.html()).to.contain(
       'You haven’t selected any benefits to learn about.',
     );
@@ -37,7 +37,6 @@ describe('<PreferencesWidget>', () => {
     props.preferences.dismissedBenefitAlerts = [];
     const component = shallow(<PreferencesWidget {...props} />);
     expect(component.find('Link').length).to.equal(1);
-    expect(component.find('a').length).to.equal(0);
     expect(component.find('Link').html()).to.contain('Find VA Benefits');
     expect(component.find('Link').html()).to.not.contain(
       'Select benefits now.',


### PR DESCRIPTION
## Description
Once we have loaded the list of available benefits and the benefits the user has selected, we no longer need to make the GET calls to get them. Instead we can rely on what is already in the Redux store.

**note** the majority of the diff in the actions unit tests was moving some existing tests into a parent `describe` block.

## Testing done
- Local testing
- Expanded unit tests

## Screenshots


## Acceptance criteria
- [ ] Fetch calls are only made on initial load

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs