### PR TITLE
[Facility Locator] Fix for error-handling catch-all

### DIFF
--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -108,17 +108,17 @@ class ResultsList extends Component {
             </div>
           );
         }
-      } else {
-        return (
-          <div
-            className="search-result-title facility-result"
-            ref={this.searchResultTitle}
-          >
-            We’re sorry. We couldn’t complete your request. Please refresh the
-            page or try again later.
-          </div>
-        );
       }
+
+      return (
+        <div
+          className="search-result-title facility-result"
+          ref={this.searchResultTitle}
+        >
+          We’re sorry. We couldn’t complete your request. Please refresh the
+          page or try again later.
+        </div>
+      );
     }
 
     if (!results || results.length < 1) {


### PR DESCRIPTION
## Description
This is a follow-up to https://github.com/department-of-veterans-affairs/vets-website/pull/10206. After testing Staging, I found that the catch-all error handling wasn't working as expected, and traced it back to a bad condition. It was previously showing "No results found" when it was actually an error.

## Testing done
Tons of local

## Screenshots
Shows catch-all working after dispatching w/500 error -

![image](https://user-images.githubusercontent.com/1915775/59138487-67eb1680-895b-11e9-9bd7-092e1e059d85.png)


## Acceptance criteria
- [x] Error-handling is working

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
