### PR TITLE
Prevent double clicking of sign out

### DIFF
--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -14,6 +14,14 @@ const recordProfileEvent = recordNavUserEvent('profile');
 const recordAccountEvent = recordNavUserEvent('account');
 
 class PersonalizationDropdown extends React.Component {
+  signOut = () => {
+    // Prevent double clicking of "Sign Out"
+    if (!this.signOutDisabled) {
+      this.signOutDisabled = true;
+      logout();
+    }
+  };
+
   render() {
     return (
       <ul>
@@ -43,7 +51,7 @@ class PersonalizationDropdown extends React.Component {
           </a>
         </li>
         <li>
-          <a href="#" onClick={logout}>
+          <a href="#" onClick={this.signOut}>
             Sign Out
           </a>
         </li>


### PR DESCRIPTION
## Description
Disables "Sign Out" from being clicked twice in user nav.

## Testing done
Tested locally.

## Acceptance criteria
- [x] "Sign Out" in user nav can only be clicked once

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
