### PR TITLE
17577 dashboard va benefits cta

### DIFF
--- a/src/applications/personalization/preferences/helpers.jsx
+++ b/src/applications/personalization/preferences/helpers.jsx
@@ -190,6 +190,11 @@ export const benefitChoices = [
     gaTag: 'Family',
     introduction:
       'If you’re the family member of a Veteran or Servicemember, you may qualify for benefits yourself. If you’re a caregiver for a Veteran with service-connected disabilities, you may qualify for additional benefits and support for yourself and the Veteran you’re caring for.',
+    cta: {
+      link: '/family-member-benefits/',
+      text: 'View all related benefits',
+      gaTag: 'recommendations-family-view-benefits', // TODO: Vet this tag w/ Analytics Team.
+    },
     faqs: [
       {
         title: 'What kinds of family and caregiver benefits does VA offer?',

--- a/src/applications/personalization/preferences/helpers.jsx
+++ b/src/applications/personalization/preferences/helpers.jsx
@@ -192,7 +192,7 @@ export const benefitChoices = [
     cta: {
       link: '/family-member-benefits/',
       text: 'View all related benefits',
-      gaTag: 'recommendations-family-view-benefits', // TODO: Vet this tag w/ Analytics Team.
+      gaTag: 'View all related benefits',
     },
     faqs: [
       {

--- a/src/applications/personalization/preferences/helpers.jsx
+++ b/src/applications/personalization/preferences/helpers.jsx
@@ -192,7 +192,7 @@ export const benefitChoices = [
     cta: {
       link: '/family-member-benefits/',
       text: 'View all related benefits',
-      gaTag: 'View all related benefits',
+      gaTag: 'view-all-related-benefits',
     },
     faqs: [
       {

--- a/src/platform/site-wide/va-footer/helpers.jsx
+++ b/src/platform/site-wide/va-footer/helpers.jsx
@@ -20,19 +20,20 @@ export const FOOTER_EVENTS = {
   CRISIS_LINE: 'nav-footer-crisis',
 };
 
-const renderInnerTag = (link, captureEvent) => [
-  link.label ? (
-    <span className="va-footer-link-label">{link.label}</span>
-  ) : null,
-
-  link.href ? (
-    <a href={link.href} onClick={captureEvent} target={link.target}>
-      {link.title}
-    </a>
-  ) : (
-    <span className="va-footer-link-text">{link.title}</span>
-  ),
-];
+const renderInnerTag = (link, captureEvent) => (
+  <>
+    {link.label ? (
+      <span className="va-footer-link-label">{link.label}</span>
+    ) : null}
+    {link.href ? (
+      <a href={link.href} onClick={captureEvent} target={link.target}>
+        {link.title}
+      </a>
+    ) : (
+      <span className="va-footer-link-text">{link.title}</span>
+    )}
+  </>
+);
 
 export function generateLinkItems(links, column, direction = 'asc') {
   const captureEvent = () => recordEvent({ event: FOOTER_EVENTS[column] });


### PR DESCRIPTION
## Description
[17577](/department-of-veterans-affairs/vets.gov-team/issues/17577) - Add CTA button to Dashboard | Find VA Benefits | Family section, linking to Family Member Benefits landing page (Headline is "VA benefits for spouses, dependents, survivors, and family caregivers):
**Button copy** —  "View all related benefits"
**Link URL** — /family-member-benefits/

## Testing done
Verified locally, new button is linking to correct landing page.  (No logic-/functional-code changes -- basically just a new link.)

## Screenshots
![Dashboard-Find VA Benefits-Family and Caregiver](https://user-images.githubusercontent.com/34068740/54930842-65e1f180-4eee-11e9-99e6-cc9857a592c5.png)

## Acceptance criteria
- [ ] New CTA with correct label displayed on Dashboard page under Family and Caregiver Benefits.
- [ ] CTA-click navigates to correct landing page.

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
