### PR TITLE
18624 hca continue app evt tracking

### DIFF
--- a/src/applications/hca-v2-beta/components/HCAEnrollmentStatusFAQ.jsx
+++ b/src/applications/hca-v2-beta/components/HCAEnrollmentStatusFAQ.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import HCASubwayMap from '../components/HCASubwayMap';
+import recordEvent from 'platform/monitoring/record-event';
 
 import {
   getFAQBlock1,
@@ -56,6 +57,7 @@ const HCAEnrollmentStatusFAQ = ({
         !showingReapplyForHealthCareContent && (
           <ReapplyTextLink
             onClick={() => {
+              recordEvent('hca-form-reapply');
               showReapplyContent();
             }}
           />

--- a/src/applications/hca-v2-beta/components/HCAEnrollmentStatusFAQ.jsx
+++ b/src/applications/hca-v2-beta/components/HCAEnrollmentStatusFAQ.jsx
@@ -57,7 +57,7 @@ const HCAEnrollmentStatusFAQ = ({
         !showingReapplyForHealthCareContent && (
           <ReapplyTextLink
             onClick={() => {
-              recordEvent('hca-form-reapply');
+              recordEvent({ event: 'hca-form-reapply' });
               showReapplyContent();
             }}
           />

--- a/src/applications/hca-v2-beta/containers/IDPage.jsx
+++ b/src/applications/hca-v2-beta/containers/IDPage.jsx
@@ -8,6 +8,7 @@ import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import recordEvent from 'platform/monitoring/record-event';
 
 import { setData } from 'platform/forms-system/src/js/actions';
 import { getNextPagePath } from 'platform/forms-system/src/js/routing';
@@ -113,6 +114,7 @@ class IDPage extends React.Component {
   };
 
   formSubmit = ({ formData }) => {
+    recordEvent({ event: 'hca-continue-application!' });
     this.props.submitIDForm(formData);
   };
 

--- a/src/applications/hca-v2-beta/containers/IDPage.jsx
+++ b/src/applications/hca-v2-beta/containers/IDPage.jsx
@@ -114,7 +114,7 @@ class IDPage extends React.Component {
   };
 
   formSubmit = ({ formData }) => {
-    recordEvent({ event: 'hca-continue-application!' });
+    recordEvent({ event: 'hca-continue-application' });
     this.props.submitIDForm(formData);
   };
 

--- a/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
+++ b/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import HCASubwayMap from '../components/HCASubwayMap';
+import recordEvent from 'platform/monitoring/record-event';
 
 import {
   getFAQBlock1,
@@ -56,6 +57,7 @@ const HCAEnrollmentStatusFAQ = ({
         !showingReapplyForHealthCareContent && (
           <ReapplyTextLink
             onClick={() => {
+              recordEvent('hca-form-reapply');
               showReapplyContent();
             }}
           />

--- a/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
+++ b/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
@@ -57,7 +57,7 @@ const HCAEnrollmentStatusFAQ = ({
         !showingReapplyForHealthCareContent && (
           <ReapplyTextLink
             onClick={() => {
-              recordEvent('hca-form-reapply');
+              recordEvent({ event: 'hca-form-reapply' });
               showReapplyContent();
             }}
           />

--- a/src/applications/hca/containers/IDPage.jsx
+++ b/src/applications/hca/containers/IDPage.jsx
@@ -115,7 +115,7 @@ class IDPage extends React.Component {
   };
 
   formSubmit = ({ formData }) => {
-    recordEvent({ event: 'hca-continue-application!' });
+    recordEvent({ event: 'hca-continue-application' });
     this.props.submitIDForm(formData);
   };
 

--- a/src/applications/hca/containers/IDPage.jsx
+++ b/src/applications/hca/containers/IDPage.jsx
@@ -8,6 +8,7 @@ import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import recordEvent from 'platform/monitoring/record-event';
 
 import { setData } from 'platform/forms-system/src/js/actions';
 import { getNextPagePath } from 'platform/forms-system/src/js/routing';
@@ -114,6 +115,7 @@ class IDPage extends React.Component {
   };
 
   formSubmit = ({ formData }) => {
+    recordEvent({ event: 'hca-continue-application!' });
     this.props.submitIDForm(formData);
   };
 


### PR DESCRIPTION
## Description
[18624](/department-of-veterans-affairs/vets.gov-team/issues/18624) - Add event-tracking to (a) HCA ID Form page Continue button, and (b) HCA Application Introduction page enrollment status FAQs Reapply link.

## Testing done
Need to temporarily build branch to Dev to test -- local vets-api‘s throwing 500 error for enrollment-status api call.

## Screenshots


## Acceptance criteria
- [ ] GTM-images rec'd in browser dev tools network panel, showing “hca-continue-application" event (for ID-Form Continue btn), and “hca-form-reapply” (for Intro-Page enrollment status FAQs Reapply link.

## Definition of done
- [ ] Events are logged appropriately
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
