### PR TITLE
[Drupal] Only fail build for broken links in Production

### DIFF
--- a/src/site/stages/build/plugins/check-broken-links.js
+++ b/src/site/stages/build/plugins/check-broken-links.js
@@ -49,10 +49,7 @@ function checkBrokenLinks(buildOptions) {
     const ignoreLinks = new RegExp(ignoreGlobs.join('|'));
     const brokenLinkChecker = createBrokenLinkChecker({
       allowRedirects: true,
-      warn:
-        buildOptions.watch ||
-        buildOptions.buildtype === ENVIRONMENTS.VAGOVDEV ||
-        buildOptions.buildtype === ENVIRONMENTS.VAGOVSTAGING,
+      warn: buildOptions.buildtype === ENVIRONMENTS.VAGOVPROD,
       allowRegex: ignoreLinks,
     });
 

--- a/src/site/stages/build/plugins/check-broken-links.js
+++ b/src/site/stages/build/plugins/check-broken-links.js
@@ -49,7 +49,7 @@ function checkBrokenLinks(buildOptions) {
     const ignoreLinks = new RegExp(ignoreGlobs.join('|'));
     const brokenLinkChecker = createBrokenLinkChecker({
       allowRedirects: true,
-      warn: buildOptions.buildtype === ENVIRONMENTS.VAGOVPROD,
+      warn: buildOptions.buildtype !== ENVIRONMENTS.VAGOVPROD,
       allowRegex: ignoreLinks,
     });
 


### PR DESCRIPTION
## Description
This PR allows builds with broken links to pass on all environments except production. This is because vagov-content executes a localhost build for Heroku, and now the broken links in Drupal Dev/Staging are breaking the Heroku build.

## Acceptance criteria
- [ ] vagov-content Heroku can deploy

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
