### PR TITLE
Add hub icons, colors for Service Member and Family Members hubs 

### DIFF
--- a/src/platform/site-wide/sass/iconography.scss
+++ b/src/platform/site-wide/sass/iconography.scss
@@ -157,21 +157,21 @@
 @include make-hub(
   $hub-name: "family-member",
   $icon: $fa-var-users,
-  $color: blue,
+  $color: $color-primary-darker,
   $top-small: 7px,
-  $left-small: 6px,
+  $left-small: 5.5px,
   $top-large: 10.25px,
-  $left-large: 9px
+  $left-large: 8px
 );
 
 @include make-hub(
   $hub-name: "service-member",
   $icon: $fa-var-flag-usa,
-  $color: blue,
-  $top-small: 7px,
-  $left-small: 6px,
-  $top-large: 10.25px,
-  $left-large: 9px
+  $color: $color-primary-darker,
+  $top-small: 8px,
+  $left-small: 8px,
+  $top-large: 11px,
+  $left-large: 10px
 );
 
 .icon-large {

--- a/src/platform/site-wide/sass/iconography.scss
+++ b/src/platform/site-wide/sass/iconography.scss
@@ -154,6 +154,26 @@
   $left-large: 9px
 );
 
+@include make-hub(
+  $hub-name: "family-member",
+  $icon: $fa-var-users,
+  $color: blue,
+  $top-small: 7px,
+  $left-small: 6px,
+  $top-large: 10.25px,
+  $left-large: 9px
+);
+
+@include make-hub(
+  $hub-name: "service-member",
+  $icon: $fa-var-flag-usa,
+  $color: blue,
+  $top-small: 7px,
+  $left-small: 6px,
+  $top-large: 10.25px,
+  $left-large: 9px
+);
+
 .icon-large {
   font-size: 20px;
   height: 40px;


### PR DESCRIPTION
## Description
This PR adds the icon classes for the new hubs, Service Members and Family Members.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17148

## Testing done
Checked out homepage with icons added

## Screenshots
See icon, placement, and colors in the image below -
![image](https://user-images.githubusercontent.com/1915775/53919293-95ac8080-4037-11e9-9524-dac1b6a00564.png)

## Acceptance criteria
- [ ] New icons are added and look okay

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
