### PR TITLE
Update healthcare icon FA5

### DIFF
--- a/src/platform/site-wide/sass/iconography.scss
+++ b/src/platform/site-wide/sass/iconography.scss
@@ -63,7 +63,7 @@
 
 @include make-hub(
   $hub-name: "health-care",
-  $icon: $fa-var-medkit,
+  $icon: $fa-var-briefcase-medical,
   $color: $indigo-cool-60,
   $top-large: 10.25px,
   $left-large: 10px,


### PR DESCRIPTION
## Description
Updated Font Awesome 5 Healthcare icon from `medkit` to
 `briefcase-medical` on `hub-links-container` and `homepage-benefits-row` on homepage and 
 on healthcare hub page.



## Testing done
Viewed on local build

## Screenshots

![screen shot 2019-01-29 at 9 18 30 pm](https://user-images.githubusercontent.com/11021491/51953813-d6e3bc00-240b-11e9-90c5-57e9717e08a3.png)
![screen shot 2019-01-29 at 9 18 14 pm](https://user-images.githubusercontent.com/11021491/51953814-d77c5280-240b-11e9-8143-f1d183ee01fb.png)

## Acceptance criteria
- [X] Icon displays

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
