### PR TITLE
Fix bad /faq links

### DIFF
--- a/src/applications/personalization/account/components/AccountVerification.jsx
+++ b/src/applications/personalization/account/components/AccountVerification.jsx
@@ -32,7 +32,7 @@ export default function AccountVerification({ loa }) {
             </p>
             <p>
               <a
-                href="/faq#verifying-your-identity"
+                href="/sign-in-faq#verifying-your-identity"
                 onClick={() =>
                   recordEvent({
                     event: 'account-navigation',

--- a/src/applications/personalization/account/components/LoginSettings.jsx
+++ b/src/applications/personalization/account/components/LoginSettings.jsx
@@ -12,7 +12,7 @@ export default function LoginSettings() {
       our site-as well as to add an extra layer of security to your account.
       <br />
       <a
-        href="/faq/#what-is-idme"
+        href="/sign-in-faq/#what-is-idme"
         onClick={() =>
           recordEvent({
             event: 'account-navigation',

--- a/src/applications/personalization/dashboard/containers/DashboardApp.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardApp.jsx
@@ -292,7 +292,7 @@ class DashboardApp extends React.Component {
             </a>
             <p>
               <a
-                href="/faq#verifying-your-identity"
+                href="/sign-in-faq#verifying-your-identity"
                 onClick={recordDashboardClick('learn-more-identity')}
               >
                 Learn about how to verify your identity

--- a/src/applications/personalization/dashboard/containers/DashboardAppNew.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardAppNew.jsx
@@ -225,7 +225,7 @@ class DashboardAppNew extends React.Component {
             </a>
             <p>
               <a
-                href="/faq#verifying-your-identity"
+                href="/sign-in-faq#verifying-your-identity"
                 onClick={recordDashboardClick('learn-more-identity')}
               >
                 Learn about how to verify your identity


### PR DESCRIPTION
## Description
Our sign in faq is at /sign-in-faq, but it used to be /faq, and we have some links that aren't up to date.

## Acceptance criteria
- [x] links are fixed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
