### PR TITLE
omit address from query type

### DIFF
--- a/src/applications/facility-locator/actions/index.js
+++ b/src/applications/facility-locator/actions/index.js
@@ -184,7 +184,7 @@ export const genBBoxFromAddress = (query) => {
     dispatch({ type: SEARCH_STARTED });
 
     // commas can be stripped from query if Mapbox is returning unexpected results
-    let types = 'place,address,region,postcode,locality';
+    let types = 'place,region,postcode,locality';
     // check for postcode search
     if (query.searchString.match(/^\s*\d{5}\s*$/)) {
       types = 'postcode';


### PR DESCRIPTION
## Description
- mapbox occasionally prioritizes highly relevant street names over cities 
- removing address from the query type removes street addresses from the search results

## Testing done
verified locally following the instructions in the original ticket 

## Screenshots
(for some reason the app doesn't display the results on the map when running locally)
![screen shot 2019-02-12 at 16 01 53](https://user-images.githubusercontent.com/4998130/52674020-91c98a80-2edf-11e9-891d-cc5bc2434929.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
