### PR TITLE
Switch to componentDidUpdate

### DIFF
--- a/src/platform/forms/components/AuthorizationComponent.jsx
+++ b/src/platform/forms/components/AuthorizationComponent.jsx
@@ -15,8 +15,8 @@ class AuthorizationComponent extends React.Component {
   componentDidMount() {
     this.authorize();
   }
-  // eslint-disable-next-line
-  UNSAFE_componentWillUpdate() {
+
+  componentDidUpdate() {
     this.authorize();
   }
 


### PR DESCRIPTION
## Description
We were seeing weird behavior with the 686 gating component, ie it wouldn't actually call the endpoint to fetch the vet's disability rating. I swear this used to work before (seven months ago) but ~maybe the recent react upgrade totally broke `componentWillUpdate`.~ No, the method is still supported until React 17. Regardless, things seem to work now and dropping usage of this method is a bonus.

I made a ticket to stop using the `UNSAFE` methods: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18095

## Testing done

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/56427291-2948b200-6270-11e9-86c1-df29d4d55877.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs