### PR TITLE
Update STEM tool tip

### DIFF
--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import * as actions from '../actions';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
-import environmnet from 'platform/utilities/environment';
-import environment from '../../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 
 export class Modals extends React.Component {
   calcBeneficiaryLocationQuestionContent = () => (
@@ -584,8 +583,8 @@ export class Modals extends React.Component {
               rel="noopener noreferrer"
             >
               {' '}
-              {environmnet.isProduction() && 'visit the VBA STEM website.'}
-              {!environmnet.isProduction() &&
+              {environment.isProduction() && 'visit the VBA STEM website.'}
+              {!environment.isProduction() &&
                 'visit the Rogers STEM Scholarship website.'}
             </a>
           </p>

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import * as actions from '../actions';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import environmnet from 'platform/utilities/environment';
+import environment from '../../../platform/utilities/environment';
 
 export class Modals extends React.Component {
   calcBeneficiaryLocationQuestionContent = () => (
@@ -559,7 +560,8 @@ export class Modals extends React.Component {
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('stemIndicator')}
       >
-        <h3>STEM</h3>
+        {environment.isProduction() && <h3>STEM</h3>}
+        {!environment.isProduction() && <h3>The Rogers STEM Scholarship</h3>}
         <div>
           <p>
             The Edith Nourse Rogers STEM Scholarship provides up to 9 months of
@@ -572,7 +574,10 @@ export class Modals extends React.Component {
             degree and are getting a teaching certification.
           </p>
           <p>
-            To learn more about the STEM Scholarship,{' '}
+            {environment.isProduction() &&
+              'To learn more about the STEM Scholarship,'}{' '}
+            {!environment.isProduction() &&
+              'To learn more about this scholarship,'}{' '}
             <a
               href="https://benefits.va.gov/gibill/fgib/stem.asp"
               target="_blank"

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import * as actions from '../actions';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+import environmnet from 'platform/utilities/environment';
 
 export class Modals extends React.Component {
   calcBeneficiaryLocationQuestionContent = () => (
@@ -578,7 +579,9 @@ export class Modals extends React.Component {
               rel="noopener noreferrer"
             >
               {' '}
-              visit the VBA STEM website.
+              {environmnet.isProduction() && 'visit the VBA STEM website.'}
+              {!environmnet.isProduction() &&
+                'visit the Rogers STEM Scholarship website.'}
             </a>
           </p>
         </div>


### PR DESCRIPTION
## Description
As a comparison tool user, I need the messaging displayed in the STEM tooltip to consistent with other STEM language so that I receive a uniform experience when interacting with Rogers STEM Scholarship information

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19506

## Testing done
local testing

## Screenshots
<img width="709" alt="Screen Shot 2019-08-19 at 9 13 58 AM" src="https://user-images.githubusercontent.com/50601724/63268606-8e360800-c262-11e9-9b3d-0dd5d2a999d4.png">



## Acceptance criteria
- [x] After clicking on the "Rogers STEM Scholarship" link on the School Profile page a modal is displayed with the following text:
The Rogers STEM Scholarship

The Edith Nourse Rogers STEM Scholarship provides up to 9 months of additional Post-9/11 GI Bill benefits, to a maximum of $30,000.

Veterans and Fry Scholars may qualify for this scholarship if they're enrolled in an undergraduate program for Science, Technology, Engineering, or Math (STEM), or if they've earned a STEM degree and are getting a teaching certification.

To learn more about this scholarship, visit the Rogers STEM Scholarship website.

"visit the Rogers STEM Scholarship website" is a link to the following page:
https://benefits.va.gov/gibill/fgib/stem.asp

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
