### PR TITLE
Update messaging when enrollment status is `activeduty`

### DIFF
--- a/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
+++ b/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
@@ -46,6 +46,7 @@ const HCAEnrollmentStatusFAQ = ({
 }) => {
   const reapplyAllowed =
     new Set([
+      HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied,
       HCA_ENROLLMENT_STATUSES.deceased,
       HCA_ENROLLMENT_STATUSES.enrolled,
     ]).has(enrollmentStatus) === false;

--- a/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
+++ b/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
@@ -32,9 +32,12 @@ const ReapplyContent = ({ route }) => (
   </>
 );
 
-const ReapplyTextLink = ({ onClick }) => (
+const ReapplyTextLink = ({
+  onClick,
+  linkLabel = 'Reapply for VA health care',
+}) => (
   <button className="va-button-link schemaform-start-button" onClick={onClick}>
-    Reapply for VA health care
+    {linkLabel}
   </button>
 );
 
@@ -44,6 +47,8 @@ const HCAEnrollmentStatusFAQ = ({
   showingReapplyForHealthCareContent,
   showReapplyContent,
 }) => {
+  const applyAllowed =
+    enrollmentStatus === HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied;
   const reapplyAllowed =
     new Set([
       HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied,
@@ -56,13 +61,23 @@ const HCAEnrollmentStatusFAQ = ({
       {getFAQBlock2(enrollmentStatus)}
       {getFAQBlock3(enrollmentStatus)}
       {getFAQBlock4(enrollmentStatus)}
-      {reapplyAllowed &&
+      {(reapplyAllowed || applyAllowed) &&
         showingReapplyForHealthCareContent && <ReapplyContent route={route} />}
       {reapplyAllowed &&
         !showingReapplyForHealthCareContent && (
           <ReapplyTextLink
             onClick={() => {
               recordEvent({ event: 'hca-form-reapply' });
+              showReapplyContent();
+            }}
+          />
+        )}
+      {applyAllowed &&
+        !showingReapplyForHealthCareContent && (
+          <ReapplyTextLink
+            linkLabel="Apply for VA health care"
+            onClick={() => {
+              recordEvent({ event: 'hca-form-apply' });
               showReapplyContent();
             }}
           />

--- a/src/applications/hca/constants.js
+++ b/src/applications/hca/constants.js
@@ -1,5 +1,7 @@
 export const HCA_ENROLLMENT_STATUSES = Object.freeze({
   activeDuty: 'activeduty',
+  activeDutyHasApplied: 'activeduty_has_applied',
+  activeDutyHasNotApplied: 'activeduty_has_not_applied',
   canceledDeclined: 'canceled_declined',
   closed: 'closed',
   deceased: 'deceased',

--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -38,9 +38,13 @@ export function getWarningHeadline(enrollmentStatus) {
         'You didn’t qualify for VA health care based on your previous application';
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDuty:
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
       content =
-        'Our records show that you haven’t yet received your separation or retirement orders';
+        'Our records show that you’re an active-duty service member and you’ve already applied for VA health care';
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
+      content = 'Our records show that you’re an active-duty service member';
       break;
 
     case HCA_ENROLLMENT_STATUSES.deceased:
@@ -163,6 +167,8 @@ export function getWarningStatus(
 export function getWarningExplanation(enrollmentStatus) {
   let content = null;
   switch (enrollmentStatus) {
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
     case HCA_ENROLLMENT_STATUSES.enrolled:
     case HCA_ENROLLMENT_STATUSES.ineligFugitiveFelon:
     case HCA_ENROLLMENT_STATUSES.ineligMedicare:
@@ -247,19 +253,6 @@ export function getWarningExplanation(enrollmentStatus) {
           or Purple Heart award). To qualify for VA health care, you need to
           meet at least one of these eligibility requirements in addition to
           serving at least 24 continuous months on active duty.
-        </p>
-      );
-      break;
-
-    case HCA_ENROLLMENT_STATUSES.activeDuty:
-      content = (
-        <p>
-          You can’t qualify for VA health care until you’ve received your
-          separation or retirement orders. We welcome you to apply again once
-          you’ve received your orders.{' '}
-          <a href="/HEALTHBENEFITS/apply/active_duty.asp">
-            Learn more about transitioning to VA health care
-          </a>
         </p>
       );
       break;
@@ -437,7 +430,6 @@ export function getFAQBlock1(enrollmentStatus) {
       );
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDuty:
     case HCA_ENROLLMENT_STATUSES.canceledDeclined:
     case HCA_ENROLLMENT_STATUSES.closed:
     case HCA_ENROLLMENT_STATUSES.ineligFugitiveFelon:
@@ -500,6 +492,63 @@ export function getFAQBlock1(enrollmentStatus) {
       );
       break;
 
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
+      content = (
+        <>
+          <h4>When will I find out if I’m enrolled in VA health care?</h4>
+          <p>
+            We’ll make our final decision on your application after you've
+            separated from service.
+          </p>
+          <p>
+            If we enroll you in VA health care, the preferred VA medical center
+            you selected when you applied will contact you. You can also check
+            back here after separation to find out the current status of your
+            application.
+          </p>
+        </>
+      );
+      break;
+
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
+      content = (
+        <>
+          <h4>Can I apply for VA health care?</h4>
+          <p>
+            As an active-duty service member, you can apply for VA health care
+            if both of the below descriptions are true for you.
+          </p>
+          <p>
+            <strong>Both of these must be true:</strong>
+          </p>
+          <ul>
+            <li>You’ve received your separation orders, and</li>
+            <li>You have less than a year until your separation date</li>
+          </ul>
+          <p>
+            <strong>If you don’t meet the requirements listed above</strong>
+          </p>
+          <p>
+            Please don’t apply at this time. We welcome you to apply once you
+            meet these requirements.
+          </p>
+          <p>
+            <strong>
+              If you’ve already applied, think you've received this message in
+              error, or have any questions
+            </strong>
+          </p>
+          <p>
+            Please call our enrollment case management team at 877-222-VETS (
+            <a className="help-phone-number-link" href="tel:1-877-222-8387">
+              877-222-8387
+            </a>
+            ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+          </p>
+        </>
+      );
+      break;
+
     default:
       break;
   }
@@ -511,6 +560,20 @@ export function getFAQBlock1(enrollmentStatus) {
 export function getFAQBlock2(enrollmentStatus) {
   let content = null;
   switch (enrollmentStatus) {
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
+      content = (
+        <>
+          <h4>What should I do if I have questions about my eligibility?</h4>
+          <p>
+            Please call our enrollment case management team at 877-222-VETS (
+            <a className="help-phone-number-link" href="tel:1-877-222-8387">
+              877-222-8387
+            </a>
+            ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+          </p>
+        </>
+      );
+      break;
     case HCA_ENROLLMENT_STATUSES.ineligCharacterOfDischarge:
       content = (
         <>
@@ -557,6 +620,8 @@ export function getFAQBlock3(enrollmentStatus) {
     </>
   );
   switch (enrollmentStatus) {
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
     case HCA_ENROLLMENT_STATUSES.deceased:
     case HCA_ENROLLMENT_STATUSES.enrolled:
     case HCA_ENROLLMENT_STATUSES.ineligCHAMPVA:
@@ -668,23 +733,6 @@ export function getFAQBlock4(enrollmentStatus) {
       );
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDuty:
-      content = (
-        <>
-          <h4>Can I apply again?</h4>
-          <p>
-            Yes, but we recommend waiting until you’ve received your separation
-            or retirement orders. If you’d like to talk about your options,
-            please call our enrollment case management team at 877-222-VETS (
-            <a className="help-phone-number-link" href="tel:1-877-222-8387">
-              877-222-8387
-            </a>
-            ).
-          </p>
-        </>
-      );
-      break;
-
     case HCA_ENROLLMENT_STATUSES.closed:
     case HCA_ENROLLMENT_STATUSES.canceledDeclined:
       content = (
@@ -730,6 +778,7 @@ export function getFAQBlock4(enrollmentStatus) {
       );
       break;
 
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
     case HCA_ENROLLMENT_STATUSES.pendingOther:
     case HCA_ENROLLMENT_STATUSES.pendingUnverified:
       content = (
@@ -770,7 +819,8 @@ export function getAlertType(enrollmentStatus) {
       status = DASHBOARD_ALERT_TYPES.enrolled;
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDuty:
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
     case HCA_ENROLLMENT_STATUSES.closed:
       status = DASHBOARD_ALERT_TYPES.closed;
       break;
@@ -816,7 +866,8 @@ export function getAlertStatusHeadline(enrollmentStatus) {
       statusHeadline = 'Enrolled';
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDuty:
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
     case HCA_ENROLLMENT_STATUSES.closed:
       statusHeadline = 'Closed';
       break;
@@ -885,7 +936,8 @@ export function getAlertStatusInfo(enrollmentStatus) {
         'You didn’t qualify for VA health care based on your previous application';
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDuty:
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
       statusInfo =
         'Our records show that you haven’t yet received your separation or retirement orders';
       break;
@@ -1132,7 +1184,8 @@ export function getAlertContent(
       );
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDuty:
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
       blocks.push(
         <React.Fragment key="explanation">
           <p>

--- a/src/applications/hca/reducer.js
+++ b/src/applications/hca/reducer.js
@@ -1,4 +1,5 @@
 import formConfig from './config/form';
+import { isValidDateString } from 'platform/utilities/date';
 import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 import {
   FETCH_ENROLLMENT_STATUS_STARTED,
@@ -35,12 +36,21 @@ export function hcaEnrollmentStatus(state = initialState, action) {
 
     case FETCH_ENROLLMENT_STATUS_SUCCEEDED: {
       const {
-        parsedStatus: enrollmentStatus,
+        parsedStatus,
         applicationDate,
         effectiveDate: enrollmentStatusEffectiveDate,
         enrollmentDate,
         preferredFacility,
       } = action.data;
+
+      let enrollmentStatus = parsedStatus;
+      if (enrollmentStatus === HCA_ENROLLMENT_STATUSES.activeDuty) {
+        if (isValidDateString(applicationDate)) {
+          enrollmentStatus = HCA_ENROLLMENT_STATUSES.activeDutyHasApplied;
+        } else {
+          enrollmentStatus = HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied;
+        }
+      }
       const isInESR =
         enrollmentStatus !== HCA_ENROLLMENT_STATUSES.noneOfTheAbove;
       return {

--- a/src/applications/hca/tests/reducers.unit.spec.js
+++ b/src/applications/hca/tests/reducers.unit.spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import * as actions from '../actions';
 import { hcaEnrollmentStatus as reducer } from '../reducer';
+import { HCA_ENROLLMENT_STATUSES } from '../constants';
 
 describe('HCA Enrollment Status Reducer', () => {
   let state;
@@ -89,6 +90,34 @@ describe('HCA Enrollment Status Reducer', () => {
       });
       it('sets `noESRRecordFound` to `false`', () => {
         expect(reducedState.noESRRecordFound).to.be.false;
+      });
+    });
+
+    describe('if `parsedStatus` is `activeduty`', () => {
+      it('sets the enrollmentStatus to `activeduty_has_applied` when there is a valid `applicationDate`', () => {
+        action = {
+          type: actions.FETCH_ENROLLMENT_STATUS_SUCCEEDED,
+          data: {
+            parsedStatus: 'activeduty',
+            applicationDate: '2018-12-27T00:00:00.000-06:00',
+          },
+        };
+        reducedState = reducer(state, action);
+        expect(reducedState.enrollmentStatus).to.equal(
+          HCA_ENROLLMENT_STATUSES.activeDutyHasApplied,
+        );
+      });
+      it('sets the enrollmentStatus to `activeduty_has_not_applied` when there is not a valid `applicationDate`', () => {
+        action = {
+          type: actions.FETCH_ENROLLMENT_STATUS_SUCCEEDED,
+          data: {
+            parsedStatus: 'activeduty',
+          },
+        };
+        reducedState = reducer(state, action);
+        expect(reducedState.enrollmentStatus).to.equal(
+          HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied,
+        );
       });
     });
   });


### PR DESCRIPTION
## Description
We are changing the messaging on the HCA intro page if the user's enrollment status is `activeduty` as explained here: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19075

This change slightly complicates the logic we've used to display messages to users. In the past we've simply taken the `enrollment status` as-is from the server, but we now handle that status differently depending on if we get a valid `application date` from the server as well.

## Testing done
Local

## Screenshots
**When status is `activeduty` but they have not applied**
<img width="696" alt="Screen Shot 2019-06-25 at 10 58 26 AM" src="https://user-images.githubusercontent.com/20728956/60121659-70ec2e00-9738-11e9-86c1-00998f68dfc9.png">

**When status is `activeduty` and they have applied**
<img width="626" alt="active-has-applied" src="https://user-images.githubusercontent.com/20728956/60116964-fe765080-972d-11e9-88e8-f83643ec29a0.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs