### PR TITLE
Output validation messages in form app tester

### DIFF
--- a/src/platform/testing/e2e/form-tester/form-filler.js
+++ b/src/platform/testing/e2e/form-tester/form-filler.js
@@ -343,6 +343,13 @@ const fillForm = async (page, testData, testConfig, log) => {
       try {
         await page.waitForNavigation({ timeout: 1000 });
       } catch (e) {
+        const messages = await page.$$eval('.usa-input-error-message', errors =>
+          errors.map(error => [error.getAttribute('id'), error.innerText]),
+        );
+        messages.forEach(([id, message]) => {
+          // eslint-disable-next-line no-console
+          console.error(`${id}: ${message}`);
+        });
         throw new Error(`Expected to navigate away from ${url}`);
       }
     }


### PR DESCRIPTION
## Description
I got tired of having to run the failing test locally in debug mode to see what the problem was when it was usually a validation error. This PR outputs the validation error when we can't move to the next page because of one.

The output isn't likely to be great if we run into validation errors on multiple tests, but this is just a first pass to get something out the door.

## Testing done
I removed the claim type data from the `maximal-test.json` to test that this works as intended.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/55515383-574ab700-561f-11e9-8b76-ed15003ec2f0.png)


## Acceptance criteria
- [x] Validation errors are displayed in the console

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
