### PR TITLE
All claims new disability content mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 
+export const autoSuggestTitle = (
+  <p>
+    If you know the name of your condition, you can type it here. You can write
+    whatever you want and we’ll make suggestions for possible disabilities.
+    (Shorter descriptions are better. For example, foot pain, back pain, or
+    hearing loss.)
+  </p>
+);
+
 export const uiDescription = (
   <div>
     <AdditionalInfo triggerText="What if I don’t know the name of my condition?">

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -1,6 +1,6 @@
 import * as autosuggest from 'us-forms-system/lib/js/definitions/autosuggest';
 import disabilityLabels from '../content/disabilityLabels';
-import { uiDescription } from '../content/addDisabilities';
+import { uiDescription, autoSuggestTitle } from '../content/addDisabilities';
 import NewDisability from '../components/NewDisability';
 import { validateDisabilityName } from '../validations';
 
@@ -19,7 +19,7 @@ export const uiSchema = {
     },
     items: {
       condition: autosuggest.uiSchema(
-        'If you know the name of your condition, you can type it here. You can write whatever you want and we’ll make suggestions for possible disabilities (for example, foot pain, back pain, or hearing loss).',
+        autoSuggestTitle,
         () =>
           Promise.resolve(
             Object.entries(disabilityLabels).map(([key, value]) => ({

--- a/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
@@ -72,7 +72,7 @@ export const uiSchema = {
       },
       primaryDescription: {
         'ui:title':
-          'Please briefly describe the injury or exposure that caused your condition. For example, I operated loud machinery while in the Army, and this caused me to lose my hearing. (400 characters maximum)',
+          'Please briefly describe the injury or exposure that caused your condition. For example, I operated loud machinery while in the service, and this caused me to lose my hearing. (400 characters maximum)',
         'ui:widget': 'textarea',
         'ui:required': (formData, index) =>
           formData.newDisabilities[index].cause === 'NEW',


### PR DESCRIPTION
## Description
Updates content for the new disability adder and new disability follow up pages per linked ticket.

### Note: ###
Does not address adding the 'save' button to the new disability page because that's a bigger lift and being tracked separately in [#16468](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16468)

## Testing done
- Tested locally
- Unit tests

## Screenshots
![screen shot 2019-01-29 at 3 14 43 pm](https://user-images.githubusercontent.com/24251447/51942001-953b1d00-23db-11e9-9ed1-9997a3a4f96a.png)

-----

![screen shot 2019-01-29 at 3 19 00 pm](https://user-images.githubusercontent.com/24251447/51942007-9cfac180-23db-11e9-8dc1-b3580fbbd0e8.png)

-----

![screen shot 2019-01-29 at 3 39 26 pm](https://user-images.githubusercontent.com/24251447/51942236-28745280-23dc-11e9-9968-596d41987472.png)


## Acceptance criteria
- [x] Content updated per latest copy in linked ticket.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
