### PR TITLE
VAGOV-4903 Hub Sidebar Nav Icon Class

### DIFF
--- a/src/site/navigation/sidebar_nav.drupal.liquid
+++ b/src/site/navigation/sidebar_nav.drupal.liquid
@@ -6,7 +6,7 @@
         {% for link in sidebar.links %}
             {% if forloop.first == true %}
                 <div class="left-side-nav-title">
-                    <i class="icon-small white hub-icon-{{ link.label | handleize | remove: "-benefits" | remove: "-and-employment" }} hub-background-{{ link.label | handleize | remove: "-benefits" | remove: "-and-employment" }}"></i>
+                    <i class="icon-small white hub-icon-{{ fieldTitleIcon }} hub-background-{{ fieldTitleIcon }}"></i>
                     <h4>{{ link.label }}</h4>
                 </div>
 


### PR DESCRIPTION
## Description
Builds on previous work related to changing how hub icons are referenced in Liquid templates. This code closes the loop and actually references the fieldTitleIcon (originally from the parent landing page) in the detail page's sidebar template.

## Testing done
Observed that the correct class and icon were applied on detail pages pulled from Drupal.
Observed that the correct class and icon were applied on detail pages pulled from vagov-content.

## Screenshots
<img width="1178" alt="Screen Shot 2019-07-26 at 3 55 40 PM" src="https://user-images.githubusercontent.com/1181665/61977964-de9cab80-afbd-11e9-85ae-d2a28949b518.png">


## Acceptance criteria
- Correct icons show in detail page sidebar nav.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
