### PR TITLE
Remove duplicative Sentry log in letters

### DIFF
--- a/src/applications/letters/actions/letters.js
+++ b/src/applications/letters/actions/letters.js
@@ -111,7 +111,7 @@ export function getLetterListAndBSLOptions() {
   return dispatch =>
     getLetterList(dispatch)
       .then(() => getBenefitSummaryOptions(dispatch))
-      .catch(error => Sentry.captureException(error));
+      .catch();
 }
 
 export function getAddressFailure() {

--- a/src/applications/letters/actions/letters.js
+++ b/src/applications/letters/actions/letters.js
@@ -111,7 +111,7 @@ export function getLetterListAndBSLOptions() {
   return dispatch =>
     getLetterList(dispatch)
       .then(() => getBenefitSummaryOptions(dispatch))
-      .catch();
+      .catch(() => {});
 }
 
 export function getAddressFailure() {

--- a/src/applications/letters/tests/actions/letters.unit.spec.js
+++ b/src/applications/letters/tests/actions/letters.unit.spec.js
@@ -278,16 +278,10 @@ describe('getLetterListAndBSLOptions', () => {
     const thunk = getLetterListAndBSLOptions();
     const dispatch = () => {};
 
-    thunk(dispatch)
-      .then(() => {
-        done(
-          new Error('getLetterList should have rejected but resolved instead'),
-        );
-      })
-      .catch(() => {
-        expect(global.fetch.callCount).to.equal(1);
-        done();
-      });
+    thunk(dispatch).then(() => {
+      expect(global.fetch.callCount).to.equal(1);
+      done();
+    });
   });
 });
 

--- a/src/applications/letters/tests/actions/letters.unit.spec.js
+++ b/src/applications/letters/tests/actions/letters.unit.spec.js
@@ -278,10 +278,16 @@ describe('getLetterListAndBSLOptions', () => {
     const thunk = getLetterListAndBSLOptions();
     const dispatch = () => {};
 
-    thunk(dispatch).then(() => {
-      expect(global.fetch.callCount).to.equal(1);
-      done();
-    });
+    thunk(dispatch)
+      .then(() => {
+        done(
+          new Error('getLetterList should have rejected but resolved instead'),
+        );
+      })
+      .catch(() => {
+        expect(global.fetch.callCount).to.equal(1);
+        done();
+      });
   });
 });
 


### PR DESCRIPTION
This was showing up as `undefined` in [Sentry](http://sentry.vetsgov-internal/vets-gov/website-production/issues/64125/?query=is%3Aunresolved%20lastSeen%3A-30d%20timesSeen%3A%3E%3D100%20source%3Aletters%20event.timestamp%3A%3E2019-05-17T00%3A00%3A00). I'm removing the log in the catch statement and logging only from `getLetterList`, since it only ever gets called from `getLetterListAndBSLOptions` anyway and sentry has the breadcrumbs