### PR TITLE
show HCA status on the dashboard

### DIFF
--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 
 import { HCA_ENROLLMENT_STATUSES } from './constants';
 import { getMedicalCenterNameByID } from './helpers';
+import { DASHBOARD_ALERT_TYPES } from 'applications/personalization/dashboard/components/DashboardAlert';
 
 // There are 9 possible warning headlines to show depending on enrollment status
 export function getWarningHeadline(enrollmentStatus) {
@@ -751,4 +752,394 @@ export function getFAQBlock4(enrollmentStatus) {
       break;
   }
   return content;
+}
+
+// used by YourApplications to build a DashboardAlert depending on the user's
+// health care enrollment status
+export function getAlertType(enrollmentStatus) {
+  let status;
+  switch (enrollmentStatus) {
+    case HCA_ENROLLMENT_STATUSES.enrolled:
+      status = DASHBOARD_ALERT_TYPES.enrolled;
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.activeDuty:
+    case HCA_ENROLLMENT_STATUSES.closed:
+      status = DASHBOARD_ALERT_TYPES.closed;
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.ineligCHAMPVA:
+    case HCA_ENROLLMENT_STATUSES.ineligCharacterOfDischarge:
+    case HCA_ENROLLMENT_STATUSES.ineligCitizens:
+    case HCA_ENROLLMENT_STATUSES.ineligFilipinoScouts:
+    case HCA_ENROLLMENT_STATUSES.ineligFugitiveFelon:
+    case HCA_ENROLLMENT_STATUSES.ineligGuardReserve:
+    case HCA_ENROLLMENT_STATUSES.ineligMedicare:
+    case HCA_ENROLLMENT_STATUSES.ineligNotEnoughTime:
+    case HCA_ENROLLMENT_STATUSES.ineligNotVerified:
+    case HCA_ENROLLMENT_STATUSES.ineligOther:
+    case HCA_ENROLLMENT_STATUSES.ineligOver65:
+    case HCA_ENROLLMENT_STATUSES.ineligRefusedCopay:
+    case HCA_ENROLLMENT_STATUSES.ineligTrainingOnly:
+    case HCA_ENROLLMENT_STATUSES.rejectedIncWrongEntry:
+    case HCA_ENROLLMENT_STATUSES.rejectedRightEntry:
+    case HCA_ENROLLMENT_STATUSES.rejectedScWrongEntry:
+      status = DASHBOARD_ALERT_TYPES.decision;
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.pendingMt:
+    case HCA_ENROLLMENT_STATUSES.pendingOther:
+    case HCA_ENROLLMENT_STATUSES.pendingPurpleHeart:
+    case HCA_ENROLLMENT_STATUSES.pendingUnverified:
+      status = DASHBOARD_ALERT_TYPES.update;
+      break;
+
+    default:
+      break;
+  }
+  return status;
+}
+
+// used by YourApplications to build a DashboardAlert depending on the user's
+// health care enrollment status
+export function getAlertStatusHeadline(enrollmentStatus) {
+  let statusHeadline;
+  switch (enrollmentStatus) {
+    case HCA_ENROLLMENT_STATUSES.enrolled:
+      statusHeadline = 'Enrolled';
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.activeDuty:
+    case HCA_ENROLLMENT_STATUSES.closed:
+      statusHeadline = 'Closed';
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.ineligCHAMPVA:
+    case HCA_ENROLLMENT_STATUSES.ineligCharacterOfDischarge:
+    case HCA_ENROLLMENT_STATUSES.ineligCitizens:
+    case HCA_ENROLLMENT_STATUSES.ineligFilipinoScouts:
+    case HCA_ENROLLMENT_STATUSES.ineligFugitiveFelon:
+    case HCA_ENROLLMENT_STATUSES.ineligGuardReserve:
+    case HCA_ENROLLMENT_STATUSES.ineligMedicare:
+    case HCA_ENROLLMENT_STATUSES.ineligNotEnoughTime:
+    case HCA_ENROLLMENT_STATUSES.ineligNotVerified:
+    case HCA_ENROLLMENT_STATUSES.ineligOther:
+    case HCA_ENROLLMENT_STATUSES.ineligOver65:
+    case HCA_ENROLLMENT_STATUSES.ineligRefusedCopay:
+    case HCA_ENROLLMENT_STATUSES.ineligTrainingOnly:
+    case HCA_ENROLLMENT_STATUSES.rejectedIncWrongEntry:
+    case HCA_ENROLLMENT_STATUSES.rejectedRightEntry:
+    case HCA_ENROLLMENT_STATUSES.rejectedScWrongEntry:
+      statusHeadline = 'Decision';
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.pendingMt:
+    case HCA_ENROLLMENT_STATUSES.pendingOther:
+    case HCA_ENROLLMENT_STATUSES.pendingPurpleHeart:
+    case HCA_ENROLLMENT_STATUSES.pendingUnverified:
+      statusHeadline = 'Update';
+      break;
+
+    default:
+      break;
+  }
+  return statusHeadline;
+}
+
+// used by YourApplications to build a DashboardAlert depending on the user's
+// health care enrollment status
+export function getAlertStatusInfo(enrollmentStatus) {
+  let statusInfo;
+  switch (enrollmentStatus) {
+    case HCA_ENROLLMENT_STATUSES.enrolled:
+      statusInfo = 'We’ve enrolled you in VA health care';
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.ineligCharacterOfDischarge:
+    case HCA_ENROLLMENT_STATUSES.ineligCitizens:
+    case HCA_ENROLLMENT_STATUSES.ineligFilipinoScouts:
+    case HCA_ENROLLMENT_STATUSES.ineligFugitiveFelon:
+    case HCA_ENROLLMENT_STATUSES.ineligGuardReserve:
+    case HCA_ENROLLMENT_STATUSES.ineligMedicare:
+    case HCA_ENROLLMENT_STATUSES.ineligNotEnoughTime:
+    case HCA_ENROLLMENT_STATUSES.ineligNotVerified:
+    case HCA_ENROLLMENT_STATUSES.ineligOther:
+    case HCA_ENROLLMENT_STATUSES.ineligOver65:
+    case HCA_ENROLLMENT_STATUSES.ineligRefusedCopay:
+    case HCA_ENROLLMENT_STATUSES.ineligTrainingOnly:
+      statusInfo = 'We determined that you don’t qualify for VA health care';
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.ineligCHAMPVA:
+    case HCA_ENROLLMENT_STATUSES.rejectedIncWrongEntry:
+    case HCA_ENROLLMENT_STATUSES.rejectedRightEntry:
+    case HCA_ENROLLMENT_STATUSES.rejectedScWrongEntry:
+      statusInfo =
+        'You didn’t qualify for VA health care based on your previous application';
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.activeDuty:
+      statusInfo =
+        'Our records show that you haven’t yet received your separation or retirement orders';
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.closed:
+      statusInfo =
+        'Our records show that your application for VA health care expired';
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.pendingOther:
+    case HCA_ENROLLMENT_STATUSES.pendingUnverified:
+      statusInfo = 'We’re reviewing your application';
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.pendingMt:
+    case HCA_ENROLLMENT_STATUSES.pendingPurpleHeart:
+      statusInfo =
+        'We need more information to complete our review of your VA health care application';
+      break;
+
+    default:
+      break;
+  }
+  return statusInfo;
+}
+
+// used by YourApplications to build a DashboardAlert depending on the user's
+// health care enrollment status
+export function getAlertContent(
+  enrollmentStatus,
+  applicationDate,
+  dismissNotification,
+) {
+  // this block will be used for almost every type of enrollmentstatus
+  const whatShouldIDo1 = (
+    <p>
+      If you have questions, please call our enrollment case management team at
+      1-877-222-VETS (1-877-222-8387). We’re here Monday through Friday, 8:00
+      a.m. to 8:00 p.m. ET.
+    </p>
+  );
+  // this block will also be used for character of discharge status
+  const whatShouldIDo2 = (
+    <>
+      <p>
+        <a href="/discharge-upgrade-instructions/">
+          Find out who may qualify for a discharge upgrade
+        </a>
+      </p>
+      <p>
+        <a href="/discharge-upgrade-instructions/#other-options">
+          Learn more about the Character of Discharge review process
+        </a>
+      </p>
+    </>
+  );
+
+  const blocks = [];
+  // start with the "You applied on" info regardless of the enrollmentstatus
+  blocks.push(
+    <p>
+      <strong>You applied on:</strong>{' '}
+      {moment(applicationDate).format('MMMM D, YYYY')}
+    </p>,
+  );
+
+  switch (enrollmentStatus) {
+    case HCA_ENROLLMENT_STATUSES.ineligTrainingOnly:
+      blocks.push(
+        <p>
+          Our records show that you were called to federal active duty for
+          training purposes only. This means your service doesn't meet our
+          minimum active duty service requirement of at least 24 continuous
+          months to qualify for VA health care.
+        </p>,
+        whatShouldIDo1,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.ineligNotVerified:
+      blocks.push(
+        <p>
+          We determined that you're not eligible for VA health care because we
+          didn't have proof of your military service (like your DD214 or other
+          separation papers).
+        </p>,
+        whatShouldIDo1,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.ineligCharacterOfDischarge:
+      blocks.push(
+        <p>
+          Our records show that don't have a high enough Character of Discharge
+          to qualify for VA health care.
+        </p>,
+        whatShouldIDo1,
+        whatShouldIDo2,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.ineligCitizens:
+      blocks.push(
+        <p>
+          Our records show that you didn't serve in the U.S. military or an
+          eligible foreign military. To qualify for VA health care, you must
+          meet this service requirement.
+        </p>,
+        whatShouldIDo1,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.rejectedIncWrongEntry:
+    case HCA_ENROLLMENT_STATUSES.rejectedScWrongEntry:
+      blocks.push(
+        <p>
+          Our records show that you don't have a service-connected disability,
+          an income that falls below our income limits based on where you live,
+          or another special eligibility factor (like receiving a Medal of Honor
+          or Purple Heart award). To qualify for VA health care, you need to
+          meet at least one of these eligibility requirements in addition to
+          serving at least 24 continuous months on active duty.
+        </p>,
+        whatShouldIDo1,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.ineligGuardReserve:
+      blocks.push(
+        <p>
+          Our records show that you served in the National Guard or Reserves,
+          and weren't activated to federal active duty for at least 24
+          continuous months. To qualify for VA health care without other special
+          eligibility factors, you must have served on active duty for at least
+          24 months all at once, without a break in service.
+        </p>,
+        whatShouldIDo1,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.ineligNotEnoughTime:
+      blocks.push(
+        <p>
+          Our records show that you served on active duty for less than 24
+          continuous months. To qualify for VA health care without other special
+          eligibility factors, you must have served on active duty for at least
+          24 months all at once, without a break in service.
+        </p>,
+        whatShouldIDo1,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.ineligCHAMPVA:
+      blocks.push(
+        <p>
+          Our records show that you're enrolled in CHAMPVA. We couldn't accept
+          your application because the VA medical center you applied to doesn't
+          offer services to CHAMPVA recipients.
+        </p>,
+        whatShouldIDo1,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.closed:
+      blocks.push(
+        <p>
+          We closed your application because you didn't submit all the documents
+          needed to complete it within a year.
+        </p>,
+        whatShouldIDo1,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.pendingMt:
+      blocks.push(
+        <p>
+          We need you to submit a financial disclosure so we can determine if
+          you're eligible for VA health care based on your income.
+        </p>,
+        whatShouldIDo1,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.pendingOther:
+      blocks.push(
+        <p>
+          We're in the process of verifying your military service. We'll contact
+          you by mail if we need you to submit supporting documents (like your
+          DD214 or other discharge papers or separation documents).
+        </p>,
+        whatShouldIDo1,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.pendingUnverified:
+      blocks.push(
+        <p>
+          We're in the process of verifying your military service. We'll contact
+          you by mail if we need you to submit supporting documents (like your
+          DD214 or other discharge papers or separation documents).
+        </p>,
+        whatShouldIDo1,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.activeDuty:
+      blocks.push(
+        <p>
+          You can't qualify for VA health care until you've received your
+          separation or retirement orders. We welcome you to apply again once
+          you've received your orders.
+        </p>,
+        <p>
+          <a href="/HEALTHBENEFITS/apply/active_duty.asp">
+            Learn more about transitioning to VA health care
+          </a>
+        </p>,
+        whatShouldIDo1,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.pendingPurpleHeart:
+      blocks.push(
+        <p>
+          You included on your application that you've received a Purple Heart
+          medal. We need an official document showing that you received this
+          award so we can confirm your eligibility for VA health care.
+        </p>,
+        <p>
+          <a href="/records/get-military-service-records/">
+            Find out how to request your military records
+          </a>
+        </p>,
+        whatShouldIDo1,
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.ineligMedicare:
+    case HCA_ENROLLMENT_STATUSES.ineligRefusedCopay:
+    case HCA_ENROLLMENT_STATUSES.ineligFugitiveFelon:
+    case HCA_ENROLLMENT_STATUSES.ineligOver65:
+    case HCA_ENROLLMENT_STATUSES.ineligOther:
+      blocks.push(whatShouldIDo1);
+      break;
+
+    default:
+      break;
+  }
+
+  // add the Remove this notification button regardless of the enrollmentstatus
+  blocks.push(
+    <button
+      className="va-button-link remove-notification-link"
+      aria-label={`Dismiss health care application status notification`}
+      onClick={dismissNotification}
+    >
+      <i className="fa fa-times" />
+      <span className="remove-notification-label">
+        Remove this notification
+      </span>
+    </button>,
+  );
+  return blocks;
 }

--- a/src/applications/personalization/dashboard/containers/DashboardAppNew.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardAppNew.jsx
@@ -16,7 +16,7 @@ import { isEnrolledInVAHealthCare } from 'applications/hca/selectors';
 
 import { recordDashboardClick } from '../helpers';
 
-import FormList from '../components/FormList';
+import YourApplications from '../containers/YourApplications';
 import ManageYourVAHealthCare from '../components/ManageYourVAHealthCare';
 import ClaimsAppealsWidget from './ClaimsAppealsWidget';
 import PreferencesWidget from 'applications/personalization/preferences/containers/PreferencesWidget';
@@ -285,7 +285,6 @@ class DashboardAppNew extends React.Component {
       canAccessMessaging,
       canAccessAppeals,
       profile,
-      removeSavedForm,
       showManageYourVAHealthCare,
     } = this.props;
     const availableWidgetsCount = [
@@ -307,11 +306,7 @@ class DashboardAppNew extends React.Component {
 
         <PreferencesWidget />
 
-        <FormList
-          userProfile={profile}
-          removeSavedForm={removeSavedForm}
-          savedForms={profile.savedForms}
-        />
+        <YourApplications />
 
         {!profile.verified && this.renderLOAPrompt()}
         {profile.loa.current !== 1 &&

--- a/src/applications/personalization/dashboard/containers/YourApplications.jsx
+++ b/src/applications/personalization/dashboard/containers/YourApplications.jsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { selectProfile } from 'platform/user/selectors';
+import {
+  getDismissedHCANotification,
+  getEnrollmentStatus,
+  setDismissedHCANotification,
+} from 'applications/hca/actions';
+import {
+  dismissedHCANotificationDate,
+  isEnrollmentStatusLoading,
+  isInESR,
+  isLoadingDismissedNotification,
+  selectEnrollmentStatus,
+} from 'applications/hca/selectors';
+import {
+  getAlertContent,
+  getAlertStatusHeadline,
+  getAlertStatusInfo,
+  getAlertType,
+} from 'applications/hca/enrollment-status-helpers';
+
+import DashboardAlert from '../components/DashboardAlert';
+import FormItem from '../components/FormItem';
+import { isSIPEnabledForm } from '../helpers';
+
+class YourApplications extends React.Component {
+  componentDidMount() {
+    this.props.getEnrollmentStatus();
+    this.props.getDismissedHCANotification();
+  }
+
+  dismissHCANotification() {
+    const {
+      enrollmentStatus,
+      enrollmentStatusEffectiveDate,
+    } = this.props.hcaEnrollmentStatus;
+    this.props.setDismissedHCANotification(
+      enrollmentStatus,
+      enrollmentStatusEffectiveDate,
+    );
+  }
+
+  renderHCAStatusAlert({ applicationDate, enrollmentStatus }) {
+    return (
+      <DashboardAlert
+        status={getAlertType(enrollmentStatus)}
+        headline="Application for health care"
+        subheadline="FORM 10-10EZ"
+        statusHeadline={getAlertStatusHeadline(enrollmentStatus)}
+        statusInfo={getAlertStatusInfo(enrollmentStatus)}
+        content={getAlertContent(enrollmentStatus, applicationDate, () => {
+          this.dismissHCANotification();
+        })}
+      />
+    );
+  }
+
+  render() {
+    const {
+      hcaEnrollmentStatus,
+      savedForms,
+      shouldRenderContent,
+      shouldRenderHCAAlert,
+    } = this.props;
+
+    if (!shouldRenderContent) return null;
+
+    return (
+      <div className="profile-section medium-12 columns">
+        <h2 className="section-header">Your applications</h2>
+        {savedForms.map(form => (
+          <FormItem key={form.form} savedFormData={form} />
+        ))}
+        {shouldRenderHCAAlert && this.renderHCAStatusAlert(hcaEnrollmentStatus)}
+      </div>
+    );
+  }
+}
+
+export const mapStateToProps = state => {
+  const hcaEnrollmentStatus = selectEnrollmentStatus(state);
+  const isLoading =
+    isEnrollmentStatusLoading(state) || isLoadingDismissedNotification(state);
+  const profileState = selectProfile(state);
+  const { savedForms } = profileState;
+  const verifiedSavedForms = savedForms.filter(isSIPEnabledForm);
+  const hasVerifiedSavedForms = !!verifiedSavedForms.length;
+  const hcaStatusEffectiveDate =
+    hcaEnrollmentStatus.enrollmentStatusEffectiveDate;
+  const dismissedNotificationDate = dismissedHCANotificationDate(state);
+  const shouldRenderHCAAlert =
+    isInESR(state) &&
+    (!dismissedNotificationDate ||
+      new Date(hcaStatusEffectiveDate) > new Date(dismissedNotificationDate));
+  const shouldRenderContent =
+    !isLoading && (hasVerifiedSavedForms || shouldRenderHCAAlert);
+
+  return {
+    hcaEnrollmentStatus,
+    savedForms: verifiedSavedForms,
+    shouldRenderContent,
+    shouldRenderHCAAlert,
+  };
+};
+
+const mapDispatchToProps = {
+  getDismissedHCANotification,
+  getEnrollmentStatus,
+  setDismissedHCANotification,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(YourApplications);
+
+export { YourApplications };

--- a/src/applications/personalization/dashboard/containers/YourApplications.jsx
+++ b/src/applications/personalization/dashboard/containers/YourApplications.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import { selectProfile } from 'platform/user/selectors';
 import {
@@ -103,6 +104,27 @@ export const mapStateToProps = state => {
     shouldRenderContent,
     shouldRenderHCAAlert,
   };
+};
+
+YourApplications.propTypes = {
+  getDismissedHCANotification: PropTypes.func.isRequired,
+  getEnrollmentStatus: PropTypes.func.isRequired,
+  setDismissedHCANotification: PropTypes.func.isRequired,
+  hcaEnrollmentStatus: PropTypes.shape({
+    enrollmentStatus: PropTypes.string,
+    applicationDate: PropTypes.string,
+  }),
+  savedForms: PropTypes.arrayOf(
+    PropTypes.shape({
+      form: PropTypes.string.required,
+      metadata: PropTypes.shape({
+        lastUpdated: PropTypes.string,
+        expiresAt: PropTypes.string,
+      }),
+    }),
+  ),
+  shouldRenderContent: PropTypes.bool.isRequired,
+  shouldRenderHCAAlert: PropTypes.bool,
 };
 
 const mapDispatchToProps = {

--- a/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
@@ -7,6 +7,7 @@ import {
   YourApplications,
   mapStateToProps,
 } from '../../containers/YourApplications';
+import { HCA_ENROLLMENT_STATUSES } from 'applications/hca/constants';
 
 const defaultProps = {
   getEnrollmentStatus: sinon.stub(),
@@ -15,8 +16,16 @@ const defaultProps = {
   savedForms: [],
 };
 
-const singleForm = {
+const sipEnabledForm = {
   form: '1010ez',
+  metadata: {
+    lastUpdated: '2019-04-24T00:00:00.000-06:00',
+    expiresAt: '2019-07-24T00:00:00.000-06:00',
+  },
+};
+
+const nonSIPEnabledForm = {
+  form: 'a-non-sip-enabled-form',
   metadata: {
     lastUpdated: '2019-04-24T00:00:00.000-06:00',
     expiresAt: '2019-07-24T00:00:00.000-06:00',
@@ -46,23 +55,228 @@ describe('mapStateToProps', () => {
       },
     };
   });
-  it('should set `shouldRenderContent` to false if there are saved forms but the HCA status is loading', () => {
-    state.user.profile.savedForms = [singleForm];
-    state.hcaEnrollmentStatus.isLoadingApplicationStatus = true;
-    const mappedProps = mapStateToProps(state);
-    expect(mappedProps.shouldRenderContent).to.be.false;
+
+  describe('`hcaEnrollmentStatus`', () => {
+    it('is pulled directly out of the state', () => {
+      let mappedProps = mapStateToProps(state);
+      expect(mappedProps.hcaEnrollmentStatus).to.deep.equal(
+        state.hcaEnrollmentStatus,
+      );
+      state.hcaEnrollmentStatus.isLoadingApplicationStatus = true;
+      mappedProps = mapStateToProps(state);
+      expect(mappedProps.hcaEnrollmentStatus).to.deep.equal(
+        state.hcaEnrollmentStatus,
+      );
+    });
   });
-  it('should set `shouldRenderContent` to false if there are saved forms but the dismissed notifications is loading', () => {
-    state.user.profile.savedForms = [singleForm];
-    state.hcaEnrollmentStatus.isLoadingDismissedNotification = true;
-    const mappedProps = mapStateToProps(state);
-    expect(mappedProps.shouldRenderContent).to.be.false;
+
+  describe('`savedForms`', () => {
+    it('is the filtered version of `profile.savedForms`', () => {
+      let mappedProps = mapStateToProps(state);
+      expect(mappedProps.savedForms).to.deep.equal([]);
+      state.user.profile.savedForms = [nonSIPEnabledForm];
+      mappedProps = mapStateToProps(state);
+      expect(mappedProps.savedForms).to.deep.equal([]);
+      state.user.profile.savedForms = [sipEnabledForm];
+      mappedProps = mapStateToProps(state);
+      expect(mappedProps.savedForms).to.deep.equal([sipEnabledForm]);
+      state.user.profile.savedForms = [nonSIPEnabledForm, sipEnabledForm];
+      mappedProps = mapStateToProps(state);
+      expect(mappedProps.savedForms).to.deep.equal([sipEnabledForm]);
+    });
   });
-  it('should set `shouldRenderContent` to false if there are saved forms but the dismissed notifications is loading', () => {
-    state.user.profile.savedForms = [singleForm];
-    state.hcaEnrollmentStatus.isLoadingDismissedNotification = true;
-    const mappedProps = mapStateToProps(state);
-    expect(mappedProps.shouldRenderContent).to.be.false;
+
+  // The value of `shouldRenderHCAAlert` is based on a lot of different factors,
+  // so these unit tests cover a lot of the possible scenarios
+  describe('`shouldRenderHCAAlert`', () => {
+    beforeEach(() => {
+      state = {
+        user: {
+          profile: {
+            savedForms: [sipEnabledForm],
+          },
+        },
+        hcaEnrollmentStatus: {
+          isLoadingApplicationStatus: false,
+          isLoadingDismissedNotification: false,
+          dismissedNotificationDate: null,
+          enrollmentStatusEffectiveDate: null,
+          enrollmentStatus: null,
+        },
+      };
+    });
+    it('should be false if the user is not in ESR', () => {
+      let mappedProps = mapStateToProps(state);
+      expect(mappedProps.shouldRenderHCAAlert).to.be.false;
+      state.hcaEnrollmentStatus.enrollmentStatus =
+        HCA_ENROLLMENT_STATUSES.noneOfTheAbove;
+      mappedProps = mapStateToProps(state);
+      expect(mappedProps.shouldRenderHCAAlert).to.be.false;
+    });
+    it('should be false if the HCA status is canceled/declined', () => {
+      state.hcaEnrollmentStatus.enrollmentStatus =
+        HCA_ENROLLMENT_STATUSES.canceledDeclined;
+      const mappedProps = mapStateToProps(state);
+      expect(mappedProps.shouldRenderHCAAlert).to.be.false;
+    });
+    it('should be false if the HCA status is deceased', () => {
+      state.hcaEnrollmentStatus.enrollmentStatus =
+        HCA_ENROLLMENT_STATUSES.deceased;
+      const mappedProps = mapStateToProps(state);
+      expect(mappedProps.shouldRenderHCAAlert).to.be.false;
+    });
+    describe('when the HCA status is `enrolled`', () => {
+      beforeEach(() => {
+        state.hcaEnrollmentStatus.enrollmentStatus =
+          HCA_ENROLLMENT_STATUSES.enrolled;
+        state.hcaEnrollmentStatus.enrollmentStatusEffectiveDate =
+          '2019-05-01T00:00:00.000-06:00';
+      });
+      it('should be true if there is not `dismissedNotificationDate`', () => {
+        const mappedProps = mapStateToProps(state);
+        expect(mappedProps.shouldRenderHCAAlert).to.be.true;
+      });
+      it('should be true if the `dismissedNotificationDate` is before the `enrollmentStatusEffectiveDate`', () => {
+        state.hcaEnrollmentStatus.enrollmentStatusEffectiveDate =
+          '2019-04-01T00:00:00.000-06:00';
+        const mappedProps = mapStateToProps(state);
+        expect(mappedProps.shouldRenderHCAAlert).to.be.true;
+      });
+      it('should be false if the `dismissedNotificationDate` is equal to or after the `enrollmentStatusEffectiveDate`', () => {
+        state.hcaEnrollmentStatus.dismissedNotificationDate =
+          '2019-05-01T00:00:00.000-06:00';
+        let mappedProps = mapStateToProps(state);
+        expect(mappedProps.shouldRenderHCAAlert).to.be.false;
+        state.hcaEnrollmentStatus.dismissedNotificationDate =
+          '2019-06-01T00:00:00.000-06:00';
+        mappedProps = mapStateToProps(state);
+        expect(mappedProps.shouldRenderHCAAlert).to.be.false;
+      });
+    });
+  });
+
+  // The value of `shouldRenderContent` is based on a lot of different factors,
+  // so these unit tests cover a lot of the possible scenarios
+  describe('`shouldRenderContent`', () => {
+    describe('when there are no saved forms and no HCA status', () => {
+      beforeEach(() => {
+        state = {
+          user: {
+            profile: {
+              savedForms: [],
+            },
+          },
+          hcaEnrollmentStatus: {
+            isLoadingApplicationStatus: false,
+            isLoadingDismissedNotification: false,
+            dismissedNotificationDate: null,
+            enrollmentStatusEffectiveDate: null,
+            enrollmentStatus: null,
+          },
+        };
+      });
+      it('should be false if the dismissed notifications and HCA status are loading', () => {
+        state.hcaEnrollmentStatus.isLoadingDismissedNotification = true;
+        state.hcaEnrollmentStatus.isLoadingApplicationStatus = true;
+        const mappedProps = mapStateToProps(state);
+        expect(mappedProps.shouldRenderContent).to.be.false;
+      });
+      it('should be false if the HCA status is loading', () => {
+        state.hcaEnrollmentStatus.isLoadingApplicationStatus = true;
+        const mappedProps = mapStateToProps(state);
+        expect(mappedProps.shouldRenderContent).to.be.false;
+      });
+      it('should be false if the dismissed notifications is loading', () => {
+        state.hcaEnrollmentStatus.isLoadingDismissedNotification = true;
+        const mappedProps = mapStateToProps(state);
+        expect(mappedProps.shouldRenderContent).to.be.false;
+      });
+      it('should be false if the dismissed notifications and HCA status have loaded', () => {
+        const mappedProps = mapStateToProps(state);
+        expect(mappedProps.shouldRenderContent).to.be.false;
+      });
+    });
+
+    describe('when there is a saved form but no HCA status', () => {
+      beforeEach(() => {
+        state = {
+          user: {
+            profile: {
+              savedForms: [sipEnabledForm],
+            },
+          },
+          hcaEnrollmentStatus: {
+            isLoadingApplicationStatus: false,
+            isLoadingDismissedNotification: false,
+            dismissedNotificationDate: null,
+            enrollmentStatusEffectiveDate: null,
+            enrollmentStatus: null,
+          },
+        };
+      });
+      it('should be true if the dismissed notifications and HCA status have loaded', () => {
+        const mappedProps = mapStateToProps(state);
+        expect(mappedProps.shouldRenderContent).to.be.true;
+      });
+      it('should be false if the dismissed notifications and HCA status are loading', () => {
+        state.hcaEnrollmentStatus.isLoadingDismissedNotification = true;
+        state.hcaEnrollmentStatus.isLoadingApplicationStatus = true;
+        const mappedProps = mapStateToProps(state);
+        expect(mappedProps.shouldRenderContent).to.be.false;
+      });
+      it('should be false if the HCA status is loading', () => {
+        state.hcaEnrollmentStatus.isLoadingApplicationStatus = true;
+        const mappedProps = mapStateToProps(state);
+        expect(mappedProps.shouldRenderContent).to.be.false;
+      });
+      it('should be false if the dismissed notifications is loading', () => {
+        state.hcaEnrollmentStatus.isLoadingDismissedNotification = true;
+        const mappedProps = mapStateToProps(state);
+        expect(mappedProps.shouldRenderContent).to.be.false;
+      });
+      it('should be false if the dismissed notifications and HCA status have loaded but the saved form in not SIP-enabled', () => {
+        state.user.profile.savedForms = [nonSIPEnabledForm];
+        const mappedProps = mapStateToProps(state);
+        expect(mappedProps.shouldRenderContent).to.be.false;
+      });
+    });
+
+    describe('when there are no saved forms but there is an HCA status', () => {
+      describe('when the dismissed notifications and HCA status have loaded', () => {
+        beforeEach(() => {
+          state = {
+            user: {
+              profile: {
+                savedForms: [],
+              },
+            },
+            hcaEnrollmentStatus: {
+              isLoadingApplicationStatus: false,
+              isLoadingDismissedNotification: false,
+              dismissedNotificationDate: null,
+              enrollmentStatusEffectiveDate: '2019-05-01T00:00:00.000-06:00',
+              enrollmentStatus: HCA_ENROLLMENT_STATUSES.enrolled,
+            },
+          };
+        });
+        it('should be true if the dismissedNotificationDate is not set', () => {
+          const mappedProps = mapStateToProps(state);
+          expect(mappedProps.shouldRenderContent).to.be.true;
+        });
+        it('should be true if the dismissedNotificationDate is before the enrollmentStatusEffectiveDate', () => {
+          state.hcaEnrollmentStatus.dismissedNotificationDate =
+            '2019-04-01T00:00:00.000-06:00';
+          const mappedProps = mapStateToProps(state);
+          expect(mappedProps.shouldRenderContent).to.be.true;
+        });
+        it('should be false if the dismissedNotificationDate is equal to the enrollmentStatusEffectiveDate', () => {
+          state.hcaEnrollmentStatus.dismissedNotificationDate =
+            '2019-05-01T00:00:00.000-06:00';
+          const mappedProps = mapStateToProps(state);
+          expect(mappedProps.shouldRenderContent).to.be.false;
+        });
+      });
+    });
   });
 });
 
@@ -91,14 +305,14 @@ describe('<YourApplications>', () => {
       <YourApplications
         {...defaultProps}
         shouldRenderContent
-        savedForms={[singleForm]}
+        savedForms={[sipEnabledForm]}
       />,
     );
 
     const formItem = tree.find('FormItem');
     expect(formItem.length).to.equal(1);
-    expect(formItem.key()).to.equal(singleForm.form);
-    expect(formItem.prop('savedFormData')).to.deep.equal(singleForm);
+    expect(formItem.key()).to.equal(sipEnabledForm.form);
+    expect(formItem.prop('savedFormData')).to.deep.equal(sipEnabledForm);
     tree.unmount();
   });
 

--- a/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import {
+  YourApplications,
+  mapStateToProps,
+} from '../../containers/YourApplications';
+
+const defaultProps = {
+  getEnrollmentStatus: sinon.stub(),
+  getDismissedHCANotification: sinon.stub(),
+  setDismissedHCANotification: sinon.stub(),
+  savedForms: [],
+};
+
+const singleForm = {
+  form: '1010ez',
+  metadata: {
+    lastUpdated: '2019-04-24T00:00:00.000-06:00',
+    expiresAt: '2019-07-24T00:00:00.000-06:00',
+  },
+};
+
+const enrollmentStatus = {
+  enrollmentStatus: 'enrolled',
+  applicationDate: '2019-04-24T00:00:00.000-06:00',
+};
+
+describe('mapStateToProps', () => {
+  let state;
+  beforeEach(() => {
+    state = {
+      user: {
+        profile: {
+          savedForms: [],
+        },
+      },
+      hcaEnrollmentStatus: {
+        isLoadingApplicationStatus: false,
+        isLoadingDismissedNotification: false,
+        dismissedNotificationDate: null,
+        enrollmentStatusEffectiveDate: null,
+        enrollmentStatus: null,
+      },
+    };
+  });
+  it('should set `shouldRenderContent` to false if there are saved forms but the HCA status is loading', () => {
+    state.user.profile.savedForms = [singleForm];
+    state.hcaEnrollmentStatus.isLoadingApplicationStatus = true;
+    const mappedProps = mapStateToProps(state);
+    expect(mappedProps.shouldRenderContent).to.be.false;
+  });
+  it('should set `shouldRenderContent` to false if there are saved forms but the dismissed notifications is loading', () => {
+    state.user.profile.savedForms = [singleForm];
+    state.hcaEnrollmentStatus.isLoadingDismissedNotification = true;
+    const mappedProps = mapStateToProps(state);
+    expect(mappedProps.shouldRenderContent).to.be.false;
+  });
+  it('should set `shouldRenderContent` to false if there are saved forms but the dismissed notifications is loading', () => {
+    state.user.profile.savedForms = [singleForm];
+    state.hcaEnrollmentStatus.isLoadingDismissedNotification = true;
+    const mappedProps = mapStateToProps(state);
+    expect(mappedProps.shouldRenderContent).to.be.false;
+  });
+});
+
+describe('<YourApplications>', () => {
+  it('should not render if `shouldRenderContent` is false', () => {
+    const tree = shallow(
+      <YourApplications {...defaultProps} shouldRenderContent={false} />,
+    );
+
+    expect(tree.html()).to.be.null;
+    tree.unmount();
+  });
+
+  it('should render its default content if `shouldRenderContent` is true', () => {
+    const tree = shallow(
+      <YourApplications {...defaultProps} shouldRenderContent />,
+    );
+
+    expect(tree.find('div.profile-section').length).to.equal(1);
+    expect(tree.find('h2.section-header').text()).to.equal('Your applications');
+    tree.unmount();
+  });
+
+  it('should render a FormItem if passed a saved form', () => {
+    const tree = shallow(
+      <YourApplications
+        {...defaultProps}
+        shouldRenderContent
+        savedForms={[singleForm]}
+      />,
+    );
+
+    const formItem = tree.find('FormItem');
+    expect(formItem.length).to.equal(1);
+    expect(formItem.key()).to.equal(singleForm.form);
+    expect(formItem.prop('savedFormData')).to.deep.equal(singleForm);
+    tree.unmount();
+  });
+
+  it('should render a DashboardAlert', () => {
+    const tree = shallow(
+      <YourApplications
+        {...defaultProps}
+        shouldRenderContent
+        shouldRenderHCAAlert
+        hcaEnrollmentStatus={enrollmentStatus}
+      />,
+    );
+    const alert = tree.find('DashboardAlert');
+    expect(alert.length).to.equal(1);
+    expect(alert.prop('headline')).to.equal('Application for health care');
+    tree.unmount();
+  });
+});


### PR DESCRIPTION
TO DO:
- [x] add additional unit tests

## Description
This work updates the Dashboard, replacing the old `FormList` component with a new `YourApplications` component that is responsible for showing:
- in progress forms (which was the sole role of the `FormList` component
- the vet's HCA status if they have applied

## Testing done
- local
- additional unit tests are coming

## Screenshots
**section not shown when there are no SIP forms and not HCA status**
<img width="520" alt="hidden" src="https://user-images.githubusercontent.com/20728956/58109669-ea758700-7ba2-11e9-8d22-7a2f755b9178.png">

**section with SIP form**
<img width="684" alt="sip form" src="https://user-images.githubusercontent.com/20728956/58109599-cade5e80-7ba2-11e9-92d0-d05c0efb1ae8.png">

**section with HCA status**
<img width="962" alt="HCA status" src="https://user-images.githubusercontent.com/20728956/58109613-cdd94f00-7ba2-11e9-9913-b062f5c182be.png">

**section with both SIP form and HCA status**
<img width="531" alt="sip form and HCA status" src="https://user-images.githubusercontent.com/20728956/58109621-d0d43f80-7ba2-11e9-872a-db54de0dcd74.png">

## Acceptance criteria
- [ ] The entire Your Applications section should be hidden if there are no in progress forms or the user is not in ESR
- [ ] The section should show a `DashboardAlert` for any forms that have been saved in progress
- [ ] The section should show a `DashboardAlert` displaying the vet's status in the HCA application 
process
- [ ] The section should _not_ show a `DashboardAlert` displaying the vet's status in the HCA application process if the vet has dismissed the alert for that particular status update


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs