### PR TITLE
VAGOV-000: Adding mobile trigger to all pages with sidebars

### DIFF
--- a/src/site/layouts/bios_page.drupal.liquid
+++ b/src/site/layouts/bios_page.drupal.liquid
@@ -44,6 +44,7 @@
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
 
             <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 <article class="usa-content">
                     <h1>Our Leadership Team</h1>
                     {% for bio in pagedItems %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -87,7 +87,8 @@
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
       <div class="usa-width-three-fourths">
-        {% if !entityPublished %}
+          {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+          {% if !entityPublished %}
           <div class="usa-alert usa-alert-info">
             <div class="usa-alert-body">
               <p class="usa-alert-text">You are viewing a draft.</p>

--- a/src/site/layouts/events_page.drupal.liquid
+++ b/src/site/layouts/events_page.drupal.liquid
@@ -53,6 +53,7 @@ Example data:
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
       <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article class="usa-content">
           <h1>Events</h1>
           <div class="va-introtext vads-u-margin-bottom--6">

--- a/src/site/layouts/health_care_local_facility_page.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility_page.drupal.liquid
@@ -87,7 +87,8 @@
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
       <div class="usa-width-three-fourths">
-        {% if !entityPublished %}
+          {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+          {% if !entityPublished %}
           <div class="usa-alert usa-alert-info">
             <div class="usa-alert-body">
               <p class="usa-alert-text">You are viewing a draft.</p>

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -7,6 +7,7 @@
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
       <div class="usa-width-three-fourths">
+       {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article class="usa-content">
           <h1>{{ title }}</h1>
           <div class="va-introtext">

--- a/src/site/layouts/health_care_region_health_services_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_health_services_page.drupal.liquid
@@ -7,6 +7,7 @@
     <div class="usa-grid usa-grid-full">
         {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
         <div class="usa-width-three-fourths">
+            {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
             <article class="usa-content">
                 <h1>A-Z services</h1>
                 <div class="va-introtext">{{ fieldClinicalHealthServi.processed }}</div>

--- a/src/site/layouts/health_care_region_locations_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_locations_page.drupal.liquid
@@ -7,6 +7,7 @@
     <div class="usa-grid usa-grid-full">
         {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
         <div class="usa-width-three-fourths">
+            {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
             {% if !entityPublished %}
                 <div class="usa-alert usa-alert-info" >
                     <div class="usa-alert-body">

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -128,7 +128,8 @@ Example data:
     <div class="usa-grid usa-grid-full">
     {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
     <div class="usa-width-three-fourths">
-      {% if !entityPublished %}
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+        {% if !entityPublished %}
         <div class="usa-alert usa-alert-info" >
           <div class="usa-alert-body">
             <p class="usa-alert-text">You are viewing a draft.</p>

--- a/src/site/layouts/news_stories_page.drupal.liquid
+++ b/src/site/layouts/news_stories_page.drupal.liquid
@@ -54,6 +54,7 @@ Example data:
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
       <div class="usa-width-three-fourths">
+       {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article class="usa-content">
           <h1>Community Stories</h1>
           <div class="va-introtext vads-u-margin-bottom--6">

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -64,6 +64,7 @@ Example data:
         <div class="usa-grid usa-grid-full">
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
             <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 {% if !entityPublished %}
                     <div class="usa-alert usa-alert-info" >
                         <div class="usa-alert-body">

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -9,7 +9,8 @@
     {% include 'src/site/navigation/sidebar_nav.drupal.liquid' with sidebar %}
 
     <div class="usa-width-three-fourths">
-      {% if !entityPublished %}
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+        {% if !entityPublished %}
         <div class="usa-alert usa-alert-info" >
           <div class="usa-alert-body">
             <p class="usa-alert-text">You are viewing a draft.</p>

--- a/src/site/layouts/person_profile.drupal.liquid
+++ b/src/site/layouts/person_profile.drupal.liquid
@@ -43,6 +43,7 @@
         <div class="usa-grid usa-grid-full">
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
             <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 {% if !entityPublished %}
                     <div class="usa-alert usa-alert-info" >
                         <div class="usa-alert-body">

--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -100,6 +100,7 @@
         <div class="usa-grid usa-grid-full">
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
             <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 <article class="usa-content">
                     <section class="vads-u-margin-bottom--5">
                         <h1>{{ title }}</h1>

--- a/src/site/layouts/press_releases_page.drupal.liquid
+++ b/src/site/layouts/press_releases_page.drupal.liquid
@@ -51,6 +51,7 @@ Example data:
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with facilitySidebar %}
 
       <div class="usa-width-three-fourths">
+       {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article class="usa-content">
           <h1>Press Releases</h1>
           {% for pr in pagedItems %}


### PR DESCRIPTION
## Description
This adds back the button to show the sidebar on mobile on all pages generated with Drupal content that have a sidebar. 

## Testing done


## Screenshots
<img width="348" alt="Screen Shot 2019-03-25 at 11 06 04 AM" src="https://user-images.githubusercontent.com/3157339/54930653-05eb4b00-4eee-11e9-984c-c6757871c571.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
