### PR TITLE
VAGOV-5195: found the missing tables

### DIFF
--- a/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
@@ -17,6 +17,7 @@ const QA = '... qa';
 const LIST_OF_LINK_TEASERS = '... listOfLinkTeasers';
 const REACT_WIDGET = '... reactWidget';
 const NUMBER_CALLOUT = '... numberCallout';
+const TABLE = '... table';
 const entityElementsFromPages = require('./entityElementsForPages.graphql');
 
 // Get current feature flags
@@ -68,6 +69,7 @@ module.exports = `
         ${LIST_OF_LINK_TEASERS}
         ${REACT_WIDGET}
         ${NUMBER_CALLOUT}
+        ${TABLE}
       }
     }
     ${FIELD_RELATED_LINKS}


### PR DESCRIPTION
## Description
gets the data for the tables on health care region detail pages

## Testing done
locally with staging data

## Screenshots
![localhost_3001_pittsburgh-health-care_shuttle-schedule_](https://user-images.githubusercontent.com/19178435/62333755-a263c200-b479-11e9-9281-2ecc987ec15b.png)

## Acceptance criteria
- [ ] tables show up

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
