### PR TITLE
BAH VET TEC Update Program Selection Required Fields

### DIFF
--- a/src/applications/edu-benefits/0994/pages/trainingProgramsInformation.js
+++ b/src/applications/edu-benefits/0994/pages/trainingProgramsInformation.js
@@ -20,6 +20,9 @@ const checkLocation = field => field === 'inPerson' || field === 'both';
 const showLocation = (formData, index) =>
   checkLocation(getCourseType(formData, index));
 
+const getProgramName = (formData, index) =>
+  _.get(formData, `vetTecPrograms[${index}].programName`, '').trim();
+
 export const uiSchema = {
   'ui:description': trainingDescription,
   vetTecPrograms: {
@@ -37,6 +40,7 @@ export const uiSchema = {
       },
       courseType: {
         'ui:title': 'Is the training in-person or online?',
+        'ui:required': (formData, index) => getProgramName(formData, index),
         'ui:widget': 'radio',
         'ui:options': {
           labels: {
@@ -56,7 +60,8 @@ export const uiSchema = {
       },
       locationCity: {
         'ui:title': 'City',
-        'ui:required': (formData, index) => showLocation(formData, index),
+        'ui:required': (formData, index) =>
+          getProgramName(formData, index) && showLocation(formData, index),
         'ui:errorMessages': {
           pattern: 'Please fill in a valid city',
         },
@@ -70,13 +75,17 @@ export const uiSchema = {
         'ui:errorMessages': {
           pattern: 'Please select a valid state',
         },
-        'ui:required': (formData, index) => showLocation(formData, index),
+        'ui:required': (formData, index) =>
+          getProgramName(formData, index).trim() &&
+          showLocation(formData, index),
         'ui:options': {
           expandUnder: 'courseType',
           expandUnderCondition: checkLocation,
         },
       },
-      plannedStartDate: dateUI('What is your estimated start date?'),
+      plannedStartDate: _.merge(dateUI('What is your estimated start date?'), {
+        'ui:required': getProgramName,
+      }),
     },
   },
 };
@@ -89,7 +98,6 @@ export const schema = {
       maxItems: 3,
       items: {
         type: 'object',
-        required: ['plannedStartDate'],
         properties: {
           providerName,
           programName,

--- a/src/applications/edu-benefits/0994/pages/trainingProgramsInformation.js
+++ b/src/applications/edu-benefits/0994/pages/trainingProgramsInformation.js
@@ -76,8 +76,7 @@ export const uiSchema = {
           pattern: 'Please select a valid state',
         },
         'ui:required': (formData, index) =>
-          getProgramName(formData, index).trim() &&
-          showLocation(formData, index),
+          getProgramName(formData, index) && showLocation(formData, index),
         'ui:options': {
           expandUnder: 'courseType',
           expandUnderCondition: checkLocation,

--- a/src/applications/edu-benefits/0994/pages/trainingProgramsInformation.js
+++ b/src/applications/edu-benefits/0994/pages/trainingProgramsInformation.js
@@ -40,7 +40,7 @@ export const uiSchema = {
       },
       courseType: {
         'ui:title': 'Is the training in-person or online?',
-        'ui:required': (formData, index) => getProgramName(formData, index),
+        'ui:required': getProgramName,
         'ui:widget': 'radio',
         'ui:options': {
           labels: {

--- a/src/applications/edu-benefits/tests/0994/pages/trainingProgramsInformation.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/0994/pages/trainingProgramsInformation.unit.spec.jsx
@@ -3,9 +3,14 @@ import { expect } from 'chai';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import {
+  DefinitionTester,
+  fillData,
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 
 import formConfig from '../../../0994/config/form.js';
+
+import { ERR_MSG_CSS_CLASS } from '../../../0994/constants';
 
 describe('Training program information page', () => {
   const {
@@ -82,6 +87,50 @@ describe('Training program information page', () => {
 
     expect(form.find('input').length).to.equal(6);
     expect(form.find('select').length).to.equal(2);
+    form.unmount();
+  });
+
+  it('does not submit if the program name is entered without location or date information', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    fillData(form, 'input[name*="root_vetTecPrograms_0_programName"]', 'AWS');
+
+    form.find('form').simulate('submit');
+
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(2);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
+  it('does not submit if the program name is entered without city/state or date information', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          vetTecProgram: [{ courseType: 'both' }],
+        }}
+        formData={{}}
+      />,
+    );
+
+    fillData(form, 'input[name*="root_vetTecPrograms_0_programName"]', 'AWS');
+
+    form.find('form').simulate('submit');
+
+    expect(form.find(ERR_MSG_CSS_CLASS).length).to.equal(2);
+    expect(onSubmit.called).to.be.false;
     form.unmount();
   });
 });


### PR DESCRIPTION
## Description
This PR addresses the need to update the logic surrounding the required fields on the Program Selection page.

## Testing done
Local & Unit

## Screenshots
![screen shot 2019-02-20 at 12 11 12 pm](https://user-images.githubusercontent.com/11091836/53110336-b1c50380-3508-11e9-8089-97848d678b44.png)
![screen shot 2019-02-20 at 12 11 26 pm](https://user-images.githubusercontent.com/11091836/53110337-b1c50380-3508-11e9-8fcc-323f7f78350d.png)

## Acceptance criteria
- [x] If Program Name field is completed, then the following fields are required:
Location
Start Date
- [x] If program Name field is not completed, the the following fields are NOT required:
Location
Start Date
- [x] "(*Required)" text has been removed from next to start date

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

Associated bug: https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/17019