### PR TITLE
Let env vars override DRUPALS object

### DIFF
--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -5,7 +5,6 @@ const GET_ALL_PAGES = require('./graphql/GetAllPages.graphql');
 const GET_PAGE_BY_ID = require('./graphql/GetPageById.graphql');
 const GET_LATEST_PAGE_BY_ID = require('./graphql/GetLatestPageById.graphql');
 
-const ENVIRONMENTS = require('../../../constants/environments');
 const DRUPALS = require('../../../constants/drupals');
 
 function encodeCredentials({ user, password }) {
@@ -26,15 +25,7 @@ function getDrupalClient(buildOptions) {
   });
 
   const envConfig = DRUPALS[buildOptions.buildtype];
-  const drupalConfig = {};
-
-  if (buildOptions.buildtype === ENVIRONMENTS.LOCALHOST) {
-    // On localhost, build args can override the default environment.
-    Object.assign(drupalConfig, envConfig, buildArgs);
-  } else {
-    // Otherwise, properties from the hardcoded env configs should take priority.
-    Object.assign(drupalConfig, buildArgs, envConfig);
-  }
+  const drupalConfig = Object.assign({}, envConfig, buildArgs);
 
   const { address, user, password } = drupalConfig;
   const drupalUri = `${address}/graphql`;


### PR DESCRIPTION
## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
