### PR TITLE
Update/add GA events

### DIFF
--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router';
 
 import ProgressButton from '@department-of-veterans-affairs/formation-react/ProgressButton';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+import recordEvent from 'platform/monitoring/record-event';
 
 class FormStartControls extends React.Component {
   constructor(props) {
@@ -26,12 +27,10 @@ class FormStartControls extends React.Component {
 
   captureAnalytics = () =>
     this.props.gaStartEventName &&
-    window.dataLayer.push({ event: this.props.gaStartEventName });
+    recordEvent({ event: this.props.gaStartEventName });
 
   handleLoadPrefill = () => {
     this.captureAnalytics();
-    // temp hack to fix the fact that the START button doesn't work
-    // this.goToBeginning();
     if (this.props.prefillAvailable) {
       this.props.fetchInProgressForm(
         // TODO: where does this come from?
@@ -131,12 +130,15 @@ FormStartControls.propTypes = {
   removeInProgressForm: PropTypes.func.isRequired,
   router: PropTypes.object.isRequired,
   formSaved: PropTypes.bool.isRequired,
-  // prefillAvailable = whether the form can be pre-filled
   prefillAvailable: PropTypes.bool.isRequired,
   startPage: PropTypes.string.isRequired,
   startText: PropTypes.string,
   resumeOnly: PropTypes.bool,
   gaStartEventName: PropTypes.string,
+};
+
+FormStartControls.defaultProps = {
+  gaStartEventName: 'login-successful-start-form',
 };
 
 export default withRouter(FormStartControls);

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -6,19 +6,20 @@ import moment from 'moment';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { getNextPagePath } from 'platform/forms-system/src/js/routing';
+import recordEvent from 'platform/monitoring/record-event';
 import _ from 'platform/utilities/data';
 
 import {
   formDescriptions,
   formBenefits,
-} from '../../../applications/personalization/profile360/util/helpers';
-import { toggleLoginModal } from '../../site-wide/user-nav/actions';
+} from 'applications/personalization/profile360/util/helpers';
+import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { fetchInProgressForm, removeInProgressForm } from './actions';
 import FormStartControls from './FormStartControls';
 import { getIntroState } from './selectors';
 import DowntimeNotification, {
   externalServiceStatus,
-} from '../../monitoring/DowntimeNotification';
+} from 'platform/monitoring/DowntimeNotification';
 import DowntimeMessage from './DowntimeMessage';
 
 class SaveInProgressIntro extends React.Component {
@@ -207,11 +208,12 @@ class SaveInProgressIntro extends React.Component {
   };
 
   goToBeginning = () => {
+    recordEvent({ event: 'no-login-start-form' });
     this.props.router.push(this.getStartPage());
   };
 
   openLoginModal = () => {
-    this.props.toggleLoginModal(true);
+    this.props.toggleLoginModal(true, 'cta-form');
   };
 
   renderDowntime = (downtime, children) => {

--- a/src/platform/forms/tests/save-in-progress/FormStartControls.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/FormStartControls.unit.spec.jsx
@@ -203,7 +203,30 @@ describe('Schemaform <FormStartControls>', () => {
     expect(formDOM.querySelector('.va-modal-body')).to.be.null;
   });
 
-  it('should not capture analytics events when starting the form', () => {
+  it('should not capture analytics events when starting the form if the `gaStartEventName` prop is explicitly removed', () => {
+    const routerSpy = {
+      push: sinon.spy(),
+    };
+    global.window.dataLayer = [];
+    const fetchSpy = sinon.spy();
+    const tree = ReactTestUtils.renderIntoDocument(
+      <FormStartControls
+        formId="1010ez"
+        migrations={[]}
+        startPage={startPage}
+        router={routerSpy}
+        fetchInProgressForm={fetchSpy}
+        gaStartEventName={null}
+        prefillAvailable
+      />,
+    );
+    const formDOM = getFormDOM(tree);
+    formDOM.click('.usa-button-primary');
+
+    expect(global.window.dataLayer).to.eql([]);
+  });
+
+  it('should capture analytics events with the default event name when starting the form  if a custom `gaStartEventName` is not set', () => {
     const routerSpy = {
       push: sinon.spy(),
     };
@@ -222,10 +245,14 @@ describe('Schemaform <FormStartControls>', () => {
     const formDOM = getFormDOM(tree);
     formDOM.click('.usa-button-primary');
 
-    expect(global.window.dataLayer).to.eql([]);
+    expect(global.window.dataLayer).to.eql([
+      {
+        event: 'login-successful-start-form',
+      },
+    ]);
   });
 
-  it('should capture analytics events when starting the form', () => {
+  it('should capture analytics events with a custom event name when starting the form if a custom `gaStartEventName` is set', () => {
     const routerSpy = {
       push: sinon.spy(),
     };

--- a/src/platform/site-wide/user-nav/actions/index.js
+++ b/src/platform/site-wide/user-nav/actions/index.js
@@ -1,4 +1,4 @@
-import recordEvent from '../../../monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 
 export const TOGGLE_FORM_SIGN_IN_MODAL = 'TOGGLE_FORM_SIGN_IN_MODAL';
 export const TOGGLE_LOGIN_MODAL = 'TOGGLE_LOGIN_MODAL';


### PR DESCRIPTION
## Description
Adding/updating the GA events that are fired from each form's intro page when users are both logged in and logged out.

## Testing done
Confirmed the correct GA events are fired by temporarily inserting a `console.log()` in the `recordEvent()` method.

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs