### PR TITLE
VAGOV-1811 health services template fix

### DIFF
--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -10,8 +10,6 @@
                 {{ serviceTaxonomy.name }}
             </button>
             <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}" class="usa-accordion-content" aria-hidden="true">
-                <div>{{ serviceTaxonomy.fieldAlsoKnownAs }}</div>
-
 
                 {% if healthService.fieldBody.processed %}
                     <div>{{ healthService.fieldBody.processed }}</div>

--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -10,13 +10,12 @@
                 {{ serviceTaxonomy.name }}
             </button>
             <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}" class="usa-accordion-content" aria-hidden="true">
+                {% if serviceTaxonomy.description.processed  %}
+                    <div>{{ serviceTaxonomy.description.processed }}</div>
+                {% endif %}
 
                 {% if healthService.fieldBody.processed %}
                     <div>{{ healthService.fieldBody.processed }}</div>
-                {% endif %}
-
-                {% if serviceTaxonomy.description.processed  %}
-                    <div>{{ serviceTaxonomy.description.processed }}</div>
                 {% endif %}
 
                 {% if healthService.fieldLocalHealthCareService.length and localServiceDescription == empty %}

--- a/src/site/layouts/health_care_region_health_services_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_health_services_page.drupal.liquid
@@ -72,7 +72,7 @@
                         {% for wellnessService in healthWellnessPatientFamilyServices.entities %}
                             {% if buildtype == 'vagovprod' %}
                               {% include "src/site/facilities/health_service.old.drupal.liquid" with healthService = wellnessService %}
-                            {% elsif %}
+                            {% else %}
                               {% include "src/site/facilities/health_service.drupal.liquid" with healthService = wellnessService %}
                             {% endif %}
                         {% endfor %}


### PR DESCRIPTION
## Description
Removes some extra text showing up in health services from field_also_known_as and fixes a typo in an if statement. Also moves national service description to the top of the accordion.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
