### PR TITLE
Run multiple tests

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
@@ -11,7 +11,7 @@ const testData = getTestDataSets(join(__dirname, 'schema'), {
 });
 
 const testConfig = {
-  debug: true,
+  // debug: true,
   setup: userToken => {
     PageHelpers.initInProgressMock(userToken);
     PageHelpers.initDocumentUploadMock();

--- a/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
@@ -8,6 +8,7 @@ const PageHelpers = require('./disability-benefits-helpers');
 const testData = getTestDataSets(join(__dirname, 'schema'), {
   extension: 'json',
   ignore: ['minimal-ptsd-form-upload-test.json'],
+  // only: ['minimal-test.json'],
 });
 
 const testConfig = {

--- a/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
@@ -1,8 +1,14 @@
+const join = require('path').join;
+
 const testForm = require('../../../../platform/testing/e2e/form-tester');
+const getTestDataSets = require('../../../../platform/testing/e2e/form-tester/util')
+  .getTestDataSets;
 const PageHelpers = require('./disability-benefits-helpers');
 
-// TODO: Replace this with all the test data sets
-const testData = require('./schema/maximal-test.json');
+const testData = getTestDataSets(join(__dirname, 'schema'), {
+  extension: 'json',
+  ignore: ['minimal-ptsd-form-upload-test.json'],
+});
 
 const testConfig = {
   debug: true,
@@ -38,5 +44,5 @@ const testConfig = {
 };
 
 describe('526 all-claims e2e tests', async () => {
-  testForm({ 'maximal-test.json': testData }, testConfig);
+  testForm(testData, testConfig);
 });

--- a/src/platform/testing/e2e/form-tester/index.js
+++ b/src/platform/testing/e2e/form-tester/index.js
@@ -16,8 +16,7 @@ const fastForwardAnimations = async page => {
   await page._client.send('Animation.setPlaybackRate', { playbackRate: 10000 });
 };
 
-const getTestData = (testDataSets, testName, pathPrefix) =>
-  get(pathPrefix, testDataSets[testName], {});
+const getTestData = (contents, pathPrefix) => get(pathPrefix, contents, {});
 
 const getLogger = debugMode => (...params) => {
   if (debugMode) {
@@ -64,14 +63,12 @@ const runTest = async (page, testData, testConfig, userToken) => {
  * @property {string} url - The url for the array page
  * @property {string} arrayPath - The arrayPath as it is in the formConfig
  * ---
- * @typedef {TestDataSets}
- * @type {object}
- * @description A set of test data pulled from json files. Each property name corresponds to
- *  the file name that the data is pulled from. The values are the parsed JSON objects contained
- *  in the files.
+ * @typedef {Object} DataSet
+ * @property {String} fileName - The file name
+ * @property {Object} contents - The parsed contents
  * ---
  * @param {TestConfig} testConfig
- * @param {TestData} testDataSets
+ * @param {Array<DataSet>} testDataSets
  */
 const testForm = (testDataSets, testConfig) => {
   let browser;
@@ -97,16 +94,16 @@ const testForm = (testDataSets, testConfig) => {
     }
   });
 
-  Object.keys(testDataSets).forEach(testName =>
+  testDataSets.forEach(({ fileName, contents }) =>
     test(
-      testName,
+      fileName,
       async () => {
         const pageList = await browser.pages();
         const page = pageList[0] || (await browser.newPage());
         await fastForwardAnimations(page);
         await runTest(
           page,
-          getTestData(testDataSets, testName, testConfig.testDataPathPrefix),
+          getTestData(contents, testConfig.testDataPathPrefix),
           testConfig,
           token,
         );

--- a/src/platform/testing/e2e/form-tester/util.js
+++ b/src/platform/testing/e2e/form-tester/util.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const join = require('path').join;
+
+/**
+ * Grabs the all the data for a form.
+ * @typedef {Object} Rules
+ * @property {Stirng} extension - The file extension to look for
+ * @property {Array<String>} ignore - Specific filenames to ignore
+ * ---
+ * @typedef {Object} DataSet
+ * @property {String} fileName - The file name
+ * @property {Object} contents - The parsed contents
+ * ---
+ * @param {String} path - The path it'll look in
+ * @param {Object} rules - The rules it'll follow to find the files
+ * @return {Array<DataSet>} - All the parsed files
+ */
+function getTestDataSets(path, rules = { extension: 'json' }) {
+  return fs
+    .readdirSync(path)
+    .filter(fileName => fileName.endsWith(rules.extension))
+    .filter(
+      fileName =>
+        Array.isArray(rules.ignore) ? !rules.ignore.includes(fileName) : true,
+    )
+    .map(fileName => ({
+      fileName,
+      contents: JSON.parse(fs.readFileSync(join(path, fileName), 'utf8')),
+    }));
+}
+
+module.exports = { getTestDataSets };

--- a/src/platform/testing/e2e/form-tester/util.js
+++ b/src/platform/testing/e2e/form-tester/util.js
@@ -6,6 +6,7 @@ const join = require('path').join;
  * @typedef {Object} Rules
  * @property {Stirng} extension - The file extension to look for
  * @property {Array<String>} ignore - Specific filenames to ignore
+ * @property {Array<String>} only - Run tests on only these files
  * ---
  * @typedef {Object} DataSet
  * @property {String} fileName - The file name
@@ -19,6 +20,10 @@ function getTestDataSets(path, rules = { extension: 'json' }) {
   return fs
     .readdirSync(path)
     .filter(fileName => fileName.endsWith(rules.extension))
+    .filter(
+      fileName =>
+        Array.isArray(rules.only) ? rules.only.includes(fileName) : true,
+    )
     .filter(
       fileName =>
         Array.isArray(rules.ignore) ? !rules.ignore.includes(fileName) : true,


### PR DESCRIPTION
## Description
The form app tester runs multiple tests now. Turns out it did before, which is cool, but now the 526 v2 tester is set up to do so.

Included in this is a new utility function to grab the test data for a form. We can pass in file names to ignore (for known-broken ones) and file names to explicitly run tests on (for debugging).

## Testing done
Manually tested that the following works:
- Multiple Jest tests run
- When one fails, it doesn't stop other tests from running
- When one fails, it produces an error, which Jest catches and indicates which test data file had the failing test
- The `ignore` list works properly
- The `only` list works properly

## Screenshots
N/A

## Acceptance criteria
- [x] Multiple tests run

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs