### PR TITLE
move role off of label and onto child span el

### DIFF
--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -243,19 +243,22 @@ export default class FileField extends React.Component {
           !isUploading && (
             <div>
               <label
-                role="button"
-                onKeyPress={e => {
-                  e.preventDefault();
-                  if (['Enter', ' ', 'Spacebar'].indexOf(e.key) !== -1) {
-                    document.getElementById(idSchema.$id).click();
-                  }
-                }}
-                tabIndex="0"
                 id={`${idSchema.$id}_add_label`}
                 htmlFor={idSchema.$id}
                 className="usa-button usa-button-secondary"
               >
-                {buttonText}
+                <span
+                  role="button"
+                  onKeyPress={e => {
+                    e.preventDefault();
+                    if (['Enter', ' ', 'Spacebar'].indexOf(e.key) !== -1) {
+                      document.getElementById(idSchema.$id).click();
+                    }
+                  }}
+                  tabIndex="0"
+                >
+                  {buttonText}
+                </span>
               </label>
               <input
                 type="file"

--- a/src/platform/forms-system/test/js/definitions/file.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/file.unit.spec.jsx
@@ -15,6 +15,6 @@ describe('Schemaform definition file', () => {
     const formDOM = findDOMNode(form);
 
     expect(formDOM.querySelector('input[type="file"]')).not.to.be.null;
-    expect(formDOM.querySelector('label[role="button"]')).not.to.be.null;
+    expect(formDOM.querySelector('label>span[role="button"]')).not.to.be.null;
   });
 });


### PR DESCRIPTION
## Description
move `role` and interaction-related attributes off of `label` tag and onto a new child `span` element.

**Note that this change changes the appearance of the focus outline as the outline surrounds the child span now rather than the parent label. See screenshot.**

## Testing done
- confirmed locally that the file upload component continues to work as intended

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/60826623-19e84f00-a163-11e9-80de-48981fbef5de.png)

## Acceptance criteria
- [ ] aXe scanner — and Trevor — are happy
- [x] file uploading still works as intended

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs