### PR TITLE
List apps with `yarn apps`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Frontend build for vets.gov website static assets.",
   "scripts": {
-    "apps": "node --eval \"require('./script/manifest-helpers.js').displayApplications()\"",
+    "apps": "./script/app-list.sh",
     "analyze": "webpack-bundle-analyzer build/vagovprod/generated/stats.json",
     "build": "node --max-old-space-size=4096 script/build.js",
     "build:redirects": "node script/vets-gov-to-va-gov.js",

--- a/script/app-list.sh
+++ b/script/app-list.sh
@@ -1,0 +1,1 @@
+find src/ -name manifest.js* | xargs grep "entryName" | sed -E 's/.+:(.+)/\1/' | sed "s/['\", ]//g"


### PR DESCRIPTION
## Description
I'm not sure what happened to the manifest helper file that the `apps` script referred to, but I made a little shell script that should do basically the same thing. Probably faster? No clue.

## Testing done
I've only run it on Linux. I _think_ it should work on OS X, but somebody else will have to verify that.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/52238881-f7839a00-2881-11e9-9ef0-fd2237acffd1.png)