### PR TITLE
Fix letters address property to a string instead of object

### DIFF
--- a/src/applications/letters/reducers/index.js
+++ b/src/applications/letters/reducers/index.js
@@ -42,7 +42,7 @@ export const initialState = {
   letters: [],
   lettersAvailability: AVAILABILITY_STATUSES.awaitingResponse,
   letterDownloadStatus: {},
-  fullName: {},
+  fullName: '',
   address: {},
   addressAvailability: AVAILABILITY_STATUSES.awaitingResponse,
   isEditingAddress: false,


### PR DESCRIPTION
This fixes a [bug](http://sentry.vetsgov-internal/vets-gov/website-production/issues/55866/?query=is:unresolved%20letters) that was trying to run `toLowerCase` on an empty object instead of a string