### PR TITLE
Use well-tested selectors for enrollment status

### DIFF
--- a/src/applications/hca/containers/IntroductionPageGated.jsx
+++ b/src/applications/hca/containers/IntroductionPageGated.jsx
@@ -8,17 +8,10 @@ import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 
 import { focusElement } from 'platform/utilities/ui';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
-import {
-  selectUser,
-  selectProfile,
-  isLoggedIn,
-  isLOA1,
-  isLOA3,
-  isProfileLoading,
-} from 'platform/user/selectors';
 
 import HCAEnrollmentStatus from './HCAEnrollmentStatus';
 import HCASubwayMap from '../components/HCASubwayMap';
+import { isLoading, isUserLOA1, isLoggedOut, isUserLOA3 } from '../selectors';
 
 const VerificationRequiredAlert = () => (
   <AlertBox
@@ -111,30 +104,12 @@ class IntroductionPageGated extends React.Component {
   }
 }
 
-const mapStateToProps = state => {
-  const {
-    isLoading: isEnrollmentStatusLoading,
-    hasServerError,
-    noESRRecordFound,
-  } = state.hcaEnrollmentStatus;
-  const loading = isProfileLoading(state) || isEnrollmentStatusLoading;
-  return {
-    showMainLoader: loading,
-    showVerificationRequiredAlert:
-      !loading && isLoggedIn(state) && isLOA1(state),
-    // If we can't get enrollment status for LOA3 users, treat them like a
-    // logged-out user (ie, just let them start a new application)
-    showLoggedOutContent:
-      !loading && (!isLoggedIn(state) || hasServerError || noESRRecordFound),
-    showLOA3Content:
-      isLoggedIn(state) &&
-      isLOA3(state) &&
-      !hasServerError &&
-      !noESRRecordFound,
-    user: selectUser(state),
-    profile: selectProfile(state),
-  };
-};
+const mapStateToProps = state => ({
+  showMainLoader: isLoading(state),
+  showVerificationRequiredAlert: isUserLOA1(state),
+  showLoggedOutContent: isLoggedOut(state),
+  showLOA3Content: isUserLOA3(state),
+});
 
 export default connect(mapStateToProps)(IntroductionPageGated);
 

--- a/src/applications/hca/selectors.js
+++ b/src/applications/hca/selectors.js
@@ -1,0 +1,32 @@
+import {
+  isLOA1,
+  isLOA3,
+  isLoggedIn,
+  isProfileLoading,
+} from 'platform/user/selectors';
+
+// top-level selectors
+export const selectEnrollmentStatus = state => state.hcaEnrollmentStatus;
+export const isEnrollmentStatusLoading = state =>
+  selectEnrollmentStatus(state).isLoading;
+export const hasServerError = state =>
+  selectEnrollmentStatus(state).hasServerError;
+export const noESRRecordFound = state =>
+  selectEnrollmentStatus(state).noESRRecordFound;
+
+// compound selectors
+export const isLoading = state =>
+  isProfileLoading(state) || isEnrollmentStatusLoading(state);
+export const isUserLOA1 = state =>
+  !isLoading(state) && isLoggedIn(state) && isLOA1(state);
+export const isUserLOA3 = state =>
+  !isLoading(state) &&
+  isLoggedIn(state) &&
+  !hasServerError(state) &&
+  !noESRRecordFound(state) &&
+  isLOA3(state);
+// If we can't get enrollment status for LOA3 users, treat them like a
+// logged-out user (ie, just let them start a new application)
+export const isLoggedOut = state =>
+  !isLoading(state) &&
+  (!isLoggedIn(state) || hasServerError(state) || noESRRecordFound(state));

--- a/src/applications/hca/tests/selectors.unit.spec.js
+++ b/src/applications/hca/tests/selectors.unit.spec.js
@@ -1,0 +1,300 @@
+import { expect } from 'chai';
+import * as selectors from '../selectors';
+
+const basicEnrollmentStatusState = {
+  applicationDate: null,
+  enrollmentDate: null,
+  preferredFacility: null,
+  enrollmentStatus: null,
+  hasServerError: false,
+  isLoading: false,
+  isUserInMVI: false,
+  loginRequired: false,
+  noESRRecordFound: false,
+};
+const loggedOutUserState = {
+  login: {
+    currentlyLoggedIn: false,
+  },
+  profile: {
+    loa: {
+      current: null,
+      highest: null,
+    },
+    verified: false,
+    loading: false,
+  },
+};
+const loadingUserState = {
+  login: {
+    currentlyLoggedIn: false,
+  },
+  profile: {
+    loa: {
+      current: null,
+      highest: null,
+    },
+    verified: false,
+    loading: true,
+  },
+};
+const LOA3UserState = {
+  login: {
+    currentlyLoggedIn: true,
+  },
+  profile: {
+    loa: {
+      current: 3,
+      highest: 3,
+    },
+    verified: true,
+    loading: false,
+    status: 'OK',
+  },
+};
+const LOA1UserState = {
+  login: {
+    currentlyLoggedIn: true,
+  },
+  profile: {
+    loa: {
+      current: 1,
+      highest: 1,
+    },
+    verified: true,
+    loading: false,
+  },
+};
+describe('simple top-level selectors', () => {
+  describe('selectEnrollmentStatus', () => {
+    it('selects the correct part of the state', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+        user: { ...loggedOutUserState },
+      };
+      const enrollmentStatus = selectors.selectEnrollmentStatus(state);
+      expect(enrollmentStatus).to.deep.equal(basicEnrollmentStatusState);
+    });
+  });
+
+  describe('isEnrollmentStatusLoading', () => {
+    it('returns the correct part of the enrollment status state', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+      };
+      let isLoading = selectors.isEnrollmentStatusLoading(state);
+      expect(isLoading).to.equal(false);
+      state.hcaEnrollmentStatus.isLoading = true;
+      isLoading = selectors.isEnrollmentStatusLoading(state);
+      expect(isLoading).to.equal(true);
+    });
+  });
+
+  describe('hasServerError', () => {
+    it('returns the correct part of the enrollment status state', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+      };
+      let hasServerError = selectors.hasServerError(state);
+      expect(hasServerError).to.equal(false);
+      state.hcaEnrollmentStatus.hasServerError = true;
+      hasServerError = selectors.hasServerError(state);
+      expect(hasServerError).to.equal(true);
+    });
+  });
+
+  describe('noESRRecordFound', () => {
+    it('returns the correct part of the enrollment status state', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+      };
+      let noESRRecordFound = selectors.noESRRecordFound(state);
+      expect(noESRRecordFound).to.equal(false);
+      state.hcaEnrollmentStatus.noESRRecordFound = true;
+      noESRRecordFound = selectors.noESRRecordFound(state);
+      expect(noESRRecordFound).to.equal(true);
+    });
+  });
+});
+
+describe('compound selectors', () => {
+  describe('isLoading', () => {
+    it('returns true if the enrollment status is loading', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState, isLoading: true },
+        user: { ...loggedOutUserState },
+      };
+      const isLoading = selectors.isLoading(state);
+      expect(isLoading).to.equal(true);
+    });
+    it('returns true if the profile is loading', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+        user: { ...loadingUserState },
+      };
+      const isLoading = selectors.isLoading(state);
+      expect(isLoading).to.equal(true);
+    });
+    it('returns false if neither the profile or enrollment status is loading', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+        user: { ...loggedOutUserState },
+      };
+      const isLoading = selectors.isLoading(state);
+      expect(isLoading).to.equal(false);
+    });
+  });
+
+  describe('isUserLOA1', () => {
+    it('returns true if everything is loaded and user is LOA1', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+        user: { ...LOA1UserState },
+      };
+      const isLOA1 = selectors.isUserLOA1(state);
+      expect(isLOA1).to.equal(true);
+    });
+    it('returns false if everything is loaded and user is LOA3', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+        user: { ...LOA3UserState },
+      };
+      const isLOA1 = selectors.isUserLOA1(state);
+      expect(isLOA1).to.equal(false);
+    });
+    it('returns false if enrollment status still loading', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState, isLoading: true },
+        user: { ...LOA1UserState },
+      };
+      const isLOA1 = selectors.isUserLOA1(state);
+      expect(isLOA1).to.equal(false);
+    });
+    it('returns false if the profile still loading', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+        user: { ...loadingUserState },
+      };
+      const isLOA1 = selectors.isUserLOA1(state);
+      expect(isLOA1).to.equal(false);
+    });
+    it('returns false if the user is logged out', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+        user: { ...loggedOutUserState },
+      };
+      const isLOA1 = selectors.isUserLOA1(state);
+      expect(isLOA1).to.equal(false);
+    });
+  });
+
+  describe('isUserLOA3', () => {
+    it('returns true if everything is loaded and user is LOA3', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+        user: { ...LOA3UserState },
+      };
+      const isLOA3 = selectors.isUserLOA3(state);
+      expect(isLOA3).to.equal(true);
+    });
+    it('returns false if everything is loaded and user is LOA1', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+        user: { ...LOA1UserState },
+      };
+      const isLOA3 = selectors.isUserLOA3(state);
+      expect(isLOA3).to.equal(false);
+    });
+    it('returns false if enrollment status still loading', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState, isLoading: true },
+        user: { ...LOA3UserState },
+      };
+      const isLOA3 = selectors.isUserLOA3(state);
+      expect(isLOA3).to.equal(false);
+    });
+    it('returns false if the profile still loading', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+        user: { ...loadingUserState },
+      };
+      const isLOA3 = selectors.isUserLOA3(state);
+      expect(isLOA3).to.equal(false);
+    });
+    it('returns false if the user is logged out', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+        user: { ...loggedOutUserState },
+      };
+      const isLOA3 = selectors.isUserLOA3(state);
+      expect(isLOA3).to.equal(false);
+    });
+    it('returns false if there is a server error', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+          hasServerError: true,
+        },
+        user: { ...LOA3UserState },
+      };
+      const isLOA3 = selectors.isUserLOA3(state);
+      expect(isLOA3).to.equal(false);
+    });
+    it('returns false if the user was not found in ESR', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+          noESRRecordFound: true,
+        },
+        user: { ...LOA3UserState },
+      };
+      const isLOA3 = selectors.isUserLOA3(state);
+      expect(isLOA3).to.equal(false);
+    });
+  });
+
+  describe('isLoggedOut', () => {
+    it('returns true if the user is not logged in', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+        },
+        user: { ...loggedOutUserState },
+      };
+      const isLoggedOut = selectors.isLoggedOut(state);
+      expect(isLoggedOut).to.equal(true);
+    });
+    it('returns true if there is an enrollment status server error', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+          hasServerError: true,
+        },
+        user: { ...LOA3UserState },
+      };
+      const isLoggedOut = selectors.isLoggedOut(state);
+      expect(isLoggedOut).to.equal(true);
+    });
+    it('returns true if the user was not found in ESR', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+          noESRRecordFound: true,
+        },
+        user: { ...LOA3UserState },
+      };
+      const isLoggedOut = selectors.isLoggedOut(state);
+      expect(isLoggedOut).to.equal(true);
+    });
+    it('returns false if the user is logged in, is in ESR, and there are no enrollment status server errors', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+        },
+        user: { ...LOA3UserState },
+      };
+      const isLoggedOut = selectors.isLoggedOut(state);
+      expect(isLoggedOut).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
## Description
Refactor logic out of mapStateToProps and into selectors.

## Testing done
Added tests for the new selectors

## Screenshots
n/a

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs