### PR TITLE
Set title, breadcrumb, and path for pages without drupal nodes

### DIFF
--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -63,15 +63,7 @@ function paginationPath(pageNum) {
 }
 
 // Turn one big page into a series of paginated pages.
-function paginatePages(
-  page,
-  pagePath,
-  files,
-  field,
-  layout,
-  ariaLabel,
-  perPage,
-) {
+function paginatePages(page, files, field, layout, ariaLabel, perPage) {
   perPage = perPage || 10;
 
   if (typeof ariaLabel === 'undefined') {
@@ -105,7 +97,10 @@ function paginatePages(
       }
       for (let num = start; num < start + length; num++) {
         innerPages.push({
-          href: num === pageNum ? null : `${pagePath}${paginationPath(num)}`,
+          href:
+            num === pageNum
+              ? null
+              : `${page.entityUrl.path}${paginationPath(num)}`,
           label: num + 1,
           class: num === pageNum ? 'va-pagination-active' : '',
         });
@@ -113,19 +108,35 @@ function paginatePages(
 
       pagedPage.paginator = {
         ariaLabel,
-        prev: pageNum > 0 ? `${pagePath}${paginationPath(pageNum - 1)}` : null,
+        prev:
+          pageNum > 0
+            ? `${page.entityUrl.path}${paginationPath(pageNum - 1)}`
+            : null,
         inner: innerPages,
         next:
           pageNum < pagedEntities.length - 1
-            ? `${pagePath}${paginationPath(pageNum + 1)}`
+            ? `${page.entityUrl.path}${paginationPath(pageNum + 1)}`
             : null,
       };
     }
 
     files[
-      `drupal${pagePath}${paginationPath(pageNum)}/index.html`
+      `drupal${page.entityUrl.path}${paginationPath(pageNum)}/index.html`
     ] = createFileObj(pagedPage, layout);
   }
+}
+
+// Return page object with path, breadcrump and title set.
+function createEntityUrl(page, drupalPagePath, title) {
+  const pathSuffix = title.replace(/\s+/g, '-').toLowerCase();
+  const generatedPage = Object.assign({}, page);
+  generatedPage.entityUrl.breadcrumb.push({
+    url: { path: drupalPagePath },
+    text: page.title,
+  });
+  generatedPage.entityUrl.path = `${drupalPagePath}/${pathSuffix}`;
+  generatedPage.title = title;
+  return generatedPage;
 }
 
 // Creates the top-level health care region list pages (Locations, Services, etc.)
@@ -136,9 +147,10 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'health_care_region_locations_page.drupal.liquid',
   );
 
+  // Press Release listing page
+  const prPage = createEntityUrl(page, drupalPagePath, 'Press Releases');
   paginatePages(
-    page,
-    `${drupalPagePath}/press-releases`,
+    prPage,
     files,
     'allPressReleaseTeasers',
     'press_releases_page.drupal.liquid',


### PR DESCRIPTION
## Description
Adds a helper function to update the title and entityUrl values for generated pages, e.g. listing pages.

Also updates paginatePages() to use the entityUrl on the page object, since that's now correct.