### PR TITLE
Make it possible to hide the Need Help? footer

### DIFF
--- a/src/applications/hca/actions.js
+++ b/src/applications/hca/actions.js
@@ -1,11 +1,19 @@
 import appendQuery from 'append-query';
 import { apiRequest } from 'platform/utilities/api';
+import environment from 'platform/utilities/environment';
+
+const simulateServer = environment.isLocalhost();
 
 export const FETCH_ENROLLMENT_STATUS_STARTED =
   'FETCH_ENROLLMENT_STATUS_STARTED';
 export const FETCH_ENROLLMENT_STATUS_SUCCEEDED =
   'FETCH_ENROLLMENT_STATUS_SUCCEEDED';
 export const FETCH_ENROLLMENT_STATUS_FAILED = 'FETCH_ENROLLMENT_STATUS_FAILED';
+export const SHOW_HCA_REAPPLY_CONTENT = 'SHOW_HCA_REAPPLY_CONTENT';
+
+export function showReapplyContent() {
+  return { type: SHOW_HCA_REAPPLY_CONTENT };
+}
 
 export function getEnrollmentStatus(formData = {}) {
   return dispatch => {
@@ -29,22 +37,39 @@ export function getEnrollmentStatus(formData = {}) {
        action that corresponds to th condition you want to test:
        `dispatch({type: FETCH_ENROLLMENT_STATUS_FAILED, errors: [{ code: '404' }] });`
     */
+    if (simulateServer) {
+      new Promise(resolve => {
+        setTimeout(() => {
+          resolve();
+        }, 1000);
+      }).then(() => {
+        dispatch({
+          type: FETCH_ENROLLMENT_STATUS_SUCCEEDED,
+          data: {
+            applicationDate: '2018-01-24T00:00:00.000-06:00',
+            enrollmentDate: '2018-01-24T00:00:00.000-06:00',
+            preferredFacility: '463 - CHEY6',
+            parsedStatus: 'enrolled',
+          },
+        });
+      });
+    } else {
+      const baseUrl = `/health_care_applications/enrollment_status`;
 
-    const baseUrl = `/health_care_applications/enrollment_status`;
+      const url = appendQuery(baseUrl, {
+        'userAttributes[veteranDateOfBirth]': formData.dob,
+        'userAttributes[veteranFullName][first]': formData.firstName,
+        'userAttributes[veteranFullName][last]': formData.lastName,
+        'userAttributes[veteranSocialSecurityNumber]': formData.ssn,
+      });
 
-    const url = appendQuery(baseUrl, {
-      'userAttributes[veteranDateOfBirth]': formData.dob,
-      'userAttributes[veteranFullName][first]': formData.firstName,
-      'userAttributes[veteranFullName][last]': formData.lastName,
-      'userAttributes[veteranSocialSecurityNumber]': formData.ssn,
-    });
-
-    apiRequest(
-      url,
-      null,
-      data => dispatch({ type: FETCH_ENROLLMENT_STATUS_SUCCEEDED, data }),
-      ({ errors }) =>
-        dispatch({ type: FETCH_ENROLLMENT_STATUS_FAILED, errors }),
-    );
+      apiRequest(
+        url,
+        null,
+        data => dispatch({ type: FETCH_ENROLLMENT_STATUS_SUCCEEDED, data }),
+        ({ errors }) =>
+          dispatch({ type: FETCH_ENROLLMENT_STATUS_FAILED, errors }),
+      );
+    }
   };
 }

--- a/src/applications/hca/components/FormFooter.jsx
+++ b/src/applications/hca/components/FormFooter.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import { shouldHideFormFooter } from '../selectors';
 
-export default class FormFooter extends React.Component {
+class FormFooter extends React.Component {
   render() {
-    const { formConfig, currentLocation } = this.props;
+    const { formConfig, currentLocation, isHidden } = this.props;
     const GetFormHelp = formConfig.getHelp;
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
     const isConfirmationPage = trimmedPathname.endsWith('confirmation');
@@ -15,11 +17,23 @@ export default class FormFooter extends React.Component {
       <div className="row">
         <div className="usa-width-two-thirds medium-8 columns">
           <div className="help-footer-box">
-            <h2 className="help-heading">Need help?</h2>
-            <GetFormHelp />
+            {!isHidden && (
+              <>
+                <h2 className="help-heading">Need help?</h2>
+                <GetFormHelp />
+              </>
+            )}
           </div>
         </div>
       </div>
     );
   }
 }
+
+const mapStateToProps = state => ({
+  isHidden: shouldHideFormFooter(state),
+});
+
+export default connect(mapStateToProps)(FormFooter);
+
+export { FormFooter };

--- a/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
+++ b/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
@@ -12,7 +12,7 @@ import {
   getFAQBlock4,
 } from '../enrollment-status-helpers';
 import { HCA_ENROLLMENT_STATUSES } from '../constants';
-import { showReapplyContent } from '../actions';
+import { showReapplyContent as showReapplyContentAction } from '../actions';
 import { isShowingHCAReapplyContent } from '../selectors';
 
 const ReapplyContent = ({ route }) => (
@@ -37,44 +37,39 @@ const ReapplyTextLink = ({ onClick }) => (
   </button>
 );
 
-class HCAEnrollmentStatusFAQ extends React.Component {
-  render() {
-    const {
-      enrollmentStatus,
-      route,
-      showingReapplyForHealthCareContent,
-    } = this.props;
-    const reapplyAllowed =
-      enrollmentStatus !== HCA_ENROLLMENT_STATUSES.deceased;
-    return (
-      <>
-        {getFAQBlock1(enrollmentStatus)}
-        {getFAQBlock2(enrollmentStatus)}
-        {getFAQBlock3(enrollmentStatus)}
-        {getFAQBlock4(enrollmentStatus)}
-        {reapplyAllowed &&
-          showingReapplyForHealthCareContent && (
-            <ReapplyContent route={route} />
-          )}
-        {reapplyAllowed &&
-          !showingReapplyForHealthCareContent && (
-            <ReapplyTextLink
-              onClick={() => {
-                this.props.showReapplyContent();
-              }}
-            />
-          )}
-      </>
-    );
-  }
-}
+const HCAEnrollmentStatusFAQ = ({
+  enrollmentStatus,
+  route,
+  showingReapplyForHealthCareContent,
+  showReapplyContent,
+}) => {
+  const reapplyAllowed = enrollmentStatus !== HCA_ENROLLMENT_STATUSES.deceased;
+  return (
+    <>
+      {getFAQBlock1(enrollmentStatus)}
+      {getFAQBlock2(enrollmentStatus)}
+      {getFAQBlock3(enrollmentStatus)}
+      {getFAQBlock4(enrollmentStatus)}
+      {reapplyAllowed &&
+        showingReapplyForHealthCareContent && <ReapplyContent route={route} />}
+      {reapplyAllowed &&
+        !showingReapplyForHealthCareContent && (
+          <ReapplyTextLink
+            onClick={() => {
+              showReapplyContent();
+            }}
+          />
+        )}
+    </>
+  );
+};
 
 const mapStateToProps = state => ({
   showingReapplyForHealthCareContent: isShowingHCAReapplyContent(state),
 });
 
 const mapDispatchToProps = {
-  showReapplyContent,
+  showReapplyContent: showReapplyContentAction,
 };
 
 export default connect(

--- a/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
+++ b/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
@@ -11,6 +12,8 @@ import {
   getFAQBlock4,
 } from '../enrollment-status-helpers';
 import { HCA_ENROLLMENT_STATUSES } from '../constants';
+import { showReapplyContent } from '../actions';
+import { isShowingHCAReapplyContent } from '../selectors';
 
 const ReapplyContent = ({ route }) => (
   <>
@@ -35,16 +38,12 @@ const ReapplyTextLink = ({ onClick }) => (
 );
 
 class HCAEnrollmentStatusFAQ extends React.Component {
-  state = {
-    showReapplyForHealthCareContent: false,
-  };
-
-  showReapplyForHealthCareContent() {
-    this.setState({ showReapplyForHealthCareContent: true });
-  }
-
   render() {
-    const { enrollmentStatus, route } = this.props;
+    const {
+      enrollmentStatus,
+      route,
+      showingReapplyForHealthCareContent,
+    } = this.props;
     const reapplyAllowed =
       enrollmentStatus !== HCA_ENROLLMENT_STATUSES.deceased;
     return (
@@ -54,14 +53,14 @@ class HCAEnrollmentStatusFAQ extends React.Component {
         {getFAQBlock3(enrollmentStatus)}
         {getFAQBlock4(enrollmentStatus)}
         {reapplyAllowed &&
-          this.state.showReapplyForHealthCareContent && (
+          showingReapplyForHealthCareContent && (
             <ReapplyContent route={route} />
           )}
         {reapplyAllowed &&
-          !this.state.showReapplyForHealthCareContent && (
+          !showingReapplyForHealthCareContent && (
             <ReapplyTextLink
               onClick={() => {
-                this.showReapplyForHealthCareContent();
+                this.props.showReapplyContent();
               }}
             />
           )}
@@ -70,4 +69,15 @@ class HCAEnrollmentStatusFAQ extends React.Component {
   }
 }
 
-export default HCAEnrollmentStatusFAQ;
+const mapStateToProps = state => ({
+  showingReapplyForHealthCareContent: isShowingHCAReapplyContent(state),
+});
+
+const mapDispatchToProps = {
+  showReapplyContent,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(HCAEnrollmentStatusFAQ);

--- a/src/applications/hca/reducer.js
+++ b/src/applications/hca/reducer.js
@@ -4,6 +4,7 @@ import {
   FETCH_ENROLLMENT_STATUS_STARTED,
   FETCH_ENROLLMENT_STATUS_SUCCEEDED,
   FETCH_ENROLLMENT_STATUS_FAILED,
+  SHOW_HCA_REAPPLY_CONTENT,
 } from './actions';
 import { HCA_ENROLLMENT_STATUSES } from './constants';
 
@@ -17,6 +18,7 @@ const initialState = {
   isUserInMVI: false,
   loginRequired: false,
   noESRRecordFound: false,
+  showHCAReapplyContent: false,
 };
 
 export function hcaEnrollmentStatus(state = initialState, action) {
@@ -61,6 +63,9 @@ export function hcaEnrollmentStatus(state = initialState, action) {
         noESRRecordFound,
       };
     }
+
+    case SHOW_HCA_REAPPLY_CONTENT:
+      return { ...state, showHCAReapplyContent: true };
 
     default:
       return state;

--- a/src/applications/hca/selectors.js
+++ b/src/applications/hca/selectors.js
@@ -13,6 +13,8 @@ export const hasServerError = state =>
   selectEnrollmentStatus(state).hasServerError;
 export const noESRRecordFound = state =>
   selectEnrollmentStatus(state).noESRRecordFound;
+export const isShowingHCAReapplyContent = state =>
+  selectEnrollmentStatus(state).showHCAReapplyContent;
 
 // compound selectors
 export const isLoading = state =>
@@ -32,3 +34,7 @@ export const isLoggedOut = state =>
 export const shouldShowLoggedOutContent = state =>
   !isLoading(state) &&
   (!isLoggedIn(state) || hasServerError(state) || noESRRecordFound(state));
+export const shouldHideFormFooter = state =>
+  !isLoading(state) &&
+  (isUserLOA1(state) ||
+    (isUserLOA3(state) && !isShowingHCAReapplyContent(state)));

--- a/src/applications/hca/tests/reducers.unit.spec.js
+++ b/src/applications/hca/tests/reducers.unit.spec.js
@@ -137,4 +137,14 @@ describe('HCA Enrollment Status Reducer', () => {
       });
     });
   });
+
+  describe('SHOW_HCA_REAPPLY_CONTENT', () => {
+    it('sets `showHCAReapplyContent` to `true`', () => {
+      action = {
+        type: actions.SHOW_HCA_REAPPLY_CONTENT,
+      };
+      reducedState = reducer(state, action);
+      expect(reducedState.showHCAReapplyContent).to.be.true;
+    });
+  });
 });

--- a/src/applications/hca/tests/selectors.unit.spec.js
+++ b/src/applications/hca/tests/selectors.unit.spec.js
@@ -11,6 +11,7 @@ const basicEnrollmentStatusState = {
   isUserInMVI: false,
   loginRequired: false,
   noESRRecordFound: false,
+  showHCAReapplyContent: false,
 };
 const loggedOutUserState = {
   login: {
@@ -137,6 +138,21 @@ describe('simple top-level selectors', () => {
       state.hcaEnrollmentStatus.noESRRecordFound = true;
       noESRRecordFound = selectors.noESRRecordFound(state);
       expect(noESRRecordFound).to.equal(true);
+    });
+  });
+
+  describe('isShowingHCAReapplyContent', () => {
+    it('returns the correct part of the enrollment status state', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+      };
+      let isShowingHCAReapplyContent = selectors.isShowingHCAReapplyContent(
+        state,
+      );
+      expect(isShowingHCAReapplyContent).to.equal(false);
+      state.hcaEnrollmentStatus.showHCAReapplyContent = true;
+      isShowingHCAReapplyContent = selectors.isShowingHCAReapplyContent(state);
+      expect(isShowingHCAReapplyContent).to.equal(true);
     });
   });
 });
@@ -327,6 +343,65 @@ describe('compound selectors', () => {
         state,
       );
       expect(shouldShowLoggedOutContent).to.equal(false);
+    });
+  });
+
+  describe('shouldHideFormFooter', () => {
+    it('returns false if the user is loading', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+        },
+        user: { ...loadingUserState },
+      };
+      const shouldHideFormFooter = selectors.shouldHideFormFooter(state);
+      expect(shouldHideFormFooter).to.equal(false);
+    });
+
+    it('returns false if the enrollment status is loading', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+          isLoading: true,
+        },
+        user: { ...LOA1UserState },
+      };
+      const shouldHideFormFooter = selectors.shouldHideFormFooter(state);
+      expect(shouldHideFormFooter).to.equal(false);
+    });
+
+    it('returns true if the user is LOA1', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+        },
+        user: { ...LOA1UserState },
+      };
+      const shouldHideFormFooter = selectors.shouldHideFormFooter(state);
+      expect(shouldHideFormFooter).to.equal(true);
+    });
+
+    it('returns true if the user is LOA3 and the Reapply For Healthcare content is not shown', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+        },
+        user: { ...LOA3UserState },
+      };
+      const shouldHideFormFooter = selectors.shouldHideFormFooter(state);
+      expect(shouldHideFormFooter).to.equal(true);
+    });
+
+    it('returns false if the user is LOA3 but the Reapply For Healthcare content is shown', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+          showHCAReapplyContent: true,
+        },
+        user: { ...LOA3UserState },
+      };
+      const shouldHideFormFooter = selectors.shouldHideFormFooter(state);
+      expect(shouldHideFormFooter).to.equal(false);
     });
   });
 });

--- a/src/platform/forms-system/src/js/containers/FormApp.jsx
+++ b/src/platform/forms-system/src/js/containers/FormApp.jsx
@@ -69,7 +69,7 @@ class FormApp extends React.Component {
     }
 
     let footer;
-    if (Footer) {
+    if (Footer && !isNonFormPage) {
       footer = (
         <Footer formConfig={formConfig} currentLocation={currentLocation} />
       );


### PR DESCRIPTION
## Description
The FormFooter component is a part of each page in a form app, thanks to the work that FormApp does. This PR makes it possible for the HCA's FormFooter to hide itself based on what the new shouldHideFormFooter selectors pulls out of the redux state. 

## Testing done
Local + unit tests

## Screenshots with footer hidden
**When LOA3 and in ESR**
![image](https://user-images.githubusercontent.com/20728956/55337453-91675d80-5453-11e9-8d7e-cde4d38f0254.png)

**When LOA1 and needs to verify identity**
![image](https://user-images.githubusercontent.com/20728956/55337474-9cba8900-5453-11e9-9229-63d4b86a7993.png)

**ID Page**
![image](https://user-images.githubusercontent.com/20728956/55337505-ab08a500-5453-11e9-8726-ba40330be92e.png)

## Acceptance criteria
- [ ] Need Help footer is hidden on the ID Page
- [ ] Need Help footer is shown when logged out/not in ESR
- [ ] Need Help footer is hidden when viewing the LOA1 Verification Required alert
- [ ] Need Help footer is hidden when LOA3 and in ESR
- [ ] Need Help footer is shown when LOA3 and in ESR and the user has clicked the Reapply Again link

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs