### PR TITLE
Pre-launch design changes for connected accounts.

### DIFF
--- a/src/applications/personalization/account/components/AccountMain.jsx
+++ b/src/applications/personalization/account/components/AccountMain.jsx
@@ -7,6 +7,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
 import AccountVerification from './AccountVerification';
+import ConnectedAccountsSection from './ConnectedAccountsSection.jsx';
 import LoginSettings from './LoginSettings';
 import MultifactorMessage from './MultifactorMessage';
 import TermsAndConditions from './TermsAndConditions';
@@ -118,6 +119,7 @@ class AccountMain extends React.Component {
               >
                 Manage your DS Logon account
               </a>
+              .<span className="external-link-icon-black">&nbsp;</span>
             </div>
             <div>
               <h5>My HealtheVet</h5>
@@ -128,10 +130,12 @@ class AccountMain extends React.Component {
               >
                 Manage your My HealtheVet account
               </a>
+              .<span className="external-link-icon-black">&nbsp;</span>
             </div>
           </div>
         )}
         <LoginSettings />
+        <ConnectedAccountsSection />
         {verified && <TermsAndConditions mhvAccount={mhvAccount} />}
 
         <div className="feature">

--- a/src/applications/personalization/account/components/ConnectedAccountsSection.jsx
+++ b/src/applications/personalization/account/components/ConnectedAccountsSection.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
+
+const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
+
+export default function ConnectedAccountsSection() {
+  return (
+    <div>
+      <h3>Connected accounts</h3>
+      <div>
+        <p>
+          Manage the settings for the sites and applications you've given
+          permission to access your {propertyName} profile data.
+        </p>
+        <p>
+          <a
+            href="/account/connected-accounts"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Manage your connected accounts
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/applications/personalization/account/components/ConnectedAccountsSection.jsx
+++ b/src/applications/personalization/account/components/ConnectedAccountsSection.jsx
@@ -6,7 +6,7 @@ export default function ConnectedAccountsSection() {
       <h3>Connected accounts</h3>
       <div>
         <p>
-          Manage the settings for the sites and applications you've given
+          Manage the settings for the sites and applications you’ve given
           permission to access your VA.gov profile data.
         </p>
         <p>

--- a/src/applications/personalization/account/components/ConnectedAccountsSection.jsx
+++ b/src/applications/personalization/account/components/ConnectedAccountsSection.jsx
@@ -1,7 +1,4 @@
 import React from 'react';
-import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
-
-const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 export default function ConnectedAccountsSection() {
   return (
@@ -10,7 +7,7 @@ export default function ConnectedAccountsSection() {
       <div>
         <p>
           Manage the settings for the sites and applications you've given
-          permission to access your {propertyName} profile data.
+          permission to access your VA.gov profile data.
         </p>
         <p>
           <a

--- a/src/applications/personalization/account/components/LoginSettings.jsx
+++ b/src/applications/personalization/account/components/LoginSettings.jsx
@@ -39,8 +39,9 @@ export default function LoginSettings() {
             target="_blank"
             rel="noopener noreferrer"
           >
-            Manage your ID.me account.
+            Manage your ID.me account
           </a>
+          .<span className="external-link-icon-black">&nbsp;</span>
         </p>
         <AdditionalInfo triggerText="What is ID.me?">
           {idMeAnswer}

--- a/src/applications/personalization/account/components/LoginSettings.jsx
+++ b/src/applications/personalization/account/components/LoginSettings.jsx
@@ -1,19 +1,15 @@
 import React from 'react';
 import recordEvent from '../../../../platform/monitoring/record-event';
-import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
-
-const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
 export default function LoginSettings() {
   const idMeAnswer = (
     <p>
       <strong>Note:</strong> ID.me is a digital identity platform that provides
       the strongest identity verification system available to prevent fraud and
-      identity theft. We use ID.me to help you create a verified account on{' '}
-      {propertyName}
-      -or to connect your premium My HealtheVet or DS Logon account to our
-      site-as well as to add an extra layer of security to your account.
+      identity theft. We use ID.me to help you create a verified account on
+      VA.gov -or to connect your premium My HealtheVet or DS Logon account to
+      our site-as well as to add an extra layer of security to your account.
       <br />
       <a
         href="/faq/#what-is-idme"

--- a/src/applications/personalization/connected-accounts/components/AccountModal.jsx
+++ b/src/applications/personalization/connected-accounts/components/AccountModal.jsx
@@ -7,7 +7,6 @@ export function AccountModal({
   modalOpen,
   onCloseModal,
   onConfirmDelete,
-  propertyName,
 }) {
   return (
     <Modal
@@ -15,12 +14,12 @@ export function AccountModal({
       cssClass="va-modal"
       id="disconnect-alert"
       onClose={onCloseModal}
-      title={`Are you sure you want to disconnect from ${appName}?`}
+      title={`Please confirm you want to disconnect from ${appName}`}
       visible={modalOpen}
     >
       <p>
-        {appName} will no longer be able to access your {propertyName} account
-        informaton. You cannot undo this action.
+        {appName} won't be able to access your profile data once you disconnect.
+        You can't undo this action.
       </p>
       <button className="usa-button-primary" onClick={onConfirmDelete}>
         Confirm

--- a/src/applications/personalization/connected-accounts/components/AccountModal.jsx
+++ b/src/applications/personalization/connected-accounts/components/AccountModal.jsx
@@ -18,8 +18,8 @@ export function AccountModal({
       visible={modalOpen}
     >
       <p>
-        {appName} won't be able to access your profile data once you disconnect.
-        You can't undo this action.
+        {appName} won’t be able to access your profile data once you disconnect.
+        You can’t undo this action.
       </p>
       <button className="usa-button-primary" onClick={onConfirmDelete}>
         Confirm

--- a/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
@@ -56,7 +56,7 @@ class ConnectedApp extends React.Component {
                   Details
                   <i
                     className={`fa fa-chevron-${
-                      this.state.detailsOpen ? 'down' : 'right'
+                      this.state.detailsOpen ? 'up' : 'down'
                     }`}
                   />
                 </a>
@@ -83,7 +83,7 @@ class ConnectedApp extends React.Component {
                           Disconnect
                         </button>
                       </p>
-                      <ul>
+                      <ul className="usa-list">
                         {grants.map((a, idx) => (
                           <li key={idx}>{a.title}</li>
                         ))}

--- a/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
@@ -65,7 +65,6 @@ class ConnectedApp extends React.Component {
                   modalOpen={this.state.modalOpen}
                   onCloseModal={this.closeModal}
                   onConfirmDelete={this.confirmDelete}
-                  propertyName={this.props.propertyName}
                 />
               </th>
             </tr>
@@ -106,7 +105,6 @@ ConnectedApp.propTypes = {
   type: PropTypes.string.isRequired,
   attribtues: PropTypes.object.isRequired,
   confirmDelete: PropTypes.func.isRequired,
-  propertyName: PropTypes.string.isRequired,
   isLast: PropTypes.bool,
 };
 

--- a/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
@@ -83,7 +83,7 @@ class ConnectedApp extends React.Component {
                           Disconnect
                         </button>
                       </p>
-                      <ul className="usa-list">
+                      <ul>
                         {grants.map((a, idx) => (
                           <li key={idx}>{a.title}</li>
                         ))}

--- a/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
@@ -48,7 +48,9 @@ class ConnectedApp extends React.Component {
                   <img src={logo} alt={`${title} logo`} width="100" />
                 </a>
               </th>
-              <th>Connected on {moment(created).format('MMMM Do, YYYY')}</th>
+              <th>
+                Connected on {moment(created).format('MMMM D, YYYY h:mm A')}
+              </th>
               <th className={`${cssPrefix}-row-details `}>
                 <a className={`${cssPrefix}-row-details-toggle`} href="#">
                   Details
@@ -74,7 +76,7 @@ class ConnectedApp extends React.Component {
                     <div className={`${cssPrefix}-row-details-block-content`}>
                       <p>
                         <a href={href}>{title}</a>
-                        &nbsp;has access to the following information:
+                        &nbsp;can view your:
                         <button
                           className="usa-button-primary"
                           onClick={this.openModal}

--- a/src/applications/personalization/connected-accounts/components/ConnectedApps.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApps.jsx
@@ -47,7 +47,7 @@ export function ConnectedApps({ confirmDelete, propertyName, accounts }) {
               })
             }
           >
-            Go to connect account FAQs
+            Go to connected account FAQs
           </a>
           .
         </div>

--- a/src/applications/personalization/connected-accounts/components/ConnectedApps.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApps.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { ConnectedApp } from './ConnectedApp';
 import recordEvent from '../../../../platform/monitoring/record-event';
 
-export function ConnectedApps({ confirmDelete, propertyName, accounts }) {
+export function ConnectedApps({ confirmDelete, accounts }) {
   return (
     <div className="row va-connected-acct">
       <div className="usa-width-two-thirds medium-8 small-12 columns">
@@ -11,7 +11,7 @@ export function ConnectedApps({ confirmDelete, propertyName, accounts }) {
         <p className="va-introtext">
           {/* eslint-disable prettier/prettier */}
           You gave the sites and applications listed below permissions to
-          access some of your {propertyName} profile data. These sites and
+          access some of your VA.gov profile data. These sites and
           applications can only view your information. They can't change
           anything.
           {/* eslint-enable prettier/prettier */}
@@ -23,7 +23,6 @@ export function ConnectedApps({ confirmDelete, propertyName, accounts }) {
               <ConnectedApp
                 key={idx}
                 confirmDelete={confirmDelete}
-                propertyName={propertyName}
                 isLast={idx + 1 === accounts.length}
                 {...a}
               />
@@ -35,7 +34,7 @@ export function ConnectedApps({ confirmDelete, propertyName, accounts }) {
           <h3>Have questions about connected accounts?</h3>
           <p>
             Get answers to frequently asked questions about connected accounts
-            and how they work with your {propertyName} account.
+            and how they work with your VA.gov account.
           </p>
           <a
             href="/sign-in-faq/"

--- a/src/applications/personalization/connected-accounts/components/ConnectedApps.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApps.jsx
@@ -7,11 +7,13 @@ export function ConnectedApps({ confirmDelete, propertyName, accounts }) {
   return (
     <div className="row va-connected-acct">
       <div className="usa-width-two-thirds medium-8 small-12 columns">
-        <h1>Your Connected Accounts</h1>
+        <h1>Connected Accounts</h1>
         <p className="va-introtext">
           {/* eslint-disable prettier/prettier */}
-          You gave these sites and applications read only access to some of
-          your {propertyName} account data.
+          You gave the sites and applications listed below permissions to
+          access some of your {propertyName} profile data. These sites and
+          applications can only view your information. They can't change
+          anything.
           {/* eslint-enable prettier/prettier */}
         </p>
 
@@ -30,13 +32,11 @@ export function ConnectedApps({ confirmDelete, propertyName, accounts }) {
         </table>
 
         <div className="feature">
-          <h3>Have questions about signing in to {propertyName}?</h3>
+          <h3>Have questions about connected accounts?</h3>
           <p>
-            Get answers to frequently asked questions about how to sign in,
-            common issues with verifying your identity, and your privacy and
-            security on {propertyName}.
+            Get answers to frequently asked questions about connected accounts
+            and how they work with your {propertyName} account.
           </p>
-
           <a
             href="/sign-in-faq/"
             onClick={() =>
@@ -47,8 +47,9 @@ export function ConnectedApps({ confirmDelete, propertyName, accounts }) {
               })
             }
           >
-            Go to {propertyName} FAQs
+            Go to connect account FAQs
           </a>
+          .
         </div>
       </div>
     </div>

--- a/src/applications/personalization/connected-accounts/components/ConnectedApps.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApps.jsx
@@ -12,7 +12,7 @@ export function ConnectedApps({ confirmDelete, accounts }) {
           {/* eslint-disable prettier/prettier */}
           You gave the sites and applications listed below permissions to
           access some of your VA.gov profile data. These sites and
-          applications can only view your information. They can't change
+          applications can only view your information. They can’t change
           anything.
           {/* eslint-enable prettier/prettier */}
         </p>


### PR DESCRIPTION
## Description

This cleans up some text wording and formatting in accordance with the pre-launch checklist review. See [vets-contrib ticket #1121](https://github.com/department-of-veterans-affairs/vets-contrib/issues/1121) and [the design mockups](https://www.figma.com/proto/QHtcfdUtB4N4lZZDXQWRNR/Auth-Management-Connected-Acct?node-id=245%3A2&viewport=-2303%2C-2468%2C1.16021&scaling=min-zoom) for more details.

One aspect of the design mockups I didn't make is the list bullet point changes. The site seems to lack any disc bullet lists. The list bullet default in the brand consolidation CSS is explicitly square, so that seemed like an oversight in the mockups. @juliaelman please let me know if whether this is right or wrong.

## Testing done

Only manual testing in chromium so far. I'll be following up [with manual testing](https://github.com/department-of-veterans-affairs/vets-external-teams/blob/master/DeveloperDocs/testing/cross-browser-manual-testing.md) once I figure out how to gain access to the staging environment.

## Acceptance criteria
- [x] Incorporate all changes from the design mockups.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)

