### PR TITLE
VAGOV-1829: Facility | Update Regional Homepage Layout/Design

### DIFF
--- a/src/applications/static-pages/facilities/BasicFacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/BasicFacilityListWidget.jsx
@@ -56,14 +56,33 @@ export default class BasicFacilityListWidget extends React.Component {
 
     const facilitiesList = this.facilitiesList(this.state.facilities).map(
       facility => (
-        <div key={facility.id} className="usa-width-one-half">
-          <FacilityTitle
-            facility={facility}
-            nickname={this.props.facilities[facility.id].nickname}
-            regionPath={this.props.path}
-          />
-          <FacilityAddress facility={facility} />
-          <FacilityPhone facility={facility} />
+        <div
+          key={facility.id}
+          className="usa-width-one-whole vads-u-margin-bottom--2"
+        >
+          <section className="usa-width-two-thirds">
+            <FacilityTitle
+              facility={facility}
+              nickname={this.props.facilities[facility.id].nickname}
+              regionPath={this.props.path}
+            />
+            <FacilityAddress facility={facility} />
+            <FacilityPhone facility={facility} />
+          </section>
+          <section className="usa-width-one-third">
+            <img
+              src={
+                this.props.facilities[facility.id].derivative
+                  ? this.props.facilities[facility.id].derivative.url
+                  : ''
+              }
+              alt={
+                this.props.facilities[facility.id].alt
+                  ? this.props.facilities[facility.id].alt
+                  : ''
+              }
+            />
+          </section>
         </div>
       ),
     );

--- a/src/applications/static-pages/facilities/FacilityAddress.jsx
+++ b/src/applications/static-pages/facilities/FacilityAddress.jsx
@@ -15,7 +15,7 @@ export default class FacilityAddress extends React.Component {
 
     return (
       <div>
-        <address className="vads-u-margin-bottom--1p5">
+        <address>
           <div>{this.props.facility.attributes.address.physical.address1}</div>
           <div>
             {this.props.facility.attributes.address.physical.city}
@@ -24,7 +24,7 @@ export default class FacilityAddress extends React.Component {
             {this.props.facility.attributes.address.physical.zip}
           </div>
         </address>
-        <div className="vads-u-margin-bottom--1p5">
+        <div>
           <a
             href={`https://maps.google.com?saddr=Current+Location&daddr=${address}`}
             target="_blank"

--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -1,3 +1,39 @@
+/* Blue duo-tone for the main region landing page image */
+$duo-tone-darken: #476384;
+$duo-tone-lighten: #000000;
+
+/* The brightest duo-tone color */
+.darken::before {
+  background-color: $duo-tone-darken;
+}
+
+/* The darkest duo-tone color */
+.lighten::after {
+  background-color: $duo-tone-lighten;
+}
+
+/* Duo-tone effect */
+.duotone {
+  overflow: hidden;
+  position: relative;
+  display: inline-block;
+}
+
+.duotone::before, .duotone::after {
+  content: '';
+  width: 100%;
+  height: 100%;
+  position: absolute;
+}
+
+.duotone::before {
+  mix-blend-mode: color;
+}
+
+.duotone::after {
+  mix-blend-mode: screen;
+}
+
 .usa-accordion > ul li ul.usa-unstyled-list,
 .usa-accordion-bordered > ul li ul.usa-unstyled-list {
   list-style: none;

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -140,7 +140,11 @@ Example data:
       <article class="usa-content">
         <h1>{{ title }}</h1>
         {% assign image = fieldMedia.entity.image %}
-        <img src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="100%">
+
+        <div class="duotone darken lighten">
+          <img src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="100%">
+        </div>
+
         <div class="usa-grid usa-grid-full vads-u-margin-top--1p5">
           <div class="usa-width-one-third">
             <a class="usa-button" href="{{ entityUrl.path }}/appointments">Make an appointment</a>
@@ -160,7 +164,7 @@ Example data:
         {% endif %}
 
         <section>
-          <h2>Main Locations</h2>
+          <h2>Locations</h2>
           <div data-widget-type="basic-facility-locations-list" data-facilities="{{ mainFacilities.entities | widgetFacilitiesList | escape }}" data-path="{{ entityUrl.path }}"></div>
           <a class="usa-button usa-button-secondary vads-facility-hub-button" href="{{ entityUrl.path }}/locations">
             See all locations <i class="fa fa-chevron-right">&nbsp;</i>


### PR DESCRIPTION
## Description
- update basic facility list widget layout
- add duo-tone overlay to landing page image

## Testing done
locally with stg/prod cms data 

## Screenshots
![localhost_3001_pittsburgh-health-care_index html (2)](https://user-images.githubusercontent.com/19178435/56782496-40216400-679c-11e9-817d-13982ec3c49e.png)

## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-1829

These are front-end design updates to the VA Pittsburgh Regional Homepage based on our last round of research.

Please follow the guidance in the attached PDF mockup. (See the attached Sketch file for style references).

Please update button copy to match mockup

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
