### PR TITLE
18885 - Fix Profile direct-deposit pmt-info inifinte loading-indicator.

### DIFF
--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -68,17 +68,16 @@ class PaymentInformation extends React.Component {
     }
 
     const { paymentInformation } = this.props;
-    const directDepositNotSetup = !get(
-      'responses[0].paymentAccount.accountNumber',
-      paymentInformation,
-    );
+    const directDepositNotSetup =
+      paymentInformation &&
+      !get('responses[0].paymentAccount.accountNumber', paymentInformation);
 
     let content = null;
 
-    if (paymentInformation.error) {
-      content = <LoadFail information="payment" />;
-    } else if (!this.props.multifactorEnabled) {
+    if (!this.props.multifactorEnabled) {
       content = <PaymentInformation2FARequired />;
+    } else if (paymentInformation.error) {
+      content = <LoadFail information="payment" />;
     } else if (directDepositNotSetup) {
       content = (
         <PaymentInformationAddLink onClick={this.props.editModalToggled} />
@@ -181,7 +180,10 @@ const isEvssAvailable = createIsServiceAvailableSelector(
 const mapStateToProps = state => ({
   multifactorEnabled: isMultifactorEnabled(state),
   isEligible: isEvssAvailable(state),
-  isLoading: !state.vaProfile.paymentInformation,
+  isLoading:
+    isEvssAvailable(state) &&
+    isMultifactorEnabled(state) &&
+    !state.vaProfile.paymentInformation,
   paymentInformation: state.vaProfile.paymentInformation,
   paymentInformationUiState: state.vaProfile.paymentInformationUiState,
 });


### PR DESCRIPTION
## Description
[18885](/department-of-veterans-affairs/vets.gov-team/issues/18885) - Fix Profile direct-deposit payment-information section inifinite loading-indicator (spinner) for Users who are identity-verified but with no 2FA (use DS Logon User [jamie.wood](/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Identity/Login/reference_documents/ds%20logon/ds-logon-lower-env-test-accounts.md) to log in).

## Testing done
Verified locally in browser.

## Screenshots
### Issue on Staging:
![staging-jamie-wood-profile-bug](https://user-images.githubusercontent.com/587583/59368674-9b2efc00-8cf3-11e9-9f5c-3ccdb5ec2c76.png)

### Fixed on local:
![local-jamie-wood-profile-fixed](https://user-images.githubusercontent.com/587583/59368471-28258580-8cf3-11e9-8e97-16c979afa75b.png)


## Acceptance criteria
- [ ] 2FA prompt appears on Jamie's profile, instead of inifinte loading-indicator.

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
