### PR TITLE
Update dashboard to not skip heading levels

### DIFF
--- a/src/applications/personalization/dashboard/components/DashboardAlert.jsx
+++ b/src/applications/personalization/dashboard/components/DashboardAlert.jsx
@@ -30,7 +30,11 @@ const DashboardAlert = ({
   return (
     <div className={classes}>
       <header>
-        {subheadline && <span className="heading-desc">{subheadline}</span>}
+        {subheadline && (
+          <div className="vads-u-margin-bottom--1 heading-desc">
+            {subheadline}
+          </div>
+        )}
         <h2 className="vads-u-font-size--lg vads-u-font-family--serif vads-u-margin--0">
           {headline}
         </h2>

--- a/src/applications/personalization/dashboard/components/DashboardAlert.jsx
+++ b/src/applications/personalization/dashboard/components/DashboardAlert.jsx
@@ -44,9 +44,9 @@ const DashboardAlert = ({
           <i />
         </div>
         <div className="vads-u-flex--1">
-          <span className="vads-u-font-size--lg vads-u-font-family--sans vads-u-font-weight--bold">
+          <div className="vads-u-line-height--3 vads-u-font-size--lg vads-u-font-family--sans vads-u-font-weight--bold">
             {statusHeadline}
-          </span>
+          </div>
           {statusInfo && <p>{statusInfo}</p>}
         </div>
       </section>

--- a/src/applications/personalization/dashboard/components/DashboardAlert.jsx
+++ b/src/applications/personalization/dashboard/components/DashboardAlert.jsx
@@ -30,15 +30,19 @@ const DashboardAlert = ({
   return (
     <div className={classes}>
       <header>
-        {subheadline && <h4>{subheadline}</h4>}
-        <h3>{headline}</h3>
+        {subheadline && <span className="heading-desc">{subheadline}</span>}
+        <h2 className="vads-u-font-size--lg vads-u-font-family--serif vads-u-margin--0">
+          {headline}
+        </h2>
       </header>
       <section className="status vads-u-display--flex">
         <div className="status-icon-container vads-u-flex--auto">
           <i />
         </div>
         <div className="vads-u-flex--1">
-          <h3>{statusHeadline}</h3>
+          <span className="vads-u-font-size--lg vads-u-font-family--sans vads-u-font-weight--bold">
+            {statusHeadline}
+          </span>
           {statusInfo && <p>{statusInfo}</p>}
         </div>
       </section>

--- a/src/applications/personalization/dashboard/components/ESRError.jsx
+++ b/src/applications/personalization/dashboard/components/ESRError.jsx
@@ -26,6 +26,7 @@ const contents = {
  */
 const ESRError = ({ errorType = ESR_ERROR_TYPES.generic }) => (
   <AlertBox
+    level="2"
     content={contents[errorType]}
     headline={headlines[errorType]}
     status="error"

--- a/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
+++ b/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
@@ -54,9 +54,9 @@ const ManageYourVAHealthCare = ({
     <AlertBox
       content={
         <div>
-          <h4 className="usa-alert-heading">
+          <h3 className="usa-alert-heading">
             You are enrolled in VA Health Care
-          </h4>
+          </h3>
           {getEnrollmentDetails(
             applicationDate,
             enrollmentDate,

--- a/src/applications/personalization/dashboard/containers/DashboardApp.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardApp.jsx
@@ -103,9 +103,9 @@ const ManageBenefitsOrRequestRecords = () => (
           href="/education/gi-bill/post-9-11/ch-33-benefit"
           onClick={recordDashboardClick('post-911')}
         >
-          <h4 className="va-nav-linkslist-title">
+          <h3 className="vads-u-font-weight--bold vads-u-font-size--h4">
             Check Post-9/11 GI Bill benefits
-          </h4>
+          </h3>
           <p className="va-nav-linkslist-description">
             View and print your statement of benefits.
           </p>
@@ -116,7 +116,9 @@ const ManageBenefitsOrRequestRecords = () => (
           href="/health-care/get-medical-records/"
           onClick={recordDashboardClick('health-records')}
         >
-          <h4 className="va-nav-linkslist-title">Get your VA health records</h4>
+          <h3 className="vads-u-font-weight--bold vads-u-font-size--h4">
+            Get your VA health records
+          </h3>
           <p className="va-nav-linkslist-description">
             View, download, and print your VA health records.
           </p>
@@ -127,7 +129,9 @@ const ManageBenefitsOrRequestRecords = () => (
           href={lettersManifest.rootUrl}
           onClick={recordDashboardClick('download-letters')}
         >
-          <h4 className="va-nav-linkslist-title">Download your VA letters</h4>
+          <h3 className="vads-u-font-weight--bold vads-u-font-size--h4">
+            Download your VA letters
+          </h3>
           <p className="va-nav-linkslist-description">
             Access and download benefit letters and documents proving your
             status online.

--- a/src/applications/personalization/dashboard/sass/dashboard-alert.scss
+++ b/src/applications/personalization/dashboard/sass/dashboard-alert.scss
@@ -35,20 +35,8 @@
     padding: units(4);
   }
 
-  header {
-    h4 {
-      border: none;
-      font-family: $font-sans;
-      font-weight: $font-normal;
-      font-size: 1em;
-      margin: 0;
-      text-transform: uppercase;
-    }
-    h3 {
-      font-family: $font-serif;
-      font-size: 1.25em;
-      margin: 0;
-    }
+  header > .heading-desc {
+    text-transform: uppercase;
   }
 
   section.status {

--- a/src/applications/personalization/preferences/components/PreferenceItem.jsx
+++ b/src/applications/personalization/preferences/components/PreferenceItem.jsx
@@ -34,13 +34,15 @@ const CallToAction = ({ cta }) => {
 const FAQItem = ({ faq }) => {
   const { title, component: FAQComponent } = faq;
   return (
-    <AdditionalInfo
-      tagName={'h5'}
-      additionalClass="benefit-faq"
-      triggerText={title}
-    >
-      <FAQComponent />
-    </AdditionalInfo>
+    <div className="preference-faq-item">
+      <AdditionalInfo
+        tagName={'h4'}
+        additionalClass="benefit-faq"
+        triggerText={title}
+      >
+        <FAQComponent />
+      </AdditionalInfo>
+    </div>
   );
 };
 

--- a/src/applications/personalization/preferences/sass/preferences.scss
+++ b/src/applications/personalization/preferences/sass/preferences.scss
@@ -80,3 +80,7 @@
   max-width: 77rem;
   margin-bottom: 1.5em;
 }
+
+.preference-faq-item .additional-info-title {
+  font-size: $h5-font-size;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -685,9 +685,9 @@
     to-fast-properties "^2.0.0"
 
 "@department-of-veterans-affairs/formation-react@^4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-4.7.0.tgz#669047353992e1803c096407e348940fe46d1ed8"
-  integrity sha512-ttCpkHaSjzshsfEBXiTMhWsVhpLnX6D6GB6x99owagAaJI2JIZy71QZbO4ZuEZvpAaVGmbqzSjIdM9HfGFBezg==
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-4.8.0.tgz#08a561e8936f9f94d9cf0ebecf85cb9438f50a8d"
+  integrity sha512-JN/zlMOSr6lV3Cxbjcg1G+mI/R7ezBrilQegq8OexvH6y5ZI08zvjig7pReo4B7mTRVs8lQuS4vQFQ/I4voClg==
   dependencies:
     classnames "^2.2.6"
     lodash "^4.17.11"


### PR DESCRIPTION
## Description
The heading levels on the dashboard should progress without skipping levels, so this adjusts them in a few places to not do that and fix the styling when necessary.

## Testing done
Ran axe browser extension, verified that heading level error was limited to just the footer for several dashboard states

## Screenshots
No visual changes:
![Screen Shot 2019-06-25 at 2 02 35 PM](https://user-images.githubusercontent.com/634932/60121887-13fd7180-9752-11e9-95f6-7424a453049e.png)
![Screen Shot 2019-06-25 at 2 02 30 PM](https://user-images.githubusercontent.com/634932/60121888-13fd7180-9752-11e9-8b04-168f6d328cdd.png)

## Acceptance criteria
- [x] Heading levels aren't skipped

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
