### PR TITLE
BAH - Updating title for bank information page

### DIFF
--- a/src/applications/edu-benefits/0994/config/form.js
+++ b/src/applications/edu-benefits/0994/config/form.js
@@ -145,8 +145,8 @@ const formConfig = {
         },
         // page - banking information
         bankInformation: {
-          title: 'Bank Information',
-          path: 'bank-information',
+          title: 'Direct deposit information',
+          path: 'direct-deposit-information',
           uiSchema: bankInformation.uiSchema,
           schema: bankInformation.schema,
         },

--- a/src/applications/edu-benefits/0994/content/bankInformation.jsx
+++ b/src/applications/edu-benefits/0994/content/bankInformation.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 
-export const bankInfoTitle = <h4>Bank Information</h4>;
+export const bankInfoTitle = <h4>Direct deposit information</h4>;
 
 export const bankInfoDescription =
   'This is the bank account information we have on file for you and will use to pay you.';


### PR DESCRIPTION
## Description
This PR updates the title for the bankInformation page from `Bank Information` to `Direct deposit information`

## Testing done
Local

## Screenshots
![screen shot 2019-02-28 at 12 35 01 pm](https://user-images.githubusercontent.com/11091836/53586053-57095880-3b55-11e9-88b5-816b76724ac6.png)


## Acceptance criteria
- [x] Title update from `Bank Information` to `Direct deposit information` and is case sensitive

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

Associated ticket: https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/17155