### PR TITLE
switch view:isUserInMVI to view:isUserInMvi

### DIFF
--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -564,7 +564,7 @@ const formConfig = {
           title: 'Upload your discharge papers',
           path: 'military-service/documents',
           depends: formData =>
-            !formData['view:isUserInMVI'] && !environment.isProduction(),
+            !formData['view:isUserInMvi'] && !environment.isProduction(),
           editModeOnReviewPage: true,
           uiSchema: {
             'ui:title': 'Upload your discharge papers',

--- a/src/applications/hca/containers/IDPage.jsx
+++ b/src/applications/hca/containers/IDPage.jsx
@@ -132,7 +132,7 @@ class IDPage extends React.Component {
       veteranFullName: fullName,
       veteranDateOfBirth: idFormData.dob,
       veteranSocialSecurityNumber: idFormData.ssn,
-      'view:isUserInMVI': isUserInMVI,
+      'view:isUserInMvi': isUserInMVI,
     });
   };
 

--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -24,7 +24,7 @@ export function prefillTransformer(pages, formData, metadata, state) {
   let newData = formData;
 
   if (isInMVI(state)) {
-    newData = { ...newData, 'view:isUserInMVI': true };
+    newData = { ...newData, 'view:isUserInMvi': true };
   }
 
   return {


### PR DESCRIPTION
## Description
The formdata key `view:isUserInMVI` would get converted to `view:is_user_in_mvi` by Olive Branch when saved in the Rails backend and then restored to `view:isUserInMvi` when a saved-in-progress form was restored. So let's just use `view:isUserInMvi` from the start.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs