### PR TITLE
Bump Formation to 4.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/formation": "^6.7.1",
-    "@department-of-veterans-affairs/formation-react": "^4.9.0",
+    "@department-of-veterans-affairs/formation-react": "^4.9.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "blob-polyfill": "^2.0.20171115",

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,10 +684,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@department-of-veterans-affairs/formation-react@^4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-4.9.0.tgz#060f0c2db025f805fd4b5571cb35a5de963d09bd"
-  integrity sha512-Jbz8MG0l1DCIMXrVy51iOz8rmG/uft7Yx4n0Yrd1tUM4SeydI1eZGtRvVcWbv4s/gnyT0Py6a2CnbgwVp5wx+A==
+"@department-of-veterans-affairs/formation-react@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-4.9.1.tgz#c249f022674f45274ac880fe21570ed5db819223"
+  integrity sha512-k6gQbdBlt0V2R3UV6xQRnmfCj/bxVNFmQpr27LfFHgkUG/fF1g6cM4zR1Uq6jfH62l1jfkVzjDJHIIYfYJZTsQ==
   dependencies:
     classnames "^2.2.6"
     lodash "^4.17.11"


### PR DESCRIPTION
## Description
To receive updates from https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/149.

There will be no visual effect from this PR, because it requires a change from vagov-content. That [PR is here](https://github.com/department-of-veterans-affairs/vagov-content/pull/499). Once that is merged, the `Manage your records` heading in the Records section of the MegaMenu will be removed.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17695

## Testing done
Looked at MegaMenu

## Screenshots
N/A

## Acceptance criteria
- [x] Formation updated to account for new MegaMenu configuration

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
