### PR TITLE
[Bug] Hide side-nav on mobile

### DIFF
--- a/src/site/components/navigation-sidebar.html
+++ b/src/site/components/navigation-sidebar.html
@@ -23,7 +23,9 @@ Used to display a side navigation bar of pages in a collection.
 
 <nav {% if relatedPages != empty %}class="usa-width-one-fourth va-sidebarnav"{% endif %} id="va-detailpage-sidebar">
   <div>
-    <button type="button" aria-label="Close this menu" class="va-btn-close-icon va-sidebarnav-close"></button>
+    {% if hidesidenav === empty %}
+      <button type="button" aria-label="Close this menu" class="va-btn-close-icon va-sidebarnav-close"></button>
+    {% endif %}
     {% if relatedPages != empty %}
       {% if relatedPages.metadata.name != empty %}
         <div class="left-side-nav-title"><i class="icon-small white hub-icon-{{ relatedPages.metadata.hub }} hub-background-{{ relatedPages.metadata.hub }}"></i><h4>{{ relatedPages.metadata.name }}</h4></div>

--- a/src/site/components/navigation-sidebar.html
+++ b/src/site/components/navigation-sidebar.html
@@ -23,9 +23,8 @@ Used to display a side navigation bar of pages in a collection.
 
 <nav {% if relatedPages != empty %}class="usa-width-one-fourth va-sidebarnav"{% endif %} id="va-detailpage-sidebar">
   <div>
-    {% if hidesidenav === empty %}
-      <button type="button" aria-label="Close this menu" class="va-btn-close-icon va-sidebarnav-close"></button>
-    {% endif %}
+    <button type="button" aria-label="Close this menu" class="va-btn-close-icon va-sidebarnav-close"></button>
+  
     {% if relatedPages != empty %}
       {% if relatedPages.metadata.name != empty %}
         <div class="left-side-nav-title"><i class="icon-small white hub-icon-{{ relatedPages.metadata.hub }} hub-background-{{ relatedPages.metadata.hub }}"></i><h4>{{ relatedPages.metadata.name }}</h4></div>

--- a/src/site/includes/detail-page.html
+++ b/src/site/includes/detail-page.html
@@ -14,7 +14,10 @@
     {% include "src/site/components/navigation-sidebar.html" %}
 
     <div class="usa-width-three-fourths">
-      {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+      {% if hidesidenav === empty %}
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+      {% endif %}  
+      
       <article class="usa-content">
         <h1>{{ heading }}</h1>
         {{ contents }}

--- a/src/site/includes/detail-page.html
+++ b/src/site/includes/detail-page.html
@@ -11,7 +11,9 @@
 
 <main class="va-l-detail-page">
   <div class="usa-grid usa-grid-full">
-    {% include "src/site/components/navigation-sidebar.html" %}
+    {% if hidesidenav === empty %}
+      {% include "src/site/components/navigation-sidebar.html" %}
+    {% endif %} 
 
     <div class="usa-width-three-fourths">
       {% if hidesidenav === empty %}


### PR DESCRIPTION
## Description

According to [this ticket](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16978) the `More in this section` sidenav button displays in mobile or zoomed in view.

The intention of the AMA pages was to hide the sidenav altogether. Here are the following urls where this applies:
```
/decision-reviews/
/decision-reviews/supplemental-claim/
/decision-reviews/after-you-request-review/
/decision-reviews/higher-level-review/
/decision-reviews/board-appeal/
/decision-reviews/board-appeal/after-board-appeal-decision/
/decision-reviews/multiple-party-claims/
/decision-reviews/insurance-claims/
/decision-reviews/fiduciary-claims/
/decision-reviews/get-help-with-review-request/
/decision-reviews/faq/
```

To generate a sidenav, a group of `vagov-content` pages must first be defined in `src/site/stages/build/data/collections.json`, which the [11 AMA pages](https://github.com/department-of-veterans-affairs/vagov-content/pull/229) were not, and so the desktop sidenav would not display.

The issue is `va-btn-sidebarnav-trigger` (or `More in this section` sidenav button) becomes visible when on mobile or zoom view, but because there is no collection of `vagov-content` pages defined, it displays nothing and causes the user to be stuck.

**Solution**: I created an `if statement` in the content template page`detail-page.html`, that checks for the front matter flag `hidesidenav`. When set to `true`, the `More in this section` button on mobile and zoomed view is not displayed.


## Testing done
**Note**: You will need to use [this AMA pages content feature branch PR](https://github.com/department-of-veterans-affairs/vagov-content/pull/229) to test

Tested on local build using the above AMA pages feature branch.

Pulled up all the following pages to verify sidenav button is not visible.
```
/decision-reviews/
/decision-reviews/supplemental-claim/
/decision-reviews/after-you-request-review/
/decision-reviews/higher-level-review/
/decision-reviews/board-appeal/
/decision-reviews/board-appeal/after-board-appeal-decision/
/decision-reviews/multiple-party-claims/
/decision-reviews/insurance-claims/
/decision-reviews/fiduciary-claims/
/decision-reviews/get-help-with-review-request/
/decision-reviews/faq/
```
Then viewed the follow pages to verify the `More in this section` still displays on pages that use the `details-page.html` content template.

```
/disability/eligibility/
/disability/eligibility/hazardous-materials-exposure/
/education/eligibility/
/education/after-you-apply/
/health-care/family-caregiver-benefits/
```

## Screenshots
`More in this section` Button is no longer visible
![screen shot 2019-02-19 at 9 55 02 am](https://user-images.githubusercontent.com/11021491/53024124-6c330880-342c-11e9-8e3a-515627ee79d7.png)
![screen shot 2019-02-19 at 9 54 49 am](https://user-images.githubusercontent.com/11021491/53024126-6c330880-342c-11e9-927b-a45671e7ed57.png)


## Acceptance criteria
- [X] `More in this section` sidenav button no longer displays on mobile or zoomed view

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
