### PR TITLE
Log sentry errors from preview server

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,6 +39,7 @@
       2,
       { "args": "after-used", "argsIgnorePattern": "^_", "vars": "local" }
     ],
+    "no-restricted-imports": ["error", "raven"],
     "prefer-rest-params": 2,
     "quote-props": [2, "as-needed", { "keywords": false }],
 
@@ -117,7 +118,7 @@
         "src/applications/static-pages/**/*.jsx"
       ],
       "rules": {
-        "no-restricted-imports": ["error", "lodash/fp"]
+        "no-restricted-imports": ["error", "raven", "lodash/fp"]
       }
     },
     {
@@ -128,7 +129,7 @@
         "src/platform/testing/**/*.jsx"
       ],
       "rules": {
-        "no-restricted-imports": 0,
+        "no-restricted-imports": ["error", "raven"],
         "no-unused-expressions": 0,
         "react/no-find-dom-node": 0
       }

--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "moment": "^2.15.1",
     "number-to-words": "^1.2.4",
     "prop-types": "^15.6.1",
+    "raven": "^2.6.4",
     "raven-js": "^3.12.1",
     "react": "^16.7.0",
     "react-cropper": "^1.0.1",

--- a/script/preview.js
+++ b/script/preview.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
 require('isomorphic-fetch');
+const Raven = require('raven');
 const commandLineArgs = require('command-line-args');
 const path = require('path');
 const express = require('express');
@@ -51,6 +52,10 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'unexpected', type: String, multile: true, defaultOption: true },
 ];
 
+if (process.env.SENTRY_DSN) {
+  Raven.config(process.env.SENTRY_DSN).install();
+}
+
 const options = commandLineArgs(COMMAND_LINE_OPTIONS_DEFINITIONS);
 
 if (options.unexpected && options.unexpected.length !== 0) {
@@ -74,8 +79,17 @@ const urls = {
     'http://www.va.gov.s3-website-us-gov-west-1.amazonaws.com',
 };
 
+if (process.env.SENTRY_DSN) {
+  app.use(Raven.requestHandler());
+}
+
+// eslint-disable-next-line no-unused-vars
+app.get('/error', (req, res) => {
+  throw new Error('fake error');
+});
+
 app.get('/health', (req, res) => {
-  res.send(200);
+  res.sendStatus(200);
 });
 
 app.get('/preview', async (req, res, next) => {
@@ -171,11 +185,16 @@ if (options.buildtype !== ENVIRONMENTS.LOCALHOST) {
   app.use(express.static(path.join(__dirname, '..', options.buildpath)));
 }
 
+if (process.env.SENTRY_DSN) {
+  app.use(Raven.errorHandler());
+}
+
 // eslint-disable-next-line no-unused-vars
 app.use((err, req, res, next) => {
   console.error(err);
   res.send(`
     <p>We're sorry, something went wrong when trying to preview that page.</p>
+    <p>Error id: ${res.sentry}</p>
     <pre>${options.buildtype !== ENVIRONMENTS.VAGOVPROD ? err : ''}</pre>
   `);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7188,7 +7188,7 @@ md5-o-matic@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
 
-md5@^2.1.0:
+md5@^2.1.0, md5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
   dependencies:
@@ -9178,6 +9178,17 @@ raven-js@^3.12.1:
   version "3.14.2"
   resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.14.2.tgz#9db2ffdd282e999e9d75541d4fa018be8d5266f4"
 
+raven@^2.6.4:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/raven/-/raven-2.6.4.tgz#458d4a380c8fbb59e0150c655625aaf60c167ea3"
+  integrity sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==
+  dependencies:
+    cookie "0.3.1"
+    md5 "^2.2.1"
+    stack-trace "0.0.10"
+    timed-out "4.0.1"
+    uuid "3.3.2"
+
 raw-body@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-1.3.0.tgz#978230a156a5548f42eef14de22d0f4f610083d1"
@@ -10616,6 +10627,11 @@ stable@~0.1.3:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.6.tgz#910f5d2aed7b520c6e777499c1f32e139fdecb10"
 
+stack-trace@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
+
 stack-trace@0.0.x:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
@@ -11067,6 +11083,11 @@ thunkify@^2.1.2, thunkify@~2.1.1:
 thunky@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.0.2.tgz#a862e018e3fb1ea2ec3fce5d55605cf57f247371"
+
+timed-out@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+  integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
 
 timers-browserify@^1.0.1:
   version "1.4.2"
@@ -11548,6 +11569,10 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
+uuid@3.3.2, uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+
 uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
@@ -11555,10 +11580,6 @@ uuid@^3.0.0:
 uuid@^3.0.1, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
-
-uuid@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
## Description
This adds Sentry error monitoring to the content preview server. It's conditional on the DSN being passed as an env variable, so it currently doesn't have any affect.

## Testing done
I tested that it attempts to send to Sentry with a DSN, but I can't test successful error logging because Sentry is behind SOCKS.

## Acceptance criteria
- [x] Set up looks correct, server works as usual without env var

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
