### PR TITLE
Facility Locator map zoom fix

### DIFF
--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -468,7 +468,7 @@ class VAMap extends Component {
               {otherToolsLink}
               <Map ref="map" center={position} zoom={parseInt(currentQuery.zoomLevel, 10)}
                 style={{ width: '100%', maxHeight: '55vh' }} scrollWheelZoom={false}
-                zoomSnap={0.5} zoomDelta={0.5} onMoveEnd={this.handleBoundsChanged}
+                zoomSnap={1} zoomDelta={1} onMoveEnd={this.handleBoundsChanged}
                 onLoad={this.handleBoundsChanged} onViewReset={this.handleBoundsChanged}>
                 <TileLayer
                   url={`https://api.mapbox.com/styles/v1/mapbox/streets-v9/tiles/256/{z}/{x}/{y}?access_token=${mapboxToken}`}

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -521,7 +521,7 @@ class VAMap extends Component {
           </div>
           <div className="columns usa-width-two-thirds medium-8 small-12" style={{ minHeight: '75vh' }}>
             {otherToolsLink}
-            <Map ref="map" center={position} zoomSnap={0.5} zoomDelta={0.5}
+            <Map ref="map" center={position} zoomSnap={1} zoomDelta={1}
               zoom={parseInt(currentQuery.zoomLevel, 10)} style={{ minHeight: '75vh', width: '100%' }}
               scrollWheelZoom={false} onMoveEnd={this.handleBoundsChanged}>
               <TileLayer


### PR DESCRIPTION
## Description
__Problem__: 
According to [this bug ticket ](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/15766) there were two issues:
1. When a user attempts to zoom it, it the map would zoom back out. 
2. When a user would zoom out, it would trigger zoom out 2x 

__Solution__: 
I adjusted `zoomSnap` and `zoomDelta` from `0.5` to `1` on both desktop and mobile in `src/applications/facility-locator/containers/VAMap.jsx`. 

After doing some testing, it was determined that the `zoomLevel` wasn't functioning properly with decimal values. 

## Testing done
Visual testing on local build and internal jenkins build.

## Screenshots
![facilitylocatordemo2](https://user-images.githubusercontent.com/11021491/52074125-2d114600-2557-11e9-85a5-634f1c243b29.gif)


## Acceptance criteria
- [X] User is able to zoom one level with each double click on map or `+` on map controls.
- [X] User is able to to zoom out one level using `-` map controls.  


## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
