### PR TITLE
BAH - Remove Colmery 107 & 501 prod flags

### DIFF
--- a/src/applications/gi/components/profile/CalculatorForm.jsx
+++ b/src/applications/gi/components/profile/CalculatorForm.jsx
@@ -6,7 +6,6 @@ import Dropdown from '../Dropdown';
 import RadioButtons from '../RadioButtons';
 import { formatCurrency } from '../../utils/helpers';
 import ErrorableTextInput from '@department-of-veterans-affairs/formation-react/ErrorableTextInput';
-import environment from '../../../../platform/utilities/environment';
 
 class CalculatorForm extends React.Component {
   constructor(props) {
@@ -470,10 +469,7 @@ class CalculatorForm extends React.Component {
   }
 
   renderBeneficiaryZIP() {
-    if (
-      environment.isProduction() ||
-      !this.props.displayedInputs.beneficiaryLocationQuestion
-    ) {
+    if (!this.props.displayedInputs.beneficiaryLocationQuestion) {
       return null;
     }
 

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import * as actions from '../actions';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
-import environment from '../../../platform/utilities/environment';
 
 export class Modals extends React.Component {
   constructor(props) {
@@ -30,41 +29,7 @@ export class Modals extends React.Component {
   }
 
   calcBeneficiaryLocationQuestionContent() {
-    return environment.isProduction() ? (
-      <div>
-        <h3>Housing Allowance/BAH changes</h3>
-        <p>
-          Starting August 1, 2018, we'll determine the monthly housing allowance
-          under the Post-9/11 GI Bill based on the zip code of the campus where
-          you physically attend the majority of your classes. The location of
-          the school where you're enrolled won't be relevant.
-        </p>
-
-        <p>
-          <strong>We define "campus" as any of these locations:</strong>
-        </p>
-        <ul>
-          <li>
-            The specific campus of a school where you're taking classes (for
-            example, in the school's science center, humanities building, or
-            athletic center)
-          </li>
-          <li>
-            The physical location where you're learning in a study-abroad
-            program
-          </li>
-          <li>
-            The site of any internship, externship, practicum, or student
-            teaching
-          </li>
-        </ul>
-        <p>
-          If you first use the Post-9/11 GI Bill on or after January 1, 2018,
-          you'll receive a monthly housing allowance based directly on the
-          Department of Defense Basic Allowance for Housing (BAH).
-        </p>
-      </div>
-    ) : (
+    return (
       <div>
         <h3>Location where you'll take classes</h3>
         <p>
@@ -736,80 +701,30 @@ export class Modals extends React.Component {
   }
 
   renderProfileCalculatorModals() {
-    let whenUsedGiBill;
-    if (!environment.isProduction()) {
-      whenUsedGiBill = (
-        <div>
-          <h3 className="vads-u-padding-top--4">
-            What is Section 501 (Monthly Housing Allowance Rate)?
-          </h3>
-          <p>
-            Effective January 1, 2018, the Post-9/11 GI Bill monthly housing
-            allowance rate will be the same as the Department of Defense’s E-5
-            with dependents Basic Allowance Housing (BAH) rate.
-          </p>
-          <ul>
-            <li>
-              Students will receive this rate if they first used their Post-9/11
-              GI Bill benefits on or after January 1, 2018.
-            </li>
-            <li>
-              If the student started using their Post-9/11 GI Bill before
-              January 1, 2018, they will continue receiving payments based on
-              the slightly higher VA rate eliminated by this change.
-            </li>
-          </ul>
-        </div>
-      );
-    } else {
-      whenUsedGiBill = (
-        <div>
-          <h3>When did you first use Post-9/11 GI Bill benefits?</h3>
-          <p>
-            Effective January 1, 2018, the Post-9/11 GI Bill basic allowance for
-            housing (BAH) is based on the Department of Defense’s E-5 with
-            dependents BAH rate.
-          </p>
-          <p>
-            You’ll receive this rate if you first used your Post-9/11 GI Bill
-            benefits for one of the following:
-          </p>
-          <ul>
-            <li>
-              Tuition, housing, or books for a term that started on or after
-              January 1, 2018, or
-            </li>
-            <li>
-              To take a licensing or certification exam and/or national test
-              before January 1, 2018, and you now want to enroll in an
-              educational program that qualifies for a housing allowance.
-            </li>
-          </ul>
-          <p>
-            Also, effective August 1, 2018, the Post-9/11 GI Bill BAH is
-            calculated based on the zip code of the campus where you physically
-            attend the majority of your classes, rather than the location of the
-            school where you’re enrolled.
-          </p>
-          <p>A campus could include:</p>
+    const whenUsedGiBill = (
+      <div>
+        <h3 className="vads-u-padding-top--4">
+          What is Section 501 (Monthly Housing Allowance Rate)?
+        </h3>
+        <p>
+          Effective January 1, 2018, the Post-9/11 GI Bill monthly housing
+          allowance rate will be the same as the Department of Defense’s E-5
+          with dependents Basic Allowance Housing (BAH) rate.
+        </p>
+        <ul>
+          <li>
+            Students will receive this rate if they first used their Post-9/11
+            GI Bill benefits on or after January 1, 2018.
+          </li>
+          <li>
+            If the student started using their Post-9/11 GI Bill before January
+            1, 2018, they will continue receiving payments based on the slightly
+            higher VA rate eliminated by this change.
+          </li>
+        </ul>
+      </div>
+    );
 
-          <ul>
-            <li>
-              The individual campus of a school where you’re taking classes (for
-              example, the school’s science center, humanities building, or
-              athletic center)
-            </li>
-            <li>
-              The physical location where you’re learning in a study abroad
-              program
-            </li>
-            <li>
-              Any internship, externship, practicum, or student teaching site
-            </li>
-          </ul>
-        </div>
-      );
-    }
     return (
       <span>
         <Modal


### PR DESCRIPTION
## Description
Remove the flags hiding the Colmery 107 and 501 functionality in the production environment so the changes can be made available to the public users of the Comparison Tool

## Testing done
Dev tested and QA process

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/60607925-3d3e8300-9d8c-11e9-900a-7b8e6461f1aa.png)

![image](https://user-images.githubusercontent.com/41960449/60608210-e9806980-9d8c-11e9-94f8-6d05abf7a38f.png)

![image](https://user-images.githubusercontent.com/41960449/60608221-f1400e00-9d8c-11e9-8b10-e39a0bc2cd09.png)


## Acceptance criteria
- [x] Story #19113 is available in production
- [x] Story #18723 is available in production
- [x] Story #19031 is available in production

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
