### PR TITLE
17863 :: VET TEC: Update Military Service Content to provide clarity …

### DIFF
--- a/src/applications/edu-benefits/0994/content/militaryService.jsx
+++ b/src/applications/edu-benefits/0994/content/militaryService.jsx
@@ -17,7 +17,7 @@ export const benefitNotice = (
   </p>
 );
 
-export const reserveNationalGuardExpectedDutyTitle = (
+export const selectedReserveNationalGuardExpectedDutyTitle = (
   <p>
     Are you in the Selected Reserve or National Guard <strong>and</strong> do
     you expect to be called to duty for 30 days or more?

--- a/src/applications/edu-benefits/0994/content/militaryService.jsx
+++ b/src/applications/edu-benefits/0994/content/militaryService.jsx
@@ -11,8 +11,15 @@ export const activeDutyNotice = (
 export const benefitNotice = (
   <p>
     <strong>Note: </strong>
-    If you’re called to active duty, while you’re enrolled in VET TEC, it may
-    affect your eligibility for the program. If you're called to active duty,
-    please let us know as soon as possible.
+    Your eligibility for VET TEC may be affected if you're called to active
+    duty. Please let us know as soon as possible if there's a change in your
+    military status.
+  </p>
+);
+
+export const reserveNationalGuardExpectedDutyTitle = (
+  <p>
+    Are you in the Selected Reserve or National Guard <strong>and</strong> do
+    you expect to be called to duty for 30 days or more?
   </p>
 );

--- a/src/applications/edu-benefits/0994/pages/militaryService.js
+++ b/src/applications/edu-benefits/0994/pages/militaryService.js
@@ -1,11 +1,16 @@
 import fullSchema from 'vets-json-schema/dist/22-0994-schema.json';
-import { activeDutyNotice, benefitNotice } from '../content/militaryService';
+import {
+  activeDutyNotice,
+  benefitNotice,
+  reserveNationalGuardExpectedDutyTitle as selectedReserveNationalGuardExpectedDutyTitle,
+} from '../content/militaryService';
 
 const { activeDuty, activeDutyDuringVetTec } = fullSchema.properties;
 
 export const uiSchema = {
   activeDuty: {
-    'ui:title': 'Are you currently on active duty?',
+    'ui:title':
+      "Are you on full-time duty in the Armed Forces? (This doesn't include active-duty training for Reserve and National Guard members.)",
     'ui:widget': 'yesNo',
   },
   'view:activeDutyNotice': {
@@ -16,8 +21,7 @@ export const uiSchema = {
     },
   },
   activeDutyDuringVetTec: {
-    'ui:title':
-      'Do you expect to be called to active duty while you’re enrolled in a VET TEC program?',
+    'ui:title': selectedReserveNationalGuardExpectedDutyTitle,
     'ui:widget': 'yesNo',
   },
   'view:benefitNotice': {

--- a/src/applications/edu-benefits/0994/pages/militaryService.js
+++ b/src/applications/edu-benefits/0994/pages/militaryService.js
@@ -2,7 +2,7 @@ import fullSchema from 'vets-json-schema/dist/22-0994-schema.json';
 import {
   activeDutyNotice,
   benefitNotice,
-  reserveNationalGuardExpectedDutyTitle as selectedReserveNationalGuardExpectedDutyTitle,
+  selectedReserveNationalGuardExpectedDutyTitle,
 } from '../content/militaryService';
 
 const { activeDuty, activeDutyDuringVetTec } = fullSchema.properties;


### PR DESCRIPTION
…for National Guard / Reservists: Update military service page text.

## Description
As a VET TEC applicant, I need the content of the military service page updated to provide clarity, so I know how to answer if I'm in the National Guard or a Reservist.

Originating Issue: [17863](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17863)

## Testing done
Manual and local testing completed successfully

## Screenshots
![image](https://user-images.githubusercontent.com/48804834/55974131-02c5be00-5c55-11e9-9020-38d16e46b218.png)

## Acceptance criteria
- [x]  Replace "Are you currently on active duty?" with "Are you on full-time duty in the Armed Forces? (This doesn't include active-duty training for Reserve and National Guard members.)"
- [x]  2 - Replace "Do you expect to be called to active duty while you're enrolled in a VET TEC program?" with "Are you in the Selected Reserve or National Guard and do you expect to be called to duty for 30 days or more?"
- [x]  - Replace "Note: If you're called to active duty, while you're enrolled in VET TEC, it may affect your eligibility for the program. If you're called to active duty, please let us know as soon as possible." with "Note: Your eligibility for VET TEC may be affected if you're called to active duty. Please let us know as soon as possible if there's a change in your military status."


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
