### PR TITLE
Remove bottom padding between content and major links section

### DIFF
--- a/src/site/includes/detail-page.html
+++ b/src/site/includes/detail-page.html
@@ -20,7 +20,7 @@
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
       {% endif %}  
       
-    {% if no_article_bottom_padding == true %}
+    {% if no_article_bottom_padding %}
       <article class="usa-content vads-u-padding-bottom--0">
         <h1>{{ heading }}</h1>
         {{ contents }}

--- a/src/site/includes/detail-page.html
+++ b/src/site/includes/detail-page.html
@@ -20,10 +20,18 @@
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
       {% endif %}  
       
+    {% if no_article_bottom_padding === true %}
+      <article class="usa-content vads-u-padding-bottom--0">
+        <h1>{{ heading }}</h1>
+        {{ contents }}
+      </article>
+    {% else %}  
       <article class="usa-content">
         <h1>{{ heading }}</h1>
         {{ contents }}
       </article>
+    {% endif %}
+
       {% if majorlinks != empty %}
         {% include "src/site/components/navigation-links-list.html" %}
       {% endif %}

--- a/src/site/includes/detail-page.html
+++ b/src/site/includes/detail-page.html
@@ -20,7 +20,7 @@
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
       {% endif %}  
       
-    {% if no_article_bottom_padding === true %}
+    {% if no_article_bottom_padding == true %}
       <article class="usa-content vads-u-padding-bottom--0">
         <h1>{{ heading }}</h1>
         {{ contents }}


### PR DESCRIPTION
## Description
This PR removes the bottom padding from content pages when frontmatter property`no_article_bottom_padding` is set to `true`.

A conditional statement was added within the `src/site/includes/detail-page.html` page layout. When the frontmatter property`no_article_bottom_padding` is set to `true` on a content page, the conditional will add a spacing utility `vads-u-padding-bottom--0`, and remove the default `padding-bottom: 3em` in the `article` class.

Note: When viewing this PR, it should be paired with [this vagov-content PR](https://github.com/department-of-veterans-affairs/vagov-content/pull/307)

and on this url: /health-care/health-needs-conditions/health-issues-related-to-service-era/

## Testing done
Viewed on local build

## Screenshots
**before**:
![Screen Shot 2019-03-13 at 3 18 18 PM](https://user-images.githubusercontent.com/11021491/54308125-b464c700-45a3-11e9-8801-ff93e9266b5b.png)


**after**:
![Screen Shot 2019-03-13 at 3 18 36 PM](https://user-images.githubusercontent.com/11021491/54308143-bfb7f280-45a3-11e9-9a24-ad341498c86a.png)


## Acceptance criteria
- [X] bottom padding is removed when flag is set to `true`

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
