### PR TITLE
stop showing "reapply" button when already enrolled

### DIFF
--- a/src/applications/hca-v2-beta/components/HCAEnrollmentStatusFAQ.jsx
+++ b/src/applications/hca-v2-beta/components/HCAEnrollmentStatusFAQ.jsx
@@ -44,7 +44,11 @@ const HCAEnrollmentStatusFAQ = ({
   showingReapplyForHealthCareContent,
   showReapplyContent,
 }) => {
-  const reapplyAllowed = enrollmentStatus !== HCA_ENROLLMENT_STATUSES.deceased;
+  const reapplyAllowed =
+    new Set([
+      HCA_ENROLLMENT_STATUSES.deceased,
+      HCA_ENROLLMENT_STATUSES.enrolled,
+    ]).has(enrollmentStatus) === false;
   return (
     <>
       {getFAQBlock1(enrollmentStatus)}

--- a/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
+++ b/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
@@ -44,7 +44,11 @@ const HCAEnrollmentStatusFAQ = ({
   showingReapplyForHealthCareContent,
   showReapplyContent,
 }) => {
-  const reapplyAllowed = enrollmentStatus !== HCA_ENROLLMENT_STATUSES.deceased;
+  const reapplyAllowed =
+    new Set([
+      HCA_ENROLLMENT_STATUSES.deceased,
+      HCA_ENROLLMENT_STATUSES.enrolled,
+    ]).has(enrollmentStatus) === false;
   return (
     <>
       {getFAQBlock1(enrollmentStatus)}


### PR DESCRIPTION
## Description
If a vet is already enrolled in VA health care we no longer want to allow them to reapply for health care online so we are removing the link to do so from the HCA intro page.

## Testing done
Local

## Screenshots
**BEFORE** (with link):
![image](https://user-images.githubusercontent.com/20728956/58489981-2b304b80-8121-11e9-918d-c03bb1a5f484.png)

**AFTER** (link removed):
![image](https://user-images.githubusercontent.com/20728956/58489986-2f5c6900-8121-11e9-8797-394f8246c942.png)

## Acceptance criteria
- [x] link to reapply for health care is not show when the user is enrolled in health care

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs