### PR TITLE
16986 - Add aria-label to Dashboard Track-Claims View-Claim button.

### DIFF
--- a/src/applications/personalization/dashboard/components/ClaimsListItem.jsx
+++ b/src/applications/personalization/dashboard/components/ClaimsListItem.jsx
@@ -25,7 +25,7 @@ function handleViewClaim() {
 export default function ClaimsListItem({ claim }) {
   const inProgress = !isClaimComplete(claim);
   const dateRecd = moment(claim.attributes.dateFiled).format('MMMM D, YYYY');
-  
+
   return (
     <div className="claim-list-item-container">
       <h3 className="claim-list-item-header-v2">

--- a/src/applications/personalization/dashboard/components/ClaimsListItem.jsx
+++ b/src/applications/personalization/dashboard/components/ClaimsListItem.jsx
@@ -24,11 +24,12 @@ function handleViewClaim() {
 
 export default function ClaimsListItem({ claim }) {
   const inProgress = !isClaimComplete(claim);
+  const dateRecd = moment(claim.attributes.dateFiled).format('MMMM D, YYYY');
+  
   return (
     <div className="claim-list-item-container">
       <h3 className="claim-list-item-header-v2">
-        {getClaimType(claim)} Claim – Received{' '}
-        {moment(claim.attributes.dateFiled).format('MMMM D, YYYY')}
+        {getClaimType(claim)} Claim – Received {dateRecd}
       </h3>
       <p className="status">
         <span className="claim-item-label">
@@ -59,6 +60,7 @@ export default function ClaimsListItem({ claim }) {
       <Link
         className="usa-button usa-button-primary"
         href={`/track-claims/your-claims/${claim.id}/status`}
+        aria-label={`View claim received ${dateRecd}`}
         onClick={handleViewClaim}
       >
         View claim <i className="fa fa-chevron-right" />

--- a/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
@@ -228,8 +228,20 @@ const mapStateToProps = state => {
     .concat(claimsV2Root.claims)
     .filter(c => {
       let updateDate;
+      let evssPhaseChangeDate;
+      let evssUpdatedAtDate;
       if (c.type === 'evss_claims') {
-        updateDate = c.attributes.phaseChangeDate || c.attributes.updatedAt;
+        evssPhaseChangeDate = c.attributes.phaseChangeDate;
+        evssUpdatedAtDate = c.attributes.updatedAt;
+        if (evssPhaseChangeDate && evssUpdatedAtDate) {
+          updateDate = moment(evssPhaseChangeDate).isAfter(
+            moment(evssUpdatedAtDate),
+          )
+            ? evssPhaseChangeDate
+            : evssUpdatedAtDate;
+        } else {
+          updateDate = evssPhaseChangeDate || evssUpdatedAtDate;
+        }
       } else {
         updateDate = c.attributes.updated;
       }


### PR DESCRIPTION
## Description
[16986](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16986) - Add aria-label to Dashboard > Track Claims > View Claim button, so that screen reader announces "View claim received <received-date>".

## Testing done
Verified locally in browser using screen reader.  NOTE: Did NOT test against IE11 locally -- Windows VM IE11 can access local homepage but cannot Sign-In.
No business-logic or functionality changed.
Ran `yarn test:unit:personalization` and all unit-tests still passing.

## Screenshots
See connected ticket.

## Acceptance criteria
- [ ] Screen reader announces "View claim received <received-date>" when keyboard focus is on a View Claim button.

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
