### PR TITLE
VAGOV-4766: Careers Leftnav Icon Fix

### DIFF
--- a/src/platform/site-wide/sass/iconography.scss
+++ b/src/platform/site-wide/sass/iconography.scss
@@ -93,7 +93,7 @@
 );
 
 @include make-hub(
-  $hub-name: "careers",
+  $hub-name: "careers-and-employment",
   $icon: $fa-var-briefcase,
   $color: $orange-warm-50,
   $top-large: 10px,

--- a/src/platform/site-wide/sass/iconography.scss
+++ b/src/platform/site-wide/sass/iconography.scss
@@ -72,17 +72,6 @@
 );
 
 @include make-hub(
-  $hub-name: "education",
-  $icon: $fa-var-graduation-cap,
-  $color: $mint-cool-50,
-  $top-large: 11px,
-  $left-large: 8.2px,
-  $top-small: 8px,
-  $left-small: 5.5px,
-  $top-baseline: 9px
-);
-
-@include make-hub(
   $hub-name: "disability",
   $icon: $fa-var-file-alt,
   $color: $red-60,
@@ -90,6 +79,17 @@
   $left-large: 13px,
   $left-small: 10px,
   $top-small: 7px
+);
+
+@include make-hub(
+  $hub-name: "education-and-training",
+  $icon: $fa-var-graduation-cap,
+  $color: $mint-cool-50,
+  $top-large: 11px,
+  $left-large: 8.2px,
+  $top-small: 8px,
+  $left-small: 5.5px,
+  $top-baseline: 9px
 );
 
 @include make-hub(
@@ -113,7 +113,7 @@
 );
 
 @include make-hub(
-  $hub-name: "housing",
+  $hub-name: "housing-assistance",
   $icon: $fa-var-home,
   $color: $gold-50,
   $top-large: 10px,
@@ -134,7 +134,7 @@
 );
 
 @include make-hub(
-  $hub-name: "burials",
+  $hub-name: "burials-and-memorials",
   $icon: $fa-var-star,
   $color: $blue-50,
   $top-small: 7px,

--- a/src/platform/site-wide/sass/iconography.scss
+++ b/src/platform/site-wide/sass/iconography.scss
@@ -72,17 +72,7 @@
 );
 
 @include make-hub(
-  $hub-name: "disability",
-  $icon: $fa-var-file-alt,
-  $color: $red-60,
-  $top-large: 10px,
-  $left-large: 13px,
-  $left-small: 10px,
-  $top-small: 7px
-);
-
-@include make-hub(
-  $hub-name: "education-and-training",
+  $hub-name: "education",
   $icon: $fa-var-graduation-cap,
   $color: $mint-cool-50,
   $top-large: 11px,
@@ -93,7 +83,17 @@
 );
 
 @include make-hub(
-  $hub-name: "careers-and-employment",
+  $hub-name: "disability",
+  $icon: $fa-var-file-alt,
+  $color: $red-60,
+  $top-large: 10px,
+  $left-large: 13px,
+  $left-small: 10px,
+  $top-small: 7px
+);
+
+@include make-hub(
+  $hub-name: "careers",
   $icon: $fa-var-briefcase,
   $color: $orange-warm-50,
   $top-large: 10px,
@@ -113,7 +113,7 @@
 );
 
 @include make-hub(
-  $hub-name: "housing-assistance",
+  $hub-name: "housing",
   $icon: $fa-var-home,
   $color: $gold-50,
   $top-large: 10px,
@@ -134,7 +134,7 @@
 );
 
 @include make-hub(
-  $hub-name: "burials-and-memorials",
+  $hub-name: "burials",
   $icon: $fa-var-star,
   $color: $blue-50,
   $top-small: 7px,

--- a/src/site/navigation/sidebar_nav.drupal.liquid
+++ b/src/site/navigation/sidebar_nav.drupal.liquid
@@ -6,7 +6,7 @@
         {% for link in sidebar.links %}
             {% if forloop.first == true %}
                 <div class="left-side-nav-title">
-                    <i class="icon-small white hub-icon-{{ link.label | handleize | remove: "-benefits" }} hub-background-{{ link.label | handleize | remove: "-benefits" }}"></i>
+                    <i class="icon-small white hub-icon-{{ link.label | handleize | remove: "-benefits" | remove: "-and-employment" }} hub-background-{{ link.label | handleize | remove: "-benefits" | remove: "-and-employment" }}"></i>
                     <h4>{{ link.label }}</h4>
                 </div>
 


### PR DESCRIPTION
## Description
Code updates iconography scss so that the correct classes are created when scss is compiled. This will allow the correct icons to show up in benefit hub detail page left navs (not just career hub).

## Testing done
On local: 
 - Published careers hub detail pages in CMS.
- Pulled CMS and built front-end.
- Checked a careers hub detail page (/careers-employment/careerscope-skills-assessment).
- Confirmed icon shows up correctly.

## Screenshots
<img width="273" alt="Screen Shot 2019-07-09 at 1 50 33 PM" src="https://user-images.githubusercontent.com/1181665/60911164-92790980-a250-11e9-8952-8924ef4af4d1.png">
<img width="1350" alt="Screen Shot 2019-07-09 at 1 50 27 PM" src="https://user-images.githubusercontent.com/1181665/60911165-92790980-a250-11e9-8ddf-d31a147c391c.png">


## Acceptance criteria
- Career hub icon shows up on career hub detail pages.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
