### PR TITLE
Download referenced assets from Drupal

### DIFF
--- a/script/preview.js
+++ b/script/preview.js
@@ -61,6 +61,7 @@ app.get('/preview', async (req, res) => {
     [`${req.path.substring(1)}/index.html`]: {
       ...drupalPage,
       isPreview: true,
+      isDrupalPage: true,
       drupalSite: drupalClient.getSiteUri(),
       layout: `${drupalPage.entityBundle}.drupal.liquid`,
       contents: Buffer.from('<!-- Drupal-provided data -->'),

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -70,6 +70,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
 
     files[`drupal${drupalPagePath}/index.html`] = {
       ...page,
+      isDrupalPage: true,
       layout: `${entityBundle}.drupal.liquid`,
       contents: Buffer.from('<!-- Drupal-provided data -->'),
       debug: JSON.stringify(page, null, 4),

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -27,6 +27,7 @@ const applyFragments = require('./plugins/apply-fragments');
 const checkCollections = require('./plugins/check-collections');
 const createMegaMenu = require('./plugins/create-megamenu');
 const createTemporaryReactPages = require('./plugins/create-react-pages');
+const downloadDrupalAssets = require('./plugins/download-drupal-assets');
 
 function defaultBuild(BUILD_OPTIONS) {
   const smith = Metalsmith(__dirname); // eslint-disable-line new-cap
@@ -148,6 +149,7 @@ function defaultBuild(BUILD_OPTIONS) {
   smith.use(createBuildSettings(BUILD_OPTIONS));
 
   smith.use(updateExternalLinks(BUILD_OPTIONS));
+  smith.use(downloadDrupalAssets(BUILD_OPTIONS));
 
   configureAssets(smith, BUILD_OPTIONS);
 

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -134,7 +134,9 @@ function downloadDrupalAssets(options) {
 
       await Promise.all(downloads);
       log(`Downloaded ${downloadCount} asset(s) from Drupal`);
-      log(`${errorCount} error(s) downloading assets`);
+      if (errorCount) {
+        log(`${errorCount} error(s) downloading assets from Drupal`);
+      }
     }
 
     done();

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -1,0 +1,86 @@
+/* eslint-disable no-param-reassign */
+require('isomorphic-fetch');
+const cheerio = require('cheerio');
+const getDrupalClient = require('../drupal/api');
+const chalk = require('chalk');
+
+const DRUPAL_COLORIZED_OUTPUT = chalk.rgb(73, 167, 222);
+
+// eslint-disable-next-line no-console
+const log = message => console.log(DRUPAL_COLORIZED_OUTPUT(message));
+
+function convertAssetPath(drupalInstance, url) {
+  const withoutHost = url.replace(`${drupalInstance}/sites/default/files/`, '');
+  const path = withoutHost.split('?', 2)[0];
+
+  if (
+    ['png', 'jpg', 'jpeg', 'gif', 'svg'].some(ext =>
+      path.toLowerCase().endsWith(ext),
+    )
+  ) {
+    return `img/${path}`;
+  }
+
+  return `files/${path}`;
+}
+
+function downloadDrupalAssets(options) {
+  const drupalClient = getDrupalClient(options);
+
+  return async (files, metalsmith, done) => {
+    const assetsToDownload = [];
+
+    for (const fileName of Object.keys(files)) {
+      const file = files[fileName];
+      let fileUpdated = false;
+
+      if (file.isDrupalPage && fileName.endsWith('html')) {
+        const doc = cheerio.load(file.contents);
+        doc(`[src^="${drupalClient.getSiteUri()}"]`).each((i, el) => {
+          fileUpdated = true;
+          const item = doc(el);
+          const srcAttr = item.attr('src');
+          const newAssetPath = convertAssetPath(
+            drupalClient.getSiteUri(),
+            srcAttr,
+          );
+          assetsToDownload.push({
+            src: srcAttr,
+            dest: newAssetPath,
+          });
+
+          item.attr('src', `/${newAssetPath}`);
+        });
+
+        if (fileUpdated) {
+          file.contents = new Buffer(doc.html());
+        }
+      }
+    }
+
+    if (assetsToDownload.length) {
+      const downloads = assetsToDownload.map(async asset => {
+        if (!files[asset.dest]) {
+          const response = await fetch(asset.src);
+
+          if (response.ok) {
+            files[asset.dest] = {
+              path: asset.dest,
+              isDrupalAsset: true,
+              contents: await response.buffer(),
+            };
+          } else {
+            done(`Image download failed: ${asset.src}`);
+          }
+        }
+      });
+
+      await Promise.all(downloads);
+      log(`Downloaded ${downloads.length} assets from Drupal`);
+    }
+
+    done();
+  };
+}
+
+module.exports = downloadDrupalAssets;

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -10,10 +10,16 @@ const DRUPAL_COLORIZED_OUTPUT = chalk.rgb(73, 167, 222);
 // eslint-disable-next-line no-console
 const log = message => console.log(DRUPAL_COLORIZED_OUTPUT(message));
 
+/*
+ * Convert a Drupal asset url to a local one
+ */
 function convertAssetPath(drupalInstance, url) {
+  // After this path are other folders in the image paths,
+  // but it's hard to tell if we can strip them, so I'm leaving them alone
   const withoutHost = url.replace(`${drupalInstance}/sites/default/files/`, '');
   const path = withoutHost.split('?', 2)[0];
 
+  // This is sort of naive, but we'd like to have images in the img folder
   if (
     ['png', 'jpg', 'jpeg', 'gif', 'svg'].some(ext =>
       path.toLowerCase().endsWith(ext),
@@ -25,6 +31,10 @@ function convertAssetPath(drupalInstance, url) {
   return `files/${path}`;
 }
 
+/*
+ * Simple attribute update that replaces the url for the asset
+ * with the local one
+ */
 function updateAttr(attr, doc, client) {
   const assetsToDownload = [];
   doc(`[${attr}^="${client.getSiteUri()}/sites"]`).each((i, el) => {
@@ -67,14 +77,17 @@ function downloadDrupalAssets(options) {
         if (hrefAssets.length) fileUpdated = true;
         assetsToDownload = assetsToDownload.concat(hrefAssets);
 
+        // srset is more complicated, a requires us to parse the attribute out
         // eslint-disable-next-line no-loop-func
         doc(`[srcset*="${drupalClient.getSiteUri()}/sites"]`).each((i, el) => {
           fileUpdated = true;
           const item = doc(el);
           const srcAttr = item.attr('srcset');
+          // srcset is a comma delimited list of srcs
           const sources = srcAttr.split(',');
           const newPaths = [];
           sources.forEach(source => {
+            // Each src has a url and a size, separated by a space
             const [url, size] = source.split(' ', 2);
             const newAssetPath = convertAssetPath(
               drupalClient.getSiteUri(),
@@ -111,6 +124,8 @@ function downloadDrupalAssets(options) {
               contents: await response.buffer(),
             };
           } else {
+            // For now, not going to fail the build for a missing asset
+            // Should get caught by the broken link checker, though
             errorCount++;
             log(`Image download failed: ${response.statusText}: ${asset.src}`);
           }

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-param-reassign */
 require('isomorphic-fetch');
 const cheerio = require('cheerio');
-const getDrupalClient = require('../drupal/api');
 const chalk = require('chalk');
+
+const getDrupalClient = require('../drupal/api');
 
 const DRUPAL_COLORIZED_OUTPUT = chalk.rgb(73, 167, 222);
 
@@ -24,11 +25,28 @@ function convertAssetPath(drupalInstance, url) {
   return `files/${path}`;
 }
 
+function updateAttr(attr, doc, client) {
+  const assetsToDownload = [];
+  doc(`[${attr}^="${client.getSiteUri()}/sites"]`).each((i, el) => {
+    const item = doc(el);
+    const srcAttr = item.attr(attr);
+    const newAssetPath = convertAssetPath(client.getSiteUri(), srcAttr);
+    assetsToDownload.push({
+      src: srcAttr,
+      dest: newAssetPath,
+    });
+
+    item.attr('src', `/${newAssetPath}`);
+  });
+
+  return assetsToDownload;
+}
+
 function downloadDrupalAssets(options) {
   const drupalClient = getDrupalClient(options);
 
   return async (files, metalsmith, done) => {
-    const assetsToDownload = [];
+    let assetsToDownload = [];
 
     for (const fileName of Object.keys(files)) {
       const file = files[fileName];
@@ -36,20 +54,40 @@ function downloadDrupalAssets(options) {
 
       if (file.isDrupalPage && fileName.endsWith('html')) {
         const doc = cheerio.load(file.contents);
-        doc(`[src^="${drupalClient.getSiteUri()}"]`).each((i, el) => {
+
+        const srcAssets = updateAttr('src', doc, drupalClient);
+        if (srcAssets.length) fileUpdated = true;
+        assetsToDownload = assetsToDownload.concat(srcAssets);
+
+        const dataSrcAssets = updateAttr('data-src', doc, drupalClient);
+        if (dataSrcAssets.length) fileUpdated = true;
+        assetsToDownload = assetsToDownload.concat(dataSrcAssets);
+
+        const hrefAssets = updateAttr('href', doc, drupalClient);
+        if (hrefAssets.length) fileUpdated = true;
+        assetsToDownload = assetsToDownload.concat(hrefAssets);
+
+        // eslint-disable-next-line no-loop-func
+        doc(`[srcset*="${drupalClient.getSiteUri()}/sites"]`).each((i, el) => {
           fileUpdated = true;
           const item = doc(el);
-          const srcAttr = item.attr('src');
-          const newAssetPath = convertAssetPath(
-            drupalClient.getSiteUri(),
-            srcAttr,
-          );
-          assetsToDownload.push({
-            src: srcAttr,
-            dest: newAssetPath,
+          const srcAttr = item.attr('srcset');
+          const sources = srcAttr.split(',');
+          const newPaths = [];
+          sources.forEach(source => {
+            const [url, size] = source.split(' ', 2);
+            const newAssetPath = convertAssetPath(
+              drupalClient.getSiteUri(),
+              url,
+            );
+            assetsToDownload.push({
+              src: url,
+              dest: newAssetPath,
+            });
+            newPaths.push(`/${newAssetPath} ${size}`);
           });
 
-          item.attr('src', `/${newAssetPath}`);
+          item.attr('srcset', newPaths.join(','));
         });
 
         if (fileUpdated) {
@@ -59,24 +97,29 @@ function downloadDrupalAssets(options) {
     }
 
     if (assetsToDownload.length) {
+      let downloadCount = 0;
+      let errorCount = 0;
       const downloads = assetsToDownload.map(async asset => {
         if (!files[asset.dest]) {
           const response = await fetch(asset.src);
 
           if (response.ok) {
+            downloadCount++;
             files[asset.dest] = {
               path: asset.dest,
               isDrupalAsset: true,
               contents: await response.buffer(),
             };
           } else {
-            done(`Image download failed: ${asset.src}`);
+            errorCount++;
+            log(`Image download failed: ${response.statusText}: ${asset.src}`);
           }
         }
       });
 
       await Promise.all(downloads);
-      log(`Downloaded ${downloads.length} assets from Drupal`);
+      log(`Downloaded ${downloadCount} asset(s) from Drupal`);
+      log(`${errorCount} error(s) downloading assets`);
     }
 
     done();


### PR DESCRIPTION
## Description
If there's a page in Drupal that references an image or file, we need to download that and store it in our build output. We will also need to update the url.

## Testing done
Ran locally

## Acceptance criteria
- [x] Images are downloaded and displayed on pages

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
