### PR TITLE
Add exception for advisory 1065

### DIFF
--- a/script/security-check.js
+++ b/script/security-check.js
@@ -13,6 +13,7 @@ const exceptionSet = new Set([
   'https://npmjs.com/advisories/157',
   'https://npmjs.com/advisories/788',
   'https://npmjs.com/advisories/813',
+  'https://npmjs.com/advisories/1065',
 ]);
 
 const severitySet = new Set(['high', 'critical', 'moderate']);


### PR DESCRIPTION
## Description
We're seeing a new advisory happening from within Lodash, [example build](http://jenkins.vetsgov-internal/blue/organizations/jenkins/testing%2Fvets-website/detail/add-body-flag-office-node/1/pipeline/51). Since this version of Lodash is in a few different modules, our best bet is to just add an exception. We should look into upgrading this in Formation though.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Security step passes and nothing's broken

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
