### PR TITLE
update drupal addresses

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -5,8 +5,8 @@ DRUPAL_MAPPING = [
 ]
 
 DRUPAL_ADDRESSES = [
-  'vagovdev'    : 'http://internal-stg-vagovcms-3000-521598752.us-gov-west-1.elb.amazonaws.com',
-  'vagovstaging': 'http://internal-prod-vagovcms-3000-1370756925.us-gov-west-1.elb.amazonaws.com',
+  'vagovdev'    : 'http://internal-dev-vagovcms-3000-552087943.us-gov-west-1.elb.amazonaws.com',
+  'vagovstaging': 'http://internal-stg-vagovcms-3000-521598752.us-gov-west-1.elb.amazonaws.com',
   'vagovprod'   : 'http://internal-prod-vagovcms-3000-1370756925.us-gov-west-1.elb.amazonaws.com',
 ]
 


### PR DESCRIPTION
## Description
This PR updates the drupal addresses so that builds for each vets-website environment use the corresponding Drupal CMS environment. Dev uses dev. Staging uses staging. Production uses production.

Note that no change to the credentials used was necessary because at this point they are the same in all environments.