### PR TITLE
Update GA events for health tools/my health account validation

### DIFF
--- a/src/applications/validate-mhv-account/containers/Main.jsx
+++ b/src/applications/validate-mhv-account/containers/Main.jsx
@@ -92,9 +92,7 @@ class Main extends React.Component {
     let content;
 
     if (location.pathname !== '/' && mhvAccountLoading) {
-      content = (
-        <LoadingIndicator message="Loading your health information" setFocus />
-      );
+      content = <LoadingIndicator message="Loading..." setFocus />;
     } else if (!loadingProfile && loggedIn) {
       content = children;
     } else {

--- a/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
+++ b/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
@@ -34,28 +34,35 @@ class ValidateMHVAccount extends React.Component {
     const { profile, mhvAccount, router } = this.props;
     const { accountLevel, accountState } = mhvAccount;
     const hyphenatedAccountState = accountState.replace(/_/g, '-');
-    const gaPrefix = 'register-mhv-error';
+    const gaPrefix = 'register-mhv';
 
     if (!profile.verified) {
-      recordEvent({ event: `${gaPrefix}-needs-identity-verification` });
+      recordEvent({ event: `${gaPrefix}-info-needs-identity-verification` });
       router.replace('verify');
       return;
     }
 
     // MVI/MHV Checks
     if (this.props.mviDown) {
-      recordEvent({ event: `${gaPrefix}-mvi-down` });
+      recordEvent({ event: `${gaPrefix}-error-mvi-down` });
       router.replace('error/mvi-down');
       return;
     } else if (mhvAccount.errors) {
-      recordEvent({ event: `${gaPrefix}-mhv-down` });
+      recordEvent({ event: `${gaPrefix}-error-mhv-down` });
       router.replace('error/mhv-error');
       return;
     }
 
     // If valid account error state, record GA event
     if (ACCOUNT_STATES_SET.has(accountState)) {
-      recordEvent({ event: `${gaPrefix}-${hyphenatedAccountState}` });
+      recordEvent({
+        event: `${gaPrefix}-${
+          accountState === ACCOUNT_STATES.NEEDS_VERIFICATION ||
+          accountState === ACCOUNT_STATES.NEEDS_TERMS_ACCEPTANCE
+            ? 'info'
+            : 'error'
+        }-${hyphenatedAccountState}`,
+      });
     }
 
     switch (accountState) {

--- a/src/platform/user/profile/actions/mhv.js
+++ b/src/platform/user/profile/actions/mhv.js
@@ -1,5 +1,6 @@
 import { apiRequest } from '../../../utilities/api';
 import get from '../../../utilities/data/get';
+import recordEvent from '../../../monitoring/record-event';
 
 export const FETCHING_MHV_ACCOUNT = 'FETCHING_MHV_ACCOUNT';
 export const FETCH_MHV_ACCOUNT_FAILURE = 'FETCH_MHV_ACCOUNT_FAILURE';
@@ -31,11 +32,15 @@ export function fetchMHVAccount() {
 export function createMHVAccount() {
   return dispatch => {
     dispatch({ type: CREATING_MHV_ACCOUNT });
+    recordEvent({ event: 'register-mhv-create-attempt' });
 
     return apiRequest(
       baseUrl,
       { method: 'POST' },
-      ({ data }) => dispatch({ type: CREATE_MHV_ACCOUNT_SUCCESS, data }),
+      ({ data }) => {
+        recordEvent({ event: 'register-mhv-create-success' });
+        return dispatch({ type: CREATE_MHV_ACCOUNT_SUCCESS, data });
+      },
       () => dispatch({ type: CREATE_MHV_ACCOUNT_FAILURE }),
     );
   };
@@ -44,6 +49,7 @@ export function createMHVAccount() {
 export function upgradeMHVAccount() {
   return async dispatch => {
     dispatch({ type: UPGRADING_MHV_ACCOUNT });
+    recordEvent({ event: 'register-mhv-upgrade-attempt' });
 
     let mhvAccount;
     let userProfile;
@@ -58,6 +64,7 @@ export function upgradeMHVAccount() {
       if (!mhvAccount) return dispatch({ type: UPGRADE_MHV_ACCOUNT_FAILURE });
     }
 
+    recordEvent({ event: 'register-mhv-upgrade-success' });
     return dispatch({
       type: UPGRADE_MHV_ACCOUNT_SUCCESS,
       mhvAccount,


### PR DESCRIPTION
## Description
Made the following updates to Health Tools/My Health Account Validation GA events:
* Changed prefix for `NEEDS_VERIFICATION` and `NEEDS_TERMS_ACCEPTANCE` from `register-mhv-error` to `register-mhv-info` since they are technically not errors
* Replace `accountStates` strings in Health Tools with the same constants used in My Health Acc Validation
* Add attempt and success events for create/upgrade MHV accounts
* Use more generic messaging for loader

## Testing done
Tested locally


## Acceptance criteria
- [ ] `NEEDS_VERIFICATION` and `NEEDS_TERMS_ACCEPTANCE` accountStates should use the `register-mhv-info` prefix for GA events
- [ ] Attempt and Success events have been added for Create/Upgrade MHV account

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
