### PR TITLE
Fix another heading on dashboard

### DIFF
--- a/src/applications/personalization/dashboard/containers/DashboardApp.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardApp.jsx
@@ -210,9 +210,9 @@ class DashboardApp extends React.Component {
       <AlertBox
         content={
           <div>
-            <h4 className="usa-alert-heading">
+            <h3 className="usa-alert-heading">
               Verify your identity to access more VA.gov tools and features
-            </h4>
+            </h3>
             <p>
               When you verify your identity, you can use VA.gov to do things
               like track your claims, refill your prescriptions, and download


### PR DESCRIPTION
## Description
This heading should be an h3, to fix some aXe warnings about skipped levels.

## Testing done
Tested locally

## Screenshots
![Screen Shot 2019-07-08 at 2 01 07 PM](https://user-images.githubusercontent.com/634932/60832094-19fb4580-a189-11e9-85bc-41ba95532040.png)


## Acceptance criteria
- [x] Heading is an h3 but still looks the same

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
