### PR TITLE
Add edit link to pages when previewing

### DIFF
--- a/script/preview.js
+++ b/script/preview.js
@@ -52,6 +52,8 @@ app.get('/preview', async (req, res) => {
   const files = {
     [`${req.path.substring(1)}/index.html`]: {
       ...drupalPage,
+      isPreview: true,
+      drupalSite: drupalClient.getSiteUri(),
       layout: `${drupalPage.entityBundle}.drupal.liquid`,
       contents: Buffer.from('<!-- Drupal-provided data -->'),
       debug: JSON.stringify(drupalPage, null, 4),

--- a/src/site/includes/preview-edit.drupal.liquid
+++ b/src/site/includes/preview-edit.drupal.liquid
@@ -1,0 +1,3 @@
+{% if isPreview %}
+<a href="{{ drupalSite }}/node/{{ entityId }}/edit">Back to edit page</a>
+{% endif %}

--- a/src/site/includes/preview-edit.drupal.liquid
+++ b/src/site/includes/preview-edit.drupal.liquid
@@ -1,3 +1,11 @@
 {% if isPreview %}
-<a href="{{ drupalSite }}/node/{{ entityId }}/edit">Back to edit page</a>
+  <div class="vads-u-padding-x--1 medium-screen:vads-u-padding-x--2">
+    <div class="usa-grid-full">
+      <div class="usa-width-one-whole">
+        <div class="vads-u-margin-top--2">
+          <a data-same-tab href="{{ drupalSite }}/node/{{ entityId }}/edit">« Go back to editor</a>
+        </div>
+      </div>
+    </div>
+  </div>
 {% endif %}

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -1,4 +1,5 @@
 {% include "src/site/includes/header.html" %}
+{% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 <div id="content" class="interior">
   <main>

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -1,4 +1,5 @@
 {% include "src/site/includes/header.html" %}
+{% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 <div id="content" class="interior">
   <main class="va-l-detail-page">

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -22,6 +22,10 @@ function getDrupalClient(buildOptions) {
   };
 
   return {
+    getSiteUri() {
+      return address;
+    },
+
     async query(args) {
       const response = await fetch(drupalUri, {
         headers,

--- a/src/site/stages/build/drupal/graphql/landingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/landingPage.graphql.js
@@ -17,6 +17,7 @@ module.exports = `
         path
       }
     }
+    entityId
     entityBundle
     entityPublished
     title

--- a/src/site/stages/build/drupal/graphql/page.graphql.js
+++ b/src/site/stages/build/drupal/graphql/page.graphql.js
@@ -28,6 +28,7 @@ module.exports = `
         path
       }
     }
+    entityId
     entityBundle
     entityPublished
     title


### PR DESCRIPTION
## Description
We need to have a link for users to go back to editing a page in Drupal when a page is being previewed. This adds that link

## Testing done

Ran locally.

## Screenshots
![screen shot 2019-02-06 at 3 26 35 pm](https://user-images.githubusercontent.com/634932/52371530-cba01a00-2a23-11e9-87b3-adc69a9be73d.png)

## Acceptance criteria
- [x] Preview site renders preview link, other pages do not

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
