### PR TITLE
Add new IDForm and IDPage to hold it.

### DIFF
--- a/src/applications/hca/actions.js
+++ b/src/applications/hca/actions.js
@@ -1,0 +1,23 @@
+export const SUBMIT_ID_FORM_STARTED = 'SUBMIT_ID_FORM_STARTED';
+export const SUBMIT_ID_FORM_SUCCEEDED = 'SUBMIT_ID_FORM_SUCCEEDED';
+export const SUBMIT_ID_FORM_FAILED = 'SUBMIT_ID_FORM_FAILED';
+
+// eslint-disable-next-line no-unused-vars
+export function submitIDForm(formData) {
+  return dispatch => {
+    dispatch({
+      type: SUBMIT_ID_FORM_STARTED,
+    });
+
+    // TODO: actually call the form ID endpoint and dispatch
+    // SUBMIT_ID_FORM_FAILED or SUBMIT_ID_FORM_SUCCEEDED depending on how it
+    // resolves
+    setTimeout(() => {
+      dispatch({
+        // type: 'SUBMIT_ID_FORM_SUCCEEDED',
+        type: SUBMIT_ID_FORM_FAILED,
+        error: 'oh noes!!!!',
+      });
+    }, 2000);
+  };
+}

--- a/src/applications/hca/components/IDForm.jsx
+++ b/src/applications/hca/components/IDForm.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+
+import SchemaForm from 'us-forms-system/lib/js/components/SchemaForm';
+import currentOrPastDateUI from 'us-forms-system/lib/js/definitions/currentOrPastDate';
+import ssnUI from 'us-forms-system/lib/js/definitions/ssn';
+import constants from 'vets-json-schema/dist/constants.json';
+
+import { genderLabels } from 'platform/static-data/labels';
+import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
+
+export default class IDForm extends React.Component {
+  state = {
+    idFormData: {},
+  };
+
+  formChange = formData => {
+    this.setState({ idFormData: formData });
+  };
+
+  formSubmit = ({ formData }) => {
+    this.props.handleSubmit(formData);
+  };
+
+  schema = {
+    type: 'object',
+    properties: {
+      firstName: {
+        type: 'string',
+      },
+      lastName: {
+        type: 'string',
+      },
+      dob: {
+        type: 'string',
+        format: 'date',
+      },
+      ssn: {
+        type: 'string',
+      },
+      gender: {
+        type: 'string',
+        enum: [...constants.genders.map(option => option.value), 'NA'],
+      },
+    },
+    required: ['firstName', 'lastName', 'dob', 'ssn'],
+  };
+
+  uiSchema = {
+    firstName: {
+      'ui:title': 'First name',
+      'ui:errorMessages': {
+        required: 'Please enter your first name.',
+      },
+    },
+    lastName: {
+      'ui:title': 'Last name',
+      'ui:errorMessages': {
+        required: 'Please enter your last name.',
+      },
+    },
+    dob: {
+      ...currentOrPastDateUI('Date of birth'),
+      'ui:errorMessages': {
+        required:
+          'Please provide your date of birth. Select the month and day, then enter your birth year.',
+      },
+    },
+    ssn: {
+      ...ssnUI,
+      'ui:errorMessages': {
+        required:
+          'Please enter your Social Security number in this format: XXX-XX-XXXX.',
+        // NOTE: this `pattern` message is ignored because the pattern
+        // validation error message is hard coded in the validation function:
+        // https://github.com/usds/us-forms-system/blob/db029cb4f18362870d420e3eee5b71be98004e5e/src/js/validation.js#L231
+        pattern:
+          'Please enter your Social Security number in this format: XXX-XX-XXXX.',
+      },
+    },
+    gender: {
+      'ui:title': 'Gender',
+      'ui:labels': genderLabels,
+    },
+  };
+  render() {
+    return (
+      <SchemaForm
+        // `name` and `title` are required by SchemaForm, but are only used
+        // internally in the component
+        name="ID Form"
+        title="ID Form"
+        schema={this.schema}
+        uiSchema={this.uiSchema}
+        onSubmit={this.formSubmit}
+        onChange={this.formChange}
+        data={this.state.idFormData}
+      >
+        <LoadingButton
+          isLoading={this.props.isLoading}
+          disabled={false}
+          type="submit"
+          /* to override the `width: 100%` given to SchemaForm submit buttons */
+          style={{ width: 'auto' }}
+        >
+          Continue to the Application
+          <span className="button-icon">&nbsp;»</span>
+        </LoadingButton>
+      </SchemaForm>
+    );
+  }
+}

--- a/src/applications/hca/containers/IDPage.jsx
+++ b/src/applications/hca/containers/IDPage.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
+import FormTitle from 'us-forms-system/lib/js/components/FormTitle';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+import { focusElement } from 'platform/utilities/ui';
+
+import IDForm from '../components/IDForm';
+
+import { submitIDForm } from '../actions';
+
+class IDPage extends React.Component {
+  componentDidMount() {
+    focusElement('.va-nav-breadcrumbs-list');
+  }
+
+  render() {
+    return (
+      <div className="schemaform-intro">
+        <FormTitle title="Apply for health care benefits" />
+        <AlertBox
+          isVisible
+          status="info"
+          headline="Help us fit this application to your specific needs"
+          content={
+            <React.Fragment>
+              <p>
+                Before you start your health care application, please provide
+                the information below. This will help us make sure the
+                application gathers the right information for us to determine
+                your eligibility.
+              </p>
+              <p>
+                <strong>Want to skip this step?</strong>
+              </p>
+              <button className="va-button-link" onClick={this.goToLogin}>
+                Sign in to start your application.
+              </button>
+            </React.Fragment>
+          }
+        />
+        <IDForm
+          isLoading={this.props.isLoading}
+          handleSubmit={this.props.submitForm}
+        />
+        {this.props.error && (
+          <AlertBox
+            isVisible
+            status="error"
+            headline="Please sign in to continue your application"
+            content={
+              <React.Fragment>
+                <p>
+                  We’re sorry for the interruption, but we need you to review
+                  some information before you continue applying. Please sign in
+                  below to review. If you don’t have an account, you can create
+                  one now.
+                </p>
+                <button className="usa-button-primary" onClick={this.goToLogin}>
+                  Sign in to VA.gov
+                </button>
+              </React.Fragment>
+            }
+          />
+        )}
+        <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
+          <OMBInfo resBurden={30} ombNumber="2900-0091" expDate="05/31/2018" />
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapDispatchToProps = {
+  submitForm: submitIDForm,
+};
+
+const mapStateToProps = state => ({
+  isLoading: state.hcaIDForm.isLoading,
+  error: state.hcaIDForm.error,
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(IDPage);

--- a/src/applications/hca/containers/IntroductionPage.jsx
+++ b/src/applications/hca/containers/IntroductionPage.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'us-forms-system/lib/js/components/FormTitle';
 
-import { focusElement } from '../../../platform/utilities/ui';
-import SaveInProgressIntro from '../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import { focusElement } from 'platform/utilities/ui';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {

--- a/src/applications/hca/reducer.js
+++ b/src/applications/hca/reducer.js
@@ -1,6 +1,30 @@
 import formConfig from './config/form';
-import { createSaveInProgressFormReducer } from '../../platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
+import {
+  SUBMIT_ID_FORM_STARTED,
+  SUBMIT_ID_FORM_SUCCEEDED,
+  SUBMIT_ID_FORM_FAILED,
+} from './actions';
+
+const initialState = {
+  isLoading: false,
+  error: null,
+};
+
+function hcaIDForm(state = initialState, action) {
+  switch (action.type) {
+    case SUBMIT_ID_FORM_STARTED:
+      return { ...state, isLoading: true };
+    case SUBMIT_ID_FORM_SUCCEEDED:
+      return { ...state, isLoading: false };
+    case SUBMIT_ID_FORM_FAILED:
+      return { ...state, isLoading: false, error: action.error };
+    default:
+      return state;
+  }
+}
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),
+  hcaIDForm,
 };

--- a/src/applications/hca/routes.jsx
+++ b/src/applications/hca/routes.jsx
@@ -1,13 +1,33 @@
-import { createRoutesWithSaveInProgress } from '../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
+import environment from 'platform/utilities/environment';
 
 import formConfig from './config/form';
 import HealthCareApp from './HealthCareApp.jsx';
+import IDPage from './containers/IDPage';
 
-const route = {
-  path: '/',
-  component: HealthCareApp,
-  indexRoute: { onEnter: (nextState, replace) => replace('/introduction') },
-  childRoutes: createRoutesWithSaveInProgress(formConfig),
+const formRoutes = createRoutesWithSaveInProgress(formConfig);
+
+// If the route's path ends in `introduction` then the form system will treat it
+// as an Introduction page (ie it won't add the Title component or navigation
+// elements) which is what we want in this case.
+const idFormRoute = {
+  path: 'id-introduction',
+  component: IDPage,
+  key: 'id-introduction',
 };
 
-export default route;
+// do not allow the idFormRoute in production
+if (environment.isProduction()) {
+  idFormRoute.onEnter = (nextState, replace) => replace('/');
+}
+
+const routes = {
+  path: '/',
+  component: HealthCareApp,
+  indexRoute: {
+    onEnter: (nextState, replace) => replace('/introduction'),
+  },
+  childRoutes: [idFormRoute, ...formRoutes],
+};
+
+export default routes;

--- a/src/applications/hca/routes.jsx
+++ b/src/applications/hca/routes.jsx
@@ -16,18 +16,16 @@ const idFormRoute = {
   key: 'id-introduction',
 };
 
-// do not allow the idFormRoute in production
-if (environment.isProduction()) {
-  idFormRoute.onEnter = (nextState, replace) => replace('/');
-}
-
 const routes = {
   path: '/',
   component: HealthCareApp,
   indexRoute: {
     onEnter: (nextState, replace) => replace('/introduction'),
   },
-  childRoutes: [idFormRoute, ...formRoutes],
+  // do not allow the idFormRoute in production
+  childRoutes: environment.isProduction()
+    ? formRoutes
+    : [idFormRoute, ...formRoutes],
 };
 
 export default routes;

--- a/src/platform/forms/save-in-progress/helpers.js
+++ b/src/platform/forms/save-in-progress/helpers.js
@@ -13,11 +13,14 @@ export function createRoutesWithSaveInProgress(formConfig) {
     'introduction',
     'review-and-submit',
     'confirmation',
+    'id-form',
     '*',
   ]);
   const formPages = createFormPageList(formConfig);
   const pageList = createPageList(formConfig, formPages);
   const newRoutes = createRoutes(formConfig);
+  // eslint-disable-next-line no-debugger
+  // debugger;
 
   newRoutes.forEach((route, index) => {
     let newRoute;

--- a/src/platform/static-data/labels.jsx
+++ b/src/platform/static-data/labels.jsx
@@ -6,4 +6,5 @@ export const relationshipLabels = {
 export const genderLabels = {
   F: 'Female',
   M: 'Male',
+  NA: 'Prefer not to answer',
 };


### PR DESCRIPTION
## Description
This is still a WIP but didn't want the PR to get too big before getting some eyes on it.

The basic goal of this work is to add a new page/route to the HCA application that will allow non-logged-in uses to submit a form with their personal info so we can check to see if we have a record of them previously applying for health care.

To do so I did the following:
- Created a new IDForm component
- Added IDPage as new route to HCA
- Connected the IDPage to Redux

## Testing done
Local testing

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/52588889-65841000-2df2-11e9-8a29-ebdf894b189c.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs