### PR TITLE
update MHV downtime banner

### DIFF
--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -87,7 +87,7 @@ class SignInModal extends React.Component {
           [EXTERNAL_SERVICES.mhv],
           'You may have trouble signing in with My HealtheVet',
           'warning',
-          'We’re sorry. We’re making some scheduled updates to our My HealtheVet sign-in process. If you’d like to sign in to VA.gov with your My HealtheVet username and password, please check back later.',
+          'We’re sorry. We’re working to fix some problems with our My HealtheVet sign in process. If you’d like to sign in to VA.gov with your My HealtheVet username and password, please check back later.',
         )}
         {this.downtimeBanner(
           [EXTERNAL_SERVICES.mvi],


### PR DESCRIPTION
## Description
Update MHV downtime banner to be consistent with id.me and DS Logon. This banner is used for unscheduled downtime as well.

## Testing done
text changes only

## Screenshots
<img width="1018" alt="Screen Shot 2019-08-05 at 4 50 24 PM" src="https://user-images.githubusercontent.com/19188/62494357-511d4080-b7a1-11e9-94a3-8c084cb6f99e.png">


