### PR TITLE
Adding not a veteran siderail block to hub landing pages.

### DIFF
--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -356,7 +356,7 @@ $medium-phone-screen: 375px;
 
 
   .usa-accordion-bordered {
-    &.social {
+    &.social, &.links {
       a {
         text-decoration: underline;
       }

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -83,6 +83,7 @@
                   </li>
                 </ul>
               </section>
+
               {% if fieldSupportServices != empty %}
               <section>
                 <h4>Call us</h4>
@@ -103,6 +104,32 @@
                 </ul>
               </section>
               {% endif %}
+            </div>
+          </li>
+        </ul>
+
+        <ul class="usa-accordion-bordered links">
+          <li>
+            <button class="usa-accordion-button usa-accordion-button-dark rail-heading"
+              aria-expanded="true" aria-controls="a2">
+              Not a veteran?
+            </button>
+            <div id="a2" class="usa-accordion-content" aria-hidden="false">
+            {% if fieldLinks != empty %}
+            <section>
+              <h4>Get information for:</h4>
+              <ul class="va-nav-linkslist-list links">
+                {% for link in fieldLinks %}
+                <li>
+                  <a href="{{ link.url.path }}">
+                    <span>{{ link.title }}</span>
+                  </a>
+                </li>
+                {% endfor %}
+              </ul>
+            </section>
+            {% endif %}
+
             </div>
           </li>
         </ul>

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -98,7 +98,7 @@ module.exports = `
     }
     fieldIntroTextNewsStories {
       processed
-    }    
+    }
     ${healthCareRegionNewsStories}
     fieldIntroTextEventsPage {
       processed
@@ -107,7 +107,7 @@ module.exports = `
     fieldClinicalHealthCareServi {
       processed
     }
-    ${healthCareRegionHealthServices}    
+    ${healthCareRegionHealthServices}
     fieldPressReleaseBlurb {
       processed
     }

--- a/src/site/stages/build/drupal/graphql/landingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/landingPage.graphql.js
@@ -12,7 +12,7 @@ const { FIELD_ALERT } = require('./block-fragments/alert.block.graphql');
 const ADMIN = '...administration';
 
 module.exports = `
-  
+
   fragment landingPage on NodeLandingPage {
     ${entityElementsFromPages}
     fieldIntroText
@@ -24,10 +24,16 @@ module.exports = `
       entity {
         ...listOfLinkTeasers
       }
-    }    
-    fieldSupportServices {          
-      ...on FieldNodeFieldSupportServices {            
-        entity {      
+    }
+    fieldLinks {
+      title
+      url {
+        path
+      }
+    }
+    fieldSupportServices {
+      ...on FieldNodeFieldSupportServices {
+        entity {
           entityId
           entityBundle
           ...on NodeSupportService {
@@ -39,9 +45,9 @@ module.exports = `
                 path
               }
               title
-              options                  
+              options
             }
-            fieldPhoneNumber                
+            fieldPhoneNumber
           }
         }
       }

--- a/src/site/stages/build/drupal/graphql/landingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/landingPage.graphql.js
@@ -5,6 +5,12 @@ const {
 } = require('./paragraph-fragments/listOfLinkTeasers.paragraph.graphql');
 const { FIELD_ALERT } = require('./block-fragments/alert.block.graphql');
 
+// Get current feature flags
+const {
+  featureFlags,
+  enabledFeatureFlags,
+} = require('./../../../../utilities/featureFlags');
+
 /**
  * The top-level page for a section of the website.
  * Examples include /health-care/, /disability/, etc.
@@ -25,11 +31,10 @@ module.exports = `
         ...listOfLinkTeasers
       }
     }
-    fieldLinks {
-      title
-      url {
-        path
-      }
+    ${
+      enabledFeatureFlags[featureFlags.FEATURE_FIELD_LINKS]
+        ? 'fieldLinks { title url { path } }'
+        : ''
     }
     fieldSupportServices {
       ...on FieldNodeFieldSupportServices {

--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -10,6 +10,7 @@ const featureFlags = {
     'featureFieldCommonlyTreatedConditions',
   FEATURE_HEALTH_CARE_REGION_DETAIL_PAGE_FIELD_ALERT:
     'FEATURE_HEALTH_CARE_REGION_DETAIL_PAGE_FIELD_ALERT',
+  FEATURE_FIELD_LINKS: 'featureFieldLinks',
 };
 
 // Edit this to turn flags on or off
@@ -20,6 +21,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_FIELD_OTHER_VA_LOCATIONS,
     featureFlags.FEATURE_HEALTH_CARE_REGION_DETAIL_PAGE_FIELD_ALERT,
     featureFlags.FEATURE_FIELD_COMMONLY_TREATED_CONDITIONS,
+    featureFlags.FEATURE_FIELD_LINKS,
   ],
   vagovdev: [
     featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE,
@@ -27,12 +29,14 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_FIELD_OTHER_VA_LOCATIONS,
     featureFlags.FEATURE_HEALTH_CARE_REGION_DETAIL_PAGE_FIELD_ALERT,
     featureFlags.FEATURE_FIELD_COMMONLY_TREATED_CONDITIONS,
+    featureFlags.FEATURE_FIELD_LINKS,
   ],
   vagovstaging: [
     featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE,
     featureFlags.GRAPHQL_MODULE_UPDATE,
     featureFlags.FEATURE_FIELD_OTHER_VA_LOCATIONS,
     featureFlags.FEATURE_HEALTH_CARE_REGION_DETAIL_PAGE_FIELD_ALERT,
+    featureFlags.FEATURE_FIELD_LINKS,
   ],
   vagovprod: [featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE],
 };


### PR DESCRIPTION
## Description
Adds `LINKS FOR NON-VETERANS` block to hub landing page rail

## Definition of done
- [x] Adding right rail `LINKS FOR NON-VETERANS` content on drupal hub landing page is reflected in front end page build

