### PR TITLE
Adding operating status page for facilities.

### DIFF
--- a/src/site/layouts/health_care_facility_status.drupal.liquid
+++ b/src/site/layouts/health_care_facility_status.drupal.liquid
@@ -1,0 +1,51 @@
+{% include "src/site/includes/header.html" with drupalTags = true %}
+{% include "src/site/includes/alerts.drupal.liquid" %}
+{% include "src/site/includes/preview-edit.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+<div id="content" class="interior">
+    <main class="va-l-detail-page">
+        <div class="usa-grid usa-grid-full">
+            {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+            <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+
+                <article class="usa-content">
+                    <h1 class="vads-u-margin-bottom--2">Operating status</h1>
+                    <div class="va-introtext vads-u-margin-bottom--0">
+                        Check the latest operating status of services and
+                        facility hours for VA
+                        Pittsburgh health care.
+                    </div>
+                    <section class="locations clearfix">
+                        {% for office in mainFacilities.entities %}
+                        <h2
+                            class="vads-u-font-size--xl vads-u-margin-top--3 medium-screen:vads-u-margin-top--5 vads-u-margin-bottom--0">
+                            {{office.title}}
+                        </h2>
+                            {% if office.fieldOperatingStatusFacility == 'normal' %}
+                            <span
+                                class="operating-status usa-alert usa-alert-success background-color-only vads-u-margin-top--1 vads-u-padding--1p5">
+                                <b><i class="fa fa-info-circle" aria-hidden="true"></i> Normal services and hours</b>
+                            </span>
+                            {% elsif office.fieldOperatingStatusFacility == 'limited' %}
+
+                            <span
+                                class="operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--1 vads-u-padding--1p5">
+                                <b><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Limited services and hours</b>
+                            </span>
+
+                            {% elsif office.fieldOperatingStatusFacility == 'closed' %}
+                            <span
+                                class="operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--1 vads-u-padding--1p5">
+                                <b><i class="fa fa-exclamation-circle" aria-hidden="true"></i> Facility Closed</b>
+                            </span>
+                            {% endif %}
+                        {% endfor %}
+                    </section>
+                </article>
+            </div>
+        </div>
+    </main>
+</div>
+{% include "src/site/includes/footer.html" %}
+{% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -16,6 +16,12 @@ module.exports = `
     fieldFacilityLocatorApiId
     fieldNicknameForThisFacility
     fieldIntroText
+    ${
+      enabledFeatureFlags[featureFlags.FEATURE_FIELD_OPERATING_STATUS_FACILITY]
+        ? 'fieldOperatingStatusFacility'
+        : ''
+    }
+    fieldOperatingStatusFacility
     fieldLocationServices {
       entity {
         ... on ParagraphHealthCareLocalFacilityServi {
@@ -90,7 +96,7 @@ module.exports = `
                       }
                     }
                   }
-                }    
+                }
               }
             }
           }

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -21,7 +21,6 @@ module.exports = `
         ? 'fieldOperatingStatusFacility'
         : ''
     }
-    fieldOperatingStatusFacility
     fieldLocationServices {
       entity {
         ... on ParagraphHealthCareLocalFacilityServi {

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -73,7 +73,7 @@ module.exports = `
         path
       }
       title
-    }    
+    }
     ${
       enabledFeatureFlags[featureFlags.FEATURE_REGION_PAGE_LINKS]
         ? `
@@ -82,10 +82,18 @@ module.exports = `
             path
           }
           title
-        }        
+        }
         `
         : ''
-    } 
+    }
+    reverseFieldRegionPageNode(limit: 100000, filter:{conditions:[{field: "type", value: "health_care_local_facility"}]}) {
+      entities {
+        ... on NodeHealthCareLocalFacility {
+          title
+          fieldOperatingStatusFacility
+        }
+      }
+    }
     allPressReleaseTeasers: reverseFieldOfficeNode(filter: {
       conditions: [
         { field: "type", value: "press_release"}

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -90,7 +90,13 @@ module.exports = `
       entities {
         ... on NodeHealthCareLocalFacility {
           title
-          fieldOperatingStatusFacility
+          ${
+            enabledFeatureFlags[
+              featureFlags.FEATURE_FIELD_OPERATING_STATUS_FACILITY
+            ]
+              ? 'fieldOperatingStatusFacility'
+              : ''
+          }
         }
       }
     }

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -11,6 +11,30 @@ const {
 function createHealthCareRegionListPages(page, drupalPagePath, files) {
   const sidebar = page.facilitySidebar;
 
+  // Create the top-level facilities status page for Health Care Regions
+  const statusEntityUrl = createEntityUrlObj(drupalPagePath);
+  const statusObj = {
+    mainFacilities: page.reverseFieldRegionPageNode,
+    facilitySidebar: sidebar,
+    entityUrl: statusEntityUrl,
+    alert: page.alert,
+    title: page.title,
+  };
+
+  const statusPage = updateEntityUrlObj(
+    statusObj,
+    drupalPagePath,
+    'Operating status',
+  );
+  const statusPath = statusPage.entityUrl.path;
+  statusPage.regionOrOffice = page.title;
+  statusPage.entityUrl = generateBreadCrumbs(statusPath);
+
+  files[`${drupalPagePath}/status/index.html`] = createFileObj(
+    statusPage,
+    'health_care_facility_status.drupal.liquid',
+  );
+
   // Create the top-level locations page for Health Care Regions
   const locEntityUrl = createEntityUrlObj(drupalPagePath);
   const locObj = {

--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -25,6 +25,7 @@ const featureFlags = {
   FEATURE_REGION_DETAIL_PAGE_TOC: 'featureRegionDetailPageTOC',
   FEATURE_FEATURED_HEALTH_SERVICE_CONTENT:
     'featureFeaturedHealthServiceContent',
+  FEATURE_FIELD_OPERATING_STATUS_FACILITY: 'fieldOperatingStatusFacility',
 };
 
 // Edit this to turn flags on or off
@@ -45,6 +46,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_REGION_PAGE_LINKS,
     featureFlags.FEATURE_REGION_DETAIL_PAGE_TOC,
     featureFlags.FEATURE_FEATURED_HEALTH_SERVICE_CONTENT,
+    featureFlags.FEATURE_FIELD_OPERATING_STATUS_FACILITY,
   ],
   vagovdev: [
     featureFlags.FEATURE_FIELD_ASSET_LIBRARY_DESCRIPTION,
@@ -62,6 +64,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_REGION_PAGE_LINKS,
     featureFlags.FEATURE_REGION_DETAIL_PAGE_TOC,
     featureFlags.FEATURE_FEATURED_HEALTH_SERVICE_CONTENT,
+    featureFlags.FEATURE_FIELD_OPERATING_STATUS_FACILITY,
   ],
   vagovstaging: [
     featureFlags.FEATURE_FIELD_ADDITIONAL_INFO,
@@ -75,6 +78,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT,
     featureFlags.FEATURE_REGION_PAGE_LINKS,
     featureFlags.FEATURE_FEATURED_HEALTH_SERVICE_CONTENT,
+    featureFlags.FEATURE_FIELD_OPERATING_STATUS_FACILITY,
   ],
   vagovprod: [
     featureFlags.FEATURE_FIELD_ADDITIONAL_INFO,


### PR DESCRIPTION
## Description
 - Adds an operating status page for a regions facilities

## Testing done
 - Visual

## Screenshots
![Screenshot_2019-07-25_18-20-42](https://user-images.githubusercontent.com/2404547/61913195-56110300-af0a-11e9-999f-5096622cddc5.png)


## Definition of done
- [ ] Facilities that have an operating status selected in drupal appear on the region status page (e.g. `/pittsburgh-health-care/status/index.html`) with the correct status.
