### PR TITLE
Flesh out the Manage Your VA Health Care section

### DIFF
--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -72,19 +72,7 @@ export function getWarningHeadline(enrollmentStatus) {
   return <h4 className="usa-alert-heading">{content}</h4>;
 }
 
-function getDefaultWarningStatus(applicationDate) {
-  if (isNaN(Date.parse(applicationDate))) {
-    return null;
-  }
-  return (
-    <p>
-      <strong>You applied on: </strong>
-      {moment(applicationDate).format('MMMM D, YYYY')}
-    </p>
-  );
-}
-
-function getEnrolledWarningStatus(
+export function getEnrollmentDetails(
   applicationDate,
   enrollmentDate,
   preferredFacility,
@@ -154,7 +142,7 @@ export function getWarningStatus(
       break;
 
     case HCA_ENROLLMENT_STATUSES.enrolled:
-      content = getEnrolledWarningStatus(
+      content = getEnrollmentDetails(
         applicationDate,
         enrollmentDate,
         preferredFacility,
@@ -162,7 +150,7 @@ export function getWarningStatus(
       break;
 
     default:
-      content = getDefaultWarningStatus(applicationDate);
+      content = getEnrollmentDetails(applicationDate);
       break;
   }
   return content;

--- a/src/applications/hca/selectors.js
+++ b/src/applications/hca/selectors.js
@@ -4,6 +4,7 @@ import {
   isLoggedIn,
   isProfileLoading,
 } from 'platform/user/selectors';
+import { HCA_ENROLLMENT_STATUSES } from './constants';
 
 // top-level selectors
 export const selectEnrollmentStatus = state => state.hcaEnrollmentStatus;
@@ -15,6 +16,9 @@ export const noESRRecordFound = state =>
   selectEnrollmentStatus(state).noESRRecordFound;
 export const isShowingHCAReapplyContent = state =>
   selectEnrollmentStatus(state).showHCAReapplyContent;
+export const isEnrolledInVAHealthCare = state =>
+  selectEnrollmentStatus(state).enrollmentStatus ===
+  HCA_ENROLLMENT_STATUSES.enrolled;
 
 // compound selectors
 export const isLoading = state =>

--- a/src/applications/hca/tests/selectors.unit.spec.js
+++ b/src/applications/hca/tests/selectors.unit.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import * as selectors from '../selectors';
+import { HCA_ENROLLMENT_STATUSES } from '../constants';
 
 const basicEnrollmentStatusState = {
   applicationDate: null,
@@ -153,6 +154,42 @@ describe('simple top-level selectors', () => {
       state.hcaEnrollmentStatus.showHCAReapplyContent = true;
       isShowingHCAReapplyContent = selectors.isShowingHCAReapplyContent(state);
       expect(isShowingHCAReapplyContent).to.equal(true);
+    });
+  });
+
+  describe('isEnrolledInVAHealthCare', () => {
+    it('returns `false` if the enrollmentStatus is not set', () => {
+      const state = {
+        hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
+      };
+      const isEnrolledInVAHealthCare = selectors.isEnrolledInVAHealthCare(
+        state,
+      );
+      expect(isEnrolledInVAHealthCare).to.be.false;
+    });
+    it('returns `false` if the enrollmentStatus is not enrolled', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+          enrollmentStatus: HCA_ENROLLMENT_STATUSES.pendingOther,
+        },
+      };
+      const isEnrolledInVAHealthCare = selectors.isEnrolledInVAHealthCare(
+        state,
+      );
+      expect(isEnrolledInVAHealthCare).to.be.false;
+    });
+    it('returns `true` if the enrollmentStatus is enrolled', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+          enrollmentStatus: HCA_ENROLLMENT_STATUSES.enrolled,
+        },
+      };
+      const isEnrolledInVAHealthCare = selectors.isEnrolledInVAHealthCare(
+        state,
+      );
+      expect(isEnrolledInVAHealthCare).to.be.true;
     });
   });
 });

--- a/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
+++ b/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
@@ -58,6 +58,14 @@ const ManageYourVAHealthCare = ({
             enrollmentDate,
             preferredFacility,
           )}
+          <p>
+            <a href="/health-care/about-va-health-benefits/#health-about-basic">
+              Learn more about your VA health benefits
+            </a>
+          </p>
+          <p>
+            <a href="/find-locations/">Find your nearest VA health facility</a>
+          </p>
         </div>
       }
       status="info"

--- a/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
+++ b/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import {
   DowntimeNotification,
@@ -12,6 +14,12 @@ import {
 
 import MessagingWidget from '../containers/MessagingWidget';
 import PrescriptionsWidget from '../containers/PrescriptionsWidget';
+
+import {
+  isEnrolledInVAHealthCare,
+  selectEnrollmentStatus,
+} from 'applications/hca/selectors';
+import { getEnrollmentDetails } from 'applications/hca/enrollment-status-helpers';
 
 const ScheduleAnAppointmentWidget = () => (
   <div id="rx-widget">
@@ -31,9 +39,31 @@ const ScheduleAnAppointmentWidget = () => (
   </div>
 );
 
-const ManageYourVAHealthCare = () => (
+const ManageYourVAHealthCare = ({
+  applicationDate,
+  enrollmentDate,
+  isEnrolledInHealthCare,
+  preferredFacility,
+}) => (
   <>
     <h2>Manage your VA health care</h2>
+    <AlertBox
+      content={
+        <div>
+          <h4 className="usa-alert-heading">
+            You are enrolled in VA Health Care
+          </h4>
+          {getEnrollmentDetails(
+            applicationDate,
+            enrollmentDate,
+            preferredFacility,
+          )}
+        </div>
+      }
+      status="info"
+      isVisible={isEnrolledInHealthCare}
+      className="background-color-only"
+    />
     <DowntimeNotification
       appTitle="messaging"
       dependencies={[externalServices.mvi, externalServices.mhv]}
@@ -55,8 +85,27 @@ const ManageYourVAHealthCare = () => (
     >
       <PrescriptionsWidget />
     </DowntimeNotification>
-    <ScheduleAnAppointmentWidget />
+    {isEnrolledInHealthCare && <ScheduleAnAppointmentWidget />}
   </>
 );
 
-export default ManageYourVAHealthCare;
+const mapStateToProps = state => {
+  const isEnrolledInHealthCare = isEnrolledInVAHealthCare(state);
+  const hcaEnrollmentStatus = selectEnrollmentStatus(state);
+  const {
+    applicationDate,
+    enrollmentDate,
+    preferredFacility,
+  } = hcaEnrollmentStatus;
+
+  return {
+    applicationDate,
+    enrollmentDate,
+    isEnrolledInHealthCare,
+    preferredFacility,
+  };
+};
+
+export { ManageYourVAHealthCare };
+
+export default connect(mapStateToProps)(ManageYourVAHealthCare);

--- a/src/applications/personalization/dashboard/containers/DashboardAppNew.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardAppNew.jsx
@@ -11,6 +11,8 @@ import recordEvent from 'platform/monitoring/record-event';
 import localStorage from 'platform/utilities/storage/localStorage';
 
 import { removeSavedForm as removeSavedFormAction } from '../actions';
+import { getEnrollmentStatus as getEnrollmentStatusAction } from 'applications/hca/actions';
+import { isEnrolledInVAHealthCare } from 'applications/hca/selectors';
 
 import { recordDashboardClick } from '../helpers';
 
@@ -183,6 +185,7 @@ class DashboardAppNew extends React.Component {
 
   componentDidMount() {
     scrollToTop();
+    this.props.getEnrollmentStatus();
   }
 
   dismissAlertBox = name => () => {
@@ -357,12 +360,14 @@ const mapStateToProps = state => {
     canAccessAppeals,
     canAccessClaims,
     profile: profileState,
-    showManageYourVAHealthCare: canAccessRx || canAccessMessaging,
+    showManageYourVAHealthCare:
+      isEnrolledInVAHealthCare(state) || canAccessRx || canAccessMessaging,
   };
 };
 
 const mapDispatchToProps = {
   removeSavedForm: removeSavedFormAction,
+  getEnrollmentStatus: getEnrollmentStatusAction,
 };
 
 export default withRouter(

--- a/src/applications/personalization/dashboard/reducers/index.js
+++ b/src/applications/personalization/dashboard/reducers/index.js
@@ -1,10 +1,11 @@
-import claimsAppeals from '../../../claims-status/reducers';
+import claimsAppeals from 'applications/claims-status/reducers';
 import prescriptions from './prescriptions';
 import recipients from './recipients';
 import folders from './folders';
 import preferences from '../../preferences/reducers';
 import appointments from '../../appointments/reducers';
 import authorization from 'applications/disability-benefits/686/reducers/authorization';
+import { hcaEnrollmentStatus } from 'applications/hca/reducer';
 
 import { combineReducers } from 'redux';
 
@@ -12,6 +13,7 @@ export default {
   ...claimsAppeals,
   preferences,
   appointments,
+  hcaEnrollmentStatus,
   health: combineReducers({
     rx: combineReducers({
       prescriptions,


### PR DESCRIPTION
## Description
- Fetch and display the HCA status
- Only show the entire section if the user has a reason to see it
- Only show the health care related sub-sections if the user is enrolled
in health care

## Testing done
Local + additional unit tests

## Screenshots
The entire section with all subsections will be shown if ESR says the vet is enrolled in health care and RX and messaging are listed in their `services` array:
![enrolled+msg+rx](https://user-images.githubusercontent.com/20728956/56624372-694fc200-65ed-11e9-914e-d9c9ffee3d88.png)

The section will be shown, without the enrollment info at the top of the section or the "make an appointment" area at the bottom of the section, if ESR says the vet does _not_ have healthcare, but their `services` array includes RX and messaging:
![not-enrolled+msg+rx](https://user-images.githubusercontent.com/20728956/56624380-72409380-65ed-11e9-9a79-24a240d61897.png)

The section will be shown with only the enrollment info and "make an appointment" area if the vet is enrolled in health care but they don't have access to either messaging or RX:
![enrolled-only](https://user-images.githubusercontent.com/20728956/56624538-2cd09600-65ee-11e9-81ab-0faca6eeb790.png)

The section won't be shown at all if the user does not have healthcare, access to messaging, or access to RX:
![nada](https://user-images.githubusercontent.com/20728956/56624542-322de080-65ee-11e9-9482-8b3565709d3b.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs