### PR TITLE
[Content] Add templating for a top-level banners

### DIFF
--- a/src/site/layouts/page-breadcrumbs.html
+++ b/src/site/layouts/page-breadcrumbs.html
@@ -12,6 +12,25 @@
   {% include "src/site/includes/decision-reviews-banner.html" %}
 {% endif %}
 
+{% if banner %}
+  <div class="usa-alert-full-width usa-alert-full-width-warning" role="region">
+    {% assign bannerType = 'warning' %}
+    {% if banner.type %}
+      {% assign bannerType = banner.type %}
+    {% endif %}
+    <div class="usa-alert usa-alert-{{ bannerType }}" aria-live="assertive" role="alert">
+      <div class="usa-alert-body">
+        {% if banner.title %}
+          <h3 class="usa-alert-heading">{{ banner.title }}</h3>
+        {% endif %}
+        {% if banner.content %}
+          <div class="usa-alert-text">{{ banner.content }}</div>
+      {% endif %}
+      </div>
+    </div>
+  </div>
+{% endif %}
+
 {% include "src/site/includes/breadcrumbs.html" %}
 
 <div id="content" class="interior {{ id }}">


### PR DESCRIPTION
## Description
In the Appeals work, a new pattern has developed for add full-width banners above the heading. This is already visible on this page, https://staging.va.gov/decision-reviews/.

To make this easier for the content team to manage and so that each banner isn't a special case for devs to implement, this PR adds a new front matter property `banner` so that any page can add a banner.

This will currently change nothing on the site, but must be merged so that this PR can render its banners, https://github.com/department-of-veterans-affairs/vagov-content/pull/302/files.

## Testing done
- Local testing

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/54564865-46edd780-49a3-11e9-9bdc-05ef3fdd89d4.png)

![image](https://user-images.githubusercontent.com/1915775/54564879-4ead7c00-49a3-11e9-9c05-fa6f75300379.png)


## Acceptance criteria
- [ ] Pages can add banners

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
