### PR TITLE
VAGOV-3243: Fixes to Locations pages

### DIFF
--- a/src/applications/static-pages/facilities/BasicFacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/BasicFacilityListWidget.jsx
@@ -58,7 +58,7 @@ export default class BasicFacilityListWidget extends React.Component {
             <FacilityTitle
               facility={facility}
               nickname={this.props.facilities[facility.id].nickname}
-              regionPath={this.props.path}
+              regionPath={this.props.facilities[facility.id].entityUrl.path}
             />
             <FacilityAddress facility={facility} />
             <FacilityPhone facility={facility} />

--- a/src/applications/static-pages/facilities/FacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityListWidget.jsx
@@ -50,10 +50,7 @@ export default class FacilityListWidget extends React.Component {
 
     const facilitiesList = sortFacilitiesByName(this.state.facilities).map(
       facility => (
-        <div
-          key={facility.id}
-          className="usa-grid vads-u-background-color--gray-lightest vads-u-margin-bottom--2p5 vads-u-padding-y--1p5"
-        >
+        <div key={facility.id} className="usa-grid-full vads-u-margin-bottom--2p5">
           <section key={facility.id} className="usa-width-one-half">
             <FacilityTitle
               facility={facility}
@@ -62,14 +59,6 @@ export default class FacilityListWidget extends React.Component {
             />
             <FacilityAddress facility={facility} />
             <FacilityPhone facility={facility} />
-            <div className="location-details-link">
-              <a
-                href={this.props.facilities[facility.id].entityUrl.path}
-                className="usa-button usa-button-secondary"
-              >
-                Location details <i className="fa fa-chevron-right" />
-              </a>
-            </div>
           </section>
           <section className="usa-width-one-half">
             <a

--- a/src/applications/static-pages/facilities/FacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityListWidget.jsx
@@ -50,7 +50,10 @@ export default class FacilityListWidget extends React.Component {
 
     const facilitiesList = sortFacilitiesByName(this.state.facilities).map(
       facility => (
-        <div key={facility.id} className="usa-grid-full vads-u-margin-bottom--2p5">
+        <div
+          key={facility.id}
+          className="usa-grid-full vads-u-margin-bottom--2p5"
+        >
           <section key={facility.id} className="usa-width-one-half">
             <FacilityTitle
               facility={facility}

--- a/src/site/layouts/health_care_region_locations_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_locations_page.drupal.liquid
@@ -15,9 +15,9 @@
                     {{ fieldLocationsIntroBlurb.processed }}
                 </div>
                 <section class="locations">
-                    <h2 id="main-locations">Main locations</h2>
+                    <h2 id="main-locations">Main location(s)</h2>
                     <div class="cta-widget" data-widget-type="facility-locations-list" data-facilities="{{ mainFacilities.entities | widgetFacilitiesList | escape }}"></div>
-                    <h2 id="other-locations">Other locations</h2>
+                    <h2 id="community-clinic-locations">Community clinic locations</h2>
                     <div class="cta-widget" data-widget-type="facility-locations-list" data-facilities="{{ otherFacilities.entities | widgetFacilitiesList | escape }}"></div>
                 </section>
             </article>


### PR DESCRIPTION


## Description
- change “Main location” headline to “Main locations(s)”
- remove padding and grey container for location listings
- remove `Location details >` link from results in “Our locations” list

## Testing done
locally with dev data (staging is down?)

1. pull code
2. rebuild site
3. browse to http://localhost:3001/pittsburgh-health-care/locations/
4. check for these three things:
  - change “Main location” headline to “Main locations(s)”
  - remove padding and grey container for location listings
  - remove `Location details >` link from results in “Our locations” list

## Screenshots
![localhost_3001_pittsburgh-health-care_locations_ (1)](https://user-images.githubusercontent.com/19178435/58389569-6ecf6c00-7fe0-11e9-8baa-115b601f1b84.png)


## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-3243
(the fourth acceptance criteria does not apply as that section does not exist yet
- [ ] change “Main location” headline to “Main locations(s)”
- [ ] remove padding and grey container for location listings
- [ ] remove `Location details >` link from results in “Our locations” list
- [ ] _(does not apply as this section does not exist yet) remove “Mental health phone” number from “Our other VA locations”_

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
