### PR TITLE
All claims form526 gate mg

### DIFF
--- a/src/applications/disability-benefits/526EZ/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/526EZ/Form526EZApp.jsx
@@ -5,11 +5,11 @@ import formConfig from './config/form';
 
 import ITFWrapper from '../all-claims/containers/ITFWrapper';
 import DisabilityGate from './containers/DisabilityGate';
-import EVSSClaimsGate from '../all-claims/containers/EVSSClaimsGate';
+import RequiredServicesGate from '../all-claims/containers/RequiredServicesGate';
 
 export default function Form526Entry({ location, children }) {
   return (
-    <EVSSClaimsGate location={location}>
+    <RequiredServicesGate location={location}>
       <ITFWrapper location={location}>
         <DisabilityGate>
           {/*
@@ -25,6 +25,6 @@ export default function Form526Entry({ location, children }) {
           </RoutedSavableApp>
         </DisabilityGate>
       </ITFWrapper>
-    </EVSSClaimsGate>
+    </RequiredServicesGate>
   );
 }

--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -4,17 +4,17 @@ import RoutedSavableApp from '../../../platform/forms/save-in-progress/RoutedSav
 import formConfig from './config/form';
 
 import ITFWrapper from './containers/ITFWrapper';
-import EVSSClaimsGate from './containers/EVSSClaimsGate';
+import RequiredServicesGate from './containers/RequiredServicesGate';
 
 export default function Form526Entry({ location, children }) {
   // wraps the app and redirects user if they are not enrolled
   return (
-    <EVSSClaimsGate location={location}>
+    <RequiredServicesGate location={location}>
       <ITFWrapper location={location}>
         <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
           {children}
         </RoutedSavableApp>
       </ITFWrapper>
-    </EVSSClaimsGate>
+    </RequiredServicesGate>
   );
 }

--- a/src/applications/disability-benefits/all-claims/containers/RequiredServicesGate.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/RequiredServicesGate.jsx
@@ -6,7 +6,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import RequiredLoginView from '../../../../platform/user/authorization/components/RequiredLoginView';
 import backendServices from '../../../../platform/user/profile/constants/backendServices';
 
-export function EVSSClaimsGate({ user, location, children }) {
+export function RequiredServicesGate({ user, location, children }) {
   // Short-circuit the check on the intro page
   if (location.pathname === '/introduction') {
     return children;
@@ -14,7 +14,7 @@ export function EVSSClaimsGate({ user, location, children }) {
 
   if (
     user.login.currentlyLoggedIn &&
-    !user.profile.services.includes(backendServices.EVSS_CLAIMS)
+    !user.profile.services.includes(backendServices.FORM526)
   ) {
     return (
       <div className="usa-grid full-page-alert">
@@ -30,7 +30,7 @@ export function EVSSClaimsGate({ user, location, children }) {
 
   return (
     <RequiredLoginView
-      serviceRequired={backendServices.EVSS_CLAIMS}
+      serviceRequired={backendServices.FORM526}
       user={user}
       verify
     >
@@ -43,4 +43,4 @@ const mapStateToProps = store => ({
   user: store.user,
 });
 
-export default connect(mapStateToProps)(EVSSClaimsGate);
+export default connect(mapStateToProps)(RequiredServicesGate);

--- a/src/applications/disability-benefits/all-claims/tests/containers/RequiredServicesGate.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/RequiredServicesGate.unit.spec.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 
-import { EVSSClaimsGate } from '../../containers/EVSSClaimsGate';
+import { RequiredServicesGate } from '../../containers/RequiredServicesGate';
 
 import backendServices from '../../../../../platform/user/profile/constants/backendServices';
 
-describe('EVSSClaimsGate', () => {
+describe('RequiredServicesGate', () => {
   const disallowedUser = {
     login: { currentlyLoggedIn: true },
     profile: {
@@ -17,18 +17,18 @@ describe('EVSSClaimsGate', () => {
   const allowedUser = {
     login: { currentlyLoggedIn: true },
     profile: {
-      services: [backendServices.EVSS_CLAIMS],
+      services: [backendServices.FORM526],
     },
   };
 
   it('should not gate the form on the intro page', () => {
     const tree = mount(
-      <EVSSClaimsGate
+      <RequiredServicesGate
         user={disallowedUser}
         location={{ pathname: '/introduction' }}
       >
         <p>It worked!</p>
-      </EVSSClaimsGate>,
+      </RequiredServicesGate>,
     );
     expect(tree.text()).to.equal('It worked!');
     tree.unmount();
@@ -36,12 +36,12 @@ describe('EVSSClaimsGate', () => {
 
   it('should render a RequiredLoginView', () => {
     const tree = shallow(
-      <EVSSClaimsGate
+      <RequiredServicesGate
         user={allowedUser}
         location={{ pathname: '/middle-of-the-form' }}
       >
         <p>It worked!</p>
-      </EVSSClaimsGate>,
+      </RequiredServicesGate>,
     );
     expect(tree.find('RequiredLoginView').length).to.equal(1);
     tree.unmount();

--- a/src/platform/user/profile/constants/backendServices.js
+++ b/src/platform/user/profile/constants/backendServices.js
@@ -6,6 +6,7 @@ export default {
   HCA: 'hca',
   EDUCATION_BENEFITS: 'edu-benefits',
   EVSS_CLAIMS: 'evss-claims',
+  FORM526: 'form526', // like EVSS_CLAIMS, but must also include BIRLS ID
   APPEALS_STATUS: 'appeals-status',
   USER_PROFILE: 'user-profile',
   ID_CARD: 'id-card',


### PR DESCRIPTION
## Description
Update 526 v1 and v2 to gate access based on new form526 services entry instead of the evss_claims entry, which was missing a BIRLS ID check.

For context, here's the BE change introducing the new `form526` value:
https://github.com/department-of-veterans-affairs/vets-api/pull/2918/files

## Testing done
- Tested locally: test user 1 has this new item in his services list
- Updated unit tests

## Screenshots
N/A

## Acceptance criteria
- [x] Gate form on new entry in services list instead of old evss one.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
