### PR TITLE
Stop warning user they have unsaved work when they do not

### DIFF
--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -163,9 +163,16 @@ export class Main extends React.Component {
 }
 
 export const mapStateToProps = state => {
-  const { form = {} } = state;
-  const { formAutoSavedStatus, additionalRoutes = [] } = form;
-  const additionalSafePaths = additionalRoutes.map(route => route.path);
+  let formAutoSavedStatus;
+  let additionalRoutes;
+  let additionalSafePaths;
+  const { form } = state;
+  if (typeof form === 'object') {
+    formAutoSavedStatus = form.formAutoSavedStatus;
+    additionalRoutes = form.additionalRoutes;
+    additionalSafePaths =
+      additionalRoutes && additionalRoutes.map(route => route.path);
+  }
   const shouldConfirmLeavingForm =
     typeof formAutoSavedStatus !== 'undefined' &&
     formAutoSavedStatus !== SAVE_STATUSES.success &&

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -164,9 +164,10 @@ export class Main extends React.Component {
 
 export const mapStateToProps = state => {
   const { form = {} } = state;
-  const { formAutoSavedStatus = '', additionalRoutes = [] } = form;
+  const { formAutoSavedStatus, additionalRoutes = [] } = form;
   const additionalSafePaths = additionalRoutes.map(route => route.path);
   const shouldConfirmLeavingForm =
+    typeof formAutoSavedStatus !== 'undefined' &&
     formAutoSavedStatus !== SAVE_STATUSES.success &&
     isInProgressPath(window.location.pathname, additionalSafePaths);
 

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -243,25 +243,11 @@ describe('mapStateToProps', () => {
     it('is true when the user is on a form page and the form has not saved', () => {
       global.window.location.pathname =
         '/health-care/apply/application/veteran-info';
-      const { shouldConfirmLeavingForm } = mapStateToProps(state);
-      expect(shouldConfirmLeavingForm).to.be.true;
-    });
-    it('is false when the user is on a standard non-form page', () => {
-      global.window.location.pathname =
-        '/health-care/apply/application/introduction';
-      const { shouldConfirmLeavingForm } = mapStateToProps(state);
-      expect(shouldConfirmLeavingForm).to.be.false;
-    });
-    it('is false when the user is on a non-standard non-form page', () => {
-      global.window.location.pathname =
-        '/health-care/apply/application/id-page';
       const { shouldConfirmLeavingForm } = mapStateToProps({
         ...state,
-        form: {
-          additionalRoutes: [{ path: 'id-page' }],
-        },
+        form: { formAutoSavedStatus: 'not-attempted' },
       });
-      expect(shouldConfirmLeavingForm).to.be.false;
+      expect(shouldConfirmLeavingForm).to.be.true;
     });
     it('is false when the user is on a form page page the form has auto-saved', () => {
       global.window.location.pathname =
@@ -272,6 +258,32 @@ describe('mapStateToProps', () => {
           formAutoSavedStatus: 'success',
         },
       });
+      expect(shouldConfirmLeavingForm).to.be.false;
+    });
+    it('is false when the user is on a standard non-form page', () => {
+      global.window.location.pathname =
+        '/health-care/apply/application/introduction';
+      const { shouldConfirmLeavingForm } = mapStateToProps({
+        ...state,
+        form: { formAutoSavedStatus: 'not-attempted' },
+      });
+      expect(shouldConfirmLeavingForm).to.be.false;
+    });
+    it('is false when the user is on a non-standard non-form page', () => {
+      global.window.location.pathname =
+        '/health-care/apply/application/id-page';
+      const { shouldConfirmLeavingForm } = mapStateToProps({
+        ...state,
+        form: {
+          formAutoSavedStatus: 'not-attempted',
+          additionalRoutes: [{ path: 'id-page' }],
+        },
+      });
+      expect(shouldConfirmLeavingForm).to.be.false;
+    });
+    it('is false when the user is not in the form app', () => {
+      global.window.location.pathname = '/health-care';
+      const { shouldConfirmLeavingForm } = mapStateToProps(state);
       expect(shouldConfirmLeavingForm).to.be.false;
     });
   });


### PR DESCRIPTION
## Description
My previous work did not properly port functionality into `mapStateToProps`. Specifically I forced `formAutoSavedStatus` [to be an empty string if it was undefined](https://github.com/department-of-veterans-affairs/vets-website/commit/71844b2fe1f63e5a1ed269dda0f910e0e1445d37#diff-ffbf18d5744eabb4b2c7238f5cc081aaR167) when we really needed it to be undefined. This resulted in the user being shown an "unsaved work" warning when clicking on the Sign In button if they weren't on a form app.

## Testing done
Updated unit tests, added test for this specific case.

## Screenshots


## Acceptance criteria
- [x] User is not shown a warning when clicking on Sign In from a non-form page (such as the homepage)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs