### PR TITLE
Remove deceased options from the pre-need form

### DIFF
--- a/src/applications/pre-need/config/form.jsx
+++ b/src/applications/pre-need/config/form.jsx
@@ -186,16 +186,24 @@ const formConfig = {
                   veteran: {
                     type: 'object',
                     required: ['gender', 'maritalStatus', 'militaryStatus'],
-                    properties: _.pick(
-                      [
-                        'militaryServiceNumber',
-                        'vaClaimNumber',
-                        'placeOfBirth',
-                        'gender',
-                        'maritalStatus',
-                        'militaryStatus',
-                      ],
-                      veteran.properties,
+                    properties: _.set(
+                      'militaryStatus.enum',
+                      veteran.properties.militaryStatus.enum.filter(
+                        // Doesn't make sense to have options for the
+                        // Veteran to say they're deceased
+                        opt => !['I', 'D'].includes(opt),
+                      ),
+                      _.pick(
+                        [
+                          'militaryServiceNumber',
+                          'vaClaimNumber',
+                          'placeOfBirth',
+                          'gender',
+                          'maritalStatus',
+                          'militaryStatus',
+                        ],
+                        veteran.properties,
+                      ),
                     ),
                   },
                 },


### PR DESCRIPTION
## Description
See how I cleverly named the PR to state exactly what it does?

Actually, not quite. It removes the options for _a Veteran_ to say they're deceased.

## Testing done
Manually confirmed it worked.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/58722680-e4df2480-838c-11e9-85dc-21e5ed23876d.png)


## Acceptance criteria
- [x] The deceased options are removed only for Veterans filling out the form for themselves

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
