### PR TITLE
My HealtheVet Account Validation Final FINAL PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/formation": "^6.4.0",
-    "@department-of-veterans-affairs/formation-react": "^4.6.0",
+    "@department-of-veterans-affairs/formation-react": "^4.6.3",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "blob-polyfill": "^2.0.20171115",

--- a/src/applications/validate-mhv-account/components/MessageTemplate.jsx
+++ b/src/applications/validate-mhv-account/components/MessageTemplate.jsx
@@ -4,7 +4,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 const MessageTemplate = ({ content }) => (
   <div className="row">
-    <div className="usa-content columns medium-9 vads-u-padding-bottom--5">
+    <div className="usa-content columns medium-9">
       <h1>{content.heading}</h1>
       {content.alertContent && (
         <AlertBox

--- a/src/applications/validate-mhv-account/constants.js
+++ b/src/applications/validate-mhv-account/constants.js
@@ -9,6 +9,8 @@ export const ACCOUNT_STATES = {
   NEEDS_TERMS_ACCEPTANCE: 'needs_terms_acceptance',
 };
 
+export const ACCOUNT_STATES_SET = new Set(Object.values(ACCOUNT_STATES));
+
 export const MHV_ACCOUNT_LEVELS = {
   BASIC: 'Basic',
   ADVANCED: 'Advanced',

--- a/src/applications/validate-mhv-account/containers/VerifyIdentity.jsx
+++ b/src/applications/validate-mhv-account/containers/VerifyIdentity.jsx
@@ -13,7 +13,7 @@ const VerifyIdentity = () => {
           you access to your personal health information.
         </p>
         <button
-          onClick={() => verify({ returnURL: '/my-health-account-validation' })}
+          onClick={verify}
           className="usa-button-primary va-button-primary"
         >
           Verify your identity

--- a/src/applications/validate-mhv-account/manifest.json
+++ b/src/applications/validate-mhv-account/manifest.json
@@ -2,7 +2,7 @@
   "appName": "My Health Account Validation",
   "entryFile": "./validate-mhv-account-entry",
   "entryName": "my-health-account-validation",
-  "rootUrl": "/my-health-account-validation",
+  "rootUrl": "/health-care/my-health-account-validation",
   "noRouting": true,
   "production": true
 }

--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -47,7 +47,7 @@ export function getAuthorizedLinkData(
     myHealthLink &&
     myHealthLink.title === 'My Health'
   ) {
-    myHealthLink.href = '/my-health-account-validation/';
+    myHealthLink.href = '/health-care/my-health-account-validation/';
     myHealthLink.target = undefined;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,7 +684,7 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@department-of-veterans-affairs/formation-react@^4.6.0":
+"@department-of-veterans-affairs/formation-react@^4.6.3":
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-4.6.3.tgz#af32344f9729dae9633420ed1b3fbfefe8991a02"
   integrity sha512-GVwRpppJYJNuPzqko46VD1+XkrSW0aIvDbHPvASZjwvkG/9NEOEN3UCS5ShDsg940PwHjbMTISIXhjsmH80dLQ==


### PR DESCRIPTION
## Description
Final PR for #15348 before it is released to prod behind a feature flag.

Updates include:
* Add GA Events as listed in [#17986](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17986)
* Handle redirect after successful verification originating from flow
* Update `react-formation` version in `package.json` to 4.6.3
* Adjusted padding
* Updated routing include to be `/health-care/` as prefix
* Added comments

## Testing done
Tested locally.  Additional QA will be done on prod with feature flag.

Some additional background on how to test this body of work can be found in the [previous PR](https://github.com/department-of-veterans-affairs/vets-website/pull/10047)

Use the following to set the feature flag:
`localStorage.setItem('enableMhvAccountValidation', 'true')`

Otherwise, the "My Health" link will skip validation and redirect immediately to MHV.

## Acceptance criteria
- [ ] GA Events have been added
- [ ] Updated to redirect to `/` if user is on `/verify` and account is already verified
- [ ] Uses proper route `/health-care/my-health-account-validation`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
