### PR TITLE
Connected Accounts -- Fix visual bug on mobile safari

### DIFF
--- a/src/applications/personalization/connected-accounts/sass/connected-acct.scss
+++ b/src/applications/personalization/connected-accounts/sass/connected-acct.scss
@@ -94,6 +94,10 @@
             }
             button {
                float: right;
+
+               @include media-maxwidth($small-screen) {
+                 float: none;
+               }
             }
             ul {
                margin-left: 3em;


### PR DESCRIPTION
## Description
Floating is weird on mobile safari, and we don't need it. 

Discovered in https://github.com/department-of-veterans-affairs/vets-contrib/issues/943

## Testing done
Local browsers

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/5629145/51857814-34d7ad00-2301-11e9-9758-70507e71a588.png)

### After
![image](https://user-images.githubusercontent.com/5629145/51857835-41f49c00-2301-11e9-9ca4-9fc2d5347386.png)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
