### PR TITLE
Remove duplicate `recordDashboardClick` definitions

### DIFF
--- a/src/applications/personalization/dashboard/components/FormItem.jsx
+++ b/src/applications/personalization/dashboard/components/FormItem.jsx
@@ -2,13 +2,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
 
-import recordEvent from 'platform/monitoring/record-event';
 import {
   formTitles,
   formLinks,
   formConfigs,
   isFormAuthorizable,
   presentableFormIDs,
+  recordDashboardClick,
 } from '../helpers';
 import AuthorizationComponent from 'platform/forms/components/AuthorizationComponent';
 import DashboardAlert, {
@@ -16,14 +16,6 @@ import DashboardAlert, {
 } from 'applications/personalization/dashboard/components/DashboardAlert';
 
 class FormItem extends React.Component {
-  recordDashboardClick = (formId, actionType = 'continue-button') => () => {
-    recordEvent({
-      event: 'dashboard-navigation',
-      'dashboard-action': actionType,
-      'dashboard-product': formId,
-    });
-  };
-
   render() {
     const savedFormData = this.props.savedFormData;
     const formId = savedFormData.form;
@@ -59,7 +51,7 @@ class FormItem extends React.Component {
           className="usa-button-primary application-route vads-u-margin--0"
           aria-label={`Continue your ${itemTitle}`}
           href={`${formLinks[formId]}resume`}
-          onClick={this.recordDashboardClick(formId)}
+          onClick={recordDashboardClick(formId, 'continue-button')}
         >
           Continue your application
         </a>
@@ -86,7 +78,7 @@ class FormItem extends React.Component {
           aria-label={`Remove this notification about my ${itemTitle}`}
           onClick={() => {
             this.props.toggleModal(formId);
-            this.recordDashboardClick(formId, 'delete-link');
+            recordDashboardClick(formId, 'delete-link');
           }}
         >
           <i className="fa fa-times" />

--- a/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
@@ -15,7 +15,6 @@ import {
   getAppealsV2,
   getClaimsV2,
 } from 'applications/claims-status/actions/index.jsx';
-import recordEvent from 'platform/monitoring/record-event';
 
 import ClaimsUnavailable from 'applications/claims-status/components/ClaimsUnavailable';
 import AppealsUnavailable from 'applications/claims-status/components/AppealsUnavailable';
@@ -26,20 +25,11 @@ import DowntimeNotification, {
 } from 'platform/monitoring/DowntimeNotification';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
+import { recordDashboardClick } from '../helpers';
 import ClaimsListItem from '../components/ClaimsListItem';
 import AppealListItem from '../../../claims-status/components/appeals-v2/AppealListItemV2';
 
 const appealTypes = Object.values(APPEAL_TYPES);
-
-function recordDashboardClick(product) {
-  return () => {
-    recordEvent({
-      event: 'dashboard-navigation',
-      'dashboard-action': 'view-link',
-      'dashboard-product': product,
-    });
-  };
-}
 
 class ClaimsAppealsWidget extends React.Component {
   componentDidMount() {

--- a/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
@@ -16,6 +16,7 @@ import {
   getClaimsV2,
 } from 'applications/claims-status/actions/index.jsx';
 
+import AppealListItem from 'applications/claims-status/components/appeals-v2/AppealListItemV2';
 import ClaimsUnavailable from 'applications/claims-status/components/ClaimsUnavailable';
 import AppealsUnavailable from 'applications/claims-status/components/AppealsUnavailable';
 import ClaimsAppealsUnavailable from 'applications/claims-status/components/ClaimsAppealsUnavailable';
@@ -27,7 +28,6 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import { recordDashboardClick } from '../helpers';
 import ClaimsListItem from '../components/ClaimsListItem';
-import AppealListItem from '../../../claims-status/components/appeals-v2/AppealListItemV2';
 
 const appealTypes = Object.values(APPEAL_TYPES);
 


### PR DESCRIPTION
## Description
Our codebase had defined multiple implementations of
`recordDashboardClick` in addition to the common version defined in the
`helpers`. This PR removes those two other implementations.

For reference, here is the definition of the common version in `helpers`: https://github.com/department-of-veterans-affairs/vets-website/blob/f5945ef5b6a1891f0cebc0799b271a5bcde3b854/src/applications/personalization/dashboard/helpers.jsx#L246-L255

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs