### PR TITLE
All claims original claims flow mg

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -13,13 +13,14 @@ import GetFormHelp from '../../components/GetFormHelp';
 import ErrorText from '../../components/ErrorText';
 import FormSavedPage from '../containers/FormSavedPage';
 
-import { hasMilitaryRetiredPay, hasRatedDisabilities } from '../validations';
+import { hasMilitaryRetiredPay } from '../validations';
 
 import {
   hasGuardOrReservePeriod,
   capitalizeEachWord,
   hasVAEvidence,
   hasPrivateEvidence,
+  hasRatedDisabilities,
   hasOtherEvidence,
   needsToEnter781,
   needsToEnter781a,
@@ -162,13 +163,14 @@ const formConfig = {
         claimType: {
           title: 'Claim type',
           path: 'claim-type',
+          depends: formData => hasRatedDisabilities(formData),
           uiSchema: claimType.uiSchema,
           schema: claimType.schema,
         },
         alternateNames: {
           title: 'Service under another name',
           path: 'alternate-names',
-          depends: formData => !increaseOnly(formData),
+          depends: formData => !hasRatedDisabilities(formData),
           uiSchema: alternateNames.uiSchema,
           schema: alternateNames.schema,
         },
@@ -204,21 +206,21 @@ const formConfig = {
         separationPay: {
           title: 'Separation or Severance Pay',
           path: 'separation-pay',
-          depends: formData => !increaseOnly(formData),
+          depends: formData => !hasRatedDisabilities(formData),
           uiSchema: separationPay.uiSchema,
           schema: separationPay.schema,
         },
         retirementPay: {
           title: 'Retirement Pay',
           path: 'retirement-pay',
-          depends: formData => !increaseOnly(formData),
+          depends: formData => !hasRatedDisabilities(formData),
           uiSchema: retirementPay.uiSchema,
           schema: retirementPay.schema,
         },
         trainingPay: {
           title: 'Training Pay',
           path: 'training-pay',
-          depends: formData => !increaseOnly(formData),
+          depends: formData => !hasRatedDisabilities(formData),
           uiSchema: trainingPay.uiSchema,
           schema: trainingPay.schema,
         },
@@ -583,7 +585,7 @@ const formConfig = {
           title: 'Retirement pay waiver',
           path: 'retirement-pay-waiver',
           depends: formData =>
-            hasMilitaryRetiredPay(formData) && !increaseOnly(formData),
+            hasMilitaryRetiredPay(formData) && !hasRatedDisabilities(formData),
           uiSchema: retirementPayWaiver.uiSchema,
           schema: retirementPayWaiver.schema,
         },
@@ -591,7 +593,7 @@ const formConfig = {
           title: 'Training pay waiver',
           path: 'training-pay-waiver',
           depends: formData =>
-            formData.hasTrainingPay && !increaseOnly(formData),
+            formData.hasTrainingPay && !hasRatedDisabilities(formData),
           uiSchema: trainingPayWaiver.uiSchema,
           schema: trainingPayWaiver.schema,
         },

--- a/src/applications/disability-benefits/all-claims/prefill-transformer.js
+++ b/src/applications/disability-benefits/all-claims/prefill-transformer.js
@@ -12,17 +12,33 @@ export const addNoneDisabilityActionType = (disabilities = []) =>
     _.set('disabilityActionType', disabilityActionTypes.NONE, d),
   );
 
+export const setClaimTypeNewOnly = formData =>
+  _.set(
+    ['view:claimType'],
+    {
+      'view:claimingNew': true,
+      'view:claimingIncrease': false,
+    },
+    formData,
+  );
+
 export default function prefillTransformer(pages, formData, metadata) {
   const prefillRatedDisabilities = data => {
-    const newData = _.omit(['disabilities'], data);
     const { disabilities } = data;
-    if (disabilities) {
-      newData.ratedDisabilities = addNoneDisabilityActionType(
-        filterServiceConnected(disabilities),
-      );
+
+    if (!disabilities) {
+      return setClaimTypeNewOnly(data);
     }
 
-    return newData;
+    const transformedDisabilities = addNoneDisabilityActionType(
+      filterServiceConnected(disabilities),
+    );
+
+    const newData = _.omit(['disabilities'], data);
+
+    return transformedDisabilities.length
+      ? _.set('ratedDisabilities', transformedDisabilities, newData)
+      : setClaimTypeNewOnly(newData);
   };
 
   const prefillContactInformation = data => {

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -474,7 +474,10 @@ export function transform(formConfig, form) {
     addForm0781,
     addForm8940,
     addFileAttachmments,
-  ].reduce((formData, transformer) => transformer(formData), form.data);
+  ].reduce(
+    (formData, transformer) => transformer(formData),
+    _.cloneDeep(form.data),
+  );
 
   return JSON.stringify({ form526: transformedData });
 }

--- a/src/applications/disability-benefits/all-claims/tests/data/full-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/full-781-781a-8940-test.json
@@ -7,6 +7,9 @@
         "attachmentId": "L115"
       }
     ],
+    "view:claimType": {
+      "view:claimingNew": true
+    },
     "view:upload4192Choice": {
       "view:4192Info": true,
       "view:download4192": true,
@@ -466,8 +469,6 @@
     "view:hasEvidence": false,
     "view:powStatus": false,
     "hasTrainingPay": false,
-    "view:hasMilitaryRetiredPay": false,
-    "view:hasSeparationPay": false,
     "serviceInformation": {
       "reservesNationalGuardService": {
         "view:isTitle10Activated": false,

--- a/src/applications/disability-benefits/all-claims/tests/data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/maximal-test.json
@@ -6,9 +6,6 @@
     },
     "standardClaim": false,
     "view:fdcWarning": {},
-    "waiveTrainingPay": true,
-    "view:waiveRetirementPayDescription": {},
-    "waiveRetirementPay": true,
     "isVaEmployee": true,
     "homelessOrAtRisk": "homeless",
     "view:isHomeless": {
@@ -236,15 +233,6 @@
       }
     ],
     "view:disabilitiesClarification": {},
-    "hasTrainingPay": true,
-    "view:hasMilitaryRetiredPay": true,
-    "militaryRetiredPayBranch": "Air Force",
-    "view:hasSeparationPay": true,
-    "view:separationPayDetails": {
-      "view:separationPayDetailsDescription": {},
-      "separationPayDate": "2018",
-      "separationPayBranch": "Air Force"
-    },
     "serviceInformation": {
       "reservesNationalGuardService": {
         "view:isTitle10Activated": true,
@@ -277,18 +265,6 @@
       "view:militaryHistoryNote": {}
     },
     "servedInCombatZonePost911": true,
-    "view:hasAlternateName": true,
-    "alternateNames": [
-      {
-        "first": "William",
-        "middle": "Schwenk",
-        "last": "Gilbert"
-      },
-      {
-        "first": "Arthur",
-        "last": "Sullivan"
-      }
-    ],
     "view:selectablePtsdTypes": {},
     "view:ptsdTypeHelp": {},
     "view:upload781ChoiceHelp": {},

--- a/src/applications/disability-benefits/all-claims/tests/data/minimal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/minimal-test.json
@@ -65,7 +65,6 @@
       "view:militaryHistoryNote": {}
     },
     "servedInCombatZonePost911": false,
-    "view:hasAlternateName": false,
     "view:selectablePtsdTypes": {},
     "view:ptsdTypeHelp": {},
     "view:upload781ChoiceHelp": {},

--- a/src/applications/disability-benefits/all-claims/tests/data/newOnly-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/newOnly-test.json
@@ -1,7 +1,8 @@
 {
   "data": {
     "view:claimType": {
-      "view:claimingIncrease": true
+      "view:claimingIncrease": false,
+      "view:claimingNew": true
     },
     "isVaEmployee": false,
     "homelessOrAtRisk": "no",
@@ -58,7 +59,7 @@
       }
     ],
     "servedInCombatZonePost911": false,
-    "view:hasAlternateName": false,
+    "view:hasAlternateName": true,
     "view:selectablePtsdTypes": {},
     "view:ptsdTypeHelp": {},
     "view:upload781ChoiceHelp": {},

--- a/src/applications/disability-benefits/all-claims/tests/data/newOnly-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/newOnly-test.json
@@ -30,6 +30,15 @@
     "view:powStatus": false,
     "view:newDisabilities": false,
     "view:disabilitiesClarification": {},
+    "hasTrainingPay": true,
+    "view:hasMilitaryRetiredPay": true,
+    "militaryRetiredPayBranch": "Air Force",
+    "view:hasSeparationPay": true,
+    "view:separationPayDetails": {
+      "view:separationPayDetailsDescription": {},
+      "separationPayDate": "2018",
+      "separationPayBranch": "Air Force"
+    },
     "serviceInformation": {
       "reservesNationalGuardService": {
         "view:isTitle10Activated": false,
@@ -60,6 +69,17 @@
     ],
     "servedInCombatZonePost911": false,
     "view:hasAlternateName": true,
+    "alternateNames": [
+      {
+        "first": "William",
+        "middle": "Schwenk",
+        "last": "Gilbert"
+      },
+      {
+        "first": "Arthur",
+        "last": "Sullivan"
+      }
+    ],
     "view:selectablePtsdTypes": {},
     "view:ptsdTypeHelp": {},
     "view:upload781ChoiceHelp": {},
@@ -132,9 +152,11 @@
     "view:bankAccount": {
       "view:hasPrefilledBank": true
     },
-    "view:waiveRetirementPayDescription": {},
     "standardClaim": false,
     "view:fdcWarning": {},
+    "waiveTrainingPay": true,
+    "view:waiveRetirementPayDescription": {},
+    "waiveRetirementPay": true,
     "view:originalBankAccount": {
       "view:bankAccountType": "Checking",
       "view:bankAccountNumber": "*********1234",

--- a/src/applications/disability-benefits/all-claims/tests/data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/secondary-new-test.json
@@ -5,9 +5,6 @@
     },
     "standardClaim": false,
     "view:fdcWarning": {},
-    "waiveTrainingPay": true,
-    "view:waiveRetirementPayDescription": {},
-    "waiveRetirementPay": true,
     "isVaEmployee": true,
     "homelessOrAtRisk": "homeless",
     "view:isHomeless": {
@@ -185,15 +182,6 @@
       }
     ],
     "view:disabilitiesClarification": {},
-    "hasTrainingPay": true,
-    "view:hasMilitaryRetiredPay": true,
-    "militaryRetiredPayBranch": "Air Force",
-    "view:hasSeparationPay": true,
-    "view:separationPayDetails": {
-      "view:separationPayDetailsDescription": {},
-      "separationPayDate": "2018",
-      "separationPayBranch": "Air Force"
-    },
     "serviceInformation": {
       "reservesNationalGuardService": {
         "view:isTitle10Activated": true,
@@ -226,18 +214,6 @@
       "view:militaryHistoryNote": {}
     },
     "servedInCombatZonePost911": true,
-    "view:hasAlternateName": true,
-    "alternateNames": [
-      {
-        "first": "William",
-        "middle": "Schwenk",
-        "last": "Gilbert"
-      },
-      {
-        "first": "Arthur",
-        "last": "Sullivan"
-      }
-    ],
     "view:selectablePtsdTypes": {},
     "view:ptsdTypeHelp": {},
     "view:upload781ChoiceHelp": {},

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/full-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/full-781-781a-8940-test.json
@@ -36,7 +36,6 @@
       "state": "AK",
       "zipCode": "12345"
     },
-    "hasTrainingPay": false,
     "serviceInformation": {
       "reservesNationalGuardService": {
         "obligationTermOfServiceDateRange": {

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/maximal-test.json
@@ -1,8 +1,6 @@
 {
   "form526": {
     "standardClaim": false,
-    "waiveTrainingPay": true,
-    "waiveRetirementPay": true,
     "isVaEmployee": true,
     "homelessOrAtRisk": "homeless",
     "homelessHousingSituation": "other",
@@ -103,10 +101,6 @@
         "disabilityActionType": "NONE"
       }
     ],
-    "hasTrainingPay": true,
-    "militaryRetiredPayBranch": "Air Force",
-    "separationPayDate": "2018-XX-XX",
-    "separationPayBranch": "Air Force",
     "serviceInformation": {
       "reservesNationalGuardService": {
         "title10Activation": {
@@ -131,10 +125,6 @@
       ]
     },
     "servedInCombatZonePost911": true,
-    "alternateNames": [
-      { "first": "William", "middle": "Schwenk", "last": "Gilbert" },
-      { "first": "Arthur", "last": "Sullivan" }
-    ],
     "newPrimaryDisabilities": [
       {
         "cause": "NEW",

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/newOnly-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/newOnly-test.json
@@ -21,6 +21,10 @@
         "classificationCode": "540"
       }
     ],
+    "hasTrainingPay": true,
+    "militaryRetiredPayBranch": "Air Force",
+    "separationPayDate": "2018-XX-XX",
+    "separationPayBranch": "Air Force",
     "serviceInformation": {
       "reservesNationalGuardService": {
         "obligationTermOfServiceDateRange": {
@@ -37,6 +41,19 @@
       ]
     },
     "servedInCombatZonePost911": false,
-    "standardClaim": false
+    "alternateNames": [
+      {
+        "first": "William",
+        "middle": "Schwenk",
+        "last": "Gilbert"
+      },
+      {
+        "first": "Arthur",
+        "last": "Sullivan"
+      }
+    ],
+    "standardClaim": false,
+    "waiveTrainingPay": true,
+    "waiveRetirementPay": true
   }
 }

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/secondary-new-test.json
@@ -1,8 +1,6 @@
 {
   "form526": {
     "standardClaim": false,
-    "waiveTrainingPay": true,
-    "waiveRetirementPay": true,
     "isVaEmployee": true,
     "homelessOrAtRisk": "homeless",
     "homelessHousingSituation": "other",
@@ -86,10 +84,6 @@
         "disabilityActionType": "NONE"
       }
     ],
-    "hasTrainingPay": true,
-    "militaryRetiredPayBranch": "Air Force",
-    "separationPayDate": "2018-XX-XX",
-    "separationPayBranch": "Air Force",
     "serviceInformation": {
       "reservesNationalGuardService": {
         "title10Activation": {
@@ -114,10 +108,6 @@
       ]
     },
     "servedInCombatZonePost911": true,
-    "alternateNames": [
-      { "first": "William", "middle": "Schwenk", "last": "Gilbert" },
-      { "first": "Arthur", "last": "Sullivan" }
-    ],
     "newSecondaryDisabilities": [
       {
         "cause": "SECONDARY",

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/upload-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/upload-781-781a-8940-test.json
@@ -35,7 +35,6 @@
       "state": "AK",
       "zipCode": "12345"
     },
-    "hasTrainingPay": false,
     "serviceInformation": {
       "reservesNationalGuardService": {
         "obligationTermOfServiceDateRange": {

--- a/src/applications/disability-benefits/all-claims/tests/data/upload-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/upload-781-781a-8940-test.json
@@ -13,23 +13,7 @@
     "view:claimType": {
       "view:claimingNew": true
     },
-    "standardClaim": true,
     "view:noFdcWarning": {},
-    "view:hasSeparationPay": false,
-    "hasTrainingPay": false,
-    "isVaEmployee": false,
-    "homelessOrAtRisk": "no",
-    "phoneAndEmail": {
-      "primaryPhone": "8035555555",
-      "emailAddress": "bill@gmail.com"
-    },
-    "mailingAddress": {
-      "country": "USA",
-      "addressLine1": "100 cool ln.",
-      "city": "Charleston",
-      "state": "SC",
-      "zipCode": "29412"
-    },
     "form8940Upload": [
       {
         "name": "image.png",
@@ -112,9 +96,6 @@
     "view:contactInfoDescription": {},
     "view:hasEvidence": false,
     "view:powStatus": false,
-    "hasTrainingPay": false,
-    "view:hasMilitaryRetiredPay": false,
-    "view:hasSeparationPay": false,
     "serviceInformation": {
       "reservesNationalGuardService": {
         "view:isTitle10Activated": false,
@@ -136,7 +117,6 @@
       "view:militaryHistoryNote": {}
     },
     "servedInCombatZonePost911": false,
-    "view:hasAlternateName": false,
     "incident0": {
       "unitAssignedDates": {},
       "incidentLocation": {
@@ -204,7 +184,6 @@
     "view:bankAccount": {
       "view:hasPrefilledBank": true
     },
-    "view:waiveRetirementPayDescription": {},
     "standardClaim": false,
     "view:fdcWarning": {},
     "view:originalBankAccount": {

--- a/src/applications/disability-benefits/all-claims/tests/prefill-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/prefill-transformer.unit.spec.js
@@ -9,10 +9,16 @@ import {
   disabilityActionTypes,
 } from '../../all-claims/constants';
 
-describe('526v2 prefill transformer', () => {
+describe.only('526v2 prefill transformer', () => {
   const noTransformData = {
     metadata: { test: 'Test Metadata' },
-    formData: { testData: `This isn't getting transformed` },
+    formData: {
+      testData: `This isn't getting transformed`,
+      'view:claimType': {
+        'view:claimingIncrease': false,
+        'view:claimingNew': true,
+      },
+    },
     pages: { testPage: 'Page 1' },
   };
 
@@ -51,6 +57,53 @@ describe('526v2 prefill transformer', () => {
         formData.disabilities[0].name,
       );
     });
+
+    it('should add claimType when no rated service-connected disabilities', () => {
+      const { pages, metadata } = noTransformData;
+      const formData = {
+        disabilities: [
+          {
+            name: 'other disability',
+            decisionCode: SERVICE_CONNECTION_TYPES.notServiceConnected,
+          },
+        ],
+      };
+
+      const transformedData = prefillTransformer(pages, formData, metadata)
+        .formData;
+      expect(transformedData['view:claimType']).to.deep.equal(
+        noTransformData.formData['view:claimType'],
+      );
+    });
+
+    it('should add claimType when no disabilities', () => {
+      const { pages, metadata } = noTransformData;
+      const formData = {};
+
+      const transformedData = prefillTransformer(pages, formData, metadata)
+        .formData;
+      expect(transformedData).to.deep.equal({
+        'view:claimType': noTransformData.formData['view:claimType'],
+      });
+    });
+
+    it('should not add claimType when service-connected disabilities present', () => {
+      const { pages, metadata } = noTransformData;
+      const formData = {
+        disabilities: [
+          {
+            name: 'other disability',
+            decisionCode: SERVICE_CONNECTION_TYPES.serviceConnected,
+          },
+        ],
+      };
+
+      const transformedData = prefillTransformer(pages, formData, metadata)
+        .formData;
+      expect(transformedData.ratedDisabilities[0].name).to.equal(
+        formData.disabilities[0].name,
+      );
+    });
   });
 
   describe('prefillContactInformation', () => {
@@ -74,6 +127,7 @@ describe('526v2 prefill transformer', () => {
 
       const { primaryPhone, emailAddress, mailingAddress } = formData.veteran;
       expect(transformedData).to.deep.equal({
+        'view:claimType': noTransformData.formData['view:claimType'],
         phoneAndEmail: {
           primaryPhone,
           emailAddress,
@@ -94,6 +148,7 @@ describe('526v2 prefill transformer', () => {
         .formData;
 
       expect(transformedData).to.deep.equal({
+        'view:claimType': noTransformData.formData['view:claimType'],
         phoneAndEmail: {
           emailAddress: formData.veteran.emailAddress,
         },
@@ -123,6 +178,7 @@ describe('526v2 prefill transformer', () => {
         .formData;
       const { servicePeriods, reservesNationalGuardService } = formData;
       expect(transformedData).to.deep.equal({
+        'view:claimType': noTransformData.formData['view:claimType'],
         serviceInformation: {
           servicePeriods,
           reservesNationalGuardService,
@@ -145,6 +201,7 @@ describe('526v2 prefill transformer', () => {
         .formData;
       const { servicePeriods } = formData;
       expect(transformedData).to.deep.equal({
+        'view:claimType': noTransformData.formData['view:claimType'],
         serviceInformation: { servicePeriods },
       });
     });
@@ -169,6 +226,7 @@ describe('526v2 prefill transformer', () => {
         bankName,
       } = formData;
       expect(transformedData).to.deep.equal({
+        'view:claimType': noTransformData.formData['view:claimType'],
         'view:originalBankAccount': {
           'view:bankAccountType': bankAccountType,
           'view:bankAccountNumber': bankAccountNumber,
@@ -189,7 +247,9 @@ describe('526v2 prefill transformer', () => {
       const transformedData = prefillTransformer(pages, formData, metadata)
         .formData;
 
-      expect(transformedData).to.deep.equal({});
+      expect(transformedData).to.deep.equal({
+        'view:claimType': noTransformData.formData['view:claimType'],
+      });
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/prefill-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/prefill-transformer.unit.spec.js
@@ -9,7 +9,7 @@ import {
   disabilityActionTypes,
 } from '../../all-claims/constants';
 
-describe.only('526v2 prefill transformer', () => {
+describe('526v2 prefill transformer', () => {
   const noTransformData = {
     metadata: { test: 'Test Metadata' },
     formData: {

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -789,3 +789,6 @@ export const claimingNew = formData =>
 
 export const hasClaimedConditions = formData =>
   claimingNew(formData) || claimingRated(formData);
+
+export const hasRatedDisabilities = formData =>
+  !!formData.ratedDisabilities && formData.ratedDisabilities.length;

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -791,4 +791,4 @@ export const hasClaimedConditions = formData =>
   claimingNew(formData) || claimingRated(formData);
 
 export const hasRatedDisabilities = formData =>
-  !!formData.ratedDisabilities && formData.ratedDisabilities.length;
+  formData.ratedDisabilities && formData.ratedDisabilities.length;

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -25,9 +25,6 @@ export const hasSeparationPay = data =>
 
 export const hasTrainingPay = data => _.get('view:hasTrainingPay', data, false);
 
-export const hasRatedDisabilities = data =>
-  !!_.get('ratedDisabilities', data, []).length;
-
 export function isValidZIP(value) {
   if (value !== null) {
     return /^\d{5}(?:(?:[-\s])?\d{4})?$/.test(value);


### PR DESCRIPTION
## Description
- Updates prefill transformer to pre-fill some view data for us when no rated disabilities are present
- Updates depends logic for pages that were previously triggered under the 'increase only' flow to now only trigger when no rated disabilities are present in prefill at all
- Fixes a small bug in the submit transformer where we were unintentionally mutating some data
- Adds a bunch of test cases, updates existing tests

## Testing done
- Local testing
- Added test cases for prefill transformer and submit transformer

## Screenshots
N/A

## Acceptance criteria
- [x] Allow veterans to fill out the minimum number of questions to achieve their 526 without repeating what they've already answered or confusing them with questions that we could deduce from their prefill data (more specific AC in linked ticket)
- [x] Automated tests covering new functionality

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
