### PR TITLE
Call removeForeseeOverlay in the fillPage loop

### DIFF
--- a/src/platform/testing/e2e/form-tester/form-filler.js
+++ b/src/platform/testing/e2e/form-tester/form-filler.js
@@ -221,6 +221,8 @@ const getArrayInfo = (url, arrayPages = []) => {
 const getArrayData = (testData, arrayPageConfig) =>
   findData(`${arrayPageConfig.arrayPath}`, testData)[arrayPageConfig.index];
 
+const removeForeseeOverlay = async page => searchAndDestroy(page, '.__acs');
+
 /**
  * Enters data for each field, looping until no more fields have been expanded and
  *  no more array items are available in the test data.
@@ -239,6 +241,8 @@ const fillPage = async (page, testData, testConfig, log = () => {}) => {
   let originalSnapshot;
   /* eslint-disable no-await-in-loop */
   do {
+    await removeForeseeOverlay(page);
+
     originalSnapshot = await getSnapshot(page);
     log(
       'Field list:',
@@ -296,8 +300,6 @@ const fillPage = async (page, testData, testConfig, log = () => {}) => {
   /* eslint-enable no-await-in-loop */
 };
 
-const removeForeseeOverlay = async page => searchAndDestroy(page, '.__acs');
-
 /**
  * Waits until the URL changes or the timeout is reached before returning the current URL.
  *
@@ -345,12 +347,11 @@ const fillForm = async (page, testData, testConfig, log) => {
     log(page.url());
     // TODO: Run axe checker
 
-    await removeForeseeOverlay(page);
-
     // If there's a page hook, run that
     const url = page.url();
     const hook = _.get(`pageHooks.${parseUrl(url).path}`, testConfig);
     if (hook) {
+      await removeForeseeOverlay(page);
       await runHook(hook);
     } else {
       await fillPage(page, testData, testConfig, log);
@@ -363,7 +364,6 @@ const fillForm = async (page, testData, testConfig, log) => {
       //  and we tried to enter data too fast; try again
       // NOTE: This won't trigger if the field we missed isn't required!
       if ((await nextUrl(page, { previousUrl: url })) === url) {
-        await removeForeseeOverlay(page);
         await fillPage(page, testData, testConfig, log);
         log('Clicking continue again');
         await page.click(CONTINUE_BUTTON);

--- a/src/platform/testing/e2e/form-tester/form-filler.js
+++ b/src/platform/testing/e2e/form-tester/form-filler.js
@@ -221,7 +221,12 @@ const getArrayInfo = (url, arrayPages = []) => {
 const getArrayData = (testData, arrayPageConfig) =>
   findData(`${arrayPageConfig.arrayPath}`, testData)[arrayPageConfig.index];
 
-const removeForeseeOverlay = async page => searchAndDestroy(page, '.__acs');
+const removeForeseeOverlay = async (page, log) => {
+  if (await page.$('.__acs')) {
+    log('Foresee found; destroying the overlay...');
+    await searchAndDestroy(page, '.__acs');
+  }
+};
 
 /**
  * Enters data for each field, looping until no more fields have been expanded and
@@ -241,7 +246,7 @@ const fillPage = async (page, testData, testConfig, log = () => {}) => {
   let originalSnapshot;
   /* eslint-disable no-await-in-loop */
   do {
-    await removeForeseeOverlay(page);
+    await removeForeseeOverlay(page, log);
 
     originalSnapshot = await getSnapshot(page);
     log(
@@ -351,7 +356,7 @@ const fillForm = async (page, testData, testConfig, log) => {
     const url = page.url();
     const hook = _.get(`pageHooks.${parseUrl(url).path}`, testConfig);
     if (hook) {
-      await removeForeseeOverlay(page);
+      await removeForeseeOverlay(page, log);
       await runHook(hook);
     } else {
       await fillPage(page, testData, testConfig, log);


### PR DESCRIPTION
## Description
It looks like the Foresee overlay was appearing in the middle of filling out a page. When the form filler detected a new input (Foresee's `acsEmailSMSInput`) after entering some data in, it looped again. This time, the number of elements didn't change, so it returned.

:thinking: I'm actually not sure why the failure in [this build](http://jenkins.vetsgov-internal/blue/organizations/jenkins/testing%2Fvets-website/detail/replace-raven-with-sentry-cv/6/pipeline/) didn't have any `Clicking continue` logs. I don't know how that's possible.

I also don't know why the overlay wasn't deleted in [these](http://jenkins.vetsgov-internal/blue/organizations/jenkins/testing%2Fvets-website/detail/master/4547/pipeline/) [two](http://jenkins.vetsgov-internal/blue/organizations/jenkins/testing%2Fvets-website/detail/upgrade-webpack-jsb/2/pipeline/) build failures.

That said, I _think_ this should work, but my level of confidence isn't super high.

## Testing done
None. :see_no_evil: 

## Screenshots
N/A

## Acceptance criteria
- [x] The overlay is deleted when it shows up in a test
- [x] There's a log when the Foresee overlay is destroyed so we have an audit trail

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
