### PR TITLE
Map Drupal environments to matching vagov environment

### DIFF
--- a/src/site/constants/drupals.js
+++ b/src/site/constants/drupals.js
@@ -1,5 +1,13 @@
 const ENVIRONMENTS = require('./environments');
 
+const DRUPAL_DEV = {
+  address: 'http://dev.va.agile6.com',
+  credentials: {
+    username: 'api',
+    password: 'drupal8',
+  },
+};
+
 const DRUPAL_STAGING = {
   address: 'http://staging.va.agile6.com',
   credentials: {
@@ -8,7 +16,7 @@ const DRUPAL_STAGING = {
   },
 };
 
-const DRUPAL_PROD = {
+const DRUPAL_LIVE = {
   address: 'http://vagovcms.lndo.site',
   credentials: {},
 };
@@ -20,10 +28,10 @@ const DRUPAL_PROD = {
  * @module site/constants/drupals
  */
 const DRUPALS = {
-  [ENVIRONMENTS.LOCALHOST]: DRUPAL_STAGING,
-  [ENVIRONMENTS.VAGOVDEV]: DRUPAL_STAGING,
+  [ENVIRONMENTS.LOCALHOST]: DRUPAL_DEV,
+  [ENVIRONMENTS.VAGOVDEV]: DRUPAL_DEV,
   [ENVIRONMENTS.VAGOVSTAGING]: DRUPAL_STAGING,
-  [ENVIRONMENTS.VAGOVPROD]: DRUPAL_PROD,
+  [ENVIRONMENTS.VAGOVPROD]: DRUPAL_LIVE,
 };
 
 module.exports = DRUPALS;

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -16,6 +16,7 @@ const PULL_DRUPAL_BUILD_ARG = 'pull-drupal';
 const ENABLED_ENVIRONMENTS = new Set([
   ENVIRONMENTS.LOCALHOST,
   ENVIRONMENTS.VAGOVDEV,
+  ENVIRONMENTS.VAGOVSTAGING,
 ]);
 
 const DRUPAL_COLORIZED_OUTPUT = chalk.rgb(73, 167, 222);
@@ -67,6 +68,9 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
       layout: `${entityBundle}.drupal.liquid`,
       contents: Buffer.from('<!-- Drupal-provided data -->'),
       debug: JSON.stringify(page, null, 4),
+      // Keep these pages out of the sitemap until we remove
+      // the drupal prefix
+      private: true,
     };
   }
 


### PR DESCRIPTION
## Description
We need to line up the Drupal environments with our vagov environments correctly, this does that.

I've also enabled the pages in staging, so that we have the ability to test multiple environments, which we'll need to be able to do to fully test the build trigger from Drupal.

## Testing done
Ran locally

## Acceptance criteria
- [x] Environments pull from similar Drupal environments

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
