### PR TITLE
VAGOV-5462: Past events listing page fixes

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-facility-events.scss
+++ b/src/applications/static-pages/sass/modules/_m-facility-events.scss
@@ -14,20 +14,20 @@
   color: $color-link-default;
 }
 
-.va-c-btn-group {
-  font-size: 0;
-  line-height: 1;
-  white-space: nowrap;
-  display: inline-block;
-  .usa-button {
-    &:first-child {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-      margin-right: 0;
-    };
-    &:last-child {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
+
+@include media($medium-screen) {
+  .va-c-btn-group {
+    .usa-button {
+      &:first-child {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+        margin-right: 0;
+      };
+      &:last-child {
+        margin-top: 0;
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+      }
     }
   }
 }

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -2,10 +2,10 @@
      class="va-c-btn-group vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4"
      role="group" aria-label="Events List Toggle">
     {% if url contains 'past-events' %}
-        <a role="button" href={{ url | replace_first: 'past-events', 'events' }} class="usa-button usa-button-secondary">Upcoming events</a>
+        <a role="button" href={{ url | remove_first: 'past-events' }} class="usa-button usa-button-secondary">Upcoming events</a>
         <a role="button" href={{ url }} class="usa-button">Past events</a>
     {% else %}
         <a role="button" href={{ url }} class="usa-button">Upcoming events</a>
-        <a role="button" href={{ url | replace_first: 'events', 'past-events'}} class="usa-button usa-button-secondary">Past events</a>
+        <a role="button" href="{{ url }}/past-events" class="usa-button usa-button-secondary">Past events</a>
     {% endif %}
 </div>

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -1,11 +1,19 @@
 <div id="events-list-toggle"
-     class="usa-width-two-thirds va-c-btn-group vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4"
+     class="usa-width-two-thirds"
      role="group" aria-label="Events List Toggle">
-    {% if url contains 'past-events' %}
-        <a role="button" href={{ url | remove_first: 'past-events' }} class="usa-button usa-button-secondary">Upcoming events</a>
-        <a role="button" href={{ url }} class="usa-button">Past events</a>
-    {% else %}
-        <a role="button" href={{ url }} class="usa-button">Upcoming events</a>
-        <a role="button" href="{{ url }}/past-events" class="usa-button usa-button-secondary">Past events</a>
-    {% endif %}
+        <div class="usa-grid usa-grid-full
+        va-c-btn-group
+        vads-u-margin-bottom--3
+        medium-screen:vads-u-margin-bottom--4
+        vads-u-display--flex
+        vads-u-flex-direction--column
+        medium-screen:vads-u-flex-direction--row">
+                {% if url contains 'past-events' %}
+                        <a role="button" href={{ url | remove_first: 'past-events' }} class="usa-button usa-button-secondary">Upcoming events</a>
+                        <a role="button" href={{ url }} class="usa-button">Past events</a>
+                {% else %}
+                        <a role="button" href={{ url }} class="usa-button">Upcoming events</a>
+                        <a role="button" href="{{ url }}/past-events" class="usa-button usa-button-secondary">Past events</a>
+                {% endif %}
+        </div>
 </div>

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -1,5 +1,5 @@
 <div id="events-list-toggle"
-     class="va-c-btn-group vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4"
+     class="usa-width-two-thirds va-c-btn-group vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4"
      role="group" aria-label="Events List Toggle">
     {% if url contains 'past-events' %}
         <a role="button" href={{ url | remove_first: 'past-events' }} class="usa-button usa-button-secondary">Upcoming events</a>

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -7,13 +7,14 @@
         medium-screen:vads-u-margin-bottom--4
         vads-u-display--flex
         vads-u-flex-direction--column
-        medium-screen:vads-u-flex-direction--row">
+        medium-screen:vads-u-flex-direction--row
+        medium-screen:vads-u-align-items--flex-start">
                 {% if url contains 'past-events' %}
-                        <a role="button" href={{ url | remove_first: 'past-events' }} class="usa-button usa-button-secondary">Upcoming events</a>
-                        <a role="button" href={{ url }} class="usa-button">Past events</a>
+                        <a role="button" href="{{ url | remove_first: 'past-events' }}" class="vads-u-flex--1 usa-button usa-button-secondary vads-u-font-weight--normal">Upcoming events</a>
+                        <a role="button" href="{{ url }}" class="vads-u-flex--1 usa-button vads-u-font-weight--normal">Past events</a>
                 {% else %}
-                        <a role="button" href={{ url }} class="usa-button">Upcoming events</a>
-                        <a role="button" href="{{ url }}/past-events" class="usa-button usa-button-secondary">Past events</a>
+                        <a role="button" href="{{ url }}" class="vads-u-flex--1 usa-button vads-u-font-weight--normal">Upcoming events</a>
+                        <a role="button" href="{{ url }}/past-events" class="vads-u-flex--1 usa-button usa-button-secondary vads-u-font-weight--normal">Past events</a>
                 {% endif %}
         </div>
 </div>

--- a/src/site/layouts/events_page.drupal.liquid
+++ b/src/site/layouts/events_page.drupal.liquid
@@ -78,7 +78,9 @@ Example data:
                 <div class="vads-u-margin-bottom--2">
                   <strong>In the spotlight at {{ regionOrOffice }}</strong>
                 </div>
-                {% include "src/site/teasers/event_featured.drupal.liquid" with node = featuredEvent %}
+                {% unless url contains 'past-events' %}
+                  {% include "src/site/teasers/event_featured.drupal.liquid" with node = featuredEvent %}
+                {% endunless %}
               </div>
             </div>
           </div>

--- a/src/site/layouts/events_page.drupal.liquid
+++ b/src/site/layouts/events_page.drupal.liquid
@@ -65,25 +65,25 @@ Example data:
           {% if paginator.prev == null %}
           {% for featuredEvent in eventTeasers.entities %}
           {% if forloop.first == true %}
-          <div class="usa-width-two-thirds">
-            <div id="featured-content" class="usa-grid usa-grid-full
-              vads-u-margin-bottom--3
-              medium-screen:vads-u-margin-bottom--4
-              vads-u-display--flex
-              vads-u-flex-direction--column
-              medium-screen:vads-u-flex-direction--row
-              vads-u-border-left--7px
-              vads-u-border-color--primary-alt-lightest">
-              <div class="usa-width-full vads-u-padding-left--2">
-                <div class="vads-u-margin-bottom--2">
-                  <strong>In the spotlight at {{ regionOrOffice }}</strong>
+          {% unless entityUrl.path contains 'past-events' %}
+            <div class="usa-width-two-thirds">
+              <div id="featured-content" class="usa-grid usa-grid-full
+                vads-u-margin-bottom--3
+                medium-screen:vads-u-margin-bottom--4
+                vads-u-display--flex
+                vads-u-flex-direction--column
+                medium-screen:vads-u-flex-direction--row
+                vads-u-border-left--7px
+                vads-u-border-color--primary-alt-lightest">
+                <div class="usa-width-full vads-u-padding-left--2">
+                  <div class="vads-u-margin-bottom--2">
+                    <strong>In the spotlight at {{ regionOrOffice }}</strong>
+                  </div>
+                    {% include "src/site/teasers/event_featured.drupal.liquid" with node = featuredEvent %}
                 </div>
-                {% unless url contains 'past-events' %}
-                  {% include "src/site/teasers/event_featured.drupal.liquid" with node = featuredEvent %}
-                {% endunless %}
               </div>
             </div>
-          </div>
+          {% endunless %}
           {% endif %}
           {% endfor %}
           {% endif %}

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -204,7 +204,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   );
 
   // Past Events listing page
-  const pastEventsEntityUrl = createEntityUrlObj(drupalPagePath);
+  const pastEventsEntityUrl = createEntityUrlObj(`${drupalPagePath}/events`);
 
   const pastEventsObj = Object.assign(
     { allEventTeasers: sortedPastEventTeasers },
@@ -222,7 +222,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   );
   const pastEventsPagePath = pastEventsPage.entityUrl.path;
   pastEventsPage.regionOrOffice = page.title;
-  eventPage.entityUrl = generateBreadCrumbs(pastEventsPagePath);
+  pastEventsPage.entityUrl = generateBreadCrumbs(pastEventsPagePath);
 
   paginatePages(
     pastEventsPage,

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -207,7 +207,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   const pastEventsEntityUrl = createEntityUrlObj(drupalPagePath);
 
   const pastEventsObj = Object.assign(
-    { allEventTeasers: pastEventTeasers },
+    { allEventTeasers: sortedPastEventTeasers },
     { eventTeasers: page.eventTeasers },
     { fieldIntroTextEventsPage: page.fieldIntroTextEventsPage },
     { facilitySidebar: sidebar },

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -206,7 +206,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   );
   const pastEventsPage = updateEntityUrlObj(
     pastEventsObj,
-    drupalPagePath,
+    `${drupalPagePath}/events`,
     'Past events',
   );
   const pastEventsPagePath = pastEventsPage.entityUrl.path;

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -148,19 +148,15 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   // Events listing page
   const allEvents = page.allEventTeasers;
 
+  // store past & current events
   const pastEventTeasers = {
     entities: [],
   };
-
-  const sortedPastEventTeasers = {
-    entities: [],
-  };
-
-  // get current events
   const currentEventTeasers = {
     entities: [],
   };
 
+  // separate current events from past events;
   _.forEach(allEvents.entities, value => {
     const eventTeaser = value;
     const startDate = eventTeaser.fieldDate.startDate;
@@ -172,13 +168,12 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     }
   });
 
-  sortedPastEventTeasers.entities = _.orderBy(
+  // sort past events into reverse chronological order by start date
+  pastEventTeasers.entities = _.orderBy(
     pastEventTeasers.entities,
     ['fieldDate.startDate'],
     ['desc'],
   );
-
-  // sort past events into reverse chronological order by start date
 
   const eventEntityUrl = createEntityUrlObj(drupalPagePath);
   const eventObj = Object.assign(
@@ -207,7 +202,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   const pastEventsEntityUrl = createEntityUrlObj(`${drupalPagePath}/events`);
 
   const pastEventsObj = Object.assign(
-    { allEventTeasers: sortedPastEventTeasers },
+    { allEventTeasers: pastEventTeasers },
     { eventTeasers: page.eventTeasers },
     { fieldIntroTextEventsPage: page.fieldIntroTextEventsPage },
     { facilitySidebar: sidebar },
@@ -262,6 +257,13 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   );
 }
 
+/**
+ * Modify the page object to add social links.
+ *
+ * @param {page} page The page object.
+ * @param {pages} pages an array of page of objects containing a region page
+ * @return nothing
+ */
 function addGetUpdatesFields(page, pages) {
   const regionPage = pages.find(
     p =>

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -148,8 +148,11 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   // Events listing page
   const allEvents = page.allEventTeasers;
 
-  // get past events
   const pastEventTeasers = {
+    entities: [],
+  };
+
+  const sortedPastEventTeasers = {
     entities: [],
   };
 
@@ -168,6 +171,12 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
       currentEventTeasers.entities.push(eventTeaser);
     }
   });
+
+  sortedPastEventTeasers.entities = _.orderBy(
+    pastEventTeasers.entities,
+    ['fieldDate.startDate'],
+    ['desc'],
+  );
 
   // sort past events into reverse chronological order by start date
 
@@ -253,14 +262,9 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   );
 }
 
-// Adds the social media links and email subscription links
-// for local facility page and region detail page entity types from their respective region page
 function addGetUpdatesFields(page, pages) {
   const regionPage = pages.find(
     p =>
-      // Finds the region page based on the second link url
-      // If the url matches the region page's entityUrl.path, it is the base region page for this page
-      // Note: this is done this way because a NodeHealthCareRegionDetailPage has no association field to a NodeHealthCareRegionPage
       p.entityUrl
         ? p.entityUrl.path === page.entityUrl.breadcrumb[1].url.path
         : false,

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -169,6 +169,8 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     }
   });
 
+  // sort past events into reverse chronological order by start date
+
   const eventEntityUrl = createEntityUrlObj(drupalPagePath);
   const eventObj = Object.assign(
     { allEventTeasers: currentEventTeasers },

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -289,6 +289,7 @@ function compilePage(page, contentData) {
       break;
     case 'event': {
       // eslint-disable-next-line no-param-reassign
+      page.entityUrl = generateBreadCrumbs(entityUrl.path);
       pageCompiled = Object.assign(
         page,
         facilitySidebarNavItems,


### PR DESCRIPTION
## Description
Sorts past event listing page in reverse chronological order, makes event listing toggle buttons equal width, fixes responsive view of event listing toggle, changes url to 'events/past-events'

## Testing done
Locally with prod data. Manually set some events to dates in the past and manually set a featured event in lando local. env.

## Screenshots
![Screen Shot 2019-08-18 at 5 11 09 PM](https://user-images.githubusercontent.com/3157339/63231581-37d1b680-c1db-11e9-9b89-4f18b29dffee.png)
![Screen Shot 2019-08-18 at 3 59 58 PM](https://user-images.githubusercontent.com/3157339/63230925-677bc100-c1d1-11e9-9278-364b0ddf5cb6.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
