### PR TITLE
[Drupal] Print Drupal errors to /drupal/debug

### DIFF
--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -138,7 +138,9 @@ function getDrupalContent(buildOptions) {
       log('Successfully piped Drupal content into Metalsmith!');
       done();
     } catch (err) {
+      metalsmith.metadata({ drupalError: drupalData });
       log(err.stack);
+      log(JSON.stringify(drupalData));
       log('Failed to pipe Drupal content into Metalsmith!');
       log('Continuing with build anyway...');
       // done(err);

--- a/src/site/stages/build/plugins/create-drupal-debug.js
+++ b/src/site/stages/build/plugins/create-drupal-debug.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-param-reassign */
 
+const ENVIRONMENTS = require('../../../constants/environments');
 const { ENABLED_ENVIRONMENTS } = require('../../../constants/drupals');
 const { logDrupal: log } = require('../drupal/utilities-drupal');
 
@@ -30,7 +31,12 @@ function createIndexPage(files) {
 }
 
 function createDrupalDebugPage(buildOptions) {
-  if (!ENABLED_ENVIRONMENTS.has(buildOptions.buildtype)) {
+  // Disable this page if Drupal is not promoted to this environment, or if we're in production, because
+  // a debug page should never be built there.
+  if (
+    !ENABLED_ENVIRONMENTS.has(buildOptions.buildtype) ||
+    buildOptions.buildtype === ENVIRONMENTS.VAGOVPROD
+  ) {
     const noop = () => {};
     return noop;
   }

--- a/src/site/stages/build/plugins/create-drupal-debug.js
+++ b/src/site/stages/build/plugins/create-drupal-debug.js
@@ -47,8 +47,9 @@ function createDrupalDebugPage(buildOptions) {
     let drupalDebugPage = null;
     const { drupalError } = smith.metadata();
 
-    if (drupalError) drupalDebugPage = createErrorPage(drupalError);
-    else drupalDebugPage = createIndexPage(files);
+    drupalDebugPage = drupalError
+      ? createErrorPage(drupalError)
+      : createIndexPage(files);
 
     files['drupal/debug/index.html'] = {
       contents: Buffer.from(drupalDebugPage),

--- a/src/site/stages/build/plugins/create-drupal-debug.js
+++ b/src/site/stages/build/plugins/create-drupal-debug.js
@@ -44,10 +44,8 @@ function createDrupalDebugPage(buildOptions) {
   return (files, smith, done) => {
     log('Drupal debug page written to /drupal/debug.');
 
-    let drupalDebugPage = null;
     const { drupalError } = smith.metadata();
-
-    drupalDebugPage = drupalError
+    const drupalDebugPage = drupalError
       ? createErrorPage(drupalError)
       : createIndexPage(files);
 


### PR DESCRIPTION
## Description
This pull request improves Drupal error reporting by printing the GraphQL output to `/drupal/debug` and to the console.

## Testing done
Local builds (Drupal Staging is hitting an error now)

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/54557172-e6ee3580-4990-11e9-9845-e8b3c090e2c4.png)

### Output
```
Attempting to load Drupal content from API...
Drupal successfully loaded!
TypeError: Cannot destructure property `nodeQuery` of 'undefined' or 'null'.
    at pipeDrupalPagesIntoMetalsmith (/Users/nicksullivan/Repos/vagov/vets-website/src/site/stages/build/drupal/metalsmith-drupal.js:23:5)
    at Ware.<anonymous> (/Users/nicksullivan/Repos/vagov/vets-website/src/site/stages/build/drupal/metalsmith-drupal.js:137:7)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
{"errors":[{"message":"Cannot query field \"fieldIntroText\" on type \"NodeHealthCareRegionDetailPage\".","category":"graphql","locations":[{"line":1221,"column":5}]}]}
Failed to pipe Drupal content into Metalsmith!
Continuing with build anyway...
Drupal-generated pages set to overwrite vagov-content.
```

## Acceptance criteria
- [x] Helpful error reporting

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
