### PR TITLE
[Static pages] Apply sentence casing to apply buttons

### DIFF
--- a/src/applications/burials/containers/ConfirmationPage.jsx
+++ b/src/applications/burials/containers/ConfirmationPage.jsx
@@ -137,7 +137,7 @@ class ConfirmationPage extends React.Component {
         <div className="row form-progress-buttons schemaform-back-buttons">
           <div className="small-6 usa-width-one-half medium-6 columns">
             <a href="/">
-              <button className="usa-button-primary">Go Back to VA.gov</button>
+              <button className="usa-button-primary">Go back to VA.gov</button>
             </a>
           </div>
         </div>

--- a/src/applications/discharge-wizard/components/InstructionsPage.jsx
+++ b/src/applications/discharge-wizard/components/InstructionsPage.jsx
@@ -78,7 +78,7 @@ class InstructionsPage extends React.Component {
                             className="usa-button-primary va-button"
                             to="questions"
                           >
-                            Get Started »
+                            Get started »
                           </Link>
                         </p>
                       </div>

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -45,7 +45,7 @@ createApplicationStatus(store, {
   applyHeading: 'How do I apply?',
   additionalText: 'You can apply online right now.',
   applyLink: '/pension/how-to-apply/',
-  applyText: 'Apply for Veterans Pension Benefits',
+  applyText: 'Apply for veterans pension benefits',
   widgetType: widgetTypes.PENSION_APP_STATUS,
 });
 
@@ -54,7 +54,7 @@ createApplicationStatus(store, {
   applyHeading: 'How do I apply?',
   additionalText: 'You can apply online right now.',
   applyLink: '/health-care/how-to-apply/',
-  applyText: 'Apply for Health Care Benefits',
+  applyText: 'Apply for health care benefits',
   widgetType: widgetTypes.HEALTH_CARE_APP_STATUS,
 });
 
@@ -68,7 +68,7 @@ createApplicationStatus(store, {
   formId: '21P-530',
   applyHeading: 'How do I apply?',
   additionalText: 'You can apply online right now.',
-  applyText: 'Apply for Burial Benefits',
+  applyText: 'Apply for burial benefits',
   widgetType: widgetTypes.BURIALS_APP_STATUS,
 });
 

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -45,7 +45,7 @@ createApplicationStatus(store, {
   applyHeading: 'How do I apply?',
   additionalText: 'You can apply online right now.',
   applyLink: '/pension/how-to-apply/',
-  applyText: 'Apply for veterans pension benefits',
+  applyText: 'Apply for Veterans pension benefits',
   widgetType: widgetTypes.PENSION_APP_STATUS,
 });
 

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -177,7 +177,7 @@ class SaveInProgressIntro extends React.Component {
                 className="usa-button-primary"
                 onClick={this.openLoginModal}
               >
-                Sign in to Start Your Application
+                Sign in to start your application
               </button>
               {!this.props.hideUnauthedStartLink && (
                 <p>

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -176,7 +176,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
       'Save time—and save your work in progress—by signing in before starting your application',
     );
     expect(tree.find('.usa-button-primary').text()).to.contain(
-      'Sign in to Start Your Application',
+      'Sign in to start your application',
     );
     expect(tree.find('.va-button-link').text()).to.contain(
       'Start your application without signing in',


### PR DESCRIPTION
## Description
Switches our green apply buttons to use sentence case instead of title.

content PR - https://github.com/department-of-veterans-affairs/vagov-content/pull/478
ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18996
## Testing done
none

## Screenshots
todo

## Acceptance criteria
- [ ] letter case is consistent with style guide

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
