### PR TITLE
VAGOV-1685: Healthcare detail page

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -66,6 +66,26 @@
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+
+{% assign start_date_no_time = fieldDate.value | date: "%a, %b %d" %}
+{% assign end_date_no_time = fieldDate.endValue | date: "%a, %b %d" %}
+
+{% assign start_time = fieldDate.value | date: "%I:%M %p" %}
+{% assign end_time = fieldDate.endValue | date: "%I:%M %p" %}
+
+{% assign start_date_full = fieldDate.value | date: "%a, %b %d, %I:%M %p" %}
+{% assign end_date_full = fieldDate.endValue | date: "%a, %b %d, %I:%M %p" %}
+
+{% if fieldDate.value != empty and fieldDate.endValue == empty %}
+    {% assign date_type = "start_date_only" %}
+{% else %}
+    {% if start_date_no_time == end_date_no_time %}
+        {% assign date_type = "same_day" %}
+    {% else %}
+        {% assign date_type = "all_dates" %}
+    {% endif %}
+{% endif %}
+
 <div id="content" class="interior">
     <main class="va-l-detail-page">
         <div class="usa-grid usa-grid-full">
@@ -91,8 +111,18 @@
                             <dl class="va-c-event-info">
                                 <dt class="vads-u-font-weight--bold">When:</dt>
                                 <dd>
-                                    <span class="va-event-day vads-u-display--block">{{ fieldDate.value | formatDate: 'ddd, MMM Do' }}</span>
-                                    <span class="va-event-time">{{ fieldDate.value | formatDate: 'h:mm a' }} - {{ fieldDate.endValue | formatDate: 'h:mm a' }}</span>
+                                    {% if date_type == "start_date_only" %}
+                                        <span>{{ start_date_no_time }}</span><br>
+                                        <span>{{ start_time }}</span>
+                                    {% else %}
+                                        {% if date_type == "same_day" %}
+                                            <span>{{ start_date_no_time }}</span><br>
+                                            <span>{{ start_time }} - {{ end_time }}</span>
+                                        {% else %}
+                                            <span>{{ start_date_full }} -</span><br>
+                                            <span>{{ end_date_full }}</span>
+                                        {% endif %}
+                                    {% endif %}
                                 </dd>
                             </dl>
 

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -92,7 +92,7 @@
                                 <dt class="vads-u-font-weight--bold">When:</dt>
                                 <dd>
                                     <span class="va-event-day vads-u-display--block">{{ fieldDate.value | formatDate: 'ddd, MMM Do' }}</span>
-                                    <span class="va-event-time">{{ fieldDate.value | formatDate: 'h:mm a' }} - {{ fieldDate.value | formatDate: 'h:mm a' }}</span>
+                                    <span class="va-event-time">{{ fieldDate.value | formatDate: 'h:mm a' }} - {{ fieldDate.endValue | formatDate: 'h:mm a' }}</span>
                                 </dd>
                             </dl>
 

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -22,6 +22,7 @@
                         {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
                         {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
                     {% endfor %}
+
                     {% if fieldRelatedLinks != empty %}
                         <div class="row">
                             <div class="usa-content columns">

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -9,6 +9,9 @@
             <div class="usa-width-three-fourths">
                 <article class="usa-content">
                     <h1>{{ title }}</h1>
+                    <div class="va-introtext">
+                        <p>{{ fieldIntroText }}</p>
+                    </div>
 
                     {% assign widgetDelta = 1 %}
                     {% for block in fieldContentBlock %}

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -1,0 +1,18 @@
+{% include "src/site/includes/header.html" with drupalTags = true %}
+{% include "src/site/includes/alerts.drupal.liquid" %}
+{% include "src/site/includes/preview-edit.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+<div id="content" class="interior">
+    <main class="va-l-detail-page">
+        <div class="usa-grid usa-grid-full">
+            {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
+            <div class="usa-width-three-fourths">
+                <article class="usa-content">
+
+                </article>
+            </div>
+        </div>
+    </main>
+</div>
+{% include "src/site/includes/footer.html" %}
+{% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -26,6 +26,27 @@
                         {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
                     {% endfor %}
 
+                    {% if fieldMedia != empty %}
+                        <section class="vads-u-margin-bottom--5">
+                            <div class="vads-u-font-weight--bold vads-u-margin-bottom--1p5">Download media assets</div>
+                            {% for asset in fieldMedia %}
+                                {% assign a = asset.entity %}
+                                <ul class="vads-u-margin-bottom--1 usa-unstyled-list">
+                                    <li>
+                                        {% case a.entityBundle %}
+                                        {% when 'document' %}
+                                            <a href="{{ a.fieldDocument.entity.url }}" download>{{ a.name }}</a>
+                                        {% when a.entityBundle === 'image' %}
+                                            <a href="{{ a.image.url }}" download>{{ a.name }}</a>
+                                        {% when a.entityBundle === 'video' %}
+                                            <a href="{{ a.fieldMediaVideoEmbedField }}">{{ a.name }}</a>
+                                        {%  endcase %}
+                                    </li>
+                                </ul>
+                            {% endfor %}
+                        </section>
+                    {%  endif %}
+
                     {% if fieldRelatedLinks != empty %}
                         <div class="row">
                             <div class="usa-content columns">

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -8,6 +8,29 @@
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
             <div class="usa-width-three-fourths">
                 <article class="usa-content">
+                    <h1>{{ title }}</h1>
+
+                    {% assign widgetDelta = 1 %}
+                    {% for block in fieldContentBlock %}
+                        {% if block.entity.entityBundle == 'react_widget' and block.entity.fieldCtaWidget == false %}
+                            {% assign reactRoot = 'react-widget-' | append: widgetDelta %}
+                            {% assign block.entity.reactRoot = reactRoot %}
+                            {% assign widgetDelta = widgetDelta | plus: 1 %}
+                        {% endif %}
+
+                        {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
+                        {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+                        {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+                    {% endfor %}
+                    {% if fieldRelatedLinks != empty %}
+                        <div class="row">
+                            <div class="usa-content columns">
+                                <aside class="va-nav-linkslist va-nav-linkslist--related">
+                                    {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' entity = fieldRelatedLinks.entity %}
+                                </aside>
+                            </div>
+                        </div>
+                    {%  endif %}
 
                 </article>
             </div>

--- a/src/site/stages/build/drupal/graphql/eventPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/eventPage.graphql.js
@@ -38,8 +38,10 @@ module.exports = `
       }
     }
     fieldDate {
-      date
-      value
+        startDate
+        value
+        endDate
+        endValue
     }
     fieldAddToCalendar {
       fileref 

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionDetailPage.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionDetailPage.node.graphql.js
@@ -24,15 +24,21 @@ const DETAIL_PAGE_RESULTS = `
     ${entityElementsFromPages}
     entityBundle
     changed
+    fieldContentBlock {
+      entity {
+        entityType
+        entityBundle
+        ${WYSIWYG}
+        ${COLLAPSIBLE_PANEL}
+        ${PROCESS}
+        ${QA_SECTION}
+        ${QA}
+        ${LIST_OF_LINK_TEASERS}
+        ${REACT_WIDGET}
+        ${NUMBER_CALLOUT}
+      }
+    }
     ${FIELD_RELATED_LINKS}
-    ${WYSIWYG}
-    ${COLLAPSIBLE_PANEL}
-    ${PROCESS}
-    ${QA_SECTION}
-    ${QA}
-    ${LIST_OF_LINK_TEASERS}
-    ${REACT_WIDGET}
-    ${NUMBER_CALLOUT}
     fieldMedia {
       entity {
        entityId
@@ -68,7 +74,7 @@ function queryFilter(isAll) {
     reverseFieldOfficeNode(
     filter: {
       conditions: [
-        { field: "type", value: "health_care_detail_page"}
+        { field: "type", value: "health_care_region_detail_page"}
         { field: "status", value: "1"}
       ]
     } 

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionDetailPage.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionDetailPage.node.graphql.js
@@ -1,0 +1,85 @@
+/**
+ * The detail page containing static content for a health care region
+ */
+
+const {
+  FIELD_RELATED_LINKS,
+} = require('../paragraph-fragments/listOfLinkTeasers.paragraph.graphql');
+
+const entityElementsFromPages = require('../entityElementsForPages.graphql');
+
+const WYSIWYG = '... wysiwyg';
+const COLLAPSIBLE_PANEL = '... collapsiblePanel';
+const PROCESS = '... process';
+const QA_SECTION = '... qaSection';
+const QA = '... qa';
+const LIST_OF_LINK_TEASERS = '... listOfLinkTeasers';
+const REACT_WIDGET = '... reactWidget';
+const NUMBER_CALLOUT = '... numberCallout';
+
+const DETAIL_PAGE_RESULTS = `
+  entities {
+    ... on NodeHealthCareRegionDetailPage {
+    title
+    ${entityElementsFromPages}
+    entityBundle
+    changed
+    ${FIELD_RELATED_LINKS}
+    ${WYSIWYG}
+    ${COLLAPSIBLE_PANEL}
+    ${PROCESS}
+    ${QA_SECTION}
+    ${QA}
+    ${LIST_OF_LINK_TEASERS}
+    ${REACT_WIDGET}
+    ${NUMBER_CALLOUT}
+    fieldMedia {
+      entity {
+       entityId
+       entityBundle
+       name
+       ...on MediaDocument {
+        fieldDocument {
+          entity {
+            ...on File {
+              filename
+              url          
+            }
+          }
+        }
+      }   
+     ...on MediaImage {        
+      image {          
+        alt
+        url
+      }
+     }
+    ...on MediaVideo {
+      fieldMediaVideoEmbedField        
+    }
+  }
+  }
+    }
+  }
+`;
+
+function queryFilter(isAll) {
+  return `
+    reverseFieldOfficeNode(
+    filter: {
+      conditions: [
+        { field: "type", value: "health_care_detail_page"}
+        { field: "status", value: "1"}
+      ]
+    } 
+    sort: {field: "field_office", direction: DESC }
+    limit:${isAll ? '500' : '10'})
+  `;
+}
+
+module.exports = `
+  allHealthcareDetailPages: ${queryFilter(true)}
+    {
+    ${DETAIL_PAGE_RESULTS}
+  }
+`;

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionDetailPage.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionDetailPage.node.graphql.js
@@ -24,6 +24,7 @@ const DETAIL_PAGE_RESULTS = `
     ${entityElementsFromPages}
     entityBundle
     changed
+    fieldIntroText
     fieldContentBlock {
       entity {
         entityType

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionEvents.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionEvents.node.graphql.js
@@ -7,7 +7,10 @@ const EVENTS_RESULTS = `
     ... on NodeEvent {
         title
         fieldDate {
-          value
+            startDate
+            value
+            endDate
+            endValue
         }
         fieldDescription
         fieldLocationHumanreadable
@@ -37,11 +40,9 @@ function queryFilter(isAll) {
     ${
       isAll
         ? ''
-        : '{ field: "field_event_date", value: [$today], operator: GREATER_THAN}'
+        : '{ field: "field_date", value: [$today], operator: GREATER_THAN}'
     }
-  ]} sort: {field: "field_event_date", direction: ASC } limit: ${
-    isAll ? '500' : '2'
-  })
+  ]} sort: {field: "field_date", direction: ASC } limit: ${isAll ? '500' : '2'})
   `;
 }
 

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -4,8 +4,8 @@
  */
 const entityElementsFromPages = require('./entityElementsForPages.graphql');
 const healthCareLocalFacilities = require('./facilities-fragments/healthCareLocalFacility.node.graphql');
-const healthCarePatientFamilyServices = require('./facilities-fragments/healthCarePatientFamilyServices.node.graphql');
-const healthCareRegionHealthServices = require('./facilities-fragments/healthCareRegionHealthServices.node.graphql');
+// const healthCarePatientFamilyServices = require('./facilities-fragments/healthCarePatientFamilyServices.node.graphql');
+// const healthCareRegionHealthServices = require('./facilities-fragments/healthCareRegionHealthServices.node.graphql');
 const healthCareRegionNewsStories = require('./facilities-fragments/healthCareRegionNewsStories.node.graphql');
 const healthCareRegionEvents = require('./facilities-fragments/healthCareRegionEvents.node.graphql');
 const healthCareStaffBios = require('./facilities-fragments/healthCareRegionStaffBios.node.graphql');
@@ -94,13 +94,5 @@ module.exports = `
       processed
     }
     ${healthCareRegionEvents}
-    fieldClinicalHealthCareServi {
-      processed
-    }
-    ${healthCareRegionHealthServices}
-    fieldPatientFamilyServicesIn {
-        processed
-    }
-    ${healthCarePatientFamilyServices}
   }
 `;

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -9,6 +9,7 @@ const healthCareLocalFacilities = require('./facilities-fragments/healthCareLoca
 const healthCareRegionNewsStories = require('./facilities-fragments/healthCareRegionNewsStories.node.graphql');
 const healthCareRegionEvents = require('./facilities-fragments/healthCareRegionEvents.node.graphql');
 const healthCareStaffBios = require('./facilities-fragments/healthCareRegionStaffBios.node.graphql');
+const healthCareRegionDetailPage = require('./facilities-fragments/healthCareRegionDetailPage.node.graphql');
 
 module.exports = `
   fragment healthCareRegionPage on NodeHealthCareRegionPage {
@@ -94,5 +95,6 @@ module.exports = `
       processed
     }
     ${healthCareRegionEvents}
+    ${healthCareRegionDetailPage}
   }
 `;

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -45,8 +45,9 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   if (page.allHealthcareDetailPages !== undefined) {
     for (const detailPage of page.allHealthcareDetailPages.entities) {
       if (detailPage.entityBundle === 'health_care_region_detail_page') {
+        const pagePath = detailPage.entityUrl.path;
         const detailPageCompiled = Object.assign(detailPage, sidebar, alerts);
-        files[`drupal${drupalPagePath}/index.html`] = createFileObj(
+        files[`drupal${pagePath}/index.html`] = createFileObj(
           detailPageCompiled,
           'health_care_region_detail_page.drupal.liquid',
         );

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -185,6 +185,25 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'bios_page.drupal.liquid',
     'bio',
   );
+
+  // Create Detail Pages
+  const detailEntityUrl = createEntityUrlObj(drupalPagePath);
+  const detailObj = {
+    allHealthcareDetailPages: page.allHealthcareDetailPages,
+    facilitySidebar: sidebar,
+    entityUrl: detailEntityUrl,
+    alert: page.alert,
+    title: page.title,
+  };
+  const detailPage = updateEntityUrlObj(
+    detailObj,
+    drupalPagePath,
+    'Health Services',
+  );
+  files[`drupal${drupalPagePath}/index.html`] = createFileObj(
+    detailPage,
+    'health_care_region_detail_page.drupal.liquid',
+  );
 }
 
 module.exports = createHealthCareRegionListPages;

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -41,6 +41,19 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     }
   }
 
+  // Create the detail page for health care static information
+  if (page.allHealthcareDetailPages !== undefined) {
+    for (const detailPage of page.allHealthcareDetailPages.entities) {
+      if (detailPage.entityBundle === 'health_care_region_detail_page') {
+        const detailPageCompiled = Object.assign(detailPage, sidebar, alerts);
+        files[`drupal${drupalPagePath}/index.html`] = createFileObj(
+          detailPageCompiled,
+          'health_care_region_detail_page.drupal.liquid',
+        );
+      }
+    }
+  }
+
   // Create the top-level locations page for Health Care Regions
   const locEntityUrl = createEntityUrlObj(drupalPagePath);
   const locObj = {
@@ -184,25 +197,6 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'allStaffProfiles',
     'bios_page.drupal.liquid',
     'bio',
-  );
-
-  // Create Detail Pages
-  const detailEntityUrl = createEntityUrlObj(drupalPagePath);
-  const detailObj = {
-    allHealthcareDetailPages: page.allHealthcareDetailPages,
-    facilitySidebar: sidebar,
-    entityUrl: detailEntityUrl,
-    alert: page.alert,
-    title: page.title,
-  };
-  const detailPage = updateEntityUrlObj(
-    detailObj,
-    drupalPagePath,
-    'Health Services',
-  );
-  files[`drupal${drupalPagePath}/index.html`] = createFileObj(
-    detailPage,
-    'health_care_region_detail_page.drupal.liquid',
   );
 }
 

--- a/src/site/teasers/event.drupal.liquid
+++ b/src/site/teasers/event.drupal.liquid
@@ -4,11 +4,11 @@ Optional variable: header - the header level ('h2','h3', etc.) defaults to h4
 Example data:
      {
         "title": "Another Test Event",
-        "fieldEventDate": {
-          "value": "2019-03-15T13:00:00"
-        },
-        "fieldEventDateEnd": {
-          "value": "2019-03-15T18:00:00"
+        "fieldDate": {
+            "startDate": "2019-03-16 10:00:01 UTC",
+            "value": "2019-03-16T10:00:01",
+            "endDate": "2019-03-16 11:00:00 UTC",
+            "endValue": "2019-03-16T11:00:00"
         },
         "fieldDescription": "This gives the user an overview of the event in teaser views",
         "fieldLocationHumanreadable": "Here",
@@ -27,16 +27,16 @@ Example data:
 {% endcomment %}
 {% if node != empty %}
 
-    {% assign start_date_no_time = node.fieldEventDate.value | date: "%a, %b %d" %}
-    {% assign end_date_no_time = node.fieldEventDateEnd.value | date: "%a, %b %d" %}
+    {% assign start_date_no_time = node.fieldDate.value | date: "%a, %b %d" %}
+    {% assign end_date_no_time = node.fieldDate.endValue | date: "%a, %b %d" %}
 
-    {% assign start_time = node.fieldEventDate.value | date: "%I:%M %p" %}
-    {% assign end_time = node.fieldEventDateEnd.value | date: "%I:%M %p" %}
+    {% assign start_time = node.fieldDate.value | date: "%I:%M %p" %}
+    {% assign end_time = node.fieldDate.endValue | date: "%I:%M %p" %}
 
-    {% assign start_date_full = node.fieldEventDate.value | date: "%a, %b %d, %I:%M %p" %}
-    {% assign end_date_full = node.fieldEventDateEnd.value | date: "%a, %b %d, %I:%M %p" %}
+    {% assign start_date_full = node.fieldDate.value | date: "%a, %b %d, %I:%M %p" %}
+    {% assign end_date_full = node.fieldDate.endValue | date: "%a, %b %d, %I:%M %p" %}
 
-    {% if node.fieldEventDate.value != empty and node.fieldEventDateEnd.value == empty %}
+    {% if node.fieldDate.value != empty and node.fieldDate.endValue == empty %}
         {% assign date_type = "start_date_only" %}
     {% else %}
         {% if start_date_no_time == end_date_no_time %}


### PR DESCRIPTION
## Description
Just a basic detail page for healthcare regions. Check out /drupal/pittsburgh-health-care/play-10-automate-testing-and-deployments/index.html for an example. 

This PR also includes a few fixes for display of event dates using the updated content model and also fixes the currently broken build by commenting out query fragments for health services and patient and family services.

This vagovcms PR adds a field that's being queried in this PR: https://github.com/department-of-veterans-affairs/va.gov-cms/pull/211

## Testing done


## Screenshots
<img width="1059" alt="Screen Shot 2019-03-15 at 8 12 08 AM" src="https://user-images.githubusercontent.com/3157339/54437359-120b2780-46fa-11e9-896d-7f6254983f6c.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
