### PR TITLE
Use the featureFlags helper instead of env directly

### DIFF
--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -7,7 +7,7 @@ import DowntimeNotification, {
 } from 'platform/monitoring/DowntimeNotification';
 import DowntimeApproaching from 'platform/monitoring/DowntimeNotification/components/DowntimeApproaching';
 import recordEvent from 'platform/monitoring/record-event';
-import environment from 'platform/utilities/environment';
+import featureFlags from '../featureFlags';
 
 import Vet360TransactionReporter from 'vet360/containers/TransactionReporter';
 
@@ -28,7 +28,7 @@ const ProfileTOC = ({ militaryInformation }) => (
       <li>
         <a href="#contact-information">Contact information</a>
       </li>
-      {!environment.isProduction() && <PaymentInformationTOCItem />}
+      {featureFlags.directDeposit && <PaymentInformationTOCItem />}
       <li>
         <a href="#personal-information">Personal information</a>
       </li>


### PR DESCRIPTION
## Description
This will allow us to simply toggle a single value in the featureFlags
object to deploy Direct Deposit to prod. We are already using this
featureFlags helper to gate the rendering of the PaymentInformation
component https://github.com/department-of-veterans-affairs/vets-website/blob/c53dec3228216b8cc58d12d44a91e2fff2ea3309/src/applications/personalization/profile360/containers/PaymentInformation.jsx#L288-L290

(I should have done the gating of the Direct Deposit table of contents item this way when I implemented it weeks ago)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs