### PR TITLE
Form System: Formatting of high-tech work experience

### DIFF
--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -645,3 +645,12 @@ textarea:focus {
   outline: 2px solid #f9c642;
   outline-offset: 2px;
 }
+
+.form-checkbox>input[type=checkbox]+.schemaform-label {
+  height: 2rem;
+  line-height: 2rem;
+}
+
+.form-checkbox>input[type=checkbox]+label:before {
+  margin-right: 0.6em;
+}


### PR DESCRIPTION
## Description
When you zoom in or out on this page, the formatting gets wonky for the answer options for "Which option(s) best describe your high-tech work experience? Check all that apply."

Steps to test:
- log in as the `0` user
- go to `/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994/work-experience`.
- Click on the yes option
- Checkboxes should appear
- zoom to the lowest percent
- Checkboxes should render correctly

## Testing done
Manual

## Screenshots
<img width="1239" alt="screen shot 2019-02-27 at 2 26 29 pm" src="https://user-images.githubusercontent.com/5377648/53527393-b4d96a00-3a9b-11e9-87e9-dd8d59ee559a.png">

## Acceptance criteria
- [ ] Checkboxes should render correctly on the lowest zoom percentage

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
