### PR TITLE
Add aria accessibility labels for claims and appeals

### DIFF
--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -119,6 +119,7 @@ export default function AppealListItem({ appeal, name, external = false }) {
       )}
       {external && (
         <Link
+          aria-label={`View status of ${appealTitle} `}
           className="usa-button usa-button-primary"
           href={`/track-claims/appeals/${appeal.id}/status`}
         >

--- a/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
@@ -15,12 +15,15 @@ function listPhase(phase) {
 
 export default function ClaimsListItem({ claim }) {
   const inProgress = !isClaimComplete(claim);
+  const formattedReceiptDate = moment(claim.attributes.dateFiled).format(
+    'MMMM D, YYYY',
+  );
   return (
     <div className="claim-list-item-container">
       <h3 className="claim-list-item-header-v2">
         Claim for {getClaimType(claim)}
         <br />
-        Received {moment(claim.attributes.dateFiled).format('MMMM D, YYYY')}
+        Received {formattedReceiptDate}
       </h3>
       <div className="card-status">
         <div
@@ -53,6 +56,7 @@ export default function ClaimsListItem({ claim }) {
         ) : null}
       </ul>
       <Link
+        aria-label={`View status of claim received ${formattedReceiptDate}`}
         className="usa-button usa-button-primary"
         to={`your-claims/${claim.id}/status`}
       >


### PR DESCRIPTION
## Description

Adds accessibility attributes to claims and appeals buttons for screenreader context

Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14625

## Testing done
Local testing

## Screenshots


## Acceptance criteria
- [x] Adds accessibility attributes to claims and appeals buttons for screenreader context

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
