### PR TITLE
[SCREENREADER]: Education STEM Update - Step 6 Edit button needs an updated aria-label #762

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -67,6 +67,10 @@ export default class ReviewCollapsibleChapter extends React.Component {
     );
   }
 
+  shouldHideExpandedPageTitle = (expandedPages, chapterTitle, pageTitle) =>
+    expandedPages.length === 1 &&
+    chapterTitle.toLowerCase() === pageTitle.toLowerCase();
+
   render() {
     let pageContent = null;
 
@@ -142,6 +146,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
             const classes = classNames('form-review-panel-page', {
               'schemaform-review-page-warning': !viewedPages.has(fullPageKey),
             });
+            const title = page.reviewTitle || page.title;
 
             return (
               <div key={`${fullPageKey}`} className={classes}>
@@ -149,14 +154,18 @@ export default class ReviewCollapsibleChapter extends React.Component {
                 {pageSchema && (
                   <SchemaForm
                     name={page.pageKey}
-                    title={page.reviewTitle || page.title}
+                    title={title}
                     data={pageData}
                     appStateData={page.appStateData}
                     schema={pageSchema}
                     uiSchema={pageUiSchema}
                     trackingPrefix={this.props.form.trackingPrefix}
                     hideHeaderRow={page.hideHeaderRow}
-                    hideTitle={expandedPages.length === 1}
+                    hideTitle={this.shouldHideExpandedPageTitle(
+                      expandedPages,
+                      chapterTitle,
+                      title,
+                    )}
                     pagePerItemIndex={page.index}
                     onBlur={this.props.onBlur}
                     onEdit={() =>

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -9,7 +9,6 @@ import { focusElement } from '../utilities/ui';
 import SchemaForm from '../components/SchemaForm';
 import { getArrayFields, getNonArraySchema } from '../helpers';
 import ArrayField from './ArrayField';
-import environment from 'platform/utilities/environment';
 
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
@@ -68,15 +67,9 @@ export default class ReviewCollapsibleChapter extends React.Component {
     );
   }
 
-  shouldHideExpandedPageTitle = (expandedPages, chapterTitle, pageTitle) => {
-    if (environment.isProduction()) {
-      return expandedPages.length === 1;
-    }
-    return (
-      expandedPages.length === 1 &&
-      chapterTitle.toLowerCase() === pageTitle.toLowerCase()
-    );
-  };
+  shouldHideExpandedPageTitle = (expandedPages, chapterTitle, pageTitle) =>
+    expandedPages.length === 1 &&
+    chapterTitle.toLowerCase() === pageTitle.toLowerCase();
 
   render() {
     let pageContent = null;

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -9,6 +9,7 @@ import { focusElement } from '../utilities/ui';
 import SchemaForm from '../components/SchemaForm';
 import { getArrayFields, getNonArraySchema } from '../helpers';
 import ArrayField from './ArrayField';
+import environment from 'platform/utilities/environment';
 
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
@@ -67,9 +68,15 @@ export default class ReviewCollapsibleChapter extends React.Component {
     );
   }
 
-  shouldHideExpandedPageTitle = (expandedPages, chapterTitle, pageTitle) =>
-    expandedPages.length === 1 &&
-    chapterTitle.toLowerCase() === pageTitle.toLowerCase();
+  shouldHideExpandedPageTitle = (expandedPages, chapterTitle, pageTitle) => {
+    if (environment.isProduction()) {
+      return expandedPages.length === 1;
+    }
+    return (
+      expandedPages.length === 1 &&
+      chapterTitle.toLowerCase() === pageTitle.toLowerCase()
+    );
+  };
 
   render() {
     let pageContent = null;

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -482,7 +482,6 @@ describe('<ReviewCollapsibleChapter>', () => {
     const titleDiv = wrapper.find('.form-review-panel-page-header');
     expect(titleDiv.length).to.equal(1);
     expect(titleDiv.text()).to.equal('');
-    expect(titleDiv.text()).to.not.equal(testChapterTitle);
 
     wrapper.unmount();
   });

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -478,9 +478,11 @@ describe('<ReviewCollapsibleChapter>', () => {
         form={form}
       />,
     );
-    // console.log(wrapper.html());
-    // const titleDiv = wrapper.find('.form-review-panel-page-header');
-    // console.log(titleDiv.html());
+
+    const titleDiv = wrapper.find('.form-review-panel-page-header');
+    expect(titleDiv.length).to.equal(1);
+    expect(titleDiv.text()).to.equal('');
+    expect(titleDiv.text()).to.not.equal(testChapterTitle);
 
     wrapper.unmount();
   });

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -377,6 +377,113 @@ describe('<ReviewCollapsibleChapter>', () => {
     });
   });
 
+  it('should show single page title when != chapter title', () => {
+    const testPageTitle = 'test page title';
+    const testChapterTitle = 'test chapter title';
+
+    const onEdit = sinon.spy();
+    const pages = [
+      {
+        pageKey: 'test',
+        title: testPageTitle,
+        updateFormData: (oldData, newData) => ({ ...newData, bar: 'baz' }),
+      },
+    ];
+    const chapterKey = 'test';
+    const chapter = {
+      title: 'test chapter title',
+    };
+    const form = {
+      pages: {
+        test: {
+          title: testPageTitle,
+          schema: {
+            type: 'object',
+            properties: {
+              foo: { type: 'string' },
+            },
+          },
+          uiSchema: {},
+          editMode: false,
+        },
+      },
+      data: {},
+    };
+    const setPagesViewed = sinon.spy();
+
+    const wrapper = mount(
+      <ReviewCollapsibleChapter
+        setPagesViewed={setPagesViewed}
+        viewedPages={new Set()}
+        onEdit={onEdit}
+        open
+        expandedPages={pages}
+        chapterKey={chapterKey}
+        chapterFormConfig={chapter}
+        form={form}
+      />,
+    );
+
+    const titleDiv = wrapper.find('.form-review-panel-page-header');
+
+    expect(titleDiv.length).to.equal(1);
+    expect(titleDiv.text()).to.equal(testPageTitle);
+    expect(titleDiv.text()).to.not.equal(testChapterTitle);
+
+    wrapper.unmount();
+  });
+
+  it('should not show single page title when equals chapter title', () => {
+    const testChapterTitle = 'test chapter title';
+
+    const onEdit = sinon.spy();
+    const pages = [
+      {
+        pageKey: 'test',
+        title: testChapterTitle,
+        updateFormData: (oldData, newData) => ({ ...newData, bar: 'baz' }),
+      },
+    ];
+    const chapterKey = 'test';
+    const chapter = {
+      title: testChapterTitle,
+    };
+    const form = {
+      pages: {
+        test: {
+          title: testChapterTitle,
+          schema: {
+            type: 'object',
+            properties: {
+              foo: { type: 'string' },
+            },
+          },
+          uiSchema: {},
+          editMode: false,
+        },
+      },
+      data: {},
+    };
+    const setPagesViewed = sinon.spy();
+
+    const wrapper = mount(
+      <ReviewCollapsibleChapter
+        setPagesViewed={setPagesViewed}
+        viewedPages={new Set()}
+        onEdit={onEdit}
+        open
+        expandedPages={pages}
+        chapterKey={chapterKey}
+        chapterFormConfig={chapter}
+        form={form}
+      />,
+    );
+
+    expect(wrapper.exists('form-review-panel-page-header')).to.be.false;
+
+    wrapper.unmount();
+  });
+
   describe('updateFormData', () => {
     it('should be called on normal pages', () => {
       const setData = sinon.spy();

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -391,7 +391,7 @@ describe('<ReviewCollapsibleChapter>', () => {
     ];
     const chapterKey = 'test';
     const chapter = {
-      title: 'test chapter title',
+      title: testChapterTitle,
     };
     const form = {
       pages: {
@@ -424,11 +424,11 @@ describe('<ReviewCollapsibleChapter>', () => {
       />,
     );
 
-    const titleDiv = wrapper.find('.form-review-panel-page-header');
+    // const titleDiv = wrapper.find('.form-review-panel-page-header');
 
-    expect(titleDiv.length).to.equal(1);
-    expect(titleDiv.text()).to.equal(testPageTitle);
-    expect(titleDiv.text()).to.not.equal(testChapterTitle);
+    // expect(titleDiv.length).to.equal(1);
+    // expect(titleDiv.text()).to.equal(testPageTitle);
+    // expect(titleDiv.text()).to.not.equal(testChapterTitle);
 
     wrapper.unmount();
   });
@@ -478,8 +478,9 @@ describe('<ReviewCollapsibleChapter>', () => {
         form={form}
       />,
     );
-
-    expect(wrapper.exists('form-review-panel-page-header')).to.be.false;
+    // console.log(wrapper.html());
+    // const titleDiv = wrapper.find('.form-review-panel-page-header');
+    // console.log(titleDiv.html());
 
     wrapper.unmount();
   });

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -286,7 +286,9 @@ describe('<ReviewCollapsibleChapter>', () => {
       },
     ];
     const chapterKey = 'test';
-    const chapter = {};
+    const chapter = {
+      title: '',
+    };
     const form = {
       pages: {
         test: {
@@ -386,7 +388,9 @@ describe('<ReviewCollapsibleChapter>', () => {
         },
       ];
       const chapterKey = 'test';
-      const chapter = {};
+      const chapter = {
+        title: '',
+      };
       const form = {
         pages: {
           test: {
@@ -434,7 +438,9 @@ describe('<ReviewCollapsibleChapter>', () => {
         },
       ];
       const chapterKey = 'test';
-      const chapter = {};
+      const chapter = {
+        title: '',
+      };
       const form = {
         pages: {
           test: {

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -424,11 +424,11 @@ describe('<ReviewCollapsibleChapter>', () => {
       />,
     );
 
-    // const titleDiv = wrapper.find('.form-review-panel-page-header');
+    const titleDiv = wrapper.find('.form-review-panel-page-header');
 
-    // expect(titleDiv.length).to.equal(1);
-    // expect(titleDiv.text()).to.equal(testPageTitle);
-    // expect(titleDiv.text()).to.not.equal(testChapterTitle);
+    expect(titleDiv.length).to.equal(1);
+    expect(titleDiv.text()).to.equal(testPageTitle);
+    expect(titleDiv.text()).to.not.equal(testChapterTitle);
 
     wrapper.unmount();
   });


### PR DESCRIPTION
## Description
The changes in this PR are in response to https://github.com/department-of-veterans-affairs/va.gov-team/issues/762

The issue is 
1) Chapter name != page name
2) When there's only 1 page in the chapter, the page name is hidden
3) The edit button edits the page contents, and says the page name when using SCREENREADER or JAWS, which wasn't visible and therefore is the cause of some confusion

The proposed fix is to show the page title if it doesn't match the chapter title. 

## Testing done
- local testing

### How to test
The goal of these steps is the have a chapter with only one page and the chapter title does not equal the page title on the review screen.  The 1995 form chapter Military History in the STEM flow matches this criteria.

1. Go to http://localhost:3001/education/apply-for-education-benefits/application/1995/introduction
2. Login or start without signing in
3. Proceed to http://localhost:3001/education/apply-for-education-benefits/application/1995/benefits/stem
4. Select "Yes"
    - then "yes" or "no" then "yes"
    - See first or second screenshot below
5. Proceed to review page of application
6. Notice that "Applicant Information" chapter **does not** have a page title of "Applicant information" next to the "Edit" button for its single page (see third screenshot below)
7. Notice that "Military History" chapters **does** have a page title of "Active Duty" next to the "Edit" button for its single page (see third screenshot below)

You can confirm chapter titles and page titles by either viewing at https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/1995/config/chapters.js

## Screenshots
<img width="678" alt="Screen Shot 2019-08-06 at 9 14 49 AM" src="https://user-images.githubusercontent.com/1094999/62543002-f6c8c200-b82a-11e9-880d-a5ec9bf48f50.png">
<img width="736" alt="Screen Shot 2019-08-06 at 9 14 57 AM" src="https://user-images.githubusercontent.com/1094999/62542916-ca14aa80-b82a-11e9-9aa8-621b03381d14.png">
<img width="613" alt="Screen Shot 2019-08-06 at 9 15 25 AM" src="https://user-images.githubusercontent.com/1094999/62542919-cbde6e00-b82a-11e9-8bbf-412c174ce3f9.png">


## Acceptance criteria
- [ ] Page titles are shown when there is a single page in a chapter and the page title does not equal the chapter title


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
