### PR TITLE
Added Stem scholarship notification to landing page

### DIFF
--- a/src/applications/gi/components/content/StemScholarshipNotification.jsx
+++ b/src/applications/gi/components/content/StemScholarshipNotification.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export const StemScholarshipNotification = () => (
+  <div>
+    <span className="usa-label">New</span>
+    <div className="feature">
+      <h4>The Rogers STEM Scholarship</h4>
+      <p>
+        On August 1, 2019, VA is launching the Edith Nourse Rogers STEM
+        Scholarship program for students training in high demand STEM (Science,
+        Technology, Engineering, and Math) fields.
+      </p>
+      <p>
+        To learn more about this scholarship,{' '}
+        <a
+          href="https://benefits.va.gov/gibill/fgib/stem.asp"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {' '}
+          visit the Rogers STEM Scholarship website.
+        </a>
+      </p>
+    </div>
+  </div>
+);
+
+export default StemScholarshipNotification;

--- a/src/applications/gi/components/content/StemScholarshipNotification.jsx
+++ b/src/applications/gi/components/content/StemScholarshipNotification.jsx
@@ -8,7 +8,7 @@ export const StemScholarshipNotification = () => (
       <p>
         On August 1, 2019, VA is launching the Edith Nourse Rogers STEM
         Scholarship program for students training in high demand STEM (Science,
-        Technology, Engineering, and Math) programs.
+        Technology, Engineering, and Math) program.
       </p>
       <p>
         To learn more about this scholarship,{' '}

--- a/src/applications/gi/components/content/StemScholarshipNotification.jsx
+++ b/src/applications/gi/components/content/StemScholarshipNotification.jsx
@@ -8,7 +8,7 @@ export const StemScholarshipNotification = () => (
       <p>
         On August 1, 2019, VA is launching the Edith Nourse Rogers STEM
         Scholarship program for students training in high demand STEM (Science,
-        Technology, Engineering, and Math) fields.
+        Technology, Engineering, and Math) programs.
       </p>
       <p>
         To learn more about this scholarship,{' '}

--- a/src/applications/gi/components/content/StemScholarshipNotification.jsx
+++ b/src/applications/gi/components/content/StemScholarshipNotification.jsx
@@ -7,11 +7,11 @@ export const StemScholarshipNotification = () => (
       <h4>The Rogers STEM Scholarship</h4>
       <p>
         On August 1, 2019, VA is launching the Edith Nourse Rogers STEM
-        Scholarship program for students training in high demand STEM (Science,
+        Scholarship for students enrolled in-high demand STEM (Science,
         Technology, Engineering, and Math) program.
       </p>
       <p>
-        To learn more about this scholarship,{' '}
+        To learn more about this Scholarship,{' '}
         <a
           href="https://benefits.va.gov/gibill/fgib/stem.asp"
           target="_blank"

--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -12,6 +12,7 @@ import {
 import VideoSidebar from '../components/content/VideoSidebar';
 import KeywordSearch from '../components/search/KeywordSearch';
 import EligibilityForm from '../components/search/EligibilityForm';
+import StemScholarshipNotification from '../components/content/StemScholarshipNotification';
 
 export class LandingPage extends React.Component {
   constructor(props) {
@@ -91,6 +92,7 @@ export class LandingPage extends React.Component {
 
           <div className="small-12 usa-width-one-third medium-4 columns">
             <VideoSidebar />
+            <StemScholarshipNotification />
           </div>
         </div>
       </span>


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19024

## Testing done
Dev tested.



## Screenshots
<img width="1111" alt="Screen Shot 2019-06-26 at 1 57 28 PM" src="https://user-images.githubusercontent.com/48804654/60203302-5e4a2580-981a-11e9-8b6c-4c3072c70394.png">


## Acceptance criteria
- [ ] An information alert is displayed on the CT Landing Page in the Right Information Pane.
     - The text content is: 
        "On August 1, 2019, VA is launching the Edith Nourse Rogers STEM Scholarship for students enrolled in-high demand STEM (Science, Technology, Engineering, and Math) program.

         To learn more about this Scholarship, visit the Rogers STEM Scholarship website."
- [ ]  "visit the Rogers STEM Scholarship website" is a link to the following page: https://benefits.va.gov/gibill/fgib/stem.asp## 

Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
