### PR TITLE
Remove the @chris.valarida notification for failed tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,6 @@ node('vetsgov-general-purpose') {
             try {
               sh "docker-compose -p e2e run --rm --entrypoint npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run test:puppeteer:docker"
             } catch (error) {
-	      // Notify Chris and fail the build
               commonStages.puppeteerNotification()
               throw error
             }

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -87,7 +87,7 @@ def slackNotify() {
 }
 
 def puppeteerNotification() {
-  message = "(Testing) @chris.valarida: `${env.BRANCH_NAME}` failed the puppeteer tests. |${env.RUN_DISPLAY_URL}".stripMargin()
+  message = "`${env.BRANCH_NAME}` failed the puppeteer tests. |${env.RUN_DISPLAY_URL}".stripMargin()
   slackSend message: message,
     color: 'danger',
     failOnError: true


### PR DESCRIPTION
## Description
I made a fix to the form app tester and have been monitoring it for over a week now. I haven't been alerted for any puppeteer test failures after the fix (for branches that were created after I merged it in), so I think we're good to go.

I'm calling it official and am removing my @ mention.