### PR TITLE
Don't call endpoint if call is already in flight

### DIFF
--- a/src/applications/hca/actions.js
+++ b/src/applications/hca/actions.js
@@ -2,7 +2,10 @@ import appendQuery from 'append-query';
 import { apiRequest } from 'platform/utilities/api';
 import environment from 'platform/utilities/environment';
 import { HCA_ENROLLMENT_STATUSES } from './constants';
-import { dismissedHCANotificationDate } from './selectors';
+import {
+  dismissedHCANotificationDate,
+  isEnrollmentStatusLoading,
+} from './selectors';
 
 // flip the `false` to `true` to fake the endpoint when testing locally
 const simulateServerLocally = environment.isLocalhost() && false;
@@ -105,7 +108,10 @@ function callAPI(dispatch, formData = {}) {
 // /health_care_applications/enrollment_status endpoint, depending on the value
 // of the `simulateServerLocally` flag
 export function getEnrollmentStatus(formData) {
-  return dispatch => {
+  return (dispatch, getState) => {
+    if (isEnrollmentStatusLoading(getState())) {
+      return;
+    }
     dispatch({ type: FETCH_ENROLLMENT_STATUS_STARTED });
     /*
     When hitting the API locally, we cannot get responses other than 500s from


### PR DESCRIPTION
## Description
Adding a check in the getEnrollmentStatus() action creator so we only
call the `enrollment_status` endpoint if we aren't already waiting for a
response from the endpoint.


## Testing done
local. I saw that we don't have unit tests for these actions so I'll make a ticket to add those.

## Screenshots
N/A

## Acceptance criteria
- [x] Landing on the dashboard no longer triggers two calls to `GET enrollment_status`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs