### PR TITLE
VAGOV-000: unique element ids for exapandable alerts

### DIFF
--- a/src/site/blocks/alert.drupal.liquid
+++ b/src/site/blocks/alert.drupal.liquid
@@ -49,14 +49,16 @@
 </div>
 
 {% if expander.fieldTextExpander %}
+    {% assign element = "alertElement" | append: expander.entityId %}
   <script type="text/javascript">
-      const alertElement = document.getElementById('{{ expander.entityBundle }}-{{ expander.entityId }}');
+
+      const {{ element }} = document.getElementById('{{ expander.entityBundle }}-{{ expander.entityId }}');
 
       // Toggle the expander info
-      alertElement.addEventListener('click', function() {
+      {{ element }}.addEventListener('click', function() {
         // Toggle aria-expanded for the button
-        const ariaExpanded = alertElement.getAttribute('aria-expanded') === 'true' ? 'false' : 'true';
-        alertElement.setAttribute('aria-expanded', ariaExpanded);
+        const ariaExpanded = {{ element }}.getAttribute('aria-expanded') === 'true' ? 'false' : 'true';
+        {{ element }}.setAttribute('aria-expanded', ariaExpanded);
 
         const content = document.getElementById('{{ expander.entityBundle }}-{{ expander.entityId }}-content');
         // Toggle the expander class for the content
@@ -66,5 +68,5 @@
         const ariaHidden = content.getAttribute('aria-hidden') === 'true' ? 'false' : 'true';
         content.setAttribute('aria-hidden', ariaHidden);
       });
-    </script>
+  </script>
 {% endif %}


### PR DESCRIPTION
## Description
allows for expandable text to work with multiple alerts on a page

## Testing done


## Screenshots
![testing](https://media.giphy.com/media/8PpqDSSrV8zZZbQ8Qt/giphy.gif)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
