### PR TITLE
Remove 'beta' from intro page

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -16,7 +16,7 @@ class IntroductionPage extends React.Component {
   render() {
     return (
       <div className="schemaform-intro">
-        <FormTitle title="File for disability compensation (Beta)" />
+        <FormTitle title="File for disability compensation" />
         <p>
           Equal to VA Form 21-526EZ (Application for Disability Compensation and
           Related Compensation Benefits).


### PR DESCRIPTION
## Description


## Testing done
Looked at it locally

## Screenshots
![Screen Shot 2019-03-20 at 3 12 06 PM](https://user-images.githubusercontent.com/24251447/54715945-9ad2fa80-4b22-11e9-9ba2-cf15754769fb.png)


## Acceptance criteria
- [x] Remove '(Beta)' from form name on intro page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
