### PR TITLE
Add input transformer to AutosuggestField

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -34,11 +34,11 @@ export const uiSchema = {
             freeInput: true,
             inputTransformers: [
               input => input.replace(/["”']/g, '’'),
-              input => input.replace(/[;]/g, '--'),
+              input => input.replace(/[;–]/g, ' -- '),
               input => input.replace(/[&]/g, ' and '),
               input => input.replace(/[\\]/g, '/'),
               input => input.replace(/([^a-zA-Z0-9\-’.,/() ]+)/g, ''),
-              input => input.replace(/\s\s+/, ' '),
+              input => input.replace(/\s{2,}/, ' '),
             ],
           },
           // autoSuggest schema doesn't have any default validations as long as { `freeInput: true` }

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -32,6 +32,14 @@ export const uiSchema = {
         {
           'ui:options': {
             freeInput: true,
+            inputTransformers: [
+              input => input.replace(/["”']/g, '’'),
+              input => input.replace(/[;]/g, '--'),
+              input => input.replace(/[&]/g, ' and '),
+              input => input.replace(/[\\]/g, '/'),
+              input => input.replace(/([^a-zA-Z0-9\-’.,/() ]+)/g, ''),
+              input => input.replace(/\s\s+/, ' '),
+            ],
           },
           // autoSuggest schema doesn't have any default validations as long as { `freeInput: true` }
           'ui:validations': [validateDisabilityName],

--- a/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
+++ b/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
@@ -136,11 +136,21 @@ export default class AutosuggestField extends React.Component {
         }
       }
 
-      this.props.onChange(
-        this.props.uiSchema['ui:options'].freeInput || this.useEnum
-          ? inputValue
-          : item,
-      );
+      //
+      const { freeInput, inputTransformers } = this.props.uiSchema[
+        'ui:options'
+      ];
+
+      const inputToSave =
+        inputTransformers &&
+        Array.isArray(inputTransformers) &&
+        inputTransformers.length
+          ? inputTransformers.reduce(
+              (userInput, transformer) => transformer(userInput),
+              inputValue,
+            )
+          : inputValue;
+      this.props.onChange(freeInput || this.useEnum ? inputToSave : item);
       this.setState({
         input: inputValue,
         suggestions: this.getSuggestions(this.state.options, inputValue),

--- a/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
+++ b/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 import Downshift from 'downshift';
 import classNames from 'classnames';
@@ -261,3 +262,28 @@ export default class AutosuggestField extends React.Component {
     );
   }
 }
+
+AutosuggestField.propTypes = {
+  formContext: PropTypes.shape({
+    reviewMode: PropTypes.bool,
+  }),
+  uiSchema: PropTypes.shape({
+    'ui:options': PropTypes.shape({
+      labels: PropTypes.object,
+      getOptions: PropTypes.func,
+      debounceRate: PropTypes.number,
+      maxOptions: PropTypes.number,
+      queryForResults: PropTypes.func,
+      freeInput: PropTypes.bool,
+      inputTransformers: PropTypes.arrayOf(PropTypes.func),
+    }),
+    'ui:title': PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  }),
+  onChange: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
+  idSchema: PropTypes.shape({
+    $id: PropTypes.string,
+  }),
+  formData: PropTypes.object.isRequired,
+  schema: PropTypes.object.isRequired,
+};

--- a/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
+++ b/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
@@ -136,10 +136,7 @@ export default class AutosuggestField extends React.Component {
         }
       }
 
-      //
-      const { freeInput, inputTransformers } = this.props.uiSchema[
-        'ui:options'
-      ];
+      const { freeInput, inputTransformers } = uiOptions;
 
       const inputToSave =
         inputTransformers &&

--- a/src/platform/forms-system/test/js/fields/AutosuggestField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/AutosuggestField.unit.spec.jsx
@@ -431,4 +431,48 @@ describe('<AutosuggestField>', () => {
       done();
     });
   });
+
+  it('should run input transformers if freeInput is true and if transformers specified in ui:options', done => {
+    const onChange = sinon.spy();
+    const props = {
+      uiSchema: {
+        'ui:options': {
+          freeInput: true,
+          inputTransformers: [
+            inputValue => `${inputValue} first`,
+            inputValue => `${inputValue} second`,
+          ],
+          labels: {
+            AL: 'Label 1',
+            BC: 'Label 2',
+          },
+        },
+      },
+      schema: {
+        type: 'string',
+        enum: ['AL', 'BC'],
+      },
+      formContext: { reviewMode: false },
+      idSchema: { $id: 'id' },
+      onChange,
+      onBlur: () => {},
+    };
+    const wrapper = mount(<AutosuggestField {...props} />);
+
+    // Input something not in options
+    const input = wrapper.find('input');
+    input.simulate('focus');
+    input.simulate('change', {
+      target: {
+        value: 'konami',
+      },
+    });
+
+    setTimeout(() => {
+      const fieldData = onChange.firstCall.args[0];
+      expect(fieldData).to.equal('konami first second');
+      wrapper.unmount();
+      done();
+    });
+  });
 });


### PR DESCRIPTION
## Description
Adds a ui:option to `AutoSuggestField` that allows you to pass an array of string transformations that will take place before a `freeInput` gets saved to redux.

Transformations:
```
" -> ’
' -> ’
; -> --
& -> and
\ -> /
2+ spaces -> 1 space
```
All other invalid chars just get stripped from the input
BE only allows `([a-zA-Z0-9\-'.,\/() ]+)`

## Testing done
- Tested locally
- Added unit test for the field

## Screenshots
N/A

## Acceptance criteria
- [x] Autosuggest field runs input transformers when provided
- [x] All Claims app transforms inputs to match evss regex

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
