### PR TITLE
VAGOV-3260: Pension hub defects

### DIFF
--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -26,7 +26,9 @@
 
         {% if fieldAlert.length %}
             {% for alert in fieldAlert %}
-              {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
+              {% if alert.entity is not null %}
+                {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
+              {% endif %}
             {% endfor %}
         {% endif %}
 

--- a/src/site/stages/build/drupal/graphql/navigation-fragments/sidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/sidebar.nav.graphql.js
@@ -68,4 +68,7 @@ module.exports = `
     recordsHubSidebarQuery: ${queryFilter('records-benefits-hub')} {
       ${SIDEBAR_QUERY}
     }
+    pensionHubSidebarQuery: ${queryFilter('pension-benefits-hub')} {
+      ${SIDEBAR_QUERY}
+    }
 `;

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -177,6 +177,7 @@ function compilePage(page, contentData) {
     data: {
       healthcareHubSidebarQuery: healthcareHubSidebarNav = {},
       recordsHubSidebarQuery: recordsHubSidebarNav = {},
+      pensionHubSidebarQuery: pensionHubSidebarNav = {},
       alerts: alertsItem = {},
       facilitySidebarQuery: facilitySidebarNav = {},
       outreachSidebarQuery: outreachSidebarNav = {},
@@ -189,7 +190,11 @@ function compilePage(page, contentData) {
     owner = _.toLower(page.fieldAdministration.entity.name);
   }
   // Benefits hub side navs in an array to loop through later
-  const sideNavs = [healthcareHubSidebarNav, recordsHubSidebarNav];
+  const sideNavs = [
+    healthcareHubSidebarNav,
+    recordsHubSidebarNav,
+    pensionHubSidebarNav,
+  ];
   let sidebarNavItems;
 
   const facilitySidebarNavItems = { facilitySidebar: facilitySidebarNav };


### PR DESCRIPTION
## Description
Fixes
- VAGOV-4030 - Missing left nav on pensions hub detail pages
- VAGOV-4002 - Empty alert on pension hub detail pages

## Testing done
Locally with migrated pensions hub content from dev

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
