### PR TITLE
Update page titles in tests to match vagov-content

### DIFF
--- a/src/applications/edu-benefits/tests/1995/01-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/1995/01-all-fields.e2e.spec.js
@@ -16,7 +16,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
       }/education/apply-for-education-benefits/application/1995`,
     )
     .waitForElementVisible('body', Timeouts.normal)
-    .assert.title('Veteran Request for Change: VA.gov')
+    .assert.title('Veteran request for change: VA.gov')
     .waitForElementVisible('.schemaform-start-button', Timeouts.slow)
     .axeCheck('.main')
     .click('.schemaform-start-button');

--- a/src/applications/edu-benefits/tests/5495/01-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/5495/01-all-fields.e2e.spec.js
@@ -16,7 +16,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
       }/education/apply-for-education-benefits/application/5495`,
     )
     .waitForElementVisible('body', Timeouts.normal)
-    .assert.title('Dependents Request for Change: VA.gov')
+    .assert.title('Dependents request for change: VA.gov')
     .waitForElementVisible('.schemaform-start-button', Timeouts.slow)
     .axeCheck('.main')
     .click('.schemaform-start-button');

--- a/src/applications/edu-benefits/tests/edu-apply-wizard.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/edu-apply-wizard.e2e.spec.js
@@ -8,7 +8,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .openUrl(`${E2eHelpers.baseUrl}/education/apply/`)
     .waitForElementVisible('body', Timeouts.normal)
     .assert.title(
-      'How to Apply for the GI Bill and Other Education Benefits: VA.gov',
+      'How to apply for the GI Bill and other education benefits: VA.gov',
     )
     .waitForElementVisible('.wizard-container', Timeouts.normal)
     .click('.wizard-button')

--- a/src/applications/post-911-gib-status/tests/01-authed.e2e.spec.js
+++ b/src/applications/post-911-gib-status/tests/01-authed.e2e.spec.js
@@ -12,7 +12,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   Auth.logIn(token, client, '/education/gi-bill/post-9-11/ch-33-benefit', 3)
     .waitForElementVisible('body', Timeouts.normal)
     .axeCheck('.main')
-    .assert.title('Check Your Post-9/11 GI Bill Benefits Status: VA.gov')
+    .assert.title('Check your Post-9/11 GI Bill benefits status: VA.gov')
     .waitForElementVisible(
       '.usa-button-primary.va-button-primary',
       Timeouts.slow,


### PR DESCRIPTION
## Description
Some page titles changed in vagov-content, but we're checking the titles in our e2e tests.

## Testing done


## Screenshots


## Acceptance criteria
- [ ] Tests pass

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
