### PR TITLE
VET TEC: Update page URLs for the workflow #16931

### DIFF
--- a/src/applications/edu-benefits/0994/content/bankInformation.jsx
+++ b/src/applications/edu-benefits/0994/content/bankInformation.jsx
@@ -16,7 +16,7 @@ export const bankInfoNote = (
 
 const gaBankInfoHelpText = () => {
   window.dataLayer.push({
-    event: 'form-help-text-clicked',
+    event: 'edu-0994--form-help-text-clicked',
     'help-text-label': 'What if I don’t have a bank account?',
   });
 };

--- a/src/applications/edu-benefits/0994/manifest.json
+++ b/src/applications/edu-benefits/0994/manifest.json
@@ -2,6 +2,6 @@
   "appName": "22-0994 Education benefits form",
   "entryFile": "./edu-benefits-entry.jsx",
   "entryName": "0994-edu-benefits",
-  "rootUrl": "/education/apply-for-education-benefits/application/0994",
+  "rootUrl": "/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994",
   "production": false
 }

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -30,7 +30,7 @@ export default class EducationWizard extends React.Component {
     let url;
     switch (form) {
       case '0994':
-        url = `/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994/`;
+        url = `/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994`;
         break;
       default:
         url = `/education/apply-for-education-benefits/application/${form}`;

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -27,10 +27,19 @@ export default class EducationWizard extends React.Component {
   }
 
   getButton(form) {
+    let url;
+    switch (form) {
+      case '0994':
+        url = `/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994/`;
+        break;
+      default:
+        url = `/education/apply-for-education-benefits/application/${form}`;
+    }
+
     return (
       <a
         id="apply-now-link"
-        href={`/education/apply-for-education-benefits/application/${form}`}
+        href={url}
         className="usa-button va-button-primary"
       >
         Apply Now


### PR DESCRIPTION
## Description

As a va.gov developer I need to update the URL for each page within the 0994 workflow so that the workflow resides in the correct section within the va.gov platform. 

_Supporting Artifacts_
- TBD

_Assumptions_
- DSVA will eventually add 'VET TEC' to the left navigation under the GI Bill Benefits > How to use benefits which is why the URL pattern needs to be updated
        - url: https://staging.va.gov/education/about-gi-bill-benefits/how-to-use-benefits/
- DSVA (Peggy Gannon) is creating a New VET TEC static page
        - url: https://staging.va.gov/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program
        - DSVA will be adding a new button to apply for VET TEC to the static page
- This story is related to #16421 

## Testing done
- local testing

## Screenshots


## Acceptance criteria
- [ ] After the user answers the questions to trigger the VET TEC form under [Education>How to Apply] then the user will be routed to the first page of the 0994 workflow (intro page) and it will correspond to:  https:/staging.va.gov/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994/introduction 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
