### PR TITLE
Fix mviDown criteria

### DIFF
--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -461,7 +461,7 @@ const mapStateToProps = state => {
     isLoggedIn: isLoggedIn(state),
     profile: { loading, verified },
     mhvAccount,
-    mviDown: status !== 'OK',
+    mviDown: status === 'SERVER_ERROR',
   };
 };
 


### PR DESCRIPTION
## Description
Fixing the cta-widget to only display the MVI error when we get a `SERVER_ERROR` status

## Testing done
Tested locally


## Acceptance criteria
- [ ] `SERVER_ERROR` status indicates MVI is down

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
