### PR TITLE
Update ancillary form links to open in a new tab

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
@@ -9,7 +9,10 @@ const houseAssistanceContent = (
       Adaptation Grant (VA Form 26-4555).
     </p>
     <p>
-      <a href="https://www.vba.va.gov/pubs/forms/vba-26-4555-are.pdf">
+      <a
+        href="https://www.vba.va.gov/pubs/forms/vba-26-4555-are.pdf"
+        target="_blank"
+      >
         Download VA Form 26-4555
       </a>
       .
@@ -24,7 +27,10 @@ const carAssistanceContent = (
       equipped vehicle, you’ll need to fill out an Application for Automobile or
       Other Conveyance and Adaptive Equipment (VA Form 21-4502).
       <div>
-        <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4502-ARE.pdf">
+        <a
+          href="https://www.vba.va.gov/pubs/forms/VBA-21-4502-ARE.pdf"
+          target="_blank"
+        >
           Download VA Form 21-4502
         </a>
         .
@@ -34,7 +40,10 @@ const carAssistanceContent = (
       To file a claim for adaptive equipment, you’ll need to fill out an
       Application for Adaptive Equipment—Motor Vehicle (VA Form 10-1394).
       <div>
-        <a href="https://www.va.gov/vaforms/medical/pdf/10-1394-fill.pdf">
+        <a
+          href="https://www.va.gov/vaforms/medical/pdf/10-1394-fill.pdf"
+          target="_blank"
+        >
           Download VA Form 10-1394.
         </a>
       </div>
@@ -50,7 +59,10 @@ const aidAndAttendanceContent = (
       Attendance (VA Form 21-2680), which your doctor needs to fill out.
     </p>
     <div>
-      <a href="https://www.vba.va.gov/pubs/forms/VBA-21-2680-ARE.pdf">
+      <a
+        href="https://www.vba.va.gov/pubs/forms/VBA-21-2680-ARE.pdf"
+        target="_blank"
+      >
         Download VA Form 21-2680
       </a>
       .
@@ -68,7 +80,10 @@ const individualUnemployabilityContent = (
         A Veteran’s Application for Increased Compensation Based on
         Unemployability (VA Form 21-8940)
         <div>
-          <a href="https://www.vba.va.gov/pubs/forms/vba-21-8940-are.pdf">
+          <a
+            href="https://www.vba.va.gov/pubs/forms/vba-21-8940-are.pdf"
+            target="_blank"
+          >
             Download VA Form 21-8940
           </a>
           , <strong>and</strong>
@@ -78,7 +93,10 @@ const individualUnemployabilityContent = (
         A Request for Employment Information in Connection with Claim for
         Disability Benefits (VA Form 21-4192)
         <div>
-          <a href="https://www.vba.va.gov/pubs/forms/VBA-21-4192-ARE.pdf">
+          <a
+            href="https://www.vba.va.gov/pubs/forms/VBA-21-4192-ARE.pdf"
+            target="_blank"
+          >
             Download VA Form 21-4192
           </a>
           .

--- a/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
@@ -12,7 +12,7 @@ const houseAssistanceContent = (
       <a
         href="https://www.vba.va.gov/pubs/forms/vba-26-4555-are.pdf"
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
       >
         Download VA Form 26-4555
       </a>
@@ -31,7 +31,7 @@ const carAssistanceContent = (
         <a
           href="https://www.vba.va.gov/pubs/forms/VBA-21-4502-ARE.pdf"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
         >
           Download VA Form 21-4502
         </a>
@@ -45,7 +45,7 @@ const carAssistanceContent = (
         <a
           href="https://www.va.gov/vaforms/medical/pdf/10-1394-fill.pdf"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
         >
           Download VA Form 10-1394.
         </a>
@@ -65,7 +65,7 @@ const aidAndAttendanceContent = (
       <a
         href="https://www.vba.va.gov/pubs/forms/VBA-21-2680-ARE.pdf"
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
       >
         Download VA Form 21-2680
       </a>
@@ -87,7 +87,7 @@ const individualUnemployabilityContent = (
           <a
             href="https://www.vba.va.gov/pubs/forms/vba-21-8940-are.pdf"
             target="_blank"
-            rel="noopener"
+            rel="noopener noreferrer"
           >
             Download VA Form 21-8940
           </a>
@@ -101,7 +101,7 @@ const individualUnemployabilityContent = (
           <a
             href="https://www.vba.va.gov/pubs/forms/VBA-21-4192-ARE.pdf"
             target="_blank"
-            rel="noopener"
+            rel="noopener noreferrer"
           >
             Download VA Form 21-4192
           </a>

--- a/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
@@ -12,6 +12,7 @@ const houseAssistanceContent = (
       <a
         href="https://www.vba.va.gov/pubs/forms/vba-26-4555-are.pdf"
         target="_blank"
+        rel="noopener"
       >
         Download VA Form 26-4555
       </a>
@@ -30,6 +31,7 @@ const carAssistanceContent = (
         <a
           href="https://www.vba.va.gov/pubs/forms/VBA-21-4502-ARE.pdf"
           target="_blank"
+          rel="noopener"
         >
           Download VA Form 21-4502
         </a>
@@ -43,6 +45,7 @@ const carAssistanceContent = (
         <a
           href="https://www.va.gov/vaforms/medical/pdf/10-1394-fill.pdf"
           target="_blank"
+          rel="noopener"
         >
           Download VA Form 10-1394.
         </a>
@@ -62,6 +65,7 @@ const aidAndAttendanceContent = (
       <a
         href="https://www.vba.va.gov/pubs/forms/VBA-21-2680-ARE.pdf"
         target="_blank"
+        rel="noopener"
       >
         Download VA Form 21-2680
       </a>
@@ -83,6 +87,7 @@ const individualUnemployabilityContent = (
           <a
             href="https://www.vba.va.gov/pubs/forms/vba-21-8940-are.pdf"
             target="_blank"
+            rel="noopener"
           >
             Download VA Form 21-8940
           </a>
@@ -96,6 +101,7 @@ const individualUnemployabilityContent = (
           <a
             href="https://www.vba.va.gov/pubs/forms/VBA-21-4192-ARE.pdf"
             target="_blank"
+            rel="noopener"
           >
             Download VA Form 21-4192
           </a>

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -111,7 +111,7 @@ export const patientAcknowledgmentText = (
         <a
           href="https://www.benefits.va.gov/privateproviders/"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
         >
           https://www.benefits.va.gov/privateproviders/
         </a>

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -108,7 +108,11 @@ export const patientAcknowledgmentText = (
       <p>
         NOTE: For additional information regarding VA Form 21-4142, refer to the
         following website:
-        <a href="https://www.benefits.va.gov/privateproviders/" target="_blank">
+        <a
+          href="https://www.benefits.va.gov/privateproviders/"
+          target="_blank"
+          rel="noopener"
+        >
           https://www.benefits.va.gov/privateproviders/
         </a>
         .


### PR DESCRIPTION
## Description
Updates ancillary form links to open in new tabs. This list was generated by searching for all links in the all-claims directory and making all of them (except the crisis line) open in a new tab.
Also added `re="noopener"` attributes to prevent `window` object hijacking because why not.

## Testing done
- Tested locally

## Screenshots
NA

## Acceptance criteria
- [x] Ancillary form links open in new tabs.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
