### PR TITLE
All claims update url mg

### DIFF
--- a/src/applications/beta-enrollment/routes.js
+++ b/src/applications/beta-enrollment/routes.js
@@ -20,7 +20,7 @@ const routes = {
       path: 'all-claims',
       component: createBetaEnrollmentButton(
         features.allClaims,
-        '/disability-benefits/apply/form-526-all-claims',
+        '/disability/file-disability-claim-form-21-526ez/',
         'Get Started with the Beta Tool',
       ),
     },

--- a/src/applications/disability-benefits/all-claims/tests/00-all-fields.e2e.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/00-all-fields.e2e.spec.js
@@ -11,7 +11,7 @@ const runTest = E2eHelpers.createE2eTest(client => {
   Auth.logIn(
     token,
     client,
-    '/disability-benefits/apply/form-526-all-claims/',
+    '/disability/file-disability-claim-form-21-526ez/',
     3,
   );
 

--- a/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
@@ -20,11 +20,11 @@ const testConfig = {
     PageHelpers.initItfMock(userToken);
     PageHelpers.initPaymentInformationMock(userToken);
   },
-  url: '/disability-benefits/apply/form-526-all-claims/introduction',
+  url: '/disability/file-disability-claim-form-21-526ez/introduction',
   logIn: true,
   testDataPathPrefix: 'data',
   pageHooks: {
-    '/disability-benefits/apply/form-526-all-claims/introduction': async page => {
+    '/disability/file-disability-claim-form-21-526ez/introduction': async page => {
       // Hit the start button
       await page.click('.usa-button-primary.schemaform-start-button');
 

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -734,7 +734,7 @@ export const hasNewDisabilities = formData =>
  */
 export const urls = {
   v1: '/disability-benefits/apply/form-526-disability-claim',
-  v2: '/disability-benefits/apply/form-526-all-claims',
+  v2: '/disability/file-disability-claim-form-21-526ez',
 };
 
 /**


### PR DESCRIPTION
## Description
`disability-benefits/apply/form-526-all-claims` is changing to `disability/file-disability-claim-form-21-526ez/`. To support this transition this PR:

- Updates 526 v2 beta opt-in redirect from old form url to new form url
- Updates test file references from old url to new url

Related PRs:
Devops: https://github.com/department-of-veterans-affairs/devops/pull/4190
Content: https://github.com/department-of-veterans-affairs/vagov-content/pull/271

## Testing done
- Unit tests
- Tested locally

## Screenshots
No visual changes

## Acceptance criteria
- [x] 526 v2 is available at the new form URL to beta users
- [x] Opting into v2 526 beta leads users to a functional form start page at the right path

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
