### PR TITLE
[Drupal] Add analytics into Drupal-generated expandable alert banners

### DIFF
--- a/src/applications/disability-benefits/all-claims/analytics-functions.js
+++ b/src/applications/disability-benefits/all-claims/analytics-functions.js
@@ -1,4 +1,4 @@
-import { recordEventOnce } from './utils';
+import { recordEventOnce } from 'platform/monitoring/record-event';
 import get from 'platform/utilities/data/get';
 import { HOMELESSNESS_TYPES } from './constants';
 

--- a/src/applications/disability-benefits/all-claims/content/incidentDate.jsx
+++ b/src/applications/disability-benefits/all-claims/content/incidentDate.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
-import { recordEventOnce } from '../utils';
+import { recordEventOnce } from 'platform/monitoring/record-event';
 import {
   ANALYTICS_EVENTS,
   HELP_TEXT_CLICKED_EVENT,

--- a/src/applications/disability-benefits/all-claims/content/incomeDetails.jsx
+++ b/src/applications/disability-benefits/all-claims/content/incomeDetails.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 
-import { recordEventOnce } from '../utils';
+import { recordEventOnce } from 'platform/monitoring/record-event';
 
 const helpClicked = () =>
   recordEventOnce({

--- a/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
@@ -3,7 +3,7 @@ import AdditionalInfo from '@department-of-veterans-affairs/formation-react/Addi
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import moment from 'moment';
 
-import { recordEventOnce } from '../utils';
+import { recordEventOnce } from 'platform/monitoring/record-event';
 
 // EVSS returns dates like '2014-07-28T19:53:45.810+0000'
 const evssDateFormat = 'YYYY-MM-DDTHH:mm:ss.SSSZ';

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import { ANALYTICS_EVENTS, HELP_TEXT_CLICKED_EVENT } from '../constants';
-import { recordEventOnce } from '../utils';
+import { recordEventOnce } from 'platform/monitoring/record-event';
 
 const {
   openedPrivateRecordsAcknowledgment,

--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecordsRelease.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecordsRelease.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
-import { recordEventOnce } from '../utils';
+import { recordEventOnce } from 'platform/monitoring/record-event';
 import { ANALYTICS_EVENTS, HELP_TEXT_CLICKED_EVENT } from '../constants';
 
 export const limitedConsentTitle = (

--- a/src/applications/disability-benefits/all-claims/content/ptsdTypeInfo.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ptsdTypeInfo.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
-import { recordEventOnce } from '../utils';
+import { recordEventOnce } from 'platform/monitoring/record-event';
 import { ANALYTICS_EVENTS, HELP_TEXT_CLICKED_EVENT } from '../constants';
 
 const combatPtsdType = 'Combat';

--- a/src/applications/disability-benefits/all-claims/content/ptsdWalkthroughChoice.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ptsdWalkthroughChoice.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import { getPtsdClassification } from './ptsdClassification';
-import { recordEventOnce } from '../utils';
+import { recordEventOnce } from 'platform/monitoring/record-event';
 import {
   ANALYTICS_EVENTS,
   HELP_TEXT_CLICKED_EVENT,

--- a/src/applications/disability-benefits/all-claims/content/secondaryOtherSources.jsx
+++ b/src/applications/disability-benefits/all-claims/content/secondaryOtherSources.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
-import { recordEventOnce } from '../utils';
+import { recordEventOnce } from 'platform/monitoring/record-event';
 import { ANALYTICS_EVENTS, HELP_TEXT_CLICKED_EVENT } from '../constants';
 
 export const otherSourcesDescription = (

--- a/src/applications/disability-benefits/all-claims/content/unemployabilityDates.jsx
+++ b/src/applications/disability-benefits/all-claims/content/unemployabilityDates.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 
-import { recordEventOnce } from '../utils';
+import { recordEventOnce } from 'platform/monitoring/record-event';
 
 const helpClicked = () =>
   recordEventOnce({

--- a/src/applications/disability-benefits/all-claims/content/unemployabilityDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/unemployabilityDisabilities.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 
-import { recordEventOnce } from '../utils';
+import { recordEventOnce } from 'platform/monitoring/record-event';
 
 const helpClicked = () =>
   recordEventOnce({

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -1,7 +1,6 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import _ from '../../../../platform/utilities/data';
 
 import {
   makeSchemaForNewDisabilities,
@@ -29,7 +28,6 @@ import {
   ReservesGuardDescription,
   servedAfter911,
   viewifyFields,
-  recordEventOnce,
 } from '../utils.jsx';
 
 describe('526 helpers', () => {
@@ -812,42 +810,6 @@ describe('isAnswering781aQuestions', () => {
         },
       };
       expect(hasHospitalCare(formData)).to.be.false;
-    });
-  });
-
-  describe('recordEventOnce', () => {
-    beforeEach(() => {
-      window.oldDataLayer = _.cloneDeep(window.dataLayer);
-      window.dataLayer = [];
-    });
-
-    afterEach(() => {
-      window.dataLayer = _.cloneDeep(window.oldDataLayer);
-      delete window.oldDataLayer;
-    });
-
-    const testKey = 'help-text-label';
-    const testEvent = {
-      event: 'test-event',
-      [testKey]: 'Test Event',
-    };
-
-    it('should record event if not already in dataLayer', () => {
-      // sanity check to ensure that setup worked
-      expect(window.dataLayer.length).to.equal(0);
-
-      recordEventOnce(testEvent, testKey);
-      expect(window.dataLayer.length).to.equal(1);
-    });
-
-    it('should not record duplicate events', () => {
-      // sanity check to ensure that setup worked
-      expect(window.dataLayer.length).to.equal(0);
-
-      recordEventOnce(testEvent, testKey);
-      recordEventOnce(testEvent, testKey);
-
-      expect(window.dataLayer.length).to.equal(1);
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -6,7 +6,6 @@ import { createSelector } from 'reselect';
 import { omit } from 'lodash';
 import merge from 'lodash/merge';
 import fastLevenshtein from 'fast-levenshtein';
-import recordEvent from '../../../platform/monitoring/record-event';
 import { apiRequest } from '../../../platform/utilities/api';
 import environment from '../../../platform/utilities/environment';
 import _ from '../../../platform/utilities/data';
@@ -771,25 +770,6 @@ export const directToCorrectForm = ({
     window.location.assign(`${baseUrl}/resume`);
   } else {
     router.push(returnUrl);
-  }
-};
-
-/**
- * Pushes an event to the Analytics dataLayer if the event doesn't already
- * exist there. If the event contains a `key` property whose value matches an
- * existing item in the dataLayer with the same key/value pair, the whole event
- * and all of its properties will be skipped.
- * @param {object} event this will get pushed to `dataLayer`.
- * @param {string} key the property in the event object to use when looking for
- *                     existing matches in the dataLayer
- */
-export const recordEventOnce = (event, key) => {
-  const alreadyRecorded =
-    window.dataLayer &&
-    !!window.dataLayer.find(item => item[key] === event[key]);
-
-  if (!alreadyRecorded) {
-    recordEvent(event);
   }
 };
 

--- a/src/applications/static-pages/createAdditionalInfoWidget.js
+++ b/src/applications/static-pages/createAdditionalInfoWidget.js
@@ -1,5 +1,6 @@
+import { uniqueId } from 'lodash';
 import { qS, qSA, removeChildNodes } from './helpers';
-import recordEvent from 'platform/monitoring/record-event';
+import { recordEventOnce } from 'platform/monitoring/record-event';
 
 export default function createAdditionalInfoWidget() {
   const widgets = qSA(document, '.additional-info-container');
@@ -11,15 +12,17 @@ export default function createAdditionalInfoWidget() {
         (titleNode && titleNode.textContent) || 'More information';
       const contentContainer = qS(el, '.additional-info-content').parentNode;
       const contentMarkup = qS(el, '.additional-info-content').innerHTML;
-      const expandedContentId = `${contentContainer.id}-content`;
+      const additionalInfoId = uniqueId('additional-info-');
+      const analyticsEvent =
+        contentContainer.dataset && contentContainer.dataset.analytics;
 
       const template = `
-          <button type="button" class="additional-info-button va-button-link" aria-controls="${expandedContentId}" aria-expanded="false">
+          <button type="button" class="additional-info-button va-button-link" aria-controls="${additionalInfoId}" aria-expanded="false">
             <span class="additional-info-title">${titleText}
               <i class="fa fa-angle-down"></i>
             </span>
           </button>
-          <span id="${expandedContentId}">
+          <span id="${additionalInfoId}">
             <div class="additional-info-content">
               ${contentMarkup}
             </div>
@@ -31,7 +34,6 @@ export default function createAdditionalInfoWidget() {
 
       const chevron = qS(el, 'i.fa-angle-down');
       const button = qS(el, 'button');
-      const analyticsEvent = button.parentNode.getAttribute('data-event');
 
       button.addEventListener('click', () => {
         const ariaExpanded = JSON.parse(button.getAttribute('aria-expanded'));
@@ -41,7 +43,8 @@ export default function createAdditionalInfoWidget() {
         chevron.classList.toggle('open');
 
         if (analyticsEvent) {
-          recordEvent({ event: analyticsEvent });
+          alert(analyticsEvent);
+          recordEventOnce({ event: analyticsEvent });
         }
       });
     });

--- a/src/applications/static-pages/createAdditionalInfoWidget.js
+++ b/src/applications/static-pages/createAdditionalInfoWidget.js
@@ -43,7 +43,6 @@ export default function createAdditionalInfoWidget() {
         chevron.classList.toggle('open');
 
         if (analyticsEvent) {
-          alert(analyticsEvent);
           recordEventOnce({ event: analyticsEvent });
         }
       });

--- a/src/platform/monitoring/record-event.js
+++ b/src/platform/monitoring/record-event.js
@@ -8,3 +8,22 @@
 export default function recordEvent(data) {
   return window.dataLayer && window.dataLayer.push(data);
 }
+
+/**
+ * Pushes an event to the Analytics dataLayer if the event doesn't already
+ * exist there. If the event contains a `key` property whose value matches an
+ * existing item in the dataLayer with the same key/value pair, the whole event
+ * and all of its properties will be skipped.
+ * @param {object} event this will get pushed to `dataLayer`.
+ * @param {string} key the property in the event object to use when looking for
+ *                     existing matches in the dataLayer
+ */
+export const recordEventOnce = (event, key) => {
+  const alreadyRecorded =
+    window.dataLayer &&
+    !!window.dataLayer.find(item => item[key] === event[key]);
+
+  if (!alreadyRecorded) {
+    recordEvent(event);
+  }
+};

--- a/src/platform/monitoring/tests/record-event.unit.spec.js
+++ b/src/platform/monitoring/tests/record-event.unit.spec.js
@@ -1,6 +1,7 @@
+import _ from 'platform/utilities/data';
 import { expect } from 'chai';
 
-import recordEvent from '../record-event';
+import recordEvent, { recordEventOnce } from '../record-event';
 
 describe('recordEvent', () => {
   const oldWindow = global.window;
@@ -19,5 +20,41 @@ describe('recordEvent', () => {
     const e = { event: 'foo-bar', contextualData: 'text' };
     recordEvent(e);
     expect(global.window.dataLayer.includes(e)).to.be.true;
+  });
+});
+
+describe('recordEventOnce', () => {
+  beforeEach(() => {
+    window.oldDataLayer = _.cloneDeep(window.dataLayer);
+    window.dataLayer = [];
+  });
+
+  afterEach(() => {
+    window.dataLayer = _.cloneDeep(window.oldDataLayer);
+    delete window.oldDataLayer;
+  });
+
+  const testKey = 'help-text-label';
+  const testEvent = {
+    event: 'test-event',
+    [testKey]: 'Test Event',
+  };
+
+  it('should record event if not already in dataLayer', () => {
+    // sanity check to ensure that setup worked
+    expect(window.dataLayer.length).to.equal(0);
+
+    recordEventOnce(testEvent, testKey);
+    expect(window.dataLayer.length).to.equal(1);
+  });
+
+  it('should not record duplicate events', () => {
+    // sanity check to ensure that setup worked
+    expect(window.dataLayer.length).to.equal(0);
+
+    recordEventOnce(testEvent, testKey);
+    recordEventOnce(testEvent, testKey);
+
+    expect(window.dataLayer.length).to.equal(1);
   });
 });

--- a/src/site/blocks/alert.drupal.liquid
+++ b/src/site/blocks/alert.drupal.liquid
@@ -57,7 +57,7 @@
         <div class="additional-info-title">{{ expander.fieldTextExpander }}</div>
 
         {% if expander.fieldWysiwyg %}
-          <div class="additional-info-content usa-alert-text">{{ expander.fieldWysiwyg.processed }}</div>
+          <div class="additional-info-content usa-alert-text" hidden>{{ expander.fieldWysiwyg.processed }}</div>
         {% endif %}
       </div>
     {% endif %}

--- a/src/site/blocks/alert.drupal.liquid
+++ b/src/site/blocks/alert.drupal.liquid
@@ -35,11 +35,25 @@
       <p>{{ alert.fieldHelpText }}</p>
     {% endif %}
     {% if expander.fieldTextExpander %}
+
       {% comment %}
         NOTE: .additional-info-container is a class utilized by
         createAdditionalInfoWidget.js to add toggle functionality to info alerts
       {% endcomment %}
-      <div id="{{ expander.entityBundle }}-{{ expander.entityId }}-details" class="form-expanding-group borderless-alert additional-info-container" aria-hidden="true">
+
+      {% if alert.fieldAlertTitle contains 'homeless' %}
+        {% assign analyticsId = 'nav-crisis-homelessness-expander' %}
+      {% elsif expander.fieldTextExpander contains 'support' %}
+        {% assign analyticsId = 'nav-crisis-get-support-247' %}
+      {% elsif expander.fieldTextExpander contains 'care now' %}
+        {% assign analyticsId = 'nav-crisis-get-care-now' %}
+      {% else %}
+        {% comment %}
+          Nothing required!
+        {% endcomment %}
+      {% endif %}
+
+      <div data-analytics="{{ analyticsId }}" class="form-expanding-group borderless-alert additional-info-container">
         <div class="additional-info-title">{{ expander.fieldTextExpander }}</div>
 
         {% if expander.fieldWysiwyg %}


### PR DESCRIPTION
## Description
This pull request expands on our now-standardizes expandable alert banners by -

1. Implementing analytic events for Drupal alerts via string matching
2. Removes the need to HTML to contain hardcoded IDs
3. Upon expand, records the event only once, as opposed to every time the content is toggled.

Goes with content PR - https://github.com/department-of-veterans-affairs/vagov-content/pull/400

Tickets:
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17777
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17562

## Testing done
Local testing on -

health-care
health-care/health-needs-conditions/mental-health/
careers-employment
disability/eligibility/ptsd
family-member-benefits
housing-assistance
service-member-benefits

Your `vagov-content` branch must be `analytics-17777`.

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/56395683-8fe6b500-6209-11e9-9a21-ed6fe8c2ba6c.png)

## Acceptance criteria
- [ ] Events are captured for Drupal expandable alert banners

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
