### PR TITLE
Wrap payment info in downtime notification

### DIFF
--- a/src/applications/personalization/profile360/components/ContactInformation.jsx
+++ b/src/applications/personalization/profile360/components/ContactInformation.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import DowntimeNotification, {
   externalServices,
-} from '../../../../platform/monitoring/DowntimeNotification';
-import recordEvent from '../../../../platform/monitoring/record-event';
+} from 'platform/monitoring/DowntimeNotification';
+import recordEvent from 'platform/monitoring/record-event';
 
 import accountManifest from '../../account/manifest.json';
 

--- a/src/applications/personalization/profile360/components/DowntimeBanner.jsx
+++ b/src/applications/personalization/profile360/components/DowntimeBanner.jsx
@@ -1,22 +1,19 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import { externalServiceStatus } from '../../../../platform/monitoring/DowntimeNotification';
+import { externalServiceStatus } from 'platform/monitoring/DowntimeNotification';
 
 function DowntimeBanner({ downtime, section }) {
   return (
     <AlertBox
       status="warning"
       isVisible
+      headline={`We can’t show your ${section} information right now.`}
       content={
-        <div>
-          <h3>We can’t show your {section} information right now.</h3>
-          <p>
-            We’re sorry. The system that handles {section} information is down
-            for maintenance right now. We hope to be finished with our work by{' '}
-            {downtime.startTime.format('MMMM Do')},{' '}
-            {downtime.endTime.format('LT')} Please check back soon.
-          </p>
-        </div>
+        <p>
+          We’re sorry. The system that handles {section} information is down for
+          maintenance right now. We hope to be finished with our work by{' '}
+          {downtime.endTime.format('MMMM Do, LT')} Please check back soon.
+        </p>
       }
     />
   );

--- a/src/applications/personalization/profile360/components/DowntimeBanner.jsx
+++ b/src/applications/personalization/profile360/components/DowntimeBanner.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { externalServiceStatus } from 'platform/monitoring/DowntimeNotification';
 

--- a/src/applications/personalization/profile360/components/DowntimeBanner.jsx
+++ b/src/applications/personalization/profile360/components/DowntimeBanner.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { externalServiceStatus } from 'platform/monitoring/DowntimeNotification';
 

--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -33,7 +33,7 @@ class ProfileView extends React.Component {
     user: PropTypes.object,
   };
 
-  handleDowntime = (downtime, children) => {
+  handleDowntimeApproaching = (downtime, children) => {
     if (downtime.status === externalServiceStatus.downtimeApproaching) {
       return (
         <DowntimeApproaching
@@ -70,11 +70,12 @@ class ProfileView extends React.Component {
         content = (
           <DowntimeNotification
             appTitle={appTitle}
-            render={this.handleDowntime}
+            render={this.handleDowntimeApproaching}
             dependencies={[
               externalServices.emis,
-              externalServices.vet360,
+              externalServices.evss,
               externalServices.mvi,
+              externalServices.vet360,
             ]}
           >
             <div>

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -5,6 +5,9 @@ import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 
+import DowntimeNotification, {
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
 import {
   createIsServiceAvailableSelector,
   isMultifactorEnabled,
@@ -15,6 +18,7 @@ import get from 'platform/utilities/data/get';
 
 import ProfileFieldHeading from 'applications/personalization/profile360/vet360/components/base/ProfileFieldHeading';
 
+import { handleDowntimeForSection } from '../components/DowntimeBanner';
 import PaymentInformationAddLink from '../components/PaymentInformationAddLink';
 import LoadFail from '../components/LoadFail';
 import PaymentInformation2FARequired from '../components/PaymentInformation2FARequired';
@@ -27,6 +31,47 @@ import {
 } from '../actions/paymentInformation';
 
 import featureFlags from '../featureFlags';
+
+const AdditionalInfos = () => (
+  <>
+    <div className="vads-u-margin-bottom--2">
+      <AdditionalInfo triggerText="How do I change my direct deposit information for GI Bill and other education benefits?">
+        <p>
+          You’ll need to sign in to the eBenefits website with your Premium DS
+          Logon account to change your direct deposit information for GI Bill
+          and other education benefits online.
+        </p>
+        <p>
+          If you don’t have a Premium DS Logon account, you can register for one
+          or upgrade your Basic account to Premium. Your MyHealtheVet or ID.me
+          credentials won’t work on eBenefits.
+        </p>
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+          href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information"
+        >
+          Go to eBenefits to change your information
+        </a>
+        <br />
+        <a href="/change-direct-deposit/#mail-phone">
+          Find out how to change your information by mail or phone
+        </a>
+      </AdditionalInfo>
+    </div>
+
+    <AdditionalInfo triggerText="What’s my bank’s routing number?">
+      <p>
+        Your bank’s routing number is a 9-digit code that’s based on the U.S.
+        location where your bank was opened. It’s the first set of numbers on
+        the bottom left of your paper checks. You can also search for this
+        number on your bank’s website. If your bank has multiple routing
+        numbers, you’ll want the number for the state where you opened your
+        account.
+      </p>
+    </AdditionalInfo>
+  </>
+);
 
 class PaymentInformation extends React.Component {
   static propTypes = {
@@ -130,44 +175,15 @@ class PaymentInformation extends React.Component {
           benefits
         </h2>
 
-        <div className="vads-u-margin-bottom--2">
-          <AdditionalInfo triggerText="How do I change my direct deposit information for GI Bill and other education benefits?">
-            <p>
-              You’ll need to sign in to the eBenefits website with your Premium
-              DS Logon account to change your direct deposit information for GI
-              Bill and other education benefits online.
-            </p>
-
-            <p>
-              If you don’t have a Premium DS Logon account, you can register for
-              one or upgrade your Basic account to Premium. Your MyHealtheVet or
-              ID.me credentials won’t work on eBenefits.
-            </p>
-            <a
-              rel="noopener noreferrer"
-              target="_blank"
-              href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information"
-            >
-              Go to eBenefits to change your information
-            </a>
-            <br />
-            <a href="/change-direct-deposit/#mail-phone">
-              Find out how to change your information by mail or phone
-            </a>
-          </AdditionalInfo>
-        </div>
-
-        <AdditionalInfo triggerText="What’s my bank’s routing number?">
-          <p>
-            Your bank’s routing number is a 9-digit code that’s based on the
-            U.S. location where your bank was opened. It’s the first set of
-            numbers on the bottom left of your paper checks. You can also search
-            for this number on your bank’s website. If your bank has multiple
-            routing numbers, you’ll want the number for the state where you
-            opened your account.
-          </p>
-        </AdditionalInfo>
-        {content}
+        <DowntimeNotification
+          render={handleDowntimeForSection('payment information')}
+          dependencies={[externalServices.evss]}
+        >
+          <>
+            <AdditionalInfos />
+            {content}
+          </>
+        </DowntimeNotification>
       </>
     );
   }

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -179,10 +179,8 @@ class PaymentInformation extends React.Component {
           render={handleDowntimeForSection('payment information')}
           dependencies={[externalServices.evss]}
         >
-          <>
-            <AdditionalInfos />
-            {content}
-          </>
+          <AdditionalInfos />
+          {content}
         </DowntimeNotification>
       </>
     );

--- a/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
@@ -6,6 +6,8 @@ import sinon from 'sinon';
 import set from 'platform/utilities/data/set';
 
 import { PaymentInformation } from '../../containers/PaymentInformation';
+import ProfileFieldHeading from 'applications/personalization/profile360/vet360/components/base/ProfileFieldHeading';
+import DowntimeNotification from 'platform/monitoring/DowntimeNotification';
 
 describe('<PaymentInformation/>', () => {
   const defaultProps = {
@@ -87,14 +89,10 @@ describe('<PaymentInformation/>', () => {
 
   it('renders the payment information', () => {
     const wrapper = shallow(<PaymentInformation {...defaultProps} />);
-    const renderedText = wrapper.text();
 
-    expect(renderedText).to.contain('123', 'Account number is rendered');
-    expect(renderedText).to.contain('Checking', 'Account type is rendered');
-    expect(renderedText).to.contain(
-      'My bank',
-      'Financial insitution name is rendered',
-    );
+    expect(wrapper.find(DowntimeNotification)).to.have.lengthOf(1);
+    expect(wrapper.find('PaymentInformationEditModal')).to.have.lengthOf(1);
+    expect(wrapper.find(ProfileFieldHeading)).to.have.lengthOf(3);
 
     wrapper.unmount();
   });


### PR DESCRIPTION
## Description
Don't show the payment info if EVSS is down

## Testing done
Local

## Screenshots
**DOWNTIME**
<img width="720" alt="downtime" src="https://user-images.githubusercontent.com/20728956/59704816-e3499500-91b1-11e9-836d-ad8b2dcc76b0.png">

**NORMAL RENDER**
![image](https://user-images.githubusercontent.com/20728956/59704873-fbb9af80-91b1-11e9-9332-33029c960a43.png)

## Acceptance criteria
- [x] downtime notification renders correctly when needed
- [x] content still renders correctly when downtime is not in affect

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs