### PR TITLE
Add second link to fdc page

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
@@ -11,8 +11,17 @@ export const FDCDescription = (
     <a
       href="/disability/how-to-file-claim/evidence-needed/fully-developed-claims/"
       target="_blank"
+      rel="noopener noreferrer"
     >
       Learn more about the FDC program
+    </a>
+    .<br />
+    <a
+      href="/disability/how-to-file-claim/evidence-needed/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      View the evidence requirements for disability claims
     </a>
     .
   </div>


### PR DESCRIPTION
## Description
Adds a link to `/disability/how-to-file-claim/evidence-needed/` under the existing link on the FDC page in 526 v2.

## Testing done
- Tested locally

## Screenshots
<img width="315" alt="Screen Shot 2019-03-21 at 12 57 48 PM" src="https://user-images.githubusercontent.com/24251447/54774191-2ad37b80-4bd9-11e9-8756-fd5e1076b08c.png">

<img width="265" alt="Screen Shot 2019-03-21 at 12 57 57 PM" src="https://user-images.githubusercontent.com/24251447/54774201-3161f300-4bd9-11e9-865c-a3f5cceff2a4.png">

Link opens:
![Screen Shot 2019-03-21 at 12 59 49 PM](https://user-images.githubusercontent.com/24251447/54774234-3fb00f00-4bd9-11e9-85fd-e40cf244331f.png)


## Acceptance criteria
- [x] Add new link per ticket

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
