### PR TITLE
VAGOV-2765: Services Offered Here & Other Template Updates

### DIFF
--- a/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
@@ -21,7 +21,9 @@ export class FacilityPatientSatisfactionScoresWidget extends React.Component {
 
     return (
       <div>
-        <h2>Our patient satisfaction scores</h2>
+        <h2 id="our-patient-satisfaction-scores">
+          Our patient satisfaction scores
+        </h2>
         <p id="facility-patient-satisfaction-scores-effective-date">
           Last updated: {formatDateLong(facility.feedback.health.effectiveDate)}
         </p>

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -119,9 +119,8 @@
             </div>
           </div>
 
-
           <div class="usa-grid usa-grid-full">
-            <h2>Our location</h2>
+            <h2>Address and phone numbers</h2>
             <!-- facility details from api -->
             <div class="usa-width-one-half">
               <div data-widget-type="facility-detail" data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}"></div>
@@ -136,12 +135,31 @@
             {% endif %}
           </div>
 
+        <div class="vads-u-margin-y--2">
+            <h3>On this page</h3>
+            <ul class="usa-unstyled-list">
+                {% if fieldLocationServices != empty and fieldLocationServices.length %}
+                    <li class="vads-u-margin-bottom--2">
+                        <a href="#prepare-for-your-visit"><i class="fas fa-level-down-alt"></i> Prepare for your visit</a>
+                    </li>
+                {% endif %}
+                {% if fieldLocalHealthCareService != empty and fieldLocalHealthCareService.length %}
+                    <li class="vads-u-margin-bottom--2">
+                        <a href="#health-care-offered-here"><i class="fas fa-level-down-alt"></i> Health care offered here</a>
+                    </li>
+                {% endif %}
+                <li class="vads-u-margin-bottom--2">
+                    <a href="#our-patient-satisfaction-scores"><i class="fas fa-level-down-alt"></i> Our patient satisfaction scores</a>
+                </li>
+            </ul>
+        </div>
+
           <!-- Location services section -->
           {% capture difference %}
             {{ fieldLocationServices | size | minus:1 }}
           {% endcapture %}
           {% unless difference contains '-' %}
-            <h2>Prepare for your visit</h2>
+            <h2 id="prepare-for-your-visit">Prepare for your visit</h2>
             <div class="usa-accordion">
               <ul aria-multiselectable="false" class="usa-unstyled-list">
                 {% for accordionItem in fieldLocationServices %}
@@ -161,7 +179,7 @@
 
             <!-- Local Health Services -->
             {% if fieldLocalHealthCareService != empty and fieldLocalHealthCareService.length %}
-                <h2>Our health services</h2>
+                <h2 id="health-care-offered-here">Health care offered here</h2>
                 <section class="local-health-services" id="local-health-services">
                     {% for localService in fieldLocalHealthCareService %}
                         {% include "src/site/facilities/health_service.drupal.liquid" with healthService = localService.entity.fieldClinicalHealthServices.0.entity localServiceDescription = localService.entity.fieldBody.processed fieldFacilityLocatorApiId = fieldFacilityLocatorApiId %}


### PR DESCRIPTION
## Description
+ updated `<h2>` text
+ added jumplinks

## Testing done
+ locally with stg data
1. switch to this branch
2. re-build site (metalsmith templates)
3. go to a facility page such as http://localhost:3001/pittsburgh-health-care/locations/pittsburgh-va-medical-center-university-drive/index.html
4. click on each jumplink to make sure it goes to the correct href header
5. check the title of the "Address and phone numbers" (which used to be "Our location")

## Screenshots
![localhost_3001_pittsburgh-health-care_locations_pittsburgh-va-medical-center-university-drive_index html](https://user-images.githubusercontent.com/19178435/57601666-f3ff4f00-7511-11e9-8648-56ef03c32d5b.png)

## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-2765

As a Veteran intending to visit a local VAMC, I can see the services offered at a given location on the facility’s detail page, and all other key site information I need to prepare for my visit. 

Acceptance Criteria:

Our Location H3 is updated to “Address and phone numbers”

“On this page” Jump links are added below clinical hours with new icon – V5

https://fontawesome.com/icons/level-down-alt?style=solid

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
