### PR TITLE
Handle Drupal errors more cleanly

### DIFF
--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -154,7 +154,9 @@ function getDrupalContent(buildOptions) {
     } catch (err) {
       buildOptions.drupalError = drupalData;
       log(err.stack);
-      log(JSON.stringify(drupalData));
+      if (drupalData) {
+        log(JSON.stringify(drupalData));
+      }
       log('Failed to pipe Drupal content into Metalsmith!');
       if (buildOptions.buildtype !== ENVIRONMENTS.LOCALHOST) {
         done(err);

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -154,9 +154,6 @@ function getDrupalContent(buildOptions) {
     } catch (err) {
       buildOptions.drupalError = drupalData;
       log(err.stack);
-      if (drupalData) {
-        log(JSON.stringify(drupalData));
-      }
       log('Failed to pipe Drupal content into Metalsmith!');
       if (buildOptions.buildtype !== ENVIRONMENTS.LOCALHOST) {
         done(err);

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -86,6 +86,11 @@ async function loadDrupal(buildOptions) {
 
     console.timeEnd(drupalTimer);
 
+    if (drupalPages.errors && drupalPages.errors.length) {
+      log(JSON.stringify(drupalPages.errors, null, 2));
+      throw new Error('Drupal query returned with errors');
+    }
+
     const serialized = Buffer.from(JSON.stringify(drupalPages, null, 2));
     fs.ensureDirSync(buildOptions.cacheDirectory);
     fs.emptyDirSync(path.dirname(drupalCache));


### PR DESCRIPTION
## Description
Right now if the GraphQL returns errors, you get a TypeError in the build when we try to destructure the query data and there are missing fields. GraphQL errors come back in an errors array, so we can easily detect that and fail in a way that's more obvious in the build log.

## Testing done
Broke the query locally and verified the message

## Screenshots
![Screen Shot 2019-06-18 at 10 56 51 AM](https://user-images.githubusercontent.com/634932/59695178-cd3ed300-91b7-11e9-8b83-f87ea140b3b9.png)


## Acceptance criteria
- [x] Failure message is a little more understandable

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
