### PR TITLE
update formation to 6.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^6.5.0",
+    "@department-of-veterans-affairs/formation": "^6.5.1",
     "@department-of-veterans-affairs/formation-react": "^4.6.3",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -695,10 +695,10 @@
     prop-types "^15.6.2"
     react-transition-group "1"
 
-"@department-of-veterans-affairs/formation@^6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.5.0.tgz#2cd822e0f46cfed04b30ebe685372fa8ba6a2d70"
-  integrity sha512-BYWjgKMYiF6aWVgsJWKlvH+ufAmZwuI+kqSQWj54Si+t/ZumXaAa1ONeQ9evMwU8Lb3WejcWqZOqHyCjH9tXoQ==
+"@department-of-veterans-affairs/formation@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.5.1.tgz#2f73b0b82fb28c7d859deba68c8d6398d4eead0f"
+  integrity sha512-yEu1jmmvPeIvroZg0YkEfRjVCumuTOwPACsFeoPUoj6vWf9dgvzR6a08pCs255F1RDVp6xcmR8eQPxtnSp6B5g==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Description
This patch updates to `vets-website` to Formation 6.5.1. 6.5.1 contains a patch to prevent the `line-height` from getting overwritten when paragraphs appear inside a `va-introtext` div.

More details: 
https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/133