### PR TITLE
VAGOV-5431: Adding pittsburgh region banner.

### DIFF
--- a/src/site/blocks/pittsburgh-beta-banner.liquid
+++ b/src/site/blocks/pittsburgh-beta-banner.liquid
@@ -1,0 +1,32 @@
+{% assign pittCheck = path | isPitt %}
+{% if pittCheck == true %}
+<div class="usa-alert-full-width usa-alert-full-width-info">
+  <div aria-live="polite" role="alert" class="usa-alert usa-alert-info">
+    <div class="usa-alert-body">
+      <h3 class="usa-alert-heading">You're on a preview of the new VA Pittsburgh
+        health care website
+      </h3>
+      <div class="usa-alert-text">
+        <p>We're building a new online experience to make it easier for
+          Veterans to manage their health care. And we're building it with input
+          from you
+          — Veterans, family members, caregivers, and patient advocates —
+          through user
+          research and feedback.
+        </p>
+        <p>
+          <strong>Please note:</strong> This site is still in development.
+          You'll see new content and features added every day because we work
+          iteratively
+          using agile design and development practices.
+        </p>
+        <p>
+          <strong>Not ready to use the new site yet?</strong>
+          <a href="https://www.pittsburgh.va.gov/">Go to the official
+            Pittsburgh.VA.gov</a>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -295,6 +295,14 @@ module.exports = function registerFilters() {
     return inMenu !== -1;
   };
 
+  // check if this is a pittsburgh page
+  liquid.filters.isPitt = path => {
+    if (path.includes('pittsburgh-health-care')) {
+      return true;
+    }
+    return false;
+  };
+
   // sort a list of objects by a certain property in the object
   liquid.filters.sortObjectsBy = (entities, path) => _.sortBy(entities, path);
 

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -75,6 +75,8 @@
   {% include "src/site/includes/top-nav.html" %}
 {% endif %}
 
+{% include "src/site/blocks/pittsburgh-beta-banner.liquid" %}
+
 {% if path == '' and banner and banner.visible %}
   <div class="usa-alert-full-width usa-alert-full-width-{{ banner.type }}">
     <div aria-live="polite" role="alert" class="usa-alert usa-alert-{{ banner.type }}">
@@ -87,5 +89,4 @@
     </div>
   </div>
 {% endif %}
-
 <script async src="/js/incompatible-browser.js"></script>


### PR DESCRIPTION
## Description
Adds beta site announcement banner to all pittsburgh pages.

## Testing done
Visual

## Screenshots
![Screenshot_2019-08-15_10-37-45](https://user-images.githubusercontent.com/2404547/63102329-ead6b180-bf48-11e9-8744-5d1bb42737e0.png)

## Acceptance criteria
- [ ] When visiting any path in `/pittsburgh-health-care`, I should see the banner in the above screenshot.

## Definition of done
- [ ] Going to any path in `/pittsburgh-health-care` shows the banner from the above screenshot.