### PR TITLE
Page-footer links React iterator list-key

### DIFF
--- a/src/platform/site-wide/va-footer/helpers.jsx
+++ b/src/platform/site-wide/va-footer/helpers.jsx
@@ -20,19 +20,20 @@ export const FOOTER_EVENTS = {
   CRISIS_LINE: 'nav-footer-crisis',
 };
 
-const renderInnerTag = (link, captureEvent) => [
-  link.label ? (
-    <span className="va-footer-link-label">{link.label}</span>
-  ) : null,
-
-  link.href ? (
-    <a href={link.href} onClick={captureEvent} target={link.target}>
-      {link.title}
-    </a>
-  ) : (
-    <span className="va-footer-link-text">{link.title}</span>
-  ),
-];
+const renderInnerTag = (link, captureEvent) => (
+  <>
+    {link.label ? (
+      <span className="va-footer-link-label">{link.label}</span>
+    ) : null}
+    {link.href ? (
+      <a href={link.href} onClick={captureEvent} target={link.target}>
+        {link.title}
+      </a>
+    ) : (
+      <span className="va-footer-link-text">{link.title}</span>
+    )}
+  </>
+);
 
 export function generateLinkItems(links, column, direction = 'asc') {
   const captureEvent = () => recordEvent({ event: FOOTER_EVENTS[column] });


### PR DESCRIPTION
## Description
dev.va.gov JavaScript Error in browser Dev Tools, caused by React footer-links rendering code -- "**Warning: Each child in a list should have a unique 'key' prop.**"
See [GitHub Issue 17743](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17743) for details.  Issue also connected to this PR.

## Testing done
Verified successful fix locally, checking browser Dev Tools.  It was a React-compiler error -- neither device- nor browser-dependent.

## Screenshots
![dev-js-error-190402.png](https://images.zenhubusercontent.com/5c9e87da1a355e5cb326ae8b/9e5a6ca9-d62a-4c34-afbd-d4f024f58b10)


## Acceptance criteria
- [ ] JavaScript Error (see screenshot above) no longer occurring, verified in browser Dev Tools panel.

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
