### PR TITLE
[Forms] Fix broken links

### DIFF
--- a/src/applications/burials/components/IntroductionPage.jsx
+++ b/src/applications/burials/components/IntroductionPage.jsx
@@ -69,7 +69,7 @@ class IntroductionPage extends React.Component {
                 <strong>What if I need help filling out my application?</strong>{' '}
                 An accredited representative, like a Veterans Service Officer
                 (VSO), can help you fill out your claim.{' '}
-                <a href="/disability-benefits/apply/help/index.html">
+                <a href="/disability/get-help-filing-claim/">
                   Get help filing your claim
                 </a>
                 .

--- a/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
@@ -128,7 +128,7 @@ class IntroductionPage extends React.Component {
                 help you with your claim.
               </p>
               <p>
-                <a href="/disability-benefits/apply/help/index.html">
+                <a href="/disability/get-help-filing-claim/">
                   Get help filing your claim
                 </a>
                 .

--- a/src/applications/disability-benefits/686/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/686/containers/IntroductionPage.jsx
@@ -94,7 +94,7 @@ class IntroductionPage extends React.Component {
                 (VSO), can help you fill out your claim.
               </p>
               <div>
-                <a href="/disability-benefits/apply/help/index.html">
+                <a href="/disability/get-help-filing-claim/">
                   Get help filing your claim
                 </a>
               </div>

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -91,7 +91,7 @@ class IntroductionPage extends React.Component {
                 (VSO), can help you fill out your claim.{' '}
               </p>
               <p>
-                <a href="/disability-benefits/apply/help/index.html">
+                <a href="/disability/get-help-filing-claim/">
                   Get help filing your claim
                 </a>
                 .

--- a/src/applications/edu-benefits/0993/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/0993/containers/IntroductionPage.jsx
@@ -33,7 +33,7 @@ class IntroductionPage extends React.Component {
                 <strong>What if I need help filling out my application?</strong>{' '}
                 An accredited representative, like a Veterans Service Officer
                 (VSO), can help you fill out your claim.{' '}
-                <a href="/disability-benefits/apply/help/index.html">
+                <a href="/disability/get-help-filing-claim/">
                   Get help filing your claim
                 </a>
                 .

--- a/src/applications/edu-benefits/1990n/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1990n/containers/IntroductionPage.jsx
@@ -45,7 +45,7 @@ export class IntroductionPage extends React.Component {
                 <strong>What if I need help filling out my application?</strong>{' '}
                 An accredited representative, like a Veterans Service Officer
                 (VSO), can help you fill out your claim.{' '}
-                <a href="/disability-benefits/apply/help/index.html">
+                <a href="/disability/get-help-filing-claim/">
                   Get help filing your claim
                 </a>
                 .

--- a/src/applications/edu-benefits/1995-STEM/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1995-STEM/containers/IntroductionPage.jsx
@@ -58,7 +58,7 @@ export class IntroductionPage extends React.Component {
                   </strong>{' '}
                   An accredited representative, like a Veterans Service Officer
                   (VSO), can help you fill out your claim.{' '}
-                  <a href="/disability-benefits/apply/help/index.html">
+                  <a href="/disability/get-help-filing-claim/">
                     Get help filing your claim
                   </a>
                   .

--- a/src/applications/edu-benefits/1995/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1995/containers/IntroductionPage.jsx
@@ -58,7 +58,7 @@ export class IntroductionPage extends React.Component {
                   </strong>{' '}
                   An accredited representative, like a Veterans Service Officer
                   (VSO), can help you fill out your claim.{' '}
-                  <a href="/disability-benefits/apply/help/index.html">
+                  <a href="/disability/get-help-filing-claim/">
                     Get help filing your claim
                   </a>
                   .

--- a/src/applications/edu-benefits/5490/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/5490/containers/IntroductionPage.jsx
@@ -47,7 +47,7 @@ export class IntroductionPage extends React.Component {
                 <strong>What if I need help filling out my application?</strong>{' '}
                 An accredited representative, like a Veterans Service Officer
                 (VSO), can help you fill out your claim.{' '}
-                <a href="/disability-benefits/apply/help/index.html">
+                <a href="/disability/get-help-filing-claim/">
                   Get help filing your claim
                 </a>
                 .

--- a/src/applications/edu-benefits/5495/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/5495/containers/IntroductionPage.jsx
@@ -46,7 +46,7 @@ export class IntroductionPage extends React.Component {
                 <strong>What if I need help filling out my application?</strong>{' '}
                 An accredited representative, like a Veterans Service Officer
                 (VSO), can help you fill out your claim.{' '}
-                <a href="/disability-benefits/apply/help/index.html">
+                <a href="/disability/get-help-filing-claim/">
                   Get help filing your claim
                 </a>
                 .

--- a/src/applications/hca/components/HCASubwayMap.jsx
+++ b/src/applications/hca/components/HCASubwayMap.jsx
@@ -33,7 +33,7 @@ export default function HCASubwayMap() {
               <strong>What if I need help filling out my application?</strong>{' '}
               An accredited representative, like a Veterans Service Officer
               (VSO), can help you fill out your claim.{' '}
-              <a href="/disability-benefits/apply/help/index.html">
+              <a href="/disability/get-help-filing-claim/">
                 Get help filing your claim
               </a>
               .

--- a/src/applications/vre/chapter36/components/IntroductionPage.jsx
+++ b/src/applications/vre/chapter36/components/IntroductionPage.jsx
@@ -59,7 +59,7 @@ class IntroductionPage extends React.Component {
                 <strong>What if I need help filling out my application?</strong>{' '}
                 An accredited representative with a Veterans Service
                 Organization (VSO) can help you fill out your claim.{' '}
-                <a href="/disability-benefits/apply/help/index.html">
+                <a href="/disability/get-help-filing-claim/">
                   Get help filing your claim
                 </a>
                 .


### PR DESCRIPTION
## Description
This pull request fixes a broken link on the form introduction pages. This link is an old Vets.gov reference that snuck under the radar during our URL mappings because they contained `index.html` so did not match our URL-updating method.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/910

## Testing done
Went to the page

## Screenshots
N/A

## Acceptance criteria
- [x] No more 404

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
