### PR TITLE
Update My Health link in personalization dropdown

### DIFF
--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { logout } from 'platform/user/authentication/utilities';
 import recordEvent from 'platform/monitoring/record-event';
-import { mhvBaseUrl } from 'platform/site-wide/cta-widget/helpers';
 
 const recordNavUserEvent = section => () => {
   recordEvent({ event: 'nav-user', 'nav-user-section': section });
@@ -32,9 +31,7 @@ class PersonalizationDropdown extends React.Component {
         </li>
         <li>
           <a
-            href={`${mhvBaseUrl()}/mhv-portal-web/home`}
-            target="_blank"
-            rel="noopener noreferrer"
+            href="/health-care/my-health-account-validation/"
             onClick={recordMyHealthEvent}
           >
             My Health


### PR DESCRIPTION
## Description
The "My Health" link in the drop down when clicking a user's logged in name in the nav should direct them to `/health-care/my-health-account-validation/`

## Testing done
Tested locally

## Screenshots
![Screen Shot 2019-06-26 at 1 29 44 AM](https://user-images.githubusercontent.com/786704/60164207-01b32000-97b2-11e9-9321-f3f1e5754669.png)



## Acceptance criteria
- [ ] The "My Health" link in the drop down when clicking a user's logged in name in the nav should direct them to `/health-care/my-health-account-validation/`


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
