### PR TITLE
Add test data file name to logger

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
@@ -10,7 +10,7 @@ const PageHelpers = require('./disability-benefits-helpers');
 const testData = getTestDataSets(join(__dirname, 'data'), {
   extension: 'json',
   ignore: ['minimal-ptsd-form-upload-test.json'],
-  // only: ['secondary-new-test.json'],
+  // only: ['minimal-test.json'],
 });
 
 const testConfig = {

--- a/src/platform/testing/e2e/form-tester/index.js
+++ b/src/platform/testing/e2e/form-tester/index.js
@@ -18,14 +18,14 @@ const fastForwardAnimations = async page => {
 
 const getTestData = (contents, pathPrefix) => get(pathPrefix, contents, {});
 
-const getLogger = debugMode => (...params) => {
+const getLogger = (debugMode, testName) => (...params) => {
   if (debugMode) {
     // eslint-disable-next-line no-console
-    console.log(...params);
+    console.log(`${testName}:`, ...params);
   }
 };
 
-const runTest = async (page, testData, testConfig, userToken) => {
+const runTest = async (page, testData, testConfig, userToken, testName) => {
   // Go to the starting page either by logging in or going there directly
   if (testConfig.logIn) {
     await logIn(userToken, page, testConfig.url, 3);
@@ -33,7 +33,12 @@ const runTest = async (page, testData, testConfig, userToken) => {
     await page.goto(`${baseUrl}${testConfig.url}`);
   }
 
-  await fillForm(page, testData, testConfig, getLogger(testConfig.debug));
+  await fillForm(
+    page,
+    testData,
+    testConfig,
+    getLogger(testConfig.debug, testName),
+  );
 
   // TODO: Check for unused data
   // TODO: Submit
@@ -114,7 +119,7 @@ const testForm = (testDataSets, testConfig) => {
         const pageList = await browser.pages();
         const page = pageList[0] || (await browser.newPage());
         await fastForwardAnimations(page);
-        await runTest(page, testData, testConfig, token);
+        await runTest(page, testData, testConfig, token, fileName);
       },
       // TODO: Make the timeout based on the number of inputs by default
       testConfig.timeoutPerTest || 120000,


### PR DESCRIPTION
## Description
After adding the puppeteer tests back in CI in debug mode, I found the output wasn't _super_ helpful. This makes the log statements prepend the test data file name to the output.

## Testing done
Ran minimal test file in debug mode and saw the output.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/56247645-5ae83000-605a-11e9-89b9-a818c6554052.png)


## Acceptance criteria
- [x] The filename is in the log

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
