### PR TITLE
[Facility Locator] Patch for sending multiple API requests on single search

### DIFF
--- a/src/applications/facility-locator/actions/index.js
+++ b/src/applications/facility-locator/actions/index.js
@@ -105,6 +105,14 @@ export const searchWithBounds = ({ bounds, facilityType, serviceType, page = 1 }
   const needsAddress = [LocationType.CC_PROVIDER, LocationType.ALL];
   // eslint-disable-next-line prettier/prettier
   return (dispatch) => {
+    dispatch({
+      type: SEARCH_STARTED,
+      payload: {
+        currentPage: page,
+        searchBoundsInProgress: true,
+      },
+    });
+
     if (needsAddress.includes(facilityType) && ccLocatorEnabled()) {
       // Remove Feature-flag when going live. ^^^
       reverseGeocodeBox(bounds).then(address => {
@@ -140,13 +148,6 @@ export const searchWithBounds = ({ bounds, facilityType, serviceType, page = 1 }
  */
 // eslint-disable-next-line prettier/prettier
 const fetchLocations = async (address = null, bounds, locationType, serviceType, page, dispatch) => {
-  dispatch({
-    type: SEARCH_STARTED,
-    payload: {
-      currentPage: page,
-      searchBoundsInProgress: true,
-    },
-  });
 
   try {
     // eslint-disable-next-line prettier/prettier


### PR DESCRIPTION
## Description
Currently, if you do some searches on the Facility Locator, you will notice that it's needlessly firing off multiple API requests per search. This PR fixes that. This is a big deal at the moment because the Community Cares API seems to be low on resources.

According to the Git blame, this issue was introduced in this giant [pull request](https://github.com/department-of-veterans-affairs/vets-website/pull/8651) that rolled out the Community Cares work.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18816

## Testing done
Tons of local testing while pointing at the dev server

## Acceptance criteria
- [x] Less wastefulness

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
