### PR TITLE
Create MVI error handling for identity in logged in state

### DIFF
--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -120,6 +120,25 @@ export class CallToActionWidget extends React.Component {
   };
 
   getHealthToolContent = () => {
+    if (this.props.mviDown) {
+      return {
+        heading: 'VA.gov health tools are temporarily unavailable',
+        alertText: (
+          <>
+            <p>
+              We’re sorry. We’re having trouble accessing your Veteran records.
+            </p>
+            <h5>What you can do</h5>
+            <p>
+              Please check back in a few minutes. This issue is temporary and
+              will be resolved soon.
+            </p>
+          </>
+        ),
+        status: 'error',
+      };
+    }
+
     if (this.isAccessible()) {
       return {
         heading: 'My HealtheVet will open in a new tab',
@@ -436,12 +455,13 @@ CallToActionWidget.defaultProps = {
 
 const mapStateToProps = state => {
   const profile = selectProfile(state);
-  const { loading, mhvAccount, /* services, */ verified } = profile;
+  const { loading, mhvAccount, /* services, */ verified, status } = profile;
   return {
     // availableServices: new Set(services),
     isLoggedIn: isLoggedIn(state),
     profile: { loading, verified },
     mhvAccount,
+    mviDown: status !== 'OK',
   };
 };
 


### PR DESCRIPTION
## Description
If MVI is down, display error messaging in CTA widget on health tool pages.

## Testing done
Tested locally

## Screenshots
![image](https://user-images.githubusercontent.com/786704/56004674-72ea3900-5c81-11e9-8ac7-edb4b8c8c576.png)


## Acceptance criteria
- [ ] When MVI status is not `"OK"` display error messaging in CTA widget in health tools

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
