### PR TITLE
update the maximum separation date for the HCA

### DIFF
--- a/src/applications/hca/tests/validation.unit.spec.js
+++ b/src/applications/hca/tests/validation.unit.spec.js
@@ -30,7 +30,7 @@ describe('hca validation', () => {
 
       expect(errors.lastDischargeDate.addError.callCount).to.equal(1);
     });
-    it('should set message if discharge date is later than 730 days', () => {
+    it('should set message if discharge date is later than 365 days', () => {
       const errors = {
         lastDischargeDate: {
           addError: sinon.spy(),
@@ -40,7 +40,7 @@ describe('hca validation', () => {
         errors,
         {
           lastDischargeDate: moment()
-            .add(731, 'days')
+            .add(366, 'days')
             .format('YYYY-MM-DD'),
           lastEntryDate: '2011-01-01',
         },

--- a/src/applications/hca/tests/validation.unit.spec.js
+++ b/src/applications/hca/tests/validation.unit.spec.js
@@ -30,7 +30,7 @@ describe('hca validation', () => {
 
       expect(errors.lastDischargeDate.addError.callCount).to.equal(1);
     });
-    it('should set message if discharge date is later than 365 days', () => {
+    it('should set message if discharge date is later than 1 year from today', () => {
       const errors = {
         lastDischargeDate: {
           addError: sinon.spy(),
@@ -40,13 +40,31 @@ describe('hca validation', () => {
         errors,
         {
           lastDischargeDate: moment()
-            .add(366, 'days')
+            .add(367, 'days')
             .format('YYYY-MM-DD'),
           lastEntryDate: '2011-01-01',
         },
         {},
       );
       expect(errors.lastDischargeDate.addError.callCount).to.equal(1);
+    });
+    it('should not set message if discharge date is 1 year from today', () => {
+      const errors = {
+        lastDischargeDate: {
+          addError: sinon.spy(),
+        },
+      };
+      validateServiceDates(
+        errors,
+        {
+          lastDischargeDate: moment()
+            .add(1, 'year')
+            .format('YYYY-MM-DD'),
+          lastEntryDate: '2011-01-01',
+        },
+        {},
+      );
+      expect(errors.lastDischargeDate.addError.callCount).to.equal(0);
     });
     it('should set message if entry date is less than 15 years after dob', () => {
       const errors = {

--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -7,8 +7,8 @@ import {
 import { isValidDateRange } from '../../platform/forms/validations';
 
 function calculateEndDate() {
-  const endDateLimit = 730;
-  const description = '2 years';
+  const endDateLimit = 365;
+  const description = '1 year';
 
   return {
     endDateLimit,

--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -7,7 +7,7 @@ import {
 import { isValidDateRange } from '../../platform/forms/validations';
 
 function calculateEndDate() {
-  const endDateLimit = 365;
+  const endDateLimit = 1;
   const description = '1 year';
 
   return {
@@ -15,7 +15,7 @@ function calculateEndDate() {
     description,
     endDate: moment()
       .endOf('day')
-      .add(endDateLimit, 'days'),
+      .add(endDateLimit, 'years'),
   };
 }
 


### PR DESCRIPTION
## Description
Discharge/separation date must be within a year from today.

~NOTE: we are actually limiting it to 365 days, not 1 year, since in the past we had used 730 days instead of 2 years.~

We have switched to measuring 1 year out, not 365 days, to better handle leap years. (https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17710#issuecomment-479158923)

## Testing done
Local + unit test updates

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/55431258-ee8f0c00-5544-11e9-9faf-fdacc3839903.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs