### PR TITLE
Only log if the name isn't actually a string

### DIFF
--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -152,9 +152,12 @@ export const capitalizeEachWord = name => {
     return name.replace(/\w[^\s-]*/g, capitalizeWord);
   }
 
-  Raven.captureMessage(
-    `form_526_v1 / form_526_v2: capitalizeEachWord requires 'name' argument of type 'string' but got ${typeof name}`,
-  );
+  if (typeof name !== 'string') {
+    Raven.captureMessage(
+      `form_526_v1 / form_526_v2: capitalizeEachWord requires 'name' argument of type 'string' but got ${typeof name}`,
+    );
+  }
+
   return 'Unknown Condition';
 };
 


### PR DESCRIPTION
## Description
Does what it says on the tin.

## Testing done
Er...none...

## Screenshots
N/A

## Acceptance criteria
- [x] `capitalizeEachWord` doesn't report an error when it's not actually an error