### PR TITLE
updated stem notification

### DIFF
--- a/src/applications/gi/components/content/StemScholarshipNotification.jsx
+++ b/src/applications/gi/components/content/StemScholarshipNotification.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import environment from '../../../../platform/utilities/environment';
 
 export const StemScholarshipNotification = () => (
   <div className="stem-notification">
@@ -6,9 +7,10 @@ export const StemScholarshipNotification = () => (
     <div className="feature">
       <h4>The Edith Nourse Rogers STEM Scholarship</h4>
       <p>
-        On August 1, 2019, VA is launching the Edith Nourse Rogers STEM
-        Scholarship for students enrolled in a high-demand STEM (Science,
-        Technology, Engineering, and Math) program.
+        {environment.isProduction() &&
+          'On August 1, 2019, VA is launching the Edith Nourse Rogers STEM Scholarship for students enrolled in a high-demand STEM (Science, Technology, Engineering, and Math) program.'}
+        {!environment.isProduction() &&
+          'On August 1, 2019, VA launched the Edith Nourse Rogers STEM Scholarship for students enrolled in a high-demand STEM (Science, Technology, Engineering, and Math) program.'}
       </p>
       <p>
         To learn more about this scholarship,{' '}


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19422

As a developer, I need to update the 111 notification text on the CT landing page so that the grammar is correct.

## Testing done
Local testing conducted

## Screenshots
![Screen Shot 2019-08-07 at 6 46 09 PM](https://user-images.githubusercontent.com/50601724/62702112-e98b0f00-b9b3-11e9-9af3-dfcf4ea1aa6f.png)

## Acceptance criteria
- [x] The first sentence of the notification "On August 1, 2019, VA is launching the Edith Nourse Rogers STEM Scholarship for students enrolled in a high-demand STEM (Science, Technology, Engineering, and Math) program." is replaced with the following sentence: "On August 1, 2019, VA launched the Edith Nourse Rogers STEM Scholarship for students enrolled in a high-demand STEM (Science, Technology, Engineering, and Math) program."

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
