### PR TITLE
Remove "Remove this notification" button from pending states

### DIFF
--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -935,17 +935,39 @@ export function getAlertContent(
       </p>
     </>
   );
-
-  const blocks = [];
-  // start with the "You applied on" info regardless of the enrollmentstatus
-  blocks.push(
-    <p>
-      <strong>You applied on:</strong>{' '}
-      {moment(applicationDate).format('MMMM D, YYYY')}
-    </p>,
+  // this block will be used for "final" enrollment status states: closed,
+  // rejected, enrolled, ineligible
+  const removeNotificationButton = (
+    <button
+      className="va-button-link remove-notification-link"
+      aria-label={`Dismiss health care application status notification`}
+      onClick={dismissNotification}
+    >
+      <i className="fa fa-times" />
+      <span className="remove-notification-label">
+        Remove this notification
+      </span>
+    </button>
   );
 
+  const blocks = [];
+
+  // start with the "You applied on" if the user isn't enrolled in health care
+  if (enrollmentStatus !== HCA_ENROLLMENT_STATUSES.enrolled) {
+    blocks.push(
+      <p>
+        <strong>You applied on:</strong>{' '}
+        {moment(applicationDate).format('MMMM D, YYYY')}
+      </p>,
+    );
+  }
+
   switch (enrollmentStatus) {
+    case HCA_ENROLLMENT_STATUSES.enrolled:
+      blocks.push(removeNotificationButton);
+
+      break;
+
     case HCA_ENROLLMENT_STATUSES.ineligTrainingOnly:
       blocks.push(
         <p>
@@ -955,7 +977,9 @@ export function getAlertContent(
           months to qualify for VA health care.
         </p>,
         whatShouldIDo1,
+        removeNotificationButton,
       );
+
       break;
 
     case HCA_ENROLLMENT_STATUSES.ineligNotVerified:
@@ -966,6 +990,7 @@ export function getAlertContent(
           separation papers).
         </p>,
         whatShouldIDo1,
+        removeNotificationButton,
       );
       break;
 
@@ -977,6 +1002,7 @@ export function getAlertContent(
         </p>,
         whatShouldIDo1,
         whatShouldIDo2,
+        removeNotificationButton,
       );
       break;
 
@@ -988,6 +1014,7 @@ export function getAlertContent(
           meet this service requirement.
         </p>,
         whatShouldIDo1,
+        removeNotificationButton,
       );
       break;
 
@@ -1003,6 +1030,7 @@ export function getAlertContent(
           serving at least 24 continuous months on active duty.
         </p>,
         whatShouldIDo1,
+        removeNotificationButton,
       );
       break;
 
@@ -1016,6 +1044,7 @@ export function getAlertContent(
           24 months all at once, without a break in service.
         </p>,
         whatShouldIDo1,
+        removeNotificationButton,
       );
       break;
 
@@ -1028,6 +1057,7 @@ export function getAlertContent(
           24 months all at once, without a break in service.
         </p>,
         whatShouldIDo1,
+        removeNotificationButton,
       );
       break;
 
@@ -1039,6 +1069,7 @@ export function getAlertContent(
           offer services to CHAMPVA recipients.
         </p>,
         whatShouldIDo1,
+        removeNotificationButton,
       );
       break;
 
@@ -1049,6 +1080,7 @@ export function getAlertContent(
           needed to complete it within a year.
         </p>,
         whatShouldIDo1,
+        removeNotificationButton,
       );
       break;
 
@@ -1097,6 +1129,7 @@ export function getAlertContent(
           </a>
         </p>,
         whatShouldIDo1,
+        removeNotificationButton,
       );
       break;
 
@@ -1121,25 +1154,12 @@ export function getAlertContent(
     case HCA_ENROLLMENT_STATUSES.ineligFugitiveFelon:
     case HCA_ENROLLMENT_STATUSES.ineligOver65:
     case HCA_ENROLLMENT_STATUSES.ineligOther:
-      blocks.push(whatShouldIDo1);
+      blocks.push(whatShouldIDo1, removeNotificationButton);
       break;
 
     default:
       break;
   }
 
-  // add the Remove this notification button regardless of the enrollmentstatus
-  blocks.push(
-    <button
-      className="va-button-link remove-notification-link"
-      aria-label={`Dismiss health care application status notification`}
-      onClick={dismissNotification}
-    >
-      <i className="fa fa-times" />
-      <span className="remove-notification-label">
-        Remove this notification
-      </span>
-    </button>,
-  );
   return blocks;
 }

--- a/src/applications/personalization/dashboard/sass/dashboard-alert.scss
+++ b/src/applications/personalization/dashboard/sass/dashboard-alert.scss
@@ -90,6 +90,10 @@
     }
   }
 
+  section.content p:last-of-type {
+    margin-bottom: 0;
+  }
+
   @include make-status-styles(
     $status: "closed",
     $color: $color-black,


### PR DESCRIPTION
Also remove the application date from the Enrolled notification

## Description


## Testing done
local

## Screenshots
<img width="691" alt="Screen Shot 2019-05-24 at 7 16 26 AM" src="https://user-images.githubusercontent.com/20728956/58335184-de353800-7df5-11e9-8ee6-ea04a982ee3e.png">
<img width="682" alt="Screen Shot 2019-05-24 at 7 15 45 AM" src="https://user-images.githubusercontent.com/20728956/58335193-e2615580-7df5-11e9-9a6e-cf42a4d154be.png">

## Acceptance criteria
- [ ] there is no "remove this notification" for "pending" statuses, only for "final" statuses: enrolled, denied, closed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs