### PR TITLE
Sitewide noopener noreferrer mg

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -96,7 +96,7 @@
     "react/jsx-indent-props": 0,
     "react/jsx-max-props-per-line": 0,
     "react/jsx-no-bind": [0, { "ignoreRefs": true }], // TODO: Enable after fixing.
-    "react/jsx-no-target-blank": 2,
+    "react/jsx-no-target-blank": [2, { "enforceDynamicLinks": "always" }],
     "react/jsx-sort-props": [
       0,
       { "callbacksLast": true, "shorthandFirst": true }

--- a/.eslintrc
+++ b/.eslintrc
@@ -96,7 +96,7 @@
     "react/jsx-indent-props": 0,
     "react/jsx-max-props-per-line": 0,
     "react/jsx-no-bind": [0, { "ignoreRefs": true }], // TODO: Enable after fixing.
-    "react/jsx-no-target-blank": 0,
+    "react/jsx-no-target-blank": [2, { "enforceDynamicLinks": "always" }],
     "react/jsx-sort-props": [
       0,
       { "callbacksLast": true, "shorthandFirst": true }

--- a/.eslintrc
+++ b/.eslintrc
@@ -96,7 +96,7 @@
     "react/jsx-indent-props": 0,
     "react/jsx-max-props-per-line": 0,
     "react/jsx-no-bind": [0, { "ignoreRefs": true }], // TODO: Enable after fixing.
-    "react/jsx-no-target-blank": [2, { "enforceDynamicLinks": "always" }],
+    "react/jsx-no-target-blank": 2,
     "react/jsx-sort-props": [
       0,
       { "callbacksLast": true, "shorthandFirst": true }

--- a/src/applications/burials/helpers.jsx
+++ b/src/applications/burials/helpers.jsx
@@ -153,7 +153,11 @@ export const burialDateWarning = (
       If filing for a non-service-connected allowance, the Veteran’s burial date
       must be no more than 2 years from the current date. Find out if you still
       qualify.{' '}
-      <a href="/burials-memorials/eligibility/" target="_blank">
+      <a
+        href="/burials-memorials/eligibility/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Learn about eligibility.
       </a>
     </span>

--- a/src/applications/burials/helpers.jsx
+++ b/src/applications/burials/helpers.jsx
@@ -153,11 +153,7 @@ export const burialDateWarning = (
       If filing for a non-service-connected allowance, the Veteran’s burial date
       must be no more than 2 years from the current date. Find out if you still
       qualify.{' '}
-      <a
-        href="/burials-memorials/eligibility/"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
+      <a href="/burials-memorials/eligibility/" target="_blank">
         Learn about eligibility.
       </a>
     </span>

--- a/src/applications/claims-status/components/ClaimsDecision.jsx
+++ b/src/applications/claims-status/components/ClaimsDecision.jsx
@@ -19,7 +19,11 @@ class ClaimsDecision extends React.Component {
           packet to arrive before contacting a VA call center. If you haven’t
           received the packet with the full details of your claim decision yet,
           you can see your rating by going to your disability page in eBenefits.{' '}
-          <a href="https://www.ebenefits.va.gov" target="_blank">
+          <a
+            href="https://www.ebenefits.va.gov"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Check your disability page in eBenefits for your rating
           </a>
           .
@@ -32,7 +36,11 @@ class ClaimsDecision extends React.Component {
           If we decided that an issue you claimed wasn’t service connected, and
           you have new evidence that you haven’t submitted yet, you can ask VA
           to reopen your claim.{' '}
-          <a href="/disability/how-to-file-claim/when-to-file/" target="_blank">
+          <a
+            href="/disability/how-to-file-claim/when-to-file/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Find out how to reopen your claim
           </a>
           .
@@ -48,14 +56,22 @@ class ClaimsDecision extends React.Component {
         <p>
           If you disagree with the decision on your claim, you can file an
           appeal.{' '}
-          <a href="/disability/file-an-appeal/" target="_blank">
+          <a
+            href="/disability/file-an-appeal/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Learn more about filing an appeal
           </a>
           .
         </p>
         <p>
           Are you enrolled in VA health care? If not, you can apply now.
-          <a href="/health-care/how-to-apply/" target="_blank">
+          <a
+            href="/health-care/how-to-apply/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Apply for VA health care
           </a>
           .

--- a/src/applications/claims-status/components/ClaimsDecision.jsx
+++ b/src/applications/claims-status/components/ClaimsDecision.jsx
@@ -36,11 +36,7 @@ class ClaimsDecision extends React.Component {
           If we decided that an issue you claimed wasn’t service connected, and
           you have new evidence that you haven’t submitted yet, you can ask VA
           to reopen your claim.{' '}
-          <a
-            href="/disability/how-to-file-claim/when-to-file/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a href="/disability/how-to-file-claim/when-to-file/" target="_blank">
             Find out how to reopen your claim
           </a>
           .
@@ -56,22 +52,14 @@ class ClaimsDecision extends React.Component {
         <p>
           If you disagree with the decision on your claim, you can file an
           appeal.{' '}
-          <a
-            href="/disability/file-an-appeal/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a href="/disability/file-an-appeal/" target="_blank">
             Learn more about filing an appeal
           </a>
           .
         </p>
         <p>
           Are you enrolled in VA health care? If not, you can apply now.
-          <a
-            href="/health-care/how-to-apply/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a href="/health-care/how-to-apply/" target="_blank">
             Apply for VA health care
           </a>
           .

--- a/src/applications/claims-status/components/FeaturesWarning.jsx
+++ b/src/applications/claims-status/components/FeaturesWarning.jsx
@@ -9,6 +9,7 @@ export default function FeaturesWarning() {
         or view your uploaded documents, go to{' '}
         <a
           target="_blank"
+          rel="noopener noreferrer"
           href="https://www.ebenefits.va.gov/ebenefits-portal/ebenefits.portal"
         >
           eBenefits

--- a/src/applications/claims-status/components/MailOrFax.jsx
+++ b/src/applications/claims-status/components/MailOrFax.jsx
@@ -25,6 +25,7 @@ export default function MailOrFax({ onClose }) {
           Mail or fax them to the{' '}
           <a
             target="_blank"
+            rel="noopener noreferrer"
             href="http://www.benefits.va.gov/COMPENSATION/mailingaddresses.asp"
           >
             VA Claims Intake Center.

--- a/src/applications/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/applications/claims-status/components/appeals-v2/Docket.jsx
@@ -99,6 +99,7 @@ function Docket({
           <a
             target="_blank"
             href="/disability/file-an-appeal/request-priority-review/"
+            rel="noopener noreferrer"
           >
             Learn more about requesting Advanced on Docket status.
           </a>

--- a/src/applications/claims-status/components/appeals-v2/Docket.jsx
+++ b/src/applications/claims-status/components/appeals-v2/Docket.jsx
@@ -99,7 +99,6 @@ function Docket({
           <a
             target="_blank"
             href="/disability/file-an-appeal/request-priority-review/"
-            rel="noopener noreferrer"
           >
             Learn more about requesting Advanced on Docket status.
           </a>

--- a/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ButtonContainer.jsx
@@ -59,8 +59,8 @@ export default function ButtonContainer(props) {
         <a
           className="usa-button-primary"
           href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation"
-          rel="noopener"
           target="_blank"
+          rel="noopener noreferrer"
         >
           Go to eBenefits
           <span className="button-icon"> »</span>

--- a/src/applications/disability-benefits/526EZ/components/PaymentView.jsx
+++ b/src/applications/disability-benefits/526EZ/components/PaymentView.jsx
@@ -52,6 +52,7 @@ const PaymentView = response => {
             <a
               href="https://www.vba.va.gov/pubs/forms/vba-24-0296-are.pdf"
               target="_blank"
+              rel="noopener noreferrer"
             >
               Download VA Form 24-0296
             </a>
@@ -62,6 +63,7 @@ const PaymentView = response => {
             <a
               href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information"
               target="_blank"
+              rel="noopener noreferrer"
             >
               Go to eBenefits
             </a>

--- a/src/applications/disability-benefits/526EZ/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/526EZ/content/confirmation-page.jsx
@@ -22,6 +22,7 @@ const privateRecordReleaseContent = (
       <a
         href="https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf"
         target="_blank"
+        rel="noopener noreferrer"
       >
         Download VA Form 21-4142
       </a>

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -414,7 +414,7 @@ export const download4142Notice = (
       doctor.
     </p>
     <p>
-      <a href={VA_FORM4142_URL} target="_blank">
+      <a href={VA_FORM4142_URL} target="_blank" rel="noopener noreferrer">
         Download VA Form 21-4142
       </a>
       .<p>Please print the form, fill it out, and send it to:</p>
@@ -882,7 +882,11 @@ export const patientAcknowledgmentText = (
     <p>
       NOTE: For additional information regarding VA Form 21-4142, refer to the
       following website:
-      <a href="https://www.benefits.va.gov/privateproviders/" target="_blank">
+      <a
+        href="https://www.benefits.va.gov/privateproviders/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         https://www.benefits.va.gov/privateproviders/
       </a>
       .

--- a/src/applications/disability-benefits/686/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/686/containers/ConfirmationPage.jsx
@@ -48,6 +48,7 @@ export class ConfirmationPage extends React.Component {
         </p>
         <a
           target="_blank"
+          rel="noopener noreferrer"
           href="https://www.vba.va.gov/pubs/forms/VBA-21-674-ARE.pdf"
         >
           Download VA Form 21-674.

--- a/src/applications/disability-benefits/686/helpers.jsx
+++ b/src/applications/disability-benefits/686/helpers.jsx
@@ -177,6 +177,7 @@ export const schoolAttendanceWarning = (
         <a
           href="https://www.vba.va.gov/pubs/forms/VBA-21-674-ARE.pdf"
           target="_blank"
+          rel="noopener noreferrer"
         >
           VA Form 21-674
         </a>

--- a/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
+++ b/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
@@ -5,7 +5,7 @@ import { claimsIntakeAddress } from './itfWrapper';
 export const download4192Notice = (
   <div>
     <p>
-      <a href={VA_FORM4192_URL} target="_blank" rel="noopener">
+      <a href={VA_FORM4192_URL} target="_blank" rel="noopener noreferrer">
         Download VA Form 21-4192
       </a>
     </p>

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -108,7 +108,11 @@ export const patientAcknowledgmentText = (
       <p>
         NOTE: For additional information regarding VA Form 21-4142, refer to the
         following website:
-        <a href="https://www.benefits.va.gov/privateproviders/" target="_blank">
+        <a
+          href="https://www.benefits.va.gov/privateproviders/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           https://www.benefits.va.gov/privateproviders/
         </a>
         .

--- a/src/applications/discharge-wizard/containers/GuidancePage.jsx
+++ b/src/applications/discharge-wizard/containers/GuidancePage.jsx
@@ -96,12 +96,17 @@ class GuidancePage extends React.Component {
             your military record before your separation. But, if the PDBR finds
             that your disability rating was unjustly low, it may help you make
             your case to upgrade your discharge.{' '}
-            <a target="_blank" href="https://health.mil/PDBR">
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://health.mil/PDBR"
+            >
               Learn more about PBDR reviews
             </a>
             .{' '}
             <a
               target="_blank"
+              rel="noopener noreferrer"
               href="https://health.mil/Military-Health-Topics/Conditions-and-Treatments/Physical-Disability/Disability-Evaluation/Physical-Disability-Board-of-Review/PDBR-Application-Process"
             >
               Apply for a PBDR review
@@ -276,7 +281,7 @@ class GuidancePage extends React.Component {
           <a
             target="_blank"
             href={form.link}
-            rel="external"
+            rel="noopener noreferrer external"
             className="usa-button-primary usa-button"
             ref={el => {
               this.downloadFormBtn = el;
@@ -300,6 +305,7 @@ class GuidancePage extends React.Component {
                   cost, or ask other Veterans for recommendations.{' '}
                   <a
                     target="_blank"
+                    rel="noopener noreferrer"
                     href="https://www.benefits.va.gov/vso/varo.asp"
                   >
                     Find a VSO near you
@@ -330,6 +336,7 @@ class GuidancePage extends React.Component {
           Military Personnel File, or OMPF) online.{' '}
           <a
             target="_blank"
+            rel="noopener noreferrer"
             href="https://www.dpris.dod.mil/veteranaccess.html"
           >
             Get your military personnel record.
@@ -345,6 +352,7 @@ class GuidancePage extends React.Component {
           you should request the full set of records.{' '}
           <a
             target="_blank"
+            rel="noopener noreferrer"
             href="https://www.archives.gov/veterans/military-service-records"
           >
             Get your military personnel record.
@@ -447,6 +455,7 @@ class GuidancePage extends React.Component {
         requestQuestion = (
           <a
             target="_blank"
+            rel="noopener noreferrer"
             href="https://www.archives.gov/st-louis/military-personnel/ompf-background.html"
           >
             Find out how to request your military medical records.
@@ -472,6 +481,7 @@ class GuidancePage extends React.Component {
               submitting VA Form 10-5345 to your local VA Medical Center.{' '}
               <a
                 target="_blank"
+                rel="noopener noreferrer"
                 href="https://www.va.gov/vaforms/medical/pdf/vha-10-5345-fill.pdf"
               >
                 Download VA Form 10-5345.
@@ -583,7 +593,11 @@ class GuidancePage extends React.Component {
       onlineSubmissionMsg = (
         <p>
           You can also submit this information online at ACTSOnline.{' '}
-          <a target="_blank" href="http://actsonline.army.mil/">
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="http://actsonline.army.mil/"
+          >
             Visit ACTSOnline to submit your information
           </a>
           .
@@ -665,6 +679,7 @@ class GuidancePage extends React.Component {
                     DD214. If you get a new DD214,{' '}
                     <a
                       target="_blank"
+                      rel="noopener noreferrer"
                       href="https://www.dpris.dod.mil/veteranaccess.html"
                     >
                       request a copy
@@ -678,6 +693,7 @@ class GuidancePage extends React.Component {
                     services. For now, you may still apply for VA eligibility by{' '}
                     <a
                       target="_blank"
+                      rel="noopener noreferrer"
                       href="https://www.benefits.va.gov/BENEFITS/docs/COD_Factsheet.pdf"
                     >
                       requesting a Character of Discharge review
@@ -810,6 +826,7 @@ class GuidancePage extends React.Component {
         <li>
           <a
             target="_blank"
+            rel="noopener noreferrer"
             href="https://www.benefits.va.gov/BENEFITS/docs/COD_Factsheet.pdf"
           >
             VA Guidance on Character of Discharge Reviews
@@ -817,7 +834,11 @@ class GuidancePage extends React.Component {
         </li>
         {serviceBranch === 'army' && (
           <li>
-            <a target="_blank" href="http://arba.army.pentagon.mil">
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="http://arba.army.pentagon.mil"
+            >
               Army Review Boards Agency
             </a>
           </li>
@@ -827,6 +848,7 @@ class GuidancePage extends React.Component {
             <li>
               <a
                 target="_blank"
+                rel="noopener noreferrer"
                 href="http://arba.army.pentagon.mil/adrb-overview.html"
               >
                 Army Discharge Review Board
@@ -838,6 +860,7 @@ class GuidancePage extends React.Component {
             <li>
               <a
                 target="_blank"
+                rel="noopener noreferrer"
                 href="http://arba.army.pentagon.mil/abcmr-overview.html"
               >
                 Army Board for Correction of Military Records
@@ -848,6 +871,7 @@ class GuidancePage extends React.Component {
           <li>
             <a
               target="_blank"
+              rel="noopener noreferrer"
               href="http://www.secnav.navy.mil/mra/CORB/pages/ndrb/default.aspx"
             >
               Naval Discharge Review Board
@@ -859,6 +883,7 @@ class GuidancePage extends React.Component {
             <li>
               <a
                 target="_blank"
+                rel="noopener noreferrer"
                 href="http://www.afpc.af.mil/Board-for-Correction-of-Military-Records/"
               >
                 Air Force Board for Correction of Military Records
@@ -870,6 +895,7 @@ class GuidancePage extends React.Component {
             <li>
               <a
                 target="_blank"
+                rel="noopener noreferrer"
                 href="https://www.uscg.mil/Resources/legal/BCMR/"
               >
                 Coast Guard Board for Correction of Military Records
@@ -881,6 +907,7 @@ class GuidancePage extends React.Component {
             <li>
               <a
                 target="_blank"
+                rel="noopener noreferrer"
                 href="https://www.uscg.mil/Resources/Legal/DRB.aspx/"
               >
                 Coast Guard Discharge Review Board

--- a/src/applications/edu-benefits/1990/helpers.jsx
+++ b/src/applications/edu-benefits/1990/helpers.jsx
@@ -46,7 +46,11 @@ export function directDepositDescription() {
         If you don’t have a bank account, VA will pay you through the Direct
         Express® Debit MasterCard®. Apply for a Direct Express® Debit
         MasterCard® at{' '}
-        <a href="https://www.usdirectexpress.com/" target="_blank">
+        <a
+          href="https://www.usdirectexpress.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           www.usdirectexpress.com
         </a>{' '}
         or by calling <a href="tel:18003331795">1-800-333-1795</a>. To request a

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -234,6 +234,7 @@ export default class EducationWizard extends React.Component {
                     </h4>
                     <a
                       target="_blank"
+                      rel="noopener noreferrer"
                       href="https://milconnect.dmdc.osd.mil/milconnect/public/faq/Education_Benefits-How_to_Transfer_Benefits"
                     >
                       Instructions for your sponsor to transfer education

--- a/src/applications/edu-benefits/utils/labels.jsx
+++ b/src/applications/edu-benefits/utils/labels.jsx
@@ -144,16 +144,20 @@ export const directDepositWarning = (
     isn’t an option for Chapter 32 (VEAP) recipients). If you don’t have a bank
     account, you must get your payment through Direct Express Debit MasterCard.
     To request a Direct Express Debit MasterCard you must apply at{' '}
-    <a href="http://www.usdirectexpress.com" target="_blank">
+    <a
+      href="http://www.usdirectexpress.com"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       www.usdirectexpress.com
     </a>{' '}
     or by telephone at{' '}
-    <a href="tel:8003331795" target="_blank">
+    <a href="tel:8003331795" rel="noopener noreferrer" target="_blank">
       1-800-333-1795
     </a>
     . If you chose not to enroll, you must contact representatives handling
     waiver requests for the Department of Treasury at{' '}
-    <a href="tel:8882242950" target="_blank">
+    <a href="tel:8882242950" rel="noopener noreferrer" target="_blank">
       1-888-224-2950
     </a>
     . They will address any questions or concerns you may have and encourage

--- a/src/applications/edu-benefits/utils/labels.jsx
+++ b/src/applications/edu-benefits/utils/labels.jsx
@@ -151,16 +151,10 @@ export const directDepositWarning = (
     >
       www.usdirectexpress.com
     </a>{' '}
-    or by telephone at{' '}
-    <a href="tel:8003331795" rel="noopener noreferrer" target="_blank">
-      1-800-333-1795
-    </a>
-    . If you chose not to enroll, you must contact representatives handling
-    waiver requests for the Department of Treasury at{' '}
-    <a href="tel:8882242950" rel="noopener noreferrer" target="_blank">
-      1-888-224-2950
-    </a>
-    . They will address any questions or concerns you may have and encourage
-    your participation in EFT.
+    or by telephone at <a href="tel:8003331795">1-800-333-1795</a>. If you chose
+    not to enroll, you must contact representatives handling waiver requests for
+    the Department of Treasury at <a href="tel:8882242950">1-888-224-2950</a>.
+    They will address any questions or concerns you may have and encourage your
+    participation in EFT.
   </div>
 );

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -36,7 +36,7 @@ class FacilityDetail extends Component {
         {website &&
           website !== 'NULL' && (
             <span>
-              <a href={website} target="_blank">
+              <a href={website} target="_blank" rel="noopener noreferrer">
                 <i className="fa fa-globe" />
                 Website
               </a>

--- a/src/applications/gi/components/content/AboutThisTool.jsx
+++ b/src/applications/gi/components/content/AboutThisTool.jsx
@@ -8,6 +8,7 @@ class AboutThisTool extends React.Component {
           <a
             href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp"
             target="_blank"
+            rel="noopener noreferrer"
           >
             About this Tool
           </a>

--- a/src/applications/gi/components/content/AdditionalResources.jsx
+++ b/src/applications/gi/components/content/AdditionalResources.jsx
@@ -3,7 +3,11 @@ import React from 'react';
 export const AdditionalResourcesLinks = () => (
   <div>
     <p>
-      <a href="https://va.careerscope.net/gibill" target="_blank">
+      <a
+        href="https://va.careerscope.net/gibill"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Get started with CareerScope
       </a>
     </p>
@@ -11,12 +15,17 @@ export const AdditionalResourcesLinks = () => (
       <a
         href="https://www.benefits.va.gov/gibill/choosing_a_school.asp"
         target="_blank"
+        rel="noopener noreferrer"
       >
         Get help choosing a school
       </a>
     </p>
     <p>
-      <a href="https://www.benefits.va.gov/GIBILL/Feedback.asp" target="_blank">
+      <a
+        href="https://www.benefits.va.gov/GIBILL/Feedback.asp"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Submit a complaint through our Feedback System
       </a>
     </p>

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -29,7 +29,7 @@ export class AdditionalInformation extends React.Component {
       <div>
         <strong>Veterans tuition policy:</strong>
         &nbsp;
-        <a href={it.vetWebsiteLink} target="_blank" rel="noopener">
+        <a href={it.vetWebsiteLink} target="_blank" rel="noopener noreferrer">
           View policy
         </a>
       </div>
@@ -57,7 +57,7 @@ export class AdditionalInformation extends React.Component {
                   it.cross
                 }#accred`}
                 target="_blank"
-                rel="noopener"
+                rel="noopener noreferrer"
               >
                 See accreditors
               </a>

--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -114,7 +114,7 @@ export class Calculator extends React.Component {
           <div className="link-header">
             <h5>{title}</h5>
             &nbsp;(
-            <a href={learnMoreLink} target="_blank" rel="noopener">
+            <a href={learnMoreLink} target="_blank" rel="noopener noreferrer">
               Learn more
             </a>
             )

--- a/src/applications/gi/components/profile/CautionaryInformation.jsx
+++ b/src/applications/gi/components/profile/CautionaryInformation.jsx
@@ -45,7 +45,7 @@ export class CautionaryInformation extends React.Component {
       <a
         href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#AshfordSAA"
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
       >
         More information on Ashford University
       </a>
@@ -72,7 +72,7 @@ export class CautionaryInformation extends React.Component {
       <a
         href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints_all_campuses"
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
       >
         All campuses
       </a>
@@ -139,7 +139,7 @@ export class CautionaryInformation extends React.Component {
               <a
                 href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#complaints"
                 target="_blank"
-                rel="noopener"
+                rel="noopener noreferrer"
               >
                 student complaints
               </a>
@@ -149,7 +149,7 @@ export class CautionaryInformation extends React.Component {
               <a
                 href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#sourcedata"
                 target="_blank"
-                rel="noopener"
+                rel="noopener noreferrer"
               >
                 Source
               </a>

--- a/src/applications/gi/components/profile/HeadingSummary.jsx
+++ b/src/applications/gi/components/profile/HeadingSummary.jsx
@@ -42,7 +42,7 @@ class HeadingSummary extends React.Component {
                 Are you enrolled in this school?{' '}
                 <a
                   href="https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp"
-                  rel="noopener"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   Find out if you qualify to have your benefits restored.
@@ -85,7 +85,7 @@ class HeadingSummary extends React.Component {
                 {it.city}, {it.state || it.country}
               </IconWithInfo>
               <IconWithInfo icon="globe" present={it.website}>
-                <a href={it.website} target="_blank">
+                <a href={it.website} target="_blank" rel="noopener noreferrer">
                   {it.website}
                 </a>
               </IconWithInfo>

--- a/src/applications/gi/components/profile/Outcomes.jsx
+++ b/src/applications/gi/components/profile/Outcomes.jsx
@@ -121,7 +121,7 @@ class Outcomes extends React.Component {
             <a
               title="Veteran Outcome Measures"
               href={download.link}
-              rel="noopener"
+              rel="noopener noreferrer"
               target="_blank"
             >
               Veteran Outcome Measures ({download.info})

--- a/src/applications/gi/components/profile/Programs.jsx
+++ b/src/applications/gi/components/profile/Programs.jsx
@@ -82,7 +82,11 @@ export class Programs extends React.Component {
         program.link.href && (
           <span>
             &nbsp;(
-            <a href={program.link.href} target="_blank">
+            <a
+              href={program.link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               {program.link.text}
             </a>
             )

--- a/src/applications/gi/components/search/EligibilityForm.jsx
+++ b/src/applications/gi/components/search/EligibilityForm.jsx
@@ -97,6 +97,7 @@ export class EligibilityForm extends React.Component {
                 href="http://www.benefits.va.gov/gibill/post911_gibill.asp"
                 id="anch_378"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 Post 9/11 GI Bill
               </a>{' '}
@@ -113,6 +114,7 @@ export class EligibilityForm extends React.Component {
             <a
               href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment"
               target="_blank"
+              rel="noopener noreferrer"
             >
               visit this site
             </a>

--- a/src/applications/gi/containers/GiBillApp.jsx
+++ b/src/applications/gi/containers/GiBillApp.jsx
@@ -23,6 +23,7 @@ const Disclaimer = () => (
       help.{' '}
       <a
         target="_blank"
+        rel="noopener noreferrer"
         href="https://www.va.gov/ogc/apps/accreditation/index.asp"
       >
         Search Accredited Attorneys, Claims Agents, or Veterans Service

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -136,6 +136,7 @@ export class Modals extends React.Component {
             <a
               href="https://gibill.custhelp.com/app/utils/login_form/redirect/ask"
               target="_blank"
+              rel="noopener noreferrer"
             >
               "Ask a Question" page
             </a>
@@ -154,6 +155,7 @@ export class Modals extends React.Component {
               title="Post-9/11 GI Bill"
               href="http://www.benefits.va.gov/gibill/post911_gibill.asp"
               target="_blank"
+              rel="noopener noreferrer"
             >
               Post-9/11 GI Bill
             </a>{' '}
@@ -168,6 +170,7 @@ export class Modals extends React.Component {
               title="Click here for FAQs about the Yellow Ribbon Program"
               href="http://www.benefits.va.gov/gibill/docs/factsheets/2012_Yellow_Ribbon_Student_FAQs.pdf"
               target="_blank"
+              rel="noopener noreferrer"
             >
               Click here for FAQs about the Yellow Ribbon Program..
             </a>
@@ -194,6 +197,7 @@ export class Modals extends React.Component {
               title="Principles of Excellence"
               href="http://www.gpo.gov/fdsys/pkg/FR-2012-05-02/pdf/2012-10715.pdf"
               target="_blank"
+              rel="noopener noreferrer"
             >
               Principles of Excellence
             </a>{' '}
@@ -322,6 +326,7 @@ export class Modals extends React.Component {
             <a
               href="http://www.ed.gov/veterans-and-military-families/8-keys-success-sites"
               target="_blank"
+              rel="noopener noreferrer"
             >
               8 Keys to Veterans’ Success
             </a>{' '}
@@ -345,7 +350,7 @@ export class Modals extends React.Component {
             <a
               href="http://www.benefits.va.gov/vocrehab/vsocfactsheet.asp"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               Download the VSOC fact sheet.
             </a>
@@ -354,7 +359,7 @@ export class Modals extends React.Component {
             <a
               href="http://www.benefits.va.gov/vocrehab/vsoc.asp"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               Learn more about the VSOC program.
             </a>
@@ -381,6 +386,7 @@ export class Modals extends React.Component {
               href="http://ope.ed.gov/accreditation/"
               id="anch_384"
               target="_blank"
+              rel="noopener noreferrer"
             >
               database
             </a>
@@ -395,6 +401,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#accreditation"
               target="_blank"
+              rel="noopener noreferrer"
             >
               {' '}
               about this tool
@@ -428,6 +435,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#accreditation_type"
               target="_blank"
+              rel="noopener noreferrer"
             >
               {' '}
               about this tool
@@ -547,7 +555,7 @@ export class Modals extends React.Component {
             <a
               href="https://studentaid.ed.gov/sa/about/data-center/school/hcm"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               Heightened Cash Monitoring
             </a>
@@ -556,7 +564,7 @@ export class Modals extends React.Component {
             <a
               href="http://ope.ed.gov/accreditation/"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               Accreditation
             </a>
@@ -565,7 +573,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.dodmou.com/Home/Faq"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               DoD Probation For Military Tuition Assistance
             </a>
@@ -574,7 +582,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.ftc.gov/news-events/press-releases/2016/01/ftc-brings-enforcement-action-against-devry-university"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               Federal Trade Commission Filed Suit for Deceptive Advertising
             </a>
@@ -583,7 +591,7 @@ export class Modals extends React.Component {
             <a
               href="http://www.justice.gov/opa/pr/profit-college-company-pay-955-million-settle-claims-illegal-recruiting-consumer-fraud-and"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               Settlement reached with the Federal Trade Commission (FTC)
             </a>
@@ -592,7 +600,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#caution"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               Suspended for 85/15 violation – Flight Program
             </a>
@@ -601,7 +609,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#caution"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               Denial of Recertification Application to Participate in the
               Federal Student Financial Assistance Programs
@@ -611,7 +619,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#ACICS"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               School operating under provisional accreditation (previously
               accredited by ACICS)
@@ -622,7 +630,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#caution"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               "About this Tool"
             </a>{' '}
@@ -653,7 +661,7 @@ export class Modals extends React.Component {
               href="http://nces.ed.gov/ipeds/datacenter/"
               id="anch_442"
               target="blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               IPEDS
             </a>
@@ -662,7 +670,7 @@ export class Modals extends React.Component {
               href="http://nces.ed.gov/collegenavigator/"
               id="anch_443"
               target="blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               College Navigator
             </a>
@@ -675,7 +683,7 @@ export class Modals extends React.Component {
                 'http://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#yellow_ribbon_from_school'
               }
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               About This Tool
             </a>
@@ -705,7 +713,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/resources/benefits_resources/rate_tables.asp#ch33#TUITION"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               Click here for more information.
             </a>
@@ -731,7 +739,7 @@ export class Modals extends React.Component {
               title="Click here for FAQs about the Yellow Ribbon Program"
               href="http://www.benefits.va.gov/gibill/docs/factsheets/2012_Yellow_Ribbon_Student_FAQs.pdf"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               this page.
             </a>
@@ -826,7 +834,7 @@ export class Modals extends React.Component {
               title="For more information about MHA increases or decreases click here"
               href="https://gibill.custhelp.com/app/answers/detail/a_id/1412"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               this page
             </a>
@@ -859,7 +867,7 @@ export class Modals extends React.Component {
             <a
               href="https://gibill.custhelp.com/app/answers/detail/a_id/97"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               this page
             </a>
@@ -940,7 +948,7 @@ export class Modals extends React.Component {
             <a
               href="http://www.benefits.va.gov/gibill/comparison_tool.asp"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               this page
             </a>
@@ -973,7 +981,7 @@ export class Modals extends React.Component {
             <a
               href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#cumulativeservice"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               this page
             </a>
@@ -999,7 +1007,7 @@ export class Modals extends React.Component {
               href="http://www.benefits.va.gov/gibill/mgib_ad.asp"
               id="anch_399"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               http://www.benefits.va.gov/gibill/mgib_ad.asp
             </a>
@@ -1024,7 +1032,7 @@ export class Modals extends React.Component {
               href="https://www.benefits.va.gov/gibill/reap.asp"
               id="anch_403"
               target="_blank"
-              rel="noopener"
+              rel="noopener noreferrer"
             >
               https://www.benefits.va.gov/gibill/reap.asp
             </a>

--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -76,6 +76,7 @@ export const facilityHelp = (
     you’ll need to sign up for our Foreign Medical Program.{' '}
     <a
       href="https://www.va.gov/COMMUNITYCARE/programs/veterans/fmp/index.asp"
+      rel="noopener noreferrer"
       target="_blank"
     >
       Learn more about the Foreign Medical Program
@@ -85,6 +86,7 @@ export const facilityHelp = (
       You can also visit{' '}
       <a
         href="https://www.benefits.va.gov/PERSONA/veteran-abroad.asp"
+        rel="noopener noreferrer"
         target="_blank"
       >
         Veterans Living Abroad
@@ -198,6 +200,7 @@ export const financialDisclosureText = (
     <div className="input-section">
       <a
         target="_blank"
+        rel="noopener noreferrer"
         href="http://www.va.gov/healthbenefits/cost/income_thresholds.asp"
       >
         Learn more

--- a/src/applications/letters/containers/LetterList.jsx
+++ b/src/applications/letters/containers/LetterList.jsx
@@ -91,7 +91,11 @@ export class LetterList extends React.Component {
         <p>
           To download a letter, you’ll need the latest version of Adobe Reader.
           It’s free to download.{' '}
-          <a href="https://get.adobe.com/reader/otherversions/" target="_blank">
+          <a
+            href="https://get.adobe.com/reader/otherversions/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
             Get Adobe Reader
           </a>
         </p>
@@ -121,7 +125,11 @@ export class LetterList extends React.Component {
             </a>
           </li>
           <li>
-            <a href="https://eauth.va.gov/ebenefits/coe" target="_blank">
+            <a
+              href="https://eauth.va.gov/ebenefits/coe"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               <strong>
                 Log into eBenefits to request a Certificate of Eligibility (COE)
                 for your home loan benefits.
@@ -129,7 +137,11 @@ export class LetterList extends React.Component {
             </a>
           </li>
           <li>
-            <a href="https://eauth.va.gov/ebenefits/DPRIS" target="_blank">
+            <a
+              href="https://eauth.va.gov/ebenefits/DPRIS"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               <strong>
                 Log into eBenefits to request a copy of your discharge or
                 separation papers (DD 214).

--- a/src/applications/letters/utils/helpers.jsx
+++ b/src/applications/letters/utils/helpers.jsx
@@ -56,6 +56,7 @@ export const addressModalContent = (
     </p>
     <a
       href="https://iris.custhelp.com/app/answers/detail/a_id/3045/~change-of-address"
+      rel="noopener noreferrer"
       target="_blank"
     >
       Learn how to update your address for all VA departments
@@ -73,6 +74,7 @@ export const recordsNotFound = (
         <p className="usa-alert-heading">
           <a
             target="_blank"
+            rel="noopener noreferrer"
             href="https://www.ebenefits.va.gov/ebenefits/download-letters"
           >
             If you’re a dependent, please go to eBenefits to look for your
@@ -132,7 +134,11 @@ const commissaryLetterContent = (
     this letter, a copy of your DD214 or other discharge papers, and your DD2765
     to a local military ID and pass office. You can schedule an appointment to
     get a Retiree Military ID card at the office or use the{' '}
-    <a target="_blank" href="https://rapids-appointments.dmdc.osd.mil/">
+    <a
+      target="_blank"
+      rel="noopener noreferrer"
+      href="https://rapids-appointments.dmdc.osd.mil/"
+    >
       Rapid Appointments Scheduler
     </a>
     . The Retiree Military ID card gives you access to your local base
@@ -146,7 +152,11 @@ export const bslHelpInstructions = (
     <p>
       If your service period or disability status information is incorrect,
       please send us a message through VA’s{' '}
-      <a target="_blank" href="https://iris.custhelp.com/app/ask">
+      <a
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://iris.custhelp.com/app/ask"
+      >
         Inquiry Routing & Information System (IRIS)
       </a>
       . VA will respond within 5 business days.

--- a/src/applications/pensions/helpers.jsx
+++ b/src/applications/pensions/helpers.jsx
@@ -233,6 +233,7 @@ export function fileHelp({ formData }) {
             A completed Request for Approval of School Attendance (
             <a
               href="https://www.vba.va.gov/pubs/forms/VBA-21-674-ARE.pdf"
+              rel="noopener noreferrer"
               target="_blank"
             >
               VA Form 21-674
@@ -257,6 +258,7 @@ export function fileHelp({ formData }) {
           Regular Aid and Attendance (
           <a
             href="https://www.vba.va.gov/pubs/forms/VBA-21-2680-ARE.pdf"
+            rel="noopener noreferrer"
             target="_blank"
           >
             VA Form 21-2680
@@ -268,6 +270,7 @@ export function fileHelp({ formData }) {
           Claim for Aid and Attendance (
           <a
             href="https://www.vba.va.gov/pubs/forms/VBA-21-0779-ARE.pdf"
+            rel="noopener noreferrer"
             target="_blank"
           >
             VA Form 21-0779
@@ -286,16 +289,20 @@ export const directDepositWarning = (
     electronic funds transfer (EFT), also called direct deposit. If you don’t
     have a bank account, you must get your payment through Direct Express Debit
     MasterCard. To request a Direct Express Debit MasterCard you must apply at{' '}
-    <a href="http://www.usdirectexpress.com" target="_blank">
+    <a
+      href="http://www.usdirectexpress.com"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
       www.usdirectexpress.com
     </a>{' '}
     or by telephone at{' '}
-    <a href="tel:8003331795" target="_blank">
+    <a href="tel:8003331795" rel="noopener noreferrer" target="_blank">
       1-800-333-1795
     </a>
     . If you chose not to enroll, you must contact representatives handling
     waiver requests for the Department of Treasury at{' '}
-    <a href="tel:8882242950" target="_blank">
+    <a href="tel:8882242950" rel="noopener noreferrer" target="_blank">
       1-888-224-2950
     </a>
     . They will address any questions or concerns you may have and encourage
@@ -311,6 +318,7 @@ export const wartimeWarning = (
         an{' '}
         <a
           href="http://www.benefits.va.gov/pension/wartimeperiod.asp"
+          rel="noopener noreferrer"
           target="_blank"
         >
           {' '}
@@ -446,6 +454,7 @@ export const schoolAttendanceWarning = (
         a Request for Approval of School Attendance (
         <a
           href="https://www.vba.va.gov/pubs/forms/VBA-21-674-ARE.pdf"
+          rel="noopener noreferrer"
           target="_blank"
         >
           VA Form 21-674

--- a/src/applications/pensions/helpers.jsx
+++ b/src/applications/pensions/helpers.jsx
@@ -296,17 +296,11 @@ export const directDepositWarning = (
     >
       www.usdirectexpress.com
     </a>{' '}
-    or by telephone at{' '}
-    <a href="tel:8003331795" rel="noopener noreferrer" target="_blank">
-      1-800-333-1795
-    </a>
-    . If you chose not to enroll, you must contact representatives handling
-    waiver requests for the Department of Treasury at{' '}
-    <a href="tel:8882242950" rel="noopener noreferrer" target="_blank">
-      1-888-224-2950
-    </a>
-    . They will address any questions or concerns you may have and encourage
-    your participation in EFT.
+    or by telephone at <a href="tel:8003331795">1-800-333-1795</a>. If you chose
+    not to enroll, you must contact representatives handling waiver requests for
+    the Department of Treasury at <a href="tel:8882242950">1-888-224-2950</a>.
+    They will address any questions or concerns you may have and encourage your
+    participation in EFT.
   </div>
 );
 

--- a/src/applications/personalization/account/components/AccountMain.jsx
+++ b/src/applications/personalization/account/components/AccountMain.jsx
@@ -113,6 +113,7 @@ class AccountMain extends React.Component {
               <h5>DS Logon</h5>
               <a
                 href="https://myaccess.dmdc.osd.mil/identitymanagement"
+                rel="noopener noreferrer"
                 target="_blank"
               >
                 Manage your DS Logon account
@@ -120,7 +121,11 @@ class AccountMain extends React.Component {
             </div>
             <div>
               <h5>My HealtheVet</h5>
-              <a href="https://www.myhealth.va.gov" target="_blank">
+              <a
+                href="https://www.myhealth.va.gov"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
                 Manage your My HealtheVet account
               </a>
             </div>

--- a/src/applications/personalization/account/components/LoginSettings.jsx
+++ b/src/applications/personalization/account/components/LoginSettings.jsx
@@ -34,7 +34,11 @@ export default function LoginSettings() {
       <h5>ID.me settings</h5>
       <div>
         <p>
-          <a href="https://wallet.id.me/settings" target="_blank">
+          <a
+            href="https://wallet.id.me/settings"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Manage your ID.me account.
           </a>
         </p>

--- a/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
@@ -104,6 +104,7 @@ class MessagingWidget extends React.Component {
           {isBrandConsolidationEnabled() ? (
             <a
               href={`${mhvBaseUrl()}/mhv-portal-web/secure-messaging`}
+              rel="noopener noreferrer"
               target="_blank"
             >
               View all your secure messages

--- a/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
@@ -81,6 +81,7 @@ class PrescriptionsWidget extends React.Component {
                 href={`${mhvBaseUrl()}/mhv-portal-web/${
                   environment.isProduction() ? 'web/myhealthevet/' : ''
                 }refill-prescriptions`}
+                rel="noopener noreferrer"
                 target="_blank"
               >
                 View all your prescriptions

--- a/src/applications/post-911-gib-status/containers/StatusPage.jsx
+++ b/src/applications/post-911-gib-status/containers/StatusPage.jsx
@@ -58,6 +58,7 @@ class StatusPage extends React.Component {
           If you've received education benefit payments through this program,{' '}
           <a
             target="_blank"
+            rel="noopener noreferrer"
             href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=payment-history"
           >
             you can see your payment history on eBenefits

--- a/src/applications/post-911-gib-status/utils/helpers.jsx
+++ b/src/applications/post-911-gib-status/utils/helpers.jsx
@@ -143,7 +143,11 @@ export function notQualifiedWarning() {
             If you’re enrolled in education benefits through another chapter
             (Montgomery GI Bill (MGIB) or Reservists Educational Assistance
             Program (REAP)), check our{' '}
-            <a target="_blank" href="https://www.gibill.va.gov/wave/index.do">
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://www.gibill.va.gov/wave/index.do"
+            >
               Web Automated Verification of Enrollment (W.A.V.E)
             </a>
           </li>
@@ -164,6 +168,7 @@ export function noChapter33BenefitsWarning() {
           <p className="usa-alert-heading">
             <a
               target="_blank"
+              rel="noopener noreferrer"
               href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=post-911-gi-bill-enrollment-status"
             >
               If you’re a dependent, please go to eBenefits to look up your GI

--- a/src/platform/brand-consolidation/components/SubmitSignInForm.jsx
+++ b/src/platform/brand-consolidation/components/SubmitSignInForm.jsx
@@ -11,7 +11,7 @@ export default function SubmitSignInForm({ children, startSentence }) {
       <a
         href="https://www.accesstocare.va.gov/sign-in-help"
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
       >
         {startSentence ? 'Submit' : 'submit'} a request to get help signing in
       </a>

--- a/src/platform/static-data/error-messages.jsx
+++ b/src/platform/static-data/error-messages.jsx
@@ -58,6 +58,7 @@ export const mhvAccessError = (
               about the different account types on the{' '}
               <a
                 href="https://www.myhealth.va.gov/mhv-portal-web/upgrading-your-my-healthevet-account-through-in-person-or-online-authentication"
+                rel="noopener noreferrer"
                 target="_blank"
               >
                 My HealtheVet website.


### PR DESCRIPTION
## Description
1. Turns on 'unsafe target=_blank' rule in eslint: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md
2. Updates all of the following link types to use the appropriate rel attribute values:
- Full va.gov links, which are presumed to point at a Teamsite resource
- Full links to a va.gov subdomain, e.g. `ebenefits.va.gov`
- All external links, both statically and dynamically generated
- All phone links that are set to open in a new tab, because the linter was no happy otherwise

I'm not sure about the implication of using the `noreferrer` and whether or not that messes up with any analytics we use. If this is going to be a problem, I might need to write a custom eslint rule instead, since that part of the rule isn't customizable.

## Testing done
- Ran linter with new rules
- Ran unit tests with new rules

## Screenshots
NA

## Acceptance criteria
- [x] Lint rule enabled
- [x] Linter run passes without errors
- [x] All external links updated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
