### PR TITLE
All claims remove new disabilities validation mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -244,9 +244,3 @@ export const ATTACHMENT_KEYS = [
 export const LOWERED_DISABILITY_DESCRIPTIONS = Object.values(
   disabilityLabels,
 ).map(v => v.toLowerCase());
-
-// This comes straight from EVSS but isn't documented in Swagger because
-// it's only used on disabilities that don't exist in the mapped list.
-// Note: the right single quote (’) is intentional - apostrophes are not
-//       allowed.
-export const EVSS_DISABILITY_NAME_REGEX = /^([a-zA-Z0-9\-‘.,/()]([a-zA-Z0-9\-’,. ])?)+$/;

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -216,7 +216,9 @@ describe('526 All Claims validations', () => {
   });
 
   describe('validateDisabilityName', () => {
-    it('should not add error when regex fails but disability is in list', () => {
+    const tooLong =
+      'et pharetra pharetra massa massa ultricies mi quis hendrerit dolor magna eget est lorem ipsum dolor sit amet consectetur adipiscing elit pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas integer eget aliquet nibh praesent';
+    it('should not add error when disability is in list', () => {
       const err = { addError: sinon.spy() };
       validateDisabilityName(err, disabilityLabels[7100]);
       expect(err.addError.called).to.be.false;
@@ -226,14 +228,14 @@ describe('526 All Claims validations', () => {
       validateDisabilityName(err, capitalizeEachWord(disabilityLabels[7100]));
       expect(err.addError.called).to.be.false;
     });
-    it('should not add error when disability not in list but passes regex', () => {
+    it('should not add error when disability not in list but length OK', () => {
       const err = { addError: sinon.spy() };
       validateDisabilityName(err, 'blah. (and, blah/blah)’- blah');
       expect(err.addError.called).to.be.false;
     });
-    it('should add error when disability not in list and regex fails', () => {
+    it('should add error when disability not in list and length too long', () => {
       const err = { addError: sinon.spy() };
-      validateDisabilityName(err, 'blah ;');
+      validateDisabilityName(err, tooLong);
       expect(err.addError.calledOnce).to.be.true;
     });
   });

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -8,7 +8,6 @@ import {
   MILITARY_CITIES,
   MILITARY_STATE_VALUES,
   LOWERED_DISABILITY_DESCRIPTIONS,
-  EVSS_DISABILITY_NAME_REGEX,
 } from './constants';
 
 export const hasMilitaryRetiredPay = data =>
@@ -239,10 +238,8 @@ export const isWithinServicePeriod = (errors, fieldData, formData) => {
 export const validateDisabilityName = (err, fieldData) => {
   if (
     !LOWERED_DISABILITY_DESCRIPTIONS.includes(fieldData.toLowerCase()) &&
-    !EVSS_DISABILITY_NAME_REGEX.test(fieldData)
+    fieldData.length > 255
   ) {
-    // technically single quotes (’) are allowed as well but leaving out of
-    // this message to avoid confusing veterans who can't tell the difference
-    err.addError('The only special characters allowed are: , . ( ) / -');
+    err.addError('Condition names should be less than 255 characters');
   }
 };

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -240,6 +240,6 @@ export const validateDisabilityName = (err, fieldData) => {
     !LOWERED_DISABILITY_DESCRIPTIONS.includes(fieldData.toLowerCase()) &&
     fieldData.length > 255
   ) {
-    err.addError('Condition names should be less than 255 characters');
+    err.addError('Condition names should be less than 256 characters');
   }
 };

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -236,6 +236,12 @@ export const isWithinServicePeriod = (errors, fieldData, formData) => {
 };
 
 export const validateDisabilityName = (err, fieldData) => {
+  // We're using a validator for length instead of adding a maxLength schema
+  // property because the validator is only applied conditionally - when a user
+  // chooses a disability from the list supplied to autosuggest, we don't care
+  // about the length - we only care about the length of unique user-entered
+  // disability names. We could've done this with `updateSchema` but this seems
+  // lighter-touch.
   if (
     !LOWERED_DISABILITY_DESCRIPTIONS.includes(fieldData.toLowerCase()) &&
     fieldData.length > 255


### PR DESCRIPTION
## Description
This PR updates the validation used for new condition names to only check length.
Since this validation only applies to disabilities that are not on the disabilities list, I opted to use a standard validator rather than putting a `maxLength` into the schema or running `updateSchema` conditionally. This seemed like the lowest-lift approach and works all the same - as soon as whatever the user is typing hits the magic length of 256, the validation error is displayed. I.e., they don't have to leave the field to get the error.

## Testing done
- Tested locally
- Updated / added unit tests

## Screenshots
<img width="673" alt="screen shot 2019-02-06 at 1 54 16 pm" src="https://user-images.githubusercontent.com/24251447/52369728-f5067900-2a16-11e9-8bc5-765fa2aa704e.png">

<img width="540" alt="screen shot 2019-02-06 at 1 55 41 pm" src="https://user-images.githubusercontent.com/24251447/52369759-fb94f080-2a16-11e9-90fa-bb21e2c83de6.png">


## Acceptance criteria
- [x] Regex validation removed
- [x] Length validation added

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
