### PR TITLE
Remove special handling of `activeduty` ESR status

### DIFF
--- a/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
+++ b/src/applications/hca/components/HCAEnrollmentStatusFAQ.jsx
@@ -42,11 +42,10 @@ const HCAEnrollmentStatusFAQ = ({
   showingReapplyForHealthCareContent,
   showReapplyContent,
 }) => {
-  const applyAllowed =
-    enrollmentStatus === HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied;
+  const applyAllowed = enrollmentStatus === HCA_ENROLLMENT_STATUSES.activeDuty;
   const reapplyAllowed =
     new Set([
-      HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied,
+      HCA_ENROLLMENT_STATUSES.activeDuty,
       HCA_ENROLLMENT_STATUSES.deceased,
       HCA_ENROLLMENT_STATUSES.enrolled,
     ]).has(enrollmentStatus) === false;

--- a/src/applications/hca/constants.js
+++ b/src/applications/hca/constants.js
@@ -1,9 +1,5 @@
 export const HCA_ENROLLMENT_STATUSES = Object.freeze({
-  // `activeduty` is a possible value for `parsedStatus` from `health_care_applications/enrollment_status` but we do not use it in the front end...
   activeDuty: 'activeduty',
-  // ...instead we convert it to one of these two values in the HCA reducer:
-  activeDutyHasApplied: 'activeduty_has_applied',
-  activeDutyHasNotApplied: 'activeduty_has_not_applied',
   canceledDeclined: 'canceled_declined',
   closed: 'closed',
   deceased: 'deceased',

--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -446,21 +446,6 @@ export function getFAQContent(enrollmentStatus) {
 
   const faqBlock8 = (
     <>
-      <h4>When will I find out if I’m enrolled in VA health care?</h4>
-      <p>
-        We’ll make our final decision on your application after you've separated
-        from service.
-      </p>
-      <p>
-        If we enroll you in VA health care, the preferred VA medical center you
-        selected when you applied will contact you. You can also check back here
-        after separation to find out the current status of your application.
-      </p>
-    </>
-  );
-
-  const faqBlock9 = (
-    <>
       <h4>Can I apply for VA health care?</h4>
       <p>
         As an active-duty service member, you can apply for VA health care if
@@ -492,16 +477,7 @@ export function getFAQContent(enrollmentStatus) {
     </>
   );
 
-  const faqBlock10 = (
-    <>
-      <h4>What should I do if I have questions about my eligibility?</h4>
-      <p>
-        Please {callOurTeam}. {ourHours}.
-      </p>
-    </>
-  );
-
-  const faqBlock11 = (
+  const faqBlock9 = (
     <>
       <h4>
         What if I want to review my discharge status, or think I may qualify for
@@ -634,7 +610,7 @@ export function getFAQContent(enrollmentStatus) {
     </>
   );
   const faqMap = {
-    [HCA_ENROLLMENT_STATUSES.activeDuty]: faqBlock9,
+    [HCA_ENROLLMENT_STATUSES.activeDuty]: faqBlock8,
     [HCA_ENROLLMENT_STATUSES.canceledDeclined]: wrapJSXInKeyedFragment([
       faqBlock5,
       faqBlockMentalHealthCare,
@@ -654,7 +630,7 @@ export function getFAQContent(enrollmentStatus) {
       faqBlockReapply2,
     ]),
     [HCA_ENROLLMENT_STATUSES.ineligCharacterOfDischarge]: wrapJSXInKeyedFragment(
-      [faqBlock2, faqBlock11, faqBlockMentalHealthCare, faqBlockReapply2],
+      [faqBlock2, faqBlock9, faqBlockMentalHealthCare, faqBlockReapply2],
     ),
     [HCA_ENROLLMENT_STATUSES.ineligCitizens]: wrapJSXInKeyedFragment([
       faqBlock2,

--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -38,12 +38,7 @@ export function getWarningHeadline(enrollmentStatus) {
         'You didn’t qualify for VA health care based on your previous application';
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
-      content =
-        'Our records show that you’re an active-duty service member and you’ve already applied for VA health care';
-      break;
-
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
+    case HCA_ENROLLMENT_STATUSES.activeDuty:
       content = 'Our records show that you’re an active-duty service member';
       break;
 
@@ -167,8 +162,7 @@ export function getWarningStatus(
 export function getWarningExplanation(enrollmentStatus) {
   let content = null;
   switch (enrollmentStatus) {
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied:
+    case HCA_ENROLLMENT_STATUSES.activeDuty:
     case HCA_ENROLLMENT_STATUSES.enrolled:
     case HCA_ENROLLMENT_STATUSES.ineligFugitiveFelon:
     case HCA_ENROLLMENT_STATUSES.ineligMedicare:
@@ -640,12 +634,7 @@ export function getFAQContent(enrollmentStatus) {
     </>
   );
   const faqMap = {
-    [HCA_ENROLLMENT_STATUSES.activeDutyHasApplied]: wrapJSXInKeyedFragment([
-      faqBlock8,
-      faqBlock10,
-      faqBlockReapply6,
-    ]),
-    [HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied]: faqBlock9,
+    [HCA_ENROLLMENT_STATUSES.activeDuty]: faqBlock9,
     [HCA_ENROLLMENT_STATUSES.canceledDeclined]: wrapJSXInKeyedFragment([
       faqBlock5,
       faqBlockMentalHealthCare,
@@ -786,7 +775,6 @@ export function getAlertType(enrollmentStatus) {
       status = DASHBOARD_ALERT_TYPES.decision;
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
     case HCA_ENROLLMENT_STATUSES.pendingMt:
     case HCA_ENROLLMENT_STATUSES.pendingOther:
     case HCA_ENROLLMENT_STATUSES.pendingPurpleHeart:
@@ -832,7 +820,6 @@ export function getAlertStatusHeadline(enrollmentStatus) {
       statusHeadline = 'Decision';
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
     case HCA_ENROLLMENT_STATUSES.pendingMt:
     case HCA_ENROLLMENT_STATUSES.pendingOther:
     case HCA_ENROLLMENT_STATUSES.pendingPurpleHeart:
@@ -883,7 +870,6 @@ export function getAlertStatusInfo(enrollmentStatus) {
         'Our records show that your application for VA health care expired';
       break;
 
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
     case HCA_ENROLLMENT_STATUSES.pendingOther:
     case HCA_ENROLLMENT_STATUSES.pendingUnverified:
       statusInfo = 'We’re reviewing your application';
@@ -1117,24 +1103,6 @@ export function getAlertContent(
           you by mail if we need you to submit supporting documents (like your
           DD214 or other discharge papers or separation documents).
         </p>,
-        whatShouldIDo1,
-      );
-      break;
-
-    case HCA_ENROLLMENT_STATUSES.activeDutyHasApplied:
-      blocks.push(
-        <React.Fragment key="explanation">
-          <p>
-            We’ll make our final decision on your application after you’ve
-            separated from service.
-          </p>
-          <p>
-            If we enroll you in VA health care, the preferred VA medical center
-            you selected when you applied will contact you. You can also check
-            back here after separation to find out the current status of your
-            application.
-          </p>
-        </React.Fragment>,
         whatShouldIDo1,
       );
       break;

--- a/src/applications/hca/reducer.js
+++ b/src/applications/hca/reducer.js
@@ -1,5 +1,4 @@
 import formConfig from './config/form';
-import { isValidDateString } from 'platform/utilities/date';
 import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 import {
   FETCH_ENROLLMENT_STATUS_STARTED,
@@ -43,14 +42,7 @@ export function hcaEnrollmentStatus(state = initialState, action) {
         preferredFacility,
       } = action.data;
 
-      let enrollmentStatus = parsedStatus;
-      if (enrollmentStatus === HCA_ENROLLMENT_STATUSES.activeDuty) {
-        if (isValidDateString(applicationDate)) {
-          enrollmentStatus = HCA_ENROLLMENT_STATUSES.activeDutyHasApplied;
-        } else {
-          enrollmentStatus = HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied;
-        }
-      }
+      const enrollmentStatus = parsedStatus;
       const isInESR =
         enrollmentStatus !== HCA_ENROLLMENT_STATUSES.noneOfTheAbove;
       return {

--- a/src/applications/hca/selectors.js
+++ b/src/applications/hca/selectors.js
@@ -9,7 +9,7 @@ import { HCA_ENROLLMENT_STATUSES } from './constants';
 const nonActiveInESRStatuses = new Set([
   null,
   HCA_ENROLLMENT_STATUSES.noneOfTheAbove,
-  HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied,
+  HCA_ENROLLMENT_STATUSES.activeDuty,
   HCA_ENROLLMENT_STATUSES.canceledDeclined,
   HCA_ENROLLMENT_STATUSES.deceased,
 ]);

--- a/src/applications/hca/tests/components/HCAEnrollmentStatusFAQ.unit.spec.js
+++ b/src/applications/hca/tests/components/HCAEnrollmentStatusFAQ.unit.spec.js
@@ -7,9 +7,7 @@ import { HCAEnrollmentStatusFAQ } from '../../components/HCAEnrollmentStatusFAQ'
 import { HCA_ENROLLMENT_STATUSES } from 'applications/hca/constants';
 
 const expectedOutputs = {
-  [HCA_ENROLLMENT_STATUSES.activeDutyHasApplied]:
-    '<h4>When will I find out if I’m enrolled in VA health care?</h4><p>We’ll make our final decision on your application after you&#x27;ve separated from service.</p><p>If we enroll you in VA health care, the preferred VA medical center you selected when you applied will contact you. You can also check back here after separation to find out the current status of your application.</p><h4>What should I do if I have questions about my eligibility?</h4><p>Please call our enrollment case management team at 877-222-VETS (<a class="help-phone-number-link" href="tel:1-877-222-8387">877-222-8387</a>). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.</p><h4>Should I apply again?</h4><p><strong>No. We’re in the process of reviewing your current application, and submitting a new application won’t affect our decision.</strong> If you’d like to talk about your current application, please call our enrollment case management team at 877-222-VETS (<a class="help-phone-number-link" href="tel:1-877-222-8387">877-222-8387</a>).</p><p>We only recommend applying again if you’ve already worked with our enrollment case management team, and they’ve advised you to reapply.</p><button class="va-button-link schemaform-start-button">Reapply for VA health care</button>',
-  [HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied]:
+  [HCA_ENROLLMENT_STATUSES.activeDuty]:
     '<h4>Can I apply for VA health care?</h4><p>As an active-duty service member, you can apply for VA health care if both of the below descriptions are true for you.</p><p><strong>Both of these must be true:</strong></p><ul><li>You’ve received your separation orders, and</li><li>You have less than a year until your separation date</li></ul><p><strong>If you don’t meet the requirements listed above</strong></p><p>Please don’t apply at this time. We welcome you to apply once you meet these requirements.</p><p><strong>If you’ve already applied, think you&#x27;ve received this message in error, or have any questions</strong></p><p>Please call our enrollment case management team at 877-222-VETS (<a class="help-phone-number-link" href="tel:1-877-222-8387">877-222-8387</a>). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.</p><button class="va-button-link schemaform-start-button">Apply for VA health care</button>',
   [HCA_ENROLLMENT_STATUSES.canceledDeclined]:
     '<h4>What should I do if I have questions about my eligibility?</h4><p>Please call our enrollment case management team at 877-222-VETS (<a class="help-phone-number-link" href="tel:1-877-222-8387">877-222-8387</a>). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.</p><h4>Can I still get mental health care?</h4><p>You may still be able to access certain mental health care services even if you’re not enrolled in VA health care.</p><p><a href="/health-care/health-needs-conditions/mental-health/">Learn more about getting started with VA mental health services</a></p><h4>Can I apply again?</h4><p>Yes. If you have questions about how to complete your application, please call our enrollment case management team at 877-222-VETS (<a class="help-phone-number-link" href="tel:1-877-222-8387">877-222-8387</a>).</p><button class="va-button-link schemaform-start-button">Reapply for VA health care</button>',
@@ -66,7 +64,6 @@ describe('these tests themselves', () => {
     }).filter(
       enrollmentStatus =>
         enrollmentStatus !== HCA_ENROLLMENT_STATUSES.activeDuty &&
-        enrollmentStatus !== HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied &&
         enrollmentStatus !== HCA_ENROLLMENT_STATUSES.deceased &&
         enrollmentStatus !== HCA_ENROLLMENT_STATUSES.noneOfTheAbove,
     );
@@ -106,7 +103,7 @@ describe('<HCAEnrollmentStatusFAQ />', () => {
       expect(showReapplyContentSpy.callCount).to.equal(0);
       const props = {
         ...defaultProps,
-        enrollmentStatus: HCA_ENROLLMENT_STATUSES.activeDutyHasApplied,
+        enrollmentStatus: HCA_ENROLLMENT_STATUSES.ineligNotEnoughTime,
       };
       const wrapper = shallow(<HCAEnrollmentStatusFAQ {...props} />);
       const reapplyButton = wrapper.find('ReapplyTextLink');

--- a/src/applications/hca/tests/components/HCAEnrollmentStatusWarning.unit.spec.js
+++ b/src/applications/hca/tests/components/HCAEnrollmentStatusWarning.unit.spec.js
@@ -6,9 +6,7 @@ import HCAEnrollmentStatusWarning from '../../components/HCAEnrollmentStatusWarn
 import { HCA_ENROLLMENT_STATUSES } from 'applications/hca/constants';
 
 const expectedOutputs = {
-  [HCA_ENROLLMENT_STATUSES.activeDutyHasApplied]:
-    '<div class="usa-alert usa-alert-warning"><div class="usa-alert-body"><div class="usa-alert-text"><div><h4 class="usa-alert-heading">Our records show that you’re an active-duty service member and you’ve already applied for VA health care</h4><p><strong>You applied on: </strong>April 24, 2019</p></div></div></div></div>',
-  [HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied]:
+  [HCA_ENROLLMENT_STATUSES.activeDuty]:
     '<div class="usa-alert usa-alert-warning"><div class="usa-alert-body"><div class="usa-alert-text"><div><h4 class="usa-alert-heading">Our records show that you’re an active-duty service member</h4><p><strong>You applied on: </strong>April 24, 2019</p></div></div></div></div>',
   [HCA_ENROLLMENT_STATUSES.canceledDeclined]:
     '<div class="usa-alert usa-alert-warning"><div class="usa-alert-body"><div class="usa-alert-text"><div><h4 class="usa-alert-heading">Our records show you chose to cancel or decline VA health care</h4><p><strong>You applied on: </strong>April 24, 2019</p><p>At some time in the past, we offered you enrollment in VA health care, but you declined it. Or you enrolled, but later canceled your enrollment.</p></div></div></div></div>',

--- a/src/applications/hca/tests/reducers.unit.spec.js
+++ b/src/applications/hca/tests/reducers.unit.spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 
 import * as actions from '../actions';
 import { hcaEnrollmentStatus as reducer } from '../reducer';
-import { HCA_ENROLLMENT_STATUSES } from '../constants';
 
 describe('HCA Enrollment Status Reducer', () => {
   let state;

--- a/src/applications/hca/tests/reducers.unit.spec.js
+++ b/src/applications/hca/tests/reducers.unit.spec.js
@@ -92,34 +92,6 @@ describe('HCA Enrollment Status Reducer', () => {
         expect(reducedState.noESRRecordFound).to.be.false;
       });
     });
-
-    describe('if `parsedStatus` is `activeduty`', () => {
-      it('sets the enrollmentStatus to `activeduty_has_applied` when there is a valid `applicationDate`', () => {
-        action = {
-          type: actions.FETCH_ENROLLMENT_STATUS_SUCCEEDED,
-          data: {
-            parsedStatus: 'activeduty',
-            applicationDate: '2018-12-27T00:00:00.000-06:00',
-          },
-        };
-        reducedState = reducer(state, action);
-        expect(reducedState.enrollmentStatus).to.equal(
-          HCA_ENROLLMENT_STATUSES.activeDutyHasApplied,
-        );
-      });
-      it('sets the enrollmentStatus to `activeduty_has_not_applied` when there is not a valid `applicationDate`', () => {
-        action = {
-          type: actions.FETCH_ENROLLMENT_STATUS_SUCCEEDED,
-          data: {
-            parsedStatus: 'activeduty',
-          },
-        };
-        reducedState = reducer(state, action);
-        expect(reducedState.enrollmentStatus).to.equal(
-          HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied,
-        );
-      });
-    });
   });
 
   describe('FETCH_ENROLLMENT_STATUS_FAILED', () => {

--- a/src/applications/hca/tests/selectors.unit.spec.js
+++ b/src/applications/hca/tests/selectors.unit.spec.js
@@ -212,11 +212,11 @@ describe('simple top-level selectors', () => {
       const isInESR = selectors.hasApplicationInESR(state);
       expect(isInESR).to.be.false;
     });
-    it('returns `false` if the enrollmentStatus is active duty but they have not explicitly applied for health care', () => {
+    it('returns `false` if the enrollmentStatus is active duty', () => {
       const state = {
         hcaEnrollmentStatus: {
           ...basicEnrollmentStatusState,
-          enrollmentStatus: HCA_ENROLLMENT_STATUSES.activeDutyHasNotApplied,
+          enrollmentStatus: HCA_ENROLLMENT_STATUSES.activeDuty,
         },
       };
       const isInESR = selectors.hasApplicationInESR(state);
@@ -241,16 +241,6 @@ describe('simple top-level selectors', () => {
       };
       const isInESR = selectors.hasApplicationInESR(state);
       expect(isInESR).to.be.false;
-    });
-    it('returns `true` if the enrollmentStatus is active duty and they have explicitly applied for health care', () => {
-      const state = {
-        hcaEnrollmentStatus: {
-          ...basicEnrollmentStatusState,
-          enrollmentStatus: HCA_ENROLLMENT_STATUSES.activeDutyHasApplied,
-        },
-      };
-      const isInESR = selectors.hasApplicationInESR(state);
-      expect(isInESR).to.be.true;
     });
     it('returns `true` if the enrollmentStatus is enrolled', () => {
       const state = {


### PR DESCRIPTION
## Description
- We no longer need to treat active duty statuses differently if the user has applied for health care or not. In fact if the user's status in ESR is `activeduty` we will not have an `applicationDate`.
- In other words: moving forward all `activeduty` statuses will be treated how we had been treating `activeDutyHasNotApplied` and we can remove all handling of `activeDutyHasApplied`

## Testing done
- Updated existing unit tests

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs