### PR TITLE
Remove header footer data from settings.js

### DIFF
--- a/src/site/stages/build/plugins/create-build-settings.js
+++ b/src/site/stages/build/plugins/create-build-settings.js
@@ -31,11 +31,12 @@ function createBuildSettings(options) {
       if (!entryName) continue;
 
       const validTypes = ['string', 'boolean', 'number'];
+      const keysToSkip = new Set(['headerFooterData']);
       const frontmatter = {};
 
       for (const dataKey of Object.keys(file)) {
         const data = file[dataKey];
-        if (validTypes.includes(typeof data)) {
+        if (!keysToSkip.includes(dataKey) && validTypes.includes(typeof data)) {
           frontmatter[dataKey] = data;
         }
       }

--- a/src/site/stages/build/plugins/create-build-settings.js
+++ b/src/site/stages/build/plugins/create-build-settings.js
@@ -36,7 +36,7 @@ function createBuildSettings(options) {
 
       for (const dataKey of Object.keys(file)) {
         const data = file[dataKey];
-        if (!keysToSkip.includes(dataKey) && validTypes.includes(typeof data)) {
+        if (!keysToSkip.has(dataKey) && validTypes.includes(typeof data)) {
           frontmatter[dataKey] = data;
         }
       }


### PR DESCRIPTION
## Description
We serialize the header footer menu data in the metalsmith file object, which our create build settings code sees as a string and adds to the setting.js file. Which makes the file giant: https://www.va.gov/js/settings.js.

There's no need for this data to be in the settings.js file. Thanks @gunsch for spotting this.

## Testing done
Ran locally, checked that data was removed.


## Acceptance criteria
- [x] settings.js is no longer massive

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
