### PR TITLE
removal of blue bar from calculator.jsx

### DIFF
--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -13,7 +13,6 @@ import {
 import { getCalculatedBenefits } from '../../selectors/calculator';
 import EligibilityForm from '../search/EligibilityForm';
 import CalculatorForm from '../profile/CalculatorForm';
-import enviornment from '../../../../platform/utilities/environment';
 import environment from '../../../../platform/utilities/environment';
 
 const CalculatorResultRow = ({ label, value, header, bold, visible }) =>

--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -13,6 +13,8 @@ import {
 import { getCalculatedBenefits } from '../../selectors/calculator';
 import EligibilityForm from '../search/EligibilityForm';
 import CalculatorForm from '../profile/CalculatorForm';
+import enviornment from '../../../../platform/utilities/environment';
+import environment from '../../../../platform/utilities/environment';
 
 const CalculatorResultRow = ({ label, value, header, bold, visible }) =>
   visible ? (
@@ -25,7 +27,6 @@ const CalculatorResultRow = ({ label, value, header, bold, visible }) =>
       </div>
     </div>
   ) : null;
-
 export class Calculator extends React.Component {
   constructor(props) {
     super(props);
@@ -60,9 +61,26 @@ export class Calculator extends React.Component {
         >
           {expanded ? 'Hide' : 'Edit'} eligibility details
         </button>
-        {expanded ? (
-          <EligibilityForm eligibilityChange={this.props.eligibilityChange} />
-        ) : null}
+        {environment.isProduction() && (
+          <div>
+            {expanded ? (
+              <div className="form-expanding-group-open">
+                <EligibilityForm
+                  eligibilityChange={this.props.eligibilityChange}
+                />
+              </div>
+            ) : null}
+          </div>
+        )}
+        {!environment.isProduction() && (
+          <div>
+            {expanded ? (
+              <EligibilityForm
+                eligibilityChange={this.props.eligibilityChange}
+              />
+            ) : null}
+          </div>
+        )}
       </div>
     );
   }
@@ -82,15 +100,38 @@ export class Calculator extends React.Component {
         >
           {expanded ? 'Hide' : 'Edit'} calculator fields
         </button>
-        {expanded ? (
-          <CalculatorForm
-            inputs={inputs}
-            displayedInputs={displayed}
-            onShowModal={this.props.showModal}
-            onInputChange={this.props.calculatorInputChange}
-            onBeneficiaryZIPCodeChanged={this.props.beneficiaryZIPCodeChanged}
-          />
-        ) : null}
+        {environment.isProduction() && (
+          <div>
+            {expanded ? (
+              <div className="form-expanding-group-open">
+                <CalculatorForm
+                  inputs={inputs}
+                  displayedInputs={displayed}
+                  onShowModal={this.props.showModal}
+                  onInputChange={this.props.calculatorInputChange}
+                  onBeneficiaryZIPCodeChanged={
+                    this.props.beneficiaryZIPCodeChanged
+                  }
+                />
+              </div>
+            ) : null}
+          </div>
+        )}
+        {!environment.isProduction() && (
+          <div>
+            {expanded ? (
+              <CalculatorForm
+                inputs={inputs}
+                displayedInputs={displayed}
+                onShowModal={this.props.showModal}
+                onInputChange={this.props.calculatorInputChange}
+                onBeneficiaryZIPCodeChanged={
+                  this.props.beneficiaryZIPCodeChanged
+                }
+              />
+            ) : null}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -61,9 +61,7 @@ export class Calculator extends React.Component {
           {expanded ? 'Hide' : 'Edit'} eligibility details
         </button>
         {expanded ? (
-          <div className="form-expanding-group-open">
-            <EligibilityForm eligibilityChange={this.props.eligibilityChange} />
-          </div>
+          <EligibilityForm eligibilityChange={this.props.eligibilityChange} />
         ) : null}
       </div>
     );
@@ -85,15 +83,13 @@ export class Calculator extends React.Component {
           {expanded ? 'Hide' : 'Edit'} calculator fields
         </button>
         {expanded ? (
-          <div className="form-expanding-group-open">
-            <CalculatorForm
-              inputs={inputs}
-              displayedInputs={displayed}
-              onShowModal={this.props.showModal}
-              onInputChange={this.props.calculatorInputChange}
-              onBeneficiaryZIPCodeChanged={this.props.beneficiaryZIPCodeChanged}
-            />
-          </div>
+          <CalculatorForm
+            inputs={inputs}
+            displayedInputs={displayed}
+            onShowModal={this.props.showModal}
+            onInputChange={this.props.calculatorInputChange}
+            onBeneficiaryZIPCodeChanged={this.props.beneficiaryZIPCodeChanged}
+          />
         ) : null}
       </div>
     );


### PR DESCRIPTION
## Description
As a developer i want to remove the unwanted blue bar in the Comparison Tool school profile page. 

## Testing done
Tested locally

## Screenshots
<img width="347" alt="Screen Shot 2019-08-01 at 8 02 09 AM" src="https://user-images.githubusercontent.com/50601724/62292430-5fcbc680-b434-11e9-8018-ca586551237d.png">


## Acceptance criteria
- [X] Removed blue bar from CT school profile page. 

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
