### PR TITLE
Add entityId to common fragment

### DIFF
--- a/src/site/stages/build/drupal/graphql/entityElementsForPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/entityElementsForPages.graphql.js
@@ -3,6 +3,7 @@
  */
 module.exports = `
     entityBundle
+    entityId
     entityPublished
     title
     entityUrl {

--- a/src/site/stages/build/drupal/graphql/eventPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/eventPage.graphql.js
@@ -7,7 +7,6 @@ const entityElementsFromPages = require('./entityElementsForPages.graphql');
 module.exports = `
  fragment eventPage on NodeEvent {
     ${entityElementsFromPages}
-    entityId
     changed
     title
     fieldMedia {

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -3,7 +3,6 @@ const entityElementsFromPages = require('./entityElementsForPages.graphql');
 module.exports = `
   fragment healthCareLocalFacilityPage on NodeHealthCareLocalFacility {
     ${entityElementsFromPages}
-    entityId
     changed
     fieldFacilityLocatorApiId
     fieldNicknameForThisFacility

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -12,7 +12,6 @@ const healthCareStaffBios = require('./facilities-fragments/healthCareRegionStaf
 module.exports = `
   fragment healthCareRegionPage on NodeHealthCareRegionPage {
     ${entityElementsFromPages}
-    entityId
     fieldMedia {
       entity {
         ... on MediaImage {

--- a/src/site/stages/build/drupal/graphql/landingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/landingPage.graphql.js
@@ -15,7 +15,6 @@ module.exports = `
   
   fragment landingPage on NodeLandingPage {
     ${entityElementsFromPages}
-    entityId
     fieldIntroText
     ${FIELD_PROMO}
     ${FIELD_RELATED_LINKS}

--- a/src/site/stages/build/drupal/graphql/newStoryPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/newStoryPage.graphql.js
@@ -7,7 +7,6 @@ const entityElementsFromPages = require('./entityElementsForPages.graphql');
 module.exports = `
   fragment newsStoryPage on NodeNewsStory {
     ${entityElementsFromPages}
-    entityId
     promote
     created
     fieldOffice {

--- a/src/site/stages/build/drupal/graphql/page.graphql.js
+++ b/src/site/stages/build/drupal/graphql/page.graphql.js
@@ -21,7 +21,6 @@ module.exports = `
 
   fragment page on NodePage {
     ${entityElementsFromPages}
-    entityId
     fieldIntroText
     fieldDescription
     fieldFeaturedContent {

--- a/src/site/stages/build/drupal/graphql/pressReleasePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasePage.graphql.js
@@ -6,7 +6,6 @@ const entityElementsFromPages = require('./entityElementsForPages.graphql');
 
 module.exports = `
   fragment pressReleasePage on NodePressRelease {
-    entityId
     ${entityElementsFromPages}
     fieldReleaseDate {
       value


### PR DESCRIPTION
## Description
We're missing entityId on the health care detail page, which means the Back link on preview doesn't work. We need that field for all pages, so I've added it to the common entity fields file and removed it elsewhere.

## Testing done
Ran build locally

## Acceptance criteria
- [x] Build still works

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
