### PR TITLE
Remove extra closing tag showing in summary letter page

### DIFF
--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -133,7 +133,6 @@ export class VeteranBenefitSummaryLetter extends React.Component {
               type="checkbox"
               onChange={this.handleChange}
             />
-            />
             <label name="militaryService-label" htmlFor="militaryService">
               Include military service information
             </label>


### PR DESCRIPTION
## Description
There was an extra closing tag present showing up 

## Testing done
I'm having trouble hitting the EVSS letter endpoints locally. I found this via staging and was able to track down the offending code easily enough. Still could wait to verify locally

## Screenshots
<img width="623" alt="Tag Bug" src="https://user-images.githubusercontent.com/13280995/56692218-513c7900-66a7-11e9-8214-27c25a34052c.png">

