### PR TITLE
Use spinner button on DD form

### DIFF
--- a/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
@@ -6,6 +6,7 @@ import set from 'platform/utilities/data/set';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import ErrorableTextInput from '@department-of-veterans-affairs/formation-react/ErrorableTextInput';
 import ErrorableSelect from '@department-of-veterans-affairs/formation-react/ErrorableSelect';
+import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 
 import { focusElement } from 'platform/utilities/ui';
 
@@ -163,13 +164,13 @@ class PaymentInformationEditModal extends React.Component {
             required
           />
 
-          <button
+          <LoadingButton
             type="submit"
             className="usa-button-primary vads-u-width--auto"
-            disabled={this.props.isSaving}
+            isLoading={this.props.isSaving}
           >
             Update
-          </button>
+          </LoadingButton>
 
           <button
             type="button"

--- a/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
@@ -174,6 +174,7 @@ class PaymentInformationEditModal extends React.Component {
 
           <button
             type="button"
+            disabled={this.props.isSaving}
             className="usa-button-secondary"
             onClick={this.props.onClose}
           >

--- a/src/platform/site-wide/loading-button/LoadingButton.jsx
+++ b/src/platform/site-wide/loading-button/LoadingButton.jsx
@@ -14,10 +14,10 @@ export default function LoadingButton({
   );
   return (
     <button
+      className="usa-button"
       {...props}
       disabled={isLoading || disabled}
       onClick={onClick}
-      className="usa-button"
     >
       {contents}
     </button>


### PR DESCRIPTION
## Description
The Update button is disabled when you save your info, which isn't enough feedback, so we're updating it to use the loading button that other other dashboard forms use.

## Testing done
Tested locally

## Screenshots
![Screen Shot 2019-07-02 at 12 12 32 PM](https://user-images.githubusercontent.com/634932/60528658-e7ea6f00-9cc2-11e9-8425-e86624c0f5e9.png)


## Acceptance criteria
- [x] Button has a spinner when clicked

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
