### PR TITLE
Production flag removed FY updated to 2018

### DIFF
--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -2,6 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 export class AdditionalInformation extends React.Component {
+  updateFiscalYear() {
+    return 'Total paid (FY 2018)';
+  }
   renderInstitutionSummary() {
     const it = this.props.institution;
     const isOJT = it.type.toLowerCase() === 'ojt';
@@ -153,7 +156,10 @@ export class AdditionalInformation extends React.Component {
                 {formatNumber(it.p911Recipients)}
               </div>
               <div>
-                <strong>Total paid (FY 2018):&nbsp;</strong>
+                <strong>
+                  {this.updateFiscalYear()}
+                  :&nbsp;
+                </strong>
                 {formatCurrency(it.p911TuitionFees)}
               </div>
             </div>
@@ -167,7 +173,10 @@ export class AdditionalInformation extends React.Component {
                 {formatNumber(it.p911YrRecipients)}
               </div>
               <div>
-                <strong>Total paid (FY 2018):&nbsp;</strong>
+                <strong>
+                  {this.updateFiscalYear()}
+                  :&nbsp;
+                </strong>
                 {formatCurrency(it.p911YellowRibbon)}
               </div>
             </div>
@@ -223,9 +232,7 @@ export class AdditionalInformation extends React.Component {
                 <tr>
                   <th>Benefit</th>
                   <th>Recipients</th>
-                  <th>
-                    <strong>Total paid (FY 2018)</strong>
-                  </th>
+                  <th>{this.updateFiscalYear()}</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -3,11 +3,6 @@ import React from 'react';
 import environment from '../../../../platform/utilities/environment';
 
 export class AdditionalInformation extends React.Component {
-  updateFiscalYear() {
-    return environment.isProduction()
-      ? 'Total paid (FY 2016)'
-      : 'Total paid (FY 2018)';
-  }
   renderInstitutionSummary() {
     const it = this.props.institution;
     const isOJT = it.type.toLowerCase() === 'ojt';
@@ -159,10 +154,7 @@ export class AdditionalInformation extends React.Component {
                 {formatNumber(it.p911Recipients)}
               </div>
               <div>
-                <strong>
-                  {this.updateFiscalYear()}
-                  :&nbsp;
-                </strong>
+                <strong>Total paid (FY 2018):&nbsp;</strong>
                 {formatCurrency(it.p911TuitionFees)}
               </div>
             </div>
@@ -176,10 +168,7 @@ export class AdditionalInformation extends React.Component {
                 {formatNumber(it.p911YrRecipients)}
               </div>
               <div>
-                <strong>
-                  {this.updateFiscalYear()}
-                  :&nbsp;
-                </strong>
+                <strong>Total paid (FY 2018):&nbsp;</strong>
                 {formatCurrency(it.p911YellowRibbon)}
               </div>
             </div>
@@ -235,7 +224,9 @@ export class AdditionalInformation extends React.Component {
                 <tr>
                   <th>Benefit</th>
                   <th>Recipients</th>
-                  <th>{this.updateFiscalYear()}</th>
+                  <th>
+                    <strong>Total paid (FY 2018)</strong>
+                  </th>
                 </tr>
               </thead>
               <tbody>

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import environment from '../../../../platform/utilities/environment';
 
 export class AdditionalInformation extends React.Component {
   renderInstitutionSummary() {


### PR DESCRIPTION
## Description

As a developer, I need to remove the production flag, so that the "Historical Information" column text update is visible to the users.

## Testing done
Ran local build to check if fiscal year value is 2018

## Screenshots

<img width="533" alt="Screen Shot 2019-07-12 at 10 59 09 AM" src="https://user-images.githubusercontent.com/50601724/61137890-6352da00-a494-11e9-9c00-b286dd650012.png">

## Acceptance criteria
- [x] The production flag hiding the content of story #19164 is removed.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
