### PR TITLE
Fix login action, prevent logged-in users from seeing id-introduction

### DIFF
--- a/src/applications/hca/containers/IDPage.jsx
+++ b/src/applications/hca/containers/IDPage.jsx
@@ -26,70 +26,67 @@ class IDPage extends React.Component {
     }
   }
 
-  getContent = () => {
-    if (this.props.isProfileLoading) {
-      return <LoadingIndicator />;
-    }
-    return (
-      <React.Fragment>
-        <AlertBox
-          isVisible
-          status="info"
-          headline="Help us fit this application to your specific needs"
-          content={
-            <React.Fragment>
-              <p>
-                Before you start your health care application, please provide
-                the information below. This will help us make sure the
-                application gathers the right information for us to determine
-                your eligibility.
-              </p>
-              <p>
-                <strong>Want to skip this step?</strong>
-              </p>
-              <button
-                className="va-button-link"
-                onClick={() => this.props.toggleLoginModal(true)}
-              >
-                Sign in to start your application.
-              </button>
-            </React.Fragment>
-          }
-        />
-        <br />
-        <IDForm
-          isLoading={this.props.isLoading}
-          handleSubmit={this.props.submitForm}
-        />
-        {this.props.error && (
-          <AlertBox
-            isVisible
-            status="error"
-            headline="Please sign in to continue your application"
-            content={
-              <React.Fragment>
-                <p>
-                  We’re sorry for the interruption, but we need you to review
-                  some information before you continue applying. Please sign in
-                  below to review. If you don’t have an account, you can create
-                  one now.
-                </p>
-                <button className="usa-button-primary" onClick={this.goToLogin}>
-                  Sign in to VA.gov
-                </button>
-              </React.Fragment>
-            }
-          />
-        )}
-      </React.Fragment>
-    );
-  };
-
   render() {
     return (
       <div className="schemaform-intro">
         <FormTitle title="Apply for health care benefits" />
-        {this.getContent()}
+        {this.props.isProfileLoading && <LoadingIndicator />}
+        {!this.props.isProfileLoading && (
+          <React.Fragment>
+            <AlertBox
+              isVisible
+              status="info"
+              headline="Help us fit this application to your specific needs"
+              content={
+                <React.Fragment>
+                  <p>
+                    Before you start your health care application, please
+                    provide the information below. This will help us make sure
+                    the application gathers the right information for us to
+                    determine your eligibility.
+                  </p>
+                  <p>
+                    <strong>Want to skip this step?</strong>
+                  </p>
+                  <button
+                    className="va-button-link"
+                    onClick={() => this.props.toggleLoginModal(true)}
+                  >
+                    Sign in to start your application.
+                  </button>
+                </React.Fragment>
+              }
+            />
+            <br />
+            <IDForm
+              isLoading={this.props.isLoading}
+              handleSubmit={this.props.submitForm}
+            />
+            {this.props.error && (
+              <AlertBox
+                isVisible
+                status="error"
+                headline="Please sign in to continue your application"
+                content={
+                  <React.Fragment>
+                    <p>
+                      We’re sorry for the interruption, but we need you to
+                      review some information before you continue applying.
+                      Please sign in below to review. If you don’t have an
+                      account, you can create one now.
+                    </p>
+                    <button
+                      className="usa-button-primary"
+                      onClick={this.goToLogin}
+                    >
+                      Sign in to VA.gov
+                    </button>
+                  </React.Fragment>
+                }
+              />
+            )}
+          </React.Fragment>
+        )}
         <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
           <OMBInfo resBurden={30} ombNumber="2900-0091" expDate="05/31/2018" />
         </div>

--- a/src/applications/hca/containers/IDPage.jsx
+++ b/src/applications/hca/containers/IDPage.jsx
@@ -4,8 +4,11 @@ import { connect } from 'react-redux';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'us-forms-system/lib/js/components/FormTitle';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
 import { focusElement } from 'platform/utilities/ui';
+import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
+import { isProfileLoading, isLoggedIn } from 'platform/user/selectors';
 
 import IDForm from '../components/IDForm';
 
@@ -16,10 +19,19 @@ class IDPage extends React.Component {
     focusElement('.va-nav-breadcrumbs-list');
   }
 
-  render() {
+  componentDidUpdate(prevProps) {
+    // there's no need for logged-in users to see this page
+    if (!prevProps.isLoggedIn && this.props.isLoggedIn) {
+      this.props.router.push('/');
+    }
+  }
+
+  getContent = () => {
+    if (this.props.isProfileLoading) {
+      return <LoadingIndicator />;
+    }
     return (
-      <div className="schemaform-intro">
-        <FormTitle title="Apply for health care benefits" />
+      <React.Fragment>
         <AlertBox
           isVisible
           status="info"
@@ -35,12 +47,16 @@ class IDPage extends React.Component {
               <p>
                 <strong>Want to skip this step?</strong>
               </p>
-              <button className="va-button-link" onClick={this.goToLogin}>
+              <button
+                className="va-button-link"
+                onClick={() => this.props.toggleLoginModal(true)}
+              >
                 Sign in to start your application.
               </button>
             </React.Fragment>
           }
         />
+        <br />
         <IDForm
           isLoading={this.props.isLoading}
           handleSubmit={this.props.submitForm}
@@ -65,6 +81,15 @@ class IDPage extends React.Component {
             }
           />
         )}
+      </React.Fragment>
+    );
+  };
+
+  render() {
+    return (
+      <div className="schemaform-intro">
+        <FormTitle title="Apply for health care benefits" />
+        {this.getContent()}
         <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
           <OMBInfo resBurden={30} ombNumber="2900-0091" expDate="05/31/2018" />
         </div>
@@ -75,11 +100,14 @@ class IDPage extends React.Component {
 
 const mapDispatchToProps = {
   submitForm: submitIDForm,
+  toggleLoginModal,
 };
 
 const mapStateToProps = state => ({
   isLoading: state.hcaIDForm.isLoading,
   error: state.hcaIDForm.error,
+  isProfileLoading: isProfileLoading(state),
+  isLoggedIn: isLoggedIn(state),
 });
 
 export default connect(


### PR DESCRIPTION
## Description
- The login link was previously wired up to a non-existent function. It now actually works.
- The `id-introduction` route will now only be shown to users who are not logged in, as it should be. The gating is handled by a redirect based on the user's logged in status.

The following use case is also handled now:
1. User is logged out and viewing the `id-introduction` with the IDForm
2. They log in
3. After logging in they are redirected back to the `id-introduction` route (there doesn't seem to be a way to change which page they are directed to after logging in)
4. The component will _then_ redirect them to the standard `introduction` route for the HCA form.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs