### PR TITLE
clean up imports to prep for moving entire directory

### DIFF
--- a/src/applications/personalization/profile360/vet360/actions/transactions.js
+++ b/src/applications/personalization/profile360/vet360/actions/transactions.js
@@ -1,6 +1,6 @@
-import { apiRequest } from '../../../../../platform/utilities/api';
-import { refreshProfile } from '../../../../../platform/user/profile/actions';
-import recordEvent from '../../../../../platform/monitoring/record-event';
+import { apiRequest } from 'platform/utilities/api';
+import { refreshProfile } from 'platform/user/profile/actions';
+import recordEvent from 'platform/monitoring/record-event';
 
 import localVet360, { isVet360Configured } from '../util/local-vet360';
 import {

--- a/src/applications/personalization/profile360/vet360/components/AddressField/AddressForm.jsx
+++ b/src/applications/personalization/profile360/vet360/components/AddressField/AddressForm.jsx
@@ -2,15 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
-import { focusElement } from '../../../../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 
-import ErrorableSelect from '../../../../../letters/components/ErrorableSelect';
-import ErrorableTextInput from '../../../../../letters/components/ErrorableTextInput';
+import ErrorableSelect from 'applications/letters/components/ErrorableSelect';
+import ErrorableTextInput from 'applications/letters/components/ErrorableTextInput';
 import {
   STATE_CODE_TO_NAME,
   MILITARY_CITIES,
   MILITARY_STATES,
-} from '../../../../../letters/utils/constants';
+} from 'applications/letters/utils/constants';
 
 /**
  * Input component for an address.

--- a/src/applications/personalization/profile360/vet360/components/AddressField/View.jsx
+++ b/src/applications/personalization/profile360/vet360/components/AddressField/View.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { formatAddress } from '../../../../../../platform/forms/address/helpers';
+import { formatAddress } from 'platform/forms/address/helpers';
 
 export default function AddressView({ data: address }) {
   const { street, cityStateZip, country } = formatAddress({

--- a/src/applications/personalization/profile360/vet360/components/EmailField/index.jsx
+++ b/src/applications/personalization/profile360/vet360/components/EmailField/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { API_ROUTES, FIELD_NAMES } from '../../constants';
 
-import { isValidEmail } from '../../../../../../platform/forms/validations';
+import { isValidEmail } from 'platform/forms/validations';
 
 import Vet360ProfileField from '../../containers/ProfileField';
 import EmailEditModal from './EditModal';

--- a/src/applications/personalization/profile360/vet360/components/PhoneField/index.jsx
+++ b/src/applications/personalization/profile360/vet360/components/PhoneField/index.jsx
@@ -4,7 +4,7 @@ import pickBy from 'lodash/pickBy';
 
 import { API_ROUTES, FIELD_NAMES, PHONE_TYPE, USA } from '../../constants';
 
-import { isValidPhone } from '../../../../../../platform/forms/validations';
+import { isValidPhone } from 'platform/forms/validations';
 
 import Vet360ProfileField from '../../containers/ProfileField';
 

--- a/src/applications/personalization/profile360/vet360/components/base/EditModalErrorMessage.jsx
+++ b/src/applications/personalization/profile360/vet360/components/base/EditModalErrorMessage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import facilityLocator from '../../../../../facility-locator/manifest';
+import facilityLocator from 'applications/facility-locator/manifest';
 
 import {
   LOW_CONFIDENCE_ADDRESS_ERROR_CODES,

--- a/src/applications/personalization/profile360/vet360/components/base/TransactionErrorBanner.jsx
+++ b/src/applications/personalization/profile360/vet360/components/base/TransactionErrorBanner.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import facilityLocator from '../../../../../facility-locator/manifest';
+import facilityLocator from 'applications/facility-locator/manifest';
 
 import {
   hasGenericUpdateError,

--- a/src/applications/personalization/profile360/vet360/constants/index.js
+++ b/src/applications/personalization/profile360/vet360/constants/index.js
@@ -1,4 +1,4 @@
-import { MILITARY_STATES } from '../../../../letters/utils/constants';
+import { MILITARY_STATES } from 'applications/letters/utils/constants';
 
 import states from './states.json';
 import countries from './countries.json';

--- a/src/applications/personalization/profile360/vet360/containers/CopyMailingAddress.jsx
+++ b/src/applications/personalization/profile360/vet360/containers/CopyMailingAddress.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 
-import { isEmptyAddress } from '../../../../../platform/forms/address/helpers';
+import { isEmptyAddress } from 'platform/forms/address/helpers';
 
 import { FIELD_NAMES } from '../constants';
 

--- a/src/applications/personalization/profile360/vet360/containers/ProfileField.jsx
+++ b/src/applications/personalization/profile360/vet360/containers/ProfileField.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import recordEvent from '../../../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 
 import * as VET360 from '../constants';
 

--- a/src/applications/personalization/profile360/vet360/containers/TransactionReporter.jsx
+++ b/src/applications/personalization/profile360/vet360/containers/TransactionReporter.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import scrollToTop from '../../../../../platform/utilities/ui/scrollToTop';
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
 
 import {
   selectVet360FailedTransactions,

--- a/src/applications/personalization/profile360/vet360/selectors.js
+++ b/src/applications/personalization/profile360/vet360/selectors.js
@@ -1,4 +1,4 @@
-import backendServices from '../../../../platform/user/profile/constants/backendServices';
+import backendServices from 'platform/user/profile/constants/backendServices';
 
 import { VET360_INITIALIZATION_STATUS, INIT_VET360_ID } from './constants';
 

--- a/src/applications/personalization/profile360/vet360/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile360/vet360/tests/selectors.unit.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import backendServices from '../../../../../platform/user/profile/constants/backendServices';
+import backendServices from 'platform/user/profile/constants/backendServices';
 
 import {
   TRANSACTION_STATUS,


### PR DESCRIPTION
## Description
This PR simply cleans up some of the relative paths used in `imports` that are ugly and in some cases will break when the `vet360` directory is moved into the `platform` directory (work to be done for this ticket: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11895)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs