### PR TITLE
[Disability Calculator] Improve on aria-labelledby in rating rows

### DIFF
--- a/src/applications/disability-calculator/components/DisabilityRatingCalculator.jsx
+++ b/src/applications/disability-calculator/components/DisabilityRatingCalculator.jsx
@@ -125,13 +125,9 @@ export default class DisabilityRatingCalculator extends React.Component {
               id="ratingLabel"
             >
               Disability rating
-              <span className="sr-only">Enter Disability Rating</span>
             </div>
             <div className="vads-l-col--8" id="descriptionLabel">
               Optional description
-              <span className="sr-only">
-                Enter Optional Disability Description
-              </span>
             </div>
           </div>
           {this.state.ratings.map((ratingObj, idx) => (

--- a/src/applications/disability-calculator/components/RatingRow.jsx
+++ b/src/applications/disability-calculator/components/RatingRow.jsx
@@ -23,8 +23,14 @@ const RatingRow = ({
   const onDescriptionChange = e => {
     handleChange(indx, { ...ratingObj, description: e.target.value });
   };
+
+  const rowId = `disability-row-${indx + 1}`;
+
   return (
     <div className="rating vads-l-row">
+      <span id={rowId} className="sr-only">
+        row {indx + 1}
+      </span>
       <div className="vads-l-col--2 vads-u-padding-right--2">
         <input
           type="text"
@@ -36,7 +42,7 @@ const RatingRow = ({
           pattern="\d+"
           name="rating"
           ref={inputRef}
-          aria-labelledby="ratingLabel"
+          aria-labelledby={`ratingLabel ${rowId}`}
         />
       </div>
       <div className="vads-l-col--6">
@@ -45,7 +51,7 @@ const RatingRow = ({
           name="description"
           onChange={onDescriptionChange}
           value={ratingObj.description}
-          aria-labelledby="descriptionLabel"
+          aria-labelledby={`descriptionLabel ${rowId}`}
         />
       </div>
       <div className="vads-l-col--3">


### PR DESCRIPTION
## Description
This PR improves on the `aria-labelledby` attributes in the rating input and description inputs in each row by adding an ID field.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/429
## Testing done
Looked at DOM

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/60458999-fa56a100-9c0d-11e9-84f5-875e99f20b34.png)



## Acceptance criteria
- [ ] SR support is improved

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
