### PR TITLE
[Facility Locator] Set document title to facility name

### DIFF
--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -25,6 +25,16 @@ class FacilityDetail extends Component {
     focusElement('.va-nav-breadcrumbs');
   }
 
+  componentDidUpdate(prevProps) {
+    const facilityJustLoaded = !prevProps.facility && this.props.facility;
+
+    if (facilityJustLoaded) {
+      document.title = `${
+        this.props.facility.attributes.name
+      } | Veterans Affairs`;
+    }
+  }
+
   renderFacilityInfo() {
     const { facility } = this.props;
     const { name, website } = facility.attributes;

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -26,13 +26,19 @@ class FacilityDetail extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const facilityJustLoaded = !prevProps.facility && this.props.facility;
+    const justLoaded =
+      prevProps.currentQuery.inProgress && !this.props.currentQuery.inProgress;
 
-    if (facilityJustLoaded) {
+    if (justLoaded) {
+      this.__previousDocTitle = document.title;
       document.title = `${
         this.props.facility.attributes.name
       } | Veterans Affairs`;
     }
+  }
+
+  componentWillUnmount() {
+    document.title = this.__previousDocTitle;
   }
 
   renderFacilityInfo() {

--- a/src/applications/facility-locator/containers/ProviderDetail.jsx
+++ b/src/applications/facility-locator/containers/ProviderDetail.jsx
@@ -28,13 +28,19 @@ class ProviderDetail extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const providerJustLoaded = !prevProps.location && this.props.location;
+    const justLoaded =
+      prevProps.currentQuery.inProgress && !this.props.currentQuery.inProgress;
 
-    if (providerJustLoaded) {
+    if (justLoaded) {
+      this.__previousDocTitle = document.title;
       document.title = `${
         this.props.location.attributes.name
       } | Veterans Affairs`;
     }
+  }
+
+  componentWillUnmount() {
+    document.title = this.__previousDocTitle;
   }
 
   renderFacilityInfo = () => {

--- a/src/applications/facility-locator/containers/ProviderDetail.jsx
+++ b/src/applications/facility-locator/containers/ProviderDetail.jsx
@@ -27,7 +27,7 @@ class ProviderDetail extends Component {
     focusElement('.va-nav-breadcrumbs');
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     const providerJustLoaded = !prevProps.location && this.props.location;
 
     if (providerJustLoaded) {

--- a/src/applications/facility-locator/containers/ProviderDetail.jsx
+++ b/src/applications/facility-locator/containers/ProviderDetail.jsx
@@ -27,6 +27,16 @@ class ProviderDetail extends Component {
     focusElement('.va-nav-breadcrumbs');
   }
 
+  componentDidUpdate() {
+    const providerJustLoaded = !prevProps.location && this.props.location;
+
+    if (providerJustLoaded) {
+      document.title = `${
+        this.props.location.attributes.name
+      } | Veterans Affairs`;
+    }
+  }
+
   renderFacilityInfo = () => {
     const { location } = this.props;
     const { name, orgName, website, fax, email } = location.attributes;


### PR DESCRIPTION
## Description
This PR sets the document title to that of the H1 tag on the facility detail pages and the provider detail pages.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/493

## Testing done
With localhost pointed at Dev API

- [x] Checked tab name of facility detail page
- [x] Checked tab name of provider detail page 

## Screenshots
See tab names 

### Facility
![image](https://user-images.githubusercontent.com/1915775/61910041-8ef8aa00-af01-11e9-87b3-5d1954e6d598.png)

### Provider (Community Cares)
![image](https://user-images.githubusercontent.com/1915775/61910191-eb5bc980-af01-11e9-8279-9551edd18f5b.png)


## Acceptance criteria
- [x] Document title reflects the H1

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
