### PR TITLE
remove student outcomes prod flag

### DIFF
--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -8,16 +8,13 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import { getScrollOptions } from '../../../platform/utilities/ui';
 import { fetchProfile, setPageTitle, showModal } from '../actions';
 import AccordionItem from '../components/AccordionItem';
-import If from '../components/If';
 import HeadingSummary from '../components/profile/HeadingSummary';
 import Programs from '../components/profile/Programs';
-import Outcomes from '../components/profile/Outcomes';
 import Calculator from '../components/profile/Calculator';
 import CautionaryInformation from '../components/profile/CautionaryInformation';
 import AdditionalInformation from '../components/profile/AdditionalInformation';
 import VetTecInstitutionProfile from '../components/vet-tec/VetTecInstitutionProfile';
 import { outcomeNumbers } from '../selectors/outcomes';
-import environment from 'platform/utilities/environment';
 
 const { Element: ScrollElement, scroller } = Scroll;
 
@@ -67,7 +64,7 @@ export class ProfilePage extends React.Component {
   }
 
   render() {
-    const { constants, outcomes, profile } = this.props;
+    const { profile } = this.props;
 
     let content;
 
@@ -104,22 +101,6 @@ export class ProfilePage extends React.Component {
                     />
                   </AccordionItem>
                 )}
-                {!isOJT &&
-                  (environment.isProduction() && ( // production flag to display table only on staging (story #19452, sprint 27)
-                    <AccordionItem button="Student outcomes">
-                      <If
-                        condition={
-                          !!profile.attributes.facilityCode && !!constants
-                        }
-                        comment="TODO"
-                      >
-                        <Outcomes
-                          graphing={outcomes}
-                          onShowModal={this.props.showModal}
-                        />
-                      </If>
-                    </AccordionItem>
-                  ))}
                 <AccordionItem
                   button="Cautionary information"
                   ref={c => {


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19524

## Testing done
<img width="891" alt="Screen Shot 2019-08-20 at 2 32 34 PM" src="https://user-images.githubusercontent.com/48804654/63374217-61afe800-c357-11e9-9380-8dd65cf69db5.png">


## Screenshots


## Acceptance criteria
- [ ] The “Student outcomes” section is removed from the school profile page in production.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
