### PR TITLE
fix IE11 flex-box layout issue

### DIFF
--- a/src/applications/personalization/preferences/components/PreferenceOption.jsx
+++ b/src/applications/personalization/preferences/components/PreferenceOption.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Checkbox from '../../../gi/components/Checkbox.jsx';
+import Checkbox from 'applications/gi/components/Checkbox.jsx';
 
 export default ({ item, onChange, checked }) => {
   const itemContent = (

--- a/src/applications/personalization/preferences/sass/preferences.scss
+++ b/src/applications/personalization/preferences/sass/preferences.scss
@@ -24,13 +24,13 @@
           margin: 0;
           padding-right: 0.5em;
           &:first-child {
-            flex: 1 1 0px;
+            flex: 1 1 auto;
           }
         }
         .form-checkbox {
           margin: 0;
           margin-right: -0.3em;
-          flex: 0 1 0px;
+          flex: 0 1 auto;
           input[type=checkbox] {
             cursor: pointer;
           }

--- a/src/applications/personalization/preferences/sass/preferences.scss
+++ b/src/applications/personalization/preferences/sass/preferences.scss
@@ -24,13 +24,13 @@
           margin: 0;
           padding-right: 0.5em;
           &:first-child {
-            flex: 1;
+            flex: 1 1 0px;
           }
         }
         .form-checkbox {
           margin: 0;
           margin-right: -0.3em;
-          flex: 0;
+          flex: 0 1 0px;
           input[type=checkbox] {
             cursor: pointer;
           }


### PR DESCRIPTION
## Description
~Explicitly declaring the flex-basis as `0px` instead of it getting implicitly set by the browser _might_ fix this minor layout issue that appears to be flex-box related.~
Setting `flex-basis` to `auto` works in IE11. I confirmed this by hacking one of the `PreferenceOption` components onto a non-auth-gated page and checking in BrowserStack

![image](https://user-images.githubusercontent.com/20728956/60900083-76f60a80-a220-11e9-93a4-d0ac8e800845.png)


## Testing done
Locally checked Chrome and confirmed things still look fine

## Screenshots


## Acceptance criteria
- [x] Checkboxes still look correct in "real" browsers

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs