### PR TITLE
Removed production flags

### DIFF
--- a/src/applications/edu-benefits/1995/content/stem.jsx
+++ b/src/applications/edu-benefits/1995/content/stem.jsx
@@ -1,58 +1,30 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
-import environment from '../../../../platform/utilities/environment';
 
 export const rogersStemScholarshipInfo = (
   <AdditionalInfo triggerText="What is the Rogers STEM Scholarship?">
-    {environment.isProduction() && (
-      <div>
-        <p>
-          The Edith Nourse Rogers STEM Scholarship provides up to 9 months of
-          additional Post-9/11 GI Bill benefits, to a maximum of $30,000.
-        </p>
-        <p>
-          Veterans and Fry Scholars may qualify for this scholarship if they're
-          enrolled in an undergraduate program for Science, Technology,
-          Engineering, or Math (STEM), or if they've earned a STEM degree and
-          are getting a teaching certification.
-        </p>
-        <p>
-          To learn more about the STEM Scholarship,{' '}
-          <a
-            href="https://benefits.va.gov/gibill/fgib/stem.asp"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {' '}
-            visit the VBA STEM website.
-          </a>
-        </p>
-      </div>
-    )}
-    {!environment.isProduction() && (
-      <div>
-        <p>
-          The Edith Nourse Rogers STEM Scholarship provides up to 9 months of
-          additional Post-9/11 GI Bill benefits, to a maximum of $30,000.
-          <br />
-          <br />
-          Veterans and Fry Scholars may qualify for this scholarship if they're
-          enrolled in an undergraduate program for Science, Technology,
-          Engineering, or Math (STEM), or if they've earned a STEM degree and
-          are getting a teaching certification.
-          <br />
-          <br />
-          To learn more about the STEM Scholarship,{' '}
-          <a
-            href="https://benefits.va.gov/gibill/fgib/stem.asp"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {' '}
-            visit the VBA STEM website.
-          </a>
-        </p>
-      </div>
-    )}
+    <div>
+      <p>
+        The Edith Nourse Rogers STEM Scholarship provides up to 9 months of
+        additional Post-9/11 GI Bill benefits, to a maximum of $30,000.
+        <br />
+        <br />
+        Veterans and Fry Scholars may qualify for this scholarship if they're
+        enrolled in an undergraduate program for Science, Technology,
+        Engineering, or Math (STEM), or if they've earned a STEM degree and are
+        getting a teaching certification.
+        <br />
+        <br />
+        To learn more about the STEM Scholarship,{' '}
+        <a
+          href="https://benefits.va.gov/gibill/fgib/stem.asp"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {' '}
+          visit the VBA STEM website.
+        </a>
+      </p>
+    </div>
   </AdditionalInfo>
 );

--- a/src/applications/gi/components/content/StemScholarshipNotification.jsx
+++ b/src/applications/gi/components/content/StemScholarshipNotification.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import environment from '../../../../platform/utilities/environment';
 
 export const StemScholarshipNotification = () => (
   <div className="stem-notification">
@@ -7,10 +6,9 @@ export const StemScholarshipNotification = () => (
     <div className="feature">
       <h4>The Edith Nourse Rogers STEM Scholarship</h4>
       <p>
-        {environment.isProduction() &&
-          'On August 1, 2019, VA is launching the Edith Nourse Rogers STEM Scholarship for students enrolled in a high-demand STEM (Science, Technology, Engineering, and Math) program.'}
-        {!environment.isProduction() &&
-          'On August 1, 2019, VA launched the Edith Nourse Rogers STEM Scholarship for students enrolled in a high-demand STEM (Science, Technology, Engineering, and Math) program.'}
+        On August 1, 2019, VA launched the Edith Nourse Rogers STEM Scholarship
+        for students enrolled in a high-demand STEM (Science, Technology,
+        Engineering, and Math) program.
       </p>
       <p>
         To learn more about this scholarship,{' '}

--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -13,7 +13,6 @@ import {
 import { getCalculatedBenefits } from '../../selectors/calculator';
 import EligibilityForm from '../search/EligibilityForm';
 import CalculatorForm from '../profile/CalculatorForm';
-import environment from '../../../../platform/utilities/environment';
 
 const CalculatorResultRow = ({ label, value, header, bold, visible }) =>
   visible ? (
@@ -60,26 +59,11 @@ export class Calculator extends React.Component {
         >
           {expanded ? 'Hide' : 'Edit'} eligibility details
         </button>
-        {environment.isProduction() && (
-          <div>
-            {expanded ? (
-              <div className="form-expanding-group-open">
-                <EligibilityForm
-                  eligibilityChange={this.props.eligibilityChange}
-                />
-              </div>
-            ) : null}
-          </div>
-        )}
-        {!environment.isProduction() && (
-          <div>
-            {expanded ? (
-              <EligibilityForm
-                eligibilityChange={this.props.eligibilityChange}
-              />
-            ) : null}
-          </div>
-        )}
+        <div>
+          {expanded ? (
+            <EligibilityForm eligibilityChange={this.props.eligibilityChange} />
+          ) : null}
+        </div>
       </div>
     );
   }
@@ -99,38 +83,17 @@ export class Calculator extends React.Component {
         >
           {expanded ? 'Hide' : 'Edit'} calculator fields
         </button>
-        {environment.isProduction() && (
-          <div>
-            {expanded ? (
-              <div className="form-expanding-group-open">
-                <CalculatorForm
-                  inputs={inputs}
-                  displayedInputs={displayed}
-                  onShowModal={this.props.showModal}
-                  onInputChange={this.props.calculatorInputChange}
-                  onBeneficiaryZIPCodeChanged={
-                    this.props.beneficiaryZIPCodeChanged
-                  }
-                />
-              </div>
-            ) : null}
-          </div>
-        )}
-        {!environment.isProduction() && (
-          <div>
-            {expanded ? (
-              <CalculatorForm
-                inputs={inputs}
-                displayedInputs={displayed}
-                onShowModal={this.props.showModal}
-                onInputChange={this.props.calculatorInputChange}
-                onBeneficiaryZIPCodeChanged={
-                  this.props.beneficiaryZIPCodeChanged
-                }
-              />
-            ) : null}
-          </div>
-        )}
+        <div>
+          {expanded ? (
+            <CalculatorForm
+              inputs={inputs}
+              displayedInputs={displayed}
+              onShowModal={this.props.showModal}
+              onInputChange={this.props.calculatorInputChange}
+              onBeneficiaryZIPCodeChanged={this.props.beneficiaryZIPCodeChanged}
+            />
+          ) : null}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Description

As a developer, I need to remove a production flag so that the new functionality is available in the production environment. Also removed blue bar from schools profile page and 508 keyboard trap fix. 

https://github.com/department-of-veterans-affairs/va.gov-team/issues/764

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19422

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19407

## Testing done

Local testing 
## Screenshots
![Screen Shot 2019-08-16 at 8 54 54 AM](https://user-images.githubusercontent.com/50601724/63175859-d8c14580-c012-11e9-9e42-bcdb83577450.png)
![keyboardtrap](https://user-images.githubusercontent.com/50601724/63175885-e5459e00-c012-11e9-97c7-652029800fd0.gif)
![Screen Shot 2019-08-16 at 10 45 26 AM](https://user-images.githubusercontent.com/50601724/63176051-35bcfb80-c013-11e9-8888-9e184becb4d1.png)


## Acceptance criteria
- [x] The flag hiding the updated Comparison Tool Landing Page notification text is removed.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
