### PR TITLE
Remove duplicate condition

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/disabilityLabels.js
+++ b/src/applications/disability-benefits/all-claims/content/disabilityLabels.js
@@ -718,7 +718,6 @@ export default {
   8918: 'hip replacement',
   8919: 'knee replacement',
   109: '2010 Presumptive Herbicide Condition',
-  111: '2010 Presumptive Herbicide Condition',
   8920: 'Adhesions - Digestive',
   8921: 'Adhesions - Gynecological',
   8922: 'Adhesions - Heart/Veins/Arteries',


### PR DESCRIPTION
## Description
We had a failed submission where the Veteran selected this condition. Turns out, it's a duplicate, so I removed the entry with the failing classification code.

Because the classification code is added in the submission transformer, we don't need a migration or anything.

## Testing done
I changed the condition entered in the `newOnly-test.json` and ran the puppeteer test before removing the duplicate condition. When it was finished, I checked the submission request and saw that it added the classification code 111. After removing it, I ran the test again and the classification code it submitted with was 109.

## Screenshots
N/A

## Acceptance criteria
- [x] The classification code 109 is used instead of 111

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
