### PR TITLE
Update form IDs that appear on new Dashboard `FormItem` instances

### DIFF
--- a/src/applications/personalization/dashboard/components/FormItem.jsx
+++ b/src/applications/personalization/dashboard/components/FormItem.jsx
@@ -8,6 +8,7 @@ import {
   formLinks,
   formConfigs,
   isFormAuthorizable,
+  presentableFormIDs,
 } from '../helpers';
 import AuthorizationComponent from 'platform/forms/components/AuthorizationComponent';
 import DashboardAlert, {
@@ -39,6 +40,7 @@ class FormItem extends React.Component {
     const isExpired = moment.unix(expirationTime).isBefore();
     const itemTitle = `Application for ${formTitles[formId]}`;
     const isAuthorizable = isFormAuthorizable(formConfig);
+    const formIdTitle = presentableFormIDs[formId];
 
     let activeView;
     let expiredView;
@@ -119,7 +121,7 @@ class FormItem extends React.Component {
         <DashboardAlert
           status={DASHBOARD_ALERT_TYPES.inProgress}
           headline={itemTitle}
-          subheadline={formId}
+          subheadline={formIdTitle}
           statusHeadline="In progress"
         >
           <p>

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -162,6 +162,23 @@ export const sipEnabledForms = new Set([
   'FEEDBACK-TOOL',
 ]);
 
+// A dict of presentable form IDs. Generally this is just the form ID itself
+// prefixed with `FORM` for display purposes (ex: 'FORM 21-526EZ'). The only
+// exceptions to this rule right now are the FEEDBACK-TOOL and VIC.
+export const presentableFormIDs = Object.keys(formBenefits).reduce(
+  (prefixedIDs, formID) => {
+    if (formID === 'FEEDBACK-TOOL' || formID === 'complaint-tool') {
+      prefixedIDs[formID] = 'FEEDBACK TOOL'; // eslint-disable-line no-param-reassign
+    } else if (formID === 'VIC') {
+      prefixedIDs[formID] = 'VETERAN ID CARD'; // eslint-disable-line no-param-reassign
+    } else {
+      prefixedIDs[formID] = `FORM ${formID}`; // eslint-disable-line no-param-reassign
+    }
+    return prefixedIDs;
+  },
+  {},
+);
+
 export function isSIPEnabledForm(savedForm) {
   const formNumber = savedForm.form;
   if (!formTitles[formNumber] || !formLinks[formNumber]) {

--- a/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
@@ -5,6 +5,7 @@ import {
   formLinks,
   isFormAuthorizable,
   isSIPEnabledForm,
+  presentableFormIDs,
   sipEnabledForms,
 } from '../helpers';
 
@@ -66,6 +67,22 @@ describe('profile helpers:', () => {
       sipEnabledForms.forEach(form => {
         expect(formTitles[form]).to.exist;
       });
+    });
+  });
+  describe('prefixedFormIDs', () => {
+    it('should have an entry for each verified form', () => {
+      sipEnabledForms.forEach(form => {
+        expect(presentableFormIDs[form]).to.exist;
+      });
+    });
+    it('should handle the standard case', () => {
+      expect(presentableFormIDs['22-0993']).to.equal('FORM 22-0993');
+    });
+    it('should handle VIC differently', () => {
+      expect(presentableFormIDs.VIC).to.equal('VETERAN ID CARD');
+    });
+    it('should handle Feedback Tool differently', () => {
+      expect(presentableFormIDs['FEEDBACK-TOOL']).to.equal('FEEDBACK TOOL');
     });
   });
   describe('formLinks', () => {


### PR DESCRIPTION
## Description
We are changing how saved-in-progress forms are displayed on the user Dashboard. Part of that change includes displaying a representation of the form ID itself for each in-progress form. This change accommodates those needs.

## Testing done
Local + unit tests

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/58184355-ccbd2600-7c65-11e9-946f-035ecc1187c3.png)

## Acceptance criteria
- [ ] Generally form IDs are displayed as `FORM <form-id>`
- [ ] Treat the `VIC` and `FEEDBACK-TOOL` IDs differently

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs