### PR TITLE
Stop using the entire `constants` file to get the medical facility list

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,7 +246,7 @@
     "us-forms-system": "https://github.com/usds/us-forms-system.git#1896964554d5122b236527f88253f2e1dd9d14b4",
     "uswds": "1.4.2",
     "vanilla-lazyload": "^8.17.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#467ab4c8ec3e3d616b914a9f512bc51f1c6e7f5f",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d05c38ce92e3779486d47acfbea62b32a7c736b9",
     "whatwg-fetch": "^2.0.3"
   }
 }

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -8,27 +8,26 @@ import phoneUI from 'us-forms-system/lib/js/definitions/phone';
 import {
   schema as addressSchema,
   uiSchema as addressUI,
-} from '../../../platform/forms/definitions/address';
+} from 'platform/forms/definitions/address';
 import currentOrPastDateUI from 'us-forms-system/lib/js/definitions/currentOrPastDate';
 import dateUI from 'us-forms-system/lib/js/definitions/date';
 import ssnUI from 'us-forms-system/lib/js/definitions/ssn';
 import currencyUI from 'us-forms-system/lib/js/definitions/currency';
 
-import { maritalStatuses } from '../../../platform/static-data/options-for-select';
-import { states } from '../../../platform/forms/address';
-import fullNameUI from '../../../platform/forms/definitions/fullName';
-import { genderLabels } from '../../../platform/static-data/labels';
-import { externalServices } from '../../../platform/monitoring/DowntimeNotification';
-import FormFooter from '../components/FormFooter';
-import ErrorText from '../components/ErrorText';
-import environment from '../../../platform/utilities/environment';
-import applicantDescription from '../../../platform/forms/components/ApplicantDescription';
-import PrefillMessage from '../../../platform/forms/save-in-progress/PrefillMessage';
-import MilitaryPrefillMessage from '../../../platform/forms/save-in-progress/MilitaryPrefillMessage';
-import preSubmitInfo from '../../../platform/forms/preSubmitInfo';
+import { maritalStatuses } from 'platform/static-data/options-for-select';
+import { states } from 'platform/forms/address';
+import fullNameUI from 'platform/forms/definitions/fullName';
+import { genderLabels } from 'platform/static-data/labels';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
+import environment from 'platform/utilities/environment';
+import applicantDescription from 'platform/forms/components/ApplicantDescription';
+import PrefillMessage from 'platform/forms/save-in-progress/PrefillMessage';
+import MilitaryPrefillMessage from 'platform/forms/save-in-progress/MilitaryPrefillMessage';
+import preSubmitInfo from 'platform/forms/preSubmitInfo';
 
 import DowntimeMessage from '../components/DowntimeMessage';
-
+import ErrorText from '../components/ErrorText';
+import FormFooter from '../components/FormFooter';
 import GetFormHelp from '../components/GetFormHelp';
 
 import {

--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import _ from 'lodash/fp';
 import moment from 'moment';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
-import constants from 'vets-json-schema/dist/constants.json';
+import vaMedicalFacilities from 'vets-json-schema/dist/vaMedicalFacilities.json';
 
 import {
   stringifyFormReplacer,
@@ -12,12 +12,10 @@ import {
   expandArrayPages,
   createFormPageList,
 } from 'us-forms-system/lib/js/helpers';
-import { getInactivePages } from '../../platform/forms/helpers';
-import { isValidDate } from '../../platform/forms/validations';
+import { getInactivePages } from 'platform/forms/helpers';
+import { isValidDate } from 'platform/forms/validations';
 
 import facilityLocator from '../facility-locator/manifest';
-
-const { vaMedicalFacilities } = constants;
 
 export function transform(formConfig, form) {
   const expandedPages = expandArrayPages(

--- a/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
@@ -46,6 +46,7 @@ const schemaToConfigIds = {
   VIC: 'VIC',
   definitions: 'N/A',
   constants: 'N/A',
+  vaMedicalFacilities: 'N/A',
 };
 
 const excludedForms = new Set([

--- a/src/platform/forms/tests/migrations.unit.spec.js
+++ b/src/platform/forms/tests/migrations.unit.spec.js
@@ -59,6 +59,7 @@ const excludedForms = new Set([
   '22-0994', // TODO: remove this when 0994 is ready
   'definitions',
   'constants',
+  'vaMedicalFacilities',
 ]);
 
 describe('form migrations:', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11332,9 +11332,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#467ab4c8ec3e3d616b914a9f512bc51f1c6e7f5f":
-  version "3.134.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#467ab4c8ec3e3d616b914a9f512bc51f1c6e7f5f"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#d05c38ce92e3779486d47acfbea62b32a7c736b9":
+  version "3.135.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d05c38ce92e3779486d47acfbea62b32a7c736b9"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
## Description
Pulls in the changes made here: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/327

1. Sort medical facilities alphabetically by their name
    - Resolves department-of-veterans-affairs/vets.gov-team#16559
2. Move medical facilities to own module
    - Resolves department-of-veterans-affairs/vets.gov-team#16560

## Testing done


## Screenshots
Facilities are now displayed in alpha order
<img width="557" alt="facility-list-alpha" src="https://user-images.githubusercontent.com/20728956/51921220-ce539d00-239b-11e9-8883-60bba3371439.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs