### PR TITLE
VAGOV-2272: VAGOV-3091 - add facility patient satisfaction scores widget

### DIFF
--- a/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { apiRequest } from '../../../platform/utilities/api';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { formatDateLong } from '../../../platform/utilities/date';
+import { displayPercent } from '../../../platform/utilities/ui';
 
 export default class FacilityPatientSatisfactionScoresWidget extends React.Component {
   constructor(props) {
@@ -67,8 +68,10 @@ export default class FacilityPatientSatisfactionScoresWidget extends React.Compo
               >
                 {this.state.facility.attributes.feedback.health
                   .primaryCareUrgent
-                  ? `${this.state.facility.attributes.feedback.health
-                      .primaryCareUrgent * 100}%`
+                  ? displayPercent(
+                      this.state.facility.attributes.feedback.health
+                        .primaryCareUrgent,
+                    )
                   : 'N/A'}
               </p>
             </div>
@@ -80,8 +83,10 @@ export default class FacilityPatientSatisfactionScoresWidget extends React.Compo
               >
                 {this.state.facility.attributes.feedback.health
                   .specialtyCareUrgent
-                  ? `${this.state.facility.attributes.feedback.health
-                      .specialtyCareUrgent * 100}%`
+                  ? displayPercent(
+                      this.state.facility.attributes.feedback.health
+                        .specialtyCareUrgent,
+                    )
                   : 'N/A'}
               </p>
             </div>
@@ -103,8 +108,10 @@ export default class FacilityPatientSatisfactionScoresWidget extends React.Compo
               >
                 {this.state.facility.attributes.feedback.health
                   .primaryCareRoutine
-                  ? `${this.state.facility.attributes.feedback.health
-                      .primaryCareRoutine * 100}%`
+                  ? displayPercent(
+                      this.state.facility.attributes.feedback.health
+                        .primaryCareRoutine,
+                    )
                   : 'N/A'}
               </p>
             </div>
@@ -116,8 +123,10 @@ export default class FacilityPatientSatisfactionScoresWidget extends React.Compo
               >
                 {this.state.facility.attributes.feedback.health
                   .specialtyCareRoutine
-                  ? `${this.state.facility.attributes.feedback.health
-                      .specialtyCareRoutine * 100}%`
+                  ? displayPercent(
+                      this.state.facility.attributes.feedback.health
+                        .specialtyCareRoutine,
+                    )
                   : 'N/A'}
               </p>
             </div>

--- a/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
@@ -63,7 +63,7 @@ export default class FacilityPatientSatisfactionScoresWidget extends React.Compo
               <p className="vads-u-margin--0">Primary care</p>
               <p
                 id="facility-patient-satisfaction-scores-primary-urgent-score"
-                className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0"
+                className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0 vads-u-font-family--serif"
               >
                 {this.state.facility.attributes.feedback.health
                   .primaryCareUrgent
@@ -76,7 +76,7 @@ export default class FacilityPatientSatisfactionScoresWidget extends React.Compo
               <p className="vads-u-margin--0">Specialty care</p>
               <p
                 id="facility-patient-satisfaction-scores-specialty-urgent-score"
-                className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0"
+                className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0 vads-u-font-family--serif"
               >
                 {this.state.facility.attributes.feedback.health
                   .specialtyCareUrgent
@@ -99,7 +99,7 @@ export default class FacilityPatientSatisfactionScoresWidget extends React.Compo
               <p className="vads-u-margin--0">Primary care</p>
               <p
                 id="facility-patient-satisfaction-scores-primary-routine-score"
-                className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0"
+                className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0 vads-u-font-family--serif"
               >
                 {this.state.facility.attributes.feedback.health
                   .primaryCareRoutine
@@ -112,7 +112,7 @@ export default class FacilityPatientSatisfactionScoresWidget extends React.Compo
               <p className="vads-u-margin--0">Specialty care</p>
               <p
                 id="facility-patient-satisfaction-scores-specialty-routine-score"
-                className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0"
+                className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0 vads-u-font-family--serif"
               >
                 {this.state.facility.attributes.feedback.health
                   .specialtyCareRoutine

--- a/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { apiRequest } from '../../../platform/utilities/api';
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import { formatDateLong } from '../../../platform/utilities/date';
+
+export default class FacilityPatientSatisfactionScoresWidget extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: true,
+    };
+  }
+
+  componentDidMount() {
+    const facilityId = this.props.facilityId;
+    this.request = apiRequest(
+      `/facilities/va/${facilityId}`,
+      null,
+      this.handleFacilitySuccess,
+      this.handleFacilityError,
+    );
+  }
+
+  handleFacilitySuccess = facility => {
+    this.setState({
+      loading: false,
+      facility: facility.data,
+    });
+  };
+
+  handleFacilityError = () => {
+    this.setState({ error: true });
+  };
+
+  render() {
+    if (this.state.loading) {
+      return (
+        <LoadingIndicator message="Loading facility patient satisfaction scores..." />
+      );
+    }
+    return (
+      <div>
+        <h2>Our patient satisfaction scores</h2>
+        <p id="facility-patient-satisfaction-scores-effective-date">
+          Last updated:{' '}
+          {formatDateLong(
+            this.state.facility.attributes.feedback.health.effectiveDate,
+          )}
+        </p>
+        <p>
+          Veteran-reported satisfaction scores come from the Consumer Assessment
+          of Health and Systems survey, which measures satisfaction of nearly
+          150,000 Veterans across the U.S. every 6 months.
+        </p>
+        <h3>Urgent care appointments at this location</h3>
+        <p>
+          % of Veterans who say they usually or always get an appointment when
+          they need care right away
+        </p>
+        <div className="usa-grid-full">
+          <div className="usa-width-one-half">
+            <div className="usa-width-one-half vads-u-background-color--gray-lightest vads-u-padding--1p5">
+              <p className="vads-u-margin--0">Primary care</p>
+              <p
+                id="facility-patient-satisfaction-scores-primary-urgent-score"
+                className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0"
+              >
+                {this.state.facility.attributes.feedback.health
+                  .primaryCareUrgent
+                  ? `${this.state.facility.attributes.feedback.health
+                      .primaryCareUrgent * 100}%`
+                  : 'N/A'}
+              </p>
+            </div>
+            <div className="usa-width-one-half vads-u-background-color--gray-lightest vads-u-padding--1p5">
+              <p className="vads-u-margin--0">Specialty care</p>
+              <p
+                id="facility-patient-satisfaction-scores-specialty-urgent-score"
+                className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0"
+              >
+                {this.state.facility.attributes.feedback.health
+                  .specialtyCareUrgent
+                  ? `${this.state.facility.attributes.feedback.health
+                      .specialtyCareUrgent * 100}%`
+                  : 'N/A'}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <h3>Routine care appointments at this location</h3>
+        <p>
+          % of Veterans who say they usually or always get an appointment when
+          they need it
+        </p>
+        <div className="usa-grid-full">
+          <div className="usa-width-one-half">
+            <div className="usa-width-one-half vads-u-background-color--gray-lightest vads-u-padding--1p5">
+              <p className="vads-u-margin--0">Primary care</p>
+              <p
+                id="facility-patient-satisfaction-scores-primary-routine-score"
+                className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0"
+              >
+                {this.state.facility.attributes.feedback.health
+                  .primaryCareRoutine
+                  ? `${this.state.facility.attributes.feedback.health
+                      .primaryCareRoutine * 100}%`
+                  : 'N/A'}
+              </p>
+            </div>
+            <div className="usa-width-one-half vads-u-background-color--gray-lightest vads-u-padding--1p5">
+              <p className="vads-u-margin--0">Specialty care</p>
+              <p
+                id="facility-patient-satisfaction-scores-specialty-routine-score"
+                className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0"
+              >
+                {this.state.facility.attributes.feedback.health
+                  .specialtyCareRoutine
+                  ? `${this.state.facility.attributes.feedback.health
+                      .specialtyCareRoutine * 100}%`
+                  : 'N/A'}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/applications/static-pages/facilities/facilityPatientSatisfactionScores.js
+++ b/src/applications/static-pages/facilities/facilityPatientSatisfactionScores.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export default async function createFacilityPatientSatisfactionScoresWidget() {
+  const widgets = Array.from(
+    document.querySelectorAll(
+      `[data-widget-type="facility-patient-satisfaction-scores"]`,
+    ),
+  );
+
+  if (widgets.length) {
+    const {
+      default: FacilityPatientSatisfactionScoresWidget,
+    } = await import(/* webpackChunkName: "facility-patient-satisfaction-scores" */ './FacilityPatientSatisfactionScoresWidget');
+
+    // since these widgets are on content pages, we don't want to focus on them
+    widgets.forEach(el => {
+      ReactDOM.render(
+        <FacilityPatientSatisfactionScoresWidget
+          facilityId={JSON.parse(el.dataset.facility)}
+        />,
+        el,
+      );
+    });
+  }
+}

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -29,6 +29,7 @@ import './social-share-links';
 import createFacilityListWidget from './facilities/facilityList';
 import createFacilityDetailWidget from './facilities/facilityDetail';
 import createBasicFacilityListWidget from './facilities/basicFacilityList';
+import createFacilityPatientSatisfactionScoresWidget from './facilities/facilityPatientSatisfactionScores';
 
 // Set further errors to have the appropriate source tag
 Raven.setTagsContext({
@@ -84,6 +85,7 @@ createDisabilityFormWizard(store, widgetTypes.DISABILITY_APP_STATUS);
 createFacilityListWidget();
 createFacilityDetailWidget();
 createBasicFacilityListWidget();
+createFacilityPatientSatisfactionScoresWidget();
 
 // homepage widgets
 if (location.pathname === '/') {

--- a/src/applications/static-pages/tests/facilities/FacilityPatientSatisfactionScoresWidget.unit.spec.jsx
+++ b/src/applications/static-pages/tests/facilities/FacilityPatientSatisfactionScoresWidget.unit.spec.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { mockApiRequest, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFacilityLocatorApiResponse } from './mockFacilitiesData';
+import FacilityPatientSatisfactionScoresWidget from '../../facilities/FacilityPatientSatisfactionScoresWidget';
+
+describe('facilities <FacilityPatientSatisfactionScoresWidget>', () => {
+  it('should render loading', () => {
+    const tree = shallow(
+      <FacilityPatientSatisfactionScoresWidget
+        facilityId={mockFacilityLocatorApiResponse.data[0].id}
+      />,
+      {
+        disableLifecycleMethods: true,
+      },
+    );
+
+    expect(tree.find('LoadingIndicator').exists()).to.be.true;
+    tree.unmount();
+  });
+
+  it('should render facility patient satisfaction score data', done => {
+    mockApiRequest({ data: mockFacilityLocatorApiResponse.data[0] });
+
+    const tree = shallow(
+      <FacilityPatientSatisfactionScoresWidget
+        facilityId={mockFacilityLocatorApiResponse.data[0].id}
+      />,
+    );
+    tree.instance().request.then(() => {
+      tree.update();
+      expect(tree.find('LoadingIndicator').exists()).to.be.false;
+
+      const satisfactionScoresHeader = tree.find('h2');
+      expect(satisfactionScoresHeader.text()).to.contain(
+        'Our patient satisfaction scores',
+      );
+
+      const facilityPatientSatisfactionScoresEffectiveDate = tree.find(
+        '#facility-patient-satisfaction-scores-effective-date',
+      );
+      expect(facilityPatientSatisfactionScoresEffectiveDate.text()).to.contain(
+        'Last updated: May 22, 2018',
+      );
+
+      const primaryUrgentScore = tree.find(
+        '#facility-patient-satisfaction-scores-primary-urgent-score',
+      );
+      expect(primaryUrgentScore.text()).to.contain('N/A');
+
+      const primaryRoutineScore = tree.find(
+        '#facility-patient-satisfaction-scores-primary-routine-score',
+      );
+      expect(primaryRoutineScore.text()).to.contain('88%');
+
+      const specialtyUrgentScore = tree.find(
+        '#facility-patient-satisfaction-scores-specialty-urgent-score',
+      );
+      expect(specialtyUrgentScore.text()).to.contain('76%');
+
+      const specialtyRoutineScore = tree.find(
+        '#facility-patient-satisfaction-scores-specialty-routine-score',
+      );
+      expect(specialtyRoutineScore.text()).to.contain('91%');
+
+      tree.unmount();
+      resetFetch();
+      done();
+    });
+  });
+});

--- a/src/applications/static-pages/tests/facilities/mockFacilitiesData.js
+++ b/src/applications/static-pages/tests/facilities/mockFacilitiesData.js
@@ -48,6 +48,14 @@ const mockFacilityLocatorApiResponse = {
           mentalHealthClinic: '412-360-6600',
           enrollmentCoordinator: '412-360-6993 x',
         },
+        feedback: {
+          health: {
+            effectiveDate: '2018-05-22',
+            primaryCareRoutine: 0.88,
+            specialtyCareRoutine: 0.91,
+            specialtyCareUrgent: 0.76,
+          },
+        },
       },
     },
   ],

--- a/src/platform/utilities/ui/index.js
+++ b/src/platform/utilities/ui/index.js
@@ -66,3 +66,18 @@ export function scrollAndFocus(errorEl) {
     focusElement(errorEl);
   }
 }
+
+/* Converts a percentage decimal number to a percentage number.
+*
+* Returns a string
+* ex. displayPercent(.91) returns "91%"
+* Remember that `toFixed()` rounds, so, if a decimal number such as .9177 is sent in as such:
+* displayPercent(.9177, 1), with "1" being the number of desired places to display
+* the output is: "91.8%"
+*
+* @param decimalNumber - the decimal number to convert
+* @param places (optional) - the number of places after the decimal sign to display
+*/
+export function displayPercent(decimalNumber, places = 0) {
+  return `${(decimalNumber * 100).toFixed(places)}%`;
+}

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -169,6 +169,8 @@
                 </section>
             {% endif %}
 
+            <div data-widget-type="facility-patient-satisfaction-scores" data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}"></div>
+
           <!-- List of links section -->
           {% if fieldRelatedLinks != empty %}
             {% include "src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRelatedLinks.entity %}


### PR DESCRIPTION
## Description
 - adds the `FacilityPatientSatisfactionScoresWidget` to the bottom of the facility detail page

## Testing done

- locally with stg/prod cms data using `https://dev-api.va.gov/v0/` facilities api endpoint

1. build site
2. browse to any facility page such as http://localhost:3001/pittsburgh-health-care/locations/pittsburgh-va-medical-center-university-drive/
3. scroll to the bottom to see the satisfaction scores

## Screenshots
![localhost_3001_pittsburgh-health-care_locations_pittsburgh-va-medical-center-university-drive_ (1)](https://user-images.githubusercontent.com/19178435/56845490-e9d52380-6876-11e9-84f8-1aa70dd6162f.png)

## Acceptance criteria

https://va-gov.atlassian.net/browse/VAGOV-2272

As a Veteran on a facility location page, I can see the Veteran Satisfaction Ratings so I can make a more informed decision about where I want to receive my care.

Acceptance Criteria:

The local facility detail page template is updated to reflect the design specified under 

Note - with the exception of the actual ratings, this section’s copy will be hard coded into the web template and will not be editable via CMS.   

The facility locator API integration is updated to perform a lookup of patient satisfaction score and add the scores  and last updated dates to the template.

The new front-end satisfaction ratings are viewable on VAMC Pittsburgh’s 7 facility location pages.

Mock up followed:
![2272 mock up followed](https://api.media.atlassian.com/file/f650b341-899d-4803-83e3-9cdea31ad79a/binary?token=eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI1ZWE3MGI5ZS1kMzM5LTQ3YTYtODBlOC0wMGZhODgwODJkNTAiLCJhY2Nlc3MiOnsidXJuOmZpbGVzdG9yZTpmaWxlOmY2NTBiMzQxLTg5OWQtNDgwMy04M2UzLTljZGVhMzFhZDc5YSI6WyJyZWFkIl0sInVybjpmaWxlc3RvcmU6ZmlsZToyN2M1YjM3Yi1kOWJmLTQzYjctYmNmOC0yNjE4MTkzMGFiZGYiOlsicmVhZCJdLCJ1cm46ZmlsZXN0b3JlOmZpbGU6ZTEwODRkZmEtYzIyZS00OTdiLThhZTctMDAxOGZlZmE1MmI1IjpbInJlYWQiXSwidXJuOmZpbGVzdG9yZTpmaWxlOmY0YTdmMmM5LWNmNWUtNDk3MC1hYTk3LWRlYTI3MGVmMWZlMCI6WyJyZWFkIl19LCJleHAiOjE1NTYzNDQ1MjIsIm5iZiI6MTU1NjM0MzU2Mn0.tFuKdT-201wOUIhYlbvjWKN4ijjk05_0zBzEyRRzREg&client=5ea70b9e-d339-47a6-80e8-00fa88082d50)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
