### PR TITLE
Remove `concatIncidentLocationString`

### DIFF
--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -180,23 +180,6 @@ export function getFlatIncidentKeys() {
   return incidentKeys;
 }
 
-/**
- * Concatenates incident location address object into location string. This will ignore null
- *  or undefined address fields
- * @param {Object} incidentLocation location address with city, state, country, and additional details
- * @returns {String} incident location string
- */
-export function concatIncidentLocationString(incidentLocation) {
-  return [
-    incidentLocation.city,
-    incidentLocation.state,
-    incidentLocation.country,
-    incidentLocation.additionalDetails,
-  ]
-    .filter(locationField => locationField)
-    .join(', ');
-}
-
 export function getPtsdChangeText(changeFields = {}) {
   return Object.keys(changeFields)
     .filter(
@@ -394,9 +377,6 @@ export function transform(formConfig, form) {
       .map(incidentKey => ({
         ...clonedData[incidentKey],
         personalAssault: incidentKey.includes('secondary'),
-        incidentLocation: concatIncidentLocationString(
-          clonedData[incidentKey].incidentLocation,
-        ),
       }));
     incidentKeys.forEach(incidentKey => {
       delete clonedData[incidentKey];

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -7,7 +7,6 @@ import formConfig from '../config/form';
 import {
   transform,
   transformRelatedDisabilities,
-  concatIncidentLocationString,
   getFlatIncidentKeys,
   getPtsdChangeText,
   setActionTypes,
@@ -82,29 +81,6 @@ describe('transformRelatedDisabilities', () => {
 describe('getFlatIncidentKeys', () => {
   it('should return correct amount of incident keys', () => {
     expect(getFlatIncidentKeys().length).to.eql(PTSD_INCIDENT_ITERATION * 2);
-  });
-});
-
-describe('concatIncidentLocationString', () => {
-  it('should concat full address', () => {
-    const locationString = concatIncidentLocationString({
-      city: 'Test',
-      state: 'TN',
-      country: 'USA',
-      additionalDetails: 'details',
-    });
-
-    expect(locationString).to.eql('Test, TN, USA, details');
-  });
-
-  it('should handle null and undefined values', () => {
-    const locationString = concatIncidentLocationString({
-      city: 'Test',
-      state: null,
-      additionalDetails: 'details',
-    });
-
-    expect(locationString).to.eql('Test, details');
   });
 });
 


### PR DESCRIPTION
## Description
No longer translates the PTSD incident location into a string before sending it to the API.

## Testing done
Removed the tests for `concatIncidentLocationString` and made sure the other tests pass.

This _doesn't_ test that the ancillary form data is translated properly. That's in https://github.com/department-of-veterans-affairs/vets-website/pull/9550 (yet to be merged, but reliant on this PR to be mergeable).

## Screenshots
N/A

## Acceptance criteria
- [x] The incident location is sent as an object

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
