### PR TITLE
VAGOV-4145: add "Our locations" intro text blurb to region locations page

### DIFF
--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -90,6 +90,9 @@ module.exports = `
       }
     }
     ${healthCareStaffBios}
+    fieldLocationsIntroBlurb {
+      processed
+    }
     ${healthCareLocalFacilities}
     ${
       enabledFeatureFlags[featureFlags.FEATURE_FIELD_OTHER_VA_LOCATIONS]


### PR DESCRIPTION
## Description
+ add "Our locations" intro text blurb to region locations page

## Testing done
locally with staging data

## Screenshots
![image](https://user-images.githubusercontent.com/19178435/59139056-96f68d80-8945-11e9-8b5b-2be865763274.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
