### PR TITLE
add fix for e2e script not running currectly on Mojave: feature/18170

### DIFF
--- a/script/run-mockapi.sh
+++ b/script/run-mockapi.sh
@@ -7,7 +7,8 @@ trap 'if [ $(jobs -p) ] ; then kill $(jobs -p); fi' EXIT
 if [ "$(nc -z localhost 3000; echo $?)" -ne 0 ]; then
     echo "Starting mockapi.js..."
     node src/platform/testing/e2e/mockapi.js &
-    sleep 5;
+    # waits for process to stop
+    wait;
 else
     # echo "Error: Port 3000 is already in use.  If you're sure that's OK, tests will continue in 5 seconds..."
     echo "Port 3000 is already in use."

--- a/script/run-nightwatch.sh
+++ b/script/run-nightwatch.sh
@@ -29,7 +29,7 @@ trap 'if [ $(jobs -p) ] ; then kill $(jobs -p); fi' EXIT
 
 BUILDTYPE=${BUILDTYPE:-vagovdev}
 
-"$(dirname "$0")"/run-mockapi.sh
+"$(dirname "$0")"/run-mockapi.sh &
 
 # Check to see if we already have a server running on port 3001 (as with 'npm run build')
  if [ "$(nc -z localhost 3001; echo $?)" -ne 0 ]; then


### PR DESCRIPTION
## Description
During the process of trying to write documents on unit tests, some issues were found on the e2e test while running locally.

Nightwatch script wasn't running command async, so the mock-api server on port 3000 would wait till it stopped to go further to with running the tests. It should run asynchronously. The way to solve it was to add a & after the mock-api script

The mock-api shell script sleeps after 5 seconds which will break the tests because the mock-api is no longer running, which makes the tests fail after 5 seconds.

Device: Mac
OS: Mojave
Browser: Chrome

Steps to test
- Run `$ yarn test:e2e`
- While the test is running run `$ lsof -i tcp:3000` to check if the mock-api is running
- after the test is done run `$ lsof -i tcp:3000` and make sure port 3000 stopped running

## Testing done
Local Testing

## Screenshots


## Acceptance criteria
- [ ] e2e test runs properly and doesn't get stuck
- [ ] mock-api server should stay running on port 3000 during the whole test and should shut off when finished.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
