### PR TITLE
All claims fix new disability inputs mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
+++ b/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
@@ -1,7 +1,7 @@
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import PeriodOfConfinement from '../components/PeriodOfConfinement';
-import { addCheckboxPerNewDisability } from '../utils';
+import { makeSchemaForNewDisabilities } from '../utils';
 import { isWithinServicePeriod } from '../validations';
 import { confinementDescription } from '../content/prisonerOfWar';
 
@@ -38,7 +38,7 @@ export const uiSchema = {
         'Which of your new conditions was caused or affected by your POW experience?',
       'ui:options': {
         hideIf: formData => !formData['view:newDisabilities'],
-        updateSchema: addCheckboxPerNewDisability,
+        updateSchema: makeSchemaForNewDisabilities,
       },
     },
   },

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -4,7 +4,7 @@ import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { uiSchema as autoSuggestUiSchema } from 'platform/forms-system/src/js/definitions/autosuggest';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/monthYearRange';
 import { treatmentView } from '../content/vaMedicalRecords';
-import { queryForFacilities, addCheckboxPerDisability } from '../utils';
+import { queryForFacilities, makeSchemaForAllDisabilities } from '../utils';
 import {
   validateMilitaryTreatmentCity,
   validateMilitaryTreatmentState,
@@ -51,7 +51,7 @@ export const uiSchema = {
         'ui:title':
           'Please choose the conditions for which you received treatment at this facility.',
         'ui:options': {
-          updateSchema: addCheckboxPerDisability,
+          updateSchema: makeSchemaForAllDisabilities,
           showFieldLabel: true,
         },
         'ui:validations': [validateBooleanGroup],

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -202,6 +202,24 @@ describe.only('526 helpers', () => {
         },
       });
     });
+
+    it('should return correct schema when periods used', () => {
+      const formData = {
+        newDisabilities: [
+          {
+            condition: 'period. Period.',
+          },
+        ],
+      };
+      expect(makeSchemaForNewDisabilities(formData)).to.eql({
+        properties: {
+          'period. period.': {
+            title: 'Period. Period.',
+            type: 'boolean',
+          },
+        },
+      });
+    });
   });
 
   describe('makeSchemaForRatedDisabilities', () => {

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -32,7 +32,7 @@ import {
   recordEventOnce,
 } from '../utils.jsx';
 
-describe.only('526 helpers', () => {
+describe('526 helpers', () => {
   describe('hasGuardOrReservePeriod', () => {
     it('should return true when reserve period present', () => {
       const formData = {

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -160,6 +160,14 @@ describe('526 helpers', () => {
           'some disability with hyphenated-words',
           'Some Disability With Hyphenated-Words',
         ],
+        [
+          "some disability with possessive's stuff",
+          "Some Disability With Possessive's Stuff",
+        ],
+        [
+          "some disability with possessive's-hyphen",
+          "Some Disability With Possessive's-Hyphen",
+        ],
         ['some "quote" disability', 'Some "Quote" Disability'],
       ].forEach(pair => expect(capitalizeEachWord(pair[0])).to.equal(pair[1]));
     });

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -4,7 +4,9 @@ import { shallow } from 'enzyme';
 import _ from '../../../../platform/utilities/data';
 
 import {
-  addCheckboxPerDisability,
+  makeSchemaForNewDisabilities,
+  makeSchemaForRatedDisabilities,
+  makeSchemaForAllDisabilities,
   capitalizeEachWord,
   fieldsHaveInput,
   hasGuardOrReservePeriod,
@@ -30,7 +32,7 @@ import {
   recordEventOnce,
 } from '../utils.jsx';
 
-describe('526 helpers', () => {
+describe.only('526 helpers', () => {
   describe('hasGuardOrReservePeriod', () => {
     it('should return true when reserve period present', () => {
       const formData = {
@@ -182,8 +184,8 @@ describe('526 helpers', () => {
     });
   });
 
-  describe('addCheckboxPerDisability', () => {
-    it('should return disabilitiesViews with downcased keynames', () => {
+  describe('makeSchemaForNewDisabilities', () => {
+    it('should return schema with downcased keynames', () => {
       const formData = {
         newDisabilities: [
           {
@@ -191,10 +193,69 @@ describe('526 helpers', () => {
           },
         ],
       };
-      expect(addCheckboxPerDisability(formData)).to.eql({
+      expect(makeSchemaForNewDisabilities(formData)).to.eql({
         properties: {
           'ptsd personal trauma': {
             title: 'Ptsd Personal Trauma',
+            type: 'boolean',
+          },
+        },
+      });
+    });
+  });
+
+  describe('makeSchemaForRatedDisabilities', () => {
+    it('should return schema for selected disabilities only', () => {
+      const formData = {
+        ratedDisabilities: [
+          {
+            name: 'Ptsd personal trauma',
+            'view:selected': false,
+          },
+          {
+            name: 'Diabetes mellitus',
+            'view:selected': true,
+          },
+        ],
+      };
+      expect(makeSchemaForRatedDisabilities(formData)).to.eql({
+        properties: {
+          'diabetes mellitus': {
+            title: 'Diabetes Mellitus',
+            type: 'boolean',
+          },
+        },
+      });
+    });
+  });
+
+  describe('makeSchemaForAllDisabilities', () => {
+    it('should return schema for all (selected) disabilities', () => {
+      const formData = {
+        ratedDisabilities: [
+          {
+            name: 'Ptsd personal trauma',
+            'view:selected': false,
+          },
+          {
+            name: 'Diabetes mellitus',
+            'view:selected': true,
+          },
+        ],
+        newDisabilities: [
+          {
+            condition: 'A new Condition.',
+          },
+        ],
+      };
+      expect(makeSchemaForAllDisabilities(formData)).to.eql({
+        properties: {
+          'diabetes mellitus': {
+            title: 'Diabetes Mellitus',
+            type: 'boolean',
+          },
+          'a new condition.': {
+            title: 'A New Condition.',
             type: 'boolean',
           },
         },

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -4,6 +4,7 @@ import Raven from 'raven-js';
 import appendQuery from 'append-query';
 import { createSelector } from 'reselect';
 import { omit } from 'lodash';
+import merge from 'lodash/merge';
 import recordEvent from '../../../platform/monitoring/record-event';
 import { apiRequest } from '../../../platform/utilities/api';
 import environment from '../../../platform/utilities/environment';
@@ -190,59 +191,40 @@ export function queryForFacilities(input = '') {
 
 export const disabilityIsSelected = disability => disability['view:selected'];
 
-/**
- * An updateSchema callback that adds boolean properties to the schema.
- * The property names are lowercased, while the title is title cased.
- */
-export const addCheckboxPerDisability = (formData, pageSchema) => {
-  const { ratedDisabilities, newDisabilities } = formData;
-  // This shouldn't happen, but could happen if someone directly
-  // opens the right page in the form with no SiP
-  if (!ratedDisabilities && !newDisabilities) {
-    return pageSchema;
-  }
-  const selectedRatedDisabilities = Array.isArray(ratedDisabilities)
-    ? ratedDisabilities.filter(disabilityIsSelected)
-    : [];
-
-  const selectedNewDisabilities = Array.isArray(newDisabilities)
-    ? newDisabilities
-    : [];
-
-  // We expect to get an array with conditions in it or no property
-  // at all.
-  const disabilitiesViews = selectedRatedDisabilities
-    .concat(selectedNewDisabilities)
-    .reduce((accum, curr) => {
-      const disabilityName = curr.name || curr.condition || '';
-      const capitalizedDisabilityName = capitalizeEachWord(disabilityName);
-      return _.set(
-        // downcase value for SIP consistency
-        [disabilityName.toLowerCase()],
-        { title: capitalizedDisabilityName, type: 'boolean' },
-        accum,
-      );
-    }, {});
-  return {
-    properties: disabilitiesViews,
-  };
+const createCheckboxSchema = (schema, disabilityName) => {
+  const capitalizedDisabilityName = capitalizeEachWord(disabilityName);
+  return _.set(
+    // downcase value for SIP consistency
+    [`${capitalizedDisabilityName.toLowerCase()}`],
+    { title: capitalizedDisabilityName, type: 'boolean' },
+    schema,
+  );
 };
 
-const formattedNewDisabilitiesSelector = createSelector(
+export const makeSchemaForNewDisabilities = createSelector(
   formData => formData.newDisabilities,
-  (newDisabilities = []) =>
-    newDisabilities.map(disability => capitalizeEachWord(disability.condition)),
+  (newDisabilities = []) => ({
+    properties: newDisabilities
+      .map(disability => capitalizeEachWord(disability.condition))
+      .reduce(createCheckboxSchema, {}),
+  }),
 );
 
-export const addCheckboxPerNewDisability = createSelector(
-  formattedNewDisabilitiesSelector,
-  newDisabilities => ({
-    properties: newDisabilities.reduce(
-      (accum, disability) =>
-        _.set([`${disability}`], { type: 'boolean' }, accum),
-      {},
-    ),
+export const makeSchemaForRatedDisabilities = createSelector(
+  formData => formData.ratedDisabilities,
+  (ratedDisabilities = []) => ({
+    properties: ratedDisabilities
+      .filter(disabilityIsSelected)
+      .map(disability => capitalizeEachWord(disability.name))
+      .reduce(createCheckboxSchema, {}),
   }),
+);
+
+export const makeSchemaForAllDisabilities = createSelector(
+  makeSchemaForNewDisabilities,
+  makeSchemaForRatedDisabilities,
+  (newDisabilitiesSchema, ratedDisabilitiesSchema) =>
+    merge({}, newDisabilitiesSchema, ratedDisabilitiesSchema),
 );
 
 export const hasVAEvidence = formData =>

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -218,7 +218,7 @@ export const addCheckboxPerDisability = (formData, pageSchema) => {
       const capitalizedDisabilityName = capitalizeEachWord(disabilityName);
       return _.set(
         // downcase value for SIP consistency
-        disabilityName.toLowerCase(),
+        [disabilityName.toLowerCase()],
         { title: capitalizedDisabilityName, type: 'boolean' },
         accum,
       );
@@ -238,7 +238,8 @@ export const addCheckboxPerNewDisability = createSelector(
   formattedNewDisabilitiesSelector,
   newDisabilities => ({
     properties: newDisabilities.reduce(
-      (accum, disability) => _.set([disability], { type: 'boolean' }, accum),
+      (accum, disability) =>
+        _.set([`${disability}`], { type: 'boolean' }, accum),
       {},
     ),
   }),

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -147,7 +147,7 @@ const capitalizeWord = word => {
  */
 export const capitalizeEachWord = name => {
   if (name && typeof name === 'string') {
-    return name.replace(/\w\S*/g, capitalizeWord);
+    return name.replace(/\w[^\s-]*/g, capitalizeWord);
   }
 
   Raven.captureMessage(
@@ -238,7 +238,7 @@ export const addCheckboxPerNewDisability = createSelector(
   formattedNewDisabilitiesSelector,
   newDisabilities => ({
     properties: newDisabilities.reduce(
-      (accum, disability) => _.set(disability, { type: 'boolean' }, accum),
+      (accum, disability) => _.set([disability], { type: 'boolean' }, accum),
       {},
     ),
   }),

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -147,7 +147,7 @@ const capitalizeWord = word => {
  */
 export const capitalizeEachWord = name => {
   if (name && typeof name === 'string') {
-    return name.replace(/\w+/g, capitalizeWord);
+    return name.replace(/\w\S*/g, capitalizeWord);
   }
 
   Raven.captureMessage(

--- a/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
+++ b/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
@@ -277,13 +277,13 @@ AutosuggestField.propTypes = {
       freeInput: PropTypes.bool,
       inputTransformers: PropTypes.arrayOf(PropTypes.func),
     }),
-    'ui:title': PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    'ui:title': PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   }),
   onChange: PropTypes.func.isRequired,
   onBlur: PropTypes.func.isRequired,
   idSchema: PropTypes.shape({
     $id: PropTypes.string,
   }),
-  formData: PropTypes.object.isRequired,
+  formData: PropTypes.object,
   schema: PropTypes.object.isRequired,
 };

--- a/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
+++ b/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
@@ -273,7 +273,7 @@ AutosuggestField.propTypes = {
       getOptions: PropTypes.func,
       debounceRate: PropTypes.number,
       maxOptions: PropTypes.number,
-      queryForResults: PropTypes.func,
+      queryForResults: PropTypes.bool,
       freeInput: PropTypes.bool,
       inputTransformers: PropTypes.arrayOf(PropTypes.func),
     }),


### PR DESCRIPTION
## Description
Fixes a few bugs related to the new disabilities autosuggest page, as outlined in attached ticket

- Fixes incorrect capitalization on things like `Who'S` (Who's, It's) and `Some-lastname` (Some-Lastname, Post-Traumatic, etc.)
- Fixes hangups on the disability adder page when periods are used in the disability name
- Fixes downstream schema errors related to `AddCheckboxPerDisability`'s handling of disability names with periods on the POW and VA Treatments pages
- Adds a few tests for the above cases
- Fixes a few bad proptype definitions in the AutoSuggest field which...I made in an earlier PR.

## Testing done
- Tested POW and VA Treatment pages locally with rated-only, rated+new, new-only conditions & previously-failing strings
- Added unit tests for capitalization, periods, and schema generator bugs

## Screenshots
No change

## Acceptance criteria
- [x] No more schema or UI errors on disability adder page
- [x] Can enter all allowable chars as disability name (e.g., periods) without issue
- [x] Checkboxes are generated properly for rated, new, rated + new conditions
- [x] Capitalization works as expected: `'` should not be a whitespace char, `-` should

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
