### PR TITLE
Remove bad instructions on 530 form

### DIFF
--- a/src/applications/burials/components/IntroductionPage.jsx
+++ b/src/applications/burials/components/IntroductionPage.jsx
@@ -5,8 +5,6 @@ import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from '../../../platform/forms/save-in-progress/SaveInProgressIntro';
 
-import facilityLocator from '../../facility-locator/manifest';
-
 class IntroductionPage extends React.Component {
   componentDidMount() {
     focusElement('.va-nav-breadcrumbs-list');
@@ -91,23 +89,6 @@ class IntroductionPage extends React.Component {
               <div>
                 <h5>Apply</h5>
               </div>
-              <p>
-                Complete an Application for Burial Benefits (VA Form 21P-530).
-                <br />
-                <a href="https://www.vba.va.gov/pubs/forms/VBA-21P-530-ARE.pdf">
-                  Download VA Form 21P-530
-                </a>
-                .
-              </p>
-              <p>
-                Mail the application and other paperwork to your local regional
-                benefit office.
-                <br />
-                <a href={facilityLocator.rootUrl}>
-                  Find your local regional benefit office
-                </a>
-                .
-              </p>
               <div>
                 <p>Complete this burial benefits form.</p>
                 <p>
@@ -136,7 +117,6 @@ class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
-          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           pageList={this.props.route.pageList}
           startText="Start the Burial Benefits Application"
           downtime={this.props.route.formConfig.downtime}

--- a/src/applications/burials/components/IntroductionPage.jsx
+++ b/src/applications/burials/components/IntroductionPage.jsx
@@ -117,6 +117,7 @@ class IntroductionPage extends React.Component {
         </div>
         <SaveInProgressIntro
           buttonOnly
+          prefillEnabled={this.props.route.formConfig.prefillEnabled}
           pageList={this.props.route.pageList}
           startText="Start the Burial Benefits Application"
           downtime={this.props.route.formConfig.downtime}


### PR DESCRIPTION
## Description
We missed some text last year when we were turning this form back on, so the Apply step makes it look like you need to apply in paper and online.

## Testing done
Viewed locally

## Screenshots
![Screen Shot 2019-06-19 at 5 16 00 PM](https://user-images.githubusercontent.com/634932/59801022-03627c80-92b6-11e9-81be-946d1cdfea9d.png)

## Acceptance criteria
- [x] Text is switched back to the old text

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
