### PR TITLE
526 v2 downtime notifications

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -27,6 +27,7 @@ class IntroductionPage extends React.Component {
           pageList={this.props.route.pageList}
           startText="Start the Disability Compensation Application"
           retentionPeriod="1 year"
+          downtime={this.props.route.formConfig.downtime}
         />
         {itfNotice}
         <h4>
@@ -149,6 +150,7 @@ class IntroductionPage extends React.Component {
           formId={this.props.formId}
           pageList={this.props.route.pageList}
           startText="Start the Disability Compensation Application"
+          downtime={this.props.route.formConfig.downtime}
         />
         {itfNotice}
         <div className="omb-info--container">

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -3,6 +3,8 @@ import environment from '../../../../platform/utilities/environment';
 import FormFooter from '../../../../platform/forms/components/FormFooter';
 import preSubmitInfo from '../../../../platform/forms/preSubmitInfo';
 
+import services from 'platform/monitoring/DowntimeNotification/config/externalServices';
+
 import submitFormFor from './submitForm';
 
 import IntroductionPage from '../components/IntroductionPage';
@@ -118,6 +120,9 @@ const formConfig = {
   }/v0/disability_compensation_form/submit_all_claim`,
   submit: submitFormFor('disability-526EZ'),
   trackingPrefix: 'disability-526EZ-',
+  downtime: {
+    dependencies: [services.evss, services.emis, services.mvi, services.vet360],
+  },
   formId: '21-526EZ',
   onFormLoaded: directToCorrectForm,
   version: migrations.length,

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -3,7 +3,7 @@ import environment from '../../../../platform/utilities/environment';
 import FormFooter from '../../../../platform/forms/components/FormFooter';
 import preSubmitInfo from '../../../../platform/forms/preSubmitInfo';
 
-import services from 'platform/monitoring/DowntimeNotification/config/externalServices';
+import { externalServices as services } from 'platform/monitoring/DowntimeNotification';
 
 import submitFormFor from './submitForm';
 
@@ -121,6 +121,7 @@ const formConfig = {
   submit: submitFormFor('disability-526EZ'),
   trackingPrefix: 'disability-526EZ-',
   downtime: {
+    requiredForPrefill: true,
     dependencies: [services.evss, services.emis, services.mvi, services.vet360],
   },
   formId: '21-526EZ',

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -282,16 +282,26 @@ class SaveInProgressIntro extends React.Component {
       </div>
     );
 
-    if (this.props.downtime && !this.props.isLoggedIn) {
-      return (
-        <DowntimeNotification
-          appTitle={this.props.formId}
-          render={this.renderDowntime}
-          dependencies={this.props.downtime.dependencies}
-        >
-          {content}
-        </DowntimeNotification>
-      );
+    // If the dependencies aren't required for pre-fill (but are required for submit),
+    // only render the downtime notification if the user isn't logged in.
+    //   If the user is logged in, they can at least save their form.
+    // If the dependencies _are_ required for pre-fill, render the downtime notification
+    // _unless_ the user has a form saved (so they don't need pre-fill).
+    if (this.props.downtime) {
+      if (
+        !this.props.isLoggedIn ||
+        (this.props.downtime.requiredForPrefill && !savedForm)
+      ) {
+        return (
+          <DowntimeNotification
+            appTitle={this.props.formId}
+            render={this.renderDowntime}
+            dependencies={this.props.downtime.dependencies}
+          >
+            {content}
+          </DowntimeNotification>
+        );
+      }
     }
 
     return content;

--- a/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
+++ b/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
@@ -19,7 +19,7 @@ import Down from '../components/Down';
 import DowntimeApproaching from '../components/DowntimeApproaching';
 
 /**
- * React component used to conditionally render children components based on the status (down, down-approaching, or ok) of Vets.gov services.
+ * React component used to conditionally render children components based on the status (down, down-approaching, or ok) of VA.gov services.
  * @property {string} [appTitle] - The name of the consuming application, which will be displayed in downtime messaging.
  * @property {node} [children] - React components to be rendered based on downtime.
  * @property {node} [content] - Alias for React.children.


### PR DESCRIPTION
## Description
Looks like this is already built in!

## Testing done
None. I'm not sure how to test this, actually. Thoughts?

## Screenshots
:grimacing:

## Acceptance criteria
- [x] The appropriate services are connected to the app

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
