### PR TITLE
fix redirect-on-login bug

### DIFF
--- a/src/applications/hca/containers/IDPage.jsx
+++ b/src/applications/hca/containers/IDPage.jsx
@@ -96,10 +96,11 @@ class IDPage extends React.Component {
 
     const { enrollmentStatus, noESRRecordFound, shouldRedirect } = this.props;
 
-    // Redirect to intro if a logged in user directly accessed this page.
-    if (shouldRedirect) this.props.router.push('/');
-
-    if (
+    // Redirect to intro if a logged in user directly accessed this page...
+    // ...otherwise handle the response from the ID Form
+    if (shouldRedirect) {
+      this.props.router.push('/');
+    } else if (
       noESRRecordFound ||
       enrollmentStatus === HCA_ENROLLMENT_STATUSES.noneOfTheAbove
     ) {


### PR DESCRIPTION
## Description
We have an error where when a user who has an in-progress HCA logs in while on the `id-form` route, they would get redirected to where they left off on the HCA. The intended behavior is for them to get redirected to the HCA introduction page instead.

## Testing done
local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs