### PR TITLE
19038 - Fix Dashboard Appeals-section broken-link.

### DIFF
--- a/src/applications/personalization/preferences/helperComponents.jsx
+++ b/src/applications/personalization/preferences/helperComponents.jsx
@@ -15,7 +15,7 @@ const makeUnorderedList = questions => (
 
 const appealsQuestions = [
   {
-    href: '/disability-benefits/claims-appeal',
+    href: '/disability/file-an-appeal/',
     title: 'Find out how appeals work',
   },
   {


### PR DESCRIPTION
## Description
[19038](/department-of-veterans-affairs/vets.gov-team/issues/19038) - Fix broken link “Find out how appeals work” under Dashboard Appeals section -- should now go to /disability/file-an-appeal/

## Testing done
Local.

## Acceptance criteria
- [ ] Clicking on this link successfully navigates to “File a VA disability appeal” page.

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
