### PR TITLE
[Footer] Remove Grants Management Services

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -78,43 +78,36 @@
   },
   {
     "column": 2,
-    "href": "https://www.va.gov/finance/policy/pubs/volumex.asp",
-    "order": 5,
-    "target": null,
-    "title": "Grants Management Services"
-  },
-  {
-    "column": 2,
     "href": "https://www.va.gov/ogc/accreditation.asp",
-    "order": 6,
+    "order": 5,
     "target": null,
     "title": "VA claims accreditation"
   },
   {
     "column": 2,
     "href": "https://www.accesstocare.va.gov/ourproviders/",
-    "order": 7,
+    "order": 6,
     "target": "_blank",
     "title": "Find a VA health care provider"
   },
   {
     "column": 2,
     "href": "https://www.va.gov/vso/",
-    "order": 8,
+    "order": 7,
     "target": null,
     "title": "Veterans Service Organizations (VSOs)"
   },
   {
     "column": 2,
     "href": "https://www.va.gov/statedva.htm",
-    "order": 9,
+    "order": 8,
     "target": null,
     "title": "State Veterans Affairs offices"
   },
   {
     "column": 2,
     "href": "https://www.va.gov/welcome-kit/",
-    "order": 10,
+    "order": 9,
     "target": null,
     "title": "Print your VA welcome kit"
   },


### PR DESCRIPTION
## Description
Per ticket https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18257, this office no longer exists, so we should remove the link from the footer.

## Testing done
Looked at footer

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/56920937-858eab80-6a92-11e9-9512-e2b34726e663.png)


## Acceptance criteria
- [ ] Link is removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
