### PR TITLE
Refactor how the status icons are rendered

### DIFF
--- a/src/applications/personalization/dashboard/components/DashboardAlert.jsx
+++ b/src/applications/personalization/dashboard/components/DashboardAlert.jsx
@@ -29,9 +29,14 @@ const DashboardAlert = ({
         {subheadline && <h4>{subheadline}</h4>}
         <h3>{headline}</h3>
       </header>
-      <section className="status">
-        <h3>{statusHeadline}</h3>
-        {statusInfo && <p>{statusInfo}</p>}
+      <section className="status vads-u-display--flex">
+        <div className="status-icon-container vads-u-flex--auto">
+          <i />
+        </div>
+        <div className="vads-u-flex--1">
+          <h3>{statusHeadline}</h3>
+          {statusInfo && <p>{statusInfo}</p>}
+        </div>
       </section>
       <section className="content">{alertContent}</section>
     </div>

--- a/src/applications/personalization/dashboard/sass/dashboard-alert.scss
+++ b/src/applications/personalization/dashboard/sass/dashboard-alert.scss
@@ -1,5 +1,5 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-nav-linkslist";
+// @import "~@department-of-veterans-affairs/formation/sass/modules/m-nav-linkslist";
 @import "~@fortawesome/fontawesome-free/scss/variables";
 @import "../../../../platform/forms/sass/_m-applications";
 
@@ -30,10 +30,10 @@
   background: none;
   background-color: $color-gray-lightest;
   font-family: $font-sans;
-  padding: 1.25em;
+  padding: units(2);
 
   @include media($medium-large-screen) {
-    padding: 2em;
+    padding: units(4);
   }
 
   header {
@@ -53,19 +53,19 @@
   }
 
   section.status {
-    margin: 1.5em 0;
-    padding: 1em 0;
+    margin: units(3) 0;
+    padding: units(2) 0;
     border-top: 1px solid;
     border-bottom: 1px solid;
 
     .status-icon-container {
-      width: 2em;
+      width: units(4);
       padding-top: 3px;
 
       i {
         display: inline-block;
-        width: 20px;
-        height: 20px;
+        width: units(2.5);
+        height: units(2.5);
         color: $color-white;
         border-radius: 50%;
 
@@ -129,11 +129,11 @@
 
     .remove-notification-link {
       display: block;
-      margin-top: 1em;
+      margin-top: units(2);
     }
 
     .remove-notification-label {
-      margin-left: .5em;
+      margin-left: units(1);
     }
   }
 }

--- a/src/applications/personalization/dashboard/sass/dashboard-alert.scss
+++ b/src/applications/personalization/dashboard/sass/dashboard-alert.scss
@@ -1,5 +1,4 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
-// @import "~@department-of-veterans-affairs/formation/sass/modules/m-nav-linkslist";
 @import "~@fortawesome/fontawesome-free/scss/variables";
 @import "../../../../platform/forms/sass/_m-applications";
 

--- a/src/applications/personalization/dashboard/sass/dashboard-alert.scss
+++ b/src/applications/personalization/dashboard/sass/dashboard-alert.scss
@@ -3,6 +3,29 @@
 @import "~@fortawesome/fontawesome-free/scss/variables";
 @import "../../../../platform/forms/sass/_m-applications";
 
+@mixin make-status-styles($status,
+  $color,
+  $icon: $fa-var-exclamation,
+  $top: 1px,
+  $left: 7.5px,
+  $size: 13px) {
+
+  &-#{$status} section.status {
+    border-color: $color;
+
+    .status-icon-container i {
+      background-color: $color;
+
+      &::before {
+        content: fa-content($icon);
+        font-size: $size;
+        margin-top: $top;
+        margin-left: $left;
+      }
+    }
+  }
+}
+
 .dashboard-alert {
   background: none;
   background-color: $color-gray-lightest;
@@ -31,24 +54,35 @@
 
   section.status {
     margin: 1.5em 0;
-    padding: 1em 0 1em 2em;
+    padding: 1em 0;
     border-top: 1px solid;
     border-bottom: 1px solid;
+
+    .status-icon-container {
+      width: 2em;
+      padding-top: 3px;
+
+      i {
+        display: inline-block;
+        width: 20px;
+        height: 20px;
+        color: $color-white;
+        border-radius: 50%;
+
+        &::before {
+          font-family: "Font Awesome 5 Free";
+          font-style: normal;
+          font-weight: 900;
+          position: absolute;
+        }
+      }
+    }
 
     h3 {
       font-family: $font-sans;
       font-weight: $font-bold;
       font-size: 1.25em;
       margin: 0;
-
-      &::before {
-        background: none;
-        font-family: "Font Awesome 5 Free";
-        font-size: 1em;
-        margin-left: -1.5em;
-        position: absolute;
-        font-weight: 900;
-      }
     }
 
     p {
@@ -57,50 +91,38 @@
     }
   }
 
-  &-closed section.status {
-    border-color: $color-black;
+  @include make-status-styles(
+    $status: "closed",
+    $color: $color-black,
+  );
 
-    h3::before {
-      content: fa-content($fa-var-exclamation-circle);
-      color: $color-black;
-    }
-  }
+  @include make-status-styles(
+    $status: "decision",
+    $color: $color-red,
+  );
 
-  &-decision section.status {
-    border-color: $color-red;
+  @include make-status-styles(
+    $status: "enrolled",
+    $color: $color-green,
+    $icon: $fa-var-check,
+    $top: 1px,
+    $left: 2.5px,
+    $size: 14px,
+  );
 
-    h3::before {
-      content: fa-content($fa-var-exclamation-circle);
-      color: $color-red;
-    }
-  }
+  @include make-status-styles(
+    $status: "in-progress",
+    $color: $color-light-blue,
+    $icon: $fa-var-file,
+    $top: 2px,
+    $left: 6px,
+    $size: 11px,
+  );
 
-  &-enrolled section.status {
-    border-color: $color-green;
-
-    h3::before {
-      content: fa-content($fa-var-check-circle);
-      color: $color-green;
-    }
-  }
-
-  &-in-progress section.status {
-    border-color: $color-light-blue;
-
-    h3::before {
-      content: fa-content($fa-var-circle);
-      color: $color-light-blue;
-    }
-  }
-
-  &-update section.status {
-    border-color: $color-gold-light;
-
-    h3::before {
-      content: fa-content($fa-var-exclamation-circle);
-      color: $color-gold-light;
-    }
-  }
+  @include make-status-styles(
+    $status: "update",
+    $color: $color-gold-light,
+  );
 
   section.content {
     padding: 0;


### PR DESCRIPTION
## Description
Completely refactored how the status icons are rendered. In some ways this is less elegant; it's obviously much nicer to be able to drop in an existing glyph from Font Awesome and color it vs. having to draw circle backgrounds with CSS and tweak the absolute position of the glyphs so they are centered. But this will be more flexible moving forward as we won't be limited to only the Font Awesome icons that have baked-in circle backgrounds.

On the plus side, using flexbox to lay out this little section of the alert is "better" than adding `::before` content to the `h3` and pulling it left with a negative margin.

## Testing done
Local

## Screenshots
Previews of the five possible status types (icons and color combos) are shown below
![image](https://user-images.githubusercontent.com/20728956/57110441-6d669880-6ced-11e9-92bf-7f458273a087.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs