### PR TITLE
Update sign in error message copy

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -4,7 +4,6 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
 import siteName from '../../../platform/brand-consolidation/site-name';
-import SubmitSignInForm from '../../../platform/brand-consolidation/components/SubmitSignInForm';
 import { setupProfileSession } from '../../../platform/user/profile/utilities';
 import { apiRequest } from '../../../platform/utilities/api';
 
@@ -118,13 +117,15 @@ export class AuthApp extends React.Component {
             <div>
               <p>We’re sorry. Something went wrong on our end.</p>
               <p>
-                Please{' '}
-                <SubmitSignInForm>
-                  call the {siteName} Help Desk at{' '}
-                  <a href="tel:855-574-7286">1-855-574-7286</a>, TTY:{' '}
-                  <a href="tel:18008778339">1-800-877-8339</a>. We’re open
-                  Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (ET).
-                </SubmitSignInForm>
+                Please read our answers to frequently asked questions about
+                common issues with signing in to VA.gov. These answers offer
+                steps you can take to try to fix the issue and a form to submit
+                a request for more help if needed.
+              </p>
+              <p>
+                <a href="/sign-in-faq/#sign-in-issue">
+                  Go to the sign in FAQs.
+                </a>
               </p>
             </div>
           ),


### PR DESCRIPTION
## Description

Update sign in error message copy to refer to FAQ instead of submitting help desk request

## Testing done

Tested locally simulating error code by navigating to `/auth/login/callback/?auth=fail&code=005`

## Screenshots

### Before 

![screen shot 2019-01-28 at 1 08 17 pm](https://user-images.githubusercontent.com/786704/51866442-d3faa580-22fd-11e9-9dbb-5d0ba69252dc.png)


### After

![screen shot 2019-01-28 at 1 02 50 pm](https://user-images.githubusercontent.com/786704/51866226-45862400-22fd-11e9-8ed1-3adc29a5d8a7.png)



## Acceptance criteria
- [ ] Copy has been updated
- [ ] FAQ link redirects to FAQ page with first question in "Common issues with signing in to VA.gov" section expanded (Note: need to be using `15003-update-phone-num-login-error` branch on `vagov-content` to have accordion auto expand)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
