### PR TITLE
Letters - Remove calls attempting to access undefined values on empty addresses

### DIFF
--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -279,13 +279,11 @@ export class AddressSection extends React.Component {
     const address = this.props.savedAddress || {};
     const emptyAddress = isAddressEmpty(this.props.savedAddress);
 
-    const addressContentLines = emptyAddress
-      ? {}
-      : {
-          streetAddress: formatStreetAddress(address),
-          cityStatePostal: formatCityStatePostal(address),
-          country: isInternationalAddress(address) ? address.countryName : '',
-        };
+    const addressContentLines = {
+      streetAddress: formatStreetAddress(address),
+      cityStatePostal: formatCityStatePostal(address),
+      country: isInternationalAddress(address) ? address.countryName : '',
+    };
 
     let addressFields;
     if (this.props.isEditingAddress) {
@@ -315,7 +313,7 @@ export class AddressSection extends React.Component {
           <LoadingIndicator message="Updating your address..." />
         </div>
       );
-    } else if (!emptyAddress) {
+    } else {
       const { streetAddress, cityStatePostal, country } = addressContentLines;
       const displayAddress = (
         <div>

--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -279,11 +279,21 @@ export class AddressSection extends React.Component {
     const address = this.props.savedAddress || {};
     const emptyAddress = isAddressEmpty(this.props.savedAddress);
 
+<<<<<<< HEAD
     const addressContentLines = {
       streetAddress: formatStreetAddress(address),
       cityStatePostal: formatCityStatePostal(address),
       country: isInternationalAddress(address) ? address.countryName : '',
     };
+=======
+    const addressContentLines = emptyAddress
+      ? {}
+      : {
+          streetAddress: formatStreetAddress(address),
+          cityStatePostal: formatCityStatePostal(address),
+          country: isInternationalAddress(address) ? address.countryName : '',
+        };
+>>>>>>> Refactor letters AddressSection for clarity, remove calls on empty address objects
 
     let addressFields;
     if (this.props.isEditingAddress) {
@@ -313,7 +323,11 @@ export class AddressSection extends React.Component {
           <LoadingIndicator message="Updating your address..." />
         </div>
       );
+<<<<<<< HEAD
     } else {
+=======
+    } else if (!emptyAddress) {
+>>>>>>> Refactor letters AddressSection for clarity, remove calls on empty address objects
       const { streetAddress, cityStatePostal, country } = addressContentLines;
       const displayAddress = (
         <div>

--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -279,21 +279,11 @@ export class AddressSection extends React.Component {
     const address = this.props.savedAddress || {};
     const emptyAddress = isAddressEmpty(this.props.savedAddress);
 
-<<<<<<< HEAD
     const addressContentLines = {
       streetAddress: formatStreetAddress(address),
       cityStatePostal: formatCityStatePostal(address),
       country: isInternationalAddress(address) ? address.countryName : '',
     };
-=======
-    const addressContentLines = emptyAddress
-      ? {}
-      : {
-          streetAddress: formatStreetAddress(address),
-          cityStatePostal: formatCityStatePostal(address),
-          country: isInternationalAddress(address) ? address.countryName : '',
-        };
->>>>>>> Refactor letters AddressSection for clarity, remove calls on empty address objects
 
     let addressFields;
     if (this.props.isEditingAddress) {
@@ -323,11 +313,7 @@ export class AddressSection extends React.Component {
           <LoadingIndicator message="Updating your address..." />
         </div>
       );
-<<<<<<< HEAD
     } else {
-=======
-    } else if (!emptyAddress) {
->>>>>>> Refactor letters AddressSection for clarity, remove calls on empty address objects
       const { streetAddress, cityStatePostal, country } = addressContentLines;
       const displayAddress = (
         <div>

--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -14,14 +14,12 @@ import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import {
   addressModalContent,
   addressUpdateUnavailable,
-  getStateName,
-  getZipCode,
+  formatStreetAddress,
+  formatCityStatePostal,
   inferAddressType,
-  isDomesticAddress,
   isInternationalAddress,
-  isMilitaryAddress,
-  resetDisallowedAddressFields,
   isAddressEmpty,
+  resetDisallowedAddressFields,
 } from '../utils/helpers';
 import {
   saveAddress,
@@ -280,31 +278,14 @@ export class AddressSection extends React.Component {
   render() {
     const address = this.props.savedAddress || {};
     const emptyAddress = isAddressEmpty(this.props.savedAddress);
-    // Street address: first line of address
-    const streetAddressLines = [
-      address.addressOne,
-      address.addressTwo ? `, ${address.addressTwo}` : '',
-      address.addressThree ? ` ${address.addressThree}` : '',
-    ];
-    const streetAddress = streetAddressLines.join('').toLowerCase();
 
-    // City, state, postal code: second line of address
-    const zipCode = getZipCode(address);
-    const city = address.city || '';
-    let cityStatePostal;
-    if (isDomesticAddress(address)) {
-      const state = getStateName(address.stateCode);
-      cityStatePostal = `${city}, ${state} ${zipCode}`;
-    } else if (isMilitaryAddress(address)) {
-      const militaryStateCode = address.stateCode || '';
-      cityStatePostal = `${city}, ${militaryStateCode} ${zipCode}`;
-    } else {
-      // Must be an international address, only show a city
-      cityStatePostal = `${city}`;
-    }
-
-    const country = isInternationalAddress(address) ? address.countryName : '';
-    const addressContentLines = { streetAddress, cityStatePostal, country };
+    const addressContentLines = emptyAddress
+      ? {}
+      : {
+          streetAddress: formatStreetAddress(address),
+          cityStatePostal: formatCityStatePostal(address),
+          country: isInternationalAddress(address) ? address.countryName : '',
+        };
 
     let addressFields;
     if (this.props.isEditingAddress) {
@@ -334,7 +315,8 @@ export class AddressSection extends React.Component {
           <LoadingIndicator message="Updating your address..." />
         </div>
       );
-    } else {
+    } else if (!emptyAddress) {
+      const { streetAddress, cityStatePostal, country } = addressContentLines;
       const displayAddress = (
         <div>
           <div className="letters-address street">{streetAddress}</div>

--- a/src/applications/letters/utils/helpers.jsx
+++ b/src/applications/letters/utils/helpers.jsx
@@ -563,3 +563,43 @@ export function isAddressEmpty(address) {
     true,
   );
 }
+
+export function formatStreetAddress(address) {
+  let formattedAddress = '';
+
+  if (address.addressOne) {
+    const streetAddressLines = [
+      address.addressOne,
+      address.addressTwo ? `, ${address.addressTwo}` : '',
+      address.addressThree ? ` ${address.addressThree}` : '',
+    ];
+    formattedAddress = streetAddressLines.join('').toLowerCase();
+  }
+
+  return formattedAddress;
+}
+
+export function formatCityStatePostal(address) {
+  // Formats to "city, state, postal code" for the second line of an address
+  let cityStatePostal = '';
+
+  if (isAddressEmpty(address)) {
+    return cityStatePostal;
+  }
+
+  const city = address.city || '';
+  const zipCode = getZipCode(address);
+
+  if (isDomesticAddress(address)) {
+    const state = getStateName(address.stateCode);
+    cityStatePostal = `${city}, ${state} ${zipCode}`;
+  } else if (isMilitaryAddress(address)) {
+    const militaryStateCode = address.stateCode || '';
+    cityStatePostal = `${city}, ${militaryStateCode} ${zipCode}`;
+  } else {
+    // Must be an international address, only show a city
+    cityStatePostal = `${city}`;
+  }
+
+  return cityStatePostal;
+}


### PR DESCRIPTION
`isAddressEmpty` skips over the `type` and `countryName` fields because they should always exist. This is leading to calls to `getStateName` that are throwing unnecessary errors.

This moves some of the formatting logic to the `helpers` file and attempts to make the division between displaying an address vs an empty address more clearer and without causing errors