### PR TITLE
Rename login-link-clicked GA tag for two separate occurances

### DIFF
--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -13,7 +13,7 @@ import SignInProfileMenu from './SignInProfileMenu';
 class SearchHelpSignIn extends React.Component {
   handleSignInSignUp = e => {
     e.preventDefault();
-    recordEvent({ event: 'login-link-clicked' });
+    recordEvent({ event: 'login-link-clicked-header' });
     this.props.toggleLoginModal(true);
   };
 

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -49,7 +49,11 @@ function redirect(redirectUrl, clickedEvent, openedEvent) {
 
 export function login(policy) {
   sessionStorage.removeItem('registrationPending');
-  return redirect(loginUrl(policy), 'login-link-clicked', 'login-link-opened');
+  return redirect(
+    loginUrl(policy),
+    'login-link-clicked-modal',
+    'login-link-opened',
+  );
 }
 
 export function mfa() {


### PR DESCRIPTION
## Description

The `login-link-clicked` GA event was being sent for both clicking "Sign In" in the header and when choosing a sign in option in the auth modal.  This PR changes both events to make them separate and more descriptive.

## Testing done

Tested locally.

## Screenshots

### login-link-clicked (occurrence 1)
<img width="1014" alt="screen shot 2019-01-18 at 3 09 27 pm" src="https://user-images.githubusercontent.com/21130918/51410869-d279f200-1b33-11e9-86e0-54b99039a23b.png">

### login-link-clicked (occurrence 2)
<img width="987" alt="screen shot 2019-01-18 at 3 13 29 pm" src="https://user-images.githubusercontent.com/21130918/51410857-cc841100-1b33-11e9-954c-754c8ff64cf7.png">

## Acceptance criteria
- [ ] Clicking the "Sign In" button in the header fires a `login-link-clicked-header` event
- [ ] Clicking one of the login buttons in the auth modal fires a `login-link-clicked-modal` event

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
