### PR TITLE
fix profile Military Info content and warnings

### DIFF
--- a/src/applications/personalization/profile360/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile360/components/MilitaryInformation.jsx
@@ -3,7 +3,7 @@ import { some } from 'lodash';
 
 import DowntimeNotification, {
   externalServices,
-} from '../../../../platform/monitoring/DowntimeNotification';
+} from 'platform/monitoring/DowntimeNotification';
 import moment from 'moment';
 import LoadFail from './LoadFail';
 import LoadingSection from './LoadingSection';
@@ -11,8 +11,8 @@ import { handleDowntimeForSection } from './DowntimeBanner';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
-import recordEvent from '../../../../platform/monitoring/record-event';
-import facilityLocator from '../../../facility-locator/manifest';
+import recordEvent from 'platform/monitoring/record-event';
+import facilityLocator from 'applications/facility-locator/manifest';
 
 class MilitaryInformationContent extends React.Component {
   componentDidMount() {
@@ -29,9 +29,9 @@ class MilitaryInformationContent extends React.Component {
           <AlertBox
             isVisible
             status="warning"
+            headline="We can’t access your military information"
             content={
               <div>
-                <h3>We can’t access your military information</h3>
                 <p>
                   We’re sorry. We can’t find your Department of Defense (DoD)
                   ID. We need this to access your military service records.
@@ -65,16 +65,14 @@ class MilitaryInformationContent extends React.Component {
         <AlertBox
           isVisible
           status="warning"
+          headline="We can’t access your military information"
           content={
-            <div>
-              <h3>We can’t access your military information</h3>
-              <p>
-                We’re sorry. We can’t access your military service records. If
-                you think you should be able to view your service information
-                here, please file a request to change or correct your DD214 or
-                other military records.
-              </p>
-            </div>
+            <p>
+              We’re sorry. We can’t access your military service records. If you
+              think you should be able to view your service information here,
+              please file a request to change or correct your DD214 or other
+              military records.
+            </p>
           }
         />
       );
@@ -109,10 +107,21 @@ class MilitaryInformationContent extends React.Component {
           }}
         >
           <p>
-            Some Veterans have reported seeing military service information that
-            doesn't seem right. We're aware of this problem, and we're working
-            to fix it as soon as possible. Thank you for your patience, and we
-            apologize for this issue.
+            Some Veterans have reported seeing military service information in
+            their VA.gov profiles that doesn’t seem right. When this happens,
+            it’s because there’s an error in the information we’re pulling into
+            VA.gov from the Defense Enrollment Eligibility Reporting System
+            (DEERS).
+          </p>
+          <p>
+            If the military service information in your profile doesn’t look
+            right, please call the Defense Manpower Data Center (DMDC). They’ll
+            work with you to update your information in DEERS.
+          </p>
+          <p>
+            To reach the DMDC, call 1-800-538-9552, Monday through Friday
+            (except federal holidays), 8:00 a.m. to 8:00 p.m. ET. If you have
+            hearing loss, call TTY: 1-866-363-2883.
           </p>
         </AdditionalInfo>
         <LoadingSection

--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import DowntimeNotification, {
   externalServices,
   externalServiceStatus,
-} from '../../../../platform/monitoring/DowntimeNotification';
-import DowntimeApproaching from '../../../../platform/monitoring/DowntimeNotification/components/DowntimeApproaching';
-import recordEvent from '../../../../platform/monitoring/record-event';
+} from 'platform/monitoring/DowntimeNotification';
+import DowntimeApproaching from 'platform/monitoring/DowntimeNotification/components/DowntimeApproaching';
+import recordEvent from 'platform/monitoring/record-event';
 
 import Vet360TransactionReporter from '../vet360/containers/TransactionReporter';
 

--- a/src/applications/personalization/profile360/containers/VAProfileApp.jsx
+++ b/src/applications/personalization/profile360/containers/VAProfileApp.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import backendServices from '../../../../platform/user/profile/constants/backendServices';
+import backendServices from 'platform/user/profile/constants/backendServices';
 import {
   initializeDowntimeWarnings,
   dismissDowntimeWarning,
-} from '../../../../platform/monitoring/DowntimeNotification/actions';
+} from 'platform/monitoring/DowntimeNotification/actions';
 
 import {
   fetchHero,
@@ -13,7 +13,7 @@ import {
   fetchPersonalInformation,
 } from '../actions';
 
-import RequiredLoginView from '../../../../platform/user/authorization/components/RequiredLoginView';
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 import ProfileView from '../components/ProfileView';
 
 class VAProfileApp extends React.Component {

--- a/src/applications/personalization/profile360/profile-360-entry.jsx
+++ b/src/applications/personalization/profile360/profile-360-entry.jsx
@@ -1,7 +1,7 @@
 import './sass/profile-360.scss';
-import '../../../platform/polyfills';
+import 'platform/polyfills';
 
-import startApp from '../../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';


### PR DESCRIPTION
## Description
Addresses department-of-veterans-affairs/vets.gov-team#16236 and department-of-veterans-affairs/vets.gov-team#17191

## Testing done
Local

## Screenshots
Fixed alignment of warning headlines/icons (department-of-veterans-affairs/vets.gov-team#16236):
<img width="676" alt="Screen Shot 2019-05-10 at 7 00 02 AM" src="https://user-images.githubusercontent.com/20728956/57533092-c471fc00-72f1-11e9-8c1e-7d9d45d3f7f8.png">
<img width="673" alt="Screen Shot 2019-05-10 at 6 58 29 AM" src="https://user-images.githubusercontent.com/20728956/57533094-c471fc00-72f1-11e9-984a-ef4962022835.png">

Updated content (department-of-veterans-affairs/vets.gov-team#17191):
<img width="679" alt="Screen Shot 2019-05-10 at 6 56 47 AM" src="https://user-images.githubusercontent.com/20728956/57533096-c471fc00-72f1-11e9-9701-4a95ca885602.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs