### PR TITLE
1995 Prefill and Submit Transformer Updates

### DIFF
--- a/src/applications/edu-benefits/1995/config/form.js
+++ b/src/applications/edu-benefits/1995/config/form.js
@@ -2,6 +2,7 @@ import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
 
 import { transform as oldTransform } from '../helpers';
 import { transform } from '../submit-transformer';
+import { prefillTransformer } from '../prefill-transformer';
 
 import { urlMigration } from '../../config/migrations';
 
@@ -32,6 +33,7 @@ const formConfig = {
   version: 1,
   migrations: [urlMigration('/1995')],
   prefillEnabled: true,
+  prefillTransformer,
   savedFormMessages: {
     notFound: 'Please start over to apply for education benefits.',
     noAuth:

--- a/src/applications/edu-benefits/1995/prefill-transformer.js
+++ b/src/applications/edu-benefits/1995/prefill-transformer.js
@@ -1,0 +1,19 @@
+import _ from 'lodash';
+
+export function prefillTransformer(pages, formData, metadata) {
+  const { homePhone, email } = formData;
+
+  const newFormData = {
+    ..._.omit(formData, ['homePhone', 'email']),
+    'view:otherContactInfo': {
+      homePhone,
+      email,
+    },
+  };
+
+  return {
+    metadata,
+    formData: newFormData,
+    pages,
+  };
+}

--- a/src/applications/edu-benefits/1995/submit-transformer.js
+++ b/src/applications/edu-benefits/1995/submit-transformer.js
@@ -32,9 +32,16 @@ export function transform(formConfig, form) {
   const usFormTransform = formData =>
     transformForSubmit(formConfig, { ...form, data: formData });
 
+  const contactInfoTransform = formData => ({
+    ...formData,
+    email: _.get(formData, 'view:otherContactInfo.email', undefined),
+    homePhone: _.get(formData, 'view:otherContactInfo.homePhone', undefined),
+  });
+
   const transformedData = [
     newSchoolTransform,
     fryScholarshipTransform,
+    contactInfoTransform,
     usFormTransform, // This needs to be last function call in array
   ].reduce((formData, transformer) => transformer(formData), form.data);
 

--- a/src/applications/edu-benefits/tests/1995/01-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/1995/01-all-fields.e2e.spec.js
@@ -2,7 +2,7 @@ const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
 const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
 const EduHelpers = require('../1990/edu-helpers');
 const Edu1995Helpers = require('./edu-1995-helpers');
-const testData = require('./schema/maximal-test.json');
+const testData = require('./schema/e2e-maximal-test.json');
 const FormsTestHelpers = require('../../../../platform/testing/e2e/form-helpers');
 
 module.exports = E2eHelpers.createE2eTest(client => {

--- a/src/applications/edu-benefits/tests/1995/prefill-transformer.unit.spec.js
+++ b/src/applications/edu-benefits/tests/1995/prefill-transformer.unit.spec.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+
+import {
+  minPrefillData,
+  minTransformedPrefillData,
+  maxPrefillData,
+  transformedMaxPrefillData,
+} from './schema/prefillData';
+
+import { prefillTransformer } from '../../1995/prefill-transformer';
+
+describe('prefillTransformer', () => {
+  it('should transform minimal prefill data correctly', () => {
+    expect(prefillTransformer({}, minPrefillData, {}).formData).to.deep.equal(
+      minTransformedPrefillData,
+    );
+  });
+  it('should transform maximal prefill data correctly', () => {
+    expect(prefillTransformer({}, maxPrefillData, {}).formData).to.deep.equal(
+      transformedMaxPrefillData,
+    );
+  });
+});

--- a/src/applications/edu-benefits/tests/1995/schema/e2e-maximal-test.json
+++ b/src/applications/edu-benefits/tests/1995/schema/e2e-maximal-test.json
@@ -1,0 +1,84 @@
+{
+  "data": {
+    "privacyAgreementAccepted": true,
+    "veteranFullName": {
+      "first": "asdf",
+      "middle": "t",
+      "last": "asdf",
+      "suffix": "Jr."
+    },
+    "veteranSocialSecurityNumber": "123333333",
+    "view:noSSN": true,
+    "vaFileNumber": "C12345678",
+    "benefit": "chapter30",
+    "toursOfDuty": [
+      {
+        "serviceBranch": "Army",
+        "dateRange": {
+          "from": "2010-01-01",
+          "to": "2010-01-02"
+        }
+      },
+      {
+        "serviceBranch": "Navy",
+        "dateRange": {
+          "from": "2009-01-01",
+          "to": "2010-01-01"
+        }
+      }
+    ],
+    "view:hasServiceBefore1978": true,
+    "educationType": "college",
+    "newSchoolName": "Testing",
+    "newSchoolAddress": {
+      "country": "USA",
+      "street": "123 one st",
+      "street2": "Apt 3",
+      "city": "Big city",
+      "state": "MA",
+      "postalCode": "01010"
+    },
+    "educationObjective": "Get a degree",
+    "nonVaAssistance": true,
+    "civilianBenefitsAssistance": true,
+    "oldSchool": {
+      "name": "Testing",
+      "address": {
+        "country": "USA",
+        "street": "123 one st",
+        "street2": "Apt 3",
+        "city": "Big city",
+        "state": "MA",
+        "postalCode": "01010"
+      }
+    },
+    "trainingEndDate": "2005-03-12",
+    "reasonForChange": "Bad school",
+    "preferredContactMethod": "phone",
+    "veteranAddress": {
+      "country": "USA",
+      "street": "123 one st",
+      "street2": "Apt 3",
+      "city": "Big city",
+      "state": "MA",
+      "postalCode": "01010"
+    },
+    "view:otherContactInfo": {
+      "email": "test@test.com",
+      "view:confirmEmail": "test@test.com",
+      "homePhone": "1233345454",
+      "mobilePhone": "3332213233"
+    },
+    "serviceBefore1977": {
+      "married": true,
+      "haveDependents": true,
+      "parentDependent": true
+    },
+    "bankAccountChange": "stop",
+    "bankAccount": {
+      "accountType": "checking",
+      "accountNumber": "1234344",
+      "routingNumber": "114923756"
+    }
+  }
+}

--- a/src/applications/edu-benefits/tests/1995/schema/maximal-test.json
+++ b/src/applications/edu-benefits/tests/1995/schema/maximal-test.json
@@ -1,84 +1,65 @@
 {
   "data": {
-    "privacyAgreementAccepted": true,
-    "veteranFullName": {
-      "first": "asdf",
-      "middle": "t",
-      "last": "asdf",
-      "suffix": "Jr."
+    "bankAccountChange": "startUpdate",
+    "bankAccount": {
+      "accountType": "checking",
+      "routingNumber": "021000021",
+      "accountNumber": "12345"
     },
-    "veteranSocialSecurityNumber": "123333333",
-    "view:noSSN": true,
-    "vaFileNumber": "C12345678",
-    "benefit": "chapter30",
-    "toursOfDuty": [
-      {
-        "serviceBranch": "Army",
-        "dateRange": {
-          "from": "2010-01-01",
-          "to": "2010-01-02"
-        }
-      },
-      {
-        "serviceBranch": "Navy",
-        "dateRange": {
-          "from": "2009-01-01",
-          "to": "2010-01-01"
-        }
-      }
-    ],
-    "view:hasServiceBefore1978": true,
-    "educationType": "college",
-    "newSchoolName": "Testing",
-    "newSchoolAddress": {
+    "preferredContactMethod": "mail",
+    "veteranAddress": {
+      "street": "MILITARY ADDY 3",
+      "city": "Test",
       "country": "USA",
-      "street": "123 one st",
-      "street2": "Apt 3",
-      "city": "Big city",
-      "state": "MA",
-      "postalCode": "01010"
+      "state": "TN",
+      "postalCode": "22312"
     },
-    "educationObjective": "Get a degree",
+    "view:otherContactInfo": {
+      "email": "test2@test1.net",
+      "view:confirmEmail": "test2@test1.net",
+      "homePhone": "4445551212",
+      "mobilePhone": "4445551213"
+    },
+    "newSchoolName": "Test",
+    "educationType": "correspondence",    
+    "newSchoolAddress": {
+      "street": "123 Test St",
+      "street2": "Below ground",
+      "city": "Test",
+      "country": "USA",
+      "state": "TN",
+      "postalCode": "12345"
+    },
+    "educationObjective": "Education or career goal",
     "nonVaAssistance": true,
     "civilianBenefitsAssistance": true,
     "oldSchool": {
-      "name": "Testing",
+      "name": "Old Test School",
       "address": {
+        "street": "321 Test St",
+        "street2": "On the second floor",
+        "city": "Terst",
         "country": "USA",
-        "street": "123 one st",
-        "street2": "Apt 3",
-        "city": "Big city",
-        "state": "MA",
-        "postalCode": "01010"
+        "state": "TN",
+        "postalCode": "54321"
       }
     },
-    "trainingEndDate": "2005-03-12",
-    "reasonForChange": "Bad school",
-    "preferredContactMethod": "phone",
-    "veteranAddress": {
-      "country": "USA",
-      "street": "123 one st",
-      "street2": "Apt 3",
-      "city": "Big city",
-      "state": "MA",
-      "postalCode": "01010"
+    "trainingEndDate": "2018-03-02",
+    "reasonForChange": "Stop reason",
+    "isActiveDuty": true,
+    "view:housingPaymentInfo": {},
+    "isEdithNourseRogersScholarship": false,
+    "isEnrolledStem": true,
+    "view:rogersStemScholarshipInfo": {},
+    "benefit": "chapter33",
+    "veteranFullName": {
+      "first": "Greg",
+      "middle": "A",
+      "last": "Anderson",
+      "suffix": "IV"
     },
-    "view:otherContactInfo": {
-      "email": "test@test.com",
-      "view:confirmEmail": "test@test.com",
-      "homePhone": "1233345454",
-      "mobilePhone": "3332213233"
-    },
-    "serviceBefore1977": {
-      "married": true,
-      "haveDependents": true,
-      "parentDependent": true
-    },
-    "bankAccountChange": "stop",
-    "bankAccount": {
-      "accountType": "checking",
-      "accountNumber": "1234344",
-      "routingNumber": "114923756"
-    }
+    "veteranSocialSecurityNumber": "123333333",
+    "serviceBefore1977": {},
+    "privacyAgreementAccepted": true
   }
 }

--- a/src/applications/edu-benefits/tests/1995/schema/minimal-test.json
+++ b/src/applications/edu-benefits/tests/1995/schema/minimal-test.json
@@ -1,24 +1,34 @@
 {
   "data": {
-    "privacyAgreementAccepted": true,
+    "veteranAddress": {
+      "street": "MILITARY ADDY 3",
+      "city": "Test",
+      "country": "USA",
+      "state": "TN",
+      "postalCode": "22312"
+    },
+    "view:otherContactInfo": {
+      "email": "test2@test1.net",
+      "view:confirmEmail": "test2@test1.net"
+    },
+    "newSchoolName": "Test",
+    "educationType": "correspondence",
+    "newSchoolAddress": {
+      "country": "USA"
+    },
+    "isEdithNourseRogersScholarship": false,
+    "view:rogersStemScholarshipInfo": {},
     "veteranFullName": {
       "first": "asdf",
       "last": "asdf"
     },
     "veteranSocialSecurityNumber": "123333333",
-    "newSchoolAddress": {
-      "country": "USA"
-    },
     "oldSchool": {
       "address": {
         "country": "USA"
       }
     },
-    "veteranAddress": {
-      "country": "USA"
-    },
-    "view:otherContactInfo": {},
     "serviceBefore1977": {},
-    "bankAccount": {}
+    "privacyAgreementAccepted": true
   }
 }

--- a/src/applications/edu-benefits/tests/1995/schema/prefillData.js
+++ b/src/applications/edu-benefits/tests/1995/schema/prefillData.js
@@ -1,0 +1,59 @@
+export const minPrefillData = {
+  veteranFullName: {
+    first: 'Greg',
+    middle: 'A',
+    last: 'Anderson',
+  },
+  veteranSocialSecurityNumber: '796121200',
+};
+
+export const minTransformedPrefillData = {
+  veteranFullName: {
+    first: 'Greg',
+    middle: 'A',
+    last: 'Anderson',
+  },
+  veteranSocialSecurityNumber: '796121200',
+  'view:otherContactInfo': {
+    email: undefined,
+    homePhone: undefined,
+  },
+};
+
+export const maxPrefillData = {
+  veteranFullName: {
+    first: 'Greg',
+    middle: 'A',
+    last: 'Anderson',
+  },
+  veteranSocialSecurityNumber: '796121200',
+  email: 'test@email.com',
+  homePhone: '5551234567',
+  veteranAddress: {
+    street: 'MILITARY ADDY 3',
+    city: 'DPO',
+    country: 'USA',
+    state: 'MI',
+    postalCode: '22312',
+  },
+};
+
+export const transformedMaxPrefillData = {
+  veteranFullName: {
+    first: 'Greg',
+    middle: 'A',
+    last: 'Anderson',
+  },
+  veteranSocialSecurityNumber: '796121200',
+  'view:otherContactInfo': {
+    email: 'test@email.com',
+    homePhone: '5551234567',
+  },
+  veteranAddress: {
+    street: 'MILITARY ADDY 3',
+    city: 'DPO',
+    country: 'USA',
+    state: 'MI',
+    postalCode: '22312',
+  },
+};

--- a/src/applications/edu-benefits/tests/1995/schema/transformedData.js
+++ b/src/applications/edu-benefits/tests/1995/schema/transformedData.js
@@ -1,0 +1,93 @@
+const transformedMinimalDataActual = {
+  veteranAddress: {
+    street: 'MILITARY ADDY 3',
+    city: 'Test',
+    country: 'USA',
+    state: 'TN',
+    postalCode: '22312',
+  },
+  email: 'test2@test1.net',
+  educationType: 'correspondence',
+  isEdithNourseRogersScholarship: false,
+  veteranFullName: {
+    first: 'asdf',
+    last: 'asdf',
+  },
+  veteranSocialSecurityNumber: '123333333',
+  oldSchool: {},
+  privacyAgreementAccepted: true,
+  newSchool: {
+    name: 'Test',
+  },
+};
+
+export const transformedMinimalData = JSON.stringify({
+  educationBenefitsClaim: {
+    form: JSON.stringify(transformedMinimalDataActual),
+  },
+});
+
+const transformedMaximalDataActual = {
+  bankAccountChange: 'startUpdate',
+  bankAccount: {
+    accountType: 'checking',
+    routingNumber: '021000021',
+    accountNumber: '12345',
+  },
+  preferredContactMethod: 'mail',
+  veteranAddress: {
+    street: 'MILITARY ADDY 3',
+    city: 'Test',
+    country: 'USA',
+    state: 'TN',
+    postalCode: '22312',
+  },
+  email: 'test2@test1.net',
+  homePhone: '4445551212',
+  mobilePhone: '4445551213',
+  educationType: 'correspondence',
+  educationObjective: 'Education or career goal',
+  nonVaAssistance: true,
+  civilianBenefitsAssistance: true,
+  oldSchool: {
+    name: 'Old Test School',
+    address: {
+      street: '321 Test St',
+      street2: 'On the second floor',
+      city: 'Terst',
+      country: 'USA',
+      state: 'TN',
+      postalCode: '54321',
+    },
+  },
+  trainingEndDate: '2018-03-02',
+  reasonForChange: 'Stop reason',
+  isEdithNourseRogersScholarship: false,
+  isEnrolledStem: true,
+  benefit: 'chapter33',
+  veteranFullName: {
+    first: 'Greg',
+    middle: 'A',
+    last: 'Anderson',
+    suffix: 'IV',
+  },
+  veteranSocialSecurityNumber: '123333333',
+  privacyAgreementAccepted: true,
+  newSchool: {
+    name: 'Test',
+    address: {
+      street: '123 Test St',
+      street2: 'Below ground',
+      city: 'Test',
+      country: 'USA',
+      state: 'TN',
+      postalCode: '12345',
+    },
+  },
+};
+
+export const transformedMaximalData = JSON.stringify({
+  educationBenefitsClaim: {
+    form: JSON.stringify(transformedMaximalDataActual),
+  },
+});

--- a/src/applications/edu-benefits/tests/1995/submit-transformer.unit.spec.js
+++ b/src/applications/edu-benefits/tests/1995/submit-transformer.unit.spec.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+
+import formConfig from '../../1995/config/form';
+
+import { transform } from '../../1995/submit-transformer';
+
+import {
+  transformedMinimalData,
+  transformedMaximalData,
+} from './schema/transformedData';
+
+import minimalData from './schema/minimal-test.json';
+import maximalData from './schema/maximal-test.json';
+
+describe('transform', () => {
+  it('should transform minimal data correctly', () => {
+    expect(transform(formConfig, minimalData)).to.deep.equal(
+      transformedMinimalData,
+    );
+  });
+
+  it('should transform maximal data correctly', () => {
+    expect(transform(formConfig, maximalData)).to.deep.equal(
+      transformedMaximalData,
+    );
+  });
+});


### PR DESCRIPTION
## Description
Veteran email and home phone are not being transformed correctly (both from prefill data and to submitted form data)

Fix for issue:

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19364

## Testing done
Unit tests updated, QA review

## Screenshots
N/A

## Acceptance criteria
- [x] Veteran email and home phone fields are populated from prefill data
- [x] Veteran email and home phone fields are populated in spool file

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
