### PR TITLE
[Footer] Add GA events for links along the very bottom

### DIFF
--- a/src/platform/site-wide/va-footer/helpers.jsx
+++ b/src/platform/site-wide/va-footer/helpers.jsx
@@ -10,6 +10,7 @@ export const FOOTER_COLUMNS = {
   RESOURCES: '2',
   CONNECT: '3',
   CONTACT: '4',
+  SUPERLINKS: 'bottom_rail',
 };
 
 export const FOOTER_EVENTS = {
@@ -17,6 +18,7 @@ export const FOOTER_EVENTS = {
   [FOOTER_COLUMNS.RESOURCES]: 'nav-footer-resources',
   [FOOTER_COLUMNS.CONNECT]: 'nav-footer-connect',
   [FOOTER_COLUMNS.CONTACT]: 'nav-footer-contact',
+  [FOOTER_COLUMNS.SUPERLINKS]: 'nav-footer-superlinks',
   CRISIS_LINE: 'nav-footer-crisis',
 };
 
@@ -48,6 +50,24 @@ export function generateLinkItems(links, column, direction = 'asc') {
   );
 }
 
+function generateSuperLinks(groupedList) {
+  const captureEvent = () => {
+    recordEvent({ event: FOOTER_EVENTS[FOOTER_COLUMNS.SUPERLINKS] });
+  };
+
+  return (
+    <ul>
+      {orderBy(groupedList.bottom_rail, 'order', 'asc').map(link => (
+        <li key={`${link.order}`}>
+          <a href={link.href} onClick={captureEvent} target={link.target}>
+            {link.title}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 export function createLinkGroups(links) {
   const groupedList = groupBy(replaceDomainsInData(links), 'column');
 
@@ -68,16 +88,6 @@ export function createLinkGroups(links) {
       groupedList,
       FOOTER_COLUMNS.CONTACT,
     ),
-    bottomLinks: (
-      <ul>
-        {orderBy(groupedList.bottom_rail, 'order', 'asc').map(link => (
-          <li key={`${link.order}`}>
-            <a href={link.href} target={link.target}>
-              {link.title}
-            </a>
-          </li>
-        ))}
-      </ul>
-    ),
+    bottomLinks: generateSuperLinks(groupedList),
   };
 }


### PR DESCRIPTION
## Description
This PR adds a GA event for the footer links shown in the screenshot below.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18158

## Testing done
Ran local GA Chrome extension and watched console output

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/58280486-b64ec180-7d6e-11e9-8262-dcdea51159a2.png)

## Acceptance criteria
- [x] Event is captured

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
