### PR TITLE
Capital consistency

### DIFF
--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -92,7 +92,7 @@ function getDisabilities(formData) {
 
 function getDisabilityName(disability) {
   const name = disability.name ? disability.name : disability.condition;
-  return name ? name.toLowerCase() : '';
+  return name;
 }
 
 function getClaimedConditionNames(formData) {
@@ -133,18 +133,32 @@ export const setActionTypes = formData => {
  *  name only gets added to the list if the property value is truthy and is in the list
  *  of conditions claimed on the application.
  *
- * @param {Object} object - The object with dynamically generated property names
- * @param {Object} formData - The whole form data; used to get claimed condition names
- * @return {Array} - An array of the property names with truthy values
- *                   NOTE: This will return all lower-cased names
+ * @param {Object} conditionContainer - The object with dynamically generated property names
+ *                                      For example, treatedDisabilityNames.
+ * @param {Array} claimedConditions - An array containing the names of conditions claimed,
+ *                                     both rated or new.
+ * @return {Array} - An array of the originally-cased property names with truthy values.
+ *                   "Originally-cased" = the case of the name in the disabilities list.
  */
-export function transformRelatedDisabilities(object, claimedConditions) {
-  return Object.keys(object)
-    .filter(
-      // The property name will be normal-cased in the object, but lower-cased in claimedConditions
-      key => object[key] && claimedConditions.includes(key.toLowerCase()),
-    )
-    .map(key => key.toLowerCase());
+export function transformRelatedDisabilities(
+  conditionContainer,
+  claimedConditions,
+) {
+  const findCondition = (list, name) =>
+    list.find(
+      // name should already be lower-case, but just in case...no pun intended
+      claimedName => claimedName.toLowerCase() === name.toLowerCase(),
+    );
+
+  return (
+    Object.keys(conditionContainer)
+      // The check box is checked
+      .filter(name => conditionContainer[name])
+      // It's in the list of claimed conditions
+      .filter(name => findCondition(claimedConditions, name))
+      // Return the name of the actual claimed condition (with the original casing)
+      .map(name => findCondition(claimedConditions, name))
+  );
 }
 
 /**

--- a/src/applications/disability-benefits/all-claims/tests/schema/transformedData.js
+++ b/src/applications/disability-benefits/all-claims/tests/schema/transformedData.js
@@ -98,8 +98,8 @@ export const transformedMaximalData = {
           state: 'AL',
         },
         treatedDisabilityNames: [
-          'first condition',
-          'ptsd (post traumatic stress disorder)',
+          'First Condition',
+          'PTSD (post traumatic stress disorder)',
         ],
       },
     ],
@@ -358,7 +358,7 @@ export const transformedMaximalData = {
     },
     form8940: {
       unemployability: {
-        disabilityPreventingEmployment: 'first condition',
+        disabilityPreventingEmployment: 'First Condition',
         underDoctorHopitalCarePast12M: true,
         doctorProvidedCare: [
           {

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -50,26 +50,26 @@ describe('transform', () => {
 
 describe('transformRelatedDisabilities', () => {
   it('should return an array of strings', () => {
-    const claimedConditions = ['some condition name', 'another condition name'];
+    const claimedConditions = ['Some Condition Name', 'Another Condition Name'];
     const treatedDisabilityNames = {
-      'Some condition name': true,
-      'Another condition name': true,
-      'This condition is falsey!': false,
+      'some condition name': true,
+      'another condition name': true,
+      'this condition is falsey!': false,
     };
     expect(
       transformRelatedDisabilities(treatedDisabilityNames, claimedConditions),
-    ).to.eql(['some condition name', 'another condition name']);
+    ).to.eql(['Some Condition Name', 'Another Condition Name']);
   });
   it('should not add conditions if they are not claimed', () => {
-    const claimedConditions = ['some condition name'];
+    const claimedConditions = ['Some Condition Name'];
     const treatedDisabilityNames = {
-      'Some condition name': true,
-      'Another condition name': true,
-      'This condition is falsey!': false,
+      'some condition name': true,
+      'another condition name': true,
+      'this condition is falsey!': false,
     };
     expect(
       transformRelatedDisabilities(treatedDisabilityNames, claimedConditions),
-    ).to.eql(['some condition name']);
+    ).to.eql(['Some Condition Name']);
   });
 });
 

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -184,8 +184,12 @@ export function queryForFacilities(input = '') {
 
 export const disabilityIsSelected = disability => disability['view:selected'];
 
-export const addCheckboxPerDisability = (form, pageSchema) => {
-  const { ratedDisabilities, newDisabilities } = form;
+/**
+ * An updateSchema callback that adds boolean properties to the schema.
+ * The property names are lowercased, while the title is title cased.
+ */
+export const addCheckboxPerDisability = (formData, pageSchema) => {
+  const { ratedDisabilities, newDisabilities } = formData;
   // This shouldn't happen, but could happen if someone directly
   // opens the right page in the form with no SiP
   if (!ratedDisabilities && !newDisabilities) {
@@ -199,7 +203,6 @@ export const addCheckboxPerDisability = (form, pageSchema) => {
     ? newDisabilities
     : [];
 
-  // TODO: We might be able to clean this up once we know how EVSS
   // We expect to get an array with conditions in it or no property
   // at all.
   const disabilitiesViews = selectedRatedDisabilities


### PR DESCRIPTION
## Description
This PR changes the `transformRelatedDisabilities` function to return original-cased condition names to ensure we've got a match with the associated disability.

## Testing done
Unit tests updated

## Screenshots
N/A

## Acceptance criteria
- [x] The submit transformer returns the originally-cased names for all instances where the name in a condition list must match a claimed condition
    - `treatedDisabilityNames`, for instance

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
