### PR TITLE
Add form526 to service list for mocked user

### DIFF
--- a/src/platform/testing/e2e-puppeteer/auth.js
+++ b/src/platform/testing/e2e-puppeteer/auth.js
@@ -60,6 +60,7 @@ function initUserMock(token, level) {
             'hca',
             'edu-benefits',
             'evss-claims',
+            'form526',
             'user-profile',
             'health-records',
             'rx',


### PR DESCRIPTION
## Description
The 526 was gated by a new service in [this commit](https://github.com/department-of-veterans-affairs/vets-website/commit/cd679bcdc53ba334a335cca9f99ab4cd549b4b57), but it wasn't updated in the e2e mock user. That PR also wasn't running these puppeteer tests yet, so we didn't catch it. :disappointed: 

## Testing done
Ensured the tests run again.

## Screenshots
N/A

## Acceptance criteria
- [x] The puppeteer tests make it past the gate

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
