### PR TITLE
Fix all claims analytics functions

### DIFF
--- a/src/applications/disability-benefits/all-claims/analytics-functions.js
+++ b/src/applications/disability-benefits/all-claims/analytics-functions.js
@@ -2,8 +2,10 @@ import { recordEventOnce } from 'platform/monitoring/record-event';
 import get from 'platform/utilities/data/get';
 import { HOMELESSNESS_TYPES } from './constants';
 
-const objectIsEmpty = (path, formData) =>
-  Object.values(get(path, formData, {})).every(option => !option);
+const objectIsEmpty = (obj, path) =>
+  Object.values(typeof path === 'string' ? get(path, obj, {}) : obj).every(
+    option => !option,
+  );
 
 const recordMissingField = name =>
   recordEventOnce(
@@ -16,7 +18,7 @@ const recordMissingField = name =>
 
 export default {
   claimType: formData => {
-    if (objectIsEmpty('view:claimType', formData))
+    if (objectIsEmpty(formData, 'view:claimType'))
       recordMissingField(
         'Disability - Form 526EZ - Military Service - Start Date',
       );
@@ -43,7 +45,7 @@ export default {
       );
   },
   pastEmploymentFormIntro: formData => {
-    if (objectIsEmpty('view:upload4192Choice', formData))
+    if (objectIsEmpty(formData, 'view:upload4192Choice'))
       recordMissingField(
         'Disability - Form 526EZ - Past Employment Walkthrough - Choice',
       );


### PR DESCRIPTION
## Description
There's a problem with the way the analytics function on the payment information page was calling the `objectIsEmpty` function, so I changed up the function signature to use `path` as an optional parameter.

## Testing done
Nope :see_no_evil: 

## Screenshots
N/A

## Acceptance criteria
- [ ] Calling the analytics function on the payment information page doesn't error out

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
