### PR TITLE
Update HCA Dashboard alert for activeduty

### DIFF
--- a/src/applications/hca/constants.js
+++ b/src/applications/hca/constants.js
@@ -1,5 +1,7 @@
 export const HCA_ENROLLMENT_STATUSES = Object.freeze({
+  // `activeduty` is a possible value for `parsedStatus` from `health_care_applications/enrollment_status` but we do not use it in the front end...
   activeDuty: 'activeduty',
+  // ...instead we convert it to one of these two values in the HCA reducer:
   activeDutyHasApplied: 'activeduty_has_applied',
   activeDutyHasNotApplied: 'activeduty_has_not_applied',
   canceledDeclined: 'canceled_declined',

--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -819,8 +819,6 @@ export function getAlertType(enrollmentStatus) {
       status = DASHBOARD_ALERT_TYPES.enrolled;
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
     case HCA_ENROLLMENT_STATUSES.closed:
       status = DASHBOARD_ALERT_TYPES.closed;
       break;
@@ -844,6 +842,7 @@ export function getAlertType(enrollmentStatus) {
       status = DASHBOARD_ALERT_TYPES.decision;
       break;
 
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
     case HCA_ENROLLMENT_STATUSES.pendingMt:
     case HCA_ENROLLMENT_STATUSES.pendingOther:
     case HCA_ENROLLMENT_STATUSES.pendingPurpleHeart:
@@ -866,8 +865,6 @@ export function getAlertStatusHeadline(enrollmentStatus) {
       statusHeadline = 'Enrolled';
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
     case HCA_ENROLLMENT_STATUSES.closed:
       statusHeadline = 'Closed';
       break;
@@ -891,6 +888,7 @@ export function getAlertStatusHeadline(enrollmentStatus) {
       statusHeadline = 'Decision';
       break;
 
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
     case HCA_ENROLLMENT_STATUSES.pendingMt:
     case HCA_ENROLLMENT_STATUSES.pendingOther:
     case HCA_ENROLLMENT_STATUSES.pendingPurpleHeart:
@@ -936,17 +934,12 @@ export function getAlertStatusInfo(enrollmentStatus) {
         'You didn’t qualify for VA health care based on your previous application';
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
-      statusInfo =
-        'Our records show that you haven’t yet received your separation or retirement orders';
-      break;
-
     case HCA_ENROLLMENT_STATUSES.closed:
       statusInfo =
         'Our records show that your application for VA health care expired';
       break;
 
+    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
     case HCA_ENROLLMENT_STATUSES.pendingOther:
     case HCA_ENROLLMENT_STATUSES.pendingUnverified:
       statusInfo = 'We’re reviewing your application';
@@ -1185,22 +1178,20 @@ export function getAlertContent(
       break;
 
     case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
       blocks.push(
         <React.Fragment key="explanation">
           <p>
-            You can’t qualify for VA health care until you’ve received your
-            separation or retirement orders. We welcome you to apply again once
-            you've received your orders.
+            We’ll make our final decision on your application after you’ve
+            separated from service.
           </p>
           <p>
-            <a href="/HEALTHBENEFITS/apply/active_duty.asp">
-              Learn more about transitioning to VA health care
-            </a>
+            If we enroll you in VA health care, the preferred VA medical center
+            you selected when you applied will contact you. You can also check
+            back here after separation to find out the current status of your
+            application.
           </p>
         </React.Fragment>,
         whatShouldIDo1,
-        removeNotificationButton,
       );
       break;
 

--- a/src/applications/hca/selectors.js
+++ b/src/applications/hca/selectors.js
@@ -6,9 +6,10 @@ import {
 } from 'platform/user/selectors';
 import { HCA_ENROLLMENT_STATUSES } from './constants';
 
-const nonESRStatuses = new Set([
+const nonActiveInESRStatuses = new Set([
   null,
   HCA_ENROLLMENT_STATUSES.noneOfTheAbove,
+  HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied,
   HCA_ENROLLMENT_STATUSES.canceledDeclined,
   HCA_ENROLLMENT_STATUSES.deceased,
 ]);
@@ -25,9 +26,9 @@ export const noESRRecordFound = state =>
   selectEnrollmentStatus(state).noESRRecordFound;
 export const isShowingHCAReapplyContent = state =>
   selectEnrollmentStatus(state).showHCAReapplyContent;
-export const isInESR = state => {
+export const hasApplicationInESR = state => {
   const status = selectEnrollmentStatus(state).enrollmentStatus;
-  return nonESRStatuses.has(status) === false;
+  return nonActiveInESRStatuses.has(status) === false;
 };
 export const isEnrolledInVAHealthCare = state =>
   selectEnrollmentStatus(state).enrollmentStatus ===

--- a/src/applications/hca/tests/selectors.unit.spec.js
+++ b/src/applications/hca/tests/selectors.unit.spec.js
@@ -199,7 +199,7 @@ describe('simple top-level selectors', () => {
       const state = {
         hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
       };
-      const isInESR = selectors.isInESR(state);
+      const isInESR = selectors.hasApplicationInESR(state);
       expect(isInESR).to.be.false;
     });
     it('returns `false` if the enrollmentStatus is noneOfTheAbove', () => {
@@ -209,7 +209,17 @@ describe('simple top-level selectors', () => {
           enrollmentStatus: HCA_ENROLLMENT_STATUSES.noneOfTheAbove,
         },
       };
-      const isInESR = selectors.isInESR(state);
+      const isInESR = selectors.hasApplicationInESR(state);
+      expect(isInESR).to.be.false;
+    });
+    it('returns `false` if the enrollmentStatus is active duty but they have not explicitly applied for health care', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+          enrollmentStatus: HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied,
+        },
+      };
+      const isInESR = selectors.hasApplicationInESR(state);
       expect(isInESR).to.be.false;
     });
     it('returns `false` if the enrollmentStatus is canceled', () => {
@@ -219,7 +229,7 @@ describe('simple top-level selectors', () => {
           enrollmentStatus: HCA_ENROLLMENT_STATUSES.canceledDeclined,
         },
       };
-      const isInESR = selectors.isInESR(state);
+      const isInESR = selectors.hasApplicationInESR(state);
       expect(isInESR).to.be.false;
     });
     it('returns `false` if the enrollmentStatus is deceased', () => {
@@ -229,8 +239,18 @@ describe('simple top-level selectors', () => {
           enrollmentStatus: HCA_ENROLLMENT_STATUSES.deceased,
         },
       };
-      const isInESR = selectors.isInESR(state);
+      const isInESR = selectors.hasApplicationInESR(state);
       expect(isInESR).to.be.false;
+    });
+    it('returns `true` if the enrollmentStatus is active duty and they have explicitly applied for health care', () => {
+      const state = {
+        hcaEnrollmentStatus: {
+          ...basicEnrollmentStatusState,
+          enrollmentStatus: HCA_ENROLLMENT_STATUSES.activeDutyHasApplied,
+        },
+      };
+      const isInESR = selectors.hasApplicationInESR(state);
+      expect(isInESR).to.be.true;
     });
     it('returns `true` if the enrollmentStatus is enrolled', () => {
       const state = {
@@ -239,7 +259,7 @@ describe('simple top-level selectors', () => {
           enrollmentStatus: HCA_ENROLLMENT_STATUSES.enrolled,
         },
       };
-      const isInESR = selectors.isInESR(state);
+      const isInESR = selectors.hasApplicationInESR(state);
       expect(isInESR).to.be.true;
     });
     it('returns `true` if the enrollmentStatus is pending', () => {
@@ -249,7 +269,7 @@ describe('simple top-level selectors', () => {
           enrollmentStatus: HCA_ENROLLMENT_STATUSES.pendingOther,
         },
       };
-      const isInESR = selectors.isInESR(state);
+      const isInESR = selectors.hasApplicationInESR(state);
       expect(isInESR).to.be.true;
     });
   });

--- a/src/applications/personalization/dashboard/containers/YourApplications.jsx
+++ b/src/applications/personalization/dashboard/containers/YourApplications.jsx
@@ -11,7 +11,7 @@ import {
 import {
   dismissedHCANotificationDate,
   isEnrollmentStatusLoading,
-  isInESR,
+  hasApplicationInESR,
   isLoadingDismissedNotification,
   selectEnrollmentStatus,
 } from 'applications/hca/selectors';
@@ -102,7 +102,7 @@ export const mapStateToProps = state => {
     hcaEnrollmentStatus.enrollmentStatusEffectiveDate;
   const dismissedNotificationDate = dismissedHCANotificationDate(state);
   const shouldRenderHCAAlert =
-    isInESR(state) &&
+    hasApplicationInESR(state) &&
     (!dismissedNotificationDate ||
       new Date(hcaStatusEffectiveDate) > new Date(dismissedNotificationDate));
   const shouldRenderContent =


### PR DESCRIPTION
## Description
This work updates the HCA-related Dashboard alert that is shown when a user is active duty and has explicitly applied for healthcare. It also stops showing a HCA-related Dashboard alert if the user is active duty but has _not_ applied for healthcare. 

## Testing done
Local + unit tests

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/60125155-1060ef00-9740-11e9-9250-d734022e3332.png)

## Acceptance criteria
- [x] do not show an alert if the user is active duty but did not apply for health care
- [x] update the info shown in the alert if the user is active duty and applied for health care

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs