### PR TITLE
19277: STEM: Update Rogers Scholarship Wizard Answer Text

### DIFF
--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -113,7 +113,7 @@ export default class EducationWizard extends React.Component {
                   ? [
                       {
                         label:
-                          'Extending my benefit using Edith Nourse Rogers STEM Scholarship',
+                          'Applying to extend my benefit using the Edith Nourse Rogers STEM Scholarship',
                         value: 'extend',
                       },
                     ]


### PR DESCRIPTION
## Description
As a Form 1995 user, I need the STEM answer to accurately reflect the action that I am taking and how it relates to my Education Benefits so that I complete the wizard correctly.

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19227

## Testing done
Local manual, unit, and e2e test pass.

## Screenshots
<img width="569" alt="Screen Shot 2019-07-11 at 1 43 54 PM" src="https://user-images.githubusercontent.com/48804834/61072767-fb43bb80-a3e1-11e9-8944-5074948420fb.png">


## Acceptance criteria
- [x] The answer "Extending my benefit using Edith Nourse Rogers STEM Scholarship" is replaced with the following text: "Applying to extend my benefit using the Edith Nourse Rogers STEM Scholarship".

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
