### PR TITLE
Turn on additional information flag in staging

### DIFF
--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -39,6 +39,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT,
   ],
   vagovstaging: [
+    featureFlags.FEATURE_FIELD_ADDITIONAL_INFO,
     featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE,
     featureFlags.GRAPHQL_MODULE_UPDATE,
     featureFlags.FEATURE_FIELD_OTHER_VA_LOCATIONS,


### PR DESCRIPTION
## Description
Need to turn on the flag so the build passes.

## Acceptance criteria
- [x] build works

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
