### PR TITLE
[Hubs] Add GA events for right-rail events

### DIFF
--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -4,14 +4,16 @@
         <button class="usa-accordion-button usa-accordion-button-dark rail-heading" aria-expanded="true" aria-controls="{{ accordionId }}">Connect with us</button>
         <div id="{{ accordionId }}" class="usa-accordion-content" aria-hidden="false">
             <h4 class="va-nav-linkslist-list">
-                <a href="{{ administration.fieldLink.url.path }}">{{ administration.name }}</a>
+                <a href="{{ administration.fieldLink.url.path }}"
+                  onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">{{ administration.name }}</a>
             </h4>
 
             <section>
                 <h4>Get updates</h4>
                 <ul class="va-nav-linkslist-list social">
                     <li>
-                        <a href="{{ administration.fieldEmailUpdatesUrl }}">
+                        <a href="{{ administration.fieldEmailUpdatesUrl }}"
+                          onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">
                             <i class="fas fa-envelope vads-u-padding-right--1"></i>
                             {{ administration.fieldEmailUpdatesLinkText }}
                         </a>
@@ -29,21 +31,24 @@
                         {%  if socialLink.value %}
                             {% if socialPlatform = "youtube_channel" %}
                                 <li>
-                                    <a href="http://youtube.com/channel/{{ socialLink.value }}">
+                                    <a href="http://youtube.com/channel/{{ socialLink.value }}"
+                                      onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">
                                         <i class="fab fa-youtube vads-u-padding-right--1"></i>
                                         {{ administration.name }} {{ socialPlatform | remove: '_' | capitalize }}
                                     </a>
                                 </li>
                             {% elsif socialPlatform == "youtube" %}
                                 <li>
-                                    <a href="http://{{ socialPlatform }}.com/{{ socialLink.value }}">
+                                    <a href="http://{{ socialPlatform }}.com/{{ socialLink.value }}"
+                                      onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">
                                         <i class="fab fa-{{ socialPlatform }} vads-u-padding-right--1"></i>
                                         {{ administration.name }} YouTube
                                     </a>
                                 </li>
                             {% else %}
                                 <li>
-                                    <a href="http://{{ socialPlatform }}.com/{{ socialLink.value }}">
+                                    <a href="http://{{ socialPlatform }}.com/{{ socialLink.value }}"
+                                      onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">
                                         <i class="fab fa-{{ socialPlatform }} vads-u-padding-right--1"></i>
                                         {{ administration.name }} {{ socialPlatform | capitalize }}
                                     </a>

--- a/src/site/components/merger-social.html
+++ b/src/site/components/merger-social.html
@@ -22,7 +22,10 @@ See https://help.shopify.com/themes/liquid/tags/theme-tags#include
         <a href="{{group.url}}">{{group.admin}}</a>
       </h4>
       {% endif %}
+
       {% if group.subsections.length > 0 %}
+
+        {% assign navPath = group.heading %}
 
         {% for subs in group.subsections %}
 
@@ -35,10 +38,13 @@ See https://help.shopify.com/themes/liquid/tags/theme-tags#include
             {% if subs.subhead == 'Follow us' %}
               {% assign is_social_media_links = true %}
             {% endif %}
+
+
             {% for link in subs.links %}
               {% if link.url != empty %}
                 <li>
                   <a href="{{link.url}}"
+                    onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': '{{ navPath }}' });"
                     {% if link.external == true %}
                       target="_blank" rel="noopener noreferrer"
                     {% endif %}

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -85,7 +85,8 @@
                 <h4>Message us</h4>
                 <ul class="va-nav-linkslist-list social">
                   <li>
-                    <a href="https://iris.custhelp.va.gov/app/ask">
+                    <a href="https://iris.custhelp.va.gov/app/ask"
+                      onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Ask questions' });">
                       Ask a question online
                     </a>
                   </li>
@@ -100,7 +101,8 @@
                   {% assign service = supportService.entity %}
                   <li>
                     {% if service.fieldPhoneNumber %}
-                    <a href="{{ service.fieldLink.url.path }}">
+                    <a href="{{ service.fieldLink.url.path }}"
+                      onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Ask questions' });">
                       <span>{{ service.title }}</span><br>
                       <span>{{ service.fieldPhoneNumber }}</span>
                     </a>
@@ -129,7 +131,8 @@
               <ul class="va-nav-linkslist-list links">
                 {% for link in fieldLinks %}
                 <li>
-                  <a href="{{ link.url.path }}">
+                  <a href="{{ link.url.path }}"
+                    onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Not a Veteran?' });">
                     <span>{{ link.title }}</span>
                   </a>
                 </li>


### PR DESCRIPTION
## Description
This PR adds event tracking to the link clicks in the right rail of hub landing pages.

Ticket - https://github.com/department-of-veterans-affairs/vagov-content/issues/507#issuecomment-514259306

## Testing done
Checked onclick handlers at body of HTML pages -

![image](https://user-images.githubusercontent.com/1915775/61732950-c8d47f80-ad4c-11e9-9905-a34cd0931275.png)


## Screenshots
![image](https://user-images.githubusercontent.com/1915775/61732919-b9553680-ad4c-11e9-9486-f94111180d67.png)


## Acceptance criteria
- [x] Link events in the right rail are tracked in GA

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
