### PR TITLE
TreatedDisabilityNames capitalization fix

### DIFF
--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -205,9 +205,14 @@ export const addCheckboxPerDisability = (form, pageSchema) => {
   const disabilitiesViews = selectedRatedDisabilities
     .concat(selectedNewDisabilities)
     .reduce((accum, curr) => {
-      const disabilityName = curr.name || curr.condition;
+      const disabilityName = curr.name || curr.condition || '';
       const capitalizedDisabilityName = capitalizeEachWord(disabilityName);
-      return _.set(capitalizedDisabilityName, { type: 'boolean' }, accum);
+      return _.set(
+        // downcase value for SIP consistency
+        disabilityName.toLowerCase(),
+        { title: capitalizedDisabilityName, type: 'boolean' },
+        accum,
+      );
     }, {});
   return {
     properties: disabilitiesViews,


### PR DESCRIPTION
## Description
SIP is failing to retain TreatedDisabilityNames due to a key downcasing issue. Because TreatedDisabilityNames are being sent in the form `{ NAME: true/false}`, the key name is downcased by olivebranch `NAME => name`. 

This PR uses lowercased names to store the data and avoid SIP issues.

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16083

## Testing done
local testing

## Acceptance criteria
- [x] Selected TreatedDisabilityNames are retained when reloading the form from SIP

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

