### PR TITLE
Added healthCarePay in collections.json for additional health care pages

### DIFF
--- a/src/site/stages/build/data/collections.json
+++ b/src/site/stages/build/data/collections.json
@@ -359,6 +359,14 @@
       "hub": "health-care"
     }
   },
+  "healthCarePay" : {
+    "pattern": "health-care/pay-copay-bill/*.md",
+    "sortBy": "order",
+    "metadata": {
+      "name": "Health Care",
+      "hub": "health-care" 
+    }
+  },
   "healthEligibility": {
     "pattern": "health-care/eligibility/*.md",
     "sortBy": "order",


### PR DESCRIPTION
## Description
Created addition of the healthCarePay entry into vets-`src/site/stages/build/data/collections.json`
to accommodate the addition of new parent and children pages within Health Care in support of [this PR](https://github.com/department-of-veterans-affairs/vagov-content/pull/246)

## Testing done
tested on local build

## Screenshots
n/a

## Acceptance criteria
- [X] creates new collection for parent and children health care pages

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
