### PR TITLE
Add a TOC of in-page links to the ProfileView

### DIFF
--- a/src/applications/personalization/profile360/components/Hero.jsx
+++ b/src/applications/personalization/profile360/components/Hero.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import LoadingSection from './LoadingSection';
 import DowntimeNotification, {
   externalServices,
-} from '../../../../platform/monitoring/DowntimeNotification';
+} from 'platform/monitoring/DowntimeNotification';
 import { handleDowntimeForSection } from './DowntimeBanner';
 
 class HeroContent extends React.Component {
@@ -53,8 +53,9 @@ class HeroContent extends React.Component {
           />
           {this.props.militaryInformation && this.renderService()}
           <p className="va-introtext">
-            Review your contact, personal, and military service information—and
-            find out how to make any needed updates or corrections.
+            Review your personal, military service, direct deposit, and contact
+            information—and find out how to make any needed updates or
+            corrections.
           </p>
         </div>
       </div>

--- a/src/applications/personalization/profile360/components/IdentityVerification.jsx
+++ b/src/applications/personalization/profile360/components/IdentityVerification.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
-import CallVBACenter from '../../../../platform/static-data/CallVBACenter';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 
 export default function IdentityVerification({
   learnMoreClick,

--- a/src/applications/personalization/profile360/components/MVIError.jsx
+++ b/src/applications/personalization/profile360/components/MVIError.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import facilityLocator from '../../../facility-locator/manifest';
+import facilityLocator from 'applications/facility-locator/manifest';
 
 export default function MVIError({ facilitiesClick }) {
   return (

--- a/src/applications/personalization/profile360/components/PersonalInformation.jsx
+++ b/src/applications/personalization/profile360/components/PersonalInformation.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import DowntimeNotification, {
   externalServices,
-} from '../../../../platform/monitoring/DowntimeNotification';
+} from 'platform/monitoring/DowntimeNotification';
 import moment from 'moment';
 import LoadFail from './LoadFail';
 import LoadingSection from './LoadingSection';
 import { handleDowntimeForSection } from './DowntimeBanner';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 
-import recordEvent from '../../../../platform/monitoring/record-event';
-import facilityLocator from '../../../facility-locator/manifest';
+import recordEvent from 'platform/monitoring/record-event';
+import facilityLocator from 'applications/facility-locator/manifest';
 
 function Gender({ gender }) {
   let content = 'This information is not available right now.';

--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Element, Link } from 'react-scroll';
 
 import DowntimeNotification, {
   externalServices,
@@ -25,25 +24,17 @@ const ProfileTOC = ({ militaryInformation }) => (
     <h2 className="vads-u-font-size--h3">On this page</h2>
     <ul>
       <li>
-        <Link to="contact-information" smooth duration={500}>
-          Contact information
-        </Link>
+        <a href="#contact-information">Contact information</a>
       </li>
       <li>
-        <Link activeClass="active" to="direct-deposit" smooth duration={500}>
-          Direct deposit information
-        </Link>
+        <a href="#direct-deposit">Direct deposit information</a>
       </li>
       <li>
-        <Link to="personal-information" smooth duration={500}>
-          Personal information
-        </Link>
+        <a href="#personal-information">Personal information</a>
       </li>
       {militaryInformation && (
         <li>
-          <Link to="military-information" smooth duration={500}>
-            Military service information
-          </Link>
+          <a href="#military-information">Military service information</a>
         </li>
       )}
     </ul>
@@ -117,16 +108,16 @@ class ProfileView extends React.Component {
                 militaryInformation={militaryInformation}
               />
               <ProfileTOC militaryInformation={militaryInformation} />
-              <Element name="contact-information" />
+              <div id="contact-information" />
               <ContactInformation />
-              <Element name="direct-deposit" />
+              <div id="direct-deposit" />
               <PaymentInformation />
-              <Element name="personal-information" />
+              <div id="personal-information" />
               <PersonalInformation
                 fetchPersonalInformation={fetchPersonalInformation}
                 personalInformation={personalInformation}
               />
-              {militaryInformation && <Element name="military-information" />}
+              {militaryInformation && <div id="military-information" />}
               <MilitaryInformation
                 veteranStatus={user.profile.veteranStatus}
                 fetchMilitaryInformation={fetchMilitaryInformation}

--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Element, Link } from 'react-scroll';
 
 import DowntimeNotification, {
   externalServices,
@@ -18,6 +19,36 @@ import PaymentInformation from '../containers/PaymentInformation';
 
 import IdentityVerification from './IdentityVerification';
 import MVIError from './MVIError';
+
+const ProfileTOC = ({ militaryInformation }) => (
+  <>
+    <h2 className="vads-u-font-size--h3">On this page</h2>
+    <ul>
+      <li>
+        <Link to="contact-information" smooth duration={500}>
+          Contact information
+        </Link>
+      </li>
+      <li>
+        <Link activeClass="active" to="direct-deposit" smooth duration={500}>
+          Direct deposit information
+        </Link>
+      </li>
+      <li>
+        <Link to="personal-information" smooth duration={500}>
+          Personal information
+        </Link>
+      </li>
+      {militaryInformation && (
+        <li>
+          <Link to="military-information" smooth duration={500}>
+            Military service information
+          </Link>
+        </li>
+      )}
+    </ul>
+  </>
+);
 
 class ProfileView extends React.Component {
   static propTypes = {
@@ -85,12 +116,17 @@ class ProfileView extends React.Component {
                 hero={hero}
                 militaryInformation={militaryInformation}
               />
+              <ProfileTOC militaryInformation={militaryInformation} />
+              <Element name="contact-information" />
               <ContactInformation />
+              <Element name="direct-deposit" />
               <PaymentInformation />
+              <Element name="personal-information" />
               <PersonalInformation
                 fetchPersonalInformation={fetchPersonalInformation}
                 personalInformation={personalInformation}
               />
+              {militaryInformation && <Element name="military-information" />}
               <MilitaryInformation
                 veteranStatus={user.profile.veteranStatus}
                 fetchMilitaryInformation={fetchMilitaryInformation}


### PR DESCRIPTION
## Description
Adds a section of in-page links at the top of the ProfileView to give users an overview of what info is on the page and quick access to sub-sections

**TODO:**
- [ ] try to get URL hashes working with `react-scroll` links so that the back button works with the Profile TOC

**Note that:**
- the TOC entry for Military Info does not appear until after the page actually loads the Military Info section onto the page. That is the only section in Profile that might not actually render. The others will show an error message or a no-data state
- the back button does not work with these in-page bookmarks. My first attempt at this simply used named anchors and that worked great, but lacked the smooth animation. Then I switched to using `react-scroll` to get the smooth animation when clicking on an item in the TOC at the top of the page, but was not able to get that to add the hash in the URL, thus hitting the back button will not return you to the top of the page after clicking on a TOC item. I'll take another stab at getting the `react-scroll` links to work with URL hashes so we get the best of both worlds.

## Testing done
Local + existing unit tests

## Screenshots
animated GIF shows the Military Info entry not showing up until that section of the page has actually loaded as well as the smooth scroll when clicking on an entry.
![profile-toc](https://user-images.githubusercontent.com/20728956/60850827-d236e700-a1a5-11e9-99ea-b0ba6dfabd03.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs