### PR TITLE
Remove some pre-fill data from 526 test mock data

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
@@ -236,12 +236,6 @@ function initInProgressMock(token, data = defaultData) {
           emailAddress: 'test2@test1.net',
         },
         disabilities: data.ratedDisabilities,
-        reservesNationalGuardService: {
-          obligationTermOfServiceDateRange: {
-            from: '2007-05-22',
-            to: '2008-06-05',
-          },
-        },
       },
       metadata: {
         version: 0,


### PR DESCRIPTION
## Description
There was some data getting in the way of the filler, causing the page to be filled in twice.

## Testing done
Made sure the data isn't getting filled in before the form filler gets a chance.

## Screenshots
N/A

## Acceptance criteria
- [x] The data isn't filled in twice