### PR TITLE
Add preneed to integration tests

### DIFF
--- a/src/applications/pre-need/tests/00-all-fields.e2e.spec.js
+++ b/src/applications/pre-need/tests/00-all-fields.e2e.spec.js
@@ -181,3 +181,4 @@ const runTest = E2eHelpers.createE2eTest(client => {
 });
 
 module.exports = runTest;
+module.exports['@tags'] = ['integration'];

--- a/src/applications/pre-need/tests/preneed-helpers.js
+++ b/src/applications/pre-need/tests/preneed-helpers.js
@@ -134,7 +134,7 @@ function completeBenefitSelection(client, data) {
       'input[name="root_application_claimant_desiredCemetery"]',
       data.claimant.desiredCemetery.label,
     )
-    .waitForElementPresent('#downshift-1-item-0', Timeouts.slow)
+    .waitForElementPresent('.autosuggest-item', Timeouts.slow)
     .click('body')
     // Test is flaky so have to select option twice for it to register
     .selectRadio('root_application_hasCurrentlyBuried', data.hasCurrentlyBuried)
@@ -149,7 +149,6 @@ function completeBenefitSelection(client, data) {
           `input[name="root_application_currentlyBuriedPersons_${index}_cemeteryNumber"]`,
           person.cemeteryNumber.label,
         )
-        .waitForElementPresent('#downshift-1-item-0', Timeouts.slow)
         .fillName(
           `root_application_currentlyBuriedPersons_${index}_name`,
           person.name,

--- a/src/applications/pre-need/tests/preneed-helpers.js
+++ b/src/applications/pre-need/tests/preneed-helpers.js
@@ -134,7 +134,7 @@ function completeBenefitSelection(client, data) {
       'input[name="root_application_claimant_desiredCemetery"]',
       data.claimant.desiredCemetery.label,
     )
-    .waitForElementVisible('#downshift-1-item-0', Timeouts.slow)
+    .waitForElementPresent('#downshift-1-item-0', Timeouts.slow)
     .click('body')
     // Test is flaky so have to select option twice for it to register
     .selectRadio('root_application_hasCurrentlyBuried', data.hasCurrentlyBuried)
@@ -149,7 +149,7 @@ function completeBenefitSelection(client, data) {
           `input[name="root_application_currentlyBuriedPersons_${index}_cemeteryNumber"]`,
           person.cemeteryNumber.label,
         )
-        .waitForElementVisible('#downshift-1-item-0', Timeouts.slow)
+        .waitForElementPresent('#downshift-1-item-0', Timeouts.slow)
         .fillName(
           `root_application_currentlyBuriedPersons_${index}_name`,
           person.name,

--- a/src/applications/pre-need/tests/preneed-helpers.js
+++ b/src/applications/pre-need/tests/preneed-helpers.js
@@ -134,6 +134,7 @@ function completeBenefitSelection(client, data) {
       'input[name="root_application_claimant_desiredCemetery"]',
       data.claimant.desiredCemetery.label,
     )
+    .waitForElementVisible('#downshift-1-item-0', Timeouts.slow)
     .click('body')
     // Test is flaky so have to select option twice for it to register
     .selectRadio('root_application_hasCurrentlyBuried', data.hasCurrentlyBuried)
@@ -148,6 +149,7 @@ function completeBenefitSelection(client, data) {
           `input[name="root_application_currentlyBuriedPersons_${index}_cemeteryNumber"]`,
           person.cemeteryNumber.label,
         )
+        .waitForElementVisible('#downshift-1-item-0', Timeouts.slow)
         .fillName(
           `root_application_currentlyBuriedPersons_${index}_name`,
           person.name,


### PR DESCRIPTION
## Description
This adds the preneed form to the integration tests that run daily against staging.

## Testing done
Ran test from my local machine, pointed at staging:

`BABEL_ENV=test WEB_HOST=staging.va.gov WEB_PORT=80 yarn test:integration:nightwatch`

## Acceptance criteria
- [ ] Test still runs in normal build
- [x] Test passes when running against staging

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
