### PR TITLE
CT: 105 - Update benefit level options#18517

### DIFF
--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -57,8 +57,7 @@ export class Calculator extends React.Component {
       <div className="eligibility-details">
         <button
           onClick={this.toggleEligibilityForm}
-          className="usa-accordion-button"
-          aria-expanded={expanded}
+          className="usa-button-secondary"
         >
           {expanded ? 'Hide' : 'Edit'} eligibility details
         </button>
@@ -82,8 +81,7 @@ export class Calculator extends React.Component {
       <div className="calculator-inputs">
         <button
           onClick={this.toggleCalculatorForm}
-          className="usa-accordion-button"
-          aria-expanded={expanded}
+          className="usa-button-secondary"
         >
           {expanded ? 'Hide' : 'Edit'} calculator fields
         </button>

--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -57,7 +57,8 @@ export class Calculator extends React.Component {
       <div className="eligibility-details">
         <button
           onClick={this.toggleEligibilityForm}
-          className="usa-button-secondary"
+          className="usa-accordion-button"
+          aria-expanded={expanded}
         >
           {expanded ? 'Hide' : 'Edit'} eligibility details
         </button>
@@ -81,7 +82,8 @@ export class Calculator extends React.Component {
       <div className="calculator-inputs">
         <button
           onClick={this.toggleCalculatorForm}
-          className="usa-button-secondary"
+          className="usa-accordion-button"
+          aria-expanded={expanded}
         >
           {expanded ? 'Hide' : 'Edit'} calculator fields
         </button>

--- a/src/applications/gi/components/search/EligibilityForm.jsx
+++ b/src/applications/gi/components/search/EligibilityForm.jsx
@@ -13,6 +13,42 @@ export class EligibilityForm extends React.Component {
     this.renderLearnMoreLabel = this.renderLearnMoreLabel.bind(this);
   }
 
+  cumulativeServiceOptions = () => {
+    if (!environment.isProduction()) {
+      return [
+        { value: '1.0', label: '36+ months: 100% (includes BASIC)' }, // notice not 1.00
+        { value: '0.9', label: '30 months: 90% (includes BASIC)' },
+        { value: '0.8', label: '24 months: 80% (includes BASIC)' },
+        { value: '0.7', label: '18 months: 70% (excludes BASIC)' },
+        { value: '0.6', label: '6 months: 60% (excludes BASIC)' },
+        { value: '0.5', label: '90 days: 50% (excludes BASIC)' },
+        { value: '0.0', label: 'Less than 90 days 0% (excludes BASIC)' },
+        { value: '1.00', label: 'GYSGT Fry Scholarship: 100%' }, // notice not 1.0
+        {
+          value: 'service discharge',
+          label: 'Service-Connected Discharge: 100%',
+        },
+        { value: 'purple heart', label: 'Purple Heart Service: 100%' },
+      ];
+    }
+
+    return [
+      { value: '1.0', label: '36+ months: 100% (includes BASIC)' }, // notice not 1.00
+      { value: '0.9', label: '30 months: 90% (includes BASIC)' },
+      { value: '0.8', label: '24 months: 80% (includes BASIC)' },
+      { value: '0.7', label: '18 months: 70% (excludes BASIC)' },
+      { value: '0.6', label: '12 months: 60% (excludes BASIC)' },
+      { value: '0.5', label: '6 months: 50% (excludes BASIC)' },
+      { value: '0.4', label: '90 days: 40% (excludes BASIC)' },
+      { value: '0.0', label: 'Less than 90 days 0% (excludes BASIC)' },
+      { value: '1.00', label: 'GYSGT Fry Scholarship: 100%' }, // notice not 1.0
+      {
+        value: 'service discharge',
+        label: 'Service-Connected Discharge: 100%',
+      },
+      { value: 'purple heart', label: 'Purple Heart Service: 100%' },
+    ];
+  };
   renderLearnMoreLabel({ text, modal }) {
     return (
       <span>
@@ -30,41 +66,6 @@ export class EligibilityForm extends React.Component {
   }
 
   render() {
-    let cumulativeServiceOptions = [
-      { value: '1.0', label: '36+ months: 100% (includes BASIC)' }, // notice not 1.00
-      { value: '0.9', label: '30 months: 90% (includes BASIC)' },
-      { value: '0.8', label: '24 months: 80% (includes BASIC)' },
-      { value: '0.7', label: '18 months: 70% (excludes BASIC)' },
-      { value: '0.6', label: '12 months: 60% (excludes BASIC)' },
-      { value: '0.5', label: '6 months: 50% (excludes BASIC)' },
-      { value: '0.4', label: '90 days: 40% (excludes BASIC)' },
-      { value: '0.0', label: 'Less than 90 days 0% (excludes BASIC)' },
-      { value: '1.00', label: 'GYSGT Fry Scholarship: 100%' }, // notice not 1.0
-      {
-        value: 'service discharge',
-        label: 'Service-Connected Discharge: 100%',
-      },
-      { value: 'purple heart', label: 'Purple Heart Service: 100%' },
-    ];
-
-    if (!environment.isProduction()) {
-      cumulativeServiceOptions = [
-        { value: '1.0', label: '36+ months: 100% (includes BASIC)' }, // notice not 1.00
-        { value: '0.9', label: '30 months: 90% (includes BASIC)' },
-        { value: '0.8', label: '24 months: 80% (includes BASIC)' },
-        { value: '0.7', label: '18 months: 70% (excludes BASIC)' },
-        { value: '0.6', label: '6 months: 60% (excludes BASIC)' },
-        { value: '0.5', label: '90 days: 50% (excludes BASIC)' },
-        { value: '0.0', label: 'Less than 90 days 0% (excludes BASIC)' },
-        { value: '1.00', label: 'GYSGT Fry Scholarship: 100%' }, // notice not 1.0
-        {
-          value: 'service discharge',
-          label: 'Service-Connected Discharge: 100%',
-        },
-        { value: 'purple heart', label: 'Purple Heart Service: 100%' },
-      ];
-    }
-
     return (
       <div className="eligibility-form">
         <h2>Your eligibility</h2>
@@ -164,7 +165,7 @@ export class EligibilityForm extends React.Component {
             modal: 'cumulativeService',
           })}
           name="cumulativeService"
-          options={cumulativeServiceOptions}
+          options={this.cumulativeServiceOptions()}
           value={this.props.cumulativeService}
           alt="Cumulative Post-9/11 active duty service"
           visible={this.props.giBillChapter === '33'}

--- a/src/applications/gi/components/search/EligibilityForm.jsx
+++ b/src/applications/gi/components/search/EligibilityForm.jsx
@@ -5,6 +5,7 @@ import { showModal, hideModal, eligibilityChange } from '../../actions';
 
 import Dropdown from '../Dropdown';
 import RadioButtons from '../RadioButtons';
+import environment from 'platform/utilities/environment';
 
 export class EligibilityForm extends React.Component {
   constructor(props) {
@@ -29,6 +30,41 @@ export class EligibilityForm extends React.Component {
   }
 
   render() {
+    let cumulativeServiceOptions = [
+      { value: '1.0', label: '36+ months: 100% (includes BASIC)' }, // notice not 1.00
+      { value: '0.9', label: '30 months: 90% (includes BASIC)' },
+      { value: '0.8', label: '24 months: 80% (includes BASIC)' },
+      { value: '0.7', label: '18 months: 70% (excludes BASIC)' },
+      { value: '0.6', label: '12 months: 60% (excludes BASIC)' },
+      { value: '0.5', label: '6 months: 50% (excludes BASIC)' },
+      { value: '0.4', label: '90 days: 40% (excludes BASIC)' },
+      { value: '0.0', label: 'Less than 90 days 0% (excludes BASIC)' },
+      { value: '1.00', label: 'GYSGT Fry Scholarship: 100%' }, // notice not 1.0
+      {
+        value: 'service discharge',
+        label: 'Service-Connected Discharge: 100%',
+      },
+      { value: 'purple heart', label: 'Purple Heart Service: 100%' },
+    ];
+
+    if (!environment.isProduction()) {
+      cumulativeServiceOptions = [
+        { value: '1.0', label: '36+ months: 100% (includes BASIC)' }, // notice not 1.00
+        { value: '0.9', label: '30 months: 90% (includes BASIC)' },
+        { value: '0.8', label: '24 months: 80% (includes BASIC)' },
+        { value: '0.7', label: '18 months: 70% (excludes BASIC)' },
+        { value: '0.6', label: '6 months: 60% (excludes BASIC)' },
+        { value: '0.5', label: '90 days: 50% (excludes BASIC)' },
+        { value: '0.0', label: 'Less than 90 days 0% (excludes BASIC)' },
+        { value: '1.00', label: 'GYSGT Fry Scholarship: 100%' }, // notice not 1.0
+        {
+          value: 'service discharge',
+          label: 'Service-Connected Discharge: 100%',
+        },
+        { value: 'purple heart', label: 'Purple Heart Service: 100%' },
+      ];
+    }
+
     return (
       <div className="eligibility-form">
         <h2>Your eligibility</h2>
@@ -128,22 +164,7 @@ export class EligibilityForm extends React.Component {
             modal: 'cumulativeService',
           })}
           name="cumulativeService"
-          options={[
-            { value: '1.0', label: '36+ months: 100% (includes BASIC)' }, // notice not 1.00
-            { value: '0.9', label: '30 months: 90% (includes BASIC)' },
-            { value: '0.8', label: '24 months: 80% (includes BASIC)' },
-            { value: '0.7', label: '18 months: 70% (excludes BASIC)' },
-            { value: '0.6', label: '12 months: 60% (excludes BASIC)' },
-            { value: '0.5', label: '6 months: 50% (excludes BASIC)' },
-            { value: '0.4', label: '90 days: 40% (excludes BASIC)' },
-            { value: '0.0', label: 'Less than 90 days 0% (excludes BASIC)' },
-            { value: '1.00', label: 'GYSGT Fry Scholarship: 100%' }, // notice not 1.0
-            {
-              value: 'service discharge',
-              label: 'Service-Connected Discharge: 100%',
-            },
-            { value: 'purple heart', label: 'Purple Heart Service: 100%' },
-          ]}
+          options={cumulativeServiceOptions}
           value={this.props.cumulativeService}
           alt="Cumulative Post-9/11 active duty service"
           visible={this.props.giBillChapter === '33'}

--- a/src/applications/gi/components/search/EligibilityForm.jsx
+++ b/src/applications/gi/components/search/EligibilityForm.jsx
@@ -14,14 +14,15 @@ export class EligibilityForm extends React.Component {
   }
 
   cumulativeServiceOptions = () => {
-    if (!environment.isProduction()) {
+    if (environment.isProduction()) {
       return [
         { value: '1.0', label: '36+ months: 100% (includes BASIC)' }, // notice not 1.00
         { value: '0.9', label: '30 months: 90% (includes BASIC)' },
         { value: '0.8', label: '24 months: 80% (includes BASIC)' },
         { value: '0.7', label: '18 months: 70% (excludes BASIC)' },
-        { value: '0.6', label: '6 months: 60% (excludes BASIC)' },
-        { value: '0.5', label: '90 days: 50% (excludes BASIC)' },
+        { value: '0.6', label: '12 months: 60% (excludes BASIC)' },
+        { value: '0.5', label: '6 months: 50% (excludes BASIC)' },
+        { value: '0.4', label: '90 days: 40% (excludes BASIC)' },
         { value: '0.0', label: 'Less than 90 days 0% (excludes BASIC)' },
         { value: '1.00', label: 'GYSGT Fry Scholarship: 100%' }, // notice not 1.0
         {
@@ -37,9 +38,8 @@ export class EligibilityForm extends React.Component {
       { value: '0.9', label: '30 months: 90% (includes BASIC)' },
       { value: '0.8', label: '24 months: 80% (includes BASIC)' },
       { value: '0.7', label: '18 months: 70% (excludes BASIC)' },
-      { value: '0.6', label: '12 months: 60% (excludes BASIC)' },
-      { value: '0.5', label: '6 months: 50% (excludes BASIC)' },
-      { value: '0.4', label: '90 days: 40% (excludes BASIC)' },
+      { value: '0.6', label: '6 months: 60% (excludes BASIC)' },
+      { value: '0.5', label: '90 days: 50% (excludes BASIC)' },
       { value: '0.0', label: 'Less than 90 days 0% (excludes BASIC)' },
       { value: '1.00', label: 'GYSGT Fry Scholarship: 100%' }, // notice not 1.0
       {
@@ -49,6 +49,7 @@ export class EligibilityForm extends React.Component {
       { value: 'purple heart', label: 'Purple Heart Service: 100%' },
     ];
   };
+
   renderLearnMoreLabel({ text, modal }) {
     return (
       <span>


### PR DESCRIPTION
## Description

As a Compare Tool User, I need the benefit levels to accurately reflect the benefits available so that I can make a decision about how to use my benefits based on accurate information.

Assumptions:
This law change is not effective until 08/01/2020. EDU confirmed that this work can be done up to a year prior and available in production on 08/01/2019.

## Testing done
- local testing
- unit testing

## Screenshots
![Screen Shot 2019-05-16 at 4 00 31 PM](https://user-images.githubusercontent.com/1094999/57883302-cc4f0600-77f3-11e9-9f67-77882d1b9152.png)


## Acceptance criteria
- [ ] Update "Cumulative Post-9/11 active duty service" dropdown options on all pages (Search, Search Results, School Profile):
     - "90 days: 40% (excludes BASIC)" is no longer an option in the menu.
     - The 50% option "6 months: 50% (excludes BASIC)" is replaced with "90 days: 50% (excludes BASIC)" is an option in the menu.
     - The 60% option "12 months: 60% (excludes BASIC)" is replaced with "6 months: 60% (excludes BASIC)" is an option in the menu.
- [ ] This is delivered behind a production flag.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
