### PR TITLE
Update e2e tests that depends on the HCA

### DIFF
--- a/src/applications/hca/actions.js
+++ b/src/applications/hca/actions.js
@@ -3,7 +3,8 @@ import { apiRequest } from 'platform/utilities/api';
 import environment from 'platform/utilities/environment';
 import { HCA_ENROLLMENT_STATUSES } from './constants';
 
-const simulateServerLocally = environment.isLocalhost();
+// flip the `false` to `true` to fake the endpoint when testing locally
+const simulateServerLocally = environment.isLocalhost() && false;
 
 export const FETCH_ENROLLMENT_STATUS_STARTED =
   'FETCH_ENROLLMENT_STATUS_STARTED';
@@ -65,7 +66,7 @@ function callAPI(dispatch, formData = {}) {
   );
 }
 
-export function getEnrollmentStatus(formData = { firstName: '' }) {
+export function getEnrollmentStatus(formData) {
   return dispatch => {
     dispatch({ type: FETCH_ENROLLMENT_STATUS_STARTED });
     /*
@@ -88,7 +89,11 @@ export function getEnrollmentStatus(formData = { firstName: '' }) {
        `dispatch({type: FETCH_ENROLLMENT_STATUS_FAILED, errors: [{ code: '404' }] });`
     */
     if (simulateServerLocally) {
-      if (formData.firstName.toLowerCase() === 'pat') {
+      if (
+        formData &&
+        formData.firstName &&
+        formData.firstName.toLowerCase() === 'pat'
+      ) {
         callFake404(dispatch);
       } else {
         callFakeSuccess(dispatch, HCA_ENROLLMENT_STATUSES.canceledDeclined);

--- a/src/applications/hca/tests/00-all-fields.e2e.spec.js
+++ b/src/applications/hca/tests/00-all-fields.e2e.spec.js
@@ -1,11 +1,13 @@
-const E2eHelpers = require('../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const HcaHelpers = require('./hca-helpers.js');
 const testData = require('./schema/maximal-test.json');
-const FormsTestHelpers = require('../../../platform/testing/e2e/form-helpers');
+const ENVIRONMENTS = require('site/constants/environments');
+const FormsTestHelpers = require('platform/testing/e2e/form-helpers');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   HcaHelpers.initApplicationSubmitMock();
+  HcaHelpers.initEnrollmentStatusMock();
 
   // Ensure introduction page renders.
   client
@@ -18,6 +20,14 @@ module.exports = E2eHelpers.createE2eTest(client => {
   E2eHelpers.overrideVetsGovApi(client);
   FormsTestHelpers.overrideFormsScrolling(client);
   E2eHelpers.expectNavigateAwayFrom(client, '/introduction');
+
+  if (process.env.BUILDTYPE !== ENVIRONMENTS.VAGOVPROD) {
+    // ID Form page.
+    client.expect.element('input[name="root_firstName"]').to.be.visible;
+    HcaHelpers.completeIDForm(client, testData.data);
+    client.axeCheck('.main').click('.hca-id-form-wrapper .usa-button');
+    E2eHelpers.expectNavigateAwayFrom(client, '/id-form');
+  }
 
   // Personal Information page.
   client.expect.element('input[name="root_veteranFullName_first"]').to.be

--- a/src/applications/hca/tests/hca-helpers.js
+++ b/src/applications/hca/tests/hca-helpers.js
@@ -1,7 +1,16 @@
-const mock = require('../../../platform/testing/e2e/mock-helpers');
-const Timeouts = require('../../../platform/testing/e2e/timeouts.js');
-const Auth = require('../../../platform/testing/e2e/auth.js');
+const mock = require('platform/testing/e2e/mock-helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
+const Auth = require('platform/testing/e2e/auth.js');
 const moment = require('moment');
+
+function completeIDForm(client, data) {
+  client
+    .waitForElementVisible('input[name="root_firstName"]', Timeouts.normal)
+    .fill('input[name="root_firstName"]', data.veteranFullName.first)
+    .fill('input[name="root_lastName"]', data.veteranFullName.last)
+    .fillDate('root_dob', data.veteranDateOfBirth)
+    .fill('input[name="root_ssn"]', data.veteranSocialSecurityNumber);
+}
 
 function completePersonalInformation(client, data) {
   client
@@ -368,6 +377,19 @@ function initApplicationSubmitMock() {
   });
 }
 
+function initEnrollmentStatusMock(token = null) {
+  mock(token, {
+    path: '/v0/health_care_applications/enrollment_status',
+    verb: 'get',
+    value: {
+      applicationDate: '2018-01-24T00:00:00.000-06:00',
+      enrollmentDate: '2018-01-24T00:00:00.000-06:00',
+      preferredFacility: '987 - CHEY6',
+      parsedStatus: 'none_of_the_above',
+    },
+  });
+}
+
 function initSaveInProgressMock(url, client) {
   const token = Auth.getUserToken();
 
@@ -487,6 +509,7 @@ function initSaveInProgressMock(url, client) {
       },
     },
   });
+
   mock(token, {
     path: '/v0/in_progress_forms/1010ez',
     verb: 'put',
@@ -515,6 +538,7 @@ function initSaveInProgressMock(url, client) {
   return token;
 }
 module.exports = {
+  completeIDForm,
   completePersonalInformation,
   completeBirthInformation,
   completeDemographicInformation,
@@ -533,5 +557,6 @@ module.exports = {
   completeAdditionalInformation,
   completeEntireForm,
   initApplicationSubmitMock,
+  initEnrollmentStatusMock,
   initSaveInProgressMock,
 };

--- a/src/platform/forms/tests/save-in-progress/01-sip-autosave.e2e.spec.js
+++ b/src/platform/forms/tests/save-in-progress/01-sip-autosave.e2e.spec.js
@@ -1,11 +1,12 @@
 const moment = require('moment');
-const E2eHelpers = require('../../../testing/e2e/helpers');
-const Timeouts = require('../../../testing/e2e/timeouts.js');
-const HcaHelpers = require('../../../../applications/hca/tests/hca-helpers.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
+const HcaHelpers = require('applications/hca/tests/hca-helpers.js');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const url = `${E2eHelpers.baseUrl}/health-care/apply/application`;
   const token = HcaHelpers.initSaveInProgressMock(url, client);
+  HcaHelpers.initEnrollmentStatusMock(token);
 
   // Ensure introduction page renders.
   client

--- a/src/platform/forms/tests/save-in-progress/01-sip-load-fail.e2e.spec.js
+++ b/src/platform/forms/tests/save-in-progress/01-sip-load-fail.e2e.spec.js
@@ -1,10 +1,11 @@
-const E2eHelpers = require('../../../testing/e2e/helpers');
-const Timeouts = require('../../../testing/e2e/timeouts.js');
-const HcaHelpers = require('../../../../applications/hca/tests/hca-helpers.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
+const HcaHelpers = require('applications/hca/tests/hca-helpers.js');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const url = `${E2eHelpers.baseUrl}/health-care/apply/application`;
   const token = HcaHelpers.initSaveInProgressMock(url, client);
+  HcaHelpers.initEnrollmentStatusMock(token);
 
   // Ensure introduction page renders.
   client


### PR DESCRIPTION
## Description
Fix tests that use the HCA and don't know about:
- the new ID Page at the front of the form for logged in users
- the new `enrollment_system` endpoint that intro page hits when users are logged it

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ] tests work locally and on Jenkins

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs