### PR TITLE
fix redirect-on-login bug

### DIFF
--- a/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableApp.jsx
@@ -51,7 +51,10 @@ class RoutedSavableApp extends React.Component {
     //  saved form / prefill
     // If we're in production, we'll redirect if we start in the middle of a form
     // In development, we won't redirect unless we append the URL with `?redirect`
-    const { currentLocation } = this.props;
+    const { currentLocation, formConfig } = this.props;
+    const { additionalRoutes = [] } = formConfig;
+    const additionalSafePaths =
+      additionalRoutes && additionalRoutes.map(route => route.path);
     const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
     const resumeForm = trimmedPathname.endsWith('resume');
     const devRedirect =
@@ -59,7 +62,10 @@ class RoutedSavableApp extends React.Component {
         !currentLocation.search.includes('skip')) ||
       currentLocation.search.includes('redirect');
     const goToStartPage = resumeForm || devRedirect;
-    if (isInProgressPath(currentLocation.pathname) && goToStartPage) {
+    if (
+      isInProgressPath(currentLocation.pathname, additionalSafePaths) &&
+      goToStartPage
+    ) {
       // We started on a page that isn't the first, so after we know whether
       //  we're logged in or not, we'll load or redirect as needed.
       this.shouldRedirectOrLoad = true;


### PR DESCRIPTION
## Description
Attempt no. 2 to prevent logged-in users with an in-progress HCA from getting redirected from the `id-form` route to where they left off in the HCA. Instead we want users to be redirected from the `id-form` to the `introduction` route.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs