### PR TITLE
Disable tiff/tif uploads for 526

### DIFF
--- a/src/applications/claims-status/utils/validations.js
+++ b/src/applications/claims-status/utils/validations.js
@@ -1,14 +1,5 @@
 const MAX_FILE_SIZE = 25 * 1024 * 1024;
-export const FILE_TYPES = [
-  'pdf',
-  'gif',
-  'tiff',
-  'tif',
-  'jpeg',
-  'jpg',
-  'bmp',
-  'txt',
-];
+export const FILE_TYPES = ['pdf', 'gif', 'jpeg', 'jpg', 'bmp', 'txt'];
 
 export function isNotBlank(value) {
   return value !== '';

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -766,8 +766,6 @@ const formConfig = {
                       'png',
                       'gif',
                       'bmp',
-                      'tif',
-                      'tiff',
                       'txt',
                     ],
                     maxSize: FIFTY_MB,

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -592,17 +592,7 @@ export const ancillaryFormUploadUi = (
     hideLabelText: !label,
     fileUploadUrl: `${environment.API_URL}/v0/upload_supporting_evidence`,
     addAnotherLabel,
-    fileTypes: [
-      'pdf',
-      'jpg',
-      'jpeg',
-      'png',
-      'gif',
-      'bmp',
-      'tif',
-      'tiff',
-      'txt',
-    ],
+    fileTypes: ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'txt'],
     maxSize: TWENTY_FIVE_MB,
     createPayload: file => {
       const payload = new FormData();


### PR DESCRIPTION
## Description
Disables TIFF and TIF filetypes because VBMS only allows a certain bit depth for those filetypes and we are unable to scan for that requirement on the front-end

## Testing done


## Screenshots


## Acceptance criteria
- [x] Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18607

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
