### PR TITLE
VET TEC: Saved bank information not deleted when new account information #16742

### DIFF
--- a/src/applications/edu-benefits/0994/components/PaymentView.jsx
+++ b/src/applications/edu-benefits/0994/components/PaymentView.jsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 import { srSubstitute } from '../utils';
@@ -28,12 +29,24 @@ const mask = (string, unmaskedLength) => {
 };
 
 export const PaymentView = ({ formData = {}, originalData = {} }) => {
-  const bankAccountType =
-    formData.bankAccount.accountType || originalData.bankAccountType;
-  const bankAccountNumber =
-    formData.bankAccount.accountNumber || originalData.bankAccountNumber;
-  const bankRoutingNumber =
-    formData.bankAccount.routingNumber || originalData.bankRoutingNumber;
+  const {
+    accountType: newAccountType,
+    accountNumber: newAccountNumber,
+    routingNumber: newRoutingNumber,
+  } = _.get(formData, 'bankAccount', {});
+
+  const hasNewBankAccountInfo =
+    newAccountType || newAccountNumber || newRoutingNumber;
+
+  const bankAccountType = hasNewBankAccountInfo
+    ? newAccountType
+    : originalData.bankAccountType;
+  const bankAccountNumber = hasNewBankAccountInfo
+    ? newAccountNumber
+    : originalData.bankAccountNumber;
+  const bankRoutingNumber = hasNewBankAccountInfo
+    ? newRoutingNumber
+    : originalData.bankRoutingNumber;
 
   return (
     <div>

--- a/src/platform/forms/save-in-progress/ApplicationStatus.jsx
+++ b/src/platform/forms/save-in-progress/ApplicationStatus.jsx
@@ -139,7 +139,7 @@ export class ApplicationStatus extends React.Component {
             {multipleForms && (
               <p className="no-bottom-margin">
                 You have more than one in-progress {formType} form.{' '}
-                <a href="/profile">
+                <a href="/my-va">
                   View and manage your forms on your Account page
                 </a>
                 .
@@ -183,7 +183,7 @@ export class ApplicationStatus extends React.Component {
           {multipleForms && (
             <p className="no-bottom-margin">
               You have more than one in-progress {formType} form.{' '}
-              <a href="/profile">
+              <a href="/my-va">
                 View and manage your forms on your Account page
               </a>
               .


### PR DESCRIPTION
**Specs:**
- Device: Macbook
- Browser: Chrome
- User account: 228

**Steps to Reproduce**
url: https://staging.va.gov/education/apply-for-education-benefits/application/0994/bank-information
user: 228 

**What happened:**
1. User has a saved bank account on file
![Screen Shot 2019-02-05 at 9.00.51 AM.png](https://images.zenhubusercontent.com/5b645f6fe2255460d8f0b032/29366fe9-e38a-41ce-90c2-56bebadae212)
2. Click "New Account"
![Screen Shot 2019-02-05 at 9.00.59 AM.png](https://images.zenhubusercontent.com/5b645f6fe2255460d8f0b032/ff9d7d84-7664-46be-bee6-67b5b7c70dd3)
3. Add only bank account number. Do not select account type or enter routing number. 
![Screen Shot 2019-02-05 at 9.01.12 AM.png](https://images.zenhubusercontent.com/5b645f6fe2255460d8f0b032/aa0219a5-1225-4e86-9a02-06acfd3223a1)
4. New account number added and old routing and account type are saved
![Screen Shot 2019-02-05 at 9.01.18 AM.png](https://images.zenhubusercontent.com/5b645f6fe2255460d8f0b032/afbd038b-367f-4e53-8e6a-6ebc0943d4e4)

**Desired behavior:**
When any "New account" information is added, the previous account information should be deleted. 