### PR TITLE
VetTec: When a user updates their bank account information with a blank field, the pre-filled info is still saved #17156

### DIFF
--- a/src/applications/edu-benefits/0994/components/PaymentReviewView.jsx
+++ b/src/applications/edu-benefits/0994/components/PaymentReviewView.jsx
@@ -16,9 +16,11 @@ export class PaymentReviewView extends React.Component {
     const { formData, name } = this.state;
     let value = formData;
     if (formData === undefined) {
-      const viewBankAccount = _.get(this.props.data, 'view:bankAccount', {});
-
-      if (!hasNewBankInformation(_.get(viewBankAccount, 'bankAccount', {}))) {
+      if (
+        !hasNewBankInformation(
+          _.get(this.props.data, 'view:bankAccount.bankAccount', {}),
+        )
+      ) {
         // Use prefill data
         const propName = `bank${name
           .substring(0, 1)

--- a/src/applications/edu-benefits/0994/components/PaymentReviewView.jsx
+++ b/src/applications/edu-benefits/0994/components/PaymentReviewView.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { maskBankInformation } from '../utils';
+import { maskBankInformation, hasNewBankInformation } from '../utils';
 
 export class PaymentReviewView extends React.Component {
   constructor(props) {
@@ -16,16 +16,20 @@ export class PaymentReviewView extends React.Component {
     const { formData, name } = this.state;
     let value = formData;
     if (formData === undefined) {
-      // Use prefill data
-      const propName = `bank${name
-        .substring(0, 1)
-        .toUpperCase()}${name.substring(1)}`;
-      const prefillBankAccount = _.get(
-        this.props.data,
-        'prefillBankAccount',
-        {},
-      );
-      value = _.get(prefillBankAccount, propName, '');
+      const viewBankAccount = _.get(this.props.data, 'view:bankAccount', {});
+
+      if (!hasNewBankInformation(_.get(viewBankAccount, 'bankAccount', {}))) {
+        // Use prefill data
+        const propName = `bank${name
+          .substring(0, 1)
+          .toUpperCase()}${name.substring(1)}`;
+        const prefillBankAccount = _.get(
+          this.props.data,
+          'prefillBankAccount',
+          {},
+        );
+        value = _.get(prefillBankAccount, propName, '');
+      }
     } else if (name === 'accountNumber' || name === 'routingNumber') {
       value = maskBankInformation(value, 4);
     } else if (name === 'accountType' && value.length > 0) {

--- a/src/applications/edu-benefits/0994/components/PaymentView.jsx
+++ b/src/applications/edu-benefits/0994/components/PaymentView.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { maskBankInformation } from '../utils';
+import { maskBankInformation, hasNewBankInformation } from '../utils';
 
 export const accountTitleLabels = {
   CHECKING: 'Checking Account',
@@ -10,14 +10,14 @@ export const accountTitleLabels = {
 };
 
 export const PaymentView = ({ formData = {}, originalData = {} }) => {
+  const bankAccount = _.get(formData, 'bankAccount', {});
   const {
     accountType: newAccountType,
     accountNumber: newAccountNumber,
     routingNumber: newRoutingNumber,
-  } = _.get(formData, 'bankAccount', {});
+  } = bankAccount;
 
-  const hasNewBankAccountInfo =
-    newAccountType || newAccountNumber || newRoutingNumber;
+  const hasNewBankAccountInfo = hasNewBankInformation(bankAccount);
 
   const bankAccountType = hasNewBankAccountInfo
     ? newAccountType

--- a/src/applications/edu-benefits/0994/content/bankInformation.jsx
+++ b/src/applications/edu-benefits/0994/content/bankInformation.jsx
@@ -4,13 +4,13 @@ import AdditionalInfo from '@department-of-veterans-affairs/formation-react/Addi
 export const bankInfoTitle = <h4>Direct deposit information</h4>;
 
 export const bankInfoDescription =
-  'This is the bank account information we have on file for you and will use to pay you.';
+  'This is the bank account information we have on file for you. We’ll pay your housing stipend to this account.';
+
 export const bankInfoNote = (
   <p>
     <strong>Note: </strong>
-    Changes you make to the information on this page will update your bank
-    account information for all benefits you receive from VA, including
-    Compensation, Pension and Education.
+    Any updates you make here to your contact information will also apply to
+    your other VA benefits, including compensation, pension, and education.
   </p>
 );
 
@@ -44,10 +44,10 @@ export const bankInfoHelpText = (
       or call 1-800-333-1795.
     </p>
     <p>
-      If you elect not to enroll, you must contact representatives handling
-      waiver requests for the Department of Treasury at 1-888-224-2950. They
-      will encourage your participation in EFT and address any questions or
-      concerns you may have.
+      If you choose not to enroll, you’ll need to call the Department of
+      Treasury at 1-888-224-2950 and speak to a representative handling waiver
+      requests. They’ll encourage you to participate in EFT and address any
+      questions or concerns you have.
     </p>
   </AdditionalInfo>
 );

--- a/src/applications/edu-benefits/0994/utils.jsx
+++ b/src/applications/edu-benefits/0994/utils.jsx
@@ -32,3 +32,8 @@ export const maskBankInformation = (string, unmaskedLength) => {
     </span>
   );
 };
+
+export const hasNewBankInformation = (bankAccount = {}) => {
+  const { accountType, accountNumber, routingNumber } = bankAccount;
+  return accountType || accountNumber || routingNumber;
+};

--- a/src/applications/edu-benefits/tests/0994/components/PaymentReviewView.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/0994/components/PaymentReviewView.unit.spec.jsx
@@ -35,7 +35,7 @@ describe('<PaymentReviewView>', () => {
     component.unmount();
   });
   it('should not render prefill bank info', () => {
-    const moarData = {
+    const moreData = {
       ...data,
       'view:bankAccount': {
         bankAccount: {
@@ -45,7 +45,7 @@ describe('<PaymentReviewView>', () => {
       },
     };
     const component = shallow(
-      <PaymentReviewView name="accountType" data={moarData} />,
+      <PaymentReviewView name="accountType" data={moreData} />,
     );
 
     const text = component.text();

--- a/src/applications/edu-benefits/tests/0994/components/PaymentReviewView.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/0994/components/PaymentReviewView.unit.spec.jsx
@@ -34,4 +34,23 @@ describe('<PaymentReviewView>', () => {
 
     component.unmount();
   });
+  it('should not render prefill bank info', () => {
+    const moarData = {
+      ...data,
+      'view:bankAccount': {
+        bankAccount: {
+          routingNumber: '021000021',
+          accountNumber: '12',
+        },
+      },
+    };
+    const component = shallow(
+      <PaymentReviewView name="accountType" data={moarData} />,
+    );
+
+    const text = component.text();
+    expect(text).to.not.contain('Checking');
+
+    component.unmount();
+  });
 });


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17156
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17173

## Testing done
- local testing

## Screenshots
![screen shot 2019-03-01 at 10 41 54 am](https://user-images.githubusercontent.com/1094999/53648749-aeb7ca80-3c0e-11e9-9343-bec5882db8c2.png)
![screen shot 2019-03-01 at 10 41 59 am](https://user-images.githubusercontent.com/1094999/53648752-afe8f780-3c0e-11e9-9d7e-f214591b2139.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
