### PR TITLE
Silence "Are you sure you want to leave?" modals when on HCA ID Page

### DIFF
--- a/src/applications/hca/actions.js
+++ b/src/applications/hca/actions.js
@@ -91,7 +91,7 @@ export function getEnrollmentStatus(formData = { firstName: '' }) {
       if (formData.firstName.toLowerCase() === 'pat') {
         callFake404(dispatch);
       } else {
-        callFakeSuccess(dispatch, 'canceled_declined');
+        callFakeSuccess(dispatch, HCA_ENROLLMENT_STATUSES.canceledDeclined);
       }
     } else {
       callAPI(dispatch, formData);

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -206,14 +206,16 @@ const formConfig = {
   introduction: environment.isProduction()
     ? IntroductionPage
     : IntroductionPageGated,
-  additionalRoutes: !environment.isProduction() && [
-    {
-      path: 'id-form',
-      component: IDPage,
-      pageKey: 'id-form',
-      depends: () => !hasSession(),
-    },
-  ],
+  additionalRoutes: environment.isProduction()
+    ? []
+    : [
+        {
+          path: 'id-form',
+          component: IDPage,
+          pageKey: 'id-form',
+          depends: () => !hasSession(),
+        },
+      ],
   confirmation: ConfirmationPage,
   submitErrorText: ErrorMessage,
   title: 'Apply for health care',

--- a/src/platform/forms/helpers.js
+++ b/src/platform/forms/helpers.js
@@ -38,9 +38,15 @@ export function groupPagesIntoChapters(routes, prefix = '') {
   }));
 }
 
-export function isInProgress(pathName) {
+export function isInProgress(pathName, additionalSafePaths = []) {
   const trimmedPathname = pathName.replace(/\/$/, '');
-  const safePaths = ['introduction', 'confirmation', 'form-saved', 'error'];
+  const safePaths = [
+    'introduction',
+    'confirmation',
+    'form-saved',
+    'error',
+    ...additionalSafePaths,
+  ];
   return safePaths.every(path => !trimmedPathname.endsWith(path));
 }
 

--- a/src/platform/forms/helpers.js
+++ b/src/platform/forms/helpers.js
@@ -40,12 +40,8 @@ export function groupPagesIntoChapters(routes, prefix = '') {
 
 export function isInProgress(pathName) {
   const trimmedPathname = pathName.replace(/\/$/, '');
-  return !(
-    trimmedPathname.endsWith('introduction') ||
-    trimmedPathname.endsWith('confirmation') ||
-    trimmedPathname.endsWith('form-saved') ||
-    trimmedPathname.endsWith('error')
-  );
+  const safePaths = ['introduction', 'confirmation', 'form-saved', 'error'];
+  return safePaths.every(path => !trimmedPathname.endsWith(path));
 }
 
 export function isActivePage(page, data) {

--- a/src/platform/forms/helpers.js
+++ b/src/platform/forms/helpers.js
@@ -38,16 +38,26 @@ export function groupPagesIntoChapters(routes, prefix = '') {
   }));
 }
 
-export function isInProgress(pathName, additionalSafePaths = []) {
+/**
+ * Checks if the passed-in path is part of the application form or not. This
+ * function is useful for checking if a logged-out user has started filling out
+ * a form so we can warn them if they are about to leave and lose their work.
+ *
+ * @param {string} pathName - the path to check
+ * @param {string[]} [additionalNonFormPaths=[]] - optional array of additional
+ * paths that are not part of the form
+ * @returns {boolean} - true if the path is a form page, false if it's not
+ */
+export function isInProgressPath(pathName, additionalNonFormPaths = []) {
   const trimmedPathname = pathName.replace(/\/$/, '');
-  const safePaths = [
+  const nonFormPaths = [
     'introduction',
     'confirmation',
     'form-saved',
     'error',
-    ...additionalSafePaths,
+    ...additionalNonFormPaths,
   ];
-  return safePaths.every(path => !trimmedPathname.endsWith(path));
+  return nonFormPaths.every(path => !trimmedPathname.endsWith(path));
 }
 
 export function isActivePage(page, data) {

--- a/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
@@ -17,7 +17,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 
 import { isInProgress } from '../helpers';
 import { getSaveInProgressState } from './selectors';
-import environment from '../../utilities/environment';
+import environment from 'platform/utilities/environment';
 
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
@@ -147,13 +147,15 @@ class RoutedSavableApp extends React.Component {
   }
 
   onbeforeunload = e => {
-    const { currentLocation, autoSavedStatus } = this.props;
+    const { currentLocation, autoSavedStatus, formConfig } = this.props;
+    const { additionalRoutes = [] } = formConfig;
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
+    const additionalSafePaths = additionalRoutes.map(route => route.path);
 
     let message;
     if (
       autoSavedStatus !== SAVE_STATUSES.success &&
-      isInProgress(trimmedPathname)
+      isInProgress(trimmedPathname, additionalSafePaths)
     ) {
       message =
         'Are you sure you wish to leave this application? All progress will be lost.';
@@ -172,7 +174,8 @@ class RoutedSavableApp extends React.Component {
   }
 
   redirectOrLoad(props) {
-    // Stop a user that's been redirected to be redirected again after logging in
+    // Stop a user that's been redirected from being redirected again after
+    // logging in
     this.shouldRedirectOrLoad = false;
 
     const firstPagePath =

--- a/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
@@ -15,7 +15,7 @@ import {
 } from './actions';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
-import { isInProgress } from '../helpers';
+import { isInProgressPath } from '../helpers';
 import { getSaveInProgressState } from './selectors';
 import environment from 'platform/utilities/environment';
 
@@ -59,7 +59,7 @@ class RoutedSavableApp extends React.Component {
         !currentLocation.search.includes('skip')) ||
       currentLocation.search.includes('redirect');
     const goToStartPage = resumeForm || devRedirect;
-    if (isInProgress(currentLocation.pathname) && goToStartPage) {
+    if (isInProgressPath(currentLocation.pathname) && goToStartPage) {
       // We started on a page that isn't the first, so after we know whether
       //  we're logged in or not, we'll load or redirect as needed.
       this.shouldRedirectOrLoad = true;
@@ -155,7 +155,7 @@ class RoutedSavableApp extends React.Component {
     let message;
     if (
       autoSavedStatus !== SAVE_STATUSES.success &&
-      isInProgress(trimmedPathname, additionalSafePaths)
+      isInProgressPath(trimmedPathname, additionalSafePaths)
     ) {
       message =
         'Are you sure you wish to leave this application? All progress will be lost.';

--- a/src/platform/forms/save-in-progress/reducers.js
+++ b/src/platform/forms/save-in-progress/reducers.js
@@ -131,6 +131,7 @@ export function createSaveInProgressInitialState(formConfig, initialState) {
     migrations: formConfig.migrations,
     prefillTransformer: formConfig.prefillTransformer,
     trackingPrefix: formConfig.trackingPrefix,
+    additionalRoutes: formConfig.additionalRoutes,
   });
 }
 

--- a/src/platform/forms/tests/helpers.unit.spec.js
+++ b/src/platform/forms/tests/helpers.unit.spec.js
@@ -6,14 +6,29 @@ import { isActivePage, isInProgress } from '../helpers';
 describe('Helpers unit tests', () => {
   describe('isInProgress', () => {
     describe('default behavior', () => {
-      it('returns false when passed a standard non-form-page path', () => {
+      it('returns false when passed a standard safe path', () => {
         expect(isInProgress('introduction')).to.be.false;
         expect(isInProgress('confirmation')).to.be.false;
         expect(isInProgress('form-saved')).to.be.false;
         expect(isInProgress('error')).to.be.false;
       });
-      it('returns true when passed a path that is not a non-form path', () => {
+      it('returns true when passed a path that is not a safe path', () => {
         expect(isInProgress('id-page')).to.be.true;
+      });
+    });
+    describe('when given additional safe paths', () => {
+      const additionalSafePaths = ['id-page'];
+      it('returns false when passed a standard safe path', () => {
+        expect(isInProgress('introduction', additionalSafePaths)).to.be.false;
+        expect(isInProgress('confirmation', additionalSafePaths)).to.be.false;
+        expect(isInProgress('form-saved', additionalSafePaths)).to.be.false;
+        expect(isInProgress('error', additionalSafePaths)).to.be.false;
+      });
+      it('returns false when passed a path that is one of the additional safe paths', () => {
+        expect(isInProgress('id-page', additionalSafePaths)).to.be.false;
+      });
+      it('returns true when passed a path that is not an additional safe path', () => {
+        expect(isInProgress('page-one', additionalSafePaths)).to.be.true;
       });
     });
   });

--- a/src/platform/forms/tests/helpers.unit.spec.js
+++ b/src/platform/forms/tests/helpers.unit.spec.js
@@ -1,9 +1,23 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { isActivePage } from '../helpers';
+import { isActivePage, isInProgress } from '../helpers';
 
 describe('Helpers unit tests', () => {
+  describe('isInProgress', () => {
+    describe('default behavior', () => {
+      it('returns false when passed a standard non-form-page path', () => {
+        expect(isInProgress('introduction')).to.be.false;
+        expect(isInProgress('confirmation')).to.be.false;
+        expect(isInProgress('form-saved')).to.be.false;
+        expect(isInProgress('error')).to.be.false;
+      });
+      it('returns true when passed a path that is not a non-form path', () => {
+        expect(isInProgress('id-page')).to.be.true;
+      });
+    });
+  });
+
   describe('isActivePage', () => {
     it('matches against data', () => {
       const page = {

--- a/src/platform/forms/tests/helpers.unit.spec.js
+++ b/src/platform/forms/tests/helpers.unit.spec.js
@@ -1,34 +1,36 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { isActivePage, isInProgress } from '../helpers';
+import { isActivePage, isInProgressPath } from '../helpers';
 
 describe('Helpers unit tests', () => {
   describe('isInProgress', () => {
     describe('default behavior', () => {
-      it('returns false when passed a standard safe path', () => {
-        expect(isInProgress('introduction')).to.be.false;
-        expect(isInProgress('confirmation')).to.be.false;
-        expect(isInProgress('form-saved')).to.be.false;
-        expect(isInProgress('error')).to.be.false;
+      it('returns false when passed a standard non-form path', () => {
+        expect(isInProgressPath('introduction')).to.be.false;
+        expect(isInProgressPath('confirmation')).to.be.false;
+        expect(isInProgressPath('form-saved')).to.be.false;
+        expect(isInProgressPath('error')).to.be.false;
       });
-      it('returns true when passed a path that is not a safe path', () => {
-        expect(isInProgress('id-page')).to.be.true;
+      it('returns true when passed a path that is a form path', () => {
+        expect(isInProgressPath('id-page')).to.be.true;
       });
     });
-    describe('when given additional safe paths', () => {
+    describe('when given additional non-form paths', () => {
       const additionalSafePaths = ['id-page'];
-      it('returns false when passed a standard safe path', () => {
-        expect(isInProgress('introduction', additionalSafePaths)).to.be.false;
-        expect(isInProgress('confirmation', additionalSafePaths)).to.be.false;
-        expect(isInProgress('form-saved', additionalSafePaths)).to.be.false;
-        expect(isInProgress('error', additionalSafePaths)).to.be.false;
+      it('returns false when passed a standard non-form path', () => {
+        expect(isInProgressPath('introduction', additionalSafePaths)).to.be
+          .false;
+        expect(isInProgressPath('confirmation', additionalSafePaths)).to.be
+          .false;
+        expect(isInProgressPath('form-saved', additionalSafePaths)).to.be.false;
+        expect(isInProgressPath('error', additionalSafePaths)).to.be.false;
       });
-      it('returns false when passed a path that is one of the additional safe paths', () => {
-        expect(isInProgress('id-page', additionalSafePaths)).to.be.false;
+      it('returns false when passed a path that is one of the additional non-form paths', () => {
+        expect(isInProgressPath('id-page', additionalSafePaths)).to.be.false;
       });
-      it('returns true when passed a path that is not an additional safe path', () => {
-        expect(isInProgress('page-one', additionalSafePaths)).to.be.true;
+      it('returns true when passed a path that is a form path', () => {
+        expect(isInProgressPath('page-one', additionalSafePaths)).to.be.true;
       });
     });
   });

--- a/src/platform/forms/tests/save-in-progress/reducers.unit.spec.js
+++ b/src/platform/forms/tests/save-in-progress/reducers.unit.spec.js
@@ -50,6 +50,21 @@ describe('schemaform createSaveInProgressInitialState', () => {
     expect(state.initialData).to.equal(state.data);
   });
 
+  it('creates a reducer with initial additionalRoutes if they are present in the form config', () => {
+    const formConfig = {
+      additionalRoutes: [
+        {
+          path: 'route-path',
+        },
+      ],
+      chapters: {},
+    };
+    const reducer = createSaveInProgressFormReducer(formConfig, { data: {} });
+    const state = reducer(undefined, {});
+
+    expect(state.additionalRoutes).to.deep.equal([{ path: 'route-path' }]);
+  });
+
   describe('reducer', () => {
     const formConfig = {
       chapters: {

--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -1,10 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
 
-import isBrandConsolidationEnabled from '../../../brand-consolidation/feature-flag';
-import isVATeamSiteSubdomain from '../../../brand-consolidation/va-subdomain';
-import { hasSession } from '../../../user/profile/utilities';
+import isVATeamSiteSubdomain from 'platform/brand-consolidation/va-subdomain';
+import { hasSession } from 'platform/user/profile/utilities';
 import HelpMenu from './HelpMenu';
 import SearchMenu from './SearchMenu';
 import SignInProfileMenu from './SignInProfileMenu';
@@ -41,25 +39,6 @@ class SearchHelpSignIn extends React.Component {
           isOpen={this.props.isMenuOpen.account}
           isLOA3={this.props.isLOA3}
         />
-      );
-    }
-
-    const buttonClasses = classNames({
-      'va-button-link': true,
-      'sign-in-link': true,
-    });
-
-    if (!isBrandConsolidationEnabled()) {
-      return (
-        <div className="sign-in-links">
-          <button className={buttonClasses} onClick={this.handleSignInSignUp}>
-            Sign In
-          </button>
-          <span className="sign-in-spacer">|</span>
-          <button className={buttonClasses} onClick={this.handleSignInSignUp}>
-            Sign Up
-          </button>
-        </div>
       );
     }
 

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -129,12 +129,13 @@ export class Main extends React.Component {
   };
 
   signInSignUp = () => {
-    const { formAutoSavedStatus } = this.props;
+    const { formAutoSavedStatus, additionalRoutes = [] } = this.props;
+    const additionalSafePaths = additionalRoutes.map(route => route.path);
 
     const shouldConfirmLeavingForm =
       typeof formAutoSavedStatus !== 'undefined' &&
       formAutoSavedStatus !== SAVE_STATUSES.success &&
-      isInProgress(window.location.pathname);
+      isInProgress(window.location.pathname, additionalSafePaths);
 
     if (shouldConfirmLeavingForm) {
       this.props.toggleFormSignInModal(true);
@@ -175,6 +176,7 @@ const mapStateToProps = state => ({
   isProfileLoading: isProfileLoading(state),
   isLOA3: isLOA3(state),
   userGreeting: selectUserGreeting(state),
+  additionalRoutes: state.form && state.form.additionalRoutes,
   ...state.navigation,
 });
 

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import appendQuery from 'append-query';
 import URLSearchParams from 'url-search-params';
 
-import { isInProgress } from '../../../forms/helpers';
+import { isInProgressPath } from '../../../forms/helpers';
 import FormSignInModal from '../../../forms/save-in-progress/FormSignInModal';
 import { SAVE_STATUSES } from '../../../forms/save-in-progress/actions';
 import { updateLoggedInStatus } from '../../../user/authentication/actions';
@@ -135,7 +135,7 @@ export class Main extends React.Component {
     const shouldConfirmLeavingForm =
       typeof formAutoSavedStatus !== 'undefined' &&
       formAutoSavedStatus !== SAVE_STATUSES.success &&
-      isInProgress(window.location.pathname, additionalSafePaths);
+      isInProgressPath(window.location.pathname, additionalSafePaths);
 
     if (shouldConfirmLeavingForm) {
       this.props.toggleFormSignInModal(true);

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -129,15 +129,7 @@ export class Main extends React.Component {
   };
 
   signInSignUp = () => {
-    const { formAutoSavedStatus, additionalRoutes = [] } = this.props;
-    const additionalSafePaths = additionalRoutes.map(route => route.path);
-
-    const shouldConfirmLeavingForm =
-      typeof formAutoSavedStatus !== 'undefined' &&
-      formAutoSavedStatus !== SAVE_STATUSES.success &&
-      isInProgressPath(window.location.pathname, additionalSafePaths);
-
-    if (shouldConfirmLeavingForm) {
+    if (this.props.shouldConfirmLeavingForm) {
       this.props.toggleFormSignInModal(true);
     } else {
       this.props.toggleLoginModal(true, 'header');
@@ -170,15 +162,23 @@ export class Main extends React.Component {
   }
 }
 
-const mapStateToProps = state => ({
-  currentlyLoggedIn: isLoggedIn(state),
-  formAutoSavedStatus: state.form && state.form.autoSavedStatus,
-  isProfileLoading: isProfileLoading(state),
-  isLOA3: isLOA3(state),
-  userGreeting: selectUserGreeting(state),
-  additionalRoutes: state.form && state.form.additionalRoutes,
-  ...state.navigation,
-});
+export const mapStateToProps = state => {
+  const { form = {} } = state;
+  const { formAutoSavedStatus = '', additionalRoutes = [] } = form;
+  const additionalSafePaths = additionalRoutes.map(route => route.path);
+  const shouldConfirmLeavingForm =
+    formAutoSavedStatus !== SAVE_STATUSES.success &&
+    isInProgressPath(window.location.pathname, additionalSafePaths);
+
+  return {
+    currentlyLoggedIn: isLoggedIn(state),
+    isProfileLoading: isProfileLoading(state),
+    isLOA3: isLOA3(state),
+    shouldConfirmLeavingForm,
+    userGreeting: selectUserGreeting(state),
+    ...state.navigation,
+  };
+};
 
 const mapDispatchToProps = {
   toggleFormSignInModal,

--- a/src/platform/site-wide/user-nav/selectors.js
+++ b/src/platform/site-wide/user-nav/selectors.js
@@ -6,6 +6,8 @@ import localStorage from '../../utilities/storage/localStorage';
 import { selectProfile } from '../../user/selectors';
 
 export const selectUserGreeting = createSelector(
+  // TODO: perhaps make these selectors fail gracefully if state.user, or any of
+  // the properties on the user object are not defined
   state => selectProfile(state).userFullName,
   state => selectProfile(state).email,
   () => localStorage.getItem('userFirstName'),

--- a/src/platform/site-wide/user-nav/tests/components/SearchHelpSignIn.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/SearchHelpSignIn.unit.spec.jsx
@@ -39,13 +39,6 @@ describe('<SearchHelpSignIn>', () => {
     global.window = oldWindow;
   });
 
-  it('should present login links when not logged in', () => {
-    window.settings.brandConsolidationEnabled = false;
-    const wrapper = shallow(<SearchHelpSignIn {...defaultProps} />);
-    expect(wrapper.find('.sign-in-link')).to.have.lengthOf(2);
-    wrapper.unmount();
-  });
-
   it('should present login links when not logged in on VA subdomain', () => {
     window.settings.brandConsolidationEnabled = true;
     window.location.hostname = 'www.benefits.va.gov';

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import { mockEventListeners } from '../../../../testing/unit/helpers';
-import localStorage from '../../../../utilities/storage/localStorage';
-import { Main } from '../../containers/Main';
+import { mockEventListeners } from 'platform/testing/unit/helpers';
+import localStorage from 'platform/utilities/storage/localStorage';
+import { Main, mapStateToProps } from '../../containers/Main';
 
 describe('<Main>', () => {
   const props = {
@@ -153,9 +153,7 @@ describe('<Main>', () => {
   });
 
   it('should show the modal to confirm leaving an in-progress form', () => {
-    const wrapper = shallow(
-      <Main {...props} formAutoSavedStatus="not-attempted" />,
-    );
+    const wrapper = shallow(<Main {...props} shouldConfirmLeavingForm />);
     wrapper.find('SearchHelpSignIn').prop('onSignInSignUp')();
     expect(props.toggleFormSignInModal.calledOnce).to.be.true;
     expect(props.toggleLoginModal.calledOnce).to.be.false;
@@ -213,5 +211,68 @@ describe('<Main>', () => {
     expect(props.toggleFormSignInModal.calledOnce).to.be.true;
     expect(props.toggleFormSignInModal.calledWith(false)).to.be.true;
     wrapper.unmount();
+  });
+});
+
+describe('mapStateToProps', () => {
+  // We have to mock out the login and profile because the user/selectors.js and
+  // user-nav/selectors.js are used in mapStateToProps and they do not fail
+  // gracefully when accessing properties of the login and profile objects.
+  const state = {
+    user: {
+      login: {},
+      profile: {
+        userFullName: {},
+        loa: {},
+      },
+    },
+  };
+  describe('shouldConfirmLeavingForm', () => {
+    let oldWindow;
+    beforeEach(() => {
+      oldWindow = global.window;
+      global.window = {
+        location: {
+          pathname: '',
+        },
+      };
+    });
+    afterEach(() => {
+      global.window = oldWindow;
+    });
+    it('is true when the user is on a form page and the form has not saved', () => {
+      global.window.location.pathname =
+        '/health-care/apply/application/veteran-info';
+      const { shouldConfirmLeavingForm } = mapStateToProps(state);
+      expect(shouldConfirmLeavingForm).to.be.true;
+    });
+    it('is false when the user is on a standard non-form page', () => {
+      global.window.location.pathname =
+        '/health-care/apply/application/introduction';
+      const { shouldConfirmLeavingForm } = mapStateToProps(state);
+      expect(shouldConfirmLeavingForm).to.be.false;
+    });
+    it('is false when the user is on a non-standard non-form page', () => {
+      global.window.location.pathname =
+        '/health-care/apply/application/id-page';
+      const { shouldConfirmLeavingForm } = mapStateToProps({
+        ...state,
+        form: {
+          additionalRoutes: [{ path: 'id-page' }],
+        },
+      });
+      expect(shouldConfirmLeavingForm).to.be.false;
+    });
+    it('is false when the user is on a form page page the form has auto-saved', () => {
+      global.window.location.pathname =
+        '/health-care/apply/application/veteran-info';
+      const { shouldConfirmLeavingForm } = mapStateToProps({
+        ...state,
+        form: {
+          formAutoSavedStatus: 'success',
+        },
+      });
+      expect(shouldConfirmLeavingForm).to.be.false;
+    });
   });
 });

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -158,7 +158,42 @@ describe('<Main>', () => {
     );
     wrapper.find('SearchHelpSignIn').prop('onSignInSignUp')();
     expect(props.toggleFormSignInModal.calledOnce).to.be.true;
+    expect(props.toggleLoginModal.calledOnce).to.be.false;
     expect(props.toggleFormSignInModal.calledWith(true)).to.be.true;
+    wrapper.unmount();
+  });
+
+  it('should not show the modal to confirm leaving an in-progress form if the user is on the standard form introduction page', () => {
+    const oldLocation = global.window.location;
+    global.window.location.pathname =
+      '/health-care/apply/application/introduction';
+    const wrapper = shallow(
+      <Main {...props} formAutoSavedStatus="not-attempted" />,
+    );
+    wrapper.find('SearchHelpSignIn').prop('onSignInSignUp')();
+    expect(props.toggleFormSignInModal.calledOnce).to.be.false;
+    expect(props.toggleLoginModal.calledOnce).to.be.true;
+    expect(props.toggleLoginModal.calledWith(true)).to.be.true;
+    global.window.location = oldLocation;
+    wrapper.unmount();
+  });
+
+  it('should not show the modal to confirm leaving an in-progress form if the user is on a non-form page as defined in the form config', () => {
+    const oldLocation = global.window.location;
+    global.window.location.pathname = '/health-care/apply/application/id-page';
+    const additionalRoutes = [{ path: 'id-page' }];
+    const wrapper = shallow(
+      <Main
+        {...props}
+        formAutoSavedStatus="not-attempted"
+        additionalRoutes={additionalRoutes}
+      />,
+    );
+    wrapper.find('SearchHelpSignIn').prop('onSignInSignUp')();
+    expect(props.toggleFormSignInModal.calledOnce).to.be.false;
+    expect(props.toggleLoginModal.calledOnce).to.be.true;
+    expect(props.toggleLoginModal.calledWith(true)).to.be.true;
+    global.window.location = oldLocation;
     wrapper.unmount();
   });
 

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -1,3 +1,5 @@
+// TODO: perhaps make these selectors fail gracefully if state.user, or any of
+// the properties on the user object are not defined
 export const selectUser = state => state.user;
 export const isLoggedIn = state => selectUser(state).login.currentlyLoggedIn;
 export const selectProfile = state => selectUser(state).profile;


### PR DESCRIPTION
## Description
When navigating away from the HCA's new ID Page, the user is presented "Are you sure you want to leave?" warning modals. This is because the ID Page route is handled like every other route in a form app. This PR makes the whitelist (blacklist?) of routes that don't require the warning a little bit smarter. Now any routes that are listed in the form config's optional `additionalRoutes` will be free of the "are you sure?" warning.

I'm hoping to get two +1s from folks who have more experience with the site-wide code that this is modifying.

## Testing done
- added/updated/expanded unit tests
- tested locally to confirm modal does not appear when we don't want it but it still appears when we do.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs