### PR TITLE
[Hubs] Lowercase the "u" in "Follow Us" in sidebar

### DIFF
--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -20,7 +20,7 @@
             </section>
 
             <section>
-                <h4>Follow Us</h4>
+                <h4>Follow us</h4>
                 <ul class="va-nav-linkslist-list social">
                     {% assign socialLinks =  administration.fieldSocialMediaLinks.platformValues | jsonToObj %}
                     {% assign socialPlatforms = socialLinks | keys %}

--- a/src/site/components/merger-social.html
+++ b/src/site/components/merger-social.html
@@ -32,7 +32,7 @@ See https://help.shopify.com/themes/liquid/tags/theme-tags#include
           {% endif %}
           <ul class="va-nav-linkslist-list social">
             {% assign is_social_media_links = false %}
-            {% if subs.subhead == 'Follow Us' %}
+            {% if subs.subhead == 'Follow us' %}
               {% assign is_social_media_links = true %}
             {% endif %}
             {% for link in subs.links %}


### PR DESCRIPTION
## Description
The purpose of this PR is to fix make the "U" lowercase in "Follow Us" in the sidebar on all hub pages.
```
/service-member-benefits/
/family-member-benefits/
/burials-memorials/
/careers-employment/
/housing-assistance/
/pension/
/life-insurance/
/education/
/records/
/health-care/
/disability/
```

This was achieved by updating the `/src/site/components/merger-social.html` template and copy in each hub's `index.md` files in `vagov-content` interim CMS. This PR covers that work.

**NOTE**: This vagov-content PR must be merged along with [this vagov-content PR](https://github.com/department-of-veterans-affairs/vagov-content/pull/362), or else the social icons will break.

## Testing done
Viewed on local build with feature branch [in this PR](https://github.com/department-of-veterans-affairs/vagov-content/pull/362).

## Screenshots
![Screen Shot 2019-04-01 at 9 10 38 AM](https://user-images.githubusercontent.com/11021491/55330424-fffde880-545e-11e9-985d-8f3cc7eeb3d5.png)


## Acceptance criteria
- [X] Sub-title in hub promotion sidebar says "Follow us"

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
