### PR TITLE
Update separation pay content, make optional

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/separationTrainingPay.jsx
+++ b/src/applications/disability-benefits/all-claims/content/separationTrainingPay.jsx
@@ -1,18 +1,13 @@
 import React from 'react';
 
 export const hasSeparationPayTitle = (
-  <p>
-    Did you receive separation pay or severance pay? (This includes vacation
-    payout, bonuses, medical separation pay, or any money you get from the
-    Voluntary Separation Incentive (VSI) program.)
-  </p>
+  <p>Did you receive separation pay or disability severance pay?</p>
 );
 
 export const separationPayDetailsDescription = (
   <p>
-    The amount you get for VA compensation may be reduced or withheld if you’re
-    also receiving severance or separation pay. Getting VA compensation pay and
-    separation pay at the same time may mean that we’ve paid you too much, and
-    you may need to repay the money.
+    We’re required by law to reduce or withhold some of your VA compensation pay
+    if you also receive disability severance or separation pay, such as
+    involuntary or voluntary separation pay.
   </p>
 );

--- a/src/applications/disability-benefits/all-claims/content/separationTrainingPay.jsx
+++ b/src/applications/disability-benefits/all-claims/content/separationTrainingPay.jsx
@@ -7,7 +7,6 @@ export const hasSeparationPayTitle = (
 export const separationPayDetailsDescription = (
   <p>
     We’re required by law to reduce or withhold some of your VA compensation pay
-    if you also receive disability severance or separation pay, such as
-    involuntary or voluntary separation pay.
+    if you also receive disability severance pay.
   </p>
 );

--- a/src/applications/disability-benefits/all-claims/pages/separationPay.js
+++ b/src/applications/disability-benefits/all-claims/pages/separationPay.js
@@ -45,7 +45,6 @@ export const uiSchema = {
 
 export const schema = {
   type: 'object',
-  required: ['view:hasSeparationPay'],
   properties: {
     'view:hasSeparationPay': {
       type: 'boolean',

--- a/src/applications/disability-benefits/all-claims/tests/pages/separationPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/separationPay.unit.spec.jsx
@@ -29,7 +29,7 @@ describe('Separation Pay', () => {
     form.unmount();
   });
 
-  it('should fail to submit if no answers provided', () => {
+  it('should submit if no answers provided', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
@@ -43,8 +43,8 @@ describe('Separation Pay', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
+    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(onSubmit.calledOnce).to.be.true;
     form.unmount();
   });
 


### PR DESCRIPTION
## Description
- Updates content for separation / severance pay page in 526 v2.
- Updates initial yes/no question on the page to be optional.

*Note:* we can't make all the questions optional in this ticket, as that will require changes to vets-api, vets-json-schema, and vets-website. Work for that is ticketed in [#17473](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17473)

## Testing done
- Tested locally
- Updated unit tests

## Screenshots
![Screen Shot 2019-03-20 at 11 36 32 AM](https://user-images.githubusercontent.com/24251447/54702235-7a944300-4b04-11e9-9399-bea5ffed6df5.png)

![Screen Shot 2019-03-20 at 11 36 40 AM](https://user-images.githubusercontent.com/24251447/54702251-7ec06080-4b04-11e9-90ba-69e9baf91e71.png)


## Acceptance criteria
- [x] Update content per attached ticket
- [x] Make the intro question optional

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
