### PR TITLE
Don't allow details toggle to wrap on connected accounts page.

### DIFF
--- a/src/applications/personalization/connected-accounts/sass/connected-acct.scss
+++ b/src/applications/personalization/connected-accounts/sass/connected-acct.scss
@@ -47,6 +47,7 @@
       .va-connected-acct-row-details {
          .va-connected-acct-row-details-toggle {
             text-decoration: none;
+            white-space: nowrap;
          }
          i {
             padding-left: .5em;


### PR DESCRIPTION
Tweaking the toggle on the connected accounts page.