### PR TITLE
Fix handling of logged in LOA3 user who are not in ESR

### DIFF
--- a/src/applications/hca/reducer.js
+++ b/src/applications/hca/reducer.js
@@ -19,7 +19,7 @@ const initialState = {
   noESRRecordFound: false,
 };
 
-function hcaEnrollmentStatus(state = initialState, action) {
+export function hcaEnrollmentStatus(state = initialState, action) {
   switch (action.type) {
     case FETCH_ENROLLMENT_STATUS_STARTED:
       return { ...initialState, isLoading: true };
@@ -40,6 +40,7 @@ function hcaEnrollmentStatus(state = initialState, action) {
         enrollmentDate,
         preferredFacility,
         loginRequired: isInESR,
+        noESRRecordFound: !isInESR,
         isLoading: false,
         isUserInMVI: true,
       };

--- a/src/applications/hca/tests/reducers.unit.spec.js
+++ b/src/applications/hca/tests/reducers.unit.spec.js
@@ -1,4 +1,3 @@
-// import sinon from 'sinon';
 import { expect } from 'chai';
 
 import * as actions from '../actions';

--- a/src/applications/hca/tests/reducers.unit.spec.js
+++ b/src/applications/hca/tests/reducers.unit.spec.js
@@ -1,0 +1,141 @@
+// import sinon from 'sinon';
+import { expect } from 'chai';
+
+import * as actions from '../actions';
+import { hcaEnrollmentStatus as reducer } from '../reducer';
+
+describe('HCA Enrollment Status Reducer', () => {
+  let state;
+  let reducedState;
+  let action;
+
+  beforeEach(() => {
+    state = undefined;
+  });
+
+  describe('FETCH_ENROLLMENT_STATUS_STARTED', () => {
+    it('sets the `isLoading` to `true`', () => {
+      action = {
+        type: actions.FETCH_ENROLLMENT_STATUS_STARTED,
+      };
+      reducedState = reducer(state, action);
+      expect(reducedState.isLoading).to.be.true;
+    });
+  });
+
+  describe('FETCH_ENROLLMENT_STATUS_SUCCEEDED', () => {
+    describe('regardless of `parsedStatus`', () => {
+      it('sets the state correctly', () => {
+        action = {
+          type: actions.FETCH_ENROLLMENT_STATUS_SUCCEEDED,
+          data: {
+            parsedStatus: 'enrolled',
+            applicationDate: 'application date',
+            enrollmentData: 'enrollment data',
+            preferredFacility: '123 - ABC',
+          },
+        };
+        reducedState = reducer(state, action);
+        expect(reducedState.enrollmentStatus).to.equal(
+          action.data.parsedStatus,
+        );
+        expect(reducedState.applicationDate).to.equal(
+          action.data.applicationDate,
+        );
+        expect(reducedState.enrollmentDate).to.equal(
+          action.data.enrollmentDate,
+        );
+        expect(reducedState.preferredFacility).to.equal(
+          action.data.preferredFacility,
+        );
+        expect(reducedState.isLoading).to.be.false;
+        expect(reducedState.isUserInMVI).to.be.true;
+      });
+    });
+
+    describe('if `parsedStatus` is `none_of_the_above`', () => {
+      beforeEach(() => {
+        action = {
+          type: actions.FETCH_ENROLLMENT_STATUS_SUCCEEDED,
+          data: {
+            parsedStatus: 'none_of_the_above',
+          },
+        };
+        reducedState = reducer(state, action);
+      });
+      it('sets `loginRequired` to `false`', () => {
+        expect(reducedState.loginRequired).to.be.false;
+      });
+      it('sets `noESRRecordFound` to `true`', () => {
+        expect(reducedState.noESRRecordFound).to.be.true;
+      });
+    });
+
+    describe('if `parsedStatus` is anything other than `none_of_the_above`', () => {
+      beforeEach(() => {
+        action = {
+          type: actions.FETCH_ENROLLMENT_STATUS_SUCCEEDED,
+          data: {
+            parsedStatus: 'enrolled',
+          },
+        };
+        reducedState = reducer(state, action);
+      });
+      it('sets `loginRequired` to `true`', () => {
+        expect(reducedState.loginRequired).to.be.true;
+      });
+      it('sets `noESRRecordFound` to `false`', () => {
+        expect(reducedState.noESRRecordFound).to.be.false;
+      });
+    });
+  });
+
+  describe('FETCH_ENROLLMENT_STATUS_FAILED', () => {
+    describe('regardless of the error codes', () => {
+      it('sets the state correctly', () => {
+        action = {
+          type: actions.FETCH_ENROLLMENT_STATUS_FAILED,
+          errors: [{ code: '400' }],
+        };
+        reducedState = reducer(state, action);
+        expect(reducedState.hasServerError).to.be.false;
+        expect(reducedState.isLoading).to.be.false;
+        expect(reducedState.loginRequired).to.be.false;
+        expect(reducedState.noESRRecordFound).to.be.false;
+      });
+    });
+
+    describe('if the error code if 404', () => {
+      it('sets `noESRRecordFound` to `true`', () => {
+        action = {
+          type: actions.FETCH_ENROLLMENT_STATUS_FAILED,
+          errors: [{ code: '404' }],
+        };
+        reducedState = reducer(state, action);
+        expect(reducedState.noESRRecordFound).to.be.true;
+      });
+    });
+
+    describe('if the error code is 429', () => {
+      it('sets `loginRequired` to `true`', () => {
+        action = {
+          type: actions.FETCH_ENROLLMENT_STATUS_FAILED,
+          errors: [{ code: '429' }],
+        };
+        reducedState = reducer(state, action);
+        expect(reducedState.loginRequired).to.be.true;
+      });
+    });
+
+    describe('if the error code is >=500', () => {
+      it('sets `hasServerError` to `true`', () => {
+        action = {
+          type: actions.FETCH_ENROLLMENT_STATUS_FAILED,
+          errors: [{ code: '500' }],
+        };
+        reducedState = reducer(state, action);
+        expect(reducedState.hasServerError).to.be.true;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
Instead of showing them their enrollment status, treat them like someone who has not applied for health care (because they haven't)

This was actually just a single-line fix to the reducer, but I added all the missing unit tests, too.

## Testing done
- Local verification
- added tests for the reducer

## Screenshots
**BEFORE**
![image](https://user-images.githubusercontent.com/20728956/55100988-50043600-5080-11e9-8600-88f01ed43745.png)

**AFTER**
![image](https://user-images.githubusercontent.com/20728956/55101002-5b576180-5080-11e9-9912-1b69233e1211.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs