### PR TITLE
fix CSS that unintentionally removed padding

### DIFF
--- a/src/applications/personalization/dashboard/sass/dashboard-alert.scss
+++ b/src/applications/personalization/dashboard/sass/dashboard-alert.scss
@@ -90,7 +90,7 @@
     }
   }
 
-  section.content p:last-of-type {
+  section.content p:last-child {
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
## Description
This updates a CSS rule I had added to fix an issue where there was _too much_ padding at the bottom of HCA-related DashboardAlerts that didn't have a "remove this notification" button. But that rule unintentionally removed the spacing between the text and button in the SIP-related DashboardAlerts. This fix addresses both issues as the screenshot shows

## Testing done
Local

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/58671994-a2203c80-82f9-11e9-84be-0262daf57d99.png)

## Acceptance criteria
- [x] vertically spacing looks good in DashboardAlerts used for SIP-related alerts
- [x] vertically spacing looks good in DashboardAlerts used for non-dismissible HCA-related alert

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs