### PR TITLE
VET TEC: Note on bank information screen is incorrect#17349

### DIFF
--- a/src/applications/edu-benefits/0994/content/bankInformation.jsx
+++ b/src/applications/edu-benefits/0994/content/bankInformation.jsx
@@ -9,8 +9,8 @@ export const bankInfoDescription =
 export const bankInfoNote = (
   <p>
     <strong>Note: </strong>
-    Any updates you make here to your contact information will also apply to
-    your other VA benefits, including compensation, pension, and education.
+    Any updates you make here to your bank account information will also apply
+    to your other VA benefits, including compensation, pension, and education.
   </p>
 );
 


### PR DESCRIPTION
## Description
**What happened:**
1. The "Note" text on the "Personal Information" page 6 of 7 displays text for contact information instead of the bank information "Note". 
![image.png](https://images.zenhubusercontent.com/5c814a7219e31d676cd7e33a/7fe1d408-7210-4680-81e8-6034649af602)


**Desired behavior:**
1. The "Note" text should be the following as shown in the content doc(https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Education%20Benefits/0994/Design/Content/0994%20content.md):
"**Note:** Any updates you make here to your bank account information will also apply to your other VA benefits, including compensation, pension, and education."

## Testing done
- local testing

## Screenshots
<img width="582" alt="Screen Shot 2019-03-13 at 10 26 45 AM" src="https://user-images.githubusercontent.com/1094999/54286612-89b24880-457a-11e9-9116-3d8b4ddce6ea.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
