### PR TITLE
Create React landing page if one doesn't exist

### DIFF
--- a/src/applications/terms-and-conditions/manifest.json
+++ b/src/applications/terms-and-conditions/manifest.json
@@ -2,6 +2,6 @@
   "appName": "Terms and Conditions",
   "entryFile": "./terms-and-conditions-entry.js",
   "entryName": "terms-and-conditions",
-  "rootUrl": "/",
+  "rootUrl": "/health-care/medical-information-terms-conditions",
   "production": true
 }

--- a/src/applications/veteran-id-card/manifest.json
+++ b/src/applications/veteran-id-card/manifest.json
@@ -2,7 +2,7 @@
   "appName": "Veteran ID Card V1",
   "entryFile": "./veteran-id-card-entry.jsx",
   "entryName": "veteran-id-card",
-  "rootUrl": "/veteran-id-card",
+  "rootUrl": "/records/get-veteran-id-cards/apply",
   "noRouting": true,
   "production": true
 }

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -27,6 +27,7 @@ const configureAssets = require('./plugins/configure-assets');
 const applyFragments = require('./plugins/apply-fragments');
 const checkCollections = require('./plugins/check-collections');
 const createMegaMenu = require('./plugins/create-megamenu');
+const createTemporaryReactPages = require('./plugins/create-react-pages');
 
 function defaultBuild(BUILD_OPTIONS) {
   const smith = Metalsmith(__dirname); // eslint-disable-line new-cap
@@ -52,6 +53,7 @@ function defaultBuild(BUILD_OPTIONS) {
   });
 
   smith.use(getDrupalContent(BUILD_OPTIONS));
+
   smith.use(createEnvironmentFilter(BUILD_OPTIONS));
 
   // This adds the filename into the "entry" that is passed to other plugins. Without this errors
@@ -110,6 +112,8 @@ function defaultBuild(BUILD_OPTIONS) {
       ],
     }),
   );
+
+  smith.use(createTemporaryReactPages(BUILD_OPTIONS));
 
   smith.use(
     navigation({

--- a/src/site/stages/build/plugins/create-react-pages.js
+++ b/src/site/stages/build/plugins/create-react-pages.js
@@ -7,33 +7,39 @@ const prodEnvironments = new Set([BUILD_TYPE.vagovprod]);
 
 function createTemporaryReactPages(options) {
   return (files, metalsmith, done) => {
-    const root = path.join(__dirname, '../../../../..');
-    manifestHelpers
-      .getAppManifests(root)
-      .filter(m => m.rootUrl)
-      .forEach(({ entryName, appName, rootUrl }) => {
-        const trimmedUrl = rootUrl.endsWith('/')
-          ? rootUrl.substring(1, rootUrl.length - 1)
-          : rootUrl.substring(1);
-        const filePath = `${trimmedUrl}/index.html`;
-        if (!prodEnvironments.has(options.buildtype) && !files[filePath]) {
-          console.log(`Creating temp React landing page: ${rootUrl}`);
-          files[filePath] = {
-            title: appName,
-            entryname: entryName,
-            layout: 'page-react.html',
-            path: trimmedUrl,
-            contents: new Buffer(`
-            <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
-              <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-                <li><a href="/">Home</a></li>
-                <li><a aria-current="page" href="${rootUrl}">${appName}</a></li>
-              </ul>
-            </nav>
-            `),
-          };
-        }
-      });
+    if (!prodEnvironments.has(options.buildtype)) {
+      const root = path.join(__dirname, '../../../../..');
+      manifestHelpers
+        .getAppManifests(root)
+        // Skip manifests that are mapping the url from settings.js
+        .filter(m => m.rootUrl)
+        .forEach(({ entryName, appName, rootUrl }) => {
+          // Removing leading and trailing slashes
+          const trimmedUrl = rootUrl.endsWith('/')
+            ? rootUrl.substring(1, rootUrl.length - 1)
+            : rootUrl.substring(1);
+          const filePath = `${trimmedUrl}/index.html`;
+
+          if (!files[filePath]) {
+            console.log(`Creating temp React landing page: ${rootUrl}`);
+            files[filePath] = {
+              title: appName,
+              entryname: entryName,
+              layout: 'page-react.html',
+              path: trimmedUrl,
+              contents: new Buffer(`
+              <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
+                <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+                  <li><a href="/">Home</a></li>
+                  <li><a aria-current="page" href="${rootUrl}">${appName}</a></li>
+                </ul>
+              </nav>
+              `),
+            };
+          }
+        });
+    }
+
     done();
   };
 }

--- a/src/site/stages/build/plugins/create-react-pages.js
+++ b/src/site/stages/build/plugins/create-react-pages.js
@@ -22,6 +22,7 @@ function createTemporaryReactPages(options) {
             title: appName,
             entryname: entryName,
             layout: 'page-react.html',
+            path: trimmedUrl,
             contents: new Buffer(`
             <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
               <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">

--- a/src/site/stages/build/plugins/create-react-pages.js
+++ b/src/site/stages/build/plugins/create-react-pages.js
@@ -1,0 +1,40 @@
+/* eslint-disable no-param-reassign, no-continue, no-console */
+const path = require('path');
+const manifestHelpers = require('../webpack/manifest-helpers');
+const BUILD_TYPE = require('../../../constants/environments');
+
+const prodEnvironments = new Set([BUILD_TYPE.vagovprod]);
+
+function createTemporaryReactPages(options) {
+  return (files, metalsmith, done) => {
+    const root = path.join(__dirname, '../../../../..');
+    manifestHelpers
+      .getAppManifests(root)
+      .filter(m => m.rootUrl)
+      .forEach(({ entryName, appName, rootUrl }) => {
+        const trimmedUrl = rootUrl.endsWith('/')
+          ? rootUrl.substring(1, rootUrl.length - 1)
+          : rootUrl.substring(1);
+        const filePath = `${trimmedUrl}/index.html`;
+        if (!prodEnvironments.has(options.buildtype) && !files[filePath]) {
+          console.log(`Creating temp React landing page: ${rootUrl}`);
+          files[filePath] = {
+            title: appName,
+            entryname: entryName,
+            layout: 'page-react.html',
+            contents: new Buffer(`
+            <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
+              <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+                <li><a href="/">Home</a></li>
+                <li><a aria-current="page" href="${rootUrl}">${appName}</a></li>
+              </ul>
+            </nav>
+            `),
+          };
+        }
+      });
+    done();
+  };
+}
+
+module.exports = createTemporaryReactPages;

--- a/src/site/stages/build/webpack/manifest-helpers.js
+++ b/src/site/stages/build/webpack/manifest-helpers.js
@@ -9,13 +9,13 @@ function getAppManifests(root) {
       // eslint-disable-next-line import/no-dynamic-require
       const manifest = require(file);
 
-      manifest.filePath = file;
-      manifest.entryFile = path.resolve(
-        root,
-        path.join(path.dirname(file), manifest.entryFile),
-      );
-
-      return manifest;
+      return Object.assign({}, manifest, {
+        filePath: file,
+        entryFile: path.resolve(
+          root,
+          path.join(path.dirname(file), manifest.entryFile),
+        ),
+      });
     });
 }
 


### PR DESCRIPTION
## Description
As part of the CMS work, we may want to have React landing pages live in Drupal, so they can be more easily fit into the Drupal content model and IA. This creates a blocker for local development, because we need those pages to be created to start working on an application. This change generates a React landing page based on the `rootUrl` property of a manifest if a page at that path doesn't already exist.

## Testing done
Testing locally against vic-v2 application

## Acceptance criteria
- [x] React landing pages are generated in local, dev, and staging.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
