### PR TITLE
VAGOV-5261: found the missing alerts

### DIFF
--- a/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
@@ -17,6 +17,7 @@ const QA = '... qa';
 const LIST_OF_LINK_TEASERS = '... listOfLinkTeasers';
 const REACT_WIDGET = '... reactWidget';
 const NUMBER_CALLOUT = '... numberCallout';
+const ALERT_PARAGRAPH = '... alertParagraph';
 const entityElementsFromPages = require('./entityElementsForPages.graphql');
 
 // Get current feature flags
@@ -68,6 +69,7 @@ module.exports = `
         ${LIST_OF_LINK_TEASERS}
         ${REACT_WIDGET}
         ${NUMBER_CALLOUT}
+        ${ALERT_PARAGRAPH}
       }
     }
     ${FIELD_RELATED_LINKS}


### PR DESCRIPTION
## Description
allows health care region detail pages to show alerts properly

## Testing done
local with staging data

## Screenshots
![image](https://user-images.githubusercontent.com/19178435/62335925-be1f9600-b482-11e9-927e-936b3ae999cd.png)


## Acceptance criteria
- [ ] alerts show up properly on health care region detail pages

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
