### PR TITLE
Add Configurations in preparation of 1995 development #18651

### DIFF
--- a/src/applications/edu-benefits/1995/config/form.js
+++ b/src/applications/edu-benefits/1995/config/form.js
@@ -1,42 +1,22 @@
-import _ from 'lodash/fp';
-
 import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
 
 import { transform } from '../helpers';
 
 import { urlMigration } from '../../config/migrations';
 
-import * as address from '../../../../platform/forms/definitions/address';
 import FormFooter from '../../../../platform/forms/components/FormFooter';
 import environment from '../../../../platform/utilities/environment';
 import GetFormHelp from '../../components/GetFormHelp';
 import ErrorText from '../../components/ErrorText';
 import preSubmitInfo from '../../../../platform/forms/preSubmitInfo';
 
-import educationTypeUISchema from '../../definitions/educationType';
-import serviceBefore1977UI from '../../definitions/serviceBefore1977';
-import * as toursOfDuty from '../../definitions/toursOfDuty.jsx';
-
-import createContactInformationPage from '../../pages/contactInformation';
-import createOldSchoolPage from '../../pages/oldSchool';
-import createDirectDepositChangePage from '../../pages/directDepositChange';
-import createApplicantInformationPage from '../../../../platform/forms/pages/applicantInformation';
-
-import { showSchoolAddress } from '../../utils/helpers';
-import { benefitsLabels } from '../../utils/labels';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
-
-const {
-  benefit,
-  civilianBenefitsAssistance,
-  educationObjective,
-  nonVaAssistance,
-} = fullSchema1995.properties;
+import { originalChapters } from './original-chapters';
+import { newChapters } from './new-chapters';
 
 const {
   preferredContactMethod,
-  educationType,
   date,
   dateRange,
   serviceBefore1977,
@@ -70,179 +50,7 @@ const formConfig = {
   footerContent: FormFooter,
   getHelp: GetFormHelp,
   errorText: ErrorText,
-  chapters: {
-    applicantInformation: {
-      title: 'Applicant Information',
-      pages: {
-        applicantInformation: createApplicantInformationPage(fullSchema1995, {
-          isVeteran: true,
-          fields: [
-            'veteranFullName',
-            'veteranSocialSecurityNumber',
-            'view:noSSN',
-            'vaFileNumber',
-          ],
-          required: ['veteranFullName'],
-        }),
-      },
-    },
-    benefitSelection: {
-      title: 'Education Benefit',
-      pages: {
-        benefitSelection: {
-          title: 'Education benefit',
-          path: 'benefits/eligibility',
-          initialData: {},
-          uiSchema: {
-            benefit: {
-              'ui:widget': 'radio',
-              'ui:title': 'Which benefit are you currently using?',
-              'ui:options': {
-                labels: benefitsLabels,
-              },
-            },
-          },
-          schema: {
-            type: 'object',
-            properties: {
-              benefit,
-            },
-          },
-        },
-      },
-    },
-    militaryService: {
-      title: 'Military History',
-      pages: {
-        servicePeriods: {
-          path: 'military/service',
-          title: 'Service periods',
-          initialData: {},
-          uiSchema: {
-            'view:newService': {
-              'ui:title':
-                'Do you have any new periods of service to record since you last applied for education benefits?',
-              'ui:widget': 'yesNo',
-            },
-            toursOfDuty: _.merge(toursOfDuty.uiSchema, {
-              'ui:options': { expandUnder: 'view:newService' },
-            }),
-          },
-          schema: {
-            type: 'object',
-            properties: {
-              'view:newService': {
-                type: 'boolean',
-              },
-              toursOfDuty: fullSchema1995.properties.toursOfDuty,
-            },
-          },
-        },
-        militaryHistory: {
-          title: 'Military history',
-          path: 'military/history',
-          initialData: {},
-          uiSchema: {
-            'view:hasServiceBefore1978': {
-              'ui:title':
-                'Do you have any periods of service that began before 1978?',
-              'ui:widget': 'yesNo',
-            },
-          },
-          schema: {
-            type: 'object',
-            properties: {
-              'view:hasServiceBefore1978': {
-                type: 'boolean',
-              },
-            },
-          },
-        },
-      },
-    },
-    schoolSelection: {
-      title: 'School Selection',
-      pages: {
-        newSchool: {
-          path: 'school-selection/new-school',
-          title:
-            'School, university, program, or training facility you want to attend',
-          initialData: {
-            newSchoolAddress: {},
-          },
-          uiSchema: {
-            'ui:title':
-              'School, university, program, or training facility you want to attend',
-            // Broken up because we need to fit educationType between name and address
-            // Put back together again in transform()
-            newSchoolName: {
-              'ui:title': 'Name of school, university, or training facility',
-            },
-            educationType: educationTypeUISchema,
-            newSchoolAddress: _.merge(address.uiSchema(), {
-              'ui:options': {
-                hideIf: formData => !showSchoolAddress(formData.educationType),
-              },
-            }),
-            educationObjective: {
-              'ui:title':
-                'Education or career goal (for example, “Get a bachelor’s degree in criminal justice” or “Get an HVAC technician certificate” or “Become a police officer.”)',
-              'ui:widget': 'textarea',
-            },
-            nonVaAssistance: {
-              'ui:title':
-                'Are you getting, or do you expect to get any money (including, but not limited to, federal tuition assistance) from the Armed Forces or public health services for any part of your coursework or training?',
-              'ui:widget': 'yesNo',
-            },
-            civilianBenefitsAssistance: {
-              'ui:title':
-                'Are you getting benefits from the U.S. Government as a civilian employee during the same time as you’re seeking benefits from VA?',
-              'ui:widget': 'yesNo',
-            },
-          },
-          schema: {
-            type: 'object',
-            required: ['educationType', 'newSchoolName'],
-            properties: {
-              newSchoolName: {
-                type: 'string',
-              },
-              educationType,
-              newSchoolAddress: address.schema(fullSchema1995),
-              educationObjective,
-              nonVaAssistance,
-              civilianBenefitsAssistance,
-            },
-          },
-        },
-        oldSchool: createOldSchoolPage(fullSchema1995),
-      },
-    },
-    personalInformation: {
-      title: 'Personal Information',
-      pages: {
-        contactInformation: createContactInformationPage(fullSchema1995),
-        dependents: {
-          title: 'Dependents',
-          path: 'personal-information/dependents',
-          initialData: {},
-          depends: {
-            'view:hasServiceBefore1978': true,
-          },
-          uiSchema: {
-            serviceBefore1977: serviceBefore1977UI,
-          },
-          schema: {
-            type: 'object',
-            properties: {
-              serviceBefore1977,
-            },
-          },
-        },
-        directDeposit: createDirectDepositChangePage(fullSchema1995),
-      },
-    },
-  },
+  chapters: environment.isProduction() ? originalChapters : newChapters,
 };
 
 export default formConfig;

--- a/src/applications/edu-benefits/1995/config/new-chapters.js
+++ b/src/applications/edu-benefits/1995/config/new-chapters.js
@@ -1,0 +1,200 @@
+import _ from 'lodash/fp';
+
+import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
+
+import * as address from '../../../../platform/forms/definitions/address';
+
+import educationTypeUISchema from '../../definitions/educationType';
+import serviceBefore1977UI from '../../definitions/serviceBefore1977';
+import * as toursOfDuty from '../../definitions/toursOfDuty.jsx';
+
+import createContactInformationPage from '../../pages/contactInformation';
+import createOldSchoolPage from '../../pages/oldSchool';
+import createDirectDepositChangePage from '../../pages/directDepositChange';
+import createApplicantInformationPage from '../../../../platform/forms/pages/applicantInformation';
+
+import { showSchoolAddress } from '../../utils/helpers';
+import { benefitsLabels } from '../../utils/labels';
+
+const {
+  benefit,
+  civilianBenefitsAssistance,
+  educationObjective,
+  nonVaAssistance,
+} = fullSchema1995.properties;
+
+const { educationType, serviceBefore1977 } = fullSchema1995.definitions;
+
+export const newChapters = {
+  applicantInformation: {
+    title: 'Applicant Information',
+    pages: {
+      applicantInformation: createApplicantInformationPage(fullSchema1995, {
+        isVeteran: true,
+        fields: [
+          'veteranFullName',
+          'veteranSocialSecurityNumber',
+          'view:noSSN',
+          'vaFileNumber',
+        ],
+        required: ['veteranFullName'],
+      }),
+    },
+  },
+  benefitSelection: {
+    title: 'Education Benefit',
+    pages: {
+      benefitSelection: {
+        title: 'Education benefit',
+        path: 'benefits/eligibility',
+        initialData: {},
+        uiSchema: {
+          benefit: {
+            'ui:widget': 'radio',
+            'ui:title': 'Which benefit are you currently using?',
+            'ui:options': {
+              labels: benefitsLabels,
+            },
+          },
+        },
+        schema: {
+          type: 'object',
+          properties: {
+            benefit,
+          },
+        },
+      },
+    },
+  },
+  militaryService: {
+    title: 'Military History',
+    pages: {
+      servicePeriods: {
+        path: 'military/service',
+        title: 'Service periods',
+        initialData: {},
+        uiSchema: {
+          'view:newService': {
+            'ui:title':
+              'Do you have any new periods of service to record since you last applied for education benefits?',
+            'ui:widget': 'yesNo',
+          },
+          toursOfDuty: _.merge(toursOfDuty.uiSchema, {
+            'ui:options': { expandUnder: 'view:newService' },
+          }),
+        },
+        schema: {
+          type: 'object',
+          properties: {
+            'view:newService': {
+              type: 'boolean',
+            },
+            toursOfDuty: fullSchema1995.properties.toursOfDuty,
+          },
+        },
+      },
+      militaryHistory: {
+        title: 'Military history',
+        path: 'military/history',
+        initialData: {},
+        uiSchema: {
+          'view:hasServiceBefore1978': {
+            'ui:title':
+              'Do you have any periods of service that began before 1978?',
+            'ui:widget': 'yesNo',
+          },
+        },
+        schema: {
+          type: 'object',
+          properties: {
+            'view:hasServiceBefore1978': {
+              type: 'boolean',
+            },
+          },
+        },
+      },
+    },
+  },
+  schoolSelection: {
+    title: 'School Selection',
+    pages: {
+      newSchool: {
+        path: 'school-selection/new-school',
+        title:
+          'School, university, program, or training facility you want to attend',
+        initialData: {
+          newSchoolAddress: {},
+        },
+        uiSchema: {
+          'ui:title':
+            'School, university, program, or training facility you want to attend',
+          // Broken up because we need to fit educationType between name and address
+          // Put back together again in transform()
+          newSchoolName: {
+            'ui:title': 'Name of school, university, or training facility',
+          },
+          educationType: educationTypeUISchema,
+          newSchoolAddress: _.merge(address.uiSchema(), {
+            'ui:options': {
+              hideIf: formData => !showSchoolAddress(formData.educationType),
+            },
+          }),
+          educationObjective: {
+            'ui:title':
+              'Education or career goal (for example, “Get a bachelor’s degree in criminal justice” or “Get an HVAC technician certificate” or “Become a police officer.”)',
+            'ui:widget': 'textarea',
+          },
+          nonVaAssistance: {
+            'ui:title':
+              'Are you getting, or do you expect to get any money (including, but not limited to, federal tuition assistance) from the Armed Forces or public health services for any part of your coursework or training?',
+            'ui:widget': 'yesNo',
+          },
+          civilianBenefitsAssistance: {
+            'ui:title':
+              'Are you getting benefits from the U.S. Government as a civilian employee during the same time as you’re seeking benefits from VA?',
+            'ui:widget': 'yesNo',
+          },
+        },
+        schema: {
+          type: 'object',
+          required: ['educationType', 'newSchoolName'],
+          properties: {
+            newSchoolName: {
+              type: 'string',
+            },
+            educationType,
+            newSchoolAddress: address.schema(fullSchema1995),
+            educationObjective,
+            nonVaAssistance,
+            civilianBenefitsAssistance,
+          },
+        },
+      },
+      oldSchool: createOldSchoolPage(fullSchema1995),
+    },
+  },
+  personalInformation: {
+    title: 'Personal Information',
+    pages: {
+      contactInformation: createContactInformationPage(fullSchema1995),
+      dependents: {
+        title: 'Dependents',
+        path: 'personal-information/dependents',
+        initialData: {},
+        depends: {
+          'view:hasServiceBefore1978': true,
+        },
+        uiSchema: {
+          serviceBefore1977: serviceBefore1977UI,
+        },
+        schema: {
+          type: 'object',
+          properties: {
+            serviceBefore1977,
+          },
+        },
+      },
+      directDeposit: createDirectDepositChangePage(fullSchema1995),
+    },
+  },
+};

--- a/src/applications/edu-benefits/1995/config/original-chapters.js
+++ b/src/applications/edu-benefits/1995/config/original-chapters.js
@@ -1,0 +1,200 @@
+import _ from 'lodash/fp';
+
+import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
+
+import * as address from '../../../../platform/forms/definitions/address';
+
+import educationTypeUISchema from '../../definitions/educationType';
+import serviceBefore1977UI from '../../definitions/serviceBefore1977';
+import * as toursOfDuty from '../../definitions/toursOfDuty.jsx';
+
+import createContactInformationPage from '../../pages/contactInformation';
+import createOldSchoolPage from '../../pages/oldSchool';
+import createDirectDepositChangePage from '../../pages/directDepositChange';
+import createApplicantInformationPage from '../../../../platform/forms/pages/applicantInformation';
+
+import { showSchoolAddress } from '../../utils/helpers';
+import { benefitsLabels } from '../../utils/labels';
+
+const {
+  benefit,
+  civilianBenefitsAssistance,
+  educationObjective,
+  nonVaAssistance,
+} = fullSchema1995.properties;
+
+const { educationType, serviceBefore1977 } = fullSchema1995.definitions;
+
+export const originalChapters = {
+  applicantInformation: {
+    title: 'Applicant Information',
+    pages: {
+      applicantInformation: createApplicantInformationPage(fullSchema1995, {
+        isVeteran: true,
+        fields: [
+          'veteranFullName',
+          'veteranSocialSecurityNumber',
+          'view:noSSN',
+          'vaFileNumber',
+        ],
+        required: ['veteranFullName'],
+      }),
+    },
+  },
+  benefitSelection: {
+    title: 'Education Benefit',
+    pages: {
+      benefitSelection: {
+        title: 'Education benefit',
+        path: 'benefits/eligibility',
+        initialData: {},
+        uiSchema: {
+          benefit: {
+            'ui:widget': 'radio',
+            'ui:title': 'Which benefit are you currently using?',
+            'ui:options': {
+              labels: benefitsLabels,
+            },
+          },
+        },
+        schema: {
+          type: 'object',
+          properties: {
+            benefit,
+          },
+        },
+      },
+    },
+  },
+  militaryService: {
+    title: 'Military History',
+    pages: {
+      servicePeriods: {
+        path: 'military/service',
+        title: 'Service periods',
+        initialData: {},
+        uiSchema: {
+          'view:newService': {
+            'ui:title':
+              'Do you have any new periods of service to record since you last applied for education benefits?',
+            'ui:widget': 'yesNo',
+          },
+          toursOfDuty: _.merge(toursOfDuty.uiSchema, {
+            'ui:options': { expandUnder: 'view:newService' },
+          }),
+        },
+        schema: {
+          type: 'object',
+          properties: {
+            'view:newService': {
+              type: 'boolean',
+            },
+            toursOfDuty: fullSchema1995.properties.toursOfDuty,
+          },
+        },
+      },
+      militaryHistory: {
+        title: 'Military history',
+        path: 'military/history',
+        initialData: {},
+        uiSchema: {
+          'view:hasServiceBefore1978': {
+            'ui:title':
+              'Do you have any periods of service that began before 1978?',
+            'ui:widget': 'yesNo',
+          },
+        },
+        schema: {
+          type: 'object',
+          properties: {
+            'view:hasServiceBefore1978': {
+              type: 'boolean',
+            },
+          },
+        },
+      },
+    },
+  },
+  schoolSelection: {
+    title: 'School Selection',
+    pages: {
+      newSchool: {
+        path: 'school-selection/new-school',
+        title:
+          'School, university, program, or training facility you want to attend',
+        initialData: {
+          newSchoolAddress: {},
+        },
+        uiSchema: {
+          'ui:title':
+            'School, university, program, or training facility you want to attend',
+          // Broken up because we need to fit educationType between name and address
+          // Put back together again in transform()
+          newSchoolName: {
+            'ui:title': 'Name of school, university, or training facility',
+          },
+          educationType: educationTypeUISchema,
+          newSchoolAddress: _.merge(address.uiSchema(), {
+            'ui:options': {
+              hideIf: formData => !showSchoolAddress(formData.educationType),
+            },
+          }),
+          educationObjective: {
+            'ui:title':
+              'Education or career goal (for example, “Get a bachelor’s degree in criminal justice” or “Get an HVAC technician certificate” or “Become a police officer.”)',
+            'ui:widget': 'textarea',
+          },
+          nonVaAssistance: {
+            'ui:title':
+              'Are you getting, or do you expect to get any money (including, but not limited to, federal tuition assistance) from the Armed Forces or public health services for any part of your coursework or training?',
+            'ui:widget': 'yesNo',
+          },
+          civilianBenefitsAssistance: {
+            'ui:title':
+              'Are you getting benefits from the U.S. Government as a civilian employee during the same time as you’re seeking benefits from VA?',
+            'ui:widget': 'yesNo',
+          },
+        },
+        schema: {
+          type: 'object',
+          required: ['educationType', 'newSchoolName'],
+          properties: {
+            newSchoolName: {
+              type: 'string',
+            },
+            educationType,
+            newSchoolAddress: address.schema(fullSchema1995),
+            educationObjective,
+            nonVaAssistance,
+            civilianBenefitsAssistance,
+          },
+        },
+      },
+      oldSchool: createOldSchoolPage(fullSchema1995),
+    },
+  },
+  personalInformation: {
+    title: 'Personal Information',
+    pages: {
+      contactInformation: createContactInformationPage(fullSchema1995),
+      dependents: {
+        title: 'Dependents',
+        path: 'personal-information/dependents',
+        initialData: {},
+        depends: {
+          'view:hasServiceBefore1978': true,
+        },
+        uiSchema: {
+          serviceBefore1977: serviceBefore1977UI,
+        },
+        schema: {
+          type: 'object',
+          properties: {
+            serviceBefore1977,
+          },
+        },
+      },
+      directDeposit: createDirectDepositChangePage(fullSchema1995),
+    },
+  },
+};


### PR DESCRIPTION
## Description

As a developer; I need to setup the 1995 form codebase to allow for multiple developers to work in the same section of code behind a production flag.

## Testing done
- local testing

## Screenshots


## Acceptance criteria
- [ ] The 1995 form is deployed to the following environments using environment specific configurations:
     - Staging
     - Production
- [ ] The 1995 form can be completed in its entirety in the following environments:
     - Staging
     - Production

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
