### PR TITLE
update vet tec search results styling

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecSearchResult.jsx
@@ -55,7 +55,9 @@ export class SearchResult extends React.Component {
               </div>
               <div className="small-12 usa-width-five-twelfths medium-5 columns estimated-benefits">
                 {renderPreferredProviderFlag(this.props.result)}
-                <h3 className="vads-u-padding-top--1p5">You may be eligible for up to:</h3>
+                <h3 className="vads-u-padding-top--1p5">
+                  You may be eligible for up to:
+                </h3>
                 <div className="row">
                   <div className="columns">
                     <h4>

--- a/src/applications/gi/components/vet-tec/VetTecSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecSearchResult.jsx
@@ -39,39 +39,28 @@ export class SearchResult extends React.Component {
     return (
       <div className="search-result">
         <div className="outer">
-          <div className="row">
-            <div className="small-12 usa-width-five-twelfths medium-5 columns">
-              {renderSchoolClosingFlag(this.props.result)}
-              {renderCautionFlag(this.props.result)}
-            </div>
-            <div className="small-12 usa-width-five-twelfths medium-5 columns">
-              {renderPreferredProviderFlag(this.props.result)}
-            </div>
-          </div>
+          {renderSchoolClosingFlag(this.props.result)}
+          {renderCautionFlag(this.props.result)}
           <div className="inner">
             <div className="row">
               <div className="small-12 usa-width-seven-twelfths medium-7 columns">
                 <h2>
-                  <Link
-                    className="vads-u-color--base vads-u-font-family--sans vads-u-font-size--md"
-                    to={linkTo}
-                  >
-                    {name}
-                  </Link>
+                  <Link to={linkTo}>{name}</Link>
                 </h2>
                 <div style={{ position: 'relative', bottom: 0 }}>
-                  <p>
+                  <p className="locality">
                     {city}, {state || country}
                   </p>
                 </div>
               </div>
               <div className="small-12 usa-width-five-twelfths medium-5 columns estimated-benefits">
-                <h3>You may be eligible for up to:</h3>
+                {renderPreferredProviderFlag(this.props.result)}
+                <h3 className="vads-u-padding-top--1p5">You may be eligible for up to:</h3>
                 <div className="row">
                   <div className="columns">
                     <h4>
                       <i className="fa fa-graduation-cap fa-search-result" />
-                      Tuition
+                      Tuition <span>(annually):</span>
                       <div>{tuition}</div>
                     </h4>
                   </div>

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -150,9 +150,6 @@
       text-align: right;
       font-size: 0.9em;
       font-weight: bold;
-      padding-bottom: .25em;
-      padding-right: 1.5em;
-      margin: 1em 0 0 1em;
       border-radius: 3px 3px 3px 3px;
 
       i.fa {

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -24,7 +24,7 @@ export const renderCautionFlag = result => {
 
 export const renderPreferredProviderFlag = result => {
   const { preferredProvider } = result;
-  if (!preferredProvider) return null;
+  if (!preferredProvider) return <br />;
   return (
     <div className="preferred-flag">
       <i className="fa fa-star vads-u-color--gold" />


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19360



## Testing done


## Screenshots
<img width="976" alt="Screen Shot 2019-07-25 at 11 33 35 AM" src="https://user-images.githubusercontent.com/48804654/61952100-f9046400-af80-11e9-9fe3-d0a9bffb3448.png">

## Acceptance criteria
- [ ]  On the VET TEC Search Results Page the cards will have the following layout:
     - Row 1 - warnings (if any)
     - Row 2 - Provider + Preferred Indicator (Row 1 if no warnings)
     - Row 3 - City + You may be eligible for... (Row 2 if no warnings)
- [ ]  The styling of the provider name and city/state is as follows:
     - The provider name is styled as an h2 header for the card.
     - The City, State text is displayed as a "locality".
- [ ]  If there are no warnings, there will not be a blank row on the card.
- [ ]  If there is no preferred provider indicator the "You may be eligible for" section is not moved out of the City/State row.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
