### PR TITLE
Fix 526 key name mismatches for SIP

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -869,7 +869,7 @@ const formConfig = {
                 hideIf: formData => _.get('standardClaim', formData),
               },
             },
-            'view:noFDCWarning': {
+            'view:noFdcWarning': {
               'ui:description': noFDCWarning,
               'ui:options': {
                 hideIf: formData => !_.get('standardClaim', formData),
@@ -884,7 +884,7 @@ const formConfig = {
                 type: 'object',
                 properties: {},
               },
-              'view:noFDCWarning': {
+              'view:noFdcWarning': {
                 type: 'object',
                 properties: {},
               },

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -122,7 +122,7 @@ export const SERVICE_CONNECTION_TYPES = {
 
 export const DATA_PATHS = {
   hasVAEvidence:
-    'view:hasEvidenceFollowUp.view:selectableEvidenceTypes.view:hasVAMedicalRecords',
+    'view:hasEvidenceFollowUp.view:selectableEvidenceTypes.view:hasVaMedicalRecords',
   hasPrivateEvidence:
     'view:hasEvidenceFollowUp.view:selectableEvidenceTypes.view:hasPrivateMedicalRecords',
   hasPrivateRecordsToUpload:

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
@@ -29,7 +29,7 @@ export const uiSchema = {
         atLeastOne: 'Please select at least one type of supporting evidence',
       },
       'ui:required': formData => get('view:hasEvidence', formData, false),
-      'view:hasVAMedicalRecords': { 'ui:title': 'VA medical records' },
+      'view:hasVaMedicalRecords': { 'ui:title': 'VA medical records' },
       'view:hasPrivateMedicalRecords': {
         'ui:title': 'Private medical records',
       },
@@ -58,7 +58,7 @@ export const schema = {
         'view:selectableEvidenceTypes': {
           type: 'object',
           properties: {
-            'view:hasVAMedicalRecords': { type: 'boolean' },
+            'view:hasVaMedicalRecords': { type: 'boolean' },
             'view:hasPrivateMedicalRecords': { type: 'boolean' },
             'view:hasOtherEvidence': { type: 'boolean' },
           },

--- a/src/applications/disability-benefits/all-claims/pages/fullyDevelopedClaim.js
+++ b/src/applications/disability-benefits/all-claims/pages/fullyDevelopedClaim.js
@@ -27,7 +27,7 @@ export const uiSchema = {
       hideIf: formData => get('standardClaim', formData),
     },
   },
-  'view:noFDCWarning': {
+  'view:noFdcWarning': {
     'ui:description': noFDCWarning,
     'ui:options': {
       hideIf: formData => !get('standardClaim', formData),
@@ -44,7 +44,7 @@ export const schema = {
       type: 'object',
       properties: {},
     },
-    'view:noFDCWarning': {
+    'view:noFdcWarning': {
       type: 'object',
       properties: {},
     },

--- a/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
@@ -141,7 +141,7 @@ export const uiSchema = {
           'ui:validations': [validateLength(350)],
         },
       },
-      'view:VAFollowUp': {
+      'view:vaFollowUp': {
         'ui:options': {
           expandUnder: 'cause',
           expandUnderCondition: 'VA',
@@ -201,7 +201,7 @@ export const schema = {
               worsenedEffects,
             },
           },
-          'view:VAFollowUp': {
+          'view:vaFollowUp': {
             type: 'object',
             properties: {
               vaMistreatmentDescription,

--- a/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
+++ b/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
@@ -9,7 +9,7 @@ export const uiSchema = {
     'ui:title': 'Have you ever been a POW?',
     'ui:widget': 'yesNo',
   },
-  'view:isPOW': {
+  'view:isPow': {
     'ui:options': {
       expandUnder: 'view:powStatus',
     },
@@ -46,7 +46,7 @@ export const schema = {
     'view:powStatus': {
       type: 'boolean',
     },
-    'view:isPOW': {
+    'view:isPow': {
       type: 'object',
       properties: {
         confinements: fullSchema.properties.confinements,

--- a/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
@@ -109,7 +109,7 @@ function completeEvidenceTypes(client, data) {
   client
     .selectYesNo('root_view:hasEvidence', hasEvidence)
     // .fillCheckbox(
-    //   'input[name="root_view:hasEvidenceFollowUp_view:selectableEvidenceTypes_view:hasVAMedicalRecords"]',
+    //   'input[name="root_view:hasEvidenceFollowUp_view:selectableEvidenceTypes_view:hasVaMedicalRecords"]',
     //   evidenceTypes['view:vaMedicalRecords'],
     // )
     .fillCheckbox(

--- a/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypes.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypes.unit.spec.jsx
@@ -79,7 +79,7 @@ describe('evidenceTypes', () => {
           'view:hasEvidence': true,
           'view:hasEvidenceFollowUp': {
             'view:selectableEvidenceTypes': {
-              'view:hasVAMedicalRecords': true,
+              'view:hasVaMedicalRecords': true,
             },
           },
         }}

--- a/src/applications/disability-benefits/all-claims/tests/pages/newDisabilitiesFollowUp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/newDisabilitiesFollowUp.unit.spec.jsx
@@ -363,17 +363,17 @@ describe('New disabilities follow up info', () => {
     selectRadio(form, 'root_cause', 'VA');
     fillData(
       form,
-      'textarea[id="root_view:VAFollowUp_vaMistreatmentDescription"]',
+      'textarea[id="root_view:vaFollowUp_vaMistreatmentDescription"]',
       longText,
     );
     fillData(
       form,
-      'input[id="root_view:VAFollowUp_vaMistreatmentLocation"]',
+      'input[id="root_view:vaFollowUp_vaMistreatmentLocation"]',
       longText,
     );
     fillData(
       form,
-      'input[id="root_view:VAFollowUp_vaMistreatmentDate"]',
+      'input[id="root_view:vaFollowUp_vaMistreatmentDate"]',
       longText,
     );
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
@@ -76,8 +76,8 @@ describe('Prisoner of war info', () => {
     );
 
     selectRadio(form, 'root_view:powStatus', 'Y');
-    fillDate(form, 'root_view:isPOW_confinements_0_from', '2010-05-05');
-    fillDate(form, 'root_view:isPOW_confinements_0_to', '2011-05-05');
+    fillDate(form, 'root_view:isPow_confinements_0_from', '2010-05-05');
+    fillDate(form, 'root_view:isPow_confinements_0_to', '2011-05-05');
 
     form.find('.va-growable-add-btn').simulate('click');
 
@@ -103,8 +103,8 @@ describe('Prisoner of war info', () => {
     );
 
     selectRadio(form, 'root_view:powStatus', 'Y');
-    fillDate(form, 'root_view:isPOW_confinements_0_from', '2010-05-05');
-    fillDate(form, 'root_view:isPOW_confinements_0_to', '2011-05-05');
+    fillDate(form, 'root_view:isPow_confinements_0_from', '2010-05-05');
+    fillDate(form, 'root_view:isPow_confinements_0_to', '2011-05-05');
 
     form.find('form').simulate('submit');
     expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(0);

--- a/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
@@ -143,7 +143,7 @@ describe('Summary of Evidence', () => {
           'view:hasEvidence': true,
           'view:hasEvidenceFollowUp': {
             'view:selectableEvidenceTypes': {
-              'view:hasVAMedicalRecords': true,
+              'view:hasVaMedicalRecords': true,
             },
           },
           vaTreatmentFacilities,

--- a/src/applications/disability-benefits/all-claims/tests/schema/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/schema/maximal-test.json
@@ -91,14 +91,14 @@
     "view:hasEvidence": true,
     "view:hasEvidenceFollowUp": {
       "view:selectableEvidenceTypes": {
-        "view:hasVAMedicalRecords": true,
+        "view:hasVaMedicalRecords": true,
         "view:hasPrivateMedicalRecords": true,
         "view:hasOtherEvidence": true
       },
       "view:evidenceTypeHelp": {}
     },
     "view:powStatus": true,
-    "view:isPOW": {
+    "view:isPow": {
       "confinements": [
         {
           "from": "1900-01-01",

--- a/src/applications/disability-benefits/all-claims/tests/schema/minimal-ptsd-form-upload-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/schema/minimal-ptsd-form-upload-test.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "standardClaim": true,
-    "view:noFDCWarning": {},
+    "view:noFdcWarning": {},
     "view:hasSeparationPay": false,
     "hasTrainingPay": false,
     "isVaEmployee": false,


### PR DESCRIPTION
## Description
Save in progress fails to fill in certain fields on 526 because of key name mismatch due to capitalization.

changes made:
```
view:VAFollowUp => view:vaFollowUp
view:hasVAMedicalRecords => view:hasVaMedicalRecords
view:noFDCWarning => view:noFdcWarning
view:isPOW => view:isPow
```

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16420

## Testing done
local testing


## Acceptance criteria
- [x] updates key names so that save in progress works successfully

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
