### PR TITLE
15582 file upload btn kybd focus fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:sauce:desktop": "./script/run-nightwatch.sh --sauce -e chrome,firefox,ie,edge",
     "test:sauce:mobile": "./script/run-nightwatch.sh --sauce -e ios,android",
     "test:unit": "./script/run-unit-test.sh",
+    "test:unit:form-system": "BABEL_ENV=test npx mocha --opts src/platform/testing/unit/mocha.opts --recursive 'src/platform/forms-system/test/js/**/*.unit.spec.js?(x)' src/platform/testing/unit/helper.js '$@'",
     "test:unit:hca": "BABEL_ENV=test mocha --opts src/platform/testing/unit/mocha.opts --recursive 'src/applications/hca/**/tests/**/*.unit.spec.js?(x)' ",
     "test:unit:personalization": "BABEL_ENV=test mocha --opts src/platform/testing/unit/mocha.opts --recursive 'src/applications/personalization/**/tests/**/*.unit.spec.js?(x)' ",
     "test:watch": "node script/watch.js",

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -6,12 +6,20 @@ export function focusElement(selectorOrElement, options) {
     typeof selectorOrElement === 'string'
       ? document.querySelector(selectorOrElement)
       : selectorOrElement;
+  let prevTabIdx = null;
 
   if (el) {
-    if (el.tabIndex <= 0) {
+    prevTabIdx = el.getAttribute('tabindex');
+    if (prevTabIdx && prevTabIdx <= 0) {
       el.setAttribute('tabindex', '-1');
     }
     el.focus(options);
+    // restore previous tab-index to re-enable kybd-focus
+    if (prevTabIdx) {
+      el.setAttribute('tabindex', prevTabIdx);
+    } else {
+      el.removeAttribute('tabindex');
+    }
   }
 }
 


### PR DESCRIPTION
## Description
[15582](/department-of-veterans-affairs/vets.gov-team/issues/15582) - Restore keyboard-focus support after forcing focus onto an element.

## Testing done
Verified fix locally in browser using keyboard to change focus.
Existing unit-tests still passing.

## Screenshots
See connected ticket for details.

## Acceptance criteria
- [ ] After uploading a file and keyboard-pressing **Delete file** link, keyboard-tabbing focus away from & back to **Upload a document** button works.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
