### PR TITLE
removed flags

### DIFF
--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -119,21 +119,19 @@ export class AdditionalInformation extends React.Component {
           &nbsp;
           {institution.independentStudy ? 'Yes' : 'No'}
         </div>
-        {!environment.isProduction() && (
-          <div>
-            <strong>
-              <button
-                type="button"
-                className="va-button-link learn-more-button"
-                onClick={this.props.onShowModal.bind(this, 'stemIndicator')}
-              >
-                Rogers STEM Scholarship:
-              </button>
-            </strong>
-            &nbsp;
-            {institution.stemIndicator ? 'Yes' : 'No'}
-          </div>
-        )}
+        <div>
+          <strong>
+            <button
+              type="button"
+              className="va-button-link learn-more-button"
+              onClick={this.props.onShowModal.bind(this, 'stemIndicator')}
+            >
+              Rogers STEM Scholarship:
+            </button>
+          </strong>
+          &nbsp;
+          {institution.stemIndicator ? 'Yes' : 'No'}
+        </div>
       </div>
     );
   }

--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -6,8 +6,6 @@ import Dropdown from '../Dropdown';
 import SearchResultTypeOfInstitutionFilter from './SearchResultTypeOfInstitutionFilter';
 import { addAllOption } from '../../utils/helpers';
 
-import environment from '../../../../platform/utilities/environment';
-
 class InstitutionFilterForm extends React.Component {
   handleDropdownChange = e => {
     const { name: field, value } = e.target;
@@ -95,14 +93,12 @@ class InstitutionFilterForm extends React.Component {
           label="8 Keys to Vet Success"
           onChange={this.handleCheckboxChange}
         />
-        {!environment.isProduction() && (
-          <Checkbox
-            checked={filters.stemIndicator}
-            name="stemIndicator"
-            label="Rogers STEM Scholarship"
-            onChange={this.handleCheckboxChange}
-          />
-        )}
+        <Checkbox
+          checked={filters.stemIndicator}
+          name="stemIndicator"
+          label="Rogers STEM Scholarship"
+          onChange={this.handleCheckboxChange}
+        />
         <Checkbox
           checked={filters.priorityEnrollment}
           name="priorityEnrollment"


### PR DESCRIPTION
## Description
As a developer, I need to remove the production flag that is hiding the STEM Scholarship Search Results Filter and STEM Scholarship profile indicator so that the functionality can be made available in the production environment.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19507

## Testing done
Local Testing

## Screenshots


## Acceptance criteria
- [x] The "Rogers STEM Scholarship" Filter is available under "Programs" in the Comparison Tool Search Results Filters.
- [x] The "Rogers STEM Scholarship" indicator is displayed under "Additional Information" on the School Profile Page of the Comparison Tool

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
