### PR TITLE
VAGOV-5022: Adding fields to leadership profile pages.

### DIFF
--- a/src/site/layouts/person_profile.drupal.liquid
+++ b/src/site/layouts/person_profile.drupal.liquid
@@ -61,15 +61,51 @@
                         </div>
 
                         <div class="usa-width-two-thirds vads-u-display--flex vads-u-flex-direction--column">
-                            <h1 class="vads-u-font-size--xl vads-u-margin-bottom--2">{{ title }}</h1>
-                            <p class="vads-u-font-weight--bold vads-u-margin-top--0 vads-u-line-height--1">{{ fieldDescription }}</p>
-                            {% if fieldPhotoAllowHiresDownload %}
-                                <div class="vads-u-align-content--flex-end va-c-margin-top--auto">
-                                    <i class="va-c-social-icon fas fa-download"></i>  <a href="{{ image.url }}" download>Download full size photo</a>
-                                </div>
+                            <h1 class="
+                            vads-u-font-size--xl
+                            vads-u-margin-bottom--0p5">
+                                {{ title }}
+                                {% if fieldSuffix %}
+                                {{ fieldSuffix }}
+                                {% endif %}
+                            </h1>
+                            {% if fieldDescription %}
+                            <p class="
+                            vads-u-font-weight--normal
+                            vads-u-margin--0
+                            vads-u-margin-bottom--0p5
+                            vads-u-font-family--serif
+                            vads-u-font-size--lg">
+                                {{ fieldDescription }}</p>
+                            {% endif %}
+                            {% if fieldOffice.entity.entityLabel %}
+                            <p class="
+                            vads-u-font-weight--normal
+                            vads-u-margin--0
+                            vads-u-margin-bottom--0p5
+                            vads-u-font-family--serif
+                            vads-u-font-size--lg">
+                                {{ fieldOffice.entity.entityLabel }}
+                            </p>
+                            {% endif %}
+                            {% if fieldEmailAddress %}
+                            <p class="
+                            vads-u-margin--0
+                            vads-u-margin-bottom--0p5">
+                                <span class="vads-u-font-weight--bold">Email:</span> <a target="blank"
+                                    href="{{ fieldEmailAddress }}">{{ fieldEmailAddress }}</a>
+                            </p>
+                            {% endif %}
+                            {% if fieldPhoneNumber %}
+                            <p class="
+                            vads-u-font-weight--bold
+                            vads-u-margin--0
+                            vads-u-margin-bottom--0p5">
+                                <span class="vads-u-font-weight--bold">Phone:</span> <a
+                                    href="tel:{{ fieldPhoneNumber }}">{{ fieldPhoneNumber }}</a>
+                            </p>
                             {% endif %}
                         </div>
-
                     </div>
 
                     {% if fieldIntroText %}
@@ -83,7 +119,18 @@
                         {{ fieldBody.processed }}
                     </div>
                     {% endif %}
-
+                    {% if fieldPhotoAllowHiresDownload %}
+                    <div class="vads-u-align-content--flex-end va-c-margin-top--auto vads-u-margin-bottom--2">
+                        <i class="va-c-social-icon fas fa-download"></i> <a href="{{ image.url }}"
+                            download>Download full size photo</a>
+                    </div>
+                    {% endif %}
+                    {% if fieldCompleteBiography %}
+                    <div class="vads-u-align-content--flex-end va-c-margin-top--auto vads-u-margin-bottom--2">
+                        <i class="va-c-social-icon fas fa-download"></i> <a href="{{ fieldCompleteBiography.entity.url }}"
+                            download>Download full bio (PDF)</a>
+                    </div>
+                    {% endif %}
                 </article>
 
                 <div class="last-updated usa-content">

--- a/src/site/stages/build/drupal/graphql/bioPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bioPage.graphql.js
@@ -3,6 +3,11 @@
  *
  */
 const entityElementsFromPages = require('./entityElementsForPages.graphql');
+// Get current feature flags
+const {
+  featureFlags,
+  enabledFeatureFlags,
+} = require('../../../../utilities/featureFlags');
 
 module.exports = `
  fragment bioPage on NodePersonProfile {
@@ -11,6 +16,13 @@ module.exports = `
   fieldLastName
   fieldSuffix
   fieldDescription
+  fieldEmailAddress
+  fieldPhoneNumber
+  ${
+    enabledFeatureFlags[featureFlags.FEATURE_FIELD_COMPLETE_BIOGRAPHY]
+      ? 'fieldCompleteBiography { entity { url } }'
+      : ''
+  }
   fieldOffice {
     entity {
       entityLabel

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionStaffBios.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionStaffBios.node.graphql.js
@@ -10,6 +10,8 @@ const PERSON_PROFILE_RESULTS = `
       fieldNameFirst
       fieldLastName
       fieldSuffix
+      fieldEmailAddress
+      fieldPhoneNumber
       fieldDescription
       fieldOffice {
         entity {
@@ -26,7 +28,7 @@ const PERSON_PROFILE_RESULTS = `
               alt
               title
               url
-              derivative(style: _1_1_SQUARE_MEDIUM_THUMBNAIL) {
+              derivative(style: CROP32) {
                 url
                 width
                 height

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/staffProfile.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/staffProfile.paragraph.graphql.js
@@ -1,0 +1,11 @@
+/**
+ * A Drupal paragraph containing rich text.
+ *
+ */
+module.exports = `
+  fragment wysiwyg on ParagraphWysiwyg {
+      fieldWysiwyg {
+        processed
+      }
+  }
+`;

--- a/src/site/teasers/bio.drupal.liquid
+++ b/src/site/teasers/bio.drupal.liquid
@@ -1,51 +1,100 @@
 {% comment %}
-    Required variable: node - bio entity
-    Optional variable: header - the header level ('h2','h3', etc.) defaults to h4
-    Example data:
-    {
-    "entityPublished": true,
-    "fieldNameFirst": "Sheila",
-    "fieldLastName": "Tunney",
-    "fieldSuffix": null,
-    "fieldDescription": "Public Affairs Specialist",
-    "fieldOffice": {
-    "entity": {
-    "entityLabel": "Pittsburgh Health Care System",
-    "entityType": "node"
-    }
-    },
-    "fieldIntroText": null,
-    "fieldPhotoAllowHiresDownload": false,
-    "fieldMedia": {
-    "entity": {
-    "image": {
-    "alt": "Robert L Wilkie",
-    "title": "",
-    "derivative": {
-    "url": "http://dev.va.agile6.com/sites/default/files/styles/1_1_square_medium_thumbnail/public/2019-03/Robert_L_Wilkie_8x10.jpg?h=59bf76d8&itok=Q-x_2QaJ",
-    "width": 240,
-    "height": 240
-    }
-    }
-    }
-    },
-    "fieldBody": null,
-    "changed": 1552424311,
-    "entityUrl": {
-    "path": "/pittsburgh-health-care/sheila-tunney"
-    }
-    },
+Required variable: node - bio entity
+Optional variable: header - the header level ('h2','h3', etc.) defaults to h4
+Example data:
+{
+"entityPublished": true,
+"fieldNameFirst": "Sheila",
+"fieldLastName": "Tunney",
+"fieldSuffix": null,
+"fieldDescription": "Public Affairs Specialist",
+"fieldOffice": {
+"entity": {
+"entityLabel": "Pittsburgh Health Care System",
+"entityType": "node"
+}
+},
+"fieldIntroText": null,
+"fieldPhotoAllowHiresDownload": false,
+"fieldMedia": {
+"entity": {
+"image": {
+"alt": "Robert L Wilkie",
+"title": "",
+"derivative": {
+"url":
+"http://dev.va.agile6.com/sites/default/files/styles/1_1_square_medium_thumbnail/public/2019-03/Robert_L_Wilkie_8x10.jpg?h=59bf76d8&itok=Q-x_2QaJ",
+"width": 240,
+"height": 240
+}
+}
+}
+},
+"fieldBody": null,
+"changed": 1552424311,
+"entityUrl": {
+"path": "/pittsburgh-health-care/sheila-tunney"
+}
+},
 {% endcomment %}
 {% if header == empty %}
-    {% assign header = "h4" %}
+{% assign header = "h4" %}
 {% endif %}
 <div class="usa-grid usa-grid-full vads-u-margin-bottom--4">
     <div class="usa-width-one-third">
         {% assign image = node.fieldMedia.entity.image %}
-        <img src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="{{ image.derivative.width }}" height="{{ image.derivative.height }}">
+        <img src="{{ image.derivative.url }}" alt="{{ image.alt }}"
+            title="{{ image.title }}" width="{{ image.derivative.width }}"
+            height="{{ image.derivative.height }}">
     </div>
     <div class="usa-width-two-thirds">
-        <{{ header }} class="vads-u-margin-bottom--1 vads-u-font-size--md medium-screen:vads-u-font-size--lg"><a href="{{ node.entityUrl.path }}">{{ node.fieldNameFirst }} {{ node.fieldLastName }} {{ node.fieldSuffix }}</a></{{ header }}>
-    <p class="vads-u-font-weight--bold vads-u-margin--0">{{ node.fieldDescription }}</p>
+        <h2 class="
+        vads-u-margin-bottom--1
+        vads-u-font-size--md
+        medium-screen:vads-u-font-size--lg">
+            <a href="{{ node.entityUrl.path }}">{{ node.fieldNameFirst }}
+                {{ node.fieldLastName }} {{ node.fieldSuffix }}</a>
+        </h2>
+        {% if node.fieldDescription %}
+        <p class="
+        vads-u-font-weight--normal
+        vads-u-margin--0
+        vads-u-margin-bottom--0p5
+        vads-u-font-family--serif
+        vads-u-font-size--lg">
+            {{ node.fieldDescription }}</p>
+        {% endif %}
+        {% if node.fieldOffice.entity.entityLabel %}
+        <p class="
+        vads-u-font-weight--normal
+        vads-u-margin--0
+        vads-u-margin-bottom--0p5
+        vads-u-font-family--serif
+        vads-u-font-size--lg">
+            {{ node.fieldOffice.entity.entityLabel }}
+        </p>
+        {% endif %}
+        {% if node.fieldEmailAddress %}
+        <p class="
+        vads-u-font-weight--normal
+        vads-u-margin--0
+        vads-u-margin-bottom--0p5
+        vads-u-font-family--serif
+        vads-u-font-size--lg">
+            Email: <a target="blank"
+                href="{{ node.fieldEmailAddress }}">{{ node.fieldEmailAddress }}</a>
+        </p>
+        {% endif %}
+        {% if node.fieldPhoneNumber %}
+        <p class="
+        vads-u-font-weight--normal
+        vads-u-margin--0
+        vads-u-margin-bottom--0p5
+        vads-u-font-family--serif
+        vads-u-font-size--lg">
+            Phone: <a
+                href="tel:{{ node.fieldPhoneNumber }}">{{ node.fieldPhoneNumber }}</a>
+        </p>
+        {% endif %}
     </div>
 </div>

--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -26,6 +26,7 @@ const featureFlags = {
   FEATURE_FEATURED_HEALTH_SERVICE_CONTENT:
     'featureFeaturedHealthServiceContent',
   FEATURE_FIELD_OPERATING_STATUS_FACILITY: 'fieldOperatingStatusFacility',
+  FEATURE_FIELD_COMPLETE_BIOGRAPHY: 'fieldCompleteBiography',
 };
 
 // Edit this to turn flags on or off
@@ -47,6 +48,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_REGION_DETAIL_PAGE_TOC,
     featureFlags.FEATURE_FEATURED_HEALTH_SERVICE_CONTENT,
     featureFlags.FEATURE_FIELD_OPERATING_STATUS_FACILITY,
+    featureFlags.FEATURE_FIELD_COMPLETE_BIOGRAPHY,
   ],
   vagovdev: [
     featureFlags.FEATURE_FIELD_ASSET_LIBRARY_DESCRIPTION,
@@ -65,6 +67,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_REGION_DETAIL_PAGE_TOC,
     featureFlags.FEATURE_FEATURED_HEALTH_SERVICE_CONTENT,
     featureFlags.FEATURE_FIELD_OPERATING_STATUS_FACILITY,
+    featureFlags.FEATURE_FIELD_COMPLETE_BIOGRAPHY,
   ],
   vagovstaging: [
     featureFlags.FEATURE_FIELD_ADDITIONAL_INFO,
@@ -80,6 +83,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_REGION_DETAIL_PAGE_TOC,
     featureFlags.FEATURE_FEATURED_HEALTH_SERVICE_CONTENT,
     featureFlags.FEATURE_FIELD_OPERATING_STATUS_FACILITY,
+    featureFlags.FEATURE_FIELD_COMPLETE_BIOGRAPHY,
   ],
   vagovprod: [
     featureFlags.FEATURE_FIELD_ADDITIONAL_INFO,


### PR DESCRIPTION
## Description
Adds new fields to staff profile page and staff profile listing pages

## Testing done
Visual

## Screenshots
![Screenshot_2019-07-26_18-09-36](https://user-images.githubusercontent.com/2404547/61984028-b10d2d80-afd0-11e9-9b89-68721eb61649.png)
![Screenshot_2019-07-26_18-09-52](https://user-images.githubusercontent.com/2404547/61984036-b5d1e180-afd0-11e9-9088-e139fb463bce.png)

## Acceptance criteria
- [ ] `pittsburgh-health-care/leadership/index.html` looks like screenshot
- [ ] `/va-central-office/staff-profiles/barbara-forsha/` looks like screenshot (with the exception of email and download fields, as these require manual entry in drupal)
