### PR TITLE
update json schema version

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
     "url-search-params": "^0.10.0",
     "uswds": "1.4.2",
     "vanilla-lazyload": "^8.17.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#308d5c8c4a87316857b3645c56c7336af9736c0d",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d674ca3c39e2181bea5fa642c73a9a8b17be7533",
     "whatwg-fetch": "^2.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11652,9 +11652,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#308d5c8c4a87316857b3645c56c7336af9736c0d":
-  version "3.137.8"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#308d5c8c4a87316857b3645c56c7336af9736c0d"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#d674ca3c39e2181bea5fa642c73a9a8b17be7533":
+  version "3.138.1"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d674ca3c39e2181bea5fa642c73a9a8b17be7533"
 
 vm-browserify@0.0.4, vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
## Description
When entering their education history, a user has several option from a drop down menu. One of these options is to indicate that the user has attended some high school but did not receive a diploma or GED. Currently this option is "Some High School" with all words capitalized, but should be "Some high school" with only the first word capitalized to match the capitalization of the other options.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/17738

## Testing done
Dev tested locally.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
