### PR TITLE
Put sub-page fragments into a single file to avoid duplication.

### DIFF
--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -1,12 +1,13 @@
 const landingPage = require('./landingPage.graphql');
 const page = require('./page.graphql');
-
+const fragments = require('./fragments.graphql');
 /**
  * Queries for all of the pages out of Drupal
  * To execute, run this query at http://staging.va.agile6.com/graphql/explorer.
  */
 module.exports = `
 
+  ${fragments}
   ${landingPage}
   ${page}
 

--- a/src/site/stages/build/drupal/graphql/GetPageById.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetPageById.graphql.js
@@ -1,5 +1,6 @@
 const landingPage = require('./landingPage.graphql');
 const page = require('./page.graphql');
+const fragments = require('./fragments.graphql');
 
 /**
  * Queries for a page by the page path. This will most likely need to be updated once we determine
@@ -8,6 +9,7 @@ const page = require('./page.graphql');
  */
 module.exports = `
 
+  ${fragments}
   ${landingPage}
   ${page}
 

--- a/src/site/stages/build/drupal/graphql/fragments.graphql.js
+++ b/src/site/stages/build/drupal/graphql/fragments.graphql.js
@@ -1,0 +1,21 @@
+const { alert } = require('./block-fragments/alert.block.graphql');
+const collapsiblePanel = require('./paragraph-fragments/collapsiblePanel.paragraph.graphql');
+const {
+  listOfLinkTeasers,
+} = require('./paragraph-fragments/listOfLinkTeasers.paragraph.graphql');
+const process = require('./paragraph-fragments/process.paragraph.graphql');
+const qaSection = require('./paragraph-fragments/qaSection.paragraph.graphql');
+const wysiwyg = require('./paragraph-fragments/wysiwyg.paragraph.graphql');
+const { promo } = require('./block-fragments/promo.block.graphql');
+const linkTeaser = require('./paragraph-fragments/linkTeaser.paragraph.graphql');
+
+module.exports = `
+  ${alert}
+  ${collapsiblePanel}
+  ${linkTeaser}
+  ${listOfLinkTeasers}
+  ${process}
+  ${promo}
+  ${qaSection}
+  ${wysiwyg}
+`;

--- a/src/site/stages/build/drupal/graphql/landingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/landingPage.graphql.js
@@ -1,10 +1,9 @@
-const { promo, FIELD_PROMO } = require('./block-fragments/promo.block.graphql');
+const { FIELD_PROMO } = require('./block-fragments/promo.block.graphql');
 /**
  * The top-level page for a section of the website.
  * Examples include /health-care/, /disability/, etc.
  */
 module.exports = `
-  ${promo}
   fragment landingPage on NodeLandingPage {
     entityUrl {
       ... on EntityCanonicalUrl {

--- a/src/site/stages/build/drupal/graphql/page.graphql.js
+++ b/src/site/stages/build/drupal/graphql/page.graphql.js
@@ -1,12 +1,7 @@
-const { alert, FIELD_ALERT } = require('./block-fragments/alert.block.graphql');
-const collapsiblePanel = require('./paragraph-fragments/collapsiblePanel.paragraph.graphql');
+const { FIELD_ALERT } = require('./block-fragments/alert.block.graphql');
 const {
-  listOfLinkTeasers,
   FIELD_RELATED_LINKS,
 } = require('./paragraph-fragments/listOfLinkTeasers.paragraph.graphql');
-const process = require('./paragraph-fragments/process.paragraph.graphql');
-const qaSection = require('./paragraph-fragments/qaSection.paragraph.graphql');
-const wysiwyg = require('./paragraph-fragments/wysiwyg.paragraph.graphql');
 
 /**
  * A standard content page, that is ordinarily two-levels deep (a child page of a landingPage)
@@ -20,13 +15,6 @@ const QA_SECTION = '... qaSection';
 
 module.exports = `
 
-  ${wysiwyg}
-  ${collapsiblePanel}
-  ${process}
-  ${qaSection}
-  ${alert}
-  ${listOfLinkTeasers}
-  
   fragment page on NodePage {
     entityUrl {
       ... on EntityCanonicalUrl {

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/listOfLinkTeasers.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/listOfLinkTeasers.paragraph.graphql.js
@@ -1,4 +1,3 @@
-const linkTeaser = require('./linkTeaser.paragraph.graphql');
 /**
  * The 'List of link teasers' bundle of the 'Paragraph' entity type.
  */
@@ -6,8 +5,6 @@ const LINKTEASER_FRAGMENT = '...linkTeaser';
 const LISTOFLINKTEASERS_FRAGMENT = '...listOfLinkTeasers';
 
 const listOfLinkTeasers = `
-  ${linkTeaser}
-
   fragment listOfLinkTeasers on ParagraphListOfLinkTeasers {
   	parentFieldName
     fieldTitle


### PR DESCRIPTION
## Description
Query fragments were included in other fragments that rely on them (e.g 'link teaser' fragment in 'list of link teasers', and 'list of link teasers' in 'page'). This method breaks down when more than one fragment relies on the same fragment (e.g. 'promo' also relies on 'link teaser' and  'hub page' also relies on 'list of link teasers'). When a fragment is included more than once, the query breaks.

This PR moves all of the sub-page fragments out of other fragments and into a separate 'fragments' file, which is included in the GetAllPages and GetPageById queries. Developers can add new fragments to the 'fragments' file and use them in other fragments without having to worry about duplications. 

## Testing done
Did a spot-check of drupal.json and rendered pages to make sure query results are unchanged.
