### PR TITLE
Redirect user to session expired page in case of 401

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -112,6 +112,7 @@ export class AuthApp extends React.Component {
   };
 
   handleAuthSuccess = payload => {
+    sessionStorage.setItem('shouldRedirectExpiredSession', true);
     const { type } = this.props.location.query;
     const authMetrics = new AuthMetrics(type, payload);
     authMetrics.run();

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -138,5 +138,6 @@ export function teardownProfileSession() {
   // after session cookie is fully in place.
   const sessionKeys = ['hasSession', 'userFirstName', 'sessionExpiration'];
   for (const key of sessionKeys) localStorage.removeItem(key);
+  sessionStorage.removeItem('shouldRedirectExpiredSession');
   clearRavenLoginType();
 }

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -57,6 +57,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
         : Promise.resolve(response);
 
       if (response.ok || response.status === 304) {
+        // Get session expiration from header
         const sessionExpiration = response.headers.get('X-Session-Expiration');
         if (sessionExpiration)
           localStorage.setItem('sessionExpiration', sessionExpiration);

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -66,9 +66,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
       if (environment.isProduction()) {
         const { pathname } = window.location;
         const shouldRedirectToSessionExpired =
-          response.status === 401 &&
-          resource !== '/user' &&
-          !pathname.includes('auth/login/callback');
+          response.status === 401 && !pathname.includes('auth/login/callback');
 
         if (shouldRedirectToSessionExpired) {
           window.location = '/session-expired';

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -67,7 +67,9 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
       if (environment.isProduction()) {
         const { pathname } = window.location;
         const shouldRedirectToSessionExpired =
-          response.status === 401 && !pathname.includes('auth/login/callback');
+          response.status === 401 &&
+          !pathname.includes('auth/login/callback') &&
+          sessionStorage.getItem('shouldRedirectExpiredSession') === 'true';
 
         if (shouldRedirectToSessionExpired) {
           window.location = '/session-expired';


### PR DESCRIPTION
## Purpose
Enable session expiration redirect to `session expiration page` in production. It currently shows in staging when a session expires, but is not visible in production (redirect still going to homepage with modal open).

Behavior should stay the same as what is currently in prod (but the session expiration page shows). 

Here's the expected flow:
1. Sign in
2. Idle for 30 min
3. "Session expires" - nothing happens visibly
4. Click on new page link or refresh page -> redirected to homepage with modal open (this will be replaced by session expiration page)

## What we need to do
- [x] Set `sessionStorage` flag after successful `/user` fetch in `refreshProfile`.

> This was already done, since `/user` fetch uses the `apiRequest` function

- [x] Remove the condition where `/user` is exempt from the redirect to `/session-expiration`.
- [x] Clear that `sessionStorage` flag in `teardownProfileSession` function and on logout page.
> This was already done

## Acceptance Criteria
- [x] Observe that you get redirected to session expired page if you do a full page reload (or go to a new page) while you're on the same tab.
- [x] Also observe that you don't get redirected if you try to go to VA.gov on a new tab (should be signed out and on VA.gov)