### PR TITLE
VAGOV-5252: Adding dismissable status check to alert close button.

### DIFF
--- a/src/site/includes/alerts.drupal.liquid
+++ b/src/site/includes/alerts.drupal.liquid
@@ -26,9 +26,11 @@ If we have a hit, show the alert.
     <div aria-labelledby="usa-alert-heading-{{ entity.id }}" class="usa-alert-full-width dismissable-option-header usa-alert-full-width-{{ entity.fieldAlertType }}" id="usa-alert-full-width-{{ entity.id }}" role="region">
       <div aria-live="assertive" class="usa-alert usa-alert-{{ entity.fieldAlertType }}" id="usa-alert-{{ entity.id }}" role="alert">
 
+        {% if entity.fieldAlertDismissable == true %}
         <button id="usa-alert-dismiss-{{ entity.id }}" class="va-alert-close usa-alert-dismiss" data-parentwrap="usa-alert-full-width-{{ entity.id }}" data-frequency="{{ entity.fieldAlertFrequency }}" aria-label="Close notification">
           <i aria-label="Close icon" class="fas fa-times-circle"></i>
         </button>
+        {% endif %}
 
         <div class="usa-alert-body" id="usa-alert-body-{{ entity.id }}">
           <h3 class="usa-alert-heading" id="usa-alert-heading-{{ entity.id }}">

--- a/src/site/stages/build/drupal/graphql/alerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/alerts.graphql.js
@@ -2,6 +2,12 @@
  * The alerts that appear above content.
  */
 
+// Get current feature flags
+const {
+  featureFlags,
+  enabledFeatureFlags,
+} = require('../../../../utilities/featureFlags');
+
 module.exports = `
     alerts:   blockContentQuery(filter: {conditions: [{field: "type", value: "alert"}, {field: "status", value: "1"}]},
     sort: {field: "field_node_reference", direction: DESC}
@@ -9,6 +15,11 @@ module.exports = `
     entities {
       ... on BlockContentAlert {
         id
+      ${
+        enabledFeatureFlags[featureFlags.FEATURE_FIELD_ALERT_DISMISSABLE]
+          ? 'fieldAlertDismissable'
+          : ''
+      }
         fieldAlertFrequency
         fieldNodeReference {
           targetId

--- a/src/site/stages/build/drupal/graphql/bioPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bioPage.graphql.js
@@ -38,7 +38,7 @@ module.exports = `
           alt
           title
           url
-          derivative(style: _1_1_SQUARE_MEDIUM_THUMBNAIL) {
+          derivative(style: CROP32) {
             url
             width
             height

--- a/src/site/stages/build/drupal/graphql/block-fragments/alert.block.graphql.js
+++ b/src/site/stages/build/drupal/graphql/block-fragments/alert.block.graphql.js
@@ -2,6 +2,13 @@
  * An alert block in Drupal
  *
  */
+
+// Get current feature flags
+const {
+  featureFlags,
+  enabledFeatureFlags,
+} = require('../../../../../utilities/featureFlags');
+
 const FIELD_ALERT = `
 fieldAlert {
   entity {
@@ -15,7 +22,12 @@ fieldAlert {
 
 const alert = `
 fragment alert on BlockContentAlert {
-  fieldAlertType  
+  ${
+    enabledFeatureFlags[featureFlags.FEATURE_FIELD_ALERT_DISMISSABLE]
+      ? 'fieldAlertDismissable'
+      : ''
+  }
+  fieldAlertType
   fieldAlertTitle
   fieldReusability
   fieldAlertContent {

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/alert.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/alert.paragraph.graphql.js
@@ -4,7 +4,7 @@
 *
  */
 module.exports = `
-  fragment alertParagraph on ParagraphAlert {      
+  fragment alertParagraph on ParagraphAlert {
       fieldAlertType
       fieldAlertHeading
       fieldVaParagraphs {
@@ -29,7 +29,7 @@ module.exports = `
       fieldAlertBlockReference {
         entity {
           ... on BlockContentAlert {
-            fieldAlertTitle            
+            fieldAlertTitle
             fieldAlertType
             fieldReusability
             fieldAlertContent {

--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -29,6 +29,7 @@ const featureFlags = {
   FEATURE_FIELD_COMPLETE_BIOGRAPHY: 'fieldCompleteBiography',
   FEATURE_HEALTH_SERVICE_API_ID: 'featureHealthServiceApiId',
   FEATURE_DOWNLOADABLE_FILE: 'featureDownloadableFile',
+  FEATURE_FIELD_ALERT_DISMISSABLE: 'fieldAlertDismissable',
 };
 
 // Edit this to turn flags on or off
@@ -53,6 +54,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_FIELD_COMPLETE_BIOGRAPHY,
     featureFlags.FEATURE_HEALTH_SERVICE_API_ID,
     featureFlags.FEATURE_DOWNLOADABLE_FILE,
+    featureFlags.FEATURE_FIELD_ALERT_DISMISSABLE,
   ],
   vagovdev: [
     featureFlags.FEATURE_FIELD_ASSET_LIBRARY_DESCRIPTION,
@@ -74,6 +76,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_FIELD_COMPLETE_BIOGRAPHY,
     featureFlags.FEATURE_HEALTH_SERVICE_API_ID,
     featureFlags.FEATURE_DOWNLOADABLE_FILE,
+    featureFlags.FEATURE_FIELD_ALERT_DISMISSABLE,
   ],
   vagovstaging: [
     featureFlags.FEATURE_FIELD_ADDITIONAL_INFO,
@@ -92,6 +95,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_FIELD_COMPLETE_BIOGRAPHY,
     featureFlags.FEATURE_HEALTH_SERVICE_API_ID,
     featureFlags.FEATURE_DOWNLOADABLE_FILE,
+    featureFlags.FEATURE_FIELD_ALERT_DISMISSABLE,
   ],
   vagovprod: [
     featureFlags.FEATURE_FIELD_ADDITIONAL_INFO,


### PR DESCRIPTION
## Description
Looks for presence of dismissable "TRUE" status (from drupal) before adding a close button to sitewide banners

## Testing 
Visual

## Screenshots
![alert](https://user-images.githubusercontent.com/2404547/62397260-5715e600-b543-11e9-9626-46ec8c48b179.png)

## Acceptance criteria
- [ ] Sitewide banners without dismissable true status do not have "x" close button.

## To test
- [x] In local drupal instance, check out https://github.com/department-of-veterans-affairs/va.gov-cms/pull/492 and rebuild.
- [x] In Drupal, Go to /admin/content then click on the alerts tab.
- [x] Edit a block, or add a new one.
- [x] For banner alerts (formerly known as "full width alerts"), you should be able to specify whether or not they are dismissable.
- [x] Add / edit a sitewide banner, and make it dismissable.
- [x] Load the vets-website build, and confirm that banner appears with x
- [x] Revisit same banner in drupal, and uncheck box.
- [x] Reload vets-website, and confirm that banner x no longer appears.