### PR TITLE
VAGOV-5221: Fix press release download button styling

### DIFF
--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -107,9 +107,9 @@
                         <p class="vads-u-margin-bottom--0p5">PRESS RELEASE</p>
                         <p class="vads-u-font-weight--bold vads-u-margin-bottom--3 vads-u-margin-top--0">{{ fieldReleaseDate.value | formatDate: 'MMMM D, YYYY' }}</p>
                         <div>
-                            <button type="button" class="vads-u-margin-right--4 va-button-link" onclick="window.print(); return false;"><i class="fa fa-print"></i> Print</button>
+                            <button type="button" class="vads-u-margin-right--4 va-button-link" onclick="window.print(); return false;"><i class="fa fa-print vads-u-padding-right--1"></i>Print</button>
                             {% if fieldPdfVersion != empty %}
-                                <a href="{{ fieldPdfVersion.entity.fieldDocument.entity.url }}" download><i class="fa fa-download"></i> Download a PDF version</a>
+                                <a href="{{ fieldPdfVersion.entity.fieldDocument.entity.url }}" download><i class="fa fa-download vads-u-padding-right--1"></i>Download press release (PDF)</a>
                             {% endif %}
                         </div>
                         <p class="va-introtext vads-u-font-size--lg vads-u-margin-top--3">{{ fieldAddress.locality }}, {{ fieldAddress.administrativeArea }} — {{ fieldIntroText }}</p>


### PR DESCRIPTION
## Description
Small adjustments to fix styling of download buttons on press releases

## Testing done
Locally with prod data.

## Screenshots
![Screen Shot 2019-08-12 at 5 40 19 PM](https://user-images.githubusercontent.com/3157339/62905570-4e35c900-bd28-11e9-8c39-9ce69a55547f.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
