### PR TITLE
Bah pprovideranalytics 19367

### DIFF
--- a/src/applications/gi/components/content/AdditionalResources.jsx
+++ b/src/applications/gi/components/content/AdditionalResources.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 
 export const AdditionalResourcesLinks = () => (
   <div>
@@ -7,6 +8,11 @@ export const AdditionalResourcesLinks = () => (
         href="https://va.careerscope.net/gibill"
         target="_blank"
         rel="noopener noreferrer"
+        onClick={() =>
+          recordEvent({
+            event: 'nav-profile-additional-resources',
+          })
+        }
       >
         Get started with CareerScope
       </a>
@@ -16,6 +22,11 @@ export const AdditionalResourcesLinks = () => (
         href="https://www.benefits.va.gov/gibill/choosing_a_school.asp"
         target="_blank"
         rel="noopener noreferrer"
+        onClick={() =>
+          recordEvent({
+            event: 'nav-profile-additional-resources',
+          })
+        }
       >
         Get help choosing a school
       </a>
@@ -25,12 +36,25 @@ export const AdditionalResourcesLinks = () => (
         href="/education/submit-school-feedback"
         target="_blank"
         rel="noopener noreferrer"
+        onClick={() =>
+          recordEvent({
+            event: 'nav-profile-additional-resources',
+          })
+        }
       >
         Submit a complaint through our Feedback System
       </a>
     </p>
     <p>
-      <a href="/education/how-to-apply/" target="_blank">
+      <a
+        href="/education/how-to-apply/"
+        target="_blank"
+        onClick={() =>
+          recordEvent({
+            event: 'nav-profile-additional-resources',
+          })
+        }
+      >
         Apply for education benefits
       </a>
     </p>

--- a/src/applications/gi/components/vet-tec/VetTecFilterBy.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecFilterBy.jsx
@@ -11,6 +11,12 @@ class VetTecFilterBy extends React.Component {
   };
 
   handleFilterChange = e => {
+    recordEvent({
+      event: 'gibct-form-change',
+      'gibct-form-field': 'preferredProvider',
+      'gibct-form-value': true, //false
+    });
+
     const { name: field, checked: value } = e.target;
     this.props.handleFilterChange(field, value);
   };

--- a/src/applications/gi/components/vet-tec/VetTecFilterBy.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecFilterBy.jsx
@@ -12,13 +12,12 @@ class VetTecFilterBy extends React.Component {
   };
 
   handleFilterChange = e => {
+    const { name: field, checked: value } = e.target;
     recordEvent({
       event: 'gibct-form-change',
       'gibct-form-field': 'preferredProvider',
-      'gibct-form-value': true,
+      'gibct-form-value': value,
     });
-
-    const { name: field, checked: value } = e.target;
     this.props.handleFilterChange(field, value);
   };
 

--- a/src/applications/gi/components/vet-tec/VetTecFilterBy.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecFilterBy.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Checkbox from '../Checkbox';
 import { renderLearnMoreLabel } from '../../utils/render';
+import recordEvent from 'platform/monitoring/record-event';
 
 class VetTecFilterBy extends React.Component {
   static propTypes = {
@@ -14,7 +15,7 @@ class VetTecFilterBy extends React.Component {
     recordEvent({
       event: 'gibct-form-change',
       'gibct-form-field': 'preferredProvider',
-      'gibct-form-value': true, //false
+      'gibct-form-value': true,
     });
 
     const { name: field, checked: value } = e.target;

--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -79,7 +79,7 @@ export class LandingPage extends React.Component {
     recordEvent({
       event: 'gibct-form-change',
       'gibct-form-field': 'typeOfInstitution',
-      'gibct-form-value': 'radioButtonLabel',
+      'gibct-form-value': value,
     });
 
     if (field === 'category') {


### PR DESCRIPTION
## Description
Comparison Tool 116 Analytics Support #19367

## Testing done
Tested locally through the browser console

## Screenshots
<img width="444" alt="Screen Shot 2019-07-25 at 12 48 42 PM" src="https://user-images.githubusercontent.com/50601724/61893253-a45add80-aedb-11e9-9f3d-f74e2fe9aa6f.png">
<img width="414" alt="Screen Shot 2019-07-25 at 12 50 16 PM" src="https://user-images.githubusercontent.com/50601724/61893256-a624a100-aedb-11e9-978b-514e193a4440.png">
<img width="766" alt="Screen Shot 2019-07-25 at 12 51 07 PM" src="https://user-images.githubusercontent.com/50601724/61893261-a7ee6480-aedb-11e9-9fc1-db6e840dc812.png">


## Acceptance criteria
- [x] In order to track click thrus to other VA pages thru the 'Additional Resources' side links on each profile page, we would like the following inserted with each link click:
{
"event": "nav-profile-additional-resources",
}

![](https://user-images.githubusercontent.com/48527022/61878900-ebd37080-aebf-11e9-9769-b14b73a4479c.png)

- [x] In order to track clicks of the preferred provider filter on the search results page, we would like the following dataLayer push for each click:
{
 "event": "gibct-form-change",
 "gibct-form-field": "preferredProvider",
 "gibct-form-value": true //or false
}

![](https://user-images.githubusercontent.com/48527022/61879222-a2375580-aec0-11e9-8687-0fc2cf6fdb8b.png)



## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
