### PR TITLE
Reintegrate puppeteer tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,9 +68,12 @@ node('vetsgov-general-purpose') {
         parallel (
           e2e: {
             sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p e2e up -d && docker-compose -p e2e run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker"
-            // sh "docker-compose -p e2e run --rm --entrypoint npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run test:puppeteer:docker"
-            // Test puppeteerNotification
-            commonStages.puppeteerNotification()
+            try {
+              sh "docker-compose -p e2e run --rm --entrypoint npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run test:puppeteer:docker"
+            } catch (error) {
+              commonStages.puppeteerNotification()
+              // Don't throw the error; it shouldn't stop the build for now
+            }
           },
 
           accessibility: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
+@Library('va.gov-devops-jenkins-lib') _
 import org.kohsuke.github.GitHub
 
 env.CONCURRENCY = 10
@@ -67,7 +68,9 @@ node('vetsgov-general-purpose') {
         parallel (
           e2e: {
             sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p e2e up -d && docker-compose -p e2e run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker"
-            sh "docker-compose -p e2e run --rm --entrypoint npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run test:puppeteer:docker"
+            // sh "docker-compose -p e2e run --rm --entrypoint npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run test:puppeteer:docker"
+            // Test notifySlack
+            notifySlack "This has been a test of our (non-)emergency broadcast system initiated by @chris.valarida. Don't mind me...", showTrigger: true, showBuildLink: true
           },
 
           accessibility: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,8 +69,8 @@ node('vetsgov-general-purpose') {
           e2e: {
             sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p e2e up -d && docker-compose -p e2e run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker"
             // sh "docker-compose -p e2e run --rm --entrypoint npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run test:puppeteer:docker"
-            // Test notifySlack
-            notifySlack "This has been a test of our (non-)emergency broadcast system initiated by @chris.valarida. Don't mind me...", showTrigger: true, showBuildLink: true
+            // Test puppeteerNotification
+            commonStages.puppeteerNotification()
           },
 
           accessibility: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,8 +67,7 @@ node('vetsgov-general-purpose') {
         parallel (
           e2e: {
             sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p e2e up -d && docker-compose -p e2e run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker"
-            // Temporarily disabling puppeteer tests due to flakiness
-            // sh "docker-compose -p e2e run --rm --entrypoint npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run test:puppeteer:docker"
+            sh "docker-compose -p e2e run --rm --entrypoint npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run test:puppeteer:docker"
           },
 
           accessibility: {

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -87,12 +87,10 @@ def slackNotify() {
 }
 
 def puppeteerNotification() {
-  if (IS_DEV_BRANCH || IS_STAGING_BRANCH || IS_PROD_BRANCH) {
-    message = "(Testing) @chris.valarida: `${env.BRANCH_NAME}` failed the puppeteer tests. |${env.RUN_DISPLAY_URL}".stripMargin()
-    slackSend message: message,
-      color: 'danger',
-      failOnError: true
-  }
+  message = "(Testing) @chris.valarida: `${env.BRANCH_NAME}` failed the puppeteer tests. |${env.RUN_DISPLAY_URL}".stripMargin()
+  slackSend message: message,
+    color: 'danger',
+    failOnError: true
 }
 
 def setup() {

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -86,6 +86,15 @@ def slackNotify() {
   }
 }
 
+def puppeteerNotification() {
+  if (IS_DEV_BRANCH || IS_STAGING_BRANCH || IS_PROD_BRANCH) {
+    message = "(Testing) @chris.valarida: `${env.BRANCH_NAME}` failed the puppeteer tests. |${env.RUN_DISPLAY_URL}".stripMargin()
+    slackSend message: message,
+      color: 'danger',
+      failOnError: true
+  }
+}
+
 def setup() {
   stage("Setup") {
 

--- a/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
@@ -14,7 +14,7 @@ const testData = getTestDataSets(join(__dirname, 'data'), {
 });
 
 const testConfig = {
-  // debug: true,
+  debug: true,
   setup: userToken => {
     PageHelpers.initDocumentUploadMock();
     PageHelpers.initApplicationSubmitMock();

--- a/src/platform/testing/e2e/form-tester/index.js
+++ b/src/platform/testing/e2e/form-tester/index.js
@@ -74,6 +74,7 @@ const runTest = async (page, testData, testConfig, userToken) => {
 const testForm = (testDataSets, testConfig) => {
   let browser;
   const token = getUserToken();
+  const headlessMode = !testConfig.debug || process.env.IN_DOCKER;
 
   beforeAll(() => {
     if (testConfig.setup) {
@@ -89,12 +90,15 @@ const testForm = (testDataSets, testConfig) => {
         '--no-sandbox',
         '--disable-setuid-sandbox',
       ],
-      devtools: testConfig.debug && !process.env.IN_DOCKER,
+      devtools: !headlessMode,
     });
   });
 
   afterEach(async () => {
-    if (!testConfig.debug) {
+    // The assumption here is that debug mode is turned on to see what's causing a failure,
+    //  so keep the window open.
+    // When running in docker, it will always be in headless mode, so always close it.
+    if (headlessMode) {
       await browser.close();
     }
   });

--- a/src/platform/testing/e2e/form-tester/index.js
+++ b/src/platform/testing/e2e/form-tester/index.js
@@ -89,7 +89,7 @@ const testForm = (testDataSets, testConfig) => {
         '--no-sandbox',
         '--disable-setuid-sandbox',
       ],
-      devtools: testConfig.debug,
+      devtools: testConfig.debug && !process.env.IN_DOCKER,
     });
   });
 


### PR DESCRIPTION
## Description
This PR re-enables puppeteer tests running in CI. The idea here is that while they may still be flaky, they're running in debug mode now and should give a better sense of _why_ they're failing.

## Testing done
That's what this is PR is for? :man_shrugging: 

## Screenshots
N/A

## Acceptance criteria
- [x] The tests run in CI

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
