### PR TITLE
Update aria labels in HCA notification confirmation

### DIFF
--- a/src/applications/hca/actions.js
+++ b/src/applications/hca/actions.js
@@ -5,7 +5,7 @@ import { HCA_ENROLLMENT_STATUSES } from './constants';
 import { dismissedHCANotificationDate } from './selectors';
 
 // flip the `false` to `true` to fake the endpoint when testing locally
-const simulateServerLocally = environment.isLocalhost() && true;
+const simulateServerLocally = environment.isLocalhost() && false;
 
 // action types related to calling /health_care_applications/enrollment_status
 export const FETCH_ENROLLMENT_STATUS_STARTED =

--- a/src/applications/hca/actions.js
+++ b/src/applications/hca/actions.js
@@ -5,7 +5,7 @@ import { HCA_ENROLLMENT_STATUSES } from './constants';
 import { dismissedHCANotificationDate } from './selectors';
 
 // flip the `false` to `true` to fake the endpoint when testing locally
-const simulateServerLocally = environment.isLocalhost() && false;
+const simulateServerLocally = environment.isLocalhost() && true;
 
 // action types related to calling /health_care_applications/enrollment_status
 export const FETCH_ENROLLMENT_STATUS_STARTED =

--- a/src/applications/personalization/dashboard/components/HCAStatusAlert.jsx
+++ b/src/applications/personalization/dashboard/components/HCAStatusAlert.jsx
@@ -41,14 +41,14 @@ const HCAStatusAlert = ({ applicationDate, enrollmentStatus, onRemove }) => {
         </p>
         <button
           className="usa-button-primary vads-u-margin-y--0"
-          aria-label="Confirm remove health care application status notification"
+          aria-label="Remove the notification of my health care application status"
           onClick={onRemove}
         >
           Remove the notification
         </button>
         <button
           className="usa-button-secondary vads-u-margin-y--0"
-          aria-label="Do not remove the health care application status notification"
+          aria-label="Cancel the removal of my the health care application status notification"
           onClick={hideConfirmation}
         >
           Cancel


### PR DESCRIPTION
## Description
The aria labels on a couple buttons in the confirmation component for HCA notifications should match their visual text.

## Testing done
Tested locally

## Screenshots
![Screen Shot 2019-06-19 at 2 57 09 PM](https://user-images.githubusercontent.com/634932/59792599-88439b00-92a2-11e9-8c8c-ff4d2e05aac8.png)


## Acceptance criteria
- [x] Buttons have aria label text that matches the visual text, with more context

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
