### PR TITLE
Add helper to look up and display facility IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,4 +344,4 @@ disabled by the feature flag.
 
 - React JSON Schemaform
   - [Building a Form](https://github.com/usds/us-forms-system/blob/master/docs/building-a-form/README.md) - walkthrough for using schemaform and the form config
- 
+

--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment';
 
 import { HCA_ENROLLMENT_STATUSES } from './constants';
+import { getMedicalCenterNameByID } from './helpers';
 
 // There are 9 possible warning headlines to show depending on enrollment status
 export function getWarningHeadline(enrollmentStatus) {
@@ -79,6 +80,7 @@ export function getWarningStatus(
   preferredFacility,
 ) {
   let content = null;
+  const facilityName = getMedicalCenterNameByID(preferredFacility);
   switch (enrollmentStatus) {
     case HCA_ENROLLMENT_STATUSES.deceased:
       content = null;
@@ -93,9 +95,8 @@ export function getWarningStatus(
           <strong>We enrolled you on: </strong>
           {moment(enrollmentDate).format('MMMM D, YYYY')}
           <br />
-          {/* TODO: map this facility code to an actual facility */}
           <strong>Your preferred VA medical center is: </strong>
-          {preferredFacility}
+          {facilityName}
         </p>
       );
       break;

--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -200,6 +200,18 @@ export const medicalCenterLabels = Object.keys(vaMedicalFacilities).reduce(
   {},
 );
 
+/**
+ *
+ * @param {string} facilityId - facility id in the form: `123 - ABCD` where the
+ * id to look up is the first part of the string
+ * @returns {string} - either the actual name of the medical center or the
+ * passed in id if no match was found
+ */
+export function getMedicalCenterNameByID(facilityId = '') {
+  const [id] = facilityId.split(' - ');
+  return medicalCenterLabels[id] || facilityId;
+}
+
 export const dischargeTypeLabels = {
   honorable: 'Honorable',
   general: 'General',

--- a/src/applications/hca/tests/helpers.unit.spec.jsx
+++ b/src/applications/hca/tests/helpers.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import {
   expensesLessThanIncome,
   getCSTOffset,
+  getMedicalCenterNameByID,
   getOffsetTime,
   getAdjustedTime,
   isAfterCentralTimeDate,
@@ -170,6 +171,23 @@ describe('HCA helpers', () => {
       };
       const transformedData = transformAttachments(inputData);
       expect(transformedData).to.deep.equal(expectedOutputData);
+    });
+  });
+  describe('getMedicalCenterNameByID', () => {
+    it('should return the name if the id is a known id', () => {
+      expect(getMedicalCenterNameByID('463 - ABC')).to.equal(
+        'ANCHORAGE VA MEDICAL CENTER',
+      );
+    });
+    it('should return the name if the id is a known id', () => {
+      expect(getMedicalCenterNameByID('463')).to.equal(
+        'ANCHORAGE VA MEDICAL CENTER',
+      );
+    });
+    it('should return the id if the id is not a known id', () => {
+      expect(getMedicalCenterNameByID('46333 - NOT A VALID ID')).to.equal(
+        '46333 - NOT A VALID ID',
+      );
     });
   });
 });


### PR DESCRIPTION
## Description
Adds a helper function that attempts to look up and return the facility ID from [our facility list](https://github.com/department-of-veterans-affairs/vets-json-schema/blob/d05c38ce92e3779486d47acfbea62b32a7c736b9/dist/vaMedicalFacilities.json).

## Testing done
Local

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/55081294-cf800e00-505c-11e9-9379-60b46c3d4fdd.png)

## Acceptance criteria
- [x] Displays the facility name from our list if we find a match for its ID, otherwise just display exactly what we get from the HCA E&E server.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs