### PR TITLE
[Static pages] Change widget heading to H2

### DIFF
--- a/src/applications/disability-benefits/wizard/createWizard.jsx
+++ b/src/applications/disability-benefits/wizard/createWizard.jsx
@@ -24,7 +24,7 @@ export default function createDisabilityIncreaseApplicationStatus(
             stayAfterDelete
             applyRender={() => (
               <div itemScope itemType="http://schema.org/Question">
-                <h3 itemProp="name">How do I file my claim?</h3>
+                <h2 itemProp="name">How do I file my claim?</h2>
                 <div
                   itemProp="acceptedAnswer"
                   itemScope


### PR DESCRIPTION
## Description
This PR changes the heading tag for appplication-status React widgets on disability pages to H2.

## Testing done
Todo

## Screenshots
Todo

## Acceptance criteria
- [x] Correct heading tag is used

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
