### PR TITLE
STEM: Add Conditional Military History Page to 1995 #18659

### DIFF
--- a/src/applications/edu-benefits/1995/config/form.js
+++ b/src/applications/edu-benefits/1995/config/form.js
@@ -1,7 +1,7 @@
 import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
 
 import { transform as oldTransform } from '../helpers';
-import { transform as newTransform } from '../submit-transformer';
+import { transform } from '../submit-transformer';
 
 import { urlMigration } from '../../config/migrations';
 
@@ -36,7 +36,7 @@ const formConfig = {
     noAuth:
       'Please sign in again to resume your application for education benefits.',
   },
-  transformForSubmit: environment.isProduction() ? oldTransform : newTransform,
+  transformForSubmit: environment.isProduction() ? oldTransform : transform,
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   defaultDefinitions: {

--- a/src/applications/edu-benefits/1995/config/form.js
+++ b/src/applications/edu-benefits/1995/config/form.js
@@ -1,6 +1,7 @@
 import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
 
-import { transform } from '../helpers';
+import { transform as oldTransform } from '../helpers';
+import { transform as newTransform } from '../submit-transformer';
 
 import { urlMigration } from '../../config/migrations';
 
@@ -35,7 +36,7 @@ const formConfig = {
     noAuth:
       'Please sign in again to resume your application for education benefits.',
   },
-  transformForSubmit: transform,
+  transformForSubmit: environment.isProduction() ? oldTransform : newTransform,
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   defaultDefinitions: {

--- a/src/applications/edu-benefits/1995/config/new-chapters.js
+++ b/src/applications/edu-benefits/1995/config/new-chapters.js
@@ -71,6 +71,7 @@ export const newChapters = {
   militaryService: {
     title: 'Military History',
     pages: {
+      // 1995-STEM related
       activeDuty: {
         title: 'Active Duty',
         path: 'active-duty',
@@ -81,7 +82,7 @@ export const newChapters = {
       servicePeriods: {
         path: 'military/service',
         title: 'Service periods',
-        depends: form => !displayActiveDutyStem(form),
+        depends: form => !displayActiveDutyStem(form), // 1995-STEM related
         uiSchema: {
           'view:newService': {
             'ui:title':
@@ -105,7 +106,7 @@ export const newChapters = {
       militaryHistory: {
         title: 'Military history',
         path: 'military/history',
-        depends: form => !displayActiveDutyStem(form),
+        depends: form => !displayActiveDutyStem(form), // 1995-STEM related
         uiSchema: {
           'view:hasServiceBefore1978': {
             'ui:title':

--- a/src/applications/edu-benefits/1995/config/new-chapters.js
+++ b/src/applications/edu-benefits/1995/config/new-chapters.js
@@ -14,7 +14,10 @@ import createDirectDepositChangePage from '../../pages/directDepositChange';
 import createApplicantInformationPage from '../../../../platform/forms/pages/applicantInformation';
 
 import { showSchoolAddress } from '../../utils/helpers';
+import { displayActiveDutyStem } from '../helpers';
 import { benefitsLabels } from '../../utils/labels';
+
+import { activeDuty } from '../pages';
 
 const {
   benefit,
@@ -47,7 +50,6 @@ export const newChapters = {
       benefitSelection: {
         title: 'Education benefit',
         path: 'benefits/eligibility',
-        initialData: {},
         uiSchema: {
           benefit: {
             'ui:widget': 'radio',
@@ -69,10 +71,17 @@ export const newChapters = {
   militaryService: {
     title: 'Military History',
     pages: {
+      activeDuty: {
+        title: 'Active Duty',
+        path: 'active-duty',
+        depends: displayActiveDutyStem,
+        uiSchema: activeDuty.uiSchema,
+        schema: activeDuty.schema,
+      },
       servicePeriods: {
         path: 'military/service',
         title: 'Service periods',
-        initialData: {},
+        depends: form => !displayActiveDutyStem(form),
         uiSchema: {
           'view:newService': {
             'ui:title':
@@ -96,7 +105,7 @@ export const newChapters = {
       militaryHistory: {
         title: 'Military history',
         path: 'military/history',
-        initialData: {},
+        depends: form => !displayActiveDutyStem(form),
         uiSchema: {
           'view:hasServiceBefore1978': {
             'ui:title':
@@ -180,7 +189,6 @@ export const newChapters = {
       dependents: {
         title: 'Dependents',
         path: 'personal-information/dependents',
-        initialData: {},
         depends: {
           'view:hasServiceBefore1978': true,
         },

--- a/src/applications/edu-benefits/1995/config/new-chapters.js
+++ b/src/applications/edu-benefits/1995/config/new-chapters.js
@@ -74,7 +74,7 @@ export const newChapters = {
       activeDuty: {
         title: 'Active Duty',
         path: 'active-duty',
-        // depends: displayActiveDutyStem,
+        depends: displayActiveDutyStem,
         uiSchema: activeDuty.uiSchema,
         schema: activeDuty.schema,
       },

--- a/src/applications/edu-benefits/1995/config/new-chapters.js
+++ b/src/applications/edu-benefits/1995/config/new-chapters.js
@@ -74,7 +74,7 @@ export const newChapters = {
       activeDuty: {
         title: 'Active Duty',
         path: 'active-duty',
-        depends: displayActiveDutyStem,
+        // depends: displayActiveDutyStem,
         uiSchema: activeDuty.uiSchema,
         schema: activeDuty.schema,
       },

--- a/src/applications/edu-benefits/1995/content/activeDuty.jsx
+++ b/src/applications/edu-benefits/1995/content/activeDuty.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+export const housingPaymentInfo = () => (
+  <div className="feature">
+    If you are on active duty or if you anticipate going on active duty, it may
+    impact your housing payment while receiving the STEM scholarship
+  </div>
+);

--- a/src/applications/edu-benefits/1995/content/activeDuty.jsx
+++ b/src/applications/edu-benefits/1995/content/activeDuty.jsx
@@ -3,6 +3,6 @@ import React from 'react';
 export const housingPaymentInfo = () => (
   <div className="feature">
     If you are on active duty or if you anticipate going on active duty, it may
-    impact your housing payment while receiving the STEM scholarship
+    impact your housing payment while receiving the STEM scholarship.
   </div>
 );

--- a/src/applications/edu-benefits/1995/helpers.jsx
+++ b/src/applications/edu-benefits/1995/helpers.jsx
@@ -23,5 +23,6 @@ export function transform(formConfig, form) {
   });
 }
 
+// 1995-STEM related
 export const displayActiveDutyStem = form =>
   form.isEnrolledStem || form.isPursuingTeachingCert;

--- a/src/applications/edu-benefits/1995/helpers.jsx
+++ b/src/applications/edu-benefits/1995/helpers.jsx
@@ -22,3 +22,6 @@ export function transform(formConfig, form) {
     },
   });
 }
+
+export const displayActiveDutyStem = form =>
+  form.isEnrolledStem || form.isPursuingTeachingCert;

--- a/src/applications/edu-benefits/1995/pages/activeDuty.js
+++ b/src/applications/edu-benefits/1995/pages/activeDuty.js
@@ -1,4 +1,6 @@
 import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
+import { housingPaymentInfo } from '../content/activeDuty';
+import _ from 'lodash';
 
 const { isActiveDuty } = fullSchema1995.properties;
 
@@ -9,11 +11,21 @@ export const uiSchema = {
       'Are you currently on active duty or do you anticipate you will be going on active duty?',
     'ui:widget': 'yesNo',
   },
+  'view:housingPaymentInfo': {
+    'ui:description': housingPaymentInfo,
+    'ui:options': {
+      hideIf: data => !_.get(data, 'isActiveDuty', false),
+    },
+  },
 };
 
 export const schema = {
   type: 'object',
   properties: {
     isActiveDuty,
+    'view:housingPaymentInfo': {
+      type: 'object',
+      properties: {},
+    },
   },
 };

--- a/src/applications/edu-benefits/1995/pages/activeDuty.js
+++ b/src/applications/edu-benefits/1995/pages/activeDuty.js
@@ -1,0 +1,19 @@
+import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
+
+const { isActiveDuty } = fullSchema1995.properties;
+
+export const uiSchema = {
+  isActiveDuty: {
+    'ui:title': ' ',
+    'ui:description':
+      'Are you currently on active duty or do you anticipate you will be going on active duty?',
+    'ui:widget': 'yesNo',
+  },
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    isActiveDuty,
+  },
+};

--- a/src/applications/edu-benefits/1995/pages/index.js
+++ b/src/applications/edu-benefits/1995/pages/index.js
@@ -1,0 +1,3 @@
+import * as activeDuty from './activeDuty';
+
+export { activeDuty };

--- a/src/applications/edu-benefits/1995/submit-transformer.js
+++ b/src/applications/edu-benefits/1995/submit-transformer.js
@@ -1,0 +1,37 @@
+import _ from 'lodash';
+import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
+
+export function transform(formConfig, form) {
+  const newSchoolTransform = formData => {
+    let clonedData = _.cloneDeep(formData);
+
+    delete clonedData.newSchoolName;
+    delete clonedData.newSchoolAddress;
+
+    clonedData = {
+      ...clonedData,
+      newSchool: {
+        ...clonedData.newSchool,
+        name: formData.newSchoolName,
+        address: formData.newSchoolAddress,
+      },
+    };
+
+    return clonedData;
+  };
+
+  // This needs to be last function call in array below
+  const usFormTransform = formData =>
+    transformForSubmit(formConfig, { ...form, data: formData });
+
+  const transformedData = [
+    newSchoolTransform,
+    usFormTransform, // This needs to be last function call in array
+  ].reduce((formData, transformer) => transformer(formData), form.data);
+
+  return JSON.stringify({
+    educationBenefitsClaim: {
+      form: transformedData,
+    },
+  });
+}

--- a/src/applications/edu-benefits/tests/1995/pages/activeDuty.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/1995/pages/activeDuty.unit.spec.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+import {
+  DefinitionTester,
+  selectRadio,
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+
+import formConfig from '../../../1995/config/form.js';
+
+describe('Active Duty Military History page', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.militaryService.pages.activeDuty;
+
+  it('renders the active duty page', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(2);
+
+    form.unmount();
+  });
+
+  it('renders the housing payment infomation when yes is selected', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    selectRadio(form, 'root_isActiveDuty', 'Y');
+    expect(form.find('.feature').length, 1);
+    form.unmount();
+  });
+});

--- a/src/applications/edu-benefits/tests/1995/schema/schema.unit.spec.js
+++ b/src/applications/edu-benefits/tests/1995/schema/schema.unit.spec.js
@@ -3,8 +3,6 @@ import fs from 'fs';
 import path from 'path';
 import { Validator } from 'jsonschema';
 
-// import { transform } from '../../../1995/helpers';
-import { transform } from '../../../1995/submit-transformer';
 import formConfig from '../../../1995/config/form';
 import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
 
@@ -16,8 +14,9 @@ describe('1995 schema tests', () => {
       const contents = JSON.parse(
         fs.readFileSync(path.join(__dirname, file), 'utf8'),
       );
-      const submitData = JSON.parse(transform(formConfig, contents))
-        .educationBenefitsClaim.form;
+      const submitData = JSON.parse(
+        formConfig.transformForSubmit(formConfig, contents),
+      ).educationBenefitsClaim.form;
       const result = v.validate(JSON.parse(submitData), fullSchema1995);
 
       if (!result.valid) {

--- a/src/applications/edu-benefits/tests/1995/schema/schema.unit.spec.js
+++ b/src/applications/edu-benefits/tests/1995/schema/schema.unit.spec.js
@@ -3,7 +3,8 @@ import fs from 'fs';
 import path from 'path';
 import { Validator } from 'jsonschema';
 
-import { transform } from '../../../1995/helpers';
+// import { transform } from '../../../1995/helpers';
+import { transform } from '../../../1995/submit-transformer';
 import formConfig from '../../../1995/config/form';
 import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
 
@@ -20,7 +21,7 @@ describe('1995 schema tests', () => {
       const result = v.validate(JSON.parse(submitData), fullSchema1995);
 
       if (!result.valid) {
-          console.log(result.errors); // eslint-disable-line
+        console.log(result.errors); // eslint-disable-line
       }
       expect(result.valid).to.be.true;
     });


### PR DESCRIPTION
## Description
As a Chapter 33 benefit recipient, I need the ability to specify my active duty status while applying for the Rogers STEM Scholarship so that I can provide accurate information while applying for the scholarship.

Assumptions
1. This work will be completed behind a flag so that is is only available in staging/lower environments and not available in production.
2. The supporting document is a mockup of how the page could look.
3. The UI implementation will follow DSVA patterns and practices for displaying conditional questions/pages.

## Testing done
- local testing
- unit testing

## Screenshots
![Screen Shot 2019-05-29 at 12 13 54 PM](https://user-images.githubusercontent.com/1094999/58573210-437c9500-820b-11e9-8f42-d3de358098bc.png)


## Acceptance criteria
- [ ] The "Active Duty" questions page is displayed when the user selects one of the following answers on the first STEM questions "Education Benefit" page:
     - "Yes" is selected as the answer to "Are you enrolled in an undergraduate STEM degree program?"
     - "Yes" is selected as the answer to "Do you have a STEM undergraduate degree and are now pursuing a teaching certification?"
- [ ] The "Active Duty" questions page has the following questions:
     - "Are you currently on active duty or do you anticipate you will be going on active duty?"
- [ ] The available answers to all questions in AC-2 are "Yes" and "No".
- [ ] The question "Are you currently on active duty or do you anticipate you will be going on active duty?" has the following behaviors:
     - If the answer is "Yes" it conditionally displays the alert text "If you are on active duty or if you anticipate going on active duty, it may impact your housing payment while receiving the STEM scholarship".
- [ ] The workflow continues to the first page of the "School Selection" section upon clicking "Continue". 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
