### PR TITLE
GI Bill Comparison Tool - Colmery 111 - Remove STEM content

### DIFF
--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -1,13 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import environment from 'platform/utilities/environment';
 
 export class AdditionalInformation extends React.Component {
-  stemLabel = () =>
-    environment.isProduction()
-      ? 'STEM (Science, Technology, Engineering, and Math):'
-      : 'Rogers STEM Scholarship:';
-
   renderInstitutionSummary() {
     const it = this.props.institution;
     const isOJT = it.type.toLowerCase() === 'ojt';
@@ -113,19 +107,6 @@ export class AdditionalInformation extends React.Component {
           </strong>
           &nbsp;
           {it.independentStudy ? 'Yes' : 'No'}
-        </div>
-        <div>
-          <strong>
-            <button
-              type="button"
-              className="va-button-link learn-more-button"
-              onClick={this.props.onShowModal.bind(this, 'stemOffered')}
-            >
-              {this.stemLabel()}
-            </button>
-          </strong>
-          &nbsp;
-          {it.stemOffered ? 'Yes' : 'No'}
         </div>
       </div>
     );

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -3,11 +3,6 @@ import React from 'react';
 import environment from 'platform/utilities/environment';
 
 export class AdditionalInformation extends React.Component {
-  stemLabel = () =>
-    environment.isProduction()
-      ? 'STEM (Science, Technology, Engineering, and Math):'
-      : 'Rogers STEM Scholarship:';
-
   renderInstitutionSummary() {
     const it = this.props.institution;
     const isOJT = it.type.toLowerCase() === 'ojt';
@@ -122,7 +117,7 @@ export class AdditionalInformation extends React.Component {
                 className="va-button-link learn-more-button"
                 onClick={this.props.onShowModal.bind(this, 'stemOffered')}
               >
-                {this.stemLabel()}
+                Rogers STEM Scholarship:
               </button>
             </strong>
             &nbsp;

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -1,7 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import environment from 'platform/utilities/environment';
 
 export class AdditionalInformation extends React.Component {
+  stemLabel = () =>
+    environment.isProduction()
+      ? 'STEM (Science, Technology, Engineering, and Math):'
+      : 'Rogers STEM Scholarship:';
+
   renderInstitutionSummary() {
     const it = this.props.institution;
     const isOJT = it.type.toLowerCase() === 'ojt';
@@ -108,6 +114,21 @@ export class AdditionalInformation extends React.Component {
           &nbsp;
           {it.independentStudy ? 'Yes' : 'No'}
         </div>
+        {!environment.isProduction() && (
+          <div>
+            <strong>
+              <button
+                type="button"
+                className="va-button-link learn-more-button"
+                onClick={this.props.onShowModal.bind(this, 'stemOffered')}
+              >
+                {this.stemLabel()}
+              </button>
+            </strong>
+            &nbsp;
+            {it.stemOffered ? 'Yes' : 'No'}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import environment from 'platform/utilities/environment';
 
 export class AdditionalInformation extends React.Component {
   renderInstitutionSummary() {
@@ -109,21 +108,6 @@ export class AdditionalInformation extends React.Component {
           &nbsp;
           {it.independentStudy ? 'Yes' : 'No'}
         </div>
-        {!environment.isProduction() && (
-          <div>
-            <strong>
-              <button
-                type="button"
-                className="va-button-link learn-more-button"
-                onClick={this.props.onShowModal.bind(this, 'stemOffered')}
-              >
-                Rogers STEM Scholarship:
-              </button>
-            </strong>
-            &nbsp;
-            {it.stemOffered ? 'Yes' : 'No'}
-          </div>
-        )}
       </div>
     );
   }

--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import environment from 'platform/utilities/environment';
 import Checkbox from '../Checkbox';
 import RadioButtons from '../RadioButtons';
 import Dropdown from '../Dropdown';
@@ -17,11 +16,6 @@ class InstitutionFilterForm extends React.Component {
     this.renderProgramFilters = this.renderProgramFilters.bind(this);
     this.renderTypeFilter = this.renderTypeFilter.bind(this);
   }
-
-  stemLabel = () =>
-    environment.isProduction()
-      ? 'STEM (Science, Technology, Engineering, and Math)'
-      : 'Rogers STEM Scholarship';
 
   handleDropdownChange(e) {
     const { name: field, value } = e.target;
@@ -123,12 +117,6 @@ class InstitutionFilterForm extends React.Component {
           checked={filters.eightKeysToVeteranSuccess}
           name="eightKeysToVeteranSuccess"
           label="8 Keys to Vet Success"
-          onChange={this.handleCheckboxChange}
-        />
-        <Checkbox
-          checked={filters.stemOffered}
-          name="stemOffered"
-          label={this.stemLabel()}
           onChange={this.handleCheckboxChange}
         />
         <Checkbox

--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import environment from 'platform/utilities/environment';
 import Checkbox from '../Checkbox';
 import RadioButtons from '../RadioButtons';
 import Dropdown from '../Dropdown';
@@ -16,6 +17,11 @@ class InstitutionFilterForm extends React.Component {
     this.renderProgramFilters = this.renderProgramFilters.bind(this);
     this.renderTypeFilter = this.renderTypeFilter.bind(this);
   }
+
+  stemLabel = () =>
+    environment.isProduction()
+      ? 'STEM (Science, Technology, Engineering, and Math)'
+      : 'Rogers STEM Scholarship';
 
   handleDropdownChange(e) {
     const { name: field, value } = e.target;
@@ -119,6 +125,14 @@ class InstitutionFilterForm extends React.Component {
           label="8 Keys to Vet Success"
           onChange={this.handleCheckboxChange}
         />
+        {!environment.isProduction() && (
+          <Checkbox
+            checked={filters.stemOffered}
+            name="stemOffered"
+            label={this.stemLabel()}
+            onChange={this.handleCheckboxChange}
+          />
+        )}
         <Checkbox
           checked={filters.priorityEnrollment}
           name="priorityEnrollment"

--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -18,11 +18,6 @@ class InstitutionFilterForm extends React.Component {
     this.renderTypeFilter = this.renderTypeFilter.bind(this);
   }
 
-  stemLabel = () =>
-    environment.isProduction()
-      ? 'STEM (Science, Technology, Engineering, and Math)'
-      : 'Rogers STEM Scholarship';
-
   handleDropdownChange(e) {
     const { name: field, value } = e.target;
     this.props.onFilterChange(field, value);
@@ -129,7 +124,7 @@ class InstitutionFilterForm extends React.Component {
           <Checkbox
             checked={filters.stemOffered}
             name="stemOffered"
-            label={this.stemLabel()}
+            label="Rogers STEM Scholarship"
             onChange={this.handleCheckboxChange}
           />
         )}

--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import environment from 'platform/utilities/environment';
 import Checkbox from '../Checkbox';
 import RadioButtons from '../RadioButtons';
 import Dropdown from '../Dropdown';
@@ -120,14 +119,6 @@ class InstitutionFilterForm extends React.Component {
           label="8 Keys to Vet Success"
           onChange={this.handleCheckboxChange}
         />
-        {!environment.isProduction() && (
-          <Checkbox
-            checked={filters.stemOffered}
-            name="stemOffered"
-            label="Rogers STEM Scholarship"
-            onChange={this.handleCheckboxChange}
-          />
-        )}
         <Checkbox
           checked={filters.priorityEnrollment}
           name="priorityEnrollment"

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import * as actions from '../actions';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
-import environment from '../../../platform/utilities/environment';
 
 export class Modals extends React.Component {
   constructor(props) {

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -371,39 +371,6 @@ export class Modals extends React.Component {
   }
 
   renderProfileSummaryModals() {
-    const stemOfferedModal = (
-      <div>
-        <p>
-          The Edith Nourse Rogers STEM Scholarship provides up to 9 months of
-          additional Post-9/11 GI Bill benefits, to a maximum of $30,000.
-        </p>
-        <p>
-          Veterans and Fry Scholars may qualify for this scholarship if they're
-          enrolled in an undergraduate program for Science, Technology,
-          Engineering, or Math (STEM), or if they've earned a STEM degree and
-          are getting a teaching certification.
-        </p>
-        <p>
-          To learn more about the STEM Scholarship,{' '}
-          <a
-            href="https://benefits.va.gov/gibill/fgib/stem.asp"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {' '}
-            visit the VBA STEM website.
-          </a>
-        </p>
-      </div>
-    );
-    const stemOfferedModalProduction = (
-      <p>
-        VA will provide up to 9 months of additional Post-9/11 GI Bill benefits
-        if you're eligible and enrolled in a Science, Technology, Engineering,
-        or Math educational program.
-      </p>
-    );
-
     return (
       <span>
         <Modal
@@ -503,9 +470,29 @@ export class Modals extends React.Component {
           visible={this.shouldDisplayModal('stemOffered')}
         >
           <h3>STEM</h3>
-          {environment.isProduction()
-            ? stemOfferedModalProduction
-            : stemOfferedModal}
+          <div>
+            <p>
+              The Edith Nourse Rogers STEM Scholarship provides up to 9 months
+              of additional Post-9/11 GI Bill benefits, to a maximum of $30,000.
+            </p>
+            <p>
+              Veterans and Fry Scholars may qualify for this scholarship if
+              they're enrolled in an undergraduate program for Science,
+              Technology, Engineering, or Math (STEM), or if they've earned a
+              STEM degree and are getting a teaching certification.
+            </p>
+            <p>
+              To learn more about the STEM Scholarship,{' '}
+              <a
+                href="https://benefits.va.gov/gibill/fgib/stem.asp"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {' '}
+                visit the VBA STEM website.
+              </a>
+            </p>
+          </div>
         </Modal>
         <Modal
           onClose={this.props.hideModal}


### PR DESCRIPTION
## Description
Update the GI Bill Comparison Tool  in order to remove the STEM filter from the search page and the STEM display and info link from the school profile page.

## Testing done
Tested locally and passed QA

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/59035208-c8366700-883a-11e9-8d16-043bb60b5be0.png)

![image](https://user-images.githubusercontent.com/41960449/59035233-d2f0fc00-883a-11e9-86d4-11ae90100370.png)


## Acceptance criteria
- [x] The "STEM (Science, Technology, Engineering, Math)" Filter is hidden on the "Search Results" page.
- [x] The "STEM (Science, Technology, Engineering, and Math): No" indicator in the "Institution Summary" section on the "School Profile" page is hidden.
a. The modal that displays when the user clicks on "STEM (Science, Technology, Engineering, and Math)" is not available.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
