### PR TITLE
exit jenkins with non-zero if cms download fails

### DIFF
--- a/src/site/stages/build/plugins/download-assets.js
+++ b/src/site/stages/build/plugins/download-assets.js
@@ -9,6 +9,11 @@ const decompress = require('decompress');
 const buckets = require('../../../constants/buckets');
 const assetSources = require('../../../constants/assetSources');
 
+// exits with non-zero if a download failed (for jenkins)
+process.on('unhandledRejection', up => {
+  throw up;
+});
+
 function downloadFile(url, dest) {
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(dest);


### PR DESCRIPTION
## Description
Fail the jenkins build immediately when a CMS download fails rather than marching on and failing later.

## Testing done
None.

## Screenshots
![image](https://user-images.githubusercontent.com/3077884/59874456-3cf5bf00-936c-11e9-9684-0e9538f70f77.png)


## Acceptance criteria
- [ x ] A jenkins build for `vets-website` fails immediately when a CMS download fails

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
