### PR TITLE
VAGOV-4760

### DIFF
--- a/src/applications/public-outreach-materials/libraries/library-filters.js
+++ b/src/applications/public-outreach-materials/libraries/library-filters.js
@@ -2,15 +2,7 @@ const cards = document.querySelectorAll('.asset-card');
 let activePage = 1;
 let numCards;
 const itemsPerPage = 10;
-const benefit = 'benefit';
-const events = 'events';
 const pages = Math.ceil(cards.length / itemsPerPage);
-
-export function libraryGetQParam() {
-  const urlParams = new URLSearchParams(window.location.search);
-  const currentPage = urlParams.getAll('q');
-  return currentPage[0];
-}
 
 export function libraryNumCards() {
   return document.querySelectorAll(
@@ -20,10 +12,8 @@ export function libraryNumCards() {
 
 export function libraryCount() {
   if (document.getElementById('no-results')) {
-    if (libraryGetQParam() === benefit) {
-      document.getElementById('no-results').style.display = 'none';
-      document.getElementById('va-pager-div').style.display = 'flex';
-    }
+    document.getElementById('no-results').style.display = 'none';
+    document.getElementById('va-pager-div').style.display = 'flex';
   }
 
   if (document.getElementById('total-pages')) {
@@ -33,11 +23,9 @@ export function libraryCount() {
         numCards < 0 ? 0 : numCards;
     }
     document.getElementById('total-all').innerText = ` of ${cards.length}`;
-    if (libraryGetQParam() === benefit) {
-      if (numCards < 1 && document.getElementById('no-results')) {
-        document.getElementById('va-pager-div').style.display = 'none';
-        document.getElementById('no-results').style.display = 'block';
-      }
+    if (numCards < 1 && document.getElementById('no-results')) {
+      document.getElementById('va-pager-div').style.display = 'none';
+      document.getElementById('no-results').style.display = 'block';
     }
   }
 }
@@ -186,26 +174,6 @@ export function libraryFilters(el) {
 }
 
 export function libraryListeners() {
-  const page = libraryGetQParam();
-  let el;
-  switch (page) {
-    case benefit:
-      el = document.querySelectorAll('.library-show');
-      break;
-
-    case events:
-      el = document.querySelectorAll('.events-show');
-      break;
-
-    default:
-      el = document.querySelectorAll('.office-show');
-      break;
-  }
-  el.forEach(value => {
-    const v = value;
-    v.style.display = 'block';
-  });
-
   const typeItem = document.getElementById('outreach-type');
   const topicItem = document.getElementById('outreach-topic');
   const pagingEl = document.querySelector('.va-pagination');

--- a/src/applications/public-outreach-materials/sass/public-outreach-materials.scss
+++ b/src/applications/public-outreach-materials/sass/public-outreach-materials.scss
@@ -91,12 +91,6 @@ button.va-page-numbers {
   display: none;
 }
 
-.events-show,
-.library-show,
-.office-show {
-  display: none;
-}
-
 /*
 Currently, necessary combination of classes in formation
 is not available to accomplish styling / layout

--- a/src/site/components/events_list.drupal.liquid
+++ b/src/site/components/events_list.drupal.liquid
@@ -1,5 +1,6 @@
 <div class="events-listing events-show">
-  {% for event in reverseFieldOfficeNode.entities%}
+  {% for event in fieldOffice.entity.reverseFieldOfficeNode.entities %}
+  {% if event.title.length%}
   <div class="vads-u-margin-bottom--2">
     <h4><a href="{{event.entityUrl.path}}">{{event.title}}</a></h4>
     <p>{{event.fieldDescription}}</p>
@@ -28,5 +29,6 @@
       {% endif %}
     </div>
   </div>
+  {% endif %}
   {% endfor %}
 </div>

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -77,15 +77,16 @@ module.exports = function registerFilters() {
     // Change phone to tap to dial.
     const replacePattern = /(?:(?:\+?([1-9]|[0-9][0-9]|[0-9][0-9][0-9])\s*(?:[.-]\s*)?)?(?:\(\s*([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9])\s*\)|([0-9][1-9]|[0-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\s*(?:[.-]\s*)?)?([2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]{2})\s*(?:[.-]\s*)?([0-9]{4})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?/;
 
-    if (data) {
-      const number = data.match(replacePattern);
+    if (data.match(replacePattern)) {
+      const number = data.match(replacePattern)[0];
       const replacedText = data.replace(
         replacePattern,
-        `<a href="tel:${number}">Phone: ${number}</a>`,
+        `<a target="_blank" href="tel:${number}">Phone: ${number}</a>`,
       );
 
       return replacedText;
     }
+
     return data;
   };
 

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -1,5 +1,5 @@
-{% include "src/site/includes/header.html" with drupalTags = true %}
 
+{% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
@@ -23,15 +23,13 @@
             <h1>{{ title }}</h1>
             <div class="vads-l-grid-container--full--full">
               <div class="va-introtext">
-                <p class="office-show" id="office-main-description">
-                  {{ fieldDescription }}
+                {% if fieldEventListingDescription %}
+                <p class="events-show" id="office-events-description">
+                  {{ fieldIntroText }}
                 </p>
+                {% endif %}
               </div>
-              {% if fieldBody.processed %}
-              <div class="office-show">
-                {{ fieldBody.processed }}
-              </div>
-              {% endif %}
+              {% include 'src/site/components/events_list.drupal.liquid' %}
             </div>
           </div>
         </article>

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -18,10 +18,10 @@
         </div>
         {% endif %}
 
-        <article class="vads-l-grid-container--full--full">
-          <div class="vads-l-grid-container--full--full">
+        <article class="vads-l-grid-container--full">
+          <div class="vads-l-grid-container--full">
             <h1>{{ title }}</h1>
-            <div class="vads-l-grid-container--full--full">
+            <div class="vads-l-grid-container--full">
               <div class="va-introtext">
                 {% if fieldEventListingDescription %}
                 <p class="events-show" id="office-events-description">

--- a/src/site/layouts/office.drupal.liquid
+++ b/src/site/layouts/office.drupal.liquid
@@ -18,10 +18,10 @@
         </div>
         {% endif %}
 
-        <article class="vads-l-grid-container--full--full">
-          <div class="vads-l-grid-container--full--full">
+        <article class="vads-l-grid-container--full">
+          <div class="vads-l-grid-container--full">
             <h1>{{ title }}</h1>
-            <div class="vads-l-grid-container--full--full">
+            <div class="vads-l-grid-container--full">
               <div class="va-introtext">
                 <p class="office-show" id="office-main-description">
                   {{ fieldDescription }}

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -1,0 +1,261 @@
+{% assign entryname = "public-outreach-materials" %}
+{% include "src/site/includes/header.html" with drupalTags = true %}
+{% include "src/site/includes/alerts.drupal.liquid" %}
+{% include "src/site/includes/preview-edit.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+
+<div class="interior" id="content">
+  <main class="va-l-detail-page">
+    <div class="usa-grid usa-grid-full">
+      {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
+      <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+        {% if !entityPublished %}
+        <div class="usa-alert usa-alert-info">
+          <div class="usa-alert-body">
+            <p class="usa-alert-text">You are viewing a draft.</p>
+          </div>
+        </div>
+        {% endif %}
+
+        <article class="vads-l-grid-container--full--full">
+          <div class="vads-l-grid-container--full--full">
+            <h1>{{ title }}</h1>
+            <div class="vads-l-grid-container--full--full">
+              <div class="va-introtext">
+                {% if fieldIntroText %}
+                <p class="library-show" id="office-benefits-description">
+                  {{ fieldIntroText }}
+                </p>
+                {% endif %}
+              </div>
+            </div>
+
+            <div
+              class="vads-l-grid-container--full--full asset-component-library library-show"
+              id="search-entry">
+
+              <form class="usa-form outreach-asset-form-filters library-show">
+                <div class="vads-l-row vads-u-justify-content--space-between">
+                  <div class="vads-l-col--12
+                                medium-screen:vads-l-col--12
+                                small-desktop-screen:vads-l-col--12
+                                large-screen:vads-l-col--5">
+                    <label class="vads-u-margin-top--0"
+                      for="outreach-topic">Select a topic</label>
+                    <select class="vads-u-max-width--100 usa-select"
+                      name="outreach-topic" id="outreach-topic">
+                      <option value="select">- All topics -</option>
+                      <option value="healthcare">Health Care</option>
+                      <option value="disability">Disability Compensation
+                      </option>
+                      <option value="education">Education And Training
+                        Benefits
+                      </option>
+                      <option value="careers">Careers And Employment</option>
+                      <option value="pension">Pension Benefits</option>
+                      <option value="housing">Housing Assistance</option>
+                      <option value="insurance">Life Insurance</option>
+                      <option value="general">General Benefits Information
+                      </option>
+                      <option value="burial">Burial Benefits And Memorial
+                        Items
+                      </option>
+                      <option value="records">Records</option>
+                      <option value="service">Service Member Benefits</option>
+                      <option value="family">Family member benefits</option>
+                    </select>
+                  </div>
+                  <div class="vads-l-col--12
+                medium-screen:vads-l-col--12
+                small-desktop-screen:vads-l-col--12
+                large-screen:vads-l-col--5">
+                    <label class="vads-u-margin-top--0" for="outreach-type">View
+                      file type</label>
+                    <select class="vads-u-max-width--100 usa-select"
+                      name="outreach-type" id="outreach-type">
+                      <option value="select">- All types -</option>
+                      <option value="video">Videos</option>
+                      <option value="social_share">Social share images, text,
+                        and badges</option>
+                      <option value="newsletter_content">Newsletter content
+                      </option>
+                      <option value="document">Poster, Flyer, brochure and
+                        fact sheets</option>
+
+                    </select>
+                  </div>
+                </div>
+              </form>
+
+              <div id="total-pages-div">
+                <div class="break-div">Showing
+                  <span id="total-pages"></span>
+                  <span id="total-all"></span> results
+                </div>
+              </div>
+              {% for entity in outreachAssetsDataArray.entities %}
+              {% if entity.fieldOffice.targetId == fieldOffice.targetId %}
+              <div data-topic="{{entity.fieldBenefits}}"
+                {{entity.fieldBenefits | breakIntoSingles}}
+                data-type="{{entity.fieldFormat}}" data-number={{forloop.index}}
+                class="vads-l-col--12
+                vads-l-row
+                medium-card-utility
+                large-screen:vads-l-col--6
+                vads-u-padding-right--4
+                vads-u-padding-bottom--4
+                asset-card
+                show-type
+                show-topic">
+                <div class="card-inside-wrap">
+                  <div class="asset-head-wrap
+                medium-screen:vads-l-col--4
+                medium-head-utility
+                large-screen:vads-l-col--12
+                  {{entity.fieldMedia.entity.entityBundle}}-asset-wrap">
+                    {% if entity.fieldMedia.entity.entityBundle == 'document' %}
+                    {% case entity.fieldBenefits %}
+                    {% when 'general' %}
+                    <img src="/img/hub-illustrations/records.png" />
+                    {% when 'burial' %}
+                    <img src="/img/hub-illustrations/burials.png" />
+                    {% when 'careers' %}
+                    <img src="/img/hub-illustrations/careers.png" />
+                    {% when 'disability' %}
+                    <img src="/img/hub-illustrations/disability.png" />
+                    {% when 'education' %}
+                    <img src="/img/hub-illustrations/education.png" />
+                    {% when 'family' %}
+                    <img src="/img/hub-illustrations/family-caregiver.png" />
+                    {% when 'healthcare' %}
+                    <img src="/img/hub-illustrations/health-care.png" />
+                    {% when 'housing' %}
+                    <img src="/img/hub-illustrations/housing.png" />
+                    {% when 'insurance' %}
+                    <img src="/img/hub-illustrations/life-insurance.png" />
+                    {% when 'pension' %}
+                    <img src="/img/hub-illustrations/pension.png" />
+                    {% when 'service' %}
+                    <img src="/img/hub-illustrations/service-member.png" />
+                    {% when 'records' %}
+                    <img src="/img/hub-illustrations/records.png" />
+                    {% else %}
+                    <img src="/img/hub-illustrations/records.png" />
+                    {% endcase %}
+                    {% endif %}
+
+                    {% if entity.fieldMedia.entity.entityBundle == 'image' %}
+                    {% if entity.fieldMedia.entity.image.url %}
+                    <img src="{{entity.fieldMedia.entity.image.url}}"
+                      onerror="this.onerror=null;this.src='https://via.placeholder.com/318x212';" />
+                    {% elsif entity.derivedFields.absoluteUrl %}
+                    <img src="{{entity.derivedFields.absoluteUrl}}"
+                      onerror="this.onerror=null;this.src='https://via.placeholder.com/318x212';" />
+                    {% endif %}
+                    {% endif %}
+
+                    {% if entity.fieldMedia.entity.entityBundle == 'video' %}
+                    {% if entity.fieldMedia.entity.thumbnail.derivative.url %}
+                    <img
+                      src="{{entity.fieldMedia.entity.thumbnail.derivative.url}}" />
+                    {%else%}
+                    <img
+                      src="{{entity.fieldMedia.entity.fieldMediaVideoEmbedField | videoThumbnail}}" />
+                    {%endif%}
+                    {% endif %}
+                  </div>
+
+                  <div class="asset-body-wrap
+                  medium-screen:vads-l-col--8
+                  medium-body-utility
+                  large-screen:vads-l-col--12">
+                    <i>{{entity.fieldBenefits | capitalize}}</i>
+                    <h3 class="asset-body-header vads-u-margin-y--1">
+                      {{entity.title| truncate: 36}}</h3>
+                    <div class="asset-body-text">
+                      {{entity.fieldDescription | truncate: 81 }}</div>
+                    {% if entity.fieldBenefits != '' %}
+                    <div class="asset-category-text capitalize-first"></div>
+                    {% endif %}
+
+                    <div class="asset-download-trigger">
+                      {% if entity.fieldMedia.entity.entityBundle == 'document' %}
+                      {% assign url = entity.fieldMedia.entity.fieldDocument.entity.url %}
+                      {% if entity.derivedFields.absoluteUrl %}
+                      {% assign url = entity.derivedFields.absoluteUrl %}
+                      {% endif %}
+                      <a class="file-download-with-icon" target="_blank"
+                        href="{{url}}" download="{{url}}"><i
+                          class="fas fa-download vads-u-padding-right--1"></i>Download
+                        {{entity.fieldMedia.entity.entityBundle | fileType}}
+                        {{url | fileExt}}</a>
+                      {% endif %}
+
+                      {% if entity.fieldMedia.entity.entityBundle == 'video' %}
+                      <a class="video-link" target="_blank"
+                        href="{{entity.fieldMedia.entity.fieldMediaVideoEmbedField}}"><i
+                          class="fab fa-youtube vads-u-padding-right--1"></i>Go
+                        to
+                        video</a>
+                      {% endif %}
+
+                      {% if entity.fieldMedia.entity.entityBundle == 'image' %}
+                      {% assign url = entity.fieldMedia.entity.image.url %}
+                      {% if entity.derivedFields.absoluteUrl %}
+                      {% assign url = entity.derivedFields.absoluteUrl %}
+                      {% endif %}
+                      <a class="file-download-with-icon" target="_blank"
+                        href="{{url}}" download="{{url}}"><i
+                          class="fas fa-download vads-u-padding-right--1"></i>Download
+                        {{entity.fieldMedia.entity.entityBundle | fileType}}
+                        {{url | fileExt}}</a>
+                      {% endif %}
+
+                    </div>
+                  </div>
+                </div>
+              </div>
+              {% endif %}
+              {% endfor %}
+            </div>
+          </div>
+
+          <div class="va-pagination library-show" id="va-pager-div">
+            <span class="vads-u-display--none
+              medium-screen::vads-u-display--block
+              small-desktop-screen:vads-u-display--block
+              large-screen:vads-u-display--block max-control">
+              <button class="va-button-link" id="first-click">First</button>
+            </span>
+            <span class="va-pagination-prev">
+              <button class="va-button-link" id="pager-previous-click"
+                aria-label="Load previous page undefined"
+                tabindex="0">Prev</button>
+            </span>
+            <div id="pager-nums-insert" class="va-pagination-inner">
+            </div>
+            <span class="va-pagination-next">
+              <button class="va-button-link" id="pager-next-click"
+                aria-label="Load next page" tabindex="0">Next</button>
+            </span>
+            <span class="vads-u-display--none
+              medium-screen::vads-u-display--block
+              small-desktop-screen:vads-u-display--block
+              large-screen:vads-u-display--block max-control">
+              <button class="va-button-link" id="last-click">Last</button>
+            </span>
+          </div>
+          <div class="library-show" id="no-results">
+            <div>No results.</div><button id="start-over">Click here to start
+              over.</button>
+          </div>
+
+        </article>
+
+      </div>
+    </div>
+  </main>
+</div>
+{% include "src/site/includes/footer.html" %}
+{% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -18,10 +18,10 @@
         </div>
         {% endif %}
 
-        <article class="vads-l-grid-container--full--full">
-          <div class="vads-l-grid-container--full--full">
+        <article class="vads-l-grid-container--full">
+          <div class="vads-l-grid-container--full">
             <h1>{{ title }}</h1>
-            <div class="vads-l-grid-container--full--full">
+            <div class="vads-l-grid-container--full">
               <div class="va-introtext">
                 {% if fieldIntroText %}
                 <p class="library-show" id="office-benefits-description">
@@ -30,9 +30,8 @@
                 {% endif %}
               </div>
             </div>
-
             <div
-              class="vads-l-grid-container--full--full asset-component-library library-show"
+              class="vads-l-grid-container--full asset-component-library library-show"
               id="search-entry">
 
               <form class="usa-form outreach-asset-form-filters library-show">

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -15,6 +15,8 @@ const outreachSidebarQuery = require('./navigation-fragments/outreachSidebar.nav
 const icsFileQuery = require('./file-fragments/ics.file.graphql');
 const outreachAssetsQuery = require('./file-fragments/outreachAssets.graphql');
 const bioPage = require('./bioPage.graphql');
+const benefitListingPage = require('./benefitListingPage.graphql');
+const eventListingPage = require('./eventListingPage.graphql');
 
 // Get current feature flags
 const {
@@ -46,6 +48,8 @@ module.exports = `
   ${eventPage}
   ${officePage}
   ${bioPage}
+  ${benefitListingPage}
+  ${eventListingPage}
 
   query GetAllPages($today: String!, $onlyPublishedContent: Boolean!) {
     nodeQuery(limit: 500, filter: {
@@ -64,6 +68,8 @@ module.exports = `
         ... eventPage
         ... officePage
         ... bioPage
+        ... benefitListingPage
+        ... eventListingPage
       }
     }
     ${icsFileQuery}

--- a/src/site/stages/build/drupal/graphql/benefitListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/benefitListingPage.graphql.js
@@ -1,0 +1,18 @@
+/**
+ * An event detail page
+ * Example: /pittsburgh-health-care/events/example-event
+ */
+const entityElementsFromPages = require('./entityElementsForPages.graphql');
+
+module.exports = `
+ fragment benefitListingPage on NodePublicationListing {
+    ${entityElementsFromPages}
+    changed
+    title
+    fieldIntroText
+    entityId
+    fieldOffice {
+      targetId
+    }
+ }
+`;

--- a/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
@@ -1,0 +1,46 @@
+/**
+ * An event detail page
+ * Example: /pittsburgh-health-care/events/example-event
+ */
+const entityElementsFromPages = require('./entityElementsForPages.graphql');
+
+module.exports = `
+ fragment eventListingPage on NodeEventListing {
+    ${entityElementsFromPages}
+    changed
+    title
+    fieldIntroText
+    entityId
+    fieldOffice {
+      targetId
+      entity {
+        reverseFieldOfficeNode(limit: 500, sort: {field: "changed", direction: DESC}) {
+            entities {
+              ... on NodeEvent {
+                title
+                entityUrl {
+                  path
+                }
+                fieldDate {
+                  startDate
+                  value
+                  endDate
+                  endValue
+                }
+                fieldDescription
+                fieldLocationHumanreadable
+                fieldFacilityLocation {
+                  entity {
+                    title
+                    entityUrl {
+                      path
+                    }
+                  }
+                }
+            }
+          }
+        }
+      }
+    }
+ }
+`;

--- a/src/site/stages/build/drupal/graphql/officePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/officePage.graphql.js
@@ -20,16 +20,6 @@ module.exports = `
         ? 'fieldBody { processed }'
         : ''
     }
-    ${
-      enabledFeatureFlags[featureFlags.FEATURE_FIELD_ASSET_LIBRARY_DESCRIPTION]
-        ? 'fieldAssetLibraryDescription'
-        : ''
-    }
-    ${
-      enabledFeatureFlags[featureFlags.FEATURE_FIELD_EVENT_LISTING_DESCRIPTION]
-        ? 'fieldEventListingDescription'
-        : ''
-    }
     reverseFieldOfficeNode {
       entities {
     ... on NodeEvent {

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -229,6 +229,8 @@ function compilePage(page, contentData) {
 
   switch (entityBundle) {
     case 'office':
+    case 'publication_listing':
+    case 'event_listing':
       pageCompiled = Object.assign(
         {},
         page,


### PR DESCRIPTION
## Description

- Front End work for outreach and assets 
- Here's the reader's digest version of what this pr does: move `/outreach-and-events?q=events` to `/outreach-and-events/events` and move `/outreach-and-events?q=benefits` to `/outreach-and-events/benefit-materials`. Doing so required us to setup two new content types in drupal. I added two new graphql queries, and two new templates. This was mostly just copy paste stuff, and visually, the appearances of the new paths are identical to the appearances of the old paths

## Testing done

- Visual

## QA
- [ ] See Jira - too be performed on stage by @jefflbrauer 
