### PR TITLE
All claims extra ptsd triggers mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -27,6 +27,7 @@ import {
   servedAfter911,
   isNotUploadingPrivateMedical,
   hasNewPtsdDisability,
+  isDisabilityPtsd,
 } from '../utils';
 
 import prefillTransformer from '../prefill-transformer';
@@ -96,7 +97,7 @@ import { createFormConfig781, createFormConfig781a } from './781';
 
 import createformConfig8940 from './8940';
 
-import { PTSD, PTSD_INCIDENT_ITERATION } from '../constants';
+import { PTSD_INCIDENT_ITERATION } from '../constants';
 
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
@@ -241,8 +242,7 @@ const formConfig = {
           depends: form => form['view:newDisabilities'] === true,
           path: 'new-disabilities/follow-up/:index',
           showPagePerItem: true,
-          itemFilter: item =>
-            item.condition && !item.condition.toLowerCase().includes(PTSD),
+          itemFilter: item => !isDisabilityPtsd(item.condition),
           arrayPath: 'newDisabilities',
           uiSchema: newDisabilityFollowUp.uiSchema,
           schema: newDisabilityFollowUp.schema,

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -143,7 +143,6 @@ export const TWENTY_FIVE_MB = 26214400;
 
 export const FIFTY_MB = 52428800;
 
-export const PTSD = 'ptsd';
 export const PTSD_MATCHES = [
   'ptsd',
   'post traumatic stress disorder',

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -144,6 +144,13 @@ export const TWENTY_FIVE_MB = 26214400;
 export const FIFTY_MB = 52428800;
 
 export const PTSD = 'ptsd';
+export const PTSD_MATCHES = [
+  'ptsd',
+  'post traumatic stress disorder',
+  'post-traumatic stress disorder',
+  'post traumatic stress',
+  'post-traumatic stress',
+];
 
 // Max number of incident iterations a user can go through.
 export const PTSD_INCIDENT_ITERATION = 3;

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -23,7 +23,6 @@ import {
   NINE_ELEVEN,
   HOMELESSNESS_TYPES,
   TWENTY_FIVE_MB,
-  PTSD,
   PTSD_MATCHES,
 } from './constants';
 
@@ -388,8 +387,10 @@ export const isDisabilityPtsd = disability => {
   }
 
   const loweredDisability = disability.toLowerCase();
-  return PTSD_MATCHES.some(ptsdString =>
-    ptsdString.includes(loweredDisability),
+  return PTSD_MATCHES.some(
+    ptsdString =>
+      ptsdString.includes(loweredDisability) ||
+      loweredDisability.includes(ptsdString),
   );
 };
 

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import Raven from 'raven-js';
 import appendQuery from 'append-query';
 import { createSelector } from 'reselect';
-import { omit, some, lowerCase } from 'lodash';
+import { omit } from 'lodash';
 import { apiRequest } from '../../../platform/utilities/api';
 import environment from '../../../platform/utilities/environment';
 import _ from '../../../platform/utilities/data';
@@ -24,6 +24,7 @@ import {
   HOMELESSNESS_TYPES,
   TWENTY_FIVE_MB,
   PTSD,
+  PTSD_MATCHES,
 } from './constants';
 
 /**
@@ -381,13 +382,21 @@ const post911Periods = createSelector(
 
 export const servedAfter911 = formData => !!post911Periods(formData).length;
 
-export const isDisabilityPtsd = disability =>
-  lowerCase(disability).includes(PTSD);
+export const isDisabilityPtsd = disability => {
+  if (!disability || typeof disability !== 'string') {
+    return false;
+  }
+
+  const loweredDisability = disability.toLowerCase();
+  return PTSD_MATCHES.some(ptsdString =>
+    ptsdString.includes(loweredDisability),
+  );
+};
 
 export const hasNewPtsdDisability = formData =>
   _.get('view:newDisabilities', formData, false) &&
-  some(_.get('newDisabilities', formData, []), item =>
-    isDisabilityPtsd(item.condition),
+  _.get('newDisabilities', formData, []).some(disability =>
+    isDisabilityPtsd(disability.condition),
   );
 
 export const needsToEnter781 = formData =>


### PR DESCRIPTION
## Description
- Adds some more 'trigger words' to indicate that a newly-entered disability is actually PTSD
- Updates the checker to include both instances where one of our trigger strings is in the disability name that was typed, *or* that the disability name that was types is in one of the trigger strings
- Updates references to old PTSD constant to instead make use of the `isPtsd` helper function
- Removes some unnecessary lodash usage

## Testing done
- Tested locally (that the PTSD page triggers when it should and vice-versa for non-PTSD follow-up pages).

## Screenshots
- NA

## Acceptance criteria
- [x] Allow other PTSD-ish things to trigger 781/a follow up pages

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
