### PR TITLE
Fix errors on master - Drupal and security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "history": "3",
     "ics-js": "^0.10.2",
     "ismobilejs": "^0.4.0",
-    "js-yaml": "^3.13.0",
+    "js-yaml": "^3.13.1",
     "jsonschema": "^1.1.1",
     "leaflet": "^1.0.3",
     "leaflet-control-geocoder": "^1.5.1",

--- a/script/security-check.js
+++ b/script/security-check.js
@@ -11,6 +11,7 @@ const packageJSON = require('../package.json');
 const exceptionSet = new Set([
   'https://npmjs.com/advisories/577',
   'https://npmjs.com/advisories/157',
+  'https://npmjs.com/advisories/788',
   'https://npmjs.com/advisories/813',
 ]);
 

--- a/script/security-check.js
+++ b/script/security-check.js
@@ -11,7 +11,7 @@ const packageJSON = require('../package.json');
 const exceptionSet = new Set([
   'https://npmjs.com/advisories/577',
   'https://npmjs.com/advisories/157',
-  'https://npmjs.com/advisories/788',
+  'https://npmjs.com/advisories/813',
 ]);
 
 const severitySet = new Set(['high', 'critical', 'moderate']);

--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -27,7 +27,7 @@
           {% else %}
             {% assign crumbPath = crumb.url.path %}
           {% endif %}
-          {% if crumb.text != "Get Benefits" and crumb.text != "Manage Benefits" and crumb.text != "More Resources" %}
+          {% if crumb.text != "Get benefits" and crumb.text != "Manage benefits" and crumb.text != "More resources" %}
         <li>
           {% if crumbPath != empty %}
           <a href="{{crumbPath}}"

--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -22,7 +22,7 @@
           </a>
         </li>
         {% else %}
-          {% if crumb.text == "Health Care" %}
+          {% if crumb.text == "Health care" %}
             {% assign crumbPath = "/health-care" %}
           {% else %}
             {% assign crumbPath = crumb.url.path %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6404,10 +6404,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.0:
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.0.tgz#38ee7178ac0eea2c97ff6d96fff4b18c7d8cf98e"
-  integrity sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
+js-yaml@^3.13.1, js-yaml@^3.9.0:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -6422,14 +6422,6 @@ js-yaml@^3.4.6, js-yaml@^3.5.1, js-yaml@^3.5.4, js-yaml@^3.8.1, js-yaml@^3.9.1:
 js-yaml@^3.7.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.9.0:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
-  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
## Description
This pull request fixes the errors we are seeing on master.

1. Fixes a Drupal template error, occurring because of a letter case mismatch in values being tied between template and the CMS.
2. Fixes the two security exceptions as seen below. It updates the module in our package.json, but has to add an exception for the error anyway because Metalsmith uses it under-the-hood.

```
Security advisory:
  Title: Code Injection
  Module name: js-yaml
  Dependency: js-yaml
  Path: js-yaml
  Severity: high
  Details: https://npmjs.com/advisories/813

Security advisory:
  Title: Code Injection
  Module name: js-yaml
  Dependency: metalsmith
  Path: metalsmith>gray-matter>js-yaml
  Severity: high
  Details: https://npmjs.com/advisories/813
```

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
