### PR TITLE
VET TEC: Program City, State, Start date not required #16747

### DIFF
--- a/src/applications/edu-benefits/0994/pages/trainingProgramsInformation.js
+++ b/src/applications/edu-benefits/0994/pages/trainingProgramsInformation.js
@@ -15,9 +15,10 @@ const {
 const getCourseType = (formData, index) =>
   _.get(formData, `vetTecPrograms[${index}].courseType`, '');
 
+const checkLocation = field => field === 'inPerson' || field === 'both';
+
 const showLocation = (formData, index) =>
-  getCourseType(formData, index) === 'inPerson' ||
-  getCourseType(formData, index) === 'both';
+  checkLocation(getCourseType(formData, index));
 
 export const uiSchema = {
   'ui:description': trainingDescription,
@@ -45,23 +46,34 @@ export const uiSchema = {
           },
         },
       },
-      location: {
+      'view:location': {
+        'ui:title': ' ',
         'ui:description': 'Where will you take this training?',
         'ui:options': {
           expandUnder: 'courseType',
-          expandUnderCondition: field =>
-            field === 'inPerson' || field === 'both',
+          expandUnderCondition: checkLocation,
         },
-        city: {
-          'ui:title': 'City',
-          'ui:required': (formData, index) => showLocation(formData, index),
-          'ui:errorMessages': {
-            pattern: 'Please fill in a valid city',
-          },
+      },
+      locationCity: {
+        'ui:title': 'City',
+        'ui:required': (formData, index) => showLocation(formData, index),
+        'ui:errorMessages': {
+          pattern: 'Please fill in a valid city',
         },
-        state: {
-          'ui:title': 'State',
-          'ui:required': (formData, index) => showLocation(formData, index),
+        'ui:options': {
+          expandUnder: 'courseType',
+          expandUnderCondition: checkLocation,
+        },
+      },
+      locationState: {
+        'ui:title': 'State',
+        'ui:errorMessages': {
+          pattern: 'Please select a valid state',
+        },
+        'ui:required': (formData, index) => showLocation(formData, index),
+        'ui:options': {
+          expandUnder: 'courseType',
+          expandUnderCondition: checkLocation,
         },
       },
       plannedStartDate: dateUI('What is your estimated start date?'),
@@ -82,8 +94,17 @@ export const schema = {
           providerName,
           programName,
           courseType,
-          location: {
-            ...location,
+          'view:location': {
+            type: 'object',
+            properties: {},
+            'ui:collapsed': true,
+          },
+          locationCity: {
+            ...location.properties.city,
+            'ui:collapsed': true,
+          },
+          locationState: {
+            ...location.properties.state,
             'ui:collapsed': true,
           },
           plannedStartDate,

--- a/src/applications/edu-benefits/0994/submit-transformer.js
+++ b/src/applications/edu-benefits/0994/submit-transformer.js
@@ -53,11 +53,41 @@ export function transform(formConfig, form) {
     return formData;
   };
 
+  const transformProgramSelection = formData => {
+    if (formData.vetTecPrograms) {
+      const clonedData = _.cloneDeep(formData);
+      const vetTecPrograms = clonedData.vetTecPrograms.map(program => {
+        let location = undefined;
+
+        if (program.locationCity && program.locationState) {
+          location = {
+            city: program.locationCity,
+            state: program.locationState,
+          };
+        }
+
+        return {
+          providerName: program.providerName,
+          programName: program.programName,
+          courseType: program.courseType,
+          plannedStartDate: program.plannedStartDate,
+          location,
+        };
+      });
+
+      return {
+        ...clonedData,
+        vetTecPrograms,
+      };
+    }
+    return formData;
+  };
   const tranformedData = [
     usFormTransform,
     removePrefillBankAccount,
     addPhoneAndEmail,
     transformHighTechnologyEmploymentType,
+    transformProgramSelection,
   ].reduce((formData, transformer) => transformer(formData), form.data);
 
   return JSON.stringify({

--- a/src/applications/edu-benefits/tests/0994/schema/maximal-test.json
+++ b/src/applications/edu-benefits/tests/0994/schema/maximal-test.json
@@ -35,10 +35,14 @@
         "programName": "AWS Media Services",
         "courseType": "inPerson",
         "plannedStartDate": "2010-01-02",
-        "location": {
-          "city": "Nowhere",
-          "state": "SC"
-        }
+        "locationCity": "Nowhere",
+        "locationState": "SC"
+      },
+      {
+        "providerName": "Amazon Web Services",
+        "programName": "AWS Media Services",
+        "courseType": "online",
+        "plannedStartDate": "2010-01-02"
       }
     ],
     "view:trainingProgramsChoice": true,

--- a/src/applications/edu-benefits/tests/0994/schema/transformedData.js
+++ b/src/applications/edu-benefits/tests/0994/schema/transformedData.js
@@ -58,6 +58,12 @@ const transformedMaximalDataActual = {
         state: 'SC',
       },
     },
+    {
+      providerName: 'Amazon Web Services',
+      programName: 'AWS Media Services',
+      courseType: 'online',
+      plannedStartDate: '2010-01-02',
+    },
   ],
   currentHighTechnologyEmployment: false,
   pastHighTechnologyEmployment: true,


### PR DESCRIPTION
## Description

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/16747

On bah-0994-schema-changes, the City and State fields are appearing as expected and have "required" next to them, but if the fields are left blank, the user can enter a start date, click continue and go on to the next page. If the "in-person" or "online and in-person" radio is selected and no information is entered, the "please provide a response" message shows for the start date field, but not City or State.

## Testing done
- [x] local testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
