### PR TITLE
18213 - Restore bottom sign-in CTAs on application-intro pages.

### DIFF
--- a/src/applications/burials/components/IntroductionPage.jsx
+++ b/src/applications/burials/components/IntroductionPage.jsx
@@ -129,7 +129,7 @@ class IntroductionPage extends React.Component {
               </div>
               <p>
                 After we process your claim, you’ll get a notice in the mail
-                about the decision!
+                about the decision.
               </p>
             </li>
           </ol>

--- a/src/applications/burials/components/IntroductionPage.jsx
+++ b/src/applications/burials/components/IntroductionPage.jsx
@@ -129,13 +129,14 @@ class IntroductionPage extends React.Component {
               </div>
               <p>
                 After we process your claim, you’ll get a notice in the mail
-                about the decision.
+                about the decision!
               </p>
             </li>
           </ol>
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           pageList={this.props.route.pageList}
           startText="Start the Burial Benefits Application"
           downtime={this.props.route.formConfig.downtime}

--- a/src/applications/edu-benefits/0994/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/0994/containers/IntroductionPage.jsx
@@ -20,7 +20,7 @@ export class IntroductionPage extends React.Component {
         <FormTitle title="Apply for Veteran Employment Through Technology Education Courses (VET TEC)" />
         <p>
           Equal to VA Form 22-0994 Application for Veteran Employment Through
-          Technology Education Courses (VET TEC)
+          Technology Education Courses (VET TEC).
         </p>
         <CallToActionWidget appId="vet-tec">
           <SaveInProgressIntro
@@ -130,6 +130,11 @@ export class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          hideUnauthedStartLink
+          verifyRequiredPrefill={
+            this.props.route.formConfig.verifyRequiredPrefill
+          }
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
           startText="Start the VET TEC application"

--- a/src/applications/edu-benefits/1990/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1990/containers/IntroductionPage.jsx
@@ -100,6 +100,7 @@ export class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
           startText="Start the education application"

--- a/src/applications/edu-benefits/1990e/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1990e/containers/IntroductionPage.jsx
@@ -103,6 +103,7 @@ export class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
           startText="Start the education application"

--- a/src/applications/edu-benefits/1990n/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1990n/containers/IntroductionPage.jsx
@@ -102,6 +102,7 @@ export class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
           startText="Start the education application"

--- a/src/applications/edu-benefits/1995-STEM/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1995-STEM/containers/IntroductionPage.jsx
@@ -124,6 +124,7 @@ export class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
           startText="Start the education application"

--- a/src/applications/edu-benefits/1995/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1995/containers/IntroductionPage.jsx
@@ -124,6 +124,7 @@ export class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
           startText="Start the education application"

--- a/src/applications/edu-benefits/5490/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/5490/containers/IntroductionPage.jsx
@@ -104,6 +104,7 @@ export class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
           startText="Start the education application"

--- a/src/applications/edu-benefits/5495/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/5495/containers/IntroductionPage.jsx
@@ -104,6 +104,7 @@ export class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
           startText="Start the education application"

--- a/src/applications/edu-benefits/feedback-tool/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/feedback-tool/containers/IntroductionPage.jsx
@@ -99,6 +99,7 @@ class IntroductionPage extends React.Component {
           buttonOnly
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           startText="Submit Your Feedback"
         />
         <div className="omb-info--container" style={{ paddingLeft: '0px' }}>

--- a/src/applications/hca-v2-beta/containers/IntroductionPage.jsx
+++ b/src/applications/hca-v2-beta/containers/IntroductionPage.jsx
@@ -108,6 +108,7 @@ const LoggedOutContent = connect(
     <HCASubwayMap />
     <SaveInProgressIntro
       buttonOnly
+      prefillEnabled={route.formConfig.prefillEnabled}
       messages={route.formConfig.savedFormMessages}
       pageList={route.pageList}
       startText="Start the Health Care Application"

--- a/src/applications/hca/containers/IntroductionPage.jsx
+++ b/src/applications/hca/containers/IntroductionPage.jsx
@@ -138,6 +138,7 @@ class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
           startText="Start the Health Care Application"

--- a/src/applications/hca/containers/IntroductionPageGated.jsx
+++ b/src/applications/hca/containers/IntroductionPageGated.jsx
@@ -97,7 +97,7 @@ const LoggedOutContent = connect(
               className="va-button-link"
               onClick={() => showLoginModal(true, 'hcainfo')}
             >
-              Sign in to check your application status
+              Sign in to check your application status.
             </button>
           }
           isVisible
@@ -117,6 +117,7 @@ const LoggedOutContent = connect(
     <HCASubwayMap />
     <SaveInProgressIntro
       buttonOnly
+      prefillEnabled={route.formConfig.prefillEnabled}
       messages={route.formConfig.savedFormMessages}
       pageList={route.pageList}
       startText="Start the Health Care Application"

--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -152,6 +152,7 @@ class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           pageList={this.props.route.pageList}
           startText="Start the pension application"
           downtime={this.props.route.formConfig.downtime}

--- a/src/applications/pre-need/components/IntroductionPage.jsx
+++ b/src/applications/pre-need/components/IntroductionPage.jsx
@@ -24,7 +24,7 @@ class IntroductionPage extends React.Component {
         <FormTitle title="Apply for pre-need eligibility determination" />
         <p>
           Equal to VA Form 40-10007 (Application for Pre-Need Determination of
-          Eligibility for Burial in a VA National Cemetery)
+          Eligibility for Burial in a VA National Cemetery).
         </p>
         <SaveInProgressIntro
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
@@ -156,6 +156,7 @@ class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
           startText="Start the pre-need eligibility application"

--- a/src/applications/veteran-representative/containers/IntroductionPage.jsx
+++ b/src/applications/veteran-representative/containers/IntroductionPage.jsx
@@ -60,6 +60,7 @@ class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
           startText="Start the Application"

--- a/src/applications/vic-v2/containers/IntroductionPage.jsx
+++ b/src/applications/vic-v2/containers/IntroductionPage.jsx
@@ -81,7 +81,6 @@ class IntroductionPage extends React.Component {
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
           pageList={this.props.route.pageList}
           startText="Start the VIC Application"
-          resumeOnly
         >
           Please complete the Veteran ID Card form to apply for a card.
         </SaveInProgressIntro>
@@ -307,27 +306,9 @@ class IntroductionPage extends React.Component {
               </strong>
             </div>
           )}
-        {!signedIn && (
-          <div>
-            <p>
-              <strong>
-                Sign in or create an account before you apply for a Veteran ID
-                Card.
-              </strong>
-              <button
-                className="usa-button usa-button-primary"
-                onClick={() => this.props.toggleLoginModal(true)}
-              >
-                Sign In or Create an Account
-              </button>
-            </p>
-            <strong>
-              Start the Veteran ID Card application without signing in.
-            </strong>
-          </div>
-        )}
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           pageList={this.props.route.pageList}
           startText="Start the Veteran ID Card Application"
         />

--- a/src/applications/vre/chapter31/components/IntroductionPage.jsx
+++ b/src/applications/vre/chapter31/components/IntroductionPage.jsx
@@ -97,6 +97,7 @@ class IntroductionPage extends React.Component {
           </ol>
         </div>
         <SaveInProgressIntro
+          buttonOnly
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
           pageList={this.props.route.pageList}
           startText="Start the VR&E Application"

--- a/src/applications/vre/chapter36/components/IntroductionPage.jsx
+++ b/src/applications/vre/chapter36/components/IntroductionPage.jsx
@@ -97,6 +97,7 @@ class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           pageList={this.props.route.pageList}
           startText="Start the VR&E Application"
         />

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -129,8 +129,24 @@ class SaveInProgressIntro extends React.Component {
     } else if (renderSignInMessage) {
       alert = renderSignInMessage(prefillEnabled);
     } else if (prefillEnabled && !verifyRequiredPrefill) {
-      const { retentionPeriod } = this.props;
-      alert = (
+      const { buttonOnly, retentionPeriod } = this.props;
+      alert = buttonOnly ? (
+        <>
+          <button className="usa-button-primary" onClick={this.openLoginModal}>
+            Sign in to Start Your Application
+          </button>
+          {!this.props.hideUnauthedStartLink && (
+            <p>
+              <button
+                className="va-button-link schemaform-start-button"
+                onClick={this.goToBeginning}
+              >
+                Start your application without signing in
+              </button>
+            </p>
+          )}
+        </>
+      ) : (
         <div className="usa-alert usa-alert-info schemaform-sip-alert">
           <div className="usa-alert-body">
             <h3 className="usa-alert-heading">
@@ -169,7 +185,7 @@ class SaveInProgressIntro extends React.Component {
                     className="va-button-link schemaform-start-button"
                     onClick={this.goToBeginning}
                   >
-                    Start your application without signing in.
+                    Start your application without signing in
                   </button>
                 </p>
               )}
@@ -263,6 +279,9 @@ class SaveInProgressIntro extends React.Component {
     const content = (
       <div>
         {!this.props.buttonOnly && this.getAlert(savedForm)}
+        {this.props.buttonOnly &&
+          !this.props.user.login.currentlyLoggedIn &&
+          this.getAlert(savedForm)}
         {this.props.user.login.currentlyLoggedIn && (
           <FormStartControls
             resumeOnly={this.props.resumeOnly}

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -133,7 +133,7 @@ class SaveInProgressIntro extends React.Component {
       alert = buttonOnly ? (
         <>
           <button className="usa-button-primary" onClick={this.openLoginModal}>
-            Sign in to Start Your Application
+            Sign in to start your application
           </button>
           {!this.props.hideUnauthedStartLink && (
             <p>

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -179,7 +179,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
       'Sign in to Start Your Application',
     );
     expect(tree.find('.va-button-link').text()).to.contain(
-      'Start your application without signing in.',
+      'Start your application without signing in',
     );
     expect(tree.find('withRouter(FormStartControls)').exists()).to.be.false;
     tree.unmount();


### PR DESCRIPTION
## Description
[18213](/department-of-veterans-affairs/vets.gov-team/issues/18213) - Restore bottom Sign-In/Continue CTAs on application introduction pages, below subway-map.

## Testing done
Verified locally in browser.
No business-logic or functional code changes.

## Screenshots
NOTE: For applications requiring sign-in, the “Start your application without signing in” link will be hidden. 
<img width="309" alt="Screen Shot 2019-06-10 at 5 49 41 PM" src="https://user-images.githubusercontent.com/587583/59235892-75e1a700-8ba8-11e9-9d0a-3d265aa9fd95.png">

## Acceptance criteria
- [ ] Sign-in CTAs appear below subway-map on app-intro pages.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
