### PR TITLE
Add CSS rule to avoid golden outline around #content

### DIFF
--- a/src/applications/letters/sass/letters.scss
+++ b/src/applications/letters/sass/letters.scss
@@ -9,6 +9,14 @@
   }
 }
 
+// When AddressSection mounts, it calls focusElement('#content')
+// The function needs to set a tabindex so it can focus on the element
+// This triggers the [tabindex]:focus rule in USWDS which gives a golden outline
+// We don't want that outline around #content
+#content[tabindex]:focus {
+    outline: none;
+}
+
 .letters {
   h5 {
     padding-top: 1.5em;


### PR DESCRIPTION
## Description
As I mentioned in the comment above the new selector, when `AddressSection` loads, the `componentDidMount` lifecycle function calls `focusElement` which requires that a `tabindex` be present on the DOM element. If not, it sets one. This triggers the USWDS rule that gives the element a golden outline.

This PR removes that outline.

## Testing done
Manually tested

## Screenshots
I mean, I _could_ show you a screenshot without the outline, but what would that prove?

## Acceptance criteria
- [x] The outline is gone

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
