### PR TITLE
Fix undefined cms preview server output when running locally

### DIFF
--- a/src/site/stages/build/plugins/rewrite-cms-aws-urls.js
+++ b/src/site/stages/build/plugins/rewrite-cms-aws-urls.js
@@ -2,18 +2,20 @@
 
 function rewriteAWSUrls(options) {
   return (files, metalsmith, done) => {
-    Object.keys(files)
-      .filter(
-        fileName => fileName.endsWith('html') && files[fileName].isDrupalPage,
-      )
-      .forEach(fileName => {
-        const file = files[fileName];
-        let contents = file.contents.toString();
-        const regex = new RegExp(options['drupal-address'], 'g');
-        contents = contents.replace(regex, file.drupalSite);
+    if (options['drupal-address']) {
+      Object.keys(files)
+        .filter(
+          fileName => fileName.endsWith('html') && files[fileName].isDrupalPage,
+        )
+        .forEach(fileName => {
+          const file = files[fileName];
+          let contents = file.contents.toString();
+          const regex = new RegExp(options['drupal-address'], 'g');
+          contents = contents.replace(regex, file.drupalSite);
 
-        file.contents = new Buffer(contents);
-      });
+          file.contents = new Buffer(contents);
+        });
+    }
     done();
   };
 }


### PR DESCRIPTION
## Description
Running the preview server locally was resulting in some bad output, even though it works fine in other environments. The reason for this ended up being a regex trying to replace `undefined` in the page which led to the weird output. This skips the step with the replacement.

## Testing done
Ran `yarn build --pull-drupal; yarn preview` locally and verified that http://localhost:3001/preview?nodeId=72 displayed the careers page.

## Acceptance criteria
- [x] Preview server works locally

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
