### PR TITLE
Check for "Closed" time

### DIFF
--- a/src/applications/facility-locator/components/LocationHours.jsx
+++ b/src/applications/facility-locator/components/LocationHours.jsx
@@ -25,7 +25,7 @@ export default class LocationHours extends Component {
 
   formatLocationHours(hours) {
     return Object.keys(hours).reduce((accum, key) => {
-      if (hours[key] === '-') {
+      if (hours[key] === '-' || hours[key] === 'Closed') {
         return { ...accum, [key]: 'Closed' };
       }
 

--- a/src/applications/facility-locator/tests/components/LocationHours.unit.spec.js
+++ b/src/applications/facility-locator/tests/components/LocationHours.unit.spec.js
@@ -115,7 +115,7 @@ describe('LocatorHours Helper Method Tests', () => {
       thursday: '800AM-430PM',
       friday: '00AM-30PM',
       saturday: '-',
-      sunday: '-',
+      sunday: 'Closed',
     };
 
     const expected = {


### PR DESCRIPTION
## Description
We're getting a _lot_ of these [`API location hours data is malformed`](http://sentry.vetsgov-internal/vets-gov/website-production/issues/57864/events/3d46e9a2fe6645a68cbca76df42bc459/) errors in Sentry. Looking at the data sent along with it, I think the issue is that we're checking for a time of `-` to determine whether the location is closed, but we're seeing a lot of `Closed` instead.

## Testing done
I updated the unit test.

## Screenshots
N/A

## Acceptance criteria
- [x] The facility locator location hours accepts `Closed` as a "valid" time range

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
