### PR TITLE
remove sidenav css from shame file

### DIFF
--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -207,23 +207,6 @@ $medium-phone-screen: 375px;
       flex-direction: column;
     }
 
-    .va-sidebarnav {
-      display: none;
-    }
-
-    button {
-      &.va-sidebarnav-close {
-        position: absolute;
-        right: 2px;
-        top: 2px;
-
-        &:hover,
-        &:focus {
-          background-color: $mm-gray;
-        }
-      }
-    }
-
     #menu-rule {
       border-bottom: 0;
       padding-bottom: 0;
@@ -322,10 +305,6 @@ $medium-phone-screen: 375px;
       margin-bottom: 0 !important; //hard override; what does this break elsewhere
     }
 
-    .va-sidebarnav--opened {
-      position: fixed;
-      display: block;
-    }
     .va-navigation-nextprevious {
       padding-left: 0.9375rem;
       padding-right: 0.9375rem;
@@ -501,14 +480,6 @@ $medium-phone-screen: 375px;
 .va-l-detail-page > .usa-grid-full {
   padding-right: inherit;
   padding-left: inherit;
-}
-
-.left-side-nav-title {
-  color: $color-black;
-  padding-left: 1em;
-  @include media($small-desktop-screen) {
-    padding-left: 0;
-  }
 }
 
 .flex-container {


### PR DESCRIPTION
## Description
This PR removes several selectors from the shame file since they are now in Formation's css.

## Testing done
Tested pages with left navigation to determine there are zero differences in visual design

## Screenshots
Local:
<img width="872" alt="Screen Shot 2019-05-23 at 11 13 03 AM" src="https://user-images.githubusercontent.com/25435289/58264482-f3558c80-7d4b-11e9-950f-f21fab61a8cd.png">
<img width="311" alt="Screen Shot 2019-05-23 at 11 13 13 AM" src="https://user-images.githubusercontent.com/25435289/58264723-5515f680-7d4c-11e9-9d62-3c460bfbfefb.png">


Va.gov (looks the same)
<img width="840" alt="Screen Shot 2019-05-23 at 11 15 25 AM" src="https://user-images.githubusercontent.com/25435289/58264624-2730b200-7d4c-11e9-86e4-d62960ea641b.png">
<img width="340" alt="Screen Shot 2019-05-23 at 11 15 35 AM" src="https://user-images.githubusercontent.com/25435289/58264630-2a2ba280-7d4c-11e9-8df6-914fb5530e1d.png">

## Acceptance criteria
- [ ] No differences in presentation between localhost and va.gov

