### PR TITLE
Remove title assertions in education e2e tests

### DIFF
--- a/src/applications/edu-benefits/tests/1990/01-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/1990/01-all-fields.e2e.spec.js
@@ -16,7 +16,6 @@ const test = E2eHelpers.createE2eTest(client => {
       }/education/apply-for-education-benefits/application/1990`,
     )
     .waitForElementVisible('body', Timeouts.normal)
-    .assert.title('Apply for education benefits | Veterans Affairs')
     .waitForElementVisible('.schemaform-start-button', Timeouts.slow)
     .axeCheck('.main')
     .click('.schemaform-start-button');

--- a/src/applications/edu-benefits/tests/1990e/01-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/1990e/01-all-fields.e2e.spec.js
@@ -16,7 +16,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
       }/education/apply-for-education-benefits/application/1990E`,
     )
     .waitForElementVisible('body', Timeouts.normal)
-    .assert.title('Apply for education benefits | Veterans Affairs')
     .waitForElementVisible('.schemaform-start-button', Timeouts.slow)
     .axeCheck('.main')
     .click('.schemaform-start-button');

--- a/src/applications/edu-benefits/tests/1990n/01-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/1990n/01-all-fields.e2e.spec.js
@@ -15,7 +15,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
       }/education/apply-for-education-benefits/application/1990N`,
     )
     .waitForElementVisible('body', Timeouts.normal)
-    .assert.title('Apply for education benefits | Veterans Affairs')
     .waitForElementVisible('.schemaform-start-button', Timeouts.slow)
     .axeCheck('.main')
     .click('.schemaform-start-button');

--- a/src/applications/edu-benefits/tests/1995-STEM/01-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/1995-STEM/01-all-fields.e2e.spec.js
@@ -18,7 +18,6 @@ if (process.env.BUILDTYPE !== ENVIRONMENTS.VAGOVPROD) {
         }/education/apply-for-education-benefits/application/1995-STEM`,
       )
       .waitForElementVisible('body', Timeouts.normal)
-      .assert.title('Veteran request for change | Veterans Affairs')
       .waitForElementVisible('.schemaform-start-button', Timeouts.slow)
       .axeCheck('.main')
       .click('.schemaform-start-button');

--- a/src/applications/edu-benefits/tests/1995/01-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/1995/01-all-fields.e2e.spec.js
@@ -16,7 +16,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
       }/education/apply-for-education-benefits/application/1995`,
     )
     .waitForElementVisible('body', Timeouts.normal)
-    .assert.title('Veteran request for change | Veterans Affairs')
     .waitForElementVisible('.schemaform-start-button', Timeouts.slow)
     .axeCheck('.main')
     .click('.schemaform-start-button');

--- a/src/applications/edu-benefits/tests/5490/01-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/5490/01-all-fields.e2e.spec.js
@@ -16,7 +16,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
       }/education/apply-for-education-benefits/application/5490`,
     )
     .waitForElementVisible('body', Timeouts.normal)
-    .assert.title('Apply for education benefits | Veterans Affairs')
     .waitForElementVisible('.schemaform-start-button', Timeouts.slow)
     .axeCheck('.main')
     .click('.schemaform-start-button');

--- a/src/applications/edu-benefits/tests/5495/01-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/5495/01-all-fields.e2e.spec.js
@@ -16,7 +16,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
       }/education/apply-for-education-benefits/application/5495`,
     )
     .waitForElementVisible('body', Timeouts.normal)
-    .assert.title('Dependents request for change | Veterans Affairs')
     .waitForElementVisible('.schemaform-start-button', Timeouts.slow)
     .axeCheck('.main')
     .click('.schemaform-start-button');

--- a/src/applications/edu-benefits/tests/edu-apply-wizard.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/edu-apply-wizard.e2e.spec.js
@@ -7,9 +7,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client
     .openUrl(`${E2eHelpers.baseUrl}/education/how-to-apply/`)
     .waitForElementVisible('body', Timeouts.normal)
-    .assert.title(
-      'How to apply for the GI Bill and other education benefits | Veterans Affairs',
-    )
     .waitForElementVisible('.wizard-container', Timeouts.normal)
     .click('.wizard-button')
     .waitForElementVisible('label[for="newBenefit-0"]', Timeouts.normal)

--- a/src/applications/post-911-gib-status/tests/01-authed.e2e.spec.js
+++ b/src/applications/post-911-gib-status/tests/01-authed.e2e.spec.js
@@ -12,9 +12,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
   Auth.logIn(token, client, '/education/gi-bill/post-9-11/ch-33-benefit', 3)
     .waitForElementVisible('body', Timeouts.normal)
     .axeCheck('.main')
-    .assert.title(
-      'Check your Post-9/11 GI Bill benefits status | Veterans Affairs',
-    )
     .waitForElementVisible(
       '.usa-button-primary.va-button-primary',
       Timeouts.slow,


### PR DESCRIPTION
## Description
The title casing changed on these pages, which is breaking these tests in master. We probably shouldn't be testing against these titles anyway, it's just content.

## Acceptance criteria
- [x] Build passes

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
