### PR TITLE
Bump up number of people who can see all claims beta banner

### DIFF
--- a/src/platform/site-wide/announcements/components/AllClaimsBetaBanner.jsx
+++ b/src/platform/site-wide/announcements/components/AllClaimsBetaBanner.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { features } from '../../../../applications/beta-enrollment/routes';
+import environment from '../../../../platform/utilities/environment';
 
 export default function AllClaimsBetaBanner({ dismiss, profile }) {
   // skip probability logic if user is enrolled
   if (!profile.services.includes(features.allClaims)) {
-    // only allow a small percentage of users to see the banner
+    // allow 1000-3000 users to see the banner
     // if user was selected, persist in localStorage
+    // always show banner if not in production
     if (!localStorage.getItem('all-claims-beta')) {
-      if (Math.random() > 0.02) return null;
+      if (environment.isProduction() && Math.random() > 0.35) return null;
       localStorage.setItem('all-claims-beta', true);
     }
   }


### PR DESCRIPTION
## Description
- Bumps up number of users who can see the all claims beta banner
- Always show the banner in non-production environments

## Testing done
Local testing

## Screenshots


## Acceptance criteria
- [x] Beta banner show probability is increased

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
