### PR TITLE
Hide foresee from form tester

### DIFF
--- a/src/platform/testing/e2e/form-tester/index.js
+++ b/src/platform/testing/e2e/form-tester/index.js
@@ -25,7 +25,20 @@ const getLogger = (debugMode, testName) => (...params) => {
   }
 };
 
+/**
+ * Function to start the test. This logs in if necessary, navigates to the starting
+ *  URL, sets up CSS injection to hide the Foresee overlay, and starts filling out
+ *  the form.
+ */
 const runTest = async (page, testData, testConfig, userToken, testName) => {
+  // Hide the Foresee overlay
+  await page.evaluateOnNewDocument(() => {
+    const style = document.createElement('style');
+    style.type = 'text/css';
+    style.innerHTML = `.__acs { display: none !important; }`;
+    document.getElementsByTagName('head')[0].appendChild(style);
+  });
+
   // Go to the starting page either by logging in or going there directly
   if (testConfig.logIn) {
     await logIn(userToken, page, testConfig.url, 3);


### PR DESCRIPTION
## Description
Just like it says on the tin, this hides the Foresee overlay from the form tester by injecting CSS into the document whenever a new one is loaded.

## Testing done
I can't actually test this locally (easily), so I'm relying on CI testing. If the tests still fail, it's status quo. :man_shrugging: 

## Screenshots
N/A

## Acceptance criteria
- [x] The Foresee overlay doesn't break the form tester tests :crossed_fingers: 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x[ No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
