### PR TITLE
Run mock API in the background for puppeteer tests

### DIFF
--- a/script/run-puppeteer-tests.sh
+++ b/script/run-puppeteer-tests.sh
@@ -4,7 +4,7 @@
 trap 'jobs -p; if [ $? -eq 0 ] ; then kill $(jobs -p); fi' EXIT
 
 # Fire up the mock api server
-"$(dirname "$0")"/run-mockapi.sh
+"$(dirname "$0")"/run-mockapi.sh &
 
 # Fire up the test
 export WEB_PORT=3001


### PR DESCRIPTION
## Description
With the changes to `run-mockapi.sh` to have it `wait` instead of `sleep 5`, this hung up for me locally. To be perfectly honest, I'm not sure how it _isn't_ hanging up in CI. :confused:

## Testing done
Ran the puppeteer tests locally on Linux.

**TODO:** Test this on macOS. @bshyong @hinzed1127 Could one of you try this out?

## Screenshots
N/A

## Acceptance criteria
- [x] Puppeteer tests are actually run locally