### PR TITLE
Add name to address in update failure state

### DIFF
--- a/src/applications/letters/components/AddressContent.jsx
+++ b/src/applications/letters/components/AddressContent.jsx
@@ -2,11 +2,19 @@ import React from 'react';
 import UpdateFailureAlert from './UpdateFailureAlert';
 import AddressBlock from './AddressBlock';
 
-const AddressContent = ({ saveError, addressObject, children }) => (
+const AddressContent = ({
+  saveError,
+  addressObject,
+  recipientName,
+  children,
+}) => (
   <div className="step-content">
     <p>Downloaded documents will list your address as:</p>
     {saveError ? (
-      <UpdateFailureAlert addressObject={addressObject} />
+      <UpdateFailureAlert
+        addressObject={addressObject}
+        recipientName={recipientName}
+      />
     ) : (
       <AddressBlock>{children}</AddressBlock>
     )}

--- a/src/applications/letters/components/UpdateFailureAlert.jsx
+++ b/src/applications/letters/components/UpdateFailureAlert.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const UpdateFailureAlert = ({ addressObject }) => {
+const UpdateFailureAlert = ({ addressObject, recipientName }) => {
   const addressLines = Object.keys(addressObject).map(key => (
     <div className="letters-address" key={key}>
       {addressObject[key]}
@@ -16,7 +16,12 @@ const UpdateFailureAlert = ({ addressObject }) => {
             <strong>VA letters and documents are still valid</strong> even with
             your old address:
           </div>
-          <div id="warning-address-block">{addressLines}</div>
+          <div className="address-block">
+            <h5 className="letters-address">
+              {(recipientName || '').toLowerCase()}
+            </h5>
+            <div id="warning-address-block">{addressLines}</div>
+          </div>
           <div>
             <strong>
               Please continue to download your letter or document.

--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -376,6 +376,7 @@ export class AddressSection extends React.Component {
     } else {
       addressContent = (
         <AddressContent
+          recipientName={this.props.recipientName}
           saveError={this.props.saveAddressError}
           addressObject={addressContentLines}
         >

--- a/src/applications/letters/sass/letters.scss
+++ b/src/applications/letters/sass/letters.scss
@@ -39,6 +39,12 @@
     }
   }
 
+  .usa-alert {
+    .address-block h5 {
+      margin-top: 0.5rem;
+    }
+  }
+
   .address-block {
     background-color: $color-gray-lightest;
     padding: 1em;


### PR DESCRIPTION
## Description
Adds recipient name to address block when there is an address update failure

Connected to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18856

## Testing done
Local testing

## Screenshots
<img width="727" alt="Screen Shot 2019-06-25 at 1 53 57 PM" src="https://user-images.githubusercontent.com/303289/60132906-4a86bc80-9751-11e9-90a9-c67010ba86cb.png">


## Acceptance criteria
- [x] Adds recipient name to address update failure state

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
