### PR TITLE
added logged out sign in alert

### DIFF
--- a/src/applications/hca/selectors.js
+++ b/src/applications/hca/selectors.js
@@ -25,8 +25,10 @@ export const isUserLOA3 = state =>
   !hasServerError(state) &&
   !noESRRecordFound(state) &&
   isLOA3(state);
+export const isLoggedOut = state =>
+  !isProfileLoading(state) && !isLoggedIn(state);
 // If we can't get enrollment status for LOA3 users, treat them like a
 // logged-out user (ie, just let them start a new application)
-export const isLoggedOut = state =>
+export const shouldShowLoggedOutContent = state =>
   !isLoading(state) &&
   (!isLoggedIn(state) || hasServerError(state) || noESRRecordFound(state));

--- a/src/applications/hca/tests/selectors.unit.spec.js
+++ b/src/applications/hca/tests/selectors.unit.spec.js
@@ -66,6 +66,30 @@ const LOA1UserState = {
   },
 };
 describe('simple top-level selectors', () => {
+  describe('isLoggedOut', () => {
+    it('is `true` if the profile is not loading and the user is not logged in', () => {
+      const state = {
+        user: { ...loggedOutUserState },
+      };
+      const isLoggedOut = selectors.isLoggedOut(state);
+      expect(isLoggedOut).to.be.true;
+    });
+    it('is `false` if the profile is loading', () => {
+      const state = {
+        user: { ...loadingUserState },
+      };
+      const isLoggedOut = selectors.isLoggedOut(state);
+      expect(isLoggedOut).to.be.false;
+    });
+    it('is `false` if the profile is not loading and the user is logged in', () => {
+      const state = {
+        user: { ...LOA3UserState },
+      };
+      const isLoggedOut = selectors.isLoggedOut(state);
+      expect(isLoggedOut).to.be.false;
+    });
+  });
+
   describe('selectEnrollmentStatus', () => {
     it('selects the correct part of the state', () => {
       const state = {
@@ -253,7 +277,7 @@ describe('compound selectors', () => {
     });
   });
 
-  describe('isLoggedOut', () => {
+  describe('shouldShowLoggedOutContent', () => {
     it('returns true if the user is not logged in', () => {
       const state = {
         hcaEnrollmentStatus: {
@@ -261,8 +285,10 @@ describe('compound selectors', () => {
         },
         user: { ...loggedOutUserState },
       };
-      const isLoggedOut = selectors.isLoggedOut(state);
-      expect(isLoggedOut).to.equal(true);
+      const shouldShowLoggedOutContent = selectors.shouldShowLoggedOutContent(
+        state,
+      );
+      expect(shouldShowLoggedOutContent).to.equal(true);
     });
     it('returns true if there is an enrollment status server error', () => {
       const state = {
@@ -272,8 +298,10 @@ describe('compound selectors', () => {
         },
         user: { ...LOA3UserState },
       };
-      const isLoggedOut = selectors.isLoggedOut(state);
-      expect(isLoggedOut).to.equal(true);
+      const shouldShowLoggedOutContent = selectors.shouldShowLoggedOutContent(
+        state,
+      );
+      expect(shouldShowLoggedOutContent).to.equal(true);
     });
     it('returns true if the user was not found in ESR', () => {
       const state = {
@@ -283,8 +311,10 @@ describe('compound selectors', () => {
         },
         user: { ...LOA3UserState },
       };
-      const isLoggedOut = selectors.isLoggedOut(state);
-      expect(isLoggedOut).to.equal(true);
+      const shouldShowLoggedOutContent = selectors.shouldShowLoggedOutContent(
+        state,
+      );
+      expect(shouldShowLoggedOutContent).to.equal(true);
     });
     it('returns false if the user is logged in, is in ESR, and there are no enrollment status server errors', () => {
       const state = {
@@ -293,8 +323,10 @@ describe('compound selectors', () => {
         },
         user: { ...LOA3UserState },
       };
-      const isLoggedOut = selectors.isLoggedOut(state);
-      expect(isLoggedOut).to.equal(false);
+      const shouldShowLoggedOutContent = selectors.shouldShowLoggedOutContent(
+        state,
+      );
+      expect(shouldShowLoggedOutContent).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
## Description
We are now showing a new Alert if the user is logged out. Note that previously we had been treating a user as "logged out" in the case that they were logged in but were not in ESR or if there was an ESR server error.

## Testing done
Local + new unit tests

## Screenshots
<img width="715" alt="Screen Shot 2019-03-28 at 7 42 11 AM 1" src="https://user-images.githubusercontent.com/20728956/55167308-f22e2780-512d-11e9-8edd-b0186e9ede9e.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs