### PR TITLE
replace missing branchname variable

### DIFF
--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,6 +1,6 @@
 node('vetsgov-general-purpose') {
   dir("vets-website") {
-    checkout scm: [$class: 'GitSCM', branches: [[name: branchName]], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
+    checkout scm: [$class: 'GitSCM', branches: [[name: params.ref]], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
   }
 
   def commonStages = load "vets-website/jenkins/common.groovy"


### PR DESCRIPTION
In my haste to remove unused code I deleted a variable. Because of https://github.com/department-of-veterans-affairs/vets-website/pull/10228 the `branchName` is missing. 