### PR TITLE
[CMS] Check for deleted outreach assets

### DIFF
--- a/src/site/stages/build/plugins/create-outreach-assets-data.js
+++ b/src/site/stages/build/plugins/create-outreach-assets-data.js
@@ -29,6 +29,7 @@ function createOutreachAssetsData(buildSettings) {
     for (const entity of outreachAssets.entities) {
       let relativeUrl = '';
 
+      // eslint-disable-next-line
       if (!entity.fieldMedia.entity) continue;
 
       switch (entity.fieldMedia.entity.entityBundle) {

--- a/src/site/stages/build/plugins/create-outreach-assets-data.js
+++ b/src/site/stages/build/plugins/create-outreach-assets-data.js
@@ -22,42 +22,45 @@ function createOutreachAssetsData(buildSettings) {
       return;
     }
 
-    const {
-      data: { outreachAssets },
-    } = drupalData;
+    try {
+      const {
+        data: { outreachAssets },
+      } = drupalData;
 
-    for (const entity of outreachAssets.entities) {
-      let relativeUrl = '';
+      for (const entity of outreachAssets.entities) {
+        let relativeUrl = '';
 
-      // eslint-disable-next-line
-      if (!entity.fieldMedia.entity) continue;
+        if (!entity.fieldMedia.entity) continue;
 
-      switch (entity.fieldMedia.entity.entityBundle) {
-        case ENTITY_BUNDLES.DOCUMENT:
-          relativeUrl = entity.fieldMedia.entity.fieldDocument.entity.url;
-          break;
-        case ENTITY_BUNDLES.IMAGE:
-          relativeUrl = entity.fieldMedia.entity.image.url;
-          break;
-        default:
-          break;
+        switch (entity.fieldMedia.entity.entityBundle) {
+          case ENTITY_BUNDLES.DOCUMENT:
+            relativeUrl = entity.fieldMedia.entity.fieldDocument.entity.url;
+            break;
+          case ENTITY_BUNDLES.IMAGE:
+            relativeUrl = entity.fieldMedia.entity.image.url;
+            break;
+          default:
+            break;
+        }
+
+        if (!relativeUrl) continue;
+
+        const noSlash = relativeUrl.slice(1);
+        const absoluteUrl = `${bucket}${relativeUrl}`;
+        const fileSize = files[noSlash].contents.byteLength;
+
+        entity.derivedFields = { absoluteUrl, fileSize };
       }
 
-      if (!relativeUrl) continue;
+      const outreachAssetsFileName = 'generated/outreach-assets.json';
+      const serializedOutreachAssets = JSON.stringify(outreachAssets, null, 2);
 
-      const noSlash = relativeUrl.slice(1);
-      const absoluteUrl = `${bucket}${relativeUrl}`;
-      const fileSize = files[noSlash].contents.byteLength;
-
-      entity.derivedFields = { absoluteUrl, fileSize };
+      files[outreachAssetsFileName] = {
+        contents: Buffer.from(serializedOutreachAssets),
+      };
+    } catch (err) {
+      // This should be added back
     }
-
-    const outreachAssetsFileName = 'generated/outreach-assets.json';
-    const serializedOutreachAssets = JSON.stringify(outreachAssets, null, 2);
-
-    files[outreachAssetsFileName] = {
-      contents: Buffer.from(serializedOutreachAssets),
-    };
 
     done();
   };

--- a/src/site/stages/build/plugins/create-outreach-assets-data.js
+++ b/src/site/stages/build/plugins/create-outreach-assets-data.js
@@ -29,6 +29,8 @@ function createOutreachAssetsData(buildSettings) {
     for (const entity of outreachAssets.entities) {
       let relativeUrl = '';
 
+      if (!entity.fieldMedia.entity) continue;
+
       switch (entity.fieldMedia.entity.entityBundle) {
         case ENTITY_BUNDLES.DOCUMENT:
           relativeUrl = entity.fieldMedia.entity.fieldDocument.entity.url;


### PR DESCRIPTION
## Description
This PR fixes an error occurring when an outreach asset is deleted, but still returning in the GraphQL query. We should probably update the GraphQL query later.

This is to enable merging https://github.com/department-of-veterans-affairs/vagov-content/pull/447. it should be considered a temporary change because this is not a good solution.

## Testing done
None - if master builds okay then we're golden.

## Acceptance criteria
- [ ] Master builds

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
