### PR TITLE
Handle case where auto-suggestions come if after exact match

### DIFF
--- a/src/platform/forms-system/test/js/fields/AutosuggestField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/AutosuggestField.unit.spec.jsx
@@ -475,4 +475,30 @@ describe('<AutosuggestField>', () => {
       done();
     });
   });
+
+  it('should call onChange if input exists when setting options', () => {
+    const uiSchema = {
+      'ui:options': {
+        getOptions: () => Promise.resolve([]),
+      },
+    };
+    const formContext = {
+      reviewMode: false,
+    };
+    const onChange = sinon.spy();
+    const tree = mount(
+      <AutosuggestField
+        formData={{ widget: 'autosuggest', label: 'label' }}
+        formContext={formContext}
+        idSchema={{ $id: 'id' }}
+        onChange={onChange}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    onChange.reset();
+    tree.instance().setOptions([]);
+    expect(onChange.called).to.be.true;
+    tree.unmount();
+  });
 });


### PR DESCRIPTION
## Description
While trying to get the preneed e2e tests to work when pointing at staging, I discovered an Autosuggest bug on the cemeteries list field. If you enter an exact match into the search box before the results come back from the server, then the field won't recognize an exact match, and if you click away from the field your input will be erased (unless you're using freeInput). 

This is pretty rare, but it shows up in staging integration tests because the text is entered immediately, but there's now a delay getting the list of cemeteries (because they're actually being fetched from a backend).

## Testing done
Delayed when the api call finishes locally and tested out changes

## Acceptance criteria
- [x] Autosuggest still works fine
- [x] Fully entered matches are highlighted when results come in

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
