### PR TITLE
Make claim status headings and links use sentence case

### DIFF
--- a/src/applications/claims-status/components/AppealLayout.jsx
+++ b/src/applications/claims-status/components/AppealLayout.jsx
@@ -8,7 +8,7 @@ export default function AppealLayout({ children }) {
       <div className="row">
         <ClaimsBreadcrumbs>
           <li>
-            <Link to="your-claims">Track Your Claims and Appeals</Link>
+            <Link to="your-claims">Track your claims and appeals</Link>
           </li>
         </ClaimsBreadcrumbs>
       </div>

--- a/src/applications/claims-status/components/ClaimDetailLayout.jsx
+++ b/src/applications/claims-status/components/ClaimDetailLayout.jsx
@@ -46,7 +46,7 @@ export default class ClaimDetailLayout extends React.Component {
                   onClose={clearNotification}
                 />
               )}
-              <h1 className="claim-title">Your {getClaimType(claim)} Claim</h1>
+              <h1 className="claim-title">Your {getClaimType(claim)} claim</h1>
               {!synced && <ClaimSyncWarning olderVersion={!synced} />}
             </div>
           </div>

--- a/src/applications/claims-status/components/ClaimDetailLayout.jsx
+++ b/src/applications/claims-status/components/ClaimDetailLayout.jsx
@@ -32,7 +32,7 @@ export default class ClaimDetailLayout extends React.Component {
           <div className="row">
             <div className="medium-12 columns">
               <ClaimsBreadcrumbs>
-                <Link to={claimsPath}>Status Details</Link>
+                <Link to={claimsPath}>Status details</Link>
               </ClaimsBreadcrumbs>
             </div>
           </div>

--- a/src/applications/claims-status/components/ClaimsBreadcrumbs.jsx
+++ b/src/applications/claims-status/components/ClaimsBreadcrumbs.jsx
@@ -9,7 +9,7 @@ class ClaimsBreadcrumbs extends React.Component {
         Home
       </a>,
       <Link to="your-claims" key="claims-home">
-        Check Your Claims and Appeals
+        Check your claims and appeals
       </Link>,
     ];
 

--- a/src/applications/claims-status/components/appeals-v2/AlertsList.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AlertsList.jsx
@@ -17,7 +17,7 @@ const AlertsList = ({ alerts, appealIsActive }) => {
   );
 
   const takeActionHeader = takeActionAlertsPresent ? (
-    <h3>Take Action</h3>
+    <h3>Take action</h3>
   ) : null;
 
   const alertsList = allAlertsContent.map((alert, index) => {

--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -11,14 +11,14 @@ import {
 } from '../../utils/appeals-v2-helpers';
 
 const programAreaMap = {
-  compensation: 'Disability Compensation',
+  compensation: 'Disability compensation',
   pension: 'Pension',
   insurance: 'Insurance',
-  loan_guaranty: 'Loan Guaranty', // eslint-disable-line
+  loan_guaranty: 'Loan guaranty', // eslint-disable-line
   education: 'Education',
-  vre: 'Vocational Rehabilitation and Employment',
-  medical: 'Health Care',
-  burial: 'Burial Benefits',
+  vre: 'Vocational rehabilitation and employment',
+  medical: 'Health care',
+  burial: 'Burial benefits',
   fiduciary: 'Fiduciary',
 };
 
@@ -79,7 +79,7 @@ export default function AppealListItem({ appeal, name, external = false }) {
   }
 
   if (requestEvent) {
-    appealTitle += ` Received ${moment(requestEvent.date).format(
+    appealTitle += ` received ${moment(requestEvent.date).format(
       'MMMM D, YYYY',
     )}`;
   }

--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -11,15 +11,20 @@ import {
 } from '../../utils/appeals-v2-helpers';
 
 const programAreaMap = {
-  compensation: 'Disability compensation',
-  pension: 'Pension',
-  insurance: 'Insurance',
-  loan_guaranty: 'Loan guaranty', // eslint-disable-line
-  education: 'Education',
-  vre: 'Vocational rehabilitation and employment',
-  medical: 'Health care',
-  burial: 'Burial benefits',
-  fiduciary: 'Fiduciary',
+  compensation: 'disability compensation',
+  pension: 'pension',
+  insurance: 'insurance',
+  loan_guaranty: 'loan guaranty', // eslint-disable-line
+  education: 'education',
+  vre: 'vocational rehabilitation and employment',
+  medical: 'health care',
+  burial: 'burial benefits',
+  fiduciary: 'fiduciary',
+};
+
+const capitalizeWord = word => {
+  const capFirstLetter = word[0].toUpperCase();
+  return `${capFirstLetter}${word.slice(1)}`;
 };
 
 // This component is also used by the personalization application, which will pass the external flag.
@@ -83,6 +88,7 @@ export default function AppealListItem({ appeal, name, external = false }) {
       'MMMM D, YYYY',
     )}`;
   }
+  appealTitle = capitalizeWord(appealTitle);
 
   return (
     <div className="claim-list-item-container">

--- a/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
@@ -23,7 +23,7 @@ export default function ClaimsListItem({ claim }) {
       <h3 className="claim-list-item-header-v2">
         Claim for {getClaimType(claim)}
         <br />
-        Received {formattedReceiptDate}
+        received {formattedReceiptDate}
       </h3>
       <div className="card-status">
         <div

--- a/src/applications/claims-status/components/appeals-v2/CurrentStatus.jsx
+++ b/src/applications/claims-status/components/appeals-v2/CurrentStatus.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const CurrentStatus = ({ title, description, isClosed }) => (
   <div className={`current-status ${isClosed ? 'closed' : ''}`}>
-    <h2>Current Status</h2>
+    <h2>Current status</h2>
     <div className="current-status-content">
       <h3>{title}</h3>
       <div>{description}</div>

--- a/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
@@ -84,8 +84,8 @@ class AdditionalEvidencePage extends React.Component {
           <div className="row">
             <div className="medium-12 columns">
               <ClaimsBreadcrumbs>
-                <Link to={claimsPath}>Status Details</Link>
-                <Link to={filesPath}>Additional Evidence</Link>
+                <Link to={claimsPath}>Status details</Link>
+                <Link to={filesPath}>Additional evidence</Link>
               </ClaimsBreadcrumbs>
             </div>
           </div>

--- a/src/applications/claims-status/containers/AppealInfo.jsx
+++ b/src/applications/claims-status/containers/AppealInfo.jsx
@@ -124,7 +124,7 @@ export class AppealInfo extends React.Component {
           <div>
             <ClaimsBreadcrumbs>
               <Link to={`appeals/${appeal.id}`} key="claims-appeal">
-                Status Details
+                Status details
               </Link>
             </ClaimsBreadcrumbs>
           </div>

--- a/src/applications/claims-status/containers/AppealInfo.jsx
+++ b/src/applications/claims-status/containers/AppealInfo.jsx
@@ -24,6 +24,11 @@ import {
 } from '../utils/appeals-v2-helpers';
 import CallVBACenter from '../../../platform/static-data/CallVBACenter';
 
+const capitalizeWord = word => {
+  const capFirstLetter = word[0].toUpperCase();
+  return `${capFirstLetter}${word.slice(1)}`;
+};
+
 const appealsDownMessage = (
   <div className="row" id="appealsDownMessage">
     <div className="small-12 columns">
@@ -86,10 +91,10 @@ export class AppealInfo extends React.Component {
       event => event.type === requestEventType,
     );
 
-    let appealTitle = getTypeName(this.props.appeal);
+    let appealTitle = capitalizeWord(getTypeName(this.props.appeal));
 
     if (requestEvent) {
-      appealTitle += ` Received ${moment(requestEvent.date).format(
+      appealTitle += ` received ${moment(requestEvent.date).format(
         'MMMM YYYY',
       )}`;
     }

--- a/src/applications/claims-status/containers/AppealStatusPage.jsx
+++ b/src/applications/claims-status/containers/AppealStatusPage.jsx
@@ -125,7 +125,7 @@ class AppealStatusPage extends React.Component {
         <div className="row">
           <div>
             <h1 className="claims-container-title">
-              Your Compensation Appeal Status
+              Your compensation appeal status
             </h1>
             <p>
               This information is accurate as of{' '}

--- a/src/applications/claims-status/containers/AskVAPage.jsx
+++ b/src/applications/claims-status/containers/AskVAPage.jsx
@@ -51,10 +51,10 @@ class AskVAPage extends React.Component {
           <div className="medium-12 columns">
             <ClaimsBreadcrumbs>
               <Link to={`your-claims/${this.props.params.id}`}>
-                Status Details
+                Status details
               </Link>
               <Link to={`your-claims/${this.props.params.id}/ask-va-to-decide`}>
-                Ask for Claim Decision
+                Ask for claim decision
               </Link>
             </ClaimsBreadcrumbs>
           </div>

--- a/src/applications/claims-status/containers/AskVAPage.jsx
+++ b/src/applications/claims-status/containers/AskVAPage.jsx
@@ -54,7 +54,7 @@ class AskVAPage extends React.Component {
                 Status details
               </Link>
               <Link to={`your-claims/${this.props.params.id}/ask-va-to-decide`}>
-                Ask for claim decision
+                Ask for your claim decision
               </Link>
             </ClaimsBreadcrumbs>
           </div>
@@ -62,7 +62,7 @@ class AskVAPage extends React.Component {
         <div className="row">
           <div className="usa-width-two-thirds medium-8 columns">
             <div>
-              <h1>Ask for your Claim Decision</h1>
+              <h1>Ask for your claim decision</h1>
               <p className="first-of-type">
                 We sent you a letter in the mail asking for more evidence to
                 support your claim. We’ll wait 30 days for your evidence. If you

--- a/src/applications/claims-status/containers/ClaimEstimationPage.jsx
+++ b/src/applications/claims-status/containers/ClaimEstimationPage.jsx
@@ -29,7 +29,7 @@ class ClaimEstimationPage extends React.Component {
         <div className="row">
           <div className="usa-width-two-thirds medium-8 columns">
             <div>
-              <h1>How We Come Up with Your Estimated Decision Date</h1>
+              <h1>How we come up with your estimated decision date</h1>
               <p className="first-of-type">
                 We look at every claim carefully before making a decision.
                 Sometimes we can decide quickly, but more complex claims take

--- a/src/applications/claims-status/containers/ClaimEstimationPage.jsx
+++ b/src/applications/claims-status/containers/ClaimEstimationPage.jsx
@@ -18,10 +18,10 @@ class ClaimEstimationPage extends React.Component {
           <div className="medium-12 columns">
             <ClaimsBreadcrumbs>
               <Link to={`your-claims/${this.props.params.id}/status`}>
-                Status Details
+                Status details
               </Link>
               <Link to={`your-claims/${this.props.params.id}/claim-estimate`}>
-                Estimated Decision Date
+                Estimated decision date
               </Link>
             </ClaimsBreadcrumbs>
           </div>

--- a/src/applications/claims-status/containers/DetailsPage.jsx
+++ b/src/applications/claims-status/containers/DetailsPage.jsx
@@ -42,7 +42,7 @@ class DetailsPage extends React.Component {
     if (!loading) {
       content = (
         <dl className="claim-details">
-          <dt className="claim-detail-label">Claim Type</dt>
+          <dt className="claim-detail-label">Claim type</dt>
           <dd>{claim.attributes.claimType || 'Not Available'}</dd>
           <dt className="claim-detail-label">What you’ve claimed</dt>
           <dd>
@@ -59,10 +59,10 @@ class DetailsPage extends React.Component {
               'Not Available'
             )}
           </dd>
-          <dt className="claim-detail-label">Date Received</dt>
+          <dt className="claim-detail-label">Date received</dt>
           <dd>{moment(claim.attributes.dateFiled).format('MMM D, YYYY')}</dd>
           <dt className="claim-detail-label">
-            Your Representative for VA Claims
+            Your representative for VA claims
           </dt>
           <dd>{claim.attributes.vaRepresentative || 'Not Available'}</dd>
         </dl>

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -95,8 +95,8 @@ class DocumentRequestPage extends React.Component {
           <div className="row">
             <div className="medium-12 columns">
               <ClaimsBreadcrumbs>
-                <Link to={filesPath}>Status Details</Link>
-                <Link to={itemPath}>Document Request</Link>
+                <Link to={filesPath}>Status details</Link>
+                <Link to={itemPath}>Document request</Link>
               </ClaimsBreadcrumbs>
             </div>
           </div>

--- a/src/applications/claims-status/containers/FilesPage.jsx
+++ b/src/applications/claims-status/containers/FilesPage.jsx
@@ -44,8 +44,8 @@ class FilesPage extends React.Component {
   }
   setTitle() {
     document.title = this.props.loading
-      ? 'Files - Your Claim'
-      : `Files - Your ${getClaimType(this.props.claim)} Claim`;
+      ? 'Files - Your claim'
+      : `Files - Your ${getClaimType(this.props.claim)} claim`;
   }
   render() {
     const { claim, loading, message, synced } = this.props;

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -193,7 +193,7 @@ class YourClaimsPageV2 extends React.Component {
             <div className="row">
               <div className="small-12 columns">
                 <h1 className="claims-container-title">
-                  Check Your Claim or Appeal Status
+                  Check your claim or appeal status
                 </h1>
               </div>
               <div className="small-12 columns">

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
@@ -93,7 +93,7 @@ describe('<AppealListItemV2/>', () => {
         .find('h3.claim-list-item-header-v2')
         .render()
         .text(),
-    ).to.equal('Supplemental Claim for Health Care Received May 1, 2016');
+    ).to.equal('Supplemental claim for health care received May 1, 2016');
     wrapper.unmount();
   });
 

--- a/src/applications/claims-status/tests/e2e/00.claims-list-breadcrumb.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list-breadcrumb.e2e.spec.js
@@ -21,7 +21,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .element(
       '.va-nav-breadcrumbs-list li:nth-of-type(2) a[aria-current="page"]',
     )
-    .text.to.equal('Check Your Claims and Appeals');
+    .text.to.equal('Check your claims and appeals');
   client.expect
     .element(
       '.va-nav-breadcrumbs-list li:nth-of-type(2) a[aria-current="page"]',

--- a/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
@@ -27,13 +27,13 @@ module.exports = E2eHelpers.createE2eTest(client => {
   // Verify text on page
   client.expect
     .element('.claims-container h1')
-    .text.to.equal('Check Your Claim or Appeal Status');
+    .text.to.equal('Check your claim or appeal status');
 
   client.expect
     .element('.claim-list-item-header-v2')
     // .text.to.equal('Disability Compensation Claim – Received September 23, 2008');
     .text.to.equal(
-      'Claim for Disability Compensation\nReceived September 23, 2008',
+      'Claim for disability compensation\nreceived September 23, 2008',
     );
 
   // Click to detail view

--- a/src/applications/claims-status/tests/e2e/03.claim-details.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/03.claim-details.e2e.spec.js
@@ -31,15 +31,15 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
   client.expect
     .element('.claim-detail-label:nth-of-type(1)')
-    .text.to.equal('Claim Type');
+    .text.to.equal('Claim type');
   client.expect
     .element('.claim-detail-label:nth-of-type(2)')
     .text.to.equal('What you’ve claimed');
   client.expect
     .element('.claim-detail-label:nth-of-type(3)')
-    .text.to.equal('Date Received');
+    .text.to.equal('Date received');
   client.expect
     .element('.claim-detail-label:nth-of-type(4)')
-    .text.to.equal('Your Representative for VA Claims');
+    .text.to.equal('Your representative for VA claims');
   client.end();
 });

--- a/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.e2e.spec.js
@@ -34,7 +34,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .element(
       '.va-nav-breadcrumbs-list li:nth-of-type(4) a[aria-current="page"]',
     )
-    .text.to.equal('Estimated Decision Date');
+    .text.to.equal('Estimated decision date');
   client.expect
     .element(
       '.va-nav-breadcrumbs-list li:nth-of-type(4) a[aria-current="page"]',

--- a/src/applications/claims-status/tests/e2e/06.claim-estimation.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/06.claim-estimation.e2e.spec.js
@@ -30,7 +30,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
   client.expect
     .element('.claims-status-content h1')
-    .text.to.equal('How We Come Up with Your Estimated Decision Date');
+    .text.to.equal('How we come up with your estimated decision date');
 
   client.end();
 });

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -383,7 +383,7 @@ describe('Disability benefits helpers: ', () => {
           claimType: 'Awesome',
         },
       };
-      expect(getClaimType(claim)).to.equal('Awesome');
+      expect(getClaimType(claim)).to.equal('awesome');
     });
     it('should return the default claim type', () => {
       const claim = {
@@ -391,7 +391,7 @@ describe('Disability benefits helpers: ', () => {
           claimType: undefined,
         },
       };
-      expect(getClaimType(claim)).to.equal('Disability Compensation');
+      expect(getClaimType(claim)).to.equal('disability compensation');
     });
   });
 

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -584,7 +584,7 @@ export function getStatusContents(appeal, name = {}) {
             older appeal that was closest to receiving a Board decision.
           </p>
           <p>
-            Check <Link to="/your-claims">Your Claims and Appeals</Link> for the
+            Check <Link to="/your-claims">Your claims and appeals</Link> for the
             appeal that contains the issues merged from this appeal.
           </p>
         </div>
@@ -602,7 +602,7 @@ export function getStatusContents(appeal, name = {}) {
             into one of the new decision review options.
           </p>
           <p>
-            Check <Link to="/your-claims">Your Claims and Appeals</Link> for the
+            Check <Link to="/your-claims">Your claims and appeals</Link> for the
             decision review that contains the issues from this appeal, or learn
             more about{' '}
             <a href="/decision-reviews">

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -34,12 +34,12 @@ const appealTypes = Object.values(APPEAL_TYPES);
 export function getTypeName(appeal) {
   switch (appeal.type) {
     case APPEAL_TYPES.supplementalClaim:
-      return 'Supplemental Claim';
+      return 'supplemental claim';
     case APPEAL_TYPES.higherLevelReview:
-      return 'Higher-Level Review';
+      return 'higher-level review';
     case APPEAL_TYPES.legacy:
     case APPEAL_TYPES.appeal:
-      return 'Appeal';
+      return 'appeal';
     default:
       Sentry.withScope(scope => {
         scope.setExtra('type', appeal.type);

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -310,7 +310,9 @@ export function getCompletedDate(claim) {
 }
 
 export function getClaimType(claim) {
-  return claim.attributes.claimType || 'Disability Compensation';
+  return (
+    claim.attributes.claimType || 'disability compensation'
+  ).toLowerCase();
 }
 
 export const mockData = {


### PR DESCRIPTION
## Description
Claim status is pretty old and doesn't appear to use sentence case. This updates that everywhere I can find to update

## Testing done
Tested with local mocked data. This data isn't great, so some more testing on staging to verify will be necessary.

## Screenshots
![Screen Shot 2019-07-10 at 4 38 34 PM](https://user-images.githubusercontent.com/634932/61003217-671a1b80-a331-11e9-99ad-5ee9485a62b5.png)
![Screen Shot 2019-07-10 at 4 41 38 PM](https://user-images.githubusercontent.com/634932/61003318-a47ea900-a331-11e9-8e5e-7eaf85a79c30.png)

![Screen Shot 2019-07-10 at 4 42 57 PM](https://user-images.githubusercontent.com/634932/61003403-df80dc80-a331-11e9-88f3-0b48e259515c.png)

![Screen Shot 2019-07-10 at 4 37 45 PM](https://user-images.githubusercontent.com/634932/61003220-67b2b200-a331-11e9-959d-cc718b1fc2a4.png)


![Screen Shot 2019-07-10 at 4 37 41 PM](https://user-images.githubusercontent.com/634932/61003221-67b2b200-a331-11e9-922d-58c6f4a4792c.png)


## Acceptance criteria
- [x] Headings and links use sentence case

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
