### PR TITLE
All claims fix homelessness mg

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
     "url-search-params": "^0.10.0",
     "uswds": "1.4.2",
     "vanilla-lazyload": "^8.17.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0387db93d7fad4ac530afe0a5a4e5cd91cde8c99",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#76083e33f175fb00392e31f1f5f90654d05f1fd2",
     "whatwg-fetch": "^2.0.3"
   }
 }

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -55,7 +55,7 @@ export const uiSchema = {
               input => input.replace(/([^a-zA-Z0-9\-’.,/() ]+)/g, ''),
               // Get rid of extra whitespace characters
               input => input.trim(),
-              input => input.replace(/\s{2,}/, ' '),
+              input => input.replace(/\s{2,}/g, ' '),
             ],
           },
           // autoSuggest schema doesn't have any default validations as long as { `freeInput: true` }

--- a/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
+++ b/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
@@ -148,6 +148,9 @@ export const schema = {
       ...homelessnessContact,
       properties: {
         ...homelessnessContact.properties,
+        // we want veterans to be able to type in anything they want, we'll
+        // sanitize their input to adhere to the pattern in vets-json-schema in
+        // the submit transformer
         name: _.omit('pattern', homelessnessContact.properties.name),
       },
     },

--- a/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
+++ b/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
@@ -144,6 +144,12 @@ export const schema = {
         otherAtRiskHousing,
       },
     },
-    homelessnessContact,
+    homelessnessContact: {
+      ...homelessnessContact,
+      properties: {
+        ...homelessnessContact.properties,
+        name: _.omit('pattern', homelessnessContact.properties.name),
+      },
+    },
   },
 };

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -367,7 +367,7 @@ export function transform(formConfig, form) {
     // But neither field is required unless the other is present
     const sanitizedHomelessnessContact = {
       name: homelessnessContact.name
-        .replace(/[^a-zA-Z0-9-/' ]/g, '')
+        .replace(/[^a-zA-Z0-9-/' ]/g, ' ')
         .trim()
         .replace(/\s{2,}/g, ' '),
       phoneNumber: homelessnessContact.phoneNumber,

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -349,6 +349,33 @@ export function transform(formConfig, form) {
     );
   };
 
+  /**
+   * We want veterans to be able to type in all chars in the homelessness POC
+   * name field, but we only want to send allowed characters (per schema) to
+   * vets-api
+   * @param {object} formData
+   * @returns {object} either formData, or if homelessness contact name exists,
+   * a copy of formData with the homelessness POC name sanitized
+   */
+  const sanitizeHomelessnessContact = formData => {
+    const { homelessnessContact } = formData;
+    if (!homelessnessContact || !homelessnessContact.name) {
+      return formData;
+    }
+
+    // When name is present, phoneNumber is required and vice-versa
+    // But neither field is required unless the other is present
+    const sanitizedHomelessnessContact = {
+      name: homelessnessContact.name
+        .replace(/[^a-zA-Z0-9-/' ]/g, '')
+        .trim()
+        .replace(/\s{2,}/g, ' '),
+      phoneNumber: homelessnessContact.phoneNumber,
+    };
+
+    return _.set('homelessnessContact', sanitizedHomelessnessContact, formData);
+  };
+
   const addForm4142 = formData => {
     if (!formData.providerFacility) {
       return formData;
@@ -467,6 +494,7 @@ export function transform(formConfig, form) {
     splitNewDisabilities,
     stringifyRelatedDisabilities,
     transformSeparationPayDate,
+    sanitizeHomelessnessContact,
     addForm4142,
     addForm0781,
     addForm8940,

--- a/src/applications/disability-benefits/all-claims/tests/data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/maximal-test.json
@@ -17,7 +17,7 @@
       "needToLeaveHousing": true
     },
     "homelessnessContact": {
-      "name": "Name Here",
+      "name": "Name Here, and invalid chars with email elmer@fud.com",
       "phoneNumber": "1231231234"
     },
     "view:bankAccount": {

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/maximal-test.json
@@ -8,7 +8,10 @@
     "homelessHousingSituation": "other",
     "otherHomelessHousing": "Under a bridge",
     "needToLeaveHousing": true,
-    "homelessnessContact": { "name": "Name Here", "phoneNumber": "1231231234" },
+    "homelessnessContact": {
+      "name": "Name Here and invalid chars with email elmer fud com",
+      "phoneNumber": "1231231234"
+    },
     "bankAccountType": "Checking",
     "bankAccountNumber": "1233",
     "bankRoutingNumber": "123123123",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11963,9 +11963,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#0387db93d7fad4ac530afe0a5a4e5cd91cde8c99":
-  version "3.136.6"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#0387db93d7fad4ac530afe0a5a4e5cd91cde8c99"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#76083e33f175fb00392e31f1f5f90654d05f1fd2":
+  version "3.137.7"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#76083e33f175fb00392e31f1f5f90654d05f1fd2"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
## Description
- Updates vets-json-schema version on vets-website to latest, which includes a small patch for the same homelessness POC name
- Allows veterans to type in whatever they want to the homelessness POC field
- Sanitizes veteran homelessness POC input in the submit transformer

## Testing done
- Tested locally
- Added test case

## Screenshots
N/A

## Acceptance criteria
- [x] don't validate veteran input on the homelessness POC name field
- [x] Ensure vets-api is only sent values that jive with the schema in vets-json-schema

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
