### PR TITLE
VAGOV-4053: update event to show full name of day of week using moment

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -76,14 +76,14 @@ Example data:
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
-{% assign start_date_no_time = fieldDate.value | date: "%a, %b %d" %}
-{% assign end_date_no_time = fieldDate.endValue | date: "%a, %b %d" %}
+{% assign start_date_no_time = fieldDate.value | formatDate: "dddd, MMM D" %}
+{% assign end_date_no_time = fieldDate.endValue | formatDate: "dddd, MMM D" %}
 
-{% assign start_time = fieldDate.value | date: "%I:%M %p" %}
-{% assign end_time = fieldDate.endValue | date: "%I:%M %p" %}
+{% assign start_time = fieldDate.value | formatDate: "h:mm A" %}
+{% assign end_time = fieldDate.endValue | formatDate: "h:mm A" %}
 
-{% assign start_date_full = fieldDate.value | date: "%a, %b %d, %I:%M %p" %}
-{% assign end_date_full = fieldDate.endValue | date: "%a, %b %d, %I:%M %p" %}
+{% assign start_date_full = fieldDate.value | formatDate: "dddd, MMM D, h:mm A" %}
+{% assign end_date_full = fieldDate.endValue | formatDate: "dddd, MMM D, h:mm A" %}
 
 {% assign start_timestamp = fieldDate.value | unixFromDate %}
 {% assign current_timestamp = fieldDate.value | currentUnixFromDate %}

--- a/src/site/teasers/event.drupal.liquid
+++ b/src/site/teasers/event.drupal.liquid
@@ -27,14 +27,14 @@ Example data:
 {% endcomment %}
 {% if node != empty %}
 
-    {% assign start_date_no_time = node.fieldDate.value | date: "%a, %b %d" %}
-    {% assign end_date_no_time = node.fieldDate.endValue | date: "%a, %b %d" %}
+    {% assign start_date_no_time = node.fieldDate.value | formatDate: "dddd, MMM D" %}
+    {% assign end_date_no_time = node.fieldDate.endValue | formatDate: "dddd, MMM D" %}
 
-    {% assign start_time = node.fieldDate.value | date: "%I:%M %p" %}
-    {% assign end_time = node.fieldDate.endValue | date: "%I:%M %p" %}
+    {% assign start_time = node.fieldDate.value | formatDate: "h:mm A" %}
+    {% assign end_time = node.fieldDate.endValue | formatDate: "h:mm A" %}
 
-    {% assign start_date_full = node.fieldDate.value | date: "%a, %b %d, %I:%M %p" %}
-    {% assign end_date_full = node.fieldDate.endValue | date: "%a, %b %d, %I:%M %p" %}
+    {% assign start_date_full = node.fieldDate.value | formatDate: "dddd, MMM D, h:mm A" %}
+    {% assign end_date_full = node.fieldDate.endValue | formatDate: "dddd, MMM D, h:mm A" %}
 
     {% if node.fieldDate.value != empty and node.fieldDate.endValue == empty %}
         {% assign date_type = "start_date_only" %}


### PR DESCRIPTION
## Description
show the full day of week for events
note: the `%A` for formatting ruby dates was not working so i switched the event date parsing over to moment.js

## Testing done
locally with staging data

## Screenshots
![localhost_3001_pittsburgh-health-care_events_](https://user-images.githubusercontent.com/19178435/59948310-7db10f00-9424-11e9-95cf-8fd0229219d5.png)

## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-4053

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
