### PR TITLE
Remove duplicate `recordDashboardClick` definitions

### DIFF
--- a/src/applications/personalization/dashboard/components/FormItem.jsx
+++ b/src/applications/personalization/dashboard/components/FormItem.jsx
@@ -2,13 +2,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
 
-import recordEvent from 'platform/monitoring/record-event';
 import {
   formTitles,
   formLinks,
   formConfigs,
   isFormAuthorizable,
   presentableFormIDs,
+  recordDashboardClick,
 } from '../helpers';
 import AuthorizationComponent from 'platform/forms/components/AuthorizationComponent';
 import DashboardAlert, {
@@ -16,14 +16,6 @@ import DashboardAlert, {
 } from 'applications/personalization/dashboard/components/DashboardAlert';
 
 class FormItem extends React.Component {
-  recordDashboardClick = (formId, actionType = 'continue-button') => () => {
-    recordEvent({
-      event: 'dashboard-navigation',
-      'dashboard-action': actionType,
-      'dashboard-product': formId,
-    });
-  };
-
   render() {
     const savedFormData = this.props.savedFormData;
     const formId = savedFormData.form;
@@ -59,7 +51,7 @@ class FormItem extends React.Component {
           className="usa-button-primary application-route vads-u-margin--0"
           aria-label={`Continue your ${itemTitle}`}
           href={`${formLinks[formId]}resume`}
-          onClick={this.recordDashboardClick(formId)}
+          onClick={recordDashboardClick(formId, 'continue-button')}
         >
           Continue your application
         </a>
@@ -86,7 +78,7 @@ class FormItem extends React.Component {
           aria-label={`Remove this notification about my ${itemTitle}`}
           onClick={() => {
             this.props.toggleModal(formId);
-            this.recordDashboardClick(formId, 'delete-link');
+            recordDashboardClick(formId, 'delete-link');
           }}
         >
           <i className="fa fa-times" />

--- a/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/ClaimsAppealsWidget.jsx
@@ -15,8 +15,8 @@ import {
   getAppealsV2,
   getClaimsV2,
 } from 'applications/claims-status/actions/index.jsx';
-import recordEvent from 'platform/monitoring/record-event';
 
+import AppealListItem from 'applications/claims-status/components/appeals-v2/AppealListItemV2';
 import ClaimsUnavailable from 'applications/claims-status/components/ClaimsUnavailable';
 import AppealsUnavailable from 'applications/claims-status/components/AppealsUnavailable';
 import ClaimsAppealsUnavailable from 'applications/claims-status/components/ClaimsAppealsUnavailable';
@@ -26,20 +26,10 @@ import DowntimeNotification, {
 } from 'platform/monitoring/DowntimeNotification';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
+import { recordDashboardClick } from '../helpers';
 import ClaimsListItem from '../components/ClaimsListItem';
-import AppealListItem from '../../../claims-status/components/appeals-v2/AppealListItemV2';
 
 const appealTypes = Object.values(APPEAL_TYPES);
-
-function recordDashboardClick(product) {
-  return () => {
-    recordEvent({
-      event: 'dashboard-navigation',
-      'dashboard-action': 'view-link',
-      'dashboard-product': product,
-    });
-  };
-}
 
 class ClaimsAppealsWidget extends React.Component {
   componentDidMount() {


### PR DESCRIPTION
Our codebase had defined multiple implementations of
`recordDashboardClick` in addition to the common version defined in the
`helpers`. This PR removes those two other implementations.

## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs