### PR TITLE
Add confirmation step before dismissing the HCAStatusAlert

### DIFF
--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -950,7 +950,7 @@ export function getAlertContent(
   const removeNotificationButton = (
     <button
       className="va-button-link remove-notification-link"
-      aria-label={`Dismiss health care application status notification`}
+      aria-label={`Remove health care application status notification`}
       onClick={dismissNotification}
       key="dismiss-notification-button"
     >

--- a/src/applications/personalization/dashboard/components/HCAStatusAlert.jsx
+++ b/src/applications/personalization/dashboard/components/HCAStatusAlert.jsx
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+import { HCA_ENROLLMENT_STATUSES } from 'applications/hca/constants';
+import {
+  getAlertContent,
+  getAlertStatusHeadline,
+  getAlertStatusInfo,
+  getAlertType,
+} from 'applications/hca/enrollment-status-helpers';
+import DashboardAlert from './DashboardAlert';
+
+const HCAStatusAlert = ({ applicationDate, enrollmentStatus, onRemove }) => {
+  const [isShowingConfirmation, setIsShowingConfirmation] = useState(false);
+
+  const showConfirmation = () => {
+    setIsShowingConfirmation(true);
+  };
+
+  const hideConfirmation = () => {
+    setIsShowingConfirmation(false);
+  };
+
+  if (isShowingConfirmation) {
+    return (
+      <AlertBox
+        headline="Are you sure you want to permanently remove this notification?"
+        status="warning"
+      >
+        <p>
+          Please confirm that you want to remove this notification from your My
+          VA dashboard. Removing it won’t affect the status of your health care
+          application in any way. But once you remove the notification, you
+          can’t add it back again.
+        </p>
+        <button
+          className="usa-button-primary vads-u-margin-y--0"
+          aria-label="Confirm remove health care application status notification"
+          onClick={onRemove}
+        >
+          Remove the notification
+        </button>
+        <button
+          className="usa-button-secondary vads-u-margin-y--0"
+          aria-label="Do not remove the health care application status notification"
+          onClick={hideConfirmation}
+        >
+          Cancel
+        </button>
+      </AlertBox>
+    );
+  }
+
+  return (
+    <DashboardAlert
+      status={getAlertType(enrollmentStatus)}
+      headline="Application for health care"
+      subheadline="FORM 10-10EZ"
+      statusHeadline={getAlertStatusHeadline(enrollmentStatus)}
+      statusInfo={getAlertStatusInfo(enrollmentStatus)}
+      content={getAlertContent(
+        enrollmentStatus,
+        applicationDate,
+        showConfirmation,
+      )}
+    />
+  );
+};
+
+export default HCAStatusAlert;
+
+HCAStatusAlert.propTypes = {
+  applicationDate: PropTypes.string.isRequired,
+  enrollmentStatus: PropTypes.oneOf(Object.values(HCA_ENROLLMENT_STATUSES))
+    .isRequired,
+  onRemove: PropTypes.func.isRequired,
+};

--- a/src/applications/personalization/dashboard/components/HCAStatusAlert.jsx
+++ b/src/applications/personalization/dashboard/components/HCAStatusAlert.jsx
@@ -30,10 +30,10 @@ const HCAStatusAlert = ({ applicationDate, enrollmentStatus, onRemove }) => {
         status="warning"
       >
         <p>
-          Please confirm that you want to remove this notification from your My
-          VA dashboard. Removing it won’t affect the status of your health care
-          application in any way. But once you remove the notification, you
-          can’t add it back again.
+          Please confirm that you want to remove this notification from your{' '}
+          <strong>My VA</strong> dashboard. Removing it won’t affect the status
+          of your health care application in any way. But once you remove the
+          notification, you can’t add it back again.
         </p>
         <button
           className="usa-button-primary vads-u-margin-y--0"

--- a/src/applications/personalization/dashboard/containers/YourApplications.jsx
+++ b/src/applications/personalization/dashboard/containers/YourApplications.jsx
@@ -15,15 +15,9 @@ import {
   isLoadingDismissedNotification,
   selectEnrollmentStatus,
 } from 'applications/hca/selectors';
-import {
-  getAlertContent,
-  getAlertStatusHeadline,
-  getAlertStatusInfo,
-  getAlertType,
-} from 'applications/hca/enrollment-status-helpers';
 
-import DashboardAlert from '../components/DashboardAlert';
 import FormItem from '../components/FormItem';
+import HCAStatusAlert from '../components/HCAStatusAlert';
 import { isSIPEnabledForm, sipFormSorter } from '../helpers';
 
 class YourApplications extends React.Component {
@@ -32,7 +26,7 @@ class YourApplications extends React.Component {
     this.props.getDismissedHCANotification();
   }
 
-  dismissHCANotification() {
+  dismissHCANotification = () => {
     const {
       enrollmentStatus,
       enrollmentStatusEffectiveDate,
@@ -41,22 +35,7 @@ class YourApplications extends React.Component {
       enrollmentStatus,
       enrollmentStatusEffectiveDate,
     );
-  }
-
-  renderHCAStatusAlert({ applicationDate, enrollmentStatus }) {
-    return (
-      <DashboardAlert
-        status={getAlertType(enrollmentStatus)}
-        headline="Application for health care"
-        subheadline="FORM 10-10EZ"
-        statusHeadline={getAlertStatusHeadline(enrollmentStatus)}
-        statusInfo={getAlertStatusInfo(enrollmentStatus)}
-        content={getAlertContent(enrollmentStatus, applicationDate, () => {
-          this.dismissHCANotification();
-        })}
-      />
-    );
-  }
+  };
 
   render() {
     const {
@@ -74,7 +53,13 @@ class YourApplications extends React.Component {
         {savedForms.map(form => (
           <FormItem key={form.form} savedFormData={form} />
         ))}
-        {shouldRenderHCAAlert && this.renderHCAStatusAlert(hcaEnrollmentStatus)}
+        {shouldRenderHCAAlert && (
+          <HCAStatusAlert
+            applicationDate={hcaEnrollmentStatus.applicationDate}
+            enrollmentStatus={hcaEnrollmentStatus.enrollmentStatus}
+            onRemove={this.dismissHCANotification}
+          />
+        )}
       </div>
     );
   }

--- a/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
@@ -316,7 +316,7 @@ describe('<YourApplications>', () => {
     tree.unmount();
   });
 
-  it('should render a DashboardAlert', () => {
+  it('should render a HCAStatusAlert', () => {
     const tree = shallow(
       <YourApplications
         {...defaultProps}
@@ -325,9 +325,11 @@ describe('<YourApplications>', () => {
         hcaEnrollmentStatus={enrollmentStatus}
       />,
     );
-    const alert = tree.find('DashboardAlert');
+    const alert = tree.find('HCAStatusAlert');
     expect(alert.length).to.equal(1);
-    expect(alert.prop('headline')).to.equal('Application for health care');
+    expect(alert.prop('enrollmentStatus')).to.equal(
+      enrollmentStatus.enrollmentStatus,
+    );
     tree.unmount();
   });
 });


### PR DESCRIPTION
## Description
Make removing HCA-related Dashboard notifications a two step process

Instead of using a `DashboardAlert` directly in `YourApplications`, we now have a new `HCAStatusAlert` that can toggle between two views depending on if the user is confirming dismissal or not.

## Testing done
Local

## Screenshots
**GIF showing the confirmation view working correctly:**
![confirmation](https://user-images.githubusercontent.com/20728956/59314980-865b5580-8c6c-11e9-95b4-23b85e66823c.gif)

**Still image of new confirmation view:**
![image](https://user-images.githubusercontent.com/20728956/59357805-52ba1300-8ce0-11e9-8b40-91701a0861d1.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs