### PR TITLE
Squash the "Skipping..." logs into one

### DIFF
--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -30,17 +30,21 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
     },
   } = contentData;
 
+  const skippedContent = {
+    nullEntities: 0,
+    emptyEntities: 0,
+  };
   for (const page of pages) {
     // At this time, null values are returned for pages that are not yet published.
     // Once the Content-Preview server is up and running, then unpublished pages should
     // reliably return like any other page and we can delete this.
     if (!page) {
-      log('Skipping null entity...');
+      skippedContent.nullEntities++;
       continue;
     }
 
     if (!Object.keys(page).length) {
-      log('Skipping empty entity...');
+      skippedContent.emptyEntities++;
       continue;
     }
 
@@ -75,6 +79,14 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
       createHealthCareRegionListPages(pageCompiled, drupalPageDir, files);
     }
   }
+
+  if (skippedContent.nullEntities) {
+    log(`Skipped ${skippedContent.nullEntities} null entities`);
+  }
+  if (skippedContent.emptyEntities) {
+    log(`Skipped ${skippedContent.emptyEntities} empty entities`);
+  }
+
   addHomeContent(contentData, files);
 }
 


### PR DESCRIPTION
## Description
Previously, the output would be saturated with `Skipping empty entity...` lines.
![image](https://user-images.githubusercontent.com/12970166/63381352-55bf2880-c34d-11e9-9026-6b6c53bc395f.png)

This PR is a quick fix to squash them into a single log.

## Testing done
I tried `yarn watch --pull-drupal` using the latest `master`, but ran into a GraphQL error, so :man_shrugging: 

## Screenshots
None

## Acceptance criteria
- [x] The duplicate `Skipping [empty|null] entity...` lines are squashed and use a count instead

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
