### PR TITLE
VAGOV-2038: write out expected prod link display for "Connect with us" section

### DIFF
--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -31,14 +31,25 @@
                                 <li>
                                     <a href="http://youtube.com/channel/{{ socialLink.value }}">
                                         <i class="fab fa-youtube"></i>
-                                         Youtube
+                                         Veterans Health Youtube channel
                                     </a>
                                 </li>
                             {% else %}
                                 <li>
                                     <a href="http://{{ socialPlatform }}.com/{{ socialLink.value }}">
                                         <i class="fab fa-{{ socialPlatform }}"></i>
-                                         {{ socialPlatform }}
+                                        {% case socialPlatform %}
+                                            {% when "twitter" %}
+                                                Veterans Health Twitter
+                                            {% when "facebook" %}
+                                                Veterans Health Facebook
+                                            {% when "youtube" %}
+                                                Veterans Health YouTube
+                                            {% when "instagram" %}
+                                                Veterans Health Instagram
+                                            {% when "linkedin" %}
+                                                Veterans Health LinkedIn
+                                        {% endcase %}
                                     </a>
                                 </li>
                             {% endif %}


### PR DESCRIPTION

## Description
Fixes this:

![image](https://user-images.githubusercontent.com/19178435/54844285-bc9fbf00-4c93-11e9-8683-3c1f2dfc0745.png)

## Testing done
Locally with prod data

## Screenshots
![localhost_3001_drupal_health-care_](https://user-images.githubusercontent.com/19178435/54844308-d04b2580-4c93-11e9-83db-021e552e9a01.png)


## Acceptance criteria
- https://va-gov.atlassian.net/browse/VAGOV-2038: Slide 11 - Missing "Connect with Us" Box

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
