### PR TITLE
Updating Learn More for Which GI Bill modal

### DIFF
--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -971,7 +971,7 @@ export class Modals extends React.Component {
             For detailed information on eligibility requirements and general
             program benefits, visit{' '}
             <a
-              href="http://www.benefits.va.gov/gibill/comparison_tool.asp"
+              href="/education/eligibility/"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
Updating learn more link to /education/eligibility so that it doesn't get caught in a redirect loop.

## Description

The current link was going to a page which had been placed with a redirect. I've pointed it at the proper page on VA.gov

## Testing done

No. 

## Screenshots

## Acceptance criteria
- [ ] Open Learn More modal for "Which GI Bill benefit do you want to use?" click on "this page," should go to "https://www.va.gov/education/eligibility/

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
