### PR TITLE
Vagov 4370 Careers Sidebar Menu

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/sidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/sidebar.nav.graphql.js
@@ -71,4 +71,7 @@ module.exports = `
     pensionHubSidebarQuery: ${queryFilter('pension-benefits-hub')} {
       ${SIDEBAR_QUERY}
     }
+    careersHubSidebarQuery: ${queryFilter('careers-employment-benefits')} {
+      ${SIDEBAR_QUERY}
+    }
 `;

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -43,7 +43,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
       entityUrl: { path: drupalUrl },
       entityBundle,
     } = page;
-
+    console.log(page);
     const pageCompiled = compilePage(page, contentData);
     const drupalPageDir = path.join('.', drupalUrl);
     const drupalFileName = path.join(drupalPageDir, 'index.html');

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -43,7 +43,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
       entityUrl: { path: drupalUrl },
       entityBundle,
     } = page;
-    console.log(page);
+
     const pageCompiled = compilePage(page, contentData);
     const drupalPageDir = path.join('.', drupalUrl);
     const drupalFileName = path.join(drupalPageDir, 'index.html');

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -169,7 +169,7 @@ function getHubSidebar(navsArray, owner) {
   // Get the right benefits hub sidebar
   for (const nav of navsArray) {
     if (nav !== null && nav.links.length) {
-      const navName = _.toLower(nav.name);
+      const navName = _.toLower(nav.name.replace(/&/g, 'and'));
       if (owner !== null && owner === navName) {
         return { sidebar: nav };
       }
@@ -186,6 +186,7 @@ function compilePage(page, contentData) {
       healthcareHubSidebarQuery: healthcareHubSidebarNav = {},
       recordsHubSidebarQuery: recordsHubSidebarNav = {},
       pensionHubSidebarQuery: pensionHubSidebarNav = {},
+      careersHubSidebarQuery: careersHubSidebarNav = {},
       alerts: alertsItem = {},
       facilitySidebarQuery: facilitySidebarNav = {},
       outreachSidebarQuery: outreachSidebarNav = {},
@@ -202,6 +203,7 @@ function compilePage(page, contentData) {
     healthcareHubSidebarNav,
     recordsHubSidebarNav,
     pensionHubSidebarNav,
+    careersHubSidebarNav,
   ];
   let sidebarNavItems;
 


### PR DESCRIPTION
## Description
- Updates GraphQL query and content parsing so that Careers & Employment Benefits Hub sidebar menu appears on Careers & Employment Benefits Hub detail pages.
- Accounts for a cases where "&" is used in menu titles in place of "and."

## Testing done
- Migrated careers content and menus into Dev CMS. 
- Set 6 career details pages to Published.
- Ran metalsmith locally with a --pull-drupal flag.
- The menu appeared on career details pages as expected.

## Screenshots
<img width="1398" alt="Screen Shot 2019-06-18 at 2 33 27 PM" src="https://user-images.githubusercontent.com/1181665/59710032-26b5fa80-91d6-11e9-83d6-85bd517e4af6.png">
Note that only the Published pages show up.

## Acceptance criteria
- [ ] Careers and Employment Benefits Hub sidebar menu appears on Careers and Employment Benefits Hub detail pages.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
