### PR TITLE
Change connected accounts details toggle to be a button for 508

### DIFF
--- a/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
@@ -52,14 +52,15 @@ class ConnectedApp extends React.Component {
                 Connected on {moment(created).format('MMMM D, YYYY h:mm A')}
               </th>
               <th className={`${cssPrefix}-row-details `}>
-                <a className={`${cssPrefix}-row-details-toggle`} href="#">
+                <button className={`${cssPrefix}-row-details-toggle`}
+                  aria-expanded={this.state.detailsOpen ? 'true' : 'false'}>
                   Details
                   <i
                     className={`fa fa-chevron-${
                       this.state.detailsOpen ? 'up' : 'down'
                     }`}
                   />
-                </a>
+                </button>
                 <AccountModal
                   appName={title}
                   modalOpen={this.state.modalOpen}
@@ -103,7 +104,7 @@ class ConnectedApp extends React.Component {
 ConnectedApp.propTypes = {
   id: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
-  attribtues: PropTypes.object.isRequired,
+  attributes: PropTypes.object.isRequired,
   confirmDelete: PropTypes.func.isRequired,
   isLast: PropTypes.bool,
 };

--- a/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
@@ -39,10 +39,7 @@ class ConnectedApp extends React.Component {
       <tr>
         <table className={`${cssPrefix}-row-table ${lastClass}`}>
           <tbody>
-            <tr
-              className={`${cssPrefix}-row ${toggled}`}
-              onClick={this.toggleDetails}
-            >
+            <tr className={`${cssPrefix}-row ${toggled}`}>
               <th scope="row">
                 <a href={href} className="no-external-icon">
                   <img src={logo} alt={`${title} logo`} width="100" />
@@ -51,9 +48,12 @@ class ConnectedApp extends React.Component {
               <th>
                 Connected on {moment(created).format('MMMM D, YYYY h:mm A')}
               </th>
-              <th className={`${cssPrefix}-row-details `}>
-                <button className={`${cssPrefix}-row-details-toggle`}
-                  aria-expanded={this.state.detailsOpen ? 'true' : 'false'}>
+              <th className={`${cssPrefix}-row-details`}>
+                <button
+                  className={`${cssPrefix}-row-details-toggle va-button-link`}
+                  aria-expanded={this.state.detailsOpen ? 'true' : 'false'}
+                  onClick={this.toggleDetails}
+                >
                   Details
                   <i
                     className={`fa fa-chevron-${

--- a/src/applications/personalization/connected-accounts/sass/connected-acct.scss
+++ b/src/applications/personalization/connected-accounts/sass/connected-acct.scss
@@ -64,6 +64,13 @@
          }
       }
    }
+
+   .va-connected-acct-row-details-toggle {
+      color: #004795;
+      background-color: inherit;
+      cursor: pointer;
+      transition: color 0.3s ease-in-out;
+   }
 }
 
 

--- a/src/applications/personalization/connected-accounts/sass/connected-acct.scss
+++ b/src/applications/personalization/connected-accounts/sass/connected-acct.scss
@@ -29,7 +29,6 @@
       }
    }
    .va-connected-acct-row {
-      cursor: pointer;
       th {
          padding-top: 0;
          padding-bottom: 0;
@@ -45,10 +44,6 @@
          }
       }
       .va-connected-acct-row-details {
-         .va-connected-acct-row-details-toggle {
-            text-decoration: none;
-            white-space: nowrap;
-         }
          i {
             padding-left: .5em;
          }
@@ -66,10 +61,8 @@
    }
 
    .va-connected-acct-row-details-toggle {
-      color: #004795;
-      background-color: inherit;
-      cursor: pointer;
       transition: color 0.3s ease-in-out;
+      text-decoration: none;
    }
 }
 

--- a/src/applications/personalization/connected-accounts/tests/components/ConnectedApp.unit.spec.jsx
+++ b/src/applications/personalization/connected-accounts/tests/components/ConnectedApp.unit.spec.jsx
@@ -30,7 +30,7 @@ describe('<ConnectedApp>', () => {
     const row = tree.dive(['table', 'tbody', 'tr']);
     row.props.onClick();
 
-    tree.subTree('button').props.onClick({ target: {} });
+    tree.subTree('.usa-button-primary').props.onClick({ target: {} });
 
     expect(tree.subTree('AccountModal').props.modalOpen).to.be.true;
   });

--- a/src/applications/personalization/connected-accounts/tests/components/ConnectedApp.unit.spec.jsx
+++ b/src/applications/personalization/connected-accounts/tests/components/ConnectedApp.unit.spec.jsx
@@ -28,7 +28,8 @@ describe('<ConnectedApp>', () => {
     );
 
     const row = tree.dive(['table', 'tbody', 'tr']);
-    row.props.onClick();
+    const toggleButton = row.subTree('.va-connected-acct-row-details-toggle');
+    toggleButton.props.onClick();
 
     tree.subTree('.usa-button-primary').props.onClick({ target: {} });
 


### PR DESCRIPTION
## Description

Changes the details toggle on the Connected Accounts page to be a button, rather than a link, for standard accessibility reasons. Completes ticket [#1434](https://github.com/department-of-veterans-affairs/vets-contrib/issues/1434).

## Testing done

- Inspected the updated DOM to check that the Details control is a button, not an anchor
- Verified that mouse press and `Enter` press both expand/collapse the section
- Ensured that the screenreader expression of the control was "Details, button, collapsed" or "Details, button, expanded"
    - Also checked in the DOM that it has the correct `aria-expanded` value in either state 
- Checked that the styling is largely unchanged, except for minor behavior that can change for link -> button

## Screenshots

<img width="961" alt="oauthconnectedaccountsdetails" src="https://user-images.githubusercontent.com/3241493/53970631-27180300-40c9-11e9-8bd7-58c123f881dc.png">

## Acceptance criteria
- [ ] The Details control is a `button` element.
- [ ] The Details button has the correct `aria-expanded` attribute when its section is expanded (true) or collapsed (false).
- [ ] Screen readers announce the details button as expected - either "Details, button, collapsed" or "Details, button, expanded".
- [ ] The Details button works as expected for keyboard users.
- [ ] The UI behaves correctly with minimal changes to the visual presentation.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
