### PR TITLE
Extend the footer color to the bottom of the screen

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-footer.scss
+++ b/src/platform/site-wide/sass/modules/_m-footer.scss
@@ -5,6 +5,7 @@
   background: $color-primary-darkest;
   position: relative;
   overflow: hidden;
+  box-shadow: 0 50vh 0 50vh $color-primary-darkest;
 
   @include media($medium-large-screen) {
     flex-wrap: nowrap;


### PR DESCRIPTION
## Description
Covers up that white space for pages with little content viewed in large windows.

## Testing done
Manual verification.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/57548150-18420c80-7315-11e9-97af-6cdde134df00.png)
(I just deleted the content in the dev tools to get a screenshot.)

## Acceptance criteria
- [x] The footer color is extended to the bottom of the screen, leaving no white space

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
