### PR TITLE
[Site-wide] Fix for empty sidebars

### DIFF
--- a/src/site/includes/detail-page.html
+++ b/src/site/includes/detail-page.html
@@ -10,16 +10,16 @@
 {% endcomment %}
 
 <main class="va-l-detail-page">
-  {% if hidesidenav === empty %}
+  {% if hidesidenav == empty %}
     {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
   {% endif %}
   <div class="vads-l-grid-container large-screen:vads-u-padding-x--0">
     <div class="vads-l-row vads-u-margin-x--neg2p5">
-      <div class="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--4 large-screen:vads-l-col--3">
-        {% if hidesidenav === empty %}
+      {% if hidesidenav == empty %}
+        <div class="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--4 large-screen:vads-l-col--3">
           {% include "src/site/components/navigation-sidebar.html" with newGrid = true %}
-        {% endif %}
-      </div>
+        </div>
+      {% endif %}
       <div class="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--8 large-screen:vads-l-col--9">
       {% if no_article_bottom_padding %}
         <article class="usa-content new-grid vads-u-padding-bottom--0">


### PR DESCRIPTION
## Description
On pages where `hidesidenav: true`, we were seeing an empty block showing up where the side bar would be. 

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19169

## Testing done
- tested pages with `hidesidenav: true`
- tested pages with `hidesidenav` omitted 

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/1915775/60822735-0d202700-a174-11e9-8931-f60610f0d379.png)


### After
![image](https://user-images.githubusercontent.com/1915775/60822709-04c7ec00-a174-11e9-9505-62601d0d6192.png)



## Acceptance criteria
- [ ] Layout is fixed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
