### PR TITLE
Stop checking ESR when user is LOA1

### DIFF
--- a/src/applications/personalization/dashboard/containers/DashboardAppNew.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardAppNew.jsx
@@ -189,7 +189,9 @@ class DashboardAppNew extends React.Component {
 
   componentDidMount() {
     scrollToTop();
-    this.props.getEnrollmentStatus();
+    if (this.props.profile.verified) {
+      this.props.getEnrollmentStatus();
+    }
   }
 
   dismissAlertBox = name => () => {

--- a/src/applications/personalization/dashboard/containers/YourApplications.jsx
+++ b/src/applications/personalization/dashboard/containers/YourApplications.jsx
@@ -22,8 +22,10 @@ import { isSIPEnabledForm, sipFormSorter } from '../helpers';
 
 class YourApplications extends React.Component {
   componentDidMount() {
-    this.props.getEnrollmentStatus();
-    this.props.getDismissedHCANotification();
+    if (this.props.profileState.verified) {
+      this.props.getEnrollmentStatus();
+      this.props.getDismissedHCANotification();
+    }
   }
 
   dismissHCANotification = () => {
@@ -65,6 +67,27 @@ class YourApplications extends React.Component {
   }
 }
 
+YourApplications.propTypes = {
+  getDismissedHCANotification: PropTypes.func.isRequired,
+  getEnrollmentStatus: PropTypes.func.isRequired,
+  setDismissedHCANotification: PropTypes.func.isRequired,
+  hcaEnrollmentStatus: PropTypes.shape({
+    enrollmentStatus: PropTypes.string,
+    applicationDate: PropTypes.string,
+  }),
+  savedForms: PropTypes.arrayOf(
+    PropTypes.shape({
+      form: PropTypes.string.required,
+      metadata: PropTypes.shape({
+        lastUpdated: PropTypes.number,
+        expiresAt: PropTypes.number,
+      }),
+    }),
+  ),
+  shouldRenderContent: PropTypes.bool.isRequired,
+  shouldRenderHCAAlert: PropTypes.bool,
+};
+
 export const mapStateToProps = state => {
   const hcaEnrollmentStatus = selectEnrollmentStatus(state);
   const isLoading =
@@ -91,27 +114,6 @@ export const mapStateToProps = state => {
     shouldRenderContent,
     shouldRenderHCAAlert,
   };
-};
-
-YourApplications.propTypes = {
-  getDismissedHCANotification: PropTypes.func.isRequired,
-  getEnrollmentStatus: PropTypes.func.isRequired,
-  setDismissedHCANotification: PropTypes.func.isRequired,
-  hcaEnrollmentStatus: PropTypes.shape({
-    enrollmentStatus: PropTypes.string,
-    applicationDate: PropTypes.string,
-  }),
-  savedForms: PropTypes.arrayOf(
-    PropTypes.shape({
-      form: PropTypes.string.required,
-      metadata: PropTypes.shape({
-        lastUpdated: PropTypes.number,
-        expiresAt: PropTypes.number,
-      }),
-    }),
-  ),
-  shouldRenderContent: PropTypes.bool.isRequired,
-  shouldRenderHCAAlert: PropTypes.bool,
 };
 
 const mapDispatchToProps = {

--- a/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
@@ -336,6 +336,7 @@ describe('<YourApplications>', () => {
           shouldRenderHCAAlert
           hcaEnrollmentStatus={enrollmentStatus}
           profileState={{ verified: true }}
+          savedForms={[sipEnabledForm]}
         />,
       );
     });
@@ -355,6 +356,12 @@ describe('<YourApplications>', () => {
         enrollmentStatus.enrollmentStatus,
       );
     });
+    it('should render the saved in progress forms', () => {
+      const formItem = tree.find('FormItem');
+      expect(formItem.length).to.equal(1);
+      expect(formItem.key()).to.equal(sipEnabledForm.form);
+      expect(formItem.prop('savedFormData')).to.deep.equal(sipEnabledForm);
+    });
   });
 
   describe('if user is not verified', () => {
@@ -369,6 +376,7 @@ describe('<YourApplications>', () => {
           getDismissedHCANotification={dismissedNotificationsSpy}
           shouldRenderContent
           profileState={{ verified: false }}
+          savedForms={[sipEnabledForm]}
         />,
       );
     });
@@ -384,6 +392,12 @@ describe('<YourApplications>', () => {
     it('should not render a HCAStatusAlert', () => {
       const alert = tree.find('HCAStatusAlert');
       expect(alert.length).to.equal(0);
+    });
+    it('should still render the saved in progress forms', () => {
+      const formItem = tree.find('FormItem');
+      expect(formItem.length).to.equal(1);
+      expect(formItem.key()).to.equal(sipEnabledForm.form);
+      expect(formItem.prop('savedFormData')).to.deep.equal(sipEnabledForm);
     });
   });
 });

--- a/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
@@ -9,9 +9,15 @@ import {
 } from '../../containers/YourApplications';
 import { HCA_ENROLLMENT_STATUSES } from 'applications/hca/constants';
 
+let enrollmentStatusSpy;
+let dismissedNotificationsSpy;
+
 const defaultProps = {
   getEnrollmentStatus: sinon.stub(),
   getDismissedHCANotification: sinon.stub(),
+  profileState: {
+    verified: false,
+  },
   setDismissedHCANotification: sinon.stub(),
   savedForms: [],
 };
@@ -316,20 +322,68 @@ describe('<YourApplications>', () => {
     tree.unmount();
   });
 
-  it('should render a HCAStatusAlert', () => {
-    const tree = shallow(
-      <YourApplications
-        {...defaultProps}
-        shouldRenderContent
-        shouldRenderHCAAlert
-        hcaEnrollmentStatus={enrollmentStatus}
-      />,
-    );
-    const alert = tree.find('HCAStatusAlert');
-    expect(alert.length).to.equal(1);
-    expect(alert.prop('enrollmentStatus')).to.equal(
-      enrollmentStatus.enrollmentStatus,
-    );
-    tree.unmount();
+  describe('if user is verified', () => {
+    let tree;
+    beforeEach(() => {
+      enrollmentStatusSpy = sinon.spy();
+      dismissedNotificationsSpy = sinon.spy();
+      tree = shallow(
+        <YourApplications
+          {...defaultProps}
+          getEnrollmentStatus={enrollmentStatusSpy}
+          getDismissedHCANotification={dismissedNotificationsSpy}
+          shouldRenderContent
+          shouldRenderHCAAlert
+          hcaEnrollmentStatus={enrollmentStatus}
+          profileState={{ verified: true }}
+        />,
+      );
+    });
+    afterEach(() => {
+      tree.unmount();
+    });
+    it('should call the `enrollment_status` endpoint', () => {
+      expect(enrollmentStatusSpy.called).to.be.true;
+    });
+    it('should call the `dismissed_statuses` endpoint', () => {
+      expect(dismissedNotificationsSpy.called).to.be.true;
+    });
+    it('should render a HCAStatusAlert', () => {
+      const alert = tree.find('HCAStatusAlert');
+      expect(alert.length).to.equal(1);
+      expect(alert.prop('enrollmentStatus')).to.equal(
+        enrollmentStatus.enrollmentStatus,
+      );
+    });
+  });
+
+  describe('if user is not verified', () => {
+    let tree;
+    beforeEach(() => {
+      enrollmentStatusSpy = sinon.spy();
+      dismissedNotificationsSpy = sinon.spy();
+      tree = shallow(
+        <YourApplications
+          {...defaultProps}
+          getEnrollmentStatus={enrollmentStatusSpy}
+          getDismissedHCANotification={dismissedNotificationsSpy}
+          shouldRenderContent
+          profileState={{ verified: false }}
+        />,
+      );
+    });
+    afterEach(() => {
+      tree.unmount();
+    });
+    it('should not call the `enrollment_status` endpoint', () => {
+      expect(enrollmentStatusSpy.notCalled).to.be.true;
+    });
+    it('should not call the `dismissed_statuses` endpoint', () => {
+      expect(dismissedNotificationsSpy.notCalled).to.be.true;
+    });
+    it('should not render a HCAStatusAlert', () => {
+      const alert = tree.find('HCAStatusAlert');
+      expect(alert.length).to.equal(0);
+    });
   });
 });


### PR DESCRIPTION
**TODO:**
- [x] expand the test coverage for this

## Description
The dashboard was hitting the `enrollment_status` endpoint a couple of
times even if the user is LOA1 and thus not authorized to see their
health care enrollment status. This change adds a check to see if the
user is LOA3 before hitting that endpoint

I discovered this when looking at the new dashboard on prod (at the "secret" URL: va.gov/dashboard2) with my own LOA1 account. I was seeing an ESR error at the top of the dashboard because the endpoint returns a 500 if a non-LOA3 user attempts to hit it without query params.

## Testing done
Local

## Screenshots
N/A

## Acceptance criteria
- [ ] No longer see ESR error at top of Dashboard when logged in as LOA1 user
- [ ] No longer see console errors when loading Dashboard as a LOA1 user

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs