### PR TITLE
change GA tag for logging in from HCA intro page

### DIFF
--- a/src/applications/hca-v2-beta/containers/IntroductionPage.jsx
+++ b/src/applications/hca-v2-beta/containers/IntroductionPage.jsx
@@ -86,7 +86,7 @@ const LoggedOutContent = connect(
           content={
             <button
               className="va-button-link"
-              onClick={() => showLoginModal(true)}
+              onClick={() => showLoginModal(true, 'hcainfo')}
             >
               Sign in to check your application status
             </button>

--- a/src/applications/hca/containers/IntroductionPageGated.jsx
+++ b/src/applications/hca/containers/IntroductionPageGated.jsx
@@ -86,7 +86,7 @@ const LoggedOutContent = connect(
           content={
             <button
               className="va-button-link"
-              onClick={() => showLoginModal(true)}
+              onClick={() => showLoginModal(true, 'hcainfo')}
             >
               Sign in to check your application status
             </button>


### PR DESCRIPTION
## Description
When a user clicks the "Sign in to check your application status" link they see on the HCA intro page when logged out, we want to use a different GA event name.

Handles change described [here](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16807#issuecomment-490990785)

## Testing done
local

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs