### PR TITLE
clear selected value on input value change

### DIFF
--- a/src/applications/facility-locator/components/ServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/ServiceTypeAhead.jsx
@@ -73,6 +73,12 @@ class ServiceTypeAhead extends Component {
         onChange={this.handleOnSelect}
         defaultSelectedItem={defaultSelectedItem}
         itemToString={renderService}
+        onInputValueChange={(inputValue, stateAndHelpers) => {
+          const { selectedItem, clearSelection } = stateAndHelpers;
+          if (selectedItem && inputValue !== selectedItem.name.trim()) {
+            clearSelection();
+          }
+        }}
         key={defaultSelectedItem}
       >
         {({


### PR DESCRIPTION
## Description
- currently there is no way to return to the default service type (all) on the facility locator 
- Downshift is a selection component and only fires a selection event when an item is selected from the list
- there is no "All" item available in the current list 
- The current implementation allows manual editing of the input field to filter a list 


This fix does the following 
- if the input is edited, then the selection is cleared effectively selecting the default item
- to filter on an item after the input is edited, a selection _must_ be made. if a selection is not made, then the input will be cleared if the user selects search or tabs away from the input

Open to feedback on this. I don't like clearing an input value if they don't make a selection but the expected behavior on a partial edit -> search is murky. Using an input like this can imply that a partial string will be matched on search- it doesn't necessarily convey that a single item must be selected.

## Testing done


## Screenshots
![facility-locator-search-clear](https://user-images.githubusercontent.com/4998130/53533130-dc89fb80-3ab6-11e9-93c7-e2f448baa870.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
