### PR TITLE
[CMS] Fix for smith.metadata wiping old metadata

### DIFF
--- a/src/site/stages/build/plugins/create-outreach-assets-data.js
+++ b/src/site/stages/build/plugins/create-outreach-assets-data.js
@@ -51,6 +51,7 @@ function createOutreachAssetsData(buildSettings) {
 
     metalsmith.metadata({
       outreachAssetsDataArray: outreachAssets,
+      ...metalsmith.metadata(),
     });
 
     done();


### PR DESCRIPTION
## Description
`metalsmith.metadata` wipes out old metadata, causing out `buildtype` to be wiped -

(prod)
![image](https://user-images.githubusercontent.com/1915775/59037898-27e34100-8840-11e9-8148-82cc0f21b957.png)


This PR fixes that.

## Testing done
None yet

## Screenshots


## Acceptance criteria
- [ ] metadata is retained

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
