### PR TITLE
moved period out of link

### DIFF
--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -583,10 +583,11 @@ export class Modals extends React.Component {
               rel="noopener noreferrer"
             >
               {' '}
-              {environment.isProduction() && 'visit the VBA STEM website.'}
+              {environment.isProduction() && 'visit the VBA STEM website'}
               {!environment.isProduction() &&
-                'visit the Rogers STEM Scholarship website.'}
+                'visit the Rogers STEM Scholarship website'}
             </a>
+            .
           </p>
         </div>
       </Modal>


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19522

CT 111: Period is within link when it should not be outside of link

## Testing done
Local Testing

## Screenshots

<img width="330" alt="Screen Shot 2019-08-20 at 11 55 31 AM" src="https://user-images.githubusercontent.com/50601724/63363899-7f268700-c342-11e9-850a-565bd8b12b6d.png">

## Acceptance criteria
- [x] Period outside of link

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
