### PR TITLE
fix fragile date formatting unit test

### DIFF
--- a/src/applications/personalization/dashboard/tests/components/PrescriptionCard.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/PrescriptionCard.unit.spec.jsx
@@ -11,8 +11,8 @@ describe('<PrescriptionCard />', () => {
       attributes: {
         prescriptionName: 'Test name',
         isTrackable: false,
-        refillDate: '2018-03-28T05:00:00.000Z',
-        refillSubmitDate: '2019-05-28T23:27:53.000Z',
+        refillDate: '2018-03-28T12:00:00.000Z',
+        refillSubmitDate: '2019-05-28T12:00:00.000Z',
       },
     };
 
@@ -42,8 +42,8 @@ describe('<PrescriptionCard />', () => {
       attributes: {
         prescriptionName: 'Test name',
         isTrackable: true,
-        refillDate: '2018-03-28T05:00:00.000Z',
-        refillSubmitDate: '2019-05-28T23:27:53.000Z',
+        refillDate: '2018-03-28T12:00:00.000Z',
+        refillSubmitDate: '2019-05-28T12:00:00.000Z',
       },
     };
 
@@ -64,7 +64,7 @@ describe('<PrescriptionCard />', () => {
       attributes: {
         prescriptionName: 'Test name',
         isTrackable: false,
-        refillDate: '2018-03-28T05:00:00.000Z',
+        refillDate: '2018-03-28T12:00:00.000Z',
         refillSubmitDate: null,
       },
     };


### PR DESCRIPTION
## Description
~Fix a unit test that was failing locally when run in PDT at 6:30am~
Duh, the time I ran it doesn't matter at all, it only matters that I ran it on a computer in the PDT timezone.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs