### PR TITLE
Add support for showing server errors on ID Page

### DIFF
--- a/src/applications/hca/actions.js
+++ b/src/applications/hca/actions.js
@@ -1,6 +1,5 @@
 import appendQuery from 'append-query';
 import { apiRequest } from 'platform/utilities/api';
-import environment from 'platform/utilities/environment';
 
 export const SUBMIT_ID_FORM_STARTED = 'SUBMIT_ID_FORM_STARTED';
 export const SUBMIT_ID_FORM_SUCCEEDED = 'SUBMIT_ID_FORM_SUCCEEDED';
@@ -9,14 +8,26 @@ export const SUBMIT_ID_FORM_FAILED = 'SUBMIT_ID_FORM_FAILED';
 export function submitIDForm(formData) {
   return dispatch => {
     dispatch({ type: SUBMIT_ID_FORM_STARTED });
-
-    // We need bypass the local API when running locally, so hit dev-api
-    // directly. As an aside, if we want to get a 500 server error when testing
-    // locally, reverse this check to make the app hit the local API instead.
-    const urlPrefix = environment.isLocalhost()
-      ? 'https://dev-api.va.gov/v0'
-      : '';
-    const baseUrl = `${urlPrefix}/health_care_applications/enrollment_status`;
+    /*
+    When hitting the API locally, we cannot get responses other than 404s from
+    the endpoint. This is due to the endpoint's need to connect to MVI, which
+    cannot easily been done locally. There are a few ways around this:
+    1. Temporarily change the `baseUrl` to:
+       'https://dev-api.va.gov/v0/health_care_applications/enrollment_status, so
+       that we bypass the local APi. If you use the following user creds the
+       backend will respond with a 200 and the expected response body:
+       WESLEY
+       FORD
+       1986-05-06
+       796043735
+    2. You can add something like this `return render(json: { "parsed_status" =>
+       'enrolled' })` to the first line of the enrollment_status method in
+       vets-api: app/controllers/v0/health_care_applications_controller.rb#L25
+    3. Instead of making the apiRequest here, you can immediately dispatch the
+       action that corresponds to th condition you want to test:
+       `dispatch({type: SUBMIT_ID_FORM_FAILED, errors: [{ code: '500' }] });`
+    */
+    const baseUrl = `/health_care_applications/enrollment_status`;
 
     const url = appendQuery(baseUrl, {
       'userAttributes[veteranDateOfBirth]': formData.dob,

--- a/src/applications/hca/components/IDForm.jsx
+++ b/src/applications/hca/components/IDForm.jsx
@@ -75,6 +75,47 @@ export default class IDForm extends React.Component {
     },
   };
 
+  renderServerErrorAlert = () => {
+    const { errors } = this.props;
+    if (errors && errors.some(error => error.code === '500')) {
+      return (
+        <AlertBox
+          isVisible
+          status="error"
+          headline="Server Error"
+          content={
+            <>
+              <p>
+                We’re sorry for the interruption, but we have encountered an
+                error. Please try again later.
+              </p>
+            </>
+          }
+        />
+      );
+    }
+    return null;
+  };
+
+  renderRateLimitErrorAlert = () => {
+    const { errors } = this.props;
+    if (errors && errors.some(error => error.code === '429')) {
+      return (
+        <AlertBox
+          isVisible
+          status="error"
+          headline="Rate Limit Error"
+          content={
+            <>
+              <p>Please try again in an hour!</p>
+            </>
+          }
+        />
+      );
+    }
+    return null;
+  };
+
   renderContinueButtonOrStatus = () => {
     const { enrollmentStatus } = this.props;
     if (enrollmentStatus && enrollmentStatus !== 'none_of_the_above') {
@@ -133,6 +174,8 @@ export default class IDForm extends React.Component {
         onChange={this.formChange}
         data={this.state.idFormData}
       >
+        {this.renderServerErrorAlert()}
+        {this.renderRateLimitErrorAlert()}
         {this.renderContinueButtonOrStatus()}
       </SchemaForm>
     );

--- a/src/applications/hca/containers/IDPage.jsx
+++ b/src/applications/hca/containers/IDPage.jsx
@@ -82,6 +82,7 @@ class IDPage extends React.Component {
             />
             <br />
             <IDForm
+              errors={this.props.errors}
               enrollmentStatus={this.props.enrollmentStatus}
               isLoading={this.props.isSubmittingIDForm}
               handleSignIn={this.showSignInModal}
@@ -105,6 +106,7 @@ const mapDispatchToProps = {
 
 const mapStateToProps = state => ({
   enrollmentStatus: state.hcaIDForm.enrollmentStatus,
+  errors: state.hcaIDForm.errors,
   form: state.form,
   noESRRecordFound: state.hcaIDForm.noESRRecordFound,
   isSubmittingIDForm: state.hcaIDForm.isSubmitting,

--- a/src/applications/hca/reducer.js
+++ b/src/applications/hca/reducer.js
@@ -17,7 +17,7 @@ const initialState = {
 function hcaIDForm(state = initialState, action) {
   switch (action.type) {
     case SUBMIT_ID_FORM_STARTED:
-      return { ...state, isSubmitting: true };
+      return { ...state, isSubmitting: true, errors: null };
 
     case SUBMIT_ID_FORM_SUCCEEDED: {
       const { parsedStatus: enrollmentStatus } = action.data;


### PR DESCRIPTION
## Description
Render placeholder server errors at the bottom of the ID form, just above the form submit button, when 500 or 429 (rate limit) errors are returned. Keep the form submit button visible and active so the user can resubmit.

## Testing done
Local

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/54367642-fb989980-462f-11e9-83e9-f8e9eb1b87fb.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs