### PR TITLE
Actually pass the profileState to the component

### DIFF
--- a/src/applications/personalization/dashboard/containers/YourApplications.jsx
+++ b/src/applications/personalization/dashboard/containers/YourApplications.jsx
@@ -110,6 +110,7 @@ export const mapStateToProps = state => {
 
   return {
     hcaEnrollmentStatus,
+    profileState,
     savedForms: verifiedSavedForms,
     shouldRenderContent,
     shouldRenderHCAAlert,

--- a/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
@@ -49,6 +49,7 @@ describe('mapStateToProps', () => {
     state = {
       user: {
         profile: {
+          verified: true,
           savedForms: [],
         },
       },
@@ -73,6 +74,13 @@ describe('mapStateToProps', () => {
       expect(mappedProps.hcaEnrollmentStatus).to.deep.equal(
         state.hcaEnrollmentStatus,
       );
+    });
+  });
+
+  describe('`profileState`', () => {
+    it('is the same as the `profile` on state', () => {
+      const mappedProps = mapStateToProps(state);
+      expect(mappedProps.profileState).to.deep.equal(state.user.profile);
     });
   });
 


### PR DESCRIPTION
## Description
This is embarrassing but I forgot to pass the profileState into the YourApplications component with my last PR

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs