### PR TITLE
19452 - Remove 'student outcome' table from school profile page

### DIFF
--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -17,6 +17,7 @@ import CautionaryInformation from '../components/profile/CautionaryInformation';
 import AdditionalInformation from '../components/profile/AdditionalInformation';
 import VetTecInstitutionProfile from '../components/vet-tec/VetTecInstitutionProfile';
 import { outcomeNumbers } from '../selectors/outcomes';
+import environment from 'platform/utilities/environment';
 
 const { Element: ScrollElement, scroller } = Scroll;
 
@@ -103,21 +104,22 @@ export class ProfilePage extends React.Component {
                     />
                   </AccordionItem>
                 )}
-                {!isOJT && (
-                  <AccordionItem button="Student outcomes">
-                    <If
-                      condition={
-                        !!profile.attributes.facilityCode && !!constants
-                      }
-                      comment="TODO"
-                    >
-                      <Outcomes
-                        graphing={outcomes}
-                        onShowModal={this.props.showModal}
-                      />
-                    </If>
-                  </AccordionItem>
-                )}
+                {!isOJT ||
+                  (environment.isProduction() && ( // production flag to remove incorrect table from view (story #19452, sprint 27)
+                    <AccordionItem button="Student outcomes">
+                      <If
+                        condition={
+                          !!profile.attributes.facilityCode && !!constants
+                        }
+                        comment="TODO"
+                      >
+                        <Outcomes
+                          graphing={outcomes}
+                          onShowModal={this.props.showModal}
+                        />
+                      </If>
+                    </AccordionItem>
+                  ))}
                 <AccordionItem
                   button="Cautionary information"
                   ref={c => {

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -105,7 +105,7 @@ export class ProfilePage extends React.Component {
                   </AccordionItem>
                 )}
                 {!isOJT ||
-                  (environment.isProduction() && ( // production flag to remove incorrect table from view (story #19452, sprint 27)
+                  (!environment.isProduction() && ( // production flag to remove incorrect table from view (story #19452, sprint 27)
                     <AccordionItem button="Student outcomes">
                       <If
                         condition={

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -104,8 +104,8 @@ export class ProfilePage extends React.Component {
                     />
                   </AccordionItem>
                 )}
-                {!isOJT ||
-                  (!environment.isProduction() && ( // production flag to remove incorrect table from view (story #19452, sprint 27)
+                {!isOJT &&
+                  (environment.isProduction() && ( // production flag to display table only on staging (story #19452, sprint 27)
                     <AccordionItem button="Student outcomes">
                       <If
                         condition={


### PR DESCRIPTION
## Description
As a Comparison Tool user, I should not be able to view the student outcome section because it contains inaccurate information. This work is completed behind a flag so that it is only available in the staging environments and below. We'll need another story to go in and remove the actual code black and prod flag.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19452

## Testing done
Confirmed in UI locally

## Screenshots
Before production flag added that hides this section on staging:
<img width="1010" alt="Screen Shot 2019-08-09 at 2 00 01 PM" src="https://user-images.githubusercontent.com/52166695/62799174-23d8d700-baae-11e9-8cac-b2c6374e1b84.png">

After hiding section behind a production flag (section to be removed entirely upon approval):
<img width="1139" alt="Screen Shot 2019-08-09 at 1 57 49 PM" src="https://user-images.githubusercontent.com/52166695/62799206-34894d00-baae-11e9-9be2-e81465eb0229.png">

## Acceptance criteria
- [x] This work is completed behind a flag so that it is only available in the staging environments and below.

## Definition of done
- [x] section isn't visible in staging, but still is visible on Production (for now)
