### PR TITLE
Appealsv2 add appeal type mg

### DIFF
--- a/src/applications/claims-status/components/ClosedClaimMessage.jsx
+++ b/src/applications/claims-status/components/ClosedClaimMessage.jsx
@@ -3,11 +3,11 @@ import { Link } from 'react-router';
 import moment from 'moment';
 import { orderBy } from 'lodash';
 import recordEvent from '../../../platform/monitoring/record-event';
-import { APPEAL_V2_TYPE } from '../utils/appeals-v2-helpers';
+import { APPEAL_TYPES } from '../utils/appeals-v2-helpers';
 
 import { getClaimType } from '../utils/helpers';
 
-const appealTypes = ['appeals_status_models_appeals', APPEAL_V2_TYPE];
+const appealTypes = Object.values(APPEAL_TYPES);
 
 export default function ClosedClaimMessage({ claims, onClose }) {
   const closedClaims = claims

--- a/src/applications/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/applications/claims-status/components/appeals-v2/Docket.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 
 import DocketCard from './DocketCard';
-import { APPEAL_TYPES } from '../../utils/appeals-v2-helpers';
+import { APPEAL_STATUSES } from '../../utils/appeals-v2-helpers';
 
 /**
  * @param {Number} ahead - The number of appeals ahead of this one
@@ -49,7 +49,7 @@ function Docket({
         </p>
       </div>
     );
-  } else if (appealType === APPEAL_TYPES.postCavcRemand) {
+  } else if (appealType === APPEAL_STATUSES.postCavcRemand) {
     // Post-CAVC remand should over-ride default content but not AoD
     content = (
       <p>

--- a/src/applications/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/applications/claims-status/containers/AppealsV2StatusPage.jsx
@@ -6,7 +6,7 @@ import {
   getStatusContents,
   getNextEvents,
   ALERT_TYPES,
-  APPEAL_TYPES,
+  APPEAL_STATUSES,
   EVENT_TYPES,
   STATUS_TYPES,
 } from '../utils/appeals-v2-helpers';
@@ -53,8 +53,8 @@ const AppealsV2StatusPage = ({ appeal, fullName }) => {
     STATUS_TYPES.bvaDevelopment,
   ];
   const hideDocketAppealTypes = [
-    APPEAL_TYPES.reconsideration,
-    APPEAL_TYPES.cue,
+    APPEAL_STATUSES.reconsideration,
+    APPEAL_STATUSES.cue,
   ];
   const shouldShowDocket =
     appealIsActive &&

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -13,7 +13,7 @@ import {
   sortClaims,
 } from '../actions/index.jsx';
 import {
-  APPEAL_V2_TYPE,
+  APPEAL_TYPES,
   claimsAvailability,
   appealsAvailability,
   sortByLastUpdated,
@@ -74,7 +74,7 @@ class YourClaimsPageV2 extends React.Component {
   }
 
   renderListItem(claim) {
-    if (claim.type === APPEAL_V2_TYPE) {
+    if (claim.type === APPEAL_TYPES.current) {
       return (
         <AppealListItem
           key={claim.id}

--- a/src/applications/claims-status/reducers/claims-list.js
+++ b/src/applications/claims-status/reducers/claims-list.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 import moment from 'moment';
-import { APPEAL_V2_TYPE } from '../utils/appeals-v2-helpers';
+import { APPEAL_TYPES } from '../utils/appeals-v2-helpers';
 
 import {
   SET_CLAIMS,
@@ -57,15 +57,14 @@ const sortPropertyFn = {
   claimType,
 };
 
+const appealTypesArray = Object.values(APPEAL_TYPES);
+
 function filterList(list, filter) {
   let filteredList = list;
   if (filter) {
     const open = filter === 'open';
     filteredList = filteredList.filter(claim => {
-      if (
-        claim.type === 'appeals_status_models_appeals' ||
-        claim.type === APPEAL_V2_TYPE
-      ) {
+      if (appealTypesArray.includes(claim.type)) {
         return claim.attributes.active === open;
       }
       return claim.attributes.open === open;
@@ -77,10 +76,7 @@ function filterList(list, filter) {
 function sortList(list, sortProperty) {
   const sortOrder = sortProperty === 'claimType' ? 'asc' : 'desc';
   const sortFunc = el => {
-    if (
-      el.type === 'appeals_status_models_appeals' ||
-      el.type === APPEAL_V2_TYPE
-    ) {
+    if (appealTypesArray.includes(el.type)) {
       const events = _.orderBy(
         [e => moment(e.date).unix()],
         'desc',

--- a/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
@@ -22,7 +22,7 @@ describe('<YourClaimsPageV2>', () => {
         id: '1122334455',
       },
       {
-        type: 'appealSeries',
+        type: 'LegacyAppeal',
         id: '1122334455',
       },
     ],

--- a/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
@@ -22,7 +22,7 @@ describe('<YourClaimsPageV2>', () => {
         id: '1122334455',
       },
       {
-        type: 'LegacyAppeal',
+        type: 'legacyAppeal',
         id: '1122334455',
       },
     ],

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealsV2StatusPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealsV2StatusPage.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
 import { mockData } from '../../../utils/helpers';
-import { APPEAL_TYPES } from '../../../utils/appeals-v2-helpers';
+import { APPEAL_STATUSES } from '../../../utils/appeals-v2-helpers';
 import AppealsV2StatusPage from '../../../containers/AppealsV2StatusPage';
 
 describe('<AppealsV2StatusPage/>', () => {
@@ -84,7 +84,7 @@ describe('<AppealsV2StatusPage/>', () => {
       ...defaultProps,
       attributes: {
         ...defaultProps.attributes,
-        type: APPEAL_TYPES.cue,
+        type: APPEAL_STATUSES.cue,
       },
     };
     const wrapper = shallow(<AppealsV2StatusPage {...props} />);

--- a/src/applications/claims-status/tests/components/appeals-v2/Docket.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/Docket.unit.spec.jsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
 import Docket from '../../../components/appeals-v2/Docket';
-import { APPEAL_TYPES } from '../../../utils/appeals-v2-helpers';
+import { APPEAL_STATUSES } from '../../../utils/appeals-v2-helpers';
 
 describe('Appeals V2 Docket', () => {
   const defaultProps = {
@@ -11,7 +11,7 @@ describe('Appeals V2 Docket', () => {
     ahead: 23456,
     form9Date: '2006-10-24',
     docketMonth: '2004-04-15',
-    appealType: APPEAL_TYPES.original,
+    appealType: APPEAL_STATUSES.original,
     aod: false,
     frontOfDocket: false,
   };
@@ -53,7 +53,10 @@ describe('Appeals V2 Docket', () => {
   });
 
   it('should not render DocketCard for postCavcRemand', () => {
-    const props = { ...defaultProps, appealType: APPEAL_TYPES.postCavcRemand };
+    const props = {
+      ...defaultProps,
+      appealType: APPEAL_STATUSES.postCavcRemand,
+    };
     const wrapper = shallow(<Docket {...props} />);
     expect(wrapper.find('DocketCard').length).to.equal(0);
     wrapper.unmount();
@@ -62,7 +65,7 @@ describe('Appeals V2 Docket', () => {
   it('should render aod when both aod and appeal type postCavcRemand', () => {
     const props = {
       ...defaultProps,
-      appealType: APPEAL_TYPES.postCavcRemand,
+      appealType: APPEAL_STATUSES.postCavcRemand,
       aod: true,
     };
     const wrapper = shallow(<Docket {...props} />);
@@ -80,7 +83,10 @@ describe('Appeals V2 Docket', () => {
   });
 
   it('should display postCavcRemand text', () => {
-    const props = { ...defaultProps, appealType: APPEAL_TYPES.postCavcRemand };
+    const props = {
+      ...defaultProps,
+      appealType: APPEAL_STATUSES.postCavcRemand,
+    };
     const wrapper = shallow(<Docket {...props} />);
     expect(wrapper.text()).to.contain(
       'Your appeal was remanded by the Court of Appeals for Veterans’ Claims.',

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -8,7 +8,7 @@ import siteName from '../../../platform/brand-consolidation/site-name';
 // This literally determines how many rows are displayed per page on the v2 index page
 export const ROWS_PER_PAGE = 10;
 
-export const APPEAL_TYPES = {
+export const APPEAL_STATUSES = {
   original: 'original',
   postRemand: 'post_remand',
   postCavcRemand: 'post_cavc_remand',
@@ -16,7 +16,7 @@ export const APPEAL_TYPES = {
   cue: 'cue',
 };
 
-export const APPEAL_V2_TYPE = 'appealSeries';
+export const APPEAL_V2_TYPES = 'appealSeries';
 
 // TO DO: Replace these properties and content with real versions once finalized.
 export const STATUS_TYPES = {

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -16,7 +16,13 @@ export const APPEAL_STATUSES = {
   cue: 'cue',
 };
 
-export const APPEAL_V2_TYPES = 'appealSeries';
+// Only `LegacyAppeal` is currently supported as the team works on adding new
+// appeal types, but leaving the other old ones in here just in case
+export const APPEAL_TYPES = {
+  current: 'LegacyAppeal',
+  v2Legacy: 'appealSeries',
+  v1Legacy: 'appeals_status_models_appeals',
+};
 
 // TO DO: Replace these properties and content with real versions once finalized.
 export const STATUS_TYPES = {
@@ -1522,7 +1528,7 @@ const getDate = item => {
     return '0';
   }
 
-  return item.type === APPEAL_V2_TYPE
+  return item.type === APPEAL_STATUSES.current
     ? getAppealDate(item)
     : getClaimDate(item);
 };

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -16,10 +16,10 @@ export const APPEAL_STATUSES = {
   cue: 'cue',
 };
 
-// Only `LegacyAppeal` is currently supported as the team works on adding new
+// Only `legacyAppeal` is currently supported as the team works on adding new
 // appeal types, but leaving the other old ones in here just in case
 export const APPEAL_TYPES = {
-  current: 'LegacyAppeal',
+  current: 'legacyAppeal',
   v2Legacy: 'appealSeries',
   v1Legacy: 'appeals_status_models_appeals',
 };

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -315,7 +315,7 @@ export const mockData = {
     {
       // Status: Review your statement of the case - pending_form9
       id: '7387389',
-      type: 'LegacyAppeal',
+      type: 'legacyAppeal',
       attributes: {
         appealIds: ['7387389', '123'],
         updated: '2018-01-03T09:30:15-05:00',
@@ -402,7 +402,7 @@ export const mockData = {
     {
       // Status: Waiting to be assigned to a judge - on_docket
       id: '7387390',
-      type: 'LegacyAppeal',
+      type: 'legacyAppeal',
       attributes: {
         appealIds: ['7387390', '456'],
         updated: '2018-01-03T09:30:15-05:00',
@@ -482,7 +482,7 @@ export const mockData = {
     {
       // Status: The Board has made a decision on your appeal - bva_decision
       id: '7387391',
-      type: 'LegacyAppeal',
+      type: 'legacyAppeal',
       attributes: {
         appealIds: ['7387391', '789'],
         updated: '2018-01-03T09:30:15-05:00',

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -315,7 +315,7 @@ export const mockData = {
     {
       // Status: Review your statement of the case - pending_form9
       id: '7387389',
-      type: 'appealSeries',
+      type: 'LegacyAppeal',
       attributes: {
         appealIds: ['7387389', '123'],
         updated: '2018-01-03T09:30:15-05:00',
@@ -402,7 +402,7 @@ export const mockData = {
     {
       // Status: Waiting to be assigned to a judge - on_docket
       id: '7387390',
-      type: 'appealSeries',
+      type: 'LegacyAppeal',
       attributes: {
         appealIds: ['7387390', '456'],
         updated: '2018-01-03T09:30:15-05:00',
@@ -482,7 +482,7 @@ export const mockData = {
     {
       // Status: The Board has made a decision on your appeal - bva_decision
       id: '7387391',
-      type: 'appealSeries',
+      type: 'LegacyAppeal',
       attributes: {
         appealIds: ['7387391', '789'],
         updated: '2018-01-03T09:30:15-05:00',

--- a/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import backendServices from 'platform/user/profile/constants/backendServices';
 import {
-  APPEAL_STATUSES,
+  APPEAL_TYPES,
   claimsAvailability,
   appealsAvailability,
 } from 'applications/claims-status/utils/appeals-v2-helpers';
@@ -54,7 +54,7 @@ class ClaimsAppealsWidget extends React.Component {
   }
 
   renderListItem(claim) {
-    if (claim.type === APPEAL_STATUSES.current) {
+    if (claim.type === APPEAL_TYPES.current) {
       return (
         <AppealListItem
           key={claim.id}

--- a/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import backendServices from 'platform/user/profile/constants/backendServices';
 import {
-  APPEAL_V2_TYPE,
+  APPEAL_STATUSES,
   claimsAvailability,
   appealsAvailability,
 } from 'applications/claims-status/utils/appeals-v2-helpers';
@@ -54,7 +54,7 @@ class ClaimsAppealsWidget extends React.Component {
   }
 
   renderListItem(claim) {
-    if (claim.type === APPEAL_V2_TYPE) {
+    if (claim.type === APPEAL_STATUSES.current) {
       return (
         <AppealListItem
           key={claim.id}

--- a/src/applications/personalization/dashboard/tests/containers/ClaimsAppealsWidget.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/ClaimsAppealsWidget.unit.spec.jsx
@@ -76,7 +76,7 @@ const props = {
         updated: '2018-05-10T10:20:42-05:00',
       },
       id: '1196201',
-      type: 'LegacyAppeal',
+      type: 'legacyAppeal',
     },
   ],
 };

--- a/src/applications/personalization/dashboard/tests/containers/ClaimsAppealsWidget.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/ClaimsAppealsWidget.unit.spec.jsx
@@ -76,7 +76,7 @@ const props = {
         updated: '2018-05-10T10:20:42-05:00',
       },
       id: '1196201',
-      type: 'appealSeries',
+      type: 'LegacyAppeal',
     },
   ],
 };


### PR DESCRIPTION
## Description
Fixes a bug where all appeals show as closed because they're incorrectly treated as claims. The origin of this is an upstream change where the value of the `type` property for an appeal changed from `appealSeries` to `legacyAppeal`. This change broke the FE filter that determines whether a given array item is a claim or appeal, so the wrong checks were applied to appeals and the result was that all appeals appeared closed to veterans.

A longer-term fix would probably be to not intermingle appeals and claims in one array, which would fix us having to deduce whether an item is a claim or an appeal based on its `type` in the first place. This would be fairly straightforward as `appeals` and `claims` each has its own property in the v2 claims store root.

### Update ###
Tested in staging and everything seems to work as intended.

## Testing done
- [x] Tested locally
- [x] Updated unit tests with new `type` values

## Screenshots
No change

## Acceptance criteria
- [x] Open claims and appeals show as open
- [x] Closed claims and appeals show as closed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
