### PR TITLE
Update Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,12 +114,10 @@ node('vetsgov-general-purpose') {
       if (!commonStages.isDeployable()) { return }
 
       if (commonStages.IS_DEV_BRANCH && commonStages.VAGOV_BUILDTYPES.contains('vagovdev')) {
-        commonStages.runDeploy('deploys/vets-website-dev', ref)
         commonStages.runDeploy('deploys/vets-website-vagovdev', ref)
       }
 
       if (commonStages.IS_STAGING_BRANCH && commonStages.VAGOV_BUILDTYPES.contains('vagovstaging')) {
-        commonStages.runDeploy('deploys/vets-website-staging', ref)
         commonStages.runDeploy('deploys/vets-website-vagovstaging', ref)
       }
     } catch (error) {

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -4,12 +4,6 @@ DRUPAL_MAPPING = [
   'live': 'vagovprod',
 ]
 
-VETSGOV_BUILDTYPES = [
-  'development',
-  'staging',
-  'production'
-]
-
 ALL_VAGOV_BUILDTYPES = [
   'vagovdev',
   'vagovstaging',


### PR DESCRIPTION
We no longer need to maintain the old vets-website environments so we can remove the deploy triggers to the old staging and dev environments..

This PR removes references to the old staging and dev environments.