### PR TITLE
VAGOV-5081: styling updates for outreach events materials

### DIFF
--- a/src/applications/public-outreach-materials/sass/public-outreach-materials.scss
+++ b/src/applications/public-outreach-materials/sass/public-outreach-materials.scss
@@ -4,10 +4,7 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-nav-sidebar";
 
 .outreach-asset-form-filters {
-  padding: 15px;
   background: $color-gray-lightest;
-  max-width: 95%;
-  margin-bottom: 25px;
 }
 .va-sidebarnav .left-side-nav-title h4 {
   width: 100%;
@@ -17,9 +14,15 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
     min-height: 450px;
     float: left;
     display: none;
+
+    @media (min-width: $large-screen) {
+      &.large-screen\:vads-l-col--6 {
+        max-width: 48.35%;
+      }
+    }
+
     .card-inside-wrap {
       background: $color-gray-lightest;
-      padding: 15px;
       height: 100%;
     }
     &.show-type {
@@ -63,7 +66,15 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
     }
     .asset-body-wrap {
       height: 250px;
-      padding: 15px;
+
+      @media (min-width: $medium-screen) {
+        height: 100%;
+      }
+
+      @media (min-width: $large-screen) {
+        height: 250px;
+      }
+
       .asset-body-text,
       .asset-category-text,
       .asset-filetype-text {
@@ -73,6 +84,9 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
         text-transform: capitalize;
       }
     }
+  }
+  .va-c-margin-top--auto {
+    margin-top: auto;
   }
 }
 
@@ -105,7 +119,6 @@ Only way to accomplish everything required is with this method.
     &.medium-card-utility {
       margin-bottom: 25px;
       min-height: 0;
-      height: 250px;
       .medium-head-utility {
         background: none;
         max-width: none;

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -18,7 +18,7 @@
         </div>
         {% endif %}
 
-        <article class="vads-l-grid-container--full">
+        <article class="usa-content vads-l-grid-container--full">
           <div class="vads-l-grid-container--full">
             <h1>{{ title }}</h1>
             <div class="vads-l-grid-container--full">
@@ -34,12 +34,13 @@
               class="vads-l-grid-container--full asset-component-library library-show"
               id="search-entry">
 
-              <form class="usa-form outreach-asset-form-filters library-show">
+              <form class="usa-form outreach-asset-form-filters library-show vads-u-max-width--100 vads-u-padding-y--3 vads-u-padding-x--1p5 vads-u-margin-bottom--2">
                 <div class="vads-l-row vads-u-justify-content--space-between">
                   <div class="vads-l-col--12
                                 medium-screen:vads-l-col--12
                                 small-desktop-screen:vads-l-col--12
-                                large-screen:vads-l-col--5">
+                                large-screen:vads-l-col--6
+                                vads-u-padding-x--1p5">
                     <label class="vads-u-margin-top--0"
                       for="outreach-topic">Select a topic</label>
                     <select class="vads-u-max-width--100 usa-select"
@@ -68,9 +69,10 @@
                   <div class="vads-l-col--12
                 medium-screen:vads-l-col--12
                 small-desktop-screen:vads-l-col--12
-                large-screen:vads-l-col--5">
-                    <label class="vads-u-margin-top--0" for="outreach-type">View
-                      file type</label>
+                large-screen:vads-l-col--6
+                vads-u-padding-x--1p5
+                ">
+                    <label class="vads-u-margin-top--0" for="outreach-type">Select file type</label>
                     <select class="vads-u-max-width--100 usa-select"
                       name="outreach-type" id="outreach-type">
                       <option value="select">- All types -</option>
@@ -87,14 +89,17 @@
                 </div>
               </form>
 
-              <div id="total-pages-div">
+              <div id="total-pages-div" class="vads-u-margin-bottom--1">
                 <div class="break-div">Showing
                   <span id="total-pages"></span>
                   <span id="total-all"></span> results
                 </div>
               </div>
+              {% assign even = true %}
               {% for entity in outreachAssetsDataArray.entities %}
               {% if entity.fieldOffice.targetId == fieldOffice.targetId %}
+
+
               <div data-topic="{{entity.fieldBenefits}}"
                 {{entity.fieldBenefits | breakIntoSingles}}
                 data-type="{{entity.fieldFormat}}" data-number={{forloop.index}}
@@ -102,12 +107,12 @@
                 vads-l-row
                 medium-card-utility
                 large-screen:vads-l-col--6
-                vads-u-padding-right--4
-                vads-u-padding-bottom--4
+                {% if even %} large-screen:vads-u-margin-right--3 {% endif %}
+                vads-u-margin-bottom--3
                 asset-card
                 show-type
                 show-topic">
-                <div class="card-inside-wrap">
+                <div class="card-inside-wrap clearfix vads-u-padding--3">
                   <div class="asset-head-wrap
                 medium-screen:vads-l-col--4
                 medium-head-utility
@@ -181,6 +186,9 @@
                   </div>
 
                   <div class="asset-body-wrap
+                  vads-u-display--flex
+                  vads-u-flex-direction--column
+                  vads-u-padding-top--1
                   medium-screen:vads-l-col--8
                   medium-body-utility
                   large-screen:vads-l-col--12">
@@ -193,7 +201,7 @@
                     <div class="asset-category-text capitalize-first"></div>
                     {% endif %}
 
-                    <div class="asset-download-trigger">
+                    <div class="asset-download-trigger va-c-margin-top--auto">
                       {% if entity.fieldMedia.entity.entityBundle == 'document' %}
                       {% assign url = entity.fieldMedia.entity.fieldDocument.entity.url %}
                       {% if entity.derivedFields.absoluteUrl %}
@@ -231,8 +239,14 @@
                 </div>
               </div>
               {% endif %}
-              {% endfor %}
-            </div>
+
+            {% if even %}
+              {% assign even = false %}
+            {% else %}
+              {% assign even = true %}
+            {% endif %}
+            {% endfor %}
+
           </div>
 
           <div class="va-pagination library-show" id="va-pager-div">


### PR DESCRIPTION
## Description
styling updates for outreach materials

## Testing done
local with staging data
http://localhost:3001/outreach-and-events/outreach-materials/

## Screenshots
![localhost_3001_outreach-and-events_outreach-materials_](https://user-images.githubusercontent.com/19178435/61569956-a685ed80-aa3e-11e9-9044-53a40de14529.png)

## Acceptance criteria
rows marked with "aurora" here: https://va-gov.atlassian.net/wiki/spaces/VAGOV/pages/128876545/2019-07-16.1+Sprint+18+final+sprint+release+1

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
