### PR TITLE
DO NOT MERGE YET - Revert "temporarily disable sending analytics client_id"

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -1,4 +1,4 @@
-// import appendQuery from 'append-query';
+import appendQuery from 'append-query';
 import Raven from 'raven-js';
 
 import recordEvent from '../../monitoring/record-event';
@@ -41,7 +41,6 @@ export function clearRavenLoginType() {
   Raven.setTagsContext(tags);
 }
 
-/* Commented to verify a possible issue with browser extensions
 function redirectWithGAClientId(redirectUrl) {
   try {
     // eslint-disable-next-line no-undef
@@ -65,21 +64,17 @@ function redirectWithGAClientId(redirectUrl) {
     window.location = redirectUrl;
   }
 }
-*/
 
 function redirect(redirectUrl, clickedEvent) {
   // Keep track of the URL to return to after auth operation.
   sessionStorage.setItem(authnSettings.RETURN_URL, window.location);
   recordEvent({ event: clickedEvent });
 
-  /* temporarily commented out to test a possible plugin related issue
   if (redirectUrl.includes('idme')) {
     redirectWithGAClientId(redirectUrl);
   } else {
     window.location = redirectUrl;
   }
-*/
-  window.location = redirectUrl;
 }
 
 export function login(policy) {


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-website#9948

There need to be a backend ticket to this as well, ensuring that the client_id is appended to the end of the generated URL. Appended to the beginning of the URL causes all other query strings to be dropped by Ad Blocker because of "Do Not Track Me" feature.