### PR TITLE
VAGOV-2737: Fixing link teaser paragraph template

### DIFF
--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -25,9 +25,9 @@
     {% endif %}
 {% endif %}
 <li {% if parentFieldName === 'field_spokes' %}class="hub-page-link-list__item"{% endif %}>
-    <a href="{{linkTeaser.fieldLink.url.path}}" {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
-        {% if linkTeaser.fieldLink.title != empty %}
-            <{{ header }} class="{{ headerClass }}">{{ linkTeaser.fieldLink.title }}</{{ header }}>
+    <a href="{{linkTeaser.fieldLink.0.url.path}}" {% if linkTeaser.fieldLink.0.options["target"] %}target="{{ linkTeaser.fieldLink.0.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
+        {% if linkTeaser.fieldLink.0.title != empty %}
+            <{{ header }} class="{{ headerClass }}">{{ linkTeaser.fieldLink.0.title }}</{{ header }}>
             {% if parentFieldName === "field_spokes" %}
                 <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
             {% endif %}

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -24,17 +24,22 @@
         {% assign headerClass = "va-nav-linkslist-title" %}
     {% endif %}
 {% endif %}
-<li {% if parentFieldName === 'field_spokes' %}class="hub-page-link-list__item"{% endif %}>
-    <a href="{{linkTeaser.fieldLink.0.url.path}}" {% if linkTeaser.fieldLink.0.options["target"] %}target="{{ linkTeaser.fieldLink.0.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
-        {% if linkTeaser.fieldLink.0.title != empty %}
-            <{{ header }} class="{{ headerClass }}">{{ linkTeaser.fieldLink.0.title }}</{{ header }}>
+
+{% for link in linkTeaser.fieldLink %}
+    {% if link.url.path != empty %}
+        <li {% if parentFieldName === 'field_spokes' %}class="hub-page-link-list__item"{% endif %}>
+            <a href="{{link.url.path}}" {% if link.options["target"] %}target="{{ link.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
+                {% if link.title != empty %}
+                <{{ header }} class="{{ headerClass }}">{{ link.title }}</{{ header }}>
             {% if parentFieldName === "field_spokes" %}
                 <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
             {% endif %}
-        {% endif %}
+            {% endif %}
 
-        {% if linkTeaser.fieldLinkSummary != empty %}
-            <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>
-        {% endif %}
-    </a>
-</li>
+            {% if linkTeaser.fieldLinkSummary != empty %}
+                <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>
+            {% endif %}
+            </a>
+        </li>
+    {% endif %}
+{% endfor %}

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -29,11 +29,11 @@
     {% if link.url.path != empty %}
         <li {% if parentFieldName === 'field_spokes' %}class="hub-page-link-list__item"{% endif %}>
             <a href="{{link.url.path}}" {% if link.options["target"] %}target="{{ link.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
-                {% if link.title != empty %}
+            {% if link.title != empty %}
                 <{{ header }} class="{{ headerClass }}">{{ link.title }}</{{ header }}>
-            {% if parentFieldName === "field_spokes" %}
-                <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
-            {% endif %}
+                {% if parentFieldName === "field_spokes" %}
+                    <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
+                {% endif %}
             {% endif %}
 
             {% if linkTeaser.fieldLinkSummary != empty %}


### PR DESCRIPTION
## Description
Restoring link headings to list of links teasers on hub landing pages. 

## Testing done
Tested locally with staging data. 

## Screenshots
![image](https://user-images.githubusercontent.com/3157339/56042744-fdba4a80-5cf8-11e9-8250-30d378a6f23e.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
