### PR TITLE
[Facility Locator] Add error-handling

### DIFF
--- a/src/applications/facility-locator/api/LocatorApi.js
+++ b/src/applications/facility-locator/api/LocatorApi.js
@@ -37,7 +37,14 @@ class LocatorApi {
         .then(
           data => resolve(data),
           error => reject(error)
-        );
+        ).catch(() => {
+          resolve({
+            errors: [{
+              code: '408',
+              }
+            ]
+          })
+        })
         /* eslint-enable prettier/prettier */
     });
   }

--- a/src/applications/facility-locator/api/LocatorApi.js
+++ b/src/applications/facility-locator/api/LocatorApi.js
@@ -37,14 +37,7 @@ class LocatorApi {
         .then(
           data => resolve(data),
           error => reject(error)
-        ).catch(() => {
-          resolve({
-            errors: [{
-              code: '408',
-              }
-            ]
-          });
-        })
+        );
         /* eslint-enable prettier/prettier */
     });
   }

--- a/src/applications/facility-locator/api/LocatorApi.js
+++ b/src/applications/facility-locator/api/LocatorApi.js
@@ -43,7 +43,7 @@ class LocatorApi {
               code: '408',
               }
             ]
-          })
+          });
         })
         /* eslint-enable prettier/prettier */
     });

--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -92,21 +92,19 @@ class ResultsList extends Component {
               ref={this.searchResultTitle}
             >
               <p>We’re sorry. We couldn’t complete your request.</p>
-              <p>
-                <strong>To try again, please:</strong>
-                <ul className="vads-u-margin-y--1p5">
-                  <li>
-                    <strong>Add a service type</strong> (like “primary care”),
-                    and select the option that best meets your needs. This will
-                    help to narrow your search.
-                  </li>
-                  <li>
-                    <strong>Or enter a different search term</strong> (street,
-                    city, state, or postal code).
-                  </li>
-                </ul>
-                Then click <strong>Search</strong>.
-              </p>
+              <strong>To try again, please:</strong>
+              <ul className="vads-u-margin-y--1p5">
+                <li>
+                  <strong>Add a service type</strong> (like “primary care”), and
+                  select the option that best meets your needs. This will help
+                  to narrow your search.
+                </li>
+                <li>
+                  <strong>Or enter a different search term</strong> (street,
+                  city, state, or postal code).
+                </li>
+              </ul>
+              Then click <strong>Search</strong>.
             </div>
           );
         }

--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -18,7 +18,7 @@ import { updateSearchQuery, searchWithBounds } from '../actions';
 import SearchResult from './SearchResult';
 import DelayedRender from 'platform/utilities/ui/DelayedRender';
 
-const timeoutErrorCode = '504';
+const TIMEOUTS = new Set(['408', '504', '503']);
 
 class ResultsList extends Component {
   constructor(props) {
@@ -81,19 +81,72 @@ class ResultsList extends Component {
       );
     }
 
-    if (error && error.find(err => err.code === timeoutErrorCode)) {
-      /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-      return (
-        <div
-          className="search-result-title facility-result"
-          ref={this.searchResultTitle}
-        >
-          The search has timed out, please retry your search.
-        </div>
-      );
-      /* eslint-enable jsx-a11y/no-noninteractive-tabindex */
+    if (error) {
+      // For some reason, an error can be an HTTP response, or just a string.
+      if (error.find) {
+        const timedOut = error.find(err => TIMEOUTS.has(err.code));
+        if (timedOut) {
+          return (
+            <div
+              className="search-result-title facility-result"
+              ref={this.searchResultTitle}
+            >
+              <p>We’re sorry. We couldn’t complete your request.</p>
+              <p>
+                <strong>To try again, please:</strong>
+                <ul className="vads-u-margin-y--1p5">
+                  <li>
+                    <strong>Add a service type</strong> (like “primary care”),
+                    and select the option that best meets your needs. This will
+                    help to narrow your search.
+                  </li>
+                  <li>
+                    <strong>Or enter a different search term</strong> (street,
+                    city, state, or postal code).
+                  </li>
+                </ul>
+                Then click <strong>Search</strong>.
+              </p>
+            </div>
+          );
+        }
+      } else {
+        return (
+          <div
+            className="search-result-title facility-result"
+            ref={this.searchResultTitle}
+          >
+            We’re sorry. We couldn’t complete your request. Please refresh the
+            page or try again later.
+          </div>
+        );
+      }
     }
+
     if (!results || results.length < 1) {
+      if (this.props.facilityTypeName === facilityTypes.cc_provider) {
+        return (
+          <div
+            className="search-result-title facility-result"
+            ref={this.searchResultTitle}
+          >
+            We didn't find any facilities near you. <br />
+            <strong>To try again, please:</strong>
+            <ul className="vads-u-margin-y--1p5">
+              <li>
+                <strong>Enter a different search term</strong> (street, city,
+                state, or postal code), <strong>or</strong>
+              </li>
+              <li>
+                <strong>Add a service type</strong> (like “primary care”), and
+                select the option that best meets your needs. This will help to
+                narrow your search.
+              </li>
+            </ul>
+            Then click <strong>Search</strong>.
+          </div>
+        );
+      }
       /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
       return (
         <div
@@ -106,6 +159,7 @@ class ResultsList extends Component {
       );
       /* eslint-enable jsx-a11y/no-noninteractive-tabindex */
     }
+
     const currentLocation = position;
     const sortedResults = results
       .map(result => {


### PR DESCRIPTION
## Description
This PR implements some error-handling into the Facility Locator. Up to this point, it appears that the only error-handling in the FL was for detecting timeouts from Community Cares implemented yesterday, which I was not able to see working from my testing. It looks like it needed to check for additional status codes. My testing was with the Dev API, so maybe PPMS in Prod acts differently. 

This PR -

- Adds a few more status codes  for detecting timeouts while searching the Community Cares, based on my testing. I 
- Adds an error catch-all (also encountered a lot of `500` errors while search Community Cares)
- Adds special messaging for when there are no results found for a Community Cares search.
- I was randomly seeing  unknown `fetch` errors, so I added a `catch` block to where the API request is made.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18878

This error-handling still feels very frail and should definitely be revisited as a whole.

## Testing done
Locally, pointing at the Dev API

## Screenshots

### Example timeout
![image](https://user-images.githubusercontent.com/1915775/59121738-f5f8da00-8926-11e9-97a9-572619792023.png)

### Example no results

## Acceptance criteria
- [ ] Error-handling is in place for Facility Locator

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
