### PR TITLE
18966 account secure btn label change

### DIFF
--- a/src/applications/personalization/account/components/MultifactorMessage.jsx
+++ b/src/applications/personalization/account/components/MultifactorMessage.jsx
@@ -29,7 +29,7 @@ export default function MultifactorMessage({ multifactor }) {
         your password.
       </p>
       <button className="usa-button-primary" onClick={recordAnalyticEvent}>
-        Secure your account
+        Set up 2-factor authentication
       </button>
     </div>
   );


### PR DESCRIPTION
## Description
18966 - Change Account-page Secure-your-account button-label to “Set up 2-factor authentication”.

## Testing done
Local.
All account-app unit-tests still passing.  No account-app e2e test exists.

## Acceptance criteria
- [ ] Button label change verified.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
