### PR TITLE
VAGOV-5241: Fixing news stories page features item presentation.

### DIFF
--- a/src/site/layouts/news_stories_page.drupal.liquid
+++ b/src/site/layouts/news_stories_page.drupal.liquid
@@ -62,11 +62,12 @@ Example data:
           </div>
           {% if paginator.prev == null %}
           {% for storyFeature in newsStoryTeasers.entities %}
+            {% if forloop.first == true %}
               {% include "src/site/teasers/news_story_page_feature.drupal.liquid" with node = storyFeature %}
+            {% endif %}
           {% endfor %}
           {% endif %}
-          {% assign sortedItems = pagedItems | sort_by: 'fieldFeatured', 'desc'  %}
-          {% for story in sortedItems %}
+          {% for story in pagedItems %}
               {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
           {% endfor %}
           {% include "src/site/includes/pagination.drupal.liquid" %}

--- a/src/site/layouts/news_stories_page.drupal.liquid
+++ b/src/site/layouts/news_stories_page.drupal.liquid
@@ -60,6 +60,11 @@ Example data:
           <div class="va-introtext vads-u-margin-bottom--4">
             {{ fieldIntroTextNewsStories.processed }}
           </div>
+          {% if paginator.prev == null %}
+          {% for storyFeature in newsStoryTeasers.entities %}
+              {% include "src/site/teasers/news_story_page_feature.drupal.liquid" with node = storyFeature %}
+          {% endfor %}
+          {% endif %}
           {% assign sortedItems = pagedItems | sort_by: 'fieldFeatured', 'desc'  %}
           {% for story in sortedItems %}
               {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNewsStories.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNewsStories.node.graphql.js
@@ -36,9 +36,9 @@ function queryFilter(isAll) {
       conditions: [
         { field: "type", value: "news_story"}
         { field: "status", value: "1"}
-        ${isAll ? '' : '{ field: "field_featured" value: "1"}'}        
-      ]} sort: {field: "changed", direction: DESC } limit:${
-        isAll ? '500' : '2'
+        ${isAll ? '' : '{ field: "field_featured" value: "1"}'}
+      ]} sort: {field: "changed", direction: DESC }, limit:${
+        isAll ? '500' : '1'
       })
   `;
 }

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNewsStories.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNewsStories.node.graphql.js
@@ -38,7 +38,7 @@ function queryFilter(isAll) {
         { field: "status", value: "1"}
         ${isAll ? '' : '{ field: "field_featured" value: "1"}'}
       ]} sort: {field: "changed", direction: DESC }, limit:${
-        isAll ? '500' : '1'
+        isAll ? '500' : '2'
       })
   `;
 }

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -121,6 +121,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   const nsEntityUrl = createEntityUrlObj(drupalPagePath);
   const nsObj = {
     allNewsStoryTeasers: page.allNewsStoryTeasers,
+    newsStoryTeasers: page.newsStoryTeasers,
     fieldIntroTextNewsStories: page.fieldIntroTextNewsStories,
     facilitySidebar: sidebar,
     entityUrl: nsEntityUrl,

--- a/src/site/teasers/news_story_page.drupal.liquid
+++ b/src/site/teasers/news_story_page.drupal.liquid
@@ -28,20 +28,6 @@ Example data:
 {% endif %}
 {% assign isStoriesPage = entityUrl.path | isPage: "stories" %}
 
-{% if node.fieldFeatured == true %}
-<div id="featured-content" class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest">
-    <div class="usa-width-one-half medium-screen:vads-u-padding-left--2">
-        <span class="vads-u-font-weight--bold vads-u-display--block">In the spotlight at {{ regionOrOffice | remove: "health care" }}</span>
-        <h2 class="vads-u-margin-y--1"><a href="{{ node.entityUrl.path }}">{{ node.title }}</a></h2>
-        <p class="vads-u-margin-y--0">{{ node.fieldIntroText | truncatewords: 60, "..." }}</p>
-    </div>
-    <div class="usa-width-one-half {% if isStoriesPage %}stories-list{% endif %} vads-u-order--first medium-screen:vads-u-order--initial vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">
-        {% assign image = node.fieldMedia.entity.image %}
-        <img class="news-img" src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="{{ image.derivative.width }}" height="{{ image.derivative.height }}">
-    </div>
-</div>
-{% endif %}
-
 <div class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
     <div class="usa-width-two-thirds">
         <{{ header }} class="{% if isStoriesPage %}vads-u-font-size--md medium-screen:vads-u-font-size--lg{% endif %} medium-screen:vads-u-margin-bottom--0p5"><a href="{{ node.entityUrl.path }}">{{ node.title }}</a></{{ header }}>

--- a/src/site/teasers/news_story_page_feature.drupal.liquid
+++ b/src/site/teasers/news_story_page_feature.drupal.liquid
@@ -1,0 +1,16 @@
+{% if header == empty %}
+    {% assign header = "h4" %}
+{% endif %}
+{% assign isStoriesPage = entityUrl.path | isPage: "stories" %}
+
+<div id="featured-content" class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest">
+    <div class="usa-width-one-half medium-screen:vads-u-padding-left--2">
+        <span class="vads-u-font-weight--bold vads-u-display--block">In the spotlight at {{ regionOrOffice | remove: "health care" }}</span>
+        <h2 class="vads-u-margin-y--1"><a href="{{ node.entityUrl.path }}">{{ node.title }}</a></h2>
+        <p class="vads-u-margin-y--0">{{ node.fieldIntroText | truncatewords: 60, "..." }}</p>
+    </div>
+    <div class="usa-width-one-half {% if isStoriesPage %}stories-list{% endif %} vads-u-order--first medium-screen:vads-u-order--initial vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">
+        {% assign image = node.fieldMedia.entity.image %}
+        <img class="news-img" src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="{{ image.derivative.width }}" height="{{ image.derivative.height }}">
+    </div>
+</div>


### PR DESCRIPTION
## Description
Changes feature display to only show one item, and not have feature item appear immediately below.

## Testing done
Visual

## Screenshots
![Screenshot_2019-08-01_20-47-28](https://user-images.githubusercontent.com/2404547/62336303-aefa1180-b49d-11e9-8f01-6a8aebe77043.png)

## Acceptance criteria
- [ ] Go to `pittsburgh-health-care/stories/` - you should see one featured item, and the corresponding item should appear in the paged list as well, but not immediately below.