### PR TITLE
VAGOV-2802: Open first level of side nav on pittsburgh landing page

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -199,6 +199,12 @@ module.exports = function registerFilters() {
 
   liquid.filters.isContactPage = path => path.includes('contact');
 
+  // check is this is a root level page
+  liquid.filters.isRootPage = path => {
+    const isRoot = /^\/[\w-]+$/;
+    return isRoot.test(path);
+  };
+
   // sort a list of objects by a certain property in the object
   liquid.filters.sortObjectsBy = (entities, path) => _.sortBy(entities, path);
 };

--- a/src/site/navigation/facility_sidebar_nav.drupal.liquid
+++ b/src/site/navigation/facility_sidebar_nav.drupal.liquid
@@ -14,10 +14,11 @@
                     {% assign deepLinksString = link.links | findCurrentPathDepth: entityUrl.path %}
                     {% assign deepLinksObj = deepLinksString | jsonToObj %}
                     {% assign depth = deepLinksObj.depth  %}
+                    {% assign isRoot = entityUrl.path | isRootPage %}
 
                     <button class="usa-accordion-button"
                             {% if deepLinksString == "false" and forloop.index == 1 and depth is null ||
-                                entityUrl.path contains "locations" and forloop.index == 1 || entityUrl.path = "/pittsburgh-health-care"  and forloop.index == 1 %}
+                                entityUrl.path contains "locations" and forloop.index == 1 || isRoot== true and forloop.index == 1 %}
                                 aria-expanded="true"
                             {% else %}
                                 aria-expanded="false"

--- a/src/site/navigation/facility_sidebar_nav.drupal.liquid
+++ b/src/site/navigation/facility_sidebar_nav.drupal.liquid
@@ -17,7 +17,7 @@
 
                     <button class="usa-accordion-button"
                             {% if deepLinksString == "false" and forloop.index == 1 and depth is null ||
-                                entityUrl.path contains "locations" and forloop.index == 1 %}
+                                entityUrl.path contains "locations" and forloop.index == 1 || entityUrl.path = "/pittsburgh-health-care"  and forloop.index == 1 %}
                                 aria-expanded="true"
                             {% else %}
                                 aria-expanded="false"


### PR DESCRIPTION
## Description


## Testing done
Locally with staging data

## Screenshots
<img width="1173" alt="Screen Shot 2019-06-11 at 9 27 02 AM" src="https://user-images.githubusercontent.com/3157339/59285353-19739b80-8c2b-11e9-81d4-fae81d70a0a2.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
