### PR TITLE
VAGOV-4355: updating string comparison to avoid false matches

### DIFF
--- a/src/site/navigation/sidebar_nav.drupal.liquid
+++ b/src/site/navigation/sidebar_nav.drupal.liquid
@@ -33,7 +33,7 @@
                                 {% if listSize > 0 %}
                                     <ul class="usa-sidenav-list">
                                         {% for link in link.links %}
-                                            <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
+                                            <li {% if link.url.path contains entityUrl.path %} class="active-level" {% endif %}>
                                                 <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
                                                         href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
                                                 {% assign subListSize = link.links | size %}


### PR DESCRIPTION
## Description
Changing the order of a string comparison in the sidebar template. 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
