### PR TITLE
VAGOV-1755: Sidebar accessibility fix

### DIFF
--- a/src/site/navigation/sidebar_nav.drupal.liquid
+++ b/src/site/navigation/sidebar_nav.drupal.liquid
@@ -27,9 +27,9 @@
                                                         {% for link in link.links %}
                                                             {% assign subSubListSize = link.links | size %}
                                                             {% if subSubListSize > 0 %}
-                                                                <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                                        href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
                                                                 <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
+                                                                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
                                                                     <ul class="usa-sidenav-sub_list">
                                                                         {% for link in link.links %}
                                                                             <li>


### PR DESCRIPTION
## Description
Makes sure every <a> tag in a sidebar has a <ul> and <li> parent.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
