### PR TITLE
Vagov 1648 press release listing drupal

### DIFF
--- a/src/platform/site-wide/sass/brand-consolidation.scss
+++ b/src/platform/site-wide/sass/brand-consolidation.scss
@@ -30,6 +30,7 @@
 @import "modules/m-facilities";
 
 @import "modules/m-layers";
+@import "modules/m-facilities";
 // ----- mobile typography -- see #6214 on vets.gov-team ---- //
 
 @import "~@department-of-veterans-affairs/formation/sass/mobile-typography";

--- a/src/platform/site-wide/sass/modules/_m-facilities.scss
+++ b/src/platform/site-wide/sass/modules/_m-facilities.scss
@@ -1,3 +1,4 @@
+@import "~@department-of-veterans-affairs/formation/sass/modules/va-pagination";
 // Facilities Hub
 .vads-facility-main-cta {
   border-left: 4px solid $color-link-default;

--- a/src/site/includes/pagination.drupal.liquid
+++ b/src/site/includes/pagination.drupal.liquid
@@ -1,0 +1,38 @@
+{% comment %}
+  paginator {
+    prev: url or null
+    page {
+      href: url or null
+      class:
+      href:
+      label
+    }
+    prev: url or null
+  }
+{% endcomment %}
+
+{% if paginator != empty %}
+  <div class="va-pagination">
+    {% if paginator.prev != empty %}
+      <span class="va-pagination-prev">
+      <a href="{{ paginator.prev }}" aria-label="Load previous page{{ paginator.ariaLabel }}">
+        <abbr title="Previous">Prev</abbr>
+      </a>
+    </span>
+    {% endif %}
+    <div class="va-pagination-inner">
+      {% for page in paginator.inner %}
+        <a href="{{ page.href }}" class="{{ page.class }}" aria-label="Load page {{ page.label }}{{ paginator.ariaLabel }}">
+          {{ page.label }}
+        </a>
+      {% endfor %}
+    </div>
+    {% if paginator.next != empty %}
+      <span class="va-pagination-next">
+        <a href="{{ paginator.next }}" aria-label="Load next page{{ paginator.ariaLabel }}">
+          Next
+        </a>
+      </span>
+    {% endif %}
+  </div>
+{% endif %}

--- a/src/site/layouts/press_releases_page.drupal.liquid
+++ b/src/site/layouts/press_releases_page.drupal.liquid
@@ -1,0 +1,74 @@
+{% comment %}
+Example data:
+"entityUrl": {
+  "breadcrumb": [
+    {
+      "url": {
+        "path": "/",
+        "routed": true
+      },
+      "text": "Home"
+    }
+  ],
+  "path": "/pittsburgh-health-care"
+},
+"entityId": "83",
+"entityBundle": "health_care_region_page",
+"entityPublished": true,
+"title": "Pittsburgh Health Care System",
+"allPressReleaseTeasers": {
+  "entities": [
+    {
+      "title": "Fayette County Veterans getting larger, more modern VA outpatient clinic",
+      "entityUrl": {
+        "path": "/pittsburgh-health-care/press-releases/fayette-county-veterans-getting-larger-more-modern-va-outpatient-clinic"
+      }
+      "fieldReleaseDate": {
+        "value": "2018-11-26T05:43:34"
+      },
+      "fieldIntroText": "The Fayette County VA Outpatient Clinic will move to its new, larger space in the Fayette Plaza at 627 Pittsburgh Road, Suite 2, Uniontown, PA, on Dec. 3."
+    },
+    {
+      "title": "Cogo Duis Magna",
+      "entityUrl": {
+        "path": "/pittsburgh-health-care/press-releases/cogo-duis-magna"
+      }
+      "fieldReleaseDate": {
+        "value": "2018-11-19T03:20:44"
+      },
+      "fieldIntroText": "Eligo iustum mauris nimis ratis roto tego velit. Abluo consectetuer duis. Camur decet exerci pala paulatim vicis volutpat..."
+    },
+}
+{% endcomment %}
+{% include "src/site/includes/header.html" %}
+{% include "src/site/includes/preview-edit.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+<div id="content" class="interior">
+  <main class="va-l-detail-page">
+    <div class="usa-grid usa-grid-full">
+    <nav class="usa-width-one-fourth va-sidebarnav" id="va-detailpage-sidebar">
+      <h5>{{ title }}</h5>
+    </nav>
+    <div class="usa-width-three-fourths">
+      {% if !entityPublished %}
+        <div class="usa-alert usa-alert-info" >
+          <div class="usa-alert-body">
+            <p class="usa-alert-text">You are viewing a draft.</p>
+          </div>
+        </div>
+      {% endif %}
+
+      <article class="usa-content">
+        <h1>Press Releases</h1>
+        {% for pr in allPressReleaseTeasers.entities %}
+          <section class="vads-u-margin-bottom--3">
+            <h3><a href="{{ pr.entityUrl.path }}">{{ pr.title }}</a></h3>
+            <strong>{{ pr.fieldReleaseDate.value | formatDate: "MMMM DD, YYYY" }}</strong>
+            <p>{{ pr.fieldIntroText | truncatewords: 60, "..." }}</p>
+          </section>
+        {% endfor %}
+    </article>
+    </div>
+</main>
+{% include "src/site/includes/footer.html" %}
+{% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/press_releases_page.drupal.liquid
+++ b/src/site/layouts/press_releases_page.drupal.liquid
@@ -46,29 +46,31 @@ Example data:
 <div id="content" class="interior">
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
-    <nav class="usa-width-one-fourth va-sidebarnav" id="va-detailpage-sidebar">
-      <h5>{{ title }}</h5>
-    </nav>
-    <div class="usa-width-three-fourths">
-      {% if !entityPublished %}
-        <div class="usa-alert usa-alert-info" >
-          <div class="usa-alert-body">
-            <p class="usa-alert-text">You are viewing a draft.</p>
+      <nav class="usa-width-one-fourth va-sidebarnav" id="va-detailpage-sidebar">
+        <h5>{{ title }}</h5>
+      </nav>
+      <div class="usa-width-three-fourths">
+        {% if !entityPublished %}
+          <div class="usa-alert usa-alert-info" >
+            <div class="usa-alert-body">
+              <p class="usa-alert-text">You are viewing a draft.</p>
+            </div>
           </div>
-        </div>
-      {% endif %}
+        {% endif %}
 
-      <article class="usa-content">
-        <h1>Press Releases</h1>
-        {% for pr in allPressReleaseTeasers.entities %}
-          <section class="vads-u-margin-bottom--3">
-            <h3><a href="{{ pr.entityUrl.path }}">{{ pr.title }}</a></h3>
-            <strong>{{ pr.fieldReleaseDate.value | formatDate: "MMMM DD, YYYY" }}</strong>
-            <p>{{ pr.fieldIntroText | truncatewords: 60, "..." }}</p>
-          </section>
-        {% endfor %}
-    </article>
+        <article class="usa-content">
+          <h1>Press Releases</h1>
+          {% for pr in pagedItems %}
+            <section class="vads-u-margin-bottom--3">
+              <h3><a href="{{ pr.entityUrl.path }}">{{ pr.title }}</a></h3>
+              <strong>{{ pr.fieldReleaseDate.value | formatDate: "MMMM DD, YYYY" }}</strong>
+              <p>{{ pr.fieldIntroText | truncatewords: 60, "..." }}</p>
+            </section>
+          {% endfor %}
+          {% include "src/site/includes/pagination.drupal.liquid" %}
+        </article>
+      </div>
     </div>
-</main>
+  </main>
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -82,17 +82,17 @@ module.exports = `
         { field: "status", value: "1"}
         { field: "field_event_date", value: [$today], operator: GREATER_THAN}
       ]} sort: {field: "field_event_date", direction: ASC } limit: 2)
-      {
-        entities {
-          ... on NodeEvent {
-            title
-            fieldEventDate {
-              value
-            }
-            fieldEventDateEnd {
-              value
-            }
-            fieldDescription
+    {
+      entities {
+        ... on NodeEvent {
+          title
+          fieldEventDate {
+            value
+          }
+          fieldEventDateEnd {
+            value
+          }
+          fieldDescription
             fieldLocationHumanreadable
             fieldFacilityLocation {
               entity {
@@ -104,10 +104,29 @@ module.exports = `
             }
           }
           
+        entityUrl {
+          path
+        }
+      }      
+    }
+    allPressReleaseTeasers: reverseFieldOfficeNode(filter: {
+      conditions: [
+        { field: "type", value: "press_release"}
+        { field: "status", value: "1"}
+      ]} sort: {field: "field_release_date", direction: DESC } limit: 100)
+    {
+      entities {
+        ... on NodePressRelease {
+          title
           entityUrl {
             path
           }
-        }      
+          fieldReleaseDate {
+            value
+          }
+          fieldIntroText
+        }
+      }
     }
   }
 `;

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -64,6 +64,10 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     page,
     'health_care_region_locations_page.drupal.liquid',
   );
+  files[`drupal${drupalPagePath}/press-releases/index.html`] = createFileObj(
+    page,
+    'press_releases_page.drupal.liquid',
+  );
 
   const relatedLinks = { fieldRelatedLinks: page.fieldRelatedLinks };
 

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -3,6 +3,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const chalk = require('chalk');
+const _ = require('lodash');
 
 const ENVIRONMENTS = require('../../../constants/environments');
 const getApiClient = require('./api');
@@ -57,6 +58,76 @@ function createFileObj(page, layout) {
   };
 }
 
+function paginationPath(pageNum) {
+  return pageNum === 0 ? '' : `/page-${pageNum + 1}`;
+}
+
+// Turn one big page into a series of paginated pages.
+function paginatePages(
+  page,
+  pagePath,
+  files,
+  field,
+  layout,
+  ariaLabel,
+  perPage,
+) {
+  perPage = perPage || 10;
+
+  if (typeof ariaLabel === 'undefined') {
+    ariaLabel = '';
+  } else {
+    ariaLabel = ` of ${ariaLabel}`;
+  }
+
+  const pagedEntities = _.chunk(page[field].entities, perPage);
+  for (let pageNum = 0; pageNum < pagedEntities.length; pageNum++) {
+    const pagedPage = Object.assign({}, page);
+    pagedPage.pagedItems = pagedEntities[pageNum];
+    const innerPages = [];
+
+    if (pagedEntities.length > 1) {
+      // add page numbers
+      const numPageLinks = 3;
+      let start;
+      let length;
+      if (pagedEntities.length <= numPageLinks) {
+        start = 0;
+        length = pagedEntities.length;
+      } else {
+        length = numPageLinks;
+
+        if (pageNum + numPageLinks > pagedEntities.length) {
+          start = pagedEntities.length - numPageLinks;
+        } else {
+          start = pageNum;
+        }
+      }
+      for (let num = start; num < start + length; num++) {
+        innerPages.push({
+          href: num === pageNum ? null : `${pagePath}${paginationPath(num)}`,
+          label: num + 1,
+          class: num === pageNum ? 'va-pagination-active' : '',
+        });
+      }
+
+      pagedPage.paginator = {
+        ariaLabel,
+        prev: pageNum > 0 ? `${pagePath}${paginationPath(pageNum - 1)}` : null,
+        inner: innerPages,
+        next:
+          pageNum < pagedEntities.length - 1
+            ? `${pagePath}${paginationPath(pageNum + 1)}`
+            : null,
+      };
+    }
+
+    files[
+      `drupal${pagePath}${paginationPath(pageNum)}/index.html`
+    ] = createFileObj(pagedPage, layout);
+  }
+}
+
 // Creates the top-level health care region list pages (Locations, Services, etc.)
 function createHealthCareRegionListPages(page, drupalPagePath, files) {
   // Create the top-level locations page for Health Care Regions
@@ -64,9 +135,14 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     page,
     'health_care_region_locations_page.drupal.liquid',
   );
-  files[`drupal${drupalPagePath}/press-releases/index.html`] = createFileObj(
+
+  paginatePages(
     page,
+    `${drupalPagePath}/press-releases`,
+    files,
+    'allPressReleaseTeasers',
     'press_releases_page.drupal.liquid',
+    'press releases',
   );
 
   const relatedLinks = { fieldRelatedLinks: page.fieldRelatedLinks };


### PR DESCRIPTION
## Description
Creates a list page for press releases (e.g. /drupal/pittsburgh-health-care/press-releases/index.html). If there are more than 10 press releases, creates additional pages, e.g. /drupal/pittsburgh-health-care/press-releases/page-2/index.html and adds pagination to the bottom of each page.

The pagination follows the logic of the search page pagination. There is a function to generate paginated pages as well as a separate pagination template to enable reuse.
