### PR TITLE
[Teamsite] Fix for text cut off in MegaMenu

### DIFF
--- a/src/applications/proxy-rewrite/sass/consolidated-patches.scss
+++ b/src/applications/proxy-rewrite/sass/consolidated-patches.scss
@@ -103,6 +103,10 @@ header.merger {
       .vetnav-panel {
         width: 487px;
 
+        .mm-link-container {
+          width: 220px;
+        }
+
         &.column-one {
           .mm-link-container {
             width: 200px;


### PR DESCRIPTION
## Description
Currently, the text in the MegaMenu on TeamSite pages gets cut off sometimes. The container size on TeamSite vs. VA.gov is different, so I think that's the cause here. We just need to shorten a container element to fix it.

See screenshots below.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15578

## Testing done
- `npm run watch -- --local-proxy-rewrite`
- Visit http://localhost:3001/?target=https://www.va.gov/health/
- Open mega menu

## Screenshots

### Before
See far right link -
![image](https://user-images.githubusercontent.com/1915775/61157789-20f5c100-a4c5-11e9-8f41-c455919ed3b6.png)


### After
![image](https://user-images.githubusercontent.com/1915775/61157714-ec820500-a4c4-11e9-8a3c-1edf67abcd3c.png)

## Acceptance criteria
- [x]  Text is no longer cut off

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
