### PR TITLE
16115 - Add aria-label to Dashboard remove-button.

### DIFF
--- a/src/applications/personalization/preferences/components/PreferenceItem.jsx
+++ b/src/applications/personalization/preferences/components/PreferenceItem.jsx
@@ -114,6 +114,7 @@ export default class PreferenceItem extends React.Component {
           <button
             ref={this.removeBtnRef}
             className="va-button-link"
+            aria-label={`Remove ${title} preference`}
             onClick={() => this.props.handleViewToggle(code)}
           >
             <i className="fas fa-times" /> <span>Remove</span>


### PR DESCRIPTION
## Description
[16115](/department-of-veterans-affairs/vets.gov-team/issues/16115) - Add aria-label to Dashboard preference-item remove button.

## Testing done
Verified locally in browser, using screenreader.
No logic-/functional-code changes.
Ran `yarn test:unit:personalization` and all unit-tests still passing.

## Screenshots
\[See connected ticket.\]

## Acceptance criteria
- [ ] Verify screenreader announces description of remove-button (“Remove \[benefit-title\] preference”) for each added benefit-preference on the Dashboard.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
