### PR TITLE
[Drupal] Use dynamic source property for links to Drupal downloads

### DIFF
--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -46,7 +46,7 @@ function updateAttr(attr, doc, client) {
       dest: newAssetPath,
     });
 
-    item.attr('src', `/${newAssetPath}`);
+    item.attr(attr, `/${newAssetPath}`);
   });
 
   return assetsToDownload;


### PR DESCRIPTION
## Description
This PR is a quick patch for downloading assets from the Drupal server during the build. This template -

```
<a href="{{ fieldPdfVersion.entity.fieldDocument.entity.url }}" download><i class="fa fa-download"></i> Download a PDF version</a>
```

Was resulting  in -

```
<a href="http://stg.va.agile6.com/sites/default/files/2019-02/VAMC-Region-2019-02-21_0.pdf" download="" target="_blank" rel="noopener " src="/files/2019-02/VAMC-Region-2019-02-21_0.pdf"><i class="fa fa-download"></i> Download a PDF version</a>
```

It should use `href` instead of `src` for `<a>` tags.

## Testing done
Confirmed that -

```
<a href="http://dev.va.agile6.com/sites/default/files/test.pdf" download="test"><i class="fa fa-download"></i> Download a PDF version</a>
```

Results in -

```
<a href="/files/test.pdf" download="test" target="_blank" rel="noopener "><i class="fa fa-download"></i> Download a PDF version</a>
```

(No `src` atrribute`

## Acceptance criteria
- [x] Correct rendered markup

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
