### PR TITLE
Fix for metalsmith.metadata wiping previous metadata values

### DIFF
--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -144,11 +144,10 @@ function getDrupalContent(buildOptions) {
       loadCachedDrupalFiles(buildOptions, files);
       pipeDrupalPagesIntoMetalsmith(drupalData, files);
       log('Successfully piped Drupal content into Metalsmith!');
-
-      metalsmith.metadata({ drupalData });
+      buildOptions.drupalData = drupalData;
       done();
     } catch (err) {
-      metalsmith.metadata({ drupalError: drupalData });
+      buildOptions.drupalError = drupalData;
       log(err.stack);
       log(JSON.stringify(drupalData));
       log('Failed to pipe Drupal content into Metalsmith!');

--- a/src/site/stages/build/plugins/create-drupal-debug.js
+++ b/src/site/stages/build/plugins/create-drupal-debug.js
@@ -44,7 +44,7 @@ function createDrupalDebugPage(buildOptions) {
   return (files, smith, done) => {
     log('Drupal debug page written to /drupal/debug.');
 
-    const { drupalError } = smith.metadata();
+    const { drupalError } = buildOptions;
     const drupalDebugPage = drupalError
       ? createErrorPage(drupalError)
       : createIndexPage(files);

--- a/src/site/stages/build/plugins/create-outreach-assets-data.js
+++ b/src/site/stages/build/plugins/create-outreach-assets-data.js
@@ -15,7 +15,7 @@ function createOutreachAssetsData(buildSettings) {
       : BUCKETS[buildSettings.buildtype];
 
   return (files, metalsmith, done) => {
-    const { drupalData } = metalsmith.metadata();
+    const { drupalData } = buildSettings;
 
     if (!drupalData) {
       done();


### PR DESCRIPTION
## Description
Evidently the `metalsmith.metadata` function should only be used once, because every call to `metadata()` will wipe all previous `metadata`. This PR fixes that by binding values (`drupalData`) to `buildOptions` instead of `metadata` to pass data from plugin to plugin.

This was discovered when Foresee didn't seem to be showing up lately.

## Testing done
Local

## Acceptance criteria
- [ ] `buildtype` is available in templates again

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
