### PR TITLE
Turn on graphql flag in staging

### DIFF
--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -17,9 +17,10 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE,
     featureFlags.GRAPHQL_MODULE_UPDATE,
   ],
-  // vagovstaging: [featureFlags.FEATURE1],
-  vagovstaging: [featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE],
-  // vagovprod: [featureFlags.FEATURE1],
+  vagovstaging: [
+    featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE,
+    featureFlags.GRAPHQL_MODULE_UPDATE,
+  ],
   vagovprod: [featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE],
 };
 


### PR DESCRIPTION
## Description
Turns on the graphql flag in staging.

## Acceptance criteria
- [x] Build works

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
