### PR TITLE
Allow drupal api call to fail on dev and staging

### DIFF
--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -145,7 +145,7 @@ function getDrupalContent(buildOptions) {
       log(err.stack);
       log(JSON.stringify(drupalData));
       log('Failed to pipe Drupal content into Metalsmith!');
-      if (buildOptions.buildtype !== ENVIRONMENTS.LOCALHOST) {
+      if (buildOptions.buildtype === ENVIRONMENTS.VAGOVPROD) {
         done(err);
       } else {
         done();


### PR DESCRIPTION
## Description
This allows the drupal api call to fail on dev and staging without breaking the build.

## Testing done

## Acceptance criteria
- [x] Build passes

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
