### PR TITLE
Add advisory to exception list

### DIFF
--- a/script/security-check.js
+++ b/script/security-check.js
@@ -14,6 +14,7 @@ const exceptionSet = new Set([
   'https://npmjs.com/advisories/788',
   'https://npmjs.com/advisories/813',
   'https://npmjs.com/advisories/1065',
+  'https://npmjs.com/advisories/996',
 ]);
 
 const severitySet = new Set(['high', 'critical', 'moderate']);


### PR DESCRIPTION
## Description
We are seeing a few advisories for `Prototype Pollution` from our Metalsmith plugins. [Example](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/heroku-compile-all/2/pipeline).

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
