### PR TITLE
VAGOV-4854: allow alerts to be displayed on landing page

### DIFF
--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -35,11 +35,11 @@
         </ul>
         {% endif %}
         {% if fieldAlert.length %}
-          {% if alert.entity is not null %}
             {% for alert in fieldAlert %}
-              {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
+              {% if alert.entity != empty %}
+                {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
+              {% endif %}
             {% endfor %}
-          {% endif %}
         {% endif %}
         {% if fieldSpokes != empty %}
         {% for spoke in fieldSpokes %}


### PR DESCRIPTION
## Description
adds alerts to landing page. fixes https://va-gov.atlassian.net/browse/VAGOV-4854

## Testing done
locally with prod data

## Screenshots
![localhost_3001_health-care_](https://user-images.githubusercontent.com/19178435/60926091-4a5ee480-a25a-11e9-93bc-02f8df11ffbb.png)


## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-4854

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
