### PR TITLE
removed text from STEM question

### DIFF
--- a/src/applications/edu-benefits/1995/pages/stem.js
+++ b/src/applications/edu-benefits/1995/pages/stem.js
@@ -11,7 +11,7 @@ const {
 export const uiSchema = {
   isEdithNourseRogersScholarship: {
     'ui:title':
-      'Are you applying for the Edith Nourse Rogers STEM Scholarship (Chapter 33)?',
+      'Are you applying for the Edith Nourse Rogers STEM Scholarship?',
     'ui:widget': 'yesNo',
   },
   isEnrolledStem: {


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19328

## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/48804654/61640524-7bccac80-ac6b-11e9-8033-9ee329f8102a.png)


## Acceptance criteria
- [ ] The question "Are you applying for the Edith Nourse Rogers STEM Scholarship (Chapter 33)?" on the "Education Benefits" page is replaced with "Are you applying for the Edith Nourse Rogers STEM Scholarship?"

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
