### PR TITLE
[Bug] Fix Facility Locator results pagination

### DIFF
--- a/src/applications/facility-locator/api/MockLocatorApi.js
+++ b/src/applications/facility-locator/api/MockLocatorApi.js
@@ -868,6 +868,96 @@ export const facilityData = {
       },
     },
     {
+      id: 'vba_3125',
+      type: 'va_facilities',
+      attributes: {
+        uniqueId: '3143w',
+        name: 'Fort Knox Outbased Office',
+        facilityType: 'va_benefits_facility',
+        classification: 'Outbased',
+        website: 'NULL',
+        lat: 39.6924384001,
+        long: -77.13654307,
+        address: {
+          mailing: {},
+          physical: {
+            zip: '22060',
+            city: 'Fort Belvoir',
+            state: 'VA',
+            address1: '34 Farrell Road',
+            address2: 'Room NS 104',
+            address3: null,
+          },
+        },
+        phone: {
+          fax: '215-991-1442',
+          main: '301-400-2463',
+        },
+        hours: {
+          friday: '7:00AM-3:30PM',
+          monday: '7:00AM-3:30PM',
+          sunday: 'Closed',
+          tuesday: '7:00AM-3:30PM',
+          saturday: 'Closed',
+          thursday: '7:00AM-3:30PM',
+          wednesday: '7:00AM-3:30PM',
+        },
+        services: {
+          benefits: {
+            other: null,
+            standard: [],
+          },
+        },
+        feedback: {},
+        access: {},
+      },
+    },
+    {
+      id: 'vba_5414w',
+      type: 'va_facilities',
+      attributes: {
+        uniqueId: '454s',
+        name: 'Fort Brooklyn Outbased Office',
+        facilityType: 'va_benefits_facility',
+        classification: 'Outbased',
+        website: 'NULL',
+        lat: 37.6924387600001,
+        long: -78.13654307,
+        address: {
+          mailing: {},
+          physical: {
+            zip: '22060',
+            city: 'Fort Belvoir',
+            state: 'VA',
+            address1: '808 Farrell Road',
+            address2: 'Room NS 104',
+            address3: null,
+          },
+        },
+        phone: {
+          fax: '215-991-1442',
+          main: '301-400-2463',
+        },
+        hours: {
+          friday: '7:00AM-3:30PM',
+          monday: '7:00AM-3:30PM',
+          sunday: 'Closed',
+          tuesday: '7:00AM-3:30PM',
+          saturday: 'Closed',
+          thursday: '7:00AM-3:30PM',
+          wednesday: '7:00AM-3:30PM',
+        },
+        services: {
+          benefits: {
+            other: null,
+            standard: [],
+          },
+        },
+        feedback: {},
+        access: {},
+      },
+    },
+    {
       id: 'vba_372d',
       type: 'va_facilities',
       attributes: {
@@ -1120,7 +1210,7 @@ export const facilityData = {
     pagination: {
       currentPage: 1,
       perPage: 20,
-      totalPages: 1,
+      totalPages: 2,
       totalEntries: 16,
     },
   },

--- a/src/applications/facility-locator/api/MockLocatorApi.js
+++ b/src/applications/facility-locator/api/MockLocatorApi.js
@@ -1211,7 +1211,7 @@ export const facilityData = {
       currentPage: 1,
       perPage: 20,
       totalPages: 2,
-      totalEntries: 16,
+      totalEntries: 21,
     },
   },
 };

--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -38,7 +38,6 @@ class ResultsList extends Component {
       serviceType: this.props.serviceType,
       page,
     });
-    console.log(this.props);
   };
 
   // handlePageSelect = page => {

--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -30,16 +30,27 @@ class ResultsList extends Component {
   }
 
   handlePageSelect = page => {
-    const { currentQuery } = this.props;
-
+    // const { currentQuery } = this.props;
+    // console.log(this.props);
     this.props.searchWithBounds({
-      bounds: currentQuery.bounds,
-      facilityType: currentQuery.facilityType,
-      serviceType: currentQuery.serviceType,
+      bounds: this.props.bounds,
+      facilityType: this.props.facilityType,
+      serviceType: this.props.serviceType,
       page,
     });
+    console.log(this.props);
   };
 
+  // handlePageSelect = page => {
+  //   const { currentQuery } = this.props;
+
+  //   this.props.searchWithBounds({
+  //     bounds: currentQuery.bounds,
+  //     facilityType: currentQuery.facilityType,
+  //     serviceType: currentQuery.serviceType,
+  //     page,
+  //   });
+  // };
   render() {
     const {
       context,

--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -30,8 +30,6 @@ class ResultsList extends Component {
   }
 
   handlePageSelect = page => {
-    // const { currentQuery } = this.props;
-    // console.log(this.props);
     this.props.searchWithBounds({
       bounds: this.props.bounds,
       facilityType: this.props.facilityType,
@@ -40,16 +38,6 @@ class ResultsList extends Component {
     });
   };
 
-  // handlePageSelect = page => {
-  //   const { currentQuery } = this.props;
-
-  //   this.props.searchWithBounds({
-  //     bounds: currentQuery.bounds,
-  //     facilityType: currentQuery.facilityType,
-  //     serviceType: currentQuery.serviceType,
-  //     page,
-  //   });
-  // };
   render() {
     const {
       context,


### PR DESCRIPTION
## Description
This PR fixes a bug with the Facility locator pagination when there are more than twenty facility results and a user attempts to click through to view past the first page of the facility results list 

## Testing done
Viewed on local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
