### PR TITLE
Fix lint on save

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -96,7 +96,7 @@
     "react/jsx-indent-props": 0,
     "react/jsx-max-props-per-line": 0,
     "react/jsx-no-bind": [0, { "ignoreRefs": true }], // TODO: Enable after fixing.
-    "react/jsx-no-target-blank": [2, { "enforceDynamicLinks": "always" }],
+    "react/jsx-no-target-blank": 2,
     "react/jsx-sort-props": [
       0,
       { "callbacksLast": true, "shorthandFirst": true }


### PR DESCRIPTION
## Description
For some reason (probably because we're pretty far behind the latest eslint version), passing target=_blank rule an array was causing issues with auto linting on save. The rule did seem to work in general, as running `npm run lint` would produce the correct results. But I think the right thing to do is to partially role this rule back and revisit after we're able to upgrade eslint and/or the react/jsx plugin.

NB: This happened with VS Code for at least two of us. I don't have eslint installed globally and VSCode seemed to be using the same version as the project.

## How Does This Affect the Rule? ##
Since we have to turn off the `enforceDynamicLinks` part of the rule, any link with a dynamically generated url will pass the linter even if it's an external link. I think this is OK because not all of our dynamic URLs pointed to external resources, so it's a case where we're switching from being overly-aggressive to maybe missing an edge case.


## Testing done
- Tested that the rule produces in-editor errors in vscode.
- Tested with multiple vscode users

## Screenshots


## Acceptance criteria
- [x] Eslint shows errors in editor of choice.
- [x] Eslint works correctly when using the `run lint` script

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
