### PR TITLE
Revert "VAGOV-2737: Fixing link teaser paragraph template (#9916)"

### DIFF
--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -24,22 +24,17 @@
         {% assign headerClass = "va-nav-linkslist-title" %}
     {% endif %}
 {% endif %}
-
-{% for link in linkTeaser.fieldLink %}
-    {% if link.url.path != empty %}
-        <li {% if parentFieldName === 'field_spokes' %}class="hub-page-link-list__item"{% endif %}>
-            <a href="{{link.url.path}}" {% if link.options["target"] %}target="{{ link.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
-            {% if link.title != empty %}
-                <{{ header }} class="{{ headerClass }}">{{ link.title }}</{{ header }}>
-                {% if parentFieldName === "field_spokes" %}
-                    <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
-                {% endif %}
+<li {% if parentFieldName === 'field_spokes' %}class="hub-page-link-list__item"{% endif %}>
+    <a href="{{linkTeaser.fieldLink.url.path}}" {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
+        {% if linkTeaser.fieldLink.title != empty %}
+            <{{ header }} class="{{ headerClass }}">{{ linkTeaser.fieldLink.title }}</{{ header }}>
+            {% if parentFieldName === "field_spokes" %}
+                <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
             {% endif %}
+        {% endif %}
 
-            {% if linkTeaser.fieldLinkSummary != empty %}
-                <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>
-            {% endif %}
-            </a>
-        </li>
-    {% endif %}
-{% endfor %}
+        {% if linkTeaser.fieldLinkSummary != empty %}
+            <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>
+        {% endif %}
+    </a>
+</li>


### PR DESCRIPTION
This reverts commit 303c72552d297f77b1bf61d35bea4d73a19d0b51, which is causing the prod error seen in the screenshot below -

![image](https://user-images.githubusercontent.com/1915775/56321535-e6ce8a80-6134-11e9-9244-d6a9335985e9.png)

## Acceptance criteria
- [ ] `/health-care` is fixed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
