### PR TITLE
only show Direct Deposit in profile TOC is the user has that feature

### DIFF
--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -16,6 +16,7 @@ import ContactInformation from './ContactInformation';
 import PersonalInformation from './PersonalInformation';
 import MilitaryInformation from './MilitaryInformation';
 import PaymentInformation from '../containers/PaymentInformation';
+import PaymentInformationTOCItem from '../containers/PaymentInformationTOCItem';
 
 import IdentityVerification from './IdentityVerification';
 import MVIError from './MVIError';
@@ -27,11 +28,7 @@ const ProfileTOC = ({ militaryInformation }) => (
       <li>
         <a href="#contact-information">Contact information</a>
       </li>
-      {!environment.isProduction() && (
-        <li>
-          <a href="#direct-deposit">Direct deposit information</a>
-        </li>
-      )}
+      {!environment.isProduction() && <PaymentInformationTOCItem />}
       <li>
         <a href="#personal-information">Personal information</a>
       </li>

--- a/src/applications/personalization/profile360/containers/PaymentInformationTOCItem.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformationTOCItem.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { createIsServiceAvailableSelector } from 'platform/user/selectors';
+import backendServices from 'platform/user/profile/constants/backendServices';
+
+class PaymentInformationTOCItem extends React.Component {
+  static propTypes = {
+    isEligible: PropTypes.bool.isRequired,
+  };
+
+  render() {
+    if (!this.props.isEligible) {
+      return null;
+    }
+    return (
+      <li>
+        <a href="#direct-deposit">Direct deposit information</a>
+      </li>
+    );
+  }
+}
+
+const isEvssAvailable = createIsServiceAvailableSelector(
+  backendServices.EVSS_CLAIMS,
+);
+
+const mapStateToProps = state => ({
+  isEligible: isEvssAvailable(state),
+});
+
+const PaymentInformationTOCItemContainer = connect(mapStateToProps)(
+  PaymentInformationTOCItem,
+);
+
+export default PaymentInformationTOCItemContainer;

--- a/src/applications/personalization/profile360/containers/PaymentInformationTOCItem.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformationTOCItem.jsx
@@ -35,3 +35,5 @@ const PaymentInformationTOCItemContainer = connect(mapStateToProps)(
 );
 
 export default PaymentInformationTOCItemContainer;
+
+export { PaymentInformationTOCItem };

--- a/src/applications/personalization/profile360/tests/containers/PaymentInformationTOCItem.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/containers/PaymentInformationTOCItem.unit.spec.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import { PaymentInformationTOCItem } from '../../containers/PaymentInformationTOCItem';
+
+describe('<PaymentInformationTOCItem />', () => {
+  it('renders when the user is eligible for direct deposit', () => {
+    const wrapper = shallow(<PaymentInformationTOCItem isEligible />);
+    expect(wrapper.find('li > a')).to.have.length(1);
+    wrapper.unmount();
+  });
+
+  it('does not render if the user is not eligible for jdirect deposit', () => {
+    const wrapper = shallow(<PaymentInformationTOCItem isEligible={false} />);
+    expect(wrapper.text()).to.be.empty;
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
TODO:
- [ ] add some basic tests for the new component

## Description
Conditionally show/hide the Direct Deposit link in the Profile's TOC based on if the user has that feature or not

## Testing done
Local + unit tests

## Screenshots


## Acceptance criteria
- [ ] Direct Deposit is listed in Profile TOC if the user has that section on their Profile
- [ ] Direct Deposit is _not_ listed in Profile TOC if the user does _not_ have that section on their Profile (such as user 360)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs