### PR TITLE
Homepage user icon fix

### DIFF
--- a/src/applications/static-pages/createMyVALoginWidget.js
+++ b/src/applications/static-pages/createMyVALoginWidget.js
@@ -9,7 +9,7 @@ export default function createMyVALoginWidget(store) {
       root.innerHTML =
         `<a href="${rootUrl}" class="homepage-button">` +
         '<div class="icon-wrapper">' +
-        '<i class="fa fa-user-circle-o homepage-button-icon"></i>' +
+        '<i class="fas fa-user-circle homepage-button-icon"></i>' +
         '</div>' +
         '<div class="button-inner">' +
         '<span>Go to your personalized “My VA” page</span>' +

--- a/src/site/layouts/home.html
+++ b/src/site/layouts/home.html
@@ -77,7 +77,7 @@
         <div class="usa-width-one-third" id="myva-login">
           <button onclick="recordEvent({ event: 'nav-main-sign-in' });" class="homepage-button signin-signup-modal-trigger">
             <div class="icon-wrapper">
-              <i class="fa fa-user-circle homepage-button-icon"></i>
+              <i class="fas fa-user-circle homepage-button-icon"></i>
             </div>
             <div class="button-inner">
               <span>Sign in or create an account to use more tools</span>


### PR DESCRIPTION
## Description
The user circle icon on the homepage button does not appear while logged in.

![screen shot 2019-01-22 at 3 49 40 pm](https://user-images.githubusercontent.com/11021491/51566886-c52a7380-1e63-11e9-803b-f0cd769196a9.png)


## Testing done
Logged in locally and user circle icon loaded successfully.

## Screenshots
![screen shot 2019-01-22 at 5 11 50 pm](https://user-images.githubusercontent.com/11021491/51568902-de81ee80-1e68-11e9-8fc2-6dd650ca3221.png)


## Acceptance criteria
- [X] Icon displays while logged 

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
