### PR TITLE
Fix for "entry" arg

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -48,7 +48,7 @@ const configGenerator = (buildOptions, apps) => {
   const enableCSSSourcemaps =
     buildOptions.buildtype !== ENVIRONMENTS.LOCALHOST ||
     buildOptions['local-css-sourcemaps'] ||
-    buildOptions.entry;
+    !!buildOptions.entry;
 
   const baseConfig = {
     mode: 'development',


### PR DESCRIPTION
## Description
First spotted this as a build error in Heroku keeping review instances from deploying, but traced it back to the `entry` arg.

```
npm run watch -- --entry=profile360

> vets-website@1.0.0 watch /Users/nicksullivan/Repos/vagov/vets-website
> node script/build.js --watch "--entry=profile360"

[metalsmith-watch] ✓ Live reload server started on port: 35729
Attempting to load Drupal content from cache...
To pull latest, run with "--pull-drupal" flag.
Drupal successfully loaded!
Drupal index page written to /drupal.
Successfully piped Drupal content into Metalsmith!
[metalsmith-watch] ✔︎ Watching ../../../../../vagov-content/**/*
[metalsmith-watch] ✔︎ Watching ../../includes/**/*
[metalsmith-watch] ✔︎ Watching ../../components/**/*
[metalsmith-watch] ✔︎ Watching ../../layouts/**/*
[metalsmith-webpack-dev-server]: Running webpack dev server at http://localhost:3001
Metalsmith build finished!  Starting webpack-dev-server...
✖ ｢wdm｣: Time: 14163ms
Built at: 2019-1-22 14:25:30

ERROR in ./src/platform/site-wide/sass/brand-consolidation.scss
Module build failed: ReferenceError: profile360 is not defined
```

## Testing done
- Local builds

## Acceptance criteria
- [ ] Heroku instances deploy

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
