### PR TITLE
Adding placeholder text for when no events appear in listing.

### DIFF
--- a/src/site/components/events_list.drupal.liquid
+++ b/src/site/components/events_list.drupal.liquid
@@ -1,9 +1,8 @@
 <div class="events-listing events-show">
   {% assign count = 0 %}
   {% for event in fieldOffice.entity.reverseFieldOfficeNode.entities %}
-  {% if event.title.length%}
-  {% assign count = count | plus: 1 %}
-  {% if count != 0 %}
+  {% if event.title.length %}
+  {% assign count = count | plus:1 %}
   <div class="vads-u-margin-bottom--2">
     <h4><a href="{{event.entityUrl.path}}">{{event.title}}</a></h4>
     <p>{{event.fieldDescription}}</p>
@@ -33,17 +32,15 @@
     </div>
   </div>
   {% endif %}
-  {% endif %}
   {% endfor %}
   {% if count == 0 %}
   <div class="vads-u-margin-bottom--2">
     <div class="va-introtext">
       <p>
         VA proudly works alongside others to connect Veterans to the benefits
-        they’ve
-        earned. Explore resources for our outreach partners such as Veteran
-        Service
-        Organizations (VSOs), and sign up for events.</p>
+        they’ve earned. Explore resources for our outreach
+        partners such as Veteran Service Organizations (VSOs),
+        and sign up for events.</p>
     </div>
     <div>
       <p>

--- a/src/site/components/events_list.drupal.liquid
+++ b/src/site/components/events_list.drupal.liquid
@@ -1,6 +1,9 @@
 <div class="events-listing events-show">
+  {% assign count = 0 %}
   {% for event in fieldOffice.entity.reverseFieldOfficeNode.entities %}
   {% if event.title.length%}
+  {% assign count = count | plus: 1 %}
+  {% if count != 0 %}
   <div class="vads-u-margin-bottom--2">
     <h4><a href="{{event.entityUrl.path}}">{{event.title}}</a></h4>
     <p>{{event.fieldDescription}}</p>
@@ -30,5 +33,23 @@
     </div>
   </div>
   {% endif %}
+  {% endif %}
   {% endfor %}
+  {% if count == 0 %}
+  <div class="vads-u-margin-bottom--2">
+    <div class="va-introtext">
+      <p>
+        VA proudly works alongside others to connect Veterans to the benefits
+        they’ve
+        earned. Explore resources for our outreach partners such as Veteran
+        Service
+        Organizations (VSOs), and sign up for events.</p>
+    </div>
+    <div>
+      <p>
+        <i>We're sorry, there are no events to display at this time</i>
+      </p>
+    </div>
+  </div>
+  {% endif %}
 </div>


### PR DESCRIPTION
## Description
Adds placeholder text to events listing page when result set is empty

## Testing done
Visual

## Screenshots
![Screenshot_2019-07-25_14-01-26](https://user-images.githubusercontent.com/2404547/61897297-c311a200-aee4-11e9-87e6-edf896c5985e.png)

## Acceptance criteria
- [ ] When visiting outreach-and-events/events/, you should see the placeholder text captured in the above screenshot.

## Definition of done
- [ ] When visiting outreach-and-events/events/, you should see the placeholder text captured in the above screenshot.