### PR TITLE
Add heading level back for homepage items

### DIFF
--- a/src/site/layouts/home.html
+++ b/src/site/layouts/home.html
@@ -12,7 +12,7 @@
       <div class="hub-links-row">
       {% for card in cards %}
         <div class="hub-links-container">
-          <h2 class="hub-links-title"><i class="icon-large-baseline icon-heading hub-icon-{{card.hub}} hub-color-{{card.hub}}"></i>{{ card.heading }}</h2>
+          <h2 class="heading-level-3 hub-links-title"><i class="icon-large-baseline icon-heading hub-icon-{{card.hub}} hub-color-{{card.hub}}"></i>{{ card.heading }}</h2>
           <ul class="hub-links-list">
             {% assign parentCard = card %}
 


### PR DESCRIPTION
## Description
Fixes the homepage card headings sizing

## Testing done
Local testing

## Screenshots
![Screen Shot 2019-06-11 at 4 03 20 PM](https://user-images.githubusercontent.com/634932/59302651-72aaf180-8c62-11e9-88e6-13dfbe0642b3.png)


## Acceptance criteria
- [x] Home page looks good again

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
