### PR TITLE
Add aria label to disconnect button

### DIFF
--- a/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
@@ -77,6 +77,7 @@ class ConnectedApp extends React.Component {
                         <a href={href}>{title}</a>
                         &nbsp;can view your:
                         <button
+                          aria-label="Disconnect this account"
                           className="usa-button-primary"
                           onClick={this.openModal}
                         >

--- a/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
@@ -77,7 +77,7 @@ class ConnectedApp extends React.Component {
                         <a href={href}>{title}</a>
                         &nbsp;can view your:
                         <button
-                          aria-label="Disconnect this account"
+                          aria-label={`Disconnect ${title} from your account`}
                           className="usa-button-primary"
                           onClick={this.openModal}
                         >


### PR DESCRIPTION
## Description
Resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/1436

Adds an aria-label tag to the disconnect button so that its purpose is more clear to screen reader users. @1Copenut I made it a little more specific than "this account" per your advice


## Acceptance criteria
- [ ] Screen readers announce the button in a useful way

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
