### PR TITLE
VAGOV-2406: region detail page - check if first link exists

### DIFF
--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -62,7 +62,7 @@
             </section>
           {%  endif %}
 
-          {% if fieldRelatedLinks != empty %}
+          {% if fieldRelatedLinks != empty and fieldRelatedLink.entity.fieldVaParagraphs.length and fieldRelatedLink.entity.fieldVaParagraphs.0.fieldLink != empty %}
             <div class="row">
               <div class="usa-content columns">
                 <aside class="va-nav-linkslist va-nav-linkslist--related">


### PR DESCRIPTION
## Description
Fixes a bug that displays an empty gray box section with a lone `<hr>`  if there are no related links on a facility detail page

## Testing done
Locally with staging data

## Screenshots
this page has no related links at the bottom and now the gray box with the`<hr>` does not show up

![localhost_3001_pittsburgh-health-care_pharmacy_index html](https://user-images.githubusercontent.com/19178435/55763955-2e129800-5a1e-11e9-809c-8f5b793c9798.png)

what's in this screenshot is not as important as what is _not_ in the screenshot... 🙂 
## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
