### PR TITLE
Add and use `isValidDateString()` helper

### DIFF
--- a/src/applications/hca-v2-beta/enrollment-status-helpers.jsx
+++ b/src/applications/hca-v2-beta/enrollment-status-helpers.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 
+import { isValidDateString } from 'platform/utilities/date';
 import { HCA_ENROLLMENT_STATUSES } from './constants';
 import { getMedicalCenterNameByID } from './helpers';
 
@@ -73,15 +74,16 @@ export function getWarningHeadline(enrollmentStatus) {
 }
 
 function getDefaultWarningStatus(applicationDate) {
-  if (isNaN(Date.parse(applicationDate))) {
-    return null;
+  if (isValidDateString(applicationDate)) {
+    return (
+      <p>
+        <strong>You applied on: </strong>
+        {moment(applicationDate).format('MMMM D, YYYY')}
+      </p>
+    );
   }
-  return (
-    <p>
-      <strong>You applied on: </strong>
-      {moment(applicationDate).format('MMMM D, YYYY')}
-    </p>
-  );
+
+  return null;
 }
 
 function getEnrolledWarningStatus(
@@ -92,7 +94,7 @@ function getEnrolledWarningStatus(
   const facilityName = getMedicalCenterNameByID(preferredFacility);
   const blocks = [];
   // add "you applied on" block if the application date is valid
-  if (!isNaN(Date.parse(applicationDate))) {
+  if (isValidDateString(applicationDate)) {
     blocks.push(
       <>
         <strong>You applied on: </strong>
@@ -101,7 +103,7 @@ function getEnrolledWarningStatus(
     );
   }
   // add "we enrolled you" block if the enrollment date is valid
-  if (!isNaN(Date.parse(enrollmentDate))) {
+  if (isValidDateString(enrollmentDate)) {
     blocks.push(
       <>
         <strong>We enrolled you on: </strong>

--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 
+import { isValidDateString } from 'platform/utilities/date';
 import { HCA_ENROLLMENT_STATUSES } from './constants';
 import { getMedicalCenterNameByID } from './helpers';
 import { DASHBOARD_ALERT_TYPES } from 'applications/personalization/dashboard/components/DashboardAlert';
@@ -81,7 +82,7 @@ export function getEnrollmentDetails(
   const facilityName = getMedicalCenterNameByID(preferredFacility);
   const blocks = [];
   // add "you applied on" block if the application date is valid
-  if (!isNaN(Date.parse(applicationDate))) {
+  if (isValidDateString(applicationDate)) {
     blocks.push(
       <>
         <strong>You applied on: </strong>
@@ -90,7 +91,7 @@ export function getEnrollmentDetails(
     );
   }
   // add "we enrolled you" block if the enrollment date is valid
-  if (!isNaN(Date.parse(enrollmentDate))) {
+  if (isValidDateString(enrollmentDate)) {
     blocks.push(
       <>
         <strong>We enrolled you on: </strong>
@@ -953,7 +954,10 @@ export function getAlertContent(
   const blocks = [];
 
   // start with the "You applied on" if the user isn't enrolled in health care
-  if (enrollmentStatus !== HCA_ENROLLMENT_STATUSES.enrolled) {
+  if (
+    enrollmentStatus !== HCA_ENROLLMENT_STATUSES.enrolled &&
+    isValidDateString(applicationDate)
+  ) {
     blocks.push(
       <p>
         <strong>You applied on:</strong>{' '}

--- a/src/platform/utilities/date/index.js
+++ b/src/platform/utilities/date/index.js
@@ -67,3 +67,14 @@ export function timeFromNow(date, userFromDate = null) {
 
   return 'a moment';
 }
+
+/**
+ * Checks if the passed-in arg is a valid date string, meaning it can be parsed
+ * by Date.parse()
+ *
+ * @param {string} dateString The string to validate
+ * @returns {boolean} If the string is a valid date string
+ */
+export function isValidDateString(dateString) {
+  return !isNaN(Date.parse(dateString));
+}

--- a/src/platform/utilities/tests/date.unit.spec.js
+++ b/src/platform/utilities/tests/date.unit.spec.js
@@ -8,6 +8,7 @@ import {
   formatDateParsedZoneShort,
   formatDateLong,
   formatDateParsedZoneLong,
+  isValidDateString,
 } from '../date';
 
 describe('Helpers unit tests', () => {
@@ -139,6 +140,20 @@ describe('Helpers unit tests', () => {
       expect(formatDateParsedZoneLong(almostMidnightOffsetNegative1)).to.equal(
         'November 12, 1995',
       );
+    });
+  });
+  describe('isValidDateString', () => {
+    it('returns `false` when passed an invalid argument', () => {
+      expect(isValidDateString()).to.be.false;
+      expect(isValidDateString(false)).to.be.false;
+      expect(isValidDateString({})).to.be.false;
+    });
+    it('returns `false` when passed a string that cannot be parsed as a date', () => {
+      expect(isValidDateString('not a date')).to.be.false;
+    });
+    it('returns `true` when passed a string that can be parsed as a date', () => {
+      expect(isValidDateString('1986-05-06')).to.be.true;
+      expect(isValidDateString('2018-01-24T00:00:00.000-06:00')).to.be.true;
     });
   });
 });


### PR DESCRIPTION
- Use it in place of places I was using `!isNan()` directly
- Use it when generating the content for the Dashboard's HCA enrollment status alert

## Description
An issue was uncovered where I wasn't checking to see if a date string from the server was valid before formatting it and displaying it to the user (https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18766). I already had a method for checking if a string was a valid date string but wasn't using it in this case. I took this opportunity to wrap that check in a helper function, mainly to aid readability.

## Testing done
Unit test and local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs