### PR TITLE
Add analytics for beta enrollment events

### DIFF
--- a/src/applications/beta-enrollment/beta-enrollment-entry.jsx
+++ b/src/applications/beta-enrollment/beta-enrollment-entry.jsx
@@ -4,9 +4,21 @@ import startApp from '../../platform/startup';
 
 import routes from './routes';
 import manifest from './manifest.json';
+import { REGISTER_SERVICE } from './actions';
+
+const analyticsEvents = [
+  {
+    action: REGISTER_SERVICE,
+    event: (store, action) => ({
+      event: 'beta-enrollment',
+      appName: action.service,
+    }),
+  },
+];
 
 startApp({
   url: manifest.rootUrl,
   routes,
   entryName: manifest.entryName,
+  analyticsEvents,
 });

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -630,3 +630,13 @@ legend.schemaform-label.schemaform-file-label {
   margin-top: 0;
   margin-bottom: 1em;
 }
+
+// highlighted outlines for accessibility
+[role=button]:focus,
+button:focus,
+input:focus,
+select:focus,
+textarea:focus {
+  outline: 2px solid #f9c642;
+  outline-offset: 2px;
+}

--- a/src/platform/site-wide/announcements/components/AllClaimsBetaBanner.jsx
+++ b/src/platform/site-wide/announcements/components/AllClaimsBetaBanner.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { features } from '../../../../applications/beta-enrollment/routes';
+import environment from '../../../../platform/utilities/environment';
 
 export default function AllClaimsBetaBanner({ dismiss, profile }) {
   // skip probability logic if user is enrolled
   if (!profile.services.includes(features.allClaims)) {
-    // only allow a small percentage of users to see the banner
+    // allow 1000-3000 users to see the banner
     // if user was selected, persist in localStorage
+    // always show banner if not in production
     if (!localStorage.getItem('all-claims-beta')) {
-      if (Math.random() > 0.02) return null;
+      if (environment.isProduction() && Math.random() > 0.35) return null;
       localStorage.setItem('all-claims-beta', true);
     }
   }

--- a/src/platform/startup/analytics-middleware.js
+++ b/src/platform/startup/analytics-middleware.js
@@ -18,8 +18,7 @@ function createAnalyticsMiddleware(analyticsEvents) {
     if (e) {
       const event =
         typeof e.event === 'function' ? e.event(store, action) : e.event;
-      const eventData = typeof event === 'string' ? { event } : event;
-      window.dataLayer.push(eventData);
+      window.dataLayer.push(typeof event === 'string' ? { event } : event);
     }
 
     return next(action);

--- a/src/platform/startup/analytics-middleware.js
+++ b/src/platform/startup/analytics-middleware.js
@@ -18,7 +18,8 @@ function createAnalyticsMiddleware(analyticsEvents) {
     if (e) {
       const event =
         typeof e.event === 'function' ? e.event(store, action) : e.event;
-      window.dataLayer.push({ event });
+      const eventData = typeof event === 'string' ? { event } : event;
+      window.dataLayer.push({ eventData });
     }
 
     return next(action);

--- a/src/platform/startup/analytics-middleware.js
+++ b/src/platform/startup/analytics-middleware.js
@@ -19,7 +19,7 @@ function createAnalyticsMiddleware(analyticsEvents) {
       const event =
         typeof e.event === 'function' ? e.event(store, action) : e.event;
       const eventData = typeof event === 'string' ? { event } : event;
-      window.dataLayer.push({ eventData });
+      window.dataLayer.push(eventData);
     }
 
     return next(action);


### PR DESCRIPTION
## Description
We currently do not track analytics events for beta enrollments. Using existing analytics middleware, beta enrollments can be tracked to more accurately identify the number of users who have enrolled in beta.

## Testing done
Local testing

## Screenshots


## Acceptance criteria
- [x] Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17096

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
