### PR TITLE
VetTec: Case sensitivity for title on Contact Information page #17022

### DIFF
--- a/src/applications/edu-benefits/0994/config/form.js
+++ b/src/applications/edu-benefits/0994/config/form.js
@@ -134,7 +134,7 @@ const formConfig = {
     },
     // Chapter - Personal Information
     personalInformation: {
-      title: 'Personal Information',
+      title: 'Contact Information',
       pages: {
         // page - contact information
         contactInformation: {

--- a/src/applications/edu-benefits/0994/config/form.js
+++ b/src/applications/edu-benefits/0994/config/form.js
@@ -134,11 +134,11 @@ const formConfig = {
     },
     // Chapter - Personal Information
     personalInformation: {
-      title: 'Contact Information',
+      title: 'Personal Information',
       pages: {
         // page - contact information
         contactInformation: {
-          title: 'Contact Information',
+          title: 'Contact information',
           path: 'contact-information',
           uiSchema: contactInformation.uiSchema,
           schema: contactInformation.schema,

--- a/src/applications/edu-benefits/0994/pages/contactInformation.js
+++ b/src/applications/edu-benefits/0994/pages/contactInformation.js
@@ -39,7 +39,7 @@ const addressUiSchema = addressUISchema(
 const address = addressSchema(fullSchema, true);
 
 export const uiSchema = {
-  'ui:title': 'Contact Information',
+  'ui:title': 'Contact information',
   'ui:description': contactInfoDescription,
   'view:phoneAndEmail': {
     'ui:title': 'Phone & email',

--- a/src/applications/edu-benefits/tests/0994/e2e/00-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/0994/e2e/00-all-fields.e2e.spec.js
@@ -23,7 +23,8 @@ import {
 } from './vet-tec-helpers';
 
 const dirName = path.join(__dirname, '../schema/');
-const startUrl = '/education/apply-for-education-benefits/application/0994/';
+const startUrl =
+  '/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994/';
 
 const authentication = client => {
   const token = Auth.getUserToken();

--- a/src/applications/personalization/profile360/util/helpers.jsx
+++ b/src/applications/personalization/profile360/util/helpers.jsx
@@ -55,7 +55,8 @@ export const formLinks = {
   '21P-530': '/burials-and-memorials/application/530/',
   '1010ez': '/health-care/apply/application/',
   '22-0993': '/education/opt-out-information-sharing/opt-out-form-0993/',
-  '22-0994': '/education/apply-for-education-benefits/application/0994/',
+  '22-0994':
+    '/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994/',
   '22-1990': '/education/apply-for-education-benefits/application/1990/',
   '22-1990E': '/education/apply-for-education-benefits/application/1990E/',
   '22-1990N': '/education/apply-for-education-benefits/application/1990N/',


### PR DESCRIPTION
## Description
As a developer I need to make sure the title is updated on the Contact Information page.


## Testing done
- local testing

## Screenshots


## Acceptance criteria
- [ ] Page title sentence case shows as: Contact information


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
