### PR TITLE
App state selector on submit

### DIFF
--- a/src/platform/forms-system/src/js/review/SubmitController.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitController.jsx
@@ -48,7 +48,7 @@ class SubmitController extends React.Component {
   };
 
   handleSubmit = () => {
-    const { form, formConfig, pagesByChapter, trackingPrefix } = this.props;
+    const { form, formConfig, pageList, trackingPrefix } = this.props;
 
     // If a pre-submit agreement is required, make sure it was accepted
     const preSubmit = this.getPreSubmit(formConfig);
@@ -60,7 +60,7 @@ class SubmitController extends React.Component {
 
     // Validation errors in this situation are not visible, so we’d
     // like to know if they’re common
-    const { isValid, errors } = isValidForm(form, pagesByChapter);
+    const { isValid, errors } = isValidForm(form, pageList);
     if (!isValid) {
       recordEvent({
         event: `${trackingPrefix}-validation-failed`,

--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -232,10 +232,11 @@ export function errorSchemaIsValid(errorSchema) {
   return _.values(_.omit('__errors', errorSchema)).every(errorSchemaIsValid);
 }
 
-export function isValidForm(form, pageListByChapters) {
-  const pageConfigs = _.flatten(_.values(pageListByChapters));
+export function isValidForm(form, pageList) {
+  const pageListMap = new Map();
+  pageList.forEach(page => pageListMap.set(page.pageKey, page));
   const validPages = Object.keys(form.pages).filter(pageKey =>
-    isActivePage(_.find({ pageKey }, pageConfigs), form.data),
+    isActivePage(_.find({ pageKey }, pageList), form.data),
   );
 
   const v = new Validator();
@@ -249,6 +250,7 @@ export function isValidForm(form, pageListByChapters) {
         itemFilter,
         arrayPath,
       } = form.pages[page];
+      const { appStateData } = pageListMap.get(page);
       let formData = form.data;
 
       if (showPagePerItem) {

--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -270,7 +270,15 @@ export function isValidForm(form, pageList) {
 
       if (result.valid) {
         const customErrors = {};
-        uiSchemaValidate(customErrors, uiSchema, schema, formData);
+        uiSchemaValidate(
+          customErrors,
+          uiSchema,
+          schema,
+          formData,
+          '',
+          null,
+          appStateData,
+        );
 
         return {
           isValid: isValid && errorSchemaIsValid(customErrors),

--- a/src/platform/forms-system/test/js/validation.unit.spec.js
+++ b/src/platform/forms-system/test/js/validation.unit.spec.js
@@ -445,16 +445,14 @@ describe('Schemaform validations', () => {
           },
         },
       };
-      const pageListByChapters = {
-        testChapter: [
-          {
-            pageKey: 'testPage',
-            chapterKey: 'testChapter',
-          },
-        ],
-      };
+      const pageList = [
+        {
+          pageKey: 'testPage',
+          chapterKey: 'testChapter',
+        },
+      ];
 
-      expect(isValidForm(form, pageListByChapters).isValid).to.be.false;
+      expect(isValidForm(form, pageList).isValid).to.be.false;
     });
     it('should validate only filtered items for pagePerItem schema', () => {
       const form = {
@@ -482,16 +480,14 @@ describe('Schemaform validations', () => {
           },
         },
       };
-      const pageListByChapters = {
-        testChapter: [
-          {
-            pageKey: 'testPage',
-            chapterKey: 'testChapter',
-          },
-        ],
-      };
+      const pageList = [
+        {
+          pageKey: 'testPage',
+          chapterKey: 'testChapter',
+        },
+      ];
 
-      expect(isValidForm(form, pageListByChapters).isValid).to.be.true;
+      expect(isValidForm(form, pageList).isValid).to.be.true;
     });
     it('should not validate pages where depends is false', () => {
       const form = {
@@ -527,23 +523,20 @@ describe('Schemaform validations', () => {
           },
         },
       };
-      const pageListByChapters = {
-        testChapter: [
-          {
-            pageKey: 'testPage',
-            chapterKey: 'testChapter',
-          },
-          {
-            pageKey: 'testPage2',
-            chapterKey: 'testChapter',
-            depends: sinon.stub().returns(false),
-          },
-        ],
-      };
+      const pageList = [
+        {
+          pageKey: 'testPage',
+          chapterKey: 'testChapter',
+        },
+        {
+          pageKey: 'testPage2',
+          chapterKey: 'testChapter',
+          depends: sinon.stub().returns(false),
+        },
+      ];
 
-      expect(isValidForm(form, pageListByChapters).isValid).to.be.true;
-      expect(pageListByChapters.testChapter[1].depends.calledWith(form.data)).to
-        .be.true;
+      expect(isValidForm(form, pageList).isValid).to.be.true;
+      expect(pageList[1].depends.calledWith(form.data)).to.be.true;
     });
   });
   describe('validateMonthYear', () => {

--- a/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
@@ -191,7 +191,12 @@ function mapStateToProps(state, ownProps) {
     form,
     formConfig,
     formContext,
-    pageList,
+    pageList: pageList.map(
+      page =>
+        page.appStateSelector
+          ? { ...page, appStateData: page.appStateSelector(state) }
+          : page,
+    ),
     showLoginModal: state.navigation.showLoginModal,
     path,
     route,


### PR DESCRIPTION
## Description
There's a bug preventing submission. Essentially, when the form is submitted, it'll run the data through the validator one more time, but this time, it doesn't have each page's `appStateData` to send to the `ui:validations` functions. This PR fixes that.

## Testing done
Much manual testing.

## Screenshots
N/A

## Acceptance criteria
- [x] The `ui:validations` functions are called with `appStateData` when the form data is submitted

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
