### PR TITLE
Handle 'other' appeal action type

### DIFF
--- a/src/applications/claims-status/containers/AppealsV2StatusPage.jsx
+++ b/src/applications/claims-status/containers/AppealsV2StatusPage.jsx
@@ -45,6 +45,7 @@ const AppealsV2StatusPage = ({ appeal, fullName }) => {
   const hideDocketAppealActions = [
     APPEAL_ACTIONS.reconsideration,
     APPEAL_ACTIONS.cue,
+    APPEAL_ACTIONS.other,
   ];
 
   let shouldShowDocket;

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -15,6 +15,7 @@ export const APPEAL_ACTIONS = {
   postCavcRemand: 'post_cavc_remand',
   reconsideration: 'reconsideration',
   cue: 'cue',
+  other: 'other',
 };
 
 export const APPEAL_TYPES = {


### PR DESCRIPTION
## Description

@cvalarida reported a sentry error that was traced to the appeal having a `null` docket. This is the case because the appeal's action type was `other`.