### PR TITLE
[1995] Submit Form Success GA

### DIFF
--- a/src/applications/edu-benefits/1995/config/form.js
+++ b/src/applications/edu-benefits/1995/config/form.js
@@ -2,6 +2,7 @@ import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
 
 import { transform } from '../submit-transformer';
 import { prefillTransformer } from '../prefill-transformer';
+import submitForm from '../submitForm';
 
 import { urlMigration } from '../../config/migrations';
 
@@ -26,6 +27,7 @@ const {
 const formConfig = {
   urlPrefix: '/',
   submitUrl: `${environment.API_URL}/v0/education_benefits_claims/1995`,
+  submit: submitForm,
   trackingPrefix: 'edu-1995-',
   formId: VA_FORM_IDS.FORM_22_1995,
   version: 1,

--- a/src/applications/edu-benefits/1995/submitForm.js
+++ b/src/applications/edu-benefits/1995/submitForm.js
@@ -1,0 +1,23 @@
+import { submitToUrl } from 'platform/forms-system/src/js/actions';
+import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
+
+const submitForm = (form, formConfig) => {
+  const body = formConfig.transformForSubmit
+    ? formConfig.transformForSubmit(formConfig, form)
+    : transformForSubmit(formConfig, form);
+
+  const eventData = {
+    'edu-stem-applicant': form.data.isEdithNourseRogersScholarship
+      ? 'Yes'
+      : 'No',
+  };
+
+  return submitToUrl(
+    body,
+    formConfig.submitUrl,
+    formConfig.trackingPrefix,
+    eventData,
+  );
+};
+
+export default submitForm;

--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -77,7 +77,7 @@ export function setViewedPages(pageKeys) {
   };
 }
 
-export function submitToUrl(body, submitUrl, trackingPrefix) {
+export function submitToUrl(body, submitUrl, trackingPrefix, eventData) {
   return new Promise((resolve, reject) => {
     const req = new XMLHttpRequest();
     req.open('POST', submitUrl);
@@ -85,6 +85,7 @@ export function submitToUrl(body, submitUrl, trackingPrefix) {
       if (req.status >= 200 && req.status < 300) {
         recordEvent({
           event: `${trackingPrefix}-submission-successful`,
+          ...eventData,
         });
         // got this from the fetch polyfill, keeping it to be safe
         const responseBody =


### PR DESCRIPTION
## Description
Recording GA event data on successful submit of the 1995 form requires updating the platform `submitToUrl`function

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19412

## Testing done
QA tested

## Screenshots
N/A

## Acceptance criteria
- [x] Record `isEdithNourseRogersScholarship` on form submit success

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
