### PR TITLE
show DowntimeNotification for Pagerduty warning status

### DIFF
--- a/src/platform/monitoring/external-services/ExternalServicesError.jsx
+++ b/src/platform/monitoring/external-services/ExternalServicesError.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { getBackendStatuses } from './actions';
 import { EXTERNAL_SERVICES } from './config';
 
-const OPERATIONAL_STATUSES = ['active', 'warning'];
+const OPERATIONAL_STATUSES = ['active'];
 
 /**
  * A wrapper component that render its children if the application's dependencies are failing.


### PR DESCRIPTION
## Description
After a few weeks of use it seems like it's preferable to show the downtime banner when t Pagerduty has a status of warning. It means that no action is necessary for a PD alert and the banner will be removed automatically when the service resolves.  The tradeoff is that we have no way to remove the banner, other than resolving the alert, but so far we've seen no need to do so.

related documentation and alert language in https://github.com/department-of-veterans-affairs/devops/pull/5347
## Testing done
none


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
