### PR TITLE
updating title copy on  auth callback 005 for session expiration

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -257,7 +257,7 @@ export class AuthApp extends React.Component {
 
       // Session expired error
       case '005':
-        header = 'Your session expired';
+        header = "We've signed you out of VA.gov";
         alertContent = (
           <p>
             We take your privacy very seriously. You didn’t take any action on

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -257,7 +257,7 @@ export class AuthApp extends React.Component {
 
       // Session expired error
       case '005':
-        header = "We've signed you out of VA.gov";
+        header = 'We’ve signed you out of VA.gov';
         alertContent = (
           <p>
             We take your privacy very seriously. You didn’t take any action on


### PR DESCRIPTION
## Description
Updating copy title of session expiration messaging for our auth callback 005 page (similar to session-expiration page [here](https://github.com/department-of-veterans-affairs/vagov-content/pull/462), but for different purposes)

## Testing done
Verified locally

## Screenshots
### Before
![Screen Shot 2019-06-06 at 10 37 25 AM](https://user-images.githubusercontent.com/21130918/59041678-181b2b00-8847-11e9-8278-708211be7af1.png)


### After
![Screen Shot 2019-06-06 at 10 36 56 AM](https://user-images.githubusercontent.com/21130918/59041683-1b161b80-8847-11e9-8daa-476a0df21b0b.png)