### PR TITLE
Minor refactor in authentication logic with fix for login redirecting back to error page

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -4,6 +4,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
 import siteName from '../../../platform/brand-consolidation/site-name';
+import { authnSettings } from '../../../platform/user/authentication/utilities';
 import { setupProfileSession } from '../../../platform/user/profile/utilities';
 import { apiRequest } from '../../../platform/utilities/api';
 
@@ -25,8 +26,8 @@ export class AuthApp extends React.Component {
 
   handleAuthSuccess = payload => {
     setupProfileSession(payload);
-    const returnUrl = sessionStorage.getItem('authReturnUrl');
-    sessionStorage.removeItem('authReturnUrl');
+    const returnUrl = sessionStorage.getItem(authnSettings.RETURN_URL);
+    sessionStorage.removeItem(authnSettings.RETURN_URL);
     window.location = returnUrl || '/';
   };
 

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -26,9 +26,12 @@ export class AuthApp extends React.Component {
 
   handleAuthSuccess = payload => {
     setupProfileSession(payload);
+
     const returnUrl = sessionStorage.getItem(authnSettings.RETURN_URL);
     sessionStorage.removeItem(authnSettings.RETURN_URL);
-    window.location = returnUrl || '/';
+
+    const redirectUrl = (returnUrl !== window.location && returnUrl) || '/';
+    window.location = redirectUrl;
   };
 
   // Fetch the user to get the login policy and validate the session.

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -5,7 +5,10 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 
 import siteName from '../../../platform/brand-consolidation/site-name';
 import { authnSettings } from '../../../platform/user/authentication/utilities';
-import { setupProfileSession } from '../../../platform/user/profile/utilities';
+import {
+  hasSession,
+  setupProfileSession,
+} from '../../../platform/user/profile/utilities';
 import { apiRequest } from '../../../platform/utilities/api';
 
 import facilityLocator from '../../facility-locator/manifest';
@@ -17,7 +20,7 @@ export class AuthApp extends React.Component {
   }
 
   componentDidMount() {
-    if (!this.state.error) this.validateSession();
+    if (!this.state.error || hasSession()) this.validateSession();
   }
 
   handleAuthError = () => {
@@ -26,12 +29,15 @@ export class AuthApp extends React.Component {
 
   handleAuthSuccess = payload => {
     setupProfileSession(payload);
+    this.redirect();
+  };
 
-    const returnUrl = sessionStorage.getItem(authnSettings.RETURN_URL);
+  redirect = () => {
+    const returnUrl = sessionStorage.getItem(authnSettings.RETURN_URL) || '';
     sessionStorage.removeItem(authnSettings.RETURN_URL);
 
-    const redirectUrl = (returnUrl !== window.location && returnUrl) || '/';
-    window.location = redirectUrl;
+    window.location =
+      (!returnUrl.match(window.location.pathname) && returnUrl) || '/';
   };
 
   // Fetch the user to get the login policy and validate the session.

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -4,6 +4,11 @@ import recordEvent from '../../monitoring/record-event';
 import { apiRequest } from '../../utilities/api';
 import environment from '../../utilities/environment';
 
+export const authnSettings = {
+  RETURN_URL: 'authReturnUrl',
+  REGISTRATION_PENDING: 'registrationPending',
+};
+
 const SESSIONS_URI = `${environment.API_URL}/sessions`;
 const sessionTypeUrl = type => `${SESSIONS_URI}/${type}/new`;
 
@@ -27,7 +32,7 @@ const loginUrl = policy => {
 
 function redirect(redirectUrl, clickedEvent, openedEvent) {
   // Keep track of the URL to return to after auth operation.
-  sessionStorage.setItem('authReturnUrl', window.location);
+  sessionStorage.setItem(authnSettings.RETURN_URL, window.location);
 
   recordEvent({ event: clickedEvent });
 
@@ -48,7 +53,7 @@ function redirect(redirectUrl, clickedEvent, openedEvent) {
 }
 
 export function login(policy) {
-  sessionStorage.removeItem('registrationPending');
+  sessionStorage.removeItem(authnSettings.REGISTRATION_PENDING);
   return redirect(
     loginUrl(policy),
     'login-link-clicked-modal',
@@ -73,7 +78,7 @@ export function logout() {
 }
 
 export function signup() {
-  sessionStorage.setItem('registrationPending', true);
+  sessionStorage.setItem(authnSettings.REGISTRATION_PENDING, true);
   return redirect(
     appendQuery(IDME_URL, { signup: true }),
     'register-link-clicked',

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -32,7 +32,7 @@ const loginUrl = policy => {
 
 function redirect(redirectUrl, clickedEvent, openedEvent) {
   // Keep track of the URL to return to after auth operation.
-  sessionStorage.setItem(authnSettings.RETURN_URL, window.location);
+  sessionStorage.setItem(authnSettings.RETURN_URL, window.location.pathname);
 
   recordEvent({ event: clickedEvent });
 

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -38,7 +38,7 @@ function redirect(redirectUrl, clickedEvent, openedEvent) {
 
   return apiRequest(
     redirectUrl,
-    null,
+    { headers: { Accept: 'application/json' } },
     ({ url }) => {
       if (url) {
         recordEvent({ event: openedEvent });

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -1,6 +1,7 @@
 import camelCaseKeysRecursive from 'camelcase-keys-recursive';
 
 import recordEvent from '../../../monitoring/record-event';
+import { authnSettings } from '../../authentication/utilities';
 import get from '../../../utilities/data/get';
 import localStorage from '../../../utilities/storage/localStorage';
 
@@ -81,7 +82,7 @@ export function setupProfileSession(payload) {
   // this avoids setting the first name to the string 'null'.
   if (firstName) localStorage.setItem('userFirstName', firstName);
 
-  if (sessionStorage.getItem('registrationPending') === 'true') {
+  if (sessionStorage.getItem(authnSettings.REGISTRATION_PENDING)) {
     // Record GA success event for the register method.
     recordEvent({ event: `register-success-${loginPolicy}` });
     sessionStorage.removeItem('registrationPending');


### PR DESCRIPTION
## Description
* Fixed login redirecting back to error page.
* Ensured any interaction with callback page will redirect appropriately.
* Made constants out of sessionStorage key names.
* Setup for two-phase refactor to use redirect URLs instead of fetching JSON for session/new API endpoints.

## Testing done
Local testing.

## Acceptance criteria
- [x] Logging in after an error should not redirect back to the error page.
- [x] Login, logout, etc. should continue to work.
- [x] Navigating to auth callback page while logged in should redirect away.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
