### PR TITLE
fix bug in `isFormAuthorizable` helper

### DIFF
--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -28,6 +28,7 @@ import feedbackConfig from 'applications/edu-benefits/feedback-tool/config/form.
 import burialsConfig from 'applications/burials/config/form.js';
 import edu1990Config from 'applications/edu-benefits/1990/config/form.js';
 import edu1995Config from 'applications/edu-benefits/1995/config/form.js';
+import edu1995StemConfig from 'applications/edu-benefits/1995-STEM/config/form.js';
 import edu1990eConfig from 'applications/edu-benefits/1990e/config/form.js';
 import edu1990nConfig from 'applications/edu-benefits/1990n/config/form.js';
 import edu5490Config from 'applications/edu-benefits/5490/config/form.js';
@@ -51,6 +52,7 @@ export const formConfigs = {
   '22-1990E': edu1990eConfig,
   '22-1990N': edu1990nConfig,
   '22-1995': edu1995Config,
+  '22-1995-STEM': edu1995StemConfig,
   '22-5490': edu5490Config,
   '22-5495': edu5495Config,
   '40-10007': preneedConfig,

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -176,7 +176,8 @@ export function isSIPEnabledForm(savedForm) {
   return true;
 }
 
-export const isFormAuthorizable = formConfig => !!formConfig.authorize;
+export const isFormAuthorizable = formConfig =>
+  !!formConfig && !!formConfig.authorize;
 
 export const getFormAuthorizationState = (formConfig, state) =>
   formConfig.getAuthorizationState(state);

--- a/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import {
   formTitles,
   formLinks,
+  isFormAuthorizable,
   isSIPEnabledForm,
   sipEnabledForms,
 } from '../helpers';
@@ -74,6 +75,23 @@ describe('profile helpers:', () => {
       });
     });
   });
+  describe('isFormAuthorizable', () => {
+    it('should return `true` if `authorize` is defined on the passed-in form config', () => {
+      const formConfig = {
+        authorize: () => {},
+      };
+      expect(isFormAuthorizable(formConfig)).to.be.true;
+    });
+    it('should return `false` if `authorize` is not defined on the passed-in form config', () => {
+      const formConfig = {};
+      expect(isFormAuthorizable(formConfig)).to.be.false;
+    });
+    it('should return `false` if it is passed in an undefined form config', () => {
+      let formConfig;
+      expect(isFormAuthorizable(formConfig)).to.be.false;
+    });
+  });
+
   describe('sipEnabledForms', () => {
     it('should include all and only SIP enabled forms', () => {
       const configs = [


### PR DESCRIPTION
## Description


## Testing done
Added unit tests. Actually did this the TDD way, writing a test that failed, which essentially recreated the issue. Then adjusted how the helper worked so the test passed.

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs