### PR TITLE
move properties configuration to seed job

### DIFF
--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,6 +1,4 @@
 node('vetsgov-general-purpose') {
-  properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', daysToKeepStr: '60']]]);
-
   dir("vets-website") {
     checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: params.ref]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', noTags: true, reference: '', shallow: true]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
   }

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -1,7 +1,7 @@
 DRUPAL_MAPPING = [
   'dev': 'vagovdev',
   'staging': 'vagovstaging',
-  'live': 'vagovprod',
+  'prod': 'vagovprod',
 ]
 
 ALL_VAGOV_BUILDTYPES = [


### PR DESCRIPTION
Move all properties to the seed job in the devops repo.

It seems that if we define properties here they overwrite the properties in the seed job so lets move all properties to the seed job.
