### PR TITLE
Fingerprint claims and appeals fetch errors

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -185,7 +185,9 @@ export function getClaimsV2(poll = pollRequest) {
       onError: response => {
         const errorCode = getErrorStatus(response);
         if (errorCode && errorCode !== UNKNOWN_STATUS) {
-          Raven.captureException(`vets_claims_v2_err_get_claims ${errorCode}`);
+          Raven.captureException(`vets_claims_v2_err_get_claims`, {
+            fingerprint: ['{{default}}', errorCode],
+          });
         }
         dispatch({ type: FETCH_CLAIMS_ERROR });
       },

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -117,7 +117,7 @@ export function getAppealsV2() {
             action.type = FETCH_APPEALS_ERROR;
             break;
         }
-        Raven.captureException(`vets_appeals_v2_err_get_appeals`, {
+        Raven.captureException(`vets_appeals_v2_err_get_appeals ${status}`, {
           fingerprint: ['{{default}}', status],
         });
         return dispatch(action);
@@ -185,7 +185,7 @@ export function getClaimsV2(poll = pollRequest) {
       onError: response => {
         const errorCode = getErrorStatus(response);
         if (errorCode && errorCode !== UNKNOWN_STATUS) {
-          Raven.captureException(`vets_claims_v2_err_get_claims`, {
+          Raven.captureException(`vets_claims_v2_err_get_claims ${errorCode}`, {
             fingerprint: ['{{default}}', errorCode],
           });
         }

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -117,7 +117,9 @@ export function getAppealsV2() {
             action.type = FETCH_APPEALS_ERROR;
             break;
         }
-        Raven.captureException(`vets_appeals_v2_err_get_appeals ${status}`);
+        Raven.captureException(`vets_appeals_v2_err_get_appeals`, {
+          fingerprint: ['{{default}}', status],
+        });
         return dispatch(action);
       },
     );


### PR DESCRIPTION
## Description
I was browsing through Sentry and found [this](http://sentry.vetsgov-internal/vets-gov/website-production/issues/52129/events/9336b5bbfbe24806ad8b17c715aee59c/). I only saw 404 errors, but if there are any others, they'd get lost in the crowd, so I decided I'd break them up. That was originally the intent by having the status in the error message, but it didn't work like we anticipated.

Fingerprinting is the right way to go, it turns out.

## Testing done
None. :see_no_evil: 

## Screenshots
N/A

## Acceptance criteria
- [ ] The different error codes are broken up into separate Sentry...things

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
