### PR TITLE
Make temp React landing pages prod check actually work

### DIFF
--- a/src/site/stages/build/plugins/create-react-pages.js
+++ b/src/site/stages/build/plugins/create-react-pages.js
@@ -3,7 +3,7 @@ const path = require('path');
 const manifestHelpers = require('../webpack/manifest-helpers');
 const BUILD_TYPE = require('../../../constants/environments');
 
-const prodEnvironments = new Set([BUILD_TYPE.vagovprod]);
+const prodEnvironments = new Set([BUILD_TYPE.VAGOVPROD]);
 
 function createTemporaryReactPages(options) {
   return (files, metalsmith, done) => {


### PR DESCRIPTION
## Description
We're creating temporary React landing pages when they don't exist in vagov-content. This was meant to be disabled in prod, but the check was incorrect.

## Testing done
Ran a prod build locally

## Acceptance criteria
- [x] prod build doesn't have hidden React apps

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
