### PR TITLE
[Drupal] Change frontmatter property "draft" to use a string value

### DIFF
--- a/src/site/stages/build/plugins/create-environment-filter.js
+++ b/src/site/stages/build/plugins/create-environment-filter.js
@@ -9,7 +9,9 @@ function createEnvironmentFilter(options) {
       const file = files[fileName];
 
       if (environmentName !== ENVIRONMENTS.LOCALHOST) {
-        if (file.draft) delete files[fileName];
+        if (file.status === 'draft') {
+          delete files[fileName];
+        }
       }
 
       if (file[environmentName] === false) {


### PR DESCRIPTION
## Description
Follow up to https://github.com/department-of-veterans-affairs/vets-website/pull/9769

Per the request of the CMS team, instead of using `draft: true`, we'll use `status: 'draft'` to indicate a page being a draft to Drupal.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17477

## Acceptance criteria
- [ ] Frontmatter uses string instead of boolean

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
