### PR TITLE
Search and destroy foresee

### DIFF
--- a/src/platform/testing/e2e/form-tester/form-filler.js
+++ b/src/platform/testing/e2e/form-tester/form-filler.js
@@ -296,6 +296,8 @@ const fillPage = async (page, testData, testConfig, log = () => {}) => {
   /* eslint-enable no-await-in-loop */
 };
 
+const removeForeseeOverlay = page => searchAndDestroy(page, '.__acs');
+
 /**
  * This is the main entry point. After all the setup has been performed, this function
  *  loops through the pages, filling in all the data it can until it gets to the review
@@ -309,7 +311,7 @@ const fillForm = async (page, testData, testConfig, log) => {
     log(page.url());
     // TODO: Run axe checker
 
-    searchAndDestroy(page, '.__acs');
+    removeForeseeOverlay(page);
 
     // If there's a page hook, run that
     const url = page.url();

--- a/src/platform/testing/e2e/form-tester/form-filler.js
+++ b/src/platform/testing/e2e/form-tester/form-filler.js
@@ -296,7 +296,7 @@ const fillPage = async (page, testData, testConfig, log = () => {}) => {
   /* eslint-enable no-await-in-loop */
 };
 
-const removeForeseeOverlay = page => searchAndDestroy(page, '.__acs');
+const removeForeseeOverlay = async page => searchAndDestroy(page, '.__acs');
 
 /**
  * This is the main entry point. After all the setup has been performed, this function
@@ -311,7 +311,7 @@ const fillForm = async (page, testData, testConfig, log) => {
     log(page.url());
     // TODO: Run axe checker
 
-    removeForeseeOverlay(page);
+    await removeForeseeOverlay(page);
 
     // If there's a page hook, run that
     const url = page.url();
@@ -339,6 +339,7 @@ const fillForm = async (page, testData, testConfig, log) => {
       if (page.url() === url) {
         // TODO: Figure out how to remove this arbitrary time
         await page.waitFor(500);
+        await removeForeseeOverlay(page);
         await fillPage(page, testData, testConfig, log);
         log('Clicking continue again');
         await page.click(CONTINUE_BUTTON);

--- a/src/platform/testing/e2e/form-tester/form-filler.js
+++ b/src/platform/testing/e2e/form-tester/form-filler.js
@@ -1,6 +1,8 @@
 const { parse: parseUrl } = require('url');
 const _ = require('lodash/fp');
 
+const { searchAndDestroy } = require('./util');
+
 const FIELD_SELECTOR = 'input, select, textarea';
 const CONTINUE_BUTTON = '.form-progress-buttons .usa-button-primary';
 const ARRAY_ITEM_SELECTOR =
@@ -306,6 +308,8 @@ const fillForm = async (page, testData, testConfig, log) => {
   while (!page.url().endsWith('review-and-submit')) {
     log(page.url());
     // TODO: Run axe checker
+
+    searchAndDestroy(page, '.__acs');
 
     // If there's a page hook, run that
     const url = page.url();

--- a/src/platform/testing/e2e/form-tester/index.js
+++ b/src/platform/testing/e2e/form-tester/index.js
@@ -31,14 +31,6 @@ const getLogger = (debugMode, testName) => (...params) => {
  *  the form.
  */
 const runTest = async (page, testData, testConfig, userToken, testName) => {
-  // Hide the Foresee overlay
-  await page.evaluateOnNewDocument(() => {
-    const style = document.createElement('style');
-    style.type = 'text/css';
-    style.innerHTML = `.__acs { display: none !important; }`;
-    document.getElementsByTagName('head')[0].appendChild(style);
-  });
-
   // Go to the starting page either by logging in or going there directly
   if (testConfig.logIn) {
     await logIn(userToken, page, testConfig.url, 3);

--- a/src/platform/testing/e2e/form-tester/util.js
+++ b/src/platform/testing/e2e/form-tester/util.js
@@ -34,4 +34,19 @@ function getTestDataSets(path, rules = { extension: 'json' }) {
     }));
 }
 
-module.exports = { getTestDataSets };
+/**
+ * Searches for DOM elements found by selectors in page and removes
+ * them from the DOM.
+ * @param {Page} page - Puppeteer browser page
+ * @param {...String} - The selectors used to find the elements to
+ *                      remove
+ */
+function searchAndDestroy(page, ...selectors) {
+  selectors.forEach(sel =>
+    page.$$eval(sel, elements =>
+      elements.forEach(el => el.parentNode.removeChild(el)),
+    ),
+  );
+}
+
+module.exports = { getTestDataSets, searchAndDestroy };

--- a/src/platform/testing/e2e/form-tester/util.js
+++ b/src/platform/testing/e2e/form-tester/util.js
@@ -41,10 +41,12 @@ function getTestDataSets(path, rules = { extension: 'json' }) {
  * @param {...String} - The selectors used to find the elements to
  *                      remove
  */
-function searchAndDestroy(page, ...selectors) {
-  selectors.forEach(sel =>
-    page.$$eval(sel, elements =>
-      elements.forEach(el => el.parentNode.removeChild(el)),
+async function searchAndDestroy(page, ...selectors) {
+  await Promise.all(
+    selectors.map(async sel =>
+      page.$$eval(sel, elements =>
+        elements.forEach(el => el.parentNode.removeChild(el)),
+      ),
     ),
   );
 }


### PR DESCRIPTION
## Description
The CSS route wasn't working, so I decided to be more aggressive about making sure the foresee overlay didn't stop the form tester tests.

I made a search and destroy function.

## Testing done
I tested that the search and destroy function works as intended by having it remove the header and footer elements.

## Screenshots
N/A (though I could show the form sans header and footer, I suppose :man_shrugging:)

## Acceptance criteria
- [x] The Foresee overlay is removed as soon as it's detected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
