### PR TITLE
Add new app so we can do UAT of Dashboard changes on prod

### DIFF
--- a/src/applications/personalization/dashboard-new/dashboard-entry.jsx
+++ b/src/applications/personalization/dashboard-new/dashboard-entry.jsx
@@ -1,0 +1,20 @@
+import 'platform/polyfills';
+import 'applications/personalization/profile360/sass/user-profile.scss';
+import 'applications/claims-status/sass/claims-status.scss';
+import 'applications/personalization/dashboard/sass/dashboard.scss';
+import 'applications/personalization/dashboard/sass/dashboard-alert.scss';
+import 'applications/personalization/dashboard/sass/messaging/messaging.scss';
+import 'applications/personalization/preferences/sass/preferences.scss';
+
+import startApp from 'platform/startup';
+
+import routes from './routes';
+import reducer from 'applications/personalization/dashboard/reducers';
+import manifest from './manifest';
+
+startApp({
+  url: manifest.rootUrl,
+  reducer,
+  routes,
+  entryName: manifest.entryName,
+});

--- a/src/applications/personalization/dashboard-new/manifest.js
+++ b/src/applications/personalization/dashboard-new/manifest.js
@@ -1,0 +1,12 @@
+module.exports = {
+  appName: 'Dashboard Preview',
+  entryFile: './dashboard-entry.jsx',
+  entryName: 'dashboard-new',
+  rootUrl: '/dashboard2', // Default value for teamsite
+  receiveContentProps({ path }) {
+    this.rootUrl = `/${path}`;
+  },
+  production: true,
+  contentPage: 'dashboard2/index.md',
+  hideInvitation: true,
+};

--- a/src/applications/personalization/dashboard-new/routes.jsx
+++ b/src/applications/personalization/dashboard-new/routes.jsx
@@ -1,0 +1,19 @@
+import DashboardAppNew from 'applications/personalization/dashboard/containers/DashboardAppNew';
+import DashboardAppWrapper from 'applications/personalization/dashboard/containers/DashboardAppWrapper';
+import SetPreferences from 'applications/personalization/preferences/containers/SetPreferences';
+
+export const findBenefitsRoute = {
+  path: 'find-benefits',
+  component: SetPreferences,
+  key: 'find-benefits',
+  name: 'Find VA benefits',
+};
+
+const routes = {
+  path: '/',
+  component: DashboardAppWrapper,
+  indexRoute: { component: DashboardAppNew },
+  childRoutes: [findBenefitsRoute],
+};
+
+export default routes;


### PR DESCRIPTION
## Description
Rather than duplicate all the code, I just made a new manifest, etc. and point it at the existing components.

The corresponding content app update is: https://github.com/department-of-veterans-affairs/vagov-content/pull/464

## Testing done
Local; the dashboard shows up at `dashboard2`

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs