### PR TITLE
Bump formation-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/formation": "^5.4.2",
-    "@department-of-veterans-affairs/formation-react": "^4.1.2",
+    "@department-of-veterans-affairs/formation-react": "^4.1.3",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "blob-polyfill": "^2.0.20171115",

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,10 +684,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@department-of-veterans-affairs/formation-react@^4.1.2":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-4.1.2.tgz#e709463591b7b10383efbad364304a605fe1da43"
-  integrity sha512-I18k+TaMpdpePs+LcacEhumnudr2iMnF4CeO1nWePREJQGszCjZ+TTqJ27AzvQ7fHnb4DCAN2AZOTqHnuiqQ3g==
+"@department-of-veterans-affairs/formation-react@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-4.1.3.tgz#e03af34a058343a96194f4c908b17771ec5051b9"
+  integrity sha512-qBR/t4/AG4p7lJnADicu/QihabtJmbRtcEWiN/CsRyxrnJYcY2QEM0o7pZW+KNWrSiaCJArnd0mNckJ1sgmTIg==
   dependencies:
     classnames "^2.2.6"
     lodash "^4.17.11"


### PR DESCRIPTION
## Description
Bumps formation-react version, which resolves a problem where  '>' was getting prepended to radio labels.

## Testing done
- Tested locally with new formation version to confirm that visual regression was fixed.

## Screenshots
Before:
![Screen Shot 2019-03-22 at 9 39 06 AM](https://user-images.githubusercontent.com/24251447/54832310-e9e76f80-4c89-11e9-8127-e40cd9243c72.png)

After:
![Screen Shot 2019-03-22 at 9 22 20 AM](https://user-images.githubusercontent.com/24251447/54832338-f2d84100-4c89-11e9-9743-f73f9e01995f.png)

## Acceptance criteria
- [x] Fix visual regression

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
