### PR TITLE
Display correct housing rate on profile page for OJT institutions

### DIFF
--- a/src/applications/gi/selectors/calculator.js
+++ b/src/applications/gi/selectors/calculator.js
@@ -2,6 +2,7 @@ import { isEmpty } from 'lodash';
 import { createSelector } from 'reselect';
 
 import { formatCurrency } from '../utils/helpers';
+import environment from '../../../platform/utilities/environment';
 
 const getConstants = state => state.constants.constants;
 
@@ -562,7 +563,12 @@ const getDerivedValues = createSelector(
     } else if (isFlightOrCorrespondence) {
       housingAllowTerm1 = 0;
     } else if (isOJT) {
-      housingAllowTerm1 = ropOjt * (tier * bah + kickerBenefit);
+      // Changes for 18970. Keeping the changes behind a production flag until EDU can review the fix.
+      if (onlineClasses === 'yes' && !environment.isProduction()) {
+        housingAllowTerm1 = ropOjt * ((tier * avgBah) / 2 + kickerBenefit);
+      } else {
+        housingAllowTerm1 = ropOjt * (tier * bah + kickerBenefit);
+      }
     } else if (onlineClasses === 'yes') {
       housingAllowTerm1 =
         termLength * rop * ((tier * avgBah) / 2 + kickerBenefit);

--- a/src/applications/gi/tests/selectors/calculator.unit.spec.js
+++ b/src/applications/gi/tests/selectors/calculator.unit.spec.js
@@ -502,4 +502,33 @@ describe('getCalculatedBenefits', () => {
       getCalculatedBenefits(state).outputs.housingAllowance.value,
     ).to.equal(`${formatCurrency(monthlyRateFinal)}/mo`);
   });
+
+  it('should calculate housing allowance using half the average DOD/VA rate if OJT and online only courses', () => {
+    const working = '30';
+    const state = {
+      ...defaultState,
+      calculator: {
+        ...defaultState.calculator,
+        type: 'OJT',
+        working,
+      },
+      eligibility: {
+        ...defaultState.eligibility,
+        onlineClasses: 'yes',
+      },
+      profile: {
+        ...defaultState.profile,
+        attributes: {
+          ...defaultState.profile.attributes,
+          type: 'ojt',
+        },
+      },
+    };
+    const ropOjt = working / 30;
+    const monthlyRateFinal =
+      (ropOjt * defaultState.constants.constants.AVGDODBAH) / 2;
+    expect(
+      getCalculatedBenefits(state).outputs.housingAllowance.value,
+    ).to.equal(`${formatCurrency(monthlyRateFinal)}/mo`);
+  });
 });


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/18970

When users search for an "online only" OJT institution in the comparison tool, the search results page and profile page should display half the dod/va BAH average. 

## Testing done
QA and dev tested.

## Screenshots
<img width="712" alt="Screen Shot 2019-06-17 at 10 18 53 AM" src="https://user-images.githubusercontent.com/48804654/59611549-7f5b9980-90e9-11e9-9350-4e3a57e40a9e.png">

---

<img width="1123" alt="Screen Shot 2019-06-17 at 10 19 49 AM" src="https://user-images.githubusercontent.com/48804654/59611590-900c0f80-90e9-11e9-9894-ea54bb171437.png">

---

<img width="1123" alt="Screen Shot 2019-06-17 at 10 20 01 AM" src="https://user-images.githubusercontent.com/48804654/59611612-99957780-90e9-11e9-8fdd-8be7d3c3ef3a.png">

---

## Acceptance criteria
Display half the VA/DOD rate when "Online Only" is selected for OJT institutions.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
