### PR TITLE
Set tags globally instead of using context

### DIFF
--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -62,6 +62,11 @@ import './sass/static-pages.scss';
 // New sidebar menu
 import './sidebar-navigation.js';
 
+// Set further errors to have the appropriate source tag
+Raven.setTagsContext({
+  source: 'static-pages',
+});
+
 const store = createCommonStore();
 Raven.context(
   {
@@ -72,74 +77,66 @@ Raven.context(
   },
 );
 
-Raven.context(
-  {
-    tags: { source: 'static-pages' },
-  },
-  () => {
-    createAdditionalInfoWidget();
+createAdditionalInfoWidget();
 
-    if (pensionPages.has(location.pathname)) {
-      createApplicationStatus(store, {
-        formId: '21P-527EZ',
-        applyHeading: 'How do I apply?',
-        additionalText: 'You can apply online right now.',
-        applyLink: '/pension/how-to-apply/',
-        applyText: 'Apply for Veterans Pension Benefits',
-      });
-    }
+if (pensionPages.has(location.pathname)) {
+  createApplicationStatus(store, {
+    formId: '21P-527EZ',
+    applyHeading: 'How do I apply?',
+    additionalText: 'You can apply online right now.',
+    applyLink: '/pension/how-to-apply/',
+    applyText: 'Apply for Veterans Pension Benefits',
+  });
+}
 
-    if (healthcarePages.has(location.pathname)) {
-      createApplicationStatus(store, {
-        formId: '1010ez',
-        applyHeading: 'How do I apply?',
-        additionalText: 'You can apply online right now.',
-        applyLink: '/health-care/how-to-apply/',
-        applyText: 'Apply for Health Care Benefits',
-      });
-    }
+if (healthcarePages.has(location.pathname)) {
+  createApplicationStatus(store, {
+    formId: '1010ez',
+    applyHeading: 'How do I apply?',
+    additionalText: 'You can apply online right now.',
+    applyLink: '/health-care/how-to-apply/',
+    applyText: 'Apply for Health Care Benefits',
+  });
+}
 
-    if (ctaTools.has(location.pathname)) {
-      createCallToActionWidget(store);
-    }
+if (ctaTools.has(location.pathname)) {
+  createCallToActionWidget(store);
+}
 
-    if (eduPages.has(location.pathname)) {
-      createEducationApplicationStatus(store);
-    }
+if (eduPages.has(location.pathname)) {
+  createEducationApplicationStatus(store);
+}
 
-    if (location.pathname === eduOptOutPage) {
-      createOptOutApplicationStatus(store);
-    }
+if (location.pathname === eduOptOutPage) {
+  createOptOutApplicationStatus(store);
+}
 
-    if (burialPages.has(location.pathname)) {
-      createApplicationStatus(store, {
-        formId: '21P-530',
-        applyHeading: 'How do I apply?',
-        additionalText: 'You can apply online right now.',
-        applyText: 'Apply for Burial Benefits',
-      });
-    }
+if (burialPages.has(location.pathname)) {
+  createApplicationStatus(store, {
+    formId: '21P-530',
+    applyHeading: 'How do I apply?',
+    additionalText: 'You can apply online right now.',
+    applyText: 'Apply for Burial Benefits',
+  });
+}
 
-    if (disabilityPages.has(location.pathname)) {
-      createDisabilityIncreaseApplicationStatus(store);
-    }
+if (disabilityPages.has(location.pathname)) {
+  createDisabilityIncreaseApplicationStatus(store);
+}
 
-    if (
-      location.pathname ===
-      '/disability-benefits/apply/form-526-disability-claim/'
-    ) {
-      create526EmailForm(store);
-    }
+if (
+  location.pathname === '/disability-benefits/apply/form-526-disability-claim/'
+) {
+  create526EmailForm(store);
+}
 
-    // homepage widgets
-    if (location.pathname === '/') {
-      createMyVALoginWidget(store);
-    }
+// homepage widgets
+if (location.pathname === '/') {
+  createMyVALoginWidget(store);
+}
 
-    /* eslint-disable no-unused-vars,camelcase */
-    const lazyLoad = new LazyLoad({
-      elements_selector: '.lazy',
-    });
-    /* eslint-enable */
-  },
-);
+/* eslint-disable no-unused-vars,camelcase */
+const lazyLoad = new LazyLoad({
+  elements_selector: '.lazy',
+});
+/* eslint-enable */

--- a/src/platform/startup/index.js
+++ b/src/platform/startup/index.js
@@ -36,6 +36,11 @@ export default function startApp({
   analyticsEvents,
   entryName = 'unknown',
 }) {
+  // Set further errors to have the appropriate source tag
+  Raven.setTagsContext({
+    source: entryName,
+  });
+
   const store = createCommonStore(reducer, analyticsEvents);
 
   let history = browserHistory;
@@ -64,12 +69,5 @@ export default function startApp({
     content = <Router history={history}>{routes}</Router>;
   }
 
-  Raven.context(
-    {
-      tags: { source: entryName },
-    },
-    () => {
-      startReactApp(<Provider store={store}>{content}</Provider>);
-    },
-  );
+  startReactApp(<Provider store={store}>{content}</Provider>);
 }


### PR DESCRIPTION
## Description
So far, most errors are coming into Sentry with the `unknown` source tag. This looks like it's because `Raven.context` doesn't wrap all of the code imported in entry files. Rather than wrap every entry file with context, I'm switching to setting it globally when start up happens. Some errors that are pre-startup may still have unknown, but the only way around that is to read the entry name from the page somehow.

## Acceptance criteria
- [x] Build passes

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
