### PR TITLE
Update Facility Locator Breadcrumb

### DIFF
--- a/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
+++ b/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
@@ -37,7 +37,7 @@ class FacilityLocatorApp extends React.Component {
         Home
       </a>,
       <Link to={appendQuery('/', searchQueryObj)} key="facility-locator">
-        Find Facilities & Services
+        Find Locations
       </Link>,
     ];
 

--- a/src/applications/facility-locator/tests/02-breadcrumbs.e2e.spec.js
+++ b/src/applications/facility-locator/tests/02-breadcrumbs.e2e.spec.js
@@ -22,7 +22,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .element(
       '.va-nav-breadcrumbs-list li:nth-of-type(2) a[aria-current="page"]',
     )
-    .text.to.equal('Find Facilities & Services');
+    .text.to.equal('Find Locations');
 
   client.expect
     .element(


### PR DESCRIPTION
## Description
This PR is an update to the Facility Locator Breadcrumb. 

The `url` and `<h1>` were updated to for the web brand consolidation launch and this fix is to reflect those changes according to this ticket: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15489

I changed  the second segment of the breadcrumb from:
`Home > Find Facilities & Services` to `Home > Find Locations` 
in `/src/applications/facility-locator/containers/FacilityLocatorApp.jsx`

## Testing done
View changes on local build

## Screenshots
*Breadcrumb Before*
![screen shot 2019-02-15 at 4 00 50 pm](https://user-images.githubusercontent.com/11021491/52884605-6b545b00-313c-11e9-8ca4-5af8b97473f0.png)

*Breadcrumb After* 
![screen shot 2019-02-15 at 4 00 40 pm](https://user-images.githubusercontent.com/11021491/52884568-51b31380-313c-11e9-809d-62ea22d41ce0.png)

## Acceptance criteria
- [X] second segement of breadcrumb displays `Find Locations`

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
