### PR TITLE
Remove feature flag for My HealtheVet Account Validation tool

### DIFF
--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -11,7 +11,6 @@ import {
 import recordEvent from '../../../monitoring/record-event';
 import { isLoggedIn } from '../../../user/selectors';
 import { replaceDomainsInData } from '../../../utilities/environment/stagingDomains';
-import localStorage from '../../../utilities/storage/localStorage';
 
 import MegaMenu from '@department-of-veterans-affairs/formation-react/MegaMenu';
 
@@ -33,27 +32,9 @@ export function getAuthorizedLinkData(
   defaultLinks,
   authenticatedLinks = authenticatedUserLinkData,
 ) {
-  const authLinks = authenticatedLinks;
-
-  const myHealthLink = authLinks[1];
-
-  /* 
-    Feature flag:  Once tested, My Health link in
-    mega-menu-link-data-for-authenticated-users.json will be
-    replaced and this code block will be removed
-  */
-  if (
-    localStorage.getItem('enableMhvAccountValidation') === 'true' &&
-    myHealthLink &&
-    myHealthLink.title === 'My Health'
-  ) {
-    myHealthLink.href = '/health-care/my-health-account-validation/';
-    myHealthLink.target = undefined;
-  }
-
   return [
     ...replaceDomainsInData(defaultLinks),
-    ...(loggedIn ? replaceDomainsInData(authLinks) : []),
+    ...(loggedIn ? replaceDomainsInData(authenticatedLinks) : []),
   ];
 }
 

--- a/src/platform/site-wide/mega-menu/mega-menu-link-data-for-authenticated-users.json
+++ b/src/platform/site-wide/mega-menu/mega-menu-link-data-for-authenticated-users.json
@@ -5,7 +5,6 @@
     },
     {
         "title": "My Health",
-        "href": "https://www.myhealth.va.gov/mhv-portal-web/home",
-        "target": "_blank"
+        "href": "/health-care/my-health-account-validation/"
     }
 ]


### PR DESCRIPTION
## Description
The MyHealtheVet Account Validation tool has gone through testing and is ready to go live. This PR removes the feature flag check that enables access to the tool.

## Testing done
Tested locally

## Screenshots


## Acceptance criteria
- [ ] "My Health" link in user nav directs user to `/health-care/my-health-account-validation` without feature flag

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
