### PR TITLE
Add missing forward slash in 526 root url

### DIFF
--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -118,7 +118,7 @@ export const formDescriptions = Object.keys(formBenefits).reduce(
 );
 
 export const formLinks = {
-  [VA_FORM_IDS.FORM_21_526EZ]: DISABILITY_526_V2_ROOT_URL,
+  [VA_FORM_IDS.FORM_21_526EZ]: `${DISABILITY_526_V2_ROOT_URL}/`,
   [VA_FORM_IDS.FORM_21P_527EZ]: `${pensionManifest.rootUrl}/`,
   [VA_FORM_IDS.FORM_21P_530]: `${burialsManifest.rootUrl}/`,
   [VA_FORM_IDS.FORM_10_10EZ]: `${hcaManifest.rootUrl}/`,


### PR DESCRIPTION
This was somehow still working, but this adds the forward slash when so we get `${rootUrl}/resume` and not  `${rootUrl}resume`