### PR TITLE
[Site-wide] Fix 508 issue with Veterans Crisis Line modal

### DIFF
--- a/src/platform/site-wide/accessible-VCL-modal.js
+++ b/src/platform/site-wide/accessible-VCL-modal.js
@@ -5,6 +5,8 @@ import {
   getTabbableElements,
 } from '../utilities/accessibility';
 
+import { focusElement } from 'platform/utilities/ui';
+
 /*
  * Creates function that captures/releases Veterans Crisis Line modal focus.
  */
@@ -23,13 +25,13 @@ export default function addFocusBehaviorToCrisisLineModal() {
     if (e.target === closeControl) {
       if (isReverseTab(e)) {
         e.preventDefault();
-        lastTabbableElement.focus();
+        focusElement(lastTabbableElement);
       }
     }
     if (e.target === lastTabbableElement) {
       if (isTab(e)) {
         e.preventDefault();
-        closeControl.focus();
+        focusElement(closeControl);
       }
     }
   }
@@ -38,12 +40,12 @@ export default function addFocusBehaviorToCrisisLineModal() {
     if (isEscape(e)) {
       overlay.classList.remove('va-overlay--open');
       document.body.classList.remove('va-pos-fixed');
-      openControl.focus();
+      focusElement(openControl);
     }
   }
 
   function resetFocus() {
-    openControl.focus();
+    focusElement(openControl);
   }
 
   // We're saving the element that triggered this modal


### PR DESCRIPTION
## Description
This is an attempt to fix the issue described in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16394.

The platform utility used in this PR does some work with setting `tabindex` after applying focus that I'm hopeful may fix this problem, but I'm not sure. 

## Testing done
Local testing, but I was unable to recreate the issue described in the ticket.

## Screenshots
N/A

## Acceptance criteria
- [x] Accessibility issue with VCL modal is resolved

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
