### PR TITLE
VAGOV-4920 Fix Promo Block Link

### DIFF
--- a/src/site/blocks/promo.drupal.liquid
+++ b/src/site/blocks/promo.drupal.liquid
@@ -37,7 +37,7 @@
     <section class="hub-promo-text">
         <h4 class="heading">
           <a onClick="recordEvent({ event: 'nav-hub-promo' });"
-            href="{{ entity.fieldPromoLink.entity.fieldLink.0.url.path }}">{{ entity.fieldPromoLink.entity.fieldLink.0.title }}</a>
+            href="{{ entity.fieldPromoLink.entity.fieldLink.url.path }}">{{ entity.fieldPromoLink.entity.fieldLink.title }}</a>
         </h4>
         <p>{{ entity.fieldPromoLink.entity.fieldLinkSummary }}</p>
     </section>

--- a/src/site/blocks/promo.drupal.liquid
+++ b/src/site/blocks/promo.drupal.liquid
@@ -34,10 +34,11 @@
 <div class="merger-r-rail hub-promo" id="promo">
     <img src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="{{ image.derivative.width }}" height="{{ image.derivative.height }}">
   {% if entity.fieldPromoLink != empty %}
+    {% assign link = entity.fieldPromoLink.entity.fieldLink | featureSingleValueFieldLink %}
     <section class="hub-promo-text">
         <h4 class="heading">
           <a onClick="recordEvent({ event: 'nav-hub-promo' });"
-            href="{{ entity.fieldPromoLink.entity.fieldLink.url.path }}">{{ entity.fieldPromoLink.entity.fieldLink.title }}</a>
+            href="{{ link.url.path }}">{{ link.title }}</a>
         </h4>
         <p>{{ entity.fieldPromoLink.entity.fieldLinkSummary }}</p>
     </section>


### PR DESCRIPTION
## Description
Link teasers have disappeared on hub promo blocks. 

The issue was that field_promo_link became single value, and the block template needed to be updated.

## Testing done

- Loaded the page before fix was in place.
- Confirmed link teaser was not present.
- Reloaded page after fix was made.
- Confirmed link teaser was present.
- Clicked link.

## Screenshots


<img width="1217" alt="Screen Shot 2019-07-16 at 12 45 11 PM" src="https://user-images.githubusercontent.com/1181665/61313215-06bf2a00-a7c8-11e9-94b9-393ec3fa8287.png">

<img width="334" alt="Screen Shot 2019-07-16 at 12 45 23 PM" src="https://user-images.githubusercontent.com/1181665/61313213-06bf2a00-a7c8-11e9-8875-492294c18009.png">




## Acceptance criteria
- [ ] Link teaser is now present in promo blocks.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
