### PR TITLE
Redirect to session expired page if a logged out user makes an authorized request

### DIFF
--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -1,5 +1,4 @@
 import Raven from 'raven-js';
-import appendQuery from 'append-query';
 
 import environment from '../environment';
 import localStorage from '../storage/localStorage';
@@ -66,16 +65,13 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
 
       if (environment.isProduction()) {
         const { pathname } = window.location;
-        const shouldRedirectToLogin =
+        const shouldRedirectToSessionExpired =
           response.status === 401 &&
           resource !== '/user' &&
           !pathname.includes('auth/login/callback');
 
-        if (shouldRedirectToLogin) {
-          const loginUrl = appendQuery(environment.BASE_URL, {
-            next: pathname,
-          });
-          window.location = loginUrl;
+        if (shouldRedirectToSessionExpired) {
+          window.location = '/session-expired';
         }
       }
 


### PR DESCRIPTION
## Description
If a user accesses a page that makes an authorized request and gets 401, they get redirected to the session expired page.

## Testing done
To be tested on staging.

## Acceptance criteria
- [x] Users should get redirected to the session expiration page when they access a page that makes an authorized request (other than the request for the user profile) after their session expires.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
