### PR TITLE
Fix broken link to FAQ on in VerifyApp

### DIFF
--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -69,7 +69,7 @@ export class VerifyApp extends React.Component {
                   We'll need to verify your identity so that you can securely
                   access and manage your benefits.
                   <br />
-                  <a href="/faq/#why-verify" target="_blank">
+                  <a href="/sign-in-faq/#why-verify" target="_blank">
                     Why does {siteName} verify identity?
                   </a>
                 </p>


### PR DESCRIPTION
## Description
This PR fixes a broken link in the `VerifyApp`.

On [va.gov/verify/](va.gov/verify/), the link to *Why does VA.gov verify identity?* has been updated to go to [va.gov/sign-in-faq/#why-verify](va.gov/sign-in-faq/#why-verify)


## Testing done
Viewed and clicked on local build.

In order to test, **you must comment out lines** `36-38` in `src/applications/verify/containers/VerifyApp.jsx` before navigating to /verify/ or else it will redirect you back to the homepage.

## Screenshots
![screen shot 2019-02-11 at 3 30 14 pm](https://user-images.githubusercontent.com/11021491/52591788-c58aae80-2e12-11e9-8cc0-4bafc4001e74.png)

takes you here:
![screen shot 2019-02-11 at 3 35 43 pm](https://user-images.githubusercontent.com/11021491/52591812-cfacad00-2e12-11e9-90d9-9c2a609ecf72.png)


## Acceptance criteria
- [X] Link takes you to [va.gov/sign-in-faq/#why-verify](va.gov/sign-in-faq/#why-verify))

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
