### PR TITLE
All claims add helper analytics mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -245,6 +245,11 @@ export const LOWERED_DISABILITY_DESCRIPTIONS = Object.values(
   disabilityLabels,
 ).map(v => v.toLowerCase());
 
+export const PTSD_TYPES_TO_FORMS = {
+  combatNonCombat: '781',
+  personalAssaultSexualTrauma: '781a',
+};
+
 export const HELP_TEXT_CLICKED_EVENT = 'help-text-label';
 
 export const ANALYTICS_EVENTS = {
@@ -262,5 +267,35 @@ export const ANALYTICS_EVENTS = {
     event: 'form-help-text-clicked',
     [HELP_TEXT_CLICKED_EVENT]:
       'Disability - Form 4142 - Private Medical Records Release: What does this mean',
+  },
+  openedPtsdTypeHelp: {
+    event: 'form-help-text-clicked',
+    [HELP_TEXT_CLICKED_EVENT]:
+      'Disability - PTSD Intro - Which should I choose',
+  },
+  openedPtsd781WalkthroughChoiceHelp: {
+    event: 'form-help-text-clicked',
+    [HELP_TEXT_CLICKED_EVENT]:
+      'Disability - Form 21-0781 - Which should I choose',
+  },
+  openedPtsd781aWalkthroughChoiceHelp: {
+    event: 'form-help-text-clicked',
+    [HELP_TEXT_CLICKED_EVENT]:
+      'Disability - Form 21-0781a - Which should I choose',
+  },
+  openedPtsd781IncidentDateHelp: {
+    event: 'form-help-text-clicked',
+    [HELP_TEXT_CLICKED_EVENT]:
+      'Disability - Form 21-0781 - What if I can’t remember the date',
+  },
+  openedPtsd781aIncidentDateHelp: {
+    event: 'form-help-text-clicked',
+    [HELP_TEXT_CLICKED_EVENT]:
+      'Disability - Form 21-0781a - What if I can’t remember the date',
+  },
+  openedPtsd781aOtherSourcesHelp: {
+    event: 'form-help-text-clicked',
+    [HELP_TEXT_CLICKED_EVENT]:
+      'Disability - Form 21-0781a - Which should I choose',
   },
 };

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -254,48 +254,48 @@ export const HELP_TEXT_CLICKED_EVENT = 'help-text-label';
 
 export const ANALYTICS_EVENTS = {
   openedPrivateRecordsAcknowledgment: {
-    event: 'form-help-text-clicked',
+    event: 'disability-526EZ-form-help-text-clicked',
     [HELP_TEXT_CLICKED_EVENT]:
       'Disability - Form 4142 - Private Medical Records: Read the full text',
   },
   openedPrivateChoiceHelp: {
-    event: 'form-help-text-clicked',
+    event: 'disability-526EZ-form-help-text-clicked',
     [HELP_TEXT_CLICKED_EVENT]:
       'Disability - Form 4142 - Private Medical Records: Which should I choose',
   },
   openedLimitedConsentHelp: {
-    event: 'form-help-text-clicked',
+    event: 'disability-526EZ-form-help-text-clicked',
     [HELP_TEXT_CLICKED_EVENT]:
       'Disability - Form 4142 - Private Medical Records Release: What does this mean',
   },
   openedPtsdTypeHelp: {
-    event: 'form-help-text-clicked',
+    event: 'disability-526EZ-form-help-text-clicked',
     [HELP_TEXT_CLICKED_EVENT]:
       'Disability - PTSD Intro - Which should I choose',
   },
   openedPtsd781WalkthroughChoiceHelp: {
-    event: 'form-help-text-clicked',
+    event: 'disability-526EZ-form-help-text-clicked',
     [HELP_TEXT_CLICKED_EVENT]:
-      'Disability - Form 21-0781 - Which should I choose',
+      'Disability - Form 21-0781 - Walkthrough Choice - Which should I choose',
   },
   openedPtsd781aWalkthroughChoiceHelp: {
-    event: 'form-help-text-clicked',
+    event: 'disability-526EZ-form-help-text-clicked',
     [HELP_TEXT_CLICKED_EVENT]:
-      'Disability - Form 21-0781a - Which should I choose',
+      'Disability - Form 21-0781a - Walkthrough Choice - Which should I choose',
   },
   openedPtsd781IncidentDateHelp: {
-    event: 'form-help-text-clicked',
+    event: 'disability-526EZ-form-help-text-clicked',
     [HELP_TEXT_CLICKED_EVENT]:
       'Disability - Form 21-0781 - What if I can’t remember the date',
   },
   openedPtsd781aIncidentDateHelp: {
-    event: 'form-help-text-clicked',
+    event: 'disability-526EZ-form-help-text-clicked',
     [HELP_TEXT_CLICKED_EVENT]:
       'Disability - Form 21-0781a - What if I can’t remember the date',
   },
   openedPtsd781aOtherSourcesHelp: {
-    event: 'form-help-text-clicked',
+    event: 'disability-526EZ-form-help-text-clicked',
     [HELP_TEXT_CLICKED_EVENT]:
-      'Disability - Form 21-0781a - Which should I choose',
+      'Disability - Form 21-0781a - PTSD Secondary Sources - Which should I choose',
   },
 };

--- a/src/applications/disability-benefits/all-claims/content/incidentDate.jsx
+++ b/src/applications/disability-benefits/all-claims/content/incidentDate.jsx
@@ -1,27 +1,46 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import { recordEventOnce } from '../utils';
+import {
+  ANALYTICS_EVENTS,
+  HELP_TEXT_CLICKED_EVENT,
+  PTSD_TYPES_TO_FORMS,
+} from '../constants';
 
-const eventHelpText = (
-  <AdditionalInfo triggerText="What if I can’t remember the date?">
-    <p>
-      Providing an estimated date within a couple of months of the event will
-      help us research your claim.
-    </p>
-    <p>
-      If you’re having trouble remembering the exact date, try remembering the
-      time of year or whether the event happened early or late in your military
-      service.
-    </p>
-  </AdditionalInfo>
-);
+const { combatNonCombat, personalAssaultSexualTrauma } = PTSD_TYPES_TO_FORMS;
 
-export const ptsdDateDescription = (
-  <div>
-    <h5>Estimated event date</h5>
-    <p>
-      Please tell us when this event happened. If it happened over a period of
-      time, please tell us when it started.
-    </p>
-    {eventHelpText}
-  </div>
-);
+export const PtsdDateDescription = ({ formType }) => {
+  let ptsdDateEvent;
+  if (formType === combatNonCombat) {
+    ptsdDateEvent = ANALYTICS_EVENTS.openedPtsd781IncidentDateHelp;
+  } else if (formType === personalAssaultSexualTrauma) {
+    ptsdDateEvent = ANALYTICS_EVENTS.openedPtsd781aIncidentDateHelp;
+  }
+
+  return (
+    <div>
+      <h5>Estimated event date</h5>
+      <p>
+        Please tell us when this event happened. If it happened over a period of
+        time, please tell us when it started.
+      </p>
+      <AdditionalInfo
+        triggerText="What if I can’t remember the date?"
+        onClick={() =>
+          ptsdDateEvent &&
+          recordEventOnce(ptsdDateEvent, HELP_TEXT_CLICKED_EVENT)
+        }
+      >
+        <p>
+          Providing an estimated date within a couple of months of the event
+          will help us research your claim.
+        </p>
+        <p>
+          If you’re having trouble remembering the exact date, try remembering
+          the time of year or whether the event happened early or late in your
+          military service.
+        </p>
+      </AdditionalInfo>
+    </div>
+  );
+};

--- a/src/applications/disability-benefits/all-claims/content/ptsdTypeInfo.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ptsdTypeInfo.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import { recordEventOnce } from '../utils';
+import { ANALYTICS_EVENTS, HELP_TEXT_CLICKED_EVENT } from '../constants';
 
 const combatPtsdType = 'Combat';
 
@@ -24,7 +26,15 @@ export const nonCombatPtsdTypeLong = (
 );
 
 export const ptsdTypeHelp = (
-  <AdditionalInfo triggerText="Which should I choose?">
+  <AdditionalInfo
+    triggerText="Which should I choose?"
+    onClick={() =>
+      recordEventOnce(
+        ANALYTICS_EVENTS.openedPtsdTypeHelp,
+        HELP_TEXT_CLICKED_EVENT,
+      )
+    }
+  >
     <h4>Types of stressful events</h4>
     <h5>Combat</h5>
     <p>

--- a/src/applications/disability-benefits/all-claims/content/ptsdWalkthroughChoice.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ptsdWalkthroughChoice.jsx
@@ -2,29 +2,53 @@ import React from 'react';
 
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import { getPtsdClassification } from './ptsdClassification';
+import { recordEventOnce } from '../utils';
+import {
+  ANALYTICS_EVENTS,
+  HELP_TEXT_CLICKED_EVENT,
+  PTSD_TYPES_TO_FORMS,
+} from '../constants';
 
-export const PtsdUploadChoiceDescription = ({ formType }) => (
-  <AdditionalInfo triggerText="Which should I choose?">
-    <h5>Answer questions</h5>
-    <p>
-      If you choose this option, we’ll ask you several questions about the
-      events related to your PTSD. If you have evidence or documents to include,
-      you’ll be able to upload them later in the application.
-    </p>
-    <h5>Upload your completed form</h5>
-    <p>
-      If you choose to upload a completed VA Form {`21-0${formType}`}, you’ll
-      move to the next section of the disability application.
-    </p>
-  </AdditionalInfo>
-);
+const { combatNonCombat, personalAssaultSexualTrauma } = PTSD_TYPES_TO_FORMS;
+
+export const PtsdUploadChoiceDescription = ({ formType }) => {
+  let ptsdWalkthroughEvent;
+  if (formType === combatNonCombat) {
+    ptsdWalkthroughEvent = ANALYTICS_EVENTS.openedPtsd781WalkthroughChoiceHelp;
+  } else if (formType === personalAssaultSexualTrauma) {
+    ptsdWalkthroughEvent = ANALYTICS_EVENTS.openedPtsd781aWalkthroughChoiceHelp;
+  }
+
+  return (
+    <AdditionalInfo
+      triggerText="Which should I choose?"
+      onClick={() =>
+        ptsdWalkthroughEvent &&
+        recordEventOnce(ptsdWalkthroughEvent, HELP_TEXT_CLICKED_EVENT)
+      }
+    >
+      <h5>Answer questions</h5>
+      <p>
+        If you choose this option, we’ll ask you several questions about the
+        events related to your PTSD. If you have evidence or documents to
+        include, you’ll be able to upload them later in the application.
+      </p>
+      <h5>Upload your completed form</h5>
+      <p>
+        If you choose to upload a completed VA Form {`21-0${formType}`}, you’ll
+        move to the next section of the disability application.
+      </p>
+    </AdditionalInfo>
+  );
+};
 
 const UploadExplanation = ({ formType }) => (
   <div>
     <p>
       You can either answer the questions online, or if you’ve already completed
       a Claim for Service Connection for Post-Traumatic Stress Disorder{' '}
-      {formType === '781a' && 'Secondary to Personal Assault '}
+      {formType === personalAssaultSexualTrauma &&
+        'Secondary to Personal Assault '}
       (VA Form {`21-0${formType}`}
       ), you can upload the form.
     </p>

--- a/src/applications/disability-benefits/all-claims/content/secondaryOtherSources.jsx
+++ b/src/applications/disability-benefits/all-claims/content/secondaryOtherSources.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import { recordEventOnce } from '../utils';
+import { ANALYTICS_EVENTS, HELP_TEXT_CLICKED_EVENT } from '../constants';
 
 export const otherSourcesDescription = (
   <div>
@@ -18,7 +20,15 @@ export const otherSourcesDescription = (
 );
 
 export const otherSourcesHelpText = (
-  <AdditionalInfo triggerText="Which should I choose">
+  <AdditionalInfo
+    triggerText="Which should I choose"
+    onClick={() =>
+      recordEventOnce(
+        ANALYTICS_EVENTS.openedPtsd781aOtherSourcesHelp,
+        HELP_TEXT_CLICKED_EVENT,
+      )
+    }
+  >
     <h5>
       Choose "Yes" if you’d like help getting private medical treatment records
       or statements from military authorities

--- a/src/applications/disability-benefits/all-claims/pages/incidentDate.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/incidentDate.jsx
@@ -1,15 +1,20 @@
+import React from 'react';
+
 import currentOrPastDateUI from 'us-forms-system/lib/js/definitions/currentOrPastDate';
 
 import { ptsd781NameTitle } from '../content/ptsdClassification';
-import { ptsdDateDescription } from '../content/incidentDate';
+import { PtsdDateDescription } from '../content/incidentDate';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
+import { PTSD_TYPES_TO_FORMS } from '../constants';
 
 const { incidentDate } = fullSchema.definitions.ptsdIncident.properties;
 
 export const uiSchema = index => ({
   'ui:title': ptsd781NameTitle,
   [`incident${index}`]: {
-    'ui:description': ptsdDateDescription,
+    'ui:description': (
+      <PtsdDateDescription formType={PTSD_TYPES_TO_FORMS.combatNonCombat} />
+    ),
     incidentDate: currentOrPastDateUI(' '),
   },
 });

--- a/src/applications/disability-benefits/all-claims/pages/ptsdWalkthroughChoice781.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/ptsdWalkthroughChoice781.jsx
@@ -5,11 +5,13 @@ import {
   PtsdUploadChoiceDescription,
   UploadPtsdDescription,
 } from '../content/ptsdWalkthroughChoice';
+import { PTSD_TYPES_TO_FORMS } from '../constants';
 
+const { combatNonCombat } = PTSD_TYPES_TO_FORMS;
 export const uiSchema = {
   'ui:title': ptsd781NameTitle,
   'ui:description': ({ formData }) => (
-    <UploadPtsdDescription formData={formData} formType="781" />
+    <UploadPtsdDescription formData={formData} formType={combatNonCombat} />
   ),
   'view:upload781Choice': {
     'ui:title': ' ',
@@ -24,7 +26,9 @@ export const uiSchema = {
     },
   },
   'view:upload781ChoiceHelp': {
-    'ui:description': <PtsdUploadChoiceDescription formType="781" />,
+    'ui:description': (
+      <PtsdUploadChoiceDescription formType={combatNonCombat} />
+    ),
   },
 };
 

--- a/src/applications/disability-benefits/all-claims/pages/ptsdWalkthroughChoice781a.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/ptsdWalkthroughChoice781a.jsx
@@ -5,11 +5,16 @@ import {
   PtsdUploadChoiceDescription,
   UploadPtsdDescription,
 } from '../content/ptsdWalkthroughChoice';
+import { PTSD_TYPES_TO_FORMS } from '../constants';
 
+const { personalAssaultSexualTrauma } = PTSD_TYPES_TO_FORMS;
 export const uiSchema = {
   'ui:title': ptsd781aNameTitle,
   'ui:description': ({ formData }) => (
-    <UploadPtsdDescription formData={formData} formType="781a" />
+    <UploadPtsdDescription
+      formData={formData}
+      formType={personalAssaultSexualTrauma}
+    />
   ),
   'view:upload781aChoice': {
     'ui:title': ' ',
@@ -24,7 +29,9 @@ export const uiSchema = {
     },
   },
   'view:upload781aChoiceHelp': {
-    'ui:description': <PtsdUploadChoiceDescription formType="781a" />,
+    'ui:description': (
+      <PtsdUploadChoiceDescription formType={personalAssaultSexualTrauma} />
+    ),
   },
 };
 

--- a/src/applications/disability-benefits/all-claims/pages/secondaryIncidentDate.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/secondaryIncidentDate.jsx
@@ -1,8 +1,11 @@
+import React from 'react';
+
 import currentOrPastDateUI from 'us-forms-system/lib/js/definitions/currentOrPastDate';
 
 import { ptsd781aNameTitle } from '../content/ptsdClassification';
-import { ptsdDateDescription } from '../content/incidentDate';
+import { PtsdDateDescription } from '../content/incidentDate';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
+import { PTSD_TYPES_TO_FORMS } from '../constants';
 
 const {
   incidentDate,
@@ -10,7 +13,11 @@ const {
 
 export const uiSchema = index => ({
   'ui:title': ptsd781aNameTitle,
-  'ui:description': ptsdDateDescription,
+  'ui:description': (
+    <PtsdDateDescription
+      formType={PTSD_TYPES_TO_FORMS.personalAssaultSexualTrauma}
+    />
+  ),
   [`secondaryIncident${index}`]: {
     incidentDate: currentOrPastDateUI(' '),
   },


### PR DESCRIPTION
## Description
- Records some more `<AdditionalInfo />` expander clicks as analytics events.
- Updates the `event` values for all the help click events per conversation in linked ticket.
- Had to reorganize some content and refactor a bit to get this working cleanly.

To Do: One of the events is a duplicate, waiting on unique text.

## Testing done
- Tested locally

## Screenshots
N/A

## Acceptance criteria
- [x] All 6 events are recorded to analytics
- [x] Each event recorded once

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
