### PR TITLE
Use captureException in unhandled rejection event listener

### DIFF
--- a/src/platform/monitoring/sentry.js
+++ b/src/platform/monitoring/sentry.js
@@ -34,7 +34,7 @@ if (trackErrors) {
       if (evt && evt.reason) {
         Sentry.captureException(evt.reason);
       } else {
-        Sentry.captureMessage('Unhandled promise rejection');
+        Sentry.captureException('Unhandled promise rejection');
       }
     });
   });

--- a/src/platform/monitoring/sentry.js
+++ b/src/platform/monitoring/sentry.js
@@ -23,19 +23,4 @@ if (trackErrors) {
   Sentry.configureScope(scope => {
     scope.setLevel('error');
   });
-
-  // this is for errors that happen in promises
-  // it does not work locally with the webpack devtool setting we
-  // use but does with the one we use in prod/staging
-  window.addEventListener('unhandledrejection', evt => {
-    Sentry.withScope(scope => {
-      scope.setExtra('evt', evt);
-
-      if (evt && evt.reason) {
-        Sentry.captureException(evt.reason);
-      } else {
-        Sentry.captureException('Unhandled promise rejection');
-      }
-    });
-  });
 }


### PR DESCRIPTION
## Description
We're getting a lot of [`Unhandled promise rejection`s from Sentry](http://sentry.vetsgov-internal/vets-gov/website-production/issues/12537/), but we have no stack trace to help figure out what the cause is. Using `captureException` should give us a stack trace. _Hopefully_ that will help us figure out what fired the event.

## Testing done
:see_no_evil: 

## Screenshots
N/A

## Acceptance criteria
- [x] The `unhandledrejection` event captures the exception whether there's an `evt.reason` or not

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
