### PR TITLE
Don't show future dates in rx list

### DIFF
--- a/src/applications/personalization/dashboard/components/PrescriptionCard.jsx
+++ b/src/applications/personalization/dashboard/components/PrescriptionCard.jsx
@@ -1,21 +1,6 @@
-// import { Link } from 'react-router';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
-
-// import recordEvent from '../../../../platform/monitoring/record-event';
-import { formatDate } from '../utils/helpers';
-
-// Disabling interactivity.
-// See: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14499
-// function recordDashboardClick(product) {
-//   return () => {
-//     recordEvent({
-//       event: 'dashboard-navigation',
-//       'dashboard-action': 'view-button',
-//       'dashboard-product': product,
-//     });
-//   };
-// }
 
 export default function PrescriptionCard({ prescription }) {
   const {
@@ -24,6 +9,13 @@ export default function PrescriptionCard({ prescription }) {
     refillDate,
     isTrackable,
   } = prescription.attributes;
+
+  const submittedDate = moment(refillSubmitDate || refillDate).startOf('day');
+  const dateInPast =
+    submittedDate.isValid() &&
+    moment()
+      .startOf('day')
+      .isSameOrAfter(submittedDate);
 
   return (
     <div className="claim-list-item-container">
@@ -34,59 +26,22 @@ export default function PrescriptionCard({ prescription }) {
           ? 'We’ve shipped your order'
           : 'We’re working to fill your prescription'}
       </p>
-      <p>
-        <strong>You submitted your refill order on:</strong>{' '}
-        {formatDate(refillSubmitDate || refillDate, {
-          format: 'L',
-        })}
-      </p>
-      <p>
-        {
-          // Disabling interactivity.
-          // See: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14499
-          //   isTrackable ? (
-          //   <Link
-          //     key={`rx-${prescription.id}-track`}
-          //     className="rx-track-package-link usa-button"
-          //     href={`/health-care/prescriptions/${prescription.id}/track`}
-          //     onClick={recordDashboardClick('track-your-package')}
-          //   >
-          //     Track Your Package
-          //   </Link>
-          // ) : (
-          //   <Link
-          //     className="usa-button usa-button-primary"
-          //     href={`/health-care/prescriptions/${prescription.id}`}
-          //     onClick={recordDashboardClick('view-your-prescription')}
-          //   >
-          //     View Your Prescription
-          //     <i className="fa fa-chevron-right" />
-          //   </Link>
-          //   )
-        }
-      </p>
+      {dateInPast && (
+        <p>
+          <strong>You submitted your refill order on:</strong>{' '}
+          {submittedDate.format('L')}
+        </p>
+      )}
     </div>
   );
 }
 
 PrescriptionCard.propTypes = {
   prescription: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    type: PropTypes.string.isRequired,
     attributes: PropTypes.shape({
-      prescriptionId: PropTypes.number.isRequired,
-      prescriptionNumber: PropTypes.string.isRequired,
       prescriptionName: PropTypes.string.isRequired,
       refillSubmitDate: PropTypes.string,
       refillDate: PropTypes.string.isRequired,
-      refillRemaining: PropTypes.number.isRequired,
-      facilityName: PropTypes.string.isRequired,
-      orderedDate: PropTypes.string.isRequired,
-      quantity: PropTypes.number.isRequired,
-      expirationDate: PropTypes.string.isRequired,
-      dispensedDate: PropTypes.string,
-      stationNumber: PropTypes.string,
-      isRefillable: PropTypes.bool.isRequired,
       isTrackable: PropTypes.bool.isRequired,
     }).isRequired,
   }),

--- a/src/applications/personalization/dashboard/tests/components/PrescriptionCard.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/PrescriptionCard.unit.spec.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import moment from 'moment';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import PrescriptionCard from '../../components/PrescriptionCard';
+
+describe('<PrescriptionCard />', () => {
+  it('should display name and status', () => {
+    const prescription = {
+      attributes: {
+        prescriptionName: 'Test name',
+        isTrackable: false,
+        refillDate: '2018-03-28T05:00:00.000Z',
+        refillSubmitDate: '2019-05-28T23:27:53.000Z',
+      },
+    };
+
+    const wrapper = shallow(<PrescriptionCard prescription={prescription} />);
+
+    expect(wrapper.find('h3').text()).to.equal(
+      prescription.attributes.prescriptionName,
+    );
+    expect(
+      wrapper
+        .find('p')
+        .first()
+        .text(),
+    ).to.contain('We’re working to fill your prescription');
+    expect(
+      wrapper
+        .find('p')
+        .at(1)
+        .text(),
+    ).to.contain('05/28/2019');
+
+    wrapper.unmount();
+  });
+
+  it('should display shipped status', () => {
+    const prescription = {
+      attributes: {
+        prescriptionName: 'Test name',
+        isTrackable: true,
+        refillDate: '2018-03-28T05:00:00.000Z',
+        refillSubmitDate: '2019-05-28T23:27:53.000Z',
+      },
+    };
+
+    const wrapper = shallow(<PrescriptionCard prescription={prescription} />);
+
+    expect(
+      wrapper
+        .find('p')
+        .first()
+        .text(),
+    ).to.contain('We’ve shipped your order');
+
+    wrapper.unmount();
+  });
+
+  it('should fall back to past refill date', () => {
+    const prescription = {
+      attributes: {
+        prescriptionName: 'Test name',
+        isTrackable: false,
+        refillDate: '2018-03-28T05:00:00.000Z',
+        refillSubmitDate: null,
+      },
+    };
+
+    const wrapper = shallow(<PrescriptionCard prescription={prescription} />);
+    expect(
+      wrapper
+        .find('p')
+        .at(1)
+        .text(),
+    ).to.contain('03/28/2018');
+
+    wrapper.unmount();
+  });
+
+  it('should hide date if in the future', () => {
+    const prescription = {
+      attributes: {
+        prescriptionName: 'Test name',
+        isTrackable: false,
+        refillDate: moment()
+          .add(3, 'days')
+          .toISOString(),
+        refillSubmitDate: null,
+      },
+    };
+
+    const wrapper = shallow(<PrescriptionCard prescription={prescription} />);
+    expect(wrapper.find('p').length).to.equal(1);
+
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Description
Sometimes we get a next refill date instead of a submit/refilled date, this change hides the date paragraph when that happens so that we don't confuse users.

## Testing done
Tested locally

## Screenshots
![Screen Shot 2019-06-28 at 12 06 41 PM](https://user-images.githubusercontent.com/634932/60362604-612a4f00-99af-11e9-9500-df94af460aa1.png)


## Acceptance criteria
- [x] Date doesn't show when refill date is in the future and there's no submit date

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
