### PR TITLE
Redirect 526 v1 to v2 if no saved forms exist

### DIFF
--- a/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
@@ -10,6 +10,7 @@ import SaveInProgressIntro from '../../../../platform/forms/save-in-progress/Sav
 import CallToActionWidget from '../../../../platform/site-wide/cta-widget';
 import { toggleLoginModal } from '../../../../platform/site-wide/user-nav/actions';
 import { focusElement } from '../../../../platform/utilities/ui';
+import { urls } from '../../all-claims/utils';
 
 import { VerifiedAlert } from '../helpers';
 import FormStartControls from './FormStartControls';
@@ -18,6 +19,9 @@ const gaStartEventName = 'disability-526EZ-start';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
+    if (!this.hasSavedForm()) {
+      window.location.replace(urls.v2);
+    }
     focusElement('.va-nav-breadcrumbs-list');
   }
 

--- a/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
@@ -28,6 +28,7 @@ class IntroductionPage extends React.Component {
   hasSavedForm = () => {
     const { user } = this.props;
     return (
+      user &&
       user.profile &&
       user.profile.savedForms
         .filter(f => moment.unix(f.metadata.expiresAt).isAfter())

--- a/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
@@ -20,7 +20,7 @@ const gaStartEventName = 'disability-526EZ-start';
 class IntroductionPage extends React.Component {
   componentDidMount() {
     if (!this.hasSavedForm()) {
-      window.location.replace(urls.v2);
+      window.location.replace(`${urls.v2}/introduction`);
     }
     focusElement('.va-nav-breadcrumbs-list');
   }

--- a/src/applications/disability-benefits/526EZ/tests/components/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/IntroductionPage.unit.spec.jsx
@@ -8,6 +8,7 @@ import { IntroductionPage } from '../../components/IntroductionPage';
 const defaultProps = {
   user: {
     profile: {
+      // need to have a saved form or else form will redirect to v2
       savedForms: [
         {
           form: '21-526EZ',

--- a/src/applications/disability-benefits/526EZ/tests/components/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/IntroductionPage.unit.spec.jsx
@@ -1,10 +1,21 @@
 import React from 'react';
+import moment from 'moment';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
 import { IntroductionPage } from '../../components/IntroductionPage';
 
 const defaultProps = {
+  user: {
+    profile: {
+      savedForms: [
+        {
+          form: '21-526EZ',
+          metadata: { lastUpdated: 3000, expiresAt: moment().unix() + 2000 },
+        },
+      ],
+    },
+  },
   saveInProgress: {
     user: {},
   },
@@ -22,7 +33,10 @@ const defaultProps = {
 };
 
 describe('IntroductionPage', () => {
-  it('should render FormStartControls', () => {
+  it('should render SaveInProgressIntro', () => {
+    const oldWindow = global.window;
+    global.window = { location: { replace: () => {} } };
+
     const tree = shallow(<IntroductionPage {...defaultProps} />);
     const formStartControls = tree.find('FormStartControls');
     expect(formStartControls.length).to.equal(2);
@@ -30,5 +44,7 @@ describe('IntroductionPage', () => {
       'disability-526EZ-start',
     );
     tree.unmount();
+
+    global.window = oldWindow;
   });
 });


### PR DESCRIPTION
## Description
Redirects users from v1 to v2 if they don't have an existing saved 526 form

## Testing done


## Screenshots


## Acceptance criteria
- [x] Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17674

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
