### PR TITLE
[VET TEC] Contact Information Street 3 Fix

### DIFF
--- a/src/applications/edu-benefits/0994/components/AddressViewField.jsx
+++ b/src/applications/edu-benefits/0994/components/AddressViewField.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const AddressViewField = ({ formData }) => {
-  const { street, street2, city, state, postalCode } = formData;
+  const { street, street2, street3, city, state, postalCode } = formData;
   let postalString;
   if (postalCode) {
     const firstFive = postalCode.slice(0, 5);
@@ -15,6 +15,8 @@ export const AddressViewField = ({ formData }) => {
       {street && <br />}
       {street2 && street2}
       {street2 && <br />}
+      {street3 && street3}
+      {street3 && <br />}
       {city && city} {state && state} {postalString && postalString}
     </p>
   );

--- a/src/applications/edu-benefits/tests/0994/components/AddressViewField.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/0994/components/AddressViewField.unit.spec.jsx
@@ -26,7 +26,6 @@ describe('<AddressViewField>', () => {
     expect(text).to.contain(formData.city);
     expect(text).to.contain(formData.state);
     expect(text).to.contain(formData.postalCode);
-    expect(text).to.not.contain(formData.street3);
     expect(text).to.not.contain(formData.country);
 
     component.unmount();

--- a/src/applications/edu-benefits/tests/0994/components/AddressViewField.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/0994/components/AddressViewField.unit.spec.jsx
@@ -22,6 +22,7 @@ describe('<AddressViewField>', () => {
 
     expect(text).to.contain(formData.street);
     expect(text).to.contain(formData.street2);
+    expect(text).to.contain(formData.street3);
     expect(text).to.contain(formData.city);
     expect(text).to.contain(formData.state);
     expect(text).to.contain(formData.postalCode);


### PR DESCRIPTION
## Description
Added address street 3 as a displayed field on the `AddressViewField` component

## Testing done
Tested locally and updated unit test

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/54220525-fddfe400-44c7-11e9-9925-ebfc74ba8593.png)


## Acceptance criteria
- [x] Address line 3 displays

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
