### PR TITLE
Add CMS url check

### DIFF
--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -29,6 +29,7 @@ const checkCollections = require('./plugins/check-collections');
 const createHeaderFooter = require('./plugins/create-header-footer');
 const createTemporaryReactPages = require('./plugins/create-react-pages');
 const downloadDrupalAssets = require('./plugins/download-drupal-assets');
+const checkForCMSUrls = require('./plugins/check-cms-urls');
 
 function defaultBuild(BUILD_OPTIONS) {
   const smith = Metalsmith(__dirname); // eslint-disable-line new-cap
@@ -158,6 +159,7 @@ function defaultBuild(BUILD_OPTIONS) {
   smith.use(createSitemaps(BUILD_OPTIONS));
   smith.use(createRedirects(BUILD_OPTIONS));
   smith.use(checkBrokenLinks(BUILD_OPTIONS));
+  smith.use(checkForCMSUrls(BUILD_OPTIONS));
 
   /* eslint-disable no-console */
   smith.build(err => {

--- a/src/site/stages/build/plugins/check-cms-urls.js
+++ b/src/site/stages/build/plugins/check-cms-urls.js
@@ -1,0 +1,35 @@
+/* eslint-disable no-console */
+const ignoredPages = new Set(['drupal/test/index.html']);
+
+function checkForCMSUrls(BUILD_OPTIONS) {
+  return (files, metalsmith, done) => {
+    const filesWithBadUrls = [];
+    for (const fileName of Object.keys(files)) {
+      const file = files[fileName];
+      if (file.isDrupalPage && !ignoredPages.has(fileName)) {
+        const contents = file.contents.toString();
+        if (
+          contents.includes('cms.va.gov') ||
+          contents.includes('va.agile6.com')
+        ) {
+          filesWithBadUrls.push(fileName);
+        }
+      }
+    }
+
+    if (filesWithBadUrls.length) {
+      console.log(
+        'The following pages have cms.va.gov or va.agile6.com referenced:',
+      );
+      console.log(filesWithBadUrls.join('\n'));
+
+      if (!BUILD_OPTIONS.watch) {
+        throw new Error('Pages found that reference internal CMS urls');
+      }
+    }
+
+    done();
+  };
+}
+
+module.exports = checkForCMSUrls;


### PR DESCRIPTION
## Description
We're transforming asset urls from their Drupal url to local urls and we'd like to be sure we're not missing any of them. This adds a plugin to check that at the end of the build process.

## Testing done
Ran build locally

## Screenshots


## Acceptance criteria
- [x] Build process runs

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
