### PR TITLE
Ignore and remove downloaded assets

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,7 @@ docs/*
 build/*
 src/applications/**/README.md
 coverage/*
+temp/*
 .nyc_output/*
 script/watch.js
 script/mocha.js

--- a/src/site/stages/build/plugins/download-assets.js
+++ b/src/site/stages/build/plugins/download-assets.js
@@ -88,6 +88,8 @@ async function downloadFromArchive(files, assetSource, buildtype) {
       contents: fs.readFileSync(path.join(assetsPath, 'generated', file)),
     };
   });
+
+  fs.emptyDirSync(assetsPath);
 }
 
 function downloadAssets(buildOptions) {


### PR DESCRIPTION
## Description
Sometimes eslint is running on downloaded assets in a temp directory. We should ignore that directory and also remove it after using it.

## Testing done
Ran locally

## Acceptance criteria
- [x] Temp directory is emptied

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
