### PR TITLE
Remove devops from Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,4 @@
 #  @department-of-veterans-affairs/frontend-review-group will be requested for
 # review when someone opens a pull request.
 
-*       @department-of-veterans-affairs/frontend-review-group @department-of-veterans-affairs/ad-hoc-devops
-
+*       @department-of-veterans-affairs/frontend-review-group


### PR DESCRIPTION
because it's too noisy to tag `@department-of-veterans-affairs/ad-hoc-devops` 

While it's fine to have the devops team review PR's when they see fit, it's not worth the extra noise of them being tagged on every PR, so I'm removing them from the CODEOWNERS file.  Should it be necessary, someone from `@department-of-veterans-affairs/frontend-review-group` can rubber-stamp a PR.