### PR TITLE
Support multiple appeal types (Appeals Status)

### DIFF
--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -10,7 +10,7 @@ import {
   getStatusContents,
 } from '../../utils/appeals-v2-helpers';
 
-const appealTypeMap = {
+const programAreaMap = {
   compensation: 'Disability Compensation',
   pension: 'Pension',
   insurance: 'Insurance',
@@ -26,41 +26,55 @@ export default function AppealListItem({ appeal, name }) {
   const { status } = appeal.attributes;
 
   let requestEventType;
+  let isAppeal;
+
   switch (appeal.type) {
     case APPEAL_TYPES.legacy:
       requestEventType = EVENT_TYPES.nod;
+      isAppeal = true;
       break;
     case APPEAL_TYPES.supplementalClaim:
       requestEventType = EVENT_TYPES.scRequest;
+      isAppeal = false;
       break;
     case APPEAL_TYPES.higherLevelReview:
       requestEventType = EVENT_TYPES.hlrRequest;
+      isAppeal = false;
       break;
     case APPEAL_TYPES.appeal:
       requestEventType = EVENT_TYPES.amaNod;
+      isAppeal = true;
       break;
     default:
     // do nothing
   }
 
   const requestEvent = appeal.attributes.events.find(
-    a => a.type === requestEventType,
+    event => event.type === requestEventType,
   );
-  const appealType = appealTypeMap[appeal.attributes.programArea];
-  const isAppeal =
-    appeal.type === APPEAL_TYPES.appeal || appeal.type === APPEAL_TYPES.legacy;
+  const programArea = programAreaMap[appeal.attributes.programArea];
+
+  // appealTitle is in the format:
+  // "Supplemental Claim for Disability Compensation Receieved March 6, 2019"
+  //
+  // If it's an appeal:
+  // "Disability Compensation Appeal Receieved March 6, 2019"
+  //
+  // programArea or requestEvent might be missing:
+  // "Appeal Received March 6, 2019"
+  // "Disability Compensation Appeal"
 
   let appealTitle = '';
 
   if (isAppeal) {
-    if (appealType) {
-      appealTitle = `${appealType} `;
+    if (programArea) {
+      appealTitle = `${programArea} `;
     }
     appealTitle += getTypeName(appeal);
   } else {
     appealTitle = getTypeName(appeal);
-    if (appealType) {
-      appealTitle += ` for ${appealType}`;
+    if (programArea) {
+      appealTitle += ` for ${programArea}`;
     }
   }
 

--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -1,43 +1,78 @@
-import _ from 'lodash';
 import { Link } from 'react-router';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { getStatusContents } from '../../utils/appeals-v2-helpers';
+import {
+  APPEAL_TYPES,
+  EVENT_TYPES,
+  getTypeName,
+  getStatusContents,
+} from '../../utils/appeals-v2-helpers';
 
-// TODO: Get a proper mapping of programArea -> display output
 const appealTypeMap = {
-  compensation: 'Compensation',
+  compensation: 'Disability Compensation',
   pension: 'Pension',
   insurance: 'Insurance',
   loan_guaranty: 'Loan Guaranty', // eslint-disable-line
   education: 'Education',
-  vre: 'VRE',
-  medical: 'Medical',
-  burial: 'Burial',
-  bva: 'BVA',
-  other: 'Other',
-  multiple: 'Multiple',
+  vre: 'Vocational Rehabilitation and Employment',
+  medical: 'Medical Benefits',
+  burial: 'Burial Benefits',
+  fiduciary: 'Fiduciary',
 };
 
 export default function AppealListItem({ appeal, name }) {
   const { status } = appeal.attributes;
-  // always show merged event on top
-  const events = _.orderBy(
-    appeal.attributes.events,
-    [e => e.type === 'merged', e => moment(e.date).unix()],
-    ['desc', 'desc'],
+
+  let requestEventType;
+  switch (appeal.type) {
+    case APPEAL_TYPES.legacy:
+      requestEventType = EVENT_TYPES.nod;
+      break;
+    case APPEAL_TYPES.supplementalClaim:
+      requestEventType = EVENT_TYPES.scRequest;
+      break;
+    case APPEAL_TYPES.higherLevelReview:
+      requestEventType = EVENT_TYPES.hlrRequest;
+      break;
+    case APPEAL_TYPES.appeal:
+      requestEventType = EVENT_TYPES.amaNod;
+      break;
+    default:
+    // do nothing
+  }
+
+  const requestEvent = appeal.attributes.events.find(
+    a => a.type === requestEventType,
   );
-  const firstEvent = events[events.length - 1];
+  const appealType = appealTypeMap[appeal.attributes.programArea];
+  const isAppeal =
+    appeal.type === APPEAL_TYPES.appeal || appeal.type === APPEAL_TYPES.legacy;
+
+  let appealTitle = '';
+
+  if (isAppeal) {
+    if (appealType) {
+      appealTitle = `${appealType} `;
+    }
+    appealTitle += getTypeName(appeal);
+  } else {
+    appealTitle = getTypeName(appeal);
+    if (appealType) {
+      appealTitle += ` for ${appealType}`;
+    }
+  }
+
+  if (requestEvent) {
+    appealTitle += ` Received ${moment(requestEvent.date).format(
+      'MMMM D, YYYY',
+    )}`;
+  }
 
   return (
     <div className="claim-list-item-container">
-      <h3 className="claim-list-item-header-v2">
-        Appeal of {appealTypeMap[appeal.attributes.programArea]}
-        <br />
-        Decision Received {moment(firstEvent.date).format('MMMM D, YYYY')}
-      </h3>
+      <h3 className="claim-list-item-header-v2">{appealTitle}</h3>
       <div className="card-status">
         <div
           className={`status-circle ${
@@ -53,7 +88,7 @@ export default function AppealListItem({ appeal, name }) {
         <p style={{ marginTop: 0 }}>
           <strong>
             {appeal.attributes.issues.length === 1 ? 'Issue' : 'Issues'} on
-            appeal:
+            {isAppeal ? ' appeal' : ' review'}:
           </strong>{' '}
           {appeal.attributes.description}
         </p>
@@ -83,7 +118,7 @@ AppealListItem.propTypes = {
         }),
       ),
       programArea: PropTypes.string.isRequired,
-      active: PropTypes.string.isRequired,
+      active: PropTypes.bool.isRequired,
       issues: PropTypes.array.isRequired,
       description: PropTypes.string.isRequired,
     }),

--- a/src/applications/claims-status/components/appeals-v2/AppealsV2TabNav.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealsV2TabNav.jsx
@@ -33,7 +33,7 @@ const AppealsV2TabNav = ({ appealId }) => (
   </div>
 );
 
-AppealsV2TabNav.PropTypes = {
+AppealsV2TabNav.propTypes = {
   appealId: PropTypes.string.isRequired,
 };
 

--- a/src/applications/claims-status/components/appeals-v2/CurrentStatus.jsx
+++ b/src/applications/claims-status/components/appeals-v2/CurrentStatus.jsx
@@ -15,7 +15,7 @@ const CurrentStatus = ({ title, description, isClosed }) => (
   </div>
 );
 
-CurrentStatus.PropTypes = {
+CurrentStatus.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.element.isRequired,
   isClosed: PropTypes.bool,

--- a/src/applications/claims-status/components/appeals-v2/Issues.jsx
+++ b/src/applications/claims-status/components/appeals-v2/Issues.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/CollapsiblePanel';
 
-const Issues = ({ issues }) => {
+const Issues = ({ issues, isAppeal }) => {
   const open = issues.filter(i => i.status === 'open');
   const remand = issues.filter(i => i.status === 'remand');
   const granted = issues.filter(i => i.status === 'granted');
@@ -65,7 +65,10 @@ const Issues = ({ issues }) => {
   if (openListItems.length || remandListItems.length) {
     // Active panel should always render as expanded by default (when items present)
     activeItems = (
-      <CollapsiblePanel panelName={'Currently on appeal'} startOpen>
+      <CollapsiblePanel
+        panelName={`Currently on ${isAppeal ? 'appeal' : 'review'}`}
+        startOpen
+      >
         {openSection}
         {remandSection}
       </CollapsiblePanel>
@@ -110,6 +113,7 @@ Issues.propTypes = {
       description: PropTypes.string.isRequired,
     }),
   ).isRequired,
+  isAppeal: PropTypes.bool.isRequired,
 };
 
 export default Issues;

--- a/src/applications/claims-status/containers/AppealInfo.jsx
+++ b/src/applications/claims-status/containers/AppealInfo.jsx
@@ -95,7 +95,7 @@ export class AppealInfo extends React.Component {
       // do nothing
     }
     const requestEvent = this.props.appeal.attributes.events.find(
-      a => a.type === requestEventType,
+      event => event.type === requestEventType,
     );
 
     let appealTitle = getTypeName(this.props.appeal);

--- a/src/applications/claims-status/containers/AppealInfo.jsx
+++ b/src/applications/claims-status/containers/AppealInfo.jsx
@@ -15,10 +15,12 @@ import AppealHelpSidebar from '../components/appeals-v2/AppealHelpSidebar';
 import { setUpPage, scrollToTop } from '../utils/page';
 
 import {
+  APPEAL_TYPES,
   EVENT_TYPES,
   isolateAppeal,
   RECORD_NOT_FOUND_ERROR,
   AVAILABLE,
+  getTypeName,
 } from '../utils/appeals-v2-helpers';
 import siteName from '../../../platform/brand-consolidation/site-name';
 import CallVBACenter from '../../../platform/brand-consolidation/components/CallVBACenter';
@@ -75,13 +77,36 @@ export class AppealInfo extends React.Component {
   }
 
   createHeading = () => {
-    const firstClaim = this.props.appeal.attributes.events.find(
-      a => a.type === EVENT_TYPES.claimDecision,
+    let requestEventType;
+    switch (this.props.appeal.type) {
+      case APPEAL_TYPES.legacy:
+        requestEventType = EVENT_TYPES.nod;
+        break;
+      case APPEAL_TYPES.supplementalClaim:
+        requestEventType = EVENT_TYPES.scRequest;
+        break;
+      case APPEAL_TYPES.higherLevelReview:
+        requestEventType = EVENT_TYPES.hlrRequest;
+        break;
+      case APPEAL_TYPES.appeal:
+        requestEventType = EVENT_TYPES.amaNod;
+        break;
+      default:
+      // do nothing
+    }
+    const requestEvent = this.props.appeal.attributes.events.find(
+      a => a.type === requestEventType,
     );
-    const appealDate = firstClaim
-      ? moment(firstClaim.date, 'YYYY-MM-DD').format(' MMMM YYYY')
-      : '';
-    return `Appeal of ${appealDate} Claim Decision`;
+
+    let appealTitle = getTypeName(this.props.appeal);
+
+    if (requestEvent) {
+      appealTitle += ` Received ${moment(requestEvent.date).format(
+        'MMMM YYYY',
+      )}`;
+    }
+
+    return appealTitle;
   };
 
   render() {

--- a/src/applications/claims-status/containers/AppealsV2DetailPage.jsx
+++ b/src/applications/claims-status/containers/AppealsV2DetailPage.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Issues from '../components/appeals-v2/Issues';
-import { addStatusToIssues } from '../utils/appeals-v2-helpers';
+import { APPEAL_TYPES, addStatusToIssues } from '../utils/appeals-v2-helpers';
 
 const AppealsV2DetailPage = ({ appeal }) => {
   const issues = addStatusToIssues(appeal.attributes.issues);
+  const isAppeal =
+    appeal.type === APPEAL_TYPES.appeal || appeal.type === APPEAL_TYPES.legacy;
   return (
     <div aria-labelledby="tabv2detail" id="tabPanelv2detail" role="tabpanel">
-      <Issues issues={issues} />
+      <Issues issues={issues} isAppeal={isAppeal} />
     </div>
   );
 };

--- a/src/applications/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/applications/claims-status/containers/AppealsV2StatusPage.jsx
@@ -8,6 +8,7 @@ import {
   ALERT_TYPES,
   APPEAL_STATUSES,
   EVENT_TYPES,
+  STATUS_TYPES,
 } from '../utils/appeals-v2-helpers';
 
 import Timeline from '../components/appeals-v2/Timeline';
@@ -45,12 +46,20 @@ const AppealsV2StatusPage = ({ appeal, fullName }) => {
   const form9Date = form9Event && form9Event.date;
 
   // Gates the What's Next and Docket chunks
+  const hideDocketStatusTypes = [
+    STATUS_TYPES.pendingSoc,
+    STATUS_TYPES.pendingForm9,
+    STATUS_TYPES.decisionInProgress,
+    STATUS_TYPES.bvaDevelopment,
+  ];
   const hideDocketAppealTypes = [
     APPEAL_STATUSES.reconsideration,
     APPEAL_STATUSES.cue,
   ];
   const shouldShowDocket =
-    appealIsActive && docket && !hideDocketAppealTypes.includes(appealType);
+    appealIsActive &&
+    !hideDocketStatusTypes.includes(status.type) &&
+    !hideDocketAppealTypes.includes(appealType);
 
   const filteredAlerts = alerts.filter(a => a.type !== ALERT_TYPES.cavcOption);
   const afterNextAlerts = (

--- a/src/applications/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/applications/claims-status/containers/AppealsV2StatusPage.jsx
@@ -8,7 +8,6 @@ import {
   ALERT_TYPES,
   APPEAL_STATUSES,
   EVENT_TYPES,
-  STATUS_TYPES,
 } from '../utils/appeals-v2-helpers';
 
 import Timeline from '../components/appeals-v2/Timeline';
@@ -46,20 +45,12 @@ const AppealsV2StatusPage = ({ appeal, fullName }) => {
   const form9Date = form9Event && form9Event.date;
 
   // Gates the What's Next and Docket chunks
-  const hideDocketStatusTypes = [
-    STATUS_TYPES.pendingSoc,
-    STATUS_TYPES.pendingForm9,
-    STATUS_TYPES.decisionInProgress,
-    STATUS_TYPES.bvaDevelopment,
-  ];
   const hideDocketAppealTypes = [
     APPEAL_STATUSES.reconsideration,
     APPEAL_STATUSES.cue,
   ];
   const shouldShowDocket =
-    appealIsActive &&
-    !hideDocketStatusTypes.includes(status.type) &&
-    !hideDocketAppealTypes.includes(appealType);
+    appealIsActive && docket && !hideDocketAppealTypes.includes(appealType);
 
   const filteredAlerts = alerts.filter(a => a.type !== ALERT_TYPES.cavcOption);
   const afterNextAlerts = (

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -37,6 +37,8 @@ import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
 
 import siteName from '../../../platform/brand-consolidation/site-name';
 
+const appealTypes = Object.values(APPEAL_TYPES);
+
 class YourClaimsPageV2 extends React.Component {
   constructor(props) {
     super(props);
@@ -74,7 +76,7 @@ class YourClaimsPageV2 extends React.Component {
   }
 
   renderListItem(claim) {
-    if (claim.type === APPEAL_TYPES.current) {
+    if (appealTypes.includes(claim.type)) {
       return (
         <AppealListItem
           key={claim.id}

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
@@ -10,6 +10,7 @@ describe('<AppealListItemV2/>', () => {
   const defaultProps = {
     appeal: {
       id: 1234,
+      type: 'legacyAppeal',
       attributes: {
         status: {
           type: STATUS_TYPES.pendingForm9,
@@ -17,18 +18,37 @@ describe('<AppealListItemV2/>', () => {
         },
         events: [
           {
-            type: EVENT_TYPES.claimDecision,
+            type: EVENT_TYPES.nod,
             date: '2016-05-01',
-          },
-          {
-            type: EVENT_TYPES.merged,
-            date: '2015-06-04',
           },
         ],
         // These should really be objects, but AppealListItemV2 doesn't really care
         issues: ["I'm an issue!", 'So am I!'],
         description: 'Description here.',
         programArea: 'compensation',
+        active: true,
+      },
+    },
+  };
+  const vhaScProps = {
+    appeal: {
+      id: 1234,
+      type: 'supplementalClaim',
+      attributes: {
+        status: {
+          type: STATUS_TYPES.scReceived,
+          details: {},
+        },
+        events: [
+          {
+            type: EVENT_TYPES.scRequest,
+            date: '2016-05-01',
+          },
+        ],
+        // These should really be objects, but AppealListItemV2 doesn't really care
+        issues: ["I'm an issue!", 'So am I!'],
+        description: 'Description here.',
+        programArea: 'medical',
         active: true,
       },
     },
@@ -66,6 +86,17 @@ describe('<AppealListItemV2/>', () => {
     wrapper.unmount();
   });
 
+  it('should correctly title a VHA Supplemental Claim', () => {
+    const wrapper = shallow(<AppealListItemV2 {...vhaScProps} />);
+    expect(
+      wrapper
+        .find('h3.claim-list-item-header-v2')
+        .render()
+        .text(),
+    ).to.equal('Supplemental Claim for Medical Benefits Received May 1, 2016');
+    wrapper.unmount();
+  });
+
   it('should say "issue" if there is only one issue on appeal', () => {
     const props = _.set(
       'appeal.attributes.issues',
@@ -89,6 +120,16 @@ describe('<AppealListItemV2/>', () => {
       .first()
       .text();
     expect(issuesText).to.contain('Issues');
+    wrapper.unmount();
+  });
+
+  it('should say "review" if the appeal is a Supplemental Claim', () => {
+    const wrapper = shallow(<AppealListItemV2 {...vhaScProps} />);
+    const issuesText = wrapper
+      .find('.card-status + p')
+      .first()
+      .text();
+    expect(issuesText).to.contain('review');
     wrapper.unmount();
   });
 

--- a/src/applications/claims-status/tests/components/appeals-v2/Issues.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/Issues.unit.spec.jsx
@@ -4,17 +4,21 @@ import { shallow, mount } from 'enzyme';
 import Issues from '../../../components/appeals-v2/Issues';
 import { addStatusToIssues } from '../../../utils/appeals-v2-helpers';
 import { mockData } from '../../../utils/helpers';
+import _ from 'lodash/fp';
 
 describe('<Issues/>', () => {
-  const emptyIssues = { issues: addStatusToIssues([]) };
+  const emptyIssues = { issues: addStatusToIssues([]), isAppeal: true };
   const oneOpenIssue = {
     issues: addStatusToIssues(mockData.data[1].attributes.issues),
+    isAppeal: true,
   };
   const oneClosedIssue = {
     issues: addStatusToIssues([mockData.data[2].attributes.issues[3]]),
+    isAppeal: true,
   };
   const manyIssues = {
     issues: addStatusToIssues(mockData.data[2].attributes.issues),
+    isAppeal: true,
   };
 
   it('should render', () => {
@@ -61,6 +65,7 @@ describe('<Issues/>', () => {
   it('should render a list of open items when open items exist', () => {
     const props = {
       issues: [{ status: 'open', description: 'test open issue' }],
+      isAppeal: true,
     };
     const wrapper = mount(<Issues {...props} />);
     const panelButton = wrapper.find('.usa-accordion-button');
@@ -124,6 +129,14 @@ describe('<Issues/>', () => {
       .props();
     expect(closedPanelProps.panelName).to.equal('Closed');
     expect(closedPanelProps.startOpen).to.be.false;
+    wrapper.unmount();
+  });
+
+  it('should use the word "review" if a Supplemental Claim or Higher-Level Review', () => {
+    const props = _.set('isAppeal', false, oneOpenIssue);
+    const wrapper = shallow(<Issues {...props} />);
+    const activePanelProps = wrapper.find('CollapsiblePanel').props();
+    expect(activePanelProps.panelName).to.equal('Currently on review');
     wrapper.unmount();
   });
 });

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -476,7 +476,7 @@ describe('Disability benefits helpers: ', () => {
     it('returns sane object when given unknown type', () => {
       const type = 123;
       const contents = getStatusContents(type);
-      expect(contents.title).to.equal('We don’t know your appeal status');
+      expect(contents.title).to.equal('We don’t know your status');
       expect(contents.description.props.children).to.eql([
         // React splits it up into separate nodes when variables are inserted
         'We’re sorry, ',

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -16,13 +16,36 @@ export const APPEAL_STATUSES = {
   cue: 'cue',
 };
 
-// Only `legacyAppeal` is currently supported as the team works on adding new
-// appeal types, but leaving the other old ones in here just in case
 export const APPEAL_TYPES = {
-  current: 'legacyAppeal',
-  v2Legacy: 'appealSeries',
-  v1Legacy: 'appeals_status_models_appeals',
+  legacy: 'legacyAppeal',
+  supplementalClaim: 'supplementalClaim',
+  higherLevelReview: 'higherLevelReview',
+  appeal: 'appeal',
 };
+
+/**
+ * Returns a string with the formatted name of the type of appeal.
+ * @param {Object} appeal
+ * @returns {string}
+ */
+export function getTypeName(appeal) {
+  switch (appeal.type) {
+    case APPEAL_TYPES.supplementalClaim:
+      return 'Supplemental Claim';
+    case APPEAL_TYPES.higherLevelReview:
+      return 'Higher-Level Review';
+    case APPEAL_TYPES.legacy:
+    case APPEAL_TYPES.appeal:
+      return 'Appeal';
+    default:
+      Raven.captureMessage('appeals-unknown-type', {
+        extra: {
+          type: appeal.type,
+        },
+      });
+      return null;
+  }
+}
 
 // TO DO: Replace these properties and content with real versions once finalized.
 export const STATUS_TYPES = {
@@ -579,7 +602,6 @@ export function getStatusContents(statusType, details = {}, name = {}) {
       break;
     case STATUS_TYPES.merged:
       contents.title = 'Your appeal was merged';
-      // TODO: When we change the url to remove -v2, change it here too
       contents.description = (
         <div>
           <p>
@@ -589,14 +611,14 @@ export function getStatusContents(statusType, details = {}, name = {}) {
             older appeal that was closest to receiving a Board decision.
           </p>
           <p>
-            Check <Link to="/your-claims-v2">Your Claims and Appeals</Link> for
-            the appeal that contains the issues merged from this appeal.
+            Check <Link to="/your-claims">Your Claims and Appeals</Link> for the
+            appeal that contains the issues merged from this appeal.
           </p>
         </div>
       );
       break;
     default:
-      contents.title = 'We don’t know your appeal status';
+      contents.title = 'We don’t know your status';
       contents.description = (
         <p>We’re sorry, {siteName} will soon be updated to show your status.</p>
       );
@@ -628,6 +650,18 @@ export const EVENT_TYPES = {
   reconsideration: 'reconsideration',
   vacated: 'vacated',
   otherClose: 'other_close',
+  amaNod: 'ama_nod',
+  docketChange: 'docket_change',
+  distributedToVlj: 'distributed_to_vlj',
+  bvaDecisionEffectuation: 'bva_decision_effectuation',
+  dtaDecision: 'dta_decision',
+  scRequest: 'sc_request',
+  scDecision: 'sc_decision',
+  scOtherClose: 'sc_other_close',
+  hlrRequest: 'hlr_request',
+  hlrDecision: 'hlr_decision',
+  hlrDtaError: 'hlr_dta_error',
+  hlrOtherClose: 'hlr_other_close',
 };
 
 /**

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -336,13 +336,7 @@ export const mockData = {
             socTimeliness: [2, 16],
           },
         },
-        docket: {
-          front: false,
-          total: 206900,
-          ahead: 109203,
-          ready: 22109,
-          eta: '2019-08-31',
-        },
+        docket: null,
         issues: [
           {
             active: true,

--- a/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
@@ -30,6 +30,8 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import ClaimsListItem from '../components/ClaimsListItem';
 import AppealListItem from '../components/AppealsListItemV2';
 
+const appealTypes = Object.values(APPEAL_TYPES);
+
 function recordDashboardClick(product) {
   return () => {
     recordEvent({
@@ -54,7 +56,7 @@ class ClaimsAppealsWidget extends React.Component {
   }
 
   renderListItem(claim) {
-    if (claim.type === APPEAL_TYPES.current) {
+    if (appealTypes.includes(claim.type)) {
       return (
         <AppealListItem
           key={claim.id}


### PR DESCRIPTION
## Description
After February 19, the Caseflow API will begin returning more types of appeals than just the "legacyAppeal" type seen today. This PR clears the way for those appeals to appear on VA.gov. Note these new types of appeals generally will use different events, statuses and alerts. These will be added later (and currently result in error statuses like "We don't know your status").

Issue here: https://github.com/department-of-veterans-affairs/caseflow/issues/8980

## Testing done

Tested against the mock-api-data.

## Screenshots

<img width="644" alt="screen shot 2019-02-06 at 3 28 53 pm" src="https://user-images.githubusercontent.com/5375557/52371716-4701cb80-2a24-11e9-941d-ecc1478c3e2c.png">
<img width="655" alt="screen shot 2019-02-06 at 3 29 56 pm" src="https://user-images.githubusercontent.com/5375557/52371743-5719ab00-2a24-11e9-8e3c-4f7b6f8f6f37.png">
<img width="648" alt="screen shot 2019-02-06 at 3 30 54 pm" src="https://user-images.githubusercontent.com/5375557/52371751-5aad3200-2a24-11e9-8911-48fa039f8e16.png">
<img width="972" alt="screen shot 2019-02-06 at 3 29 03 pm" src="https://user-images.githubusercontent.com/5375557/52371721-4a955280-2a24-11e9-9588-fe25c0f1743d.png">
<img width="969" alt="screen shot 2019-02-06 at 3 29 10 pm" src="https://user-images.githubusercontent.com/5375557/52371729-4ec17000-2a24-11e9-8474-8a0182416d57.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs