### PR TITLE
VAGOV-000: Hardcoded fix for youtube name in landing page right rail

### DIFF
--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -34,6 +34,13 @@
                                         {{ administration.name }} {{ socialPlatform | remove: '_' | capitalize }}
                                     </a>
                                 </li>
+                            {% elsif socialPlatform == "youtube" %}
+                                <li>
+                                    <a href="http://{{ socialPlatform }}.com/{{ socialLink.value }}">
+                                        <i class="fab fa-{{ socialPlatform }} vads-u-padding-right--1"></i>
+                                        {{ administration.name }} YouTube
+                                    </a>
+                                </li>
                             {% else %}
                                 <li>
                                     <a href="http://{{ socialPlatform }}.com/{{ socialLink.value }}">


### PR DESCRIPTION
## Description
changes Youtube to YouTube in connect with us box on hub landing pages like /health-care. Done this way because the incorrect case is coming from a Drupal module and can't be modified without a patch.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
