### PR TITLE
CT116  - Accessibility Issue - Remove autocomplete from radio button input

### DIFF
--- a/src/applications/gi/components/RadioButtons.jsx
+++ b/src/applications/gi/components/RadioButtons.jsx
@@ -56,7 +56,6 @@ class RadioButtons extends React.Component {
         >
           <input
             className="gids-radio-buttons-input"
-            autoComplete="false"
             checked={checked}
             id={`${this.inputId}-${index}`}
             name={this.props.name}


### PR DESCRIPTION
## Description
GI Bill tool accessibility issues need corrections. Profile page and landing pages have errors via Axe accessibility plugin.

## Testing done
Errors confirmed gone from Axe plugin on appropriate pages 

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19398

## Screenshots
(no screenshots available, console errors)

## Acceptance criteria
- [x] remove console errors from axe plugin console

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
