### PR TITLE
revert change that sets mhvAccount.loading to true by default

### DIFF
--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -345,10 +345,7 @@ export class CallToActionWidget extends React.Component {
 
   render() {
     const { setFocus } = this.props;
-    if (
-      this.props.profile.loading ||
-      (this._isHealthTool && this.props.mhvAccount.loading)
-    ) {
+    if (this.props.profile.loading || this.props.mhvAccount.loading) {
       return (
         <LoadingIndicator
           setFocus={setFocus}

--- a/src/platform/user/profile/reducers/index.js
+++ b/src/platform/user/profile/reducers/index.js
@@ -38,7 +38,7 @@ const initialState = {
     accountLevel: null,
     accountState: null,
     errors: null,
-    loading: true,
+    loading: false,
     termsAndConditionsAccepted: false,
   },
   vet360: {},

--- a/src/platform/user/tests/profile/reducers/index.unit.spec.js
+++ b/src/platform/user/tests/profile/reducers/index.unit.spec.js
@@ -19,9 +19,9 @@ import {
 
 describe('Profile reducer', () => {
   describe('initial state', () => {
-    it('should set mhvAccount.loading to true', () => {
+    it('should set mhvAccount.loading to false', () => {
       const state = reducer(undefined, { type: 'not a valid event type' });
-      expect(state.mhvAccount.loading).to.be.true;
+      expect(state.mhvAccount.loading).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description
To address https://github.com/department-of-veterans-affairs/va.gov-team/issues/629. Simply reverting a change I made as part of https://github.com/department-of-veterans-affairs/vets-website/pull/10411/files. Will need to revisit this issue as the `AccountMain` component will now mount all of its children components twice: once because the MHV loading flag is `false` on init, then a second time when the MHV loading flag flips _back_ to `false` after the call to get MHV status has resolved.

## Testing done
Local; spinners resolve in both logged in and logged out states

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs