### PR TITLE
Compare attempted loginPolicy to serviceName received from backend.  …

### DIFF
--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -122,12 +122,28 @@ export function mapRawUserDataToState(json) {
 // as a trigger to properly update any components that subscribe to it.
 export const hasSession = () => localStorage.getItem('hasSession');
 
+function compareLoginPolicy(loginPolicy) {
+  let attemptedLoginPolicy = sessionStorage.getItem(
+    authnSettings.PENDING_LOGIN_TYPE,
+  );
+
+  attemptedLoginPolicy =
+    attemptedLoginPolicy === 'mhv' ? 'myhealthevet' : attemptedLoginPolicy;
+
+  if (loginPolicy !== attemptedLoginPolicy) {
+    recordEvent({
+      event: `login-mismatch-${attemptedLoginPolicy}-${loginPolicy}`,
+    });
+  }
+}
+
 export function setupProfileSession(payload) {
   localStorage.setItem('hasSession', true);
   const userData = get('data.attributes.profile', payload, {});
   const { firstName, signIn, loa } = userData;
 
-  const loginPolicy = get('serviceName', signIn, 'idme');
+  const loginPolicy = get('serviceName', signIn, null);
+  compareLoginPolicy(loginPolicy);
 
   // Since localStorage coerces everything into String,
   // this avoids setting the first name to the string 'null'.


### PR DESCRIPTION
## Description
In GA, `login-success-idme` seems to be much higher than `login-attempted-idme`. One of the theories we have about the cause of this is that the `serviceName` provided by the backend may not be 100% accurate.  

To test this, we'll compare the attempted login policy which we are storing in `sessionStorage` to the `serviceName` provided by the backend, and report it to GA when there is a mismatch. We were also defaulting the `serviceName` to `idme` if it was empty, which may also result in extra `login-success-idme`.  Having these metrics will hopefully help us get to the root of the mismatch.

## Testing done

Tested locally

## Acceptance criteria
- [ ] Mismatches between `serviceName` and the attempted login type are reported to GA
- [ ] `serviceName` (loginPolicy) defaults to `null` if empty and records a `login-success-null` to GA

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
