### PR TITLE
update prod cms url

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -7,7 +7,7 @@ DRUPAL_MAPPING = [
 DRUPAL_ADDRESSES = [
   'vagovdev'    : 'http://internal-stg-vagovcms-3000-521598752.us-gov-west-1.elb.amazonaws.com',
   'vagovstaging': 'http://internal-stg-vagovcms-3000-521598752.us-gov-west-1.elb.amazonaws.com',
-  'vagovprod'   : 'http://internal-prod-vagovcms-3000-1370756925.us-gov-west-1.elb.amazonaws.com',
+  'vagovprod'   : 'http://internal-prod-vagovcms-3001-2053888503.us-gov-west-1.elb.amazonaws.com',
 ]
 
 DRUPAL_CREDENTIALS = [

--- a/src/site/constants/drupals.js
+++ b/src/site/constants/drupals.js
@@ -50,7 +50,7 @@ const PUBLIC_URLS = {
     'http://dev.cms.va.gov',
   'http://internal-stg-vagovcms-3000-521598752.us-gov-west-1.elb.amazonaws.com':
     'http://staging.cms.va.gov',
-  'http://internal-prod-vagovcms-3000-1370756925.us-gov-west-1.elb.amazonaws.com':
+  'http://internal-prod-vagovcms-3001-2053888503.us-gov-west-1.elb.amazonaws.com':
     'http://prod.cms.va.gov',
 };
 


### PR DESCRIPTION
Updates all references to the production CMS to reflect the new ELB URL.

Wait to merge until go ahead is given.