### PR TITLE
Pull in Formation IE11 fixes

### DIFF
--- a/src/applications/discharge-wizard/discharge-wizard-entry.jsx
+++ b/src/applications/discharge-wizard/discharge-wizard-entry.jsx
@@ -1,6 +1,5 @@
 import '../../platform/polyfills';
 import './sass/discharge-wizard.scss';
-import '@department-of-veterans-affairs/formation/js/sidenav';
 
 import startApp from '../../platform/startup';
 

--- a/src/applications/post-911-gib-status/post-911-gib-status-entry.jsx
+++ b/src/applications/post-911-gib-status/post-911-gib-status-entry.jsx
@@ -1,6 +1,5 @@
 import '../../platform/polyfills';
 import './sass/post-911-gib-status.scss';
-import '@department-of-veterans-affairs/formation/js/sidenav';
 
 import startApp from '../../platform/startup';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,12 +696,13 @@
     react-transition-group "1"
 
 "@department-of-veterans-affairs/formation@^6.3.4":
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.3.5.tgz#425196bc95dcb85397877316aa30654a65af0225"
-  integrity sha512-fhj/DD3+aan/WpoTkKXEFEyzBd+R4OmhlbXdU418nc8OlYKJjd2lfsJAKoItvfxCDQR35WdrpLFjBHVzCSnLuw==
+  version "6.3.6"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.3.6.tgz#10e1ce3eea3085b91d5a056d63c5a0ad5516934a"
+  integrity sha512-5/mPeac/msuU8wpTNd8K5iAhuDK2B+QahrSgyYOVaLJEPI5ZgFR3HLe4SDpv9J6yjN2LV94tpoBFO5GGVA3JFw==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"
+    element-closest "^3.0.1"
     foundation-sites "5"
 
 "@department-of-veterans-affairs/react-jsonschema-form@^1.0.0":
@@ -3458,6 +3459,11 @@ elem-dataset@^1.1.1:
 element-closest@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/element-closest/-/element-closest-2.0.2.tgz#72a740a107453382e28df9ce5dbb5a8df0f966ec"
+
+element-closest@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/element-closest/-/element-closest-3.0.1.tgz#0b2000266ae43a800274401dc39486f5e4bfbce2"
+  integrity sha512-Wm8B0in+k6GsSCra8vLVnFIjIrff2T1s2b++jU6VL6mqIteP19THxDXwT5JDrmJPlqT3YifOK9cu28+uRGUdew==
 
 elliptic@^6.0.0:
   version "6.4.0"


### PR DESCRIPTION
## Description
The plain Formation js did not work at all in IE11 for a couple reasons. This brings in the fixes for that.

## Testing done
Tested in IE11 with Browserstack

## Acceptance criteria
- [x] Accordions, main menu, and sidebar all work cross browser

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
