### PR TITLE
Replace authnContext with signIn to get more accurate sign in method

### DIFF
--- a/src/applications/hca/tests/hca-helpers.js
+++ b/src/applications/hca/tests/hca-helpers.js
@@ -404,7 +404,9 @@ function initSaveInProgressMock(url, client) {
       data: {
         attributes: {
           profile: {
-            authn_context: 'idme',
+            sign_in: {
+              service_name: 'idme',
+            },
             email: 'fake@fake.com',
             loa: { current: 3 },
             first_name: 'Jane',

--- a/src/applications/static-pages/tests/application-status.e2e.spec.js
+++ b/src/applications/static-pages/tests/application-status.e2e.spec.js
@@ -40,7 +40,9 @@ module.exports = E2eHelpers.createE2eTest(client => {
         data: {
           attributes: {
             profile: {
-              authn_context: 'idme',
+              sign_in: {
+                service_name: 'idme',
+              },
               email: 'fake@fake.com',
               loa: { current: 3 },
               first_name: 'Jane',

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -21,7 +21,7 @@ export class VerifyApp extends React.Component {
       myhealthevet: 'My HealtheVet',
     };
 
-    this.signInMethod = signinMethodLabels[serviceName];
+    this.signInMethod = signinMethodLabels[serviceName] || 'ID.me';
   }
   componentDidMount() {
     if (!hasSession()) {
@@ -61,7 +61,7 @@ export class VerifyApp extends React.Component {
               <div>
                 <h1>Verify your identity</h1>
                 <AlertBox
-                  content={`You signed in with ${this.signInMethod || 'ID.me'}`}
+                  content={`You signed in with ${this.signInMethod}`}
                   isVisible
                   status="success"
                 />

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -11,6 +11,18 @@ import siteName from '../../../platform/brand-consolidation/site-name';
 import SubmitSignInForm from '../../../platform/brand-consolidation/components/SubmitSignInForm';
 
 export class VerifyApp extends React.Component {
+  constructor(props) {
+    super(props);
+    const { profile } = this.props;
+    const serviceName = (profile.signIn || {}).serviceName;
+
+    const signinMethodLabels = {
+      dslogon: 'DS Logon',
+      myhealthevet: 'My HealtheVet',
+    };
+
+    this.signInMethod = signinMethodLabels[serviceName];
+  }
   componentDidMount() {
     if (!hasSession()) {
       return window.location.replace('/');
@@ -35,18 +47,11 @@ export class VerifyApp extends React.Component {
   }
 
   render() {
-    const profile = this.props.profile;
+    const { profile } = this.props;
 
     if (profile.loading) {
       return <LoadingIndicator message="Loading the application..." />;
     }
-
-    const signInMethod = (profile.signIn || {}).serviceName;
-
-    const signinMethodLabel = {
-      dslogon: 'DS Logon',
-      myhealthevet: 'My HealtheVet',
-    };
 
     return (
       <main className="verify">
@@ -56,9 +61,7 @@ export class VerifyApp extends React.Component {
               <div>
                 <h1>Verify your identity</h1>
                 <AlertBox
-                  content={`You signed in with ${signinMethodLabel[
-                    signInMethod
-                  ] || 'ID.me'}`}
+                  content={`You signed in with ${this.signInMethod || 'ID.me'}`}
                   isVisible
                   status="success"
                 />

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -35,11 +35,15 @@ export class VerifyApp extends React.Component {
   }
 
   render() {
-    if (this.props.profile.loading) {
+    const profile = this.props.profile;
+
+    if (profile.loading) {
       return <LoadingIndicator message="Loading the application..." />;
     }
 
-    const signinMethod = {
+    const signInMethod = (profile.signIn || {}).serviceName;
+
+    const signinMethodLabel = {
       dslogon: 'DS Logon',
       myhealthevet: 'My HealtheVet',
     };
@@ -52,8 +56,8 @@ export class VerifyApp extends React.Component {
               <div>
                 <h1>Verify your identity</h1>
                 <AlertBox
-                  content={`You signed in with ${signinMethod[
-                    this.props.profile.authnContext
+                  content={`You signed in with ${signinMethodLabel[
+                    signInMethod
                   ] || 'ID.me'}`}
                   isVisible
                   status="success"

--- a/src/platform/testing/e2e-puppeteer/auth.js
+++ b/src/platform/testing/e2e-puppeteer/auth.js
@@ -33,7 +33,9 @@ function initUserMock(token, level) {
       data: {
         attributes: {
           profile: {
-            authn_context: 'idme',
+            sign_in: {
+              service_name: 'idme',
+            },
             email: 'fake@fake.com',
             loa: { current: level },
             first_name: 'Jane',

--- a/src/platform/testing/e2e/auth.js
+++ b/src/platform/testing/e2e/auth.js
@@ -32,7 +32,9 @@ function initUserMock(token, level) {
       data: {
         attributes: {
           profile: {
-            authn_context: 'idme',
+            sign_in: {
+              service_name: 'idme',
+            },
             email: 'fake@fake.com',
             loa: { current: level },
             first_name: 'Jane',

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -34,7 +34,7 @@ export function mapRawUserDataToState(json) {
         inProgressForms: savedForms,
         prefillsAvailable,
         profile: {
-          authnContext,
+          signIn,
           birthDate: dob,
           email,
           firstName: first,
@@ -56,7 +56,7 @@ export function mapRawUserDataToState(json) {
 
   const userState = {
     accountType: loa.current,
-    authnContext,
+    signIn,
     dob,
     email,
     gender,
@@ -120,8 +120,11 @@ export const hasSession = () => localStorage.getItem('hasSession');
 export function setupProfileSession(payload) {
   localStorage.setItem('hasSession', true);
   const userData = get('data.attributes.profile', payload, {});
-  const { firstName, authnContext, loa } = userData;
-  const loginPolicy = authnContext || 'idme';
+  const { firstName, signIn, loa } = userData;
+
+  const serviceName = (signIn || {}).serviceName;
+
+  const loginPolicy = serviceName || 'idme';
 
   // Since localStorage coerces everything into String,
   // this avoids setting the first name to the string 'null'.

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -122,9 +122,7 @@ export function setupProfileSession(payload) {
   const userData = get('data.attributes.profile', payload, {});
   const { firstName, signIn, loa } = userData;
 
-  const serviceName = (signIn || {}).serviceName;
-
-  const loginPolicy = serviceName || 'idme';
+  const loginPolicy = get('serviceName', signIn, 'idme');
 
   // Since localStorage coerces everything into String,
   // this avoids setting the first name to the string 'null'.

--- a/src/platform/user/tests/profile/utilities/index.unit.spec.js
+++ b/src/platform/user/tests/profile/utilities/index.unit.spec.js
@@ -7,7 +7,9 @@ function createDefaultData() {
   return {
     attributes: {
       profile: {
-        authn_context: 'idme',
+        sign_in: {
+          service_name: 'idme',
+        },
         email: 'fake@fake.com',
         loa: { current: 3 },
         first_name: 'Jane',


### PR DESCRIPTION
## Description
We are currently using `authnContext` provided by the API to report the sign in method to Google Analytics, but this has proven to be inaccurate depending on certain factors.

A new attribute called `signIn` is being exposed in this API PR: https://github.com/department-of-veterans-affairs/vets-api/pull/2778

This PR replaces the uses of `authnContext` with `signIn.serviceName`.

## Testing done
Tested locally using `16384-replace-authnContext` branch of API

## Acceptance criteria
- [ ] Appropriate sign in method is being reported to GA
- [ ] Verify App displays accurate sign in method (`src/applications/verify/containers/VerifyApp.jsx` line 59)
- [ ] Tests have been updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
