### PR TITLE
Add aria-label to option labels for accessibility

### DIFF
--- a/src/applications/edu-benefits/utils/labels.jsx
+++ b/src/applications/edu-benefits/utils/labels.jsx
@@ -4,7 +4,7 @@ import { states } from '../../../platform/forms/address';
 import { createUSAStateLabels } from 'platform/forms-system/src/js/helpers';
 
 
-export const ARIA_LABEL = "Learn more about Post-9/11 benefits";
+const ARIA_LABEL = "Learn more about Post-9/11 benefits";
 
 export const chapterNames = {
   veteranInformation: 'Veteran Information',

--- a/src/applications/edu-benefits/utils/labels.jsx
+++ b/src/applications/edu-benefits/utils/labels.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { states } from '../../../platform/forms/address';
 import { createUSAStateLabels } from 'platform/forms-system/src/js/helpers';
 
-const ARIA_LABEL = 'Learn more about Post-9/11 benefits';
+const ariaLabel = 'Learn more about Post-9/11 benefits';
 
 export const chapterNames = {
   veteranInformation: 'Veteran Information',
@@ -22,7 +22,7 @@ export const benefitsLabels = {
       Post-9/11 GI Bill (Chapter 33)
       <br />
       <a
-        aria-label={ARIA_LABEL}
+        aria-label={ariaLabel}
         href="/education/about-gi-bill-benefits/post-9-11/"
         target="_blank"
       >
@@ -36,7 +36,7 @@ export const benefitsLabels = {
       Fry Scholarship (Chapter 33)
       <br />
       <a
-        aria-label={ARIA_LABEL}
+        aria-label={ariaLabel}
         href="/education/survivor-dependent-benefits/fry-scholarship/"
         target="_blank"
       >
@@ -49,7 +49,7 @@ export const benefitsLabels = {
       Montgomery GI Bill (MGIB-AD, Chapter 30)
       <br />
       <a
-        aria-label={ARIA_LABEL}
+        aria-label={ariaLabel}
         href="/education/about-gi-bill-benefits/montgomery-active-duty/"
         target="_blank"
       >
@@ -62,7 +62,7 @@ export const benefitsLabels = {
       Montgomery GI Bill Selected Reserve (MGIB-SR, Chapter 1606)
       <br />
       <a
-        aria-label={ARIA_LABEL}
+        aria-label={ariaLabel}
         href="/education/about-gi-bill-benefits/montgomery-selected-reserve/"
         target="_blank"
       >
@@ -77,7 +77,7 @@ export const benefitsLabels = {
       (VEAP, Chapter 32)
       <br />
       <a
-        aria-label={ARIA_LABEL}
+        aria-label={ariaLabel}
         href="/education/other-va-education-benefits/veap/"
         target="_blank"
       >
@@ -90,7 +90,7 @@ export const benefitsLabels = {
       Reserve Educational Assistance Program (REAP, Chapter 1607)
       <br />
       <a
-        aria-label={ARIA_LABEL}
+        aria-label={ariaLabel}
         href="/education/other-va-education-benefits/reap/"
         target="_blank"
       >
@@ -103,7 +103,7 @@ export const benefitsLabels = {
       Transfer of Entitlement Program (TOE)
       <br />
       <a
-        aria-label={ARIA_LABEL}
+        aria-label={ariaLabel}
         href="/education/transfer-post-9-11-gi-bill-benefits/"
         target="_blank"
       >
@@ -122,7 +122,7 @@ export const survivorBenefitsLabels = {
       (DEA, Chapter 35)
       <br />
       <a
-        aria-label={ARIA_LABEL}
+        aria-label={ariaLabel}
         href="/education/survivor-dependent-benefits/dependents-education-assistance/"
         target="_blank"
       >
@@ -135,7 +135,7 @@ export const survivorBenefitsLabels = {
       The Fry Scholarship (Chapter 33)
       <br />
       <a
-        aria-label={ARIA_LABEL}
+        aria-label={ariaLabel}
         href="/education/survivor-dependent-benefits/fry-scholarship/"
         target="_blank"
       >

--- a/src/applications/edu-benefits/utils/labels.jsx
+++ b/src/applications/edu-benefits/utils/labels.jsx
@@ -3,6 +3,9 @@ import React from 'react';
 import { states } from '../../../platform/forms/address';
 import { createUSAStateLabels } from 'platform/forms-system/src/js/helpers';
 
+
+export const ARIA_LABEL = "Learn more about Post-9/11 benefits";
+
 export const chapterNames = {
   veteranInformation: 'Veteran Information',
   benefitsEligibility: 'Benefits Eligibility',
@@ -20,7 +23,7 @@ export const benefitsLabels = {
       Post-9/11 GI Bill (Chapter 33)
       <br />
       <a 
-        aria-label="Learn more about Post-9/11 benefits"
+        aria-label={ARIA_LABEL}
         href="/education/about-gi-bill-benefits/post-9-11/"
         target="_blank"
       >
@@ -34,7 +37,7 @@ export const benefitsLabels = {
       Fry Scholarship (Chapter 33)
       <br />
       <a
-        aria-label="Learn more about Post-9/11 benefits"
+        aria-label={ARIA_LABEL}
         href="/education/survivor-dependent-benefits/fry-scholarship/"
         target="_blank"
       >
@@ -47,7 +50,7 @@ export const benefitsLabels = {
       Montgomery GI Bill (MGIB-AD, Chapter 30)
       <br />
       <a
-        aria-label="Learn more about Post-9/11 benefits"
+        aria-label={ARIA_LABEL}
         href="/education/about-gi-bill-benefits/montgomery-active-duty/"
         target="_blank"
       >
@@ -60,7 +63,7 @@ export const benefitsLabels = {
       Montgomery GI Bill Selected Reserve (MGIB-SR, Chapter 1606)
       <br />
       <a
-        aria-label="Learn more about Post-9/11 benefits"
+        aria-label={ARIA_LABEL}
         href="/education/about-gi-bill-benefits/montgomery-selected-reserve/"
         target="_blank"
       >
@@ -75,7 +78,7 @@ export const benefitsLabels = {
       (VEAP, Chapter 32)
       <br />
       <a 
-        aria-label="Learn more about Post-9/11 benefits"
+        aria-label={ARIA_LABEL}
         href="/education/other-va-education-benefits/veap/"
         target="_blank"
       >
@@ -88,7 +91,7 @@ export const benefitsLabels = {
       Reserve Educational Assistance Program (REAP, Chapter 1607)
       <br />
       <a 
-        aria-label="Learn more about Post-9/11 benefits"
+        aria-label={ARIA_LABEL}
         href="/education/other-va-education-benefits/reap/"
         target="_blank"
       >
@@ -101,7 +104,7 @@ export const benefitsLabels = {
       Transfer of Entitlement Program (TOE)
       <br />
       <a 
-        aria-label="Learn more about Post-9/11 benefits"
+        aria-label={ARIA_LABEL}
         href="/education/transfer-post-9-11-gi-bill-benefits/"
         target="_blank"
       >
@@ -120,7 +123,7 @@ export const survivorBenefitsLabels = {
       (DEA, Chapter 35)
       <br />
       <a
-        aria-label="Learn more about Post-9/11 benefits"
+        aria-label={ARIA_LABEL}
         href="/education/survivor-dependent-benefits/dependents-education-assistance/"
         target="_blank"
       >
@@ -133,7 +136,7 @@ export const survivorBenefitsLabels = {
       The Fry Scholarship (Chapter 33)
       <br />
       <a
-        aria-label="Learn more about Post-9/11 benefits"
+        aria-label={ARIA_LABEL}
         href="/education/survivor-dependent-benefits/fry-scholarship/"
         target="_blank"
       >

--- a/src/applications/edu-benefits/utils/labels.jsx
+++ b/src/applications/edu-benefits/utils/labels.jsx
@@ -19,7 +19,11 @@ export const benefitsLabels = {
     <p>
       Post-9/11 GI Bill (Chapter 33)
       <br />
-      <a href="/education/about-gi-bill-benefits/post-9-11/" target="_blank">
+      <a 
+        aria-label="Learn more about Post-9/11 benefits"
+        href="/education/about-gi-bill-benefits/post-9-11/"
+        target="_blank"
+      >
         Learn more
       </a>
     </p>
@@ -30,6 +34,7 @@ export const benefitsLabels = {
       Fry Scholarship (Chapter 33)
       <br />
       <a
+        aria-label="Learn more about Post-9/11 benefits"
         href="/education/survivor-dependent-benefits/fry-scholarship/"
         target="_blank"
       >
@@ -42,6 +47,7 @@ export const benefitsLabels = {
       Montgomery GI Bill (MGIB-AD, Chapter 30)
       <br />
       <a
+        aria-label="Learn more about Post-9/11 benefits"
         href="/education/about-gi-bill-benefits/montgomery-active-duty/"
         target="_blank"
       >
@@ -54,6 +60,7 @@ export const benefitsLabels = {
       Montgomery GI Bill Selected Reserve (MGIB-SR, Chapter 1606)
       <br />
       <a
+        aria-label="Learn more about Post-9/11 benefits"
         href="/education/about-gi-bill-benefits/montgomery-selected-reserve/"
         target="_blank"
       >
@@ -67,7 +74,11 @@ export const benefitsLabels = {
       <br />
       (VEAP, Chapter 32)
       <br />
-      <a href="/education/other-va-education-benefits/veap/" target="_blank">
+      <a 
+        aria-label="Learn more about Post-9/11 benefits"
+        href="/education/other-va-education-benefits/veap/"
+        target="_blank"
+      >
         Learn more
       </a>
     </p>
@@ -76,7 +87,11 @@ export const benefitsLabels = {
     <p>
       Reserve Educational Assistance Program (REAP, Chapter 1607)
       <br />
-      <a href="/education/other-va-education-benefits/reap/" target="_blank">
+      <a 
+        aria-label="Learn more about Post-9/11 benefits"
+        href="/education/other-va-education-benefits/reap/"
+        target="_blank"
+      >
         Learn more
       </a>
     </p>
@@ -85,7 +100,11 @@ export const benefitsLabels = {
     <p>
       Transfer of Entitlement Program (TOE)
       <br />
-      <a href="/education/transfer-post-9-11-gi-bill-benefits/" target="_blank">
+      <a 
+        aria-label="Learn more about Post-9/11 benefits"
+        href="/education/transfer-post-9-11-gi-bill-benefits/"
+        target="_blank"
+      >
         Learn more
       </a>
     </p>
@@ -101,6 +120,7 @@ export const survivorBenefitsLabels = {
       (DEA, Chapter 35)
       <br />
       <a
+        aria-label="Learn more about Post-9/11 benefits"
         href="/education/survivor-dependent-benefits/dependents-education-assistance/"
         target="_blank"
       >
@@ -113,6 +133,7 @@ export const survivorBenefitsLabels = {
       The Fry Scholarship (Chapter 33)
       <br />
       <a
+        aria-label="Learn more about Post-9/11 benefits"
         href="/education/survivor-dependent-benefits/fry-scholarship/"
         target="_blank"
       >

--- a/src/applications/edu-benefits/utils/labels.jsx
+++ b/src/applications/edu-benefits/utils/labels.jsx
@@ -3,8 +3,7 @@ import React from 'react';
 import { states } from '../../../platform/forms/address';
 import { createUSAStateLabels } from 'platform/forms-system/src/js/helpers';
 
-
-const ARIA_LABEL = "Learn more about Post-9/11 benefits";
+const ARIA_LABEL = 'Learn more about Post-9/11 benefits';
 
 export const chapterNames = {
   veteranInformation: 'Veteran Information',
@@ -22,7 +21,7 @@ export const benefitsLabels = {
     <p>
       Post-9/11 GI Bill (Chapter 33)
       <br />
-      <a 
+      <a
         aria-label={ARIA_LABEL}
         href="/education/about-gi-bill-benefits/post-9-11/"
         target="_blank"
@@ -77,7 +76,7 @@ export const benefitsLabels = {
       <br />
       (VEAP, Chapter 32)
       <br />
-      <a 
+      <a
         aria-label={ARIA_LABEL}
         href="/education/other-va-education-benefits/veap/"
         target="_blank"
@@ -90,7 +89,7 @@ export const benefitsLabels = {
     <p>
       Reserve Educational Assistance Program (REAP, Chapter 1607)
       <br />
-      <a 
+      <a
         aria-label={ARIA_LABEL}
         href="/education/other-va-education-benefits/reap/"
         target="_blank"
@@ -103,7 +102,7 @@ export const benefitsLabels = {
     <p>
       Transfer of Entitlement Program (TOE)
       <br />
-      <a 
+      <a
         aria-label={ARIA_LABEL}
         href="/education/transfer-post-9-11-gi-bill-benefits/"
         target="_blank"

--- a/src/applications/edu-benefits/utils/labels.jsx
+++ b/src/applications/edu-benefits/utils/labels.jsx
@@ -3,8 +3,6 @@ import React from 'react';
 import { states } from '../../../platform/forms/address';
 import { createUSAStateLabels } from 'platform/forms-system/src/js/helpers';
 
-const ariaLabel = 'Learn more about Post-9/11 benefits';
-
 export const chapterNames = {
   veteranInformation: 'Veteran Information',
   benefitsEligibility: 'Benefits Eligibility',
@@ -22,7 +20,7 @@ export const benefitsLabels = {
       Post-9/11 GI Bill (Chapter 33)
       <br />
       <a
-        aria-label={ariaLabel}
+        aria-label="Learn more about Post-9/11 benefits"
         href="/education/about-gi-bill-benefits/post-9-11/"
         target="_blank"
       >
@@ -36,7 +34,7 @@ export const benefitsLabels = {
       Fry Scholarship (Chapter 33)
       <br />
       <a
-        aria-label={ariaLabel}
+        aria-label="Learn more about Fry Scholarship benefits"
         href="/education/survivor-dependent-benefits/fry-scholarship/"
         target="_blank"
       >
@@ -49,7 +47,7 @@ export const benefitsLabels = {
       Montgomery GI Bill (MGIB-AD, Chapter 30)
       <br />
       <a
-        aria-label={ariaLabel}
+        aria-label="Learn more about Montgomery GI Bill benefits"
         href="/education/about-gi-bill-benefits/montgomery-active-duty/"
         target="_blank"
       >
@@ -62,7 +60,7 @@ export const benefitsLabels = {
       Montgomery GI Bill Selected Reserve (MGIB-SR, Chapter 1606)
       <br />
       <a
-        aria-label={ariaLabel}
+        aria-label="Learn more about Montgomery GI Bill Selected Reserve benefits"
         href="/education/about-gi-bill-benefits/montgomery-selected-reserve/"
         target="_blank"
       >
@@ -77,7 +75,7 @@ export const benefitsLabels = {
       (VEAP, Chapter 32)
       <br />
       <a
-        aria-label={ariaLabel}
+        aria-label="Learn more about Post-Vietnam Era Veterans’ Educational Assistance Program benefits"
         href="/education/other-va-education-benefits/veap/"
         target="_blank"
       >
@@ -90,7 +88,7 @@ export const benefitsLabels = {
       Reserve Educational Assistance Program (REAP, Chapter 1607)
       <br />
       <a
-        aria-label={ariaLabel}
+        aria-label="Learn more about Reserve Educational Assistance Program benefits"
         href="/education/other-va-education-benefits/reap/"
         target="_blank"
       >
@@ -103,7 +101,7 @@ export const benefitsLabels = {
       Transfer of Entitlement Program (TOE)
       <br />
       <a
-        aria-label={ariaLabel}
+        aria-label="Learn more about Transfer of Entitlement Program benefits"
         href="/education/transfer-post-9-11-gi-bill-benefits/"
         target="_blank"
       >
@@ -122,7 +120,7 @@ export const survivorBenefitsLabels = {
       (DEA, Chapter 35)
       <br />
       <a
-        aria-label={ariaLabel}
+        aria-label="Learn more about Survivors’ and Dependents’ Educational Assistance benefits"
         href="/education/survivor-dependent-benefits/dependents-education-assistance/"
         target="_blank"
       >
@@ -135,7 +133,7 @@ export const survivorBenefitsLabels = {
       The Fry Scholarship (Chapter 33)
       <br />
       <a
-        aria-label={ariaLabel}
+        aria-label="Learn more about Fry Scholarship benefits"
         href="/education/survivor-dependent-benefits/fry-scholarship/"
         target="_blank"
       >


### PR DESCRIPTION
## Description
Step 2 has Learn more links about each type of benefit. This text is repeated several times and doesn't provide a lot of context about what users will learn. I'd like to see if we can rewrite these links to be more clear calls to action or add an aria-label to each link. 
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/768

## Testing done
confirmed in UI with screenreader utility

## Screenshots
*NO visual changes made

## Acceptance criteria
- [x] As a screen reader user, I would like to hear a clear explanation like "Learn more about Post 9/11 benefits" when I focus a link on Step 2

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
