### PR TITLE
VAGOV-3554: fix leadership page

### DIFF
--- a/src/site/layouts/bios_page.drupal.liquid
+++ b/src/site/layouts/bios_page.drupal.liquid
@@ -48,7 +48,7 @@
                 <article class="usa-content">
                     <h1>Our Leadership Team</h1>
                     {% for bio in pagedItems %}
-                        {% include "src/site/teasers/bio.drupal.liquid" with node = bio %}
+                        {% include "src/site/teasers/bio.drupal.liquid" with node = bio.entity %}
                     {% endfor %}
                     {% include "src/site/includes/pagination.drupal.liquid" %}
                 </article>

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionStaffBios.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionStaffBios.node.graphql.js
@@ -3,7 +3,7 @@
  */
 
 const PERSON_PROFILE_RESULTS = `
-  entities {
+  entity {
     ... on NodePersonProfile {
       entityPublished
       title
@@ -46,22 +46,8 @@ const PERSON_PROFILE_RESULTS = `
   }
 `;
 
-function queryFilter(isAll) {
-  return `
-    reverseFieldOfficeNode(
-    filter: {
-      conditions: [
-        { field: "type", value: "person_profile"}
-        { field: "status", value: "1"}
-      ]
-    } 
-    sort: {field: "field_office", direction: DESC }
-    limit:${isAll ? '500' : '10'})
-  `;
-}
-
 module.exports = `
-  allStaffProfiles: ${queryFilter(true)}
+  fieldLeadership
     {
     ${PERSON_PROFILE_RESULTS}
   }

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -130,6 +130,9 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
 
   // Staff bio listing page
   const bioEntityUrl = createEntityUrlObj(drupalPagePath);
+  page.allStaffProfiles = {
+    entities: [...page.fieldLeadership],
+  };
   const bioObj = {
     allStaffProfiles: page.allStaffProfiles,
     facilitySidebar: sidebar,


### PR DESCRIPTION
## Description
- uses the correct data for leadership list

## Testing done
locally with stg data
1. build the site with new query
2. browse to http://localhost:3001/pittsburgh-health-care/leadership/index.html

## Screenshots
![localhost_3001_pittsburgh-health-care_leadership_index html](https://user-images.githubusercontent.com/19178435/57796293-e1953900-76fc-11e9-9d3f-e6dd839e25c4.png)

## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-3554

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
