### PR TITLE
1995 bah 19026

### DIFF
--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -14,27 +14,6 @@ const levels = [
   ['sponsorTransferredBenefits'],
 ];
 
-const newBenefitOptions = !environment.isProduction()
-  ? [
-      { label: 'Applying for a new benefit', value: 'yes' },
-      {
-        label: 'Updating my current education benefits',
-        value: 'no',
-      },
-      {
-        label:
-          'Extending my benefit using Edith Nourse Rogers STEM Scholarship',
-        value: 'extend',
-      },
-    ]
-  : [
-      { label: 'Applying for a new benefit', value: 'yes' },
-      {
-        label: 'Updating my current education benefits',
-        value: 'no',
-      },
-    ];
-
 export default class EducationWizard extends React.Component {
   constructor(props) {
     super(props);
@@ -124,7 +103,16 @@ export default class EducationWizard extends React.Component {
               additionalFieldsetClass="wizard-fieldset"
               name="newBenefit"
               id="newBenefit"
-              options={newBenefitOptions}
+              options={[
+                { label: 'Applying for a new benefit', value: 'yes' },
+                {
+                  label: 'Updating my current education benefits',
+                  value: 'no',
+                },
+                ...(environment.isProduction()
+                  ? [{ label: 'STEM', value: 'extend' }]
+                  : []),
+              ]}
               onValueChange={({ value }) =>
                 this.answerQuestion('newBenefit', value)
               }

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -291,12 +291,10 @@ export default class EducationWizard extends React.Component {
               nationalCallToService === 'no' &&
               vetTecBenefit === 'yes' &&
               this.getButton('0994')}
-            {!environment.isProduction() &&
-              newBenefit === 'extend' &&
-              this.getButton('1995')}
-            {newBenefit === 'no' &&
-              (transferredEduBenefits === 'transferred' ||
-                transferredEduBenefits === 'own') &&
+            {((!environment.isProduction() && newBenefit === 'extend') ||
+              (newBenefit === 'no' &&
+                (transferredEduBenefits === 'transferred' ||
+                  transferredEduBenefits === 'own'))) &&
               this.getButton('1995')}
             {newBenefit === 'no' &&
               transferredEduBenefits === 'fry' &&

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -4,6 +4,8 @@ import classNames from 'classnames';
 
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 
+import environment from '../../../platform/utilities/environment';
+
 const levels = [
   ['newBenefit'],
   ['serviceBenefitBasedOn', 'transferredEduBenefits'],
@@ -107,7 +109,7 @@ export default class EducationWizard extends React.Component {
                   label: 'Updating my current education benefits',
                   value: 'no',
                 },
-                {
+                !environment.isProduction() && {
                   label:
                     'Extending my benefit using Edith Nourse Rogers STEM Scholarship',
                   value: 'extend',
@@ -289,7 +291,9 @@ export default class EducationWizard extends React.Component {
               nationalCallToService === 'no' &&
               vetTecBenefit === 'yes' &&
               this.getButton('0994')}
-            {newBenefit === 'extend' && this.getButton('1995')}
+            {!environment.isProduction() &&
+              newBenefit === 'extend' &&
+              this.getButton('1995')}
             {newBenefit === 'no' &&
               (transferredEduBenefits === 'transferred' ||
                 transferredEduBenefits === 'own') &&

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -107,6 +107,11 @@ export default class EducationWizard extends React.Component {
                   label: 'Updating my current education benefits',
                   value: 'no',
                 },
+                {
+                  label:
+                    'Extending my benefit using Edith Nourse Rogers STEM Scholarship',
+                  value: 'extend',
+                },
               ]}
               onValueChange={({ value }) =>
                 this.answerQuestion('newBenefit', value)
@@ -284,6 +289,7 @@ export default class EducationWizard extends React.Component {
               nationalCallToService === 'no' &&
               vetTecBenefit === 'yes' &&
               this.getButton('0994')}
+            {newBenefit === 'extend' && this.getButton('1995')}
             {newBenefit === 'no' &&
               (transferredEduBenefits === 'transferred' ||
                 transferredEduBenefits === 'own') &&

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -14,6 +14,27 @@ const levels = [
   ['sponsorTransferredBenefits'],
 ];
 
+const newBenefitOptions = !environment.isProduction()
+  ? [
+      { label: 'Applying for a new benefit', value: 'yes' },
+      {
+        label: 'Updating my current education benefits',
+        value: 'no',
+      },
+      {
+        label:
+          'Extending my benefit using Edith Nourse Rogers STEM Scholarship',
+        value: 'extend',
+      },
+    ]
+  : [
+      { label: 'Applying for a new benefit', value: 'yes' },
+      {
+        label: 'Updating my current education benefits',
+        value: 'no',
+      },
+    ];
+
 export default class EducationWizard extends React.Component {
   constructor(props) {
     super(props);
@@ -103,18 +124,7 @@ export default class EducationWizard extends React.Component {
               additionalFieldsetClass="wizard-fieldset"
               name="newBenefit"
               id="newBenefit"
-              options={[
-                { label: 'Applying for a new benefit', value: 'yes' },
-                {
-                  label: 'Updating my current education benefits',
-                  value: 'no',
-                },
-                !environment.isProduction() && {
-                  label:
-                    'Extending my benefit using Edith Nourse Rogers STEM Scholarship',
-                  value: 'extend',
-                },
-              ]}
+              options={newBenefitOptions}
               onValueChange={({ value }) =>
                 this.answerQuestion('newBenefit', value)
               }
@@ -291,10 +301,12 @@ export default class EducationWizard extends React.Component {
               nationalCallToService === 'no' &&
               vetTecBenefit === 'yes' &&
               this.getButton('0994')}
-            {((!environment.isProduction() && newBenefit === 'extend') ||
-              (newBenefit === 'no' &&
-                (transferredEduBenefits === 'transferred' ||
-                  transferredEduBenefits === 'own'))) &&
+            {!environment.isProduction() &&
+              newBenefit === 'extend' &&
+              this.getButton('1995')}
+            {newBenefit === 'no' &&
+              (transferredEduBenefits === 'transferred' ||
+                transferredEduBenefits === 'own') &&
               this.getButton('1995')}
             {newBenefit === 'no' &&
               transferredEduBenefits === 'fry' &&

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -109,8 +109,14 @@ export default class EducationWizard extends React.Component {
                   label: 'Updating my current education benefits',
                   value: 'no',
                 },
-                ...(environment.isProduction()
-                  ? [{ label: 'STEM', value: 'extend' }]
+                ...(!environment.isProduction()
+                  ? [
+                      {
+                        label:
+                          'Extending my benefit using Edith Nourse Rogers STEM Scholarship',
+                        value: 'extend',
+                      },
+                    ]
                   : []),
               ]}
               onValueChange={({ value }) =>

--- a/src/applications/edu-benefits/tests/components/EducationWizard.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/components/EducationWizard.unit.spec.jsx
@@ -63,6 +63,12 @@ describe('<EducationWizard>', () => {
   });
   it('should show 1995 button', () => {
     const tree = SkinDeep.shallowRender(<EducationWizard />);
+    answerQuestion(tree, 'newBenefit', 'extend');
+    expect(tree.subTree('#apply-now-link').props.href.endsWith('1995')).to.be
+      .true;
+  });
+  it('should show 1995 button', () => {
+    const tree = SkinDeep.shallowRender(<EducationWizard />);
 
     answerQuestion(tree, 'newBenefit', 'no');
     answerQuestion(tree, 'transferredEduBenefits', 'own');


### PR DESCRIPTION
## Description
As a user, I need to be able to find the STEM application using the form wizard so that I can apply for the STEM Scholarship.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19026

## Testing done
Manual, unit, and E2E Tests all pass locally

## Screenshots
<img width="783" alt="Screen Shot 2019-06-26 at 12 04 17 PM" src="https://user-images.githubusercontent.com/48804834/60196199-99445d00-980a-11e9-9d19-dd3dfafd63ec.png">

<img width="750" alt="Screen Shot 2019-06-26 at 12 04 28 PM" src="https://user-images.githubusercontent.com/48804834/60196232-a5c8b580-980a-11e9-9e56-2223c0ae6b88.png">


## Acceptance criteria
- [x] The following question "Are you applying for a new benefit or updating your current education benefits?" has the following available answers:
"Applying for a new benefit"
"Updating current education benefits"
"Extending my benefit using Edith Nourse Rogers STEM Scholarship"
- [x] There is no change to the wizard workflow if the user answers "Applying for a new benefit" to the question in AC#1.
- [x] There is no change to the wizard workflow if the user answers "Updating current education benefits" to the question in AC#1.
- [x] The user is redirected to form 22-1995 if the user answers "Extending my benefit using Edith Nourse Rogers STEM Scholarship" to the question in AC#1.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
