### PR TITLE
Sort the SIP forms on the user dashboard by when they expire

### DIFF
--- a/src/applications/personalization/dashboard/components/FormList.jsx
+++ b/src/applications/personalization/dashboard/components/FormList.jsx
@@ -7,7 +7,7 @@ import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import recordEvent from 'platform/monitoring/record-event';
 
 import FormItem from './FormItem';
-import { isSIPEnabledForm } from '../helpers';
+import { isSIPEnabledForm, sipFormSorter } from '../helpers';
 
 class FormList extends React.Component {
   constructor(props) {
@@ -34,7 +34,10 @@ class FormList extends React.Component {
 
   render() {
     const { savedForms: forms } = this.props;
-    const verifiedSavedForms = forms.filter(isSIPEnabledForm);
+    // Remove non-SIP-enabled forms and then sort them by when the forms expire
+    const verifiedSavedForms = forms
+      .filter(isSIPEnabledForm)
+      .sort(sipFormSorter);
     const hasVerifiedSavedForms = !!verifiedSavedForms.length;
 
     return !hasVerifiedSavedForms ? null : (

--- a/src/applications/personalization/dashboard/containers/YourApplications.jsx
+++ b/src/applications/personalization/dashboard/containers/YourApplications.jsx
@@ -24,7 +24,7 @@ import {
 
 import DashboardAlert from '../components/DashboardAlert';
 import FormItem from '../components/FormItem';
-import { isSIPEnabledForm } from '../helpers';
+import { isSIPEnabledForm, sipFormSorter } from '../helpers';
 
 class YourApplications extends React.Component {
   componentDidMount() {
@@ -86,7 +86,9 @@ export const mapStateToProps = state => {
     isEnrollmentStatusLoading(state) || isLoadingDismissedNotification(state);
   const profileState = selectProfile(state);
   const { savedForms } = profileState;
-  const verifiedSavedForms = savedForms.filter(isSIPEnabledForm);
+  const verifiedSavedForms = savedForms
+    .filter(isSIPEnabledForm)
+    .sort(sipFormSorter);
   const hasVerifiedSavedForms = !!verifiedSavedForms.length;
   const hcaStatusEffectiveDate =
     hcaEnrollmentStatus.enrollmentStatusEffectiveDate;

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Raven from 'raven-js';
+import { isPlainObject } from 'lodash';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
@@ -193,6 +194,31 @@ export function isSIPEnabledForm(savedForm) {
     );
   }
   return true;
+}
+
+// Callback to use with Array.sort that expects two properly formatted form
+// objects (that have `metadata.expiresAt` properties). Used to sort form
+// objects, placing the form that expires sooner before the form that expires
+// later
+export function sipFormSorter(formA, formB) {
+  // simple helper to make sure the arg is an object with a metadata.expiresAt
+  // prop
+  function isValidForm(arg) {
+    if (!isPlainObject(arg)) {
+      throw new TypeError(`${arg} is not a plain object`);
+    }
+    if (
+      !arg.metadata ||
+      !arg.metadata.expiresAt ||
+      typeof arg.metadata.expiresAt !== 'number'
+    ) {
+      throw new TypeError(`'metadata.expiresAt' is not set on ${arg}`);
+    }
+    return true;
+  }
+
+  [formA, formB].forEach(isValidForm);
+  return formA.metadata.expiresAt - formB.metadata.expiresAt;
 }
 
 export const isFormAuthorizable = formConfig =>

--- a/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
@@ -7,6 +7,7 @@ import {
   isSIPEnabledForm,
   presentableFormIDs,
   sipEnabledForms,
+  sipFormSorter,
 } from '../helpers';
 
 import fullSchema1010ez from 'applications/hca/config/form';
@@ -69,6 +70,7 @@ describe('profile helpers:', () => {
       });
     });
   });
+
   describe('prefixedFormIDs', () => {
     it('should have an entry for each verified form', () => {
       sipEnabledForms.forEach(form => {
@@ -85,6 +87,7 @@ describe('profile helpers:', () => {
       expect(presentableFormIDs['FEEDBACK-TOOL']).to.equal('FEEDBACK TOOL');
     });
   });
+
   describe('formLinks', () => {
     it('should have link information for each verified form', () => {
       sipEnabledForms.forEach(form => {
@@ -92,6 +95,7 @@ describe('profile helpers:', () => {
       });
     });
   });
+
   describe('isFormAuthorizable', () => {
     it('should return `true` if `authorize` is defined on the passed-in form config', () => {
       const formConfig = {
@@ -143,9 +147,119 @@ describe('profile helpers:', () => {
       expect(sipEnabledForms).to.deep.equal(new Set(sipEnabledFormIds));
     });
   });
+
   describe('handleIncompleteInformation', () => {
     it('should push error into window if a form is missing title or link information', () => {
       expect(isSIPEnabledForm('missingInfoForm')).to.be.false;
+    });
+  });
+
+  describe('sipFormSorter', () => {
+    const formA = {
+      form: '21P-527EZ',
+      metadata: {
+        version: 3,
+        returnUrl: '/review-and-submit',
+        savedAt: 1557507430028,
+        expiresAt: 1562691437,
+        lastUpdated: 1557507437,
+      },
+      lastUpdated: 1557507437,
+    };
+    const formB = {
+      form: '1010ez',
+      metadata: {
+        version: 6,
+        returnUrl: '/military-service/documents',
+        savedAt: 1558027285255,
+        expiresAt: 1563211286,
+        lastUpdated: 1558027286,
+      },
+      lastUpdated: 1558027286,
+    };
+    const formC = {
+      form: '22-1995-STEM',
+      metadata: {
+        version: 1,
+        returnUrl: '/personal-information/contact-information',
+        savedAt: 1558440074236,
+        expiresAt: 1563624074,
+        lastUpdated: 1558440074,
+      },
+      lastUpdated: 1558440074,
+    };
+    const invalidExpiresAt = {
+      metadata: {
+        expiresAt: 'not a number',
+      },
+    };
+    const notAForm = {
+      veteranStatus: {
+        status: 'OK',
+        isVeteran: true,
+        servedInMilitary: true,
+      },
+    };
+    describe('unhappy path', () => {
+      it('should throw an error when no args are passed', () => {
+        expect(() => sipFormSorter()).to.throw(TypeError, 'plain object');
+      });
+      it('should throw an error when a single invalid object is passed', () => {
+        expect(() => sipFormSorter(notAForm)).to.throw(
+          TypeError,
+          'metadata.expiresAt',
+        );
+      });
+      it('should throw an error when a single valid form is passed', () => {
+        expect(() => sipFormSorter(formA)).to.throw(TypeError, 'plain object');
+      });
+      it('should throw an error when the second arg is a string', () => {
+        expect(() => sipFormSorter(formA, 'not a form')).to.throw(
+          TypeError,
+          'plain object',
+        );
+      });
+      it('should throw an error when the second arg is an array', () => {
+        expect(() => sipFormSorter(formA, [])).to.throw(
+          TypeError,
+          'plain object',
+        );
+      });
+      it('should throw an error when the second arg is a number', () => {
+        expect(() => sipFormSorter(formA, 42)).to.throw(
+          TypeError,
+          'plain object',
+        );
+      });
+      it('should throw an error when the second arg is an invalid object', () => {
+        expect(() => sipFormSorter(formA, notAForm)).to.throw(
+          TypeError,
+          'metadata.expiresAt',
+        );
+      });
+      it('should throw an error when the second arg is an empty object', () => {
+        expect(() => sipFormSorter(formA, {})).to.throw(
+          TypeError,
+          'metadata.expiresAt',
+        );
+      });
+      it('should throw an error when an arg has an invalid value for `metadata.expiresAt`', () => {
+        expect(() => sipFormSorter(formA, invalidExpiresAt)).to.throw(
+          TypeError,
+          'metadata.expiresAt',
+        );
+      });
+    });
+
+    it('should sort forms correctly when used with Array.sort', () => {
+      expect([formA].sort(sipFormSorter)).to.deep.equal([formA]);
+      expect([formA, formB].sort(sipFormSorter)).to.deep.equal([formA, formB]);
+      expect([formB, formA].sort(sipFormSorter)).to.deep.equal([formA, formB]);
+      expect([formB, formC, formA].sort(sipFormSorter)).to.deep.equal([
+        formA,
+        formB,
+        formC,
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Description
This PR sorts the list of in-progress forms that show up on the user Dashboard. They will be sorted by when they expire, with the forms expiring sooner showing up before the forms expiring later.

Trying to test this locally is a bit fiddly, but when this is merged we can check out user 1's dashboard on staging as there are a number of in-progress forms with different expiration dates.

## Testing done
Added unit tests for the new sorting callback

## Screenshots


## Acceptance criteria
- [ ] When there are multiple forms in progress shown on a user's dashboard, they should be sorted by expiration date (sooner expiration dates listed before expiration dates further in the future)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs