### PR TITLE
[Facility Locator] Add check for empty feedback and access

### DIFF
--- a/src/applications/facility-locator/components/AccessToCare.jsx
+++ b/src/applications/facility-locator/components/AccessToCare.jsx
@@ -21,6 +21,10 @@ export default class AccessToCare extends Component {
 
     const healthFeedbackAttrs = location.attributes.feedback.health;
 
+    if (!healthFeedbackAttrs) {
+      return null;
+    }
+
     if (
       isEmpty(
         compact([

--- a/src/applications/facility-locator/components/AppointmentInfo.jsx
+++ b/src/applications/facility-locator/components/AppointmentInfo.jsx
@@ -44,6 +44,10 @@ export default class AppointmentInfo extends Component {
 
     const healthAccessAttrs = location.attributes.access.health;
 
+    if (!healthAccessAttrs) {
+      return null;
+    }
+
     if (
       !this.anyWaitTimes(healthAccessAttrs, 'new') &&
       !this.anyWaitTimes(healthAccessAttrs, 'established')


### PR DESCRIPTION
## Description
The `feedback` and `access` properties of the FL response data is returning empty, and there is no FE handling for this, resulting in a runtime bug that breaks the whole page. The former is used for the `AccessToCare` and the latter for `AppointmentInfo`.

## Testing done
I could not find a way to fully test this because it's a special case in the API response data and I do not see this occurring in any environment outside of Prod.

## Screenshots
### Broken
`https://www.va.gov/find-locations/facility/vha_541GG`
![image](https://user-images.githubusercontent.com/1915775/57782304-f2907b00-76f9-11e9-927b-19f1665429d3.png)

## Acceptance criteria
- [ ] Facilities render in Prod

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
