### PR TITLE
19378: CT 116: Final MVP Content Updates based on UX Feedback

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecSearchForm.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecSearchForm.jsx
@@ -48,7 +48,7 @@ class VetTecSearchForm extends React.Component {
 
     const inPersonLabel = (
       <div>
-        In Person &nbsp; <i className="fas fa-user" />
+        In person &nbsp; <i className="fas fa-user" />
       </div>
     );
     const onlineLabel = (
@@ -58,7 +58,7 @@ class VetTecSearchForm extends React.Component {
     );
     return (
       <div>
-        <p>Learning Format</p>
+        <p>Learning format</p>
         <Checkbox
           checked={inPerson}
           name="inPerson"

--- a/src/applications/gi/components/vet-tec/VetTecSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecSearchResult.jsx
@@ -62,7 +62,7 @@ export class SearchResult extends React.Component {
                   <div className="columns">
                     <h4>
                       <i className="fa fa-graduation-cap fa-search-result" />
-                      Tuition <span>(annually):</span>
+                      Tuition:
                       <div>{tuition}</div>
                     </h4>
                   </div>

--- a/src/applications/gi/selectors/vetTecCalculator.js
+++ b/src/applications/gi/selectors/vetTecCalculator.js
@@ -14,39 +14,39 @@ export const getCalculatedBenefits = createSelector(
   getConstants,
   getInstitution,
   (inputs, constants, institution) => {
-    const inputsNull =
+    const vetTecTuitionInputNull =
       inputs.vetTecTuitionFees === null || inputs.vetTecTuitionFees === 0;
 
-    const paysToProviderValue = inputsNull
+    const paysToProviderValue = vetTecTuitionInputNull
       ? null
       : Math.max(inputs.vetTecTuitionFees - inputs.vetTecScholarships, 0);
 
-    const quarterPaysToProviderValue = inputsNull
+    const quarterPaysToProviderValue = vetTecTuitionInputNull
       ? null
       : paysToProviderValue * 0.25;
 
-    const halfPaysToProviderValue = inputsNull
+    const halfPaysToProviderValue = vetTecTuitionInputNull
       ? null
       : paysToProviderValue * 0.5;
 
     const determineOutOfPocketFees = () => {
-      let oop;
-      if (inputs.vetTecTuitionFees === null || inputs.vetTecTuitionFees === 0) {
-        oop = null;
+      let outOfPocketFees;
+      if (vetTecTuitionInputNull) {
+        outOfPocketFees = null;
       } else if (institution.preferredProvider) {
-        oop = 0;
+        outOfPocketFees = 0;
       } else if (inputs.vetTecTuitionFees > constants.TFCAP) {
-        oop =
+        outOfPocketFees =
           inputs.vetTecTuitionFees -
           constants.TFCAP -
           inputs.vetTecScholarships;
-        if (oop < 0) {
-          oop = 0;
+        if (outOfPocketFees < 0) {
+          outOfPocketFees = 0;
         }
       } else {
-        oop = 0;
+        outOfPocketFees = 0;
       }
-      return oop;
+      return outOfPocketFees;
     };
 
     return {

--- a/src/applications/gi/selectors/vetTecCalculator.js
+++ b/src/applications/gi/selectors/vetTecCalculator.js
@@ -37,13 +37,10 @@ export const getCalculatedBenefits = createSelector(
       outOfPocketFees = 0;
     } else if (
       !institution.preferredProvider &&
-      vetTecTuitionFees > constants.TFCAP
+      vetTecTuitionFees > constants.TFCAP - vetTecScholarships
     ) {
       outOfPocketFees =
         vetTecTuitionFees - constants.TFCAP - vetTecScholarships;
-      if (outOfPocketFees < 0) {
-        outOfPocketFees = 0;
-      }
     }
 
     return {

--- a/src/applications/gi/selectors/vetTecCalculator.js
+++ b/src/applications/gi/selectors/vetTecCalculator.js
@@ -35,14 +35,15 @@ export const getCalculatedBenefits = createSelector(
       outOfPocketFees = null;
     } else if (institution.preferredProvider) {
       outOfPocketFees = 0;
-    } else if (vetTecTuitionFees > constants.TFCAP) {
+    } else if (
+      !institution.preferredProvider &&
+      vetTecTuitionFees > constants.TFCAP
+    ) {
       outOfPocketFees =
         vetTecTuitionFees - constants.TFCAP - vetTecScholarships;
       if (outOfPocketFees < 0) {
         outOfPocketFees = 0;
       }
-    } else if (vetTecTuitionFees <= constants.TFCAP) {
-      outOfPocketFees = 0;
     }
 
     return {

--- a/src/applications/gi/selectors/vetTecCalculator.js
+++ b/src/applications/gi/selectors/vetTecCalculator.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { createSelector } from 'reselect';
 import { formatCurrency } from '../utils/helpers';
 

--- a/src/applications/gi/selectors/vetTecCalculator.js
+++ b/src/applications/gi/selectors/vetTecCalculator.js
@@ -37,10 +37,13 @@ export const getCalculatedBenefits = createSelector(
       outOfPocketFees = 0;
     } else if (
       !institution.preferredProvider &&
-      vetTecTuitionFees > constants.TFCAP - vetTecScholarships
+      vetTecTuitionFees > constants.TFCAP
     ) {
       outOfPocketFees =
         vetTecTuitionFees - constants.TFCAP - vetTecScholarships;
+      if (outOfPocketFees < 0) {
+        outOfPocketFees = 0;
+      }
     }
 
     return {

--- a/src/applications/gi/selectors/vetTecCalculator.js
+++ b/src/applications/gi/selectors/vetTecCalculator.js
@@ -14,53 +14,47 @@ export const getCalculatedBenefits = createSelector(
   getConstants,
   getInstitution,
   (inputs, constants, institution) => {
-    const vetTecTuitionInputNull =
-      inputs.vetTecTuitionFees === null || inputs.vetTecTuitionFees === 0;
+    const { vetTecTuitionFees, vetTecScholarships } = inputs;
 
-    const paysToProviderValue = vetTecTuitionInputNull
+    const inputsNull = vetTecTuitionFees === null || vetTecTuitionFees === 0;
+
+    const paysToProviderValue = inputsNull
       ? null
-      : Math.max(inputs.vetTecTuitionFees - inputs.vetTecScholarships, 0);
+      : Math.max(vetTecTuitionFees - vetTecScholarships, 0);
 
-    const quarterPaysToProviderValue = vetTecTuitionInputNull
+    const quarterPaysToProviderValue = inputsNull
       ? null
       : paysToProviderValue * 0.25;
 
-    const halfPaysToProviderValue = vetTecTuitionInputNull
+    const halfPaysToProviderValue = inputsNull
       ? null
       : paysToProviderValue * 0.5;
 
-    const determineOutOfPocketFees = () => {
-      let outOfPocketFees;
-      if (vetTecTuitionInputNull) {
-        outOfPocketFees = null;
-      } else if (institution.preferredProvider) {
-        outOfPocketFees = 0;
-      } else if (inputs.vetTecTuitionFees > constants.TFCAP) {
-        outOfPocketFees =
-          inputs.vetTecTuitionFees -
-          constants.TFCAP -
-          inputs.vetTecScholarships;
-        if (outOfPocketFees < 0) {
-          outOfPocketFees = 0;
-        }
-      } else {
+    let outOfPocketFees = 0;
+    if (inputsNull) {
+      outOfPocketFees = null;
+    } else if (institution.preferredProvider) {
+      outOfPocketFees = 0;
+    } else if (vetTecTuitionFees > constants.TFCAP) {
+      outOfPocketFees =
+        vetTecTuitionFees - constants.TFCAP - vetTecScholarships;
+      if (outOfPocketFees < 0) {
         outOfPocketFees = 0;
       }
-      return outOfPocketFees;
-    };
+    } else if (vetTecTuitionFees <= constants.TFCAP) {
+      outOfPocketFees = 0;
+    }
 
     return {
       outputs: {
         vetTecTuitionFees: formatCurrencyNullTBD(
-          inputs.vetTecTuitionFees === 0 ? null : inputs.vetTecTuitionFees,
+          vetTecTuitionFees === 0 ? null : vetTecTuitionFees,
         ),
-        vetTecScholarships: formatCurrency(inputs.vetTecScholarships),
+        vetTecScholarships: formatCurrency(vetTecScholarships),
         vaPaysToProvider: formatCurrencyNullTBD(paysToProviderValue),
         quarterVetTecPayment: formatCurrencyNullTBD(quarterPaysToProviderValue),
         halfVetTecPayment: formatCurrencyNullTBD(halfPaysToProviderValue),
-        outOfPocketTuitionFees: formatCurrencyNullTBD(
-          determineOutOfPocketFees(),
-        ),
+        outOfPocketTuitionFees: formatCurrencyNullTBD(outOfPocketFees),
         inPersonRate: `${formatCurrency(institution.dodBah)}/mo`,
         onlineRate: `${formatCurrency(constants.AVGDODBAH * 0.5)}/mo`,
       },

--- a/src/applications/gi/tests/selectors/vetTecCalculator.unit.spec.js
+++ b/src/applications/gi/tests/selectors/vetTecCalculator.unit.spec.js
@@ -91,9 +91,9 @@ describe('getCalculatedBenefits', () => {
     const calculatedBenefits = getCalculatedBenefits(state);
     expect(calculatedBenefits.outputs.vetTecTuitionFees).to.equal('TBD');
     expect(calculatedBenefits.outputs.vetTecScholarships).to.equal('$100');
-    expect(calculatedBenefits.outputs.vaPaysToProvider).to.equal('$0');
-    expect(calculatedBenefits.outputs.quarterVetTecPayment).to.equal('$0');
-    expect(calculatedBenefits.outputs.halfVetTecPayment).to.equal('$0');
+    expect(calculatedBenefits.outputs.vaPaysToProvider).to.equal('TBD');
+    expect(calculatedBenefits.outputs.quarterVetTecPayment).to.equal('TBD');
+    expect(calculatedBenefits.outputs.halfVetTecPayment).to.equal('TBD');
   });
 
   it('should correctly calculate and format fields based on vetTecScholarships and vetTecTuitionFees', () => {


### PR DESCRIPTION
## Description
As a developer, I need to make the final pre-launch pass of content updates so that the user has a consistent experience and is provided with accurate and complete information.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19378

## Testing done
Local manual, e2e, and unit tests pass.

## Screenshots
![image](https://user-images.githubusercontent.com/48804834/62159679-4c0f4b80-b2e0-11e9-99a7-b3797629b3ad.png)
![image](https://user-images.githubusercontent.com/48804834/62159688-4fa2d280-b2e0-11e9-8ed6-19fc35bdf8a6.png)
![image](https://user-images.githubusercontent.com/48804834/62159697-53cef000-b2e0-11e9-9cff-c6cb3fd985e1.png)


## Acceptance criteria
- [x] 1. On the VET TEC Search Results, the "Learning Format" filter label text is formatted as: "Learning format"
The filter option "In Person" label text is formatted as: "In person"
- [x] 2. On the VET TEC Search Results, the card text "Tuition (annually):" label text is formatted as: "Tuition:"
- [x] 3. On the VET TEC Profile Page the "Out of Pocket Cost" calculates the cost based on the following rules:
If the user enters nothing in the tuition field, "TBD" is displayed.
If the user enters tuition greater than the cap and the provider is not preferred, the amount displayed is: Tuition amount entered - T&F Cap (TFCAP Constant) - Scholarships entered.
If the user enters tuition less than the cap and the provider is not preferred, the amount displayed is: $0
- [x] 4. If the user enters tuition and the provider is preferred, the amount displayed is: $0
- [x] 5. If the user clears out / sets the tuition field to $0, all calculated fields in the calculator are reset to "TBD".
If the user only enters a scholarship amount, all calculated fields in the calculator are set to "TBD".

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
