### PR TITLE
Only log actual response errors to sentry

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -6,7 +6,7 @@ import environment from '../../../platform/utilities/environment';
 import { apiRequest } from '../../../platform/utilities/api';
 import { makeAuthRequest } from '../utils/helpers';
 import {
-  getStatus,
+  getErrorStatus,
   USER_FORBIDDEN_ERROR,
   RECORD_NOT_FOUND_ERROR,
   VALIDATION_ERROR,
@@ -98,7 +98,7 @@ export function getAppealsV2() {
       null,
       appeals => dispatch(fetchAppealsSuccess(appeals)),
       response => {
-        const status = getStatus(response);
+        const status = getErrorStatus(response);
         const action = { type: '' };
         switch (status) {
           case '403':
@@ -181,7 +181,7 @@ export function getClaimsV2(poll = pollRequest) {
 
     poll({
       onError: response => {
-        const errorCode = getStatus(response);
+        const errorCode = getErrorStatus(response);
         if (errorCode && errorCode !== UNKNOWN_STATUS) {
           Raven.captureException(`vets_claims_v2_err_get_claims ${errorCode}`);
         }

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -181,11 +181,9 @@ export function getClaimsV2(poll = pollRequest) {
 
     poll({
       onError: response => {
-        const responseCode = getStatus(response);
-        if (responseCode && responseCode !== UNKNOWN_STATUS) {
-          Raven.captureException(
-            `vets_claims_v2_err_get_claims ${responseCode}`,
-          );
+        const errorCode = getStatus(response);
+        if (errorCode && errorCode !== UNKNOWN_STATUS) {
+          Raven.captureException(`vets_claims_v2_err_get_claims ${errorCode}`);
         }
         dispatch({ type: FETCH_CLAIMS_ERROR });
       },

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -18,6 +18,7 @@ import {
   FETCH_CLAIMS_ERROR,
   ROWS_PER_PAGE,
   CHANGE_INDEX_PAGE,
+  UNKNOWN_STATUS,
 } from '../utils/appeals-v2-helpers';
 
 // -------------------- v2 and v1 -------------
@@ -181,7 +182,7 @@ export function getClaimsV2(poll = pollRequest) {
     poll({
       onError: response => {
         const responseCode = getStatus(response);
-        if (responseCode && responseCode !== 'unknown') {
+        if (responseCode && responseCode !== UNKNOWN_STATUS) {
           Raven.captureException(
             `vets_claims_v2_err_get_claims ${responseCode}`,
           );

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -180,9 +180,12 @@ export function getClaimsV2(poll = pollRequest) {
 
     poll({
       onError: response => {
-        Raven.captureException(
-          `vets_claims_v2_err_get_claims ${getStatus(response)}`,
-        );
+        const responseCode = getStatus(response);
+        if (responseCode && responseCode !== 'unknown') {
+          Raven.captureException(
+            `vets_claims_v2_err_get_claims ${responseCode}`,
+          );
+        }
         dispatch({ type: FETCH_CLAIMS_ERROR });
       },
       onSuccess: response => dispatch(fetchClaimsSuccess(response)),

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -2059,7 +2059,7 @@ export const UNKNOWN_STATUS = 'unknown';
  * @param {Object} response error response object from vets-api
  * @returns {string} status code or 'unknown'
  */
-export const getStatus = response => {
+export const getErrorStatus = response => {
   if (response instanceof Error) {
     Raven.captureException(response, { tags: { location: 'getStatus' } });
   }

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -2051,6 +2051,8 @@ export function getAlertContent(alert, appealIsActive) {
   }
 }
 
+export const UNKNOWN_STATUS = 'unknown';
+
 /**
  * Tests an http error response for an errors array and status property for the
  * first error in the array. Returns the status code or 'unknown'
@@ -2063,7 +2065,7 @@ export const getStatus = response => {
   }
   return response.errors && response.errors.length
     ? response.errors[0].status
-    : 'unknown';
+    : UNKNOWN_STATUS;
 };
 
 // Series of utility functions to sort claims and appeals by last updated date


### PR DESCRIPTION
## Description
Stops logging all the `200` `meta.syncStatus: 'FAILED'`s for `v0/evss_claims_async` to sentry, since these should only be logged in vets-api.

## Acceptance criteria
- [x] Only actual response errors should be logged in sentry for claims tool.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
