### PR TITLE
Fix property name string in required property

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/vaEmployee.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaEmployee.js
@@ -10,6 +10,6 @@ export const uiSchema = {
 
 export const schema = {
   type: 'object',
-  required: ['isVAEmployee'],
+  required: ['isVaEmployee'],
   properties: { isVaEmployee },
 };


### PR DESCRIPTION
## Description
Fixes isVAEmployee being a required property. There is no such property anymore - it's called `isVaEmployee` now.

## Testing done
Tested locally

## Screenshots
NA

## Acceptance criteria
- [x] Can advance past 'are you a VA employee' page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
