### PR TITLE
VAGOV-3734: facility page health service accordion rearrange content

### DIFF
--- a/src/site/facilities/facility_health_service.drupal.liquid
+++ b/src/site/facilities/facility_health_service.drupal.liquid
@@ -14,14 +14,14 @@
             </button>
             <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}" class="usa-accordion-content" aria-hidden="true">
                 {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}<div><span class="vads-u-font-style--italic">Common Conditions: </span>{{ serviceTaxonomy.fieldCommonlyTreatedCondition }}</div>{% endif %}
-                {% if serviceTaxonomy.description.processed  %}<div>{{ serviceTaxonomy.description.processed }}</div>{% endif %}
 
-                {% if healthService.fieldBody.processed %}<div>{{ healthService.fieldBody.processed }}</div>{% endif %}
+                {% if serviceTaxonomy.description.processed  %}<div>{{ serviceTaxonomy.description.processed }}</div>{% endif %}
 
                 <div>{{ localServiceDescription }}</div>
 
                 <div data-widget-type="facility-appointment-wait-times-widget" data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}" data-service="{{ serviceTaxonomy.name | escape }}"></div>
 
+                {% if healthService.fieldBody.processed %}<div>{{ healthService.fieldBody.processed }}</div>{% endif %}
             </div>
         </li>
     </ul>


### PR DESCRIPTION
## Description
makes sure that the local accordions has this order

https://app.mural.co/t/vagov6717/m/vagov6717/1559847745386/53c7586b3261876c77b1f5108707c9bd51f6d64c

## Testing done
locally with staging data

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
