### PR TITLE
Fix git issues with content build

### DIFF
--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,9 +1,6 @@
-def isReleaseBuild() {
-  return params.ref.startsWith('vets-website')
-}
-
 node('vetsgov-general-purpose') {
-  if (isReleaseBuild()) {
+	// params.ref can either be a git commit ref or a tag
+  if (params.ref.startsWith('vets-website')) {
     branchName = "refs/tags/${params.ref}"
   } else {
     branchName = params.ref

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,6 +1,12 @@
 node('vetsgov-general-purpose') {
+	if (params.ref.startsWith('vets-website')) {
+		branchName = "refs/tags/${params.ref}"
+	} else {
+		branchName = params.ref
+	}
+
   dir("vets-website") {
-    checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: params.ref]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', noTags: true, reference: '', shallow: true]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
+    checkout scm: [$class: 'GitSCM', branches: [[name: branchName]], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
   }
 
   def commonStages = load "vets-website/jenkins/common.groovy"

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,5 +1,6 @@
 node('vetsgov-general-purpose') {
-	// params.ref can either be a git commit ref or a tag
+  // params.ref can either be a git commit ref or a tag
+  // If its a tag, the checkout function requires 'refs/tags/' prepended to the tag to function properly
   if (params.ref.startsWith('vets-website')) {
     branchName = "refs/tags/${params.ref}"
   } else {

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,5 +1,9 @@
+def isReleaseBuild() {
+  return params.ref.startsWith('vets-website')
+}
+
 node('vetsgov-general-purpose') {
-  if (params.ref.startsWith('vets-website')) {
+  if (isReleaseBuild()) {
     branchName = "refs/tags/${params.ref}"
   } else {
     branchName = params.ref

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,9 +1,9 @@
 node('vetsgov-general-purpose') {
-	if (params.ref.startsWith('vets-website')) {
-		branchName = "refs/tags/${params.ref}"
-	} else {
-		branchName = params.ref
-	}
+  if (params.ref.startsWith('vets-website')) {
+    branchName = "refs/tags/${params.ref}"
+  } else {
+    branchName = params.ref
+  }
 
   dir("vets-website") {
     checkout scm: [$class: 'GitSCM', branches: [[name: branchName]], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]


### PR DESCRIPTION
This PR should fix the  content only vets-website build in Jenkins.

There was a lot of unneeded options specified with the checkout command and one that was breaking everything. The option to do a shallow clone was breaking the ability to build older refs. This PR removes those extra options and adds a little logic to handle tags correctly.