### PR TITLE
Dashboard alerts did not handle a couple possible statuses

### DIFF
--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -1011,6 +1011,7 @@ export function getAlertContent(
       break;
 
     case HCA_ENROLLMENT_STATUSES.ineligCitizens:
+    case HCA_ENROLLMENT_STATUSES.ineligFilipinoScouts:
       blocks.push(
         <p>
           Our records show that you didn't serve in the U.S. military or an
@@ -1024,6 +1025,7 @@ export function getAlertContent(
 
     case HCA_ENROLLMENT_STATUSES.rejectedIncWrongEntry:
     case HCA_ENROLLMENT_STATUSES.rejectedScWrongEntry:
+    case HCA_ENROLLMENT_STATUSES.rejectedRightEntry:
       blocks.push(
         <p>
           Our records show that you don't have a service-connected disability,

--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -1024,8 +1024,8 @@ export function getAlertContent(
       break;
 
     case HCA_ENROLLMENT_STATUSES.rejectedIncWrongEntry:
-    case HCA_ENROLLMENT_STATUSES.rejectedScWrongEntry:
     case HCA_ENROLLMENT_STATUSES.rejectedRightEntry:
+    case HCA_ENROLLMENT_STATUSES.rejectedScWrongEntry:
       blocks.push(
         <p>
           Our records show that you don't have a service-connected disability,


### PR DESCRIPTION
## Description


## Testing done
A couple of possible status types were not handled by the HCA status alerts that show up on the dashboard.

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs