### PR TITLE
update redirect for decision-ready-claims deprecation

### DIFF
--- a/src/applications/proxy-rewrite/redirects/disabilityRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/disabilityRedirects.json
@@ -162,7 +162,7 @@
   {
     "domain": "www.benefits.va.gov",
     "src": "/compensation/drc.asp",
-    "dest": "/disability/how-to-file-claim/evidence-needed/decision-ready-claims/"
+    "dest": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims/"
   },
   {
     "domain": "www.benefits.va.gov",

--- a/src/applications/proxy-rewrite/redirects/otherDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/otherDomainRedirects.json
@@ -272,7 +272,7 @@
   {
     "domain": "www.benefits.va.gov",
     "src": "/compensation/drc.asp",
-    "dest": "/disability/how-to-file-claim/evidence-needed/decision-ready-claims/"
+    "dest": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims/"
   },
   {
     "domain": "www.benefits.va.gov",


### PR DESCRIPTION
## Description

Update redirect for decision-ready-claims deprecation.

Requested in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16798

HOLD until the ticket has been approved to go forward, expected on Friday Feb 15.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
