### PR TITLE
Remove ability to use tags in the content only build

### DIFF
--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,15 +1,7 @@
 node('vetsgov-general-purpose') {
-  // params.ref can either be a git commit ref or a tag
-  // If its a tag, the checkout function requires 'refs/tags/' prepended to the tag to function properly
-  if (params.ref.startsWith('vets-website')) {
-    branchName = "refs/tags/${params.ref}"
-  } else {
-    branchName = params.ref
-  }
 
   dir("vets-website") {
-    checkout scm: [$class: 'GitSCM', branches: [[name: branchName]], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
-    ref = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+    checkout scm: [$class: 'GitSCM', branches: [[name: params.ref]], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
   }
 
   def commonStages = load "vets-website/jenkins/common.groovy"
@@ -17,9 +9,9 @@ node('vetsgov-general-purpose') {
   // Setup stage
   dockerContainer = commonStages.setup()
   // Build stage
-  commonStages.build(ref, dockerContainer, true)
+  commonStages.build(params.ref, dockerContainer, true)
   // Prearchive stage
   commonStages.prearchive(dockerContainer)
   // Archive stage
-  commonStages.archive(dockerContainer, ref)
+  commonStages.archive(dockerContainer, params.ref)
 }

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -9,6 +9,7 @@ node('vetsgov-general-purpose') {
 
   dir("vets-website") {
     checkout scm: [$class: 'GitSCM', branches: [[name: branchName]], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
+		ref = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
   }
 
   def commonStages = load "vets-website/jenkins/common.groovy"
@@ -16,9 +17,9 @@ node('vetsgov-general-purpose') {
   // Setup stage
   dockerContainer = commonStages.setup()
   // Build stage
-  commonStages.build(params.ref, dockerContainer, true)
+  commonStages.build(ref, dockerContainer, true)
   // Prearchive stage
   commonStages.prearchive(dockerContainer)
   // Archive stage
-  commonStages.archive(dockerContainer, params.ref)
+  commonStages.archive(dockerContainer, ref)
 }

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -9,7 +9,7 @@ node('vetsgov-general-purpose') {
 
   dir("vets-website") {
     checkout scm: [$class: 'GitSCM', branches: [[name: branchName]], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
-		ref = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+    ref = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
   }
 
   def commonStages = load "vets-website/jenkins/common.groovy"


### PR DESCRIPTION
This PR removes the content-only builds ability to take a tag as the `ref` parameter. I think it is better that the logic for handling tags/releases be handled outside of this job.

I will follow this PR with another one that updates the warn-release-deploy job and possibly adds a function the shared jenkins library. 
https://github.com/department-of-veterans-affairs/va.gov-devops-jenkins-lib/pull/10 -- adds a new shared function to get a git release
https://github.com/department-of-veterans-affairs/devops/pull/4290 -- removes requirement for content build to take a tag as a parameter

