### PR TITLE
v1 -> v2 redirect

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
@@ -11,14 +11,25 @@ import CallToActionWidget from '../../../../platform/site-wide/cta-widget';
 import { toggleLoginModal } from '../../../../platform/site-wide/user-nav/actions';
 import { focusElement } from '../../../../platform/utilities/ui';
 
+import { features } from '../../../beta-enrollment/routes';
+import { createIsServiceAvailableSelector } from '../../../../platform/user/selectors';
+
 import { VerifiedAlert } from '../helpers';
 import FormStartControls from './FormStartControls';
+import { urls } from '../../all-claims/utils';
 
 const gaStartEventName = 'disability-526EZ-start';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
     focusElement('.va-nav-breadcrumbs-list');
+  }
+
+  componentDidUpdate() {
+    // Redirect if necessary
+    if (this.props.signedUpForV2Beta) {
+      window.location.replace(urls.v2);
+    }
   }
 
   hasSavedForm = () => {
@@ -233,7 +244,11 @@ class IntroductionPage extends React.Component {
 
 function mapStateToProps(state) {
   const { form, user } = state;
-  return { form, user };
+  return {
+    form,
+    user,
+    signedUpForV2Beta: createIsServiceAvailableSelector(features.allClaims),
+  };
 }
 
 const mapDispatchToProps = {

--- a/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
@@ -247,7 +247,9 @@ function mapStateToProps(state) {
   return {
     form,
     user,
-    signedUpForV2Beta: createIsServiceAvailableSelector(features.allClaims),
+    signedUpForV2Beta: createIsServiceAvailableSelector(features.allClaims)(
+      state,
+    ),
   };
 }
 

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -16,7 +16,7 @@ class IntroductionPage extends React.Component {
   render() {
     return (
       <div className="schemaform-intro">
-        <FormTitle title="File for disability compensation" />
+        <FormTitle title="File for disability compensation (Beta)" />
         <p>
           Equal to VA Form 21-526EZ (Application for Disability Compensation and
           Related Compensation Benefits).

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -624,7 +624,7 @@ export const hasNewDisabilities = formData =>
  * @readonly
  * @enum {String}
  */
-const urls = {
+export const urls = {
   v1: '/disability-benefits/apply/form-526-disability-claim',
   v2: '/disability-benefits/apply/form-526-all-claims',
 };


### PR DESCRIPTION
## Description
When on the v1 intro page, if the user is signed up for the v2 beta, they'll be redirected.

## Testing done
Manually tested that a user not signed up for beta (including an unauthed user) isn't redirected and a user that is signed up for beta _is_ redirected.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/53056346-b681ad00-345f-11e9-9f07-7391393f35e6.png)
Added `(Beta)` to the v2 intro page to call out that this is the new one.

## Acceptance criteria
- [x] Unuathed users are not redirected
- [x] Users who have not opted into beta for v2 are not redirected
- [x] Users who _have_ opted into beta for v2 _are_ redirected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
