### PR TITLE
Re-ordered options on VetTec search results page

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecSearchForm.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecSearchForm.jsx
@@ -133,9 +133,9 @@ class VetTecSearchForm extends React.Component {
               }
             />
 
-            {this.renderLearningFormat()}
             {this.renderCountryFilter()}
             {this.renderStateFilter()}
+            {this.renderLearningFormat()}
           </div>
           <div className="results-button">
             <button className="usa-button" onClick={this.props.toggleFilter}>


### PR DESCRIPTION
## Description
As a comparison tool user, I need the VET TEC Search Results Page of the comparison tool to provide descriptive text and modal information so that I am not confused by the questions that I am answering.
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19335

## Testing done
Confirmed correct order in UI

## Screenshots
<img width="401" alt="Screen Shot 2019-07-22 at 1 45 40 PM" src="https://user-images.githubusercontent.com/52166695/61652911-0a9af280-ac87-11e9-8763-37fbab2f766b.png">

## Acceptance criteria
- [x] The "Refine Search" criteria are displayed in the following order:
     "City, school, or training provider"
     "Country"
     "State"
     "Learning Format"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
