### PR TITLE
Add check for mobile safari to open new downloads correctly

### DIFF
--- a/src/applications/letters/actions/letters.js
+++ b/src/applications/letters/actions/letters.js
@@ -178,16 +178,19 @@ export function getLetterPdf(letterType, letterName, letterOptions) {
     });
     dispatch({ type: GET_LETTER_PDF_DOWNLOADING, data: letterType });
 
+    const { userAgent } = window.navigator;
+    const iOS = !!userAgent.match(/iPad/i) || !!userAgent.match(/iPhone/i);
+    const webkit = !!userAgent.match(/WebKit/i);
+    const isMobileSafari = iOS && webkit && !userAgent.match(/CriOS/i);
     // We handle IE10 separately but assume all other vets.gov-supported
     // browsers have blob URL support.
     // TODO: possibly want to explicitly check for blob URL support with something like
     // const blobSupported = !!(/^blob:/.exec(downloadUrl));
     const isIE = !!window.navigator.msSaveOrOpenBlob;
     const save = document.createElement('a');
-    const downloadSupported = typeof save.download !== 'undefined';
     let downloadWindow;
 
-    if (!downloadSupported && !isIE) {
+    if (isMobileSafari) {
       // Instead of giving the file a readable name and downloading
       // it directly, open it in a new window with an ugly hash URL
       // NOTE: We're opening the window here because Safari won't open
@@ -206,15 +209,18 @@ export function getLetterPdf(letterType, letterName, letterOptions) {
           } else {
             window.URL = window.URL || window.webkitURL;
             downloadUrl = window.URL.createObjectURL(blob);
-            if (downloadSupported) {
-              // Give the file a readable name if the download attribute is supported.
+
+            // Give the file a readable name if the download attribute is supported.
+            if (typeof save.download !== 'undefined') {
               save.download = letterName;
-              save.href = downloadUrl;
-              save.target = '_blank';
-              document.body.appendChild(save);
-              save.click();
-              document.body.removeChild(save);
-            } else {
+            }
+            save.href = downloadUrl;
+            save.target = '_blank';
+            document.body.appendChild(save);
+            save.click();
+            document.body.removeChild(save);
+
+            if (isMobileSafari) {
               downloadWindow.location.href = downloadUrl;
             }
           }


### PR DESCRIPTION
## Description
Relevant [Sentry log](http://sentry.vetsgov-internal/vets-gov/website-production/issues/38323/?query=is%3Aunresolved%20lastSeen%3A-30d%20timesSeen%3A%3E%3D100%20letters) 

**tl;dr** Mobile safari doesn't have the `download` attribute on anchor tags, so this code currently opens a new window but gets undefined for the subsequent operation of that property.

## Testing done
Need to deploy this to a dev site and verify with both desktop safari and mobile safari

## Acceptance criteria
- [ Downloads continue working, as well as no issues on mobile safari]
