### PR TITLE
Added content collection for Compensation Rates

### DIFF
--- a/src/site/stages/build/data/collections.json
+++ b/src/site/stages/build/data/collections.json
@@ -84,7 +84,6 @@
     "metadata": {
       "name": "Disability Benefits",
       "hub": "disability"
-
     }
   },
   "disabilityApply": {
@@ -109,11 +108,18 @@
     "metadata": {
       "name": "Disability Benefits",
       "hub": "disability"
-
     }
   },
   "disabilityClaimTypesPredischarge": {
     "pattern": "disability/how-to-file-claim/when-to-file/pre-discharge-claim/*.md",
+    "sortBy": "order",
+    "metadata": {
+      "name": "Disability Benefits",
+      "hub": "disability"
+    }
+  },
+  "disabilityCompensationRates": {
+    "pattern": "disability/compensation-rates/*.md",
     "sortBy": "order",
     "metadata": {
       "name": "Disability Benefits",
@@ -359,12 +365,12 @@
       "hub": "health-care"
     }
   },
-  "healthCarePay" : {
+  "healthCarePay": {
     "pattern": "health-care/pay-copay-bill/*.md",
     "sortBy": "order",
     "metadata": {
       "name": "Health Care",
-      "hub": "health-care" 
+      "hub": "health-care"
     }
   },
   "healthEligibility": {
@@ -456,7 +462,7 @@
       "hub": "life-insurance"
     }
   },
-   "lifeInsuranceVGLI": {
+  "lifeInsuranceVGLI": {
     "pattern": "life-insurance/options-eligibility/vgli/*.md",
     "sortBy": "order",
     "metadata": {


### PR DESCRIPTION
## Description
This PR adds children pages in the sidenav for new Compensation Rates page.

Note: Compensation pages are not live yet. You will need to pull the feature branch here: https://github.com/department-of-veterans-affairs/vagov-content/pull/268

## Testing done
Viewed on local build.

**Note**: In order to properly test, you will need to use the [feature branch](https://github.com/department-of-veterans-affairs/vagov-content/pull/268). 

## Screenshots
![screen shot 2019-03-04 at 12 48 14 pm](https://user-images.githubusercontent.com/11021491/53752134-d069b980-3e7b-11e9-9eb9-e8026dcca4bf.png)


## Acceptance criteria
- [X] Children pages display under `/disability/compensation-rates/`

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
