### PR TITLE
Fix Error Code Mapping Mismatch and Add GA Events/Sentry Errors

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -18,7 +18,6 @@ import recordEvent from '../../../platform/monitoring/record-event';
 export class AuthApp extends React.Component {
   constructor(props) {
     super(props);
-
     this.state = { error: props.location.query.auth === 'fail' };
   }
 

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -18,6 +18,7 @@ import recordEvent from '../../../platform/monitoring/record-event';
 export class AuthApp extends React.Component {
   constructor(props) {
     super(props);
+
     this.state = { error: props.location.query.auth === 'fail' };
   }
 
@@ -26,7 +27,15 @@ export class AuthApp extends React.Component {
   }
 
   handleAuthError = e => {
-    Raven.captureException(e);
+    const loginType = sessionStorage.getItem(authnSettings.PENDING_LOGIN_TYPE);
+
+    Raven.captureException(e, {
+      tags: {
+        loginType,
+      },
+    });
+
+    sessionStorage.removeItem(authnSettings.PENDING_LOGIN_TYPE);
 
     recordEvent({
       event: `login-error-user-fetch`,

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import Raven from 'raven-js';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import SubmitSignInForm from '../../../brand-consolidation/components/SubmitSignInForm';
@@ -13,6 +14,7 @@ import DowntimeBanner from '../../../../platform/monitoring/DowntimeNotification
 import siteName from '../../../brand-consolidation/site-name';
 
 const loginHandler = loginType => () => {
+  Raven.setTagsContext({ loginType });
   recordEvent({ event: `login-attempted-${loginType}` });
   login(loginType);
 };

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Raven from 'raven-js';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import SubmitSignInForm from '../../../brand-consolidation/components/SubmitSignInForm';
@@ -14,7 +13,6 @@ import DowntimeBanner from '../../../../platform/monitoring/DowntimeNotification
 import siteName from '../../../brand-consolidation/site-name';
 
 const loginHandler = loginType => () => {
-  Raven.setTagsContext({ loginType });
   recordEvent({ event: `login-attempted-${loginType}` });
   login(loginType);
 };

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -1,4 +1,5 @@
 import appendQuery from 'append-query';
+import Raven from 'raven-js';
 
 import recordEvent from '../../monitoring/record-event';
 import environment from '../../utilities/environment';
@@ -6,6 +7,7 @@ import environment from '../../utilities/environment';
 export const authnSettings = {
   RETURN_URL: 'authReturnUrl',
   REGISTRATION_PENDING: 'registrationPending',
+  PENDING_LOGIN_TYPE: 'pendingLoginType',
 };
 
 const SESSIONS_URI = `${environment.API_URL}/sessions`;
@@ -29,6 +31,14 @@ const loginUrl = policy => {
   }
 };
 
+export function setRavenLoginType(loginType) {
+  Raven.setTagsContext({ loginType });
+}
+
+export function clearRavenLoginType() {
+  Raven.setTagsContext({ loginType: undefined });
+}
+
 function redirect(redirectUrl, clickedEvent) {
   // Keep track of the URL to return to after auth operation.
   sessionStorage.setItem(authnSettings.RETURN_URL, window.location.pathname);
@@ -38,6 +48,7 @@ function redirect(redirectUrl, clickedEvent) {
 
 export function login(policy) {
   sessionStorage.removeItem(authnSettings.REGISTRATION_PENDING);
+  sessionStorage.setItem(authnSettings.PENDING_LOGIN_TYPE, policy);
   return redirect(loginUrl(policy), 'login-link-clicked-modal');
 }
 
@@ -50,6 +61,7 @@ export function verify() {
 }
 
 export function logout() {
+  clearRavenLoginType();
   return redirect(LOGOUT_URL, 'logout-link-clicked');
 }
 

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -1,7 +1,11 @@
 import camelCaseKeysRecursive from 'camelcase-keys-recursive';
 
 import recordEvent from '../../../monitoring/record-event';
-import { authnSettings } from '../../authentication/utilities';
+import {
+  authnSettings,
+  setRavenLoginType,
+  clearRavenLoginType,
+} from '../../authentication/utilities';
 import get from '../../../utilities/data/get';
 import localStorage from '../../../utilities/storage/localStorage';
 
@@ -138,6 +142,11 @@ export function setupProfileSession(payload) {
     recordEvent({ event: `login-success-${loginPolicy}` });
   }
 
+  sessionStorage.removeItem(authnSettings.PENDING_LOGIN_TYPE);
+
+  // Set Sentry Tag so we can associate errors with the login policy
+  setRavenLoginType(loginPolicy);
+
   // Report out the current level of assurance for the user.
   if (loa && loa.current) {
     recordEvent({ event: `login-loa-current-${loa.current}` });
@@ -152,4 +161,6 @@ export function teardownProfileSession() {
   for (const key of sessionKeys) {
     localStorage.removeItem(key);
   }
+
+  clearRavenLoginType();
 }


### PR DESCRIPTION
## Description
Login errors are not currently being logged on the FE.  
* Renamed 005 code to 007 to match BE
* Added GA event for when callback has `auth=fail&code={code}` in query string
* Added GA event and Sentry error log when the API call to `/user` fails
* Added `loginType` as global tag when the user clicks a login option to provide context

## Testing done
Tested locally


## Acceptance criteria
- [ ] Login errors are logged in Sentry and GA
- [ ] Error codes match BE

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
