### PR TITLE
[Facility Locator] Make service type required for Community Care searches

### DIFF
--- a/src/applications/facility-locator/components/SearchControls.jsx
+++ b/src/applications/facility-locator/components/SearchControls.jsx
@@ -4,6 +4,7 @@ import ServiceTypeAhead from './ServiceTypeAhead';
 import recordEvent from '../../../platform/monitoring/record-event';
 import { LocationType } from '../constants';
 import { healthServices, benefitsServices, vetCenterServices } from '../config';
+import { focusElement } from 'platform/utilities/ui';
 
 class SearchControls extends Component {
   handleEditSearch = () => {
@@ -30,7 +31,15 @@ class SearchControls extends Component {
   handleSubmit = e => {
     e.preventDefault();
 
-    const { facilityType } = this.props.currentQuery;
+    const { facilityType, serviceType } = this.props.currentQuery;
+
+    if (facilityType === LocationType.CC_PROVIDER) {
+      if (!serviceType) {
+        focusElement('#service-type-ahead-input');
+        return;
+      }
+    }
+
     // Report event here to only send analytics event when a user clicks on the button
     recordEvent({
       event: 'fl-search',

--- a/src/applications/facility-locator/components/ServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/ServiceTypeAhead.jsx
@@ -90,12 +90,17 @@ class ServiceTypeAhead extends Component {
           selectedItem,
         }) => (
           <div>
-            <label {...getLabelProps()}>Service type (optional)</label>
+            <label {...getLabelProps()}>
+              Service type{' '}
+              <span className="vads-u-color--secondary-dark">(*Required)</span>
+            </label>
             <span id="service-typeahead">
               <input
                 {...getInputProps({
                   placeholder: 'Like primary care, cardiology',
                 })}
+                id="service-type-ahead-input"
+                required
               />
               {isOpen && inputValue.length >= 2 ? (
                 <div className="dropdown" role="listbox">


### PR DESCRIPTION
## Description
This PR makes the field for service-type required for Community Care searches. There is no error messaging - it just indicates focused above the field and focuses on the input on submit if the field is blank. I would have added error messaging, but the height of the search controls is fixed, and I didn't want to start tinkering with the height of that on limited time, because this may need to be deployed tonight.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18853
## Testing done
Local

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/59059104-216abe80-886c-11e9-962c-52dfb8478330.png)


## Acceptance criteria
- [ ] CC searches require service type (may make it faster)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
