### PR TITLE
[Drupal] Fix encoding error in file names of downloaded assets

### DIFF
--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -118,8 +118,9 @@ function downloadDrupalAssets(options) {
 
           if (response.ok) {
             downloadCount++;
-            files[asset.dest] = {
-              path: asset.dest,
+            const decodedFileName = decodeURIComponent(asset.dest);
+            files[decodedFileName] = {
+              path: decodedFileName,
               isDrupalAsset: true,
               contents: await response.buffer(),
             };


### PR DESCRIPTION
## Description
This PR fixes an error that came out of Drupal-uploaded assets that contain spaces in their file name. The file names end up being written as -

![image](https://user-images.githubusercontent.com/1915775/53445818-70889400-39df-11e9-830b-288f5e4f031c.png)

Which leads to weird encoding issues.

## Testing done
- Updated localhost to point to Staging
- Added a link to `http://stg.va.agile6.com/sites/default/files/2019-02/Service%20Migration%20Patterns%20from%20Azure_0.docx` in `page.drupal.liquid`
- Opened http://localhost:3001/drupal/va-vision-care/index.html
- Confirmed that the link successfully downloaded the word doc

Also confirmed that the file name preserved the spaces by checking the build output -
![image](https://user-images.githubusercontent.com/1915775/53442808-1801c880-39d8-11e9-9259-657bae477dad.png)


## Acceptance criteria
- [ ] Spaces are allowed in Drupal-uploaded assets

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
