### PR TITLE
VAGOV-000: Remove iswysiwyg check from headings plugin

### DIFF
--- a/src/site/stages/build/plugins/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/add-id-to-subheadings.js
@@ -40,11 +40,10 @@ function generateHeadingIds() {
         doc('h2, h3').each((i, el) => {
           const heading = doc(el);
           const parent = heading.parent();
-          const isInWysiwyg = parent.hasClass('processed-content');
           const isInAccordionButton = parent.hasClass('usa-accordion-button');
 
-          // skip heading if it already has an id and skip heading if it's in wysiwyg content
-          if (!heading.attr('id') && !isInWysiwyg && !isInAccordionButton) {
+          // skip heading if it already has an id and skip heading if it's in an accordion button
+          if (!heading.attr('id') && !isInAccordionButton) {
             const headingID = createUniqueId(heading);
             heading.attr('id', headingID);
             idAdded = true;


### PR DESCRIPTION
## Description
add-ids-to-headings plugin now automatically generates ids for H2s and H3s in wysiwygs

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
