### PR TITLE
guard against `ga` being incorrectly initialized

### DIFF
--- a/src/applications/personalization/profile360/actions/paymentInformation.js
+++ b/src/applications/personalization/profile360/actions/paymentInformation.js
@@ -26,12 +26,18 @@ export function fetchPaymentInformation() {
 
 export function savePaymentInformation(fields) {
   return async dispatch => {
+    let gaClientId;
+    try {
+      // eslint-disable-next-line no-undef
+      gaClientId = ga.getAll()[0].get('clientId');
+    } catch (e) {
+      // don't want to break submitting because of a weird GA issue
+    }
     const apiRequestOptions = {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         ...fields,
-        // eslint-disable-next-line no-undef
-        gaClientId: ga.getAll()[0].get('clientId'),
+        gaClientId,
       }),
       method: 'PUT',
       mode: 'cors',

--- a/src/applications/personalization/profile360/tests/actions/paymentInformation.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/actions/paymentInformation.unit.spec.js
@@ -6,12 +6,10 @@ import * as paymentInformationActions from '../../actions/paymentInformation';
 let oldFetch;
 let oldGA;
 
-const setup = () => {
+const setup = ({ mockGA }) => {
   oldFetch = global.fetch;
   oldGA = global.ga;
   global.fetch = sinon.stub();
-  global.ga = sinon.stub();
-  global.ga.getAll = sinon.stub();
   global.fetch.returns(
     Promise.resolve({
       headers: { get: () => 'application/json' },
@@ -24,15 +22,19 @@ const setup = () => {
         }),
     }),
   );
-  global.ga.getAll.returns([
-    {
-      get: key => {
-        const value = key === 'clientId' ? '1234567890:0987654321' : undefined;
-
-        return value;
+  if (mockGA) {
+    global.ga = sinon.stub();
+    global.ga.getAll = sinon.stub();
+    global.ga.getAll.returns([
+      {
+        get: key => {
+          const value =
+            key === 'clientId' ? '1234567890:0987654321' : undefined;
+          return value;
+        },
       },
-    },
-  ]);
+    ]);
+  }
 };
 
 const teardown = () => {
@@ -41,37 +43,62 @@ const teardown = () => {
 };
 
 describe('actions/paymentInformation', () => {
-  beforeEach(setup);
-  afterEach(teardown);
+  describe('when global `ga` is set up correctly', () => {
+    beforeEach(() => setup({ mockGA: true }));
+    afterEach(teardown);
 
-  it('calls fetch and dispatches FETCH_PAYMENT_INFORMATION_SUCCESS', async () => {
-    const actionCreator = paymentInformationActions.fetchPaymentInformation();
-    const dispatch = sinon.spy();
+    it('calls fetch and dispatches FETCH_PAYMENT_INFORMATION_SUCCESS', async () => {
+      const actionCreator = paymentInformationActions.fetchPaymentInformation();
+      const dispatch = sinon.spy();
 
-    await actionCreator(dispatch);
+      await actionCreator(dispatch);
 
-    expect(dispatch.called).to.be.true;
-    expect(dispatch.firstCall.args[0].type).to.be.equal(
-      paymentInformationActions.PAYMENT_INFORMATION_FETCH_SUCCEEDED,
-    );
-    expect(global.fetch.called).to.be.true;
+      expect(dispatch.called).to.be.true;
+      expect(dispatch.firstCall.args[0].type).to.be.equal(
+        paymentInformationActions.PAYMENT_INFORMATION_FETCH_SUCCEEDED,
+      );
+      expect(global.fetch.called).to.be.true;
+    });
+
+    it('calls fetch and dispatches SAVE_PAYMENT_INFORMATION', async () => {
+      const actionCreator = paymentInformationActions.savePaymentInformation({
+        data: 'value',
+      });
+      const dispatch = sinon.spy();
+
+      await actionCreator(dispatch);
+
+      expect(global.fetch.called).to.be.true;
+      expect(dispatch.calledTwice).to.be.true;
+      expect(dispatch.firstCall.args[0].type).to.be.equal(
+        paymentInformationActions.PAYMENT_INFORMATION_SAVE_STARTED,
+      );
+      expect(dispatch.secondCall.args[0].type).to.be.equal(
+        paymentInformationActions.PAYMENT_INFORMATION_SAVE_SUCCEEDED,
+      );
+    });
   });
 
-  it('calls fetch and dispatches SAVE_PAYMENT_INFORMATION', async () => {
-    const actionCreator = paymentInformationActions.savePaymentInformation({
-      data: 'value',
+  describe('when `ga` is not set up correctly', () => {
+    beforeEach(() => setup({ mockGA: false }));
+    afterEach(teardown);
+
+    it('calls fetch and dispatches SAVE_PAYMENT_INFORMATION', async () => {
+      const actionCreator = paymentInformationActions.savePaymentInformation({
+        data: 'value',
+      });
+      const dispatch = sinon.spy();
+
+      await actionCreator(dispatch);
+
+      expect(global.fetch.called).to.be.true;
+      expect(dispatch.calledTwice).to.be.true;
+      expect(dispatch.firstCall.args[0].type).to.be.equal(
+        paymentInformationActions.PAYMENT_INFORMATION_SAVE_STARTED,
+      );
+      expect(dispatch.secondCall.args[0].type).to.be.equal(
+        paymentInformationActions.PAYMENT_INFORMATION_SAVE_SUCCEEDED,
+      );
     });
-    const dispatch = sinon.spy();
-
-    await actionCreator(dispatch);
-
-    expect(global.fetch.called).to.be.true;
-    expect(dispatch.calledTwice).to.be.true;
-    expect(dispatch.firstCall.args[0].type).to.be.equal(
-      paymentInformationActions.PAYMENT_INFORMATION_SAVE_STARTED,
-    );
-    expect(dispatch.secondCall.args[0].type).to.be.equal(
-      paymentInformationActions.PAYMENT_INFORMATION_SAVE_SUCCEEDED,
-    );
   });
 });


### PR DESCRIPTION
## Description
I ran into an issue locally where this line attempting to pull data out of `ga` failed silently (console error only) and prevented the direct deposit payment info from getting updated.

## Testing done
Added a test for the case where `ga` is not properly set up.

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs