### PR TITLE
VAGOV-5014: add inline images and media download templates

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -177,6 +177,27 @@ $duo-tone-lighten: #000000;
   margin-top: auto;
 }
 
+.va-c-position--relative {
+  position: relative;
+}
+
+.va-c-position--absolute {
+  position: absolute;
+}
+
+.va-c-position-top-right-corner {
+  right: 0;
+  top: 0;
+}
+
+.expand-image-button {
+  background-color: #ffffff;
+  border-radius: 5px;
+  box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.3);
+  height: 32px;
+  width: 32px;
+}
+
 .social-links {
   &:last-child.vads-u-margin-bottom--2 {
     margin-bottom: 0 !important;

--- a/src/site/paragraphs/downloadable_file.drupal.liquid
+++ b/src/site/paragraphs/downloadable_file.drupal.liquid
@@ -1,0 +1,49 @@
+{% comment %}
+    Example data:
+    {
+        "entity": {
+            "entityType": "paragraph",
+            "entityBundle": "downloadable_file",
+            "fieldTitle": "Download map",
+            "fieldMarkup": null,
+            "fieldMedia": {
+                "entity": {
+                    "entityBundle": "image",
+                    "image": {
+                        "url": "https://dev.cms.va.gov/sites/default/files/2019-08/UD-sitemap.gif",
+                        "alt": "university drive site map",
+                        "title": ""
+                    }
+                }
+            }
+        }
+    }
+{% endcomment %}
+
+<div class="vads-u-margin-y--1p5">
+    {% if entity.fieldMedia.entity.entityBundle == 'image' %}
+
+        {% assign url = entity.fieldMedia.entity.image.url %}
+
+        <a aria-label="Download {{entity.fieldMedia.entity.image.alt}}" class="file-download-with-icon" target="_blank"
+           href="{{url}}" download="{{url}}">
+            <i class="fas fa-download vads-u-margin--0p5"></i>{{entity.fieldTitle}} ({{url | fileExt | upcase}})
+        </a>
+    {% endif %}
+
+    {% if entity.fieldMedia.entity.entityBundle == 'document' %}
+        {% assign url = entity.fieldMedia.entity.fieldDocument.entity.url %}
+        <a aria-label="Download {{entity.fieldMedia.entity.fieldDocument.filename}}" class="file-download-with-icon" target="_blank"
+           href="{{url}}" download="{{url}}">
+            <i class="fas fa-download vads-u-margin--0p5"></i>{{entity.fieldTitle}} ({{url | fileExt | upcase}})
+        </a>
+    {% endif %}
+
+    {% if entity.fieldMedia.entity.entityBundle == 'video' %}
+        <a aria-label="View {{entity.fieldTitle}}" class="video-link" target="_blank"
+           href="{{entity.fieldMedia.entity.fieldMediaVideoEmbedField}}">
+            <i class="fas fa-play-circle vads-u-margin--0p5"></i>Go to video
+        </a>
+    {% endif %}
+</div>
+

--- a/src/site/paragraphs/media.drupal.liquid
+++ b/src/site/paragraphs/media.drupal.liquid
@@ -1,0 +1,32 @@
+{% comment %}
+    Example data:
+    {
+        "entity": {
+        "entityType": "paragraph",
+        "entityBundle": "media",
+        "fieldAllowClicksOnThisImage": true,
+        "fieldMedia": {
+            "entity": {
+                "entityBundle": "image",
+                "image": {
+                    "url": "https://dev.cms.va.gov/sites/default/files/2019-08/UD-sitemap.gif",
+                    "alt": "university drive site map",
+                    "title": ""
+                }
+            }
+        }
+    }
+}
+{% endcomment %}
+<div class="vads-u-display--block">
+    <div class="va-c-position--relative vads-u-display--inline-block vads-u-margin-y--1p5">
+        <a
+            aria-label="Open image in new tab"
+            class="vads-u-text-decoration--none vads-u-display--flex vads-u-align-items--center expand-image-button va-c-position--absolute va-c-position-top-right-corner vads-u-justify-content--center"
+            href="{{ entity.fieldMedia.entity.image.url }}"
+            target="_blank">
+            <i class="fas fa-expand-arrows-alt"></i>
+        </a>
+        <img src="{{ entity.fieldMedia.entity.image.url }}" alt="{{ entity.fieldMedia.entity.image.alt }}"/>
+    </div>
+</div>

--- a/src/site/stages/build/drupal/graphql/fragments.graphql.js
+++ b/src/site/stages/build/drupal/graphql/fragments.graphql.js
@@ -16,6 +16,14 @@ const spanishSummary = require('./paragraph-fragments/spanishSummary.paragraph.g
 const numberCallout = require('./paragraph-fragments/numberCallout.paragraph.graphql');
 const alertParagraph = require('./paragraph-fragments/alert.paragraph.graphql');
 const table = require('./paragraph-fragments/table.paragraph.graphql');
+const downloadableFile = require('./paragraph-fragments/downloadableFile.paragraph.graphql');
+const embeddedImage = require('./paragraph-fragments/media.paragraph.graphql');
+
+// Get current feature flags
+const {
+  featureFlags,
+  enabledFeatureFlags,
+} = require('./../../../../utilities/featureFlags');
 
 module.exports = `
   ${alert}
@@ -33,5 +41,16 @@ module.exports = `
   ${spanishSummary}
   ${numberCallout}
   ${alertParagraph}
-  ${table}
+  ${table}  
+  ${
+    enabledFeatureFlags[featureFlags.FEATURE_DOWNLOADABLE_FILE]
+      ? `
+        ${downloadableFile}
+        ${embeddedImage}
+     `
+      : ''
+  }
+  
+  
+  
 `;

--- a/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
@@ -19,6 +19,8 @@ const REACT_WIDGET = '... reactWidget';
 const NUMBER_CALLOUT = '... numberCallout';
 const TABLE = '... table';
 const ALERT_PARAGRAPH = '... alertParagraph';
+const DOWNLOADABLE_FILE_PARAGRAPH = '... downloadableFile';
+const MEDIA_PARAGRAPH = '... embeddedImage';
 const entityElementsFromPages = require('./entityElementsForPages.graphql');
 
 // Get current feature flags
@@ -71,7 +73,16 @@ module.exports = `
         ${REACT_WIDGET}
         ${NUMBER_CALLOUT}
         ${TABLE}
-        ${ALERT_PARAGRAPH}
+        ${ALERT_PARAGRAPH}        
+        ${
+          enabledFeatureFlags[featureFlags.FEATURE_DOWNLOADABLE_FILE]
+            ? `
+                ${DOWNLOADABLE_FILE_PARAGRAPH}        
+                ${MEDIA_PARAGRAPH}
+
+              `
+            : ''
+        }        
       }
     }
     ${FIELD_RELATED_LINKS}

--- a/src/site/stages/build/drupal/graphql/page.graphql.js
+++ b/src/site/stages/build/drupal/graphql/page.graphql.js
@@ -18,6 +18,8 @@ const REACT_WIDGET = '... reactWidget';
 const SPANISH_SUMMARY = '... spanishSummary';
 const ALERT_PARAGRAPH = '... alertParagraph';
 const TABLE = '... table';
+const DOWNLOADABLE_FILE_PARAGRAPH = '... downloadableFile';
+const MEDIA_PARAGRAPH = '... embeddedImage';
 
 // Get current feature flags
 const {
@@ -59,6 +61,14 @@ module.exports = `
         ${SPANISH_SUMMARY}
         ${TABLE}
         ${ALERT_PARAGRAPH}
+        ${
+          enabledFeatureFlags[featureFlags.FEATURE_DOWNLOADABLE_FILE]
+            ? `
+            ${DOWNLOADABLE_FILE_PARAGRAPH}
+            ${MEDIA_PARAGRAPH}
+            `
+            : ''
+        }
       }
     }
     ${FIELD_ALERT} 

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/downloadableFile.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/downloadableFile.paragraph.graphql.js
@@ -1,0 +1,35 @@
+/**
+ * The 'Link to file or video' bundle of the 'Paragraph' entity type.
+ *
+ */
+module.exports = `
+  fragment downloadableFile on ParagraphDownloadableFile {
+    fieldTitle
+    fieldMarkup
+    fieldMedia {
+      entity {
+        entityBundle
+        ... on MediaImage {
+          image {
+            url
+            alt
+            title
+          }        
+        }
+        ... on MediaVideo {        
+          fieldMediaVideoEmbedField
+        }
+        ... on MediaDocument {
+          fieldDocument {
+            entity {
+              ... on File {
+                filename
+                url
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/media.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/media.paragraph.graphql.js
@@ -1,0 +1,21 @@
+/**
+ * The 'Embedded image' bundle of the 'Paragraph' entity type.
+ *
+ */
+module.exports = `
+  fragment embeddedImage on ParagraphMedia {  
+    fieldAllowClicksOnThisImage
+    fieldMedia {    
+      entity {
+        entityBundle
+        ... on MediaImage {
+          image {
+            url
+            alt
+            title
+          }        
+        }
+      }
+    }
+  }
+`;

--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -28,6 +28,7 @@ const featureFlags = {
   FEATURE_FIELD_OPERATING_STATUS_FACILITY: 'fieldOperatingStatusFacility',
   FEATURE_FIELD_COMPLETE_BIOGRAPHY: 'fieldCompleteBiography',
   FEATURE_HEALTH_SERVICE_API_ID: 'featureHealthServiceApiId',
+  FEATURE_DOWNLOADABLE_FILE: 'featureDownloadableFile',
 };
 
 // Edit this to turn flags on or off
@@ -51,6 +52,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_FIELD_OPERATING_STATUS_FACILITY,
     featureFlags.FEATURE_FIELD_COMPLETE_BIOGRAPHY,
     featureFlags.FEATURE_HEALTH_SERVICE_API_ID,
+    featureFlags.FEATURE_DOWNLOADABLE_FILE,
   ],
   vagovdev: [
     featureFlags.FEATURE_FIELD_ASSET_LIBRARY_DESCRIPTION,
@@ -71,6 +73,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_FIELD_OPERATING_STATUS_FACILITY,
     featureFlags.FEATURE_FIELD_COMPLETE_BIOGRAPHY,
     featureFlags.FEATURE_HEALTH_SERVICE_API_ID,
+    featureFlags.FEATURE_DOWNLOADABLE_FILE,
   ],
   vagovstaging: [
     featureFlags.FEATURE_FIELD_ADDITIONAL_INFO,
@@ -88,6 +91,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_FIELD_OPERATING_STATUS_FACILITY,
     featureFlags.FEATURE_FIELD_COMPLETE_BIOGRAPHY,
     featureFlags.FEATURE_HEALTH_SERVICE_API_ID,
+    featureFlags.FEATURE_DOWNLOADABLE_FILE,
   ],
   vagovprod: [
     featureFlags.FEATURE_FIELD_ADDITIONAL_INFO,


### PR DESCRIPTION
## Description
Adds the inline/embedded image content type and media download templates

## Testing done
locally with staging and dev data

Pre-req: need a page that uses these content types
1. go to cms and make a detail page https://staging.cms.va.gov/node/add/health_care_region_detail_page
2. fill out necessary information
3. in the "Main Content" section, click "Add Content block"
4. choose "Link to file or video"
5. for this path, choose to browse media and find an image or document
6. fill in "Link text" field
6. add another content block
7. choose "Embedded Image"
8. browse media again
9. click "Allow clicks on this image to open it in new tab"
10. add another content block
11. choose "Link to file or video"
12. "Browse media" and choose a video link that has been entered already
13. add another content block
14. choose "Embedded Image" and choose or upload an image
15. make sure to _*NOT*_ click "Allows clicks on this image to open it in a new tab"
16. you can add as many links and images as you see fit to test this
17. make sure you add a menu item and link to this page if necessary (such as the map page). if you're just testing the content block types, you don't need to do this, you should be able to simply browse to the page to see the content
18. re-build the front-end

to test:
1. with the front-end re-built, browse to the page you just
2. make sure the embedded images show up
3. check to make sure the "Allow clicks on this image to open it in new tab" works by verifying the image with it checked has the little "X" in top-right corner to click on and goes to a new tab. if the image did not have this checked, make sure the "X" does not show up
4. make sure the download links download the correct file
5. make sure the video links link to the correct place and goes to a new tab

## Screenshots
![image](https://user-images.githubusercontent.com/19178435/62572858-91d09480-b849-11e9-96fe-ad7ef26800ec.png)


## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-5014
- [ ] all the things above

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
