### PR TITLE
Update FDC link for MVP and v2

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
@@ -8,7 +8,10 @@ export const FDCDescription = (
       uploaded all the supporting documents or supplemental forms needed to
       support your claim.
     </p>
-    <a href="/pension/how-to-apply/fully-developed-claim/" target="_blank">
+    <a
+      href="/disability/how-to-file-claim/evidence-needed/fully-developed-claims/"
+      target="_blank"
+    >
       Learn more about the FDC program
     </a>
     .


### PR DESCRIPTION
## Description
Updates FDC link for v2 and mvp of 526 form.

## Testing done
- Tested the links locally
- Unit tests

## Screenshots
This link:
![screen shot 2019-01-28 at 11 49 12 am](https://user-images.githubusercontent.com/24251447/51855713-811bf080-22f3-11e9-913f-8ac2ff328e4e.png)

Goes to:
![screen shot 2019-01-28 at 11 49 17 am](https://user-images.githubusercontent.com/24251447/51855721-85e0a480-22f3-11e9-90ac-83fd28d6b577.png)


## Acceptance criteria
- [x] Update FDC links on mvp and v2

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
