### PR TITLE
VAGOV-4300: Fixing case of Not a Veteran in hub landing side bar

### DIFF
--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -115,7 +115,7 @@
           <li>
             <button class="usa-accordion-button usa-accordion-button-dark rail-heading"
               aria-expanded="true" aria-controls="a2">
-              Not a veteran?
+              Not a Veteran?
             </button>
             <div id="a2" class="usa-accordion-content" aria-hidden="false">
             <section>


### PR DESCRIPTION
## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
