### PR TITLE
VAOGV-3223 && VAGOV-4079: fixes to styling in facility templates

### DIFF
--- a/src/applications/static-pages/facilities/BasicFacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/BasicFacilityListWidget.jsx
@@ -54,7 +54,7 @@ export default class BasicFacilityListWidget extends React.Component {
           key={facility.id}
           className="region-list usa-width-one-whole vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--4"
         >
-          <section className="region-grid usa-width-one-half">
+          <section className="region-grid vads-u-margin-right--2">
             <FacilityTitle
               facility={facility}
               nickname={this.props.facilities[facility.id].nickname}
@@ -63,7 +63,7 @@ export default class BasicFacilityListWidget extends React.Component {
             <FacilityAddress facility={facility} />
             <FacilityPhone facility={facility} />
           </section>
-          <section className="region-grid usa-width-one-half vads-u-order--first small-screen:vads-u-order--initial vads-u-margin-bottom--2">
+          <section className="region-grid vads-u-order--first small-screen:vads-u-order--initial vads-u-margin-bottom--2">
             <a
               href={this.props.facilities[facility.id].entityUrl.path}
               aria-label={this.props.facilities[facility.id].nickname}

--- a/src/applications/static-pages/facilities/FacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityListWidget.jsx
@@ -54,7 +54,10 @@ export default class FacilityListWidget extends React.Component {
           key={facility.id}
           className="region-list usa-width-one-whole vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--4 medium-screen:vads-u-margin-bottom--5"
         >
-          <section key={facility.id} className="region-grid">
+          <section
+            key={facility.id}
+            className="region-grid vads-u-margin-right--2"
+          >
             <FacilityTitle
               facility={facility}
               nickname={this.props.facilities[facility.id].nickname}

--- a/src/applications/static-pages/facilities/FacilityPhone.jsx
+++ b/src/applications/static-pages/facilities/FacilityPhone.jsx
@@ -15,7 +15,7 @@ export default class FacilityPhone extends React.Component {
 
     return (
       <div className="vads-u-margin-bottom--0">
-        <div className="main-phone vads-u-margin-bottom--2">
+        <div className="main-phone vads-u-margin-bottom--1">
           <strong>Main phone: </strong>
           <a
             href={`tel:${this.props.facility.attributes.phone.main.replace(

--- a/src/applications/static-pages/facilities/FacilityTitle.jsx
+++ b/src/applications/static-pages/facilities/FacilityTitle.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 export default class FacilityTitle extends React.Component {
   render() {
     return (
-      <h3 className="vads-u-margin-bottom--1 vads-u-margin-top--0 vads-u-font-size--md">
+      <h3 className="vads-u-margin-bottom--1 vads-u-margin-top--0 vads-u-font-size--md medium-screen:vads-u-font-size--lg">
         <a href={this.props.regionPath}>
           {this.props.facility.attributes.name}
         </a>

--- a/src/applications/static-pages/facilities/OtherFacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/OtherFacilityListWidget.jsx
@@ -52,14 +52,14 @@ export default class OtherFacilityListWidget extends React.Component {
           className="region-list usa-width-one-whole vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--2p5 small-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-bottom--5"
         >
           <section key={facility.id} className="usa-width-one-half">
-            <h3 className="vads-u-margin-bottom--1 vads-u-font-size--md">
+            <h3 className="vads-u-margin-bottom--1 vads-u-font-size--md medium-screen:vads-u-font-size--lg">
               <a href={`/find-locations/facility/${facility.id}`}>
                 {facility.attributes.name}
               </a>
             </h3>
             <FacilityAddress facility={facility} />
             <div className="vads-u-margin-bottom--0">
-              <div className="main-phone">
+              <div className="main-phone vads-u-margin-bottom--1">
                 <strong>Main phone: </strong>
                 <a
                   href={`tel:${facility.attributes.phone.main.replace(
@@ -70,12 +70,14 @@ export default class OtherFacilityListWidget extends React.Component {
                   {facility.attributes.phone.main.replace(/[ ]?x/, '')}
                 </a>
               </div>
-              <div className="facility-type">
-                <p className="vads-u-margin--0">
-                  <strong>Facility type:</strong>
-                  {` ${facility.attributes.classification}`}
-                </p>
-              </div>
+              {facility.attributes.classification && (
+                <div className="facility-type">
+                  <p className="vads-u-margin--0">
+                    <strong>Facility type:</strong>
+                    {` ${facility.attributes.classification}`}
+                  </p>
+                </div>
+              )}
             </div>
           </section>
         </div>

--- a/src/site/facilities/facility_social_links.drupal.liquid
+++ b/src/site/facilities/facility_social_links.drupal.liquid
@@ -5,13 +5,13 @@
             <div class="usa-grid usa-grid-full">
                 {% if fieldFacebook != empty %}
                     <div class="social-links social-links-facebook usa-width-one-half vads-u-margin-bottom--2">
-                        <a target="_blank" href="{{ fieldFacebook.url.path }}"><i class="fab fa-facebook"></i> {{ fieldFacebook.title }}</a>
+                        <a target="_blank" href="{{ fieldFacebook.url.path }}"><i class="fab fa-facebook vads-u-text-decoration--none vads-u-margin-right--0p5"></i>{{ fieldFacebook.title }}</a>
                     </div>
                 {% endif %}
 
                 {% if fieldTwitter != empty %}
                     <div class="social-links social-links-twitter usa-width-one-half vads-u-margin-bottom--2">
-                        <a target="_blank" href="{{ fieldTwitter.url.path }}"><i class="fab fa-twitter"></i> {{ fieldTwitter.title }}</a>
+                        <a target="_blank" href="{{ fieldTwitter.url.path }}"><i class="fab fa-twitter vads-u-text-decoration--none vads-u-margin-right--0p5"></i>{{ fieldTwitter.title }}</a>
                     </div>
                 {% endif %}
             </div>
@@ -21,13 +21,13 @@
             <div class="usa-grid usa-grid-full">
                 {% if fieldFlickr != empty %}
                     <div class="social-links social-links-flickr usa-width-one-half vads-u-margin-bottom--2">
-                        <a target="_blank" href="{{ fieldFlickr.url.path }}"><i class="fab fa-flickr"></i> {{ fieldFlickr.title }}</a>
+                        <a target="_blank" href="{{ fieldFlickr.url.path }}"><i class="fab fa-flickr vads-u-text-decoration--none vads-u-margin-right--0p5"></i>{{ fieldFlickr.title }}</a>
                     </div>
                 {% endif %}
 
                 {% if fieldInstagram != empty %}
                     <div class="social-links social-links-instagram usa-width-one-half vads-u-margin-bottom--2">
-                        <a target="_blank" href="{{ fieldInstagram.url.path }}"><i class="fab fa-instagram"></i> {{ fieldInstagram.title }}</a>
+                        <a target="_blank" href="{{ fieldInstagram.url.path }}"><i class="fab fa-instagram vads-u-text-decoration--none vads-u-margin-right--0p5"></i>{{ fieldInstagram.title }}</a>
                     </div>
                 {% endif %}
             </div>
@@ -36,7 +36,7 @@
         {% if fieldEmailSubscription != empty %}
             <div class="usa-grid usa-grid-full">
                 <div class="social-links social-links-email usa-width-one-half vads-u-margin-bottom--2">
-                    <a target="_blank" href="{{ fieldEmailSubscription.url.path }}"><i class="fas fa-envelope"></i> {{ fieldEmailSubscription.title }}</a>
+                    <a target="_blank" href="{{ fieldEmailSubscription.url.path }}"><i class="fas fa-envelope vads-u-text-decoration--none vads-u-margin-right--0p5" ></i>{{ fieldEmailSubscription.title }}</a>
                 </div>
             </div>
         {% endif %}

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -35,7 +35,7 @@
           {% endif %}
 
 
-          {% assign isContactPage = entityUrl.path | isPage: "contact" %}
+          {% assign isContactPage = entityUrl.path | isPage: "contact-us" %}
           {% if isContactPage %}
             <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">{% assign basePath = entityUrl.path | regionBasePath %}
                   {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}</div>

--- a/src/site/layouts/health_care_region_locations_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_locations_page.drupal.liquid
@@ -9,7 +9,7 @@
         <div class="usa-width-three-fourths">
             {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
 
-            <article class="vads-u-width--full vads-u-padding--2 small-screen:vads-u-padding--3">
+            <article class="vads-u-width--full vads-u-padding-x--2 small-screen:vads-u-padding-x--3">
                 <h1 class="vads-u-margin-bottom--2">Our Locations</h1>
                 <div class="va-introtext vads-u-margin-bottom--0">
                     {{ fieldLocationsIntroBlurb.processed }}

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -137,7 +137,7 @@ Example data:
         </div>
       {% endif %}
 
-      <article class="vads-u-width--full vads-u-padding--2 small-screen:vads-u-padding--3">
+      <article class="vads-u-width--full vads-u-padding-x--2 small-screen:vads-u-padding-x--3">
         <h1>{{ title }}</h1>
         {% assign image = fieldMedia.entity.image %}
 
@@ -167,30 +167,30 @@ Example data:
           <h3>Manage your health online</h3>
           <div class="usa-grid usa-grid-full">
             <div class="usa-width-one-half vads-facility-hub-cta">
-              <a href="/health-care/refill-track-prescriptions/">
+              <a href="/health-care/refill-track-prescriptions/" class="vads-u-height--full vads-u-width--full">
                 <i class=" fa fa-prescription-bottle vads-facility-hub-cta-circle">&nbsp;</i>
-                <span class="vads-facility-hub-cta-label">Refill and track your prescriptions <i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                <span class="vads-facility-hub-cta-label">Refill and track your prescriptions<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
               </a>
             </div>
             <div class="usa-width-one-half vads-facility-hub-cta">
-            <a href="/health-care/get-medical-records/">
+            <a href="/health-care/get-medical-records/" class="vads-u-height--full vads-u-width--full">
               <i class="fa fa-file-medical vads-facility-hub-cta-circle">&nbsp;</i>
-              <span class="vads-facility-hub-cta-label">Download your VA medical records (Blue Button) <i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+              <span class="vads-facility-hub-cta-label">Download your VA medical records (Blue Button)<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
             </a>
             </div>
           </div>
           <div class="usa-grid usa-grid-full">
             <div class="usa-width-one-half vads-facility-hub-cta">
-              <a href="/health-care/secure-messaging/">
+              <a href="/health-care/secure-messaging/" class="vads-u-height--full vads-u-width--full">
                 <i class="far fa-comments vads-facility-hub-cta-circle">&nbsp;</i>
-                <span class="vads-facility-hub-cta-label">Send a secure message to your health care team <i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                <span class="vads-facility-hub-cta-label">Send a secure message to your health care team<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
               </a>
             </div>
             <div class="usa-width-one-half vads-facility-hub-cta">
 
-              <a href="/health-care/view-test-and-lab-results/">
+              <a href="/health-care/view-test-and-lab-results/" class="vads-u-height--full vads-u-width--full">
                 <i class="fa fa-clipboard-list vads-facility-hub-cta-circle">&nbsp;</i>
-                <span class="vads-facility-hub-cta-label">View your lab and test results <i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                <span class="vads-facility-hub-cta-label">View your lab and test results<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
               </a>
 
             </div>
@@ -198,15 +198,15 @@ Example data:
           <div class="usa-grid usa-grid-full">
             <div class="usa-width-one-half vads-facility-hub-cta vads-facility-hub-cta-last-line">
 
-              <a href="/health-care/schedule-view-va-appointments/">
+              <a href="/health-care/schedule-view-va-appointments/" class="vads-u-height--full vads-u-width--full">
                 <i class="far fa-calendar-check vads-facility-hub-cta-circle">&nbsp;</i>
-                <span class="vads-facility-hub-cta-label">Schedule and view your appointments <i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                <span class="vads-facility-hub-cta-label">Schedule and view your appointments<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
               </a>
             </div>
-            <div class="usa-width-one-half vads-facility-hub-cta vads-facility-hub-cta-last-line">
-              <a href="/health-care/order-hearing-aid-batteries-prosthetic-socks/">
+            <div class="usa-width-one-half vads-facility-hub-cta vads-facility-hub-cta-last-line vads-u-border-top--0 medium-screen:vads-u-border-top--1px vads-u-border-color--primary-alt-light">
+              <a href="/health-care/order-hearing-aid-batteries-prosthetic-socks/" class="vads-u-height--full vads-u-width--full">
                 <i class="fa fa-deaf vads-facility-hub-cta-circle">&nbsp;</i>
-                <span class="vads-facility-hub-cta-label">Order hearing aid batteries and prosthetic socks <i class="fa fa-chevron-right vads-vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                <span class="vads-facility-hub-cta-label">Order hearing aid batteries and prosthetic socks<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
               </a>
             </div>
           </div>

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -231,7 +231,7 @@ Example data:
 
         <!-- Events -->
         <section>
-          <h3 class="vads-u-margin-top--4 vads-u-margin-bottom--0">Community Events</h3>
+          <h3 class="vads-u-margin-top--4 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--2p5">Community Events</h3>
           <div class="usa-grid usa-grid-full region-list vads-u-margin-bottom--2 vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
           {% for event in eventTeasers.entities %}
             <div class="region-grid event">

--- a/src/site/layouts/press_releases_page.drupal.liquid
+++ b/src/site/layouts/press_releases_page.drupal.liquid
@@ -56,7 +56,7 @@ Example data:
           <h1 class="vads-u-margin-bottom--5">News Releases</h1>
           {% for pr in pagedItems %}
             <section class="vads-u-margin-bottom--4">
-              <h3 class="vads-u-margin-bottom--1p5"><a href="{{ pr.entityUrl.path }}">{{ pr.title }}</a></h3>
+              <h3 class="vads-u-margin-bottom--1p5 vads-u-font-size--md medium-screen:vads-u-font-size--lg"><a href="{{ pr.entityUrl.path }}">{{ pr.title }}</a></h3>
               <strong>{{ pr.fieldReleaseDate.value | formatDate: "MMMM DD, YYYY" }}</strong>
               <p class="vads-u-margin-top--0">{{ pr.fieldIntroText | truncatewords: 60, "..." }}</p>
             </section>

--- a/src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid
+++ b/src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid
@@ -6,31 +6,30 @@
     }
 {% endcomment %}
 {% if paragraph != empty %}
-<section class="feature vads-u-padding-x--2 small-screen:vads-u-padding-x--4 vads-u-padding-y--3">
-    <h3>
+<section class="feature vads-u-padding-x--2 small-screen:vads-u-padding-x--4 vads-u-padding-top--3 vads-u-padding-bottom--2">
+    <h3 class="vads-u-margin-bottom--2">
         {{ paragraph.fieldTitle }}
     </h3>
     <div class="va-c-list-link-teasers">
         {% assign even = true %}
         {% for linkTeaser in paragraph.fieldVaParagraphs %}
-            {% for link in linkTeaser.entity.fieldLink %}
-                {% if even %}
-                    <div class="usa-grid usa-grid-full">
-                {% endif %}
-                <div class="usa-width-one-half vads-u-margin-bottom--2">
-                <a href="{{link.url.path}}">
-                        {{ link.title }}
-                    </a>
+            {% assign link = linkTeaser.entity.fieldLink %}
+            {% if even %}
+                <div class="usa-grid usa-grid-full">
+            {% endif %}
+            <div class="usa-width-one-half vads-u-margin-bottom--2">
+            <a href="{{link.url.path}}">
+                    {{ link.title }}
+                </a>
+            </div>
+            {% if !even %}
                 </div>
-                {% if !even %}
-                    </div>
-                {% endif %}
-                {% if even %}
-                    {% assign even = false %}
-                {% else %}
-                    {% assign even = true %}
-                {% endif %}
-            {% endfor %}
+            {% endif %}
+            {% if even %}
+                {% assign even = false %}
+            {% else %}
+                {% assign even = true %}
+            {% endif %}
         {% endfor %}
         {% if !even %}
       </div>

--- a/src/site/teasers/event.drupal.liquid
+++ b/src/site/teasers/event.drupal.liquid
@@ -49,8 +49,9 @@ Example data:
   {% if header == empty %}
       {% assign header = "h4" %}
   {% endif %}
+  {% assign isEventsPage = entityUrl.path | isPage: "events" %}
   <div class="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4">
-      <{{ header }} class="vads-u-margin-top--0 vad-u-margin-bottom-1 vads-u-font-size--md medium-screen:vads-u-font-size--lg"><a href="{{ node.entityUrl.path }}">{{ node.title }}</a></{{ header }}>
+      <{{ header }} class="vads-u-margin-top--0 vad-u-margin-bottom-1 {% if isEventsPage %}vads-u-font-size--md medium-screen:vads-u-font-size--lg{% endif %}"><a href="{{ node.entityUrl.path }}">{{ node.title }}</a></{{ header }}>
       <p class="vads-u-margin-bottom--1p5 vads-u-margin-top--0">{{ node.fieldDescription | truncatewords: 60, "..." }}</p>
       <div class="usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--row vads-u-margin-bottom--1">
         <div class="vads-u-margin-right--2 when-where-width">

--- a/src/site/teasers/news_story.drupal.liquid
+++ b/src/site/teasers/news_story.drupal.liquid
@@ -28,7 +28,7 @@ Example data:
 {% endif %}
 {% assign isStoriesPage = entityUrl.path | isPage: "stories" %}
 <div class="region-list usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
-    <div class="region-grid {% if isStoriesPage %}stories-list{% endif %}">
+    <div class="region-grid vads-u-margin-right--2 {% if isStoriesPage %}stories-list{% endif %}">
         <{{ header }} class="{% if isStoriesPage %}vads-u-font-size--md medium-screen:vads-u-font-size--lg{% endif %} vads-u-margin-top--0 medium-screen:vads-u-margin-bottom--0p5"><a href="{{ node.entityUrl.path }}">{{ node.title }}</a></{{ header }}>
         <p class="vads-u-margin-y--0">{{ node.fieldIntroText | truncatewords: 60, "..." }}</p>
     </div>


### PR DESCRIPTION
## Description
styling fixes for facility templates
- fixed bug with fieldRelatedLinks not showing up
- band-aid for "contact-us" big blue buttons

## Testing done
locally with staging data

1. build site
2. browse to http://localhost:3001/pittsburgh-health-care/ 
3. check for a lot of the items in both lists
4. browse to http://localhost:3001/pittsburgh-health-care/locations/
5. a couple of ryan's comments are on this page as well

## Screenshots

![localhost_3001_pittsburgh-health-care_ (3)](https://user-images.githubusercontent.com/19178435/60566395-9f12d480-9d1b-11e9-8393-9debf9f901de.png)

![localhost_3001_pittsburgh-health-care_ (4)](https://user-images.githubusercontent.com/19178435/60566396-a20dc500-9d1b-11e9-8415-6b4c6bbea68e.png)


## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-3223
comment from ryan thurlwell. all except for #7 are in this PR.
In the Manage your health online section, “Order hearing aid batteries and prosthetic socks”, it looks like the chevron > is too large. It should match the other chevrons.

The hover state in all of the Manage your health online section should span the full width of the button (currently the hover state is limited to the type and the >).

In the Manage your health online section, in the single column view, the last item looks like the horizontal rule is thicker than the rest. 

In the Manage your health online section, in the chevron should never reflow onto its own line—it should stay coupled with the last word in the list.

The phone numbers in the Locations section should be closer together (we should standardize this component/pattern across all of our pages). Changing class="main-phone vads-u-margin-bottom--2" to class="main-phone vads-u-margin-bottom--1" should do the trick.
I know there are a bunch of comments floating around, so for clarity I indicated the same edit here: VAGOV-4079: Facility | Update desktop layouts for mobile responsivenessIN PROGRESS 

All headings for Community Stories, Locations, Events, etc should be H3s on medium-screen or larger. I’d love to specify a mobile-friendly type scale, but I’m not sure we want to open that pandora’s box at this point. In the interim, let’s set the headers at H3 and go from there. Please ping me if you have any questions!

The entire column of main content looks like it is pushed to the right and down. I believe we can use usa-content in the article in place of vads-u-width--full vads-u-padding--2 small-screen:vads-u-padding--3. This applies to all pages. If this introduces a conflict, please let me know and we can work with Jared and figure out a fix.

The layout proportions for the images/text in Locations should be identical to the Community stories. It looks like the images in the Community stories section are offset to the left:  

In the Related information section, there is too much light blue space beneath the Library link. Let’s shave off ~8px or so.

In the Related information section, let’s put a little space after the header, I think margin-bottom: 1em; should do the trick.

https://va-gov.atlassian.net/browse/VAGOV-4079
comment from ryan thurlwell. all are in this PR

a couple small items:

Let’s snug the phone numbers to each other. I think changing class="main-phone vads-u-margin-bottom--2" to class="main-phone vads-u-margin-bottom--1" should do the trick

If we do not know the Facility type, we should not display it. Currently, we’re displaying “Facility type: null”. Looking at the VA Locator, it seems like every facility has a type listed, so maybe there is an error pulling certain facility types ¯\_(ツ)_/¯

Locations headers should be H3s (rendering at 20px).


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
