### PR TITLE
Update links to 526 and refactor to common constants

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -133,6 +133,9 @@ export const DATA_PATHS = {
     'view:hasEvidenceFollowUp.view:selectableEvidenceTypes.view:hasOtherEvidence',
 };
 
+export const DISABILITY_526_V2_ROOT_URL =
+  '/disability/file-disability-claim-form-21-526ez';
+
 export const VA_FORM4142_URL =
   'https://www.vba.va.gov/pubs/forms/VBA-21-4142-ARE.pdf';
 

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -11,6 +11,7 @@ import environment from '../../../platform/utilities/environment';
 import _ from '../../../platform/utilities/data';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
+import disability526Manifest from 'applications/disability-benefits/526EZ/manifest.json';
 import {
   validateMilitaryCity,
   validateMilitaryState,
@@ -20,6 +21,7 @@ import ReviewCardField from './components/ReviewCardField';
 
 import {
   DATA_PATHS,
+  DISABILITY_526_V2_ROOT_URL,
   HOMELESSNESS_TYPES,
   MILITARY_CITIES,
   MILITARY_STATE_LABELS,
@@ -747,8 +749,8 @@ export const hasNewDisabilities = formData =>
  * @enum {String}
  */
 export const urls = {
-  v1: '/disability-benefits/apply/form-526-disability-claim',
-  v2: '/disability/file-disability-claim-form-21-526ez',
+  v1: disability526Manifest.rootUrl,
+  v2: DISABILITY_526_V2_ROOT_URL,
 };
 
 /**

--- a/src/applications/disability-benefits/wizard/pages/file-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
 import { pageNames } from './pageList';
 
 const FileClaimPage = () => (
   <div>
     <p>
       <a
-        href="/disability/file-disability-claim-form-21-526ez/introduction"
+        href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
         className="usa-button-primary va-button-primary"
       >
         File a disability compensation claim

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -23,7 +23,7 @@ import edu0993Manifest from 'applications/edu-benefits/0993/manifest.json';
 import edu0994Manifest from 'applications/edu-benefits/0994/manifest.json';
 import preneedManifest from 'applications/pre-need/manifest.json';
 import pensionManifest from 'applications/pensions/manifest.json';
-import disability526Manifest from 'applications/disability-benefits/526EZ/manifest.json';
+import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
 
 import hcaConfig from 'applications/hca/config/form.js';
 import dependentStatusConfig from 'applications/disability-benefits/686/config/form';
@@ -118,7 +118,7 @@ export const formDescriptions = Object.keys(formBenefits).reduce(
 );
 
 export const formLinks = {
-  [VA_FORM_IDS.FORM_21_526EZ]: `${disability526Manifest.rootUrl}/`,
+  [VA_FORM_IDS.FORM_21_526EZ]: DISABILITY_526_V2_ROOT_URL,
   [VA_FORM_IDS.FORM_21P_527EZ]: `${pensionManifest.rootUrl}/`,
   [VA_FORM_IDS.FORM_21P_530]: `${burialsManifest.rootUrl}/`,
   [VA_FORM_IDS.FORM_10_10EZ]: `${hcaManifest.rootUrl}/`,


### PR DESCRIPTION
## Description
Navigate to 526 v2 by default, let the form handle redirection from there.

I consolidated usage of the v1 and v2 links to the manifest for v1 and a newly defined constant for v2