### PR TITLE
Add support for two new CTA widget types

### DIFF
--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -7,6 +7,8 @@ export const frontendApps = {
   MESSAGING: 'messaging',
   LAB_AND_TEST_RESULTS: 'lab-and-test-results',
   APPOINTMENTS: 'appointments',
+  VIEW_APPOINTMENTS: 'view-appointments',
+  SCHEDULE_APPOINTMENTS: 'schedule-appointments',
   GI_BILL_BENEFITS: 'gi-bill-benefits',
   DISABILITY_BENEFITS: 'disability-benefits',
   CLAIMS_AND_APPEALS: 'claims-and-appeals',
@@ -22,6 +24,8 @@ const HEALTH_TOOLS = [
   frontendApps.MESSAGING,
   frontendApps.LAB_AND_TEST_RESULTS,
   frontendApps.APPOINTMENTS,
+  frontendApps.VIEW_APPOINTMENTS,
+  frontendApps.SCHEDULE_APPOINTMENTS,
   frontendApps.DIRECT_DEPOSIT,
 ];
 
@@ -36,6 +40,8 @@ export const hasRequiredMhvAccount = (appId, accountLevel) => {
       return MHV_ACCOUNT_TYPES.slice(0, 2).includes(accountLevel);
     case frontendApps.MESSAGING:
     case frontendApps.APPOINTMENTS:
+    case frontendApps.VIEW_APPOINTMENTS:
+    case frontendApps.SCHEDULE_APPOINTMENTS:
       return accountLevel === 'Premium';
     default:
       // Not a recognized health tool.
@@ -66,6 +72,8 @@ export const mhvToolName = appId => {
       return 'Lab and Test Results';
 
     case frontendApps.APPOINTMENTS:
+    case frontendApps.VIEW_APPOINTMENTS:
+    case frontendApps.SCHEDULE_APPOINTMENTS:
       return 'VA Appointments';
 
     case frontendApps.DIRECT_DEPOSIT:
@@ -103,6 +111,18 @@ export const toolUrl = (appId, index) => {
           `${mhvBaseUrl()}/mhv-portal-web/appointments`,
           `${mhvBaseUrl()}/mhv-portal-web/web/myhealthevet/scheduling-a-va-appointment`,
         ][index],
+        redirect: false,
+      };
+
+    case frontendApps.VIEW_APPOINTMENTS:
+      return {
+        url: `${mhvBaseUrl()}/mhv-portal-web/appointments`,
+        redirect: false,
+      };
+
+    case frontendApps.SCHEDULE_APPOINTMENTS:
+      return {
+        url: `${mhvBaseUrl()}/mhv-portal-web/web/myhealthevet/scheduling-a-va-appointment`,
         redirect: false,
       };
 
@@ -178,6 +198,8 @@ export const requiredServices = appId => {
 
     case frontendApps.LAB_AND_TEST_RESULTS:
     case frontendApps.APPOINTMENTS:
+    case frontendApps.VIEW_APPOINTMENTS:
+    case frontendApps.SCHEDULE_APPOINTMENTS:
       return null;
 
     case frontendApps.GI_BILL_BENEFITS:
@@ -218,6 +240,12 @@ export const serviceDescription = (appId, index) => {
         'view your appointments',
         'schedule, reschedule, or cancel a VA appointment online',
       ][index];
+
+    case frontendApps.VIEW_APPOINTMENTS:
+      return 'view your appointments';
+
+    case frontendApps.SCHEDULE_APPOINTMENTS:
+      return 'schedule, reschedule, or cancel a VA appointment online';
 
     case frontendApps.GI_BILL_BENEFITS:
       return 'check your GI Bill Benefits';


### PR DESCRIPTION
## Description
With this change users of the VA.gov CMS can choose which type of
appointment component/widget to embed. Previously the only way to embed
an appointment widget for scheduling/cancelling appointments was to
embed two appoint widgets on the page and the FE code would make the
first widget a "view" appointments widget and it would make the second a
"schedule" appointments widget.

When this is merged a member of the content team can use a value of `schedule-appointments` for Widget Type to get the widget for scheduling and canceling appointments. Or they can use a value of `view-appointments` to get the widget for viewing appointments.

![edit_benefits_detail_page_schedule_and_view_va_appointments_online___veterans_affairs](https://user-images.githubusercontent.com/20728956/63188116-6f8f0180-c015-11e9-9d00-1cb00e220606.jpg)


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs