### PR TITLE
VAGOV-4649: Home Page Drupal FE Implementation (Closed)

### DIFF
--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -1,0 +1,138 @@
+{% include "src/site/includes/header.html" %}
+<main>
+
+  <!-- the hub -->
+  <section class="homepage-hub">
+
+    <div class="homepage-hub-container">
+
+      <h1 class="heading-level-2 homepage-heading">{{ heading }}</h1>
+
+      <!-- top row -->
+      <div class="hub-links-row">
+      {% for card in cards %}
+        <div class="hub-links-container">
+          <h2 class="heading-level-3 hub-links-title"><i class="icon-large-baseline icon-heading hub-icon-{{card.hub}} hub-color-{{card.hub}}"></i>{{ card.heading }}</h2>
+          <ul class="hub-links-list">
+            {% assign parentCard = card %}
+
+            {% for link in card.links %}
+              <li><a data-nav-path="{{parentCard.heading}}->{% if link.nav_path != empty %}{{link.nav_path}}{% else %}{{ link.title }}{% endif %}" href="{{link.url}}">{{link.title}}</a></li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% if card.end_row == true and forloop.last != true %}
+        </div>
+        <div class="hub-links-row">
+        {% endif %}
+      {% endfor %}
+      </div>
+    </div>
+
+    {% include "src/site/includes/veteran-banner.html" %}
+
+  </section>
+  <!-- /the hub -->
+
+  <section id="content">
+
+    <section id="homepage-benefits">
+      <div class="usa-grid usa-grid-full homepage-benefits-row">
+      {% for hub in hubs %}
+        <div class="usa-width-one-third">
+          <h3 class="heading-level-4"><a href="{{ hub.url }}" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small icon-heading hub-icon-{{hub.hub}} hub-background-{{hub.hub}} white"></i>{{hub.heading}}</a></h4>
+          <p class="homepage-benefits-description">{{hub.description}}</p>
+        </div>
+        {% if hub.end_row == true and forloop.last != true %}
+        </div>
+        <div class="usa-grid usa-grid-full homepage-benefits-row">
+        {% endif %}
+      {% endfor %}
+      </div>
+    </section>
+
+    <section id="homepage-popular">
+      <div class="usa-grid usa-grid-full">
+        <div class="usa-width-one-third">
+          <a href="/find-locations/" onclick="recordEvent({ event: 'nav-main-health' });" class="homepage-button">
+            <div class="icon-wrapper">
+              <i class="fa fa-map-marker-alt homepage-button-icon"></i>
+            </div>
+            <!-- div required for alignment -->
+            <div class="button-inner">
+              <span>Find a VA health facility, benefit office, or cemetery</span>
+            </div>
+          </a>
+        </div>
+
+        <div class="usa-width-one-third">
+          <button onclick="recordEvent({ event: 'nav-main-vcl' });" class="homepage-button vcl va-overlay-trigger" data-show="#modal-crisisline">
+            <div class="icon-wrapper vcl"></div>
+            <div class="button-inner">
+              <span>Talk to a Veterans Crisis Line responder now</span>
+            </div>
+          </button>
+        </div>
+
+        <div class="usa-width-one-third" id="myva-login">
+          <button onclick="recordEvent({ event: 'nav-main-sign-in' });" class="homepage-button signin-signup-modal-trigger">
+            <div class="icon-wrapper">
+              <i class="fas fa-user-circle homepage-button-icon"></i>
+            </div>
+            <div class="button-inner">
+              <span>Sign in or create an account to use more tools</span>
+            </div>
+          </button>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- end triple column -->
+
+  </div> <!-- end #content -->
+
+  <section class="usa-grid usa-grid-full">
+    <div class="va-h-ruled--stars"></div>
+  </section>
+
+
+  <section id="homepage-news">
+
+    <div class="usa-grid usa-grid-full">
+    {% for story in news %}
+      <div class="usa-width-one-third homepage-news-story">
+        <div class="homepage-image-wrapper">
+          <img class="lazy" width="552" data-src="{{ story.img }}" alt="{{ story.alt }}"/>
+        </div>
+        <h4 class="homepage-news-story-title"><a class="no-external-icon" href="{{ story.href }}"
+          onClick="recordEvent({ event: 'nav-footer-news-story' });"/>{{ story.title }}</a></h4>
+        <p class="homepage-news-story-desc">{{ story.description }}</p>
+      </div>
+      {% if hub.end_row == true and forloop.last != true %}
+      </div>
+      <div class="usa-grid usa-grid-full">
+      {% endif %}
+    {% endfor %}
+    </div>
+
+  </section>
+
+</main>
+
+<script type="text/javascript">
+  var hubLinksList = document.getElementsByClassName('hub-links-list');
+
+  for (var i=0; i < hubLinksList.length; i++) {
+    hubLinksList[i].addEventListener('click', function(e) {
+      var linkData = e.target.dataset;
+
+      recordEvent({
+        event: 'nav-zone-one',
+        'nav-path': linkData.navPath,
+      });
+    });
+  }
+</script>
+
+{% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -6,22 +6,22 @@
 
     <div class="homepage-hub-container">
 
-      <h1 class="heading-level-2 homepage-heading">{{ heading }}</h1>
+      <h1 class="heading-level-2 homepage-heading">Access and manage your VA benefits and health care</h1>
 
       <!-- top row -->
       <div class="hub-links-row">
       {% for card in cards %}
         <div class="hub-links-container">
-          <h2 class="heading-level-3 hub-links-title"><i class="icon-large-baseline icon-heading hub-icon-{{card.hub}} hub-color-{{card.hub}}"></i>{{ card.heading }}</h2>
+          <h2 class="heading-level-3 hub-links-title"><i class="icon-large-baseline icon-heading hub-icon-{{ card.label | downcase | replace: ' ', '-' }} hub-color-{{ card.label | downcase | replace: ' ', '-' }}"></i>{{ card.label }}</h2>
           <ul class="hub-links-list">
             {% assign parentCard = card %}
 
-            {% for link in card.links %}
-              <li><a data-nav-path="{{parentCard.heading}}->{% if link.nav_path != empty %}{{link.nav_path}}{% else %}{{ link.title }}{% endif %}" href="{{link.url}}">{{link.title}}</a></li>
+            {% for link in parentCard.links %}
+              <li><a data-nav-path="{{ parentCard.label }}->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}" href="{{ link.url.path }}">{{ link.label }}</a></li>
             {% endfor %}
           </ul>
         </div>
-        {% if card.end_row == true and forloop.last != true %}
+        {% if forloop.index == 2 %}
         </div>
         <div class="hub-links-row">
         {% endif %}
@@ -40,8 +40,8 @@
       <div class="usa-grid usa-grid-full homepage-benefits-row">
       {% for hub in hubs %}
         <div class="usa-width-one-third">
-          <h3 class="heading-level-4"><a href="{{ hub.url }}" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small icon-heading hub-icon-{{hub.hub}} hub-background-{{hub.hub}} white"></i>{{hub.heading}}</a></h4>
-          <p class="homepage-benefits-description">{{hub.description}}</p>
+          <h3 class="heading-level-4"><a href="{{ hub.url }}" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small icon-heading hub-icon-{{hub.entity.fieldTitleIcon}} hub-background-{{hub.entity.fieldTitleIcon}} white"></i>{{hub.entity.entityLabel}}</a></h4>
+          <p class="homepage-benefits-description">{{hub.entity.fieldTeaserText}}</p>
         </div>
         {% if hub.end_row == true and forloop.last != true %}
         </div>
@@ -100,14 +100,14 @@
   <section id="homepage-news">
 
     <div class="usa-grid usa-grid-full">
-    {% for story in news %}
+    {% for promo in promos %}
       <div class="usa-width-one-third homepage-news-story">
         <div class="homepage-image-wrapper">
-          <img class="lazy" width="552" data-src="{{ story.img }}" alt="{{ story.alt }}"/>
+          <img class="lazy" width="552" data-src="{{ promo.entity.fieldImage.entity.image.url }}" alt="{{ promo.entity.fieldImage.entity.image.alt }}"/>
         </div>
-        <h4 class="homepage-news-story-title"><a class="no-external-icon" href="{{ story.href }}"
-          onClick="recordEvent({ event: 'nav-footer-news-story' });"/>{{ story.title }}</a></h4>
-        <p class="homepage-news-story-desc">{{ story.description }}</p>
+        <h4 class="homepage-news-story-title"><a class="no-external-icon" href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}"
+          onClick="recordEvent({ event: 'nav-footer-news-story' });"/>{{ promo.entity.fieldPromoLink.entity.fieldLink.title }}</a></h4>
+        <p class="homepage-news-story-desc">{{ promo.entity.fieldPromoLink.entity.fieldLinkSummary }}</p>
       </div>
       {% if hub.end_row == true and forloop.last != true %}
       </div>
@@ -136,3 +136,4 @@
 </script>
 
 {% include "src/site/includes/footer.html" %}
+{% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -17,6 +17,7 @@ const outreachAssetsQuery = require('./file-fragments/outreachAssets.graphql');
 const bioPage = require('./bioPage.graphql');
 const benefitListingPage = require('./benefitListingPage.graphql');
 const eventListingPage = require('./eventListingPage.graphql');
+const homePage = require('./homePage.graphql');
 
 // Get current feature flags
 const {

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -17,7 +17,7 @@ const outreachAssetsQuery = require('./file-fragments/outreachAssets.graphql');
 const bioPage = require('./bioPage.graphql');
 const benefitListingPage = require('./benefitListingPage.graphql');
 const eventListingPage = require('./eventListingPage.graphql');
-const homePage = require('./homePage.graphql');
+const homePageQuery = require('./homePage.graphql');
 
 // Get current feature flags
 const {
@@ -79,6 +79,7 @@ module.exports = `
     ${outreachSidebarQuery}
     ${alertsQuery}
     ${outreachAssetsQuery}
+    ${homePageQuery}
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/homePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/homePage.graphql.js
@@ -6,7 +6,12 @@ const menu = 'homepage-top-tasks-blocks';
 const hubListQueue = 'home_page_hub_list';
 const promoBlocksQueue = 'home_page_promos';
 
-module.exports = `
+const {
+  featureFlags,
+  enabledFeatureFlags,
+} = require('../../../../utilities/featureFlags');
+
+const query = `
   homePageMenuQuery:menuByName(name: "${menu}") {
     name
     links {
@@ -76,3 +81,7 @@ module.exports = `
     }
   }
 `;
+
+module.exports = enabledFeatureFlags[featureFlags.FEATURE_HOME_PAGE]
+  ? query
+  : '';

--- a/src/site/stages/build/drupal/graphql/homePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/homePage.graphql.js
@@ -2,19 +2,77 @@
  * Home page
  */
 
+const menu = 'homepage-top-tasks-blocks';
+const hubListQueue = 'home_page_hub_list';
+const promoBlocksQueue = 'home_page_promos';
+
 module.exports = `
- fragment entitySubqueueById(id: "home_page_hub_list") {
-  ... on EntitySubqueueHomePageHubList {
-    itemsOfEntitySubqueueHomePageHubList {
-      targetId
-      entity {
-        ... on NodeLandingPage {
-          entityId
-          entityLabel
-          fieldDescription
+  homePageMenuQuery:menuByName(name: "${menu}") {
+    name
+    links {
+      label
+      url {
+        path
+      }
+      links {
+        label
+        url {
+          path
         }
       }
     }
   }
-}
+  homePageHubListQuery: entitySubqueueById(id: "${hubListQueue}") {
+    ... on EntitySubqueueHomePageHubList {
+      itemsOfEntitySubqueueHomePageHubList {
+        entity {
+          ... on NodeLandingPage {
+            entityId
+            entityLabel
+            fieldTeaserText
+            fieldTitleIcon
+          }
+        }
+      }
+    }
+  }
+  homePagePromoBlockQuery: entitySubqueueById(id: "${promoBlocksQueue}") {
+    ... on EntitySubqueueHomePagePromos {
+      itemsOfEntitySubqueueHomePagePromos {
+         entity {
+          ... on BlockContentPromo {
+            entityId
+            entityLabel
+            fieldImage {
+              targetId
+              entity {
+                ...on MediaImage {
+                  image {
+                    url
+                    alt
+                  }
+                }
+
+              }
+            }
+            fieldPromoLink {
+              targetId
+              ...on FieldBlockContentPromoFieldPromoLink {
+                entity {
+                  ... on ParagraphLinkTeaser {
+                    fieldLink {
+                      uri
+                      title
+                      options
+                    }
+                    fieldLinkSummary
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 `;

--- a/src/site/stages/build/drupal/graphql/homePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/homePage.graphql.js
@@ -1,0 +1,20 @@
+/**
+ * Home page
+ */
+
+module.exports = `
+ fragment entitySubqueueById(id: "home_page_hub_list") {
+  ... on EntitySubqueueHomePageHubList {
+    itemsOfEntitySubqueueHomePageHubList {
+      targetId
+      entity {
+        ... on NodeLandingPage {
+          entityId
+          entityLabel
+          fieldDescription
+        }
+      }
+    }
+  }
+}
+`;

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -1,18 +1,26 @@
 /* eslint-disable no-param-reassign, no-continue */
-const {
-  createEntityUrlObj,
-  createFileObj,
-  paginatePages,
-  updateEntityUrlObj,
-  generateBreadCrumbs,
-} = require('./page');
+const { createEntityUrlObj, createFileObj } = require('./page');
 
+function addHomeContent(contentData, files) {
+  const menuLength = 4;
+  const hubListLength = 11;
+  const promoBlockLength = 3;
+  const homeEntityObj = createEntityUrlObj('/');
+  const {
+    data: { homePageMenuQuery, homePageHubListQuery, homePagePromoBlockQuery },
+  } = contentData;
 
-function addHomeContent(contentData, files, drupalPagePath) {
-  files[`${drupalPagePath}/index.html`] = createFileObj(
-    createEntityUrlObj({}, 'Home'),
-    'home.drupal.liquid',
+  homeEntityObj.cards = homePageMenuQuery.links.slice(0, menuLength);
+  homeEntityObj.hubs = homePageHubListQuery.itemsOfEntitySubqueueHomePageHubList.slice(
+    0,
+    hubListLength,
   );
+  homeEntityObj.promos = homePagePromoBlockQuery.itemsOfEntitySubqueueHomePagePromos.slice(
+    0,
+    promoBlockLength,
+  );
+
+  files[`./index.html`] = createFileObj(homeEntityObj, 'home.drupal.liquid');
 }
 
 module.exports = { addHomeContent };

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-param-reassign, no-continue */
+const {
+  createEntityUrlObj,
+  createFileObj,
+  paginatePages,
+  updateEntityUrlObj,
+  generateBreadCrumbs,
+} = require('./page');
+
+
+function addHomeContent(contentData, files, drupalPagePath) {
+  files[`${drupalPagePath}/index.html`] = createFileObj(
+    createEntityUrlObj({}, 'Home'),
+    'home.drupal.liquid',
+  );
+}
+
+module.exports = { addHomeContent };

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -6,27 +6,34 @@ function addHomeContent(contentData, files) {
   const menuLength = 4;
   const hubListLength = 11;
   const promoBlockLength = 3;
-  const homeEntityObj = createEntityUrlObj('/');
-  const {
-    data: { homePageMenuQuery, homePageHubListQuery, homePagePromoBlockQuery },
-  } = contentData;
 
-  // Add Top Tasks Menu.
-  homeEntityObj.cards = homePageMenuQuery.links.slice(0, menuLength);
+  if (contentData.data.homePageMenuQuery) {
+    const homeEntityObj = createEntityUrlObj('/');
+    const {
+      data: {
+        homePageMenuQuery,
+        homePageHubListQuery,
+        homePagePromoBlockQuery,
+      },
+    } = contentData;
 
-  // Add full hub list.
-  homeEntityObj.hubs = homePageHubListQuery.itemsOfEntitySubqueueHomePageHubList.slice(
-    0,
-    hubListLength,
-  );
+    // Add Top Tasks Menu.
+    homeEntityObj.cards = homePageMenuQuery.links.slice(0, menuLength);
 
-  // Add promo blocks.
-  homeEntityObj.promos = homePagePromoBlockQuery.itemsOfEntitySubqueueHomePagePromos.slice(
-    0,
-    promoBlockLength,
-  );
+    // Add full hub list.
+    homeEntityObj.hubs = homePageHubListQuery.itemsOfEntitySubqueueHomePageHubList.slice(
+      0,
+      hubListLength,
+    );
 
-  files[`./index.html`] = createFileObj(homeEntityObj, 'home.drupal.liquid');
+    // Add promo blocks.
+    homeEntityObj.promos = homePagePromoBlockQuery.itemsOfEntitySubqueueHomePagePromos.slice(
+      0,
+      promoBlockLength,
+    );
+
+    files[`./index.html`] = createFileObj(homeEntityObj, 'home.drupal.liquid');
+  }
 }
 
 module.exports = { addHomeContent };

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign, no-continue */
 const { createEntityUrlObj, createFileObj } = require('./page');
 
+// Processes the data received from the home page query.
 function addHomeContent(contentData, files) {
   const menuLength = 4;
   const hubListLength = 11;
@@ -10,11 +11,16 @@ function addHomeContent(contentData, files) {
     data: { homePageMenuQuery, homePageHubListQuery, homePagePromoBlockQuery },
   } = contentData;
 
+  // Add Top Tasks Menu.
   homeEntityObj.cards = homePageMenuQuery.links.slice(0, menuLength);
+
+  // Add full hub list.
   homeEntityObj.hubs = homePageHubListQuery.itemsOfEntitySubqueueHomePageHubList.slice(
     0,
     hubListLength,
   );
+
+  // Add promo blocks.
   homeEntityObj.promos = homePagePromoBlockQuery.itemsOfEntitySubqueueHomePagePromos.slice(
     0,
     promoBlockLength,

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -75,7 +75,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
       createHealthCareRegionListPages(pageCompiled, drupalPageDir, files);
     }
   }
-  addHomeContent(contentData, files, path.join('.', '/'));
+  addHomeContent(contentData, files);
 }
 
 async function loadDrupal(buildOptions) {

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -15,6 +15,7 @@ const {
   addGetUpdatesFields,
 } = require('./health-care-region');
 const { addHubIconField } = require('./benefit-hub');
+const { addHomeContent } = require('./home');
 
 const DRUPAL_CACHE_FILENAME = 'drupal/pages.json';
 
@@ -74,6 +75,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
       createHealthCareRegionListPages(pageCompiled, drupalPageDir, files);
     }
   }
+  addHomeContent(contentData, files, path.join('.', '/'));
 }
 
 async function loadDrupal(buildOptions) {

--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -29,6 +29,7 @@ const featureFlags = {
   FEATURE_FIELD_COMPLETE_BIOGRAPHY: 'fieldCompleteBiography',
   FEATURE_HEALTH_SERVICE_API_ID: 'featureHealthServiceApiId',
   FEATURE_DOWNLOADABLE_FILE: 'featureDownloadableFile',
+  FEATURE_HOME_PAGE: 'featureHomePage',
 };
 
 // Edit this to turn flags on or off


### PR DESCRIPTION
## Description
This branch implements a Drupal-powered home page. 
- Adds GraphQL to retrieve the individual Drupal-powered sections of the home page.
- Adds a function to `metalsmith-drupal.js` (imported from a new `home.js` file) to process the queried data and prepare it for templating.
- Adds a new home page template that largely mirrors the non-Drupal template, but uses Drupal data instead of `vagov-content`.
- Adds a feature flag for the home page query so that it is not run on an environment until the flag is added.

## Testing done
*Part 1*
- Created home page content on local CMS.
- Added feature flag to `localhost` environment.
- Built local web environment, pulling local CMS data.
- Observed CMS content populated the home page.

*Part 2*
- Removed feature flag from `localhost` environment.
- Rebuilt local web environment, pulling local CMS data.
- Observed the home page had returned to "normal" with `vagov-content`.

## Screenshots
*Home page menu content in CMS*
<img width="1583" alt="Screen Shot 2019-08-13 at 5 26 32 PM" src="https://user-images.githubusercontent.com/1181665/62978728-f4003b00-bdef-11e9-9e0b-abce206afedd.png">

*Feature flag on: CMS home page menu content populates home page*
<img width="1222" alt="Screen Shot 2019-08-13 at 5 28 30 PM" src="https://user-images.githubusercontent.com/1181665/62978745-fc587600-bdef-11e9-8146-b133e00d521c.png">

*Feature flag off: Home page populated by `vagov-content`*
![screencapture-localhost-3001-2019-08-13-17_23_19](https://user-images.githubusercontent.com/1181665/62978760-067a7480-bdf0-11e9-975e-96bae5eb1ee8.png)


## Acceptance criteria
- [ ] Home page content is powered by Drupal.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
