### PR TITLE
VAGOV-4054: add share links to community stories pages

### DIFF
--- a/src/site/facilities/facility_social_links.drupal.liquid
+++ b/src/site/facilities/facility_social_links.drupal.liquid
@@ -1,4 +1,4 @@
-<section class="feature vads-u-background-color--gray-lightest vads-u-padding-x--4 vads-u-padding-y--3">
+<section class="feature vads-u-background-color--gray-lightest vads-u-margin-top--4 small-screen:vads-u-margin-top--6 vads-u-padding-x--2 small-screen:vads-u-padding-x--4 vads-u-padding-y--3">
     <h3>Get updates from us</h3>
     <div class="va-c-list-link-teasers">
         {% if fieldFacebook != empty || fieldTwitter != empty %}

--- a/src/site/facilities/story_social_share.drupal.liquid
+++ b/src/site/facilities/story_social_share.drupal.liquid
@@ -1,0 +1,20 @@
+{% comment %}
+    @TODO:
+    click analytics
+{% endcomment %}
+
+<div id="va-c-social-share" class="vads-u-margin-bottom--0p5 medium-screen:vads-u-margin-bottom--2">
+    <ul class="usa-unstyled-list vads-u-display--flex">
+        <li class="vads-u-margin-right--5 medium-screen:vads-u-margin-right--2p5">
+            <a class="va-js-share-link" href="https://www.facebook.com/sharer/sharer.php?href={{ hostUrl }}{{ entityUrl.path }}">
+                <i class="va-c-social-icon fab fa-facebook vads-u-margin-right--0p5"></i>Share on Facebook
+            </a>
+        </li>
+
+        <li class="vads-u-flex--1">
+            <a class="va-js-share-link" href="https://twitter.com/intent/tweet?text={{ title }}&url={{ hostUrl }}{{ entityUrl.path }}">
+                <i class="va-c-social-icon fab fa-twitter vads-u-margin-right--0p5"></i>Share on Twitter
+            </a>
+        </li>
+    </ul>
+</div>

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -182,7 +182,7 @@ Example data:
           <div class="usa-grid usa-grid-full">
             <div class="usa-width-one-half vads-facility-hub-cta">
               <a href="/health-care/secure-messaging/">
-                <i class="fa fa-comments vads-facility-hub-cta-circle">&nbsp;</i>
+                <i class="far fa-comments vads-facility-hub-cta-circle">&nbsp;</i>
                 <span class="vads-facility-hub-cta-label">Send a secure message to your health care team <i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
               </a>
             </div>
@@ -199,7 +199,7 @@ Example data:
             <div class="usa-width-one-half vads-facility-hub-cta vads-facility-hub-cta-last-line">
 
               <a href="/health-care/schedule-view-va-appointments/">
-                <i class="fa fa-calendar-check vads-facility-hub-cta-circle">&nbsp;</i>
+                <i class="far fa-calendar-check vads-facility-hub-cta-circle">&nbsp;</i>
                 <span class="vads-facility-hub-cta-label">Schedule and view your appointments <i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
               </a>
             </div>
@@ -231,7 +231,7 @@ Example data:
 
         <!-- Events -->
         <section>
-          <h3 class="vads-u-margin-bottom--2p5">Community Events</h3>
+          <h3 class="vads-u-margin-top--4 vads-u-margin-bottom--0">Community Events</h3>
           <div class="usa-grid usa-grid-full region-list vads-u-margin-bottom--2 vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
           {% for event in eventTeasers.entities %}
             <div class="region-grid event">

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -82,9 +82,12 @@ Example data:
                         {% assign author = fieldAuthor.entity %}
                         <div class="authored-by-line vads-u-margin-bottom--0p5 vads-u-font-weight--bold">By {{ author.title }}{% if author.fieldDescription != empty %}, {{ author.fieldDescription }} {% endif %}</div>
                     {% endif %}
-                    <div class="created-line ">
+                    <div class="created-line vads-u-margin-bottom--2p5">
                         <time datetime="{{ created | dateFromUnix: 'YYYY-MM-DD'}}">{{ created | humanizeTimestamp }}</time>
                     </div>
+
+                    {% include "src/site/facilities/story_social_share.drupal.liquid" %}
+
                     <div class="usa-grid usa-grid-full vads-u-margin-bottom--2">
                         <div class="va-introtext">
                             <p>{{ fieldIntroText }}</p>

--- a/src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid
+++ b/src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid
@@ -6,7 +6,7 @@
     }
 {% endcomment %}
 {% if paragraph != empty %}
-<section class="feature vads-u-padding-x--4 vads-u-padding-y--3">
+<section class="feature vads-u-padding-x--2 small-screen:vads-u-padding-x--4 vads-u-padding-y--3">
     <h3>
         {{ paragraph.fieldTitle }}
     </h3>

--- a/src/site/teasers/news_story.drupal.liquid
+++ b/src/site/teasers/news_story.drupal.liquid
@@ -29,7 +29,7 @@ Example data:
 {% assign isStoriesPage = entityUrl.path | isPage: "stories" %}
 <div class="region-list usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
     <div class="region-grid {% if isStoriesPage %}stories-list{% endif %}">
-        <{{ header }} class="{% if isStoriesPage %}vads-u-font-size--md medium-screen:vads-u-font-size--lg{% endif %} medium-screen:vads-u-margin-bottom--0p5"><a href="{{ node.entityUrl.path }}">{{ node.title }}</a></{{ header }}>
+        <{{ header }} class="{% if isStoriesPage %}vads-u-font-size--md medium-screen:vads-u-font-size--lg{% endif %} vads-u-margin-top--0 medium-screen:vads-u-margin-bottom--0p5"><a href="{{ node.entityUrl.path }}">{{ node.title }}</a></{{ header }}>
         <p class="vads-u-margin-y--0">{{ node.fieldIntroText | truncatewords: 60, "..." }}</p>
     </div>
     <div class="region-grid {% if isStoriesPage %}stories-list{% endif %} vads-u-order--first small-screen:vads-u-order--initial vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">


### PR DESCRIPTION
#10156  Description
+ add share links to community stories pages
+ minor styling fixes for responsive views

## Testing done
locally with staging data

1. rebuild site
2. browse to a community story page such as http://localhost:3001/pittsburgh-health-care/stories/i-care-award-winners-recognized/
3. check to make sure the facebook and twitter links show up and link to the correct page

## Screenshots
![image](https://user-images.githubusercontent.com/19178435/60140848-e3c0cd80-9767-11e9-9a94-24682198e5a3.png)

## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-4054
- Includes `Share on Facebook` and `Share on twitter` links, beneath date published
(everything else was already completed in a different story)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
