### PR TITLE
[Announcements] Add banner for MISSION Act

### DIFF
--- a/src/platform/site-wide/announcements/components/MissionAct.jsx
+++ b/src/platform/site-wide/announcements/components/MissionAct.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function MissionAct({ dismiss }) {
+  return (
+    <div className="personalization-announcement">
+      <span className="usa-label va-label-primary">New</span>{' '}
+      <a onClick={dismiss} href="https://missionact.va.gov/">
+        Learn how you may be able to get non-VA care in your community with the
+        MISSION Act
+      </a>
+      <button
+        type="button"
+        aria-label="Dismiss this announcement"
+        onClick={dismiss}
+        className="va-modal-close"
+      >
+        <i className="fas fa-times-circle" />
+      </button>
+    </div>
+  );
+}

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -3,6 +3,7 @@ import Profile360Intro from '../components/Profile360Intro';
 import PersonalizationBanner from '../components/PersonalizationBanner';
 import VAPlusVetsModal from '../components/VAPlusVetsModal';
 import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
+import MissionAct from '../components/MissionAct';
 
 const config = {
   announcements: [
@@ -17,6 +18,11 @@ const config = {
       name: 'welcome-to-new-va',
       paths: /^\/$/,
       component: WelcomeToNewVAModal,
+    },
+    {
+      name: 'mission-act',
+      paths: /^\/$/,
+      component: MissionAct,
     },
     {
       name: 'find-benefits-intro',

--- a/src/platform/site-wide/announcements/selectors.js
+++ b/src/platform/site-wide/announcements/selectors.js
@@ -11,11 +11,8 @@ export function selectAnnouncement(
   if (announcements.isInitialized) {
     announcement = config.announcements
       .filter(a => !a.disabled)
+      .filter(a => !announcements.dismissed.includes(a.name))
       .find(a => a.paths.test(path));
-
-    if (announcement && announcements.dismissed.includes(announcement.name)) {
-      announcement = null;
-    }
   }
 
   return announcement;

--- a/src/platform/site-wide/announcements/tests/selectors.unit.spec.js
+++ b/src/platform/site-wide/announcements/tests/selectors.unit.spec.js
@@ -69,14 +69,30 @@ describe('selectAnnouncement', () => {
     expect(result.name).to.be.equal('dummy3');
   });
 
-  it('returns null when a matched annoucement has been dismissed', () => {
+  it('returns undefined when a matched annoucement has been dismissed', () => {
     state.announcements.dismissed.push('dummy3');
     const result = selectors.selectAnnouncement(
       state,
       config,
       '/some-route-3/',
     );
-    expect(result).to.be.null;
+    expect(result).to.be.undefined;
+  });
+
+  it('returns the next matched announcement when the first matched annoucement has been dismissed', () => {
+    state.announcements.dismissed.push('dummy3');
+
+    config.announcements.push({
+      name: 'dummy3-conflict',
+      paths: /^(\/some-route-3\/)$/,
+    });
+
+    const result = selectors.selectAnnouncement(
+      state,
+      config,
+      '/some-route-3/',
+    );
+    expect(result.name).to.be.equal('dummy3-conflict');
   });
 
   it('bypasses disabled announcements and looks instead for the next match', () => {


### PR DESCRIPTION
## Description
This PR does the following:
- Adjusts the selector of the announcements, so that more than one announcement can be enabled on the same page without needing to disable old announcements. Previously, announcements were designed conservatively, thinking that we would retire one announcement before releasing the next and that we wouldn't want more than one announcement showing up on the same page. This isn't the case anymore.
- Adds an announcement for the MISSION Act

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18835

## Testing done
- Local testing
- Unit tests

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/58834287-f93b4f80-8620-11e9-9d7e-8700e2ea06a7.png)

## Acceptance criteria
- [ ] MISSION Act announcement is up

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
