### PR TITLE
[Drupal] Add method for prod credentials

### DIFF
--- a/script/preview.js
+++ b/script/preview.js
@@ -24,6 +24,17 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'protocol', type: String, defaultValue: 'http' },
   { name: 'destination', type: String, defaultValue: null },
   { name: 'content-directory', type: String, defaultValue: defaultContentDir },
+  {
+    name: 'drupal-address',
+    type: String,
+    defaultValue: process.env.DRUPAL_ADDRESS,
+  },
+  { name: 'drupal-user', type: String, defaultValue: process.env.DRUPAL_USER },
+  {
+    name: 'drupal-password',
+    type: String,
+    defaultValue: process.env.DRUPAL_PASSWORD,
+  },
   { name: 'unexpected', type: String, multile: true, defaultOption: true },
 ];
 

--- a/src/site/constants/drupals.js
+++ b/src/site/constants/drupals.js
@@ -2,18 +2,14 @@ const ENVIRONMENTS = require('./environments');
 
 // const DRUPAL_DEV = {
 //   address: 'http://dev.va.agile6.com',
-//   credentials: {
-//     username: 'api',
-//     password: 'drupal8',
-//   },
+//   user: 'api',
+//   password: 'drupal8',
 // };
 
 const DRUPAL_STAGING = {
   address: 'http://staging.va.agile6.com',
-  credentials: {
-    username: 'api',
-    password: 'drupal8',
-  },
+  user: 'api',
+  password: 'drupal8',
 };
 
 const DRUPAL_LIVE = {

--- a/src/site/constants/drupals.js
+++ b/src/site/constants/drupals.js
@@ -18,7 +18,6 @@ const DRUPAL_STAGING = {
 
 const DRUPAL_LIVE = {
   address: 'http://vagovcms.lndo.site',
-  credentials: {},
 };
 
 /**

--- a/src/site/constants/drupals.js
+++ b/src/site/constants/drupals.js
@@ -7,7 +7,7 @@ const ENVIRONMENTS = require('./environments');
 // };
 
 const DRUPAL_STAGING = {
-  address: 'http://staging.va.agile6.com',
+  address: 'http://stg.va.agile6.com',
   user: 'api',
   password: 'drupal8',
 };

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -1,11 +1,11 @@
 const moment = require('moment');
-
 const fetch = require('node-fetch');
 
 const GET_ALL_PAGES = require('./graphql/GetAllPages.graphql');
 const GET_PAGE_BY_ID = require('./graphql/GetPageById.graphql');
 const GET_LATEST_PAGE_BY_ID = require('./graphql/GetLatestPageById.graphql');
 
+const ENVIRONMENTS = require('../../../constants/environments');
 const DRUPALS = require('../../../constants/drupals');
 
 function encodeCredentials({ username, password }) {
@@ -15,7 +15,30 @@ function encodeCredentials({ username, password }) {
 }
 
 function getDrupalClient(buildOptions) {
-  const { address, credentials } = DRUPALS[buildOptions.buildtype];
+  let drupalConfig = {};
+
+  const drupalBuildOptions = {
+    address: buildOptions['drupal-address'],
+    credentials: {
+      user: buildOptions['drupal-user'],
+      password: buildOptions['drupal-password'],
+    },
+  };
+
+  if (buildOptions.buildtype === ENVIRONMENTS.LOCALHOST) {
+    // On localhost, build args should take priority.
+    drupalConfig = {
+      ...DRUPALS[ENVIRONMENTS.VAGOVDEV],
+      drupalBuildOptions,
+    };
+  } else {
+    drupalConfig = {
+      drupalBuildOptions,
+      ...DRUPALS[buildOptions.buildtype],
+    };
+  }
+
+  const { address, credentials } = drupalConfig;
   const drupalUri = `${address}/graphql`;
   const encodedCredentials = encodeCredentials(credentials);
   const headers = {

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -25,6 +25,17 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'asset-source', type: String, defaultValue: assetSources.LOCAL },
   { name: 'content-directory', type: String, defaultValue: defaultContentDir },
   { name: 'pull-drupal', type: Boolean, defaultValue: false },
+  {
+    name: 'drupal-address',
+    type: String,
+    defaultValue: process.env.DRUPAL_ADDRESS,
+  },
+  { name: 'drupal-user', type: String, defaultValue: process.env.DRUPAL_USER },
+  {
+    name: 'drupal-password',
+    type: String,
+    defaultValue: process.env.DRUPAL_PASSWORD,
+  },
   { name: 'local-proxy-rewrite', type: Boolean, defaultValue: false },
   { name: 'local-css-sourcemaps', type: Boolean, defaultValue: false },
   { name: 'unexpected', type: String, multile: true, defaultOption: true },


### PR DESCRIPTION
## Description
This pull request adds build args for Drupal's address, user, and password. This method gives us flexibility for local builds, is consistent with how we currently pass build information, and provides us a method of passing private production credentials.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16653

1. On Localhost builds, build args always take priority, but default to `vagovdev`. This way, we can easily point our local website to a custom Drupal, which I think will be useful for building Production Drupal without the risk  of committing files that have been modified to take production credentials.
2. On non-local builds, the hardcoded environment config corresponding to the buildtype always takes priority. However, it falls back to build args if there are missing values. This way we can pass user/password for `vagovprod` builds.

### Examples
On local, connect to a custom Drupal, which I think will be useful for testing production -
```
npm run watch -- --drupal-address=https://some-drupal.com --drupal-user=my-user --drupal-password=my-password
```
Builds args have no effect on building `vagovstaging`, because we have hardcoded settings for that env.
```
npm run build -- --buildtype=vagovstaging --drupal-password=does-nothing
```
This way Jenkins can build the site for each buildtype and pass in the user/password, knowing they'll be ignored for dev/staging.

## Testing done
- Ran local builds to confirm Drupal settings are derived properly

## Acceptance criteria
- [x] Build can receive prod credentials

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
