### PR TITLE
Automatically show sign-in warning banners based on backend statuses API endpoint

### DIFF
--- a/src/platform/monitoring/external-services/ExternalServicesError.jsx
+++ b/src/platform/monitoring/external-services/ExternalServicesError.jsx
@@ -1,0 +1,63 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { getBackendStatuses } from './actions';
+import { EXTERNAL_SERVICES } from './config';
+
+const OPERATIONAL_STATUSES = ['active', 'warning'];
+
+/**
+ * A wrapper component that render its children if the application's dependencies are failing.
+ * @property {node} children - Content to be rendered if there are failing dependencies.
+ * @property {Array<string>} dependencies - Upstream services required by the application.
+ * @property {function} getBackendStatuses - Gets the statuses of external backend services.
+ */
+class ExternalServicesError extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    dependencies: PropTypes.arrayOf(
+      PropTypes.oneOf(Object.values(EXTERNAL_SERVICES)),
+    ).isRequired,
+    getBackendStatuses: PropTypes.func.isRequired,
+  };
+
+  componentDidMount() {
+    if (!this.props.loading && !this.props.statuses) {
+      this.props.getBackendStatuses();
+    }
+  }
+
+  /**
+   * Checks whether a service is a dependency and if it's operational.
+   * @param {Object} service - The service to be checked.
+   * @param {string} service.serviceId - The service's human readable ID.
+   * @param {string} service.status - The service's status.
+   * @return {boolean} Whether the service is a failing dependency (true) or not (false).
+   */
+  isFailingDependency = ({ serviceId, status }) =>
+    this.props.dependencies.includes(serviceId) &&
+    !OPERATIONAL_STATUSES.includes(status);
+
+  render() {
+    const { children, statuses } = this.props;
+    if (!statuses) return null;
+
+    const shouldRender = statuses.some(this.isFailingDependency);
+    if (!shouldRender) return null;
+
+    return children;
+  }
+}
+
+const mapStateToProps = state => {
+  const { loading, statuses } = state.externalServiceStatuses;
+  return { loading, statuses };
+};
+
+const mapDispatchToProps = { getBackendStatuses };
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ExternalServicesError);

--- a/src/platform/monitoring/external-services/ExternalServicesError.jsx
+++ b/src/platform/monitoring/external-services/ExternalServicesError.jsx
@@ -23,13 +23,13 @@ class ExternalServicesError extends React.Component {
   };
 
   componentDidMount() {
-    if (!this.props.loading && !this.props.statuses) {
+    if (this.props.shouldGetBackendStatuses) {
       this.props.getBackendStatuses();
     }
   }
 
   /**
-   * Checks whether a service is a dependency and if it's operational.
+   * Checks whether a service is a dependency and operational.
    * @param {Object} service - The service to be checked.
    * @param {string} service.serviceId - The service's human readable ID.
    * @param {string} service.status - The service's status.
@@ -50,12 +50,15 @@ class ExternalServicesError extends React.Component {
   }
 }
 
-const mapStateToProps = state => {
+export const mapStateToProps = state => {
   const { loading, statuses } = state.externalServiceStatuses;
-  return { loading, statuses };
+  const shouldGetBackendStatuses = !loading && !statuses;
+  return { shouldGetBackendStatuses, statuses };
 };
 
 const mapDispatchToProps = { getBackendStatuses };
+
+export { ExternalServicesError };
 
 export default connect(
   mapStateToProps,

--- a/src/platform/monitoring/external-services/ExternalServicesError.jsx
+++ b/src/platform/monitoring/external-services/ExternalServicesError.jsx
@@ -59,5 +59,5 @@ const mapDispatchToProps = { getBackendStatuses };
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(ExternalServicesError);

--- a/src/platform/monitoring/external-services/actions.js
+++ b/src/platform/monitoring/external-services/actions.js
@@ -1,0 +1,20 @@
+import { apiRequest } from 'platform/utilities/api';
+
+export const FETCH_BACKEND_STATUSES_FAILURE = 'FETCH_BACKEND_STATUSES_FAILURE';
+export const FETCH_BACKEND_STATUSES_SUCCESS = 'FETCH_BACKEND_STATUSES_SUCCESS';
+export const LOADING_BACKEND_STATUSES = 'LOADING_BACKEND_STATUSES';
+
+const BASE_URL = '/backend_statuses';
+
+export function getBackendStatuses() {
+  return dispatch => {
+    dispatch({ type: LOADING_BACKEND_STATUSES });
+
+    return apiRequest(
+      BASE_URL,
+      null,
+      ({ data }) => dispatch({ type: FETCH_BACKEND_STATUSES_SUCCESS, data }),
+      () => dispatch({ type: FETCH_BACKEND_STATUSES_FAILURE }),
+    );
+  }
+};

--- a/src/platform/monitoring/external-services/actions.js
+++ b/src/platform/monitoring/external-services/actions.js
@@ -16,5 +16,5 @@ export function getBackendStatuses() {
       ({ data }) => dispatch({ type: FETCH_BACKEND_STATUSES_SUCCESS, data }),
       () => dispatch({ type: FETCH_BACKEND_STATUSES_FAILURE }),
     );
-  }
-};
+  };
+}

--- a/src/platform/monitoring/external-services/config.js
+++ b/src/platform/monitoring/external-services/config.js
@@ -27,4 +27,3 @@ export const EXTERNAL_SERVICES = {
   // Veteran ID Card v1
   vic: 'vic',
 };
-

--- a/src/platform/monitoring/external-services/config.js
+++ b/src/platform/monitoring/external-services/config.js
@@ -1,0 +1,30 @@
+/**
+ * List of external backend services that we monitor as defined by the VA API:
+ * https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/settings.yml#L338
+ */
+export const EXTERNAL_SERVICES = {
+  appeals: 'appeals',
+  arcgis: 'arcgis',
+  dslogon: 'dslogon',
+  emis: 'emis',
+  // Enrollment System (HCA submissions)
+  es: 'es',
+  evss: 'evss',
+  // Intake, conversion, and mail handling services (central mail)
+  icmhs: 'icmhs',
+  // ID.me, identity provider
+  idme: 'idme',
+  // My HealtheVet
+  mhv: 'mhv',
+  // Master Veteran Index (source of veteran profile info)
+  mvi: 'mvi',
+  // Search.gov API
+  search: 'search',
+  // The Image Management System (education forms)
+  tims: 'tims',
+  // Vet360 - data source for centralized veteran contact information
+  vet360: 'vet360',
+  // Veteran ID Card v1
+  vic: 'vic',
+};
+

--- a/src/platform/monitoring/external-services/reducer.js
+++ b/src/platform/monitoring/external-services/reducer.js
@@ -17,12 +17,12 @@ export default function externalServiceStatuses(state = INITIAL_STATE, action) {
     case FETCH_BACKEND_STATUSES_FAILURE:
       return { ...state, loading: false };
 
-    case FETCH_BACKEND_STATUSES_SUCCESS:
+    case FETCH_BACKEND_STATUSES_SUCCESS: {
       const { statuses } = action.data.attributes;
       return { ...state, loading: false, statuses };
+    }
 
     default:
       return state;
   }
 }
-

--- a/src/platform/monitoring/external-services/reducer.js
+++ b/src/platform/monitoring/external-services/reducer.js
@@ -1,0 +1,28 @@
+import {
+  FETCH_BACKEND_STATUSES_FAILURE,
+  FETCH_BACKEND_STATUSES_SUCCESS,
+  LOADING_BACKEND_STATUSES,
+} from './actions';
+
+const INITIAL_STATE = {
+  loading: false,
+  statuses: null,
+};
+
+export default function externalServiceStatuses(state = INITIAL_STATE, action) {
+  switch (action.type) {
+    case LOADING_BACKEND_STATUSES:
+      return { ...state, loading: true };
+
+    case FETCH_BACKEND_STATUSES_FAILURE:
+      return { ...state, loading: false };
+
+    case FETCH_BACKEND_STATUSES_SUCCESS:
+      const { statuses } = action.data.attributes;
+      return { ...state, loading: false, statuses };
+
+    default:
+      return state;
+  }
+}
+

--- a/src/platform/monitoring/external-services/tests/ExternalServiceError.unit.spec.jsx
+++ b/src/platform/monitoring/external-services/tests/ExternalServiceError.unit.spec.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount, shallow } from 'enzyme';
+import sinon from 'sinon';
+
+import {
+  ExternalServicesError,
+  mapStateToProps,
+} from '../ExternalServicesError';
+
+describe('<ExternalServicesError>', () => {
+  const props = {
+    dependencies: [],
+    getBackendStatuses: sinon.spy(),
+    shouldGetBackendStatuses: false,
+    statuses: null,
+  };
+
+  it('should get backend statuses when mounted', () => {
+    const wrapper = mount(
+      <ExternalServicesError {...props} shouldGetBackendStatuses />,
+    );
+    expect(props.getBackendStatuses.calledOnce).to.be.true;
+    wrapper.unmount();
+  });
+
+  it('should not render anything when services are up', () => {
+    const dependencies = ['mvi'];
+    const statuses = [{ serviceId: 'mvi', status: 'active' }];
+    const wrapper = shallow(
+      <ExternalServicesError
+        {...props}
+        dependencies={dependencies}
+        statuses={statuses}
+      >
+        <div id="error-message" />
+      </ExternalServicesError>,
+    );
+    expect(wrapper.find('#error-message').exists()).to.be.false;
+    wrapper.unmount();
+  });
+
+  it('should render anything when services are down', () => {
+    const wrapper = shallow(
+      <ExternalServicesError
+        {...props}
+        dependencies={['mvi']}
+        statuses={[{ serviceId: 'mvi', status: 'down' }]}
+      >
+        <div id="error-message" />
+      </ExternalServicesError>,
+    );
+    expect(wrapper.find('#error-message').exists()).to.be.true;
+    wrapper.unmount();
+  });
+});
+
+describe('mapStateToProps', () => {
+  describe('shouldGetBackendStatuses', () => {
+    it('should get backend statuses by default', () => {
+      expect(
+        mapStateToProps({
+          externalServiceStatuses: {
+            loading: false,
+            statuses: null,
+          },
+        }).shouldGetBackendStatuses,
+      ).to.be.true;
+    });
+
+    it('should not get backend statuses if a request is in progress', () => {
+      expect(
+        mapStateToProps({
+          externalServiceStatuses: {
+            loading: true,
+            statuses: null,
+          },
+        }).shouldGetBackendStatuses,
+      ).to.be.false;
+    });
+
+    it('should not get backend statuses if statuses have already been fetched', () => {
+      expect(
+        mapStateToProps({
+          externalServiceStatuses: {
+            loading: false,
+            statuses: [{ serviceId: 'mvi', status: 'active' }],
+          },
+        }).shouldGetBackendStatuses,
+      ).to.be.false;
+    });
+  });
+});

--- a/src/platform/monitoring/external-services/tests/actions.unit.spec.js
+++ b/src/platform/monitoring/external-services/tests/actions.unit.spec.js
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { mockApiRequest } from 'platform/testing/unit/helpers';
+
+import {
+  FETCH_BACKEND_STATUSES_FAILURE,
+  FETCH_BACKEND_STATUSES_SUCCESS,
+  LOADING_BACKEND_STATUSES,
+  getBackendStatuses,
+} from '../actions';
+
+const originalFetch = global.fetch;
+
+describe('External services actions', () => {
+  describe('getBackendStatuses', () => {
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('should handle a success response', () => {
+      const response = {
+        data: {
+          attributes: {
+            statuses: [
+              {
+                service: 'Master Veterans Index (MVI)',
+                serviceId: 'mvi',
+                status: 'active',
+                lastIncidentTimestamp: '2019-07-09T07:00:40.000-04:00',
+              },
+            ],
+          },
+        },
+      };
+
+      mockApiRequest(response);
+      const dispatch = sinon.spy();
+      return getBackendStatuses()(dispatch).then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          LOADING_BACKEND_STATUSES,
+        );
+        expect(dispatch.secondCall.args[0]).to.eql({
+          type: FETCH_BACKEND_STATUSES_SUCCESS,
+          data: response.data,
+        });
+      });
+    });
+
+    it('should handle an error response', () => {
+      const response = {
+        data: { attributes: { code: 400 } },
+      };
+
+      mockApiRequest(response, false);
+      const dispatch = sinon.spy();
+      return getBackendStatuses()(dispatch).then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          LOADING_BACKEND_STATUSES,
+        );
+        expect(dispatch.secondCall.args[0].type).to.equal(
+          FETCH_BACKEND_STATUSES_FAILURE,
+        );
+      });
+    });
+  });
+});

--- a/src/platform/monitoring/external-services/tests/reducer.unit.spec.js
+++ b/src/platform/monitoring/external-services/tests/reducer.unit.spec.js
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+
+import {
+  FETCH_BACKEND_STATUSES_FAILURE,
+  FETCH_BACKEND_STATUSES_SUCCESS,
+  LOADING_BACKEND_STATUSES,
+} from '../actions';
+
+import reducer from '../reducer';
+
+describe('External service statuses reducer', () => {
+  it('should have a default state', () => {
+    const state = reducer(undefined, {});
+    expect(state.loading).to.be.false;
+    expect(state.statuses).to.be.null;
+  });
+
+  it('should handle in progress requests for backend statuses', () => {
+    const state = reducer(undefined, { type: LOADING_BACKEND_STATUSES });
+    expect(state.loading).to.be.true;
+  });
+
+  it('should handle failed requests for backend statuses', () => {
+    const state = reducer(undefined, { type: FETCH_BACKEND_STATUSES_FAILURE });
+    expect(state.loading).to.be.false;
+  });
+
+  it('should handle successful requests for backend statuses', () => {
+    const statuses = [
+      {
+        service: 'Master Veterans Index (MVI)',
+        serviceId: 'mvi',
+        status: 'active',
+        lastIncidentTimestamp: '2019-07-09T07:00:40.000-04:00',
+      },
+      {
+        service: 'My Healthe Vet (MHV)',
+        serviceId: 'mhv',
+        status: 'active',
+        lastIncidentTimestamp: '2019-07-10T22:06:56.000-04:00',
+      },
+      {
+        service: 'search.gov',
+        serviceId: 'search',
+        status: 'active',
+        lastIncidentTimestamp: '2019-07-10T14:44:54.000-04:00',
+      },
+    ];
+
+    const state = reducer(undefined, {
+      type: FETCH_BACKEND_STATUSES_SUCCESS,
+      data: { attributes: { statuses } },
+    });
+
+    expect(state.loading).to.be.false;
+    expect(state.statuses).to.eql(statuses);
+  });
+});

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -6,6 +6,7 @@ import URLSearchParams from 'url-search-params';
 import { isInProgressPath } from 'platform/forms/helpers';
 import FormSignInModal from 'platform/forms/save-in-progress/FormSignInModal';
 import { SAVE_STATUSES } from 'platform/forms/save-in-progress/actions';
+import { getBackendStatuses } from 'platform/monitoring/external-services/actions';
 import { updateLoggedInStatus } from 'platform/user/authentication/actions';
 import SessionTimeoutModal from 'platform/user/authentication/components/SessionTimeoutModal';
 import SignInModal from 'platform/user/authentication/components/SignInModal';
@@ -18,7 +19,7 @@ import {
   toggleFormSignInModal,
   toggleLoginModal,
   toggleSearchHelpUserMenu,
-} from '../../../site-wide/user-nav/actions';
+} from 'platform/site-wide/user-nav/actions';
 
 import SearchHelpSignIn from '../components/SearchHelpSignIn';
 import { selectUserGreeting } from '../selectors';
@@ -134,6 +135,10 @@ export class Main extends React.Component {
     if (this.props.shouldConfirmLeavingForm) {
       this.props.toggleFormSignInModal(true);
     } else {
+      // Make only one upfront request to get all backend statuses to prevent
+      // each identity dependency's warning banner from making duplicate
+      // requests when the sign-in modal renders.
+      this.props.getBackendStatuses();
       this.props.toggleLoginModal(true, 'header');
     }
   };
@@ -197,11 +202,12 @@ export const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = {
+  getBackendStatuses,
+  initializeProfile,
   toggleFormSignInModal,
   toggleLoginModal,
   toggleSearchHelpUserMenu,
   updateLoggedInStatus,
-  initializeProfile,
 };
 
 export default connect(

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -21,6 +21,7 @@ describe('<Main>', () => {
       help: false,
       account: false,
     },
+    getBackendStatuses: sinon.spy(),
     toggleFormSignInModal: sinon.spy(),
     toggleLoginModal: sinon.spy(),
     toggleSearchHelpUserMenu: sinon.spy(),
@@ -37,6 +38,7 @@ describe('<Main>', () => {
   });
 
   afterEach(() => {
+    props.getBackendStatuses.reset();
     props.toggleFormSignInModal.reset();
     props.toggleLoginModal.reset();
     props.toggleSearchHelpUserMenu.reset();
@@ -146,15 +148,16 @@ describe('<Main>', () => {
   it('should show the login modal when the sign-in button is clicked', () => {
     const wrapper = shallow(<Main {...props} />);
     wrapper.find('SearchHelpSignIn').prop('onSignInSignUp')();
+    expect(props.getBackendStatuses.calledOnce).to.be.true;
     expect(props.toggleLoginModal.calledOnce).to.be.true;
     expect(props.toggleLoginModal.calledWith(true, 'header')).to.be.true;
-
     wrapper.unmount();
   });
 
   it('should show the modal to confirm leaving an in-progress form', () => {
     const wrapper = shallow(<Main {...props} shouldConfirmLeavingForm />);
     wrapper.find('SearchHelpSignIn').prop('onSignInSignUp')();
+    expect(props.getBackendStatuses.calledOnce).to.be.false;
     expect(props.toggleFormSignInModal.calledOnce).to.be.true;
     expect(props.toggleLoginModal.calledOnce).to.be.false;
     expect(props.toggleFormSignInModal.calledWith(true)).to.be.true;
@@ -169,6 +172,7 @@ describe('<Main>', () => {
       <Main {...props} formAutoSavedStatus="not-attempted" />,
     );
     wrapper.find('SearchHelpSignIn').prop('onSignInSignUp')();
+    expect(props.getBackendStatuses.calledOnce).to.be.true;
     expect(props.toggleFormSignInModal.calledOnce).to.be.false;
     expect(props.toggleLoginModal.calledOnce).to.be.true;
     expect(props.toggleLoginModal.calledWith(true)).to.be.true;
@@ -188,6 +192,7 @@ describe('<Main>', () => {
       />,
     );
     wrapper.find('SearchHelpSignIn').prop('onSignInSignUp')();
+    expect(props.getBackendStatuses.calledOnce).to.be.true;
     expect(props.toggleFormSignInModal.calledOnce).to.be.false;
     expect(props.toggleLoginModal.calledOnce).to.be.true;
     expect(props.toggleLoginModal.calledWith(true)).to.be.true;

--- a/src/platform/startup/store.js
+++ b/src/platform/startup/store.js
@@ -5,15 +5,17 @@
  */
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
 import thunk from 'redux-thunk';
+
+import buildSettings from '../monitoring/BuildSettings/reducer';
 import scheduledDowntime from '../monitoring/DowntimeNotification/reducer';
+import externalServiceStatuses from '../monitoring/external-services/reducer';
 import announcements from '../site-wide/announcements/reducers';
+import megaMenu from '../site-wide/mega-menu/reducers';
 import navigation from '../site-wide/user-nav/reducers';
 import login from '../user/authentication/reducers';
 import profile from '../user/profile/reducers';
-import buildSettings from '../monitoring/BuildSettings/reducer';
-import megaMenu from '../site-wide/mega-menu/reducers';
-import createAnalyticsMiddleware from './analytics-middleware';
 import environment from '../utilities/environment';
+import createAnalyticsMiddleware from './analytics-middleware';
 
 const brandConsolidatedReducers = {
   megaMenu,
@@ -24,11 +26,12 @@ const brandConsolidatedReducers = {
  * @type {object}
  */
 export const commonReducer = {
-  user: combineReducers({ login, profile }),
-  navigation,
-  scheduledDowntime,
   announcements,
   buildSettings,
+  externalServiceStatuses,
+  navigation,
+  scheduledDowntime,
+  user: combineReducers({ login, profile }),
   ...brandConsolidatedReducers,
 };
 

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -3,13 +3,13 @@ import React from 'react';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
-import SubmitSignInForm from '../../../static-data/SubmitSignInForm';
 
-import environment from '../../../utilities/environment';
-import recordEvent from '../../../monitoring/record-event';
-import { login, signup } from '../../../user/authentication/utilities';
-import { externalServices } from '../../../../platform/monitoring/DowntimeNotification';
-import DowntimeBanner from '../../../../platform/monitoring/DowntimeNotification/components/Banner';
+import ExternalServicesError from 'platform/monitoring/external-services/ExternalServicesError';
+import { EXTERNAL_SERVICES } from 'platform/monitoring/external-services/config';
+import recordEvent from 'platform/monitoring/record-event';
+import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
+import { login, signup } from 'platform/user/authentication/utilities';
+import environment from 'platform/utilities/environment';
 
 const loginHandler = loginType => () => {
   recordEvent({ event: `login-attempted-${loginType}` });
@@ -33,7 +33,7 @@ class SignInModal extends React.Component {
   }
 
   downtimeBanner = (dependencies, headline, status, message) => (
-    <DowntimeBanner dependencies={dependencies}>
+    <ExternalServicesError dependencies={dependencies}>
       <div className="downtime-notification row">
         <div className="columns small-12">
           <div className="form-warning-banner">
@@ -44,7 +44,7 @@ class SignInModal extends React.Component {
           </div>
         </div>
       </div>
-    </DowntimeBanner>
+    </ExternalServicesError>
   );
 
   renderModalContent = () => (
@@ -72,25 +72,25 @@ class SignInModal extends React.Component {
           </div>
         </div>
         {this.downtimeBanner(
-          [externalServices.idme],
+          [EXTERNAL_SERVICES.idme],
           'Our sign in process isn’t working right now',
           'error',
           'We’re sorry. We’re working to fix some problems with our sign in process. If you’d like to sign in to VA.gov, please check back later.',
         )}
         {this.downtimeBanner(
-          [externalServices.dslogon],
+          [EXTERNAL_SERVICES.dslogon],
           'You may have trouble signing in with DS Logon',
           'warning',
           'We’re sorry. We’re working to fix some problems with our DS Logon sign in process. If you’d like to sign in to VA.gov with your DS Logon account, please check back later.',
         )}
         {this.downtimeBanner(
-          [externalServices.mhv],
+          [EXTERNAL_SERVICES.mhv],
           'You may have trouble signing in with My HealtheVet',
           'warning',
           'We’re sorry. We’re making some scheduled updates to our My HealtheVet sign-in process. If you’d like to sign in to VA.gov with your My HealtheVet username and password, please check back later.',
         )}
         {this.downtimeBanner(
-          [externalServices.mvi],
+          [EXTERNAL_SERVICES.mvi],
           'You may have trouble signing in or using some tools or services',
           'warning',
           'We’re sorry. We’re working to fix a problem that affects some parts of our site. If you have trouble signing in or using any tools or services, please check back soon.',


### PR DESCRIPTION
## Description
The warning banners will display for services that are down according to the `/backend_statuses` endpoint.

These changes also introduce a wrapper component that invokes the endpoint and displays its children when its dependencies have error statuses in the response.

## Screenshots
> ![Automated DS Logon Banner](https://user-images.githubusercontent.com/1067024/61570300-b65efb00-aa59-11e9-9d19-794e78acac5f.png)


## Testing done
Local testing and unit tests.

## Acceptance criteria
- [x] Warning banners in the sign-in modal should depend on the statuses from the `/backend_statuses` endpoint.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs