### PR TITLE
Add 005 session expired error

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -250,6 +250,27 @@ export class AuthApp extends React.Component {
         );
         break;
 
+      // Session expired error
+      case '005':
+        header = 'Your session expired';
+        alertContent = (
+          <p>
+            We’re sorry. We signed you out of VA.gov because your session
+            expired. We take your privacy very seriously. To protect your
+            personal information, we sign you out if you don’t take any action
+            on the site for 30 minutes.
+          </p>
+        );
+        troubleshootingContent = (
+          <>
+            <p>Please try signing in again.</p>
+            <button onClick={this.props.openLoginModal}>
+              Try signing in again
+            </button>
+          </>
+        );
+        break;
+
       // Catch all generic error
       default:
         alertContent = (


### PR DESCRIPTION
## Description
We've created a new 005 backend error code (issue here #17304) that will get triggered whenever a **user is logged out, but hits an expired SAML response.** 

This will often happen when the user has multiple tabs open that are signed into VA.gov, then signs out on one tab, and revisits an old, signed out tab. 

When this happens, the user should be taken to our [Session Expired message, shown here](https://adhoc.invisionapp.com/share/EMQW97NKD7B#/screens/350979554), but on the 005 auth callback page.


## Testing done
Tested locally by navigating to http://localhost:3001/auth/login/callback/?auth=fail&code=005

## Screenshots
![image](https://user-images.githubusercontent.com/786704/56782600-aa3a0900-679c-11e9-9417-571847c53f4b.png)

## Acceptance criteria
- [ ] Switch case 005 has been added and matches copy

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
