### PR TITLE
added preferred provider indicator on vet tec profile page

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
@@ -3,10 +3,9 @@ import React from 'react';
 
 import VetTecAdditionalResources from './VetTecAdditionalResources';
 
-const IconWithInfo = ({ icon, children }) => (
+const IconWithInfo = ({ icon, iconClassName, children }) => (
   <p className="icon-with-info">
-    <i className={`fa fa-${icon}`} />
-    &nbsp;
+    <i className={`fa fa-${icon} ${iconClassName}`} />
     {children}
   </p>
 );
@@ -18,7 +17,8 @@ export const VetTecHeadingSummary = ({ institution }) => (
       <div>
         <div className="usa-width-one-half medium-6 small-12 column">
           <IconWithInfo
-            icon="star vads-u-color--gold"
+            icon="star"
+            iconClassName="vads-u-color--gold"
             present={
               institution.preferredProvider &&
               institution.preferredProvider === true

--- a/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
@@ -17,15 +17,15 @@ export const VetTecHeadingSummary = ({ institution }) => (
       <h1>{institution.name}</h1>
       <div>
         <div className="usa-width-one-half medium-6 small-12 column">
-            <IconWithInfo
-                icon="star vads-u-color--gold"
-                present={
-                    institution.preferredProvider &&
-                    institution.preferredProvider === true
-                }
-            >
-                Preferred provider (<a>Learn more</a>)
-            </IconWithInfo>
+          <IconWithInfo
+            icon="star vads-u-color--gold"
+            present={
+              institution.preferredProvider &&
+              institution.preferredProvider === true
+            }
+          >
+            Preferred provider (<a>Learn more</a>)
+          </IconWithInfo>
           {institution.city &&
             institution.country && (
               <IconWithInfo icon="map-marker">

--- a/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
@@ -3,12 +3,15 @@ import React from 'react';
 
 import VetTecAdditionalResources from './VetTecAdditionalResources';
 
-const IconWithInfo = ({ icon, iconClassName, children }) => (
-  <p className="icon-with-info">
-    <i className={`fa fa-${icon} ${iconClassName}`} />
-    {children}
-  </p>
-);
+const IconWithInfo = ({ icon, iconClassName, children, present }) => {
+  if (!present) return null;
+  return (
+    <p className="icon-with-info">
+      <i className={`fa fa-${icon} ${iconClassName}`} />
+      {children}
+    </p>
+  );
+};
 
 export const VetTecHeadingSummary = ({ institution }) => (
   <div className="heading row">
@@ -28,7 +31,11 @@ export const VetTecHeadingSummary = ({ institution }) => (
           </IconWithInfo>
           {institution.city &&
             institution.country && (
-              <IconWithInfo icon="map-marker">
+              <IconWithInfo
+                icon="map-marker"
+                present={institution.city && institution.country}
+              >
+                &nbsp;
                 {institution.city}, {institution.state || institution.country}
               </IconWithInfo>
             )}

--- a/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
@@ -17,6 +17,15 @@ export const VetTecHeadingSummary = ({ institution }) => (
       <h1>{institution.name}</h1>
       <div>
         <div className="usa-width-one-half medium-6 small-12 column">
+            <IconWithInfo
+                icon="star vads-u-color--gold"
+                present={
+                    institution.preferredProvider &&
+                    institution.preferredProvider === true
+                }
+            >
+                Preferred provider (<a>Learn more</a>)
+            </IconWithInfo>
           {institution.city &&
             institution.country && (
               <IconWithInfo icon="map-marker">

--- a/src/applications/gi/tests/selectors/calculator.unit.spec.js
+++ b/src/applications/gi/tests/selectors/calculator.unit.spec.js
@@ -88,7 +88,6 @@ defaultState = {
       persistanceRateVeteranBa: 1.0,
       persistanceRateVeteranOtb: 0.5,
       poe: true,
-      preferredProvider: false,
       repaymentRateAllStudents: 0.187458943,
       retentionAllStudentsBa: null,
       retentionAllStudentsOtb: null,

--- a/src/applications/gi/tests/selectors/calculator.unit.spec.js
+++ b/src/applications/gi/tests/selectors/calculator.unit.spec.js
@@ -88,6 +88,7 @@ defaultState = {
       persistanceRateVeteranBa: 1.0,
       persistanceRateVeteranOtb: 0.5,
       poe: true,
+      preferredProvider: false,
       repaymentRateAllStudents: 0.187458943,
       retentionAllStudentsBa: null,
       retentionAllStudentsOtb: null,


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19181

## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/48804654/61387080-6d554e00-a883-11e9-865d-938f5e24a0ae.png)


## Acceptance criteria
- [ ] If the institution is a preferred provider (as indicated by the WEAMS.csv Preferred Provider column), "Preferred provider" is displayed in the institution details section of the VET TEC Profile page.
     - There is a yellow star icon to the left of the text.
- [ ] If the institution is not a preferred provider, there is no gap where the indicator would have been displayed.
## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
