### PR TITLE
VAGOV-2476: All headings in hub right rail are sentence case

### DIFF
--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -8,7 +8,7 @@
             </h4>
 
             <section>
-                <h4>Get Updates</h4>
+                <h4>Get updates</h4>
                 <ul class="va-nav-linkslist-list social">
                     <li>
                         <a href="{{ administration.fieldEmailUpdatesUrl }}">

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -70,11 +70,11 @@
             <button
               class="usa-accordion-button usa-accordion-button-dark rail-heading"
               aria-expanded="true" aria-controls="a1">
-              Ask Questions
+              Ask questions
             </button>
             <div id="a1" class="usa-accordion-content" aria-hidden="false">
               <section>
-                <h4>Message Us</h4>
+                <h4>Message us</h4>
                 <ul class="va-nav-linkslist-list social">
                   <li>
                     <a href="https://iris.custhelp.va.gov/app/ask">
@@ -85,7 +85,7 @@
               </section>
               {% if fieldSupportServices != empty %}
               <section>
-                <h4>Call Us</h4>
+                <h4>Call us</h4>
                 <ul class="va-nav-linkslist-list social">
                   {% for supportService in fieldSupportServices %}
                   {% assign service = supportService.entity %}


### PR DESCRIPTION
## Description
All titles in va.gov/health-care sidebar are sentence case: Ask questions, Follow us, Follow us, Connect with us, Get updates. 

## Testing done
Tested locally with staging data.

## Screenshots
<img width="445" alt="Screen Shot 2019-04-10 at 11 59 43 PM" src="https://user-images.githubusercontent.com/3157339/55934085-c199c380-5bec-11e9-84f5-1338766e6b51.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
