### PR TITLE
stop adding hub icon markup if hub is not specified

### DIFF
--- a/src/site/includes/level2-index.html
+++ b/src/site/includes/level2-index.html
@@ -10,9 +10,11 @@ Used for index pages in top-level paths (e.g. hubpages /health-care/index.html)
 <main>
   <div class="usa-grid usa-grid-full">
     <article class="usa-width-two-thirds">
-      <div class="inline hub-main-icon">
-        <i class="icon-large white hub-icon-{{hub}} hub-background-{{hub}}"></i>
-      </div>
+      {% if hub != empty %}
+        <div class="inline hub-main-icon">
+          <i class="icon-large white hub-icon-{{hub}} hub-background-{{hub}}"></i>
+        </div>
+      {% endif %}
       <div class="inline hub-main-title">
         <h1>
           {{ heading }}


### PR DESCRIPTION
## Description
Pages using the `level2-index` template render wrapper markup for the hub icon even if a hub icon is not specified in the content markdown. This PR makes rendering that markup conditional on the existence of a hub.

## Testing done
local

## Screenshots
**BEFORE**
![image](https://user-images.githubusercontent.com/20728956/60275092-2f7d8f00-98ae-11e9-8946-acb1ec499e16.png)

**AFTER**
![image](https://user-images.githubusercontent.com/20728956/60275100-35737000-98ae-11e9-9f46-97622166ad35.png)

## Acceptance criteria
- [x] Pages still look correct when a hub icon is specified

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs