### PR TITLE
Handling focus and revising a URL handler for keyboard nav.

### DIFF
--- a/src/applications/facility-locator/components/ProviderServiceDescription.jsx
+++ b/src/applications/facility-locator/components/ProviderServiceDescription.jsx
@@ -14,7 +14,7 @@ import React from 'react';
 const ProviderServiceDescription = ({ provider, details = false }) => {
   if (details) {
     const { specialty } = provider.attributes;
-    if (specialty.length < 1) return null;
+    if (specialty && specialty.length < 1) return null;
 
     return (
       <ul>

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { fetchVAFacility } from '../actions';
+import { focusElement } from '../../../platform/utilities/ui';
 import AccessToCare from '../components/AccessToCare';
 import LocationAddress from '../components/search-results/LocationAddress';
 import LocationDirectionsLink from '../components/search-results/LocationDirectionsLink';
@@ -18,6 +19,10 @@ class FacilityDetail extends Component {
   UNSAFE_componentWillMount() {
     this.props.fetchVAFacility(this.props.params.id);
     window.scrollTo(0, 0);
+  }
+
+  componentDidMount() {
+    focusElement('.va-nav-breadcrumbs');
   }
 
   renderFacilityInfo() {

--- a/src/applications/facility-locator/containers/ProviderDetail.jsx
+++ b/src/applications/facility-locator/containers/ProviderDetail.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { object, func } from 'prop-types';
 import { fetchProviderDetail } from '../actions';
+import { focusElement } from '../../../platform/utilities/ui';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import LocationMap from '../components/LocationMap';
 import LocationAddress from '../components/search-results/LocationAddress';
@@ -20,6 +21,10 @@ class ProviderDetail extends Component {
   UNSAFE_componentWillMount() {
     this.props.fetchProviderDetail(this.props.params.id);
     window.scrollTo(0, 0);
+  }
+
+  componentDidMount() {
+    focusElement('.va-nav-breadcrumbs');
   }
 
   renderFacilityInfo = () => {

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable arrow-body-style */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { browserHistory, Link } from 'react-router';
+import { browserHistory } from 'react-router';
 import { connect } from 'react-redux';
 import { Tabs, TabList, TabPanel, Tab } from 'react-tabs';
 import { Map, TileLayer, FeatureGroup } from 'react-leaflet';
@@ -377,16 +377,15 @@ class VAMap extends Component {
   renderFacilityMarkers = () => {
     const { results } = this.props;
 
-    // TODO: Remove this commented block after verified stable in Staging and Prod
     // need to use this because Icons are rendered outside of Router context (Leaflet manipulates the DOM directly)
-    // const linkAction = (id, isProvider = false, e) => {
-    //   e.preventDefault();
-    //   if (isProvider) {
-    //     this.context.router.push(`provider/${id}`);
-    //   } else {
-    //     this.context.router.push(`facility/${id}`);
-    //   }
-    // };
+    const linkAction = (id, isProvider = false, e) => {
+      e.preventDefault();
+      if (isProvider) {
+        this.context.router.push(`provider/${id}`);
+      } else {
+        this.context.router.push(`facility/${id}`);
+      }
+    };
 
     return results.map(r => {
       const iconProps = {
@@ -415,9 +414,9 @@ class VAMap extends Component {
         <div>
           {r.type === LocationType.CC_PROVIDER ? (
             <div>
-              <Link to={`/provider/${r.id}`}>
+              <a href={`/provider/${r.id}`} onClick={linkAction.bind(this, r.id, true)}>
                 <h5>{r.attributes.name}</h5>
-              </Link>
+              </a>
               <h6>{r.attributes.orgName}</h6>
               <p>
                 Services:{' '}
@@ -428,9 +427,9 @@ class VAMap extends Component {
             </div>
           ) : (
             <div>
-              <Link to={`/facility/${r.id}`}>
+              <a href={`/facility/${r.id}`} onClick={linkAction.bind(this, r.id, false)}>
                 <h5>{r.attributes.name}</h5>
-              </Link>
+              </a>
               <p>
                 Facility type:{' '}
                 <strong>{facilityTypes[r.attributes.facilityType]}</strong>

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -378,14 +378,14 @@ class VAMap extends Component {
     const { results } = this.props;
 
     // need to use this because Icons are rendered outside of Router context (Leaflet manipulates the DOM directly)
-    const linkAction = (id, isProvider = false, e) => {
-      e.preventDefault();
-      if (isProvider) {
-        this.context.router.push(`provider/${id}`);
-      } else {
-        this.context.router.push(`facility/${id}`);
-      }
-    };
+    // const linkAction = (id, isProvider = false, e) => {
+    //   e.preventDefault();
+    //   if (isProvider) {
+    //     this.context.router.push(`provider/${id}`);
+    //   } else {
+    //     this.context.router.push(`facility/${id}`);
+    //   }
+    // };
 
     return results.map(r => {
       const iconProps = {
@@ -414,7 +414,7 @@ class VAMap extends Component {
         <div>
           {r.type === LocationType.CC_PROVIDER ? (
             <div>
-              <a onClick={linkAction.bind(this, r.id, true)}>
+              <a href={`/provider/${r.id}`}>
                 <h5>{r.attributes.name}</h5>
               </a>
               <h6>{r.attributes.orgName}</h6>
@@ -427,7 +427,7 @@ class VAMap extends Component {
             </div>
           ) : (
             <div>
-              <a onClick={linkAction.bind(this, r.id, false)}>
+              <a href={`/facility/${r.id}`}>
                 <h5>{r.attributes.name}</h5>
               </a>
               <p>

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -377,6 +377,7 @@ class VAMap extends Component {
   renderFacilityMarkers = () => {
     const { results } = this.props;
 
+    // TODO: Remove this commented block after verified stable in Staging and Prod
     // need to use this because Icons are rendered outside of Router context (Leaflet manipulates the DOM directly)
     // const linkAction = (id, isProvider = false, e) => {
     //   e.preventDefault();

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable arrow-body-style */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { browserHistory } from 'react-router';
+import { browserHistory, Link } from 'react-router';
 import { connect } from 'react-redux';
 import { Tabs, TabList, TabPanel, Tab } from 'react-tabs';
 import { Map, TileLayer, FeatureGroup } from 'react-leaflet';
@@ -414,9 +414,9 @@ class VAMap extends Component {
         <div>
           {r.type === LocationType.CC_PROVIDER ? (
             <div>
-              <a href={`/provider/${r.id}`}>
+              <Link to={`/provider/${r.id}`}>
                 <h5>{r.attributes.name}</h5>
-              </a>
+              </Link>
               <h6>{r.attributes.orgName}</h6>
               <p>
                 Services:{' '}
@@ -427,9 +427,9 @@ class VAMap extends Component {
             </div>
           ) : (
             <div>
-              <a href={`/facility/${r.id}`}>
+              <Link to={`/facility/${r.id}`}>
                 <h5>{r.attributes.name}</h5>
-              </a>
+              </Link>
               <p>
                 Facility type:{' '}
                 <strong>{facilityTypes[r.attributes.facilityType]}</strong>

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -125,7 +125,13 @@
     }
 
     a {
+      display: block;
       text-decoration: none;
+
+      &::focus {
+        outline: 2px solid #f9c642;
+        outline-offset: 2px;
+      }
     }
 
     p {

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -727,3 +727,7 @@
 .top-z {
   z-index: 1000 !important;
 }
+
+.va-nav-breadcrumbs:focus {
+  outline: 0;
+}

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -128,7 +128,7 @@
       display: block;
       text-decoration: none;
 
-      &::focus {
+      &:focus {
         outline: 2px solid #f9c642;
         outline-offset: 2px;
       }


### PR DESCRIPTION
## Description
The Facility Locator was not handling focus when users clicked on a link from the search results. This was causing screen readers not to announce the page change. I added a `componentDidMount()` lifecycle call to our custom focus handler on the Facility Locator detail view.

I added our custom focus helper to both the ProviderDetail.jsx and the FacilityDetail.jsx so to account for Facilities and Community Care Providers.

In the course of testing this, I found an instance where the `<a>` tag that appears when I clicked on the map icons had no `href`, so it was not keyboard focusable. I fixed that by adding an `href` to the existing code.

## Related Issue Tickets
* [#15452](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15452)

## Testing done
**Testing for the focus management**
* Ran the test suite locally using `yarn test` and `yarn test:e2e:headless` because some tests were failing on the full run. This was at least in part due to some tests resizing browser windows to 375px, but Chrome now only allows a minimum 500px width.
* Tested the focus management announcing breadcrumbs with VoiceOver for providers and facilities
* This technique should work well with JAWS
* This technique should work well with NVDA when a long-standing bug is fixed. It's the same pattern we use with the Claims and Appeals app.

**Testing for the keyboard focus on map**
* Tested with Chrome, Safari, Firefox on MacOS Mojave
* Tested with Chrome, IE11, Firefox on Win10

## Screenshots
![Screen Shot 2019-06-19 at 5 27 02 PM](https://user-images.githubusercontent.com/934879/59805693-97811380-92b7-11e9-9acb-4c0ed45a4409.png)


## Acceptance criteria
- [ ] Screenreaders announce the change to a facility detail view
- [ ] URLs resolve correctly when users click an icon, then click the popup link

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
