### PR TITLE
18454 - Refactor Profile Direct Deposit add-link GA-events.

### DIFF
--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -141,10 +141,10 @@ class PaymentInformation extends React.Component {
     });
   };
 
-  renderSetupButton(label) {
+  renderSetupButton(label, gaProfileSection) {
     return (
       <a
-        onClick={() => this.handleLinkClick('add', label)}
+        onClick={() => this.handleLinkClick('add', gaProfileSection)}
       >{`Please add your ${label}`}</a>
     );
   }
@@ -177,41 +177,44 @@ class PaymentInformation extends React.Component {
           <div className="vet360-profile-field">
             <ProfileFieldHeading
               onEditClick={
-                directDepositIsSetUp &&
+                !directDepositIsSetUp &&
                 (() => this.handleLinkClick('edit', 'bank-name'))
               }
             >
               Bank name
             </ProfileFieldHeading>
-            {directDepositIsSetUp
+            {!directDepositIsSetUp
               ? paymentAccount.financialInstitutionName
-              : this.renderSetupButton('bank name')}
+              : this.renderSetupButton('bank name', 'bank-name')}
           </div>
           <div className="vet360-profile-field">
             <ProfileFieldHeading
               onEditClick={
-                directDepositIsSetUp &&
+                !directDepositIsSetUp &&
                 (() => this.handleLinkClick('edit', 'account-number'))
               }
             >
               Account number
             </ProfileFieldHeading>
-            {directDepositIsSetUp
+            {!directDepositIsSetUp
               ? paymentAccount.accountNumber
-              : this.renderSetupButton('account number')}
+              : this.renderSetupButton('account number', 'account-number')}
           </div>
           <div className="vet360-profile-field">
             <ProfileFieldHeading
               onEditClick={
-                directDepositIsSetUp &&
+                !directDepositIsSetUp &&
                 (() => this.handleLinkClick('edit', 'account-type'))
               }
             >
               Account type
             </ProfileFieldHeading>
-            {directDepositIsSetUp
+            {!directDepositIsSetUp
               ? paymentAccount.accountType
-              : this.renderSetupButton('account type (checking or savings)')}
+              : this.renderSetupButton(
+                  'account type (checking or savings)',
+                  'account-type',
+                )}
           </div>
           {directDepositIsSetUp && (
             <p>

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -177,39 +177,39 @@ class PaymentInformation extends React.Component {
           <div className="vet360-profile-field">
             <ProfileFieldHeading
               onEditClick={
-                !directDepositIsSetUp &&
+                directDepositIsSetUp &&
                 (() => this.handleLinkClick('edit', 'bank-name'))
               }
             >
               Bank name
             </ProfileFieldHeading>
-            {!directDepositIsSetUp
+            {directDepositIsSetUp
               ? paymentAccount.financialInstitutionName
               : this.renderSetupButton('bank name', 'bank-name')}
           </div>
           <div className="vet360-profile-field">
             <ProfileFieldHeading
               onEditClick={
-                !directDepositIsSetUp &&
+                directDepositIsSetUp &&
                 (() => this.handleLinkClick('edit', 'account-number'))
               }
             >
               Account number
             </ProfileFieldHeading>
-            {!directDepositIsSetUp
+            {directDepositIsSetUp
               ? paymentAccount.accountNumber
               : this.renderSetupButton('account number', 'account-number')}
           </div>
           <div className="vet360-profile-field">
             <ProfileFieldHeading
               onEditClick={
-                !directDepositIsSetUp &&
+                directDepositIsSetUp &&
                 (() => this.handleLinkClick('edit', 'account-type'))
               }
             >
               Account type
             </ProfileFieldHeading>
-            {!directDepositIsSetUp
+            {directDepositIsSetUp
               ? paymentAccount.accountType
               : this.renderSetupButton(
                   'account type (checking or savings)',


### PR DESCRIPTION
## Description
18454 - Add separate GA-event props to Profile Direct Deposit add-links.

Add-link labels and GA-event props turns out to have different string-values.  This PR adds a separate gaProfileSection prop to renderSetupButton method, so that the GA-event prop does not share the label-values.

## Testing done
Local, via browser dev-tools \[watch window.dataLayer array\].

## Acceptance criteria
- [ ] Add-link GA-events pushed to window.dataLayer.

## Definition of done
- [ ] Events are logged appropriately
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
