### PR TITLE
VAGOV-4584: fieldAlert is now single value in CMS

### DIFF
--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -35,9 +35,17 @@
         </ul>
         {% endif %}
 
+        {% if fieldAlert.length %}
+          {% for alert in fieldAlert %}
+            {% if alert.entity != empty %}
+                {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
+              {% endif %}
+          {% endfor %}
+        {% else %}
           {% if fieldAlert.entity != empty %}
             {% include "src/site/blocks/alert.drupal.liquid" with alert = fieldAlert.entity %}
           {% endif %}
+        {% endif %}
 
         {% if fieldSpokes != empty %}
         {% for spoke in fieldSpokes %}

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -34,13 +34,11 @@
           {% endfor %}
         </ul>
         {% endif %}
-        {% if fieldAlert.length %}
-            {% for alert in fieldAlert %}
-              {% if alert.entity != empty %}
-                {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
-              {% endif %}
-            {% endfor %}
-        {% endif %}
+
+          {% if fieldAlert.entity != empty %}
+            {% include "src/site/blocks/alert.drupal.liquid" with alert = fieldAlert.entity %}
+          {% endif %}
+
         {% if fieldSpokes != empty %}
         {% for spoke in fieldSpokes %}
         <section class="usa-grid">

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -23,9 +23,17 @@
         <div class="va-introtext">
           <p>{{ fieldIntroText }}</p>
         </div>
+        {% if fieldAlert.length %}
+          {% for alert in fieldAlert %}
+            {% if alert.entity != empty %}
+              {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
+            {% endif %}
+          {% endfor %}
+        {% else %}
           {% if fieldAlert.entity != empty %}
             {% include "src/site/blocks/alert.drupal.liquid" with alert = fieldAlert.entity %}
           {% endif %}
+        {% endif %}
 
         {% assign featureCount = fieldFeaturedContent | size  %}
         {% if featureCount > 0 %}

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -23,14 +23,9 @@
         <div class="va-introtext">
           <p>{{ fieldIntroText }}</p>
         </div>
-
-        {% if fieldAlert.length %}
-            {% for alert in fieldAlert %}
-              {% if alert.entity != empty %}
-                {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
-              {% endif %}
-            {% endfor %}
-        {% endif %}
+          {% if fieldAlert.entity != empty %}
+            {% include "src/site/blocks/alert.drupal.liquid" with alert = fieldAlert.entity %}
+          {% endif %}
 
         {% assign featureCount = fieldFeaturedContent | size  %}
         {% if featureCount > 0 %}


### PR DESCRIPTION
## Description
fieldAlert is now single value in CMS for landing page and page content types

## Testing done
locally with staging data

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
