### PR TITLE
VAGOV-1948: allow multiple alerts on a page and landing page

### DIFF
--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -34,8 +34,10 @@
           {% endfor %}
         </ul>
         {% endif %}
-        {% if fieldAlert != empty %}
-        {% include "src/site/blocks/alert.drupal.liquid" with alert = fieldAlert.entity %}
+        {% if fieldAlert.length %}
+            {% for alert in fieldAlert %}
+                {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
+            {% endfor %}
         {% endif %}
         {% if fieldSpokes != empty %}
         {% for spoke in fieldSpokes %}

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -23,8 +23,10 @@
           <p>{{ fieldIntroText }}</p>
         </div>
 
-        {% if fieldAlert %}
-            {% include "src/site/blocks/alert.drupal.liquid" with alert = fieldAlert.entity %}
+        {% if fieldAlert.length %}
+            {% for alert in fieldAlert %}
+              {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
+            {% endfor %}
         {% endif %}
 
         {% assign featureCount = fieldFeaturedContent | size  %}


### PR DESCRIPTION
## Description
Allows multiple alerts on benefits pages and landing pages

## Testing done
Locally with staging data - had to add alerts on metal health page

http://localhost:3001/drupal/health-care/health-needs-conditions/mental-health/

## Screenshots
![localhost_3001_drupal_health-care_health-needs-conditions_mental-health_](https://user-images.githubusercontent.com/19178435/54851222-743dcc80-4ca6-11e9-87b2-d296b349b098.png)


## Acceptance criteria
- https://va-gov.atlassian.net/browse/VAGOV-1948
As a VBA content author, I can add up to three alerts on a single page so that users are aware of ALL the really important things they should know.

Acceptance Criteria:

The drupal content model is updated to allow up to three alerts of any type to be displayed on a single page

The migration script is re-run and no issues are found

The metalsmith templates are tested for one, two or three alerts

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
