### PR TITLE
Update label text for content preference removal buttons

### DIFF
--- a/src/applications/personalization/preferences/components/PreferenceItem.jsx
+++ b/src/applications/personalization/preferences/components/PreferenceItem.jsx
@@ -94,12 +94,14 @@ export default class PreferenceItem extends React.Component {
               .”
             </p>
             <button
+              aria-label={`Remove ${title} content`}
               className="usa-button-primary"
               onClick={() => this.props.handleRemove(code)}
             >
               Remove
             </button>
             <button
+              aria-label={`Cancel this change and keep ${title} content`}
               className="usa-button-secondary"
               onClick={() => this.onCancelRemove(code)}
             >


### PR DESCRIPTION
## Description
The buttons in the confirm change alert need more explanatory text for screen reader users

## Testing done
Tested locally

## Screenshots
![Screen Shot 2019-06-28 at 10 54 09 AM](https://user-images.githubusercontent.com/634932/60351125-139fe900-9993-11e9-98eb-97593da1f1ef.png)


## Acceptance criteria
- [x] Buttons have aria-label text

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
