### PR TITLE
635 - Change super-footer link-text.

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -234,7 +234,7 @@
     "href": "https://www.va.gov/privacy/",
     "order": 6,
     "target": null,
-    "title": "VA Privacy Service office"
+    "title": "VA Privacy Service"
   },
   {
     "column": "bottom_rail",


### PR DESCRIPTION
## Description
[635](/department-of-veterans-affairs/va.gov-team/issues/635) - Update super-footer‘s “VA Privacy Service office” link-text to “VA Privacy Service”.

## Testing done
Local - visual verification of text-only change.  No code-changes.

## Acceptance criteria
- [ ] Link text shows “VA Privacy Service” (without “ office”).

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
