### PR TITLE
Use the partially applied function

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -5,7 +5,7 @@ import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
 // NOTE: Easier to run schema locally with hot reload for dev
 // import fullSchema526EZ from '/path/Sites/vets-json-schema/dist/21-526EZ-schema.json';
 
-import submitForm from '../../all-claims/config/submitForm';
+import submitFormFor from '../../all-claims/config/submitForm';
 
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
 import ServicePeriodView from '../../../../platform/forms/components/ServicePeriodView';
@@ -132,7 +132,7 @@ const formConfig = {
   },
   formSavedPage: FormSavedPage,
   transformForSubmit: transform,
-  submit: submitForm,
+  submit: submitFormFor('526-v1'),
   introduction: IntroductionPage,
   confirmation: ConfirmationPoll,
   footerContent: FormFooter,


### PR DESCRIPTION
## Description
TL;DR: I did a dumb thing in https://github.com/department-of-veterans-affairs/vets-website/pull/9611. This fixes it.

I made this a partially-applied function so we can customize the submission event and then I completely forgot that v1 also uses this function. :grimacing:

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
