### PR TITLE
Update grid layout on the page-breadcrumb template

### DIFF
--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -1,6 +1,16 @@
 $medium-phone-screen: 375px;
 /* OVERRIDE */
 .merger {
+
+  // Begin new-grid override
+  // Overrides some default properties with a
+  // class name that makes it more clear we remove
+  // it when the work is complete.
+  .va-sidebarnav.new-grid {
+    width: 100% !important;
+  }
+  // End new-grid override
+
   .login {
     .container {
       width: 100%;
@@ -278,11 +288,17 @@ $medium-phone-screen: 375px;
     #homepage-benefits,
     #homepage-news,
     .va-h-ruled--stars,
-    //.va-nav-breadcrumbs,
-    //article,
+    .va-nav-breadcrumbs,
+    article,
     #hub-rail {
       padding-left: 0.5em;
       padding-right: 0.5em;
+    }
+
+    .va-nav-breadcrumbs.new-grid,
+    article.new-grid {
+      padding-left: 0;
+      padding-right: 0;
     }
 
     .va-nav-breadcrumbs {
@@ -345,11 +361,17 @@ $medium-phone-screen: 375px;
     #homepage-benefits,
     #homepage-news,
     .va-h-ruled--stars,
-    //.va-nav-breadcrumbs,
-    //article,
+    .va-nav-breadcrumbs,
+    article,
     #hub-rail {
       padding-left: 1em;
       padding-right: 1em;
+    }
+
+    .va-nav-breadcrumbs.new-grid,
+    article.new-grid {
+      padding-left: 0;
+      padding-right: 0;
     }
   }
 
@@ -504,3 +526,4 @@ img[data-srcset] {
 .process-accordion > li {
   list-style: none !important;
 }
+

--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -278,8 +278,8 @@ $medium-phone-screen: 375px;
     #homepage-benefits,
     #homepage-news,
     .va-h-ruled--stars,
-    .va-nav-breadcrumbs,
-    article,
+    //.va-nav-breadcrumbs,
+    //article,
     #hub-rail {
       padding-left: 0.5em;
       padding-right: 0.5em;
@@ -345,8 +345,8 @@ $medium-phone-screen: 375px;
     #homepage-benefits,
     #homepage-news,
     .va-h-ruled--stars,
-    .va-nav-breadcrumbs,
-    article,
+    //.va-nav-breadcrumbs,
+    //article,
     #hub-rail {
       padding-left: 1em;
       padding-right: 1em;

--- a/src/site/components/navigation-sidebar.html
+++ b/src/site/components/navigation-sidebar.html
@@ -21,7 +21,7 @@ Used to display a side navigation bar of pages in a collection.
   {% assign spokes = "Get benefits,Manage benefits,More resources" | split: ',' %}
 {% endif %}
 
-<nav {% if relatedPages != empty %}class="usa-width-one-fourth va-sidebarnav"{% endif %} id="va-detailpage-sidebar">
+<nav {% if relatedPages != empty %}class="usa-width-one-fourth va-sidebarnav {%  if fullWidth == true %} vads-u-width--full{% endif %}"{% endif %} id="va-detailpage-sidebar">
   <div>
     <button type="button" aria-label="Close this menu" class="va-btn-close-icon va-sidebarnav-close"></button>
 

--- a/src/site/components/navigation-sidebar.html
+++ b/src/site/components/navigation-sidebar.html
@@ -21,7 +21,7 @@ Used to display a side navigation bar of pages in a collection.
   {% assign spokes = "Get benefits,Manage benefits,More resources" | split: ',' %}
 {% endif %}
 
-<nav {% if relatedPages != empty %}class="usa-width-one-fourth va-sidebarnav {%  if fullWidth == true %} vads-u-width--full{% endif %}"{% endif %} id="va-detailpage-sidebar">
+<nav {% if relatedPages != empty %}class="usa-width-one-fourth va-sidebarnav {%  if newGrid == true %} new-grid{% endif %}"{% endif %} id="va-detailpage-sidebar">
   <div>
     <button type="button" aria-label="Close this menu" class="va-btn-close-icon va-sidebarnav-close"></button>
 

--- a/src/site/components/navigation-sidebar.html
+++ b/src/site/components/navigation-sidebar.html
@@ -27,7 +27,7 @@ Used to display a side navigation bar of pages in a collection.
 
     {% if relatedPages != empty %}
       {% if relatedPages.metadata.name != empty %}
-        <div class="left-side-nav-title"><i class="icon-small white hub-icon-{{ relatedPages.metadata.hub }} hub-background-{{ relatedPages.metadata.hub }}"></i><h4>{{ relatedPages.metadata.name }}</h4></div>
+        <div class="left-side-nav-title {% if newGrid %}vads-u-padding-x--0{% endif %}"><i class="icon-small white hub-icon-{{ relatedPages.metadata.hub }} hub-background-{{ relatedPages.metadata.hub }}"></i><h4>{{ relatedPages.metadata.name }}</h4></div>
       {% endif %}
 
       {% if spoke != empty %}

--- a/src/site/includes/breadcrumbs.html
+++ b/src/site/includes/breadcrumbs.html
@@ -1,6 +1,6 @@
 {% if gatePage === true %} {% assign gatePageClassName = 'va-nav-breadcrumbs--gate' %} {% endif %}
 
-<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs {{gatePageClassName}}" id="va-breadcrumbs">
+<nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs {{gatePageClassName}} {% if newGrid %}new-grid{% endif %}" id="va-breadcrumbs">
   <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
     <li>
       <a href="/" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">Home</a>

--- a/src/site/includes/detail-page.html
+++ b/src/site/includes/detail-page.html
@@ -15,12 +15,12 @@
   {% endif %}
   <div class="vads-l-grid-container large-screen:vads-u-padding-x--0">
     <div class="vads-l-row vads-u-margin-x--neg2p5">
-      <div class="vads-l-col--12 medium-screen:vads-u-padding-x--2 large-screen:vads-u-padding-x--2p5 medium-screen:vads-l-col--4 large-screen:vads-l-col--3">
+      <div class="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--4 large-screen:vads-l-col--3">
         {% if hidesidenav === empty %}
           {% include "src/site/components/navigation-sidebar.html" with newGrid = true %}
         {% endif %}
       </div>
-      <div class="vads-l-col--12 vads-u-padding-x--2 large-screen:vads-u-padding-x--2p5 medium-screen:vads-l-col--8 large-screen:vads-l-col--9">
+      <div class="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--8 large-screen:vads-l-col--9">
       {% if no_article_bottom_padding %}
         <article class="usa-content new-grid vads-u-padding-bottom--0">
           <h1>{{ heading }}</h1>

--- a/src/site/includes/detail-page.html
+++ b/src/site/includes/detail-page.html
@@ -17,17 +17,17 @@
     <div class="vads-l-row vads-u-margin-x--neg2p5">
       <div class="vads-l-col--12 medium-screen:vads-u-padding-x--2 large-screen:vads-u-padding-x--2p5 medium-screen:vads-l-col--4 large-screen:vads-l-col--3">
         {% if hidesidenav === empty %}
-          {% include "src/site/components/navigation-sidebar.html" with fullWidth = true %}
+          {% include "src/site/components/navigation-sidebar.html" with newGrid = true %}
         {% endif %}
       </div>
       <div class="vads-l-col--12 vads-u-padding-x--2 large-screen:vads-u-padding-x--2p5 medium-screen:vads-l-col--8 large-screen:vads-l-col--9">
       {% if no_article_bottom_padding %}
-        <article class="usa-content vads-u-padding-bottom--0">
+        <article class="usa-content new-grid vads-u-padding-bottom--0">
           <h1>{{ heading }}</h1>
           {{ contents }}
         </article>
       {% else %}
-        <article class="usa-content">
+        <article class="usa-content new-grid">
           <h1>{{ heading }}</h1>
           {{ contents }}
         </article>

--- a/src/site/includes/detail-page.html
+++ b/src/site/includes/detail-page.html
@@ -10,37 +10,39 @@
 {% endcomment %}
 
 <main class="va-l-detail-page">
-  <div class="usa-grid usa-grid-full">
-    {% if hidesidenav === empty %}
-      {% include "src/site/components/navigation-sidebar.html" %}
-    {% endif %} 
-
-    <div class="usa-width-three-fourths">
-      {% if hidesidenav === empty %}
-        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
-      {% endif %}  
-      
-    {% if no_article_bottom_padding %}
-      <article class="usa-content vads-u-padding-bottom--0">
-        <h1>{{ heading }}</h1>
-        {{ contents }}
-      </article>
-    {% else %}  
-      <article class="usa-content">
-        <h1>{{ heading }}</h1>
-        {{ contents }}
-      </article>
-    {% endif %}
-
-      {% if majorlinks != empty %}
-        {% include "src/site/components/navigation-links-list.html" %}
+  {% if hidesidenav === empty %}
+    {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+  {% endif %}
+  <div class="vads-l-grid-container large-screen:vads-u-padding-x--0">
+    <div class="vads-l-row vads-u-margin-x--neg2p5">
+      <div class="vads-l-col--12 medium-screen:vads-u-padding-x--2 large-screen:vads-u-padding-x--2p5 medium-screen:vads-l-col--4 large-screen:vads-l-col--3">
+        {% if hidesidenav === empty %}
+          {% include "src/site/components/navigation-sidebar.html" with fullWidth = true %}
+        {% endif %}
+      </div>
+      <div class="vads-l-col--12 vads-u-padding-x--2 large-screen:vads-u-padding-x--2p5 medium-screen:vads-l-col--8 large-screen:vads-l-col--9">
+      {% if no_article_bottom_padding %}
+        <article class="usa-content vads-u-padding-bottom--0">
+          <h1>{{ heading }}</h1>
+          {{ contents }}
+        </article>
+      {% else %}
+        <article class="usa-content">
+          <h1>{{ heading }}</h1>
+          {{ contents }}
+        </article>
       {% endif %}
 
-      {% if relatedlinks != empty %}
-        {% include "src/site/components/navigation-links-list.html" with isRelated = true %}
-      {% endif %}
+        {% if majorlinks != empty %}
+          {% include "src/site/components/navigation-links-list.html" %}
+        {% endif %}
 
-      {% include "src/site/includes/last-update.html" %}
+        {% if relatedlinks != empty %}
+          {% include "src/site/components/navigation-links-list.html" with isRelated = true %}
+        {% endif %}
+
+        {% include "src/site/includes/last-update.html" %}
+      </div>
     </div>
   </div>
 </main>

--- a/src/site/includes/level2-index.html
+++ b/src/site/includes/level2-index.html
@@ -8,51 +8,57 @@ Used for index pages in top-level paths (e.g. hubpages /health-care/index.html)
 {% endcomment %}
 
 <main>
-  <div class="usa-grid usa-grid-full">
-    <article class="usa-width-two-thirds">
-      {% if hub != empty %}
-        <div class="inline hub-main-icon">
-          <i class="icon-large white hub-icon-{{hub}} hub-background-{{hub}}"></i>
-        </div>
-      {% endif %}
-      <div class="inline hub-main-title">
-        <h1>
-          {{ heading }}
-        </h1>
+    <div class="vads-l-grid-container large-screen:vads-u-padding-x--0">
+      <div class="vads-l-row medium-screen:vads-u-margin-x--neg2p5">
+         <div class="vads-l-col--12 medium-screen:vads-u-padding-x--2p5 medium-screen:vads-l-col--8">
+        <article class="new-grid">
+          <div class="medium-screen:vads-u-display--flex">
+            {% if hub != empty %}
+            <div class="hub-main-icon vads-u-margin-right--1p5 vads-u-margin-top--1">
+              <i class="icon-large white hub-icon-{{hub}} hub-background-{{hub}}"></i>
+            </div>
+            {% endif %}
+            <div class="hub-main-title">
+              <h1>
+              {{ heading }}
+              </h1>
+            </div>
+          </div>
+          {{ contents }}
+
+          {% if hublinks != empty %}
+            {% include "src/site/components/hub-page-link-list.html" %}
+          {% endif %}
+
+
+          {% if crosslinks != empty %}
+            {% include "src/site/components/merger-crosslinks.html" %}
+          {% endif %}
+
+        </article>
       </div>
-      {{ contents }}
 
-      {% if hublinks != empty %}
-        {% include "src/site/components/hub-page-link-list.html" %}
-      {% endif %}
+      <div class="vads-l-col--12 medium-screen:vads-u-padding-x--2p5 medium-screen:vads-l-col--4" id="hub-rail">
 
+        {% if administration != empty %}
+          {% include "src/site/components/merger-administration.html" %}
+        {% endif %}
 
-      {% if crosslinks != empty %}
-        {% include "src/site/components/merger-crosslinks.html" %}
-      {% endif %}
+        {% if promo != empty %}
+          {% include "src/site/components/merger-promo.html" %}
+        {% endif %}
 
-    </article>
+        {% if social != empty %}
+          {% include "src/site/components/merger-social.html" %}
+        {% endif %}
 
-    <div class="usa-width-one-third" id="hub-rail">
+        {% if mobile != empty %}
+          {% include "src/site/components/merger-mobile.html" %}
+        {% endif %}
 
-      {% if administration != empty %}
-        {% include "src/site/components/merger-administration.html" %}
-      {% endif %}
-
-      {% if promo != empty %}
-        {% include "src/site/components/merger-promo.html" %}
-      {% endif %}
-
-      {% if social != empty %}
-        {% include "src/site/components/merger-social.html" %}
-      {% endif %}
-
-      {% if mobile != empty %}
-        {% include "src/site/components/merger-mobile.html" %}
-      {% endif %}
+      </div>
 
     </div>
-
   </div>
 
 

--- a/src/site/includes/topic-landing.html
+++ b/src/site/includes/topic-landing.html
@@ -9,24 +9,27 @@
 {% endcomment %}
 
 <main class="va-l-detail-page">
-  <div class="usa-grid usa-grid-full">
-    {% include "src/site/components/navigation-sidebar.html" %}
+  {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+  <div class="vads-l-grid-container large-screen:vads-u-padding-x--0">
+    <div class="vads-l-row vads-u-margin-x--neg2p5">
+      <div class="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--4 large-screen:vads-l-col--3">
+        {% include "src/site/components/navigation-sidebar.html" with newGrid = true %}
+      </div>
+      <div class="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--8 large-screen:vads-l-col--9">
+        <article class="usa-content new-grid">
+          <h1>{{ heading }}</h1>
+          {{ contents }}
+        </article>
+        {% if majorlinks != empty %}
+          {% include "src/site/components/navigation-links-list.html" %}
+        {% endif %}
 
-    <div class="usa-width-three-fourths">
-      {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
-      <article class="usa-content">
-        <h1>{{ heading }}</h1>
-        {{ contents }}
-      </article>
-      {% if majorlinks != empty %}
-        {% include "src/site/components/navigation-links-list.html" %}
-      {% endif %}
+        {% if relatedlinks != empty %}
+          {% include "src/site/components/navigation-links-list.html" with isRelated = true %}
+        {% endif %}
 
-      {% if relatedlinks != empty %}
-        {% include "src/site/components/navigation-links-list.html" with isRelated = true %}
-      {% endif %}
-
-      {% include "src/site/includes/last-update.html" %}
+        {% include "src/site/includes/last-update.html" %}
+      </div>
     </div>
   </div>
 </main>

--- a/src/site/layouts/page-breadcrumbs.html
+++ b/src/site/layouts/page-breadcrumbs.html
@@ -13,7 +13,7 @@
 {% endif %}
 
 <div class="vads-l-grid-container large-screen:vads-u-padding-x--0">
-  {% include "src/site/includes/breadcrumbs.html" %}
+  {% include "src/site/includes/breadcrumbs.html" newGrid=true %}
 </div>
 
 <div id="content" class="interior {{ id }}">

--- a/src/site/layouts/page-breadcrumbs.html
+++ b/src/site/layouts/page-breadcrumbs.html
@@ -12,9 +12,12 @@
   {% include "src/site/includes/decision-reviews-banner.html" %}
 {% endif %}
 
-{% include "src/site/includes/breadcrumbs.html" %}
+<div class="vads-l-grid-container large-screen:vads-u-padding-x--0">
+  {% include "src/site/includes/breadcrumbs.html" %}
+</div>
 
 <div id="content" class="interior {{ id }}">
+
 
   {% if !heading %}
     {% assign heading = title %}


### PR DESCRIPTION
## Description
This pull request is the explore how we may remove grid classes from components such as the sidenav and from the `<article>` and place them in divs that serve solely to create layout.

This also uses Formation’s [flexbox grid](https://design.va.gov/layout/flexbox-grid), along with [padding](https://design.va.gov/utilities/padding) and [margin](https://design.va.gov/utilities/margins) utilities, which gives greater control over handling responsive design than USWDS's float grid.

Perhaps at some point, we can clean these layout files to where we have them only for 1-col, 2-col, and 3-col?

## Testing done
Working on this page `http://localhost:3001/disability/how-to-file-claim/`, comparing the layout of the content that appears between the main navigation and the footer with the same page in production.

Still not sure how big of a lift this will be for the other layouts, because I didn't dig too much into how all the layouts, includes, and components are collected. 

## Screenshots
While there are only minute differences (<10px shift or so), which I think is acceptable, the main difference is at ~tablet size. I like the local version better. In production, it has always bugged me how the left navigation butts right against the side of the browser.

**Production**
<img width="1000" alt="Screen Shot 2019-05-24 at 11 46 48 AM" src="https://user-images.githubusercontent.com/25435289/58340446-e1421f80-7e19-11e9-8e6a-77bfad728bb8.png">

**Local**
<img width="1000" alt="Screen Shot 2019-05-24 at 11 47 06 AM" src="https://user-images.githubusercontent.com/25435289/58340840-ca4ffd00-7e1a-11e9-897e-5007d421067d.png">

I took a look at this in IE11 too and seems to work

Anyway, @jbalboni and @ncksllvn, I would love to hear some of your thoughts on this. I just took a single layout to work with, but perhaps this should at least help push our conversation forward.