### PR TITLE
Strip periods from disability names

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -52,8 +52,11 @@ export const uiSchema = {
               input => input.replace(/[;–]/g, ' -- '),
               input => input.replace(/[&]/g, ' and '),
               input => input.replace(/[\\]/g, '/'),
+              // TODO: Remove the period replacer once permanent fix in place
+              input => input.replace(/[.]/g, ' '),
               // Strip out everything that's not valid and doesn't need to be replaced
-              input => input.replace(/([^a-zA-Z0-9\-'.,/() ]+)/g, ''),
+              // TODO: Add period back into allowed chars regex
+              input => input.replace(/([^a-zA-Z0-9\-',/() ]+)/g, ''),
               // Get rid of extra whitespace characters
               input => input.trim(),
               input => input.replace(/\s{2,}/g, ' '),


### PR DESCRIPTION
## Description
We're getting weird formData in checkboxes that are generated based on disability names with periods in them. This update removes the periods from the disability names as a temporary workaround. The real fix needs to happen in the forms system, but this is causing some submission errors, hence this quick fix.

## Testing done
- Tested locally

## Screenshots
N/A

## Acceptance criteria
- [x] Strip periods from new disability names

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
