### PR TITLE
[Downtime Notifications] Remove end time from messaging when a service is down

### DIFF
--- a/src/platform/monitoring/DowntimeNotification/components/Down.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/Down.jsx
@@ -2,15 +2,8 @@ import React from 'react';
 import externalServiceStatus from '../config/externalServiceStatus';
 import DowntimeNotificationWrapper from './Wrapper';
 
+// eslint-disable-next-line no-unused-vars
 export function DownMessaging({ endTime, appTitle }) {
-  if (endTime) {
-    return (
-      <p>
-        We’re making some updates to the {appTitle}. We’re sorry it’s not
-        working right now. Please check back soon.
-      </p>
-    );
-  }
   return (
     <p>
       We’re making some updates to the {appTitle}. We’re sorry it’s not working

--- a/src/platform/monitoring/DowntimeNotification/components/Down.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/Down.jsx
@@ -7,8 +7,7 @@ export function DownMessaging({ endTime, appTitle }) {
     return (
       <p>
         We’re making some updates to the {appTitle}. We’re sorry it’s not
-        working right now, and we hope to be finished by{' '}
-        {endTime.format('MMMM Do, LT')} Please check back soon.
+        working right now. Please check back soon.
       </p>
     );
   }


### PR DESCRIPTION
## Description
Most often, a maintenance window will stretch for an indefinite amount of time instead of having a certain end time. There isn't a way to distinguish this on the FE though, sine Pager Duty requires an end time always be added. So, this PR makes the default messaging for the downtime notification omit the end time.

## Testing done
Content only

## Acceptance criteria
- [ ] End time is omitted from downtime notification content

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
