### PR TITLE
Download files via query data instead of html output

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "puppeteer": "^1.9.0",
     "quick_check": "^0.7.0",
     "react-test-renderer": "^16.7.0",
+    "recursive-readdir": "^2.2.2",
     "recursive-uncache": "^0.1.1",
     "request": "^2.79.0",
     "sass-lint": "^1.10.2",

--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -1,0 +1,70 @@
+const getDrupalClient = require('./api');
+
+function replacePathInData(data, replacer) {
+  let current = data;
+  if (Array.isArray(data)) {
+    // This means we're always creating a shallow copy of arrays, but
+    // that seems worth the complexity trade-off
+    current = data.map(item => replacePathInData(item, replacer));
+  } else if (!!current && typeof current === 'object') {
+    Object.keys(current).forEach(key => {
+      let newValue = current;
+
+      if (typeof current[key] === 'string') {
+        newValue = replacer(current[key]);
+      } else {
+        newValue = replacePathInData(current[key], replacer);
+      }
+
+      if (newValue !== current[key]) {
+        current = Object.assign({}, current, {
+          [key]: newValue,
+        });
+      }
+    });
+  }
+
+  return current;
+}
+
+function convertAssetPath(drupalInstance, url) {
+  // After this path are other folders in the image paths,
+  // but it's hard to tell if we can strip them, so I'm leaving them alone
+  const withoutHost = url.replace(`${drupalInstance}/sites/default/files/`, '');
+  const path = withoutHost.split('?', 2)[0];
+
+  // This is sort of naive, but we'd like to have images in the img folder
+  if (
+    ['png', 'jpg', 'jpeg', 'gif', 'svg'].some(ext =>
+      path.toLowerCase().endsWith(ext),
+    )
+  ) {
+    return `/img/${path}`;
+  }
+
+  return `/files/${path}`;
+}
+
+function convertDrupalFilesToLocal(drupalData, files, options) {
+  const client = getDrupalClient(options);
+
+  return replacePathInData(drupalData, data => {
+    if (data.startsWith(`${client.getSiteUri()}/sites/default/files`)) {
+      const newPath = convertAssetPath(client.getSiteUri(), data);
+      const decodedFileName = decodeURIComponent(newPath).substring(1);
+      // eslint-disable-next-line no-param-reassign
+      files[decodedFileName] = {
+        path: decodedFileName,
+        source: data,
+        isDrupalAsset: true,
+        contents: '',
+      };
+
+      return newPath;
+    }
+
+    return data;
+  });
+}
+
+module.exports = convertDrupalFilesToLocal;

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -278,10 +278,9 @@ async function loadDrupal(buildOptions) {
 }
 
 async function loadCachedDrupalFiles(buildOptions, files) {
-  if (!buildOptions[PULL_DRUPAL_BUILD_ARG]) {
-    const cachedDrupalFiles = await recursiveRead(
-      path.join(buildOptions.cacheDirectory, 'drupalFiles'),
-    );
+  const cachedFilesPath = path.join(buildOptions.cacheDirectory, 'drupalFiles');
+  if (!buildOptions[PULL_DRUPAL_BUILD_ARG] && fs.existsSync(cachedFilesPath)) {
+    const cachedDrupalFiles = await recursiveRead(cachedFilesPath);
     cachedDrupalFiles.forEach(file => {
       const relativePath = path.relative(
         path.join(buildOptions.cacheDirectory, 'drupalFiles'),

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -1,135 +1,50 @@
 /* eslint-disable no-param-reassign */
 require('isomorphic-fetch');
-const cheerio = require('cheerio');
+const path = require('path');
+const fs = require('fs-extra');
 const chalk = require('chalk');
 
-const getDrupalClient = require('../drupal/api');
+const ENVIRONMENTS = require('../../../constants/environments');
 
 const DRUPAL_COLORIZED_OUTPUT = chalk.rgb(73, 167, 222);
 
 // eslint-disable-next-line no-console
 const log = message => console.log(DRUPAL_COLORIZED_OUTPUT(message));
 
-/*
- * Convert a Drupal asset url to a local one
- */
-function convertAssetPath(drupalInstance, url) {
-  // After this path are other folders in the image paths,
-  // but it's hard to tell if we can strip them, so I'm leaving them alone
-  const withoutHost = url.replace(`${drupalInstance}/sites/default/files/`, '');
-  const path = withoutHost.split('?', 2)[0];
-
-  // This is sort of naive, but we'd like to have images in the img folder
-  if (
-    ['png', 'jpg', 'jpeg', 'gif', 'svg'].some(ext =>
-      path.toLowerCase().endsWith(ext),
-    )
-  ) {
-    return `img/${path}`;
-  }
-
-  return `files/${path}`;
-}
-
-/*
- * Simple attribute update that replaces the url for the asset
- * with the local one
- */
-function updateAttr(attr, doc, client) {
-  const assetsToDownload = [];
-  doc(`[${attr}^="${client.getSiteUri()}/sites"]`).each((i, el) => {
-    const item = doc(el);
-    const srcAttr = item.attr(attr);
-    const newAssetPath = convertAssetPath(client.getSiteUri(), srcAttr);
-    assetsToDownload.push({
-      src: srcAttr,
-      dest: newAssetPath,
-    });
-
-    item.attr(attr, `/${newAssetPath}`);
-  });
-
-  return assetsToDownload;
-}
-
 function downloadDrupalAssets(options) {
-  const drupalClient = getDrupalClient(options);
-
   return async (files, metalsmith, done) => {
-    let assetsToDownload = [];
-
-    for (const fileName of Object.keys(files)) {
-      const file = files[fileName];
-      let fileUpdated = false;
-
-      if (file.isDrupalPage && fileName.endsWith('html')) {
-        const doc = cheerio.load(file.contents);
-
-        const srcAssets = updateAttr('src', doc, drupalClient);
-        if (srcAssets.length) fileUpdated = true;
-        assetsToDownload = assetsToDownload.concat(srcAssets);
-
-        const dataSrcAssets = updateAttr('data-src', doc, drupalClient);
-        if (dataSrcAssets.length) fileUpdated = true;
-        assetsToDownload = assetsToDownload.concat(dataSrcAssets);
-
-        const hrefAssets = updateAttr('href', doc, drupalClient);
-        if (hrefAssets.length) fileUpdated = true;
-        assetsToDownload = assetsToDownload.concat(hrefAssets);
-
-        // srset is more complicated, a requires us to parse the attribute out
-        // eslint-disable-next-line no-loop-func
-        doc(`[srcset*="${drupalClient.getSiteUri()}/sites"]`).each((i, el) => {
-          fileUpdated = true;
-          const item = doc(el);
-          const srcAttr = item.attr('srcset');
-          // srcset is a comma delimited list of srcs
-          const sources = srcAttr.split(',');
-          const newPaths = [];
-          sources.forEach(source => {
-            // Each src has a url and a size, separated by a space
-            const [url, size] = source.split(' ', 2);
-            const newAssetPath = convertAssetPath(
-              drupalClient.getSiteUri(),
-              url,
-            );
-            assetsToDownload.push({
-              src: url,
-              dest: newAssetPath,
-            });
-            newPaths.push(`/${newAssetPath} ${size}`);
-          });
-
-          item.attr('srcset', newPaths.join(','));
-        });
-
-        if (fileUpdated) {
-          file.contents = new Buffer(doc.html());
-        }
-      }
-    }
+    const assetsToDownload = Object.entries(files)
+      .filter(entry => entry[1].isDrupalAsset && !entry[1].contents)
+      .map(([key, value]) => ({
+        src: value.source,
+        dest: key,
+      }));
 
     if (assetsToDownload.length) {
       let downloadCount = 0;
       let errorCount = 0;
-      const downloads = assetsToDownload.map(async asset => {
-        if (!files[asset.dest]) {
-          const response = await fetch(asset.src);
 
-          if (response.ok) {
-            downloadCount++;
-            const decodedFileName = decodeURIComponent(asset.dest);
-            files[decodedFileName] = {
-              path: decodedFileName,
-              isDrupalAsset: true,
-              contents: await response.buffer(),
-            };
-          } else {
-            // For now, not going to fail the build for a missing asset
-            // Should get caught by the broken link checker, though
-            errorCount++;
-            log(`Image download failed: ${response.statusText}: ${asset.src}`);
+      const downloads = assetsToDownload.map(async asset => {
+        const response = await fetch(asset.src);
+
+        if (response.ok) {
+          downloadCount++;
+          files[asset.dest] = {
+            path: asset.dest,
+            isDrupalAsset: true,
+            contents: await response.buffer(),
+          };
+          if (options.buildtype === ENVIRONMENTS.LOCALHOST) {
+            fs.outputFileSync(
+              path.join(options.cacheDirectory, 'drupalFiles', asset.dest),
+              files[asset.dest].contents,
+            );
           }
+        } else {
+          // For now, not going to fail the build for a missing asset
+          // Should get caught by the broken link checker, though
+          errorCount++;
+          log(`Image download failed: ${response.statusText}: ${asset.src}`);
         }
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7742,7 +7742,7 @@ minimatch@0.3.0:
     lru-cache "2"
     sigmund "~1.0.0"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -9831,6 +9831,13 @@ recursive-readdir@^2.1.0:
   resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.1.1.tgz#a01cfc7f7f38a53ec096a096f63a50489c3e297c"
   dependencies:
     minimatch "3.0.3"
+
+recursive-readdir@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.2.tgz#9946fb3274e1628de6e36b2f6714953b4845094f"
+  integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
+  dependencies:
+    minimatch "3.0.4"
 
 recursive-uncache@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
## Description
This updates the Drupal asset download process to find urls in the GraphQL output, rather than the html output. This lets us catch them before they go into React applications or any other output. 

I also updated our build process to cache the assets, so that FE devs don't have to download them everytime they start a build.

## Testing done
Ran locally, verified that images were still showing up. Also verified that images in React widgets were using a local path, rather than drupal.

## Screenshots


## Acceptance criteria
- [x] All images are still downloaded
- [x] Images are not downloaded when --pull-drupal flag is not used

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
