### PR TITLE
Ignore security advisory temporarily

### DIFF
--- a/script/security-check.js
+++ b/script/security-check.js
@@ -11,6 +11,7 @@ const packageJSON = require('../package.json');
 const exceptionSet = new Set([
   'https://npmjs.com/advisories/577',
   'https://npmjs.com/advisories/157',
+  'https://npmjs.com/advisories/782',
 ]);
 
 const severitySet = new Set(['high', 'critical', 'moderate']);


### PR DESCRIPTION
## Description

There's a new security advisory out for Lodash, which will require several of our dependencies to update. In the interim, we're going to ignore this advisory, so builds can continue.

## Testing done
Ran security check locally

## Acceptance criteria
- [x] Security check passes

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
