### PR TITLE
Bump Formation to 5.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^5.0.0",
+    "@department-of-veterans-affairs/formation": "^5.3.1",
     "@department-of-veterans-affairs/formation-react": "^4.0.0",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -783,7 +783,7 @@
     react-transition-group "1"
     window-or-global "^1.0.1"
 
-"@department-of-veterans-affairs/formation@^5.0.0":
+"@department-of-veterans-affairs/formation@^5.3.1":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-5.3.1.tgz#df760bd104d7e2fc8b26f346092e5eefba7ae540"
   integrity sha512-k/S1HVfcjg1ZQCtF9Ri9jo31G1RXtSaJ6ujYESeuilfPkcR9z7d7sqwlfyK/OFUfAovWGQtcTe1ixbpKr/7Z4A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,9 +784,9 @@
     window-or-global "^1.0.1"
 
 "@department-of-veterans-affairs/formation@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-5.0.0.tgz#db0d42a3bb59bc765cac5c74243f04e64d860930"
-  integrity sha512-DII2iRhkdXws7lo/uBvQ+YDgKHX6q/pV8FMD1gdNV7evhC5uccGkh0J+Me+g+ZS4P7gQIxDcQdH6D8wwygPxwA==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-5.3.1.tgz#df760bd104d7e2fc8b26f346092e5eefba7ae540"
+  integrity sha512-k/S1HVfcjg1ZQCtF9Ri9jo31G1RXtSaJ6ujYESeuilfPkcR9z7d7sqwlfyK/OFUfAovWGQtcTe1ixbpKr/7Z4A==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     foundation-sites "5"


### PR DESCRIPTION
## Description
This PR upgrades Formation from `5.0.0` to `5.3.1` to receive https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/5.

## Testing done
Started site locally

## Acceptance criteria
- [ ] Received latest design system updates

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
