### PR TITLE
19401: VET TEC search results filters: Menu bar covers other fields on mobile: Update Z Index

### DIFF
--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -1,15 +1,16 @@
 .gi-app .search-page {
-
   .filters-sidebar {
     h2 {
       font-size: 1.15em;
     }
 
-    label, legend {
+    label,
+    legend {
       margin-top: 1em;
     }
 
-    .institution-filter-form, .eligibility-form {
+    .institution-filter-form,
+    .eligibility-form {
       margin-top: 1.5em;
     }
 
@@ -22,7 +23,7 @@
       position: fixed;
       top: 0;
       width: 100%;
-      z-index: 1;
+      z-index: 200;
 
       &.opened {
         display: block;
@@ -36,7 +37,8 @@
     }
   }
 
-  .filter-button, .results-button {
+  .filter-button,
+  .results-button {
     display: none;
 
     @include media-maxwidth($small-screen) {
@@ -87,7 +89,7 @@
 
     h2 {
       font-size: 1.35em;
-      margin-bottom: .8rem;
+      margin-bottom: 0.8rem;
       padding-bottom: 0;
       margin-top: 0;
       a {
@@ -111,7 +113,8 @@
     }
 
     .estimated-benefits {
-      h3, h4 {
+      h3,
+      h4 {
         margin-top: 0;
         font-size: 1em;
         font-family: $font-sans;
@@ -156,6 +159,5 @@
         margin-right: 0.4em;
       }
     }
-
   }
 }

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -1,16 +1,15 @@
 .gi-app .search-page {
+
   .filters-sidebar {
     h2 {
       font-size: 1.15em;
     }
 
-    label,
-    legend {
+    label, legend {
       margin-top: 1em;
     }
 
-    .institution-filter-form,
-    .eligibility-form {
+    .institution-filter-form, .eligibility-form {
       margin-top: 1.5em;
     }
 
@@ -37,8 +36,7 @@
     }
   }
 
-  .filter-button,
-  .results-button {
+  .filter-button, .results-button {
     display: none;
 
     @include media-maxwidth($small-screen) {
@@ -89,7 +87,7 @@
 
     h2 {
       font-size: 1.35em;
-      margin-bottom: 0.8rem;
+      margin-bottom: .8rem;
       padding-bottom: 0;
       margin-top: 0;
       a {
@@ -113,8 +111,7 @@
     }
 
     .estimated-benefits {
-      h3,
-      h4 {
+      h3, h4 {
         margin-top: 0;
         font-size: 1em;
         font-family: $font-sans;
@@ -159,5 +156,6 @@
         margin-right: 0.4em;
       }
     }
+
   }
 }


### PR DESCRIPTION
## Description
When viewing filter options after searching for VET TEC institutions the Search, Contact Us, and Sign in options from the header are covering the other fields on the page. This can be reproduced using a mobile device. 

This issue is not specific to VET TEC, but all filter pages

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19401

## Testing done
Local Manual, Unit, and E2E Tests pass

## Screenshots
![image](https://user-images.githubusercontent.com/48804834/62304835-cfe64680-b44c-11e9-8f37-19759d9b4067.png)


## Acceptance criteria
- [x] Erroneous behavior corrected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
