### PR TITLE
19379  - Fix right alignment of profile page benefit values

### DIFF
--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -20,7 +20,7 @@ const CalculatorResultRow = ({ label, value, header, bold, visible }) =>
       <div className="small-6 columns">
         {header ? <h5>{label}:</h5> : <div>{label}:</div>}
       </div>
-      <div className="small-6 columns value">
+      <div className="small-6 columns vads-u-text-align--right">
         {header ? <h5>{value}</h5> : <div>{value}</div>}
       </div>
     </div>

--- a/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
@@ -142,7 +142,7 @@ export class VetTecCalculator extends React.Component {
         <div className="small-8 columns">
           <div>In person rate:</div>
         </div>
-        <div className="small-4 columns">
+        <div className="small-4 columns vads-u-text-align--right">
           <div>{outputs.inPersonRate}</div>
         </div>
       </div>
@@ -151,7 +151,7 @@ export class VetTecCalculator extends React.Component {
         <div className="small-8 columns">
           <div>Online rate:</div>
         </div>
-        <div className="small-4 columns">
+        <div className="small-4 columns vads-u-text-align--right">
           <div>{outputs.onlineRate}</div>
         </div>
       </div>


### PR DESCRIPTION
## Description
The dollar values in the Estimate Your Benefits section of a provider profile page should be aligned right, but are currently not.
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19379

## Testing done
Confirmed in UI

## Screenshots
VetTec profile with right alignment (third through fifth 'TBD' are meant to be pulled in a bit)
<img width="993" alt="Screen Shot 2019-07-29 at 2 12 57 PM" src="https://user-images.githubusercontent.com/52166695/62071886-76430980-b20b-11e9-95b9-2e1b63d9e9e7.png">

Normal profile page
<img width="897" alt="Screen Shot 2019-07-29 at 2 13 44 PM" src="https://user-images.githubusercontent.com/52166695/62071994-af7b7980-b20b-11e9-82ed-ee57de126042.png">

## Acceptance criteria
- [x] Dollar values in the Estimate Your Benefits section of a provider profile page should be aligned right

## Definition of done
- [x ] Events are logged appropriately
- [x ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
