### PR TITLE
VAGOV-4039: add featured content to regional detail pages

### DIFF
--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -24,6 +24,17 @@
             {% endfor %}
           {% endif %}
 
+          {% if fieldFeaturedContent != empty and fieldFeaturedContent.length > 0 %}
+            <div class="feature">
+              {% for block in fieldFeaturedContent %}
+                {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
+                {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+                {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+              {% endfor %}
+            </div>
+          {% endif %}
+
+
           {% assign isContactPage = entityUrl.path | isContactPage %}
           {% if isContactPage %}
             <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">{% assign basePath = entityUrl.path | regionBasePath %}

--- a/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
@@ -31,6 +31,23 @@ module.exports = `
     entityBundle
     changed
     fieldIntroText
+    ${
+      enabledFeatureFlags[
+        featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT
+      ]
+        ? `
+          fieldFeaturedContent {
+            entity {
+              entityType
+              entityBundle
+              ${WYSIWYG}      
+              ${QA}        
+            }
+          }
+        `
+        : ''
+    }
+    
     fieldContentBlock {
       entity {
         entityType

--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -11,6 +11,7 @@ const featureFlags = {
   FEATURE_HEALTH_CARE_REGION_DETAIL_PAGE_FIELD_ALERT:
     'FEATURE_HEALTH_CARE_REGION_DETAIL_PAGE_FIELD_ALERT',
   FEATURE_FIELD_LINKS: 'featureFieldLinks',
+  FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT: 'fieldFeaturedContent',
 };
 
 // Edit this to turn flags on or off
@@ -22,6 +23,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_HEALTH_CARE_REGION_DETAIL_PAGE_FIELD_ALERT,
     featureFlags.FEATURE_FIELD_COMMONLY_TREATED_CONDITIONS,
     featureFlags.FEATURE_FIELD_LINKS,
+    featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT,
   ],
   vagovdev: [
     featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE,
@@ -30,6 +32,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_HEALTH_CARE_REGION_DETAIL_PAGE_FIELD_ALERT,
     featureFlags.FEATURE_FIELD_COMMONLY_TREATED_CONDITIONS,
     featureFlags.FEATURE_FIELD_LINKS,
+    featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT,
   ],
   vagovstaging: [
     featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE,
@@ -37,6 +40,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_FIELD_OTHER_VA_LOCATIONS,
     featureFlags.FEATURE_HEALTH_CARE_REGION_DETAIL_PAGE_FIELD_ALERT,
     featureFlags.FEATURE_FIELD_LINKS,
+    featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT,
   ],
   vagovprod: [featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE],
 };


### PR DESCRIPTION
## Description
+ adds featured content to regional detail pages

## Testing done
locally with staging data

pre-req: requires featured content to be filled out in the CMS on a region detail page 
http://staging.cms.va.gov/node/490/edit?destination=/admin/content

1. rebuild app
2. go to said detail page. in my example, i used a test page that was already there: http://localhost:3001/pittsburgh-health-care/test-alerts/

## Screenshots
![localhost_3001_pittsburgh-health-care_test-alerts_](https://user-images.githubusercontent.com/19178435/59139772-3027a300-894a-11e9-9d6f-bd475637928e.png)

## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-4039

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
