### PR TITLE
[CMS] Fix for cache directory

### DIFF
--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -103,14 +103,18 @@ async function loadDrupal(buildOptions) {
 }
 
 async function loadCachedDrupalFiles(buildOptions, files) {
-  const cachedFilesPath = path.join(buildOptions.cacheDirectory, 'drupal');
+  const cachedFilesPath = path.join(
+    buildOptions.cacheDirectory,
+    'drupal/downloads',
+  );
   if (!buildOptions[PULL_DRUPAL_BUILD_ARG] && fs.existsSync(cachedFilesPath)) {
     const cachedDrupalFiles = await recursiveRead(cachedFilesPath);
     cachedDrupalFiles.forEach(file => {
       const relativePath = path.relative(
-        path.join(buildOptions.cacheDirectory, 'drupalFiles'),
+        path.join(buildOptions.cacheDirectory, 'drupal/downloads'),
         file,
       );
+      log(`Loaded Drupal asset from cache: ${relativePath}`);
       files[relativePath] = {
         path: relativePath,
         isDrupalAsset: true,

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -103,7 +103,7 @@ async function loadDrupal(buildOptions) {
 }
 
 async function loadCachedDrupalFiles(buildOptions, files) {
-  const cachedFilesPath = path.join(buildOptions.cacheDirectory, 'drupalFiles');
+  const cachedFilesPath = path.join(buildOptions.cacheDirectory, 'drupal');
   if (!buildOptions[PULL_DRUPAL_BUILD_ARG] && fs.existsSync(cachedFilesPath)) {
     const cachedDrupalFiles = await recursiveRead(cachedFilesPath);
     cachedDrupalFiles.forEach(file => {


### PR DESCRIPTION
## Description
We've started caching CMS assets by environment, and I missed adjusting this instance of the cache directory name. This causes builds to hang if not connected to SOCKS. This PR fixes that.

## Testing done
Local testing

## Acceptance criteria
- [ ] Cache directory is updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
