### PR TITLE
WIP Add hub icons, colors for Service Member and Family Members hubs

### DIFF
--- a/src/platform/site-wide/sass/iconography.scss
+++ b/src/platform/site-wide/sass/iconography.scss
@@ -154,6 +154,26 @@
   $left-large: 9px
 );
 
+@include make-hub(
+  $hub-name: "family-member",
+  $icon: $fa-var-users,
+  $color: blue,
+  $top-small: 7px,
+  $left-small: 6px,
+  $top-large: 10.25px,
+  $left-large: 9px
+);
+
+@include make-hub(
+  $hub-name: "service-member",
+  $icon: $fa-var-flag-usa,
+  $color: blue,
+  $top-small: 7px,
+  $left-small: 6px,
+  $top-large: 10.25px,
+  $left-large: 9px
+);
+
 .icon-large {
   font-size: 20px;
   height: 40px;


### PR DESCRIPTION
## Description
This PR adds the icon classes for the new hubs, Service Members and Family Members.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17148

## Testing done


## Screenshots
Todo

## Acceptance criteria
- [ ] New icons are added and look okay

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
