### PR TITLE
18948: Personal Information page that should not appear when changing answer to STEM question

### DIFF
--- a/src/applications/edu-benefits/1995/config/new-chapters.js
+++ b/src/applications/edu-benefits/1995/config/new-chapters.js
@@ -186,9 +186,9 @@ export const newChapters = {
       dependents: {
         title: 'Dependents',
         path: 'personal-information/dependents',
-        depends: {
-          'view:hasServiceBefore1978': true,
-        },
+        depends: form =>
+          form.isEdithNourseRogersScholarship !== true &&
+          form['view:hasServiceBefore1978'] === true,
         uiSchema: {
           serviceBefore1977: serviceBefore1977UI,
         },

--- a/src/applications/edu-benefits/1995/config/new-chapters.js
+++ b/src/applications/edu-benefits/1995/config/new-chapters.js
@@ -187,7 +187,7 @@ export const newChapters = {
         title: 'Dependents',
         path: 'personal-information/dependents',
         depends: form =>
-          form.isEdithNourseRogersScholarship !== true &&
+          !displayActiveDutyStem(form) &&
           form['view:hasServiceBefore1978'] === true,
         uiSchema: {
           serviceBefore1977: serviceBefore1977UI,


### PR DESCRIPTION
## Description
When filling out the 1995 form, if a user first answers No to "Are you applying for the Edith Nourse Rogers STEM Scholarship (Chapter 33)?" they are eventually asked "Do you have any periods of service that began before 1978?". When the user answers Yes to this question they are later presented with a personal information page that has three questions (see screenshot below). This page should only appear if the user answers No to "Are you applying for the Edith Nourse Rogers STEM Scholarship (Chapter 33)?" and Yes to "Do you have any periods of service that began before 1978?".

Currently if a user answers Yes to "Do you have any periods of service that began before 1978?" and then goes back to the STEM question and changes their answer to Yes, the personal information page will still show.

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18948

## Testing done
Manual Testing, Unit, and End to End Tests pass locally.

## Screenshots
N/A

## Acceptance criteria
- [x] Bug fixed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
