### PR TITLE
Bah nav tag fix 19383

### DIFF
--- a/src/applications/gi/components/content/AdditionalResources.jsx
+++ b/src/applications/gi/components/content/AdditionalResources.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import recordEvent from 'platform/monitoring/record-event';
 
 export const AdditionalResourcesLinks = () => (
   <div>

--- a/src/applications/gi/components/content/AdditionalResources.jsx
+++ b/src/applications/gi/components/content/AdditionalResources.jsx
@@ -8,11 +8,6 @@ export const AdditionalResourcesLinks = () => (
         href="https://va.careerscope.net/gibill"
         target="_blank"
         rel="noopener noreferrer"
-        onClick={() =>
-          recordEvent({
-            event: 'nav-profile-additional-resources',
-          })
-        }
       >
         Get started with CareerScope
       </a>
@@ -22,11 +17,6 @@ export const AdditionalResourcesLinks = () => (
         href="https://www.benefits.va.gov/gibill/choosing_a_school.asp"
         target="_blank"
         rel="noopener noreferrer"
-        onClick={() =>
-          recordEvent({
-            event: 'nav-profile-additional-resources',
-          })
-        }
       >
         Get help choosing a school
       </a>
@@ -36,11 +26,6 @@ export const AdditionalResourcesLinks = () => (
         href="/education/submit-school-feedback"
         target="_blank"
         rel="noopener noreferrer"
-        onClick={() =>
-          recordEvent({
-            event: 'nav-profile-additional-resources',
-          })
-        }
       >
         Submit a complaint through our Feedback System
       </a>
@@ -49,11 +34,7 @@ export const AdditionalResourcesLinks = () => (
       <a
         href="/education/how-to-apply/"
         target="_blank"
-        onClick={() =>
-          recordEvent({
-            event: 'nav-profile-additional-resources',
-          })
-        }
+        rel="noopener noreferrer"
       >
         Apply for education benefits
       </a>

--- a/src/applications/gi/components/search/LandingPageTypeOfInstitutionFilter.jsx
+++ b/src/applications/gi/components/search/LandingPageTypeOfInstitutionFilter.jsx
@@ -24,7 +24,7 @@ class LandingPageTypeOfInstitutionFilter extends React.Component {
       const vetTecLabel = (
         <span>
           VET TEC training providers only &nbsp;(
-          <a onClick={() => this.props.showModal('VET TEC')}>
+          <a onClick={() => this.props.showModal('vetTec')}>
             Learn More)
             <br />
           </a>

--- a/src/applications/gi/components/vet-tec/VetTecAdditionalResources.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecAdditionalResources.jsx
@@ -1,9 +1,19 @@
 import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 
 export const VetTecAdditionalResourcesLinks = () => (
   <div>
     <p>
-      <a href="https://va.careerscope.net/gibill" rel="nofollow">
+      <a
+        href="https://va.careerscope.net/gibill"
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={() =>
+          recordEvent({
+            event: 'nav-profile-additional-resources',
+          })
+        }
+      >
         Get started with CareerScope
       </a>
     </p>
@@ -12,6 +22,11 @@ export const VetTecAdditionalResourcesLinks = () => (
         href="/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/"
         target="_blank"
         rel="noopener noreferrer"
+        onClick={() =>
+          recordEvent({
+            event: 'nav-profile-additional-resources',
+          })
+        }
       >
         Learn more about VET TEC
       </a>
@@ -20,6 +35,12 @@ export const VetTecAdditionalResourcesLinks = () => (
       <a
         href="/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994/introduction"
         target="_blank"
+        rel="noopener noreferrer"
+        onClick={() =>
+          recordEvent({
+            event: 'nav-profile-additional-resources',
+          })
+        }
       >
         Apply for VET TEC
       </a>
@@ -29,6 +50,11 @@ export const VetTecAdditionalResourcesLinks = () => (
         href="/education/submit-school-feedback"
         target="/education/submit-school-feedback/introduction"
         rel="noopener noreferrer"
+        onClick={() =>
+          recordEvent({
+            event: 'nav-profile-additional-resources',
+          })
+        }
       >
         Submit a complaint through our Feedback System
       </a>

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -1025,7 +1025,7 @@ export class Modals extends React.Component {
 
       <Modal
         onClose={this.props.hideModal}
-        visible={this.shouldDisplayModal('VET TEC')}
+        visible={this.shouldDisplayModal('vetTec')}
       >
         <div>
           <div>


### PR DESCRIPTION
## Description
Update vettec additional resources to display nav-profile-additional-resources in data layer.
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19383

Update text on modal from VET TEC to vetTec

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19384





## Testing done
Tested locallly

## Screenshots
<img width="1680" alt="Screen Shot 2019-07-30 at 11 02 28 AM" src="https://user-images.githubusercontent.com/50601724/62142263-fcb72400-b2bb-11e9-951e-24a668d59e03.png">
<img width="1656" alt="Screen Shot 2019-07-30 at 10 45 41 AM" src="https://user-images.githubusercontent.com/50601724/62142269-004aab00-b2bc-11e9-9d8f-6f856c76edd8.png">


## Acceptance criteria
- [x] The Vet Tec "Learn more" modal on the comparision tool landing page should populate with vetTec upon click with the following value in the dataLayer.
- [x] it appears our nav-profile-additional-resources event dataLayer push may have been missed.
Currently gibct-modal-displayed: "VET TEC"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
