### PR TITLE
VAGOV-5239: make featured content blocks the same height

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -182,3 +182,17 @@ $duo-tone-lighten: #000000;
     margin-bottom: 0 !important;
   }
 }
+
+// featured services
+.featured-services-list-item {
+  width: 100%;
+  margin-right: 16px;
+
+  &:last-child {
+    margin-right: 0;
+  }
+
+  @include media($medium-screen){
+    width: 33%;
+  }
+}

--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -186,7 +186,7 @@ $duo-tone-lighten: #000000;
 // featured content
 .featured-content-list-item {
   width: 100%;
-  margin-right: 16px;
+  margin-right: 1em;
 
   &:last-child {
     margin-right: 0;

--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -184,7 +184,7 @@ $duo-tone-lighten: #000000;
 }
 
 // featured services
-.featured-services-list-item {
+.featured-content-list-item {
   width: 100%;
   margin-right: 16px;
 
@@ -195,4 +195,8 @@ $duo-tone-lighten: #000000;
   @include media($medium-screen){
     width: 33%;
   }
+}
+
+.featured-content-hr {
+  width: 40px;
 }

--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -183,7 +183,7 @@ $duo-tone-lighten: #000000;
   }
 }
 
-// featured services
+// featured content
 .featured-content-list-item {
   width: 100%;
   margin-right: 16px;

--- a/src/site/layouts/health_care_region_health_services_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_health_services_page.drupal.liquid
@@ -116,7 +116,7 @@
                 {% if featuredContentHealthServices.length %}
                     <section class="featured-services" id="featured-services">
                         <h3>In the spotlight at {{ regionOrOffice | remove: "health care" }}</h3>
-                        <ul class="usa-grid usa-grid-full vads-u-margin-top--3 vads-u-margin-bottom--4">
+                        <ul class="usa-grid usa-grid-full vads-u-margin-top--3 vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
                             {% for featuredService in featuredContentHealthServices %}
                                 {% include "src/site/paragraphs/link_teaser_featured_content.drupal.liquid" with linkTeaser = featuredService.entity %}
                             {% endfor %}

--- a/src/site/paragraphs/link_teaser_featured_content.drupal.liquid
+++ b/src/site/paragraphs/link_teaser_featured_content.drupal.liquid
@@ -1,4 +1,4 @@
-<li class="vads-u-background-color--primary-alt-lightest usa-width-one-third vads-u-padding-y--1p5 vads-u-padding-x--1p5">
+<li class="featured-services-list-item vads-u-background-color--primary-alt-lightest  vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-display--flex vads-u-flex-direction--column">
     {% assign link = linkTeaser.fieldLink | featureSingleValueFieldLink %}
     {% if link.title != empty %}
         <b>{{ link.title }}</b>

--- a/src/site/paragraphs/link_teaser_featured_content.drupal.liquid
+++ b/src/site/paragraphs/link_teaser_featured_content.drupal.liquid
@@ -8,6 +8,6 @@
         <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>
     {% endif %}
     <a class="vads-u-display--block vads-u-padding-top--1 vads-u-text-decoration--none" href="{{link.url.path}}" {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %} onClick="recordEvent({ event: 'nav-linkslist' });">
-        <span>Read More<i class="fa fa-chevron-right vads-facility-hub-cta-arrow"></i></span>
+        <span>Read more<i class="fa fa-chevron-right vads-facility-hub-cta-arrow"></i></span>
     </a>
 </li>

--- a/src/site/paragraphs/link_teaser_featured_content.drupal.liquid
+++ b/src/site/paragraphs/link_teaser_featured_content.drupal.liquid
@@ -1,8 +1,8 @@
-<li class="featured-services-list-item vads-u-background-color--primary-alt-lightest  vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-display--flex vads-u-flex-direction--column">
+<li class="featured-content-list-item vads-u-background-color--primary-alt-lightest  vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-display--flex vads-u-flex-direction--column">
     {% assign link = linkTeaser.fieldLink | featureSingleValueFieldLink %}
     {% if link.title != empty %}
         <b>{{ link.title }}</b>
-        <hr class="vads-u-margin-y--1p5 vads-u-border-color--primary" style="width:30%;">
+        <hr class="featured-content-hr vads-u-margin-y--1p5 vads-u-border-color--primary">
     {% endif %}
     {% if linkTeaser.fieldLinkSummary != empty %}
         <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>


### PR DESCRIPTION
## Description
makes the "featured content" containers the same height depending on content

## Testing done
locally with staging data
pre-req: make sure there is featured content on the health care region health services section
1. go to edit the health care region node
ex. http://staging.cms.va.gov/node/318/edit
![image](https://user-images.githubusercontent.com/19178435/62252567-0f0e8c00-b3a8-11e9-8444-19d69f3aa432.png)
2. open up the "Health Services Page" section
3. enter in Featured Content
4. save
5. rebuild front-end

to test:
1. navigate to http://localhost:3001/pittsburgh-health-care/health-services/
2. look at the "In the spotlight" section
3. make sure the blue parts are the same height

notes: Andy L. did not want the "Read more" links pinned to the bottom of the container

## Screenshots
![image](https://user-images.githubusercontent.com/19178435/62253058-898bdb80-b3a9-11e9-9e79-5a966926d1fb.png)

## Acceptance criteria
- [ ] featured content blocks should be the same height

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
