### PR TITLE
Fixing width for h4 on assets gallery page.

### DIFF
--- a/src/applications/public-outreach-materials/sass/public-outreach-materials.scss
+++ b/src/applications/public-outreach-materials/sass/public-outreach-materials.scss
@@ -9,7 +9,9 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
   max-width: 95%;
   margin-bottom: 25px;
 }
-
+.va-sidebarnav .left-side-nav-title h4 {
+  width: 100%;
+}
 .asset-component-library {
   .asset-card {
     min-height: 450px;


### PR DESCRIPTION
## Description
Sidebar h4 on this page is set to 75% width: https://staging.va.gov/outreach-and-events/outreach-materials/ - Needs to be 100%.

## Testing done
Visual

## Screenshots
![bad](https://user-images.githubusercontent.com/2404547/61392748-85ca6600-a88d-11e9-9d0e-921f950eb75e.png)
![good](https://user-images.githubusercontent.com/2404547/61392750-85ca6600-a88d-11e9-8c1d-a22c7aa33ca2.png)

## Acceptance criteria
- [ ] Sidebar h4 on https://staging.va.gov/outreach-and-events/outreach-materials/ page is 100% width.



