### PR TITLE
Fix URL mispelling for unemployability form upload

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/8940/index.js
+++ b/src/applications/disability-benefits/all-claims/config/8940/index.js
@@ -47,7 +47,7 @@ export default function() {
       // 8940 - Upload 8940
       unemployabilityFormUpload: {
         title: 'Upload Unemployability Form',
-        path: 'new-disabilities/unemployability-form-uplaod',
+        path: 'new-disabilities/unemployability-form-upload',
         depends: isUploading8940Form,
         uiSchema: unemployabilityFormUpload.uiSchema,
         schema: unemployabilityFormUpload.schema,


### PR DESCRIPTION
## Description
Fixes mispelled URL

## Testing done
local testing

## Screenshots


## Acceptance criteria
- [x] Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17180

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
