### PR TITLE
Use the Next URL parameter for redirects

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -1,6 +1,5 @@
 import appendQuery from 'append-query';
 import Raven from 'raven-js';
-import URLSearchParams from 'url-search-params';
 
 import recordEvent from '../../monitoring/record-event';
 import environment from '../../utilities/environment';
@@ -42,11 +41,7 @@ export function clearRavenLoginType() {
 
 function redirect(redirectUrl, clickedEvent) {
   // Keep track of the URL to return to after auth operation.
-  sessionStorage.setItem(
-    authnSettings.RETURN_URL,
-    new URLSearchParams(window.location.search).get('next') ||
-      window.location.pathname,
-  );
+  sessionStorage.setItem(authnSettings.RETURN_URL, window.location);
   recordEvent({ event: clickedEvent });
   window.location = redirectUrl;
 }

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -1,5 +1,6 @@
 import appendQuery from 'append-query';
 import Raven from 'raven-js';
+import URLSearchParams from 'url-search-params';
 
 import recordEvent from '../../monitoring/record-event';
 import environment from '../../utilities/environment';
@@ -41,7 +42,11 @@ export function clearRavenLoginType() {
 
 function redirect(redirectUrl, clickedEvent) {
   // Keep track of the URL to return to after auth operation.
-  sessionStorage.setItem(authnSettings.RETURN_URL, window.location.pathname);
+  sessionStorage.setItem(
+    authnSettings.RETURN_URL,
+    new URLSearchParams(window.location.search).get('next') ||
+      window.location.pathname,
+  );
   recordEvent({ event: clickedEvent });
   window.location = redirectUrl;
 }


### PR DESCRIPTION
## Description
Currently, login-gated applications always redirect to the homepage; we want users to be redirected to the login-gated app after a successful login instead.

This is happening because the `next` parameter is not utilized in the redirect.

## Testing done
Local testing

## Acceptance criteria
- [x] Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16993

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
