### PR TITLE
18235 - Change Profile LOA1 Verify Your Identity page-title case.

### DIFF
--- a/src/applications/personalization/profile360/components/IdentityVerification.jsx
+++ b/src/applications/personalization/profile360/components/IdentityVerification.jsx
@@ -9,7 +9,7 @@ export default function IdentityVerification({
 }) {
   return (
     <div>
-      <h1>Verify Your Identity to View Your Profile</h1>
+      <h1>Verify your identity to view your profile</h1>
       <p>
         We need to make sure you’re you—and not someone pretending to be
         you—before we give you access to your personal and health-related


### PR DESCRIPTION
## Description
[18235](/department-of-veterans-affairs/vets.gov-team/issues/18235) - Change case of Profile LOA1 “Verify Your Identity to View Your Profile” page-title from title-case to sentence-case.

## Testing done
With LOA1 user login \[Reviewer: you may need to create a new user account for login\], verified case-change locally via browser.
No logic- or functional-code changes.
Ran `yarn test:unit:personalization` and all unit-tests still passing; no e2e tests are referencing this page-title.

## Screenshots
### Before change:
<img width="611" alt="Screen Shot 2019-04-26 at 4 36 49 PM" src="https://user-images.githubusercontent.com/34068740/56835962-add49b00-6843-11e9-80f8-2313067bd224.png">

### After change:
![18235-after-change](https://user-images.githubusercontent.com/587583/56840363-0bfd8000-683c-11e9-88dd-79d28a3c46f2.png)

## Acceptance criteria
- [ ] Page-title case-change verified in browser.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
