### PR TITLE
fix state property

### DIFF
--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -168,7 +168,7 @@ export const mapStateToProps = state => {
   let additionalSafePaths;
   const { form } = state;
   if (typeof form === 'object') {
-    formAutoSavedStatus = form.formAutoSavedStatus;
+    formAutoSavedStatus = form.autoSavedStatus;
     additionalRoutes = form.additionalRoutes;
     additionalSafePaths =
       additionalRoutes && additionalRoutes.map(route => route.path);

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -245,7 +245,7 @@ describe('mapStateToProps', () => {
         '/health-care/apply/application/veteran-info';
       const { shouldConfirmLeavingForm } = mapStateToProps({
         ...state,
-        form: { formAutoSavedStatus: 'not-attempted' },
+        form: { autoSavedStatus: 'not-attempted' },
       });
       expect(shouldConfirmLeavingForm).to.be.true;
     });
@@ -255,7 +255,7 @@ describe('mapStateToProps', () => {
       const { shouldConfirmLeavingForm } = mapStateToProps({
         ...state,
         form: {
-          formAutoSavedStatus: 'success',
+          autoSavedStatus: 'success',
         },
       });
       expect(shouldConfirmLeavingForm).to.be.false;
@@ -265,7 +265,7 @@ describe('mapStateToProps', () => {
         '/health-care/apply/application/introduction';
       const { shouldConfirmLeavingForm } = mapStateToProps({
         ...state,
-        form: { formAutoSavedStatus: 'not-attempted' },
+        form: { autoSavedStatus: 'not-attempted' },
       });
       expect(shouldConfirmLeavingForm).to.be.false;
     });
@@ -275,7 +275,7 @@ describe('mapStateToProps', () => {
       const { shouldConfirmLeavingForm } = mapStateToProps({
         ...state,
         form: {
-          formAutoSavedStatus: 'not-attempted',
+          autoSavedStatus: 'not-attempted',
           additionalRoutes: [{ path: 'id-page' }],
         },
       });


### PR DESCRIPTION
## Description
My previous fix was looking for the wrong prop on the `form` state, resulting the user _never_ seeing the "will lose progress" warning

## Testing done
Verified locally:
- warning shows up when logged out and form is in progress
- does not show up when a form is not in progress

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs