### PR TITLE
Add page to aXe exceptions

### DIFF
--- a/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
@@ -45,6 +45,7 @@ function sitemapURLs() {
         '/disability/how-to-file-claim/when-to-file/pre-discharge-claim/',
         '/disability/how-to-file-claim/evidence-needed/fully-developed-claims/',
         '/disability/how-to-file-claim/evidence-needed/decision-ready-claims/',
+        '/disability/how-to-file-claim/evidence-needed/',
       ];
       // Whitelist of URLs to only test against the 'section508' rule set and not
       // the stricter 'wcag2a' rule set. For each URL added to this list, please


### PR DESCRIPTION
## Description
The PR adds `/disability/how-to-file-claim/evidence-needed/` to the aXe-check ignore list, due to the `aria-multiselectable` attribute.

## Acceptance criteria
- [ ] aXe check passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
