### PR TITLE
Upgrade js-yaml to 3.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
     "history": "3",
     "ics-js": "^0.10.2",
     "ismobilejs": "^0.4.0",
-    "js-yaml": "^3.12.0",
+    "js-yaml": "^3.13.0",
     "jsonschema": "^1.1.1",
     "leaflet": "^1.0.3",
     "leaflet-control-geocoder": "^1.5.1",

--- a/script/security-check.js
+++ b/script/security-check.js
@@ -11,7 +11,7 @@ const packageJSON = require('../package.json');
 const exceptionSet = new Set([
   'https://npmjs.com/advisories/577',
   'https://npmjs.com/advisories/157',
-  'https://www.npmjs.com/advisories/788',
+  'https://npmjs.com/advisories/788',
 ]);
 
 const severitySet = new Set(['high', 'critical', 'moderate']);

--- a/script/security-check.js
+++ b/script/security-check.js
@@ -11,6 +11,7 @@ const packageJSON = require('../package.json');
 const exceptionSet = new Set([
   'https://npmjs.com/advisories/577',
   'https://npmjs.com/advisories/157',
+  'https://www.npmjs.com/advisories/788',
 ]);
 
 const severitySet = new Set(['high', 'critical', 'moderate']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6278,9 +6278,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@^3.12.0, js-yaml@^3.7.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+js-yaml@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.0.tgz#38ee7178ac0eea2c97ff6d96fff4b18c7d8cf98e"
+  integrity sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -6288,6 +6289,13 @@ js-yaml@^3.12.0, js-yaml@^3.7.0:
 js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@^3.8.1, js-yaml@^3.9.1:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.7.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
## Description
We're getting a security error from version `3.12.0`, so upgrading this module.

Build - http://jenkins.vetsgov-internal/blue/organizations/jenkins/testing%2Fvets-website/detail/drupal-prod/3/pipeline

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
