### PR TITLE
VAGOV-4903 Benefit Hub Title Icon Class

### DIFF
--- a/src/site/stages/build/drupal/benefit-hub.js
+++ b/src/site/stages/build/drupal/benefit-hub.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-param-reassign, no-continue */
+
+// Adds the title icon field from a benefits hub landing page to its associated detail pages.
+function addHubIconField(page, pages) {
+  const rootPath = `/${page.entityUrl.path.split('/')[1]}`;
+  const landingPage = pages.find(
+    // Find the corresponding landing page for this detail page.
+    p => p.entityBundle === 'landing_page' && p.entityUrl.path === rootPath,
+  );
+
+  // If we found a landing page, grab the icon field.
+  if (landingPage) {
+    page.fieldTitleIcon = landingPage.fieldTitleIcon;
+  }
+}
+
+module.exports = { addHubIconField };

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -14,6 +14,7 @@ const {
   createHealthCareRegionListPages,
   addGetUpdatesFields,
 } = require('./health-care-region');
+const { addHubIconField } = require('./benefit-hub');
 
 const DRUPAL_CACHE_FILENAME = 'drupal/pages.json';
 
@@ -57,6 +58,9 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
         break;
       case 'health_care_region_detail_page':
         addGetUpdatesFields(pageCompiled, pages);
+        break;
+      case 'page':
+        addHubIconField(pageCompiled, pages);
         break;
       default:
     }


### PR DESCRIPTION
## Description
Changes the method by which classes are generated for icons on Benefit Hub landing and detail pages.

We now look for FieldTitleIcon of the associated Benefit Hub landing page when building a detail page. This is added to the page object and used in the appropriate templates.

## Testing done

- Pulled down current database.
- Rebuilt site with `node watch`.
- Observed that benefit hub landing and detail pages that were built by Drupal had the appropriate classes and icons.

## Screenshots
<img width="1412" alt="Screen Shot 2019-07-19 at 2 05 31 PM" src="https://user-images.githubusercontent.com/1181665/61555855-4d15c280-aa2e-11e9-94e9-be853d81a9ae.png">
<img width="1331" alt="Screen Shot 2019-07-19 at 2 05 20 PM" src="https://user-images.githubusercontent.com/1181665/61555856-4d15c280-aa2e-11e9-84e9-276dffea74c1.png">
<img width="1335" alt="Screen Shot 2019-07-19 at 2 05 11 PM" src="https://user-images.githubusercontent.com/1181665/61555857-4d15c280-aa2e-11e9-9a00-cdb975e0a5b4.png">
<img width="1630" alt="Screen Shot 2019-07-19 at 2 04 51 PM" src="https://user-images.githubusercontent.com/1181665/61555858-4dae5900-aa2e-11e9-96ba-66dfdb594350.png">
<img width="1671" alt="Screen Shot 2019-07-19 at 2 04 29 PM" src="https://user-images.githubusercontent.com/1181665/61555859-4dae5900-aa2e-11e9-9ee1-5f9679949e31.png">


## Acceptance criteria
- Icon CSS class is generated correctly.
- Correct icon appears on Drupal-generated landing pages.
- Correct icon appears on Drupal-generated detail pages.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
