### PR TITLE
18572 - Add GA event-tracking to HCA Intro page.

### DIFF
--- a/src/applications/hca/containers/IntroductionPageGated.jsx
+++ b/src/applications/hca/containers/IntroductionPageGated.jsx
@@ -9,6 +9,7 @@ import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 
 import { focusElement } from 'platform/utilities/ui';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
+import recordEvent from 'platform/monitoring/record-event';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import environment from 'platform/utilities/environment';
 
@@ -21,6 +22,19 @@ import {
   isUserLOA3,
   shouldShowLoggedOutContent,
 } from '../selectors';
+
+const onVyiBtnClick = (clickEvent, gaEventName) => {
+  // Fires recordEvent, and navigates away after GA-image request completes.
+  const linkPathname = clickEvent.target.pathname;
+
+  clickEvent.preventDefault();
+  recordEvent({
+    event: gaEventName,
+    eventCallback: function vyiBtnHitCallback() {
+      location.href = linkPathname;
+    },
+  });
+};
 
 const VerificationRequiredAlert = () => (
   <AlertBox
@@ -65,7 +79,13 @@ const VerificationRequiredAlert = () => (
           </li>
         </ul>
         <p>
-          <a className="usa-button-primary va-button-primary" href="/verify">
+          <a
+            className="usa-button-primary va-button-primary"
+            href="/verify"
+            onClick={e => {
+              onVyiBtnClick(e, 'verify-link-clicked');
+            }}
+          >
             Verify your identity
           </a>
         </p>

--- a/src/applications/hca/containers/IntroductionPageGated.jsx
+++ b/src/applications/hca/containers/IntroductionPageGated.jsx
@@ -23,19 +23,6 @@ import {
   shouldShowLoggedOutContent,
 } from '../selectors';
 
-const onVyiBtnClick = (clickEvent, gaEventName) => {
-  // Fires recordEvent, and navigates away after GA-image request completes.
-  const linkPathname = clickEvent.target.pathname;
-
-  clickEvent.preventDefault();
-  recordEvent({
-    event: gaEventName,
-    eventCallback: function vyiBtnHitCallback() {
-      location.href = linkPathname;
-    },
-  });
-};
-
 const VerificationRequiredAlert = () => (
   <AlertBox
     content={
@@ -82,8 +69,8 @@ const VerificationRequiredAlert = () => (
           <a
             className="usa-button-primary va-button-primary"
             href="/verify"
-            onClick={e => {
-              onVyiBtnClick(e, 'verify-link-clicked');
+            onClick={() => {
+              recordEvent({ event: 'verify-link-clicked' });
             }}
           >
             Verify your identity


### PR DESCRIPTION
## Description
[18572](/department-of-veterans-affairs/vets.gov-team/issues/18572) - Add GA event-tracking to HCA Introduction page‘s “Verify Your Identity” button (in conditional LOA1-specific “Verify Your Identity” content-section).

## Testing done
Verified locally in browser dev tools -- Returning GA-image is received with request-parameters showing correct event-name (ea) “verifiy-link-clicked”.

## Screenshots


## Acceptance criteria
- [ ] Verified GA-event's returning GA-image is received -- turn on Dev Tools Network panel's Preserve log option before clicking Verify-Your-Identity button.
- [ ] \[GA Team, once this is on an environment GA tracks\] Verified GA-event is captured & reported on GA.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
