### PR TITLE
Rated disability label styles

### DIFF
--- a/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/526EZ/sass/disability-benefits.scss
@@ -82,6 +82,10 @@
     margin-bottom: 1em;
   }
 
+  label {
+    display: inline-block;
+  }
+
   input[type="checkbox"] + label {
     // The former margin was to separate the checkbox from the elements above it, but now
     //  that we have the outline, we need to move the whitespace to the outside of the border.
@@ -167,7 +171,7 @@
 
 .itf-agreement {
   margin-top: 0;
-  
+
   &.unauthenticated {
     margin-top: 1em;
   }

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -65,6 +65,10 @@ ul.original-disability-list {
     margin-bottom: 1em;
   }
 
+  label {
+    display: inline-block;
+  }
+
   input[type='checkbox'] + label {
     // The former margin was to separate the checkbox from the elements above it, but now
     //  that we have the outline, we need to move the whitespace to the outside of the border.


### PR DESCRIPTION
## Description
Rated disability labels are having style conflicts. This patch modifies widget-styles (used only in all-claims) to resolve visual bugs

## Testing done
local testing

## Screenshots


## Acceptance criteria
- [x] Rated disability outline boxes display as expected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs


Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17203