### PR TITLE
VAGOV-000: Updated links from drupal.

### DIFF
--- a/src/site/blocks/promo.drupal.liquid
+++ b/src/site/blocks/promo.drupal.liquid
@@ -35,7 +35,7 @@
     <img src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="{{ image.derivative.width }}" height="{{ image.derivative.height }}">
   {% if entity.fieldPromoLink != empty %}
     <section class="hub-promo-text">
-        <h4 class="heading"><a href="{{ entity.fieldPromoLink.entity.fieldLink.uri }}">{{ entity.fieldPromoLink.entity.fieldLink.title }}</a></h4>
+        <h4 class="heading"><a href="{{ entity.fieldPromoLink.entity.fieldLink.url.path }}">{{ entity.fieldPromoLink.entity.fieldLink.title }}</a></h4>
         <p>{{ entity.fieldPromoLink.entity.fieldLinkSummary }}</p>
     </section>
   {% endif %}

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -72,7 +72,7 @@
                         {% assign service = supportService.entity %}
                         <li>
                           {% if service.fieldPhoneNumber %}
-                            <a href="{{ service.fieldLink.uri }}">
+                            <a href="{{ service.fieldLink.url.path }}">
                               <span>{{ service.title }}</span><br>
                               <span>{{ service.fieldPhoneNumber }}</span>
                             </a>

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -25,7 +25,7 @@
     {% endif %}
 {% endif %}
 <li {% if parentFieldName === 'field_spokes' %}class="hub-page-link-list__item"{% endif %}>
-    <a href="{{linkTeaser.fieldLink.uri}}" {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
+    <a href="{{linkTeaser.fieldLink.url.path}}" {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
         {% if linkTeaser.fieldLink.title != empty %}
             <{{ header }} class="{{ headerClass }}">{{ linkTeaser.fieldLink.title }}</{{ header }}>
             {% if parentFieldName === "field_spokes" %}

--- a/src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid
+++ b/src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid
@@ -17,7 +17,7 @@
         <div class="usa-grid-full">
         {% endif %}
         <div class="usa-width-one-half vads-u-padding-bottom--2">
-            <a href="{{linkTeaser.entity.fieldLink.uri}}">
+            <a href="{{linkTeaser.entity.fieldLink.url.path}}">
                 {{ linkTeaser.entity.fieldLink.title }}
             </a>
         </div>

--- a/src/site/paragraphs/react_widget.drupal.liquid
+++ b/src/site/paragraphs/react_widget.drupal.liquid
@@ -40,7 +40,7 @@
           {% else %}
             {% assign classes = '' %}
           {% endif %}
-          <a href="{{ entity.fieldDefaultLink.uri }}" {{ classes }}>{{ entity.fieldDefaultLink.title }}</a>
+          <a href="{{ entity.fieldDefaultLink.url.path }}" {{ classes }}>{{ entity.fieldDefaultLink.title }}</a>
         {% endif %}
       </div>
   {% endif %}

--- a/src/site/stages/build/drupal/graphql/landingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/landingPage.graphql.js
@@ -48,7 +48,9 @@ module.exports = `
             entityBundle
             title
             fieldLink {
-              uri
+              url {
+                path
+              }
               title
               options                  
             }

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/linkTeaser.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/linkTeaser.paragraph.graphql.js
@@ -4,7 +4,9 @@
 module.exports = `
   fragment linkTeaser on ParagraphLinkTeaser {
     fieldLink {
-      uri
+      url {
+        path
+      }
       title
       options      
     }

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/reactWidget.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/reactWidget.paragraph.graphql.js
@@ -8,7 +8,9 @@ module.exports = `
     fieldCtaWidget
     fieldWidgetType
     fieldDefaultLink {
-      uri
+      url {
+        path
+      }
       title
     }
     fieldButtonFormat


### PR DESCRIPTION
## Description
Now that the paths are all set in drupal, we should be using path.url instead of uri to get page links. This branch updates all of the existing queries and templates that use uri to use path.url instead.