### PR TITLE
[Hubs] Add Padding to Social Icons

### DIFF
--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -381,6 +381,9 @@ $medium-phone-screen: 375px;
       a {
         text-decoration: underline;
       }
+        .social-icon {
+          text-decoration: none;
+        }
 
       .usa-accordion-content {
         h4:first-child {

--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -12,7 +12,7 @@
                 <ul class="va-nav-linkslist-list social">
                     <li>
                         <a href="{{ administration.fieldEmailUpdatesUrl }}">
-                            <i class="fas fa-envelope vads-u-margin-right--0p5"></i>
+                            <i class="fas fa-envelope vads-u-padding-right--1"></i>
                             {{ administration.fieldEmailUpdatesLinkText }}
                         </a>
                     </li>
@@ -30,14 +30,14 @@
                             {% if socialPlatform = "youtube_channel" %}
                                 <li>
                                     <a href="http://youtube.com/channel/{{ socialLink.value }}">
-                                        <i class="fab fa-youtube vads-u-margin-right--0p5"></i>
+                                        <i class="fab fa-youtube vads-u-padding-right--1"></i>
                                         {{ administration.name }} {{ socialPlatform | remove: '_' | capitalize }}
                                     </a>
                                 </li>
                             {% else %}
                                 <li>
                                     <a href="http://{{ socialPlatform }}.com/{{ socialLink.value }}">
-                                        <i class="fab fa-{{ socialPlatform }} vads-u-margin-right--0p5"></i>
+                                        <i class="fab fa-{{ socialPlatform }} vads-u-padding-right--1"></i>
                                         {{ administration.name }} {{ socialPlatform | capitalize }}
                                     </a>
                                 </li>

--- a/src/site/components/merger-social.html
+++ b/src/site/components/merger-social.html
@@ -45,9 +45,9 @@ See https://help.shopify.com/themes/liquid/tags/theme-tags#include
                     >
                     {% if link.icon != empty %}
                       {% if is_social_media_links %}
-                        <i class="fab {{link.icon}}"></i>
+                        <i class="fab {{link.icon}} social-icon vads-u-padding-right--1"></i>
                       {% else %}
-                        <i class="fas {{link.icon}}"></i>
+                        <i class="fas {{link.icon}} social-icon vads-u-padding-right--1"></i>
                       {% endif %}
                     {% endif %}
 


### PR DESCRIPTION
## Description
The purpose of this PR is to add padding to right side of the social icons on hub pages' right-rail social section.

This was performed by 
1. Using the spacing utility `vads-u-padding-right--1` from the [design system](https://department-of-veterans-affairs.github.io/vets-design-system-documentation/utilities/padding.html)
2. Creating a SCSS class `social-icon` in `/src/platform/site-wide/sass/shame.scss` to remove `text-decoration: underline`  from the space between the social icon and link text.

## Testing done
View on local build

## Screenshots
**Before**:
![Screen Shot 2019-04-12 at 2 46 58 PM](https://user-images.githubusercontent.com/11021491/56059366-e64b8380-5d31-11e9-8981-b44eec51848e.png)


**After**:
![Screen Shot 2019-04-12 at 2 42 34 PM](https://user-images.githubusercontent.com/11021491/56059303-c87e1e80-5d31-11e9-8834-b2e8222ea028.png)


## Acceptance criteria
- [X] Social icons have padding between text on hub pages

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
