### PR TITLE
VAGOV-5545: Embedded Staff Profiles without images should left align

### DIFF
--- a/src/site/includes/bioParagraph.drupal.liquid
+++ b/src/site/includes/bioParagraph.drupal.liquid
@@ -1,10 +1,12 @@
 <div class="usa-grid usa-grid-full vads-u-margin-bottom--4">
-  <div class="usa-width-one-fourth">
-    {% assign image = bio.fieldMedia.entity.image %}
-    <img class="circular-profile-image" src="{{ image.derivative.url }}" alt="{{ image.alt }}"
-      title="{{ image.title }}" width="{{ image.derivative.width }}"
-      height="{{ image.derivative.height }}">
-  </div>
+  {% if bio.fieldMedia != emtpy %}
+    <div class="usa-width-one-fourth">
+      {% assign image = bio.fieldMedia.entity.image %}
+      <img class="circular-profile-image" src="{{ image.derivative.url }}" alt="{{ image.alt }}"
+        title="{{ image.title }}" width="{{ image.derivative.width }}"
+        height="{{ image.derivative.height }}">
+    </div>
+  {% endif %}
   <div class="usa-width-two-thirds">
     <h2 class="
         vads-u-margin-bottom--1

--- a/src/site/teasers/bio.drupal.liquid
+++ b/src/site/teasers/bio.drupal.liquid
@@ -41,12 +41,14 @@ Example data:
 {% assign header = "h4" %}
 {% endif %}
 <div class="usa-grid usa-grid-full vads-u-margin-bottom--4">
-    <div class="usa-width-one-third">
-        {% assign image = node.fieldMedia.entity.image %}
-        <img src="{{ image.derivative.url }}" alt="{{ image.alt }}"
-            title="{{ image.title }}" width="{{ image.derivative.width }}"
-            height="{{ image.derivative.height }}">
-    </div>
+    {% if node.fieldMedia != empty %}
+        <div class="usa-width-one-third">
+            {% assign image = node.fieldMedia.entity.image %}
+            <img src="{{ image.derivative.url }}" alt="{{ image.alt }}"
+                title="{{ image.title }}" width="{{ image.derivative.width }}"
+                height="{{ image.derivative.height }}">
+        </div>
+    {% endif %}
     <div class="usa-width-two-thirds">
         <h2 class="
         vads-u-margin-bottom--1


### PR DESCRIPTION
## Description
left aligns the staff profiles without images

## Testing done
locally with staging data

## Screenshots
![localhost_3001_pittsburgh-health-care_caregiver-support-coordinators_](https://user-images.githubusercontent.com/19178435/63291975-82097500-c279-11e9-902e-04431a9412ad.png)

## Acceptance criteria
- [ ] staff profiles are left aligned if there is no image

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
