### PR TITLE
Announce deleted accounts

### DIFF
--- a/src/applications/personalization/connected-accounts/actions/index.js
+++ b/src/applications/personalization/connected-accounts/actions/index.js
@@ -10,6 +10,8 @@ export const ERROR_DELETING_CONNECTED_ACCOUNT =
   'ERROR_DELETING_CONNECTED_ACCOUNT';
 export const FINISHED_DELETING_CONNECTED_ACCOUNT =
   'FINISHED_DELETING_CONNECTED_ACCOUNT';
+export const DELETED_ACCOUNT_ALERT_DISMISSED =
+  'DELETED_ACCOUNT_ALERT_DISMISSED';
 
 const grantsUrl = '/profile/connected_applications';
 
@@ -38,4 +40,9 @@ export function deleteConnectedAccount(accountId) {
         dispatch({ type: ERROR_DELETING_CONNECTED_ACCOUNT, accountId, errors }),
     );
   };
+}
+
+export function dismissDeletedAccountAlert(accountId) {
+  return async dispatch =>
+    dispatch({ type: DELETED_ACCOUNT_ALERT_DISMISSED, accountId });
 }

--- a/src/applications/personalization/connected-accounts/components/AppDeletedAlert.jsx
+++ b/src/applications/personalization/connected-accounts/components/AppDeletedAlert.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+export class AppDeletedAlert extends React.Component {
+  componentDidMount() {
+    this.alert.focus();
+  }
+
+  alertMessage() {
+    // eslint-disable-next-line prettier/prettier
+    return `${this.props.account.attributes.title} has been disconnected from your account.`;
+  }
+
+  render() {
+    return (
+      <div
+        tabIndex="-1"
+        ref={alert => {
+          this.alert = alert;
+        }}
+      >
+        <AlertBox
+          status="success"
+          headline="Account Disconnected"
+          content={this.alertMessage()}
+          onCloseAlert={() => this.props.dismissAlert(this.props.account.id)}
+        />
+      </div>
+    );
+  }
+}

--- a/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApp.jsx
@@ -104,7 +104,7 @@ class ConnectedApp extends React.Component {
 ConnectedApp.propTypes = {
   id: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
-  attribtues: PropTypes.object.isRequired,
+  attributes: PropTypes.object.isRequired,
   confirmDelete: PropTypes.func.isRequired,
   isLast: PropTypes.bool,
 };

--- a/src/applications/personalization/connected-accounts/components/ConnectedApps.jsx
+++ b/src/applications/personalization/connected-accounts/components/ConnectedApps.jsx
@@ -2,8 +2,11 @@ import React from 'react';
 
 import { ConnectedApp } from './ConnectedApp';
 import recordEvent from '../../../../platform/monitoring/record-event';
+import { AppDeletedAlert } from './AppDeletedAlert';
 
-export function ConnectedApps({ confirmDelete, accounts }) {
+export function ConnectedApps({ confirmDelete, accounts, dismissAlert }) {
+  const deletedAccounts = accounts.filter(account => account.deleted);
+  const activeAccounts = accounts.filter(account => !account.deleted);
   return (
     <div className="row va-connected-acct">
       <div className="usa-width-two-thirds medium-8 small-12 columns">
@@ -16,10 +19,17 @@ export function ConnectedApps({ confirmDelete, accounts }) {
           anything.
           {/* eslint-enable prettier/prettier */}
         </p>
+        {deletedAccounts.map((account, i) => (
+          <AppDeletedAlert
+            account={account}
+            key={i}
+            dismissAlert={dismissAlert}
+          />
+        ))}
 
         <table className="va-table-connected-acct usa-table-borderless">
           <tbody>
-            {accounts.map((a, idx) => (
+            {activeAccounts.map((a, idx) => (
               <ConnectedApp
                 key={idx}
                 confirmDelete={confirmDelete}

--- a/src/applications/personalization/connected-accounts/components/NoConnectedApps.jsx
+++ b/src/applications/personalization/connected-accounts/components/NoConnectedApps.jsx
@@ -10,31 +10,38 @@ const recordAction = () => {
   });
 };
 
-export function NoConnectedApps({ errors, propertyName }) {
-  let title;
-  if (errors.length > 0) {
-    title = <h3>Sorry — we can’t seem to find any connected accounts.</h3>;
-  } else {
-    title = <h3>You do not have any connected accounts.</h3>;
+export class NoConnectedApps extends React.Component {
+  constructor(props) {
+    super(props);
   }
 
-  return (
-    <div className="row va-connected-acct-null">
-      <div className="usa-width-two-thirds medium-8 small-12 columns">
-        {title}
-        <div className="feature">
-          <h3>Have questions about signing in to {propertyName}?</h3>
-          <p>
-            Get answers to frequently asked questions about how to sign in,
-            common issues with verifying your identity, and your privacy and
-            security on {propertyName}.
-          </p>
+  componentDidMount() {
+    this.header.focus();
+  }
 
-          <a href="/sign-in-faq/" onClick={recordAction}>
-            Go to {propertyName} FAQs
-          </a>
+  noAccountsMessage() {
+    return this.props.errors.length > 0 ? "Sorry — we can’t seem to find any connected accounts." : "You do not have any connected accounts.";
+  }
+
+  render () {
+    return (
+      <div className="row va-connected-acct-null">
+        <div className="usa-width-two-thirds medium-8 small-12 columns">
+          <h3 tabindex="-1" ref={header => this.header = header}>{this.noAccountsMessage()}</h3>
+          <div className="feature">
+            <h3>Have questions about signing in to {this.props.propertyName}?</h3>
+            <p>
+              Get answers to frequently asked questions about how to sign in,
+              common issues with verifying your identity, and your privacy and
+              security on {this.props.propertyName}.
+            </p>
+
+            <a href="/sign-in-faq/" onClick={recordAction}>
+              Go to {this.props.propertyName} FAQs
+            </a>
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
+  }
 }

--- a/src/applications/personalization/connected-accounts/components/NoConnectedApps.jsx
+++ b/src/applications/personalization/connected-accounts/components/NoConnectedApps.jsx
@@ -11,25 +11,32 @@ const recordAction = () => {
 };
 
 export class NoConnectedApps extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-
   componentDidMount() {
     this.header.focus();
   }
 
   noAccountsMessage() {
-    return this.props.errors.length > 0 ? "Sorry — we can’t seem to find any connected accounts." : "You do not have any connected accounts.";
+    return this.props.errors.length > 0
+      ? 'Sorry — we can’t seem to find any connected accounts.'
+      : 'You do not have any connected accounts.';
   }
 
-  render () {
+  render() {
     return (
       <div className="row va-connected-acct-null">
         <div className="usa-width-two-thirds medium-8 small-12 columns">
-          <h3 tabIndex="-1" ref={header => this.header = header}>{this.noAccountsMessage()}</h3>
+          <h3
+            tabIndex="-1"
+            ref={header => {
+              this.header = header;
+            }}
+          >
+            {this.noAccountsMessage()}
+          </h3>
           <div className="feature">
-            <h3>Have questions about signing in to {this.props.propertyName}?</h3>
+            <h3>
+              Have questions about signing in to {this.props.propertyName}?
+            </h3>
             <p>
               Get answers to frequently asked questions about how to sign in,
               common issues with verifying your identity, and your privacy and

--- a/src/applications/personalization/connected-accounts/components/NoConnectedApps.jsx
+++ b/src/applications/personalization/connected-accounts/components/NoConnectedApps.jsx
@@ -27,7 +27,7 @@ export class NoConnectedApps extends React.Component {
     return (
       <div className="row va-connected-acct-null">
         <div className="usa-width-two-thirds medium-8 small-12 columns">
-          <h3 tabindex="-1" ref={header => this.header = header}>{this.noAccountsMessage()}</h3>
+          <h3 tabIndex="-1" ref={header => this.header = header}>{this.noAccountsMessage()}</h3>
           <div className="feature">
             <h3>Have questions about signing in to {this.props.propertyName}?</h3>
             <p>

--- a/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
+++ b/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
@@ -35,15 +35,16 @@ class ConnectedAcctApp extends React.Component {
     this.props.dismissDeletedAccountAlert(accountId);
   };
 
+  numActiveAccounts = () =>
+    this.props.accounts.filter(account => !account.deleted).length;
+
   render() {
     let connectedAccountsView;
     if (this.props.loading) {
       connectedAccountsView = (
         <LoadingIndicator message="Loading your connected accounts..." />
       );
-    } else if (
-      this.props.accounts.filter(account => !account.deleted).length > 0
-    ) {
+    } else if (this.numActiveAccounts() > 0) {
       connectedAccountsView = (
         <ConnectedApps
           confirmDelete={this.confirmDelete}

--- a/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
+++ b/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
@@ -8,7 +8,11 @@ import isBrandConsolidationEnabled from '../../../../platform/brand-consolidatio
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
-import { loadConnectedAccounts, deleteConnectedAccount } from '../actions';
+import {
+  loadConnectedAccounts,
+  deleteConnectedAccount,
+  dismissDeletedAccountAlert,
+} from '../actions';
 import { NoConnectedApps, ConnectedApps } from '../components';
 
 const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
@@ -27,18 +31,25 @@ class ConnectedAcctApp extends React.Component {
     this.props.deleteConnectedAccount(accountId);
   };
 
+  dismissAlert = accountId => {
+    this.props.dismissDeletedAccountAlert(accountId);
+  };
+
   render() {
     let connectedAccountsView;
     if (this.props.loading) {
       connectedAccountsView = (
         <LoadingIndicator message="Loading your connected accounts..." />
       );
-    } else if (this.props.accounts.length > 0) {
+    } else if (
+      this.props.accounts.filter(account => !account.deleted).length > 0
+    ) {
       connectedAccountsView = (
         <ConnectedApps
           confirmDelete={this.confirmDelete}
           accounts={this.props.accounts}
           propertyName={propertyName}
+          dismissAlert={this.dismissAlert}
         />
       );
     } else {
@@ -75,6 +86,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = {
   loadConnectedAccounts,
   deleteConnectedAccount,
+  dismissDeletedAccountAlert,
 };
 
 export default connect(

--- a/src/applications/personalization/connected-accounts/reducers/index.js
+++ b/src/applications/personalization/connected-accounts/reducers/index.js
@@ -9,6 +9,7 @@ import {
   DELETING_CONNECTED_ACCOUNT,
   ERROR_DELETING_CONNECTED_ACCOUNT,
   FINISHED_DELETING_CONNECTED_ACCOUNT,
+  DELETED_ACCOUNT_ALERT_DISMISSED,
 } from '../actions';
 
 const initialState = {
@@ -22,7 +23,7 @@ function connectedAccounts(state = initialState, action) {
     case LOADING_CONNECTED_ACCOUNTS:
       return { ...state, loading: true };
     case FINISHED_CONNECTED_ACCOUNTS:
-      return { accounts: action.data, loading: false, errors: [] };
+      return { ...state, accounts: action.data, loading: false, errors: [] };
     case ERROR_CONNECTED_ACCOUNTS:
       return { ...state, loading: false, errors: action.errors };
     case DELETING_CONNECTED_ACCOUNT: {
@@ -44,6 +45,15 @@ function connectedAccounts(state = initialState, action) {
       return { ...state, accounts };
     }
     case FINISHED_DELETING_CONNECTED_ACCOUNT: {
+      const accounts = state.accounts.map(account => {
+        if (account.id === action.accountId) {
+          return { ...account, deleting: false, deleted: true };
+        }
+        return account;
+      });
+      return { ...state, accounts };
+    }
+    case DELETED_ACCOUNT_ALERT_DISMISSED: {
       const accounts = state.accounts.filter(
         account => account.id !== action.accountId,
       );

--- a/src/applications/personalization/connected-accounts/tests/reducers/index.unit.spec.js
+++ b/src/applications/personalization/connected-accounts/tests/reducers/index.unit.spec.js
@@ -60,6 +60,14 @@ describe('connectedAccounts', () => {
       type: actions.FINISHED_DELETING_CONNECTED_ACCOUNT,
       accountId: 'fake-id',
     });
+    expect(state.accounts.filter(account => !account.deleted).length).to.eq(0);
+  });
+
+  it('removes an account after alert dismissed', () => {
+    const state = reducer.connectedAccounts(loadedState, {
+      type: actions.DELETED_ACCOUNT_ALERT_DISMISSED,
+      accountId: 'fake-id',
+    });
     expect(state.accounts.length).to.eq(0);
   });
 


### PR DESCRIPTION
This is technically a WIP, since I need to fix/add some tests, but I'd like some feedback (based on the video linked below) before that, since it's very likely that there are some issues with the functionality itself. If you have trouble with the video or need more info, let me know and I can demo it for you live.

## Description
Resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/1441

- Focus "You do not have any connected accounts." message after last account removed
- Add alert after each account is deleted

## Testing done
Tested with macos safari + voiceover

Unit tests TK!

## Screenshots

Here's a video of me deleting two connected accounts with voiceover on:
https://drive.google.com/file/d/1KLczLi7gdaMoiJlXiD9gMuIdzee-ruP0/view?usp=sharing

## Acceptance criteria
- [ ] Screen reader users get appropriate feedback as they delete connected accounts

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
