### PR TITLE
17494 mvi down cta

### DIFF
--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -120,6 +120,25 @@ export class CallToActionWidget extends React.Component {
   };
 
   getHealthToolContent = () => {
+    if (this.props.mviDown) {
+      return {
+        heading: 'VA.gov health tools are temporarily unavailable',
+        alertText: (
+          <>
+            <p>
+              We’re sorry. We’re having trouble accessing your Veteran records.
+            </p>
+            <h5>What you can do</h5>
+            <p>
+              Please check back in a few minutes. This issue is temporary and
+              will be resolved soon.
+            </p>
+          </>
+        ),
+        status: 'error',
+      };
+    }
+
     if (this.isAccessible()) {
       return {
         heading: 'My HealtheVet will open in a new tab',
@@ -436,12 +455,13 @@ CallToActionWidget.defaultProps = {
 
 const mapStateToProps = state => {
   const profile = selectProfile(state);
-  const { loading, mhvAccount, /* services, */ verified } = profile;
+  const { loading, mhvAccount, /* services, */ verified, status } = profile;
   return {
     // availableServices: new Set(services),
     isLoggedIn: isLoggedIn(state),
     profile: { loading, verified },
     mhvAccount,
+    mviDown: status !== 'OK',
   };
 };
 

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -461,7 +461,7 @@ const mapStateToProps = state => {
     isLoggedIn: isLoggedIn(state),
     profile: { loading, verified },
     mhvAccount,
-    mviDown: status !== 'OK',
+    mviDown: status === 'SERVER_ERROR',
   };
 };
 


### PR DESCRIPTION
## Description
Fixing the cta-widget to only display the MVI error when we get a `SERVER_ERROR` status

## Testing done
Tested locally


## Acceptance criteria
- [ ] `SERVER_ERROR` status indicates MVI is down

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
