### PR TITLE
Prevent redirect to same page when there is no return URL

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -122,9 +122,10 @@ export class AuthApp extends React.Component {
   redirect = () => {
     const returnUrl = sessionStorage.getItem(authnSettings.RETURN_URL) || '';
     sessionStorage.removeItem(authnSettings.RETURN_URL);
-    const redirectUrl = !returnUrl.match(REDIRECT_IGNORE_PATTERN)
-      ? returnUrl
-      : '/';
+
+    const redirectUrl =
+      (!returnUrl.match(REDIRECT_IGNORE_PATTERN) && returnUrl) || '/';
+
     window.location.replace(redirectUrl);
   };
 


### PR DESCRIPTION
## Description
This fixes a bug where clicking back after a successful login will cause a redirect loop to the auth callback page.

## Testing done
Local testing. Was able to reproduce issue and fix.

## Acceptance criteria
- [x] The auth callback page should not infinitely redirect back to itself when clicking back after logging in.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs