### PR TITLE
Removal of production flags for stories 19402 and 19418

### DIFF
--- a/src/applications/gi/components/search/LandingPageTypeOfInstitutionFilter.jsx
+++ b/src/applications/gi/components/search/LandingPageTypeOfInstitutionFilter.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import RadioButtons from '../RadioButtons';
 import PropTypes from 'prop-types';
 
-import environment from 'platform/utilities/environment';
-
 class LandingPageTypeOfInstitutionFilter extends React.Component {
   static propTypes = {
     category: PropTypes.string.isRequired,
@@ -23,35 +21,19 @@ class LandingPageTypeOfInstitutionFilter extends React.Component {
       },
     ];
     if (this.props.displayVetTecOption) {
-      const vetTecLabel =
-        // Production flag for 19402
-        !environment.isProduction() ? (
-          <span className="vads-u-padding-top--1 vads-u-margin-left--0p5 learnMoreLabel">
-            {' '}
-            <button
-              aria-label="VET TEC training providers only learn more"
-              type="button"
-              className="va-button-link learn-more-button"
-              onClick={() => this.props.showModal('vetTec')}
-            >
-              (Learn more)
-            </button>{' '}
-          </span>
-        ) : (
-          <span className="vads-u-padding-top--1 vads-u-margin-left--0p5">
-            {' '}
-            (
-            <button
-              aria-label="VET TEC training providers only learn more"
-              type="button"
-              className="va-button-link learn-more-button"
-              onClick={() => this.props.showModal('vetTec')}
-            >
-              Learn more
-            </button>
-            ){' '}
-          </span>
-        );
+      const vetTecLabel = (
+        <span className="vads-u-padding-top--1 vads-u-margin-left--0p5 learnMoreLabel">
+          {' '}
+          <button
+            aria-label="VET TEC training providers only learn more"
+            type="button"
+            className="va-button-link learn-more-button"
+            onClick={() => this.props.showModal('vetTec')}
+          >
+            (Learn more)
+          </button>{' '}
+        </span>
+      );
 
       options.push({
         value: 'vettec',

--- a/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
@@ -1,15 +1,9 @@
 import React from 'react';
-import environment from 'platform/utilities/environment';
-
-// Production flag for 19418
-const VetTecApplicationProcessClassname =
-  !environment.isProduction() && 'medium-screen:vads-l-col--10';
 
 const VetTecApplicationProcess = () => (
   <div
     className={
-      ('columns vads-u-margin-top--neg1p5 vads-u-margin-x--neg1p5',
-      VetTecApplicationProcessClassname)
+      'columns vads-u-margin-top--neg1p5 vads-u-margin-x--neg1p5 medium-screen:vads-l-col--10'
     }
   >
     <h4>Enrolling in VET TEC is a two-step process:</h4>
@@ -26,10 +20,7 @@ const VetTecApplicationProcess = () => (
         target="_blank"
         rel="noopener noreferrer"
       >
-        {/* Production flag for 19418 */}
-        {!environment.isProduction()
-          ? 'Apply for VET TEC (VA Form 22-0994)'
-          : 'Apply for VET TEC (VA Form 22-1994)'}
+        Apply for VET TEC (VA Form 22-0994)
       </a>
     </p>
     <p>

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import environment from 'platform/utilities/environment';
-
 export const renderSchoolClosingFlag = result => {
   const { schoolClosing } = result;
   if (!schoolClosing) return null;
@@ -35,29 +33,15 @@ export const renderPreferredProviderFlag = result => {
   );
 };
 
-export const renderLearnMoreLabel = ({ text, modal, showModal, component }) =>
-  // Production flag for 19402
-  !environment.isProduction() ? (
-    <span>
-      {text}{' '}
-      <button
-        type="button"
-        className="va-button-link learn-more-button"
-        onClick={showModal.bind(component, modal)}
-      >
-        (Learn more)
-      </button>
-    </span>
-  ) : (
-    <span>
-      {text} (
-      <button
-        type="button"
-        className="va-button-link learn-more-button"
-        onClick={showModal.bind(component, modal)}
-      >
-        Learn more
-      </button>
-      )
-    </span>
-  );
+export const renderLearnMoreLabel = ({ text, modal, showModal, component }) => (
+  <span>
+    {text}{' '}
+    <button
+      type="button"
+      className="va-button-link learn-more-button"
+      onClick={showModal.bind(component, modal)}
+    >
+      (Learn more)
+    </button>
+  </span>
+);


### PR DESCRIPTION
## Description
Removing the productions flags used for:
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19402

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19418

Originating Issue (for 19418): 
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19469

## Testing done
Local Unit tests pass QA and UX approval in staging environment

## Screenshots
![image](https://user-images.githubusercontent.com/48804834/63103289-cc71b580-bf4a-11e9-921a-3f2b77f03fae.png)

![fullpage](https://user-images.githubusercontent.com/48804834/63104170-73a31c80-bf4c-11e9-829f-a5c65363832d.png)

## Acceptance criteria
- [x] Production flags removed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
