### PR TITLE
Remove VET TEC logo prod flags

### DIFF
--- a/src/applications/gi/components/search/LandingPageTypeOfInstitutionFilter.jsx
+++ b/src/applications/gi/components/search/LandingPageTypeOfInstitutionFilter.jsx
@@ -74,13 +74,15 @@ class LandingPageTypeOfInstitutionFilter extends React.Component {
     }
 
     return (
-      <RadioButtons
-        label="Type of institution"
-        name="category"
-        options={options}
-        value={this.props.category}
-        onChange={this.props.onChange}
-      />
+      <div className="type-of-institution-filter">
+        <RadioButtons
+          label="Type of institution"
+          name="category"
+          options={options}
+          value={this.props.category}
+          onChange={this.props.onChange}
+        />
+      </div>
     );
   }
 }

--- a/src/applications/gi/components/search/LandingPageTypeOfInstitutionFilter.jsx
+++ b/src/applications/gi/components/search/LandingPageTypeOfInstitutionFilter.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import RadioButtons from '../RadioButtons';
 import PropTypes from 'prop-types';
 
-import environment from 'platform/utilities/environment';
 import classNames from 'classnames';
 import { renderVetTecLogo } from '../../utils/render';
 
@@ -25,35 +24,19 @@ class LandingPageTypeOfInstitutionFilter extends React.Component {
       },
     ];
     if (this.props.displayVetTecOption) {
-      const vetTecLabel =
-        // Production flag for 19402
-        !environment.isProduction() ? (
-          <span className="vads-u-padding-top--1 vads-u-margin-left--0p5 learnMoreLabel">
-            {' '}
-            <button
-              aria-label="VET TEC training providers only learn more"
-              type="button"
-              className="va-button-link learn-more-button"
-              onClick={() => this.props.showModal('vetTec')}
-            >
-              (Learn more)
-            </button>{' '}
-          </span>
-        ) : (
-          <span className="vads-u-padding-top--1 vads-u-margin-left--0p5">
-            {' '}
-            (
-            <button
-              aria-label="VET TEC training providers only learn more"
-              type="button"
-              className="va-button-link learn-more-button"
-              onClick={() => this.props.showModal('vetTec')}
-            >
-              Learn more
-            </button>
-            ){' '}
-          </span>
-        );
+      const vetTecLabel = (
+        <span className="vads-u-padding-top--1 vads-u-margin-left--0p5 learnMoreLabel">
+          {' '}
+          <button
+            aria-label="VET TEC training providers only learn more"
+            type="button"
+            className="va-button-link learn-more-button"
+            onClick={() => this.props.showModal('vetTec')}
+          >
+            (Learn more)
+          </button>{' '}
+        </span>
+      );
 
       const imgClass = classNames(
         'vettec-logo',
@@ -69,7 +52,7 @@ class LandingPageTypeOfInstitutionFilter extends React.Component {
         value: 'vettec',
         label: 'VET TEC training providers only',
         learnMore: vetTecLabel,
-        additional: environment.isProduction() ? null : vetTecLogo,
+        additional: vetTecLogo,
       });
     }
 

--- a/src/applications/gi/components/vet-tec/VetTecAdditionalResources.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecAdditionalResources.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
-import environment from 'platform/utilities/environment';
 import { renderVetTecLogo } from '../../utils/render';
 import classNames from 'classnames';
 
@@ -67,11 +66,9 @@ export const VetTecAdditionalResourcesLinks = () => (
 
 const VetTecAdditionalResources = () => (
   <div className="additional-resources usa-width-one-third medium-4 small-12 column">
-    {!environment.isProduction() && (
-      <div className="vettec-logo-container">
-        {renderVetTecLogo(classNames('vettec-logo'))}
-      </div>
-    )}
+    <div className="vettec-logo-container">
+      {renderVetTecLogo(classNames('vettec-logo'))}
+    </div>
     <h4 className="highlight vettec-additional-resources-header">
       Additional Resources
     </h4>

--- a/src/applications/gi/components/vet-tec/VetTecInstitutionProfile.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecInstitutionProfile.jsx
@@ -7,17 +7,14 @@ import VetTecApprovedPrograms from './VetTecApprovedPrograms';
 import VetTecCalculator from './VetTecCalculator';
 import VetTecHeadingSummary from './VetTecHeadingSummary';
 import VetTecContactInformation from './VetTecContactInformation';
-import environment from 'platform/utilities/environment';
 import { renderVetTecLogo } from '../../utils/render';
 import classNames from 'classnames';
 
 const VetTecInstitutionProfile = ({ institution, showModal }) => (
   <div>
-    {!environment.isProduction() && (
-      <div className="vads-u-display--block small-screen:vads-u-display--none vettec-logo-container">
-        {renderVetTecLogo(classNames('vettec-logo'))}
-      </div>
-    )}
+    <div className="vads-u-display--block small-screen:vads-u-display--none vettec-logo-container">
+      {renderVetTecLogo(classNames('vettec-logo'))}
+    </div>
     <VetTecHeadingSummary institution={institution} showModal={showModal} />
     <div className="usa-accordion">
       <ul>

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -25,7 +25,6 @@ import VetTecSearchResult from '../components/vet-tec/VetTecSearchResult';
 import InstitutionSearchForm from '../components/search/InstitutionSearchForm';
 import VetTecSearchForm from '../components/vet-tec/VetTecSearchForm';
 import { isVetTecSelected } from '../utils/helpers';
-import environment from 'platform/utilities/environment';
 import { renderVetTecLogo } from '../utils/render';
 
 const { Element: ScrollElement, scroller } = Scroll;
@@ -235,25 +234,19 @@ export class SearchPage extends React.Component {
 
   renderVetTecSearchForm = (searchResults, filtersClass) => (
     <div>
-      {!environment.isProduction() && (
-        <div className="vads-u-display--block small-screen:vads-u-display--none vettec-logo-container">
-          {renderVetTecLogo(classNames('vettec-logo'))}
+      <div className="vads-u-display--block small-screen:vads-u-display--none vettec-logo-container">
+        {renderVetTecLogo(classNames('vettec-logo'))}
+      </div>
+      <div className="vads-l-row vads-u-justify-content--space-between vads-u-align-items--flex-end">
+        <div className="vads-l-col--10">
+          {this.renderSearchResultsHeader(this.props.search)}
         </div>
-      )}
-      {!environment.isProduction() && (
-        <div className="vads-l-row vads-u-justify-content--space-between vads-u-align-items--flex-end">
-          <div className="vads-l-col--10">
-            {this.renderSearchResultsHeader(this.props.search)}
-          </div>
-          <div className="vads-l-col--2">
-            <div className="vads-u-display--none small-screen:vads-u-display--block vettec-logo-container">
-              {renderVetTecLogo(classNames('vettec-logo'))}
-            </div>
+        <div className="vads-l-col--2">
+          <div className="vads-u-display--none small-screen:vads-u-display--block vettec-logo-container">
+            {renderVetTecLogo(classNames('vettec-logo'))}
           </div>
         </div>
-      )}
-      {environment.isProduction() &&
-        this.renderSearchResultsHeader(this.props.search)}
+      </div>
       <VetTecSearchForm
         filtersClass={filtersClass}
         search={this.props.search}

--- a/src/applications/gi/sass/partials/_gi-landing-page.scss
+++ b/src/applications/gi/sass/partials/_gi-landing-page.scss
@@ -32,4 +32,8 @@
       width: 179px;	
     }
   }
+
+  .type-of-institution-filter .form-expanding-group-open {
+    padding-left: 2rem;
+  }
 }


### PR DESCRIPTION
## Description
Remove the production flags hiding the VET TEC logos in the Comparison Tool so that they are displayed in the production environment.

## Testing done
Tested locally, QA approved

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/63169087-ed4a1180-c003-11e9-855f-73e43e1fc010.png)
![image](https://user-images.githubusercontent.com/41960449/63169094-f0dd9880-c003-11e9-9b7e-6c03192cf890.png)
![image](https://user-images.githubusercontent.com/41960449/63169105-f5a24c80-c003-11e9-9020-9cddd3643a39.png)
![image](https://user-images.githubusercontent.com/41960449/63169113-fa670080-c003-11e9-9a14-e1e1dc5b32aa.png)
![image](https://user-images.githubusercontent.com/41960449/63169119-fdfa8780-c003-11e9-8e1a-2f32a9196e33.png)
![image](https://user-images.githubusercontent.com/41960449/63169130-0226a500-c004-11e9-957e-72532ddc72df.png)

## Acceptance criteria
- [x] The VET TEC is displayed on the Comparison tool landing page when the "VET TEC" option is selected as the answer to "Type of institution".
- [x] The VET TEC logo is displayed on the Comparison Tool VET TEC Search Results.
- [x] The VET TEC logo is displayed on the Comparison Tool VET TEC Profile Page.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
