### PR TITLE
Add seperate error logs in letters for Sentry granularity

### DIFF
--- a/src/applications/letters/actions/letters.js
+++ b/src/applications/letters/actions/letters.js
@@ -78,6 +78,7 @@ export function getLetterList(dispatch) {
       Raven.captureException(lettersError, {
         fingerprint: ['{{ default }}', status],
       });
+      return Promise.reject();
     },
   );
 }

--- a/src/applications/letters/actions/letters.js
+++ b/src/applications/letters/actions/letters.js
@@ -289,7 +289,9 @@ export function saveAddress(address) {
           response.data.attributes.address,
         );
         if (!isEqual(stripEmpties(address), stripEmpties(responseAddress))) {
-          throw new Error("letters-address-update addresses don't match");
+          Raven.captureException(
+            new Error("letters-address-update addresses don't match"),
+          );
         }
         return dispatch(saveAddressSuccess(responseAddress));
       },

--- a/src/applications/letters/actions/letters.js
+++ b/src/applications/letters/actions/letters.js
@@ -135,7 +135,9 @@ export function getMailingAddress() {
       response => {
         const status = getStatus(response);
         Raven.captureException(
-          new Error(`vets_letters_error_getMailingAddress: ${status}`),
+          new Error(`vets_letters_error_getMailingAddress`, {
+            fingerprint: ['{{ default }}', status],
+          }),
         );
         return dispatch(getAddressFailure());
       },
@@ -222,7 +224,9 @@ export function getLetterPdf(letterType, letterName, letterOptions) {
       response => {
         const status = getStatus(response);
         Raven.captureException(
-          new Error(`vets_letters_error_getLetterPdf_${letterType}: ${status}`),
+          new Error(`vets_letters_error_getLetterPdf_${letterType}`, {
+            fingerprint: ['{{ default }}', status],
+          }),
         );
         return dispatch(getLetterPdfFailure(letterType));
       },
@@ -284,17 +288,16 @@ export function saveAddress(address) {
           response.data.attributes.address,
         );
         if (!isEqual(stripEmpties(address), stripEmpties(responseAddress))) {
-          const mismatchError = new Error(
-            "letters-address-update addresses don't match",
-          );
-          Raven.captureException(mismatchError);
+          throw new Error("letters-address-update addresses don't match");
         }
         return dispatch(saveAddressSuccess(responseAddress));
       },
       response => {
         const status = getStatus(response);
         Raven.captureException(
-          new Error(`vets_letters_error_saveAddress: ${status}`),
+          new Error(`vets_letters_error_saveAddress`, {
+            fingerprint: ['{{ default }}', status],
+          }),
         );
         return dispatch(saveAddressFailure());
       },
@@ -318,7 +321,9 @@ export function getAddressCountries() {
         const status = getStatus(response);
         recordEvent({ event: 'letter-get-address-countries-failure' });
         Raven.captureException(
-          new Error(`vets_letters_error_getAddressCountries: ${status}`),
+          new Error(`vets_letters_error_getAddressCountries`, {
+            fingerprint: ['{{ default }}', status],
+          }),
         );
         return dispatch({ type: GET_ADDRESS_COUNTRIES_FAILURE });
       },
@@ -341,7 +346,9 @@ export function getAddressStates() {
         const status = getStatus(response);
         recordEvent({ event: 'letter-get-address-states-success' });
         Raven.captureException(
-          new Error(`vets_letters_error_getAddressStates: ${status}`),
+          new Error(`vets_letters_error_getAddressStates`, {
+            fingerprint: ['{{ default }}', status],
+          }),
         );
         return dispatch({ type: GET_ADDRESS_STATES_FAILURE });
       },

--- a/src/applications/letters/actions/letters.js
+++ b/src/applications/letters/actions/letters.js
@@ -61,20 +61,24 @@ export function getLetterList(dispatch) {
       if (status === '403') {
         // Backend authentication problem
         dispatch({ type: BACKEND_AUTHENTICATION_ERROR });
+        throw new Error(`vets_letters_error_getLetterList: ${status}`);
       } else if (status === '422') {
         // User has an invalid address for his or her letters
         dispatch({ type: INVALID_ADDRESS_PROPERTY });
+        throw new Error(`vets_letters_error_getLetterList: ${status}`);
       } else if (status === '502') {
         // Some of the partner services are down, so we cannot verify the
         // eligibility of some letters
         dispatch({ type: LETTER_ELIGIBILITY_ERROR });
+        throw new Error(`vets_letters_error_getLetterList: ${status}`);
       } else if (status === '503' || status === '504') {
         // Either EVSS or a partner service is down or EVSS times out
         dispatch({ type: BACKEND_SERVICE_ERROR });
+        throw new Error(`vets_letters_error_getLetterList: ${status}`);
       } else {
         dispatch({ type: GET_LETTERS_FAILURE });
+        throw new Error(`vets_letters_error_getLetterList: ${status}`);
       }
-      throw new Error(`vets_letters_error_getLetterList: ${status}`);
     },
   );
 }

--- a/src/applications/letters/actions/letters.js
+++ b/src/applications/letters/actions/letters.js
@@ -61,24 +61,23 @@ export function getLetterList(dispatch) {
       if (status === '403') {
         // Backend authentication problem
         dispatch({ type: BACKEND_AUTHENTICATION_ERROR });
-        throw new Error(`vets_letters_error_getLetterList: ${status}`);
       } else if (status === '422') {
         // User has an invalid address for his or her letters
         dispatch({ type: INVALID_ADDRESS_PROPERTY });
-        throw new Error(`vets_letters_error_getLetterList: ${status}`);
       } else if (status === '502') {
         // Some of the partner services are down, so we cannot verify the
         // eligibility of some letters
         dispatch({ type: LETTER_ELIGIBILITY_ERROR });
-        throw new Error(`vets_letters_error_getLetterList: ${status}`);
       } else if (status === '503' || status === '504') {
         // Either EVSS or a partner service is down or EVSS times out
         dispatch({ type: BACKEND_SERVICE_ERROR });
-        throw new Error(`vets_letters_error_getLetterList: ${status}`);
       } else {
         dispatch({ type: GET_LETTERS_FAILURE });
-        throw new Error(`vets_letters_error_getLetterList: ${status}`);
       }
+      const lettersError = new Error('vets_letters_error_getLetterList');
+      Raven.captureException(lettersError, {
+        fingerprint: ['{{ default }}', status],
+      });
     },
   );
 }


### PR DESCRIPTION
Attempting to shed some light on #18551

Sentry groups errors by the line they occurred, so it's hard to get a more specific tally of what's causing the most errors in letter fetching. This should fix that