### PR TITLE
Change remandReturn value to match what's coming from Caseflow

### DIFF
--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -838,7 +838,7 @@ export const EVENT_TYPES = {
   transcript: 'transcript',
   bvaDecision: 'bva_decision',
   cavcDecision: 'cavc_decision',
-  remandReturn: 'remandReturn',
+  remandReturn: 'remand_return',
   rampNotice: 'ramp_notice',
   fieldGrant: 'field_grant',
   withdrawn: 'withdrawn',


### PR DESCRIPTION
## Description
We're getting a lot of [`appeals-unknown-event`](https://github.com/department-of-veterans-affairs/vets-website/blob/fix-event-type-cv/src/applications/claims-status/utils/appeals-v2-helpers.jsx#L1048) events in Sentry. After looking into it, I found that mostly the events are `remand_return`. The `EVENT_TYPES.remandReturn` was camel-cased (`remandReturn`) instead of being snake-cased (`remand_return`).

*Impact of the bug:* It looks like the only place the `remandReturn` event type is used is in [`getEventContent`](https://github.com/department-of-veterans-affairs/vets-website/blob/fix-event-type-cv/src/applications/claims-status/utils/appeals-v2-helpers.jsx#L929), which is only used in the [`Timeline`](https://github.com/department-of-veterans-affairs/vets-website/blob/fix-event-type-cv/src/applications/claims-status/components/appeals-v2/Timeline.jsx#L40). The `title` and `description` are deconstructed from the return value and passed to `PastEvent`, where they're used to [display what's happening](https://github.com/department-of-veterans-affairs/vets-website/blob/fix-event-type-cv/src/applications/claims-status/components/appeals-v2/PastEvent.jsx#L10).

Basically, the veteran would see a blank event, from what I can tell.

## Testing done
None. :grimacing:

## Screenshots
Example of the sentry error: 
![image](https://user-images.githubusercontent.com/12970166/53433832-102b2f80-39aa-11e9-9c18-058437c21486.png)


## Acceptance criteria
- [x] The proper event name is used

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
