### PR TITLE
Pass clientId to BE for Cross-domain GA with ID.me

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -57,8 +57,9 @@ function redirectWithGAClientId(redirectUrl) {
       }
     }
 
-    const updatedUrl = `${redirectUrl}?clientId=${clientId}`;
-    window.location = updatedUrl;
+    window.location = clientId
+      ? appendQuery(redirectUrl, { clientId })
+      : redirectUrl;
   } catch (e) {
     window.location = redirectUrl;
   }

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -42,11 +42,38 @@ export function clearRavenLoginType() {
   Raven.setTagsContext(tags);
 }
 
+function redirectWithGAClientId(redirectUrl) {
+  try {
+    let clientId;
+
+    // eslint-disable-next-line
+    const trackers = ga.getAll();
+
+    for (let i = 0; i < trackers.length; i++) {
+      const trackingId = trackers[i].get('trackingId');
+      if (trackingId === 'UA-50123418-16' || trackingId === 'UA-50123418-17') {
+        clientId = trackers[i].get('clientId');
+        break;
+      }
+    }
+
+    const updatedUrl = `${redirectUrl}?clientId=${clientId}`;
+    window.location = updatedUrl;
+  } catch (e) {
+    window.location = redirectUrl;
+  }
+}
+
 function redirect(redirectUrl, clickedEvent) {
   // Keep track of the URL to return to after auth operation.
   sessionStorage.setItem(authnSettings.RETURN_URL, window.location);
   recordEvent({ event: clickedEvent });
-  window.location = redirectUrl;
+
+  if (redirectUrl.indexOf('idme') !== -1) {
+    redirectWithGAClientId(redirectUrl);
+  } else {
+    window.location = redirectUrl;
+  }
 }
 
 export function login(policy) {

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -44,18 +44,18 @@ export function clearRavenLoginType() {
 
 function redirectWithGAClientId(redirectUrl) {
   try {
-    let clientId;
-
-    // eslint-disable-next-line
+    // eslint-disable-next-line no-undef
     const trackers = ga.getAll();
 
-    for (let i = 0; i < trackers.length; i++) {
-      const trackingId = trackers[i].get('trackingId');
-      if (trackingId === 'UA-50123418-16' || trackingId === 'UA-50123418-17') {
-        clientId = trackers[i].get('clientId');
-        break;
-      }
-    }
+    // Tracking IDs for Staging and Prod
+    const vagovTrackingIds = ['UA-50123418-16', 'UA-50123418-17'];
+
+    const tracker = trackers.find(t => {
+      const trackingId = t.get('trackingId');
+      return vagovTrackingIds.includes(trackingId);
+    });
+
+    const clientId = tracker && tracker.get('clientId');
 
     window.location = clientId
       ? appendQuery(redirectUrl, { clientId })
@@ -70,7 +70,7 @@ function redirect(redirectUrl, clickedEvent) {
   sessionStorage.setItem(authnSettings.RETURN_URL, window.location);
   recordEvent({ event: clickedEvent });
 
-  if (redirectUrl.indexOf('idme') !== -1) {
+  if (redirectUrl.includes('idme')) {
     redirectWithGAClientId(redirectUrl);
   } else {
     window.location = redirectUrl;


### PR DESCRIPTION
## Description
In order to enable cross-domain GA, we need to pass along the user's `clientId` to ID.me as a querystring.  Added a check in our redirect logic to append the `clientId` as a param if the user is being redirected to ID.me.

## Testing done
Tested locally along with changes on the `13866-cross-domain-ga` branch for `vets-api`.

**Note:** There are a couple redirects that occur so the clientId is a little hard to track in the URL.  I used [this extension](https://chrome.google.com/webstore/detail/link-redirect-trace/nnpljppamoaalgkieeciijbcccohlpoh) to track the redirects.


## Acceptance criteria
- [ ] `clientId` is appended to the URL when redirecting to the API
- [ ] Redirect URL returned from API also has `clientId` appended

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
