### PR TITLE
Change form intro CTA button from blue to green

### DIFF
--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -112,7 +112,7 @@ class FormStartControls extends React.Component {
         <ProgressButton
           onButtonClick={this.handleLoadPrefill}
           buttonText={this.props.startText || 'Get Started'}
-          buttonClass="usa-button-primary schemaform-start-button"
+          buttonClass="usa-button-primary va-button-primary schemaform-start-button"
           afterText="»"
         />
       </div>


### PR DESCRIPTION
## Description
This button color change was originally requested for the HCA but it will be used for _all_ "Start the form" CTA buttons on the form intro pages

This work will be followed by the more substantial work to update the content of the form intro page https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/16553

## Testing done
local in browser

## Screenshots
**BEFORE:**
<img width="980" alt="screen shot 2019-01-30 at 11 35 58 am" src="https://user-images.githubusercontent.com/20728956/52007461-5b255600-2483-11e9-98cd-d526b62e59bd.png">
<img width="980" alt="screen shot 2019-01-30 at 11 35 12 am" src="https://user-images.githubusercontent.com/20728956/52007462-5b255600-2483-11e9-9862-c642215ed6c6.png">

**AFTER:**
<img width="972" alt="screen shot 2019-01-30 at 11 26 43 am" src="https://user-images.githubusercontent.com/20728956/52007195-d5090f80-2482-11e9-838d-c19d1124dd9b.png">
<img width="972" alt="screen shot 2019-01-30 at 11 25 55 am" src="https://user-images.githubusercontent.com/20728956/52007196-d5090f80-2482-11e9-8d91-981977294728.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs