### PR TITLE
Remove use of updatedAt date in dashboard claim status widget

### DIFF
--- a/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
@@ -228,19 +228,17 @@ const mapStateToProps = state => {
     .concat(claimsV2Root.claims)
     .filter(c => {
       let updateDate;
-      let evssPhaseChangeDate;
-      let evssUpdatedAtDate;
       if (c.type === 'evss_claims') {
-        evssPhaseChangeDate = c.attributes.phaseChangeDate;
-        evssUpdatedAtDate = c.attributes.updatedAt;
-        if (evssPhaseChangeDate && evssUpdatedAtDate) {
+        const evssPhaseChangeDate = c.attributes.phaseChangeDate;
+        const evssDateFiled = c.attributes.dateFiled;
+        if (evssPhaseChangeDate && evssDateFiled) {
           updateDate = moment(evssPhaseChangeDate).isAfter(
-            moment(evssUpdatedAtDate),
+            moment(evssDateFiled),
           )
             ? evssPhaseChangeDate
-            : evssUpdatedAtDate;
+            : evssDateFiled;
         } else {
-          updateDate = evssPhaseChangeDate || evssUpdatedAtDate;
+          updateDate = evssPhaseChangeDate || evssDateFiled;
         }
       } else {
         updateDate = c.attributes.updated;


### PR DESCRIPTION
## Description
We're showing claims that have updates in the last 30 days on the dashboard, but one of the dates we're using is `updatedAt`, which is a date that comes from our local claims db and is updated whenever we sync claims from evss. It's not a reliable indicator of which claims have recent updates, from what I can tell.

This PR changes the date logic to to match the claim status app, which uses the phase change date and the filed date.

## Testing done
Tested locally with user 228. 

## Acceptance criteria
- [x] Old claims no longer show up

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
