### PR TITLE
Remove feature flag requirement for custom session expiration fetch

### DIFF
--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -4,12 +4,8 @@ import environment from '../environment';
 import localStorage from '../storage/localStorage';
 
 export function fetchAndUpdateSessionExpiration(...args) {
-  // Only replace with custom fetch if not stubbed for testing
-  // and feature flag is enabled
-  if (
-    fetch.displayName !== 'stub' &&
-    localStorage.getItem('useCustomFetch') === 'true'
-  ) {
+  // Only replace with custom fetch if not stubbed for unit testing
+  if (fetch.displayName !== 'stub') {
     return fetch.apply(this, args).then(response => {
       const apiURL = environment.API_URL;
 


### PR DESCRIPTION
## Description
Last PR for #18322 was originally released with a feature flag.  Did some testing on prod using a couple different apps and verified that custom fetch is functioning properly.

## Testing done
Tested on production using facility locator, pensions app, and claims

## Screenshots


## Acceptance criteria
- [ ] Feature flag removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
