### PR TITLE
HOTFIX: Changing video thumb filter to account for more cases.

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -69,7 +69,7 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.videoThumbnail = data => {
-    const string = data.split('?v=')[1];
+    const string = data.split('v=')[1];
     return `https://img.youtube.com/vi/${string}/sddefault.jpg`;
   };
 


### PR DESCRIPTION
## Description

HOTFIX to account for different url pattern when users link youtube vids. This pattern is used to grab video thumbnails.
