### PR TITLE
Ga attempted success mismatch

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -26,15 +26,19 @@ export class AuthApp extends React.Component {
   }
 
   handleAuthError = e => {
-    const loginType = sessionStorage.getItem(authnSettings.PENDING_LOGIN_TYPE);
+    const loginType = localStorage.getItem(authnSettings.PENDING_LOGIN_TYPE);
 
-    Raven.captureException(e, {
+    Raven.captureMessage(`User fetch error: ${e.message}`, {
+      extra: {
+        error: e,
+      },
       tags: {
         loginType,
       },
     });
 
-    sessionStorage.removeItem(authnSettings.PENDING_LOGIN_TYPE);
+    localStorage.removeItem(authnSettings.PENDING_LOGIN_TYPE);
+    localStorage.removeItem(authnSettings.REGISTRATION_PENDING);
 
     recordEvent({
       event: `login-error-user-fetch`,

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -26,7 +26,7 @@ export class AuthApp extends React.Component {
   }
 
   handleAuthError = e => {
-    const loginType = localStorage.getItem(authnSettings.PENDING_LOGIN_TYPE);
+    const loginType = localStorage.getItem('pendingLoginPolicy');
 
     Raven.captureMessage(`User fetch error: ${e.message}`, {
       extra: {
@@ -37,8 +37,8 @@ export class AuthApp extends React.Component {
       },
     });
 
-    localStorage.removeItem(authnSettings.PENDING_LOGIN_TYPE);
-    localStorage.removeItem(authnSettings.REGISTRATION_PENDING);
+    localStorage.removeItem('pendingLoginPolicy');
+    localStorage.removeItem('pendingAuthAction');
 
     recordEvent({
       event: `login-error-user-fetch`,

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -36,7 +36,10 @@ export function setRavenLoginType(loginType) {
 }
 
 export function clearRavenLoginType() {
-  Raven.setTagsContext({ loginType: undefined });
+  const context = Raven.getContext(); // Note: Do not mutate context directly.
+  const tags = { ...context.tags };
+  delete tags.loginType;
+  Raven.setTagsContext(tags);
 }
 
 function redirect(redirectUrl, clickedEvent) {
@@ -47,8 +50,8 @@ function redirect(redirectUrl, clickedEvent) {
 }
 
 export function login(policy) {
-  sessionStorage.removeItem(authnSettings.REGISTRATION_PENDING);
-  sessionStorage.setItem(authnSettings.PENDING_LOGIN_TYPE, policy);
+  localStorage.removeItem(authnSettings.REGISTRATION_PENDING);
+  localStorage.setItem(authnSettings.PENDING_LOGIN_TYPE, policy);
   return redirect(loginUrl(policy), 'login-link-clicked-modal');
 }
 
@@ -66,7 +69,7 @@ export function logout() {
 }
 
 export function signup() {
-  sessionStorage.setItem(authnSettings.REGISTRATION_PENDING, true);
+  localStorage.setItem(authnSettings.REGISTRATION_PENDING, true);
   return redirect(
     appendQuery(IDME_URL, { signup: true }),
     'register-link-clicked',

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -6,8 +6,6 @@ import environment from '../../utilities/environment';
 
 export const authnSettings = {
   RETURN_URL: 'authReturnUrl',
-  REGISTRATION_PENDING: 'registrationPending',
-  PENDING_LOGIN_TYPE: 'pendingLoginType',
 };
 
 const SESSIONS_URI = `${environment.API_URL}/sessions`;
@@ -50,8 +48,8 @@ function redirect(redirectUrl, clickedEvent) {
 }
 
 export function login(policy) {
-  localStorage.removeItem(authnSettings.REGISTRATION_PENDING);
-  localStorage.setItem(authnSettings.PENDING_LOGIN_TYPE, policy);
+  localStorage.setItem('pendingAuthAction', 'login');
+  localStorage.setItem('pendingLoginPolicy', policy);
   return redirect(loginUrl(policy), 'login-link-clicked-modal');
 }
 
@@ -69,7 +67,7 @@ export function logout() {
 }
 
 export function signup() {
-  localStorage.setItem(authnSettings.REGISTRATION_PENDING, true);
+  localStorage.setItem('pendingAuthAction', 'register');
   return redirect(
     appendQuery(IDME_URL, { signup: true }),
     'register-link-clicked',

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -131,7 +131,7 @@ function compareLoginPolicy(loginPolicy) {
 
   if (attemptedLoginPolicy === null) {
     Raven.captureMessage(
-      `localStorage error: 'pendingLoginPolicy' was not stored`,
+      "localStorage error: 'pendingLoginPolicy' was not stored",
     );
   }
 
@@ -167,7 +167,7 @@ export function setupProfileSession(payload) {
   } else {
     recordEvent({ event: `login-or-register-success-${loginPolicy}` });
     Raven.captureMessage(
-      `localStorage error: 'pendingAuthAction' was not stored`,
+      "localStorage error: 'pendingAuthAction' was not stored",
     );
   }
 

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -151,7 +151,7 @@ export function setupProfileSession(payload) {
   if (localStorage.getItem(authnSettings.REGISTRATION_PENDING)) {
     // Record GA success event for the register method.
     recordEvent({ event: `register-success-${loginPolicy}` });
-    sessionStorage.removeItem(authnSettings.REGISTRATION_PENDING);
+    localStorage.removeItem(authnSettings.REGISTRATION_PENDING);
   } else {
     // Report GA success event for the login method.
     compareLoginPolicy(loginPolicy);

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -123,7 +123,7 @@ export function mapRawUserDataToState(json) {
 export const hasSession = () => localStorage.getItem('hasSession');
 
 function compareLoginPolicy(loginPolicy) {
-  let attemptedLoginPolicy = sessionStorage.getItem(
+  let attemptedLoginPolicy = localStorage.getItem(
     authnSettings.PENDING_LOGIN_TYPE,
   );
 
@@ -149,16 +149,16 @@ export function setupProfileSession(payload) {
   // this avoids setting the first name to the string 'null'.
   if (firstName) localStorage.setItem('userFirstName', firstName);
 
-  if (sessionStorage.getItem(authnSettings.REGISTRATION_PENDING)) {
+  if (localStorage.getItem(authnSettings.REGISTRATION_PENDING)) {
     // Record GA success event for the register method.
     recordEvent({ event: `register-success-${loginPolicy}` });
-    sessionStorage.removeItem('registrationPending');
+    sessionStorage.removeItem(authnSettings.REGISTRATION_PENDING);
   } else {
     // Report GA success event for the login method.
     recordEvent({ event: `login-success-${loginPolicy}` });
   }
 
-  sessionStorage.removeItem(authnSettings.PENDING_LOGIN_TYPE);
+  localStorage.removeItem(authnSettings.PENDING_LOGIN_TYPE);
 
   // Set Sentry Tag so we can associate errors with the login policy
   setRavenLoginType(loginPolicy);

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -147,7 +147,7 @@ function compareLoginPolicy(loginPolicy) {
   localStorage.removeItem('pendingLoginPolicy');
 }
 
-function recordGAAuthEvent(loginPolicy, firstName, loa) {
+function recordGAAuthEvent(loginPolicy, loa) {
   // The payload we receive from authenticating does not specify whether
   // the user has logged in or if they are a new user. To differentiate, we are
   // retrieving a "pendingAuthAction" stored in localStorage when the user
@@ -187,7 +187,7 @@ export function setupProfileSession(payload) {
   // this avoids setting the first name to the string 'null'.
   if (firstName) localStorage.setItem('userFirstName', firstName);
 
-  if (!hasSession()) recordGAAuthEvent(loginPolicy, firstName, loa);
+  if (!hasSession()) recordGAAuthEvent(loginPolicy, loa);
 
   localStorage.setItem('hasSession', true);
 

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -143,7 +143,6 @@ export function setupProfileSession(payload) {
   const { firstName, signIn, loa } = userData;
 
   const loginPolicy = get('serviceName', signIn, null);
-  compareLoginPolicy(loginPolicy);
 
   // Since localStorage coerces everything into String,
   // this avoids setting the first name to the string 'null'.
@@ -155,6 +154,7 @@ export function setupProfileSession(payload) {
     sessionStorage.removeItem(authnSettings.REGISTRATION_PENDING);
   } else {
     // Report GA success event for the login method.
+    compareLoginPolicy(loginPolicy);
     recordEvent({ event: `login-success-${loginPolicy}` });
   }
 

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -130,9 +130,7 @@ function compareLoginPolicy(loginPolicy) {
   let attemptedLoginPolicy = localStorage.getItem('pendingLoginPolicy');
 
   attemptedLoginPolicy =
-    attemptedLoginPolicy === 'mhv'
-      ? 'myhealthevet'
-      : localStorage.getItem('pendingLoginPolicy');
+    attemptedLoginPolicy === 'mhv' ? 'myhealthevet' : attemptedLoginPolicy;
 
   if (attemptedLoginPolicy === null) {
     Raven.captureMessage(
@@ -151,7 +149,7 @@ function compareLoginPolicy(loginPolicy) {
 
 function recordGAAuthEvent(loginPolicy, firstName, loa) {
   // The payload we receive from authenticating does not specify whether
-  // the user has logged in, or is a new user. To differentiate, we are
+  // the user has logged in or if they are a new user. To differentiate, we are
   // retrieving a "pendingAuthAction" stored in localStorage when the user
   // clicks a sign in/register button in the Sign In Modal
 

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -9,12 +9,15 @@ import {
 } from '../../authentication/utilities';
 
 let oldSessionStorage;
+let oldLocalStorage;
 let oldWindow;
 
 const fakeWindow = () => {
   oldSessionStorage = global.sessionStorage;
+  oldLocalStorage = global.localStorage;
   oldWindow = global.window;
   global.sessionStorage = { setItem: () => {}, removeItem: () => {} };
+  global.localStorage = { setItem: () => {}, removeItem: () => {} };
   global.window = {
     dataLayer: [],
     location: {
@@ -31,6 +34,7 @@ describe('authentication URL helpers', () => {
   afterEach(() => {
     global.window = oldWindow;
     global.sessionStorage = oldSessionStorage;
+    global.localStorage = oldLocalStorage;
   });
 
   it('should redirect for signup', () => {

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -64,6 +64,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
           // If the user receives a 401 when trying to log out, it means their session
           // has expired.  Redirect them home.  In all other cases, redirect to login
           if (isLogout) {
+            window.localStorage.removeItem('hasSession');
             window.location.href = '/';
           } else if (!pathname.includes('auth/login/callback')) {
             const loginUrl = appendQuery(environment.BASE_URL, {


### PR DESCRIPTION
## Description
Retrieving `authnSettings.PENDING_LOGIN_TYPE` and `authnSettings.REGISTRATION_PENDING` from `localStorage` is still returning as `null` in some cases.  I'm really not certain what is causing the issue, but as a last resort I'd like to try using regular strings to access the `localStorage` instead of the `authnSettings` string enum that was set up.  

My only other thought is that the localStorage items are somehow being removed before I try to access them, resulting in `null`. @U-DON If you have a little extra time, maybe you can help me review where/how I am setting/getting from `localStorage` so that I can confirm I'm not going crazy. 😬

Additionally, I've renamed `registrationPending` to `pendingAuthAction` and am storing either `register` or `login` as its value.  If it is `null` upon successful authentication, we will report it to GA as `login-or-register-success-idme`. This way they are not being misreported as logins.

Finally, I am logging occurrences of `null` localStorage values to Sentry as Kam suggested.

## Testing done
Tested locally

## Screenshots


## Acceptance criteria
- [ ] Updated `localStorage` accessors for pending login type and pending auth action
- [ ] Log cases of null localStorage to Sentry

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
