### PR TITLE
Use localStorage instead of sessionStorage to track attempted login t…

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -26,15 +26,19 @@ export class AuthApp extends React.Component {
   }
 
   handleAuthError = e => {
-    const loginType = sessionStorage.getItem(authnSettings.PENDING_LOGIN_TYPE);
+    const loginType = localStorage.getItem(authnSettings.PENDING_LOGIN_TYPE);
 
-    Raven.captureException(e, {
+    Raven.captureMessage(`User fetch error: ${e.message}`, {
+      extra: {
+        error: e,
+      },
       tags: {
         loginType,
       },
     });
 
-    sessionStorage.removeItem(authnSettings.PENDING_LOGIN_TYPE);
+    localStorage.removeItem(authnSettings.PENDING_LOGIN_TYPE);
+    localStorage.removeItem(authnSettings.REGISTRATION_PENDING);
 
     recordEvent({
       event: `login-error-user-fetch`,

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -36,7 +36,10 @@ export function setRavenLoginType(loginType) {
 }
 
 export function clearRavenLoginType() {
-  Raven.setTagsContext({ loginType: undefined });
+  const context = Raven.getContext(); // Note: Do not mutate context directly.
+  const tags = { ...context.tags };
+  delete tags.loginType;
+  Raven.setTagsContext(tags);
 }
 
 function redirect(redirectUrl, clickedEvent) {
@@ -47,8 +50,8 @@ function redirect(redirectUrl, clickedEvent) {
 }
 
 export function login(policy) {
-  sessionStorage.removeItem(authnSettings.REGISTRATION_PENDING);
-  sessionStorage.setItem(authnSettings.PENDING_LOGIN_TYPE, policy);
+  localStorage.removeItem(authnSettings.REGISTRATION_PENDING);
+  localStorage.setItem(authnSettings.PENDING_LOGIN_TYPE, policy);
   return redirect(loginUrl(policy), 'login-link-clicked-modal');
 }
 
@@ -66,7 +69,7 @@ export function logout() {
 }
 
 export function signup() {
-  sessionStorage.setItem(authnSettings.REGISTRATION_PENDING, true);
+  localStorage.setItem(authnSettings.REGISTRATION_PENDING, true);
   return redirect(
     appendQuery(IDME_URL, { signup: true }),
     'register-link-clicked',

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -151,7 +151,7 @@ export function setupProfileSession(payload) {
   if (localStorage.getItem(authnSettings.REGISTRATION_PENDING)) {
     // Record GA success event for the register method.
     recordEvent({ event: `register-success-${loginPolicy}` });
-    sessionStorage.removeItem(authnSettings.REGISTRATION_PENDING);
+    localStorage.removeItem(authnSettings.REGISTRATION_PENDING);
   } else {
     // Report GA success event for the login method.
     compareLoginPolicy(loginPolicy);

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -123,7 +123,7 @@ export function mapRawUserDataToState(json) {
 export const hasSession = () => localStorage.getItem('hasSession');
 
 function compareLoginPolicy(loginPolicy) {
-  let attemptedLoginPolicy = sessionStorage.getItem(
+  let attemptedLoginPolicy = localStorage.getItem(
     authnSettings.PENDING_LOGIN_TYPE,
   );
 
@@ -149,16 +149,16 @@ export function setupProfileSession(payload) {
   // this avoids setting the first name to the string 'null'.
   if (firstName) localStorage.setItem('userFirstName', firstName);
 
-  if (sessionStorage.getItem(authnSettings.REGISTRATION_PENDING)) {
+  if (localStorage.getItem(authnSettings.REGISTRATION_PENDING)) {
     // Record GA success event for the register method.
     recordEvent({ event: `register-success-${loginPolicy}` });
-    sessionStorage.removeItem('registrationPending');
+    sessionStorage.removeItem(authnSettings.REGISTRATION_PENDING);
   } else {
     // Report GA success event for the login method.
     recordEvent({ event: `login-success-${loginPolicy}` });
   }
 
-  sessionStorage.removeItem(authnSettings.PENDING_LOGIN_TYPE);
+  localStorage.removeItem(authnSettings.PENDING_LOGIN_TYPE);
 
   // Set Sentry Tag so we can associate errors with the login policy
   setRavenLoginType(loginPolicy);

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -143,7 +143,6 @@ export function setupProfileSession(payload) {
   const { firstName, signIn, loa } = userData;
 
   const loginPolicy = get('serviceName', signIn, null);
-  compareLoginPolicy(loginPolicy);
 
   // Since localStorage coerces everything into String,
   // this avoids setting the first name to the string 'null'.
@@ -155,6 +154,7 @@ export function setupProfileSession(payload) {
     sessionStorage.removeItem(authnSettings.REGISTRATION_PENDING);
   } else {
     // Report GA success event for the login method.
+    compareLoginPolicy(loginPolicy);
     recordEvent({ event: `login-success-${loginPolicy}` });
   }
 

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -9,12 +9,15 @@ import {
 } from '../../authentication/utilities';
 
 let oldSessionStorage;
+let oldLocalStorage;
 let oldWindow;
 
 const fakeWindow = () => {
   oldSessionStorage = global.sessionStorage;
+  oldLocalStorage = global.localStorage;
   oldWindow = global.window;
   global.sessionStorage = { setItem: () => {}, removeItem: () => {} };
+  global.localStorage = { setItem: () => {}, removeItem: () => {} };
   global.window = {
     dataLayer: [],
     location: {
@@ -31,6 +34,7 @@ describe('authentication URL helpers', () => {
   afterEach(() => {
     global.window = oldWindow;
     global.sessionStorage = oldSessionStorage;
+    global.localStorage = oldLocalStorage;
   });
 
   it('should redirect for signup', () => {


### PR DESCRIPTION
## Description
`sessionStorage` does not seem to be reliably storing the attempted login type or pending registration after redirects, as detailed in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17070#issuecomment-467964587.  Several thousand events show that retrieving the attemptedLoginPolicy from sessionStorage results in `null` even though it seems to be set properly. I cannot reproduce it locally, so my thought is to try using `localStorage` instead.

Some additional minor changes include
- Add additional info to the errors that occur during `/user` fetch
- Clear sentry tag context properly according to docs
- Only call `compareLoginPolicy()` for logins

## Testing done
Tested locally


## Acceptance criteria
- [ ] Replace `sessionStorage` with `localStorage` for storing attempted login policy and whether a user is pending registration

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
