### PR TITLE
VAGOV-3844, 3129, 3138, 3130, 2854: health care region ui updates

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-facility-detail.scss
+++ b/src/applications/static-pages/sass/modules/_m-facility-detail.scss
@@ -23,4 +23,10 @@
    li.active-level > .usa-sidenav-sub_list {
       display: block;
    }
+
+   &.va-sidebarnav {
+      h4 {
+         width: 100%;
+      }
+   }
 }

--- a/src/site/facilities/facilities_health_services_buttons.drupal.liquid
+++ b/src/site/facilities/facilities_health_services_buttons.drupal.liquid
@@ -1,12 +1,14 @@
 {% comment %}
     This is used for Facility details pages and (A-Z) Health Services page
 {% endcomment %}
-<div class="usa-width-one-third">
-    <a href="/{{ path }}/make-an-appointment" class="usa-button usa-button-primary">Make an appointment</a>
-</div>
-<div class="usa-width-one-third">
-    <a href="/{{ path }}/become-a-patient" class="usa-button usa-button-primary">Become a patient</a>
-</div>
-<div class="usa-width-one-third">
-    <a  href="/{{ path }}/pharmacy" class="usa-button">Pharmacy</a>
+<div class="vads-l-row vads-u-justify-content--space-between">
+    <div class="medium-screen:vads-l-col--4 vads-l-col--12">
+        <a class="usa-button vads-u-width--full" href="/{{ path }}/make-an-appointment">Make an appointment</a>
+    </div>
+    <div class="medium-screen:vads-l-col--4 vads-l-col--12">
+        <a class="usa-button vads-u-margin-x--0 vads-u-width--full" href="/{{ path }}/become-a-patient">Become a patient</a>
+    </div>
+    <div class="medium-screen:vads-l-col--3 vads-l-col--12 vads-u-text-align--right">
+        <a class="usa-button vads-u-margin-x--0 vads-u-width--full" href="/{{ path }}/pharmacy">Pharmacy</a>
+    </div>
 </div>

--- a/src/site/facilities/facility_health_service.drupal.liquid
+++ b/src/site/facilities/facility_health_service.drupal.liquid
@@ -1,4 +1,4 @@
-<div class="usa-accordion">
+<div class="usa-accordion-bordered">
     <ul class="usa-unstyled-list">
         {% assign serviceTaxonomy = healthService.fieldServiceNameAndDescripti.entity %}
         <li>

--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -1,4 +1,4 @@
-<div class="usa-accordion">
+<div class="usa-accordion-bordered">
     <ul class="usa-unstyled-list">
         {% assign serviceTaxonomy = healthService.fieldServiceNameAndDescripti.entity %}
         <li>

--- a/src/site/facilities/main_buttons.drupal.liquid
+++ b/src/site/facilities/main_buttons.drupal.liquid
@@ -1,12 +1,14 @@
 {% comment %}
     This is used for Region Landing page and Contact us page
 {% endcomment %}
-<div class="usa-width-one-third">
-    <a class="usa-button" href="/{{ path }}/make-an-appointment">Make an appointment</a>
-</div>
-<div class="usa-width-one-third">
-    <a class="usa-button" href="/{{ path }}/health-services">View A-Z Health Services</a>
-</div>
-<div class="usa-width-one-third">
-    <a class="usa-button" href="/{{ path }}/become-a-patient">Become a patient</a>
+<div class="vads-l-row vads-u-justify-content--space-between">
+    <div class="medium-screen:vads-l-col--4 vads-l-col--12">
+        <a class="usa-button vads-u-width--full" href="/{{ path }}/make-an-appointment">Make an appointment</a>
+    </div>
+    <div class="medium-screen:vads-l-col--4 vads-l-col--12">
+        <a class="usa-button vads-u-width--full" href="/{{ path }}/health-services">View A-Z Health Services</a>
+    </div>
+    <div class="medium-screen:vads-l-col--3 vads-l-col--12 vads-u-text-align--right">
+        <a class="usa-button vads-u-margin-x--0 vads-u-width--full" href="/{{ path }}/become-a-patient">Become a patient</a>
+    </div>
 </div>

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -156,4 +156,33 @@ module.exports = function registerFilters() {
   liquid.filters.regionBasePath = path => path.split('/')[1];
 
   liquid.filters.isContactPage = path => path.includes('contact');
+
+  // TODO: these are totally hacky and unpredictable
+  liquid.filters.facilitySidebarName = name => {
+    if (name.toLowerCase().includes('health care')) {
+      const splitName = name.split(' ');
+      const topName = [];
+      const bottomName = [];
+      let healthFound = false;
+      splitName.forEach(word => {
+        if (healthFound) {
+          bottomName.push(word);
+        } else if (word.toLowerCase().includes('health')) {
+          healthFound = true;
+          bottomName.push(word);
+        } else {
+          topName.push(word);
+        }
+      });
+
+      return `
+        <span class="vads-u-display--block">${topName.join(' ')}</span>
+        <span class="vads-u-display--block">${bottomName.join(' ')}</span>
+      `;
+    }
+
+    return `<span class="vads-u-display--block">${name}</span>`;
+  };
+
+  liquid.filters.homePath = description => `/${description.split('/')[1]}`;
 };

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -155,7 +155,7 @@
           {% endcapture %}
           {% unless difference contains '-' %}
             <h2 id="prepare-for-your-visit">Prepare for your visit</h2>
-            <div class="usa-accordion">
+            <div class="usa-accordion-bordered">
               <ul aria-multiselectable="false" class="usa-unstyled-list">
                 {% for accordionItem in fieldLocationServices %}
                   {% assign item = accordionItem.entity %}

--- a/src/site/navigation/facility_sidebar_nav.drupal.liquid
+++ b/src/site/navigation/facility_sidebar_nav.drupal.liquid
@@ -1,8 +1,12 @@
-<nav id="va-detailpage-sidebar" data-drupal-sidebar class="va-c-facility-sidebar usa-width-one-fourth va-sidebarnav">
+<nav id="va-detailpage-sidebar" data-drupal-sidebar class="va-c-facility-sidebar usa-width-one-fourth va-sidebarnav va-c-facility-sidebar">
     <div>
         <button class="va-btn-close-icon va-sidebarnav-close" type="button" aria-label="Close this menu"></button>
         <div class="left-side-nav-title">
-            <h4>{{ facilitySidebar.name }}</h4>
+            <a href="{{ facilitySidebar.description | homePath }}" class="vads-u-display--block">
+                <h4>
+                    {{ facilitySidebar.name | facilitySidebarName }}
+                </h4>
+            </a>
         </div>
         <ul class="usa-accordion">
             {% for link in facilitySidebar.links %}

--- a/src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid
+++ b/src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid
@@ -13,25 +13,27 @@
     <div class="va-c-list-link-teasers">
         {% assign even = true %}
         {% for linkTeaser in paragraph.fieldVaParagraphs %}
-            {% if even %}
-                <div class="usa-grid usa-grid-full">
-            {% endif %}
-            <div class="usa-width-one-half vads-u-margin-bottom--2">
-            <a href="{{linkTeaser.entity.fieldLink.url.path}}">
-                    {{ linkTeaser.entity.fieldLink.title }}
-                </a>
-            </div>
-            {% if !even %}
+            {% for link in linkTeaser.entity.fieldLink %}
+                {% if even %}
+                    <div class="usa-grid usa-grid-full">
+                {% endif %}
+                <div class="usa-width-one-half vads-u-margin-bottom--2">
+                <a href="{{link.url.path}}">
+                        {{ link.title }}
+                    </a>
                 </div>
-            {% endif %}
-            {% if even %}
-                {% assign even = false %}
-            {% else %}
-                {% assign even = true %}
-            {% endif %}
+                {% if !even %}
+                    </div>
+                {% endif %}
+                {% if even %}
+                    {% assign even = false %}
+                {% else %}
+                    {% assign even = true %}
+                {% endif %}
+            {% endfor %}
         {% endfor %}
         {% if !even %}
-    </div>
+      </div>
     {% endif %}
 </section>
 {% endif %}


### PR DESCRIPTION
## Description
+ 3844: fix link teasers on region page
+ 3129: make width of nav header 100%; make "health care" on separate line
+ 3138: left nav title is now clickable to go to region page
+ 3130: blue button spacing
+ 2854: bordered accordions

## Testing done
locally with staging and dev data

1. rebuild site
2. go to http://localhost:3001/pittsburgh-health-care/
3. check out the blue buttons and the left nav title width (should be 100%). also make sure the related links are showing up now
4. go to http://localhost:3001/pittsburgh-health-care/health-services/
5. check out the blue buttons and make sure the accordion content is bordered
6. click on the left nav title and make sure it goes to http://localhost:3001/pittsburgh-health-care/
7. go to http://localhost:3001/pittsburgh-health-care/locations/hj-heinz/
8. check out the blue buttons and open up some accordions. make sure the content is bordered

## Screenshots
too many. browse around the health care region portion of the site

## Acceptance criteria
- [ ] https://va-gov.atlassian.net/browse/VAGOV-3844 (related links)
- [ ] https://va-gov.atlassian.net/browse/VAGOV-3129 (title of nav)
- [ ] https://va-gov.atlassian.net/browse/VAGOV-3138 (clickable title of nav)
- [ ] https://va-gov.atlassian.net/browse/VAGOV-3130 (blue button spacing)
- [ ] https://va-gov.atlassian.net/browse/VAGOV-2854 (bordered accordion content)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
