### PR TITLE
Turn on all the flags for cms

### DIFF
--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -18,13 +18,13 @@
 {% for tag in entityMetatags %}
     {% case tag.__typename %}
       {% when "MetaValue" %}
+<meta name="{{ tag.key }}" content="{{ tag.value }}">
+      {% when "MetaProperty" %}
         {% if tag.key == "title" %}
 <title>{{ tag.value }}</title>
         {% else %}
-<meta name="{{ tag.key }}" content="{{ tag.value }}">
-        {% endif %}
-      {% when "MetaProperty" %}
 <meta property="{{ tag.key }}" content="{{ tag.value }}">
+        {% endif %}
       {% when "MetaLink" %}
 <link rel="{{ tag.key }}" href="{{ tag.value }}">
     {% endcase %}

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -18,13 +18,13 @@
 {% for tag in entityMetatags %}
     {% case tag.__typename %}
       {% when "MetaValue" %}
-<meta name="{{ tag.key }}" content="{{ tag.value }}">
-      {% when "MetaProperty" %}
         {% if tag.key == "title" %}
 <title>{{ tag.value }}</title>
         {% else %}
-<meta property="{{ tag.key }}" content="{{ tag.value }}">
+<meta name="{{ tag.key }}" content="{{ tag.value }}">
         {% endif %}
+      {% when "MetaProperty" %}
+<meta property="{{ tag.key }}" content="{{ tag.value }}">
       {% when "MetaLink" %}
 <link rel="{{ tag.key }}" href="{{ tag.value }}">
     {% endcase %}

--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -43,7 +43,15 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_FIELD_LINKS,
     featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT,
   ],
-  vagovprod: [featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE],
+  vagovprod: [
+    featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE,
+    featureFlags.GRAPHQL_MODULE_UPDATE,
+    featureFlags.FEATURE_FIELD_OTHER_VA_LOCATIONS,
+    featureFlags.FEATURE_HEALTH_CARE_REGION_DETAIL_PAGE_FIELD_ALERT,
+    featureFlags.FEATURE_FIELD_COMMONLY_TREATED_CONDITIONS,
+    featureFlags.FEATURE_FIELD_LINKS,
+    featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT,
+  ],
 };
 
 // Exported feature flag state, which can be used in code as needed


### PR DESCRIPTION
## Description
A prod deploy just happened and all the staging flags went live! This turns them on on the front end, so that builds/preview server work again

## Testing done
Ran the build locally

## Acceptance criteria
- [ ] Build works and doesn't fail over to cache

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
