### PR TITLE
Polyfill fetch for all unit tests

### DIFF
--- a/src/applications/vic-v2/tests/components/PhotoPreview.unit.spec.jsx
+++ b/src/applications/vic-v2/tests/components/PhotoPreview.unit.spec.jsx
@@ -2,12 +2,8 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
-import 'isomorphic-fetch';
 
-import {
-  mockFetch,
-  resetFetch,
-} from '../../../../platform/testing/unit/helpers';
+import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
 
 import PhotoPreview from '../../components/PhotoPreview.jsx';
 

--- a/src/platform/testing/unit/mocha.opts
+++ b/src/platform/testing/unit/mocha.opts
@@ -3,6 +3,7 @@
 --require choma
 --require @babel/polyfill
 --require blob-polyfill
+--require isomorphic-fetch
 --compilers js:@babel/register,jsx:@babel/register
 --prof
 --reporter dot


### PR DESCRIPTION
## Description
Before making this fix, unit tests that expected Response to be defined
would fail if you ran them in isolation. But they did pass just fine if
you ran all unit tests. Turns out the problem was that the vic-v2 unit
tests imported the `isomorphic-fetch` package and that was the reason
that Response-dependent tests would pass if you ran them all. This
change adds `isomorphic-fetch` to the list of packages required by
Mocha. Thus any unit test that expects fetch-related classes to be
defined (in our case that's just the Response class) will now pass when
run in isolation.

## Testing done
All existing unit tests pass.

## Screenshots
N/A

## Acceptance criteria
- [ ] Unit tests the rely on Response being defined will pass when run in isolation

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs