### PR TITLE
All claims match ptsd levenshtein mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -151,6 +151,8 @@ export const PTSD_MATCHES = [
   'post-traumatic stress',
 ];
 
+export const MAX_LEVENSHTEIN_DISTANCE = 0.25;
+
 // Max number of incident iterations a user can go through.
 export const PTSD_INCIDENT_ITERATION = 3;
 

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -151,7 +151,10 @@ export const PTSD_MATCHES = [
   'post-traumatic stress',
 ];
 
-export const MAX_LEVENSHTEIN_DISTANCE = 0.25;
+// Percent of string length used to calculate maximum levenshtein edit distance
+// E.g., for a 10-char string, we'd say the max edit distance is:
+// Math.ceil(10 x TYPO_THRESHOLD)
+export const TYPO_THRESHOLD = 0.25;
 
 // Max number of incident iterations a user can go through.
 export const PTSD_INCIDENT_ITERATION = 3;

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -44,6 +44,7 @@ export const uiSchema = {
           ),
         {
           'ui:options': {
+            debounceRate: 200,
             freeInput: true,
             inputTransformers: [
               // Replace a bunch of things that aren't valid with valid equivalents

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -5,6 +5,7 @@ import appendQuery from 'append-query';
 import { createSelector } from 'reselect';
 import { omit } from 'lodash';
 import merge from 'lodash/merge';
+import fastLevenshtein from 'fast-levenshtein';
 import recordEvent from '../../../platform/monitoring/record-event';
 import { apiRequest } from '../../../platform/utilities/api';
 import environment from '../../../platform/utilities/environment';
@@ -31,6 +32,7 @@ import {
   STATE_VALUES,
   TWENTY_FIVE_MB,
   USA,
+  MAX_LEVENSHTEIN_DISTANCE,
 } from './constants';
 
 /**
@@ -481,12 +483,24 @@ export const isDisabilityPtsd = disability => {
     return false;
   }
 
-  const loweredDisability = disability.toLowerCase();
-  return PTSD_MATCHES.some(
-    ptsdString =>
-      ptsdString.includes(loweredDisability) ||
-      loweredDisability.includes(ptsdString),
-  );
+  const strippedDisability = disability.toLowerCase().replace(/[^a-zA-Z]/g, '');
+
+  return PTSD_MATCHES.some(ptsdString => {
+    const strippedString = ptsdString.replace(/[^a-zA-Z]/g, '');
+    if (strippedString === strippedDisability) {
+      return true;
+    }
+
+    // does the veteran's input contain a string from our match list?
+    if (strippedDisability.includes(strippedString)) {
+      return true;
+    }
+
+    return (
+      fastLevenshtein.get(ptsdString, strippedDisability) <
+      Math.ceil(strippedDisability.length * MAX_LEVENSHTEIN_DISTANCE)
+    );
+  });
 };
 
 export const hasNewPtsdDisability = formData =>

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -32,7 +32,7 @@ import {
   STATE_VALUES,
   TWENTY_FIVE_MB,
   USA,
-  MAX_LEVENSHTEIN_DISTANCE,
+  TYPO_THRESHOLD,
 } from './constants';
 
 /**
@@ -497,8 +497,8 @@ export const isDisabilityPtsd = disability => {
     }
 
     return (
-      fastLevenshtein.get(ptsdString, strippedDisability) <
-      Math.ceil(strippedDisability.length * MAX_LEVENSHTEIN_DISTANCE)
+      fastLevenshtein.get(strippedString, strippedDisability) <
+      Math.ceil(strippedDisability.length * TYPO_THRESHOLD)
     );
   });
 };


### PR DESCRIPTION
## Description
1. Updates the utility that identifies strings as ptsd or not to use fuzzy matching. This means that in addition to exact matches and substring matches (wherein the user's input contains a string we care about), we're also adding a fuzzy-matcher to match on close misspellings. 
2. Lowers the debounce time so that we get faster autosuggest results. Tested this with CPU throttling and 200ms seems to be the best tradeoff of speed and responsiveness on slow hardware. Lowering the debounce time is theorized to help people select an item from the autosuggest list, instead of entering their own custom item.


## Testing done
- Tested locally
- Added unit tests for some common cases

| Test Word                      | Is Match? | Should Match? |
|--------------------------------|-----------|---------------|
| post traumatic stress          | Yes       | Yes           |
| post-traumatic stress          | Yes       | Yes           |
| Osteoarthritis, Post-Traumatic | No        | No            |
| Post-Traumatic Stress Disorder | Yes       | Yes           |
| ptsd                           | Yes       | Yes           |
| ptsd personal trauma           | Yes       | Yes           |
| post traumatic stress disordre | Yes       | Yes           |
| post traumtaic stress disorder | Yes       | Yes           |
| plst rraumatic etress disordre | Yes        | Yes           |
| post rraumtaic etress disordre | Yes        | Yes           |
| post rraumatic stress disordre | Yes       | Yes           |

## Screenshots
N/A

## Acceptance criteria
- [x] fuzzy match user input against known PTSD strings to correctly ID close misspellings of PTSD

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
