### PR TITLE
Add context to "login-link-clicked" GA events

### DIFF
--- a/src/platform/site-wide/user-nav/actions/index.js
+++ b/src/platform/site-wide/user-nav/actions/index.js
@@ -1,3 +1,5 @@
+import recordEvent from '../../../monitoring/record-event';
+
 export const TOGGLE_LOGIN_MODAL = 'TOGGLE_LOGIN_MODAL';
 export const UPDATE_SEARCH_HELP_USER_MENU = 'UPDATE_SEARCH_HELP_USER_MENU';
 
@@ -9,7 +11,15 @@ export function toggleSearchHelpUserMenu(menu, isOpen) {
   };
 }
 
-export function toggleLoginModal(isOpen) {
+export function toggleLoginModal(isOpen, context) {
+  if (isOpen) {
+    const event = context
+      ? `login-link-clicked-${context}`
+      : `login-link-clicked-forms`;
+
+    recordEvent({ event });
+  }
+
   return {
     type: TOGGLE_LOGIN_MODAL,
     isOpen,

--- a/src/platform/site-wide/user-nav/actions/index.js
+++ b/src/platform/site-wide/user-nav/actions/index.js
@@ -15,7 +15,7 @@ export function toggleLoginModal(isOpen, context) {
   if (isOpen) {
     const event = context
       ? `login-link-clicked-${context}`
-      : `login-link-clicked-forms`;
+      : `login-link-clicked-cta`;
 
     recordEvent({ event });
   }

--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -4,7 +4,6 @@ import classNames from 'classnames';
 
 import isBrandConsolidationEnabled from '../../../brand-consolidation/feature-flag';
 import isVATeamSiteSubdomain from '../../../brand-consolidation/va-subdomain';
-import recordEvent from '../../../monitoring/record-event';
 import { hasSession } from '../../../user/profile/utilities';
 import HelpMenu from './HelpMenu';
 import SearchMenu from './SearchMenu';
@@ -13,8 +12,7 @@ import SignInProfileMenu from './SignInProfileMenu';
 class SearchHelpSignIn extends React.Component {
   handleSignInSignUp = e => {
     e.preventDefault();
-    recordEvent({ event: 'login-link-clicked-header' });
-    this.props.toggleLoginModal(true);
+    this.props.toggleLoginModal(true, 'header');
   };
 
   handleMenuClick = menu => () => {


### PR DESCRIPTION
## Description
We want to be able to have context of where the sign in modal is being launched from.  Added a `context` parameter to the `toggleLoginModal()` action and moved the GA `recordEvent` from the button click to the action.  Now, when calling `toggleLoginModal()`, if context is provided, the GA event will be recorded as `login-link-clicked-${context}`.  Context can be added as needed, but will default to `cta` if none is provided.

## Testing done
Tested locally


## Acceptance criteria
- [ ] Clicking the "Sign In" link in the header results in a `login-link-clicked-header` event
- [ ] Clicking a sign in link CTA from the following apps should result in a `login-link-clicked-tools` event
  - `rx`
  - `messaging`
  - `appointments`
  - `lab-and-test-results`
  - `health-records`
  - `letters`
- [ ] Clicking a sign in link or CTA elsewhere results in a `login-link-clicked-forms` event

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
