### PR TITLE
remove duplicate info from HCA footer

### DIFF
--- a/src/applications/hca/components/FormFooter.jsx
+++ b/src/applications/hca/components/FormFooter.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import CallHRC from '../../../platform/brand-consolidation/components/CallHRC';
 
 export default class FormFooter extends React.Component {
   render() {
@@ -8,23 +7,18 @@ export default class FormFooter extends React.Component {
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
     const isConfirmationPage = trimmedPathname.endsWith('confirmation');
 
+    if (isConfirmationPage) {
+      return null;
+    }
+
     return (
-      <div>
-        {!isConfirmationPage && (
-          <div className="row">
-            <div className="usa-width-two-thirds medium-8 columns">
-              <div className="help-footer-box">
-                <h2 className="help-heading">Need help?</h2>
-                <GetFormHelp />
-                <p className="help-talk">
-                  To report a problem with this form,
-                  <br />
-                  please <CallHRC />
-                </p>
-              </div>
-            </div>
+      <div className="row">
+        <div className="usa-width-two-thirds medium-8 columns">
+          <div className="help-footer-box">
+            <h2 className="help-heading">Need help?</h2>
+            <GetFormHelp />
           </div>
-        )}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Description
There was info that was essentially repeated on the Health Care Application footer.

## Testing done
Local

## Screenshots
**BEFORE**
![before](https://user-images.githubusercontent.com/20728956/54639842-92f45700-4a4b-11e9-826c-de220afb321e.png)

**AFTER**
![image](https://user-images.githubusercontent.com/20728956/54639851-97b90b00-4a4b-11e9-8e1d-2e11f13728d8.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs