### PR TITLE
VAGOV-1610 add Spanish Summary Paragraph to Benefit pages

### DIFF
--- a/src/site/paragraphs/spanish_translation_summary.drupal.liquid
+++ b/src/site/paragraphs/spanish_translation_summary.drupal.liquid
@@ -1,0 +1,21 @@
+{% comment %}
+  Example data:
+  "entity": {
+    "entityType": "paragraph",
+    "entityBundle": "spanish_translation_summary",
+    "entityId": "937",
+    "fieldWysiwyg": {
+      "processed": "..."
+    },
+    "fieldTextExpander": "Obtenga instrucciones para esta solicitud en Español. "
+  }
+{% endcomment %}
+
+<div class="form-expanding-group additional-info-container">
+  <span class="additional-info-title">{{ entity.fieldTextExpander }}</span>
+    <span id="spanishhelptext-{{ entity.entityId }}">
+      <div class="additional-info-content">
+        {{ entity.fieldWysiwyg.processed }}
+      </div>
+    </span>
+</div>

--- a/src/site/stages/build/drupal/graphql/fragments.graphql.js
+++ b/src/site/stages/build/drupal/graphql/fragments.graphql.js
@@ -11,6 +11,7 @@ const { promo } = require('./block-fragments/promo.block.graphql');
 const linkTeaser = require('./paragraph-fragments/linkTeaser.paragraph.graphql');
 const administration = require('./taxonomy-fragments/administration.taxonomy.graphql');
 const reactWidget = require('./paragraph-fragments/reactWidget.paragraph.graphql');
+const spanishSummary = require('./paragraph-fragments/spanishSummary.paragraph.graphql');
 
 module.exports = `
   ${alert}
@@ -24,4 +25,5 @@ module.exports = `
   ${wysiwyg}
   ${administration}
   ${reactWidget}
+  ${spanishSummary}
 `;

--- a/src/site/stages/build/drupal/graphql/page.graphql.js
+++ b/src/site/stages/build/drupal/graphql/page.graphql.js
@@ -2,18 +2,18 @@ const { FIELD_ALERT } = require('./block-fragments/alert.block.graphql');
 const {
   FIELD_RELATED_LINKS,
 } = require('./paragraph-fragments/listOfLinkTeasers.paragraph.graphql');
-
 /**
  * A standard content page, that is ordinarily two-levels deep (a child page of a landingPage)
  * For example, /health-care/apply.
  */
 
-const WYSIWYG = '...wysiwyg';
+const WYSIWYG = '... wysiwyg';
 const COLLAPSIBLE_PANEL = '... collapsiblePanel';
 const PROCESS = '... process';
 const QA_SECTION = '... qaSection';
 const LIST_OF_LINK_TEASERS = '... listOfLinkTeasers';
 const REACT_WIDGET = '... reactWidget';
+const SPANISH_SUMMARY = '... spanishSummary';
 
 module.exports = `
 
@@ -54,6 +54,7 @@ module.exports = `
         ${QA_SECTION}
         ${LIST_OF_LINK_TEASERS}
         ${REACT_WIDGET} 
+        ${SPANISH_SUMMARY}
       }
     }
     ${FIELD_ALERT} 

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/spanishSummary.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/spanishSummary.paragraph.graphql.js
@@ -1,0 +1,13 @@
+/**
+ * A Drupal paragraph containing rich text.
+ *
+ */
+module.exports = `
+  fragment spanishSummary on ParagraphSpanishTranslationSummary {
+    entityId
+    fieldWysiwyg {
+      processed
+    }
+    fieldTextExpander
+  }
+`;

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/spanishSummary.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/spanishSummary.paragraph.graphql.js
@@ -1,5 +1,5 @@
 /**
- * A Drupal paragraph containing rich text.
+ * The 'Spanish summary' bundle of the 'Paragraph' entity type.
  *
  */
 module.exports = `


### PR DESCRIPTION
## Description
Spanish Summaries Paragraphs can be part of a Benefits Page Node.

## Testing done
Locally with dev data

## Screenshots
![screen shot 2019-02-15 at 3 39 23 pm](https://user-images.githubusercontent.com/19178435/52890124-e8310600-3137-11e9-8dbc-ae530a6b4003.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
