### PR TITLE
Fix forms focus logic

### DIFF
--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -8,6 +8,9 @@ export function focusElement(selectorOrElement, options) {
       : selectorOrElement;
 
   if (el) {
+    if (el.tabIndex === 0) {
+      el.setAttribute('tabindex', '0');
+    }
     if (el.tabIndex < 0) {
       el.setAttribute('tabindex', '-1');
     }

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -6,20 +6,12 @@ export function focusElement(selectorOrElement, options) {
     typeof selectorOrElement === 'string'
       ? document.querySelector(selectorOrElement)
       : selectorOrElement;
-  let prevTabIdx = null;
 
   if (el) {
-    prevTabIdx = el.getAttribute('tabindex');
-    if (prevTabIdx && prevTabIdx <= 0) {
+    if (el.tabIndex < 0) {
       el.setAttribute('tabindex', '-1');
     }
     el.focus(options);
-    // restore previous tab-index to re-enable kybd-focus
-    if (prevTabIdx) {
-      el.setAttribute('tabindex', prevTabIdx);
-    } else {
-      el.removeAttribute('tabindex');
-    }
   }
 }
 

--- a/src/platform/utilities/ui/index.js
+++ b/src/platform/utilities/ui/index.js
@@ -21,7 +21,7 @@ export function focusElement(selectorOrElement, options) {
       : selectorOrElement;
 
   if (el) {
-    if (el.tabIndex <= 0) {
+    if (el.tabIndex < 0) {
       el.setAttribute('tabindex', '-1');
     }
     el.focus(options);

--- a/src/platform/utilities/ui/index.js
+++ b/src/platform/utilities/ui/index.js
@@ -21,6 +21,9 @@ export function focusElement(selectorOrElement, options) {
       : selectorOrElement;
 
   if (el) {
+    if (el.tabIndex === 0) {
+      el.setAttribute('tabindex', '0');
+    }
     if (el.tabIndex < 0) {
       el.setAttribute('tabindex', '-1');
     }


### PR DESCRIPTION
## Description
A previous change broke our focus helper in the forms code. This fixes it.

## Testing done
There are three scenarios where this has to work:
- Moving between pages on non-IE browsers
- Moving between pages on IE 11
- The document upload button after deleting a file on the HCA form

## Acceptance criteria
- [x] Code works in all three scenarios

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
