### PR TITLE
Add Breadcrumbs to Dashboard/Find VA Benefits

### DIFF
--- a/src/applications/personalization/dashboard/containers/DashboardAppWrapper.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardAppWrapper.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { Link } from 'react-router';
 
 import Modal from '@department-of-veterans-affairs/formation/Modal';
+import Breadcrumbs from '@department-of-veterans-affairs/formation/Breadcrumbs';
 
 import backendServices from 'platform/user/profile/constants/backendServices';
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
@@ -9,6 +11,8 @@ import {
   DowntimeNotification,
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
+
+import { findBenefitsRoute } from '../routes';
 
 class DashboardAppWrapper extends React.Component {
   constructor(props) {
@@ -63,6 +67,30 @@ class DashboardAppWrapper extends React.Component {
     }
   };
 
+  renderBreadcrumbs = location => {
+    const { pathname } = location;
+    const crumbs = [
+      <a href="/" key="home">
+        Home
+      </a>,
+      <Link to="/" key="dashboard">
+        My VA
+      </Link>,
+    ];
+
+    if (pathname.match(findBenefitsRoute.path)) {
+      crumbs.push(
+        <Link
+          to={`my-va/${findBenefitsRoute.path}`}
+          key={findBenefitsRoute.path}
+        >
+          {findBenefitsRoute.name}
+        </Link>,
+      );
+    }
+    return crumbs;
+  };
+
   render() {
     return (
       <RequiredLoginView
@@ -78,6 +106,10 @@ class DashboardAppWrapper extends React.Component {
           ]}
           render={this.renderDowntimeNotification}
         >
+          <Breadcrumbs>
+            {this.renderBreadcrumbs(this.props.location)}
+          </Breadcrumbs>
+
           {this.props.children}
         </DowntimeNotification>
       </RequiredLoginView>

--- a/src/applications/personalization/dashboard/routes.jsx
+++ b/src/applications/personalization/dashboard/routes.jsx
@@ -2,7 +2,7 @@ import DashboardApp from './containers/DashboardApp';
 import DashboardAppWrapper from './containers/DashboardAppWrapper';
 import SetPreferences from '../preferences/containers/SetPreferences';
 
-const findBenefitsRoute = {
+export const findBenefitsRoute = {
   path: 'find-benefits',
   component: SetPreferences,
   key: 'find-benefits',


### PR DESCRIPTION
## Description
Replace static breadcrumbs (that never actually worked properly) with the Breadcrumbs component.

This vagov-content PR should be merged at the same time: https://github.com/department-of-veterans-affairs/vagov-content/pull/234

## Testing done
Local

## Screenshots


## Acceptance criteria
- [x] Breadcrumbs appear and links work correctly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs