### PR TITLE
smarter handling of null/undefined arguments

### DIFF
--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -207,7 +207,10 @@ export const medicalCenterLabels = Object.keys(vaMedicalFacilities).reduce(
  * @returns {string} - either the actual name of the medical center or the
  * passed in id if no match was found
  */
-export function getMedicalCenterNameByID(facilityId = '') {
+export function getMedicalCenterNameByID(facilityId) {
+  if (!facilityId || typeof facilityId !== 'string') {
+    return '';
+  }
   const [id] = facilityId.split(' - ');
   return medicalCenterLabels[id] || facilityId;
 }

--- a/src/applications/hca/tests/helpers.unit.spec.jsx
+++ b/src/applications/hca/tests/helpers.unit.spec.jsx
@@ -174,6 +174,18 @@ describe('HCA helpers', () => {
     });
   });
   describe('getMedicalCenterNameByID', () => {
+    it('should return an empty string if it is passed null', () => {
+      expect(getMedicalCenterNameByID(null)).to.equal('');
+    });
+    it('should return an empty string if it is passed undefined', () => {
+      expect(getMedicalCenterNameByID(null)).to.equal('');
+    });
+    it('should return an empty string if it is passed nothing', () => {
+      expect(getMedicalCenterNameByID()).to.equal('');
+    });
+    it('should return an empty string if it is passed a number', () => {
+      expect(getMedicalCenterNameByID(123)).to.equal('');
+    });
     it('should return the name if the id is a known id', () => {
       expect(getMedicalCenterNameByID('463 - ABC')).to.equal(
         'ANCHORAGE VA MEDICAL CENTER',


### PR DESCRIPTION
## Description
The previous version did not properly handle when the function was explicitly passed `null` as its argument. ES6 default args do not apply when `null` is passed, so this would blow up when trying to `split()` `null`.

## Testing done
Local + expanded unit tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs