### PR TITLE
Use header footer info from build output on preview

### DIFF
--- a/script/preview.js
+++ b/script/preview.js
@@ -18,7 +18,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
     type: String,
     defaultValue: process.env.PREVIEW_BUILD_TYPE || defaultBuildtype,
   },
-  { name: 'buildpath', type: String, defaultValue: 'build/localhost' },
+  { name: 'buildpath', type: String, defaultValue: null },
   { name: 'host', type: String, defaultValue: defaultHost },
   { name: 'port', type: Number, defaultValue: process.env.PORT || 3001 },
   { name: 'entry', type: String, defaultValue: null },
@@ -34,6 +34,10 @@ if (options.unexpected && options.unexpected.length !== 0) {
   throw new Error(`Unexpected arguments: '${options.unexpected}'`);
 }
 
+if (options.buildpath === null) {
+  options.buildpath = `build/${options.buildtype}`;
+}
+
 const app = express();
 const drupalClient = getDrupalClient(options);
 
@@ -46,7 +50,7 @@ app.get('/health', (req, res) => {
 app.get('/preview', async (req, res) => {
   const smith = createPipieline({
     ...options,
-    port: process.env.PORT,
+    port: process.env.PORT || 3001,
   });
 
   const drupalData = await drupalClient.getLatestPageById(req.query.nodeId);
@@ -63,16 +67,14 @@ app.get('/preview', async (req, res) => {
       ...drupalPage,
       isPreview: true,
       isDrupalPage: true,
-      headerFooterData: JSON.parse(
-        fs.readFileSync(
-          path.join(
-            __dirname,
-            '..',
-            options.buildpath,
-            'generated/headerFooter.json',
-          ),
-          'utf8',
+      headerFooterData: fs.readFileSync(
+        path.join(
+          __dirname,
+          '..',
+          options.buildpath,
+          'generated/drupalHeaderFooter.json',
         ),
+        'utf8',
       ),
       drupalSite: drupalClient.getSiteUri(),
       layout: `${drupalPage.entityBundle}.drupal.liquid`,

--- a/script/preview.js
+++ b/script/preview.js
@@ -1,5 +1,6 @@
 const commandLineArgs = require('command-line-args');
 const path = require('path');
+const fs = require('fs');
 const express = require('express');
 const createPipieline = require('../src/site/stages/preview');
 
@@ -62,6 +63,17 @@ app.get('/preview', async (req, res) => {
       ...drupalPage,
       isPreview: true,
       isDrupalPage: true,
+      headerFooterData: JSON.parse(
+        fs.readFileSync(
+          path.join(
+            __dirname,
+            '..',
+            options.buildpath,
+            'generated/headerFooter.json',
+          ),
+          'utf8',
+        ),
+      ),
       drupalSite: drupalClient.getSiteUri(),
       layout: `${drupalPage.entityBundle}.drupal.liquid`,
       contents: Buffer.from('<!-- Drupal-provided data -->'),

--- a/src/site/stages/build/plugins/add-asset-hashes.js
+++ b/src/site/stages/build/plugins/add-asset-hashes.js
@@ -1,4 +1,4 @@
-function addAssetHashes() {
+function addAssetHashes(isPreview = false) {
   // In non-development modes, we add hashes to the names of asset files in order to support
   // cache busting. That is done via WebPack, but WebPack doesn't know anything about our HTML
   // files, so we have to replace the references to those files in HTML and CSS files after the
@@ -46,21 +46,23 @@ function addAssetHashes() {
       }
     });
 
-    // Create a copy of the proxy-write files without cache-bust hashes
-    [
-      'proxy-rewrite.entry.js',
-      'styleConsolidated.css',
-      'static-pages.css',
-      'vendor.entry.js',
-      'polyfills.entry.js',
-    ].forEach(unhashedName => {
-      const hashedName = manifest[unhashedName];
+    if (!isPreview) {
+      // Create a copy of the proxy-write files without cache-bust hashes
+      [
+        'proxy-rewrite.entry.js',
+        'styleConsolidated.css',
+        'static-pages.css',
+        'vendor.entry.js',
+        'polyfills.entry.js',
+      ].forEach(unhashedName => {
+        const hashedName = manifest[unhashedName];
 
-      // When an --entry is specified that isn't proxy-rewrite, these files won't be here
-      if (hashedName) {
-        files[`generated/${unhashedName}`] = files[hashedName.substr(1)]; // eslint-disable-line no-param-reassign
-      }
-    });
+        // When an --entry is specified that isn't proxy-rewrite, these files won't be here
+        if (hashedName) {
+          files[`generated/${unhashedName}`] = files[hashedName.substr(1)]; // eslint-disable-line no-param-reassign
+        }
+      });
+    }
 
     done();
   };

--- a/src/site/stages/build/plugins/configure-assets.js
+++ b/src/site/stages/build/plugins/configure-assets.js
@@ -29,7 +29,7 @@ function configureAssets(smith, buildOptions) {
     }
 
     if (!isDevBuild) {
-      smith.use(addAssetHashes(buildOptions));
+      smith.use(addAssetHashes());
     }
   }
 }

--- a/src/site/stages/build/plugins/create-header-footer.js
+++ b/src/site/stages/build/plugins/create-header-footer.js
@@ -90,6 +90,11 @@ function createHeaderFooterData(buildOptions) {
       contents: new Buffer(serialized),
     };
 
+    // eslint-disable-next-line no-param-reassign
+    files['generated/drupalHeaderFooter.json'] = {
+      contents: new Buffer(drupalMenuSerialized),
+    };
+
     done();
   };
 }

--- a/src/site/stages/preview/index.js
+++ b/src/site/stages/preview/index.js
@@ -132,6 +132,9 @@ function createPipeline(options) {
 
   smith.use(updateExternalLinks(BUILD_OPTIONS));
 
+  // For prod builds, we need to add asset hashes, but since this is a live
+  // request, we're not doing a webpack build. So we need to put the manifest
+  // in the files object so that we can reuse the addAssetHashes plugin
   if (!isDevBuild) {
     smith.use((files, metalsmith, done) => {
       const fileManifestPath = 'generated/file-manifest.json';

--- a/src/site/stages/preview/index.js
+++ b/src/site/stages/preview/index.js
@@ -14,7 +14,6 @@ const updateExternalLinks = require('../build/plugins/update-external-links');
 const createEnvironmentFilter = require('../build/plugins/create-environment-filter');
 const nonceTransformer = require('../build/plugins/nonceTransformer');
 const leftRailNavResetLevels = require('../build/plugins/left-rail-nav-reset-levels');
-// const createHeaderFooter = require('../build/plugins/create-header-footer');
 const rewriteVaDomains = require('../build/plugins/rewrite-va-domains');
 const applyFragments = require('../build/plugins/apply-fragments');
 
@@ -85,8 +84,6 @@ function createPipeline(options) {
       ],
     }),
   );
-
-  // smith.use(createHeaderFooter(BUILD_OPTIONS));
 
   smith.use(
     navigation({

--- a/src/site/stages/preview/index.js
+++ b/src/site/stages/preview/index.js
@@ -14,7 +14,7 @@ const updateExternalLinks = require('../build/plugins/update-external-links');
 const createEnvironmentFilter = require('../build/plugins/create-environment-filter');
 const nonceTransformer = require('../build/plugins/nonceTransformer');
 const leftRailNavResetLevels = require('../build/plugins/left-rail-nav-reset-levels');
-const createHeaderFooter = require('../build/plugins/create-header-footer');
+// const createHeaderFooter = require('../build/plugins/create-header-footer');
 const rewriteVaDomains = require('../build/plugins/rewrite-va-domains');
 const applyFragments = require('../build/plugins/apply-fragments');
 
@@ -86,7 +86,7 @@ function createPipeline(options) {
     }),
   );
 
-  smith.use(createHeaderFooter(BUILD_OPTIONS));
+  // smith.use(createHeaderFooter(BUILD_OPTIONS));
 
   smith.use(
     navigation({

--- a/src/site/stages/preview/index.js
+++ b/src/site/stages/preview/index.js
@@ -1,4 +1,6 @@
 // Builds the site using Metalsmith as the top-level build runner.
+const fs = require('fs');
+const path = require('path');
 const Metalsmith = require('metalsmith');
 const collections = require('metalsmith-collections');
 const inPlace = require('metalsmith-in-place');
@@ -9,6 +11,7 @@ const permalinks = require('metalsmith-permalinks');
 const registerLiquidFilters = require('../../filters/liquid');
 
 const getOptions = require('../build/options');
+const environments = require('../../constants/environments');
 const createBuildSettings = require('../build/plugins/create-build-settings');
 const updateExternalLinks = require('../build/plugins/update-external-links');
 const createEnvironmentFilter = require('../build/plugins/create-environment-filter');
@@ -16,10 +19,14 @@ const nonceTransformer = require('../build/plugins/nonceTransformer');
 const leftRailNavResetLevels = require('../build/plugins/left-rail-nav-reset-levels');
 const rewriteVaDomains = require('../build/plugins/rewrite-va-domains');
 const applyFragments = require('../build/plugins/apply-fragments');
+const addAssetHashes = require('../build/plugins/add-asset-hashes');
 
 function createPipeline(options) {
   const BUILD_OPTIONS = getOptions(options);
   const smith = Metalsmith(__dirname); // eslint-disable-line new-cap
+  const isDevBuild = [environments.LOCALHOST, environments.VAGOVDEV].includes(
+    BUILD_OPTIONS.buildtype,
+  );
 
   registerLiquidFilters();
 
@@ -125,7 +132,25 @@ function createPipeline(options) {
 
   smith.use(updateExternalLinks(BUILD_OPTIONS));
 
-  // smith.use(addAssetHashes(BUILD_OPTIONS));
+  if (!isDevBuild) {
+    smith.use((files, metalsmith, done) => {
+      const fileManifestPath = 'generated/file-manifest.json';
+      // eslint-disable-next-line no-param-reassign
+      files[fileManifestPath] = {
+        path: fileManifestPath,
+        contents: fs.readFileSync(
+          path.join(
+            __dirname,
+            '../../../..',
+            BUILD_OPTIONS.buildpath,
+            fileManifestPath,
+          ),
+        ),
+      };
+      done();
+    });
+    smith.use(addAssetHashes(true));
+  }
 
   return smith;
 }


### PR DESCRIPTION
## Description
We can get the sidebar output from the file written to the generated folder, which should let us avoid depending on vagov-content for anything related to drupal pages.

## Testing done
Ran locally

## Screenshots


## Acceptance criteria
- [x] Preview server runs locally without vagov-content available

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
