### PR TITLE
Update React widgets to trigger off widget-type instead of url

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/createDisabilityIncreaseApplicationStatus.jsx
+++ b/src/applications/disability-benefits/526EZ/components/createDisabilityIncreaseApplicationStatus.jsx
@@ -4,8 +4,11 @@ import { Provider } from 'react-redux';
 
 const disabilityForms = new Set(['21-526EZ']);
 
-export default function createDisabilityIncreaseApplicationStatus(store) {
-  const root = document.getElementById('react-applicationStatus');
+export default function createDisabilityIncreaseApplicationStatus(
+  store,
+  widgetType,
+) {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
     import(/* webpackChunkName: "disability-application-status" */
     '../disabilityIncreaseEntry').then(module => {

--- a/src/applications/edu-benefits/components/createEducationApplicationStatus.jsx
+++ b/src/applications/edu-benefits/components/createEducationApplicationStatus.jsx
@@ -12,8 +12,8 @@ const eduForms = new Set([
   '22-1990N',
 ]);
 
-export default function createEducationApplicationStatus(store) {
-  const root = document.getElementById('react-applicationStatus');
+export default function createEducationApplicationStatus(store, widgetType) {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
     import(/* webpackChunkName: "education-application-status" */
     '../utils/educationStatus').then(module => {

--- a/src/applications/edu-benefits/components/createOptOutApplicationStatus.jsx
+++ b/src/applications/edu-benefits/components/createOptOutApplicationStatus.jsx
@@ -4,8 +4,8 @@ import { Provider } from 'react-redux';
 
 const eduForms = new Set(['22-0993']);
 
-export default function createOptOutApplicationStatus(store) {
-  const root = document.getElementById('react-applicationStatus');
+export default function createOptOutApplicationStatus(store, widgetType) {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
     import(/* webpackChunkName: "opt-out-application-status" */ '../utils/optOutStatus.js').then(
       module => {

--- a/src/applications/static-pages/createApplicationStatus.js
+++ b/src/applications/static-pages/createApplicationStatus.js
@@ -3,7 +3,9 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
 export default function createApplicationStatus(store, form) {
-  const root = document.getElementById('react-applicationStatus');
+  const root = document.querySelector(
+    `[data-widget-type="${form.widgetType}"]`,
+  );
   if (root) {
     import(/* webpackChunkName: "application-status" */
     '../../platform/forms/save-in-progress/ApplicationStatus').then(module => {

--- a/src/applications/static-pages/createCallToActionWidget.js
+++ b/src/applications/static-pages/createCallToActionWidget.js
@@ -2,8 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
-export default async function createCallToActionWidget(store) {
-  const widgets = Array.from(document.querySelectorAll('.cta-widget'));
+export default async function createCallToActionWidget(store, widgetType) {
+  const widgets = Array.from(
+    document.querySelectorAll(`[data-widget-type="${widgetType}"]`),
+  );
 
   if (widgets.length) {
     const {

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -66,7 +66,7 @@ createApplicationStatus(store, {
   applyHeading: 'How do I apply?',
   additionalText: 'You can apply online right now.',
   applyText: 'Apply for Burial Benefits',
-  widgetType: widgetTypes.BURIAL_APP_STATUS,
+  widgetType: widgetTypes.BURIALS_APP_STATUS,
 });
 
 createDisabilityIncreaseApplicationStatus(

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -37,80 +37,42 @@ Raven.context(
 
 createAdditionalInfoWidget();
 
-if (
-  document.querySelector(
-    `[data-widget-type="${widgetTypes.PENSION_APP_STATUS}"]`,
-  )
-) {
-  createApplicationStatus(store, {
-    formId: '21P-527EZ',
-    applyHeading: 'How do I apply?',
-    additionalText: 'You can apply online right now.',
-    applyLink: '/pension/how-to-apply/',
-    applyText: 'Apply for Veterans Pension Benefits',
-    widgetType: widgetTypes.PENSION_APP_STATUS,
-  });
-}
+createApplicationStatus(store, {
+  formId: '21P-527EZ',
+  applyHeading: 'How do I apply?',
+  additionalText: 'You can apply online right now.',
+  applyLink: '/pension/how-to-apply/',
+  applyText: 'Apply for Veterans Pension Benefits',
+  widgetType: widgetTypes.PENSION_APP_STATUS,
+});
 
-if (
-  document.querySelector(
-    `[data-widget-type="${widgetTypes.HEALTH_CARE_APP_STATUS}"]`,
-  )
-) {
-  createApplicationStatus(store, {
-    formId: '1010ez',
-    applyHeading: 'How do I apply?',
-    additionalText: 'You can apply online right now.',
-    applyLink: '/health-care/how-to-apply/',
-    applyText: 'Apply for Health Care Benefits',
-    widgetType: widgetTypes.HEALTH_CARE_APP_STATUS,
-  });
-}
+createApplicationStatus(store, {
+  formId: '1010ez',
+  applyHeading: 'How do I apply?',
+  additionalText: 'You can apply online right now.',
+  applyLink: '/health-care/how-to-apply/',
+  applyText: 'Apply for Health Care Benefits',
+  widgetType: widgetTypes.HEALTH_CARE_APP_STATUS,
+});
 
-if (document.querySelector(`[data-widget-type="${widgetTypes.CTA}"]`)) {
-  createCallToActionWidget(store, widgetTypes.CTA);
-}
+createCallToActionWidget(store, widgetTypes.CTA);
 
-if (
-  document.querySelector(
-    `[data-widget-type="${widgetTypes.EDUCATION_APP_STATUS}"]`,
-  )
-) {
-  createEducationApplicationStatus(store, widgetTypes.EDUCATION_APP_STATUS);
-}
+createEducationApplicationStatus(store, widgetTypes.EDUCATION_APP_STATUS);
 
-if (
-  document.querySelector(
-    `[data-widget-type="${widgetTypes.OPT_OUT_APP_STATUS}"]`,
-  )
-) {
-  createOptOutApplicationStatus(store, widgetTypes.OPT_OUT_APP_STATUS);
-}
+createOptOutApplicationStatus(store, widgetTypes.OPT_OUT_APP_STATUS);
 
-if (
-  document.querySelector(
-    `[data-widget-type="${widgetTypes.BURIAL_APP_STATUS}"]`,
-  )
-) {
-  createApplicationStatus(store, {
-    formId: '21P-530',
-    applyHeading: 'How do I apply?',
-    additionalText: 'You can apply online right now.',
-    applyText: 'Apply for Burial Benefits',
-    widgetType: widgetTypes.BURIAL_APP_STATUS,
-  });
-}
+createApplicationStatus(store, {
+  formId: '21P-530',
+  applyHeading: 'How do I apply?',
+  additionalText: 'You can apply online right now.',
+  applyText: 'Apply for Burial Benefits',
+  widgetType: widgetTypes.BURIAL_APP_STATUS,
+});
 
-if (
-  document.querySelector(
-    `[data-widget-type="${widgetTypes.DISABILITY_APP_STATUS}"]`,
-  )
-) {
-  createDisabilityIncreaseApplicationStatus(
-    store,
-    widgetTypes.DISABILITY_APP_STATUS,
-  );
-}
+createDisabilityIncreaseApplicationStatus(
+  store,
+  widgetTypes.DISABILITY_APP_STATUS,
+);
 
 // homepage widgets
 if (location.pathname === '/') {

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -5,6 +5,7 @@ import Raven from 'raven-js';
 import createCommonStore from '../../platform/startup/store';
 import startSitewideComponents from '../../platform/site-wide';
 
+import widgetTypes from './widgetTypes';
 import createAdditionalInfoWidget from './createAdditionalInfoWidget';
 import createApplicationStatus from './createApplicationStatus';
 import createCallToActionWidget from './createCallToActionWidget';
@@ -12,49 +13,6 @@ import createMyVALoginWidget from './createMyVALoginWidget';
 import createDisabilityIncreaseApplicationStatus from '../disability-benefits/526EZ/components/createDisabilityIncreaseApplicationStatus';
 import createEducationApplicationStatus from '../edu-benefits/components/createEducationApplicationStatus';
 import createOptOutApplicationStatus from '../edu-benefits/components/createOptOutApplicationStatus';
-import create526EmailForm from '../disability-benefits/526EZ/components/create526EmailForm';
-
-const pensionPages = new Set([
-  '/pension/',
-  '/pension/how-to-apply/',
-  '/pension/eligibility/',
-]);
-
-const healthcarePages = new Set([
-  '/health-care/',
-  '/health-care/how-to-apply/',
-  '/health-care/eligibility/',
-]);
-
-const ctaTools = new Set([
-  '/claim-or-appeal-status/',
-  '/health-care/get-medical-records/',
-  '/health-care/refill-track-prescriptions/',
-  '/health-care/secure-messaging/',
-  '/health-care/schedule-view-va-appointments/',
-  '/health-care/view-test-and-lab-results/',
-  '/records/download-va-letters/',
-  '/records/get-veteran-id-cards/vic/',
-]);
-
-const burialPages = new Set([
-  '/burials-memorials/',
-  '/burials-memorials/veterans-burial-allowance/',
-]);
-
-const eduPages = new Set([
-  '/education/',
-  '/education/eligibility/',
-  '/education/how-to-apply/',
-]);
-
-const eduOptOutPage = '/education/opt-out-information-sharing/';
-
-const disabilityPages = new Set([
-  '/disability/',
-  '/disability/how-to-file-claim/',
-  '/disability/eligibility/',
-]);
 
 // No-react styles.
 import './sass/static-pages.scss';
@@ -79,55 +37,79 @@ Raven.context(
 
 createAdditionalInfoWidget();
 
-if (pensionPages.has(location.pathname)) {
+if (
+  document.querySelector(
+    `[data-widget-type="${widgetTypes.PENSION_APP_STATUS}"]`,
+  )
+) {
   createApplicationStatus(store, {
     formId: '21P-527EZ',
     applyHeading: 'How do I apply?',
     additionalText: 'You can apply online right now.',
     applyLink: '/pension/how-to-apply/',
     applyText: 'Apply for Veterans Pension Benefits',
+    widgetType: widgetTypes.PENSION_APP_STATUS,
   });
 }
 
-if (healthcarePages.has(location.pathname)) {
+if (
+  document.querySelector(
+    `[data-widget-type="${widgetTypes.HEALTH_CARE_APP_STATUS}"]`,
+  )
+) {
   createApplicationStatus(store, {
     formId: '1010ez',
     applyHeading: 'How do I apply?',
     additionalText: 'You can apply online right now.',
     applyLink: '/health-care/how-to-apply/',
     applyText: 'Apply for Health Care Benefits',
+    widgetType: widgetTypes.HEALTH_CARE_APP_STATUS,
   });
 }
 
-if (ctaTools.has(location.pathname)) {
-  createCallToActionWidget(store);
+if (document.querySelector(`[data-widget-type="${widgetTypes.CTA}"]`)) {
+  createCallToActionWidget(store, widgetTypes.CTA);
 }
 
-if (eduPages.has(location.pathname)) {
-  createEducationApplicationStatus(store);
+if (
+  document.querySelector(
+    `[data-widget-type="${widgetTypes.EDUCATION_APP_STATUS}"]`,
+  )
+) {
+  createEducationApplicationStatus(store, widgetTypes.EDUCATION_APP_STATUS);
 }
 
-if (location.pathname === eduOptOutPage) {
-  createOptOutApplicationStatus(store);
+if (
+  document.querySelector(
+    `[data-widget-type="${widgetTypes.OPT_OUT_APP_STATUS}"]`,
+  )
+) {
+  createOptOutApplicationStatus(store, widgetTypes.OPT_OUT_APP_STATUS);
 }
 
-if (burialPages.has(location.pathname)) {
+if (
+  document.querySelector(
+    `[data-widget-type="${widgetTypes.BURIAL_APP_STATUS}"]`,
+  )
+) {
   createApplicationStatus(store, {
     formId: '21P-530',
     applyHeading: 'How do I apply?',
     additionalText: 'You can apply online right now.',
     applyText: 'Apply for Burial Benefits',
+    widgetType: widgetTypes.BURIAL_APP_STATUS,
   });
 }
 
-if (disabilityPages.has(location.pathname)) {
-  createDisabilityIncreaseApplicationStatus(store);
-}
-
 if (
-  location.pathname === '/disability-benefits/apply/form-526-disability-claim/'
+  document.querySelector(
+    `[data-widget-type="${widgetTypes.DISABILITY_APP_STATUS}"]`,
+  )
 ) {
-  create526EmailForm(store);
+  createDisabilityIncreaseApplicationStatus(
+    store,
+    widgetTypes.DISABILITY_APP_STATUS,
+  );
 }
 
 // homepage widgets

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -3,7 +3,7 @@ export default {
   EDUCATION_APP_STATUS: 'education-app-status',
   HEALTH_CARE_APP_STATUS: 'health-care-app-status',
   PENSION_APP_STATUS: 'pension-app-status',
-  BURIAL_APP_STATUS: 'burial-app-status',
+  BURIALS_APP_STATUS: 'burials-app-status',
   OPT_OUT_APP_STATUS: 'opt-out-app-status',
   DISABILITY_APP_STATUS: 'disability-app-status',
 };

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -1,0 +1,9 @@
+export default {
+  CTA: 'cta',
+  EDUCATION_APP_STATUS: 'education-app-status',
+  HEALTH_CARE_APP_STATUS: 'health-care-app-status',
+  PENSION_APP_STATUS: 'pension-app-status',
+  BURIAL_APP_STATUS: 'burial-app-status',
+  OPT_OUT_APP_STATUS: 'opt-out-app-status',
+  DISABILITY_APP_STATUS: 'disability-app-status',
+};

--- a/src/site/paragraphs/react_widget.drupal.liquid
+++ b/src/site/paragraphs/react_widget.drupal.liquid
@@ -31,7 +31,7 @@
 {% endcomment %}
 
   {% if entity.fieldCtaWidget %}
-      <div class="cta-widget" data-app-id="{{ entity.fieldWidgetType }}"></div>
+      <div class="cta-widget" data-widget-type="cta" data-app-id="{{ entity.fieldWidgetType }}"></div>
   {% else %}
       <div id="{{ reactRoot }}" class="static-page-widget" data-widget-type={{ entity.fieldWidgetType }}>
         {% if entity.fieldDefaultLink != empty %}


### PR DESCRIPTION
## Description
With the move to Drupal, we'll want to be more flexible in how React widgets on static pages are linked to the React code. Hardcoding urls isn't a good path forward, since we won't have much visibility into how those change. Instead, we should trigger these widgets by the existence of elements with a `data-widget-type` attribute. This should let us be more flexible in linking Drupal paragraph types to our widget code.

Related content changes: https://github.com/department-of-veterans-affairs/vagov-content/pull/266

## Testing done
Tested existing widgets locally

## Acceptance criteria
- [ ] Existing widgets still work properly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
