### PR TITLE
Feature/16722: Facility Page does not render

### DIFF
--- a/src/applications/facility-locator/api/MockLocatorApi.js
+++ b/src/applications/facility-locator/api/MockLocatorApi.js
@@ -157,6 +157,93 @@ export const facilityData = {
       },
     },
     {
+      id: 'vha_438GE',
+      type: 'va_facilities',
+      attributes: {
+        uniqueId: '438GE',
+        name: 'Wagner VA Clinic',
+        facilityType: 'va_health_facility',
+        classification: 'Other Outpatient Services (OOS)',
+        website: 'http://www.siouxfalls.va.gov/locations/wagner.asp',
+        lat: 43.0818390000001,
+        long: -98.297446,
+        address: {
+          mailing: {},
+          physical: {
+            zip: '57380-9369',
+            city: 'Wagner',
+            state: 'SD',
+            address1: '400 West South Dakota Highway 46',
+            address2: null,
+            address3: null,
+          },
+        },
+        phone: {
+          fax: '605-384-2345 x',
+          main: '605-384-2340 x',
+          pharmacy: '800-316-8387 x',
+          afterHours: '605-336-3230 x',
+          patientAdvocate: '605-336-3230 x6688',
+          mentalHealthClinic: '',
+          enrollmentCoordinator: '605-373-4196 x',
+        },
+        hours: {
+          monday: '800AM-430PM',
+          tuesday: '800AM-430PM',
+          wednesday: '800AM-1200PM',
+          thursday: '800AM-430PM',
+          friday: '00AM-30PM',
+          saturday: '-',
+          sunday: '-',
+        },
+        services: {
+          other: ['Online Scheduling'],
+          health: [
+            {
+              sl1: ['PrimaryCare'],
+              sl2: [],
+            },
+            {
+              sl1: ['Audiology'],
+              sl2: [],
+            },
+            {
+              sl1: ['Orthopedics'],
+              sl2: [],
+            },
+          ],
+          lastUpdated: '2019-02-12',
+        },
+        feedback: {
+          health: {
+            effectiveDate: '2018-05-22',
+            primaryCareRoutine: 0.94,
+          },
+        },
+        access: {
+          health: {
+            audiology: {
+              new: null,
+              established: 0,
+            },
+            orthopedics: {
+              new: null,
+              established: 0,
+            },
+            primaryCare: {
+              new: 20,
+              established: 7,
+            },
+            mentalHealth: {
+              new: null,
+              established: 5,
+            },
+            effectiveDate: '2019-02-04',
+          },
+        },
+      },
+    },
+    {
       id: 'vha_691GE',
       type: 'va_facilities',
       attributes: {

--- a/src/applications/facility-locator/components/LocationHours.jsx
+++ b/src/applications/facility-locator/components/LocationHours.jsx
@@ -7,6 +7,11 @@ import React, { Component } from 'react';
 export default class LocationHours extends Component {
   colonizeTime(time) {
     const found = time.match(/(\d?\d)(\d\d)(\w\w)/);
+
+    if (!found) {
+      return '0:00AM';
+    }
+
     return `${found[1]}:${found[2]}${found[3]}`;
   }
 

--- a/src/platform/site-wide/user-nav/selectors.js
+++ b/src/platform/site-wide/user-nav/selectors.js
@@ -19,12 +19,15 @@ export const selectUserGreeting = createSelector(
     }
 
     return [
-      <span key="show-for-small-only" className="show-for-small-only">
+      <span
+        key="show-for-small-only"
+        className="small-screen:vads-u-visibility--visible medium-screen:vads-u-display--none"
+      >
         My Account
       </span>,
       <span
         key="show-for-medium-up"
-        className="user-dropdown-email show-for-medium-up"
+        className="user-dropdown-email medium-screen:vads-u-visibility--visible"
       >
         {email}
       </span>,


### PR DESCRIPTION
## Description
Facility Page does not render

Repro:
1/ Go to VA.gov -> Find a Location
2/ Type in "Wagner, SD", select "VA Health", click Search
3/ In the results list click "Wagner, SD VA Clinic"
--> The page renders with header and footer but no body content.
--> https://www.va.gov/find-locations/facility/vha_438GE

According to @ayaleloehr the API is returning complete, valid results. So this appears to be a bug in the tool itself.

## Testing done
Manual

## Screenshots
<img width="339" alt="screen shot 2019-02-14 at 4 55 17 am" src="https://user-images.githubusercontent.com/5377648/52788921-4a461a00-3017-11e9-9b0e-cd68ce0b4591.png">

## Acceptance criteria
- [ ] Page should render

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
