### PR TITLE
19402: GIBCT landing page: Learn more link is not displaying properly on mobile

### DIFF
--- a/src/applications/gi/components/search/LandingPageTypeOfInstitutionFilter.jsx
+++ b/src/applications/gi/components/search/LandingPageTypeOfInstitutionFilter.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import RadioButtons from '../RadioButtons';
 import PropTypes from 'prop-types';
 
+import environment from 'platform/utilities/environment';
+
 class LandingPageTypeOfInstitutionFilter extends React.Component {
   static propTypes = {
     category: PropTypes.string.isRequired,
@@ -21,21 +23,35 @@ class LandingPageTypeOfInstitutionFilter extends React.Component {
       },
     ];
     if (this.props.displayVetTecOption) {
-      const vetTecLabel = (
-        <span className="vads-u-padding-top--1 vads-u-margin-left--0p5">
-          {' '}
-          (
-          <button
-            aria-label="VET TEC training providers only learn more"
-            type="button"
-            className="va-button-link learn-more-button"
-            onClick={() => this.props.showModal('vetTec')}
-          >
-            Learn more
-          </button>
-          ){' '}
-        </span>
-      );
+      const vetTecLabel =
+        // Production flag for 19402
+        !environment.isProduction() ? (
+          <span className="vads-u-padding-top--1 vads-u-margin-left--0p5 learnMoreLabel">
+            {' '}
+            <button
+              aria-label="VET TEC training providers only learn more"
+              type="button"
+              className="va-button-link learn-more-button"
+              onClick={() => this.props.showModal('vetTec')}
+            >
+              (Learn more)
+            </button>{' '}
+          </span>
+        ) : (
+          <span className="vads-u-padding-top--1 vads-u-margin-left--0p5">
+            {' '}
+            (
+            <button
+              aria-label="VET TEC training providers only learn more"
+              type="button"
+              className="va-button-link learn-more-button"
+              onClick={() => this.props.showModal('vetTec')}
+            >
+              Learn more
+            </button>
+            ){' '}
+          </span>
+        );
 
       options.push({
         value: 'vettec',

--- a/src/applications/gi/sass/gi.scss
+++ b/src/applications/gi/sass/gi.scss
@@ -106,7 +106,9 @@
 
 .gids-radio-buttons {
   position: relative;
-  display: flex;
+  @include media($small-screen) {
+    display: flex;
+  }
 }
 
 .gids-radio-buttons-input {

--- a/src/applications/gi/sass/partials/_gi-landing-page.scss
+++ b/src/applications/gi/sass/partials/_gi-landing-page.scss
@@ -1,5 +1,4 @@
 .gi-app .landing-page {
-
   p.subheading {
     color: $color-primary;
     letter-spacing: normal;
@@ -12,8 +11,16 @@
   }
 
   .video-sidebar h5 {
-    margin-top: .5em;
+    margin-top: 0.5em;
     padding: 0;
   }
 
+  .learnMoreLabel {
+    @include media-maxwidth($small-screen) {
+      padding-left: 1.5em;
+      padding-top: 0 !important;
+      display: block;
+      margin-top: -0.5em !important;
+    }
+  }
 }

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import environment from 'platform/utilities/environment';
+
 export const renderSchoolClosingFlag = result => {
   const { schoolClosing } = result;
   if (!schoolClosing) return null;
@@ -33,16 +35,29 @@ export const renderPreferredProviderFlag = result => {
   );
 };
 
-export const renderLearnMoreLabel = ({ text, modal, showModal, component }) => (
-  <span>
-    {text} (
-    <button
-      type="button"
-      className="va-button-link learn-more-button"
-      onClick={showModal.bind(component, modal)}
-    >
-      Learn more
-    </button>
-    )
-  </span>
-);
+export const renderLearnMoreLabel = ({ text, modal, showModal, component }) =>
+  // Production flag for 19402
+  !environment.isProduction() ? (
+    <span>
+      {text}{' '}
+      <button
+        type="button"
+        className="va-button-link learn-more-button"
+        onClick={showModal.bind(component, modal)}
+      >
+        (Learn more)
+      </button>
+    </span>
+  ) : (
+    <span>
+      {text} (
+      <button
+        type="button"
+        className="va-button-link learn-more-button"
+        onClick={showModal.bind(component, modal)}
+      >
+        Learn more
+      </button>
+      )
+    </span>
+  );


### PR DESCRIPTION
## Description
Text wrapping for all "Learn More" links should be updated to have consistency with the text they are associated with on the landing page of the GI Bill Comparison Tool on Mobile view.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19402

## Testing done
UX approval, Unit, E2E, and Manual testing pass locally

## Screenshots
![LearnMore](https://user-images.githubusercontent.com/48804834/62717229-8314e980-b9d1-11e9-9f4a-3ae0b6cbdb2f.png)


## Acceptance criteria
- [x] Issue corrected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
