### PR TITLE
Temporarily disable logging to sentry in capitalizeEachWord

### DIFF
--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -163,9 +163,9 @@ export const capitalizeEachWord = name => {
   }
 
   if (typeof name !== 'string') {
-    Sentry.captureMessage(
-      `form_526_v1 / form_526_v2: capitalizeEachWord requires 'name' argument of type 'string' but got ${typeof name}`,
-    );
+    // Sentry.captureMessage(
+    //   `form_526_v1 / form_526_v2: capitalizeEachWord requires 'name' argument of type 'string' but got ${typeof name}`,
+    // );
   }
 
   // TODO: Refactor this out; the function name doesn't imply that it


### PR DESCRIPTION
## Description
We're getting a _ton_ of these messages and it's...kind of a problem. This temporarily disables this message until we figure out a better solution.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
