### PR TITLE
19400 - remove input grouping css for vet tec profile

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
@@ -29,7 +29,7 @@ export class VetTecCalculator extends React.Component {
 
     return (
       <div className="calculator-inputs vads-u-margin-x--neg1p5">
-        <div className="form-expanding-group-open">
+        <div>
           <VetTecCalculatorForm
             inputs={inputs}
             displayedInputs={displayed}


### PR DESCRIPTION
## Description
When using a mobile phone or Chrome's responsive feature to view the VET TEC provider page, there is a blue bar that is used to indicate grouped content next to the Tuition and Fees & Scholarship fields. This bar should not be present.
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19400

## Testing done
confirmed in UI at various scales in Chrome browser. Also confirmed no new errors present via Axe plugin concerning accessibility due to change. 

## Screenshots
Normal, fullscreen view after change (no difference in appearance)
<img width="981" alt="Screen Shot 2019-07-31 at 4 00 59 PM" src="https://user-images.githubusercontent.com/52166695/62244887-5e57bb00-b3ae-11e9-9474-626fc1c58c3a.png">

"Mobile" view via Chrome tools, no grouping bar visible at any size
<img width="475" alt="Screen Shot 2019-07-31 at 4 00 44 PM" src="https://user-images.githubusercontent.com/52166695/62244984-87784b80-b3ae-11e9-8062-4e248cf0152d.png">

## Acceptance criteria
- [x] Blue bar indicating grouped content is NOT PRESENT on indicated portion of VetTec profile page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
