### PR TITLE
[Vet Tec] Update transform to filter invalid high technology type

### DIFF
--- a/src/applications/edu-benefits/0994/submit-transformer.js
+++ b/src/applications/edu-benefits/0994/submit-transformer.js
@@ -31,7 +31,7 @@ export function transform(formConfig, form) {
 
       const highTechnologyEmploymentTypes = Object.keys(
         highTechnologyEmploymentType,
-      ).filter(key => highTechnologyEmploymentType[key]);
+      ).filter(key => highTechnologyEmploymentType[key] && key !== 'noneApply');
 
       delete clonedData.highTechnologyEmploymentType;
 

--- a/src/applications/edu-benefits/tests/0994/schema/maximal-test.json
+++ b/src/applications/edu-benefits/tests/0994/schema/maximal-test.json
@@ -49,7 +49,7 @@
         "computerSoftware": true,
         "informationSciences": true,
         "mediaApplication": true,
-        "noneApply": false
+        "noneApply": true
       }
     },
     "highestLevelofEducation": "other",


### PR DESCRIPTION
## Description
Filtered "None of these apply" in the high technology type field because it isn't in the schema and `vets-api` already handles an empty selection as `N/A`

Resolves issue: https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/16730

## Testing done
Tested locally and updated unit test.

## Screenshots
N/A

## Acceptance criteria
- [x] Submission without error

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
