### PR TITLE
CT 116: Hide VET TEC Institution Type based Military Status #19230

### DIFF
--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -84,9 +84,9 @@ export class LandingPage extends React.Component {
     this.props.institutionFilterChange(filters);
   };
 
-  shouldDisplayTypeOfInstitution = () =>
-    this.props.eligibility.militaryStatus !== 'active duty' &&
-    this.props.eligibility.giBillChapter === '33';
+  shouldDisplayTypeOfInstitution = (eligibility = this.props.eligibility) =>
+    eligibility.militaryStatus === 'veteran' &&
+    eligibility.giBillChapter === '33';
 
   // ***CT 116***
   isVetTecNotSelected = () =>
@@ -97,10 +97,12 @@ export class LandingPage extends React.Component {
     const field = e.target.name;
     const value = e.target.value;
 
+    const eligibility = { ...this.props.eligibility };
+    eligibility[field] = value;
+
     if (
       this.props.filters.category === 'vettec' &&
-      ((field === 'militaryStatus' && value === 'active duty') ||
-        (field === 'giBillChapter' && value !== '33'))
+      !this.shouldDisplayTypeOfInstitution(eligibility)
     ) {
       this.props.institutionFilterChange({
         ...this.props.filters,
@@ -124,14 +126,6 @@ export class LandingPage extends React.Component {
 
     this.props.institutionFilterChange(filters);
   };
-
-  shouldDisplayTypeOfInstitution = () =>
-    this.props.eligibility.militaryStatus !== 'active duty' &&
-    this.props.eligibility.giBillChapter === '33';
-
-  shouldDisplayKeywordSearch = () =>
-    environment.isProduction() ||
-    (!environment.isProduction() && !isVetTecSelected(this.props.filters));
 
   render() {
     return (

--- a/src/applications/gi/tests/containers/LandingPage.unit.spec.js
+++ b/src/applications/gi/tests/containers/LandingPage.unit.spec.js
@@ -1,19 +1,26 @@
 import React from 'react';
 import { expect } from 'chai';
-import SkinDeep from 'skin-deep';
 import sinon from 'sinon';
+import { shallow, mount } from 'enzyme';
+import { Provider } from 'react-redux';
 
 import createCommonStore from '../../../../platform/startup/store';
 import { LandingPage } from '../../containers/LandingPage';
 import reducer from '../../reducers';
 
-const defaultProps = createCommonStore(reducer).getState();
+const defaultStore = createCommonStore(reducer);
+const defaultProps = {
+  ...defaultStore.getState(),
+  showModal: sinon.spy(),
+  setPageTitle: sinon.spy(),
+  eligibilityChange: sinon.spy(),
+};
 
 describe('<LandingPage>', () => {
   it('should render', () => {
-    const tree = SkinDeep.shallowRender(<LandingPage {...defaultProps} />);
-    const vdom = tree.getRenderOutput();
-    expect(vdom).to.not.be.undefined;
+    const tree = shallow(<LandingPage {...defaultProps} />);
+    expect(tree).to.not.be.undefined;
+    tree.unmount();
   });
 
   it('should handleSubmit correctly', () => {
@@ -22,10 +29,52 @@ describe('<LandingPage>', () => {
       router: { push: sinon.spy() },
       location: { query: {} },
       autocomplete: { searchTerm: 'foo' },
+      handleSubmit: sinon.spy(),
     };
 
-    const tree = SkinDeep.shallowRender(<LandingPage {...props} />);
-    tree.getMountedInstance().handleSubmit({ preventDefault: () => {} });
+    const tree = mount(
+      <Provider store={defaultStore}>
+        <LandingPage {...props} />
+      </Provider>,
+    );
+    tree.find('form').simulate('submit');
     expect(props.router.push.called).to.be.true;
+    tree.unmount();
+  });
+
+  it('should display VET TEC type of institution filter', () => {
+    const props = {
+      ...defaultProps,
+      router: { push: sinon.spy() },
+      location: { query: {} },
+      autocomplete: { searchTerm: null },
+    };
+
+    const store = {
+      ...defaultStore,
+      state: {
+        ...defaultProps,
+        eligibility: {
+          ...defaultProps.eligibility,
+          militaryStatus: 'veteran',
+          giBillChapter: '33',
+        },
+      },
+    };
+    const tree = mount(
+      <Provider store={store}>
+        <LandingPage {...props} />
+      </Provider>,
+    );
+
+    const vetTecOption = tree
+      .find('TypeOfInstitutionFilter')
+      .find('RadioButtons')
+      .find('span');
+
+    expect(vetTecOption.text()).to.equal(
+      'VET TEC training providers only  (Learn More)',
+    );
+    tree.unmount();
   });
 });


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19230

As a non-veteran Comparison Tool user, I should not be able to select the VET TEC as an institution type because I am not eligible for the VET TEC program.


## Testing done
- local testing
- unit testing

## Screenshots
![Screen Shot 2019-07-17 at 11 33 19 AM](https://user-images.githubusercontent.com/1094999/61389339-bf4ba300-a886-11e9-878c-21fffa5a12ad.png)
![Screen Shot 2019-07-17 at 11 33 32 AM](https://user-images.githubusercontent.com/1094999/61389342-c1156680-a886-11e9-865a-7dea14481fc1.png)
![Screen Shot 2019-07-17 at 11 33 37 AM](https://user-images.githubusercontent.com/1094999/61389359-c5418400-a886-11e9-860d-0b89d689231d.png)


## Acceptance criteria
- [ ] The option "VET TEC Providers" for the "Type of Institution" question on the Comparison Tool Landing page is ONLY available when the answer to "What is your military status?" question is "Veteran".
 
## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
