### PR TITLE
only build one env per content only build

### DIFF
--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,12 +1,4 @@
 node('vetsgov-general-purpose') {
-  // params.ref can either be a git commit ref or a tag
-  // If its a tag, the checkout function requires 'refs/tags/' prepended to the tag to function properly
-  if (params.ref.startsWith('vets-website')) {
-    branchName = "refs/tags/${params.ref}"
-  } else {
-    branchName = params.ref
-  }
-
   dir("vets-website") {
     checkout scm: [$class: 'GitSCM', branches: [[name: branchName]], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
   }
@@ -16,7 +8,9 @@ node('vetsgov-general-purpose') {
   // Setup stage
   dockerContainer = commonStages.setup()
   // Build stage
-  commonStages.buildAll(params.ref, dockerContainer, true)
+  stage("Build") {
+    commonStages.build(params.ref, dockerContainer, params.ref, params.env, false)
+  }
   // Prearchive stage
   commonStages.prearchive(dockerContainer)
   // Archive stage


### PR DESCRIPTION
## Description
Currently the content only build Jenkins job runs a content build for all environments. This has caused problems when we want to deploy production but dev or staging is broken. This PR updates the content only build to only update content for one env. It also removes unused/outdated code.

There is a corresponding PR in the devops repo [here](https://github.com/department-of-veterans-affairs/devops/pull/5012) that updates Jenkins jobs.