### PR TITLE
Update content for GIBS 503/504 and generic error messaging

### DIFF
--- a/src/applications/post-911-gib-status/containers/Main.jsx
+++ b/src/applications/post-911-gib-status/containers/Main.jsx
@@ -7,6 +7,7 @@ import { getEnrollmentData } from '../actions/post-911-gib-status';
 import {
   backendErrorMessage,
   authenticationErrorMessage,
+  genericErrorMessage,
 } from '../utils/helpers';
 
 export class Main extends React.Component {
@@ -29,10 +30,12 @@ export class Main extends React.Component {
       case 'noChapter33Record':
         appContent = authenticationErrorMessage;
         break;
-      case 'unavailable':
+      case 'getEnrollmentDataFailure':
       case 'backendServiceError':
-      default:
         appContent = backendErrorMessage;
+        break;
+      default:
+        appContent = genericErrorMessage;
     }
 
     return <div>{appContent}</div>;

--- a/src/applications/post-911-gib-status/reducers/index.js
+++ b/src/applications/post-911-gib-status/reducers/index.js
@@ -32,7 +32,7 @@ function post911GIBStatus(state = initialState, action) {
     case NO_CHAPTER33_RECORD_AVAILABLE:
       return set('availability', 'noChapter33Record', state);
     case GET_ENROLLMENT_DATA_FAILURE:
-      return set('availability', 'unavailable', state);
+      return set('availability', 'getEnrollmentDataFailure', state);
     case SET_SERVICE_AVAILABILITY:
       return set('serviceAvailability', action.serviceAvailability, state);
     case SET_SERVICE_UPTIME_REMAINING:

--- a/src/applications/post-911-gib-status/tests/containers/Main.unit.spec.jsx
+++ b/src/applications/post-911-gib-status/tests/containers/Main.unit.spec.jsx
@@ -69,8 +69,10 @@ describe('Main', () => {
     expect(tree.subTree('#authenticationErrorMessage')).to.be.ok;
   });
 
-  it('should show system down message when service is unavailable', () => {
-    const props = _.merge({}, defaultProps, { availability: 'unavailable' });
+  it('should show system down message when fetching enrollment data fails', () => {
+    const props = _.merge({}, defaultProps, {
+      availability: 'getEnrollmentDataFailure',
+    });
     const tree = SkinDeep.shallowRender(<Main {...props} />);
     expect(tree.subTree('#backendErrorMessage')).to.be.ok;
   });

--- a/src/applications/post-911-gib-status/tests/reducers/index.unit.spec.js
+++ b/src/applications/post-911-gib-status/tests/reducers/index.unit.spec.js
@@ -62,7 +62,7 @@ describe('post911GIBStatus reducer', () => {
     });
 
     expect(state.enrollmentData).to.be.null;
-    expect(state.availability).to.equal('unavailable');
+    expect(state.availability).to.equal('getEnrollmentDataFailure');
   });
 
   it('should handle setting the service availability', () => {

--- a/src/applications/post-911-gib-status/utils/helpers.jsx
+++ b/src/applications/post-911-gib-status/utils/helpers.jsx
@@ -4,7 +4,6 @@ import { Link } from 'react-router';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import { formatDateParsedZoneLong } from '../../../platform/utilities/date';
-import CallHRC from '../../../platform/static-data/CallHRC';
 import EducationWizard from '../components/EducationWizard';
 import wizardConfig from './wizardConfig';
 
@@ -157,43 +156,23 @@ export function notQualifiedWarning() {
 }
 
 export const backendErrorMessage = (
-  <div id="backendErrorMessage" className="row">
-    <div className="medium-8 columns">
-      <h3>We’re sorry. Something went wrong on our end.</h3>
-      <p>
-        We’re having trouble finding your Post-9/11 GI Bill Statement of
-        Benefits right now.
-      </p>
-      <p>
-        <strong>This could be for 1 of 3 reasons:</strong>
-      </p>
-      <ul>
-        <li>
-          We’re still processing your education benefits application and we
-          haven’t yet created a record for you. We usually process applications
-          within 30 days. If you applied less than 30 days ago, please check
-          back soon.
-        </li>
-        <li>
-          The name on your VA.gov account doesn’t exactly match the name we have
-          in our Post-9/11 GI Bill records.
-        </li>
-        <li>
-          You haven’t yet applied for Post-9/11 GI Bill education benefits.
-        </li>
-      </ul>
-      <p>
-        If you think your Statement of Benefits should be here, please{' '}
-        <CallHRC />
-      </p>
-      <Link className="usa-button usa-button-primary" to="/">
-        Back to Post-9/11 GI Bill
-      </Link>
-      <br />
-      <br />
-      <br />
-      <br />
-    </div>
+  <div id="backendErrorMessage">
+    <h3>
+      We’re sorry. Our system isn't working right now. Please try again or check
+      back soon.
+    </h3>
+    <Link className="usa-button usa-button-primary" to="/">
+      Back to Post-9/11 GI Bill
+    </Link>
+  </div>
+);
+
+export const genericErrorMessage = (
+  <div>
+    <h3>We’re sorry. Something went wrong on our end. Please try again.</h3>
+    <Link className="usa-button usa-button-primary" to="/">
+      Back to Post-9/11 GI Bill
+    </Link>
   </div>
 );
 


### PR DESCRIPTION
## Description
This makes updates to our `50x` errors in letters, as well as updating the default fallback now

## Testing done
Manual verification in the GIBS app

## Screenshots

**Before**
<img width="959" alt="old error message" src="https://user-images.githubusercontent.com/13280995/60138933-b6791d00-9771-11e9-845e-7ec900e65966.png">

**After (503/504 error OR getEnrollmentDataFailure)**

<img width="1015" alt="backEndServiceError" src="https://user-images.githubusercontent.com/13280995/60138938-baa53a80-9771-11e9-8340-b43eaba81bf1.png">

**Generic Fallback Message**
<img width="998" alt="generic message" src="https://user-images.githubusercontent.com/13280995/60138983-dd375380-9771-11e9-841c-d875242d6488.png">

