### PR TITLE
adjust gating of dashboard widget heading styles

### DIFF
--- a/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
@@ -11,6 +11,15 @@ import { fetchFolder, fetchRecipients } from '../actions/messaging';
 import { mhvBaseUrl } from 'platform/site-wide/cta-widget/helpers';
 import environment from 'platform/utilities/environment';
 
+// we want to show the new heading style on prod _only_ if we are on the
+// `dashboard2` route
+function showNewHeadingStyle() {
+  return (
+    !environment.isProduction() ||
+    window.location.pathname.indexOf('dashboard2') > -1
+  );
+}
+
 class MessagingWidget extends React.Component {
   componentDidMount() {
     if (this.props.canAccessMessaging) {
@@ -87,8 +96,8 @@ class MessagingWidget extends React.Component {
 
     return (
       <div id="msg-widget">
-        {environment.isProduction() && <h2>Check secure messages</h2>}
-        {!environment.isProduction() && <h3>Check secure messages</h3>}
+        {!showNewHeadingStyle() && <h2>Check secure messages</h2>}
+        {showNewHeadingStyle() && <h3>Check secure messages</h3>}
         {content}
         <p>
           <a

--- a/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
@@ -11,6 +11,15 @@ import CallVBACenter from 'platform/static-data/CallVBACenter';
 import { mhvBaseUrl } from 'platform/site-wide/cta-widget/helpers';
 import environment from 'platform/utilities/environment';
 
+// we want to show the new heading style on prod _only_ if we are on the
+// `dashboard2` route
+function showNewHeadingStyle() {
+  return (
+    !environment.isProduction() ||
+    window.location.pathname.indexOf('dashboard2') > -1
+  );
+}
+
 class PrescriptionsWidget extends React.Component {
   componentDidMount() {
     if (this.props.canAccessRx) {
@@ -54,8 +63,8 @@ class PrescriptionsWidget extends React.Component {
 
     return (
       <div id="rx-widget">
-        {environment.isProduction() && <h2>Refill Prescriptions</h2>}
-        {!environment.isProduction() && <h3>Refill prescriptions</h3>}
+        {!showNewHeadingStyle() && <h2>Refill Prescriptions</h2>}
+        {showNewHeadingStyle() && <h3>Refill prescriptions</h3>}
         <div>{content}</div>
         <p>
           <a


### PR DESCRIPTION
## Description
This is a quick hack to make the widget headings look correct while doing UAT at www.va.gov/dashboard2. We noticed in the first UAT sessions that the headings were wrong because our gating logic was simply checking to see if we are on prod or not

## Testing done
local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs