### PR TITLE
updated Fiscal year to 2018 behind a prod flag

### DIFF
--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import environment from '../../../../platform/utilities/environment';
 
 export class AdditionalInformation extends React.Component {
-  updateFiscalYearto2018() {
+  updateFiscalYear() {
     return environment.isProduction()
       ? 'Total paid (FY 2016)'
       : 'Total paid (FY 2018)';
@@ -160,7 +160,7 @@ export class AdditionalInformation extends React.Component {
               </div>
               <div>
                 <strong>
-                  {this.updateFiscalYearto2018()}
+                  {this.updateFiscalYear()}
                   :&nbsp;
                 </strong>
                 {formatCurrency(it.p911TuitionFees)}
@@ -177,7 +177,7 @@ export class AdditionalInformation extends React.Component {
               </div>
               <div>
                 <strong>
-                  {this.updateFiscalYearto2018()}
+                  {this.updateFiscalYear()}
                   :&nbsp;
                 </strong>
                 {formatCurrency(it.p911YellowRibbon)}
@@ -235,7 +235,7 @@ export class AdditionalInformation extends React.Component {
                 <tr>
                   <th>Benefit</th>
                   <th>Recipients</th>
-                  <th>{this.updateFiscalYearto2018()}</th>
+                  <th>{this.updateFiscalYear()}</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -1,7 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import environment from '../../../../platform/utilities/environment';
 
 export class AdditionalInformation extends React.Component {
+  updateFiscalYearto2018() {
+    return environment.isProduction()
+      ? 'Total paid (FY 2016)'
+      : 'Total paid (FY 2018)';
+  }
   renderInstitutionSummary() {
     const it = this.props.institution;
     const isOJT = it.type.toLowerCase() === 'ojt';
@@ -153,7 +159,10 @@ export class AdditionalInformation extends React.Component {
                 {formatNumber(it.p911Recipients)}
               </div>
               <div>
-                <strong>Total paid (FY 2016):&nbsp;</strong>
+                <strong>
+                  {this.updateFiscalYearto2018()}
+                  :&nbsp;
+                </strong>
                 {formatCurrency(it.p911TuitionFees)}
               </div>
             </div>
@@ -167,7 +176,10 @@ export class AdditionalInformation extends React.Component {
                 {formatNumber(it.p911YrRecipients)}
               </div>
               <div>
-                <strong>Total paid (FY 2016):&nbsp;</strong>
+                <strong>
+                  {this.updateFiscalYearto2018()}
+                  :&nbsp;
+                </strong>
                 {formatCurrency(it.p911YellowRibbon)}
               </div>
             </div>
@@ -223,7 +235,7 @@ export class AdditionalInformation extends React.Component {
                 <tr>
                   <th>Benefit</th>
                   <th>Recipients</th>
-                  <th>Total paid (FY 2016)</th>
+                  <th>{this.updateFiscalYearto2018()}</th>
                 </tr>
               </thead>
               <tbody>


### PR DESCRIPTION
## Description
As a user of the Comparison Tool, I need to see current Historical Information when reviewing the School Profile so that I have accurate information on which to base my decisions.

## Testing done
Ran the comparison tool locally and ensured changes are behind a production flag. 

## Screenshots
![Screen Shot 2019-07-08 at 2 27 23 PM](https://user-images.githubusercontent.com/50601724/60833681-c7238d00-a18c-11e9-9af6-abcbf8510040.png)


## Acceptance criteria
- [X] On the School Profile Page under the "Additional Information" section; the "Historical Information" table header "Total paid (FY 2016)" is replaced with "Total paid (FY 2018)".

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
