### PR TITLE
[Profile] Fix for broken phone number input

### DIFF
--- a/src/applications/personalization/profile360/vet360/components/PhoneField/EditModal.jsx
+++ b/src/applications/personalization/profile360/vet360/components/PhoneField/EditModal.jsx
@@ -7,19 +7,23 @@ import AlertBox from '@department-of-veterans-affairs/formation/AlertBox';
 import Vet360EditModal from '../base/EditModal';
 
 class PhoneTextInput extends ErrorableTextInput {
-  componentDidMount() {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'usa-only-phone-wrapper';
+  // componentDidMount() {
+  //   const wrapper = document.createElement('div');
+  //   wrapper.className = 'usa-only-phone-wrapper';
 
-    const inputField = document.querySelector('input.usa-only-phone');
+  //   const inputField = document.querySelector('input.usa-only-phone');
 
-    inputField.parentNode.insertBefore(wrapper, inputField);
-    wrapper.appendChild(inputField);
+  //   inputField.parentNode.insertBefore(wrapper, inputField);
+  //   wrapper.appendChild(inputField);
 
-    const prefixEl = document.createElement('span');
-    prefixEl.innerText = '+1';
-    prefixEl.className = 'usa-only-phone-prefix';
-    inputField.insertAdjacentElement('beforebegin', prefixEl);
+  //   const prefixEl = document.createElement('span');
+  //   prefixEl.innerText = '+1';
+  //   prefixEl.className = 'usa-only-phone-prefix';
+  //   inputField.insertAdjacentElement('beforebegin', prefixEl);
+  // }
+
+  render() {
+    return <ErrorableTextInput {...this.props} />;
   }
 }
 


### PR DESCRIPTION
## Description
On the Profile, the screen blanks out when typing into empty phone number fields with the error below.  I believe this was due to some DOM operations happening during `componentDidMount` that were incompatible with React 16. 

![image](https://user-images.githubusercontent.com/1915775/51416928-a5383e80-1b49-11e9-80c8-06ac3ff1a657.png)

I believe those DOM operations were intended to be temporary until we had a proper implementation, but they were there so that the `+` could be added before the `ErrorableFormInput`.

![image](https://user-images.githubusercontent.com/1915775/51416975-fba57d00-1b49-11e9-9238-04c585cf6b2e.png)

## Testing done
Confirmed locally that the error is gone

## Acceptance criteria
- [ ] Bug is fixed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
