### PR TITLE
[VET TEC]Add conditional language to 0994 confirmation page

### DIFF
--- a/src/applications/edu-benefits/0994/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/0994/containers/ConfirmationPage.jsx
@@ -96,9 +96,9 @@ class ConfirmationPage extends React.Component {
         {!_.get(form.data, 'appliedForVaEducationBenefits', true) && (
           <div>
             <p>
-              Since you haven’t submitted an Application for VA Education
-              Benefits (VA Form 22-1990) before, you should do that now. We need
-              that information to determine your eligibility for VET TEC.
+              We’ll also need you to complete the Application for VA Education
+              Benefits (VA Form 22-1990) to determine your eligibility for VET
+              TEC. We recommend you do that now.
             </p>
             <div className="row form-progress-buttons">
               <div className="small-6 usa-width-one-half medium-6 columns">

--- a/src/applications/edu-benefits/0994/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/0994/containers/ConfirmationPage.jsx
@@ -94,13 +94,20 @@ class ConfirmationPage extends React.Component {
           </ul>
         </div>
         {!_.get(form.data, 'appliedForVaEducationBenefits', true) && (
-          <div className="row form-progress-buttons">
-            <div className="small-6 usa-width-one-half medium-6 columns">
-              <a href={url1990}>
-                <button className="usa-button-primary">
-                  Continue to VA Form 22-1990
-                </button>
-              </a>
+          <div>
+            <p>
+              Since you haven’t submitted an Application for VA Education
+              Benefits (VA Form 22-1990) before, you should do that now. We need
+              that information to determine your eligibility for VET TEC.
+            </p>
+            <div className="row form-progress-buttons">
+              <div className="small-6 usa-width-one-half medium-6 columns">
+                <a href={url1990}>
+                  <button className="usa-button-primary">
+                    Continue to VA Form 22-1990
+                  </button>
+                </a>
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Description
Added additional language to the 0994 confirmation page that is displayed along with the existing 1990 apply button

## Testing done
Tested locally

## Screenshots
<img width="843" alt="screen shot 2019-02-13 at 11 48 16 am" src="https://user-images.githubusercontent.com/41960449/52728567-85980880-2f85-11e9-9e70-347748c48c10.png">


## Acceptance criteria
- [x] The confirmation page is updated to include the following text: Since you haven't submitted an Application for VA Education Benefits (VA Form 22-1990) before, you should do that now. We need that information to determine your eligibility for VET TEC.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
