### PR TITLE
Improve CTA for creating MHV accounts on health tool pages

### DIFF
--- a/src/platform/site-wide/cta-widget/CallToActionAlert.jsx
+++ b/src/platform/site-wide/cta-widget/CallToActionAlert.jsx
@@ -20,18 +20,14 @@ export default function CallToActionAlert({
       <div>
         {alertText}
         {buttonText && (
-          <button
-            className={buttonClass}
-            onClick={buttonHandler}
-            style={secondaryLinkText ? { marginRight: '1em' } : {}}
-          >
+          <button className={buttonClass} onClick={buttonHandler}>
             {buttonText}
           </button>
         )}
         {secondaryLinkText && (
-          <a href="#" onClick={secondaryLinkHandler}>
+          <button className="va-button-link" onClick={secondaryLinkHandler}>
             {secondaryLinkText}
-          </a>
+          </button>
         )}
       </div>
     ),

--- a/src/platform/site-wide/cta-widget/CallToActionAlert.jsx
+++ b/src/platform/site-wide/cta-widget/CallToActionAlert.jsx
@@ -26,9 +26,8 @@ export default function CallToActionAlert({
         )}
         {secondaryButtonText && (
           <button
-            className="va-button-link"
+            className="va-button-link vads-u-margin-left--2"
             onClick={secondaryButtonHandler}
-            style={{ marginLeft: '1rem' }}
           >
             {secondaryButtonText}
           </button>

--- a/src/platform/site-wide/cta-widget/CallToActionAlert.jsx
+++ b/src/platform/site-wide/cta-widget/CallToActionAlert.jsx
@@ -5,8 +5,8 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 export default function CallToActionAlert({
   heading,
   alertText,
-  buttonText,
-  buttonHandler,
+  primaryButtonText,
+  primaryButtonHandler,
   secondaryLinkText,
   secondaryLinkHandler,
   status,
@@ -19,9 +19,9 @@ export default function CallToActionAlert({
     content: (
       <div>
         {alertText}
-        {buttonText && (
-          <button className={buttonClass} onClick={buttonHandler}>
-            {buttonText}
+        {primaryButtonText && (
+          <button className={buttonClass} onClick={primaryButtonHandler}>
+            {primaryButtonText}
           </button>
         )}
         {secondaryLinkText && (

--- a/src/platform/site-wide/cta-widget/CallToActionAlert.jsx
+++ b/src/platform/site-wide/cta-widget/CallToActionAlert.jsx
@@ -7,8 +7,8 @@ export default function CallToActionAlert({
   alertText,
   primaryButtonText,
   primaryButtonHandler,
-  secondaryLinkText,
-  secondaryLinkHandler,
+  secondaryButtonText,
+  secondaryButtonHandler,
   status,
 }) {
   const buttonClass =
@@ -24,9 +24,13 @@ export default function CallToActionAlert({
             {primaryButtonText}
           </button>
         )}
-        {secondaryLinkText && (
-          <button className="va-button-link" onClick={secondaryLinkHandler}>
-            {secondaryLinkText}
+        {secondaryButtonText && (
+          <button
+            className="va-button-link"
+            onClick={secondaryButtonHandler}
+            style={{ marginLeft: '1rem' }}
+          >
+            {secondaryButtonText}
           </button>
         )}
       </div>

--- a/src/platform/site-wide/cta-widget/CallToActionAlert.jsx
+++ b/src/platform/site-wide/cta-widget/CallToActionAlert.jsx
@@ -7,6 +7,8 @@ export default function CallToActionAlert({
   alertText,
   buttonText,
   buttonHandler,
+  secondaryLinkText,
+  secondaryLinkHandler,
   status,
 }) {
   const buttonClass =
@@ -21,6 +23,15 @@ export default function CallToActionAlert({
           <button className={buttonClass} onClick={buttonHandler}>
             {buttonText}
           </button>
+        )}
+        {secondaryLinkText && (
+          <a
+            href="#"
+            onClick={secondaryLinkHandler}
+            className="cta-alert-secondary-link"
+          >
+            {secondaryLinkText}
+          </a>
         )}
       </div>
     ),

--- a/src/platform/site-wide/cta-widget/CallToActionAlert.jsx
+++ b/src/platform/site-wide/cta-widget/CallToActionAlert.jsx
@@ -20,16 +20,16 @@ export default function CallToActionAlert({
       <div>
         {alertText}
         {buttonText && (
-          <button className={buttonClass} onClick={buttonHandler}>
+          <button
+            className={buttonClass}
+            onClick={buttonHandler}
+            style={secondaryLinkText ? { marginRight: '1em' } : {}}
+          >
             {buttonText}
           </button>
         )}
         {secondaryLinkText && (
-          <a
-            href="#"
-            onClick={secondaryLinkHandler}
-            className="cta-alert-secondary-link"
-          >
+          <a href="#" onClick={secondaryLinkHandler}>
             {secondaryLinkText}
           </a>
         )}

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -92,8 +92,8 @@ export class CallToActionWidget extends React.Component {
             If you don’t have any of those accounts, you can create one.
           </p>
         ),
-        buttonText: 'Sign In or Create an Account',
-        buttonHandler: this.openLoginModal,
+        primaryButtonText: 'Sign In or Create an Account',
+        primaryButtonHandler: this.openLoginModal,
         status: 'continue',
       };
     }
@@ -110,8 +110,8 @@ export class CallToActionWidget extends React.Component {
             give you access to your personal health information.
           </p>
         ),
-        buttonText: 'Verify Your Identity',
-        buttonHandler: verify,
+        primaryButtonText: 'Verify Your Identity',
+        primaryButtonHandler: verify,
         status: 'continue',
       };
     }
@@ -132,8 +132,8 @@ export class CallToActionWidget extends React.Component {
             will be able to open.
           </p>
         ),
-        buttonText: 'Go to My HealtheVet',
-        buttonHandler: this.goToTool,
+        primaryButtonText: 'Go to My HealtheVet',
+        primaryButtonHandler: this.goToTool,
         status: 'info',
       };
     }
@@ -182,8 +182,8 @@ export class CallToActionWidget extends React.Component {
               can give you access to your personal health information.
             </p>
           ),
-          buttonText: 'Verify Your Identity',
-          buttonHandler: verify,
+          primaryButtonText: 'Verify Your Identity',
+          primaryButtonHandler: verify,
           status: 'continue',
         };
 
@@ -271,8 +271,8 @@ export class CallToActionWidget extends React.Component {
        * case 'no_account':
        *   return {
        *     heading: `You’ll need to create a My HealtheVet account before you can ${this._serviceDescription`,
-       *     buttonText: 'Create a My HealtheVet Account',
-       *     buttonHandler: this.props.createAndUpgradeMHVAccount,
+       *     primaryButtonText: 'Create a My HealtheVet Account',
+       *     primaryButtonHandler: this.props.createAndUpgradeMHVAccount,
        *     status: 'continue'
        *   };
 
@@ -280,8 +280,8 @@ export class CallToActionWidget extends React.Component {
        * case 'registered':
        *   return {
        *     heading: `You’ll need to upgrade your account before you can ${this._serviceDescription}`,
-       *     buttonText: 'Upgrade Your Account',
-       *     buttonHandler: this.props.upgradeMHVAccount,
+       *     primaryButtonText: 'Upgrade Your Account',
+       *     primaryButtonHandler: this.props.upgradeMHVAccount,
        *     status: 'continue'
        *   };
        */
@@ -372,8 +372,8 @@ export class CallToActionWidget extends React.Component {
             </p>
           </>
         ),
-        buttonText: 'Create your free account',
-        buttonHandler:
+        primaryButtonText: 'Create your free account',
+        primaryButtonHandler:
           accountState === 'needs_terms_acceptance'
             ? redirectToTermsAndConditions
             : this.props.createAndUpgradeMHVAccount,
@@ -387,8 +387,8 @@ export class CallToActionWidget extends React.Component {
       heading: `You’ll need to upgrade your My HealtheVet account before you can ${
         this._serviceDescription
       }. It’ll only take us a minute to do this for you, and it’s free.`,
-      buttonText: 'Upgrade Your My HealtheVet Account',
-      buttonHandler:
+      primaryButtonText: 'Upgrade Your My HealtheVet Account',
+      primaryButtonHandler:
         accountState === 'needs_terms_acceptance'
           ? redirectToTermsAndConditions
           : this.props.upgradeMHVAccount,

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -361,8 +361,9 @@ export class CallToActionWidget extends React.Component {
         alertText: (
           <>
             <p>
-              You’ll need to create a My HealtheVet account before you can
-              refill prescriptions online. This account is cost-free and secure.
+              You’ll need to create a My HealtheVet account before you can{' '}
+              {this._serviceDescription} online. This account is cost-free and
+              secure.
             </p>
             <p>
               <strong>If you already have a My HealtheVet account,</strong>{' '}

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -363,7 +363,9 @@ export class CallToActionWidget extends React.Component {
             <p>
               You’ll need to create a My HealtheVet account before you can{' '}
               {this._serviceDescription}
-              {this._serviceDescription.endsWith('online') ? '. ' : ' online. '}
+              {this._serviceDescription.endsWith('online')
+                ? '.'
+                : ' online.'}{' '}
               This account is cost-free and secure.
             </p>
             <p>

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -9,7 +9,8 @@ import CallVBACenter from '../../brand-consolidation/components/CallVBACenter';
 import SubmitSignInForm from '../../brand-consolidation/components/SubmitSignInForm';
 
 import { toggleLoginModal } from '../user-nav/actions';
-import { verify } from '../../user/authentication/utilities';
+import { logout, verify } from '../../user/authentication/utilities';
+import recordEvent from '../../../platform/monitoring/record-event';
 
 import {
   createAndUpgradeMHVAccount,
@@ -354,14 +355,29 @@ export class CallToActionWidget extends React.Component {
 
     if (!accountLevel) {
       return {
-        heading: `You’ll need to create a My HealtheVet account before you can ${
+        heading: `Please create a My HealtheVet account to ${
           this._serviceDescription
         }`,
-        buttonText: 'Create a My HealtheVet Account',
+        alertText: (
+          <>
+            <p>
+              You’ll need to create a My HealtheVet account before you can
+              refill prescriptions online. This account is cost-free and secure.
+            </p>
+            <p>
+              <strong>If you already have a My HealtheVet account,</strong>{' '}
+              please sign out of VA.gov. Then sign in again with your My{' '}
+              HealtheVet username and password.
+            </p>
+          </>
+        ),
+        buttonText: 'Create your free account',
         buttonHandler:
           accountState === 'needs_terms_acceptance'
             ? redirectToTermsAndConditions
             : this.props.createAndUpgradeMHVAccount,
+        secondaryLinkText: 'Sign out of VA.gov',
+        secondaryLinkHandler: this.signOut,
         status: 'continue',
       };
     }
@@ -412,6 +428,11 @@ export class CallToActionWidget extends React.Component {
         this._popup = true;
       }
     }
+  };
+
+  signOut = () => {
+    recordEvent({ event: 'logout-link-clicked-createcta-mhv' });
+    logout();
   };
 
   render() {

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -362,8 +362,9 @@ export class CallToActionWidget extends React.Component {
           <>
             <p>
               You’ll need to create a My HealtheVet account before you can{' '}
-              {this._serviceDescription} online. This account is cost-free and
-              secure.
+              {this._serviceDescription}
+              {this._serviceDescription.endsWith('online') ? '. ' : ' online. '}
+              This account is cost-free and secure.
             </p>
             <p>
               <strong>If you already have a My HealtheVet account,</strong>{' '}

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -377,8 +377,8 @@ export class CallToActionWidget extends React.Component {
           accountState === 'needs_terms_acceptance'
             ? redirectToTermsAndConditions
             : this.props.createAndUpgradeMHVAccount,
-        secondaryLinkText: 'Sign out of VA.gov',
-        secondaryLinkHandler: this.signOut,
+        secondaryButtonText: 'Sign out of VA.gov',
+        secondaryButtonHandler: this.signOut,
         status: 'continue',
       };
     }


### PR DESCRIPTION
## Description

MHV account creation is not performing properly at the moment. We believe some data is inconsistent between MVI and MHV, and some users are being prompted to create MHV account from tool pages, when in fact they already have an MHV account (these users logged in with DS Logon or ID.me).

This PR updates the following to address this:
* Update copy for My HealtheVet account creation in CTA widget
* Add "Sign Out" link
* Add a GA event to track sign outs

See mockups: https://adhoc.invisionapp.com/share/EJO686H9AS3#/321325312_Create_A_MHV_Account

## Testing done
Tested locally

## Screenshots
![image](https://user-images.githubusercontent.com/786704/55821332-1389fe80-5ab2-11e9-83fc-a64d6e691411.png)


## Acceptance criteria
- [ ] Copy has been updated
- [ ] Sign out link has beed added
- [ ] GA event fires on sign out click

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
