### PR TITLE
Hide unauthed start link for all claims

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -150,6 +150,7 @@ class IntroductionPage extends React.Component {
           </ol>
         </div>
         <SaveInProgressIntro
+          hideUnauthedStartLink
           buttonOnly
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
           formId={this.props.formId}

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -162,14 +162,16 @@ class SaveInProgressIntro extends React.Component {
               >
                 Sign in to Start Your Application
               </button>
-              <p>
-                <button
-                  className="va-button-link schemaform-start-button"
-                  onClick={this.goToBeginning}
-                >
-                  Start your application without signing in.
-                </button>
-              </p>
+              {!this.props.hideUnauthedStartLink && (
+                <p>
+                  <button
+                    className="va-button-link schemaform-start-button"
+                    onClick={this.goToBeginning}
+                  >
+                    Start your application without signing in.
+                  </button>
+                </p>
+              )}
             </div>
           </div>
         </div>
@@ -333,6 +335,7 @@ SaveInProgressIntro.propTypes = {
   downtime: PropTypes.object,
   gaStartEventName: PropTypes.string,
   startMessageOnly: PropTypes.bool,
+  hideUnauthedStartLink: PropTypes.bool,
 };
 
 SaveInProgressIntro.defaultProps = {


### PR DESCRIPTION
## Description
Hide the unauthed start path for 526 because the form requires signin

## Testing done
local testing

## Screenshots


## Acceptance criteria
- [x] Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17608

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
