### PR TITLE
Updated terms and conditions

### DIFF
--- a/src/applications/terms-and-conditions/containers/MhvTermsAndConditions.jsx
+++ b/src/applications/terms-and-conditions/containers/MhvTermsAndConditions.jsx
@@ -108,6 +108,7 @@ export class MhvTermsAndConditions extends React.Component {
   };
 
   renderAcceptButton = () => {
+    const { loading } = this.props;
     const shouldHideSection =
       !this.props.user.loggedIn ||
       !this.props.user.verified ||
@@ -117,7 +118,10 @@ export class MhvTermsAndConditions extends React.Component {
       return null;
     }
     const submitButton = (
-      <button className="usa-button submit-button">
+      <button
+        className="usa-button submit-button"
+        disabled={loading.acceptance}
+      >
         Accept terms and conditions
       </button>
     );
@@ -158,14 +162,18 @@ export class MhvTermsAndConditions extends React.Component {
     const { termsContent } = this.props.attributes;
 
     return (
-      <div>
+      <>
         <h1>Terms and conditions for medical information</h1>
         {this.renderBanner()}
         <form onSubmit={this.handleSubmit}>
-          <div dangerouslySetInnerHTML={{ __html: termsContent }} />
+          <h2>Terms and conditions</h2>
+          <div
+            dangerouslySetInnerHTML={{ __html: termsContent }}
+            className="terms-text"
+          />
           {this.renderAcceptButton()}
         </form>
-      </div>
+      </>
     );
   };
   /* eslint-enable react/no-danger */
@@ -176,7 +184,7 @@ export class MhvTermsAndConditions extends React.Component {
         <div className="container">
           <div className="row">
             <div
-              className="columns medium-10"
+              className="columns medium-9"
               role="region"
               aria-label="Terms and Conditions"
             >

--- a/src/applications/terms-and-conditions/containers/MhvTermsAndConditions.jsx
+++ b/src/applications/terms-and-conditions/containers/MhvTermsAndConditions.jsx
@@ -69,37 +69,34 @@ export class MhvTermsAndConditions extends React.Component {
   };
 
   renderBanner = () => {
-    let bannerProps;
-    if (this.props.accepted) {
-      bannerProps = {
-        headline: `You’ve accepted the Terms and Conditions for using VA.gov health tools`,
-        content: '',
-        status: 'success',
-      };
-    } else {
-      bannerProps = {
-        headline: `Accept our terms and conditions to use VA.gov health tools`,
-        content: (
-          <>
-            <p>
-              Before you can use the health tools on VA.gov, you’ll need to read
-              and agree to the terms and conditions below. This will give us
-              permission to share your VA medical information with you so you
-              can:
-            </p>
-            <ul>
-              <li>Refill your VA prescriptions</li>
-              <li>Download your VA health records</li>
-              <li>Communicate securely with your health care team</li>
-            </ul>
-            <div className="vads-u-margin-top--2">
-              {this.renderAcceptButton()}
-            </div>
-          </>
-        ),
-        status: 'info',
-      };
-    }
+    const bannerProps = this.props.accepted
+      ? {
+          headline: `You’ve accepted the Terms and Conditions for using VA.gov health tools`,
+          content: '',
+          status: 'success',
+        }
+      : {
+          headline: `Accept our terms and conditions to use VA.gov health tools`,
+          content: (
+            <>
+              <p>
+                Before you can use the health tools on VA.gov, you’ll need to
+                read and agree to the terms and conditions below. This will give
+                us permission to share your VA medical information with you so
+                you can:
+              </p>
+              <ul>
+                <li>Refill your VA prescriptions</li>
+                <li>Download your VA health records</li>
+                <li>Communicate securely with your health care team</li>
+              </ul>
+              <div className="vads-u-margin-top--2">
+                {this.renderAcceptButton()}
+              </div>
+            </>
+          ),
+          status: 'info',
+        };
 
     return (
       bannerProps && (

--- a/src/applications/terms-and-conditions/containers/MhvTermsAndConditions.jsx
+++ b/src/applications/terms-and-conditions/containers/MhvTermsAndConditions.jsx
@@ -21,20 +21,11 @@ const scroller = Scroll.scroller;
 
 const TERMS_NAME = 'mhvac';
 
-const unagreedBannerProps = {
-  headline: `Using VA.gov Health Tools`,
-  content: `Before you can use the health tools on VA.gov, you’ll need to read and agree to the Terms and Conditions below. This will give us your permission to show you your VA medical information on this site.`,
-  status: 'warning',
-};
-
 export class MhvTermsAndConditions extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      isAgreementChecked: false,
       isSubmitted: false,
-      showAcceptedMessage: false,
-      showCanceledMessage: false,
     };
   }
 
@@ -59,21 +50,10 @@ export class MhvTermsAndConditions extends React.Component {
     }
   };
 
-  handleAgreementCheck = () => {
-    this.setState({ isAgreementChecked: !this.state.isAgreementChecked });
-    recordEvent({
-      event: 'account-navigation',
-      'account-action': 'agree-check',
-      'account-section': 'terms',
-    });
-  };
-
   handleAcceptanceSuccess = () => {
-    this.setState({ showAcceptedMessage: true }, () => {
-      scroller.scrollTo('banner', getScrollOptions());
-      recordEvent({ event: 'account-terms-transaction' });
-      this.redirect();
-    });
+    scroller.scrollTo('banner', getScrollOptions());
+    recordEvent({ event: 'account-terms-transaction' });
+    this.redirect();
   };
 
   handleSubmit = e => {
@@ -88,52 +68,49 @@ export class MhvTermsAndConditions extends React.Component {
     });
   };
 
-  handleCancel = e => {
-    e.preventDefault();
-    this.setState({ showCanceledMessage: true }, () => {
-      scroller.scrollTo('banner', getScrollOptions());
-    });
-    recordEvent({
-      event: 'account-navigation',
-      'account-action': 'cancel-button',
-      'account-section': 'terms',
-    });
-  };
-
-  handleCloseBanner = () => {
-    this.setState({
-      showAcceptedMessage: false,
-      showCanceledMessage: false,
-    });
-  };
-
   renderBanner = () => {
-    let bannerProps = null;
-
-    if (this.state.showAcceptedMessage) {
+    let bannerProps;
+    if (this.props.accepted) {
       bannerProps = {
         headline: `You’ve accepted the Terms and Conditions for using VA.gov health tools`,
         content: '',
         status: 'success',
       };
-    } else if (this.state.showCanceledMessage) {
-      bannerProps = unagreedBannerProps;
+    } else {
+      bannerProps = {
+        headline: `Accept our terms and conditions to use VA.gov health tools`,
+        content: (
+          <>
+            <p>
+              Before you can use the health tools on VA.gov, you’ll need to read
+              and agree to the terms and conditions below. This will give us
+              permission to share your VA medical information with you so you
+              can:
+            </p>
+            <ul>
+              <li>Refill your VA prescriptions</li>
+              <li>Download your VA health records</li>
+              <li>Communicate securely with your health care team</li>
+            </ul>
+            <div className="vads-u-margin-top--2">
+              {this.renderAcceptButton()}
+            </div>
+          </>
+        ),
+        status: 'info',
+      };
     }
 
     return (
       bannerProps && (
         <ScrollElement name="banner">
-          <AlertBox
-            {...bannerProps}
-            isVisible
-            onCloseAlert={this.handleCloseBanner}
-          />
+          <AlertBox {...bannerProps} isVisible />
         </ScrollElement>
       )
     );
   };
 
-  renderAgreementSection = () => {
+  renderAcceptButton = () => {
     const shouldHideSection =
       !this.props.user.loggedIn ||
       !this.props.user.verified ||
@@ -142,50 +119,13 @@ export class MhvTermsAndConditions extends React.Component {
     if (shouldHideSection) {
       return null;
     }
-
-    const yesCheckbox = (
-      <div>
-        <input
-          type="checkbox"
-          id="agreement-checkbox"
-          value="yes"
-          checked={this.state.isAgreementChecked}
-          onChange={this.handleAgreementCheck}
-        />
-        <label className="agreement-label" htmlFor="agreement-checkbox">
-          {this.props.attributes.yesContent}
-        </label>
-      </div>
-    );
-
     const submitButton = (
-      <button
-        className="usa-button submit-button"
-        disabled={!this.state.isAgreementChecked}
-      >
-        Submit
+      <button className="usa-button submit-button">
+        Accept terms and conditions
       </button>
     );
 
-    const cancelButton = (
-      <button
-        className="usa-button usa-button-secondary"
-        type="button"
-        onClick={this.handleCancel}
-      >
-        Cancel
-      </button>
-    );
-
-    return (
-      <div>
-        {yesCheckbox}
-        <div className="tc-buttons">
-          {submitButton}
-          {cancelButton}
-        </div>
-      </div>
-    );
+    return submitButton;
   };
 
   /* eslint-disable react/no-danger */
@@ -218,35 +158,17 @@ export class MhvTermsAndConditions extends React.Component {
       );
     }
 
-    const { title, headerContent, termsContent } = this.props.attributes;
-
-    const header = !this.props.accepted && (
-      <div>
-        {!this.state.showCanceledMessage && (
-          <div className="usa-alert usa-alert-info background-color-only">
-            <h3 className="usa-alert-heading">
-              {unagreedBannerProps.headline}
-            </h3>
-            <p className="usa-alert-text">{unagreedBannerProps.content}</p>
-          </div>
-        )}
-        <div
-          className="va-introtext"
-          dangerouslySetInnerHTML={{ __html: headerContent }}
-        />
-        <h3>Terms and Conditions</h3>
-      </div>
-    );
+    const { termsContent } = this.props.attributes;
 
     return (
-      <form onSubmit={this.handleSubmit}>
-        <h1>{title}</h1>
-        {header}
-        <hr />
-        <div dangerouslySetInnerHTML={{ __html: termsContent }} />
-        <hr />
-        {this.renderAgreementSection()}
-      </form>
+      <div>
+        <h1>Terms and conditions for medical information</h1>
+        {this.renderBanner()}
+        <form onSubmit={this.handleSubmit}>
+          <div dangerouslySetInnerHTML={{ __html: termsContent }} />
+          {this.renderAcceptButton()}
+        </form>
+      </div>
     );
   };
   /* eslint-enable react/no-danger */
@@ -256,9 +178,8 @@ export class MhvTermsAndConditions extends React.Component {
       <main className="terms-and-conditions">
         <div className="container">
           <div className="row">
-            {this.renderBanner()}
             <div
-              className="columns small-12"
+              className="columns medium-10"
               role="region"
               aria-label="Terms and Conditions"
             >

--- a/src/applications/terms-and-conditions/containers/MhvTermsAndConditions.jsx
+++ b/src/applications/terms-and-conditions/containers/MhvTermsAndConditions.jsx
@@ -71,12 +71,14 @@ export class MhvTermsAndConditions extends React.Component {
   renderBanner = () => {
     const bannerProps = this.props.accepted
       ? {
-          headline: `You’ve accepted the Terms and Conditions for using VA.gov health tools`,
+          headline:
+            'You’ve accepted the Terms and Conditions for using VA.gov health tools',
           content: '',
           status: 'success',
         }
       : {
-          headline: `Accept our terms and conditions to use VA.gov health tools`,
+          headline:
+            'Accept our terms and conditions to use VA.gov health tools',
           content: (
             <>
               <p>

--- a/src/applications/terms-and-conditions/sass/terms-and-conditions.scss
+++ b/src/applications/terms-and-conditions/sass/terms-and-conditions.scss
@@ -7,12 +7,26 @@
     margin: 1rem 0;
   }
 
-  h3 + hr {
+  h3+hr {
     margin: 0 0 2rem;
   }
 
   ul {
+    padding-left: 4rem;
     list-style: inherit;
+  }
+
+  .terms-text {
+    h3 {
+      font-size: 3rem
+    }
+
+    p {
+      strong {
+        font-size: 2rem;
+        font-family: "Bitter", "Georgia", "Cambria", "Times New Roman", "Times", serif;
+      }
+    }
   }
 }
 
@@ -22,7 +36,7 @@
   button {
     width: auto;
 
-    & + button {
+    &+button {
       margin-left: 2rem;
     }
   }

--- a/src/applications/terms-and-conditions/tests/containers/MhvTermsAndConditions.unit.spec.jsx
+++ b/src/applications/terms-and-conditions/tests/containers/MhvTermsAndConditions.unit.spec.jsx
@@ -80,21 +80,11 @@ describe('<MhvTermsAndConditions>', () => {
     wrapper.setState({ isSubmitted: true }, () => {
       wrapper.setProps({ accepted: true });
     });
-    expect(wrapper.state('showAcceptedMessage')).to.be.true;
     const alertBox = wrapper.find('AlertBox').first();
     expect(alertBox.prop('status')).to.eq('success');
     expect(alertBox.prop('headline')).to.eq(
       'You’ve accepted the Terms and Conditions for using VA.gov health tools',
     );
-    wrapper.unmount();
-  });
-
-  it('should show a success message after acceptance', () => {
-    const wrapper = shallow(<MhvTermsAndConditions {...props} />);
-    wrapper.setState({ showCanceledMessage: true });
-    const alertBox = wrapper.find('AlertBox').first();
-    expect(alertBox.prop('status')).to.eq('warning');
-    expect(alertBox.prop('headline')).to.eq('Using VA.gov Health Tools');
     wrapper.unmount();
   });
 
@@ -107,7 +97,6 @@ describe('<MhvTermsAndConditions>', () => {
     const wrapper = shallow(<MhvTermsAndConditions {...newProps} />);
     wrapper.setState({ isSubmitted: true });
     wrapper.setProps({ accepted: true });
-    expect(wrapper.state('showAcceptedMessage')).to.be.true;
     expect(global.window.location.replace.calledOnce).to.be.true;
     wrapper.unmount();
   });


### PR DESCRIPTION
## Purpose
The content has already been updated on the backend. Now the actual styling of the T&C should be updated to match the new design.

Existing page here:
https://www.va.gov/health-care/medical-information-terms-conditions/

Prototype here: 
https://adhoc.invisionapp.com/share/9XRBC0J4TEH#/355597597_Full_

Some notes for PR review:
* New mockup no longer has "Cancel" option or checkbox, so those were removed
* Use `this.props.accepted` to handle display of success message rather than component state
* For new styling, the content headers are currently stored in the backend as `<p>`'s instead of headers, so I am styling the `p.strong`'s with the design font.  If it's preferable to request a content change on the backend to replace these with headers we can do that instead.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
