### PR TITLE
VAGOV-4731: Past Events Listing Page and Detail Page Updates

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-facility-events.scss
+++ b/src/applications/static-pages/sass/modules/_m-facility-events.scss
@@ -13,3 +13,17 @@
 .va-c-social-icon {
   color: $color-link-default;
 }
+
+.va-c-event-toggle {
+  &:not(last-child) {
+    border-right: none;
+  }
+  .usa-button {
+    float: left;
+  }
+  &:after {
+    content: "";
+    clear: both;
+    display: table;
+  }
+}

--- a/src/applications/static-pages/sass/modules/_m-facility-events.scss
+++ b/src/applications/static-pages/sass/modules/_m-facility-events.scss
@@ -14,16 +14,20 @@
   color: $color-link-default;
 }
 
-.va-c-event-toggle {
-  &:not(last-child) {
-    border-right: none;
-  }
+.va-c-btn-group {
+  font-size: 0;
+  line-height: 1;
+  white-space: nowrap;
+  display: inline-block;
   .usa-button {
-    float: left;
-  }
-  &:after {
-    content: "";
-    clear: both;
-    display: table;
+    &:first-child {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+      margin-right: 0;
+    };
+    &:last-child {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
   }
 }

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -1,4 +1,9 @@
 <div id="events-list-toggle" class="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4">
-    <a href="/events" class="usa-button">Upcoming Events</a>
-    <a href="/past-events" class="usa-button usa-button-disabled">Past Events</a>
+    {% if url contains 'past-events' %}
+        <a href={{ url | replace_first: 'past-events', 'events' }} class="usa-button">Upcoming Events</a>
+        <a href={{ url }} class="usa-button">Past Events</a>
+    {% else %}
+        <a href={{ url }} class="usa-button">Upcoming Events</a>
+        <a href={{ url | replace_first: 'events', 'past-events'}} class="usa-button">Past Events</a>
+    {% endif %}
 </div>

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -1,9 +1,9 @@
-<div id="events-list-toggle" class="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4">
+<div id="events-list-toggle" class="va-c-event-toggle vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4" role="group" aria-label="Events List Toggle">
     {% if url contains 'past-events' %}
-        <a href={{ url | replace_first: 'past-events', 'events' }} class="usa-button">Upcoming Events</a>
-        <a href={{ url }} class="usa-button">Past Events</a>
+        <a role="button" href={{ url | replace_first: 'past-events', 'events' }} class="usa-button usa-button-secondary">Upcoming events</a>
+        <a role="button" href={{ url }} class="usa-button">Past events</a>
     {% else %}
-        <a href={{ url }} class="usa-button">Upcoming Events</a>
-        <a href={{ url | replace_first: 'events', 'past-events'}} class="usa-button">Past Events</a>
+        <a role="button" href={{ url }} class="usa-button">Upcoming events</a>
+        <a role="button" href={{ url | replace_first: 'events', 'past-events'}} class="usa-button usa-button-secondary">Past events</a>
     {% endif %}
 </div>

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -1,0 +1,4 @@
+<div id="events-list-toggle" class="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4">
+    <a href="/events" class="usa-button">Upcoming Events</a>
+    <a href="/past-events" class="usa-button usa-button-disabled">Past Events</a>
+</div>

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -1,4 +1,6 @@
-<div id="events-list-toggle" class="va-c-event-toggle vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4" role="group" aria-label="Events List Toggle">
+<div id="events-list-toggle"
+     class="va-c-btn-group vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4"
+     role="group" aria-label="Events List Toggle">
     {% if url contains 'past-events' %}
         <a role="button" href={{ url | replace_first: 'past-events', 'events' }} class="usa-button usa-button-secondary">Upcoming events</a>
         <a role="button" href={{ url }} class="usa-button">Past events</a>

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -322,4 +322,7 @@ module.exports = function registerFilters() {
     !!childPageEntityUrl.breadcrumb.find(
       b => b.text.toLowerCase() === parentPage.toLowerCase(),
     );
+
+  // find out if date is in the past
+  liquid.filters.isPastDate = contentDate => moment().diff(contentDate, 'days');
 };

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -78,7 +78,6 @@ Example data:
 
 {% assign start_date_no_time = fieldDate.value | formatDate: "dddd, MMM D" %}
 {% assign end_date_no_time = fieldDate.endValue | formatDate: "dddd, MMM D" %}
-{% assign days_since = fieldDate.value | isPastDate %}
 
 {% assign start_time = fieldDate.value | formatDate: "h:mm A" %}
 {% assign end_time = fieldDate.endValue | formatDate: "h:mm A" %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -78,6 +78,7 @@ Example data:
 
 {% assign start_date_no_time = fieldDate.value | formatDate: "dddd, MMM D" %}
 {% assign end_date_no_time = fieldDate.endValue | formatDate: "dddd, MMM D" %}
+{% assign days_since = fieldDate.value | isPastDate %}
 
 {% assign start_time = fieldDate.value | formatDate: "h:mm A" %}
 {% assign end_time = fieldDate.endValue | formatDate: "h:mm A" %}
@@ -192,7 +193,7 @@ Example data:
                 <div class="registration vads-u-margin-top--4 vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--1">
                     <p class="vads-u-font-weight--bold vads-u-margin-top--0 vads-u-margin-bottom--1">Registration</p>
                     {% if start_timestamp < current_timestamp %}
-                        <p class="vads-u-margin--0">This event already happened.</p>
+                        <p class="vads-u-margin--0 vads-u-color--secondary vads-u-font-weight--bold">This event already happened.</p>
                     {% else %}
                         {% if fieldLink %}
                             <p class="vads-u-margin--0"><a

--- a/src/site/layouts/events_page.drupal.liquid
+++ b/src/site/layouts/events_page.drupal.liquid
@@ -59,6 +59,9 @@ Example data:
           <div class="va-introtext vads-u-margin-bottom--6">
             {{ fieldIntroTextEventsPage.processed }}
           </div>
+
+          {% include "src/site/facilities/facilities_events_toggle.drupal.liquid" %}
+
           {% if paginator.prev == null %}
           {% for featuredEvent in eventTeasers.entities %}
           {% if forloop.first == true %}

--- a/src/site/layouts/events_page.drupal.liquid
+++ b/src/site/layouts/events_page.drupal.liquid
@@ -60,7 +60,7 @@ Example data:
             {{ fieldIntroTextEventsPage.processed }}
           </div>
 
-          {% include "src/site/facilities/facilities_events_toggle.drupal.liquid" %}
+          {% include "src/site/facilities/facilities_events_toggle.drupal.liquid" with url = entityUrl.path %}
 
           {% if paginator.prev == null %}
           {% for featuredEvent in eventTeasers.entities %}

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -207,7 +207,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   const pastEventsPage = updateEntityUrlObj(
     pastEventsObj,
     drupalPagePath,
-    'Past Events',
+    'Past events',
   );
   const pastEventsPagePath = pastEventsPage.entityUrl.path;
   pastEventsPage.regionOrOffice = page.title;

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -147,9 +147,31 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
 
   // Events listing page
   const allEvents = page.allEventTeasers;
+
+  // get past events
+  const pastEventTeasers = {
+    entities: [],
+  };
+
+  // get current events
+  const currentEventTeasers = {
+    entities: [],
+  };
+
+  _.forEach(allEvents.entities, value => {
+    const eventTeaser = value;
+    const startDate = eventTeaser.fieldDate.startDate;
+    const isPast = moment().diff(startDate, 'days');
+    if (isPast >= 1) {
+      pastEventTeasers.entities.push(eventTeaser);
+    } else {
+      currentEventTeasers.entities.push(eventTeaser);
+    }
+  });
+
   const eventEntityUrl = createEntityUrlObj(drupalPagePath);
   const eventObj = Object.assign(
-    { allEventTeasers: allEvents },
+    { allEventTeasers: currentEventTeasers },
     { eventTeasers: page.eventTeasers },
     { fieldIntroTextEventsPage: page.fieldIntroTextEventsPage },
     { facilitySidebar: sidebar },
@@ -173,20 +195,6 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   // Past Events listing page
   const pastEventsEntityUrl = createEntityUrlObj(drupalPagePath);
 
-  // get past events
-  const pastEventTeasers = {
-    entities: [],
-  };
-
-  _.forEach(allEvents.entities, value => {
-    const eventTeaser = value;
-    const startDate = eventTeaser.fieldDate.startDate;
-    const isPast = moment().diff(startDate, 'days');
-    if (isPast >= 1) {
-      pastEventTeasers.entities.push(eventTeaser);
-    }
-  });
-
   const pastEventsObj = Object.assign(
     { allEventTeasers: pastEventTeasers },
     { eventTeasers: page.eventTeasers },
@@ -206,7 +214,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   eventPage.entityUrl = generateBreadCrumbs(pastEventsPagePath);
 
   paginatePages(
-    eventPage,
+    pastEventsPage,
     files,
     'allEventTeasers',
     'events_page.drupal.liquid',

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -8,6 +8,7 @@ const {
 } = require('./page');
 
 const _ = require('lodash');
+const moment = require('moment');
 
 // Creates the facility pages
 function createHealthCareRegionListPages(page, drupalPagePath, files) {
@@ -145,9 +146,10 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   );
 
   // Events listing page
+  const allEvents = page.allEventTeasers;
   const eventEntityUrl = createEntityUrlObj(drupalPagePath);
   const eventObj = Object.assign(
-    { allEventTeasers: page.allEventTeasers },
+    { allEventTeasers: allEvents },
     { eventTeasers: page.eventTeasers },
     { fieldIntroTextEventsPage: page.fieldIntroTextEventsPage },
     { facilitySidebar: sidebar },
@@ -166,6 +168,49 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'allEventTeasers',
     'events_page.drupal.liquid',
     'events',
+  );
+
+  // Past Events listing page
+  const pastEventsEntityUrl = createEntityUrlObj(drupalPagePath);
+
+  // get past events
+  const pastEventTeasers = {
+    entities: [],
+  };
+
+  _.forEach(allEvents.entities, value => {
+    const eventTeaser = value;
+    const startDate = eventTeaser.fieldDate.startDate;
+    const isPast = moment().diff(startDate, 'days');
+    if (isPast >= 1) {
+      pastEventTeasers.entities.push(eventTeaser);
+    }
+  });
+
+  const pastEventsObj = Object.assign(
+    { allEventTeasers: pastEventTeasers },
+    { eventTeasers: page.eventTeasers },
+    { fieldIntroTextEventsPage: page.fieldIntroTextEventsPage },
+    { facilitySidebar: sidebar },
+    { entityUrl: pastEventsEntityUrl },
+    { title: page.title },
+    { alert: page.alert },
+  );
+  const pastEventsPage = updateEntityUrlObj(
+    pastEventsObj,
+    drupalPagePath,
+    'Past Events',
+  );
+  const pastEventsPagePath = pastEventsPage.entityUrl.path;
+  pastEventsPage.regionOrOffice = page.title;
+  eventPage.entityUrl = generateBreadCrumbs(pastEventsPagePath);
+
+  paginatePages(
+    eventPage,
+    files,
+    'allEventTeasers',
+    'events_page.drupal.liquid',
+    'past-events',
   );
 
   // Staff bio listing page


### PR DESCRIPTION
## Description
Creates a past events listing page for facilities (/pittsburgh-health-care/past-events/). Adds styling to event detail pages to indicate if an event has passed.

## Testing done
Tested locally with local data. To test yourself change dates for a few events to any date in the past (ex: 5/15/2019) rebuild site. Visit http://localhost:3001/pittsburgh-health-care/past-events/ and http://localhost:3001/pittsburgh-health-care/events/

## Screenshots
![Screen Shot 2019-08-12 at 4 59 49 PM](https://user-images.githubusercontent.com/3157339/62904208-a073eb80-bd22-11e9-98df-348da7bfbbff.png)

![Screen Shot 2019-08-12 at 4 25 09 PM](https://user-images.githubusercontent.com/3157339/62902741-c5b22b00-bd1d-11e9-9019-8ec7da44e59a.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
