### PR TITLE
Add a SHA stamp to the API link

### DIFF
--- a/src/applications/beta-enrollment/README.md
+++ b/src/applications/beta-enrollment/README.md
@@ -14,7 +14,7 @@ To create a similar process for another application, follow these steps:
 4. Any applications that are part of that Beta should be wrapped in a `BetaApp` tags. For example, Personalization products were wrapped in:
     - `<BetaApp featureName={features.dashboard} redirect="/beta-enrollment/personalization/">`
     - In the event the user navigated there without being enrolled, they would be redirected to the enrollment page.
-    - The FE and API have to agree on the name of your beta. Make sure it exists in the [API](https://github.com/department-of-veterans-affairs/vets-api/blob/cb0b37ec83fd5c46e7d8c918bae35027e8541696/config/routes.rb#L2432) `beta_registration` controller.
+    - The FE and API have to agree on the name of your beta. Make sure it exists in the [API](https://github.com/department-of-veterans-affairs/vets-api/blob/cb0b37ec83fd5c46e7d8c918bae35027e8541696/config/routes.rb#L243) `beta_registration` controller.
 
 ## Unenrolling from Beta
 There is an action available for deleting a service from the user's services array, but it must be implemented manually.

--- a/src/applications/beta-enrollment/README.md
+++ b/src/applications/beta-enrollment/README.md
@@ -14,7 +14,7 @@ To create a similar process for another application, follow these steps:
 4. Any applications that are part of that Beta should be wrapped in a `BetaApp` tags. For example, Personalization products were wrapped in:
     - `<BetaApp featureName={features.dashboard} redirect="/beta-enrollment/personalization/">`
     - In the event the user navigated there without being enrolled, they would be redirected to the enrollment page.
-    - The FE and API have to agree on the name of your beta. Make sure it exists in the [API](https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/routes.rb#L202) `beta_registration` controller.
+    - The FE and API have to agree on the name of your beta. Make sure it exists in the [API](https://github.com/department-of-veterans-affairs/vets-api/blob/cb0b37ec83fd5c46e7d8c918bae35027e8541696/config/routes.rb#L2432) `beta_registration` controller.
 
 ## Unenrolling from Beta
 There is an action available for deleting a service from the user's services array, but it must be implemented manually.


### PR DESCRIPTION
## Description
A piece of this doc links to a certain line of code in the API. I'd like to SHA stamp this link so that it stays correct even while that code grows on `master`. 
