### PR TITLE
[Static pages] Change heading tag of "How do I apply" to level 2

### DIFF
--- a/src/applications/edu-benefits/components/createEducationApplicationStatus.jsx
+++ b/src/applications/edu-benefits/components/createEducationApplicationStatus.jsx
@@ -29,7 +29,7 @@ export default function createEducationApplicationStatus(store, widgetType) {
             stayAfterDelete
             applyRender={() => (
               <div>
-                <h3>How do I apply?</h3>
+                <h2>How do I apply?</h2>
                 <p>
                   You can apply online right now. Just answer a few questions,
                   and we'll help you get started with the education benefits

--- a/src/platform/forms/save-in-progress/ApplicationStatus.jsx
+++ b/src/platform/forms/save-in-progress/ApplicationStatus.jsx
@@ -221,7 +221,7 @@ export class ApplicationStatus extends React.Component {
           itemScope
           itemType="http://schema.org/HowToSection"
         >
-          <h3 itemProp="name">{applyHeading}</h3>
+          <h2 itemProp="name">{applyHeading}</h2>
           <div itemProp="itemListElement">
             {this.props.additionalText && <p>{this.props.additionalText}</p>}
             <div className="sip-application-status">


### PR DESCRIPTION
## Description
Per this ticket, https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18996, these heading tags should be H2s.

## Testing done
Inspected https://vetsgov-pr-10285.herokuapp.com/education/how-to-apply/

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/59871705-28aec380-9366-11e9-84a5-4716945225a4.png)


## Acceptance criteria
- [x] Heading tags are updated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
