### PR TITLE
Fix for analytics in Additional Info expand event

### DIFF
--- a/src/applications/static-pages/createAdditionalInfoWidget.js
+++ b/src/applications/static-pages/createAdditionalInfoWidget.js
@@ -13,7 +13,7 @@ export default function createAdditionalInfoWidget() {
       const contentContainer = qS(el, '.additional-info-content').parentNode;
       const contentMarkup = qS(el, '.additional-info-content').innerHTML;
       const additionalInfoId = uniqueId('additional-info-');
-      const analyticsEvent =
+      const eventName =
         contentContainer.dataset && contentContainer.dataset.analytics;
 
       const template = `
@@ -42,8 +42,14 @@ export default function createAdditionalInfoWidget() {
         button.parentNode.classList.toggle('form-expanding-group-open');
         chevron.classList.toggle('open');
 
-        if (analyticsEvent) {
-          recordEventOnce({ event: analyticsEvent });
+        if (eventName) {
+          const key = 'additional-info-expander-label';
+          const analytic = {
+            event: eventName,
+            [key]: `Additional Info - ${titleText}`,
+          };
+
+          recordEventOnce(analytic, key);
         }
       });
     });


### PR DESCRIPTION
## Description
This PR fixes an issue with this commit, c72006cf2836bfbdf5895d28d9cb011d7a35dd03. I was missing the second parameter for `recordEventOnce`, which is required.

## Testing done
Local testing using GA Chrome plugin

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/56440782-91bb8180-62b8-11e9-9c26-dea7c195aebf.png)


## Acceptance criteria
- [ ] Event is captured

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
