### PR TITLE
Bah ctfiscalyear 19166

### DIFF
--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -7,7 +7,7 @@ export class AdditionalInformation extends React.Component {
   updateFiscalYear() {
     const constants = this.props.constants;
 
-    return !environment.isProduction() ? '2018' : constants.FISCALYEAR;
+    return environment.isProduction() ? '2018' : constants.FISCALYEAR;
   }
   renderInstitutionSummary() {
     const it = this.props.institution;

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -7,9 +7,7 @@ export class AdditionalInformation extends React.Component {
   updateFiscalYear() {
     const constants = this.props.constants;
 
-    return environment.isProduction()
-      ? 'Total paid (FY 2018)'
-      : 'Total paid (FY ' + constants.FISCALYEAR + ')';
+    return !environment.isProduction() ? '2018' : constants.FISCALYEAR;
   }
   renderInstitutionSummary() {
     const it = this.props.institution;
@@ -138,7 +136,6 @@ export class AdditionalInformation extends React.Component {
 
   render() {
     const it = this.props.institution;
-    const constants = this.props.constants;
     // Formats positive and negative currency values in USD
     const formatCurrency = num => {
       const str = Number(num)
@@ -178,8 +175,7 @@ export class AdditionalInformation extends React.Component {
               </div>
               <div>
                 <strong>
-                  {this.updateFiscalYear()}
-                  :&nbsp;
+                  Total paid (FY {this.updateFiscalYear()}) :&nbsp;
                 </strong>
                 {formatCurrency(it.p911TuitionFees)}
               </div>
@@ -195,8 +191,7 @@ export class AdditionalInformation extends React.Component {
               </div>
               <div>
                 <strong>
-                  {this.updateFiscalYear()}
-                  :&nbsp;
+                  Total paid (FY {this.updateFiscalYear()}) :&nbsp;
                 </strong>
                 {formatCurrency(it.p911YellowRibbon)}
               </div>
@@ -253,7 +248,7 @@ export class AdditionalInformation extends React.Component {
                 <tr>
                   <th>Benefit</th>
                   <th>Recipients</th>
-                  <th>{this.updateFiscalYear()}</th>
+                  <th>Total paid (FY {this.updateFiscalYear()})</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -5,7 +5,11 @@ import environment from 'platform/utilities/environment';
 
 export class AdditionalInformation extends React.Component {
   updateFiscalYear() {
-    return 'Total paid (FY 2018)';
+    const constants = this.props.constants;
+
+    return environment.isProduction()
+      ? 'Total paid (FY 2018)'
+      : 'Total paid (FY ' + constants.FISCALYEAR + ')';
   }
   renderInstitutionSummary() {
     const it = this.props.institution;
@@ -134,7 +138,7 @@ export class AdditionalInformation extends React.Component {
 
   render() {
     const it = this.props.institution;
-
+    const constants = this.props.constants;
     // Formats positive and negative currency values in USD
     const formatCurrency = num => {
       const str = Number(num)

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -175,7 +175,8 @@ export class AdditionalInformation extends React.Component {
               </div>
               <div>
                 <strong>
-                  Total paid (FY {this.updateFiscalYear()}) :&nbsp;
+                  Total paid (FY {this.updateFiscalYear()}
+                  ):&nbsp;
                 </strong>
                 {formatCurrency(it.p911TuitionFees)}
               </div>
@@ -191,7 +192,8 @@ export class AdditionalInformation extends React.Component {
               </div>
               <div>
                 <strong>
-                  Total paid (FY {this.updateFiscalYear()}) :&nbsp;
+                  Total paid (FY {this.updateFiscalYear()}
+                  ):&nbsp;
                 </strong>
                 {formatCurrency(it.p911YellowRibbon)}
               </div>

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -134,6 +134,7 @@ export class ProfilePage extends React.Component {
                   <AdditionalInformation
                     institution={profile.attributes}
                     onShowModal={this.props.showModal}
+                    constants={this.props.constants}
                   />
                 </AccordionItem>
               </ul>


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19166

As an EDU team member, I need the ability to update the FY indicator so that I do not need the development team to update it for me.

## Testing done
Testing conducted locally 

## Screenshots
<img width="687" alt="Screen Shot 2019-08-07 at 2 23 30 PM" src="https://user-images.githubusercontent.com/50601724/62647655-06c1ce00-b91f-11e9-92b7-a45fc55b2a3a.png">


## Acceptance criteria
- [x] A new calculator constant "FiscalYear" is created in the GIDS "CalculatorConstant.csv" that specifies the Fiscal Year.
- [x] The "Historical Information" table under the "Additional Information" section of the School Profile page uses the constant to populate the table header "Total paid (FY 2016)".
- [x] The updated "CalculatorConstant.csv" is included in source control
- [x] The updated "CalculatorConstant.csv" is uploaded to Staging
## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
