### PR TITLE
VAGOV-3151: fixing breadcrumbs for facility and non-facility pages

### DIFF
--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -4,6 +4,7 @@ const {
   createFileObj,
   paginatePages,
   updateEntityUrlObj,
+  generateBreadCrumbs,
 } = require('./page');
 
 // Creates the facility pages
@@ -23,7 +24,9 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     title: page.title,
   };
   const locPage = updateEntityUrlObj(locObj, drupalPagePath, 'Locations');
+  const locPath = locPage.entityUrl.path;
   locPage.regionOrOffice = page.title;
+  locPage.entityUrl = generateBreadCrumbs(locPath);
 
   files[`${drupalPagePath}/locations/index.html`] = createFileObj(
     locPage,
@@ -57,7 +60,9 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'Patient and health services',
     'health-services',
   );
+  const hsPath = hsPage.entityUrl.path;
   hsPage.regionOrOffice = page.title;
+  hsPage.entityUrl = generateBreadCrumbs(hsPath);
 
   files[`${drupalPagePath}/health-services/index.html`] = createFileObj(
     hsPage,
@@ -75,7 +80,9 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     alert: page.alert,
   };
   const prPage = updateEntityUrlObj(prObj, drupalPagePath, 'Press Releases');
+  const prPath = prPage.entityUrl.path;
   prPage.regionOrOffice = page.title;
+  prPage.entityUrl = generateBreadCrumbs(prPath);
 
   paginatePages(
     prPage,
@@ -101,7 +108,9 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'Community stories',
     'stories',
   );
+  const nsPath = nsPage.entityUrl.path;
   nsPage.regionOrOffice = page.title;
+  nsPage.entityUrl = generateBreadCrumbs(nsPath);
 
   paginatePages(
     nsPage,
@@ -122,7 +131,9 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     { alert: page.alert },
   );
   const eventPage = updateEntityUrlObj(eventObj, drupalPagePath, 'Events');
+  const eventPagePath = eventPage.entityUrl.path;
   eventPage.regionOrOffice = page.title;
+  eventPage.entityUrl = generateBreadCrumbs(eventPagePath);
 
   paginatePages(
     eventPage,
@@ -149,7 +160,9 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     drupalPagePath,
     'Leadership',
   );
+  const bioPagePath = bioListingPage.entityUrl.path;
   bioListingPage.regionOrOffice = page.title;
+  bioListingPage.entityUrl = generateBreadCrumbs(bioPagePath);
 
   paginatePages(
     bioListingPage,

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -147,12 +147,16 @@ function generateBreadCrumbs(pathString) {
   for (const value of pathArray) {
     trimmedValue = _.trim(value, '/');
     if (value) {
+      const dehandlized =
+        value === 'pittsburgh-health-care'
+          ? 'VA Pittsburgh health care'
+          : _.startCase(_.trim(value, '-'));
       entityUrlObj.breadcrumb.push({
         url: {
           path: `${previous}${value}`,
           routed: true,
         },
-        text: _.startCase(_.trim(value, '-')),
+        text: dehandlized,
       });
     }
     previous += `${trimmedValue}/`;

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -140,20 +140,24 @@ function updateEntityUrlObj(page, drupalPagePath, title, pathSuffix) {
 
 // Generate breadcrumbs from drupal page path
 function generateBreadCrumbs(pathString) {
-  const pathArray = _.split(pathString, '/');
+  const pathArray = pathString.split('/');
   const entityUrlObj = createEntityUrlObj(pathString);
+  let previous = '';
+  let trimmedValue;
   for (const value of pathArray) {
+    trimmedValue = _.trim(value, '/');
     if (value) {
       entityUrlObj.breadcrumb.push({
         url: {
-          path: `/${value}`,
+          path: `${previous}${value}`,
           routed: true,
         },
         text: _.startCase(_.trim(value, '-')),
       });
     }
+    previous += `${trimmedValue}/`;
   }
-  entityUrlObj.breadcrumb.pop();
+
   return entityUrlObj;
 }
 
@@ -205,6 +209,7 @@ function compilePage(page, contentData) {
 
   const pageIdRaw = parseInt(page.entityId, 10);
   const pageId = { pid: pageIdRaw };
+  page.entityUrl = generateBreadCrumbs(entityUrl.path);
   let pageCompiled;
 
   switch (entityBundle) {
@@ -267,7 +272,6 @@ function compilePage(page, contentData) {
       break;
     case 'event': {
       // eslint-disable-next-line no-param-reassign
-      page.entityUrl = generateBreadCrumbs(entityUrl.path);
       pageCompiled = Object.assign(
         page,
         facilitySidebarNavItems,
@@ -278,7 +282,6 @@ function compilePage(page, contentData) {
       break;
     }
     case 'person_profile':
-      page.entityUrl = generateBreadCrumbs(entityUrl.path);
       pageCompiled = Object.assign(
         page,
         facilitySidebarNavItems,
@@ -290,6 +293,7 @@ function compilePage(page, contentData) {
     default:
       // Get the right benefits hub sidebar
       sidebarNavItems = getHubSidebar(sideNavs, owner);
+      page.entityUrl = generateBreadCrumbs(entityUrl.path);
 
       // Build page with correct sidebar
       pageCompiled = Object.assign(
@@ -312,4 +316,5 @@ module.exports = {
   paginatePages,
   createEntityUrlObj,
   updateEntityUrlObj,
+  generateBreadCrumbs,
 };


### PR DESCRIPTION
## Description
Visit: https://staging.va.gov/pittsburgh-health-care/
Expected: Breadcrumb should show "Home > VA Pittsburgh health care"

Visit: https://staging.va.gov/pittsburgh-health-care/locations/
Expected: Breadcrumb shows, "Home > VA Pittsburgh health care > Locations"

## Testing done
locally with staging data.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
