### PR TITLE
[Community Cares] Add 502 to list of status codes for timeouts

### DIFF
--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -18,7 +18,7 @@ import { updateSearchQuery, searchWithBounds } from '../actions';
 import SearchResult from './SearchResult';
 import DelayedRender from 'platform/utilities/ui/DelayedRender';
 
-const TIMEOUTS = new Set(['408', '504', '503']);
+const TIMEOUTS = new Set(['408', '504', '503', '502']);
 
 class ResultsList extends Component {
   constructor(props) {


### PR DESCRIPTION
## Description
See this API PR here, https://github.com/department-of-veterans-affairs/vets-api/pull/3105.

## Testing done
None

## Screenshots
N/A

## Acceptance criteria
- [ ] FE triggers timeout message for 502

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
