### PR TITLE
Story search query in Redux state, convert search results breadcrumb to link

### DIFF
--- a/src/applications/gi/actions/index.js
+++ b/src/applications/gi/actions/index.js
@@ -163,7 +163,7 @@ export function fetchSearchResults(query = {}) {
   const url = `${api.url}/institutions/search?${queryString}`;
 
   return dispatch => {
-    dispatch({ type: SEARCH_STARTED, name: query.name || '' });
+    dispatch({ type: SEARCH_STARTED, query });
 
     return fetch(url, api.settings)
       .then(res => res.json())

--- a/src/applications/gi/components/heading/GiBillBreadcrumbs.jsx
+++ b/src/applications/gi/components/heading/GiBillBreadcrumbs.jsx
@@ -1,59 +1,52 @@
 import { Link } from 'react-router';
-import PropTypes from 'prop-types';
 import React from 'react';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 
-class GiBillBreadcrumbs extends React.Component {
-  render() {
-    const { pathname, search } = this.props.location;
-    const query = this.props.query;
-    const root = {
-      pathname: '',
-      query: query && query.version ? { version: query.version } : {},
-    };
-    const facilityCode = this.props.facilityCode;
+export default function GiBillBreadcrumbs({
+  searchQuery,
+  facilityCode,
+  location,
+}) {
+  const { pathname, query } = location;
 
-    const crumbs = [
-      <a href="/" key="home">
-        Home
-      </a>,
-      <a href="/education/" key="education">
-        Education and Training
-      </a>,
-      <Link to={root} key="main">
-        GI Bill® Comparison Tool
+  const root = {
+    pathname: '',
+    query: query && query.version ? { version: query.version } : {},
+  };
+
+  const crumbs = [
+    <a href="/" key="home">
+      Home
+    </a>,
+    <a href="/education/" key="education">
+      Education and Training
+    </a>,
+    <Link to={root} key="main">
+      GI Bill® Comparison Tool
+    </Link>,
+  ];
+
+  const onSearchPage = pathname.match(/search/);
+  const onProfilePage = pathname.match(/profile/);
+
+  if (searchQuery && (onSearchPage || onProfilePage)) {
+    crumbs.push(
+      <Link
+        to={{ pathname: 'search', query: searchQuery }}
+        key="search-results"
+      >
+        Search Results
       </Link>,
-    ];
-
-    if (pathname.match(/search/)) {
-      crumbs.push(
-        <Link to={`search/${search}`} key="search-results">
-          Search Results
-        </Link>,
-      );
-    }
-
-    if (pathname.match(/profile/)) {
-      if (this.props.includeSearch) {
-        crumbs.push(
-          <Link to={{ pathname: 'search', query }} key="search-results">
-            Search Results
-          </Link>,
-        );
-      }
-      crumbs.push(
-        <Link to={`profile/${facilityCode}`} key="result-detail">
-          School Details
-        </Link>,
-      );
-    }
-
-    return <Breadcrumbs>{crumbs}</Breadcrumbs>;
+    );
   }
+
+  if (onProfilePage) {
+    crumbs.push(
+      <Link to={`profile/${facilityCode}`} key="result-detail">
+        School Details
+      </Link>,
+    );
+  }
+
+  return <Breadcrumbs>{crumbs}</Breadcrumbs>;
 }
-
-Breadcrumbs.propTypes = {
-  includeSearch: PropTypes.bool,
-};
-
-export default GiBillBreadcrumbs;

--- a/src/applications/gi/components/heading/GiBillBreadcrumbs.jsx
+++ b/src/applications/gi/components/heading/GiBillBreadcrumbs.jsx
@@ -1,16 +1,16 @@
-import { Link, browserHistory } from 'react-router';
+import { Link } from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 
 class GiBillBreadcrumbs extends React.Component {
   render() {
-    const {
-      pathname,
-      query: { version },
-      search,
-    } = this.props.location;
-    const root = { pathname: '', query: version ? { version } : {} };
+    const { pathname, search } = this.props.location;
+    const query = this.props.query;
+    const root = {
+      pathname: '',
+      query: query && query.version ? { version: query.version } : {},
+    };
     const facilityCode = this.props.facilityCode;
 
     const crumbs = [
@@ -36,14 +36,9 @@ class GiBillBreadcrumbs extends React.Component {
     if (pathname.match(/profile/)) {
       if (this.props.includeSearch) {
         crumbs.push(
-          <button
-            type="button"
-            className="va-button-link learn-more-button"
-            onClick={browserHistory.goBack}
-            key="search-results"
-          >
+          <Link to={{ pathname: 'search', query }} key="search-results">
             Search Results
-          </button>,
+          </Link>,
         );
       }
       crumbs.push(

--- a/src/applications/gi/containers/GiBillApp.jsx
+++ b/src/applications/gi/containers/GiBillApp.jsx
@@ -98,10 +98,9 @@ export class GiBillApp extends React.Component {
               />
             )}
             <GiBillBreadcrumbs
-              query={search.query}
+              searchQuery={search.query}
               facilityCode={facilityCode}
               location={this.props.location}
-              includeSearch={search.count !== null}
             />
             {content}
             <AboutThisTool />

--- a/src/applications/gi/containers/GiBillApp.jsx
+++ b/src/applications/gi/containers/GiBillApp.jsx
@@ -98,6 +98,7 @@ export class GiBillApp extends React.Component {
               />
             )}
             <GiBillBreadcrumbs
+              query={search.query}
               facilityCode={facilityCode}
               location={this.props.location}
               includeSearch={search.count !== null}

--- a/src/applications/gi/gi-entry.jsx
+++ b/src/applications/gi/gi-entry.jsx
@@ -5,7 +5,7 @@ import startApp from '../../platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';
-import manifest from './manifest';
+import manifest from './manifest.json';
 
 startApp({
   url: manifest.rootUrl,

--- a/src/applications/gi/manifest.js
+++ b/src/applications/gi/manifest.js
@@ -1,8 +1,0 @@
-module.exports = {
-  appName: 'GI Bill Comparison Tool',
-  entryFile: './gi-entry.jsx',
-  entryName: 'gi',
-  receiveContentProps({ path: rootUrl }) {
-    this.rootUrl = `/${rootUrl}`;
-  },
-};

--- a/src/applications/gi/manifest.json
+++ b/src/applications/gi/manifest.json
@@ -1,0 +1,6 @@
+{
+  "appName": "GI Bill Comparison Tool",
+  "entryFile": "./gi-entry.jsx",
+  "entryName": "gi",
+  "rootUrl": "/gi-bill-comparison-tool"
+}

--- a/src/applications/gi/reducers/search.js
+++ b/src/applications/gi/reducers/search.js
@@ -25,6 +25,7 @@ const INITIAL_STATE = {
   results: [],
   count: null,
   version: {},
+  query: null,
   pagination: {
     currentPage: 1,
     totalPages: 1,

--- a/src/applications/gi/reducers/search.js
+++ b/src/applications/gi/reducers/search.js
@@ -79,7 +79,7 @@ export default function(state = INITIAL_STATE, action) {
     case FILTER_TOGGLED:
       return { ...state, filterOpened: !state.filterOpened };
     case SEARCH_STARTED:
-      return { ...state, inProgress: true };
+      return { ...state, query: action.query, inProgress: true };
     case SEARCH_FAILED:
       return {
         ...state,


### PR DESCRIPTION
## Description
Currently the search results breadcrumb is a button rather than a link, which is a bit odd. This PR stores the search query info so that we can construct a link for the results, instead of using the history api to go back a page

## Testing done
Tested out locally. Found a weird local issue where sometimes the app will stop loading routes client side and do full refreshes, but it's not related to this change and it doesn't happen on staging.

## Screenshots
![Screen Shot 2019-05-28 at 12 01 56 PM](https://user-images.githubusercontent.com/634932/58493202-6aba6000-8140-11e9-843c-310e7cd4fb1b.png)

## Acceptance criteria
- [x] Breadcrumbs show up as all links with hrefs

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
