### PR TITLE
VAGOV-4052

### DIFF
--- a/src/site/facilities/facility_social_links.drupal.liquid
+++ b/src/site/facilities/facility_social_links.drupal.liquid
@@ -1,4 +1,4 @@
-<section class="feature vads-u-background-color--gray-lightest">
+<section class="feature vads-u-background-color--gray-lightest vads-u-padding-x--4 vads-u-padding-y--3">
     <h3>Get updates from us</h3>
     <div class="va-c-list-link-teasers">
         {% if fieldFacebook != empty || fieldTwitter != empty %}

--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -18,12 +18,8 @@
                     <div>{{ serviceTaxonomy.description.processed }}</div>
                 {% endif %}
 
-                {% if healthService.fieldBody.processed %}
-                    <div>{{ healthService.fieldBody.processed }}</div>
-                {% endif %}
-
                 {% if healthService.fieldLocalHealthCareService.length > 0 %}
-                    <p class="vads-u-font-weight--bold">Available at</p>
+                    <p class="vads-u-font-weight--bold vads-u-font-family--serif">Available at</p>
                     <ul class="usa-unstyled-list">
                         {% for location in healthService.fieldLocalHealthCareService %}
                             {% assign facility = location.entity.fieldFacilityLocation.entity %}
@@ -31,6 +27,10 @@
                                 <a href="{{ facility.entityUrl.path }}">{{ facility.fieldNicknameForThisFacility }}</a></li>{% endif %}
                         {% endfor %}
                     </ul>
+                {% endif %}
+
+                {% if healthService.fieldBody.processed %}
+                    <div>{{ healthService.fieldBody.processed }}</div>
                 {% endif %}
             </div>
         </li>

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -246,8 +246,8 @@ Example data:
 
         <!-- Social Links -->
         {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty %}
-            <section class="feature vads-u-background-color--gray-lightest">
-                <h3>Get updates from us</h3>
+            <section class="feature vads-u-background-color--gray-lightest vads-u-padding-x--4 vads-u-padding-y--3">
+                <h3 class="vads-u-margin-bottom--1p5">Get updates from us</h3>
                 <div class="va-c-list-link-teasers">
                     {% if fieldFacebook != empty || fieldTwitter != empty %}
                         <div class="usa-grid usa-grid-full">

--- a/src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid
+++ b/src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid
@@ -6,7 +6,7 @@
     }
 {% endcomment %}
 {% if paragraph != empty %}
-<section class="feature">
+<section class="feature vads-u-padding-x--4 vads-u-padding-y--3">
     <h3>
         {{ paragraph.fieldTitle }}
     </h3>


### PR DESCRIPTION
## Description
updates some styles for the region page and placing "Available at" above the `fieldbody` for health services accordions

## Testing done
locally with staging data

## Screenshots
![localhost_3001_pittsburgh-health-care_](https://user-images.githubusercontent.com/19178435/60049501-3e342e00-9683-11e9-976c-4f0ae0ea4b9c.png)

![localhost_3001_pittsburgh-health-care_health-services_ (3)](https://user-images.githubusercontent.com/19178435/60049685-ad118700-9683-11e9-8126-de9fe317e644.png)

## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-4052 (except for the content stuff)
https://app.zeplin.io/project/5d014fd159c9931608872c98/screen/5d01536c628fd215c74bde73

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
