### PR TITLE
update copy for MHV downtime banner

### DIFF
--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -87,7 +87,7 @@ class SignInModal extends React.Component {
           [externalServices.mhv],
           'You may have trouble signing in with My HealtheVet',
           'warning',
-          'We’re sorry. We’re working to fix some problems with our My HealtheVet sign in process. If you’d like to sign in to VA.gov with your My HealtheVet account, please check back later.',
+          'We’re sorry. We’re making some scheduled updates to our My HealtheVet sign-in process. If you’d like to sign in to VA.gov with your My HealtheVet username and password, please check back later.',
         )}
         {this.downtimeBanner(
           [externalServices.mvi],


### PR DESCRIPTION
<img width="1567" alt="Screen Shot 2019-05-17 at 1 01 11 PM" src="https://user-images.githubusercontent.com/19188/57944144-07107700-78a4-11e9-9066-056eb85a3d42.png">
copy-pasted copy from https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18625#event-2349882782 . The only change to the copy was changing '  to ’.