### PR TITLE
Enabling additional info flag on prod.

### DIFF
--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -49,6 +49,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT,
   ],
   vagovprod: [
+    featureFlags.FEATURE_FIELD_ADDITIONAL_INFO,
     featureFlags.FEATURE_FIELD_REGIONAL_HEALTH_SERVICE,
     featureFlags.GRAPHQL_MODULE_UPDATE,
     featureFlags.FEATURE_FIELD_OTHER_VA_LOCATIONS,


### PR DESCRIPTION
## Description
Adds featureFlags.FEATURE_FIELD_ADDITIONAL_INFO to vagovprod array.