### PR TITLE
Fix optional text line height on claim status

### DIFF
--- a/src/applications/claims-status/components/RequestedFilesInfo.jsx
+++ b/src/applications/claims-status/components/RequestedFilesInfo.jsx
@@ -57,7 +57,7 @@ export default class RequestedFilesInfo extends React.Component {
                 <p className="submission-description">
                   {truncateDescription(stripHtml(item.description))}
                 </p>
-                <div className="claims-optional-desc">
+                <div className="vads-u-margin-top--0p5 vads-u-font-size--sm">
                   <strong>Optional</strong> - We requested this from others, but
                   you may upload it if you have it.
                 </div>

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -945,6 +945,7 @@ h1:focus {
   font-size: 1.15em;
   line-height: 1.5;
   padding-bottom: 0;
+  margin-top: 0;
 }
 
 .file-request-list-item-optional {

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -453,12 +453,6 @@ $color-inactive: #9b9b9b;
   }
 }
 
-.claims-optional-desc {
-  font-size: 0.9em;
-  line-height: 0.3em;
-  margin-top: 5px;
-}
-
 h1:focus {
   outline: none;
 }


### PR DESCRIPTION
## Description
Noticed this when testing in staging. The optional text has a bad line height and heading margin:

![Screen Shot 2019-07-15 at 3 36 28 PM](https://user-images.githubusercontent.com/634932/61243880-e97e5300-a716-11e9-9681-1fbb6ffaad41.png)

## Testing done
Checked locally

## Screenshots
![Screen Shot 2019-07-15 at 3 46 52 PM](https://user-images.githubusercontent.com/634932/61244286-dddf5c00-a717-11e9-99da-30424c2f1324.png)

## Acceptance criteria
- [x] Optional text looks normal again

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
