### PR TITLE
Bug/16101 - Dashboard - Focus not managed when pressing Remove button

### DIFF
--- a/src/applications/personalization/preferences/components/PreferenceItem.jsx
+++ b/src/applications/personalization/preferences/components/PreferenceItem.jsx
@@ -58,16 +58,14 @@ export default class PreferenceItem extends React.Component {
 
     this.removeBtnRef = React.createRef();
     this.alertHeaderRef = React.createRef();
-    this.removeCancelled = false;
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     // Set focus for keyboard-users upon content-swap.
-    if (this.props.isRemoving) {
+    if (!prevProps.isRemoving && this.props.isRemoving) {
       this.alertHeaderRef.current.focus();
-    } else if (this.removeCancelled) {
+    } else if (prevProps.isRemoving && !this.props.isRemoving) {
       this.removeBtnRef.current.focus();
-      this.removeCancelled = false;
     }
   }
 
@@ -89,7 +87,7 @@ export default class PreferenceItem extends React.Component {
             <p>
               We’ll remove this content. If you’d like to see the information
               again, you can always add it back. Just click on the “Find More
-              Benefits” button at the top of your dashboard, then select "
+              Benefits” button at the top of your dashboard, then select “
               {title}
               .”
             </p>

--- a/src/applications/personalization/preferences/components/PreferenceItem.jsx
+++ b/src/applications/personalization/preferences/components/PreferenceItem.jsx
@@ -57,11 +57,15 @@ export default class PreferenceItem extends React.Component {
     super(props);
 
     this.removeBtnRef = React.createRef();
+    this.alertHeaderRef = React.createRef();
     this.removeCancelled = false;
   }
 
   componentDidUpdate() {
-    if (!this.props.isRemoving && this.removeCancelled) {
+    // Set focus for keyboard-users upon content-swap.
+    if (this.props.isRemoving) {
+      this.alertHeaderRef.current.focus();
+    } else if (this.removeCancelled) {
       this.removeBtnRef.current.focus();
       this.removeCancelled = false;
     }
@@ -78,7 +82,7 @@ export default class PreferenceItem extends React.Component {
     if (this.props.isRemoving) {
       return (
         <div>
-          <h3 className="benefit-title" tabIndex="-1">
+          <h3 ref={this.alertHeaderRef} className="benefit-title" tabIndex="-1">
             {title}
           </h3>
           <AlertBox status="warning" headline="Please confirm this change">
@@ -107,7 +111,7 @@ export default class PreferenceItem extends React.Component {
     }
     return (
       <div>
-        <div className="title-container preference-item-title" data-code={code}>
+        <div className="title-container preference-item-title">
           <h3>{title}</h3>
           <button
             ref={this.removeBtnRef}

--- a/src/applications/personalization/preferences/components/PreferenceItem.jsx
+++ b/src/applications/personalization/preferences/components/PreferenceItem.jsx
@@ -52,57 +52,77 @@ const FAQList = ({ faqs }) => (
   </div>
 );
 
-export default function PreferenceItem({
-  handleViewToggle,
-  handleRemove,
-  isRemoving,
-  benefit,
-}) {
-  const { title, introduction, code, cta, faqs } = benefit;
+export default class PreferenceItem extends React.Component {
+  constructor(props) {
+    super(props);
 
-  if (isRemoving) {
+    this.removeBtnRef = React.createRef();
+    this.removeCancelled = false;
+  }
+
+  componentDidUpdate() {
+    if (!this.props.isRemoving && this.removeCancelled) {
+      this.removeBtnRef.current.focus();
+      this.removeCancelled = false;
+    }
+  }
+
+  onCancelRemove(code) {
+    this.removeCancelled = true;
+    this.props.handleViewToggle(code);
+  }
+
+  render() {
+    const { title, introduction, code, cta, faqs } = this.props.benefit;
+
+    if (this.props.isRemoving) {
+      return (
+        <div>
+          <h3 className="benefit-title" tabIndex="-1">
+            {title}
+          </h3>
+          <AlertBox status="warning" headline="Please confirm this change">
+            <p>
+              We’ll remove this content. If you’d like to see the information
+              again, you can always add it back. Just click on the “Find More
+              Benefits” button at the top of your dashboard, then select "
+              {title}
+              .”
+            </p>
+            <button
+              className="usa-button-primary"
+              onClick={() => this.props.handleRemove(code)}
+            >
+              Remove
+            </button>
+            <button
+              className="usa-button-secondary"
+              onClick={() => this.onCancelRemove(code)}
+            >
+              Cancel
+            </button>
+          </AlertBox>
+        </div>
+      );
+    }
     return (
       <div>
-        <h3 className="benefit-title">{title}</h3>
-        <AlertBox status="warning" headline="Please confirm this change">
-          <p>
-            We’ll remove this content. If you’d like to see the information
-            again, you can always add it back. Just click on the “Find More
-            Benefits” button at the top of your dashboard, then select “{title}
-            .”
-          </p>
+        <div className="title-container preference-item-title" data-code={code}>
+          <h3>{title}</h3>
           <button
-            className="usa-button-primary"
-            onClick={() => handleRemove(code)}
+            ref={this.removeBtnRef}
+            className="va-button-link"
+            onClick={() => this.props.handleViewToggle(code)}
           >
-            Remove
+            <i className="fas fa-times" /> <span>Remove</span>
           </button>
-          <button
-            className="usa-button-secondary"
-            onClick={() => handleViewToggle(code)}
-          >
-            Cancel
-          </button>
-        </AlertBox>
+        </div>
+        <p className="va-introtext">{introduction}</p>
+        {faqs && <FAQList faqs={faqs} />}
+        {cta && <CallToAction cta={cta} />}
       </div>
     );
   }
-  return (
-    <div>
-      <div className="title-container preference-item-title">
-        <h3>{title}</h3>
-        <button
-          className="va-button-link"
-          onClick={() => handleViewToggle(code)}
-        >
-          <i className="fas fa-times" /> <span>Remove</span>
-        </button>
-      </div>
-      <p className="va-introtext">{introduction}</p>
-      {faqs && <FAQList faqs={faqs} />}
-      {cta && <CallToAction cta={cta} />}
-    </div>
-  );
 }
 
 PreferenceItem.propTypes = {

--- a/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
+++ b/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
@@ -250,7 +250,7 @@ class PreferencesWidget extends React.Component {
             />
           )}
         </ReactCSSTransitionGroup>
-        <div ariaLive="polite">{this.renderContent()}</div>
+        <div aria-live="polite">{this.renderContent()}</div>
       </div>
     );
   }

--- a/src/platform/site-wide/va-footer/helpers.jsx
+++ b/src/platform/site-wide/va-footer/helpers.jsx
@@ -20,19 +20,20 @@ export const FOOTER_EVENTS = {
   CRISIS_LINE: 'nav-footer-crisis',
 };
 
-const renderInnerTag = (link, captureEvent) => [
-  link.label ? (
-    <span className="va-footer-link-label">{link.label}</span>
-  ) : null,
-
-  link.href ? (
-    <a href={link.href} onClick={captureEvent} target={link.target}>
-      {link.title}
-    </a>
-  ) : (
-    <span className="va-footer-link-text">{link.title}</span>
-  ),
-];
+const renderInnerTag = (link, captureEvent) => (
+  <>
+    {link.label ? (
+      <span className="va-footer-link-label">{link.label}</span>
+    ) : null}
+    {link.href ? (
+      <a href={link.href} onClick={captureEvent} target={link.target}>
+        {link.title}
+      </a>
+    ) : (
+      <span className="va-footer-link-text">{link.title}</span>
+    )}
+  </>
+);
 
 export function generateLinkItems(links, column, direction = 'asc') {
   const captureEvent = () => recordEvent({ event: FOOTER_EVENTS[column] });


### PR DESCRIPTION
## Description
[16101](/department-of-veterans-affairs/vets.gov-team/issues/16101) - On the Dashboard, under Find VA Benefits, after pressing the Remove button via keyboard, focus is not actively managed.

## Testing done
Verified locally using Mac OS X VoiceOver screen-reader.  (No logic-/functional-code changes.)

## Screenshots
![screen shot 2019-01-07 at 1 42 04 pm](https://user-images.githubusercontent.com/934879/50789859-f19a9900-1282-11e9-8bee-325b0c671e87.png)

## Acceptance criteria
- [ ] After keyboard-pressing the X Remove button, focus is set on the heading of the newly-displayed confirm box.
- [ ] After tabbing to & keyboard-pressing Cancel button, focus returns to the Remove button.

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
