### PR TITLE
Focus H3 of "remove notification" alert

### DIFF
--- a/src/applications/personalization/dashboard/components/HCAStatusAlert.jsx
+++ b/src/applications/personalization/dashboard/components/HCAStatusAlert.jsx
@@ -25,10 +25,14 @@ const HCAStatusAlert = ({ applicationDate, enrollmentStatus, onRemove }) => {
 
   if (isShowingConfirmation) {
     return (
-      <AlertBox
-        headline="Are you sure you want to permanently remove this notification?"
-        status="warning"
-      >
+      <AlertBox status="warning">
+        <h3
+          className="usa-alert-heading"
+          tabIndex="-1"
+          ref={el => el && el.focus()}
+        >
+          Are you sure you want to permanently remove this notification?
+        </h3>
         <p>
           Please confirm that you want to remove this notification from your{' '}
           <strong>My VA</strong> dashboard. Removing it won’t affect the status


### PR DESCRIPTION
## Description
The h3 header should receive focus when the confirmation alert appears. Using the technique described here https://stackoverflow.com/questions/28889826/set-focus-on-input-after-render?rq=1#answer-40235334

## Testing done
Local

## Screenshots
![screenreader](https://user-images.githubusercontent.com/20728956/59641002-c27f3200-9114-11e9-9ca1-6968268efa3f.gif)

## Acceptance criteria
- [ ] h3 is focused when the alert is added to the DOM

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs