### PR TITLE
Remove support for `appointments` widget type

### DIFF
--- a/src/applications/static-pages/createCallToActionWidget.js
+++ b/src/applications/static-pages/createCallToActionWidget.js
@@ -13,14 +13,10 @@ export default async function createCallToActionWidget(store, widgetType) {
     } = await import(/* webpackChunkName: "cta-widget" */ '../../platform/site-wide/cta-widget');
 
     // since these widgets are on content pages, we don't want to focus on them
-    widgets.forEach((el, index) => {
+    widgets.forEach(el => {
       ReactDOM.render(
         <Provider store={store}>
-          <CallToActionWidget
-            appId={el.dataset.appId}
-            index={index}
-            setFocus={false}
-          />
+          <CallToActionWidget appId={el.dataset.appId} setFocus={false} />
         </Provider>,
         el,
       );

--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -1,7 +1,11 @@
 import backendServices from 'platform/user/profile/constants/backendServices';
 import environment from 'platform/utilities/environment';
 
-export const frontendApps = {
+/**
+ * These are the valid values for the Widget Type field in the Drupal CMS when
+ * embedding a Call To Action React Widget in a static page
+ */
+export const widgetTypes = {
   HEALTH_RECORDS: 'health-records',
   RX: 'rx',
   MESSAGING: 'messaging',
@@ -18,27 +22,27 @@ export const frontendApps = {
 };
 
 const HEALTH_TOOLS = [
-  frontendApps.HEALTH_RECORDS,
-  frontendApps.RX,
-  frontendApps.MESSAGING,
-  frontendApps.LAB_AND_TEST_RESULTS,
-  frontendApps.VIEW_APPOINTMENTS,
-  frontendApps.SCHEDULE_APPOINTMENTS,
-  frontendApps.DIRECT_DEPOSIT,
+  widgetTypes.HEALTH_RECORDS,
+  widgetTypes.RX,
+  widgetTypes.MESSAGING,
+  widgetTypes.LAB_AND_TEST_RESULTS,
+  widgetTypes.VIEW_APPOINTMENTS,
+  widgetTypes.SCHEDULE_APPOINTMENTS,
+  widgetTypes.DIRECT_DEPOSIT,
 ];
 
 const MHV_ACCOUNT_TYPES = ['Premium', 'Advanced', 'Basic'];
 
 export const hasRequiredMhvAccount = (appId, accountLevel) => {
   switch (appId) {
-    case frontendApps.HEALTH_RECORDS:
-    case frontendApps.LAB_AND_TEST_RESULTS:
+    case widgetTypes.HEALTH_RECORDS:
+    case widgetTypes.LAB_AND_TEST_RESULTS:
       return MHV_ACCOUNT_TYPES.includes(accountLevel);
-    case frontendApps.RX:
+    case widgetTypes.RX:
       return MHV_ACCOUNT_TYPES.slice(0, 2).includes(accountLevel);
-    case frontendApps.MESSAGING:
-    case frontendApps.VIEW_APPOINTMENTS:
-    case frontendApps.SCHEDULE_APPOINTMENTS:
+    case widgetTypes.MESSAGING:
+    case widgetTypes.VIEW_APPOINTMENTS:
+    case widgetTypes.SCHEDULE_APPOINTMENTS:
       return accountLevel === 'Premium';
     default:
       // Not a recognized health tool.
@@ -56,23 +60,23 @@ export const mhvBaseUrl = () => {
 
 export const mhvToolName = appId => {
   switch (appId) {
-    case frontendApps.HEALTH_RECORDS:
+    case widgetTypes.HEALTH_RECORDS:
       return 'VA Blue Button';
 
-    case frontendApps.RX:
+    case widgetTypes.RX:
       return 'Prescription Refill and Tracking';
 
-    case frontendApps.MESSAGING:
+    case widgetTypes.MESSAGING:
       return 'Secure Messaging';
 
-    case frontendApps.LAB_AND_TEST_RESULTS:
+    case widgetTypes.LAB_AND_TEST_RESULTS:
       return 'Lab and Test Results';
 
-    case frontendApps.VIEW_APPOINTMENTS:
-    case frontendApps.SCHEDULE_APPOINTMENTS:
+    case widgetTypes.VIEW_APPOINTMENTS:
+    case widgetTypes.SCHEDULE_APPOINTMENTS:
       return 'VA Appointments';
 
-    case frontendApps.DIRECT_DEPOSIT:
+    case widgetTypes.DIRECT_DEPOSIT:
       return 'Direct Deposit';
 
     default: // Not a recognized health tool.
@@ -83,80 +87,80 @@ export const mhvToolName = appId => {
 
 export const toolUrl = appId => {
   switch (appId) {
-    case frontendApps.HEALTH_RECORDS:
+    case widgetTypes.HEALTH_RECORDS:
       return {
         url: `${mhvBaseUrl()}/mhv-portal-web/download-my-data`,
         redirect: false,
       };
 
-    case frontendApps.RX:
+    case widgetTypes.RX:
       return {
         url: `${mhvBaseUrl()}/mhv-portal-web/web/myhealthevet/refill-prescriptions`,
         redirect: true,
       };
 
-    case frontendApps.MESSAGING:
+    case widgetTypes.MESSAGING:
       return {
         url: `${mhvBaseUrl()}/mhv-portal-web/secure-messaging`,
         redirect: true,
       };
 
-    case frontendApps.VIEW_APPOINTMENTS:
+    case widgetTypes.VIEW_APPOINTMENTS:
       return {
         url: `${mhvBaseUrl()}/mhv-portal-web/appointments`,
         redirect: false,
       };
 
-    case frontendApps.SCHEDULE_APPOINTMENTS:
+    case widgetTypes.SCHEDULE_APPOINTMENTS:
       return {
         url: `${mhvBaseUrl()}/mhv-portal-web/web/myhealthevet/scheduling-a-va-appointment`,
         redirect: false,
       };
 
-    case frontendApps.LAB_AND_TEST_RESULTS:
+    case widgetTypes.LAB_AND_TEST_RESULTS:
       return {
         url: `${mhvBaseUrl()}/mhv-portal-web/labs-tests`,
         redirect: true,
       };
 
-    case frontendApps.CLAIMS_AND_APPEALS:
+    case widgetTypes.CLAIMS_AND_APPEALS:
       return {
         url: '/track-claims/',
         redirect: true,
       };
 
-    case frontendApps.GI_BILL_BENEFITS:
+    case widgetTypes.GI_BILL_BENEFITS:
       return {
         url: '/education/gi-bill/post-9-11/ch-33-benefit/status',
         redirect: false,
       };
 
-    case frontendApps.DISABILITY_BENEFITS:
+    case widgetTypes.DISABILITY_BENEFITS:
       return {
         url: '/disability/how-to-file-claim',
         redirect: false,
       };
 
-    case frontendApps.LETTERS:
+    case widgetTypes.LETTERS:
       return {
         url: '/records/download-va-letters/letters',
         redirect: false,
       };
 
-    case frontendApps.VETERAN_ID_CARD:
+    case widgetTypes.VETERAN_ID_CARD:
       return {
         url: '/records/get-veteran-id-cards/apply',
         redirect: false,
       };
 
-    case frontendApps.VET_TEC:
+    case widgetTypes.VET_TEC:
       return {
         url:
           '/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994',
         redirect: false,
       };
 
-    case frontendApps.DIRECT_DEPOSIT:
+    case widgetTypes.DIRECT_DEPOSIT:
       return {
         url: '/profile',
         redirect: false,
@@ -174,32 +178,32 @@ export const toolUrl = appId => {
 
 export const requiredServices = appId => {
   switch (appId) {
-    case frontendApps.HEALTH_RECORDS:
+    case widgetTypes.HEALTH_RECORDS:
       return backendServices.HEALTH_RECORDS;
 
-    case frontendApps.RX:
+    case widgetTypes.RX:
       return backendServices.RX;
 
-    case frontendApps.MESSAGING:
+    case widgetTypes.MESSAGING:
       return backendServices.MESSAGING;
 
-    case frontendApps.LAB_AND_TEST_RESULTS:
-    case frontendApps.VIEW_APPOINTMENTS:
-    case frontendApps.SCHEDULE_APPOINTMENTS:
+    case widgetTypes.LAB_AND_TEST_RESULTS:
+    case widgetTypes.VIEW_APPOINTMENTS:
+    case widgetTypes.SCHEDULE_APPOINTMENTS:
       return null;
 
-    case frontendApps.GI_BILL_BENEFITS:
-    case frontendApps.DISABILITY_BENEFITS:
-    case frontendApps.LETTERS:
+    case widgetTypes.GI_BILL_BENEFITS:
+    case widgetTypes.DISABILITY_BENEFITS:
+    case widgetTypes.LETTERS:
       return backendServices.EVSS_CLAIMS;
 
-    case frontendApps.CLAIMS_AND_APPEALS:
+    case widgetTypes.CLAIMS_AND_APPEALS:
       return [backendServices.EVSS_CLAIMS, backendServices.APPEALS_STATUS];
 
-    case frontendApps.VETERAN_ID_CARD:
+    case widgetTypes.VETERAN_ID_CARD:
       return backendServices.ID_CARD;
 
-    case frontendApps.VET_TEC:
+    case widgetTypes.VET_TEC:
       return backendServices.EDUCATION_BENEFITS;
 
     default:
@@ -209,43 +213,43 @@ export const requiredServices = appId => {
 
 export const serviceDescription = appId => {
   switch (appId) {
-    case frontendApps.HEALTH_RECORDS:
+    case widgetTypes.HEALTH_RECORDS:
       return 'view your VA medical records';
 
-    case frontendApps.RX:
+    case widgetTypes.RX:
       return 'refill prescriptions';
 
-    case frontendApps.MESSAGING:
+    case widgetTypes.MESSAGING:
       return 'send secure messages';
 
-    case frontendApps.LAB_AND_TEST_RESULTS:
+    case widgetTypes.LAB_AND_TEST_RESULTS:
       return 'view your lab and test results';
 
-    case frontendApps.VIEW_APPOINTMENTS:
+    case widgetTypes.VIEW_APPOINTMENTS:
       return 'view your appointments';
 
-    case frontendApps.SCHEDULE_APPOINTMENTS:
+    case widgetTypes.SCHEDULE_APPOINTMENTS:
       return 'schedule, reschedule, or cancel a VA appointment online';
 
-    case frontendApps.GI_BILL_BENEFITS:
+    case widgetTypes.GI_BILL_BENEFITS:
       return 'check your GI Bill Benefits';
 
-    case frontendApps.DISABILITY_BENEFITS:
+    case widgetTypes.DISABILITY_BENEFITS:
       return 'apply for disability benefits';
 
-    case frontendApps.CLAIMS_AND_APPEALS:
+    case widgetTypes.CLAIMS_AND_APPEALS:
       return 'see your claim or appeal status';
 
-    case frontendApps.LETTERS:
+    case widgetTypes.LETTERS:
       return 'get your VA Benefit Letters';
 
-    case frontendApps.VETERAN_ID_CARD:
+    case widgetTypes.VETERAN_ID_CARD:
       return 'apply for a Veteran ID Card';
 
-    case frontendApps.VET_TEC:
+    case widgetTypes.VET_TEC:
       return 'apply for VET TEC';
 
-    case frontendApps.DIRECT_DEPOSIT:
+    case widgetTypes.DIRECT_DEPOSIT:
       return 'change your direct deposit information online';
 
     default:

--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -6,7 +6,6 @@ export const frontendApps = {
   RX: 'rx',
   MESSAGING: 'messaging',
   LAB_AND_TEST_RESULTS: 'lab-and-test-results',
-  APPOINTMENTS: 'appointments',
   VIEW_APPOINTMENTS: 'view-appointments',
   SCHEDULE_APPOINTMENTS: 'schedule-appointments',
   GI_BILL_BENEFITS: 'gi-bill-benefits',
@@ -23,7 +22,6 @@ const HEALTH_TOOLS = [
   frontendApps.RX,
   frontendApps.MESSAGING,
   frontendApps.LAB_AND_TEST_RESULTS,
-  frontendApps.APPOINTMENTS,
   frontendApps.VIEW_APPOINTMENTS,
   frontendApps.SCHEDULE_APPOINTMENTS,
   frontendApps.DIRECT_DEPOSIT,
@@ -39,7 +37,6 @@ export const hasRequiredMhvAccount = (appId, accountLevel) => {
     case frontendApps.RX:
       return MHV_ACCOUNT_TYPES.slice(0, 2).includes(accountLevel);
     case frontendApps.MESSAGING:
-    case frontendApps.APPOINTMENTS:
     case frontendApps.VIEW_APPOINTMENTS:
     case frontendApps.SCHEDULE_APPOINTMENTS:
       return accountLevel === 'Premium';
@@ -71,7 +68,6 @@ export const mhvToolName = appId => {
     case frontendApps.LAB_AND_TEST_RESULTS:
       return 'Lab and Test Results';
 
-    case frontendApps.APPOINTMENTS:
     case frontendApps.VIEW_APPOINTMENTS:
     case frontendApps.SCHEDULE_APPOINTMENTS:
       return 'VA Appointments';
@@ -85,7 +81,7 @@ export const mhvToolName = appId => {
   return null;
 };
 
-export const toolUrl = (appId, index) => {
+export const toolUrl = appId => {
   switch (appId) {
     case frontendApps.HEALTH_RECORDS:
       return {
@@ -103,15 +99,6 @@ export const toolUrl = (appId, index) => {
       return {
         url: `${mhvBaseUrl()}/mhv-portal-web/secure-messaging`,
         redirect: true,
-      };
-
-    case frontendApps.APPOINTMENTS:
-      return {
-        url: [
-          `${mhvBaseUrl()}/mhv-portal-web/appointments`,
-          `${mhvBaseUrl()}/mhv-portal-web/web/myhealthevet/scheduling-a-va-appointment`,
-        ][index],
-        redirect: false,
       };
 
     case frontendApps.VIEW_APPOINTMENTS:
@@ -197,7 +184,6 @@ export const requiredServices = appId => {
       return backendServices.MESSAGING;
 
     case frontendApps.LAB_AND_TEST_RESULTS:
-    case frontendApps.APPOINTMENTS:
     case frontendApps.VIEW_APPOINTMENTS:
     case frontendApps.SCHEDULE_APPOINTMENTS:
       return null;
@@ -221,7 +207,7 @@ export const requiredServices = appId => {
   }
 };
 
-export const serviceDescription = (appId, index) => {
+export const serviceDescription = appId => {
   switch (appId) {
     case frontendApps.HEALTH_RECORDS:
       return 'view your VA medical records';
@@ -234,12 +220,6 @@ export const serviceDescription = (appId, index) => {
 
     case frontendApps.LAB_AND_TEST_RESULTS:
       return 'view your lab and test results';
-
-    case frontendApps.APPOINTMENTS:
-      return [
-        'view your appointments',
-        'schedule, reschedule, or cancel a VA appointment online',
-      ][index];
 
     case frontendApps.VIEW_APPOINTMENTS:
       return 'view your appointments';

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -23,7 +23,7 @@ import { isLoggedIn, selectProfile } from 'platform/user/selectors';
 import titleCase from 'platform/utilities/data/titleCase';
 
 import {
-  frontendApps,
+  widgetTypes,
   hasRequiredMhvAccount,
   isHealthTool,
   mhvToolName,
@@ -148,7 +148,7 @@ export class CallToActionWidget extends React.Component {
 
     if (
       this.props.profile.verified &&
-      this.props.appId === frontendApps.DIRECT_DEPOSIT
+      this.props.appId === widgetTypes.DIRECT_DEPOSIT
     ) {
       if (!this.props.profile.multifactor) {
         return (

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -52,14 +52,14 @@ import UpgradeAccount from './components/messages/UpgradeAccount';
 export class CallToActionWidget extends React.Component {
   constructor(props) {
     super(props);
-    const { appId, index } = props;
-    const { url, redirect } = toolUrl(appId, index);
+    const { appId } = props;
+    const { url, redirect } = toolUrl(appId);
 
     this._hasRedirect = redirect;
     this._isHealthTool = isHealthTool(appId);
     this._popup = null;
     this._requiredServices = requiredServices(appId);
-    this._serviceDescription = serviceDescription(appId, index);
+    this._serviceDescription = serviceDescription(appId);
     this._mhvToolName = mhvToolName(appId);
     this._toolUrl = url;
     this._gaPrefix = 'register-mhv';


### PR DESCRIPTION
## Description
This work removes the `appointments` Widget Type ID as a valid option for content editors using the Drupal CMS. The `appointments` ID has been superseded by the new `view-appointments` and `schedule-appointments` Widget Type IDs by this PR: https://github.com/department-of-veterans-affairs/vets-website/pull/10593. The removal of the `appointments` ID has been discussed with @kevwalsh on the CMS team. He has updated all uses of the `appointments` ID, switching them to either `view-appointments` or `schedule-appointments`.

Also remove support configuring widgets differently based on their position/index on the static page. This feature was only used in this one case; to treat appointments widgets differently depending on their position on a page. This is no longer required because CMS content editors can use either the `view-appointments` or `schedule-appointments` widget type IDs to directly control the configuration of the CallToActionWidget that gets embedded in the static page

History: The handling of the `appointments` Widget Type is a little... weird. The configuration of the `CallToActionWidget` will be different depending on the _index_ of a particular widget. The first appointments widget will be treated differently than the second one that appears. This results in a situation that is fragile (if an `index` prop is not provided to the `CallToActionWidget` or the provided index is not `0` or `1`, the widget will not be configured properly) and provides no mechanism for the CMS user to set _which_ of the two appointments widgets they would like to appear.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs