### PR TITLE
Set focus on breadcrumbs when visiting connected accounts page

### DIFF
--- a/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
+++ b/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
@@ -21,7 +21,7 @@ class ConnectedAcctApp extends React.Component {
   }
 
   componentDidMount = () => {
-    focusElement('.va-nav-breadcrumbs');
+    focusElement('.va-nav-breadcrumbs-list');
     this.props.loadConnectedAccounts();
   };
 

--- a/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
+++ b/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
@@ -10,6 +10,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 
 import { loadConnectedAccounts, deleteConnectedAccount } from '../actions';
 import { NoConnectedApps, ConnectedApps } from '../components';
+import { setPageFocus } from '../../../claims-status/utils/page';
 
 const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
@@ -20,6 +21,7 @@ class ConnectedAcctApp extends React.Component {
   }
 
   componentDidMount = () => {
+    setPageFocus();
     this.props.loadConnectedAccounts();
   };
 

--- a/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
+++ b/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import backendServices from '../../../../platform/user/profile/constants/backendServices';
 import { selectUser } from '../../../../platform/user/selectors';
+import { focusElement } from '../../../../platform/utilities/ui';
 
 import RequiredLoginView from '../../../../platform/user/authorization/components/RequiredLoginView';
 import isBrandConsolidationEnabled from '../../../../platform/brand-consolidation/feature-flag';
@@ -10,7 +11,6 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 
 import { loadConnectedAccounts, deleteConnectedAccount } from '../actions';
 import { NoConnectedApps, ConnectedApps } from '../components';
-import { setPageFocus } from '../../../claims-status/utils/page';
 
 const propertyName = isBrandConsolidationEnabled() ? 'VA.gov' : 'Vets.gov';
 
@@ -21,7 +21,7 @@ class ConnectedAcctApp extends React.Component {
   }
 
   componentDidMount = () => {
-    setPageFocus();
+    focusElement('.va-nav-breadcrumbs');
     this.props.loadConnectedAccounts();
   };
 


### PR DESCRIPTION
## Description
Resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/1439

## Testing done
Local browser testing

## Acceptance criteria
- [ ] Breadcrumbs are focused after visiting connected accounts page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
