### PR TITLE
Update Account alerts

### DIFF
--- a/src/applications/personalization/account/components/AccountMain.jsx
+++ b/src/applications/personalization/account/components/AccountMain.jsx
@@ -15,25 +15,10 @@ import TermsAndConditions from './TermsAndConditions';
 import facilityLocator from 'applications/facility-locator/manifest';
 
 class AccountMain extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      'show-acct-mvi-alert': true,
-    };
-  }
-
   componentDidMount() {
     // Get MHV account to determine what to render for Terms and Conditions.
     this.props.fetchMHVAccount();
   }
-
-  dismissMVIError = () => {
-    this.setState({
-      'show-acct-mvi-alert': false,
-    });
-    localStorage.setItem('hide-acct-mvi-alert', true);
-  };
 
   renderMVIError() {
     if (
@@ -45,12 +30,10 @@ class AccountMain extends React.Component {
 
     return (
       <AlertBox
+        headline="We’re having trouble matching your information to our Veteran
+        records"
         content={
           <div>
-            <h4 className="usa-alert-heading">
-              We’re having trouble matching your information to our Veteran
-              records
-            </h4>
             <p>
               We’re sorry. We’re having trouble matching your information to our
               Veteran records, so we can’t give you access to tools for managing
@@ -69,11 +52,6 @@ class AccountMain extends React.Component {
               </a>
             </p>
           </div>
-        }
-        onCloseAlert={this.dismissMVIError}
-        isVisible={
-          this.state['show-acct-mvi-alert'] &&
-          !localStorage.getItem('hide-acct-mvi-alert')
         }
         status="warning"
       />
@@ -135,8 +113,11 @@ class AccountMain extends React.Component {
         <ConnectedAccountsSection />
         {verified && <TermsAndConditions mhvAccount={mhvAccount} />}
 
-        <div className="feature">
-          <h3>Have questions about signing in to VA.gov?</h3>
+        <AlertBox
+          status="info"
+          headline="Have questions about signing in to VA.gov?"
+          backgroundOnly
+        >
           <p>
             Get answers to frequently asked questions about how to sign in,
             common issues with verifying your identity, and your privacy and
@@ -154,7 +135,7 @@ class AccountMain extends React.Component {
           >
             Go to VA.gov FAQs
           </a>
-        </div>
+        </AlertBox>
       </div>
     );
   }

--- a/src/applications/personalization/account/components/AccountMain.jsx
+++ b/src/applications/personalization/account/components/AccountMain.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import recordEvent from 'platform/monitoring/record-event';
-import localStorage from 'platform/utilities/storage/localStorage';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';

--- a/src/applications/personalization/account/components/TermsAndConditions.jsx
+++ b/src/applications/personalization/account/components/TermsAndConditions.jsx
@@ -34,8 +34,7 @@ export default function TermsAndConditions({ mhvAccount }) {
       <div>
         <AlertBox
           status="info"
-          headline="Want to use VA.gov health tools to do things like refill your VA
-                prescriptions?"
+          headline="Want to use VA.gov health tools to do things like refill your VA prescriptions?"
           backgroundOnly
         >
           <p>

--- a/src/applications/personalization/account/components/TermsAndConditions.jsx
+++ b/src/applications/personalization/account/components/TermsAndConditions.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import recordEvent from '../../../../platform/monitoring/record-event';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import recordEvent from 'platform/monitoring/record-event';
 
 export default function TermsAndConditions({ mhvAccount }) {
   const termsConditionsUrl =
@@ -31,33 +32,30 @@ export default function TermsAndConditions({ mhvAccount }) {
   } else if (mhvAccount.accountState === 'needs_terms_acceptance') {
     content = (
       <div>
-        <div className="usa-alert usa-alert-info background-color-only">
-          <div className="usa-alert-body">
-            <div className="usa-alert-heading">
-              <strong>
-                Want to use VA.gov health tools to do things like refill your VA
-                prescriptions?
-              </strong>
-            </div>
-            <p className="usa-alert-text">
-              To get started, you’ll need to read and agree to the{' '}
-              <a
-                href={termsConditionsUrl}
-                onClick={() =>
-                  recordEvent({
-                    event: 'account-navigation',
-                    'account-action': 'view-link',
-                    'account-section': 'terms',
-                  })
-                }
-              >
-                Terms and Conditions for Medical Information
-              </a>
-              . This will give us your permission to show you your VA medical
-              information on this site.
-            </p>
-          </div>
-        </div>
+        <AlertBox
+          status="info"
+          headline="Want to use VA.gov health tools to do things like refill your VA
+                prescriptions?"
+          backgroundOnly
+        >
+          <p>
+            To get started, you’ll need to read and agree to the{' '}
+            <a
+              href={termsConditionsUrl}
+              onClick={() =>
+                recordEvent({
+                  event: 'account-navigation',
+                  'account-action': 'view-link',
+                  'account-section': 'terms',
+                })
+              }
+            >
+              Terms and Conditions for Medical Information
+            </a>
+            . This will give us your permission to show you your VA medical
+            information on this site.
+          </p>
+        </AlertBox>
         <p>
           Once you agree to these Terms and Conditions, you’ll be able to use{' '}
           VA.gov health tools to:

--- a/src/applications/personalization/account/containers/AccountApp.jsx
+++ b/src/applications/personalization/account/containers/AccountApp.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import backendServices from '../../../../platform/user/profile/constants/backendServices';
-import { selectUser, isLOA3 } from '../../../../platform/user/selectors';
+import backendServices from 'platform/user/profile/constants/backendServices';
+import { selectUser, isLOA3 } from 'platform/user/selectors';
 
 import AccountMain from '../components/AccountMain';
-import RequiredLoginView from '../../../../platform/user/authorization/components/RequiredLoginView';
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 import DowntimeNotification, {
   externalServices,
-} from '../../../../platform/monitoring/DowntimeNotification';
+} from 'platform/monitoring/DowntimeNotification';
 
-import { fetchMHVAccount } from '../../../../platform/user/profile/actions';
+import { fetchMHVAccount } from 'platform/user/profile/actions';
 
 class AccountApp extends React.Component {
   render() {

--- a/src/applications/personalization/account/tests/components/AccountMain.unit.spec.js
+++ b/src/applications/personalization/account/tests/components/AccountMain.unit.spec.js
@@ -38,10 +38,13 @@ describe('<AccountMain/>', () => {
   it('should show an MVI error when status is not OK', () => {
     props.profile.status = 'NOT_FOUND';
     const wrapper = enzyme.shallow(<AccountMain {...props} />);
-    const alertBox = wrapper.find('AlertBox');
-    expect(alertBox.html()).to.contain(
-      'We’re having trouble matching your information to our Veteran records',
+    const alertBox = wrapper.findWhere(
+      n =>
+        n.name() === 'AlertBox' &&
+        n.prop('headline') ===
+          'We’re having trouble matching your information to our Veteran records',
     );
+    expect(alertBox.isEmpty()).to.be.false;
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Description
- remove the close button (and logic related to handling the closing) from the error alert at the top of the Account page (department-of-veterans-affairs/vets.gov-team#17051)
- make info alerts at bottom of Account page consistent (department-of-veterans-affairs/vets.gov-team#18518)

## Testing done
Local

## Screenshots
**Remove the close button** (department-of-veterans-affairs/vets.gov-team#17051)
![image](https://user-images.githubusercontent.com/20728956/57536382-ef138300-72f8-11e9-8675-6e4f979b015e.png)

**Make info alerts consistent** (department-of-veterans-affairs/vets.gov-team#18518)
![image](https://user-images.githubusercontent.com/20728956/57536399-f63a9100-72f8-11e9-8a49-55133d59d981.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs