### PR TITLE
set searchTerm to empty string when vettec is selected on landing page

### DIFF
--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -77,6 +77,10 @@ export class LandingPage extends React.Component {
 
     if (field === 'category') {
       filters.vetTecProvider = value === 'vettec';
+
+      if (filters.vetTecProvider) {
+        this.props.updateAutocompleteSearchTerm('');
+      }
     }
     filters[field] = value;
 
@@ -111,19 +115,6 @@ export class LandingPage extends React.Component {
     }
 
     this.props.eligibilityChange(e);
-  };
-
-  handleTypeOfInstitutionFilterChange = e => {
-    const field = e.target.name;
-    const value = e.target.value;
-    const filters = this.props.filters;
-
-    if (field === 'category') {
-      filters.vetTecProvider = value === 'vettec';
-    }
-    filters[field] = value;
-
-    this.props.institutionFilterChange(filters);
   };
 
   render() {


### PR DESCRIPTION
## Description
- go to https://staging.va.gov/gi-bill-comparison-tool/
- Search for “college” or some string
- let autocomplete finish
- Select “VET TEC Training providers only”
- Click Search Schools
- Notice there the search term from before is still showing up
- Delete search term, hit enter
- Search term doesn’t disappear

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
