### PR TITLE
Update submit transformer to not quit without rated

### DIFF
--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -195,7 +195,10 @@ export function transform(formConfig, form) {
   // Grab ratedDisabilities before they're deleted in case the page is inactive
   // We need to send all of these to vets-api even if the veteran doesn't apply
   // for an increase on any of them
-  const savedRatedDisabilities = _.cloneDeep(form.data.ratedDisabilities);
+  const { ratedDisabilities } = form.data;
+  const savedRatedDisabilities = ratedDisabilities
+    ? _.cloneDeep(ratedDisabilities)
+    : undefined;
 
   // Define the transformations
   const filterEmptyObjects = formData =>

--- a/src/applications/disability-benefits/all-claims/tests/data/newOnly-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/newOnly-test.json
@@ -1,0 +1,144 @@
+{
+  "data": {
+    "view:claimType": {
+      "view:claimingIncrease": true
+    },
+    "isVaEmployee": false,
+    "homelessOrAtRisk": "no",
+    "phoneAndEmail": {
+      "primaryPhone": "4445551212",
+      "emailAddress": "test2@test1.net"
+    },
+    "mailingAddress": {
+      "country": "USA",
+      "addressLine1": "123 Main",
+      "city": "Bigcity",
+      "state": "AK",
+      "zipCode": "12345"
+    },
+    "newPrimaryDisabilities": [
+      {
+        "cause": "NEW",
+        "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
+        "condition": "asthma",
+        "classificationCode": "540"
+      }
+    ],
+    "view:contactInfoDescription": {},
+    "view:hasEvidence": false,
+    "view:powStatus": false,
+    "view:newDisabilities": false,
+    "view:disabilitiesClarification": {},
+    "serviceInformation": {
+      "reservesNationalGuardService": {
+        "view:isTitle10Activated": false,
+        "obligationTermOfServiceDateRange": {
+          "from": "2007-05-22",
+          "to": "2008-06-05"
+        },
+        "unitName": "Unit name here"
+      },
+      "servicePeriods": [
+        {
+          "serviceBranch": "Air Force Reserve",
+          "dateRange": {
+            "from": "2001-03-21",
+            "to": "2014-07-21"
+          }
+        }
+      ],
+      "view:militaryHistoryNote": {}
+    },
+    "newDisabilities": [
+      {
+        "cause": "NEW",
+        "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
+        "condition": "asthma",
+        "view:descriptionInfo": {}
+      }
+    ],
+    "servedInCombatZonePost911": false,
+    "view:hasAlternateName": false,
+    "view:selectablePtsdTypes": {},
+    "view:ptsdTypeHelp": {},
+    "view:upload781ChoiceHelp": {},
+    "incident0": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      }
+    },
+    "incident1": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      }
+    },
+    "incident2": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      }
+    },
+    "view:upload781aChoiceHelp": {},
+    "secondaryIncident0": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      },
+      "otherSourcesHelp": {}
+    },
+    "view:otherSourcesHelp": {},
+    "secondaryIncident1": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      },
+      "otherSourcesHelp": {}
+    },
+    "secondaryIncident2": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      },
+      "otherSourcesHelp": {}
+    },
+    "physicalChanges": {},
+    "mentalChanges": {},
+    "workBehaviorChanges": {},
+    "socialBehaviorChanges": {},
+    "view:ancillaryFormsWizardIntro": {},
+    "view:unemployabilityHelp": {},
+    "unemployability": {
+      "view:recordsInfo": {},
+      "view:unemployabilityDatesDesc": {},
+      "view:grossIncomeAdditionalInfo": {},
+      "view:supplementalBenefitsHelp": {},
+      "view:substantiallyGainfulEmploymentInfo": {},
+      "view:statementsAreTrue": {},
+      "view:informOfReturnToWork": {}
+    },
+    "view:privateMedicalFacility": {},
+    "view:upload4192Choice": {},
+    "view:downloadInfo": {},
+    "view:vaMedicalRecordsIntro": {},
+    "view:uploadPrivateRecordsQualifier": {
+      "view:aboutPrivateMedicalRecords": {},
+      "view:privateRecordsChoiceHelp": {}
+    },
+    "view:privateRecordsChoiceHelp": {},
+    "view:faqAccordion": {},
+    "view:bankAccount": {
+      "view:hasPrefilledBank": true
+    },
+    "view:waiveRetirementPayDescription": {},
+    "standardClaim": false,
+    "view:fdcWarning": {},
+    "view:originalBankAccount": {
+      "view:bankAccountType": "Checking",
+      "view:bankAccountNumber": "*********1234",
+      "view:bankRoutingNumber": "*****2115",
+      "view:bankName": "Comerica"
+    }
+  }
+}

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/newOnly-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/newOnly-test.json
@@ -1,0 +1,42 @@
+{
+  "form526": {
+    "isVaEmployee": false,
+    "homelessOrAtRisk": "no",
+    "phoneAndEmail": {
+      "primaryPhone": "4445551212",
+      "emailAddress": "test2@test1.net"
+    },
+    "mailingAddress": {
+      "country": "USA",
+      "addressLine1": "123 Main",
+      "city": "Bigcity",
+      "state": "AK",
+      "zipCode": "12345"
+    },
+    "newPrimaryDisabilities": [
+      {
+        "cause": "NEW",
+        "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
+        "condition": "asthma",
+        "classificationCode": "540"
+      }
+    ],
+    "serviceInformation": {
+      "reservesNationalGuardService": {
+        "obligationTermOfServiceDateRange": {
+          "from": "2007-05-22",
+          "to": "2008-06-05"
+        },
+        "unitName": "Unit name here"
+      },
+      "servicePeriods": [
+        {
+          "serviceBranch": "Air Force Reserve",
+          "dateRange": { "from": "2001-03-21", "to": "2014-07-21" }
+        }
+      ]
+    },
+    "servedInCombatZonePost911": false,
+    "standardClaim": false
+  }
+}


### PR DESCRIPTION
## Description
Updates the submit transformer so that it doesn't hang when someone without any rated disabilities tries to submit

## Testing done
- Tested locally
- Added test condition with a only new disabilities

## Screenshots
N/A

## Acceptance criteria
- [x] Submit transformer doesn't throw when user has no rated disabilities. Veteran should be able to submit successfully with only new disabilities.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
