### PR TITLE
Form app tester foresee edge case

### DIFF
--- a/src/platform/testing/e2e/form-tester/form-filler.js
+++ b/src/platform/testing/e2e/form-tester/form-filler.js
@@ -1,8 +1,6 @@
 const { parse: parseUrl } = require('url');
 const _ = require('lodash/fp');
 
-const { searchAndDestroy } = require('./util');
-
 const FIELD_SELECTOR = 'input, select, textarea';
 const CONTINUE_BUTTON = '.form-progress-buttons .usa-button-primary';
 const ARRAY_ITEM_SELECTOR =
@@ -221,13 +219,6 @@ const getArrayInfo = (url, arrayPages = []) => {
 const getArrayData = (testData, arrayPageConfig) =>
   findData(`${arrayPageConfig.arrayPath}`, testData)[arrayPageConfig.index];
 
-const removeForeseeOverlay = async (page, log) => {
-  if (await page.$('.__acs')) {
-    log('Foresee found; destroying the overlay...');
-    await searchAndDestroy(page, '.__acs');
-  }
-};
-
 /**
  * Enters data for each field, looping until no more fields have been expanded and
  *  no more array items are available in the test data.
@@ -246,8 +237,6 @@ const fillPage = async (page, testData, testConfig, log = () => {}) => {
   let originalSnapshot;
   /* eslint-disable no-await-in-loop */
   do {
-    await removeForeseeOverlay(page, log);
-
     originalSnapshot = await getSnapshot(page);
     log(
       'Field list:',
@@ -356,7 +345,6 @@ const fillForm = async (page, testData, testConfig, log) => {
     const url = page.url();
     const hook = _.get(`pageHooks.${parseUrl(url).path}`, testConfig);
     if (hook) {
-      await removeForeseeOverlay(page, log);
       await runHook(hook);
     } else {
       await fillPage(page, testData, testConfig, log);

--- a/src/platform/testing/e2e/form-tester/index.js
+++ b/src/platform/testing/e2e/form-tester/index.js
@@ -38,6 +38,9 @@ const runTest = async (page, testData, testConfig, userToken, testName) => {
     await page.goto(`${baseUrl}${testConfig.url}`);
   }
 
+  // Hide Foresee
+  await page.addStyleTag({ content: '.__acs { display: none !important; }' });
+
   await fillForm(
     page,
     testData,

--- a/src/platform/testing/e2e/form-tester/util.js
+++ b/src/platform/testing/e2e/form-tester/util.js
@@ -34,21 +34,4 @@ function getTestDataSets(path, rules = { extension: 'json' }) {
     }));
 }
 
-/**
- * Searches for DOM elements found by selectors in page and removes
- * them from the DOM.
- * @param {Page} page - Puppeteer browser page
- * @param {...String} - The selectors used to find the elements to
- *                      remove
- */
-async function searchAndDestroy(page, ...selectors) {
-  await Promise.all(
-    selectors.map(async sel =>
-      page.$$eval(sel, elements =>
-        elements.forEach(el => el.parentNode.removeChild(el)),
-      ),
-    ),
-  );
-}
-
-module.exports = { getTestDataSets, searchAndDestroy };
+module.exports = { getTestDataSets };


### PR DESCRIPTION
## Description
I took a different approach than the title of the connected ticket. Previously, I tried to follow the [same pattern as the e2e tests](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/nightwatch-commands/openUrl.js#L8), but to no avail. Not sure what I was doing wrong, but now that I'm more comfortable in this Puppeteer space, I figured I'd give it another go before trying something more complicated. Good news, it worked!

My process was as follows:
**Recreate the problem**
1. Figure out how to programmatically trigger the overlay
2. Trigger it in a page hook for testing purposes
3. Trigger it in the middle of filling out information on a page
4. Use a setTimeout to trigger it in the middle of filing a field
5. Log the result in the fields after entering the data to validate my assumption
6. Compare the log of the local failed test to a sample in Jenkins
    - They match; looks like this is indeed how the failure is triggered in Jenkins
  
**Test the CSS solution**
1. Insert the `<style>` tag
2. Run the test
3. If the test passes (it did), check the log to see if the Foresee overlay was triggered and removed as expected (it was)
   - This indicates that the overlay was triggered, but didn't hinder the test like it did without the style tag
4. Rejoice


## Testing done
See above

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/62243612-80dbdb00-b392-11e9-85cb-2c9637c74655.png)
:point_up: While testing, I was still running the search-and-destroy, so you can see:
1) I'm triggering the Foresee overlay (in a `setTimeout` from within the browser's context so it pops up in the middle of entering information)
2) We enter all the information successfully
3) After we go through the loop, we detect and destroy the overlay

All this means it popped up in the middle of entering information, but didn't stop us at all.

## Acceptance criteria
- [ ] Builds stop failing due to these pesky intermittent failures

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
