### PR TITLE
fixed keyboard trap issue

### DIFF
--- a/src/applications/edu-benefits/1995/content/stem.jsx
+++ b/src/applications/edu-benefits/1995/content/stem.jsx
@@ -4,6 +4,31 @@ import environment from '../../../../platform/utilities/environment';
 
 export const rogersStemScholarshipInfo = (
   <AdditionalInfo triggerText="What is the Rogers STEM Scholarship?">
+    {environment.isProduction() && (
+      <div>
+        <p>
+          The Edith Nourse Rogers STEM Scholarship provides up to 9 months of
+          additional Post-9/11 GI Bill benefits, to a maximum of $30,000.
+        </p>
+        <p>
+          Veterans and Fry Scholars may qualify for this scholarship if they're
+          enrolled in an undergraduate program for Science, Technology,
+          Engineering, or Math (STEM), or if they've earned a STEM degree and
+          are getting a teaching certification.
+        </p>
+        <p>
+          To learn more about the STEM Scholarship,{' '}
+          <a
+            href="https://benefits.va.gov/gibill/fgib/stem.asp"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {' '}
+            visit the VBA STEM website.
+          </a>
+        </p>
+      </div>
+    )}
     {!environment.isProduction() && (
       <div>
         <p>

--- a/src/applications/edu-benefits/1995/content/stem.jsx
+++ b/src/applications/edu-benefits/1995/content/stem.jsx
@@ -7,14 +7,14 @@ export const rogersStemScholarshipInfo = (
       <p>
         The Edith Nourse Rogers STEM Scholarship provides up to 9 months of
         additional Post-9/11 GI Bill benefits, to a maximum of $30,000.
-      </p>
-      <p>
+        <br />
+        <br />
         Veterans and Fry Scholars may qualify for this scholarship if they're
         enrolled in an undergraduate program for Science, Technology,
         Engineering, or Math (STEM), or if they've earned a STEM degree and are
         getting a teaching certification.
-      </p>
-      <p>
+        <br />
+        <br />
         To learn more about the STEM Scholarship,{' '}
         <a
           href="https://benefits.va.gov/gibill/fgib/stem.asp"

--- a/src/applications/edu-benefits/1995/content/stem.jsx
+++ b/src/applications/edu-benefits/1995/content/stem.jsx
@@ -1,30 +1,33 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import environment from '../../../../platform/utilities/environment';
 
 export const rogersStemScholarshipInfo = (
   <AdditionalInfo triggerText="What is the Rogers STEM Scholarship?">
-    <div>
-      <p>
-        The Edith Nourse Rogers STEM Scholarship provides up to 9 months of
-        additional Post-9/11 GI Bill benefits, to a maximum of $30,000.
-        <br />
-        <br />
-        Veterans and Fry Scholars may qualify for this scholarship if they're
-        enrolled in an undergraduate program for Science, Technology,
-        Engineering, or Math (STEM), or if they've earned a STEM degree and are
-        getting a teaching certification.
-        <br />
-        <br />
-        To learn more about the STEM Scholarship,{' '}
-        <a
-          href="https://benefits.va.gov/gibill/fgib/stem.asp"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {' '}
-          visit the VBA STEM website.
-        </a>
-      </p>
-    </div>
+    {!environment.isProduction() && (
+      <div>
+        <p>
+          The Edith Nourse Rogers STEM Scholarship provides up to 9 months of
+          additional Post-9/11 GI Bill benefits, to a maximum of $30,000.
+          <br />
+          <br />
+          Veterans and Fry Scholars may qualify for this scholarship if they're
+          enrolled in an undergraduate program for Science, Technology,
+          Engineering, or Math (STEM), or if they've earned a STEM degree and
+          are getting a teaching certification.
+          <br />
+          <br />
+          To learn more about the STEM Scholarship,{' '}
+          <a
+            href="https://benefits.va.gov/gibill/fgib/stem.asp"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {' '}
+            visit the VBA STEM website.
+          </a>
+        </p>
+      </div>
+    )}
   </AdditionalInfo>
 );

--- a/src/applications/edu-benefits/1995/content/stem.jsx
+++ b/src/applications/edu-benefits/1995/content/stem.jsx
@@ -4,17 +4,17 @@ import AdditionalInfo from '@department-of-veterans-affairs/formation-react/Addi
 export const rogersStemScholarshipInfo = (
   <AdditionalInfo triggerText="What is the Rogers STEM Scholarship?">
     <div>
-      <div className="vads-u-margin-bottom--2">
+      <p>
         The Edith Nourse Rogers STEM Scholarship provides up to 9 months of
         additional Post-9/11 GI Bill benefits, to a maximum of $30,000.
-      </div>
-      <div className="vads-u-margin-bottom--2">
+        <br />
+        <br />
         Veterans and Fry Scholars may qualify for this scholarship if they're
         enrolled in an undergraduate program for Science, Technology,
         Engineering, or Math (STEM), or if they've earned a STEM degree and are
         getting a teaching certification.
-      </div>
-      <div className="vads-u-margin-bottom--2">
+        <br />
+        <br />
         To learn more about the STEM Scholarship,{' '}
         <a
           href="https://benefits.va.gov/gibill/fgib/stem.asp"
@@ -24,7 +24,7 @@ export const rogersStemScholarshipInfo = (
           {' '}
           visit the VBA STEM website.
         </a>
-      </div>
+      </p>
     </div>
   </AdditionalInfo>
 );

--- a/src/applications/edu-benefits/1995/content/stem.jsx
+++ b/src/applications/edu-benefits/1995/content/stem.jsx
@@ -4,17 +4,17 @@ import AdditionalInfo from '@department-of-veterans-affairs/formation-react/Addi
 export const rogersStemScholarshipInfo = (
   <AdditionalInfo triggerText="What is the Rogers STEM Scholarship?">
     <div>
-      <p>
+      <div style={{ marginBottom: '15px' }}>
         The Edith Nourse Rogers STEM Scholarship provides up to 9 months of
         additional Post-9/11 GI Bill benefits, to a maximum of $30,000.
-        <br />
-        <br />
+      </div>
+      <div style={{ marginBottom: '15px' }}>
         Veterans and Fry Scholars may qualify for this scholarship if they're
         enrolled in an undergraduate program for Science, Technology,
         Engineering, or Math (STEM), or if they've earned a STEM degree and are
         getting a teaching certification.
-        <br />
-        <br />
+      </div>
+      <div style={{ marginBottom: '15px' }}>
         To learn more about the STEM Scholarship,{' '}
         <a
           href="https://benefits.va.gov/gibill/fgib/stem.asp"
@@ -24,7 +24,7 @@ export const rogersStemScholarshipInfo = (
           {' '}
           visit the VBA STEM website.
         </a>
-      </p>
+      </div>
     </div>
   </AdditionalInfo>
 );

--- a/src/applications/edu-benefits/1995/content/stem.jsx
+++ b/src/applications/edu-benefits/1995/content/stem.jsx
@@ -4,17 +4,17 @@ import AdditionalInfo from '@department-of-veterans-affairs/formation-react/Addi
 export const rogersStemScholarshipInfo = (
   <AdditionalInfo triggerText="What is the Rogers STEM Scholarship?">
     <div>
-      <div style={{ marginBottom: '15px' }}>
+      <div className="vads-u-margin-bottom--2">
         The Edith Nourse Rogers STEM Scholarship provides up to 9 months of
         additional Post-9/11 GI Bill benefits, to a maximum of $30,000.
       </div>
-      <div style={{ marginBottom: '15px' }}>
+      <div className="vads-u-margin-bottom--2">
         Veterans and Fry Scholars may qualify for this scholarship if they're
         enrolled in an undergraduate program for Science, Technology,
         Engineering, or Math (STEM), or if they've earned a STEM degree and are
         getting a teaching certification.
       </div>
-      <div style={{ marginBottom: '15px' }}>
+      <div className="vads-u-margin-bottom--2">
         To learn more about the STEM Scholarship,{' '}
         <a
           href="https://benefits.va.gov/gibill/fgib/stem.asp"


### PR DESCRIPTION
## Description
Bug: 

https://github.com/department-of-veterans-affairs/va.gov-team/issues/764

I noticed a keyboard trap when I was browsing the form with Safari + VoiceOver on MacOS Mojave (latest). The keyboard trap appeared when I was using the virtual cursor to move through, Ctrl + Option + right arrow. Animated GIF attached below.

## Testing done

Local testing 
## Screenshots
Gif shows Ctrl + Option + right arrow escaping the trap

![keyboardtrap](https://user-images.githubusercontent.com/50601724/62558900-e6731000-b847-11e9-9583-74910d127957.gif)


## Acceptance criteria
- [x] As a Safari + VoiceOver user, I want to be able to move to the next element when the STEM scholarship accordion (expand/collapse) is opened.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
