### PR TITLE
Do not open connected accounts in a new window.

### DIFF
--- a/src/applications/personalization/account/components/ConnectedAccountsSection.jsx
+++ b/src/applications/personalization/account/components/ConnectedAccountsSection.jsx
@@ -10,11 +10,7 @@ export default function ConnectedAccountsSection() {
           permission to access your VA.gov profile data.
         </p>
         <p>
-          <a
-            href="/account/connected-accounts"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a href="/account/connected-accounts" rel="noopener noreferrer">
             Manage your connected accounts
           </a>
           .


### PR DESCRIPTION
The connected accounts link was never supposed to open in a new window.