### PR TITLE
VAGOV-4005: add jumplinks to region detail page and update styles

### DIFF
--- a/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
@@ -9,24 +9,18 @@ export class FacilityPatientSatisfactionScoresWidget extends React.Component {
   render() {
     if (this.props.loading || !Object.keys(this.props.facility).length) {
       return (
-        <LoadingIndicator message="Loading facility patient satisfaction scores..." />
+        <LoadingIndicator message="Loading facility patient satisfaction scores..."/>
       );
     }
 
     if (this.props.error) {
-      return <FacilityApiAlert />;
+      return <FacilityApiAlert/>;
     }
 
     const facility = this.props.facility.attributes;
 
     return (
       <div>
-        <h2
-          id="our-patient-satisfaction-scores"
-          className="vads-u-margin-top--4 vads-u-font-size--lg small-screen:vads-u-font-size--xl"
-        >
-          Appointment access at this location
-        </h2>
         <p>
           Veteran-reported satisfaction scores come from the Consumer Assessment
           of Health and Systems survey, which measures satisfaction of nearly
@@ -42,7 +36,8 @@ export class FacilityPatientSatisfactionScoresWidget extends React.Component {
         <div className="usa-grid-full">
           <div className="vads-u-display--flex">
             {!!facility.feedback.health.primaryCareUrgent && (
-              <div className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5 vads-u-margin-right--1">
+              <div
+                className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5 vads-u-margin-right--1">
                 <p className="vads-u-margin--0">Primary care</p>
                 <p
                   id="facility-patient-satisfaction-scores-primary-urgent-score"
@@ -53,7 +48,8 @@ export class FacilityPatientSatisfactionScoresWidget extends React.Component {
               </div>
             )}
             {!!facility.feedback.health.specialtyCareUrgent && (
-              <div className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5">
+              <div
+                className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5">
                 <p className="vads-u-margin--0">Specialty care</p>
                 <p
                   id="facility-patient-satisfaction-scores-specialty-urgent-score"
@@ -76,7 +72,8 @@ export class FacilityPatientSatisfactionScoresWidget extends React.Component {
         <div className="usa-grid-full">
           <div className="vads-u-display--flex">
             {!!facility.feedback.health.primaryCareRoutine && (
-              <div className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5 vads-u-margin-right--1">
+              <div
+                className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5 vads-u-margin-right--1">
                 <p className="vads-u-margin--0">Primary care</p>
                 <p
                   id="facility-patient-satisfaction-scores-primary-routine-score"
@@ -88,7 +85,8 @@ export class FacilityPatientSatisfactionScoresWidget extends React.Component {
             )}
 
             {!!facility.feedback.health.specialtyCareRoutine && (
-              <div className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5">
+              <div
+                className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5">
                 <p className="vads-u-margin--0">Specialty care</p>
                 <p
                   id="facility-patient-satisfaction-scores-specialty-routine-score"

--- a/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
@@ -9,12 +9,12 @@ export class FacilityPatientSatisfactionScoresWidget extends React.Component {
   render() {
     if (this.props.loading || !Object.keys(this.props.facility).length) {
       return (
-        <LoadingIndicator message="Loading facility patient satisfaction scores..."/>
+        <LoadingIndicator message="Loading facility patient satisfaction scores..." />
       );
     }
 
     if (this.props.error) {
-      return <FacilityApiAlert/>;
+      return <FacilityApiAlert />;
     }
 
     const facility = this.props.facility.attributes;
@@ -36,8 +36,7 @@ export class FacilityPatientSatisfactionScoresWidget extends React.Component {
         <div className="usa-grid-full">
           <div className="vads-u-display--flex">
             {!!facility.feedback.health.primaryCareUrgent && (
-              <div
-                className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5 vads-u-margin-right--1">
+              <div className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5 vads-u-margin-right--1">
                 <p className="vads-u-margin--0">Primary care</p>
                 <p
                   id="facility-patient-satisfaction-scores-primary-urgent-score"
@@ -48,8 +47,7 @@ export class FacilityPatientSatisfactionScoresWidget extends React.Component {
               </div>
             )}
             {!!facility.feedback.health.specialtyCareUrgent && (
-              <div
-                className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5">
+              <div className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5">
                 <p className="vads-u-margin--0">Specialty care</p>
                 <p
                   id="facility-patient-satisfaction-scores-specialty-urgent-score"
@@ -72,8 +70,7 @@ export class FacilityPatientSatisfactionScoresWidget extends React.Component {
         <div className="usa-grid-full">
           <div className="vads-u-display--flex">
             {!!facility.feedback.health.primaryCareRoutine && (
-              <div
-                className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5 vads-u-margin-right--1">
+              <div className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5 vads-u-margin-right--1">
                 <p className="vads-u-margin--0">Primary care</p>
                 <p
                   id="facility-patient-satisfaction-scores-primary-routine-score"
@@ -85,8 +82,7 @@ export class FacilityPatientSatisfactionScoresWidget extends React.Component {
             )}
 
             {!!facility.feedback.health.specialtyCareRoutine && (
-              <div
-                className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5">
+              <div className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5">
                 <p className="vads-u-margin--0">Specialty care</p>
                 <p
                   id="facility-patient-satisfaction-scores-specialty-routine-score"

--- a/src/applications/static-pages/sass/modules/_m-facility-detail.scss
+++ b/src/applications/static-pages/sass/modules/_m-facility-detail.scss
@@ -34,3 +34,7 @@
 .when-where-width {
    width: 45px;
 }
+
+.va-c-font-size--xs {
+   font-size: 12px;
+}

--- a/src/applications/static-pages/tests/facilities/FacilityPatientSatisfactionScoresWidget.unit.spec.jsx
+++ b/src/applications/static-pages/tests/facilities/FacilityPatientSatisfactionScoresWidget.unit.spec.jsx
@@ -6,7 +6,7 @@ import { FacilityPatientSatisfactionScoresWidget } from '../../facilities/Facili
 
 describe('facilities <FacilityPatientSatisfactionScoresWidget>', () => {
   it('should render loading', () => {
-    const tree = shallow(<FacilityPatientSatisfactionScoresWidget loading/>);
+    const tree = shallow(<FacilityPatientSatisfactionScoresWidget loading />);
 
     expect(tree.find('LoadingIndicator').exists()).to.be.true;
     tree.unmount();

--- a/src/applications/static-pages/tests/facilities/FacilityPatientSatisfactionScoresWidget.unit.spec.jsx
+++ b/src/applications/static-pages/tests/facilities/FacilityPatientSatisfactionScoresWidget.unit.spec.jsx
@@ -6,7 +6,7 @@ import { FacilityPatientSatisfactionScoresWidget } from '../../facilities/Facili
 
 describe('facilities <FacilityPatientSatisfactionScoresWidget>', () => {
   it('should render loading', () => {
-    const tree = shallow(<FacilityPatientSatisfactionScoresWidget loading />);
+    const tree = shallow(<FacilityPatientSatisfactionScoresWidget loading/>);
 
     expect(tree.find('LoadingIndicator').exists()).to.be.true;
     tree.unmount();
@@ -21,11 +21,6 @@ describe('facilities <FacilityPatientSatisfactionScoresWidget>', () => {
     );
 
     expect(tree.find('LoadingIndicator').exists()).to.be.false;
-
-    const satisfactionScoresHeader = tree.find('h2');
-    expect(satisfactionScoresHeader.text()).to.contain(
-      'Appointment access at this location',
-    );
 
     const facilityPatientSatisfactionScoresEffectiveDate = tree.find(
       '#facility-patient-satisfaction-scores-effective-date',

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -110,6 +110,11 @@
           <div class="usa-grid usa-grid-full vads-u-margin-y--1p5 vads-u-margin-bottom--6">{% assign basePath = entityUrl.path | regionBasePath %}
               {% include "src/site/facilities/facilities_health_services_buttons.drupal.liquid" with path = basePath %}</div>
 
+            <section id="table-of-contents" class="vads-u-margin-bottom--5">
+                <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+                <ul class="usa-unstyled-list"></ul>
+            </section>
+
           <div class="region-list usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--2p5 small-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-bottom--5">
 
             <!-- facility details from api -->
@@ -129,25 +134,6 @@
                 <div data-widget-type="facility-map" data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}"></div>
               </div>
           </div>
-
-        <div class="vads-u-margin-bottom--4 small-screen:vads-u-margin-bottom--7">
-            <h2 class="vads-u-margin-top--0 vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-            <ul class="usa-unstyled-list">
-                {% if fieldLocationServices != empty and fieldLocationServices.length %}
-                    <li class="vads-u-margin-bottom--2">
-                        <a class="vads-u-text-decoration--none" href="#prepare-for-your-visit"><i class="fas fa-level-down-alt"></i> Prepare for your visit</a>
-                    </li>
-                {% endif %}
-                {% if fieldLocalHealthCareService != empty and fieldLocalHealthCareService.length %}
-                    <li class="vads-u-margin-bottom--2">
-                        <a class="vads-u-text-decoration--none" href="#health-care-offered-here"><i class="fas fa-level-down-alt"></i> Health care offered here</a>
-                    </li>
-                {% endif %}
-                <li class="vads-u-margin-bottom--2">
-                    <a class="vads-u-text-decoration--none" href="#our-patient-satisfaction-scores"><i class="fas fa-level-down-alt"></i> Appointment access at this location</a>
-                </li>
-            </ul>
-        </div>
 
           <!-- Location services section -->
           {% capture difference %}
@@ -195,6 +181,12 @@
                 </section>
             {% endif %}
 
+            <h2
+                    id="our-patient-satisfaction-scores"
+                    class="vads-u-margin-top--4 vads-u-font-size--lg small-screen:vads-u-font-size--xl"
+            >
+                Appointment access at this location
+            </h2>
             <div data-widget-type="facility-patient-satisfaction-scores" data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}"></div>
 
 

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -18,10 +18,24 @@
             <p>{{ fieldIntroText }}</p>
           </div>
 
+          {% assign isContactPage = entityUrl.path | isPage: "contact-us" %}
+          {% if isContactPage %}
+            <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">{% assign basePath = entityUrl.path | regionBasePath %}
+              {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}</div>
+          {% endif %}
+
           {% if fieldAlert != empty and fieldAlert.length %}
             {% for alert in fieldAlert %}
               {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
             {% endfor %}
+          {% endif %}
+
+
+          {% if fieldTableOfContentsBoolean != empty and fieldTableOfContentsBoolean %}
+            <section id="table-of-contents">
+              <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+              <ul class="usa-unstyled-list"></ul>
+            </section>
           {% endif %}
 
           {% if fieldFeaturedContent != empty and fieldFeaturedContent.length > 0 %}
@@ -32,20 +46,6 @@
                 {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
               {% endfor %}
             </div>
-          {% endif %}
-
-
-          {% assign isContactPage = entityUrl.path | isPage: "contact-us" %}
-          {% if isContactPage %}
-            <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">{% assign basePath = entityUrl.path | regionBasePath %}
-                  {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}</div>
-          {% endif %}
-
-          {% if fieldTableOfContentsBoolean != empty and fieldTableOfContentsBoolean %}
-            <section id="table-of-contents">
-              <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-              <ul class="usa-unstyled-list"></ul>
-            </section>
           {% endif %}
 
           {% for block in fieldContentBlock %}

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -41,6 +41,13 @@
                   {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}</div>
           {% endif %}
 
+          {% if fieldTableOfContentsBoolean != empty and fieldTableOfContentsBoolean %}
+            <section id="table-of-contents">
+              <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+              <ul class="usa-unstyled-list"></ul>
+            </section>
+          {% endif %}
+
           {% for block in fieldContentBlock %}
             {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
             {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}

--- a/src/site/layouts/health_care_region_health_services_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_health_services_page.drupal.liquid
@@ -12,47 +12,102 @@
                 <h1>Our health services</h1>
                 <div class="va-introtext">{{ fieldClinicalHealthServi.processed }}</div>
 
-                <div class="usa-grid usa-grid-full vads-u-margin-top--2 vads-u-margin-bottom--3">
-                    <div class="usa-grid usa-grid-full vads-u-margin-y--1p5 vads-u-margin-bottom--4">{% assign basePath = entityUrl.path | regionBasePath %}
+                <div class="usa-grid usa-grid-full vads-u-margin-top--3 vads-u-margin-bottom--4">
+                    <div class="usa-grid usa-grid-full vads-u-margin-y--0 vads-u-margin-bottom--0">{% assign basePath = entityUrl.path | regionBasePath %}
                         {% include "src/site/facilities/facilities_health_services_buttons.drupal.liquid" with path = basePath %}</div>
                 </div>
 
                 {% if socialProgramsPatientFamilyServices.entities.length || healthWellnessPatientFamilyServices.entities.length || primaryCareHealthServices.entities.length || mentalHealthServices.entities.length || specialtyCareHealthServices.entities.length %}
-                    <div class="usa-grid usa-grid-full vads-u-margin-top--1p5">
-                        <h3>On this page</h3>
-                        <ul>
+                    <div class="usa-grid usa-grid-full vads-u-margin-top--0">
+                        <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+                        <ul class="usa-unstyled-list">
                             {% if featuredHealthServices.entities.length %}
-                                <li><a href="#featured-services">Featured services</a></li>
+                                <li class="vads-u-margin-bottom--2">
+                                    <a href="#featured-services" class="vads-u-text-decoration--none">
+                                        <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i>
+                                        Featured services
+                                    </a>
+                                </li>
                             {% endif %}
                             {% if primaryCareHealthServices.entities.length %}
-                                <li><a href="#primary-health-services">Primary care (Family medicine, internal medicine)</a></li>
+                                <li class="vads-u-margin-bottom--2">
+                                    <a href="#primary-health-services" class="vads-u-text-decoration--none">
+                                        <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i>
+                                        Primary care (Family medicine, internal medicine)
+                                    </a>
+                                </li>
                             {% endif %}
                             {% if extendedCareHealthServices.entities.length %}
-                                <li><a href="#extended-care-health-services">Extended care and rehabilitation</a></li>
+                                <li class="vads-u-margin-bottom--2">
+                                    <a href="#extended-care-health-services" class="vads-u-text-decoration--none">
+                                        <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i>
+                                        Extended care and rehabilitation
+                                    </a>
+                                </li>
                             {% endif %}
                             {% if homelessHealthServices.entities.length %}
-                                <li><a href="#homeless-health-services">Homeless services</a></li>
+                                <li class="vads-u-margin-bottom--2">
+                                    <a href="#homeless-health-services" class="vads-u-text-decoration--none">
+                                        <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i>
+                                        Homeless services
+                                    </a>
+                                </li>
                             {% endif %}
                             {% if socialProgramsPatientFamilyServices.entities.length %}
-                                <li><a href="#social-patient-family-services">Social programs and services</a></li>
+                                <li class="vads-u-margin-bottom--2">
+                                    <a href="#social-patient-family-services" class="vads-u-text-decoration--none">
+                                        <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i>
+                                        Social programs and services
+                                    </a>
+                                </li>
                             {% endif %}
                             {% if genomicMedicineHealthServices.entities.length %}
-                                <li><a href="#genomic-medicine-health-services">Genomic medicine/medical genetics (Genetic medicine)</a></li>
+                                <li class="vads-u-margin-bottom--2">
+                                    <a href="#genomic-medicine-health-services" class="vads-u-text-decoration--none">
+                                        <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i>
+                                        Genomic medicine/medical genetics (Genetic medicine)
+                                    </a>
+                                </li>
                             {% endif %}
                             {% if healthWellnessPatientFamilyServices.entities.length %}
-                                <li><a href="#wellness-patient-family-services">Health and wellness</a></li>
+                                <li class="vads-u-margin-bottom--2">
+                                    <a href="#wellness-patient-family-services" class="vads-u-text-decoration--none">
+                                        <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i>
+                                        Health and wellness
+                                    </a>
+                                </li>
                             {% endif %}
                             {% if mentalHealthServices.entities.length %}
-                                <li><a href="#mental-health-services">Mental and behavioral health</a></li>
+                                <li class="vads-u-margin-bottom--2">
+                                    <a href="#mental-health-services" class="vads-u-text-decoration--none">
+                                        <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i>
+                                        Mental and behavioral health
+                                    </a>
+                                </li>
                             {% endif %}
                             {% if specialtyCareHealthServices.entities.length %}
-                                <li><a href="#specialty-health-services">Specialty care</a></li>
+                                <li class="vads-u-margin-bottom--2">
+                                    <a href="#specialty-health-services" class="vads-u-text-decoration--none">
+                                        <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i>
+                                        Specialty care
+                                    </a>
+                                </li>
                             {% endif %}
                             {% if veteranCareHealthServices.entities.length %}
-                              <li><a href="#veteran-care-health-services">Services for Veteran care</a></li>
+                                <li class="vads-u-margin-bottom--2">
+                                    <a href="#veteran-care-health-services" class="vads-u-text-decoration--none">
+                                        <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i>
+                                        Services for Veteran care
+                                    </a>
+                                </li>
                             {% endif %}
                             {% if otherHealthServices.entities.length %}
-                                <li><a href="#other-health-services">Other services</a></li>
+                                <li class="vads-u-margin-bottom--2">
+                                    <a href="#other-health-services" class="vads-u-text-decoration--none">
+                                        <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i>
+                                        Other services
+                                    </a>
+                                </li>
                             {% endif %}
                         </ul>
                     </div>

--- a/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
@@ -32,6 +32,12 @@ module.exports = `
     changed
     fieldIntroText
     ${
+      enabledFeatureFlags[featureFlags.FEATURE_REGION_DETAIL_PAGE_TOC]
+        ? 'fieldTableOfContentsBoolean'
+        : ''
+    }
+    
+    ${
       enabledFeatureFlags[
         featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT
       ]

--- a/src/site/stages/build/plugins/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/add-id-to-subheadings.js
@@ -37,15 +37,38 @@ function generateHeadingIds() {
 
       if (fileName.endsWith('html')) {
         const doc = cheerio.load(file.contents);
+        const tableOfContents = doc('#table-of-contents ul');
         doc('h2, h3').each((i, el) => {
           const heading = doc(el);
-          const parent = heading.parent();
+          const parent = heading.parents();
           const isInAccordionButton = parent.hasClass('usa-accordion-button');
+          const isInAccordion = parent.hasClass('usa-accordion-content');
 
           // skip heading if it already has an id and skip heading if it's in an accordion button
           if (!heading.attr('id') && !isInAccordionButton) {
             const headingID = createUniqueId(heading);
             heading.attr('id', headingID);
+            idAdded = true;
+          }
+
+          // if it is an h2, add the h2 to the table of contents
+          if (
+            el.tagName.toLowerCase() === 'h2' &&
+            tableOfContents &&
+            heading.text().toLowerCase() !== 'on this page' &&
+            !isInAccordionButton &&
+            !isInAccordion
+          ) {
+            tableOfContents.append(
+              `<li class="vads-u-margin-bottom--2">
+                  <a href="#${heading.attr(
+                    'id',
+                  )}" class="vads-u-text-decoration--none">
+                    <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i> 
+                    ${heading.text()}
+                  </a>
+                </li>`,
+            );
             idAdded = true;
           }
         });

--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -22,6 +22,7 @@ const featureFlags = {
   FEATURE_LOCAL_FACILITY_GET_IN_TOUCH: 'featureLocalFacilityGetInTouch',
   FEATURE_SINGLE_VALUE_FIELD_LINK: 'featureSingleValueFieldLink',
   FEATURE_REGION_PAGE_LINKS: 'featureRegionPageLinks',
+  FEATURE_REGION_DETAIL_PAGE_TOC: 'featureRegionDetailPageTOC',
 };
 
 // Edit this to turn flags on or off
@@ -40,6 +41,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT,
     featureFlags.FEATURE_LOCAL_FACILITY_GET_IN_TOUCH,
     featureFlags.FEATURE_REGION_PAGE_LINKS,
+    featureFlags.FEATURE_REGION_DETAIL_PAGE_TOC,
   ],
   vagovdev: [
     featureFlags.FEATURE_FIELD_ASSET_LIBRARY_DESCRIPTION,
@@ -55,6 +57,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT,
     featureFlags.FEATURE_LOCAL_FACILITY_GET_IN_TOUCH,
     featureFlags.FEATURE_REGION_PAGE_LINKS,
+    featureFlags.FEATURE_REGION_DETAIL_PAGE_TOC,
   ],
   vagovstaging: [
     featureFlags.FEATURE_FIELD_ADDITIONAL_INFO,


### PR DESCRIPTION
## Description
creates a table of contents for region detail pages that have it configured

## Testing done
locally with dev data, staging when it wants to behave

pre-req: make sure a health care region detail page has the table of contents enabled
1. go to the cms site
2. go to a region detail page such as "Contact us", or, make a test page
3. expand the "Include table of contents?" section
4. make sure it is checked
5. save the page

to test:
example jumplink styling can be found here: https://app.zeplin.io/project/5d014fd159c9931608872c98/screen/5d24c624607c06442792ea5c
1. get latest and build site
2. browse to http://localhost:3001/pittsburgh-health-care/health-services
3. check out the styling and functionality of the jumplinks
4. check out a local facility page such as http://localhost:3001/pittsburgh-health-care/locations/hj-heinz/
5. check out those jumplinks
6. go to a detail page such as "Contact us" http://localhost:3001/pittsburgh-health-care/contact-us/
7. see those jumplinks? test them out :)

## Screenshots
![image](https://user-images.githubusercontent.com/19178435/61339000-ae505280-a7f0-11e9-8bac-1c674e68bd52.png)

## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-4005

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
