### PR TITLE
Remove axe exceptions, convert to data-multiselectable attribute

### DIFF
--- a/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
@@ -30,24 +30,6 @@ function sitemapURLs() {
         '/find-locations/',
         // This is here because an aXe bug flags the autosuggest component on this page
         '/gi-bill-comparison-tool/',
-        // These pages use aria-multiselectable incorrectly, because of USWDS
-        '/sign-in-faq/',
-        '/burials-memorials/dependency-indemnity-compensation/',
-        '/disability/va-claim-exam/',
-        '/life-insurance/options-eligibility/fsgli/',
-        '/life-insurance/options-eligibility/vgli/',
-        '/housing-assistance/home-loans/how-to-apply/',
-        '/housing-assistance/home-loans/eligibility/',
-        '/pension/how-to-apply/fully-developed-claim/',
-        '/disability/how-to-file-claim/when-to-file/',
-        '/health-care/family-caregiver-benefits/champva/',
-        '/drupal/health-care/health-needs-conditions/mental-health/',
-        '/health-care/about-va-health-benefits/dental-care/',
-        '/health-care/health-needs-conditions/mental-health/',
-        '/disability/how-to-file-claim/when-to-file/pre-discharge-claim/',
-        '/disability/how-to-file-claim/evidence-needed/fully-developed-claims/',
-        '/disability/how-to-file-claim/evidence-needed/decision-ready-claims/',
-        '/disability/how-to-file-claim/evidence-needed/',
       ];
       // Whitelist of URLs to only test against the 'section508' rule set and not
       // the stricter 'wcag2a' rule set. For each URL added to this list, please

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -156,8 +156,8 @@
           {% unless difference contains '-' %}
             <div class="vads-u-margin-bottom--4">
                 <h2 id="prepare-for-your-visit" class="vads-u-margin-top--0 vads-u-font-size--lg small-screen:vads-u-font-size--xl vads-u-margin-bottom--2">Prepare for your visit</h2>
-                <div class="usa-accordion-bordered">
-                  <ul aria-multiselectable="false" class="usa-unstyled-list">
+                <div class="usa-accordion-bordered" data-multiselectable="false">
+                  <ul class="usa-unstyled-list">
                     {% for accordionItem in fieldLocationServices %}
                       {% assign item = accordionItem.entity %}
                       <li class="vads-u-margin-bottom--1">

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -156,7 +156,7 @@
           {% unless difference contains '-' %}
             <div class="vads-u-margin-bottom--4">
                 <h2 id="prepare-for-your-visit" class="vads-u-margin-top--0 vads-u-font-size--lg small-screen:vads-u-font-size--xl vads-u-margin-bottom--2">Prepare for your visit</h2>
-                <div class="usa-accordion-bordered" data-multiselectable="false">
+                <div class="usa-accordion-bordered">
                   <ul class="usa-unstyled-list">
                     {% for accordionItem in fieldLocationServices %}
                       {% assign item = accordionItem.entity %}

--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -26,8 +26,8 @@
 {% if entity.fieldCollapsiblePanelBordered %}
     {% assign accordionClass = 'usa-accordion-bordered' %}
 {% endif %}
-<div class="{{ accordionClass }}">
-    <ul class="usa-unstyled-list" aria-multiselectable="{{ entity.fieldCollapsiblePanelMulti }}">
+<div class="{{ accordionClass }}" data-multiselectable="{{ entity.fieldCollapsiblePanelMulti }}">
+    <ul class="usa-unstyled-list">
         {% for accordionItem in entity.fieldVaParagraphs %}
             {% assign item = accordionItem.entity %}
             <li>

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,9 +696,9 @@
     react-transition-group "1"
 
 "@department-of-veterans-affairs/formation@^6.6.3":
-  version "6.6.3"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.6.3.tgz#3bb2596952331514d83c405979dbe90c2f9c0b21"
-  integrity sha512-1DtAZOO2NH+5MOZq/VDCnq0PlNpZ6S85YBfrV+4N8KHuf3HgYpC7/37jweOM3bE3EabRk91s4qz2C9kdwTzxQg==
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.7.0.tgz#2f79bb8ef7b02ea70f8cf51c63105330b4283cce"
+  integrity sha512-QWEn6Vk67HYBqEm0NFmWUU68RLvwLeZNTHh3f3SLSONIn3QCZ0XYZqX49QVTHu12dPBPYZiMJU1x+2syL7yCZQ==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Description
Formation now supports using `data-multiselectable` instead of just `aria-selectable`, so we can update our code to use that instead and remove a bunch of exceptions to our axe tests.

## Testing done
Tested locally, ran tests

## Acceptance criteria
- [x] Accordions work, tests pass

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
