### PR TITLE
VAGOV-000: Link teaser fix for single value field link

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -219,6 +219,17 @@ module.exports = function registerFilters() {
       : null;
   };
 
+  liquid.filters.featureSingleValueFieldLink = fieldLink => {
+    if (
+      fieldLink &&
+      enabledFeatureFlags[featureFlags.FEATURE_SINGLE_VALUE_FIELD_LINK]
+    ) {
+      return fieldLink[0];
+    }
+
+    return fieldLink;
+  };
+
   // used to get a base url path of a health care region from entityUrl.path
   liquid.filters.regionBasePath = path => path.split('/')[1];
 

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -25,9 +25,10 @@
     {% endif %}
 {% endif %}
 <li {% if parentFieldName === 'field_spokes' %}class="hub-page-link-list__item"{% endif %}>
-    <a href="{{linkTeaser.fieldLink.url.path}}" {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
-        {% if linkTeaser.fieldLink.title != empty %}
-            <{{ header }} class="{{ headerClass }}">{{ linkTeaser.fieldLink.title }}</{{ header }}>
+    {% assign link = linkTeaser.fieldLink | featureSingleValueFieldLink %}
+    <a href="{{link.url.path}}" {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
+        {% if link.title != empty %}
+            <{{ header }} class="{{ headerClass }}">{{ link.title }}</{{ header }}>
             {% if parentFieldName === "field_spokes" %}
                 <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
             {% endif %}

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -25,9 +25,9 @@
     {% endif %}
 {% endif %}
 <li {% if parentFieldName === 'field_spokes' %}class="hub-page-link-list__item"{% endif %}>
-    <a href="{{linkTeaser.fieldLink.0.url.path}}" {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
-        {% if linkTeaser.fieldLink.0.title != empty %}
-            <{{ header }} class="{{ headerClass }}">{{ linkTeaser.fieldLink.0.title }}</{{ header }}>
+    <a href="{{linkTeaser.fieldLink.url.path}}" {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
+        {% if linkTeaser.fieldLink.title != empty %}
+            <{{ header }} class="{{ headerClass }}">{{ linkTeaser.fieldLink.title }}</{{ header }}>
             {% if parentFieldName === "field_spokes" %}
                 <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
             {% endif %}

--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -20,6 +20,7 @@ const featureFlags = {
   FEATURE_FIELD_LINKS: 'featureFieldLinks',
   FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT: 'fieldFeaturedContent',
   FEATURE_LOCAL_FACILITY_GET_IN_TOUCH: 'featureLocalFacilityGetInTouch',
+  FEATURE_SINGLE_VALUE_FIELD_LINK: 'featureSingleValueFieldLink',
 };
 
 // Edit this to turn flags on or off
@@ -71,6 +72,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_FIELD_COMMONLY_TREATED_CONDITIONS,
     featureFlags.FEATURE_FIELD_LINKS,
     featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT,
+    featureFlags.FEATURE_SINGLE_VALUE_FIELD_LINK,
   ],
 };
 


### PR DESCRIPTION
## Description
Fix display of link teaser paragraphs site wide.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
