### PR TITLE
Trim leading and trailing whitespace on all disability names

### DIFF
--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -96,7 +96,7 @@ function getDisabilities(formData) {
 
 function getDisabilityName(disability) {
   const name = disability.name ? disability.name : disability.condition;
-  return name;
+  return name && name.trim();
 }
 
 function getClaimedConditionNames(formData) {


### PR DESCRIPTION
## Description
Trims whitespace on disability names

## Testing done


## Screenshots


## Acceptance criteria
- [x] Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18174

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
