### PR TITLE
Add GA event to hub promos

### DIFF
--- a/src/site/blocks/promo.drupal.liquid
+++ b/src/site/blocks/promo.drupal.liquid
@@ -35,7 +35,10 @@
     <img src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="{{ image.derivative.width }}" height="{{ image.derivative.height }}">
   {% if entity.fieldPromoLink != empty %}
     <section class="hub-promo-text">
-        <h4 class="heading"><a href="{{ entity.fieldPromoLink.entity.fieldLink.0.url.path }}">{{ entity.fieldPromoLink.entity.fieldLink.0.title }}</a></h4>
+        <h4 class="heading">
+          <a onClick="recordEvent({ event: 'nav-hub-promo' });"
+            href="{{ entity.fieldPromoLink.entity.fieldLink.0.url.path }}">{{ entity.fieldPromoLink.entity.fieldLink.0.title }}</a>
+        </h4>
         <p>{{ entity.fieldPromoLink.entity.fieldLinkSummary }}</p>
     </section>
   {% endif %}

--- a/src/site/components/merger-promo.html
+++ b/src/site/components/merger-promo.html
@@ -22,7 +22,9 @@ See https://help.shopify.com/themes/liquid/tags/theme-tags#include
 
     {% if group.heading != empty %}
       <section class="hub-promo-text">
-        <h4 class="heading"><a href="{{group.url}}">{{ group.heading }}</a></h4>
+        <h4 class="heading">
+            <a onClick="recordEvent({ event: 'nav-hub-promo' });" href="{{group.url}}">{{ group.heading }}</a>
+        </h4>
     {% endif %}
 
     {% if group.description != empty %}


### PR DESCRIPTION
## Description
This PR adds a GA event to be triggered when the user clicks the promotion link on the right sidebar of hub landing pages.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17553

## Testing done
Watched console output using GA Chrome plugin

## Screenshots
Clicking these links triggers the event

![image](https://user-images.githubusercontent.com/1915775/57096592-af8adc80-6ce3-11e9-9319-03bdbe11fdc7.png)

## Acceptance criteria
- [ ] Event is captured

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
