### PR TITLE
Cleanup of auth metrics reporting and error handling

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -60,7 +60,7 @@ class AuthMetrics {
       default:
         recordEvent({ event: `login-or-register-success-${this.serviceName}` });
         Raven.captureMessage('Unrecognized auth event type', {
-          extra: { type: this.type },
+          extra: { type: this.type || 'N/A' },
         });
     }
 
@@ -72,13 +72,9 @@ class AuthMetrics {
 
   reportSentryErrors = () => {
     if (!Object.keys(this.userProfile).length) {
-      Raven.captureMessage('Unexpected response for user object', {
-        extra: { payload: this.payload },
-      });
+      Raven.captureMessage('Unexpected response for user object');
     } else if (!this.serviceName) {
-      Raven.captureMessage('Missing serviceName in user object', {
-        extra: { payload: this.payload },
-      });
+      Raven.captureMessage('Missing serviceName in user object');
     }
   };
 

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -20,7 +20,7 @@ class AuthMetrics {
     this.type = type;
     this.payload = payload;
     this.userProfile = get('data.attributes.profile', payload, {});
-    this.loaCurrent = get('loa.loaCurrent', this.userProfile, null);
+    this.loaCurrent = get('loa.current', this.userProfile, null);
     this.serviceName = get('signIn.serviceName', this.userProfile, null);
   }
 


### PR DESCRIPTION
## Description
LOA was incorrectly referenced, resulting in no `login-loa-current-*` events being sent to GA. I also took the opportunity to clean up some of the error handling.

## Testing done
Local testing. Still able to successfully log in.

## Acceptance criteria
- [x] Successful logins should report `login-loa-current-*` events.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
