### PR TITLE
17861 - Fix HCA form missing prefill message for Veteran Address page.

### DIFF
--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -383,6 +383,7 @@ const formConfig = {
           title: 'Permanent address',
           initialData: {},
           uiSchema: {
+            'ui:description': PrefillMessage,
             veteranAddress: _.merge(addressUI('Permanent address', true), {
               street: {
                 'ui:errorMessages': {


### PR DESCRIPTION
## Description
[17861](/department-of-veterans-affairs/vets.gov-team/issues/17861) - Fix HCA form missing prefill message for Veteran Address page.

## Testing done
Verified fix locally via browser -- prefill message now appears on Veteran Address page.
Existing form-config unit-test does not check for prefill messages; all tests still passing.

## Screenshots
### Existing bug:
![Screen Shot 2019-04-10 at 11.19.32 AM.png](https://images.zenhubusercontent.com/5b4d0309a8d8be5bda39303e/498941a1-51ef-4302-b4a2-5c2f7eebc1ea)

### Bug fixed locally:
![hca-form-missing-prefill-msg-fixed](https://user-images.githubusercontent.com/587583/56449521-35179100-62cf-11e9-901b-9ae420b419e3.png)


## Acceptance criteria
- [ ] Fix verified on deployed branch.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
