### PR TITLE
VAGOV-1998 && 1999: updates to alert block template

### DIFF
--- a/src/applications/static-pages/sass/static-pages.scss
+++ b/src/applications/static-pages/sass/static-pages.scss
@@ -77,3 +77,10 @@
     display: none;
   }
 }
+
+
+// Makes anything look like an h3
+.h3 {
+  font-size: 2rem;
+  font-weight: 700;
+}

--- a/src/applications/static-pages/sass/static-pages.scss
+++ b/src/applications/static-pages/sass/static-pages.scss
@@ -77,10 +77,3 @@
     display: none;
   }
 }
-
-
-// Makes anything look like an h3
-.h3 {
-  font-size: 2rem;
-  font-weight: 700;
-}

--- a/src/site/blocks/alert.drupal.liquid
+++ b/src/site/blocks/alert.drupal.liquid
@@ -21,8 +21,12 @@
 {% if alert.fieldAlertContent %}
     {% assign expander = alert.fieldAlertContent.entity %}
 {% endif %}
+{% assign alertType = alert.fieldAlertType %}
+{% if alertType = "information" %}
+    {% assign alertType = "info" %}
+{% endif %}
 
-<div class="usa-alert usa-alert-{{ alert.fieldAlertType }}" role="alert">
+<div class="usa-alert usa-alert-{{ alertType }}" role="alert">
     <div class="usa-alert-body">
         <h3 class="usa-alert-heading">
             {{ alert.fieldAlertTitle }}
@@ -34,6 +38,7 @@
         {% if expander.fieldTextExpander %}<div id="{{ expander.entityBundle }}-{{ expander.entityId }}-content" class="expander-content expander-content-closed" aria-hidden="true">
             <div class="expander-content-inner usa-alert-text">{{ expander.fieldWysiwyg.processed }}</div>
         </div>{% endif %}
+        {% if expander.fieldWysiwyg && expander.fieldTextExpander === empty %}<div class=" usa-alert-text">{{ expander.fieldWysiwyg.processed }}</div>{% endif %}
     </div>
 </div>
 

--- a/src/site/paragraphs/q_a.drupal.liquid
+++ b/src/site/paragraphs/q_a.drupal.liquid
@@ -25,7 +25,7 @@
   {% assign header = "h3" %}
 {% endif %}
 <div itemscope="" itemtype="http://schema.org/Question">
-  <{{ header }} itemprop="name">{{ entity.fieldQuestion }}</{{ header }}>
+  <{{ header }} {% if header == "h2" %}class="h3"{% endif %} itemprop="name">{{ entity.fieldQuestion }}</{{ header }}>
   <div itemprop="acceptedAnswer" itemscope="" itemtype="http://schema.org/Answer">
     <div itemprop="text">
     {% for answer in entity.fieldAnswer %}

--- a/src/site/paragraphs/q_a.drupal.liquid
+++ b/src/site/paragraphs/q_a.drupal.liquid
@@ -25,7 +25,7 @@
   {% assign header = "h3" %}
 {% endif %}
 <div itemscope="" itemtype="http://schema.org/Question">
-  <{{ header }} {% if header == "h2" %}class="h3"{% endif %} itemprop="name">{{ entity.fieldQuestion }}</{{ header }}>
+  <{{ header }} {% if header == "h2" %}class="heading-level-3"{% endif %} itemprop="name">{{ entity.fieldQuestion }}</{{ header }}>
   <div itemprop="acceptedAnswer" itemscope="" itemtype="http://schema.org/Answer">
     <div itemprop="text">
     {% for answer in entity.fieldAnswer %}

--- a/src/site/paragraphs/q_a_section.drupal.liquid
+++ b/src/site/paragraphs/q_a_section.drupal.liquid
@@ -12,7 +12,7 @@
   }
 {% endcomment %}
 {% if entity.fieldSectionHeader != empty %}
-  <h2>{{ entity.fieldSectionHeader }}</h2>
+  <h2 class="h3">{{ entity.fieldSectionHeader }}</h2>
 {% endif %}
 {% if entity.fieldSectionIntro != empty %}
   <p>{{ entity.fieldSectionIntro }}</p>

--- a/src/site/paragraphs/q_a_section.drupal.liquid
+++ b/src/site/paragraphs/q_a_section.drupal.liquid
@@ -12,7 +12,7 @@
   }
 {% endcomment %}
 {% if entity.fieldSectionHeader != empty %}
-  <h2 class="h3">{{ entity.fieldSectionHeader }}</h2>
+  <h2 class="heading-level-3">{{ entity.fieldSectionHeader }}</h2>
 {% endif %}
 {% if entity.fieldSectionIntro != empty %}
   <p>{{ entity.fieldSectionIntro }}</p>


### PR DESCRIPTION
## Description
- "information" -> "info" alert class
- allow alert content to show even if there is no expander text

## Testing done
locally with staging data

## Screenshots
http://localhost:3001/drupal/health-care/order-hearing-aid-batteries-prosthetic-socks/
![localhost_3001_drupal_health-care_order-hearing-aid-batteries-prosthetic-socks_](https://user-images.githubusercontent.com/19178435/54801115-a1e13200-4c22-11e9-8bfb-506c88ddc860.png)

http://localhost:3001/drupal/health-care/get-medical-records/
![localhost_3001_drupal_health-care_get-medical-records_](https://user-images.githubusercontent.com/19178435/54801138-b58c9880-4c22-11e9-9733-8d1a3eea6bbe.png)

## Acceptance criteria
- https://va-gov.atlassian.net/browse/VAGOV-1998: Slide 7 - Fix template to include correct react widget on /health-care/order-hearing-aid-batteries-prosthetic-socks/
- https://va-gov.atlassian.net/browse/VAGOV-1999: Slide 8 - Fix template to include correct react widgets on /health-care/get-medical-records/

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
