### PR TITLE
Fix E2E tests failing on master

### DIFF
--- a/src/applications/edu-benefits/tests/edu-apply-wizard.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/edu-apply-wizard.e2e.spec.js
@@ -5,7 +5,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   // Ensure education apply-wizard page renders.
   // Open education apply wizard
   client
-    .openUrl(`${E2eHelpers.baseUrl}/education/apply/`)
+    .openUrl(`${E2eHelpers.baseUrl}/education/how-to-apply/`)
     .waitForElementVisible('body', Timeouts.normal)
     .assert.title(
       'How to apply for the GI Bill and other education benefits | Veterans Affairs',

--- a/src/applications/letters/tests/01-authed.e2e.spec.js
+++ b/src/applications/letters/tests/01-authed.e2e.spec.js
@@ -25,7 +25,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   LettersHelpers.initApplicationMock(token);
 
   // Ensure main status page renders.
-  Auth.logIn(token, client, '/download-va-letters/letters', 3)
+  Auth.logIn(token, client, '/records/download-va-letters/letters', 3)
     .waitForElementVisible('body', Timeouts.normal)
     .axeCheck('.main')
     .assert.title('Download VA Letters and Documents | Veterans Affairs')

--- a/src/applications/personalization/preferences/tests/e2e/emptyPreferences.e2e.spec.js
+++ b/src/applications/personalization/preferences/tests/e2e/emptyPreferences.e2e.spec.js
@@ -117,7 +117,7 @@ module.exports = E2eHelpers.createE2eTest(browser => {
   const token = Auth.getUserToken();
 
   // Login to access the dashboard
-  Auth.logIn(token, browser, '/dashboard', 3).waitForElementVisible(
+  Auth.logIn(token, browser, '/my-va', 3).waitForElementVisible(
     '.user-profile-row',
     Timeouts.normal,
   );

--- a/src/applications/personalization/preferences/tests/e2e/selectedPreferences.e2e.spec.js
+++ b/src/applications/personalization/preferences/tests/e2e/selectedPreferences.e2e.spec.js
@@ -67,7 +67,7 @@ module.exports = E2eHelpers.createE2eTest(browser => {
   const token = Auth.getUserToken();
 
   // Login to access the dashboard
-  Auth.logIn(token, browser, '/dashboard', 3).waitForElementVisible(
+  Auth.logIn(token, browser, '/my-va', 3).waitForElementVisible(
     '.user-profile-row',
     Timeouts.normal,
   );


### PR DESCRIPTION
## Description
A PR yesterday removed a FE routing system we used during WBC, for safely routing users between Vets.gov and VA.gov paths. We have a few instances of the old app paths in our E2E tests still, that were previously redirecting to the correct page, allowing the E2E test to pass. This PR updates the page page to the correct location, since we can't rely on the redirect. 

## Testing done
If E2E tests pass, then we're ok ✔️ 

## Acceptance criteria
- [x] E2E tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
