### PR TITLE
Add id into Drupal alert-banner template

### DIFF
--- a/src/applications/static-pages/createAdditionalInfoWidget.js
+++ b/src/applications/static-pages/createAdditionalInfoWidget.js
@@ -10,16 +10,16 @@ export default function createAdditionalInfoWidget() {
       const titleText =
         (titleNode && titleNode.textContent) || 'More information';
       const contentContainer = qS(el, '.additional-info-content').parentNode;
-      const contentContainerID = contentContainer.id;
       const contentMarkup = qS(el, '.additional-info-content').innerHTML;
+      const expandedContentId = `${contentContainer.id}-expanded`;
 
       const template = `
-          <button type="button" class="additional-info-button va-button-link" aria-controls="${contentContainerID}" aria-expanded="false">
+          <button type="button" class="additional-info-button va-button-link" aria-controls="${expandedContentId}" aria-expanded="false">
             <span class="additional-info-title">${titleText}
               <i class="fa fa-angle-down"></i>
             </span>
           </button>
-          <span id="${contentContainerID}">
+          <span id="${expandedContentId}">
             <div class="additional-info-content">
               ${contentMarkup}
             </div>

--- a/src/applications/static-pages/createAdditionalInfoWidget.js
+++ b/src/applications/static-pages/createAdditionalInfoWidget.js
@@ -11,7 +11,7 @@ export default function createAdditionalInfoWidget() {
         (titleNode && titleNode.textContent) || 'More information';
       const contentContainer = qS(el, '.additional-info-content').parentNode;
       const contentMarkup = qS(el, '.additional-info-content').innerHTML;
-      const expandedContentId = `${contentContainer.id}-expanded`;
+      const expandedContentId = `${contentContainer.id}-expandable`;
 
       const template = `
           <button type="button" class="additional-info-button va-button-link" aria-controls="${expandedContentId}" aria-expanded="false">

--- a/src/applications/static-pages/createAdditionalInfoWidget.js
+++ b/src/applications/static-pages/createAdditionalInfoWidget.js
@@ -11,7 +11,7 @@ export default function createAdditionalInfoWidget() {
         (titleNode && titleNode.textContent) || 'More information';
       const contentContainer = qS(el, '.additional-info-content').parentNode;
       const contentMarkup = qS(el, '.additional-info-content').innerHTML;
-      const expandedContentId = `${contentContainer.id}-expandable`;
+      const expandedContentId = `${contentContainer.id}-content`;
 
       const template = `
           <button type="button" class="additional-info-button va-button-link" aria-controls="${expandedContentId}" aria-expanded="false">

--- a/src/site/blocks/alert.drupal.liquid
+++ b/src/site/blocks/alert.drupal.liquid
@@ -39,7 +39,7 @@
         NOTE: .additional-info-container is a class utilized by
         createAdditionalInfoWidget.js to add toggle functionality to info alerts
       {% endcomment %}
-      <div class="form-expanding-group borderless-alert additional-info-container" aria-hidden="true">
+      <div id="{{ expander.entityBundle }}-{{ expander.entityId }}-details" class="form-expanding-group borderless-alert additional-info-container" aria-hidden="true">
         <div class="additional-info-title">{{ expander.fieldTextExpander }}</div>
 
         {% if expander.fieldWysiwyg %}


### PR DESCRIPTION
## Description
This PR resolves some accessibility errors due to missing IDs on expandable alert banners rendered from Drupal. The non-Drupal templates are being updated here, https://github.com/department-of-veterans-affairs/vagov-content/pull/398.

## Testing done
Local tests

## Acceptance criteria
- [ ] Alert banners pass accessibility tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
