### PR TITLE
Update comment re: testing `enrollment_status` endpoint locally

### DIFF
--- a/src/applications/hca/actions.js
+++ b/src/applications/hca/actions.js
@@ -3,7 +3,7 @@ import { apiRequest } from 'platform/utilities/api';
 import environment from 'platform/utilities/environment';
 import { HCA_ENROLLMENT_STATUSES } from './constants';
 
-const simulateServerLocally = environment.isLocalhost();
+const simulateServerLocally = environment.isLocalhost() && false;
 
 export const FETCH_ENROLLMENT_STATUS_STARTED =
   'FETCH_ENROLLMENT_STATUS_STARTED';
@@ -71,8 +71,13 @@ export function getEnrollmentStatus(formData = { firstName: '' }) {
     /*
     When hitting the API locally, we cannot get responses other than 500s from
     the endpoint. This is due to the endpoint's need to connect to MVI, which
-    cannot easily been done locally. There are a few ways around this:
-    1. Temporarily change the `baseUrl` to:
+    cannot easily been done locally. There are a few ways around this, ordered
+    from best to worst options. (Options 2 and 3 and really listed here to be
+    informative):
+    1. Confirm that `simulateServerLocally` on line 6 evals to `true` and then
+       optionally adjust what the `callFake404` and/or `callFakeSuccess`
+       functions return.
+    2. Temporarily change the `baseUrl` to:
        'https://dev-api.va.gov/v0/health_care_applications/enrollment_status, so
        that we bypass the local APi. If you use the following user creds the
        backend will respond with a 200 and the expected response body:
@@ -80,12 +85,9 @@ export function getEnrollmentStatus(formData = { firstName: '' }) {
        FORD
        1986-05-06
        796043735
-    2. You can add something like this `return render(json: { "parsed_status" =>
+    3. You can add something like this `return render(json: { "parsed_status" =>
        'enrolled' })` to the first line of the enrollment_status method in
        vets-api: app/controllers/v0/health_care_applications_controller.rb#L25
-    3. Instead of making the apiRequest here, you can immediately dispatch the
-       action that corresponds to th condition you want to test:
-       `dispatch({type: FETCH_ENROLLMENT_STATUS_FAILED, errors: [{ code: '404' }] });`
     */
     if (simulateServerLocally) {
       if (formData.firstName.toLowerCase() === 'pat') {


### PR DESCRIPTION
## Description
Just updating some code comments that had fallen out of date

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs