### PR TITLE
VAGOV-5014: ui tweaks to media content type

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -191,11 +191,21 @@ $duo-tone-lighten: #000000;
 }
 
 .expand-image-button {
-  background-color: #ffffff;
+  background-color: $color-primary;
   border-radius: 5px;
-  box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.3);
+  color: $color-white;
   height: 32px;
   width: 32px;
+
+  &:visited {
+    background-color: $color-primary;
+    color: $color-white;
+  }
+
+  &:hover {
+    background-color: $color-primary-darker;
+    color: $color-white;
+  }
 }
 
 .social-links {

--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -191,11 +191,22 @@ $duo-tone-lighten: #000000;
 }
 
 .expand-image-button {
-  background-color: #ffffff;
+  background-color: $color-primary;
   border-radius: 5px;
   box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.3);
+  color: $color-white;
   height: 32px;
   width: 32px;
+
+  &:visited {
+    background-color: $color-primary;
+    color: $color-white;
+  }
+
+  &:hover {
+    background-color: $color-white;
+    color: $color-primary;
+  }
 }
 
 .social-links {

--- a/src/site/paragraphs/media.drupal.liquid
+++ b/src/site/paragraphs/media.drupal.liquid
@@ -23,7 +23,7 @@
         {% if entity.fieldAllowClicksOnThisImage %}
             <a
                 aria-label="Open image in new tab"
-                class="vads-u-text-decoration--none vads-u-display--flex vads-u-align-items--center expand-image-button va-c-position--absolute va-c-position-top-right-corner vads-u-justify-content--center"
+                class="vads-u-margin-right--1p5 vads-u-margin-top--1p5 vads-u-text-decoration--none vads-u-display--flex vads-u-align-items--center expand-image-button va-c-position--absolute va-c-position-top-right-corner vads-u-justify-content--center"
                 href="{{ entity.fieldMedia.entity.image.url }}"
                 target="_blank">
                 <i class="fas fa-expand-arrows-alt"></i>


### PR DESCRIPTION
- per rtwell's feedback

## Description
adds spacing to the right and top for the "expand" button
inverts the colors of the expand

## Testing done
locally with staging data

## Screenshots
![image](https://user-images.githubusercontent.com/19178435/62894306-53335200-bd01-11e9-926b-75f83fbcba57.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
