### PR TITLE
GIBCT: Filters on search results page not displaying correctly #19365

### DIFF
--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -57,7 +57,7 @@ export class SearchPage extends React.Component {
   }
 
   updateSearchResults = () => {
-    const validBooleanQueryParams = [
+    const booleanFilterParams = [
       'distanceLearning',
       'studentVeteranGroup',
       'yellowRibbonScholarship',
@@ -71,26 +71,27 @@ export class SearchPage extends React.Component {
       'preferredProvider',
     ];
 
-    const validStringQueryParams = [
+    const stringFilterParams = [
       'version',
-      'page',
-      'name',
       'category',
       'country',
       'state',
       'type',
     ];
 
+    const stringSearchParams = ['page', 'name'];
+
     const query = _.pick(this.props.location.query, [
-      ...validStringQueryParams,
-      ...validBooleanQueryParams,
+      ...stringSearchParams,
+      ...stringFilterParams,
+      ...booleanFilterParams,
     ]);
 
     // Update form selections based on query.
-    const institutionFilter = _.omit(query, ['page', 'name']);
+    const institutionFilter = _.omit(query, stringSearchParams);
 
     // Convert string to bool for params associated with checkboxes.
-    validBooleanQueryParams.forEach(filterKey => {
+    booleanFilterParams.forEach(filterKey => {
       const filterValue = institutionFilter[filterKey];
       institutionFilter[filterKey] = filterValue === 'true';
     });

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -57,14 +57,7 @@ export class SearchPage extends React.Component {
   }
 
   updateSearchResults = () => {
-    const validQueryParams = [
-      'version',
-      'page',
-      'name',
-      'category',
-      'country',
-      'state',
-      'type',
+    const validBooleanQueryParams = [
       'distanceLearning',
       'studentVeteranGroup',
       'yellowRibbonScholarship',
@@ -78,13 +71,26 @@ export class SearchPage extends React.Component {
       'preferredProvider',
     ];
 
-    const query = _.pick(this.props.location.query, validQueryParams);
+    const validStringQueryParams = [
+      'version',
+      'page',
+      'name',
+      'category',
+      'country',
+      'state',
+      'type',
+    ];
+
+    const query = _.pick(this.props.location.query, [
+      ...validStringQueryParams,
+      ...validBooleanQueryParams,
+    ]);
 
     // Update form selections based on query.
     const institutionFilter = _.omit(query, ['page', 'name']);
 
     // Convert string to bool for params associated with checkboxes.
-    validQueryParams.forEach(filterKey => {
+    validBooleanQueryParams.forEach(filterKey => {
       const filterValue = institutionFilter[filterKey];
       institutionFilter[filterKey] = filterValue === 'true';
     });

--- a/src/applications/gi/tests/containers/SearchPage.unit.spec.js
+++ b/src/applications/gi/tests/containers/SearchPage.unit.spec.js
@@ -1,8 +1,8 @@
+import _ from 'lodash';
 import React from 'react';
 import { expect } from 'chai';
-import SkinDeep from 'skin-deep';
 import sinon from 'sinon';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { Provider } from 'react-redux';
 
 import createCommonStore from '../../../../platform/startup/store';
@@ -10,13 +10,21 @@ import { SearchPage } from '../../containers/SearchPage';
 import reducer from '../../reducers';
 
 const defaultStore = createCommonStore(reducer);
-const defaultProps = defaultStore.getState();
+const defaultProps = {
+  ...defaultStore.getState(),
+  fetchSearchResults: sinon.spy(),
+  setPageTitle: sinon.spy(),
+  institutionFilterChange: sinon.spy(),
+  eligibilityChange: sinon.spy(),
+  showModal: sinon.spy(),
+  location: {},
+};
 
 describe('<SearchPage>', () => {
   it('should render', () => {
-    const tree = SkinDeep.shallowRender(<SearchPage {...defaultProps} />);
-    const vdom = tree.getRenderOutput();
-    expect(vdom).to.not.be.undefined;
+    const tree = shallow(<SearchPage {...defaultProps} />);
+    expect(tree).to.not.be.undefined;
+    tree.unmount();
   });
 
   it('should render LoadingIndicator', () => {
@@ -26,11 +34,6 @@ describe('<SearchPage>', () => {
         ...defaultProps.search,
         inProgress: true,
       },
-      fetchSearchResults: sinon.spy(),
-      setPageTitle: sinon.spy(),
-      institutionFilterChange: sinon.spy(),
-      location: {},
-      showModal: sinon.spy(),
     };
 
     const store = {
@@ -57,16 +60,116 @@ describe('<SearchPage>', () => {
   });
 
   it('should call expected actions when mounted', () => {
+    const tree = mount(
+      <Provider store={defaultStore}>
+        <SearchPage {...defaultProps} />
+      </Provider>,
+    );
+
+    expect(defaultProps.fetchSearchResults.called).to.be.true;
+    expect(defaultProps.setPageTitle.called).to.be.true;
+    tree.unmount();
+  });
+});
+
+describe('<SearchPage> functions', () => {
+  it('updateSearchResults should set store correctly', () => {
+    const booleanFilterParams = [
+      'distanceLearning',
+      'studentVeteranGroup',
+      'yellowRibbonScholarship',
+      'onlineOnly',
+      'principlesOfExcellence',
+      'eightKeysToVeteranSuccess',
+      'stemOffered',
+      'priorityEnrollment',
+      'independentStudy',
+      'vetTecProvider',
+      'preferredProvider',
+    ];
+
+    const stringFilterParams = [
+      'version',
+      'category',
+      'country',
+      'state',
+      'type',
+    ];
+
+    const stringSearchParams = ['page', 'name'];
+
+    const institutionFilterChange = institutionFilter => {
+      // Make sure searchParams are removed
+      stringSearchParams.forEach(stringParam => {
+        expect(Object.keys(institutionFilter).includes(stringParam)).to.be
+          .false;
+      });
+
+      // Make sure booleanParams have been converted from String to boolean
+      booleanFilterParams.forEach(booleanParam => {
+        expect(typeof institutionFilter[booleanParam]).to.be.equal('boolean');
+      });
+
+      // Make sure stringParams are still Strings
+      stringFilterParams.forEach(stringParam => {
+        expect(typeof institutionFilter[stringParam]).to.be.equal('string');
+      });
+    };
+
+    const query = {
+      distanceLearning: 'false',
+      studentVeteranGroup: 'false',
+      yellowRibbonScholarship: 'false',
+      onlineOnly: 'false',
+      principlesOfExcellence: 'false',
+      eightKeysToVeteranSuccess: 'false',
+      stemOffered: 'false',
+      priorityEnrollment: 'false',
+      independentStudy: 'false',
+      vetTecProvider: 'false',
+      preferredProvider: 'false',
+      version: '94ed39bf-f816-4b12-b3ce-a8241c2325b7',
+      category: 'school',
+      country: 'USA',
+      state: 'SC',
+      type: 'FLIGHT',
+      page: '2',
+      name: 'college of testing',
+    };
+
+    const search = `?${Object.keys(query)
+      .map(key => `${key}=${query[key]}`)
+      .join('&')}`;
+
+    const fetchSearchResults = queryStore => {
+      const queryCheck = _.pick(query, [
+        ...stringSearchParams,
+        ...stringFilterParams,
+        ...booleanFilterParams,
+      ]);
+      expect(queryStore.toString()).to.be.equal(queryCheck.toString());
+    };
+
     const props = {
       ...defaultProps,
-      fetchSearchResults: sinon.spy(),
-      setPageTitle: sinon.spy(),
-      institutionFilterChange: sinon.spy(),
-      location: {},
+      institutionFilterChange,
+      fetchSearchResults,
+      location: {
+        action: 'POP',
+        basename: '/gi-bill-comparison-tool',
+        hash: '',
+        key: '1nwcws',
+        pathname: '/search',
+        query,
+        search,
+        state: undefined,
+      },
     };
-    const tree = SkinDeep.shallowRender(<SearchPage {...props} />);
-    tree.getMountedInstance().componentDidMount();
-    expect(props.fetchSearchResults.called).to.be.true;
-    expect(props.setPageTitle.called).to.be.true;
+
+    const tree = shallow(<SearchPage {...props} />);
+    const instance = tree.instance();
+    instance.updateSearchResults();
+
+    tree.unmount();
   });
 });


### PR DESCRIPTION
## Description
When a user searches for institutions in the GIBCT, they are given different filters on the search results page to refine their search parameters. These filters are filtering the results as expected, but are not displaying correctly. 

1. Access https://staging.va.gov/gi-bill-comparison-tool
2. Type "college" into the search bar and click Search Schools
3. Click on one of the radio buttons under "Type of Institution"
- The results are filtered, but the radio button does not appear selected
4. Select a Country from the drop-down
- The results are filtered to institutions in the selected country, but the country filter still displays "All"
5. Select a State from the drop-down
- The results are filtered to institutions in the selected state, but the state filter still displays "All"
6. Make a selection in the Institution Type drop-down
- The results are filtered to institutions matching the selected type, but the institution type filter still displays "All"

#### After selections have been made for all four filters:
![Screen Shot 2019-07-25 at 8.44.16 AM.png](https://images.zenhubusercontent.com/5c07f000391a6f6357adc430/1b447835-fc9b-497b-87da-05e09b5d2815)



## Testing done
- local testing
- unit testing

## Screenshots
<img width="456" alt="Screen Shot 2019-07-25 at 9 52 22 AM" src="https://user-images.githubusercontent.com/1094999/61879917-ee36ca00-aec1-11e9-8d21-58fcc5bc334f.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
