### PR TITLE
Handle the type received from auth callbacks to report the proper analytics and errors

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -50,13 +50,16 @@ class AuthMetrics {
         recordEvent({ event: `login-success-${this.serviceName}` });
         this.compareLoginPolicy();
         break;
+      /*
       case 'mfa':
         recordEvent({ event: `multifactor-success-${this.serviceName}` });
         break;
       case 'verify':
         recordEvent({ event: `verify-success-${this.serviceName}` });
         break;
+      */
       default:
+        recordEvent({ event: `login-or-register-success-${this.serviceName}` });
         Raven.captureMessage('Unrecognized auth event type', {
           extra: { type: this.type },
         });

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -40,7 +40,7 @@ export class AuthApp extends React.Component {
         event: `login-mismatch-${attemptedLoginPolicy}-${loginPolicy}`,
       });
     }
-  }
+  };
 
   recordGAAuthEvents = userProfile => {
     const { type } = this.props.location.query;
@@ -73,7 +73,7 @@ export class AuthApp extends React.Component {
     if (loaCurrent) {
       recordEvent({ event: `login-loa-current-${loaCurrent}` });
     }
-  }
+  };
 
   reportSentryErrors = (userProfile, payload) => {
     const serviceName = get('signIn.serviceName', userProfile, null);
@@ -87,7 +87,7 @@ export class AuthApp extends React.Component {
         extra: { payload },
       });
     }
-  }
+  };
 
   handleAuthError = error => {
     const loginType = this.props.location.query.type;

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -16,7 +16,7 @@ import {
 import { apiRequest } from '../../../platform/utilities/api';
 import get from '../../../platform/utilities/data/get';
 
-class AuthSuccessHandler {
+class AuthMetrics {
   constructor(type, payload) {
     this.type = type;
     this.payload = payload;
@@ -80,14 +80,9 @@ class AuthSuccessHandler {
     }
   };
 
-  setupProfileSession = () => {
-    setupProfileSession(this.userProfile);
-  };
-
   run = () => {
     this.reportSentryErrors();
     if (!hasSession()) this.recordGAAuthEvents();
-    this.setupProfileSession();
   };
 }
 
@@ -116,8 +111,9 @@ export class AuthApp extends React.Component {
 
   handleAuthSuccess = payload => {
     const { type } = this.props.location.query;
-    const authSuccessHandler = new AuthSuccessHandler(type, payload);
-    authSuccessHandler.run();
+    const authMetrics = new AuthMetrics(type, payload);
+    authMetrics.run();
+    setupProfileSession(authMetrics.userProfile);
     this.redirect();
   };
 

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -6,13 +6,12 @@ import environment from '../../utilities/environment';
 
 export const authnSettings = {
   RETURN_URL: 'authReturnUrl',
-  PENDING_AUTH_ACTION: 'pendingAuthAction',
-  PENDING_LOGIN_POLICY: 'pendingLoginPolicy',
 };
 
 const SESSIONS_URI = `${environment.API_URL}/sessions`;
 const sessionTypeUrl = type => `${SESSIONS_URI}/${type}/new`;
 
+const SIGNUP_URL = sessionTypeUrl('signup');
 const MHV_URL = sessionTypeUrl('mhv');
 const DSLOGON_URL = sessionTypeUrl('dslogon');
 const IDME_URL = sessionTypeUrl('idme');
@@ -78,8 +77,6 @@ function redirect(redirectUrl, clickedEvent) {
 }
 
 export function login(policy) {
-  sessionStorage.setItem(authnSettings.PENDING_AUTH_ACTION, 'login');
-  sessionStorage.setItem(authnSettings.PENDING_LOGIN_POLICY, policy);
   return redirect(loginUrl(policy), 'login-link-clicked-modal');
 }
 
@@ -97,9 +94,5 @@ export function logout() {
 }
 
 export function signup() {
-  sessionStorage.setItem(authnSettings.PENDING_AUTH_ACTION, 'register');
-  return redirect(
-    appendQuery(IDME_URL, { signup: true }),
-    'register-link-clicked',
-  );
+  return redirect(SIGNUP_URL, 'register-link-clicked');
 }

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -57,7 +57,8 @@ function redirectWithGAClientId(redirectUrl) {
     const clientId = tracker && tracker.get('clientId');
 
     window.location = clientId
-      ? appendQuery(redirectUrl, { clientId })
+      ? // eslint-disable-next-line camelcase
+        appendQuery(redirectUrl, { client_id: clientId })
       : redirectUrl;
   } catch (e) {
     window.location = redirectUrl;

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -1,7 +1,5 @@
 import camelCaseKeysRecursive from 'camelcase-keys-recursive';
 
-import Raven from 'raven-js';
-
 import {
   setRavenLoginType,
   clearRavenLoginType,
@@ -123,7 +121,7 @@ export const hasSession = () => localStorage.getItem('hasSession');
 
 export function setupProfileSession(userProfile) {
   const { firstName, signIn } = userProfile;
-  const loginType = signIn && signIn.serviceName || null;
+  const loginType = (signIn && signIn.serviceName) || null;
 
   localStorage.setItem('hasSession', true);
 

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -2,13 +2,10 @@ import camelCaseKeysRecursive from 'camelcase-keys-recursive';
 
 import Raven from 'raven-js';
 
-import recordEvent from '../../../monitoring/record-event';
 import {
   setRavenLoginType,
   clearRavenLoginType,
-  authnSettings,
 } from '../../authentication/utilities';
-import get from '../../../utilities/data/get';
 import localStorage from '../../../utilities/storage/localStorage';
 
 import {
@@ -124,76 +121,18 @@ export function mapRawUserDataToState(json) {
 // as a trigger to properly update any components that subscribe to it.
 export const hasSession = () => localStorage.getItem('hasSession');
 
-function compareLoginPolicy(loginPolicy) {
-  // This is experimental code related to GA that will let us determine
-  // if the backend is returning an accurate loginPolicy (service_name)
+export function setupProfileSession(userProfile) {
+  const { firstName, signIn } = userProfile;
+  const loginType = signIn && signIn.serviceName || null;
 
-  let attemptedLoginPolicy = sessionStorage.getItem(
-    authnSettings.PENDING_LOGIN_POLICY,
-  );
-
-  attemptedLoginPolicy =
-    attemptedLoginPolicy === 'mhv' ? 'myhealthevet' : attemptedLoginPolicy;
-
-  if (attemptedLoginPolicy === null) {
-    Raven.captureMessage(
-      "sessionStorage error: 'pendingLoginPolicy' was not stored",
-    );
-  }
-
-  if (loginPolicy !== attemptedLoginPolicy) {
-    recordEvent({
-      event: `login-mismatch-${attemptedLoginPolicy}-${loginPolicy}`,
-    });
-  }
-}
-
-function recordGAAuthEvent(loginPolicy, loa) {
-  // The payload we receive from authenticating does not specify whether
-  // the user has logged in or if they are a new user. To differentiate, we are
-  // retrieving a "pendingAuthAction" stored in localStorage when the user
-  // clicks a sign in/register button in the Sign In Modal
-
-  const pendingAuthAction = sessionStorage.getItem(
-    authnSettings.PENDING_AUTH_ACTION,
-  );
-
-  if (pendingAuthAction === 'register') {
-    // Record GA success event for the register method.
-    recordEvent({ event: `register-success-${loginPolicy}` });
-  } else if (pendingAuthAction === 'login') {
-    compareLoginPolicy(loginPolicy);
-    // Report GA success event for the login method.
-    recordEvent({ event: `login-success-${loginPolicy}` });
-  } else {
-    recordEvent({ event: `login-or-register-success-${loginPolicy}` });
-    Raven.captureMessage(
-      "sessionStorage error: 'pendingAuthAction' was not stored",
-    );
-  }
-
-  // Report out the current level of assurance for the user.
-  if (loa && loa.current) {
-    recordEvent({ event: `login-loa-current-${loa.current}` });
-  }
-}
-
-export function setupProfileSession(payload) {
-  const userData = get('data.attributes.profile', payload, {});
-  const { firstName, signIn, loa } = userData;
-
-  const loginPolicy = get('serviceName', signIn, null);
+  localStorage.setItem('hasSession', true);
 
   // Since localStorage coerces everything into String,
   // this avoids setting the first name to the string 'null'.
   if (firstName) localStorage.setItem('userFirstName', firstName);
 
-  if (!hasSession()) recordGAAuthEvent(loginPolicy, loa);
-
-  localStorage.setItem('hasSession', true);
-
   // Set Sentry Tag so we can associate errors with the login policy
-  setRavenLoginType(loginPolicy);
+  setRavenLoginType(loginType);
 }
 
 export function teardownProfileSession() {

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -39,7 +39,7 @@ describe('authentication URL helpers', () => {
 
   it('should redirect for signup', () => {
     signup();
-    expect(global.window.location).to.include('/sessions/idme/new?signup');
+    expect(global.window.location).to.include('/sessions/signup/new');
   });
 
   it('should redirect for login', () => {


### PR DESCRIPTION
## Description
The callback URL will start including the type (`mhv`, `dslogon`, `idme`, `signup`, `mfa`, `verify`). These changes will use that instead of values stored in `sessionStorage` to improve the accuracy of metrics.

Also did some refactoring so that the AuthApp will handle all of the GA and Sentry reporting in one place.

## Testing done
Local testing. Will need to verify proper reporting of events for analytics when merged.

## Acceptance criteria
- [x] Login success events should be based on the type specified in the callback URL rather than the type that may or may not have gotten successfully set in storage.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
