### PR TITLE
remove the BetaApp wrapper from HCAv2

### DIFF
--- a/src/applications/beta-enrollment/routes.js
+++ b/src/applications/beta-enrollment/routes.js
@@ -6,7 +6,6 @@ export const features = {
   profile: 'profile',
   dashboard: 'dashboard',
   claimIncrease: 'claim_increase',
-  hca2: 'hca2',
 };
 
 const routes = {
@@ -15,10 +14,6 @@ const routes = {
     {
       path: 'personalization',
       component: createBetaEnrollmentButton(features.dashboard, '/dashboard'),
-    },
-    {
-      path: 'hca',
-      component: createBetaEnrollmentButton(features.hca2, '/hca2'),
     },
   ],
 };

--- a/src/applications/hca-v2-beta/HealthCareApp.jsx
+++ b/src/applications/hca-v2-beta/HealthCareApp.jsx
@@ -1,17 +1,12 @@
 import React from 'react';
 
-import RoutedSavableApp from '../../platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
-
-import BetaApp from 'applications/beta-enrollment/containers/BetaApp';
-import { features } from 'applications/beta-enrollment/routes';
 
 export default function HealthCareEntry({ location, children }) {
   return (
-    <BetaApp featureName={features.hca2} redirect="/beta-enrollment/hca/">
-      <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-        {children}
-      </RoutedSavableApp>
-    </BetaApp>
+    <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+      {children}
+    </RoutedSavableApp>
   );
 }


### PR DESCRIPTION
## Description
We are no longer hiding HCAv2 behind a BetaApp wrapper for UAT. This is because some of the changes in HCAv2 we want to test are only available to logged-out users and users must be logged in to access beta apps.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs