### PR TITLE
Revert to using sessionStorage and authnSettings enum

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -26,7 +26,9 @@ export class AuthApp extends React.Component {
   }
 
   handleAuthError = e => {
-    const loginType = localStorage.getItem('pendingLoginPolicy');
+    const loginType = sessionStorage.getItem(
+      authnSettings.PENDING_LOGIN_POLICY,
+    );
 
     Raven.captureMessage(`User fetch error: ${e.message}`, {
       extra: {
@@ -36,9 +38,6 @@ export class AuthApp extends React.Component {
         loginType,
       },
     });
-
-    localStorage.removeItem('pendingLoginPolicy');
-    localStorage.removeItem('pendingAuthAction');
 
     recordEvent({
       event: `login-error-user-fetch`,

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -6,6 +6,8 @@ import environment from '../../utilities/environment';
 
 export const authnSettings = {
   RETURN_URL: 'authReturnUrl',
+  PENDING_AUTH_ACTION: 'pendingAuthAction',
+  PENDING_LOGIN_POLICY: 'pendingLoginPolicy',
 };
 
 const SESSIONS_URI = `${environment.API_URL}/sessions`;
@@ -48,8 +50,8 @@ function redirect(redirectUrl, clickedEvent) {
 }
 
 export function login(policy) {
-  localStorage.setItem('pendingAuthAction', 'login');
-  localStorage.setItem('pendingLoginPolicy', policy);
+  sessionStorage.setItem(authnSettings.PENDING_AUTH_ACTION, 'login');
+  sessionStorage.setItem(authnSettings.PENDING_LOGIN_POLICY, policy);
   return redirect(loginUrl(policy), 'login-link-clicked-modal');
 }
 
@@ -67,7 +69,7 @@ export function logout() {
 }
 
 export function signup() {
-  localStorage.setItem('pendingAuthAction', 'register');
+  sessionStorage.setItem(authnSettings.PENDING_AUTH_ACTION, 'register');
   return redirect(
     appendQuery(IDME_URL, { signup: true }),
     'register-link-clicked',

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -6,6 +6,7 @@ import recordEvent from '../../../monitoring/record-event';
 import {
   setRavenLoginType,
   clearRavenLoginType,
+  authnSettings,
 } from '../../authentication/utilities';
 import get from '../../../utilities/data/get';
 import localStorage from '../../../utilities/storage/localStorage';
@@ -127,14 +128,16 @@ function compareLoginPolicy(loginPolicy) {
   // This is experimental code related to GA that will let us determine
   // if the backend is returning an accurate loginPolicy (service_name)
 
-  let attemptedLoginPolicy = localStorage.getItem('pendingLoginPolicy');
+  let attemptedLoginPolicy = sessionStorage.getItem(
+    authnSettings.PENDING_LOGIN_POLICY,
+  );
 
   attemptedLoginPolicy =
     attemptedLoginPolicy === 'mhv' ? 'myhealthevet' : attemptedLoginPolicy;
 
   if (attemptedLoginPolicy === null) {
     Raven.captureMessage(
-      "localStorage error: 'pendingLoginPolicy' was not stored",
+      "sessionStorage error: 'pendingLoginPolicy' was not stored",
     );
   }
 
@@ -143,8 +146,6 @@ function compareLoginPolicy(loginPolicy) {
       event: `login-mismatch-${attemptedLoginPolicy}-${loginPolicy}`,
     });
   }
-
-  localStorage.removeItem('pendingLoginPolicy');
 }
 
 function recordGAAuthEvent(loginPolicy, loa) {
@@ -153,7 +154,9 @@ function recordGAAuthEvent(loginPolicy, loa) {
   // retrieving a "pendingAuthAction" stored in localStorage when the user
   // clicks a sign in/register button in the Sign In Modal
 
-  const pendingAuthAction = localStorage.getItem('pendingAuthAction');
+  const pendingAuthAction = sessionStorage.getItem(
+    authnSettings.PENDING_AUTH_ACTION,
+  );
 
   if (pendingAuthAction === 'register') {
     // Record GA success event for the register method.
@@ -165,11 +168,9 @@ function recordGAAuthEvent(loginPolicy, loa) {
   } else {
     recordEvent({ event: `login-or-register-success-${loginPolicy}` });
     Raven.captureMessage(
-      "localStorage error: 'pendingAuthAction' was not stored",
+      "sessionStorage error: 'pendingAuthAction' was not stored",
     );
   }
-
-  localStorage.removeItem('pendingAuthAction');
 
   // Report out the current level of assurance for the user.
   if (loa && loa.current) {


### PR DESCRIPTION
## Description
After reviewing the analytics from this weekend, the number of `null` pending auth/login types went down considerably now that we are only checking for the temporary keys and recording the GA events if the user `hasSession()`.  I believe this confirm's @U-DON's theory that the storage was being re-checked after the values had already been deleted, possibly because of the user hitting the back button.

There are still a small number of cases where the temp values return `null`, and I think I think that if we revert to using `sessionStorage`, and not remove the keys manually, it should fix this problem completely.  Since the values are re-assigned as soon as a user clicks a login/register button in the modal, there really shouldn't be a need to remove the values from storage, and reverting to `sessionStorage` will ensure that the values are cleared out by themselves. 

I've also reverted to using the `authnSettings` enum.

## Testing done
Tested locally

## Acceptance criteria
- [ ] Events are being recorded properly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
