### PR TITLE
Allow user to use ID Page again after submitting it

### DIFF
--- a/src/applications/hca/containers/IDPage.jsx
+++ b/src/applications/hca/containers/IDPage.jsx
@@ -16,7 +16,11 @@ import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { isLoggedIn, isProfileLoading } from 'platform/user/selectors';
 
 import { getEnrollmentStatus } from '../actions';
-import { idFormSchema as schema, idFormUiSchema as uiSchema } from '../helpers';
+import {
+  didEnrollmentStatusChange,
+  idFormSchema as schema,
+  idFormUiSchema as uiSchema,
+} from '../helpers';
 import { HCA_ENROLLMENT_STATUSES } from '../constants';
 
 function ContinueButton({ isLoading }) {
@@ -85,7 +89,11 @@ class IDPage extends React.Component {
     focusElement('.va-nav-breadcrumbs-list');
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
+    if (!didEnrollmentStatusChange(prevProps, this.props)) {
+      return;
+    }
+
     const { enrollmentStatus, noESRRecordFound, shouldRedirect } = this.props;
 
     // Redirect to intro if a logged in user directly accessed this page.

--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -608,3 +608,23 @@ export function validateDate(date) {
   const year = newDate.year();
   return isValidDate(day, month, year);
 }
+
+/**
+ * Helper that takes two sets of props and returns true if any of its relevant
+ * props are different.
+ * @param {Object} prevProps - first set of props to compare
+ * @param {Object} props - second set of props to compare
+ * @returns {boolean} - true if any relevant props differ between the two sets
+ * of props; otherwise returns false
+ *
+ */
+export function didEnrollmentStatusChange(prevProps, props) {
+  const relevantProps = [
+    'enrollmentStatus',
+    'noESRRecordFound',
+    'shouldRedirect',
+  ];
+  return relevantProps.some(
+    propName => prevProps[propName] !== props[propName],
+  );
+}

--- a/src/applications/hca/tests/helpers.unit.spec.jsx
+++ b/src/applications/hca/tests/helpers.unit.spec.jsx
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import {
+  didEnrollmentStatusChange,
   expensesLessThanIncome,
   getCSTOffset,
   getMedicalCenterNameByID,
@@ -200,6 +201,35 @@ describe('HCA helpers', () => {
       expect(getMedicalCenterNameByID('46333 - NOT A VALID ID')).to.equal(
         '46333 - NOT A VALID ID',
       );
+    });
+  });
+  describe('didEnrollmentStatusChange', () => {
+    const defaultProps = {
+      enrollmentStatus: null,
+      noESRRecordFound: false,
+      shouldRedirect: false,
+    };
+    let prevProps;
+    let newProps;
+    it('returns `false` if none of the relevant props have changed', () => {
+      prevProps = { ...defaultProps };
+      newProps = { ...defaultProps };
+      expect(didEnrollmentStatusChange(prevProps, newProps)).to.equal(false);
+    });
+    it('returns `true` if `enrollmentStatus` changed', () => {
+      prevProps = { ...defaultProps };
+      newProps = { ...defaultProps, enrollmentStatus: 'enrolled' };
+      expect(didEnrollmentStatusChange(prevProps, newProps)).to.equal(true);
+    });
+    it('returns `true` if `noESRRecordFound` changed', () => {
+      prevProps = { ...defaultProps };
+      newProps = { ...defaultProps, noESRRecordFound: true };
+      expect(didEnrollmentStatusChange(prevProps, newProps)).to.equal(true);
+    });
+    it('returns `true` if `shouldRedirect` changed', () => {
+      prevProps = { ...defaultProps };
+      newProps = { ...defaultProps, shouldRedirect: true };
+      expect(didEnrollmentStatusChange(prevProps, newProps)).to.equal(true);
     });
   });
 });

--- a/src/applications/hca/tests/helpers.unit.spec.jsx
+++ b/src/applications/hca/tests/helpers.unit.spec.jsx
@@ -179,7 +179,7 @@ describe('HCA helpers', () => {
       expect(getMedicalCenterNameByID(null)).to.equal('');
     });
     it('should return an empty string if it is passed undefined', () => {
-      expect(getMedicalCenterNameByID(null)).to.equal('');
+      expect(getMedicalCenterNameByID(undefined)).to.equal('');
     });
     it('should return an empty string if it is passed nothing', () => {
       expect(getMedicalCenterNameByID()).to.equal('');


### PR DESCRIPTION
## Description
Checking to see if relevant props have actually changed on component
update allows us to short circuit redirecting from the ID Page to the
first page of the HCA. _Only_ do the redirect if relevant props have
changed.

## Testing done
Local + new unit tests

## Screenshots


## Acceptance criteria
- [x] After filling out and submitting the ID Form, you can go back to the ID Form, fill out with new info, and resubmit.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs