### PR TITLE
Avoid rendering connected accounts section in production.

### DIFF
--- a/src/applications/personalization/account/components/ConnectedAccountsSection.jsx
+++ b/src/applications/personalization/account/components/ConnectedAccountsSection.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 
+import environment from '../../../../platform/utilities/environment';
+
 export default function ConnectedAccountsSection() {
+  if (environment.isProduction()) {
+    return null;
+  }
+
   return (
     <div>
       <h3>Connected accounts</h3>


### PR DESCRIPTION
This connected accounts section was never supposed to be live in production. This PR is meant to hide it but leave it visible in dev/staging.

Bug ticket here: https://github.com/department-of-veterans-affairs/vets-contrib/issues/1400