### PR TITLE
Support for routing and API calls in HCA ID form

### DIFF
--- a/src/applications/hca/actions.js
+++ b/src/applications/hca/actions.js
@@ -22,7 +22,7 @@ export function submitIDForm(formData) {
     apiRequest(
       url,
       null,
-      ({ data }) => dispatch({ type: SUBMIT_ID_FORM_SUCCEEDED, data }),
+      data => dispatch({ type: SUBMIT_ID_FORM_SUCCEEDED, data }),
       ({ errors }) => dispatch({ type: SUBMIT_ID_FORM_FAILED, errors }),
     );
   };

--- a/src/applications/hca/actions.js
+++ b/src/applications/hca/actions.js
@@ -1,23 +1,29 @@
+import appendQuery from 'append-query';
+import { apiRequest } from '../../platform/utilities/api';
+
 export const SUBMIT_ID_FORM_STARTED = 'SUBMIT_ID_FORM_STARTED';
 export const SUBMIT_ID_FORM_SUCCEEDED = 'SUBMIT_ID_FORM_SUCCEEDED';
 export const SUBMIT_ID_FORM_FAILED = 'SUBMIT_ID_FORM_FAILED';
 
-// eslint-disable-next-line no-unused-vars
 export function submitIDForm(formData) {
   return dispatch => {
-    dispatch({
-      type: SUBMIT_ID_FORM_STARTED,
+    dispatch({ type: SUBMIT_ID_FORM_STARTED });
+
+    const baseUrl = '/health_care_applications/enrollment_status';
+
+    const url = appendQuery(baseUrl, {
+      'userAttributes[gender]': formData.gender,
+      'userAttributes[veteranDateOfBirth]': formData.dob,
+      'userAttributes[veteranFullName][first]': formData.firstName,
+      'userAttributes[veteranFullName][last]': formData.lastName,
+      'userAttributes[veteranSocialSecurityNumber]': formData.ssn,
     });
 
-    // TODO: actually call the form ID endpoint and dispatch
-    // SUBMIT_ID_FORM_FAILED or SUBMIT_ID_FORM_SUCCEEDED depending on how it
-    // resolves
-    setTimeout(() => {
-      dispatch({
-        // type: 'SUBMIT_ID_FORM_SUCCEEDED',
-        type: SUBMIT_ID_FORM_FAILED,
-        error: 'oh noes!!!!',
-      });
-    }, 2000);
+    apiRequest(
+      url,
+      null,
+      ({ data }) => dispatch({ type: SUBMIT_ID_FORM_SUCCEEDED, data }),
+      ({ errors }) => dispatch({ type: SUBMIT_ID_FORM_FAILED, errors }),
+    );
   };
 }

--- a/src/applications/hca/components/IDForm.jsx
+++ b/src/applications/hca/components/IDForm.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
@@ -82,6 +84,52 @@ export default class IDForm extends React.Component {
       'ui:labels': genderLabels,
     },
   };
+
+  renderContinueButtonOrStatus = () => {
+    const { enrollmentStatus } = this.props;
+    if (enrollmentStatus && enrollmentStatus !== 'none_of_the_above') {
+      return (
+        <React.Fragment>
+          <AlertBox
+            isVisible
+            status="error"
+            headline="Please sign in to continue your application"
+            content={
+              <React.Fragment>
+                <p>
+                  We’re sorry for the interruption, but we need you to review
+                  some information before you continue applying. Please sign in
+                  below to review. If you don’t have an account, you can create
+                  one now.
+                </p>
+                <button
+                  className="usa-button-primary"
+                  onClick={this.props.handleSignIn}
+                >
+                  Sign in to VA.gov
+                </button>
+              </React.Fragment>
+            }
+          />
+          <br />
+        </React.Fragment>
+      );
+    }
+
+    return (
+      <LoadingButton
+        isLoading={this.props.isLoading}
+        disabled={false}
+        type="submit"
+        /* to override the `width: 100%` given to SchemaForm submit buttons */
+        style={{ width: 'auto' }}
+      >
+        Continue to the Application
+        <span className="button-icon">&nbsp;»</span>
+      </LoadingButton>
+    );
+  };
+
   render() {
     return (
       <SchemaForm
@@ -95,16 +143,7 @@ export default class IDForm extends React.Component {
         onChange={this.formChange}
         data={this.state.idFormData}
       >
-        <LoadingButton
-          isLoading={this.props.isLoading}
-          disabled={false}
-          type="submit"
-          /* to override the `width: 100%` given to SchemaForm submit buttons */
-          style={{ width: 'auto' }}
-        >
-          Continue to the Application
-          <span className="button-icon">&nbsp;»</span>
-        </LoadingButton>
+        {this.renderContinueButtonOrStatus()}
       </SchemaForm>
     );
   }

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -19,6 +19,7 @@ import { states } from 'platform/forms/address';
 import fullNameUI from 'platform/forms/definitions/fullName';
 import { genderLabels } from 'platform/static-data/labels';
 import { externalServices } from 'platform/monitoring/DowntimeNotification';
+import { hasSession } from 'platform/user/profile/utilities';
 import environment from 'platform/utilities/environment';
 import applicantDescription from 'platform/forms/components/ApplicantDescription';
 import PrefillMessage from 'platform/forms/save-in-progress/PrefillMessage';
@@ -29,6 +30,7 @@ import DowntimeMessage from '../components/DowntimeMessage';
 import ErrorText from '../components/ErrorText';
 import FormFooter from '../components/FormFooter';
 import GetFormHelp from '../components/GetFormHelp';
+import IDPage from '../containers/IDPage';
 
 import {
   transform,
@@ -164,6 +166,14 @@ const formConfig = {
   },
   transformForSubmit: transform,
   introduction: IntroductionPage,
+  additionalRoutes: !environment.isProduction() && [
+    {
+      path: 'id-form',
+      component: IDPage,
+      pageKey: 'id-form',
+      depends: () => !hasSession(),
+    },
+  ],
   confirmation: ConfirmationPage,
   submitErrorText: ErrorMessage,
   title: 'Apply for health care',

--- a/src/applications/hca/containers/IDPage.jsx
+++ b/src/applications/hca/containers/IDPage.jsx
@@ -6,9 +6,11 @@ import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
+import { setData } from 'platform/forms-system/src/js/actions';
+import { getNextPagePath } from 'platform/forms-system/src/js/routing';
 import { focusElement } from 'platform/utilities/ui';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
-import { isProfileLoading } from 'platform/user/selectors';
+import { isLoggedIn, isProfileLoading } from 'platform/user/selectors';
 
 import IDForm from '../components/IDForm';
 
@@ -16,15 +18,43 @@ import { submitIDForm } from '../actions';
 
 class IDPage extends React.Component {
   componentDidMount() {
+    // Redirect to intro if a logged in user navigated to this page
+    // from another form page.
+    if (this.props.shouldRedirect) this.props.router.push('/');
     focusElement('.va-nav-breadcrumbs-list');
   }
 
   componentDidUpdate() {
-    // there's no need for logged-in users to see this page
-    if (this.props.shouldHideIDForm) {
-      this.props.router.push('/');
+    const { enrollmentStatus, form, hasOptionalDD214Upload } = this.props;
+
+    // Redirect to intro if a logged in user directly accessed this page.
+    if (this.props.shouldRedirect) this.props.router.push('/');
+
+    const shouldSetDD214UploadFlag =
+      hasOptionalDD214Upload && !('view:hasOptionalDD214Upload' in form.data);
+
+    if (shouldSetDD214UploadFlag) {
+      this.props.setData({ ...form.data, 'view:hasOptionalDD214Upload': true });
+    }
+
+    if (hasOptionalDD214Upload || enrollmentStatus === 'none_of_the_above') {
+      this.goToNextPage();
     }
   }
+
+  goToNextPage = () => {
+    const { form, location, route } = this.props;
+    const nextPagePath = getNextPagePath(
+      route.pageList,
+      form.data,
+      location.pathname,
+    );
+    this.props.router.push(nextPagePath);
+  };
+
+  showSignInModal = () => {
+    this.props.toggleLoginModal(true);
+  };
 
   render() {
     return (
@@ -50,7 +80,7 @@ class IDPage extends React.Component {
                   </p>
                   <button
                     className="va-button-link"
-                    onClick={() => this.props.toggleLoginModal(true)}
+                    onClick={this.showSignInModal}
                   >
                     Sign in to start your application.
                   </button>
@@ -60,34 +90,9 @@ class IDPage extends React.Component {
             <br />
             <IDForm
               isLoading={this.props.isSubmittingIDForm}
+              handleSignIn={this.showSignInModal}
               handleSubmit={this.props.submitIDForm}
             />
-            {this.props.error && (
-              <React.Fragment>
-                <AlertBox
-                  isVisible
-                  status="error"
-                  headline="Please sign in to continue your application"
-                  content={
-                    <React.Fragment>
-                      <p>
-                        We’re sorry for the interruption, but we need you to
-                        review some information before you continue applying.
-                        Please sign in below to review. If you don’t have an
-                        account, you can create one now.
-                      </p>
-                      <button
-                        className="usa-button-primary"
-                        onClick={() => this.props.toggleLoginModal(true)}
-                      >
-                        Sign in to VA.gov
-                      </button>
-                    </React.Fragment>
-                  }
-                />
-                <br />
-              </React.Fragment>
-            )}
           </React.Fragment>
         )}
         <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
@@ -99,15 +104,19 @@ class IDPage extends React.Component {
 }
 
 const mapDispatchToProps = {
+  setData,
   submitIDForm,
   toggleLoginModal,
 };
 
 const mapStateToProps = state => ({
-  shouldHideIDForm: state.hcaIDForm.shouldHideIDForm,
-  showLoadingIndicator: isProfileLoading(state),
+  enrollmentStatus: state.hcaIDForm.enrollmentStatus,
+  errors: state.hcaIDForm.errors,
+  form: state.form,
+  hasOptionalDD214Upload: state.hcaIDForm.hasOptionalDD214Upload,
   isSubmittingIDForm: state.hcaIDForm.isSubmitting,
-  error: state.hcaIDForm.error,
+  shouldRedirect: isLoggedIn(state),
+  showLoadingIndicator: isProfileLoading(state),
 });
 
 export default connect(

--- a/src/applications/hca/containers/IDPage.jsx
+++ b/src/applications/hca/containers/IDPage.jsx
@@ -89,6 +89,7 @@ class IDPage extends React.Component {
             />
             <br />
             <IDForm
+              enrollmentStatus={this.props.enrollmentStatus}
               isLoading={this.props.isSubmittingIDForm}
               handleSignIn={this.showSignInModal}
               handleSubmit={this.props.submitIDForm}
@@ -111,7 +112,6 @@ const mapDispatchToProps = {
 
 const mapStateToProps = state => ({
   enrollmentStatus: state.hcaIDForm.enrollmentStatus,
-  errors: state.hcaIDForm.errors,
   form: state.form,
   hasOptionalDD214Upload: state.hcaIDForm.hasOptionalDD214Upload,
   isSubmittingIDForm: state.hcaIDForm.isSubmitting,

--- a/src/applications/hca/reducer.js
+++ b/src/applications/hca/reducer.js
@@ -1,6 +1,5 @@
 import formConfig from './config/form';
 import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
-import { UPDATE_LOGGEDIN_STATUS } from 'platform/user/authentication/actions';
 import {
   SUBMIT_ID_FORM_STARTED,
   SUBMIT_ID_FORM_SUCCEEDED,
@@ -8,21 +7,28 @@ import {
 } from './actions';
 
 const initialState = {
+  hasOptionalDD214Upload: false,
   isSubmitting: false,
-  error: null,
-  shouldHideIDForm: false,
+  errors: null,
+  enrollmentStatus: null,
 };
 
 function hcaIDForm(state = initialState, action) {
   switch (action.type) {
     case SUBMIT_ID_FORM_STARTED:
       return { ...state, isSubmitting: true };
-    case SUBMIT_ID_FORM_SUCCEEDED:
-      return { ...state, isSubmitting: false };
-    case SUBMIT_ID_FORM_FAILED:
-      return { ...state, isSubmitting: false, error: action.error };
-    case UPDATE_LOGGEDIN_STATUS:
-      return { ...state, shouldHideIDForm: action.value };
+
+    case SUBMIT_ID_FORM_SUCCEEDED: {
+      const { parsedStatus: enrollmentStatus } = action.data;
+      return { ...state, isSubmitting: false, enrollmentStatus };
+    }
+
+    case SUBMIT_ID_FORM_FAILED: {
+      const { errors } = action;
+      const hasOptionalDD214Upload = errors.some(error => error.code === '500');
+      return { ...state, errors, hasOptionalDD214Upload, isSubmitting: false };
+    }
+
     default:
       return state;
   }

--- a/src/applications/hca/reducer.js
+++ b/src/applications/hca/reducer.js
@@ -25,7 +25,7 @@ function hcaIDForm(state = initialState, action) {
 
     case SUBMIT_ID_FORM_FAILED: {
       const { errors } = action;
-      const hasOptionalDD214Upload = errors.some(error => error.code === '500');
+      const hasOptionalDD214Upload = errors.some(error => error.code === '404');
       return { ...state, errors, hasOptionalDD214Upload, isSubmitting: false };
     }
 

--- a/src/applications/hca/reducer.js
+++ b/src/applications/hca/reducer.js
@@ -25,7 +25,8 @@ function hcaIDForm(state = initialState, action) {
 
     case SUBMIT_ID_FORM_FAILED: {
       const { errors } = action;
-      const hasOptionalDD214Upload = errors.some(error => error.code === '404');
+      const hasOptionalDD214Upload =
+        errors && errors.some(error => error.code === '404');
       return { ...state, errors, hasOptionalDD214Upload, isSubmitting: false };
     }
 

--- a/src/applications/hca/routes.jsx
+++ b/src/applications/hca/routes.jsx
@@ -1,20 +1,7 @@
 import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
-import environment from 'platform/utilities/environment';
 
 import formConfig from './config/form';
 import HealthCareApp from './HealthCareApp.jsx';
-import IDPage from './containers/IDPage';
-
-const formRoutes = createRoutesWithSaveInProgress(formConfig);
-
-// If the route's path ends in `introduction` then the form system will treat it
-// as an Introduction page (ie it won't add the Title component or navigation
-// elements) which is what we want in this case.
-const idFormRoute = {
-  path: 'id-introduction',
-  component: IDPage,
-  key: 'id-introduction',
-};
 
 const routes = {
   path: '/',
@@ -22,10 +9,7 @@ const routes = {
   indexRoute: {
     onEnter: (nextState, replace) => replace('/introduction'),
   },
-  // do not allow the idFormRoute in production
-  childRoutes: environment.isProduction()
-    ? formRoutes
-    : [idFormRoute, ...formRoutes],
+  childRoutes: createRoutesWithSaveInProgress(formConfig),
 };
 
 export default routes;

--- a/src/platform/forms-system/src/js/containers/FormApp.jsx
+++ b/src/platform/forms-system/src/js/containers/FormApp.jsx
@@ -14,6 +14,12 @@ const Element = Scroll.Element;
  */
 class FormApp extends React.Component {
   componentWillMount() {
+    const { additionalRoutes } = this.props.formConfig;
+    this.nonFormPages = [];
+    if (additionalRoutes) {
+      this.nonFormPages = additionalRoutes.map(route => route.path);
+    }
+
     setGlobalScroll();
 
     if (window.History) {
@@ -24,15 +30,19 @@ class FormApp extends React.Component {
   render() {
     const { currentLocation, formConfig, children, formData } = this.props;
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
+    const lastPathComponent = currentLocation.pathname.split('/').pop();
     const isIntroductionPage = trimmedPathname.endsWith('introduction');
+    const isNonFormPage = this.nonFormPages.includes(lastPathComponent);
     const Footer = formConfig.footerContent;
 
     let formTitle;
     let formNav;
     let renderedChildren = children;
-    if (!isIntroductionPage) {
-      // Show title only if we're not on the intro page and if there is a title
-      // specified in the form config
+    if (!isIntroductionPage && !isNonFormPage) {
+      // Show title only if:
+      // 1. we're not on the intro page *or* one of the additionalRoutes
+      //    specified in the form config
+      // 2. there is a title specified in the form config
       if (formConfig.title) {
         formTitle = (
           <FormTitle title={formConfig.title} subTitle={formConfig.subTitle} />
@@ -40,9 +50,10 @@ class FormApp extends React.Component {
       }
     }
 
-    // Show nav only if we're not on the intro, form-saved, error, or confirmation page
+    // Show nav only if we're not on the intro, form-saved, error, confirmation
+    // page or one of the additionalRoutes specified in the form config
     // Also add form classes only if on an actual form page
-    if (isInProgress(trimmedPathname)) {
+    if (!isNonFormPage && isInProgress(trimmedPathname)) {
       formNav = (
         <FormNav
           formData={formData}

--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -66,6 +66,11 @@ export function createPageListByChapter(formConfig) {
 
 export function createPageList(formConfig, formPages) {
   let pageList = formPages;
+
+  if (formConfig.additionalRoutes) {
+    pageList = formConfig.additionalRoutes.concat(pageList);
+  }
+
   if (formConfig.introduction) {
     pageList = [
       {
@@ -96,6 +101,7 @@ export function createPageList(formConfig, formPages) {
 export function createRoutes(formConfig) {
   const formPages = createFormPageList(formConfig);
   const pageList = createPageList(formConfig, formPages);
+
   let routes = formPages.map(page => ({
     path: page.path,
     component: page.component || FormPage,
@@ -103,6 +109,17 @@ export function createRoutes(formConfig) {
     pageList,
     urlPrefix: formConfig.urlPrefix,
   }));
+
+  if (formConfig.additionalRoutes) {
+    routes = formConfig.additionalRoutes
+      .map(route => ({
+        ...route,
+        formConfig,
+        pageList,
+      }))
+      .concat(routes);
+  }
+
   if (formConfig.introduction) {
     routes = [
       {

--- a/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
@@ -4,6 +4,8 @@ import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 
 import FormApp from 'platform/forms-system/src/js/containers/FormApp';
+import { getNextPagePath } from 'platform/forms-system/src/js/routing';
+
 import {
   LOAD_STATUSES,
   PREFILL_STATUSES,
@@ -38,6 +40,7 @@ class RoutedSavableApp extends React.Component {
     super(props);
     this.location = props.location || window.location;
   }
+
   componentWillMount() {
     window.addEventListener('beforeunload', this.onbeforeunload);
     if (window.History) {
@@ -102,9 +105,7 @@ class RoutedSavableApp extends React.Component {
       newProps.prefillStatus !== this.props.prefillStatus &&
       newProps.prefillStatus === PREFILL_STATUSES.unfilled
     ) {
-      newProps.router.push(
-        newProps.routes[this.props.routes.length - 1].pageList[1].path,
-      );
+      newProps.router.push(this.getFirstNonIntroPagePath(newProps));
     } else if (
       status !== LOAD_STATUSES.notAttempted &&
       status !== LOAD_STATUSES.pending &&
@@ -162,14 +163,21 @@ class RoutedSavableApp extends React.Component {
     return message;
   };
 
+  getFirstNonIntroPagePath(props) {
+    return getNextPagePath(
+      props.routes[props.routes.length - 1].pageList,
+      props.formData,
+      '/introduction',
+    );
+  }
+
   redirectOrLoad(props) {
     // Stop a user that's been redirected to be redirected again after logging in
     this.shouldRedirectOrLoad = false;
 
     const firstPagePath =
       props.routes[props.routes.length - 1].pageList[0].path;
-    const firstNonIntroPagePath =
-      props.routes[props.routes.length - 1].pageList[1].path;
+    const firstNonIntroPagePath = this.getFirstNonIntroPagePath(props);
     // If we're logged in and have a saved / pre-filled form, load that
     if (props.isLoggedIn) {
       const currentForm = props.formConfig.formId;

--- a/src/platform/forms/save-in-progress/helpers.js
+++ b/src/platform/forms/save-in-progress/helpers.js
@@ -13,9 +13,13 @@ export function createRoutesWithSaveInProgress(formConfig) {
     'introduction',
     'review-and-submit',
     'confirmation',
-    'id-form',
     '*',
   ]);
+
+  formConfig.additionalRoutes.forEach(route => {
+    protectedRoutes.add(route.path);
+  });
+
   const formPages = createFormPageList(formConfig);
   const pageList = createPageList(formConfig, formPages);
   const newRoutes = createRoutes(formConfig);

--- a/src/platform/forms/save-in-progress/helpers.js
+++ b/src/platform/forms/save-in-progress/helpers.js
@@ -16,15 +16,15 @@ export function createRoutesWithSaveInProgress(formConfig) {
     '*',
   ]);
 
-  formConfig.additionalRoutes.forEach(route => {
-    protectedRoutes.add(route.path);
-  });
+  if (Array.isArray(formConfig.additionalRoutes)) {
+    formConfig.additionalRoutes.forEach(route => {
+      protectedRoutes.add(route.path);
+    });
+  }
 
   const formPages = createFormPageList(formConfig);
   const pageList = createPageList(formConfig, formPages);
   const newRoutes = createRoutes(formConfig);
-  // eslint-disable-next-line no-debugger
-  // debugger;
 
   newRoutes.forEach((route, index) => {
     let newRoute;

--- a/src/platform/forms/tests/save-in-progress/RoutedSavableApp.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/RoutedSavableApp.unit.spec.jsx
@@ -96,10 +96,10 @@ describe('Schemaform <RoutedSavableApp>', () => {
       {
         pageList: [
           {
-            path: 'intro',
+            path: '/introduction',
           },
           {
-            path: 'test-path',
+            path: '/test-path',
           },
         ],
       },
@@ -125,9 +125,10 @@ describe('Schemaform <RoutedSavableApp>', () => {
       prefillStatus: PREFILL_STATUSES.unfilled,
       router,
       routes,
+      data: {},
     });
 
-    expect(router.push.calledWith('test-path')).to.be.true;
+    expect(router.push.calledWith('/test-path')).to.be.true;
   });
   it('should route and reset fetch status on success', () => {
     const formConfig = {


### PR DESCRIPTION
## Description
* Invoke the API endpoint for enrollment status.
* Various changes to support routing additional routes in forms (what "Start Application" goes to, back/next, etc.)

## Testing done
Local manual testing.

## Screenshots


## Acceptance criteria
- [x] Enrollment status API should get invoked and handled accordingly.
  - [x] Responses indicating some "enrolled" status from enrollment status API should prompt for login.
  - [x] 404 response from enrollment status API should be handled (continue to form with DD214 upload option).
  - [x] Unenrolled status from enrollment status API should be handled (continue to form without DD214 upload option).
- [x] When the user is logged out, ID form should exist as a route between the introduction (Start Application) and first form page (going back).
- [x] When the user is logged in, ID form should not be accessible from the introduction (Start Application) or first form page (going back).
- [x] ID form should not be accessible to a logged in user.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
