### PR TITLE
Gracefully handle missing dates and facility names

### DIFF
--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -72,6 +72,73 @@ export function getWarningHeadline(enrollmentStatus) {
   return <h4 className="usa-alert-heading">{content}</h4>;
 }
 
+function getDefaultWarningStatus(applicationDate) {
+  if (isNaN(Date.parse(applicationDate))) {
+    return null;
+  }
+  return (
+    <p>
+      <strong>You applied on: </strong>
+      {moment(applicationDate).format('MMMM D, YYYY')}
+    </p>
+  );
+}
+
+function getEnrolledWarningStatus(
+  applicationDate,
+  enrollmentDate,
+  preferredFacility,
+) {
+  const facilityName = getMedicalCenterNameByID(preferredFacility);
+  const blocks = [];
+  // add "you applied on" block if the application date is valid
+  if (!isNaN(Date.parse(applicationDate))) {
+    blocks.push(
+      <>
+        <strong>You applied on: </strong>
+        {moment(applicationDate).format('MMMM D, YYYY')}
+      </>,
+    );
+  }
+  // add "we enrolled you" block if the enrollment date is valid
+  if (!isNaN(Date.parse(enrollmentDate))) {
+    blocks.push(
+      <>
+        <strong>We enrolled you on: </strong>
+        {moment(enrollmentDate).format('MMMM D, YYYY')}
+      </>,
+    );
+  }
+  // add "preferred facility" block if there is a facility name
+  if (facilityName !== '') {
+    blocks.push(
+      <>
+        <strong>Your preferred VA medical center is: </strong>
+        {facilityName}
+      </>,
+    );
+  }
+  if (!blocks.length) {
+    return null;
+  }
+  // build the final content, adding <br/> tags between each block
+  return (
+    <p>
+      {blocks.map((block, i, array) => {
+        if (i < array.length - 1) {
+          return (
+            <>
+              {block}
+              <br />
+            </>
+          );
+        }
+        return block;
+      })}
+    </p>
+  );
+}
+
 // There are 3 options for additional warning stats. By default we just show the
 // application date. If the user is enrolled, we show additional info.
 export function getWarningStatus(
@@ -81,34 +148,21 @@ export function getWarningStatus(
   preferredFacility,
 ) {
   let content = null;
-  const facilityName = getMedicalCenterNameByID(preferredFacility);
   switch (enrollmentStatus) {
     case HCA_ENROLLMENT_STATUSES.deceased:
       content = null;
       break;
 
     case HCA_ENROLLMENT_STATUSES.enrolled:
-      content = (
-        <p>
-          <strong>You applied on: </strong>
-          {moment(applicationDate).format('MMMM D, YYYY')}
-          <br />
-          <strong>We enrolled you on: </strong>
-          {moment(enrollmentDate).format('MMMM D, YYYY')}
-          <br />
-          <strong>Your preferred VA medical center is: </strong>
-          {facilityName}
-        </p>
+      content = getEnrolledWarningStatus(
+        applicationDate,
+        enrollmentDate,
+        preferredFacility,
       );
       break;
 
     default:
-      content = (
-        <p>
-          <strong>You applied on: </strong>
-          {moment(applicationDate).format('MMMM D, YYYY')}
-        </p>
-      );
+      content = getDefaultWarningStatus(applicationDate);
       break;
   }
   return content;

--- a/src/applications/hca/tests/enrollment-status-helpers.unit.spec.js
+++ b/src/applications/hca/tests/enrollment-status-helpers.unit.spec.js
@@ -1,0 +1,147 @@
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { getWarningStatus } from '../enrollment-status-helpers';
+import { HCA_ENROLLMENT_STATUSES } from '../constants';
+
+describe('getWarningStatus', () => {
+  describe('when `enrollmentStatus` is `deceased`', () => {
+    it('should return null', () => {
+      expect(getWarningStatus(HCA_ENROLLMENT_STATUSES.deceased)).to.be.null;
+    });
+  });
+
+  describe('default behavior', () => {
+    describe('if no `applicationDate` is passed', () => {
+      it('should return null', () => {
+        expect(getWarningStatus('enrollment_status')).to.be.null;
+      });
+    });
+
+    describe('if `applicationDate` is a valid date', () => {
+      it('should return the correct markup', () => {
+        const wrapper = shallow(
+          getWarningStatus(
+            'enrollment_status',
+            '2018-01-24T00:00:00.000-06:00',
+          ),
+        );
+        expect(wrapper.find('p').length).equals(1);
+        expect(wrapper.find('strong').length).equals(1);
+        expect(wrapper.text().includes('You applied on:')).to.be.true;
+        wrapper.unmount();
+      });
+    });
+  });
+
+  describe('when `enrollmentStatus` is `enrolled`', () => {
+    describe('when all info is provided', () => {
+      it('should return the correct markup', () => {
+        const wrapper = shallow(
+          getWarningStatus(
+            HCA_ENROLLMENT_STATUSES.enrolled,
+            '2018-01-24T00:00:00.000-06:00',
+            '2018-01-24T00:00:00.000-06:00',
+            'FACILITY NAME',
+          ),
+        );
+        expect(wrapper.find('p').length).equals(1);
+        expect(wrapper.find('strong').length).equals(3);
+        expect(wrapper.find('br').length).equals(2);
+        expect(wrapper.text().includes('You applied on:')).to.be.true;
+        expect(wrapper.text().includes('We enrolled you on:')).to.be.true;
+        expect(wrapper.text().includes('Your preferred VA medical center is:'))
+          .to.be.true;
+        wrapper.unmount();
+      });
+    });
+
+    describe('when the `applicationDate` is not set', () => {
+      it('should return the correct markup', () => {
+        const wrapper = shallow(
+          getWarningStatus(
+            HCA_ENROLLMENT_STATUSES.enrolled,
+            null,
+            '2018-01-24T00:00:00.000-06:00',
+            'FACILITY NAME',
+          ),
+        );
+        expect(wrapper.find('p').length).equals(1);
+        expect(wrapper.find('strong').length).equals(2);
+        expect(wrapper.find('br').length).equals(1);
+        expect(wrapper.text().includes('You applied on:')).to.be.false;
+        expect(wrapper.text().includes('We enrolled you on:')).to.be.true;
+        expect(wrapper.text().includes('Your preferred VA medical center is:'))
+          .to.be.true;
+        wrapper.unmount();
+      });
+    });
+
+    describe('when the `enrollmentDate` is not set', () => {
+      it('should return the correct markup', () => {
+        const wrapper = shallow(
+          getWarningStatus(
+            HCA_ENROLLMENT_STATUSES.enrolled,
+            '2018-01-24T00:00:00.000-06:00',
+            null,
+            'FACILITY NAME',
+          ),
+        );
+        expect(wrapper.find('p').length).equals(1);
+        expect(wrapper.find('strong').length).equals(2);
+        expect(wrapper.find('br').length).equals(1);
+        expect(wrapper.text().includes('You applied on:')).to.be.true;
+        expect(wrapper.text().includes('We enrolled you on:')).to.be.false;
+        expect(wrapper.text().includes('Your preferred VA medical center is:'))
+          .to.be.true;
+        wrapper.unmount();
+      });
+    });
+
+    describe('when the `preferredFacility` is not set', () => {
+      it('should return the correct markup', () => {
+        const wrapper = shallow(
+          getWarningStatus(
+            HCA_ENROLLMENT_STATUSES.enrolled,
+            '2018-01-24T00:00:00.000-06:00',
+            '2018-01-24T00:00:00.000-06:00',
+          ),
+        );
+        expect(wrapper.find('p').length).equals(1);
+        expect(wrapper.find('strong').length).equals(2);
+        expect(wrapper.find('br').length).equals(1);
+        expect(wrapper.text().includes('You applied on:')).to.be.true;
+        expect(wrapper.text().includes('We enrolled you on:')).to.be.true;
+        expect(wrapper.text().includes('Your preferred VA medical center is:'))
+          .to.be.false;
+        wrapper.unmount();
+      });
+    });
+
+    describe('when only `preferredFacility` is set', () => {
+      it('should return the correct markup', () => {
+        const wrapper = shallow(
+          getWarningStatus(
+            HCA_ENROLLMENT_STATUSES.enrolled,
+            null,
+            null,
+            'FACILITY NAME',
+          ),
+        );
+        expect(wrapper.find('p').length).equals(1);
+        expect(wrapper.find('strong').length).equals(1);
+        expect(wrapper.find('br').length).equals(0);
+        expect(wrapper.text().includes('You applied on:')).to.be.false;
+        expect(wrapper.text().includes('We enrolled you on:')).to.be.false;
+        expect(wrapper.text().includes('Your preferred VA medical center is:'))
+          .to.be.true;
+        wrapper.unmount();
+      });
+    });
+
+    describe('when nothing is set', () => {
+      it('should return null', () => {
+        expect(getWarningStatus(HCA_ENROLLMENT_STATUSES.enrolled)).to.be.null;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
If we are trying to display application and enrollment dates or a
facility name in the HCA Enrollment Status Warning, completely omit the
line if the data is not set.

## Testing done
Local + added unit tests for many cases

## Screenshots
**ENROLLED - ALL DATA AVAILABLE**
<img width="673" alt="enrolled-all" src="https://user-images.githubusercontent.com/20728956/55253631-1adc1d00-5213-11e9-9ebf-62784cc52f3d.png">

**ENROLLED - MISSING APPLICATION DATE**
<img width="670" alt="enrolled-date-facility" src="https://user-images.githubusercontent.com/20728956/55253638-22032b00-5213-11e9-9b03-95dc8ec1fba1.png">

**ENROLLED - MISSING APPLICATION DATE AND FACILITY**
<img width="674" alt="enrolled-date2-only" src="https://user-images.githubusercontent.com/20728956/55253644-262f4880-5213-11e9-9b23-ed998a5a08c6.png">

**ENROLLED - MISSING APPLICATION AND ENROLLMENT DATE**
<img width="672" alt="enrolled-facility-only" src="https://user-images.githubusercontent.com/20728956/55253659-2d565680-5213-11e9-9499-c1b20f104020.png">

**PENDING - VALID DATE**
<img width="673" alt="pending-with-date" src="https://user-images.githubusercontent.com/20728956/55253674-3a734580-5213-11e9-8fea-d421c5b36561.png">

**PENDING - MISSING APPLICATION DATE**
<img width="674" alt="pending-without-date" src="https://user-images.githubusercontent.com/20728956/55253696-4101bd00-5213-11e9-93b8-15994fbc34ca.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs