### PR TITLE
VAGOV-2053: Update drupal breadcrumb template to use menu breadcrumbs.

### DIFF
--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -1,20 +1,39 @@
 <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
   <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
+    {% assign numCrumbs = entityUrl.breadcrumb | size %}
+    {% assign crumbCount = 1 %}
     {% for crumb in entityUrl.breadcrumb %}
-    <li>
-      <a href="{{crumb.url.path}}"
-        {% if crumb.url.path == "/" %}
-        onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });"
+      {% if crumbCount == numCrumbs %}
+      <li>
+        <a href="/{{path}}" aria-current="page">
+          {{crumb.text}}
+        </a>
+      </li>
+      {% else %}
+        {% if crumb.text == "Health Care" %}
+          {% assign crumbPath = "/health-care" %}
+        {% else %}
+          {% assign crumbPath = crumb.url.path %}
         {% endif %}
-        >
-        {{crumb.text}}
-      </a>
-    </li>
+        {% if crumb.text != "Get Benefits" and crumb.text != "Manage Benefits" and crumb.text != "More Resources" %}
+      <li>
+        {% if crumbPath != empty %}
+        <a href="{{crumbPath}}"
+          {% if crumb.url.path == "/" %}
+          onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });"
+          {% elsif crumb.text == lastCrumb %}
+          aria-current="page"
+          {% endif %}
+          >
+        {% endif %}
+          {{crumb.text}}
+        {% if crumbPath != empty %}
+        </a>
+        {% endif %}
+      </li>
+        {% endif %}
+      {% endif %}
+      {% assign crumbCount = crumbCount | plus: 1 %}
     {% endfor %}
-    <li>
-      <a aria-current="page" href="/{{path}}">
-        {{title}}
-      </a>
-    </li>
   </ul>
 </nav>


### PR DESCRIPTION
## Description
This updates the drupal breadcrumbs template to use breadcrumbs generated by the Menu Breadcrumbs drupal module. The module changes the contents of the breadcrumbs array passed to metalsmith, but not its form. So if this change is deployed before the corresponding drupal change, the breadcrumbs will be incorrect, but it won't break the query or cause other problems.

## Testing done
Spot check of breadcrumbs with the drupal module enabled.
