### PR TITLE
Add new delete row reqs to disability calculator

### DIFF
--- a/src/applications/disability-calculator/components/DisabilityRatingCalculator.jsx
+++ b/src/applications/disability-calculator/components/DisabilityRatingCalculator.jsx
@@ -54,15 +54,11 @@ export default class DisabilityRatingCalculator extends React.Component {
   handleSubmit = () => {
     const ratings = this.state.ratings;
     const calcRating = calculateRating(ratings);
-    const ratingArr = pullRatingsFromState(ratings);
-    const checkForTwoRatings = shouldCalculate(ratingArr);
 
-    if (checkForTwoRatings) {
-      this.setState({
-        showCombinedRating: true,
-        calculatedRating: calcRating,
-      });
-    }
+    this.setState({
+      showCombinedRating: true,
+      calculatedRating: calcRating,
+    });
   };
 
   handleAddRating = () => {
@@ -104,6 +100,9 @@ export default class DisabilityRatingCalculator extends React.Component {
   render() {
     const ratings = this.state.ratings;
     const calculatedRating = this.state.calculatedRating;
+    const ratingArr = pullRatingsFromState(ratings);
+    const checkForTwoRatings = shouldCalculate(ratingArr);
+
     return (
       <div className="disability-calculator vads-u-margin-bottom--5 vads-u-background-color--gray-lightest vads-l-grid-container">
         <div className="calc-header vads-u-padding-x--4">
@@ -168,6 +167,7 @@ export default class DisabilityRatingCalculator extends React.Component {
                 onClick={evt => {
                   this.handleSubmit(evt);
                 }}
+                disabled={!checkForTwoRatings}
               >
                 Calculate
               </button>

--- a/src/applications/disability-calculator/components/DisabilityRatingCalculator.jsx
+++ b/src/applications/disability-calculator/components/DisabilityRatingCalculator.jsx
@@ -96,7 +96,6 @@ export default class DisabilityRatingCalculator extends React.Component {
   render() {
     const ratings = this.state.ratings;
     const calculatedRating = this.state.calculatedRating;
-
     return (
       <div className="disability-calculator vads-u-margin-bottom--5 vads-u-background-color--gray-lightest vads-l-grid-container">
         <div className="calc-header vads-u-padding-x--4">
@@ -136,8 +135,8 @@ export default class DisabilityRatingCalculator extends React.Component {
               indx={idx}
               ratingRef={this.ratingRef}
               handleRemoveRating={this.handleRemoveRating}
-              canDelete={idx > 1}
               ref={this.setRef}
+              canDelete={this.state.ratings.length}
             />
           ))}
           <div className="vads-l-row">

--- a/src/applications/disability-calculator/components/DisabilityRatingCalculator.jsx
+++ b/src/applications/disability-calculator/components/DisabilityRatingCalculator.jsx
@@ -54,8 +54,10 @@ export default class DisabilityRatingCalculator extends React.Component {
   handleSubmit = () => {
     const ratings = this.state.ratings;
     const calcRating = calculateRating(ratings);
+    const ratingArr = pullRatingsFromState(ratings);
+    const checkForTwoRatings = shouldCalculate(ratingArr);
 
-    if (shouldCalculate(pullRatingsFromState(ratings))) {
+    if (checkForTwoRatings) {
       this.setState({
         showCombinedRating: true,
         calculatedRating: calcRating,

--- a/src/applications/disability-calculator/components/DisabilityRatingCalculator.jsx
+++ b/src/applications/disability-calculator/components/DisabilityRatingCalculator.jsx
@@ -144,7 +144,7 @@ export default class DisabilityRatingCalculator extends React.Component {
               ratingRef={this.ratingRef}
               handleRemoveRating={this.handleRemoveRating}
               ref={this.setRef}
-              canDelete={this.state.ratings.length}
+              disabled={ratings.length < 3}
             />
           ))}
           <div className="vads-l-row">

--- a/src/applications/disability-calculator/components/DisabilityRatingCalculator.jsx
+++ b/src/applications/disability-calculator/components/DisabilityRatingCalculator.jsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { calculateRating } from '../utils/helpers';
+import {
+  calculateRating,
+  shouldCalculate,
+  pullRatingsFromState,
+} from '../utils/helpers';
 import { CalculatedDisabilityRating } from './CalculatedDisabilityRating';
 import RatingRow from './RatingRow';
 import '../sass/disability-calculator.scss';
@@ -51,10 +55,12 @@ export default class DisabilityRatingCalculator extends React.Component {
     const ratings = this.state.ratings;
     const calcRating = calculateRating(ratings);
 
-    this.setState({
-      showCombinedRating: true,
-      calculatedRating: calcRating,
-    });
+    if (shouldCalculate(pullRatingsFromState(ratings))) {
+      this.setState({
+        showCombinedRating: true,
+        calculatedRating: calcRating,
+      });
+    }
   };
 
   handleAddRating = () => {

--- a/src/applications/disability-calculator/components/RatingRow.jsx
+++ b/src/applications/disability-calculator/components/RatingRow.jsx
@@ -7,7 +7,6 @@ const RatingRow = ({
   handleRemoveRating,
   inputRef,
   canDelete,
-  stateLength,
 }) => {
   const onRatingChange = e => {
     const val = e.target.value;

--- a/src/applications/disability-calculator/components/RatingRow.jsx
+++ b/src/applications/disability-calculator/components/RatingRow.jsx
@@ -7,6 +7,7 @@ const RatingRow = ({
   handleRemoveRating,
   inputRef,
   canDelete,
+  stateLength,
 }) => {
   const onRatingChange = e => {
     const val = e.target.value;
@@ -23,7 +24,6 @@ const RatingRow = ({
   const onDescriptionChange = e => {
     handleChange(indx, { ...ratingObj, description: e.target.value });
   };
-
   return (
     <div className="rating vads-l-row">
       <div className="vads-l-col--2 vads-u-padding-right--2">
@@ -50,18 +50,17 @@ const RatingRow = ({
         />
       </div>
       <div className="vads-l-col--3">
-        {canDelete && (
-          <div>
-            <button
-              type="button"
-              onClick={handleRemoveRating(indx)}
-              className="va-button-link delete-btn vads-u-margin--1p5"
-            >
-              <i className="fas fa-trash-alt vads-u-padding-right--0p5" />
-              Delete
-            </button>
-          </div>
-        )}
+        <div>
+          <button
+            type="button"
+            onClick={handleRemoveRating(indx)}
+            className="va-button-link delete-btn vads-u-margin--1p5"
+            disabled={canDelete < 3}
+          >
+            <i className="fas fa-trash-alt vads-u-padding-right--0p5" />
+            Delete
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/applications/disability-calculator/components/RatingRow.jsx
+++ b/src/applications/disability-calculator/components/RatingRow.jsx
@@ -6,7 +6,7 @@ const RatingRow = ({
   handleChange,
   handleRemoveRating,
   inputRef,
-  canDelete,
+  disabled,
 }) => {
   const onRatingChange = e => {
     const val = e.target.value;
@@ -54,7 +54,7 @@ const RatingRow = ({
             type="button"
             onClick={handleRemoveRating(indx)}
             className="va-button-link delete-btn vads-u-margin--1p5"
-            disabled={canDelete < 3}
+            disabled={disabled}
           >
             <i className="fas fa-trash-alt vads-u-padding-right--0p5" />
             Delete

--- a/src/applications/disability-calculator/sass/disability-calculator.scss
+++ b/src/applications/disability-calculator/sass/disability-calculator.scss
@@ -1,16 +1,19 @@
-$formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
+$formation-image-path: '~@department-of-veterans-affairs/formation/assets/img';
 
-@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
-@import "~@department-of-veterans-affairs/formation/sass/modules/va-pagination";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-nav-sidebar";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-nav-next-previous";
+@import '~@department-of-veterans-affairs/formation/sass/shared-variables';
+@import '~@department-of-veterans-affairs/formation/sass/modules/va-pagination';
+@import '~@department-of-veterans-affairs/formation/sass/modules/m-nav-sidebar';
+@import '~@department-of-veterans-affairs/formation/sass/modules/m-nav-next-previous';
 
-@import "~leaflet/dist/leaflet.css";
-@import "~react-tabs/style/react-tabs";
+@import '~leaflet/dist/leaflet.css';
+@import '~react-tabs/style/react-tabs';
 
 .disability-calculator {
   .calculate-btn {
     padding: 1rem 3rem;
+  }
+  .delete-btn[disabled] {
+    opacity: 0.5;
   }
 }
 

--- a/src/applications/disability-calculator/utils/helpers.js
+++ b/src/applications/disability-calculator/utils/helpers.js
@@ -4,7 +4,7 @@ function roundRating(num) {
   return Math.round(ratingWithDecimal / 10) * 10;
 }
 
-function pullRatingsFromState(arr) {
+export function pullRatingsFromState(arr) {
   const allRatings = [];
   arr.forEach(e => {
     allRatings.push(e.rating);
@@ -38,5 +38,20 @@ export function calculateRating(arr) {
   }
   return [undefined, undefined];
 }
-// will return array with two elements. first element in array is rounded rating
+// calculateRating will return array with two elements. first element in array is rounded rating
 // and second element is the actual rating
+
+// this is a validator to check if there are at least two ratings
+export function shouldCalculate(ratingsArr) {
+  const checkIfTwo = ratingsArr;
+  const returnArr = [];
+  checkIfTwo.forEach(e => {
+    if (typeof e === 'number') {
+      returnArr.push(e);
+    }
+  });
+  if (returnArr.length >= 2) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Description
This PR is to add delete row functionality to the disability rating calculator, where the bulk of the work is covered in this ticket: https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/18214

## Testing done
Tested on local build

## Screenshots

**First two rows now have a delete button, disabled by default**
![Screen Shot 2019-06-24 at 11 32 56 AM](https://user-images.githubusercontent.com/11021491/60032169-04a7f680-9674-11e9-9c95-d188d85b2a70.png)


**Delete button becomes active when there are more than two rows**
![Screen Shot 2019-06-24 at 11 28 29 AM](https://user-images.githubusercontent.com/11021491/60031809-6582ff00-9673-11e9-9238-21131b2bdac1.png)

**All rows are now deletable** 
![Screen Shot 2019-06-24 at 11 29 25 AM](https://user-images.githubusercontent.com/11021491/60031973-ab3fc780-9673-11e9-9a5f-4e6a085bd03a.png)


## Acceptance criteria
- [x] On the two default empty rating fields - add trash can icon/delete row function. These should be disabled on default.
- [x] When the user has more than two rows (adds a 3rd, 4th, etc.), all rows should become deletable (trash can becomes actionable).
- [x] User should be able to delete any row and still calculate the remaining ratings, as long as there are at least two ratings.
- [x] When there are only two rows left, the delete buttons become disabled.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
