### PR TITLE
Updated to latest Formation for modal changes (fixed alert modals and new close button)

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,8 +189,8 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^3.5.1",
-    "@department-of-veterans-affairs/formation-react": "^3.1.0",
+    "@department-of-veterans-affairs/formation": "^4.0.0",
+    "@department-of-veterans-affairs/formation-react": "^4.0.0",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "blob-polyfill": "^2.0.20171115",

--- a/src/applications/personalization/dashboard/sass/messaging/partials/_message-compose.scss
+++ b/src/applications/personalization/dashboard/sass/messaging/partials/_message-compose.scss
@@ -322,7 +322,7 @@ button.msg-btn-save {
 }
 
 .msg-attachment-close {
-  color: $color-va-modal-close;
+  color: rgba($color-base, .8);
   background: transparent;
   font-size: 1.25em;
   margin: 0;

--- a/src/platform/site-wide/sass/merger.scss
+++ b/src/platform/site-wide/sass/merger.scss
@@ -448,23 +448,6 @@ $medium-phone-screen: 375px;
     }
   }
 
-  button.va-modal-close {
-    font-family: "Font Awesome 5 Free";
-    color: $color-black;
-
-    .fas.fa-times-circle{
-      font-size: 0.60em;
-      color: $color-link-default;
-      &:hover {
-        color: $color-black;
-      }
-     }
-
-    .fas.fa-times {
-      font-size: 0.75em;
-    }
-  }
-
   .usa-accordion-bordered {
 
     &.social {

--- a/src/platform/site-wide/user-nav/sass/user-nav.scss
+++ b/src/platform/site-wide/user-nav/sass/user-nav.scss
@@ -32,12 +32,7 @@ span.sidelines {
   }
 }
 
-#login-root {
-  .profile-nav {
-    display: flex;
-    align-items: center;
-  }
-
+#signin-signup-modal {
   .va-modal-body {
     // Overwrite white header color.
     color: $color-gray-dark;
@@ -51,6 +46,13 @@ span.sidelines {
   .va-modal-inner {
     max-width: 62.5em;
     width: 95vw;
+  }
+}
+
+#login-root {
+  .profile-nav {
+    display: flex;
+    align-items: center;
   }
 
   .login {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@department-of-veterans-affairs/formation-react@^3.1.0":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-3.1.1.tgz#7726839d258538ec6ee059912f73c1acc4323ef2"
-  integrity sha512-pa9nMQWYZWn+Hns0DCV2RL2BLlW1dH7AI2cHuh7dDOtWLfw9w11wtgTKc/GQ8sEPcgzGEn/eF6Cw3yIFqxidyQ==
+"@department-of-veterans-affairs/formation-react@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-4.0.0.tgz#aedcc7dafc3e3294a1d3c60cbcc42abb4bb89bd5"
+  integrity sha512-PYdcXQxhCAlV6JGyNT7ZACl2CzRnLyMy7fooX75rsTT1PUVdt9VWpRfZOnmV/AUqTuTviR5EXrT8YK+zi69ZqA==
   dependencies:
     classnames "^2.2.6"
     lodash "^4.17.11"
@@ -35,10 +35,10 @@
     react-transition-group "1"
     window-or-global "^1.0.1"
 
-"@department-of-veterans-affairs/formation@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-3.5.1.tgz#9352a577ba40cd28ade22402ee3676fe5940477d"
-  integrity sha512-z2rG0mpBLko5OiLMUvwNGr5f8W4u5egvH6Mqf1qqO8ooJBTatbTH10tOxcGFaJ0+ECz66rYqDnSy8iZueivUrw==
+"@department-of-veterans-affairs/formation@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-4.0.0.tgz#96a0b93fc6722d8474eec4cadcd9d722fe0df1ac"
+  integrity sha512-Fh4h3YV9U2FQEGdX2CH5wMAUtTDbTNEMQe5Q6J4mQj1OwuPeSfgN7ZBrAeR6UvpehgKcvuenzbTEi+m4AAQPrQ==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     foundation-sites "5"


### PR DESCRIPTION
## Description
Updated to the latest Formation version. This includes fixes for broken alert modals and a new site-wide modal close button.

## Testing done
Local testing.

## Screenshots
<img width="951" alt="screen shot 2019-02-19 at 11 59 54 am" src="https://user-images.githubusercontent.com/1067024/53049577-7291a680-3465-11e9-9c35-f4f9eace0abd.png">

## Acceptance criteria
- [x] Modals should display new close button.
- [x] Alert modals should no longer appear broken.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
