### PR TITLE
Update feedback tool to use keys that match backend camel case format

### DIFF
--- a/src/applications/edu-benefits/feedback-tool/config/form.js
+++ b/src/applications/edu-benefits/feedback-tool/config/form.js
@@ -492,7 +492,7 @@ const formConfig = {
                     showFieldLabel: true,
                   },
                 },
-                'view:FFA': {
+                'view:ffa': {
                   'ui:title': 'Have you used any of these other benefits?',
                   'ui:options': {
                     showFieldLabel: true,
@@ -514,12 +514,12 @@ const formConfig = {
                     properties: {
                       'view:assistance': {
                         type: 'object',
-                        properties: omit('FFA', assistance.properties),
+                        properties: omit('ffa', assistance.properties),
                       },
-                      'view:FFA': {
+                      'view:ffa': {
                         type: 'object',
                         properties: {
-                          FFA: get('properties.FFA', assistance),
+                          ffa: get('properties.ffa', assistance),
                         },
                       },
                     },

--- a/src/applications/edu-benefits/feedback-tool/config/form.js
+++ b/src/applications/edu-benefits/feedback-tool/config/form.js
@@ -40,6 +40,8 @@ import {
   validateMatch,
 } from '../helpers';
 
+import migrations from './migrations';
+
 const {
   address: applicantAddress,
   anonymousEmail,
@@ -58,7 +60,48 @@ const {
   socialSecurityNumberLastFour,
 } = fullSchema.properties;
 
-const { assistance, programs, school } = educationDetails.properties;
+const { assistance, school } = educationDetails.properties;
+const programs = {
+  type: 'object',
+  properties: {
+    chapter33: {
+      type: 'boolean',
+      default: false,
+      title: 'Post-9/11 GI Bill (Chapter 33)',
+    },
+    chapter30: {
+      type: 'boolean',
+      default: false,
+      title: 'Montgomery GI Bill - Active Duty (MGIB-AD, Chapter 30)',
+    },
+    chapter1606: {
+      type: 'boolean',
+      default: false,
+      title: 'Montgomery GI Bill - Selected Reserve (MGIB-SR, Chapter 1606)',
+    },
+    tatu: {
+      type: 'boolean',
+      default: false,
+      title: 'Tuition Assistance Top-Up',
+    },
+    reap: {
+      type: 'boolean',
+      default: false,
+      title: 'Reserve Educational Assistance Program (REAP) (Chapter 1607)',
+    },
+    chapter35: {
+      type: 'boolean',
+      default: false,
+      title: 'Survivors’ and Dependents’ Assistance (DEA) (Chapter 35)',
+    },
+    chapter31: {
+      type: 'boolean',
+      default: false,
+      title: 'Vocational Rehabilitation and Employment (VR&E) (Chapter 31)',
+    },
+  },
+};
+
 const {
   address: schoolAddress,
   name: schoolName,
@@ -144,7 +187,8 @@ const formConfig = {
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   formId: 'FEEDBACK-TOOL',
-  version: 0,
+  version: 1,
+  migrations,
   prefillEnabled: true,
   prefillTransformer,
   defaultDefinitions: {

--- a/src/applications/edu-benefits/feedback-tool/config/form.js
+++ b/src/applications/edu-benefits/feedback-tool/config/form.js
@@ -60,7 +60,9 @@ const {
   socialSecurityNumberLastFour,
 } = fullSchema.properties;
 
-const { assistance, school } = educationDetails.properties;
+const { school } = educationDetails.properties;
+
+// Once shared schema is updated, programs and assistance can be pulled from educationDetails again
 const programs = {
   type: 'object',
   properties: {
@@ -98,6 +100,33 @@ const programs = {
       type: 'boolean',
       default: false,
       title: 'Vocational Rehabilitation and Employment (VR&E) (Chapter 31)',
+    },
+  },
+};
+
+const assistance = {
+  type: 'object',
+  properties: {
+    ta: {
+      type: 'boolean',
+      default: false,
+      title: 'Federal Tuition Assistance (TA)',
+    },
+    taAgr: {
+      type: 'boolean',
+      default: false,
+      title:
+        'State-funded Tuition Assistance (TA) for Servicemembers on Active Guard and Reserve (AGR) duties',
+    },
+    myCaa: {
+      type: 'boolean',
+      default: false,
+      title: 'Military Spouse Career Advancement Accounts (MyCAA)',
+    },
+    ffa: {
+      type: 'boolean',
+      default: false,
+      title: 'Federal financial aid',
     },
   },
 };

--- a/src/applications/edu-benefits/feedback-tool/config/migrations.js
+++ b/src/applications/edu-benefits/feedback-tool/config/migrations.js
@@ -5,13 +5,13 @@ export default [
   // 0 > 1, convert keys to camel case
   ({ formData, metadata }) => {
     const programsKeyMap = {
-      'Post-9/11 Ch 33': 'chapter33',
-      'MGIB-AD Ch 30': 'chapter30',
-      'MGIB-SR Ch 1606': 'chapter1606',
+      'post9::11 ch 33': 'chapter33',
+      'mGIBAd ch 30': 'chapter30',
+      'mGIBSr ch 1606': 'chapter1606',
       TATU: 'tatu',
       REAP: 'reap',
-      'DEA Ch 35': 'chapter35',
-      'VRE Ch 31': 'chapter31',
+      'dea ch 35': 'chapter35',
+      'vre ch 31': 'chapter31',
     };
 
     const assistanceKeyMap = {
@@ -60,8 +60,8 @@ export default [
 
     if (typeof ffa !== 'undefined') {
       newFormData = set(
-        `educationDetails.assistance.view:ffa`,
-        ffa,
+        `educationDetails.assistance.view:ffa.ffa`,
+        ffa.ffa,
         newFormData,
       );
       delete newFormData.educationDetails.assistance['view:FFA'];

--- a/src/applications/edu-benefits/feedback-tool/config/migrations.js
+++ b/src/applications/edu-benefits/feedback-tool/config/migrations.js
@@ -61,7 +61,7 @@ export default [
     if (typeof ffa !== 'undefined') {
       newFormData = set(
         `educationDetails.assistance.view:ffa.ffa`,
-        ffa.ffa,
+        ffa.FFA,
         newFormData,
       );
       delete newFormData.educationDetails.assistance['view:FFA'];

--- a/src/applications/edu-benefits/feedback-tool/config/migrations.js
+++ b/src/applications/edu-benefits/feedback-tool/config/migrations.js
@@ -4,59 +4,67 @@ import set from 'platform/utilities/data/set';
 export default [
   // 0 > 1, convert keys to camel case
   ({ formData, metadata }) => {
+    const programsKeyMap = {
+      'Post-9/11 Ch 33': 'chapter33',
+      'MGIB-AD Ch 30': 'chapter30',
+      'MGIB-SR Ch 1606': 'chapter1606',
+      TATU: 'tatu',
+      REAP: 'reap',
+      'DEA Ch 35': 'chapter35',
+      'VRE Ch 31': 'chapter31',
+    };
+
+    const assistanceKeyMap = {
+      TA: 'ta',
+      'TA-AGR': 'taAgr',
+      MyCAA: 'myCaa',
+      FFA: 'ffa',
+    };
+
     let newFormData = formData;
 
     const programs = get('educationDetails.programs', formData);
-    if (programs && programs.length) {
-      Object.entries(formData.programs).forEach(([key, value]) => {
-        switch (key) {
-          case 'Post-9/11 Ch 33':
-            newFormData = set('educationDetails.programs.chapter33', value);
-            break;
-          case 'MGIB-AD Ch 30':
-            newFormData = set('educationDetails.programs.chapter30', value);
-            break;
-          case 'MGIB-SR Ch 1606':
-            newFormData = set('educationDetails.programs.chapter1606', value);
-            break;
-          case 'TATU':
-            newFormData = set('educationDetails.programs.tatu', value);
-            break;
-          case 'REAP':
-            newFormData = set('educationDetails.programs.reap', value);
-            break;
-          case 'DEA Ch 35':
-            newFormData = set('educationDetails.programs.chapter35', value);
-            break;
-          case 'VRE Ch 31':
-            newFormData = set('educationDetails.programs.chapter31', value);
-            break;
-          default:
-            break;
+    if (programs) {
+      Object.entries(programsKeyMap).forEach(([oldKey, newKey]) => {
+        if (typeof programs[oldKey] !== 'undefined') {
+          newFormData = set(
+            `educationDetails.programs.${newKey}`,
+            programs[oldKey],
+            newFormData,
+          );
+          delete newFormData.educationDetails.programs[oldKey];
         }
       });
     }
 
-    const assistance = get('educationDetails.assistance', formData);
-    if (assistance && assistance.length) {
-      Object.entries(formData.assistance).forEach(([key, value]) => {
-        switch (key) {
-          case 'TA':
-            newFormData = set('educationDetails.assistance.ta', value);
-            break;
-          case 'TA-AGR':
-            newFormData = set('educationDetails.assistance.taAgr', value);
-            break;
-          case 'MyCAA':
-            newFormData = set('educationDetails.assistance.myCaa', value);
-            break;
-          case 'FFA':
-            newFormData = set('educationDetails.assistance.ffa', value);
-            break;
-          default:
-            break;
+    const assistance = get(
+      'educationDetails.assistance.view:assistance',
+      formData,
+    );
+    if (assistance) {
+      Object.entries(assistanceKeyMap).forEach(([oldKey, newKey]) => {
+        if (typeof assistance[oldKey] !== 'undefined') {
+          newFormData = set(
+            `educationDetails.assistance.view:assistance.${newKey}`,
+            assistance[oldKey],
+            newFormData,
+          );
+          delete newFormData.educationDetails.assistance['view:assistance'][
+            oldKey
+          ];
         }
       });
+    }
+
+    const ffa = get('educationDetails.assistance.view:FFA', formData);
+
+    if (typeof ffa !== 'undefined') {
+      newFormData = set(
+        `educationDetails.assistance.view:ffa`,
+        ffa,
+        newFormData,
+      );
+      delete newFormData.educationDetails.assistance['view:FFA'];
     }
 
     return { formData: newFormData, metadata };

--- a/src/applications/edu-benefits/feedback-tool/config/migrations.js
+++ b/src/applications/edu-benefits/feedback-tool/config/migrations.js
@@ -1,0 +1,64 @@
+import get from 'platform/utilities/data/get';
+import set from 'platform/utilities/data/set';
+
+export default [
+  // 0 > 1, convert keys to camel case
+  ({ formData, metadata }) => {
+    let newFormData = formData;
+
+    const programs = get('educationDetails.programs', formData);
+    if (programs && programs.length) {
+      Object.entries(formData.programs).forEach(([key, value]) => {
+        switch (key) {
+          case 'Post-9/11 Ch 33':
+            newFormData = set('educationDetails.programs.chapter33', value);
+            break;
+          case 'MGIB-AD Ch 30':
+            newFormData = set('educationDetails.programs.chapter30', value);
+            break;
+          case 'MGIB-SR Ch 1606':
+            newFormData = set('educationDetails.programs.chapter1606', value);
+            break;
+          case 'TATU':
+            newFormData = set('educationDetails.programs.tatu', value);
+            break;
+          case 'REAP':
+            newFormData = set('educationDetails.programs.reap', value);
+            break;
+          case 'DEA Ch 35':
+            newFormData = set('educationDetails.programs.chapter35', value);
+            break;
+          case 'VRE Ch 31':
+            newFormData = set('educationDetails.programs.chapter31', value);
+            break;
+          default:
+            break;
+        }
+      });
+    }
+
+    const assistance = get('educationDetails.assistance', formData);
+    if (assistance && assistance.length) {
+      Object.entries(formData.assistance).forEach(([key, value]) => {
+        switch (key) {
+          case 'TA':
+            newFormData = set('educationDetails.assistance.ta', value);
+            break;
+          case 'TA-AGR':
+            newFormData = set('educationDetails.assistance.taAgr', value);
+            break;
+          case 'MyCAA':
+            newFormData = set('educationDetails.assistance.myCaa', value);
+            break;
+          case 'FFA':
+            newFormData = set('educationDetails.assistance.ffa', value);
+            break;
+          default:
+            break;
+        }
+      });
+    }
+
+    return { formData: newFormData, metadata };
+  },
+];

--- a/src/applications/edu-benefits/tests/feedback-tool/config/benefitsInfo.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/config/benefitsInfo.unit.spec.js
@@ -57,11 +57,7 @@ describe('feedback tool benefits info', () => {
       />,
     );
 
-    selectCheckbox(
-      form,
-      'root_educationDetails_programs_Post-9/11 Ch 33',
-      true,
-    );
+    selectCheckbox(form, 'root_educationDetails_programs_chapter33', true);
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error').length).to.equal(0);
     expect(onSubmit.called).to.be.true;

--- a/src/applications/edu-benefits/tests/feedback-tool/config/migrations.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/config/migrations.unit.spec.js
@@ -6,8 +6,8 @@ describe('Feedback tool migrations', () => {
     const formData = {
       educationDetails: {
         programs: {
-          'Post-9/11 Ch 33': true,
-          'MGIB-AD Ch 30': false,
+          'post9::11 ch 33': true,
+          'mGIBAd ch 30': false,
         },
       },
     };
@@ -53,14 +53,17 @@ describe('Feedback tool migrations', () => {
     const formData = {
       educationDetails: {
         assistance: {
-          'view:FFA': false,
+          'view:FFA': {
+            FFA: false,
+          },
         },
       },
     };
 
     const result = migrations[0]({ formData, metadata: {} });
 
-    expect(result.formData.educationDetails.assistance['view:ffa']).to.be.false;
+    expect(result.formData.educationDetails.assistance['view:ffa'].ffa).to.be
+      .false;
 
     expect(result.formData.educationDetails.assistance['view:FFA']).to.be
       .undefined;

--- a/src/applications/edu-benefits/tests/feedback-tool/config/migrations.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/config/migrations.unit.spec.js
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+import migrations from '../../../feedback-tool/config/migrations';
+
+describe('Feedback tool migrations', () => {
+  it('should convert keys in programs object', () => {
+    const formData = {
+      educationDetails: {
+        programs: {
+          'Post-9/11 Ch 33': true,
+          'MGIB-AD Ch 30': false,
+        },
+      },
+    };
+
+    const result = migrations[0]({ formData, metadata: {} });
+
+    expect(result.formData.educationDetails.programs.chapter33).to.be.true;
+    expect(result.formData.educationDetails.programs.chapter30).to.be.false;
+
+    expect(result.formData.educationDetails.programs['Post-9/11 Ch 33']).to.be
+      .undefined;
+    expect(result.formData.educationDetails.programs['MGIB-AD Ch 30']).to.be
+      .undefined;
+  });
+
+  it('should convert keys in view:assistance object', () => {
+    const formData = {
+      educationDetails: {
+        assistance: {
+          'view:assistance': {
+            TA: true,
+            'TA-AGR': false,
+          },
+        },
+      },
+    };
+
+    const result = migrations[0]({ formData, metadata: {} });
+
+    expect(result.formData.educationDetails.assistance['view:assistance'].ta).to
+      .be.true;
+    expect(result.formData.educationDetails.assistance['view:assistance'].taAgr)
+      .to.be.false;
+
+    expect(result.formData.educationDetails.assistance['view:assistance'].TA).to
+      .be.undefined;
+    expect(
+      result.formData.educationDetails.assistance['view:assistance']['TA-AGR'],
+    ).to.be.undefined;
+  });
+
+  it('should convert ffa key in assistance object', () => {
+    const formData = {
+      educationDetails: {
+        assistance: {
+          'view:FFA': false,
+        },
+      },
+    };
+
+    const result = migrations[0]({ formData, metadata: {} });
+
+    expect(result.formData.educationDetails.assistance['view:ffa']).to.be.false;
+
+    expect(result.formData.educationDetails.assistance['view:FFA']).to.be
+      .undefined;
+  });
+});

--- a/src/applications/edu-benefits/tests/feedback-tool/schema/maximal-test.json
+++ b/src/applications/edu-benefits/tests/feedback-tool/schema/maximal-test.json
@@ -25,7 +25,7 @@
     "phone": 1234567890,
     "educationDetails": {
       "programs": {
-        "Post-9/11 Ch 33": true
+        "chapter33": true
       },
       "school": {
         "view:manualSchoolEntry": {


### PR DESCRIPTION
## Description
The feedback tool uses some properties that have spaces and capitalized word, but the backend on submission and when saving a form in progress converts these keys to a camel case format that Ruby can handle, which is then updated again to make some fields match a format the internal VA system/process expects. This updates the feedback tool to match that format, so that we don't send poorly formatted program and assistance keys to the backend. This also fixes an issue where if you save your form and come back to the benefits page, you don't see the correct options selected (because the converted keys no longer match the schema).

I'm somewhat concerned this is happening on other forms. At some point we were sending data to the in progress forms endpoint as a string, I think, so that we didn't have these json key conversion issues.

## Testing done
Unit tests, saved form on master, switched to branch and resumed form

## Screenshots
New output sent to backend:
```json
{
  "issue":{
    "other":false,
    "recruiting":false,
    "studentLoans":false,
    "quality":false,
    "creditTransfer":true,
    "accreditation":false,
    "jobOpportunities":false,
    "gradePolicy":false,
    "refundIssues":false,
    "financialIssues":false,
    "changeInDegree":false,
    "transcriptRelease":false
  },
  "issueDescription":"asdf",
  "issueResolution":"asdf",
  "educationDetails":{
    "school":{
      "name":"Massachusetts",
      "address":{
        "country":"United States",
        "street":"399 elm st",
        "city":"northampton",
        "state":"AL",
        "postalCode":"22222"
      }
    },
    "programs":{
      "chapter33":true,
      "chapter30":true,
      "chapter1606":true,
      "tatu":true,
      "reap":true,
      "chapter35":false,
      "chapter31":false
    },
    "assistance":{
      "ta":true,
      "taAgr":true,
      "myCaa":true,
      "ffa":true
    }
  },
  "address":{
    "country":"US",
    "street":"399 elm st",
    "city":"northampton",
    "state":"MA",
    "postalCode":"01050"
  },
  "applicantEmail":"jbalboni@gmail.com",
  "fullName":{
    "first":"asdf",
    "last":"asdf"
  },
  "socialSecurityNumberLastFour":"3444",
  "serviceAffiliation":"Veteran",
  "onBehalfOf":"Myself",
  "serviceDateRange":{

  },
  "privacyAgreementAccepted":true
}
```

## Acceptance criteria
- [x] Program and assistance keys match format being used on backend

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
