### PR TITLE
All claims fix no rated mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/schema/minimal-ptsd-form-upload-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/schema/minimal-ptsd-form-upload-test.json
@@ -1,5 +1,8 @@
 {
   "data": {
+    "view:claimType": {
+      "view:claimingNew": true
+    },
     "standardClaim": true,
     "view:noFdcWarning": {},
     "view:hasSeparationPay": false,

--- a/src/applications/disability-benefits/all-claims/tests/schema/minimal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/schema/minimal-test.json
@@ -1,5 +1,8 @@
 {
   "data": {
+    "view:claimType": {
+      "view:claimingIncrease": true
+    },
     "isVaEmployee": false,
     "homelessOrAtRisk": "no",
     "phoneAndEmail": {
@@ -41,9 +44,6 @@
       }
     ],
     "view:disabilitiesClarification": {},
-    "hasTrainingPay": false,
-    "view:hasMilitaryRetiredPay": false,
-    "view:hasSeparationPay": false,
     "serviceInformation": {
       "reservesNationalGuardService": {
         "view:isTitle10Activated": false,

--- a/src/applications/disability-benefits/all-claims/tests/schema/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/schema/secondary-new-test.json
@@ -1,7 +1,6 @@
 {
   "data": {
     "view:claimType": {
-      "view:claimingIncrease": true,
       "view:claimingNew": true
     },
     "standardClaim": false,
@@ -99,24 +98,7 @@
         },
         "treatedDisabilityNames": {
           "diabetes mellitus0": true,
-          "diabetes mellitus1": true,
-          "myocardial infarction (mi)": true
-        }
-      },
-      {
-        "treatmentCenterName": "Treatment Center the Second",
-        "treatmentDateRange": {
-          "from": "2010-01-XX",
-          "to": "2018-02-XX"
-        },
-        "treatmentCenterAddress": {
-          "country": "Uganda",
-          "city": "Ugandan City"
-        },
-        "treatedDisabilityNames": {
-          "asthma": true,
-          "phlebitis": true,
-          "knee replacement": true
+          "De-selected": true
         }
       }
     ],
@@ -136,30 +118,7 @@
     "view:needsCarHelp": {
       "view:alreadyClaimedVehicleAllowance": false
     },
-    "view:powStatus": true,
-    "view:isPow": {
-      "confinements": [
-        {
-          "from": "2016-01-01",
-          "to": "2017-01-01"
-        },
-        {
-          "from": "2017-01-06",
-          "to": "2017-04-01"
-        }
-      ],
-      "powDisabilities": {
-        "knee replacement": true,
-        "myocardial infarction (mi)": true
-      }
-    },
     "newDisabilities": [
-      {
-        "cause": "NEW",
-        "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
-        "condition": "asthma",
-        "view:descriptionInfo": {}
-      },
       {
         "cause": "SECONDARY",
         "view:secondaryFollowUp": {
@@ -170,22 +129,12 @@
         "view:descriptionInfo": {}
       },
       {
-        "cause": "WORSENED",
-        "view:worsenedFollowUp": {
-          "worsenedDescription": "My knee was strained in the service",
-          "worsenedEffects": "It wasn't great before, but it got bad enough I needed a replacement. Now I have to take medication for it. I think. That makes sense, right?"
+        "cause": "SECONDARY",
+        "view:secondaryFollowUp": {
+          "causedByDisability": "De-selected",
+          "causedByDisabilityDescription": "Again, this doesn't really make sense."
         },
         "condition": "knee replacement",
-        "view:descriptionInfo": {}
-      },
-      {
-        "cause": "VA",
-        "view:vaFollowUp": {
-          "vaMistreatmentDescription": "A thing happened.",
-          "vaMistreatmentLocation": "Somewhereville",
-          "vaMistreatmentDate": "A while ago"
-        },
-        "condition": "myocardial infarction (MI)",
         "view:descriptionInfo": {}
       }
     ],
@@ -200,7 +149,7 @@
         "decisionText": "Service Connected",
         "ratingPercentage": 100,
         "disabilityActionType": "NONE",
-        "view:selected": true
+        "view:selected": false
       },
       {
         "name": "Diabetes mellitus1",
@@ -211,7 +160,7 @@
         "decisionText": "Service Connected",
         "ratingPercentage": 100,
         "disabilityActionType": "NONE",
-        "view:selected": true
+        "view:selected": false
       },
       {
         "name": "De-selected",

--- a/src/applications/disability-benefits/all-claims/tests/schema/transformedData.js
+++ b/src/applications/disability-benefits/all-claims/tests/schema/transformedData.js
@@ -35,7 +35,6 @@ export const transformedMinimalData = {
         disabilityActionType: 'NONE',
       },
     ],
-    hasTrainingPay: false,
     serviceInformation: {
       reservesNationalGuardService: {
         obligationTermOfServiceDateRange: {
@@ -220,10 +219,176 @@ export const transformedMaximalData = {
     newSecondaryDisabilities: [
       {
         cause: 'SECONDARY',
-        causedByDisability: 'Asthma',
+        causedByDisability: 'Diabetes mellitus0',
         causedByDisabilityDescription: "Again, this doesn't really make sense.",
         condition: 'phlebitis',
         classificationCode: '5300',
+      },
+    ],
+    attachments: [
+      {
+        name: 'AngleSettingJig_9_25_15.pdf',
+        confirmationCode: '544f14cc-4e51-4661-b8f4-d79f71567491',
+        attachmentId: 'L107',
+      },
+      {
+        name: 'image.png',
+        confirmationCode: 'fa0c0f47-a42f-4bbc-88f3-873c5bea6ce7',
+        attachmentId: 'L023',
+      },
+      {
+        name: 'lolwut.png',
+        confirmationCode: '552067b2-9c5d-4bd8-bcd8-bc621b51a145',
+        attachmentId: 'L015',
+      },
+      {
+        name: 'image (1).png',
+        confirmationCode: '0496e5c2-0675-4a43-83d6-e1eeabd4ea0e',
+        attachmentId: 'L070',
+      },
+      {
+        name: 'Success.jpg',
+        confirmationCode: 'de89492d-2d3f-4486-a73d-1fa4868aa49d',
+        attachmentId: 'L023',
+      },
+    ],
+  },
+};
+
+export const transformedNewSecondaryData = {
+  form526: {
+    standardClaim: false,
+    waiveTrainingPay: true,
+    waiveRetirementPay: true,
+    isVaEmployee: true,
+    homelessOrAtRisk: 'homeless',
+    homelessHousingSituation: 'other',
+    otherHomelessHousing: 'Under a bridge',
+    needToLeaveHousing: true,
+    homelessnessContact: { name: 'Name Here', phoneNumber: '1231231234' },
+    bankAccountType: 'Checking',
+    bankAccountNumber: '1233',
+    bankRoutingNumber: '123123123',
+    bankName: 'Bigbank Co.',
+    phoneAndEmail: {
+      primaryPhone: '4445551212',
+      emailAddress: 'test2@test1.net',
+    },
+    mailingAddress: {
+      country: 'USA',
+      addressLine1: '123 Main',
+      city: 'Bigcity',
+      state: 'AK',
+      zipCode: '12345',
+    },
+    forwardingAddress: {
+      country: 'USA',
+      addressLine1: '321 Secondary',
+      city: 'Smallcity',
+      state: 'NY',
+      zipCode: '54321',
+      effectiveDate: { from: '2099-12-01', to: '2100-01-01' },
+    },
+    vaTreatmentFacilities: [
+      {
+        treatmentCenterName: 'Treatment Center the First',
+        treatmentDateRange: { from: '2008-01-XX', to: '2010-01-XX' },
+        treatmentCenterAddress: {
+          country: 'USA',
+          city: 'Bigcity',
+          state: 'AK',
+        },
+        treatedDisabilityNames: ['Diabetes mellitus0', 'De-selected'],
+      },
+    ],
+    ratedDisabilities: [
+      {
+        name: 'Diabetes mellitus0',
+        ratedDisabilityId: '0',
+        ratingDecisionId: '63655',
+        diagnosticCode: 5238,
+        decisionCode: 'SVCCONNCTED',
+        decisionText: 'Service Connected',
+        ratingPercentage: 100,
+        disabilityActionType: 'NONE',
+      },
+      {
+        name: 'Diabetes mellitus1',
+        ratedDisabilityId: '1',
+        ratingDecisionId: '63655',
+        diagnosticCode: 5238,
+        decisionCode: 'SVCCONNCTED',
+        decisionText: 'Service Connected',
+        ratingPercentage: 100,
+        disabilityActionType: 'NONE',
+      },
+      {
+        name: 'De-selected',
+        ratedDisabilityId: '1',
+        ratingDecisionId: '63655',
+        diagnosticCode: 5238,
+        decisionCode: 'SVCCONNCTED',
+        decisionText: 'Service Connected',
+        ratingPercentage: 100,
+        disabilityActionType: 'NONE',
+      },
+      {
+        name: 'Not selected',
+        ratedDisabilityId: '1',
+        ratingDecisionId: '63655',
+        diagnosticCode: 5238,
+        decisionCode: 'SVCCONNCTED',
+        decisionText: 'Service Connected',
+        ratingPercentage: 100,
+        disabilityActionType: 'NONE',
+      },
+    ],
+    hasTrainingPay: true,
+    militaryRetiredPayBranch: 'Air Force',
+    separationPayDate: '2018-XX-XX',
+    separationPayBranch: 'Air Force',
+    serviceInformation: {
+      reservesNationalGuardService: {
+        title10Activation: {
+          title10ActivationDate: '2015-01-01',
+          anticipatedSeparationDate: '2120-01-01',
+        },
+        obligationTermOfServiceDateRange: {
+          from: '2007-05-22',
+          to: '2008-06-05',
+        },
+        unitName: 'Seal Team Six',
+      },
+      servicePeriods: [
+        {
+          serviceBranch: 'Air Force Reserve',
+          dateRange: { from: '2001-03-21', to: '2014-07-21' },
+        },
+        {
+          serviceBranch: 'Air National Guard',
+          dateRange: { from: '2015-01-01', to: '2017-05-13' },
+        },
+      ],
+    },
+    servedInCombatZonePost911: true,
+    alternateNames: [
+      { first: 'William', middle: 'Schwenk', last: 'Gilbert' },
+      { first: 'Arthur', last: 'Sullivan' },
+    ],
+    newSecondaryDisabilities: [
+      {
+        cause: 'SECONDARY',
+        causedByDisability: 'Diabetes mellitus0',
+        causedByDisabilityDescription: "Again, this doesn't really make sense.",
+        condition: 'phlebitis',
+        classificationCode: '5300',
+      },
+      {
+        cause: 'SECONDARY',
+        causedByDisability: 'De-selected',
+        causedByDisabilityDescription: "Again, this doesn't really make sense.",
+        condition: 'knee replacement',
+        classificationCode: '8919',
       },
     ],
     attachments: [

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -17,10 +17,12 @@ import {
   transformedMinimalData,
   transformedMaximalData,
   transformedMinimalPtsdFormUploadData,
+  transformedNewSecondaryData,
 } from './schema/transformedData';
 
 import minimalData from './schema/minimal-test.json';
 import maximalData from './schema/maximal-test.json';
+import newSecondaryData from './schema/secondary-new-test.json';
 import minimalPtsdFormUploadData from './schema/minimal-ptsd-form-upload-test.json';
 
 import {
@@ -38,6 +40,11 @@ describe('transform', () => {
   it('should transform maximal data correctly', () => {
     expect(JSON.parse(transform(formConfig, maximalData))).to.deep.equal(
       transformedMaximalData,
+    );
+  });
+  it('should transform new secondary disability data correctly', () => {
+    expect(JSON.parse(transform(formConfig, newSecondaryData))).to.deep.equal(
+      transformedNewSecondaryData,
     );
   });
   it('should transform ptsd form upload data correctly', () => {


### PR DESCRIPTION
## Description
Updates the submit transformer to preserve rated disabilities data even when the rated disabilities page is filtered out due to being inactive (which happens when someone applies for 'new condition only' in the form flow).

Also updates a bunch of test data because I didn't want to make a new test case that used old data.

## Testing done
- Tested this out locally
- Added a new test case and updated existing unit tests


## Screenshots
- No change

## Acceptance criteria
- [x] Veteran can submit 'new only' form with secondary disabilities that have an unselected rated disability as their `causedByDisability`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
