### PR TITLE
18792 - Add Google-Analytics client ID to profile360 direct-deposit p…

### DIFF
--- a/src/applications/personalization/profile360/actions/paymentInformation.js
+++ b/src/applications/personalization/profile360/actions/paymentInformation.js
@@ -28,7 +28,11 @@ export function savePaymentInformation(fields) {
   return async dispatch => {
     const apiRequestOptions = {
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(fields),
+      body: JSON.stringify({
+        ...fields,
+        // eslint-disable-next-line no-undef
+        gaClientId: ga.getAll()[0].get('clientId'),
+      }),
       method: 'PUT',
       mode: 'cors',
     };

--- a/src/applications/personalization/profile360/tests/actions/paymentInformation.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/actions/paymentInformation.unit.spec.js
@@ -4,10 +4,14 @@ import sinon from 'sinon';
 import * as paymentInformationActions from '../../actions/paymentInformation';
 
 let oldFetch;
+let oldGA;
 
 const setup = () => {
   oldFetch = global.fetch;
+  oldGA = global.ga;
   global.fetch = sinon.stub();
+  global.ga = sinon.stub();
+  global.ga.getAll = sinon.stub();
   global.fetch.returns(
     Promise.resolve({
       headers: { get: () => 'application/json' },
@@ -20,10 +24,20 @@ const setup = () => {
         }),
     }),
   );
+  global.ga.getAll.returns([
+    {
+      get: key => {
+        const value = key === 'clientId' ? '1234567890:0987654321' : undefined;
+
+        return value;
+      },
+    },
+  ]);
 };
 
 const teardown = () => {
   global.fetch = oldFetch;
+  global.ga = oldGA;
 };
 
 describe('actions/paymentInformation', () => {


### PR DESCRIPTION
…mt-info update API-call.

## Description
18792 - Add Google Analytics client ID to profile360 direct-deposit pmt-info-update API-call.

## Testing done
Verified locally via Chrome Dev Tools Network panel.

## Screenshots
After submitting direct-deposit pmt-info edit form via Profile page -- gaClientId added to form-fields in API-call request-body:
![direct-deposit-pmt-info-api-call](https://user-images.githubusercontent.com/587583/59070561-1023b100-8870-11e9-8c51-40542c2717f2.png)

## Acceptance criteria
- [ ] Verified gaClientId inclusion in API-call (see screenshot above).

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
