### PR TITLE
Track pending registration in sessionStorage

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -48,6 +48,7 @@ function redirect(redirectUrl, clickedEvent, openedEvent) {
 }
 
 export function login(policy) {
+  sessionStorage.removeItem('registrationPending');
   return redirect(loginUrl(policy), 'login-link-clicked', 'login-link-opened');
 }
 
@@ -68,6 +69,7 @@ export function logout() {
 }
 
 export function signup() {
+  sessionStorage.setItem('registrationPending', true);
   return redirect(
     appendQuery(IDME_URL, { signup: true }),
     'register-link-clicked',

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -81,8 +81,14 @@ export function setupProfileSession(payload) {
   // this avoids setting the first name to the string 'null'.
   if (firstName) localStorage.setItem('userFirstName', firstName);
 
-  // Report success for the login method.
-  recordEvent({ event: `login-success-${loginPolicy}` });
+  if (sessionStorage.registrationPending) {
+    // Record GA success event for the register method.
+    recordEvent({ event: `register-success-${loginPolicy}` });
+    sessionStorage.removeItem('registrationPending');
+  } else {
+    // Report GA success event for the login method.
+    recordEvent({ event: `login-success-${loginPolicy}` });
+  }
 
   // Report out the current level of assurance for the user.
   if (loa && loa.current) {

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -81,7 +81,7 @@ export function setupProfileSession(payload) {
   // this avoids setting the first name to the string 'null'.
   if (firstName) localStorage.setItem('userFirstName', firstName);
 
-  if (sessionStorage.registrationPending) {
+  if (sessionStorage.getItem('registrationPending') === 'true') {
     // Record GA success event for the register method.
     recordEvent({ event: `register-success-${loginPolicy}` });
     sessionStorage.removeItem('registrationPending');

--- a/src/platform/utilities/tests/authentication.unit.spec.js
+++ b/src/platform/utilities/tests/authentication.unit.spec.js
@@ -16,7 +16,7 @@ let oldWindow;
 const fakeWindow = () => {
   oldSessionStorage = global.sessionStorage;
   oldWindow = global.window;
-  global.sessionStorage = { setItem: () => {} };
+  global.sessionStorage = { setItem: () => {}, removeItem: () => {} };
   global.window = {
     dataLayer: [],
     location: {


### PR DESCRIPTION
## Description

Registration success is being recorded as `login-success-{{loginPolicy}}` in GA.  The payload we get from the API in `setupProfileSession()` does not indicate whether a session is the result of a login or registration.  To differentiate between the two, I've used `sessionStorage`.

## Testing done

Tested locally by checking the event name passed to `recordEvent()` - `src/platform/monitoring/record-event.js`

## Acceptance criteria
- [ ] Registration is recorded in GA as `register-success-{{loginPolicy}}` instead of `login-success-{{loginPolicy}}

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
