### PR TITLE
Update content for retirement pay waiver screen

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/waiveRetirementPay.jsx
+++ b/src/applications/disability-benefits/all-claims/content/waiveRetirementPay.jsx
@@ -5,46 +5,57 @@ export const waiveRetirementPayDescription = (
     <p>
       If you’re eligible for both retirement pay and VA compensation pay, you
       can choose whether you want to receive VA compensation pay to balance your
-      current retirement pay or get your full retirement pay at the current tax
-      rate.
+      retirement pay or get your full retirement pay at the current tax rate.
     </p>
     <p>
-      VA compensation pay isn’t taxable. Military retirement pay is taxable. VA
-      compensation pay is always the greater benefit.
-    </p>
-    <p>
-      Below is an example showing that{' '}
+      VA compensation pay isn’t taxable. Military retirement pay is taxable.{' '}
       <strong>
-        dollar for dollar VA compensation pay is always the greater benefit.
-      </strong>{' '}
-      Tax rates will vary depending on income.
+        Dollar for dollar, VA compensation pay is always the greater benefit.
+      </strong>
+    </p>
+    <p>
+      The chart below shows an example of what your total monthly pay could be
+      depending on if you choose compensation pay versus retirement pay. The tax
+      rates below are estimated and will vary depending on income.
     </p>
     <table>
       <thead>
         <tr>
           <th />
-          <th>Monthly benefit</th>
-          <th>Take-home pay</th>
+          <th>Compensation pay</th>
+          <th>Retirement pay</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td>Retirement</td>
-          <td>$700 (minus taxes)</td>
-          <td>$630</td>
+          <td>Monthly base pay example</td>
+          <td>$700</td>
+          <td>$700</td>
+        </tr>
+        <tr>
+          <td>Estimated taxes per month</td>
+          <td>$0 (tax-free)</td>
+          <td>$70</td>
         </tr>
         <tr>
           <td>
-            <strong>Compensation</strong>
-          </td>
-          <td>
-            <strong>$700 (tax-free)</strong>
+            <strong>Total monthly pay example</strong>
           </td>
           <td>
             <strong>$700</strong>
           </td>
+          <td>
+            <strong>$630</strong>
+          </td>
         </tr>
       </tbody>
     </table>
+    <p>
+      <strong>Please note: </strong>
+      If your combined disability rating eventually exceeds 50%, you may be
+      eligible for Concurrent Retirement Disability Pay (CRDP), which lets you
+      receive your full military retirement pay and full compensation at the
+      same time. Your military retirement pay won’t be reduced.
+    </p>
   </div>
 );


### PR DESCRIPTION
## Description
Wording and layout updates. Resisted the urge to make the the chart cells all fit to a single line.

## Testing done
Visual confirmation

## Screenshots
![retirement-pay-waiver](https://user-images.githubusercontent.com/13280995/56606087-1a913080-65cb-11e9-86fe-b197b0766a55.png)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
