### PR TITLE
Consolidate mock fetch response helpers

### DIFF
--- a/src/applications/burials/tests/helpers.unit.spec.jsx
+++ b/src/applications/burials/tests/helpers.unit.spec.jsx
@@ -3,15 +3,11 @@ import sinon from 'sinon';
 
 import { submit } from '../helpers.jsx';
 
-import { mockFetch, resetFetch } from '../../../platform/testing/unit/helpers';
-
-function setFetchResponse(stub, data, headers = {}) {
-  const response = new Response();
-  response.ok = true;
-  response.headers.get = headerID => headers[headerID] || null;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
+import {
+  mockFetch,
+  resetFetch,
+  setFetchJSONResponse as setFetchResponse,
+} from 'platform/testing/unit/helpers';
 
 describe('Burials helpers', () => {
   describe('submit', () => {
@@ -41,41 +37,29 @@ describe('Burials helpers', () => {
     });
     it('should resolve if polling state is success', () => {
       mockFetch();
-      setFetchResponse(
-        global.fetch.onFirstCall(),
-        {
-          data: {
-            attributes: {
-              guid: 'test',
-            },
+      setFetchResponse(global.fetch.onFirstCall(), {
+        data: {
+          attributes: {
+            guid: 'test',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
-      setFetchResponse(
-        global.fetch.onSecondCall(),
-        {
-          data: {
-            attributes: {
-              state: 'pending',
-            },
+      });
+      setFetchResponse(global.fetch.onSecondCall(), {
+        data: {
+          attributes: {
+            state: 'pending',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
+      });
       const response = {};
-      setFetchResponse(
-        global.fetch.onThirdCall(),
-        {
-          data: {
-            attributes: {
-              state: 'success',
-              response,
-            },
+      setFetchResponse(global.fetch.onThirdCall(), {
+        data: {
+          attributes: {
+            state: 'success',
+            response,
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
+      });
       const formConfig = {
         chapters: {},
       };
@@ -89,39 +73,27 @@ describe('Burials helpers', () => {
     });
     it('should reject if polling state is failed', () => {
       mockFetch();
-      setFetchResponse(
-        global.fetch.onFirstCall(),
-        {
-          data: {
-            attributes: {
-              guid: 'test',
-            },
+      setFetchResponse(global.fetch.onFirstCall(), {
+        data: {
+          attributes: {
+            guid: 'test',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
-      setFetchResponse(
-        global.fetch.onSecondCall(),
-        {
-          data: {
-            attributes: {
-              state: 'pending',
-            },
+      });
+      setFetchResponse(global.fetch.onSecondCall(), {
+        data: {
+          attributes: {
+            state: 'pending',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
-      setFetchResponse(
-        global.fetch.onThirdCall(),
-        {
-          data: {
-            attributes: {
-              state: 'failed',
-            },
+      });
+      setFetchResponse(global.fetch.onThirdCall(), {
+        data: {
+          attributes: {
+            state: 'failed',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
+      });
       const formConfig = {
         chapters: {},
       };

--- a/src/applications/disability-benefits/686/tests/actions/authorization.unit.spec.js
+++ b/src/applications/disability-benefits/686/tests/actions/authorization.unit.spec.js
@@ -1,22 +1,17 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers.js';
+import {
+  mockFetch,
+  resetFetch,
+  setFetchJSONResponse as setFetchResponse,
+} from 'platform/testing/unit/helpers.js';
 import {
   verifyDisabilityRating,
   LOAD_30_PERCENT_DISABILITY_RATING_STARTED,
   LOAD_30_PERCENT_DISABILITY_RATING_SUCCEEDED,
   LOAD_30_PERCENT_DISABILITY_RATING_FAILED,
 } from '../../../686/actions/index';
-
-function setFetchResponse(stub, data) {
-  const response = new Response(null, {
-    headers: { 'content-type': ['application/json'] },
-  });
-  response.ok = true;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
 
 function setFetchFailure(stub, data) {
   const response = new Response(null, {

--- a/src/applications/disability-benefits/686/tests/actions/authorization.unit.spec.js
+++ b/src/applications/disability-benefits/686/tests/actions/authorization.unit.spec.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import {
   mockFetch,
   resetFetch,
+  setFetchJSONFailure as setFetchFailure,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers.js';
 import {
@@ -12,15 +13,6 @@ import {
   LOAD_30_PERCENT_DISABILITY_RATING_SUCCEEDED,
   LOAD_30_PERCENT_DISABILITY_RATING_FAILED,
 } from '../../../686/actions/index';
-
-function setFetchFailure(stub, data) {
-  const response = new Response(null, {
-    headers: { 'content-type': ['application/json'] },
-  });
-  response.ok = false;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
 
 const state = {
   user: {

--- a/src/applications/edu-benefits/tests/feedback-tool/actions/schoolSearch.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/actions/schoolSearch.unit.spec.js
@@ -3,7 +3,8 @@ import sinon from 'sinon';
 import {
   mockFetch,
   resetFetch,
-} from '../../../../../platform/testing/unit/helpers.js';
+  setFetchJSONResponse as setFetchResponse,
+} from 'platform/testing/unit/helpers.js';
 import {
   clearSearch,
   restoreFromPrefill,
@@ -12,15 +13,6 @@ import {
   selectInstitution,
   toggleManualSchoolEntry,
 } from '../../../feedback-tool/actions/schoolSearch';
-
-function setFetchResponse(stub, data) {
-  const response = new Response(null, {
-    headers: { 'content-type': ['application/json'] },
-  });
-  response.ok = true;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
 
 function setFetchFailure(stub, data) {
   const response = new Response(null, {

--- a/src/applications/edu-benefits/tests/feedback-tool/actions/schoolSearch.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/actions/schoolSearch.unit.spec.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import {
   mockFetch,
   resetFetch,
+  setFetchJSONFailure as setFetchFailure,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers.js';
 import {
@@ -13,15 +14,6 @@ import {
   selectInstitution,
   toggleManualSchoolEntry,
 } from '../../../feedback-tool/actions/schoolSearch';
-
-function setFetchFailure(stub, data) {
-  const response = new Response(null, {
-    headers: { 'content-type': ['application/json'] },
-  });
-  response.ok = false;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
 
 describe('schoolSearch actions', () => {
   describe('clearSearch', () => {

--- a/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
@@ -18,14 +18,6 @@ import {
   transformSearchToolAddress,
 } from '../../feedback-tool/helpers';
 
-// function setFetchResponse(stub, data, headers = {}) {
-//   const response = new Response();
-//   response.ok = true;
-//   response.headers.get = headerID => headers[headerID] || null;
-//   response.json = () => Promise.resolve(data);
-//   stub.resolves(response);
-// }
-
 describe('removeEmptyStringProperties', () => {
   it('removes keys that have empty string values', () => {
     expect(removeEmptyStringProperties({ key: '' })).to.eql({});

--- a/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
@@ -4,7 +4,8 @@ import sinon from 'sinon';
 import {
   mockFetch,
   resetFetch,
-} from '../../../../platform/testing/unit/helpers';
+  setFetchJSONResponse as setFetchResponse,
+} from 'platform/testing/unit/helpers';
 
 import {
   conditionallyShowPrefillMessage,
@@ -17,13 +18,13 @@ import {
   transformSearchToolAddress,
 } from '../../feedback-tool/helpers';
 
-function setFetchResponse(stub, data, headers = {}) {
-  const response = new Response();
-  response.ok = true;
-  response.headers.get = headerID => headers[headerID] || null;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
+// function setFetchResponse(stub, data, headers = {}) {
+//   const response = new Response();
+//   response.ok = true;
+//   response.headers.get = headerID => headers[headerID] || null;
+//   response.json = () => Promise.resolve(data);
+//   stub.resolves(response);
+// }
 
 describe('removeEmptyStringProperties', () => {
   it('removes keys that have empty string values', () => {
@@ -249,40 +250,28 @@ describe('feedback-tool helpers:', () => {
     it('should resolve if polling state is success', () => {
       const parsedResponse = {};
       mockFetch();
-      setFetchResponse(
-        global.fetch.onFirstCall(),
-        {
-          data: {
-            attributes: {
-              guid: 'test',
-            },
+      setFetchResponse(global.fetch.onFirstCall(), {
+        data: {
+          attributes: {
+            guid: 'test',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
-      setFetchResponse(
-        global.fetch.onSecondCall(),
-        {
-          data: {
-            attributes: {
-              state: 'pending',
-            },
+      });
+      setFetchResponse(global.fetch.onSecondCall(), {
+        data: {
+          attributes: {
+            state: 'pending',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
-      setFetchResponse(
-        global.fetch.onThirdCall(),
-        {
-          data: {
-            attributes: {
-              state: 'success',
-              parsedResponse,
-            },
+      });
+      setFetchResponse(global.fetch.onThirdCall(), {
+        data: {
+          attributes: {
+            state: 'success',
+            parsedResponse,
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
+      });
       const formConfig = {
         chapters: {},
       };
@@ -296,39 +285,27 @@ describe('feedback-tool helpers:', () => {
     });
     it('should reject if polling state is failed', () => {
       mockFetch();
-      setFetchResponse(
-        global.fetch.onFirstCall(),
-        {
-          data: {
-            attributes: {
-              guid: 'test',
-            },
+      setFetchResponse(global.fetch.onFirstCall(), {
+        data: {
+          attributes: {
+            guid: 'test',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
-      setFetchResponse(
-        global.fetch.onSecondCall(),
-        {
-          data: {
-            attributes: {
-              state: 'pending',
-            },
+      });
+      setFetchResponse(global.fetch.onSecondCall(), {
+        data: {
+          attributes: {
+            state: 'pending',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
-      setFetchResponse(
-        global.fetch.onThirdCall(),
-        {
-          data: {
-            attributes: {
-              state: 'failed',
-            },
+      });
+      setFetchResponse(global.fetch.onThirdCall(), {
+        data: {
+          attributes: {
+            state: 'failed',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
+      });
       const formConfig = {
         chapters: {},
       };

--- a/src/applications/gi/tests/actions/index.unit.spec.js
+++ b/src/applications/gi/tests/actions/index.unit.spec.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import {
   mockFetch,
   resetFetch,
+  setFetchJSONFailure as setFetchFailure,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers.js';
 
@@ -16,13 +17,6 @@ import {
   FETCH_PROFILE_FAILED,
   FETCH_PROFILE_SUCCEEDED,
 } from '../../actions/index';
-
-function setFetchFailure(stub, data) {
-  const response = new Response();
-  response.ok = false;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
 
 describe('beneficiaryZIPCodeChanged', () => {
   beforeEach(() => mockFetch());

--- a/src/applications/gi/tests/actions/index.unit.spec.js
+++ b/src/applications/gi/tests/actions/index.unit.spec.js
@@ -3,7 +3,8 @@ import sinon from 'sinon';
 import {
   mockFetch,
   resetFetch,
-} from '../../../../platform/testing/unit/helpers.js';
+  setFetchJSONResponse as setFetchResponse,
+} from 'platform/testing/unit/helpers.js';
 
 import {
   beneficiaryZIPCodeChanged,
@@ -15,13 +16,6 @@ import {
   FETCH_PROFILE_FAILED,
   FETCH_PROFILE_SUCCEEDED,
 } from '../../actions/index';
-
-function setFetchResponse(stub, data) {
-  const response = new Response();
-  response.ok = true;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
 
 function setFetchFailure(stub, data) {
   const response = new Response();

--- a/src/applications/pensions/tests/helpers.unit.spec.jsx
+++ b/src/applications/pensions/tests/helpers.unit.spec.jsx
@@ -5,14 +5,11 @@ import sinon from 'sinon';
 
 import { fileHelp, submit } from '../helpers.jsx';
 
-import { mockFetch, resetFetch } from '../../../platform/testing/unit/helpers';
-
-function setFetchResponse(stub, data) {
-  const response = new Response();
-  response.ok = true;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
+import {
+  mockFetch,
+  resetFetch,
+  setFetchJSONResponse as setFetchResponse,
+} from 'platform/testing/unit/helpers';
 
 describe('Pensions helpers', () => {
   const FileHelp = fileHelp;

--- a/src/applications/personalization/connected-accounts/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/connected-accounts/tests/actions/index.unit.spec.js
@@ -3,18 +3,11 @@ import sinon from 'sinon';
 import {
   mockFetch,
   resetFetch,
+  setFetchJSONFailure as setFetchFailure,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers.js';
 
 import * as actions from '../../actions';
-
-function setFetchFailure(stub, data) {
-  const response = new Response();
-  response.headers.set('Content-Type', 'application/json');
-  response.ok = false;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
 
 describe('loadConnectedAccounts', () => {
   beforeEach(() => mockFetch());

--- a/src/applications/personalization/connected-accounts/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/connected-accounts/tests/actions/index.unit.spec.js
@@ -3,19 +3,10 @@ import sinon from 'sinon';
 import {
   mockFetch,
   resetFetch,
-} from '../../../../../platform/testing/unit/helpers.js';
+  setFetchJSONResponse as setFetchResponse,
+} from 'platform/testing/unit/helpers.js';
 
 import * as actions from '../../actions';
-
-function setFetchResponse(stub, data = null) {
-  const response = new Response();
-  response.ok = true;
-  if (data) {
-    response.headers.set('Content-Type', 'application/json');
-    response.json = () => Promise.resolve(data);
-  }
-  stub.resolves(response);
-}
 
 function setFetchFailure(stub, data) {
   const response = new Response();

--- a/src/applications/personalization/preferences/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/preferences/tests/actions/index.unit.spec.js
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers.js';
+import {
+  mockFetch,
+  resetFetch,
+  setFetchJSONResponse as setFetchResponse,
+} from 'platform/testing/unit/helpers.js';
 import {
   fetchAvailableBenefits,
   savePreferences,
@@ -23,15 +27,6 @@ import {
   SET_USER_PREFERENCE,
   SET_DISMISSED_DASHBOARD_PREFERENCE_BENEFIT_ALERTS,
 } from '../../actions';
-
-function setFetchResponse(stub, data) {
-  const response = new Response(null, {
-    headers: { 'content-type': ['application/json'] },
-  });
-  response.ok = true;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
 
 function setFetchFailure(stub, data) {
   const response = new Response(null, {

--- a/src/applications/personalization/preferences/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/preferences/tests/actions/index.unit.spec.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import {
   mockFetch,
   resetFetch,
+  setFetchJSONFailure as setFetchFailure,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers.js';
 import {
@@ -27,15 +28,6 @@ import {
   SET_USER_PREFERENCE,
   SET_DISMISSED_DASHBOARD_PREFERENCE_BENEFIT_ALERTS,
 } from '../../actions';
-
-function setFetchFailure(stub, data) {
-  const response = new Response(null, {
-    headers: { 'content-type': ['application/json'] },
-  });
-  response.ok = false;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
 
 describe('preferences actions', () => {
   describe('fetchUserSelectedBenefits', () => {

--- a/src/applications/vic-v2/tests/components/PhotoPreview.unit.spec.jsx
+++ b/src/applications/vic-v2/tests/components/PhotoPreview.unit.spec.jsx
@@ -3,16 +3,13 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import {
+  mockFetch,
+  resetFetch,
+  setFetchBlobResponse,
+} from 'platform/testing/unit/helpers';
 
 import PhotoPreview from '../../components/PhotoPreview.jsx';
-
-function setFetchBlobResponse(stub, data) {
-  const response = new Response();
-  response.ok = true;
-  response.blob = () => Promise.resolve(data);
-  stub.resolves(response);
-}
 
 describe('<PhotoPreview>', () => {
   it('should render preview with src', () => {

--- a/src/applications/vic-v2/tests/components/PhotoPreview.unit.spec.jsx
+++ b/src/applications/vic-v2/tests/components/PhotoPreview.unit.spec.jsx
@@ -7,7 +7,7 @@ import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
 
 import PhotoPreview from '../../components/PhotoPreview.jsx';
 
-function setFetchResponse(stub, data) {
+function setFetchBlobResponse(stub, data) {
   const response = new Response();
   response.ok = true;
   response.blob = () => Promise.resolve(data);
@@ -27,7 +27,7 @@ describe('<PhotoPreview>', () => {
   it('should fetch file metadata and update', done => {
     mockFetch();
     const response = new Blob();
-    setFetchResponse(global.fetch.onFirstCall(), response);
+    setFetchBlobResponse(global.fetch.onFirstCall(), response);
 
     window.URL = {
       createObjectURL: sinon.stub().returns('test'),

--- a/src/applications/vic-v2/tests/helpers.unit.spec.js
+++ b/src/applications/vic-v2/tests/helpers.unit.spec.js
@@ -4,26 +4,14 @@ import sinon from 'sinon';
 import {
   mockFetch,
   resetFetch,
+  setFetchBlobFailure,
+  setFetchBlobResponse,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers';
 
 import fullSchemaVIC from 'vets-json-schema/dist/VIC-schema.json';
 import fullFormConfig from '../config/form';
 import { submit, prefillTransformer, transform } from '../helpers';
-
-function setFetchBlobResponse(stub, data) {
-  const response = new Response();
-  response.ok = true;
-  response.blob = () => Promise.resolve(data);
-  stub.resolves(response);
-}
-
-function setFailedBlobResponse(stub, error) {
-  const response = new Response();
-  response.ok = true;
-  response.blob = () => Promise.reject(new Error(error));
-  stub.resolves(response);
-}
 
 describe('VIC helpers:', () => {
   describe('submit', () => {
@@ -183,7 +171,7 @@ describe('VIC helpers:', () => {
     });
     it('should resolve with failed image request', () => {
       mockFetch();
-      setFailedBlobResponse(global.fetch.onFirstCall(), 'Error');
+      setFetchBlobFailure(global.fetch.onFirstCall(), 'Error');
       setFetchResponse(global.fetch.onSecondCall(), {
         data: {
           attributes: {

--- a/src/applications/vic-v2/tests/helpers.unit.spec.js
+++ b/src/applications/vic-v2/tests/helpers.unit.spec.js
@@ -1,19 +1,15 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { mockFetch, resetFetch } from '../../../platform/testing/unit/helpers';
+import {
+  mockFetch,
+  resetFetch,
+  setFetchJSONResponse as setFetchResponse,
+} from 'platform/testing/unit/helpers';
 
 import fullSchemaVIC from 'vets-json-schema/dist/VIC-schema.json';
 import fullFormConfig from '../config/form';
 import { submit, prefillTransformer, transform } from '../helpers';
-
-function setFetchResponse(stub, data, headers = {}) {
-  const response = new Response();
-  response.ok = true;
-  response.headers.get = headerID => headers[headerID] || null;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
 
 function setFetchBlobResponse(stub, data) {
   const response = new Response();
@@ -61,41 +57,29 @@ describe('VIC helpers:', () => {
     });
     it('should resolve if polling state is success', () => {
       mockFetch();
-      setFetchResponse(
-        global.fetch.onFirstCall(),
-        {
-          data: {
-            attributes: {
-              guid: 'test',
-            },
+      setFetchResponse(global.fetch.onFirstCall(), {
+        data: {
+          attributes: {
+            guid: 'test',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
-      setFetchResponse(
-        global.fetch.onSecondCall(),
-        {
-          data: {
-            attributes: {
-              state: 'pending',
-            },
+      });
+      setFetchResponse(global.fetch.onSecondCall(), {
+        data: {
+          attributes: {
+            state: 'pending',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
+      });
       const response = {};
-      setFetchResponse(
-        global.fetch.onThirdCall(),
-        {
-          data: {
-            attributes: {
-              state: 'success',
-              response,
-            },
+      setFetchResponse(global.fetch.onThirdCall(), {
+        data: {
+          attributes: {
+            state: 'success',
+            response,
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
+      });
       const formConfig = {
         chapters: {},
       };
@@ -115,39 +99,27 @@ describe('VIC helpers:', () => {
     });
     it('should reject if polling state is failed', () => {
       mockFetch();
-      setFetchResponse(
-        global.fetch.onFirstCall(),
-        {
-          data: {
-            attributes: {
-              guid: 'test',
-            },
+      setFetchResponse(global.fetch.onFirstCall(), {
+        data: {
+          attributes: {
+            guid: 'test',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
-      setFetchResponse(
-        global.fetch.onSecondCall(),
-        {
-          data: {
-            attributes: {
-              state: 'pending',
-            },
+      });
+      setFetchResponse(global.fetch.onSecondCall(), {
+        data: {
+          attributes: {
+            state: 'pending',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
-      setFetchResponse(
-        global.fetch.onThirdCall(),
-        {
-          data: {
-            attributes: {
-              state: 'failed',
-            },
+      });
+      setFetchResponse(global.fetch.onThirdCall(), {
+        data: {
+          attributes: {
+            state: 'failed',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
+      });
       const formConfig = {
         chapters: {},
       };
@@ -171,41 +143,29 @@ describe('VIC helpers:', () => {
     it('should resolve with image request', () => {
       mockFetch();
       setFetchBlobResponse(global.fetch.onFirstCall(), {});
-      setFetchResponse(
-        global.fetch.onSecondCall(),
-        {
-          data: {
-            attributes: {
-              guid: 'test',
-            },
+      setFetchResponse(global.fetch.onSecondCall(), {
+        data: {
+          attributes: {
+            guid: 'test',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
-      setFetchResponse(
-        global.fetch.onThirdCall(),
-        {
-          data: {
-            attributes: {
-              state: 'pending',
-            },
+      });
+      setFetchResponse(global.fetch.onThirdCall(), {
+        data: {
+          attributes: {
+            state: 'pending',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
+      });
       const response = {};
-      setFetchResponse(
-        global.fetch.onCall(3),
-        {
-          data: {
-            attributes: {
-              state: 'success',
-              response,
-            },
+      setFetchResponse(global.fetch.onCall(3), {
+        data: {
+          attributes: {
+            state: 'success',
+            response,
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
+      });
       const formConfig = {
         chapters: {},
       };
@@ -224,30 +184,22 @@ describe('VIC helpers:', () => {
     it('should resolve with failed image request', () => {
       mockFetch();
       setFailedBlobResponse(global.fetch.onFirstCall(), 'Error');
-      setFetchResponse(
-        global.fetch.onSecondCall(),
-        {
-          data: {
-            attributes: {
-              guid: 'test',
-            },
+      setFetchResponse(global.fetch.onSecondCall(), {
+        data: {
+          attributes: {
+            guid: 'test',
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
+      });
       const response = {};
-      setFetchResponse(
-        global.fetch.onCall(2),
-        {
-          data: {
-            attributes: {
-              state: 'success',
-              response,
-            },
+      setFetchResponse(global.fetch.onCall(2), {
+        data: {
+          attributes: {
+            state: 'success',
+            response,
           },
         },
-        { 'Content-Type': 'application/json' },
-      );
+      });
       const formConfig = {
         chapters: {},
       };

--- a/src/platform/testing/unit/helpers.js
+++ b/src/platform/testing/unit/helpers.js
@@ -109,6 +109,15 @@ export function setFetchJSONResponse(stub, data = null) {
   stub.resolves(response);
 }
 
+export function setFetchJSONFailure(stub, data) {
+  const response = new Response(null, {
+    headers: { 'content-type': ['application/json'] },
+  });
+  response.ok = false;
+  response.json = () => Promise.resolve(data);
+  stub.resolves(response);
+}
+
 /**
  * Resets the fetch mock set with mockFetch
  */

--- a/src/platform/testing/unit/helpers.js
+++ b/src/platform/testing/unit/helpers.js
@@ -99,6 +99,16 @@ export function mockFetch(returnVal, shouldResolve = true) {
     );
 }
 
+export function setFetchJSONResponse(stub, data = null) {
+  const response = new Response();
+  response.ok = true;
+  if (data) {
+    response.headers.set('Content-Type', 'application/json');
+    response.json = () => Promise.resolve(data);
+  }
+  stub.resolves(response);
+}
+
 /**
  * Resets the fetch mock set with mockFetch
  */

--- a/src/platform/testing/unit/helpers.js
+++ b/src/platform/testing/unit/helpers.js
@@ -118,6 +118,20 @@ export function setFetchJSONFailure(stub, data) {
   stub.resolves(response);
 }
 
+export function setFetchBlobResponse(stub, data) {
+  const response = new Response();
+  response.ok = true;
+  response.blob = () => Promise.resolve(data);
+  stub.resolves(response);
+}
+
+export function setFetchBlobFailure(stub, error) {
+  const response = new Response();
+  response.ok = true;
+  response.blob = () => Promise.reject(new Error(error));
+  stub.resolves(response);
+}
+
 /**
  * Resets the fetch mock set with mockFetch
  */


### PR DESCRIPTION
## Description
While writing some unit tests for HCA redux actions (https://github.com/department-of-veterans-affairs/vets-website/pull/10564) I noticed we had multiple definitions of functions that mock fetch responses. This PR moves those functions into the common unit test helper file and uses them in place of the versions that were defined ad hoc across multiple test files.

## Testing done
All existing unit tests pass

## Screenshots
N/A

## Acceptance criteria
- [x] All existing unit tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs