### PR TITLE
All claims update rest content mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/8940/index.js
+++ b/src/applications/disability-benefits/all-claims/config/8940/index.js
@@ -142,7 +142,7 @@ export default function() {
       },
       // 8940 - Education & Training
       pastEducationTraining: {
-        title: 'Education $ Training',
+        title: 'Education & Training',
         path: 'past-education-training',
         depends: needsToAnswerUnemployability,
         uiSchema: pastEducationTraining.uiSchema,

--- a/src/applications/disability-benefits/all-claims/config/8940/index.js
+++ b/src/applications/disability-benefits/all-claims/config/8940/index.js
@@ -35,8 +35,6 @@ import createFormConfig4192 from '../4192';
 export default function() {
   let configObj = {};
   if (!environment.isProduction()) {
-    // NOTE: When removing this production check, also necessary to remove the
-    // build-based logic in `content/ancillaryFormsWizardSummary.jsx#L123`
     configObj = {
       // 8940 - Introduction
       unemployabilityFormIntro: {

--- a/src/applications/disability-benefits/all-claims/config/8940/index.js
+++ b/src/applications/disability-benefits/all-claims/config/8940/index.js
@@ -35,6 +35,8 @@ import createFormConfig4192 from '../4192';
 export default function() {
   let configObj = {};
   if (!environment.isProduction()) {
+    // NOTE: When removing this production check, also necessary to remove the
+    // build-based logic in `content/ancillaryFormsWizardSummary.jsx#L123`
     configObj = {
       // 8940 - Introduction
       unemployabilityFormIntro: {

--- a/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/CollapsiblePanel';
+import environment from '../../../../platform/utilities/environment';
 
 const houseAssistanceContent = (
   <CollapsiblePanel panelName="Adapted housing assistance">
@@ -57,9 +58,10 @@ const carAssistanceContent = (
 const aidAndAttendanceContent = (
   <CollapsiblePanel panelName="Aid and Attendance">
     <p>
-      To apply for Aid and Attendance benefits, you’ll need to turn in an
+      To apply for Aid and Attendance benefits, your doctor needs to fill out an
       Examination for Housebound Status or Permanent Need for Regular Aid and
-      Attendance (VA Form 21-2680), which your doctor needs to fill out.
+      Attendance (VA Form 21-2680). You can submit this form once it's
+      completed.
     </p>
     <div>
       <a
@@ -113,9 +115,10 @@ const individualUnemployabilityContent = (
 );
 
 export default function summaryDescription({ formData }) {
-  const showUnemployableContent =
-    formData['view:unemployable'] &&
-    !formData['view:unemployabilityUploadChoice'];
+  const showUnemployableContent = environment.isProduction()
+    ? formData['view:unemployable']
+    : false;
+
   return (
     <div>
       <p>

--- a/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
@@ -117,12 +117,14 @@ const individualUnemployabilityContent = (
 export default function summaryDescription({ formData }) {
   // In production, users should see the unemployable content if they indicate
   // that they're unemployable. In other environments, they should see the
-  // unemployable content only when no selection has been made for
-  // `view:unemployabilityUploadChoice` (selecting any option for that question
-  // will evaluate to true because all the answers are strings)
-  const showUnemployableContent = environment.isProduction()
-    ? formData['view:unemployable']
-    : !formData['view:unemployabilityUploadChoice'];
+  // unemployable content only when indicate unemployability and no selection
+  // has been made for `view:unemployabilityUploadChoice` (selecting any
+  // option for that question will evaluate to true because all the answers
+  // are strings). Since `view:unemployabilityUploadChoice` is only a question
+  // in non-prod environments, it will always be `falsey` on prod
+  const showUnemployableContent =
+    formData['view:unemployable'] &&
+    !formData['view:unemployabilityUploadChoice'];
 
   return (
     <div>

--- a/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/CollapsiblePanel';
-import environment from '../../../../platform/utilities/environment';
 
 const houseAssistanceContent = (
   <CollapsiblePanel panelName="Adapted housing assistance">

--- a/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ancillaryFormsWizardSummary.jsx
@@ -115,9 +115,14 @@ const individualUnemployabilityContent = (
 );
 
 export default function summaryDescription({ formData }) {
+  // In production, users should see the unemployable content if they indicate
+  // that they're unemployable. In other environments, they should see the
+  // unemployable content only when no selection has been made for
+  // `view:unemployabilityUploadChoice` (selecting any option for that question
+  // will evaluate to true because all the answers are strings)
   const showUnemployableContent = environment.isProduction()
     ? formData['view:unemployable']
-    : false;
+    : !formData['view:unemployabilityUploadChoice'];
 
   return (
     <div>

--- a/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
@@ -12,7 +12,7 @@ export const UploadDescription = ({ uploadTitle }) => (
     </p>
     <ul>
       <li>File types you can upload: .pdf, .jpeg, or .png</li>
-      <li>Maximum file size: 25 MB</li>
+      <li>Maximum file size: 25MB</li>
     </ul>
     <p>
       <em>

--- a/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
@@ -5,7 +5,7 @@ export const FDCDescription = (
     <h5>Fully developed claim program</h5>
     <p>
       You can apply using the Fully Developed Claim (FDC) program if you’ve
-      uploaded all the supporting documents or supplemental forms needed to
+      uploaded all the supporting documents or additional forms needed to
       support your claim.
     </p>
     <a

--- a/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
@@ -40,7 +40,7 @@ export const noFDCWarning = (
           standard claim process, you have up to 1 year from the date we receive
           your claim to turn in any information and evidence.
         </p>
-        <p>You can turn in your evidence 1 of 3 ways:</p>
+        <p>You can turn in your evidence in 1 of 3 ways:</p>
         <ul>
           <li>
             Visit the Claim Status tool and upload your documents under the File

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -25,7 +25,7 @@ export const privateRecordsChoiceHelp = (
 export const patientAcknowledgmentText = (
   <div className="patient-acknowldegment-help">
     <AdditionalInfo triggerText="Read the full text.">
-      <h4>PATIENT AUTHORIZATION:</h4>
+      <h4>Patient Authorization:</h4>
       <p>
         I voluntarily authorize and request disclosure (including paper, oral,
         and electronic interchange) of: All my medical records; including
@@ -61,19 +61,19 @@ export const patientAcknowledgmentText = (
         </li>
       </ol>
       <p>
-        YOU SHOULD NOT COMPLETE THIS FORM UNLESS YOU WANT THE VA TO OBTAIN
-        PRIVATE TREATMENT RECORDS ON YOUR BEHALF. IF YOU HAVE ALREADY PROVIDED
-        THESE RECORDS OR INTEND TO OBTAIN THEM YOURSELF, THERE IS NO NEED TO
-        FILL OUT THIS FORM. DOING SO WILL LENGTHEN YOUR CLAIM PROCESSING TIME.
+        You should not complete this form unless you want the VA to obtain
+        private treatment records on your behalf. If you have already provided
+        these records or intend to obtain them yourself, there is no need to
+        fill out this form. Doing so will lengthen your claim processing time.
       </p>
-      <h4>IMPORTANT:</h4>
+      <h4>Important:</h4>
       <p>
         In accordance with 38 C.F.R. §3.159(c), "VA will not pay any fees
         charged by a custodian to provide records requested."
       </p>
-      <h4>PATIENT ACKNOWLEDGEMENT:</h4>
+      <h4>Patient Acknowledgment:</h4>
       <p>
-        I HEREBY AUTHORIZE the sources listed in Section IV, to release any
+        I hereby authorize the sources listed in Section IV, to release any
         information that may have been obtained in connection with a physical,
         psychological or psychiatric examination or treatment, with the
         understanding that VA will use this information in determining my
@@ -106,7 +106,7 @@ export const patientAcknowledgmentText = (
         to decide my claim.
       </p>
       <p>
-        NOTE: For additional information regarding VA Form 21-4142, refer to the
+        Note: For additional information regarding VA Form 21-4142, refer to the
         following website:
         <a
           href="https://www.benefits.va.gov/privateproviders/"

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecordsRelease.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecordsRelease.jsx
@@ -3,20 +3,20 @@ import AdditionalInfo from '@department-of-veterans-affairs/formation-react/Addi
 
 export const limitedConsentTitle = (
   <p>
-    I want to limit my consent for the VA to retrieve only specific information
-    from my private medical provider(s).
+    I want to limit my consent for VA to retrieve only specific information from
+    my private medical provider(s).
   </p>
 );
 
 export const limitedConsentTextTitle = (
-  <p>Describe the limitation below. (Treatment dates, Disability type, etc.)</p>
+  <p>Describe the limitation below (treatment dates, disability type, etc.).</p>
 );
 
 export const limitedConsentDescription = (
   <AdditionalInfo triggerText="What does this mean?">
     <p>
-      If you choose to limit consent, your doctor will abide by the limitation
-      you specify. Limiting consent could add to the time it takes to get your
+      If you choose to limit consent, your doctor will follow the limitation you
+      specify. Limiting consent could add to the time it takes to get your
       private medical records.
     </p>
   </AdditionalInfo>

--- a/src/applications/disability-benefits/all-claims/content/supportingEvidenceOrientation.jsx
+++ b/src/applications/disability-benefits/all-claims/content/supportingEvidenceOrientation.jsx
@@ -1,13 +1,22 @@
 import React from 'react';
 
 export const supportingEvidenceOrientation = (
-  <p>
-    On the next few screens, we’ll ask you where we can find evidence
-    (supporting documents like doctor’s reports, X-rays, and medical test
-    results) related to your claim. You don’t need to turn in any evidence that
-    you submitted with an earlier claim.{' '}
-    <strong>
-      You only need to submit new evidence that VA doesn’t already have.
-    </strong>
-  </p>
+  <div>
+    <p>
+      On the next few screens, we’ll ask you where we can find evidence
+      (supporting documents like doctor’s reports, X-rays, and medical test
+      results) related to:
+    </p>
+    <ul>
+      <li>Your rated service-connected disabilities, if you have any</li>
+      <li>Your new service-connected disabilities or conditions</li>
+    </ul>
+    <p>
+      You don’t need to turn in any evidence that you submitted with an earlier
+      claim.{' '}
+      <strong>
+        You only need to submit new evidence that VA doesn’t already have.
+      </strong>
+    </p>
+  </div>
 );

--- a/src/applications/disability-benefits/all-claims/content/trainingPayWaiver.jsx
+++ b/src/applications/disability-benefits/all-claims/content/trainingPayWaiver.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 export const waiveTrainingPayDescription = (
   <p>
-    If you’re eligible for both training pay and VA compensation, you’ll need to
-    decide which one you want to get. You can’t get VA compensation for the same
-    days you get training pay. If you want to keep your training pay, you’ll
-    need to waive (or tell us you don’t want to get) VA compensation pay for the
-    days you receive training pay.
+    You can’t get VA compensation for the same days you get training pay. If you
+    want to keep your training pay, you’ll need to waive (or tell us you don’t
+    want to get) VA compensation pay for the days you receive training pay.{' '}
+    <strong>
+      In general, training pay is going to be more than your compensation pay
+      for any given day.
+    </strong>
   </p>
 );

--- a/src/applications/disability-benefits/all-claims/content/waiveRetirementPay.jsx
+++ b/src/applications/disability-benefits/all-claims/content/waiveRetirementPay.jsx
@@ -9,8 +9,8 @@ export const waiveRetirementPayDescription = (
       rate.
     </p>
     <p>
-      VA compensation pay isn’t taxable. Military retirement pay is taxable.
-      Dollar for dollar VA compensation pay is always the greater benefit.
+      VA compensation pay isn’t taxable. Military retirement pay is taxable. VA
+      compensation pay is always the greater benefit.
     </p>
     <p>
       Below is an example showing that{' '}

--- a/src/applications/disability-benefits/all-claims/content/waiveRetirementPay.jsx
+++ b/src/applications/disability-benefits/all-claims/content/waiveRetirementPay.jsx
@@ -24,7 +24,7 @@ export const waiveRetirementPayDescription = (
         <tr>
           <th />
           <th>Monthly benefit</th>
-          <th>Take-home</th>
+          <th>Take-home pay</th>
         </tr>
       </thead>
       <tbody>

--- a/src/applications/disability-benefits/all-claims/content/waiveRetirementPay.jsx
+++ b/src/applications/disability-benefits/all-claims/content/waiveRetirementPay.jsx
@@ -12,43 +12,39 @@ export const waiveRetirementPayDescription = (
       VA compensation pay isn’t taxable. Military retirement pay is taxable.
       Dollar for dollar VA compensation pay is always the greater benefit.
     </p>
+    <p>
+      Below is an example showing that{' '}
+      <strong>
+        dollar for dollar VA compensation pay is always the greater benefit.
+      </strong>{' '}
+      Tax rates will vary depending on income.
+    </p>
     <table>
       <thead>
         <tr>
-          <th>Compensation</th>
-          <th>Retirement</th>
-          <th>Take home pay</th>
+          <th />
+          <th>Monthly benefit</th>
+          <th>Take-home</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td>
-            <del>$700/month</del>
-          </td>
-          <td>$700/month (minus taxes)</td>
-          <td>$630/month</td>
+          <td>Retirement</td>
+          <td>$700 (minus taxes)</td>
+          <td>$630</td>
         </tr>
         <tr>
           <td>
-            <strong>$700/month (tax-free)</strong>
+            <strong>Compensation</strong>
           </td>
           <td>
-            <strong>
-              <del>$700/month</del>
-            </strong>
+            <strong>$700 (tax-free)</strong>
           </td>
           <td>
-            <strong>$700/month</strong>
+            <strong>$700</strong>
           </td>
         </tr>
       </tbody>
     </table>
-    <p>
-      <em>
-        This is an example showing that dollar for dollar VA compensation pay
-        gives you more spending power than retirement pay. Tax rates will vary
-        depending on income.
-      </em>
-    </p>
   </div>
 );

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -204,7 +204,7 @@ export const uiSchema = {
       effectiveDate: merge(
         dateRangeUI(
           'Start date',
-          'End date',
+          'End date (optional)',
           'End date must be after start date',
         ),
         {

--- a/src/applications/disability-benefits/all-claims/pages/paymentInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/paymentInformation.js
@@ -13,6 +13,7 @@ const {
 export const uiSchema = {
   'view:bankAccount': {
     'ui:title': 'Payment Information',
+    'ui:description': 'We’ll pay your disability benefit to the account below.',
     'ui:field': ReviewCardField,
     'ui:options': {
       viewComponent: PaymentView,

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -65,7 +65,7 @@ export const uiSchema = {
       showFieldLabel: true,
     },
     'view:acknowledgement': {
-      'ui:title': 'Patient Acknowledgement',
+      'ui:title': 'Patient Acknowledgment',
     },
     'ui:validations': [
       (errors, item) => {

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -98,6 +98,9 @@ export const schema = {
       },
     },
     privateMedicalRecordAttachments,
+    // Note: this property is misspelled. Should be
+    // `view:patientAcknowledgment` but isn't worth writing a migration for at
+    // this time since it's only used on this page.
     'view:patientAcknowledgement': {
       type: 'object',
       required: ['view:acknowledgement'],

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
@@ -49,8 +49,8 @@ export const uiSchema = {
       },
       'ui:validations': [validateDate],
       treatmentDateRange: dateRangeUI(
-        'Approximate date of first treatment',
-        'Approximate date of last treatment',
+        'First treatment date (You can provide an estimated date.)',
+        'Last treatment date (You can provide an estimated date.)',
         'End of treatment must be after start of treatment',
       ),
       providerFacilityAddress: {
@@ -78,7 +78,7 @@ export const uiSchema = {
           'ui:title': 'State',
         },
         postalCode: {
-          'ui:title': 'Postal Code',
+          'ui:title': 'Postal code',
           'ui:validations': [validateZIP],
           'ui:errorMessages': {
             pattern:

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -64,7 +64,7 @@ export const uiSchema = {
         {},
         dateRangeUI(
           'When did you first visit this facility?',
-          'When was your most recent visit?',
+          'When was your most recent visit? (Optional)',
           'Date of last treatment must be after date of first treatment',
         ),
         {


### PR DESCRIPTION
## Description
This PR updates content for a good chunk of the 526 v2 form flow.

## Testing done
- Tested locally
- Unit tests


## Screenshots
https://staging.va.gov/disability-benefits/apply/form-526-all-claims/additional-disability-benefits-summary
![screen shot 2019-02-01 at 3 12 45 pm](https://user-images.githubusercontent.com/24251447/52240563-cb264880-2896-11e9-883a-d89f53e3a821.png)

-----

https://staging.va.gov/disability-benefits/apply/form-526-all-claims/supporting-evidence/orientation
![screen shot 2019-02-01 at 3 18 16 pm](https://user-images.githubusercontent.com/24251447/52240580-d8433780-2896-11e9-89c7-a3a77fe04c11.png)

-----

https://staging.va.gov/disability-benefits/apply/form-526-all-claims/supporting-evidence/va-medical-records
![screen shot 2019-02-01 at 3 30 22 pm](https://user-images.githubusercontent.com/24251447/52240598-e5602680-2896-11e9-8bb9-4f4a2876b357.png)

-----

https://staging.va.gov/disability-benefits/apply/form-526-all-claims/supporting-evidence/private-medical-records
This one only fixes the items listed in the ticket, not the linked 4142 full edits ticket. Also, please note that for silly technical reasons we aren't able to change the validation error message for the document type field at this time (would require an update to common forms code).
![screen shot 2019-02-04 at 12 34 11 pm](https://user-images.githubusercontent.com/24251447/52240972-19881700-2898-11e9-8538-56aef20f8c1d.png)
-----
![screen shot 2019-02-04 at 4 13 34 pm](https://user-images.githubusercontent.com/24251447/52240973-19881700-2898-11e9-854a-cea9735f4bc9.png)
-----
![screen shot 2019-02-04 at 4 13 28 pm](https://user-images.githubusercontent.com/24251447/52240974-19881700-2898-11e9-9550-6cfdfe1531ee.png)
-----
![screen shot 2019-02-04 at 4 13 20 pm](https://user-images.githubusercontent.com/24251447/52240975-19881700-2898-11e9-834d-c690fbec4209.png)

-----


https://staging.va.gov/disability-benefits/apply/form-526-all-claims/supporting-evidence/private-medical-records-release
![screen shot 2019-02-04 at 2 48 28 pm](https://user-images.githubusercontent.com/24251447/52241077-6a980b00-2898-11e9-86e2-9115aff33d30.png)
-----
![screen shot 2019-02-04 at 2 48 10 pm](https://user-images.githubusercontent.com/24251447/52241078-6a980b00-2898-11e9-93b0-9f9f135674ec.png)

-----

https://staging.va.gov/disability-benefits/apply/form-526-all-claims/supporting-evidence/additional-evidence
![screen shot 2019-02-04 at 2 50 09 pm](https://user-images.githubusercontent.com/24251447/52241101-7c79ae00-2898-11e9-82cc-fa4f7b16476f.png)

-----

https://staging.va.gov/disability-benefits/apply/form-526-all-claims/contact-information
![screen shot 2019-02-04 at 2 51 31 pm](https://user-images.githubusercontent.com/24251447/52241143-8a2f3380-2898-11e9-8421-6685e5a1f266.png)

-----

https://staging.va.gov/disability-benefits/apply/form-526-all-claims/payment-information
![screen shot 2019-02-04 at 2 53 50 pm](https://user-images.githubusercontent.com/24251447/52241157-94e9c880-2898-11e9-9ddf-56fd330d44a7.png)

-----

https://staging.va.gov/disability-benefits/apply/form-526-all-claims/retirement-pay-waiver
![screen shot 2019-02-04 at 4 21 23 pm](https://user-images.githubusercontent.com/24251447/52241335-f873f600-2898-11e9-8f87-afd1e2f23dea.png)

-----
https://staging.va.gov/disability-benefits/apply/form-526-all-claims/training-pay-waiver
![screen shot 2019-02-04 at 3 13 15 pm](https://user-images.githubusercontent.com/24251447/52242287-e2b40000-289b-11e9-8a61-7f9510c399e1.png)

-----
https://staging.va.gov/disability-benefits/apply/form-526-all-claims/fully-developed-claim
![screen shot 2019-02-04 at 3 15 10 pm](https://user-images.githubusercontent.com/24251447/52242308-f5c6d000-289b-11e9-9671-4bd3c0027853.png)

-----
https://staging.va.gov/disability-benefits/apply/form-526-all-claims/review-and-submit
[No screenshot here, but I did find where the `$` was coming from and replaced it with an ampersand.]

## Acceptance criteria
- [x] Content updated per attached ticket
- [x] Tests pass


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
