### PR TITLE
Vagov 1902 metatag updates

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -23,12 +23,6 @@
 <meta name="insight-app-sec-validation" content="ec59f99e-d869-4e3f-82d2-a61d32c65776">
 {% endif %}
 
-{% if title === 'Home' %}
-<title>VA.gov</title>
-{% else %}
-<title>{{ title }}: VA.gov</title>
-{% endif %}
-
 <!-- Icons -->
 <link href="/img/design/icons/apple-touch-icon.png" rel="apple-touch-icon-precomposed" />
 <link href="/img/design/icons/apple-touch-icon-72x72.png" rel="apple-touch-icon-precomposed" sizes="72x72" />

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -32,12 +32,18 @@
 
 {% else %}
 <!-- Metatags -->
-<meta property="og:site_name" content="VA.gov">
+  {% if regionOrOffice %}
+    {% assign metaTitle = title | append: " | " | append: regionOrOffice %}
+  {% else %}
+    {% assign metaTitle = title %}
+  {% endif %}
+  {% assign metaTitle = metaTitle | append: " | Veterans Affairs" %}
+<meta property="og:site_name" content="Veterans Affairs">
 <meta name="twitter:card" content="Summary">
 <meta name="twitter:site" content="@DeptVetAffairs">
 <meta name="twitter:image" content="{{ hostUrl }}/img/design/logo/va-og-twitter-image.png">
-<meta content="{{ title }} - Veterans Affairs" property="og:title">
-<meta content="{{ title }} - Veterans Affairs" name="twitter:title" >
+<meta content="{{ metaTitle }}" property="og:title">
+<meta content="{{ metaTitle }}" name="twitter:title" >
   {% if fieldIntroTextNewsStories %}
     {% assign description = fieldIntroTextNewsStories.processed  | strip_html %}
   {% elsif fieldIntroTextEventsPage %}
@@ -61,5 +67,5 @@
 <meta content="{{ description }}" name="description">
   {% endif %}
 <meta content="{{ hostUrl }}/img/design/logo/va-og-image.png" property="og:image">
-<title>{{ title }} - Veterans Affairs</title>
+<title>{{ metaTitle }}</title>
 {% endif %}

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -18,7 +18,11 @@
 {% for tag in entityMetatags %}
     {% case tag.__typename %}
       {% when "MetaValue" %}
+        {% if tag.key == "title" %}
+<title>{{ tag.value }}</title>
+        {% else %}
 <meta name="{{ tag.key }}" content="{{ tag.value }}">
+        {% endif %}
       {% when "MetaProperty" %}
 <meta property="{{ tag.key }}" content="{{ tag.value }}">
       {% when "MetaLink" %}
@@ -32,13 +36,8 @@
 <meta name="twitter:card" content="Summary">
 <meta name="twitter:site" content="@DeptVetAffairs">
 <meta name="twitter:image" content="{{ hostUrl }}/img/design/logo/va-og-twitter-image.png">
-  {% if title %}
-<meta content="{{ title }} - VA.gov" property="og:title">
-<meta content="{{ title }} - VA.gov" name="twitter:title" >
-  {% else %}
-<meta content="{{ hostUrl }}" property="og:title">
-<meta content="{{ hostUrl }}" name="twitter:title">
-{% endif %}
+<meta content="{{ title }} - Veterans Affairs" property="og:title">
+<meta content="{{ title }} - Veterans Affairs" name="twitter:title" >
   {% if fieldIntroTextNewsStories %}
     {% assign description = fieldIntroTextNewsStories.processed  | strip_html %}
   {% elsif fieldIntroTextEventsPage %}
@@ -62,4 +61,5 @@
 <meta content="{{ description }}" name="description">
   {% endif %}
 <meta content="{{ hostUrl }}/img/design/logo/va-og-image.png" property="og:image">
+<title>{{ title }} - Veterans Affairs</title>
 {% endif %}

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -16,17 +16,14 @@
 {% if tagsSize > 0 %}
 <!-- Metatags from Drupal -->
 {% for tag in entityMetatags %}
-{% if tag.__typename == "MetaValue" %}
+    {% case tag.__typename %}
+      {% when "MetaValue" %}
 <meta name="{{ tag.key }}" content="{{ tag.value }}">
-{% else %}
-{% if tag.__typename == "MetaProperty" %}
+      {% when "MetaProperty" %}
 <meta property="{{ tag.key }}" content="{{ tag.value }}">
-{% else %}
-{% if tag.__typename == "MetaLink" %}
+      {% when "MetaLink" %}
 <link rel="{{ tag.key }}" href="{{ tag.value }}">
-{% endif %}
-{% endif %}
-{% endif %}
+    {% endcase %}
 {% endfor %}
 
 {% else %}
@@ -42,11 +39,7 @@
 <meta content="{{ hostUrl }}" property="og:title">
 <meta content="{{ hostUrl }}" name="twitter:title">
 {% endif %}
-  {% if fieldDescription %}
-    {% assign description = fieldDescription | newline_to_br %}
-  {% elsif fieldIntroText %}
-    {% assign description = fieldIntroText.processed | strip_html %}
-  {% elsif fieldIntroTextNewsStories %}
+  {% if fieldIntroTextNewsStories %}
     {% assign description = fieldIntroTextNewsStories.processed  | strip_html %}
   {% elsif fieldIntroTextEventsPage %}
     {% assign description = fieldIntroTextEventsPage.processed | strip_html %}
@@ -56,11 +49,17 @@
     {% assign description = fieldLocationsIntroBlurb.processed | strip_html %}
   {% elsif fieldPatientFamilyServicesIn %}
     {% assign description = fieldPatientFamilyServicesIn.processed | strip_html %}
+  {% elsif fieldPressReleaseBlurb %}
+    {% assign description = fieldPressReleaseBlurb.processed | strip_html %}
+  {% elsif fieldDescription %}
+    {% assign description = fieldDescription | newline_to_br %}
+  {% elsif fieldIntroText %}
+    {% assign description = fieldIntroText.processed | strip_html %}
   {% endif %}
   {% if description %}
 <meta content="{{ description }}" property="og:description">
 <meta content="{{ description }}" name="twitter:description" >
 <meta content="{{ description }}" name="description">
-    {% endif %}
+  {% endif %}
 <meta content="{{ hostUrl }}/img/design/logo/va-og-image.png" property="og:image">
 {% endif %}

--- a/src/site/includes/metatags.liquid
+++ b/src/site/includes/metatags.liquid
@@ -31,4 +31,8 @@
 <meta content="{{ tag }}" property="article:tag">
   {% endfor %}
 {% endif %}
-
+{% if title === 'Home' %}
+<title>VA.gov</title>
+{% else %}
+<title>{{ title }}: VA.gov</title>
+{% endif %}

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -99,5 +99,8 @@ module.exports = `
     }
     ${healthCareRegionHealthServices}    
     ${healthCareRegionDetailPage}
+    fieldPressReleaseBlurb {
+      processed
+    }
   }
 `;

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -72,6 +72,8 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     title: page.title,
   };
   const locPage = updateEntityUrlObj(locObj, drupalPagePath, 'Locations');
+  locPage.regionOrOffice = page.title;
+
   files[`${drupalPagePath}/locations/index.html`] = createFileObj(
     locPage,
     'health_care_region_locations_page.drupal.liquid',
@@ -101,6 +103,8 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'Patient and health services',
     'health-services',
   );
+  hsPage.regionOrOffice = page.title;
+
   files[`${drupalPagePath}/health-services/index.html`] = createFileObj(
     hsPage,
     'health_care_region_health_services_page.drupal.liquid',
@@ -117,6 +121,8 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     alert: page.alert,
   };
   const prPage = updateEntityUrlObj(prObj, drupalPagePath, 'Press Releases');
+  prPage.regionOrOffice = page.title;
+
   paginatePages(
     prPage,
     files,
@@ -141,6 +147,8 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'Community stories',
     'stories',
   );
+  nsPage.regionOrOffice = page.title;
+
   paginatePages(
     nsPage,
     files,
@@ -160,6 +168,8 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     { alert: page.alert },
   );
   const eventPage = updateEntityUrlObj(eventObj, drupalPagePath, 'Events');
+  eventPage.regionOrOffice = page.title;
+
   paginatePages(
     eventPage,
     files,
@@ -182,6 +192,8 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     drupalPagePath,
     'Leadership',
   );
+  bioListingPage.regionOrOffice = page.title;
+
   paginatePages(
     bioListingPage,
     files,

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -110,6 +110,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   const prEntityUrl = createEntityUrlObj(drupalPagePath);
   const prObj = {
     allPressReleaseTeasers: page.allPressReleaseTeasers,
+    fieldPressReleaseBlurb: page.fieldPressReleaseBlurb,
     facilitySidebar: sidebar,
     entityUrl: prEntityUrl,
     title: page.title,


### PR DESCRIPTION
## Description
1. Moved title tag from header template to metatags templates.
2. Added 'regionOrOffice' field to listing pages.
3. Updated drupal meta tags to use Press Release blurb field as meta descriptions for press releases.
4. Updated facility listing page title tags to include region (regionOrOffice field).
5. Changed site name in title tags from "VA.gov" to "Veterans Affairs"

## Testing done
Spot checks of meta tags on listing pages.

## Acceptance criteria
- [ ] Meta tags are correct on pages coming from Drupal.

Note that the meta tags on the drupal side haven't been updated yet (there's a PR for that), so only listing pages will show the above changes until the PR is merged on the drupal side.