### PR TITLE
Require disability

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
@@ -30,21 +30,6 @@ export const descriptionInfo = (
   </div>
 );
 
-const alertContent = newOnly => (
-  <>
-    <p>
-      You’ll need to add a new disability or choose a rated disability to claim.
-      We can’t process your claim without a disability selected. Please add a
-      new disability or choose a rated disability for increased compensation.
-    </p>
-    {!newOnly && (
-      <Link to={`disabilities/rated-disabilities`}>
-        Choose a rated disability
-      </Link>
-    )}
-  </>
-);
-
 export const newOnlyAlert = ({ formContext }) => {
   // Display only after the user tries to submit with no disabilities
   if (!formContext.submitted) return null;
@@ -52,7 +37,7 @@ export const newOnlyAlert = ({ formContext }) => {
     <AlertBox
       status="error"
       headline="We need you to add a disability"
-      content={alertContent(true)}
+      content="You need to add a new disability to claim. We can’t process your claim without a disability selected."
     />
   );
 };
@@ -60,11 +45,26 @@ export const newOnlyAlert = ({ formContext }) => {
 export const increaseAndNewAlert = ({ formContext }) => {
   // Display only after the user tries to submit with no disabilities
   if (!formContext.submitted) return null;
+
+  const alertContent = (
+    <>
+      <p>
+        You’ll need to add a new disability or choose a rated disability to
+        claim. We can’t process your claim without a disability selected. Please
+        add a new disability or choose a rated disability for increased
+        compensation.
+      </p>
+      <Link to={`disabilities/rated-disabilities`}>
+        Choose a rated disability
+      </Link>
+    </>
+  );
+
   return (
     <AlertBox
       status="error"
       headline="We need you to add a disability"
-      content={alertContent(false)}
+      content={alertContent}
     />
   );
 };

--- a/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
@@ -3,8 +3,6 @@ import { Link } from 'react-router';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
-import { urls } from '../utils';
-
 export const autoSuggestTitle = (
   <p>
     If you know the name of your condition, you can type it here. You can write
@@ -40,7 +38,7 @@ const alertContent = newOnly => (
       new disability or choose a rated disability for increased compensation.
     </p>
     {!newOnly && (
-      <Link to={`${urls.v2}/disabilities/rated-disabilities`}>
+      <Link to={`disabilities/rated-disabilities`}>
         Choose a rated disability
       </Link>
     )}

--- a/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
+import { Link } from 'react-router';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
-// import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+import { urls } from '../utils';
 
 export const autoSuggestTitle = (
   <p>
@@ -29,14 +32,41 @@ export const descriptionInfo = (
   </div>
 );
 
+const alertContent = newOnly => (
+  <>
+    <p>
+      You’ll need to add a new disability or choose a rated disability to claim.
+      We can’t process your claim without a disability selected. Please add a
+      new disability or choose a rated disability for increased compensation.
+    </p>
+    {!newOnly && (
+      <Link to={`${urls.v2}/disabilities/rated-disabilities`}>
+        Choose a rated disability
+      </Link>
+    )}
+  </>
+);
+
 export const newOnlyAlert = ({ formContext }) => {
   // Display only after the user tries to submit with no disabilities
   if (!formContext.submitted) return null;
-  return <div>New-only alert!</div>;
+  return (
+    <AlertBox
+      status="error"
+      headline="We need you to add a disability"
+      content={alertContent(true)}
+    />
+  );
 };
 
 export const increaseAndNewAlert = ({ formContext }) => {
   // Display only after the user tries to submit with no disabilities
   if (!formContext.submitted) return null;
-  return <div>Increase and new alert!</div>;
+  return (
+    <AlertBox
+      status="error"
+      headline="We need you to add a disability"
+      content={alertContent(false)}
+    />
+  );
 };

--- a/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+// import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 export const autoSuggestTitle = (
   <p>
@@ -10,7 +11,7 @@ export const autoSuggestTitle = (
   </p>
 );
 
-export const uiDescription = (
+export const descriptionInfo = (
   <div>
     <AdditionalInfo triggerText="What if I don’t know the name of my condition?">
       <p>
@@ -26,4 +27,8 @@ export const uiDescription = (
       </ul>
     </AdditionalInfo>
   </div>
+);
+
+export const disabilityRequiredAlert = props => (
+  <div>{JSON.stringify(props, null, 2)}</div>
 );

--- a/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
@@ -29,6 +29,8 @@ export const descriptionInfo = (
   </div>
 );
 
-export const disabilityRequiredAlert = props => (
-  <div>{JSON.stringify(props, null, 2)}</div>
-);
+export const disabilityRequiredAlert = ({ formContext }) => {
+  // Display only after the user tries to submit with no disabilities
+  if (!formContext.submitted) return null;
+  return <div>Alert!</div>;
+};

--- a/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
@@ -29,8 +29,14 @@ export const descriptionInfo = (
   </div>
 );
 
-export const disabilityRequiredAlert = ({ formContext }) => {
+export const newOnlyAlert = ({ formContext }) => {
   // Display only after the user tries to submit with no disabilities
   if (!formContext.submitted) return null;
-  return <div>Alert!</div>;
+  return <div>New-only alert!</div>;
+};
+
+export const increaseAndNewAlert = ({ formContext }) => {
+  // Display only after the user tries to submit with no disabilities
+  if (!formContext.submitted) return null;
+  return <div>Increase and new alert!</div>;
 };

--- a/src/applications/disability-benefits/all-claims/content/ratedDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ratedDisabilities.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { capitalizeEachWord } from '../utils';
 
 /**
@@ -32,3 +33,17 @@ export const disabilitiesClarification = (
     are in progress.
   </p>
 );
+
+/**
+ * Shows the alert box only if the form has been submitted
+ */
+export const ratedDisabilitiesAlert = ({ formContext }) => {
+  if (!formContext.submitted) return null;
+  return (
+    <AlertBox
+      status="error"
+      headline="We need you to add a disability"
+      content="You’ll need to add a new disability or choose a rated disability to claim. We can’t process your claim without a disability selected."
+    />
+  );
+};

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -3,12 +3,17 @@ import disabilityLabels from '../content/disabilityLabels';
 import {
   descriptionInfo,
   autoSuggestTitle,
-  disabilityRequiredAlert,
+  newOnlyAlert,
+  increaseAndNewAlert,
 } from '../content/addDisabilities';
 import NewDisability from '../components/NewDisability';
 import ArrayField from '../components/ArrayField';
 import { validateDisabilityName, requireDisability } from '../validations';
-import { hasClaimedConditions } from '../utils';
+import {
+  newConditionsOnly,
+  newAndIncrease,
+  hasClaimedConditions,
+} from '../utils';
 
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
@@ -48,13 +53,23 @@ export const uiSchema = {
     },
   },
   // This object only shows up when the user tries to continue without claiming either a rated or new condition
-  'view:newDisabilityError': {
-    'ui:description': disabilityRequiredAlert,
+  'view:newDisabilityErrors': {
     // Put the validation here instead of on the condition so the user can't continue to the next page but
     //  aren't bombarded with two validation errors.
     'ui:validations': [requireDisability],
-    'ui:options': {
-      hideIf: hasClaimedConditions,
+    'view:newOnlyAlert': {
+      'ui:description': newOnlyAlert,
+      'ui:options': {
+        hideIf: formData =>
+          !newConditionsOnly(formData) || hasClaimedConditions(formData),
+      },
+    },
+    'view:increaseAndNewAlert': {
+      'ui:description': increaseAndNewAlert,
+      'ui:options': {
+        hideIf: formData =>
+          !newAndIncrease(formData) || hasClaimedConditions(formData),
+      },
     },
   },
 };
@@ -73,6 +88,12 @@ export const schema = {
         },
       },
     },
-    'view:newDisabilityError': { type: 'object', properties: {} },
+    'view:newDisabilityErrors': {
+      type: 'object',
+      properties: {
+        'view:newOnlyAlert': { type: 'object', properties: {} },
+        'view:increaseAndNewAlert': { type: 'object', properties: {} },
+      },
+    },
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -42,19 +42,19 @@ export const uiSchema = {
           'ui:validations': [validateDisabilityName],
         },
       ),
-      // This object only shows up when the user tries to continue without claiming either a rated or new condition
-      'view:newDisabilityError': {
-        'ui:description': disabilityRequiredAlert,
-        // Put the validation here instead of on the condition so the user can't continue to the next page but
-        //  aren't bombarded with two validation errors.
-        'ui:validations': [requireDisability],
-        'ui:options': {
-          hideIf: hasClaimedConditions,
-        },
-      },
       'view:descriptionInfo': {
         'ui:description': descriptionInfo,
       },
+    },
+  },
+  // This object only shows up when the user tries to continue without claiming either a rated or new condition
+  'view:newDisabilityError': {
+    'ui:description': disabilityRequiredAlert,
+    // Put the validation here instead of on the condition so the user can't continue to the next page but
+    //  aren't bombarded with two validation errors.
+    'ui:validations': [requireDisability],
+    'ui:options': {
+      hideIf: hasClaimedConditions,
     },
   },
 };
@@ -67,13 +67,12 @@ export const schema = {
       minItems: 1,
       items: {
         type: 'object',
-        // required: ['condition'],
         properties: {
           condition,
-          'view:newDisabilityError': { type: 'object', properties: {} },
           'view:descriptionInfo': { type: 'object', properties: {} },
         },
       },
     },
+    'view:newDisabilityError': { type: 'object', properties: {} },
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -61,6 +61,7 @@ export const uiSchema = {
       'ui:description': newOnlyAlert,
       'ui:options': {
         hideIf: formData =>
+          // Only show this alert if the veteran is claiming only new conditions
           !newConditionsOnly(formData) || hasClaimedConditions(formData),
       },
     },
@@ -68,6 +69,7 @@ export const uiSchema = {
       'ui:description': increaseAndNewAlert,
       'ui:options': {
         hideIf: formData =>
+          // Only show this alert if the veteran is claiming both rated and new conditions
           !newAndIncrease(formData) || hasClaimedConditions(formData),
       },
     },

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -1,9 +1,14 @@
 import * as autosuggest from 'platform/forms-system/src/js/definitions/autosuggest';
 import disabilityLabels from '../content/disabilityLabels';
-import { uiDescription, autoSuggestTitle } from '../content/addDisabilities';
+import {
+  descriptionInfo,
+  autoSuggestTitle,
+  disabilityRequiredAlert,
+} from '../content/addDisabilities';
 import NewDisability from '../components/NewDisability';
 import ArrayField from '../components/ArrayField';
-import { validateDisabilityName } from '../validations';
+import { validateDisabilityName, requireDisability } from '../validations';
+import { hasClaimedConditions } from '../utils';
 
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
@@ -37,8 +42,18 @@ export const uiSchema = {
           'ui:validations': [validateDisabilityName],
         },
       ),
+      // This object only shows up when the user tries to continue without claiming either a rated or new condition
+      'view:newDisabilityError': {
+        'ui:description': disabilityRequiredAlert,
+        // Put the validation here instead of on the condition so the user can't continue to the next page but
+        //  aren't bombarded with two validation errors.
+        'ui:validations': [requireDisability],
+        'ui:options': {
+          hideIf: hasClaimedConditions,
+        },
+      },
       'view:descriptionInfo': {
-        'ui:description': uiDescription,
+        'ui:description': descriptionInfo,
       },
     },
   },
@@ -52,9 +67,10 @@ export const schema = {
       minItems: 1,
       items: {
         type: 'object',
-        required: ['condition'],
+        // required: ['condition'],
         properties: {
           condition,
+          'view:newDisabilityError': { type: 'object', properties: {} },
           'view:descriptionInfo': { type: 'object', properties: {} },
         },
       },

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -29,6 +29,9 @@ export const uiSchema = {
       reviewTitle: 'New Disabilities',
       itemName: 'Disability',
     },
+    // Ideally, this would show the validation on the array itself (or the name field in an array
+    //  item), but that's not working.
+    'ui:validations': [requireDisability],
     items: {
       condition: autosuggest.uiSchema(
         autoSuggestTitle,
@@ -54,14 +57,10 @@ export const uiSchema = {
   },
   // This object only shows up when the user tries to continue without claiming either a rated or new condition
   'view:newDisabilityErrors': {
-    // Put the validation here instead of on the condition so the user can't continue to the next page but
-    //  aren't bombarded with two validation errors.
-    'ui:validations': [requireDisability],
     'view:newOnlyAlert': {
       'ui:description': newOnlyAlert,
       'ui:options': {
         hideIf: formData =>
-          // Only show this alert if the veteran is claiming only new conditions
           !newConditionsOnly(formData) || hasClaimedConditions(formData),
       },
     },

--- a/src/applications/disability-benefits/all-claims/pages/newDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilities.js
@@ -1,7 +1,18 @@
+import { increaseAndNewAlert } from '../content/addDisabilities';
+import { requireNewDisability } from '../validations';
+import { claimingRated } from '../utils';
+
 export const uiSchema = {
   'view:newDisabilities': {
     'ui:title': 'Do you have any new conditions you want to add to your claim?',
     'ui:widget': 'yesNo',
+    'ui:validations': [requireNewDisability],
+  },
+  'view:noSelectedAlert': {
+    'ui:description': increaseAndNewAlert,
+    'ui:options': {
+      hideIf: claimingRated,
+    },
   },
 };
 
@@ -12,5 +23,6 @@ export const schema = {
     'view:newDisabilities': {
       type: 'boolean',
     },
+    'view:noSelectedAlert': { type: 'object', properties: {} },
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/ratedDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/ratedDisabilities.js
@@ -3,7 +3,11 @@ import SelectArrayItemsWidget from '../components/SelectArrayItemsWidget';
 import {
   disabilityOption,
   disabilitiesClarification,
+  ratedDisabilitiesAlert,
 } from '../content/ratedDisabilities';
+
+import { increaseOnly, claimingRated } from '../utils';
+import { requireRatedDisability } from '../validations';
 
 const { ratedDisabilities } = fullSchema.properties;
 
@@ -25,6 +29,13 @@ export const uiSchema = {
   'view:disabilitiesClarification': {
     'ui:description': disabilitiesClarification,
   },
+  'view:ratedDisabilitiesAlert': {
+    'ui:description': ratedDisabilitiesAlert,
+    'ui:validations': [requireRatedDisability],
+    'ui:options': {
+      hideIf: formData => !increaseOnly(formData) || claimingRated(formData),
+    },
+  },
 };
 
 export const schema = {
@@ -32,6 +43,10 @@ export const schema = {
   properties: {
     ratedDisabilities,
     'view:disabilitiesClarification': {
+      type: 'object',
+      properties: {},
+    },
+    'view:ratedDisabilitiesAlert': {
       type: 'object',
       properties: {},
     },

--- a/src/applications/disability-benefits/all-claims/pages/ratedDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/ratedDisabilities.js
@@ -25,13 +25,13 @@ export const uiSchema = {
       widgetClassNames: 'widget-outline',
       keepInPageOnReview: true,
     },
+    'ui:validations': [requireRatedDisability],
   },
   'view:disabilitiesClarification': {
     'ui:description': disabilitiesClarification,
   },
   'view:ratedDisabilitiesAlert': {
     'ui:description': ratedDisabilitiesAlert,
-    'ui:validations': [requireRatedDisability],
     'ui:options': {
       hideIf: formData => !increaseOnly(formData) || claimingRated(formData),
     },

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -795,3 +795,11 @@ export const recordEventOnce = (event, key) => {
     recordEvent(event);
   }
 };
+
+export const hasClaimedConditions = formData => {
+  const { newDisabilities, ratedDisabilities } = formData;
+  const claimingNew = newDisabilities && newDisabilities.some(d => d.condition);
+  const claimingRated =
+    ratedDisabilities && ratedDisabilities.some(d => d['view:selected']);
+  return claimingNew || claimingRated;
+};

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -796,10 +796,12 @@ export const recordEventOnce = (event, key) => {
   }
 };
 
-export const hasClaimedConditions = formData => {
-  const { newDisabilities, ratedDisabilities } = formData;
-  const claimingNew = newDisabilities && newDisabilities.some(d => d.condition);
-  const claimingRated =
-    ratedDisabilities && ratedDisabilities.some(d => d['view:selected']);
-  return claimingNew || claimingRated;
-};
+export const claimingRated = formData =>
+  formData.ratedDisabilities &&
+  formData.ratedDisabilities.some(d => d['view:selected']);
+
+export const claimingNew = formData =>
+  formData.newDisabilities && formData.newDisabilities.some(d => d.condition);
+
+export const hasClaimedConditions = formData =>
+  claimingNew(formData) || claimingRated(formData);

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -800,6 +800,7 @@ export const claimingRated = formData =>
   formData.ratedDisabilities &&
   formData.ratedDisabilities.some(d => d['view:selected']);
 
+// TODO: Rename this to avoid collision with `isClaimingNew` above
 export const claimingNew = formData =>
   formData.newDisabilities && formData.newDisabilities.some(d => d.condition);
 

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -283,3 +283,14 @@ export const requireRatedDisability = (err, fieldData, formData) => {
     err.addError('');
   }
 };
+
+/**
+ * Require "yes" for "do you want to add new conditions" if no rated conditions
+ *  have been selected.
+ */
+export const requireNewDisability = (err, fieldData, formData) => {
+  if (!claimingRated(formData) && !fieldData) {
+    // The actual validation error is displayed as an alert field, so we don't need to add an error message here.
+    err.addError('');
+  }
+};

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -2,7 +2,12 @@ import _ from '../../../platform/utilities/data';
 import some from 'lodash/some';
 import moment from 'moment';
 
-import { isWithinRange, getPOWValidationMessage, pathWithIndex } from './utils';
+import {
+  isWithinRange,
+  getPOWValidationMessage,
+  pathWithIndex,
+  hasClaimedConditions,
+} from './utils';
 
 import {
   MILITARY_CITIES,
@@ -257,5 +262,12 @@ export const validateDisabilityName = (err, fieldData) => {
     fieldData.length > 255
   ) {
     err.addError('Condition names should be less than 256 characters');
+  }
+};
+
+export const requireDisability = (err, fieldData, formData) => {
+  if (!hasClaimedConditions(formData)) {
+    // The actual validation error is displayed as an alert field, so we don't need to add an error message here.
+    err.addError('');
   }
 };

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -7,6 +7,8 @@ import {
   getPOWValidationMessage,
   pathWithIndex,
   hasClaimedConditions,
+  increaseOnly,
+  claimingRated,
 } from './utils';
 
 import {
@@ -267,6 +269,16 @@ export const validateDisabilityName = (err, fieldData) => {
 
 export const requireDisability = (err, fieldData, formData) => {
   if (!hasClaimedConditions(formData)) {
+    // The actual validation error is displayed as an alert field, so we don't need to add an error message here.
+    err.addError('');
+  }
+};
+
+/**
+ * Requires a rated disability to be entered if the increase only path has been selected.
+ */
+export const requireRatedDisability = (err, fieldData, formData) => {
+  if (increaseOnly(formData) && !claimingRated(formData)) {
     // The actual validation error is displayed as an alert field, so we don't need to add an error message here.
     err.addError('');
   }

--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -190,7 +190,7 @@ export function uiSchemaValidate(
     }
 
     const validations = uiSchema['ui:validations'];
-    if (validations && currentData) {
+    if (validations && currentData !== undefined) {
       validations.forEach(validation => {
         const pathErrors = path ? _.get(path, errors) : errors;
         if (typeof validation === 'function') {


### PR DESCRIPTION
## Description
Requires a disability to be claimed. We're doing this in a few ways:

1. If the veteran is claiming increase only, we require them to select a rated disability
2. If the veteran is claiming new only, we require them to add a new disability
3. If the veteran is claiming both, we require they claim _either_ a rated _or_ a new disability
   - If the veteran did _not_ select a rated disability
     - We require them to select "Yes" to the "do you have any new conditions to claim" question
     - We require them to actually add a new disability

## Testing done
None yet

## Screenshots
### Increase only
![image](https://user-images.githubusercontent.com/12970166/53769153-e71a0b80-3e8f-11e9-9a71-ba3de764da98.png)

### New only
![image](https://user-images.githubusercontent.com/12970166/53975820-95a19480-40ba-11e9-9a99-f8424f22ebc0.png)

**Note:** I wasn't able to get the red line to show up for the validation error, so it's not featured in this PR. :disappointed: 

### New and increase
#### No selected
![image](https://user-images.githubusercontent.com/12970166/53767392-863c0480-3e8a-11e9-8005-7a5ffac37463.png)

#### Disability not added
![image](https://user-images.githubusercontent.com/12970166/53673918-46351180-3c3f-11e9-92cb-56a58f76c86a.png)

## Acceptance criteria
- [x] A user can't continue past the rated disability selection screen if they're claiming an increase only and have selected no conditions
- [x] A user can't continue past the yes/no question if they select "no" and haven't selected any rated disabilities
- [x] A user can't continue past the `add new disabilities` screen if
    - They're claiming both new and increase but didn't selected any rated disabilities nor added any new ones
    - OR they're claiming just new conditions but didn't add any
- [ ] The alert box is focused on when it shows up so screen readers read out the error (cc @1Copenut)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
