### PR TITLE
Fixing events intro text field display bug, changing no results text.

### DIFF
--- a/src/site/components/events_list.drupal.liquid
+++ b/src/site/components/events_list.drupal.liquid
@@ -35,16 +35,10 @@
   {% endfor %}
   {% if count == 0 %}
   <div class="vads-u-margin-bottom--2">
-    <div class="va-introtext">
-      <p>
-        VA proudly works alongside others to connect Veterans to the benefits
-        they’ve earned. Explore resources for our outreach
-        partners such as Veteran Service Organizations (VSOs),
-        and sign up for events.</p>
-    </div>
     <div>
       <p>
-        <i>We're sorry, there are no events to display at this time</i>
+        <i>We're sorry, there are no events to display at this time. Check back regularly
+        for new event listings.</i>
       </p>
     </div>
   </div>

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -23,7 +23,7 @@
             <h1>{{ title }}</h1>
             <div class="vads-l-grid-container--full">
               <div class="va-introtext">
-                {% if fieldEventListingDescription %}
+                {% if fieldIntroText %}
                 <p class="events-show" id="office-events-description">
                   {{ fieldIntroText }}
                 </p>


### PR DESCRIPTION
## Description
Intro text on events listing page is not displaying because check for field is incorrect - using name of of wrong field

## Testing done
VIsual

## Screenshots
![Screenshot_2019-07-29_18-35-31](https://user-images.githubusercontent.com/2404547/62087458-bfa55000-b22f-11e9-957b-c84528f7d0cf.png)

## Acceptance criteria
- [ ] Events listing page with no results should look like screenshot
