### PR TITLE
Update content only builds/deploys

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,11 +124,11 @@ node('vetsgov-general-purpose') {
       if (!commonStages.isDeployable()) { return }
 
       if (commonStages.IS_DEV_BRANCH && commonStages.VAGOV_BUILDTYPES.contains('vagovdev')) {
-        commonStages.runDeploy('deploys/vets-website-vagovdev', ref)
+        commonStages.runDeploy('deploys/vets-website-vagovdev', ref, false)
       }
 
       if (commonStages.IS_STAGING_BRANCH && commonStages.VAGOV_BUILDTYPES.contains('vagovstaging')) {
-        commonStages.runDeploy('deploys/vets-website-vagovstaging', ref)
+        commonStages.runDeploy('deploys/vets-website-vagovstaging', ref, false)
       }
 
     } catch (error) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,10 +5,7 @@ env.CONCURRENCY = 10
 
 
 node('vetsgov-general-purpose') {
-  properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', daysToKeepStr: '60']],
-              parameters([choice(name: "cmsEnvBuildOverride",
-                                 description: "Choose an environment to run a content only build. Select 'none' to run the regular pipeline.",
-                                 choices: ["none", "dev", "staging"].join("\n"))])]);
+  properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', daysToKeepStr: '60']]]);
 
   // Checkout vets-website code
   dir("vets-website") {
@@ -22,8 +19,6 @@ node('vetsgov-general-purpose') {
   dockerContainer = commonStages.setup()
 
   stage('Lint|Security|Unit') {
-    if (params.cmsEnvBuildOverride != 'none') { return }
-
     try {
       parallel (
         lint: {
@@ -58,7 +53,7 @@ node('vetsgov-general-purpose') {
   }
 
   // Perform a build for each build type
-  envsUsingDrupalCache = commonStages.buildAll(ref, dockerContainer, params.cmsEnvBuildOverride != 'none')
+  envsUsingDrupalCache = commonStages.buildAll(ref, dockerContainer, false)
 
   // Run E2E and accessibility tests
   stage('Integration') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,11 @@ env.CONCURRENCY = 10
 node('vetsgov-general-purpose') {
   properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', daysToKeepStr: '60']]]);
 
+  if (true) {
+    echo "hello"
+    return
+  }
+
   // Checkout vets-website code
   dir("vets-website") {
     checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,11 +7,6 @@ env.CONCURRENCY = 10
 node('vetsgov-general-purpose') {
   properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', daysToKeepStr: '60']]]);
 
-  if (true) {
-    echo "hello"
-    return
-  }
-
   // Checkout vets-website code
   dir("vets-website") {
     checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,10 @@ env.CONCURRENCY = 10
 
 
 node('vetsgov-general-purpose') {
-  properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', daysToKeepStr: '60']]]);
+  properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', daysToKeepStr: '60']],
+              parameters([choice(name: "cmsEnvBuildOverride",
+                                 description: "Choose an environment to run a content only build. Select 'none' to run the regular pipeline.",
+                                 choices: ["none", "dev", "staging"].join("\n"))])]);
 
   // Checkout vets-website code
   dir("vets-website") {
@@ -19,6 +22,8 @@ node('vetsgov-general-purpose') {
   dockerContainer = commonStages.setup()
 
   stage('Lint|Security|Unit') {
+    if (params.cmsEnvBuildOverride != 'none') { return }
+
     try {
       parallel (
         lint: {
@@ -53,7 +58,7 @@ node('vetsgov-general-purpose') {
   }
 
   // Perform a build for each build type
-  envsUsingDrupalCache = commonStages.buildAll(ref, dockerContainer, false)
+  envsUsingDrupalCache = commonStages.buildAll(ref, dockerContainer, params.cmsEnvBuildOverride != 'none')
 
   // Run E2E and accessibility tests
   stage('Integration') {

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,6 +1,11 @@
 @Library('va.gov-devops-jenkins-lib') _
 
 node('vetsgov-general-purpose') {
+  if (true) {
+    echo "hello"
+    return
+  }
+
   ref = params.ref
   if (ref == "") {
     ref = getLatestGitRef("vets-website", branch: 'master')
@@ -9,11 +14,11 @@ node('vetsgov-general-purpose') {
   // check to see if build on master is running
   is_running = jenkins.model.Jenkins.instance.getItem('testing/vets-website/master', jenkins.model.Jenkins.instance.getItem('testing')).lastBuild.building
   if (is_running) {
-    slackSend(message:"didn't run. job already running or something failed...",
+    slackSend(message:"Vetswebsite Content Build didn't build due to currently running vets-website build.",
               color: "warning",
-              channel: "#vsp-something")
+              channel: "#vsp-something") // TODO update
 
-		// TODO bail or something
+    return
   }
 
   dir("vets-website") {

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -7,9 +7,9 @@ node('vetsgov-general-purpose') {
     ref = getLatestGitRef("vets-website", branch: "master")
   }
 
-  refStatusState = getGithubRefStatusState("vets-website", ref)
+  refStatusState = getGithubRefState("vets-website", ref)
   if ("${refStatusState}" != "SUCCESS") {
-    slackSend(message:"Web content refresh on ${params.env} aborted due to unsuccessful vets-website-build on commit ${ref}.",
+    slackSend(message:"Web content refresh on ${params.env} aborted due to status: '${refStatusState}' on vets-website-build on commit ${ref}.",
               color: "warning",
               channel: "#cms-notifications")
 
@@ -42,7 +42,7 @@ node('vetsgov-general-purpose') {
       commonStages.runDeploy("deploys/vets-website-${params.env}", ref, true)
 
       slackSend(message:"Web content refresh in ${params.env} completed.",
-                color: "warning",
+                color: "good",
                 channel: "#cms-notifications")
     }
   }

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,11 +1,6 @@
 @Library('va.gov-devops-jenkins-lib') _
 
 node('vetsgov-general-purpose') {
-  if (true) {
-    echo "hello"
-    return
-  }
-
   ref = params.ref
   if (ref == "") {
     ref = getLatestGitRef("vets-website", branch: 'master')

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,13 +1,13 @@
 @Library('va.gov-devops-jenkins-lib') _
 
 node('vetsgov-general-purpose') {
-	refStatusState = ""
+  refStatusState = ""
   ref = params.ref
   if (ref == "") {
     ref = getLatestGitRef("vets-website", branch: 'master')
   }
 
-	refStatusState = getGithubRefStatusState("vets-website", ref)
+  refStatusState = getGithubRefStatusState("vets-website", ref)
   if (refStatusState != "SUCCESS") {
     slackSend(message:"Web content refresh on ${params.env} aborted due to unsuccessful vets-website-build on commit ${ref}.",
               color: "warning",

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -11,7 +11,7 @@ node('vetsgov-general-purpose') {
   if ("${refStatusState}" != "SUCCESS") {
     slackSend(message:"Web content refresh on ${params.env} aborted due to '${refStatusState}' status on vets-website commit ${ref}.",
               color: "warning",
-              channel: "#cms-notifications")
+              channel: "cms-notifications")
 
     return
   }
@@ -43,7 +43,7 @@ node('vetsgov-general-purpose') {
 
       slackSend(message:"Web content refresh in ${params.env} completed.",
                 color: "good",
-                channel: "#cms-notifications")
+                channel: "cms-notifications")
     }
   }
 }

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -9,7 +9,7 @@ node('vetsgov-general-purpose') {
 
   refStatusState = getGithubRefState("vets-website", ref)
   if ("${refStatusState}" != "SUCCESS") {
-    slackSend(message:"Web content refresh on ${params.env} aborted due to status: '${refStatusState}' on vets-website-build on commit ${ref}.",
+    slackSend(message:"Web content refresh on ${params.env} aborted due to '${refStatusState}' status on vets-website commit ${ref}.",
               color: "warning",
               channel: "#cms-notifications")
 

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,17 +1,17 @@
 @Library('va.gov-devops-jenkins-lib') _
 
 node('vetsgov-general-purpose') {
+	refStatusState = ""
   ref = params.ref
   if (ref == "") {
     ref = getLatestGitRef("vets-website", branch: 'master')
   }
 
-  // check to see if build on master is running
-  is_running = jenkins.model.Jenkins.instance.getItem('testing/vets-website/master', jenkins.model.Jenkins.instance.getItem('testing')).lastBuild.building
-  if (is_running) {
-    slackSend(message:"Vetswebsite Content Build didn't build due to currently running vets-website build.",
+	refStatusState = getGithubRefStatusState("vets-website", ref)
+  if (refStatusState != "SUCCESS") {
+    slackSend(message:"Web content refresh on ${params.env} aborted due to unsuccessful vets-website-build on commit ${ref}.",
               color: "warning",
-              channel: "#vsp-something") // TODO update
+              channel: "#cms-notifications")
 
     return
   }

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,18 +1,20 @@
 @Library('va.gov-devops-jenkins-lib') _
 
 node('vetsgov-general-purpose') {
-	ref = params.ref
-	if (ref == "") {
-		ref = getLatestGitRef("vets-website", branch: 'master')
-	}
+  ref = params.ref
+  if (ref == "") {
+    ref = getLatestGitRef("vets-website", branch: 'master')
+  }
 
-	// check to see if build on master is running
-	is_running = jenkins.model.Jenkins.instance.getItem('testing/vets-website/master', jenkins.model.Jenkins.instance.getItem('testing')).lastBuild.building
-	if (is_running) {
-		slackSend(message:"didn't run. job already running or something failed...",
-							color: "warning",
-							channel: "#vsp-something")
-	}
+  // check to see if build on master is running
+  is_running = jenkins.model.Jenkins.instance.getItem('testing/vets-website/master', jenkins.model.Jenkins.instance.getItem('testing')).lastBuild.building
+  if (is_running) {
+    slackSend(message:"didn't run. job already running or something failed...",
+              color: "warning",
+              channel: "#vsp-something")
+
+		// TODO bail or something
+  }
 
   dir("vets-website") {
     checkout scm: [$class: 'GitSCM', branches: [[name: ref]], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
@@ -35,9 +37,9 @@ node('vetsgov-general-purpose') {
     commonStages.archive(dockerContainer, ref, params.env)
   }
 
-	stage("Deploy Dev or Staging") {
-		if (params.env != "vagovprod" && params.deploy) {
-			commonStages.runDeploy('deploys/vets-website-${params.env}', ref)
-		}
-	}
+  stage("Deploy Dev or Staging") {
+    if (params.env != "vagovprod" && params.deploy) {
+      commonStages.runDeploy('deploys/vets-website-${params.env}', ref)
+    }
+  }
 }

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -8,7 +8,7 @@ node('vetsgov-general-purpose') {
   }
 
   refStatusState = getGithubRefStatusState("vets-website", ref)
-  if (refStatusState != "SUCCESS") {
+  if ("${refStatusState}" != "SUCCESS") {
     slackSend(message:"Web content refresh on ${params.env} aborted due to unsuccessful vets-website-build on commit ${ref}.",
               color: "warning",
               channel: "#cms-notifications")

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -7,7 +7,7 @@ node('vetsgov-general-purpose') {
     ref = getLatestGitRef("vets-website", branch: "master")
   }
 
-  refStatusState = getGithubRefState("vets-website", ref)
+  refStatusState = getGithubCommitState("vets-website", ref)
   if ("${refStatusState}" != "SUCCESS") {
     slackSend(message:"Web content refresh on ${params.env} aborted due to '${refStatusState}' status on vets-website commit ${ref}.",
               color: "warning",

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -4,7 +4,7 @@ node('vetsgov-general-purpose') {
   refStatusState = ""
   ref = params.ref
   if (ref == "") {
-    ref = getLatestGitRef("vets-website", branch: 'master')
+    ref = getLatestGitRef("vets-website", branch: "master")
   }
 
   refStatusState = getGithubRefStatusState("vets-website", ref)
@@ -39,7 +39,11 @@ node('vetsgov-general-purpose') {
 
   stage("Deploy Dev or Staging") {
     if (params.env != "vagovprod" && params.deploy) {
-      commonStages.runDeploy('deploys/vets-website-${params.env}', ref)
+      commonStages.runDeploy("deploys/vets-website-${params.env}", ref, true)
+
+      slackSend(message:"Web content refresh in ${params.env} completed.",
+                color: "warning",
+                channel: "#cms-notifications")
     }
   }
 }

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -1,6 +1,21 @@
+@Library('va.gov-devops-jenkins-lib') _
+
 node('vetsgov-general-purpose') {
+	ref = params.ref
+	if (ref == "") {
+		ref = getLatestGitRef("vets-website", branch: 'master')
+	}
+
+	// check to see if build on master is running
+	is_running = jenkins.model.Jenkins.instance.getItem('testing/vets-website/master', jenkins.model.Jenkins.instance.getItem('testing')).lastBuild.building
+	if (is_running) {
+		slackSend(message:"didn't run. job already running or something failed...",
+							color: "warning",
+							channel: "#vsp-something")
+	}
+
   dir("vets-website") {
-    checkout scm: [$class: 'GitSCM', branches: [[name: params.ref]], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
+    checkout scm: [$class: 'GitSCM', branches: [[name: ref]], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vets-website.git']]]
   }
 
   def commonStages = load "vets-website/jenkins/common.groovy"
@@ -9,7 +24,7 @@ node('vetsgov-general-purpose') {
   dockerContainer = commonStages.setup()
 
   stage("Build") {
-    commonStages.build(params.ref, dockerContainer, params.ref, params.env, false)
+    commonStages.build(ref, dockerContainer, ref, params.env, false)
   }
 
   stage("Prearchive") {
@@ -17,6 +32,12 @@ node('vetsgov-general-purpose') {
   }
 
   stage("Archive") {
-    commonStages.archive(dockerContainer, params.ref, params.env)
+    commonStages.archive(dockerContainer, ref, params.env)
   }
+
+	stage("Deploy Dev or Staging") {
+		if (params.env != "vagovprod" && params.deploy) {
+			commonStages.runDeploy('deploys/vets-website-${params.env}', ref)
+		}
+	}
 }

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -58,11 +58,11 @@ def shouldBail() {
     currentBuild.nextBuild
 }
 
-def runDeploy(jobName, ref) {
+def runDeploy(String jobName, String ref, boolean waitForDeploy) {
   build job: jobName, parameters: [
     booleanParam(name: 'notify_slack', value: true),
     stringParam(name: 'ref', value: ref),
-  ], wait: false
+  ], wait: waitForDeploy
 }
 
 def buildDetails(String buildtype, String ref) {

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -154,6 +154,15 @@ def buildAll(String ref, dockerContainer, Boolean contentOnlyBuild) {
       def envUsedCache = [:]
       def assetSource = contentOnlyBuild ? ref : 'local'
 
+			//if (contentOnlyBuild && IS_PROD_BRANCH) {
+			if (contentOnlyBuild) {
+				sleep_counter = 0
+				while (currentBuild.previousBuild.result == null && sleep_counter < 3) {
+					sleep 60
+					sleep_counter++
+				}
+			}
+
       for (int i=0; i<VAGOV_BUILDTYPES.size(); i++) {
         def envName = VAGOV_BUILDTYPES.get(i)
         builds[envName] = {

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -16,11 +16,15 @@ DRUPAL_CREDENTIALS = [
   'vagovprod'   : 'drupal-prod',
 ]
 
-VAGOV_BUILDTYPES = [
+ALL_VAGOV_BUILDTYPES = [
   'vagovdev',
   'vagovstaging',
   'vagovprod'
 ]
+
+BUILD_TYPE_OVERRIDE = DRUPAL_MAPPING.get(params.cmsEnvBuildOverride, null)
+
+VAGOV_BUILDTYPES = BUILD_TYPE_OVERRIDE ? [BUILD_TYPE_OVERRIDE] : ALL_VAGOV_BUILDTYPES
 
 DEV_BRANCH = 'master'
 STAGING_BRANCH = 'master'

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -16,15 +16,11 @@ DRUPAL_CREDENTIALS = [
   'vagovprod'   : 'drupal-prod',
 ]
 
-ALL_VAGOV_BUILDTYPES = [
+VAGOV_BUILDTYPES = [
   'vagovdev',
   'vagovstaging',
   'vagovprod'
 ]
-
-BUILD_TYPE_OVERRIDE = DRUPAL_MAPPING.get(params.cmsEnvBuildOverride, null)
-
-VAGOV_BUILDTYPES = BUILD_TYPE_OVERRIDE ? [BUILD_TYPE_OVERRIDE] : ALL_VAGOV_BUILDTYPES
 
 DEV_BRANCH = 'master'
 STAGING_BRANCH = 'master'
@@ -153,15 +149,6 @@ def buildAll(String ref, dockerContainer, Boolean contentOnlyBuild) {
       def builds = [:]
       def envUsedCache = [:]
       def assetSource = contentOnlyBuild ? ref : 'local'
-
-			//if (contentOnlyBuild && IS_PROD_BRANCH) {
-			if (contentOnlyBuild) {
-				sleep_counter = 0
-				while (currentBuild.previousBuild.result == null && sleep_counter < 3) {
-					sleep 60
-					sleep_counter++
-				}
-			}
 
       for (int i=0; i<VAGOV_BUILDTYPES.size(); i++) {
         def envName = VAGOV_BUILDTYPES.get(i)


### PR DESCRIPTION
ref: https://github.com/department-of-veterans-affairs/va.gov-team/issues/356

This PR has a corresponding one in devops [here](https://github.com/department-of-veterans-affairs/devops/pull/5088)

The biggest change introduced here is that the make `Jenkinsfile` will not longer do content only builds. Content builds will only be done in the vets-website content build only. That job is updated here and in the before mentioned devops PR.

~The CMS team needs to be alerted when this is merged so they can update the way in which they trigger content builds.~ They will be able to update when convenient but after they have updated we need to cleanup the `Jenkinsfile` to remove cmsEnvOverride references. Instead of triggering the `testing/vets-website/master` job they will need to trigger the `builds/vets-website-content-${env}` job.

https://github.com/department-of-veterans-affairs/va.gov-devops-jenkins-lib/pull/13 will need to be merged for this to work. It create the function used in this PR to get the commit status.