### PR TITLE
526 beta launch to production

### DIFF
--- a/src/platform/site-wide/announcements/components/AllClaimsBetaBanner.jsx
+++ b/src/platform/site-wide/announcements/components/AllClaimsBetaBanner.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import environment from '../../../utilities/environment';
+import { features } from '../../../../applications/beta-enrollment/routes';
 
-export default function AllClaimsBetaBanner({ dismiss }) {
-  // staging only. Remove before launch
-  if (environment.isProduction()) return null;
-
-  // only allow a small percentage of users to see the banner
-  // if user was selected, persist in localStorage
-  // if (!localStorage.getItem('all-claims-beta')) {
-  //   if (Math.random() > 0.02) return null;
-  //   localStorage.setItem('all-claims-beta', true);
-  // }
+export default function AllClaimsBetaBanner({ dismiss, profile }) {
+  // skip probability logic if user is enrolled
+  if (!profile.services.includes(features.allClaims)) {
+    // only allow a small percentage of users to see the banner
+    // if user was selected, persist in localStorage
+    if (!localStorage.getItem('all-claims-beta')) {
+      if (Math.random() > 0.02) return null;
+      localStorage.setItem('all-claims-beta', true);
+    }
+  }
 
   return (
     <div className="personalization-announcement">


### PR DESCRIPTION
## Description
Turn on beta banner in production. Also persist beta banner for enrolled users

## Testing done
local testing

## Screenshots


## Acceptance criteria
- [x] Beta logic is turned on in production

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16996
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17009
