### PR TITLE
Add Classification Code to new disabilities and validate names

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -243,4 +243,4 @@ export const LOWERED_DISABILITY_DESCRIPTIONS = Object.values(
 // it's only used on disabilities that don't exist in the mapped list.
 // Note: the right single quote (’) is intentional - apostrophes are not
 //       allowed.
-export const VDC_DISABILITY_NAME_REGEX = /^(?!.*[ ]{2})[a-zA-Z0-9.,’()\\-\\/ ]*$/;
+export const EVSS_DISABILITY_NAME_REGEX = /^([a-zA-Z0-9\-‘.,/()]([a-zA-Z0-9\-’,. ])?)+$/;

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -1,3 +1,5 @@
+import disabilityLabels from './content/disabilityLabels';
+
 export const itfStatuses = {
   active: 'active',
   expired: 'expired',
@@ -232,3 +234,13 @@ export const ATTACHMENT_KEYS = [
   'secondaryUploadSources1',
   'secondaryUploadSources2',
 ];
+
+export const LOWERED_DISABILITY_DESCRIPTIONS = Object.values(
+  disabilityLabels,
+).map(v => v.toLowerCase());
+
+// This comes straight from EVSS but isn't documented in Swagger because
+// it's only used on disabilities that don't exist in the mapped list.
+// Note: the right single quote (’) is intentional - apostrophes are not
+//       allowed.
+export const VDC_DISABILITY_NAME_REGEX = /^(?!.*[ ]{2})[a-zA-Z0-9.,’()\\-\\/ ]*$/;

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -2,6 +2,7 @@ import * as autosuggest from 'us-forms-system/lib/js/definitions/autosuggest';
 import disabilityLabels from '../content/disabilityLabels';
 import { uiDescription } from '../content/addDisabilities';
 import NewDisability from '../components/NewDisability';
+import { validateDisabilityName } from '../validations';
 
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
@@ -30,6 +31,8 @@ export const uiSchema = {
           'ui:options': {
             freeInput: true,
           },
+          // autoSuggest schema doesn't have any default validations as long as { `freeInput: true` }
+          'ui:validations': [validateDisabilityName],
         },
       ),
       'view:descriptionInfo': {

--- a/src/applications/disability-benefits/all-claims/tests/schema/transformedData.js
+++ b/src/applications/disability-benefits/all-claims/tests/schema/transformedData.js
@@ -115,6 +115,7 @@ export const transformedMaximalData = {
         primaryDescription: 'A thing happened.',
         condition: 'PTSD (post traumatic stress disorder)',
         specialIssues: ['POW'],
+        classificationCode: '5420',
       },
       {
         cause: 'NEW',
@@ -549,7 +550,11 @@ export const transformedMinimalPtsdFormUploadData = {
     emailAddress: 'test2@test1.net',
     privacyAgreementAccepted: true,
     newPrimaryDisabilities: [
-      { condition: 'PTSD personal trauma', cause: 'NEW' },
+      {
+        condition: 'PTSD personal trauma',
+        cause: 'NEW',
+        classificationCode: '7290',
+      },
     ],
     attachments: [
       {

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -218,22 +218,22 @@ describe('526 All Claims validations', () => {
   describe('validateDisabilityName', () => {
     it('should not add error when regex fails but disability is in list', () => {
       const err = { addError: sinon.spy() };
-      validateDisabilityName(err, disabilityLabels[5780]);
+      validateDisabilityName(err, disabilityLabels[7100]);
       expect(err.addError.called).to.be.false;
     });
     it('should not add error when disability is in list but capitalization is different', () => {
       const err = { addError: sinon.spy() };
-      validateDisabilityName(err, capitalizeEachWord(disabilityLabels[5780]));
+      validateDisabilityName(err, capitalizeEachWord(disabilityLabels[7100]));
       expect(err.addError.called).to.be.false;
     });
     it('should not add error when disability not in list but passes regex', () => {
       const err = { addError: sinon.spy() };
-      validateDisabilityName(err, 'blah. (and, blah) /blah');
+      validateDisabilityName(err, 'blah. (and, blah/blah)’- blah');
       expect(err.addError.called).to.be.false;
     });
     it('should add error when disability not in list and regex fails', () => {
       const err = { addError: sinon.spy() };
-      validateDisabilityName(err, 'blah -;');
+      validateDisabilityName(err, 'blah ;');
       expect(err.addError.calledOnce).to.be.true;
     });
   });

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -6,7 +6,11 @@ import {
   startedAfterServicePeriod,
   oneDisabilityRequired,
   hasMonthYear,
+  validateDisabilityName,
 } from '../validations';
+
+import disabilityLabels from '../content/disabilityLabels';
+import { capitalizeEachWord } from '../utils';
 
 describe('526 All Claims validations', () => {
   describe('isValidYear', () => {
@@ -208,6 +212,29 @@ describe('526 All Claims validations', () => {
       };
       hasMonthYear(err, '1980-12-XX');
       expect(err.addError.called).to.be.false;
+    });
+  });
+
+  describe('validateDisabilityName', () => {
+    it('should not add error when regex fails but disability is in list', () => {
+      const err = { addError: sinon.spy() };
+      validateDisabilityName(err, disabilityLabels[5780]);
+      expect(err.addError.called).to.be.false;
+    });
+    it('should not add error when disability is in list but capitalization is different', () => {
+      const err = { addError: sinon.spy() };
+      validateDisabilityName(err, capitalizeEachWord(disabilityLabels[5780]));
+      expect(err.addError.called).to.be.false;
+    });
+    it('should not add error when disability not in list but passes regex', () => {
+      const err = { addError: sinon.spy() };
+      validateDisabilityName(err, 'blah. (and, blah) /blah');
+      expect(err.addError.called).to.be.false;
+    });
+    it('should add error when disability not in list and regex fails', () => {
+      const err = { addError: sinon.spy() };
+      validateDisabilityName(err, 'blah -;');
+      expect(err.addError.calledOnce).to.be.true;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -5,7 +5,7 @@ import {
   MILITARY_CITIES,
   MILITARY_STATE_VALUES,
   LOWERED_DISABILITY_DESCRIPTIONS,
-  VDC_DISABILITY_NAME_REGEX,
+  EVSS_DISABILITY_NAME_REGEX,
 } from './constants';
 
 export const hasMilitaryRetiredPay = data =>
@@ -214,7 +214,7 @@ export const hasMonthYear = (err, fieldData) => {
 export const validateDisabilityName = (err, fieldData) => {
   if (
     !LOWERED_DISABILITY_DESCRIPTIONS.includes(fieldData.toLowerCase()) &&
-    !VDC_DISABILITY_NAME_REGEX.test(fieldData)
+    !EVSS_DISABILITY_NAME_REGEX.test(fieldData)
   ) {
     // technically single quotes (’) are allowed as well but leaving out of
     // this message to avoid confusing veterans who can't tell the difference

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -1,7 +1,12 @@
 import _ from '../../../platform/utilities/data';
 import some from 'lodash/some';
 import moment from 'moment';
-import { MILITARY_CITIES, MILITARY_STATE_VALUES } from './constants';
+import {
+  MILITARY_CITIES,
+  MILITARY_STATE_VALUES,
+  LOWERED_DISABILITY_DESCRIPTIONS,
+  VDC_DISABILITY_NAME_REGEX,
+} from './constants';
 
 export const hasMilitaryRetiredPay = data =>
   _.get('view:hasMilitaryRetiredPay', data, false);
@@ -203,5 +208,16 @@ export const hasMonthYear = (err, fieldData) => {
 
   if (year === 'XXXX' || month === 'XX') {
     err.addError('Please provide both month and year');
+  }
+};
+
+export const validateDisabilityName = (err, fieldData) => {
+  if (
+    !LOWERED_DISABILITY_DESCRIPTIONS.includes(fieldData.toLowerCase()) &&
+    !VDC_DISABILITY_NAME_REGEX.test(fieldData)
+  ) {
+    // technically single quotes (’) are allowed as well but leaving out of
+    // this message to avoid confusing veterans who can't tell the difference
+    err.addError('The only special characters allowed are: , . ( ) / \\');
   }
 };

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -218,6 +218,6 @@ export const validateDisabilityName = (err, fieldData) => {
   ) {
     // technically single quotes (’) are allowed as well but leaving out of
     // this message to avoid confusing veterans who can't tell the difference
-    err.addError('The only special characters allowed are: , . ( ) / \\');
+    err.addError('The only special characters allowed are: , . ( ) / -');
   }
 };


### PR DESCRIPTION
## Description
- Adds `classificationCode` to `newDisabilities` in the submit transformer
- Adds FE validation on new disability names, ensuring that names which are not on the pre-approved list are tested against VDC regex
- Adds tests for the new submit transformer functionality as well as the FE input validator

## Testing done
- Tested locally
- Added unit tests

## Screenshots
Does not pass regex and not on the disability list:
<img width="629" alt="screen shot 2019-01-22 at 3 39 05 pm" src="https://user-images.githubusercontent.com/24251447/51570762-9d3c0f80-1e65-11e9-9140-2a1d1d2d9c19.png">

-----

Does not pass validation but *is* on the disability list:
<img width="589" alt="screen shot 2019-01-22 at 3 39 19 pm" src="https://user-images.githubusercontent.com/24251447/51570800-b1800c80-1e65-11e9-89d1-58c316695afa.png">



## Acceptance criteria
- [x] Add classification code where available to submitted new disabilities
- [x] Add FE conditional validation for new disability names
- [x] Test functionality

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
