### PR TITLE
Update separation pay content

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/separationTrainingPay.jsx
+++ b/src/applications/disability-benefits/all-claims/content/separationTrainingPay.jsx
@@ -1,11 +1,18 @@
 import React from 'react';
 
+export const hasSeparationPayTitle = (
+  <p>
+    Did you receive separation pay or severance pay? (This includes vacation
+    payout, bonuses, medical separation pay, or any money you get from the
+    Voluntary Separation Incentive (VSI) program.)
+  </p>
+);
+
 export const separationPayDetailsDescription = (
   <p>
     The amount you get for VA compensation may be reduced or withheld if you’re
-    also receiving severance or separation pay. This includes medical separation
-    pay or any money you get from the Voluntary Separation Incentive (VSI)
-    program. Getting VA compensation pay and separation pay at the same time may
-    mean that we’ve paid you too much, and you may need to repay the money.
+    also receiving severance or separation pay. Getting VA compensation pay and
+    separation pay at the same time may mean that we’ve paid you too much, and
+    you may need to repay the money.
   </p>
 );

--- a/src/applications/disability-benefits/all-claims/pages/separationPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/separationPay.js
@@ -1,6 +1,9 @@
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { hasSeparationPay, isValidYear } from '../validations';
-import { separationPayDetailsDescription } from '../content/separationTrainingPay';
+import {
+  separationPayDetailsDescription,
+  hasSeparationPayTitle,
+} from '../content/separationTrainingPay';
 
 const {
   separationPayDate: separationPayDateSchema,
@@ -9,7 +12,7 @@ const {
 
 export const uiSchema = {
   'view:hasSeparationPay': {
-    'ui:title': 'Did you receive separation pay or severance pay?',
+    'ui:title': hasSeparationPayTitle,
     'ui:widget': 'yesNo',
   },
   'view:separationPayDetails': {


### PR DESCRIPTION
## Description
Updates 526 v2 separation pay page content per attached ticket.

## Testing done
- Tested locally
- Unit tests

## Screenshots
![screen shot 2019-01-29 at 3 05 29 pm](https://user-images.githubusercontent.com/24251447/51940407-83f01180-23d7-11e9-916f-eeca90162e9f.png)


## Acceptance criteria
- [x] Content updated to latest in ticket

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
