### PR TITLE
VAGOV-2863: Adding alert paragraph query & template

### DIFF
--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -1,7 +1,7 @@
 <ul class="usa-accordion-bordered social">
     <li>
         {% assign accordionId = administration.entityBundle | append: administration.entityId  %}
-        <button class="usa-accordion-button usa-accordion-button-dark rail-heading" aria-expanded="true" aria-controls="{{ accordionId }}">Connect with Us</button>
+        <button class="usa-accordion-button usa-accordion-button-dark rail-heading" aria-expanded="true" aria-controls="{{ accordionId }}">Connect with us</button>
         <div id="{{ accordionId }}" class="usa-accordion-content" aria-hidden="false">
             <h4 class="va-nav-linkslist-list">
                 <a href="{{ administration.fieldLink.url.path }}">{{ administration.name }}</a>

--- a/src/site/paragraphs/alert.drupal.liquid
+++ b/src/site/paragraphs/alert.drupal.liquid
@@ -1,0 +1,65 @@
+{% comment %}
+    Example data:
+    {
+    "entityBundle": "alert",
+    "fieldAlertType": "warning",
+    "fieldHelpText": null,
+    "fieldAlertTitle": "How do I talk to someone right now?",
+    "fieldReusability": "reusable",
+    "fieldAlertContent": {
+    "entity": {
+    "entityId": "932",
+    "entityBundle": "expandable_text"
+    "fieldWysiwyg": {
+    "processed": "..."
+    },
+    "fieldTextExpander": "Find out how to get support anytime day or night."
+    }
+    }
+    }
+{% endcomment %}
+{% if alert.fieldAlertContent %}
+    {% assign expander = alert.fieldAlertContent.entity %}
+{% endif %}
+{% assign alertType = alert.fieldAlertType %}
+{% if alertType = "information" %}
+    {% assign alertType = "info" %}
+{% endif %}
+
+<div class="usa-alert usa-alert-{{ alertType }}" role="alert">
+    <div class="usa-alert-body">
+        <h3 class="usa-alert-heading">
+            {{ alert.fieldAlertTitle }}
+        </h3>
+        {% if alert.fieldHelpText %}
+            <p>{{ alert.fieldHelpText }}</p>
+        {% endif %}
+        {% if expander.fieldTextExpander %}
+
+            {% comment %}
+                NOTE: .additional-info-container is a class utilized by
+                createAdditionalInfoWidget.js to add toggle functionality to info alerts
+            {% endcomment %}
+
+            {% if alert.fieldAlertTitle contains 'homeless' %}
+                {% assign analyticsId = 'nav-crisis-homelessness-expander' %}
+                {% elsif expander.fieldTextExpander contains 'support' %}
+                {% assign analyticsId = 'nav-crisis-get-support-247' %}
+                {% elsif expander.fieldTextExpander contains 'care now' %}
+                {% assign analyticsId = 'nav-crisis-get-care-now' %}
+            {% else %}
+                {% comment %}
+                    Nothing required!
+                {% endcomment %}
+            {% endif %}
+
+            <div data-analytics="{{ analyticsId }}" class="form-expanding-group borderless-alert additional-info-container">
+                <div class="additional-info-title">{{ expander.fieldTextExpander }}</div>
+
+                {% if expander.fieldWysiwyg %}
+                    <div class="additional-info-content usa-alert-text" hidden>{{ expander.fieldWysiwyg.processed }}</div>
+                {% endif %}
+            </div>
+        {% endif %}
+    </div>
+</div>

--- a/src/site/paragraphs/alert.drupal.liquid
+++ b/src/site/paragraphs/alert.drupal.liquid
@@ -31,47 +31,7 @@
 
 {% if entity.fieldAlertBlockReference != empty %}
     {% assign alertBlock = entity.fieldAlertBlockReference.entity %}
-    {% if alertBlock.fieldAlertContent %}
-        {% assign expander = alertBlock.fieldAlertContent.entity %}
-    {% endif %}
-
-    <div class="usa-alert usa-alert-{{ alertType }}" role="alert">
-        <div class="usa-alert-body">
-            <h3 class="usa-alert-heading">
-                {{ alertBlock.fieldAlertTitle }}
-            </h3>
-            {% if alertBlock.fieldHelpText %}
-                <p>{{ alertBlock.fieldHelpText }}</p>
-            {% endif %}
-            {% if expander.fieldTextExpander %}
-
-                {% comment %}
-                    NOTE: .additional-info-container is a class utilized by
-                    createAdditionalInfoWidget.js to add toggle functionality to info alerts
-                {% endcomment %}
-
-                {% if alertBlock.fieldAlertTitle contains 'homeless' %}
-                    {% assign analyticsId = 'nav-crisis-homelessness-expander' %}
-                    {% elsif expander.fieldTextExpander contains 'support' %}
-                    {% assign analyticsId = 'nav-crisis-get-support-247' %}
-                    {% elsif expander.fieldTextExpander contains 'care now' %}
-                    {% assign analyticsId = 'nav-crisis-get-care-now' %}
-                {% else %}
-                    {% comment %}
-                        Nothing required!
-                    {% endcomment %}
-                {% endif %}
-
-                <div data-analytics="{{ analyticsId }}" class="form-expanding-group borderless-alert additional-info-container">
-                    <div class="additional-info-title">{{ expander.fieldTextExpander }}</div>
-
-                    {% if expander.fieldWysiwyg %}
-                        <div class="additional-info-content usa-alert-text" hidden>{{ expander.fieldWysiwyg.processed }}</div>
-                    {% endif %}
-                </div>
-            {% endif %}
-        </div>
-    </div>
+    {% include "src/site/blocks/alert.drupal.liquid" with alert = alertBlock %}
 {% else %}
     <div class="usa-alert usa-alert-{{ alertType }}" role="alert">
         <div class="usa-alert-body">

--- a/src/site/paragraphs/alert.drupal.liquid
+++ b/src/site/paragraphs/alert.drupal.liquid
@@ -1,65 +1,88 @@
 {% comment %}
     Example data:
     {
+    "entity": {
+    "entityType": "paragraph",
     "entityBundle": "alert",
-    "fieldAlertType": "warning",
+    "fieldAlertType": "information",
+    "fieldAlertHeading": null,
+    "fieldAlertBlockReference": {
+    "entity": {
+    "fieldAlertTitle": "You'll need to go to eBenefits to authorize us to share your health information through the Veterans Health Information Exchange.",
     "fieldHelpText": null,
-    "fieldAlertTitle": "How do I talk to someone right now?",
+    "fieldAlertType": "information",
     "fieldReusability": "reusable",
     "fieldAlertContent": {
     "entity": {
-    "entityId": "932",
-    "entityBundle": "expandable_text"
     "fieldWysiwyg": {
-    "processed": "..."
+    "processed": "<p>To use this feature, you'll need a Premium <strong>DS Logon</strong> account. Your My HealtheVet or ID.me credentials won’t work on the eBenefits website. Go to eBenefits to sign in, register, or upgrade your <strong>DS Logon</strong> account to Premium.<br /><a class=\"usa-button-primary\" href=\"https://www.ebenefits.va.gov/ebenefits/vapii\">Go to eBenefits</a>\n</p>"
+    }
+    }
+    }
+    }
     },
-    "fieldTextExpander": "Find out how to get support anytime day or night."
-    }
-    }
+    "fieldVaParagraphs": []
     }
 {% endcomment %}
-{% if alert.fieldAlertContent %}
-    {% assign expander = alert.fieldAlertContent.entity %}
-{% endif %}
-{% assign alertType = alert.fieldAlertType %}
+{% assign alertType = entity.fieldAlertType %}
 {% if alertType = "information" %}
     {% assign alertType = "info" %}
 {% endif %}
 
-<div class="usa-alert usa-alert-{{ alertType }}" role="alert">
-    <div class="usa-alert-body">
-        <h3 class="usa-alert-heading">
-            {{ alert.fieldAlertTitle }}
-        </h3>
-        {% if alert.fieldHelpText %}
-            <p>{{ alert.fieldHelpText }}</p>
-        {% endif %}
-        {% if expander.fieldTextExpander %}
+{% if entity.fieldAlertBlockReference != empty %}
+    {% assign alertBlock = entity.fieldAlertBlockReference.entity %}
+    {% if alertBlock.fieldAlertContent %}
+        {% assign expander = alertBlock.fieldAlertContent.entity %}
+    {% endif %}
 
-            {% comment %}
-                NOTE: .additional-info-container is a class utilized by
-                createAdditionalInfoWidget.js to add toggle functionality to info alerts
-            {% endcomment %}
-
-            {% if alert.fieldAlertTitle contains 'homeless' %}
-                {% assign analyticsId = 'nav-crisis-homelessness-expander' %}
-                {% elsif expander.fieldTextExpander contains 'support' %}
-                {% assign analyticsId = 'nav-crisis-get-support-247' %}
-                {% elsif expander.fieldTextExpander contains 'care now' %}
-                {% assign analyticsId = 'nav-crisis-get-care-now' %}
-            {% else %}
-                {% comment %}
-                    Nothing required!
-                {% endcomment %}
+    <div class="usa-alert usa-alert-{{ alertType }}" role="alert">
+        <div class="usa-alert-body">
+            <h3 class="usa-alert-heading">
+                {{ alertBlock.fieldAlertTitle }}
+            </h3>
+            {% if alertBlock.fieldHelpText %}
+                <p>{{ alertBlock.fieldHelpText }}</p>
             {% endif %}
+            {% if expander.fieldTextExpander %}
 
-            <div data-analytics="{{ analyticsId }}" class="form-expanding-group borderless-alert additional-info-container">
-                <div class="additional-info-title">{{ expander.fieldTextExpander }}</div>
+                {% comment %}
+                    NOTE: .additional-info-container is a class utilized by
+                    createAdditionalInfoWidget.js to add toggle functionality to info alerts
+                {% endcomment %}
 
-                {% if expander.fieldWysiwyg %}
-                    <div class="additional-info-content usa-alert-text" hidden>{{ expander.fieldWysiwyg.processed }}</div>
+                {% if alertBlock.fieldAlertTitle contains 'homeless' %}
+                    {% assign analyticsId = 'nav-crisis-homelessness-expander' %}
+                    {% elsif expander.fieldTextExpander contains 'support' %}
+                    {% assign analyticsId = 'nav-crisis-get-support-247' %}
+                    {% elsif expander.fieldTextExpander contains 'care now' %}
+                    {% assign analyticsId = 'nav-crisis-get-care-now' %}
+                {% else %}
+                    {% comment %}
+                        Nothing required!
+                    {% endcomment %}
                 {% endif %}
-            </div>
-        {% endif %}
+
+                <div data-analytics="{{ analyticsId }}" class="form-expanding-group borderless-alert additional-info-container">
+                    <div class="additional-info-title">{{ expander.fieldTextExpander }}</div>
+
+                    {% if expander.fieldWysiwyg %}
+                        <div class="additional-info-content usa-alert-text" hidden>{{ expander.fieldWysiwyg.processed }}</div>
+                    {% endif %}
+                </div>
+            {% endif %}
+        </div>
     </div>
-</div>
+{% else %}
+    <div class="usa-alert usa-alert-{{ alertType }}" role="alert">
+        <div class="usa-alert-body">
+            <h3 class="usa-alert-heading">
+                {{ entity.fieldAlertHeading }}
+            </h3>
+            {% for paragraph in entity.fieldVaParagraphs %}
+                {% assign bundleComponent = "src/site/paragraphs/" | append: paragraph.entity.entityBundle | append: ".drupal.liquid" %}
+                {% include {{ bundleComponent }} with entity = paragraph.entity %}
+            {% endfor %}
+        </div>
+    </div>
+{% endif %}
+

--- a/src/site/paragraphs/expandable_text.drupal.liquid
+++ b/src/site/paragraphs/expandable_text.drupal.liquid
@@ -1,0 +1,21 @@
+{% comment %}
+Example data:
+    "entity": {
+    "entityId": "3887",
+    "entityBundle": "expandable_text",
+    "fieldWysiwyg": {
+    "processed": "<p>Test Test</p>"
+    },
+    "fieldTextExpander": "Test Expander"
+    }
+{% endcomment %}
+
+{% if entity.fieldTextExpander %}
+    <div class="form-expanding-group borderless-alert additional-info-container">
+        <div class="additional-info-title">{{ entity.fieldTextExpander }}</div>
+
+        {% if entity.fieldWysiwyg %}
+            <div class="additional-info-content usa-alert-text" hidden>{{ entity.fieldWysiwyg.processed }}</div>
+        {% endif %}
+    </div>
+{% endif %}

--- a/src/site/stages/build/drupal/graphql/fragments.graphql.js
+++ b/src/site/stages/build/drupal/graphql/fragments.graphql.js
@@ -13,6 +13,7 @@ const administration = require('./taxonomy-fragments/administration.taxonomy.gra
 const reactWidget = require('./paragraph-fragments/reactWidget.paragraph.graphql');
 const spanishSummary = require('./paragraph-fragments/spanishSummary.paragraph.graphql');
 const numberCallout = require('./paragraph-fragments/numberCallout.paragraph.graphql');
+const alertParagraph = require('./paragraph-fragments/alert.paragraph.graphql');
 
 module.exports = `
   ${alert}
@@ -28,4 +29,5 @@ module.exports = `
   ${reactWidget}
   ${spanishSummary}
   ${numberCallout}
+  ${alertParagraph}
 `;

--- a/src/site/stages/build/drupal/graphql/page.graphql.js
+++ b/src/site/stages/build/drupal/graphql/page.graphql.js
@@ -16,6 +16,7 @@ const QA = '... qa';
 const LIST_OF_LINK_TEASERS = '... listOfLinkTeasers';
 const REACT_WIDGET = '... reactWidget';
 const SPANISH_SUMMARY = '... spanishSummary';
+const ALERT_PARAGRAPH = '... alertParagraph';
 
 module.exports = `
 
@@ -42,6 +43,7 @@ module.exports = `
         ${LIST_OF_LINK_TEASERS}
         ${REACT_WIDGET} 
         ${SPANISH_SUMMARY}
+        ${ALERT_PARAGRAPH}
       }
     }
     ${FIELD_ALERT} 

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/alert.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/alert.paragraph.graphql.js
@@ -1,0 +1,55 @@
+/*
+*
+* A reusable or non-reusable alert, either "information status" or "warning status".
+*
+ */
+module.exports = `
+  fragment alertParagraph on ParagraphAlert {      
+      fieldAlertType
+      fieldAlertHeading
+      fieldAlertBlockReference {
+        entity {
+          ... on BlockContentAlert {
+            fieldAlertTitle
+            fieldHelpText
+            fieldAlertType
+            fieldReusability
+            fieldAlertContent {
+              entity {
+                ... on ParagraphWysiwyg {
+                  fieldWysiwyg {
+                    processed
+                  }
+                }
+                ... on ParagraphExpandableText {
+                  entityId
+                  entityBundle
+                  fieldWysiwyg {
+                    processed
+                  }
+                  fieldTextExpander
+                }
+              }
+            }
+          }
+        }
+      }
+      fieldVaParagraphs {
+        entity {
+          ... on ParagraphWysiwyg {
+            fieldWysiwyg {
+              processed
+            }
+          }
+          ... on ParagraphExpandableText {
+            entityId
+            entityBundle
+            fieldWysiwyg {
+              processed
+            }
+            fieldTextExpander
+          }
+        }
+      }
+  }
+`;

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/alert.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/alert.paragraph.graphql.js
@@ -7,6 +7,25 @@ module.exports = `
   fragment alertParagraph on ParagraphAlert {      
       fieldAlertType
       fieldAlertHeading
+      fieldVaParagraphs {
+        entity {
+          ... on ParagraphWysiwyg {
+            entityId
+            entityBundle
+            fieldWysiwyg {
+              processed
+            }
+          }
+          ... on ParagraphExpandableText {
+            entityId
+            entityBundle
+            fieldWysiwyg {
+              processed
+            }
+            fieldTextExpander
+          }
+        }
+      }
       fieldAlertBlockReference {
         entity {
           ... on BlockContentAlert {
@@ -17,6 +36,8 @@ module.exports = `
             fieldAlertContent {
               entity {
                 ... on ParagraphWysiwyg {
+                  entityId
+                  entityBundle
                   fieldWysiwyg {
                     processed
                   }
@@ -31,23 +52,6 @@ module.exports = `
                 }
               }
             }
-          }
-        }
-      }
-      fieldVaParagraphs {
-        entity {
-          ... on ParagraphWysiwyg {
-            fieldWysiwyg {
-              processed
-            }
-          }
-          ... on ParagraphExpandableText {
-            entityId
-            entityBundle
-            fieldWysiwyg {
-              processed
-            }
-            fieldTextExpander
           }
         }
       }


### PR DESCRIPTION
## Description
**This PR has a hard dependency on the content model changes in this va.gov-cms PR: https://github.com/department-of-veterans-affairs/va.gov-cms/pull/283**

Adds a GraphQL query and metalsmith templates required to display inline alerts. 

## Testing done
In order to review you must have this va.gov-cms PR pulled down and built in your local Lando environment: https://github.com/department-of-veterans-affairs/va.gov-cms/pull/283 And you have to create a test benefit detail page with an inline alert (instructions: https://va-gov.atlassian.net/browse/VAGOV-2862). Then build the front-end locally pulling from the local va.gov-cms build:

`npm run watch:static -- --pull-drupal --drupal-address=http://va-gov-cms.lndo.site`

Go to `http://localhost:3001/drupal/debug/` to find your test page. Confirm the inline alert is displaying properly. 

## Screenshots
<img width="764" alt="Screen Shot 2019-04-29 at 3 55 37 PM" src="https://user-images.githubusercontent.com/3157339/56929596-49aa1500-6a97-11e9-85f7-d7977235f424.png">


## Acceptance criteria
- [x] An editor can manually place an alert block in any location on detail page content types of va.gov

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
