### PR TITLE
[TeamSite] Add migrated styles to MegaMenu SCSS

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-vet-nav-px.scss
+++ b/src/platform/site-wide/sass/modules/_m-vet-nav-px.scss
@@ -464,3 +464,85 @@ body.va-pos-fixed {
     height: auto;
   }
 }
+
+
+.merger {
+  #vetnav {
+    // 100% width necessary for right aligned items
+    width: 100%;
+    left: initial;
+  }
+
+  @media (min-width: $xsmall-screen) and (max-width: $medium-screen - 1) {
+    #mega-menu {
+      // #vetnav {
+      //   min-height: unset;
+      // }
+      .login-container {
+        // due to these been nested, this has to have a higher z-level then vet-toolbar
+        position: relative;
+        top: -40px;
+      }
+    }
+
+    #vetnav {
+      // 100% width necessary for right aligned items
+      width: 100%;
+      left: initial;
+    }
+
+    #vetnav-controls {
+      margin-top: 7px;
+
+      svg {
+        margin-left: 0.8rem;
+      }
+    }
+
+    .mm-link-container {
+      padding-left: 10px;
+    }
+  }
+
+  // TD: need to update this on formation in the MegaMenu. If no title it should still align with the link row.
+  #vetnav-records-ms {
+    & + div {
+      .column-two h3 {
+        visibility: hidden;
+      }
+    }
+  }
+
+  #va-nav-controls {
+    position: relative;
+    width: 100px;
+
+    svg {
+      display: inline-block;
+      height: 1.6rem;
+      margin-left: 0.8rem;
+      width: 1rem;
+      vertical-align: 0;
+    }
+
+    path {
+      fill: $color-white;
+    }
+
+    @include media($medium-large-screen) {
+      display: none;
+    }
+  }
+
+  .vetnav-panel {
+    @include media($medium-large-screen) {
+      box-shadow: 0 5px 9px -3px $color-base;
+    }
+  }
+
+  // Toggle button on mobile
+  [class^="vetnav-controller"] {
+    position: relative !important;
+  }
+
+}


### PR DESCRIPTION
## Description
I didn't realize we use a totally separate SCSS sheet for the MegaMenu on TeamSite, and broke the style for the mobile expand/close button while migrating CSS out of the merger.scss in https://github.com/department-of-veterans-affairs/vets-website/pull/9799.

## Issue
![image](https://user-images.githubusercontent.com/1915775/55245396-6db8d300-5219-11e9-915e-8258ee11e1ad.png)

## Testing done
- Ran local TeamSite
- Copied and pasted styles in to vet-nav-px SCSS

## Screenshots

### Desktop 
![image](https://user-images.githubusercontent.com/1915775/55246238-2d5a5480-521b-11e9-8129-f0896cc7bfda.png)

### Mobile
![image](https://user-images.githubusercontent.com/1915775/55245425-7e694900-5219-11e9-8396-6226817fed5c.png)

## Acceptance criteria
- [ ] Menu is fixed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
