### PR TITLE
18738 - Remove duplicate recordEvent method from form-system helpers.

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/submitForm.js
+++ b/src/applications/disability-benefits/all-claims/config/submitForm.js
@@ -1,7 +1,5 @@
-import {
-  transformForSubmit,
-  recordEvent,
-} from 'platform/forms-system/src/js/helpers';
+import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
+import recordEvent from 'platform/monitoring/record-event';
 
 const submitFormFor = eventName =>
   function submitForm(form, formConfig) {

--- a/src/applications/edu-benefits/0994/submitForm.js
+++ b/src/applications/edu-benefits/0994/submitForm.js
@@ -1,10 +1,8 @@
 import _ from 'lodash';
 import { submitToUrl } from 'platform/forms-system/src/js/actions';
 
-import {
-  transformForSubmit,
-  recordEvent,
-} from 'platform/forms-system/src/js/helpers';
+import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
+import recordEvent from 'platform/monitoring/record-event';
 
 const submitForm = (form, formConfig) => {
   const body = formConfig.transformForSubmit

--- a/src/applications/edu-benefits/components/ReviewCardField.jsx
+++ b/src/applications/edu-benefits/components/ReviewCardField.jsx
@@ -7,7 +7,7 @@ import {
   getDefaultRegistry,
 } from '@department-of-veterans-affairs/react-jsonschema-form/lib/utils';
 
-import { recordEvent } from 'platform/forms-system/src/js/helpers';
+import recordEvent from 'platform/monitoring/record-event';
 import { errorSchemaIsValid } from 'platform/forms-system/src/js/validation';
 
 import set from '../../../platform/utilities/data/set';

--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -654,16 +654,6 @@ export function omitRequired(schema) {
   return newSchema;
 }
 
-/**
- * Helper function for reporting events to Google Analytics. An alias for window.dataLayer.push.
- * @module platform/monitoring/record-event
- * @see https://developers.google.com/tag-manager/devguide
- * @param {object} data - The event data that will be sent to GA.
- */
-export function recordEvent(data) {
-  return window.dataLayer && window.dataLayer.push(data);
-}
-
 /*
  * Normal transform for schemaform data
  */

--- a/src/platform/forms-system/src/js/review/SubmitController.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitController.jsx
@@ -7,11 +7,8 @@ import { withRouter } from 'react-router';
 import SubmitButtons from './SubmitButtons';
 import { PreSubmitSection } from '../components/PreSubmitSection';
 import { isValidForm } from '../validation';
-import {
-  createPageListByChapter,
-  getActiveExpandedPages,
-  recordEvent,
-} from '../helpers';
+import { createPageListByChapter, getActiveExpandedPages } from '../helpers';
+import recordEvent from 'platform/monitoring/record-event';
 import { setPreSubmit, setSubmission, submitForm } from '../actions';
 
 class SubmitController extends React.Component {


### PR DESCRIPTION
## Description
[18738](/department-of-veterans-affairs/vets.gov-team/issues/18738) - Remove duplicate recordEvent method from /src/platform/forms-system/src/js/helpers.js.

Import recordEvent from /src/platform/monitoring/record-event.js instead.

## Testing done
Local -- No compilation import-errors after changes.

## Acceptance criteria
- [ ] No compilation import-errors occur.

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
