### PR TITLE
VAGOV-2062: More flexible social media links

### DIFF
--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -12,7 +12,7 @@
                 <ul class="va-nav-linkslist-list social">
                     <li>
                         <a href="{{ administration.fieldEmailUpdatesUrl }}">
-                            <i class="fas fa-envelope"></i>
+                            <i class="fas fa-envelope vads-u-margin-right--0p5"></i>
                             {{ administration.fieldEmailUpdatesLinkText }}
                         </a>
                     </li>
@@ -30,26 +30,15 @@
                             {% if socialPlatform = "youtube_channel" %}
                                 <li>
                                     <a href="http://youtube.com/channel/{{ socialLink.value }}">
-                                        <i class="fab fa-youtube"></i>
-                                         Veterans Health Youtube channel
+                                        <i class="fab fa-youtube vads-u-margin-right--0p5"></i>
+                                        {{ administration.name }} Youtube channel
                                     </a>
                                 </li>
                             {% else %}
                                 <li>
                                     <a href="http://{{ socialPlatform }}.com/{{ socialLink.value }}">
-                                        <i class="fab fa-{{ socialPlatform }}"></i>
-                                        {% case socialPlatform %}
-                                            {% when "twitter" %}
-                                                Veterans Health Twitter
-                                            {% when "facebook" %}
-                                                Veterans Health Facebook
-                                            {% when "youtube" %}
-                                                Veterans Health YouTube
-                                            {% when "instagram" %}
-                                                Veterans Health Instagram
-                                            {% when "linkedin" %}
-                                                Veterans Health LinkedIn
-                                        {% endcase %}
+                                        <i class="fab fa-{{ socialPlatform }} vads-u-margin-right--0p5"></i>
+                                        {{ administration.name }} {{ socialPlatform | capitalize }}
                                     </a>
                                 </li>
                             {% endif %}

--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -31,7 +31,7 @@
                                 <li>
                                     <a href="http://youtube.com/channel/{{ socialLink.value }}">
                                         <i class="fab fa-youtube vads-u-margin-right--0p5"></i>
-                                        {{ administration.name }} Youtube channel
+                                        {{ administration.name }} {{ socialPlatform | remove: '_' | capitalize }}
                                     </a>
                                 </li>
                             {% else %}


### PR DESCRIPTION
## Description
This refactors social media links in the right rail of hub landing pages to be less hardcoded and include the name of the administration. 

## Testing done
Tested locally with data from staging.

## Screenshots
<img width="433" alt="Screen Shot 2019-04-10 at 11 41 47 PM" src="https://user-images.githubusercontent.com/3157339/55933337-3fa89b00-5bea-11e9-8a7d-12c81b86dfef.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
