### PR TITLE
VAGOV-2014: make q-a section h2s look like h3s

### DIFF
--- a/src/applications/static-pages/sass/static-pages.scss
+++ b/src/applications/static-pages/sass/static-pages.scss
@@ -77,3 +77,10 @@
     display: none;
   }
 }
+
+
+// Makes anything look like an h3
+.h3 {
+  font-size: 2rem;
+  font-weight: 700;
+}

--- a/src/applications/static-pages/sass/static-pages.scss
+++ b/src/applications/static-pages/sass/static-pages.scss
@@ -77,10 +77,3 @@
     display: none;
   }
 }
-
-
-// Makes anything look like an h3
-.h3 {
-  font-size: 2rem;
-  font-weight: 700;
-}

--- a/src/site/paragraphs/q_a.drupal.liquid
+++ b/src/site/paragraphs/q_a.drupal.liquid
@@ -25,7 +25,7 @@
   {% assign header = "h3" %}
 {% endif %}
 <div itemscope="" itemtype="http://schema.org/Question">
-  <{{ header }} itemprop="name">{{ entity.fieldQuestion }}</{{ header }}>
+  <{{ header }} {% if header == "h2" %}class="h3"{% endif %} itemprop="name">{{ entity.fieldQuestion }}</{{ header }}>
   <div itemprop="acceptedAnswer" itemscope="" itemtype="http://schema.org/Answer">
     <div itemprop="text">
     {% for answer in entity.fieldAnswer %}

--- a/src/site/paragraphs/q_a.drupal.liquid
+++ b/src/site/paragraphs/q_a.drupal.liquid
@@ -25,7 +25,7 @@
   {% assign header = "h3" %}
 {% endif %}
 <div itemscope="" itemtype="http://schema.org/Question">
-  <{{ header }} {% if header == "h2" %}class="h3"{% endif %} itemprop="name">{{ entity.fieldQuestion }}</{{ header }}>
+  <{{ header }} {% if header == "h2" %}class="heading-level-3"{% endif %} itemprop="name">{{ entity.fieldQuestion }}</{{ header }}>
   <div itemprop="acceptedAnswer" itemscope="" itemtype="http://schema.org/Answer">
     <div itemprop="text">
     {% for answer in entity.fieldAnswer %}

--- a/src/site/paragraphs/q_a_section.drupal.liquid
+++ b/src/site/paragraphs/q_a_section.drupal.liquid
@@ -12,7 +12,7 @@
   }
 {% endcomment %}
 {% if entity.fieldSectionHeader != empty %}
-  <h2>{{ entity.fieldSectionHeader }}</h2>
+  <h2 class="h3">{{ entity.fieldSectionHeader }}</h2>
 {% endif %}
 {% if entity.fieldSectionIntro != empty %}
   <p>{{ entity.fieldSectionIntro }}</p>

--- a/src/site/paragraphs/q_a_section.drupal.liquid
+++ b/src/site/paragraphs/q_a_section.drupal.liquid
@@ -12,7 +12,7 @@
   }
 {% endcomment %}
 {% if entity.fieldSectionHeader != empty %}
-  <h2 class="h3">{{ entity.fieldSectionHeader }}</h2>
+  <h2 class="heading-level-3">{{ entity.fieldSectionHeader }}</h2>
 {% endif %}
 {% if entity.fieldSectionIntro != empty %}
   <p>{{ entity.fieldSectionIntro }}</p>


### PR DESCRIPTION
## Description
- for qa sections and titles, make the h2 looks like an h3
- added class for that style

## Testing done
- locally with staging data
- this page has both qa section and qa accordion headers: http://localhost:3001/drupal/health-care/eligibility/

## Screenshots
![localhost_3001_drupal_health-care_eligibility_](https://user-images.githubusercontent.com/19178435/54787948-9eca4f80-4bea-11e9-9109-33d514752e95.png)

## Acceptance criteria
- https://va-gov.atlassian.net/browse/VAGOV-2014

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

