### PR TITLE
Download assets when doing a cms build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ yalc.lock
 /test-results.xml
 package-lock.json
 src/applications/proxy-rewrite/tests/__image_snapshots__/__diff_output__/
+temp
 
 # Ignore user's editor/IDE prefs
 .vscode/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,6 +82,8 @@ node('vetsgov-general-purpose') {
               [$class: 'ParametersDefinitionProperty', parameterDefinitions: [[$class: 'StringParameterDefinition', name: 'cmsEnv', defaultValue: 'none']]]]);
   def dockerImage, args, ref, imageTag
 
+  def cmsEnv = params.get('cmsEnv', 'none')
+
   // Checkout source, create output directories, build container
 
   stage('Setup') {
@@ -188,12 +190,13 @@ node('vetsgov-general-purpose') {
 
     try {
       def builds = [:]
+      def assetSource = (cmsEnv != 'none' && cmsEnv != 'live') ? '--asset-source=${ref}' : ''
 
       for (int i=0; i<VAGOV_BUILDTYPES.size(); i++) {
         def envName = VAGOV_BUILDTYPES.get(i)
         builds[envName] = {
           dockerImage.inside(args) {
-            sh "cd /application && npm --no-color run build -- --buildtype=${envName}"
+            sh "cd /application && npm --no-color run build -- --buildtype=${envName} ${assetSource}"
             sh "cd /application && echo \"${buildDetails('buildtype': envName, 'ref': ref)}\" > build/${envName}/BUILD.txt"
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -193,14 +193,13 @@ node('vetsgov-general-purpose') {
 
     try {
       def builds = [:]
-      ref = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
-      def assetSource = (cmsEnv != 'none' && cmsEnv != 'live') ? '--asset-source=${ref}' : ''
+      def assetSource = (cmsEnv != 'none' && cmsEnv != 'live') ? ref : 'local'
 
       for (int i=0; i<VAGOV_BUILDTYPES.size(); i++) {
         def envName = VAGOV_BUILDTYPES.get(i)
         builds[envName] = {
           dockerImage.inside(args) {
-            sh "cd /application && npm --no-color run build -- --buildtype=${envName} ${assetSource}"
+            sh "cd /application && npm --no-color run build -- --buildtype=${envName} --asset-source=${assetSource}"
             sh "cd /application && echo \"${buildDetails('buildtype': envName, 'ref': ref)}\" > build/${envName}/BUILD.txt"
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -193,7 +193,7 @@ node('vetsgov-general-purpose') {
 
     try {
       def builds = [:]
-      def assetSource = (cmsEnv != 'none' && cmsEnv != 'live') ? ref : 'local'
+      def assetSource = (cmsEnv != 'none' && cmsEnv != 'live') ? '3d4cbd45dd2ecf29e10593bab641b80972b3ef11' : 'local'
 
       for (int i=0; i<VAGOV_BUILDTYPES.size(); i++) {
         def envName = VAGOV_BUILDTYPES.get(i)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,6 +110,7 @@ node('vetsgov-general-purpose') {
         sh "mkdir -p build"
         sh "mkdir -p logs/selenium"
         sh "mkdir -p coverage"
+        sh "mkdir -p temp"
 
         imageTag = java.net.URLDecoder.decode(env.BUILD_TAG).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
 
@@ -192,6 +193,7 @@ node('vetsgov-general-purpose') {
 
     try {
       def builds = [:]
+      ref = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
       def assetSource = (cmsEnv != 'none' && cmsEnv != 'live') ? '--asset-source=${ref}' : ''
 
       for (int i=0; i<VAGOV_BUILDTYPES.size(); i++) {

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "command-line-args": "^3.0.1",
     "cors": "^2.7.1",
     "css-loader": "^0.28.10",
+    "decompress": "^4.2.0",
     "enhanced-resolve": "^0.7.6",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.7.1",

--- a/src/site/constants/assetSources.js
+++ b/src/site/constants/assetSources.js
@@ -1,0 +1,7 @@
+module.exports = {
+  // Build assets based on code in local branch
+  LOCAL: 'local',
+  // Build assets based on currently deployed code
+  DEPLOYED: 'deployed',
+  // any other option is expected to be a git hash
+};

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -21,7 +21,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'protocol', type: String, defaultValue: 'http' },
   { name: 'public', type: String, defaultValue: null },
   { name: 'destination', type: String, defaultValue: null },
-  { name: 'content-deployment', type: Boolean, defaultValue: false },
+  { name: 'asset-source', type: String, defaultValue: null },
   { name: 'content-directory', type: String, defaultValue: defaultContentDir },
   { name: 'pull-drupal', type: Boolean, defaultValue: false },
   { name: 'local-proxy-rewrite', type: Boolean, defaultValue: false },

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -5,6 +5,7 @@ const commandLineArgs = require('command-line-args');
 
 const ENVIRONMENTS = require('../../constants/environments');
 const HOSTNAMES = require('../../constants/hostnames');
+const assetSources = require('../../constants/assetSources');
 
 const defaultBuildtype = ENVIRONMENTS.LOCALHOST;
 const defaultHost = HOSTNAMES[defaultBuildtype];
@@ -21,7 +22,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'protocol', type: String, defaultValue: 'http' },
   { name: 'public', type: String, defaultValue: null },
   { name: 'destination', type: String, defaultValue: null },
-  { name: 'asset-source', type: String, defaultValue: 'local' },
+  { name: 'asset-source', type: String, defaultValue: assetSources.LOCAL },
   { name: 'content-directory', type: String, defaultValue: defaultContentDir },
   { name: 'pull-drupal', type: Boolean, defaultValue: false },
   { name: 'local-proxy-rewrite', type: Boolean, defaultValue: false },

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -21,7 +21,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'protocol', type: String, defaultValue: 'http' },
   { name: 'public', type: String, defaultValue: null },
   { name: 'destination', type: String, defaultValue: null },
-  { name: 'asset-source', type: String, defaultValue: null },
+  { name: 'asset-source', type: String, defaultValue: 'local' },
   { name: 'content-directory', type: String, defaultValue: defaultContentDir },
   { name: 'pull-drupal', type: Boolean, defaultValue: false },
   { name: 'local-proxy-rewrite', type: Boolean, defaultValue: false },

--- a/src/site/stages/build/plugins/configure-assets.js
+++ b/src/site/stages/build/plugins/configure-assets.js
@@ -21,7 +21,7 @@ function configureAssets(smith, buildOptions) {
     smith.use(watchMetalSmith);
     smith.use(webpackMetalsmithConnect.watchAssets(buildOptions));
   } else {
-    if (assetSource !== null) {
+    if (assetSource !== 'local') {
       smith.use(downloadAssets(buildOptions));
     } else {
       smith.use(webpackMetalsmithConnect.compileAssets(buildOptions));

--- a/src/site/stages/build/plugins/configure-assets.js
+++ b/src/site/stages/build/plugins/configure-assets.js
@@ -7,7 +7,7 @@ const downloadAssets = require('./download-assets');
 const addAssetHashes = require('./add-asset-hashes');
 
 function configureAssets(smith, buildOptions) {
-  const isContentDeployment = buildOptions['content-deployment'];
+  const assetSource = buildOptions['asset-source'];
   const isDevBuild = [environments.LOCALHOST, environments.VAGOVDEV].includes(
     buildOptions.buildtype,
   );
@@ -21,7 +21,7 @@ function configureAssets(smith, buildOptions) {
     smith.use(watchMetalSmith);
     smith.use(webpackMetalsmithConnect.watchAssets(buildOptions));
   } else {
-    if (isContentDeployment) {
+    if (assetSource !== null) {
       smith.use(downloadAssets(buildOptions));
     } else {
       smith.use(webpackMetalsmithConnect.compileAssets(buildOptions));

--- a/src/site/stages/build/plugins/configure-assets.js
+++ b/src/site/stages/build/plugins/configure-assets.js
@@ -2,6 +2,7 @@
 
 const watch = require('metalsmith-watch');
 const environments = require('../../../constants/environments');
+const assetSources = require('../../../constants/assetSources');
 const webpackMetalsmithConnect = require('../webpack');
 const downloadAssets = require('./download-assets');
 const addAssetHashes = require('./add-asset-hashes');
@@ -21,7 +22,7 @@ function configureAssets(smith, buildOptions) {
     smith.use(watchMetalSmith);
     smith.use(webpackMetalsmithConnect.watchAssets(buildOptions));
   } else {
-    if (assetSource !== 'local') {
+    if (assetSource !== assetSources.LOCAL) {
       smith.use(downloadAssets(buildOptions));
     } else {
       smith.use(webpackMetalsmithConnect.compileAssets(buildOptions));

--- a/src/site/stages/build/plugins/download-assets.js
+++ b/src/site/stages/build/plugins/download-assets.js
@@ -67,7 +67,7 @@ async function downloadFromLiveBucket(files, buildOptions) {
 async function downloadFromArchive(files, assetSource, buildtype) {
   const archiveUrl = `https://s3-us-gov-west-1.amazonaws.com/vetsgov-website-builds-s3-upload/${assetSource}/${buildtype}.tar.bz2`;
 
-  const localPath = path.join(__dirname, '../../../../../temp/assets.tar.bz2');
+  const localPath = path.join(__dirname, '../../../../../temp/site.tar.bz2');
   const assetsPath = path.dirname(localPath);
 
   fs.emptyDirSync(assetsPath);
@@ -86,7 +86,7 @@ function downloadAssets(buildOptions) {
   return async (files, smith, done) => {
     const assetSource = buildOptions['asset-source'];
 
-    if (assetSource === 'bucket') {
+    if (assetSource === 'deployed') {
       await downloadFromLiveBucket(files, buildOptions);
     } else {
       await downloadFromArchive(files, assetSource, buildOptions.buildtype);

--- a/src/site/stages/build/plugins/download-assets.js
+++ b/src/site/stages/build/plugins/download-assets.js
@@ -2,46 +2,96 @@
 /* eslint-disable no-console */
 
 require('isomorphic-fetch');
+const https = require('https');
+const fs = require('fs-extra');
+const path = require('path');
+const decompress = require('decompress');
 const buckets = require('../../../constants/buckets');
+
+function downloadFile(url, dest) {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
+    https
+      .get(url, response => {
+        response.pipe(file);
+        file.on('finish', () => {
+          file.close(resolve);
+        });
+      })
+      .on('error', err => {
+        fs.unlink(dest);
+        reject(err.message);
+      });
+  });
+}
+
+async function downloadFromLiveBucket(files, buildOptions) {
+  const bucket = buckets[buildOptions.buildtype];
+  const fileManifestPath = 'generated/file-manifest.json';
+
+  console.log(`Downloading assets from ${bucket}...`);
+
+  const fileManifestRequest = await fetch(`${bucket}/${fileManifestPath}`);
+  const fileManifest = await fileManifestRequest.json();
+
+  files[fileManifestPath] = {
+    path: fileManifestPath,
+    contents: new Buffer(JSON.stringify(fileManifest)),
+  };
+
+  const entryNames = Object.keys(fileManifest);
+
+  const downloads = entryNames.map(async entryName => {
+    let bundleFileName = fileManifest[entryName];
+    const bundleUrl = `${bucket}${bundleFileName}`;
+    const bundleResponse = await fetch(bundleUrl);
+
+    if (!bundleResponse.ok) {
+      throw new Error(`Failed to download asset: ${bundleUrl}`);
+    }
+
+    if (bundleFileName.startsWith('/'))
+      bundleFileName = bundleFileName.slice(1);
+
+    files[bundleFileName] = {
+      path: bundleFileName,
+      contents: await bundleResponse.buffer(),
+    };
+
+    console.log(`Successfully downloaded asset: ${bundleUrl}`);
+  });
+
+  return Promise.all(downloads);
+}
+
+async function downloadFromArchive(files, assetSource, buildtype) {
+  const archiveUrl = `https://s3-us-gov-west-1.amazonaws.com/vetsgov-website-builds-s3-upload/${assetSource}/${buildtype}.tar.bz2`;
+
+  const localPath = path.join(__dirname, '../../../../../temp/assets.tar.bz2');
+  const assetsPath = path.dirname(localPath);
+
+  fs.emptyDirSync(assetsPath);
+  await downloadFile(archiveUrl, localPath);
+  await decompress(localPath, assetsPath);
+
+  fs.readdirSync(path.join(assetsPath, 'generated')).forEach(file => {
+    files[`generated/${file}`] = {
+      path: `generated/${file}`,
+      contents: fs.readFileSync(path.join(assetsPath, 'generated', file)),
+    };
+  });
+}
 
 function downloadAssets(buildOptions) {
   return async (files, smith, done) => {
-    const bucket = buckets[buildOptions.buildtype];
-    const fileManifestPath = 'generated/file-manifest.json';
+    const assetSource = buildOptions['asset-source'];
 
-    console.log(`Downloading assets from ${bucket}...`);
+    if (assetSource === 'bucket') {
+      await downloadFromLiveBucket(files, buildOptions);
+    } else {
+      await downloadFromArchive(files, assetSource, buildOptions.buildtype);
+    }
 
-    const fileManifestRequest = await fetch(`${bucket}/${fileManifestPath}`);
-    const fileManifest = await fileManifestRequest.json();
-
-    files[fileManifestPath] = {
-      path: fileManifestPath,
-      contents: new Buffer(JSON.stringify(fileManifest)),
-    };
-
-    const entryNames = Object.keys(fileManifest);
-
-    const downloads = entryNames.map(async entryName => {
-      let bundleFileName = fileManifest[entryName];
-      const bundleUrl = `${bucket}${bundleFileName}`;
-      const bundleResponse = await fetch(bundleUrl);
-
-      if (!bundleResponse.ok) {
-        throw new Error(`Failed to download asset: ${bundleUrl}`);
-      }
-
-      if (bundleFileName.startsWith('/'))
-        bundleFileName = bundleFileName.slice(1);
-
-      files[bundleFileName] = {
-        path: bundleFileName,
-        contents: await bundleResponse.buffer(),
-      };
-
-      console.log(`Successfully downloaded asset: ${bundleUrl}`);
-    });
-
-    await Promise.all(downloads);
     done();
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1434,6 +1434,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-js@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"
+  integrity sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=
+
 base64-js@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.0.tgz#a39992d723584811982be5e290bb6a53d86700f1"
@@ -1488,6 +1493,14 @@ binary-extensions@^1.0.0:
 bindings@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
+
+bl@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
+  integrity sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
 
 blob-polyfill@^2.0.20171115:
   version "2.0.20171115"
@@ -1802,6 +1815,29 @@ btoa-lite@^1.0.0:
   resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
   integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
 
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
+  integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
+
+buffer-alloc@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
+  integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
+  dependencies:
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
+
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
+  integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
+
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -1817,6 +1853,15 @@ buffer-shims@~1.0.0:
 buffer-xor@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
+
+buffer@^3.0.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-3.6.0.tgz#a72c936f77b96bf52f5f7e7b467180628551defb"
+  integrity sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=
+  dependencies:
+    base64-js "0.0.8"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 buffer@^4.1.0, buffer@^4.3.0:
   version "4.9.1"
@@ -2364,6 +2409,13 @@ commander@^2.5.0, commander@~2.15.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
+commander@~2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
+  integrity sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -2876,6 +2928,59 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
+decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/decompress-tar/-/decompress-tar-4.1.1.tgz#718cbd3fcb16209716e70a26b84e7ba4592e5af1"
+  integrity sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==
+  dependencies:
+    file-type "^5.2.0"
+    is-stream "^1.1.0"
+    tar-stream "^1.5.2"
+
+decompress-tarbz2@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz#3082a5b880ea4043816349f378b56c516be1a39b"
+  integrity sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==
+  dependencies:
+    decompress-tar "^4.1.0"
+    file-type "^6.1.0"
+    is-stream "^1.1.0"
+    seek-bzip "^1.0.5"
+    unbzip2-stream "^1.0.9"
+
+decompress-targz@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/decompress-targz/-/decompress-targz-4.1.1.tgz#c09bc35c4d11f3de09f2d2da53e9de23e7ce1eee"
+  integrity sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==
+  dependencies:
+    decompress-tar "^4.1.1"
+    file-type "^5.2.0"
+    is-stream "^1.1.0"
+
+decompress-unzip@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/decompress-unzip/-/decompress-unzip-4.0.1.tgz#deaaccdfd14aeaf85578f733ae8210f9b4848f69"
+  integrity sha1-3qrM39FK6vhVePczroIQ+bSEj2k=
+  dependencies:
+    file-type "^3.8.0"
+    get-stream "^2.2.0"
+    pify "^2.3.0"
+    yauzl "^2.4.2"
+
+decompress@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/decompress/-/decompress-4.2.0.tgz#7aedd85427e5a92dacfe55674a7c505e96d01f9d"
+  integrity sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=
+  dependencies:
+    decompress-tar "^4.0.0"
+    decompress-tarbz2 "^4.0.0"
+    decompress-targz "^4.0.0"
+    decompress-unzip "^4.0.1"
+    graceful-fs "^4.1.10"
+    make-dir "^1.0.0"
+    pify "^2.3.0"
+    strip-dirs "^2.0.0"
 
 deep-eql@0.1.3:
   version "0.1.3"
@@ -4156,6 +4261,13 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
+  dependencies:
+    pend "~1.2.0"
+
 feature-detect-es6@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/feature-detect-es6/-/feature-detect-es6-1.3.1.tgz#f888736af9cb0c91f55663bfa4762eb96ee7047f"
@@ -4195,6 +4307,21 @@ file-loader@1.1.11, file-loader@^1.1.11:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^0.4.5"
+
+file-type@^3.8.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
+  integrity sha1-JXoHg4TR24CHvESdEH1SpSZyuek=
+
+file-type@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-5.2.0.tgz#2ddbea7c73ffe36368dfae49dc338c058c2b8ad6"
+  integrity sha1-LdvqfHP/42No365J3DOMBYwritY=
+
+file-type@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-6.2.0.tgz#e50cd75d356ffed4e306dc4f5bcf52a79903a919"
+  integrity sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==
 
 file-uri-to-path@0:
   version "0.0.2"
@@ -4425,6 +4552,11 @@ front-matter@2.1.0:
   dependencies:
     js-yaml "^3.4.6"
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
 fs-extra@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
@@ -4594,6 +4726,14 @@ get-stdin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
 
+get-stream@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
+  integrity sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=
+  dependencies:
+    object-assign "^4.0.1"
+    pinkie-promise "^2.0.0"
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -4732,6 +4872,11 @@ gonzales-pe@3.4.7:
   resolved "https://registry.yarnpkg.com/gonzales-pe/-/gonzales-pe-3.4.7.tgz#17c7be67ad6caff6277a3e387ac736e983d280ec"
   dependencies:
     minimist "1.1.x"
+
+graceful-fs@^4.1.10:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
@@ -5478,6 +5623,11 @@ is-my-json-valid@^2.10.0:
     generate-object-property "^1.1.0"
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
+
+is-natural-number@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
+  integrity sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=
 
 is-number-object@^1.0.3:
   version "1.0.3"
@@ -8361,7 +8511,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-pify@^2.0.0:
+pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
@@ -9247,7 +9397,7 @@ readable-stream@1.1.x:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.3.6:
+readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -9888,6 +10038,13 @@ section-matter@^1.0.0:
 seedrandom@^2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.3.tgz#2438504dad33917314bff18ac4d794f16d6aaecc"
+
+seek-bzip@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.5.tgz#cfe917cb3d274bcffac792758af53173eb1fabdc"
+  integrity sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=
+  dependencies:
+    commander "~2.8.1"
 
 select-hose@^2.0.0:
   version "2.0.0"
@@ -10620,6 +10777,13 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-dirs@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/strip-dirs/-/strip-dirs-2.1.0.tgz#4987736264fc344cf20f6c34aca9d13d1d4ed6c5"
+  integrity sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==
+  dependencies:
+    is-natural-number "^4.0.1"
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -10764,6 +10928,19 @@ tar-pack@^3.4.0:
     tar "^2.2.1"
     uid-number "^0.0.6"
 
+tar-stream@^1.5.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
+  integrity sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==
+  dependencies:
+    bl "^1.0.0"
+    buffer-alloc "^1.2.0"
+    end-of-stream "^1.0.0"
+    fs-constants "^1.0.0"
+    readable-stream "^2.3.0"
+    to-buffer "^1.1.1"
+    xtend "^4.0.0"
+
 tar@^2.0.0, tar@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
@@ -10893,6 +11070,11 @@ tmpl@1.0.x:
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
+
+to-buffer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
+  integrity sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==
 
 to-fast-properties@^1.0.3:
   version "1.0.3"
@@ -11110,6 +11292,14 @@ umd@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.3.tgz#aa9fe653c42b9097678489c01000acb69f0b26cf"
   integrity sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==
+
+unbzip2-stream@^1.0.9:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.3.1.tgz#7854da51622a7e63624221196357803b552966a1"
+  integrity sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==
+  dependencies:
+    buffer "^3.0.1"
+    through "^2.3.6"
 
 undeclared-identifiers@^1.1.2:
   version "1.1.2"
@@ -11910,3 +12100,11 @@ yauzl@2.4.1:
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
   dependencies:
     fd-slicer "~1.0.1"
+
+yauzl@^2.4.2:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"


### PR DESCRIPTION
## Description
When we do a cmsEnv build, we don't want to rebuild our assets, we want to reuse what's already built. To do this, I'm fetching them from the tarball uploaded to s3 after every master build.

This is similar to Nick's previous content-deploy flag work with a couple differences:
1. I changed the flag to `asset-source` from `content-deployment`. I think this reflects what's happening in the actual build command better; this doesn't affect deploying anything, just what is built
2. The assets we use are pulled from a tarball in `vetsgov-website-builds-s3-upload` instead of from the s3 bucket for the currently deployed code. This means we're pulling the latest master build, rather than the latest live assets. That doesn't matter for staging and dev, but it's an important difference for prod. We'll have to do an extra build for prod to deploy immediately when we get to that point.

## Testing done
Ran build locally pointed against a SHA

## Acceptance criteria
- [x] Build downloads assets instead of building

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
