### PR TITLE
Fix isUserLOA3 selector

### DIFF
--- a/src/applications/hca/selectors.js
+++ b/src/applications/hca/selectors.js
@@ -20,7 +20,7 @@ export const isLoading = state =>
 export const isUserLOA1 = state =>
   !isLoading(state) && isLoggedIn(state) && isLOA1(state);
 export const isUserLOA3 = state =>
-  !isLoading(state) &&
+  !isProfileLoading(state) &&
   isLoggedIn(state) &&
   !hasServerError(state) &&
   !noESRRecordFound(state) &&

--- a/src/applications/hca/tests/selectors.unit.spec.js
+++ b/src/applications/hca/tests/selectors.unit.spec.js
@@ -205,13 +205,13 @@ describe('compound selectors', () => {
       const isLOA3 = selectors.isUserLOA3(state);
       expect(isLOA3).to.equal(false);
     });
-    it('returns false if enrollment status still loading', () => {
+    it('returns true if enrollment status is loading but the user has resolved', () => {
       const state = {
         hcaEnrollmentStatus: { ...basicEnrollmentStatusState, isLoading: true },
         user: { ...LOA3UserState },
       };
       const isLOA3 = selectors.isUserLOA3(state);
-      expect(isLOA3).to.equal(false);
+      expect(isLOA3).to.equal(true);
     });
     it('returns false if the profile still loading', () => {
       const state = {


### PR DESCRIPTION
## Description
When migrating to selectors I screwed up this piece of logic

if isUserLOA3 returns false if we are fetching the enrollment status, we end up in an endless loop of the HCAEnrollmentStatus component mounting, fetching the enrollment status, immediately unmounting because the enrollment status is being fetched, remounting after the enrollment status fetch resolves, etc etc

## Testing done
Local + updated the unit test. Nice that I already had a unit test for this particular case, it was just written backwards 😢 

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs