### PR TITLE
VAGOV-4867: Drupal-powered homepage

### DIFF
--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -41,7 +41,8 @@
           <h3 class="heading-level-4"><a href="{{ hub.entity.entityUrl.path }}" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small icon-heading hub-icon-{{ hub.entity.fieldTitleIcon }} hub-background-{{ hub.entity.fieldTitleIcon }} white"></i>{{ hub.entity.fieldHomePageHubLabel }}</a></h4>
           <p class="homepage-benefits-description">{{ hub.entity.fieldTeaserText }}</p>
         </div>
-        {% if hub.end_row == true and forloop.last != true %}
+        {% comment %} Close this row and open a new one when needed. {% endcomment %}
+        {% if hub.endRow and forloop.last != true %}
         </div>
         <div class="usa-grid usa-grid-full homepage-benefits-row">
         {% endif %}

--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -11,7 +11,7 @@
       <!-- top row -->
       <div class="hub-links-row">
       {% for card in cards %}
-        <div class="hub-links-container">
+        <div class="hub-links-container" data-e2e="bucket">
           <h2 class="heading-level-3 hub-links-title"><i class="icon-large-baseline icon-heading hub-icon-{{ card.label | downcase | replace: ' ', '-' }} hub-color-{{ card.label | downcase | replace: ' ', '-' }}"></i>{{ card.label }}</h2>
           <ul class="hub-links-list">
             {% for link in card.links %}
@@ -37,7 +37,7 @@
     <section id="homepage-benefits">
       <div class="usa-grid usa-grid-full homepage-benefits-row">
       {% for hub in hubs %}
-        <div class="usa-width-one-third">
+        <div class="usa-width-one-third" data-e2e="hub">
           <h3 class="heading-level-4"><a href="{{ hub.entity.entityUrl.path }}" onclick="recordEvent({ event: 'nav-linkslist' });"><i class="icon-small icon-heading hub-icon-{{ hub.entity.fieldTitleIcon }} hub-background-{{ hub.entity.fieldTitleIcon }} white"></i>{{ hub.entity.fieldHomePageHubLabel }}</a></h4>
           <p class="homepage-benefits-description">{{ hub.entity.fieldTeaserText }}</p>
         </div>
@@ -100,7 +100,7 @@
     <div class="usa-grid usa-grid-full">
     {% comment %} Promos is an array of Drupal promo block entities. See /src/site/stages/build/drupal/home.js. {% endcomment %}  
     {% for promo in promos %}
-      <div class="usa-width-one-third homepage-news-story">
+      <div class="usa-width-one-third homepage-news-story" data-e2e="news">
         <div class="homepage-image-wrapper">
           <img class="lazy" width="552" data-src="{{ promo.entity.fieldImage.entity.image.url }}" alt="{{ promo.entity.fieldImage.entity.image.alt }}"/>
         </div>

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -34,7 +34,7 @@ function addHomeContent(contentData, files) {
     homeEntityObj = {
       ...homeEntityObj,
       // Since homepage is not an independent node, we don't have a source for metatags. So we need to hard-code these for now.
-      title: 'VA.gov',
+      title: 'VA.gov Home',
       description:
         'Apply for and manage the VA benefits and services you’ve earned as a Veteran, Servicemember, or family member—like health care, disability, education, and more.',
       cards: homePageMenuQuery.links.slice(0, menuLength), // Top Tasks menu. We have a hard limit.

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -33,6 +33,7 @@ function addHomeContent(contentData, files) {
 
     homeEntityObj = {
       ...homeEntityObj,
+      // Since homepage is not an independent node, we don't have a source for metatags. So we need to hard-code these for now.
       title: 'VA.gov',
       description:
         'Apply for and manage the VA benefits and services you’ve earned as a Veteran, Servicemember, or family member—like health care, disability, education, and more.',

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -33,6 +33,9 @@ function addHomeContent(contentData, files) {
 
     homeEntityObj = {
       ...homeEntityObj,
+      title: 'VA.gov',
+      description:
+        'Apply for and manage the VA benefits and services you’ve earned as a Veteran, Servicemember, or family member—like health care, disability, education, and more.',
       cards: homePageMenuQuery.links.slice(0, menuLength), // Top Tasks menu. We have a hard limit.
       hubs, // Full hub list.
       promos: homePagePromoBlockQuery.itemsOfEntitySubqueueHomePagePromos, // Promo blocks.

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -17,10 +17,24 @@ function addHomeContent(contentData, files) {
       },
     } = contentData;
 
+    // Liquid does not have a good modulo operator, so we let the template know when to end a row.
+    const hubs = homePageHubListQuery.itemsOfEntitySubqueueHomePageHubList.map(
+      (hub, i) => {
+        // We want 3 cards per row.
+        if ((i + 1) % 3 === 0) {
+          hub = {
+            ...hub,
+            endRow: true,
+          };
+        }
+        return hub;
+      },
+    );
+
     homeEntityObj = {
       ...homeEntityObj,
       cards: homePageMenuQuery.links.slice(0, menuLength), // Top Tasks menu. We have a hard limit.
-      hubs: homePageHubListQuery.itemsOfEntitySubqueueHomePageHubList, // Full hub list.
+      hubs, // Full hub list.
       promos: homePagePromoBlockQuery.itemsOfEntitySubqueueHomePagePromos, // Promo blocks.
     };
 


### PR DESCRIPTION
## Description
This PR resolves issues with the current Drupal-powered homepage code.
- Adds a property to hub entities so that the Liquid template knows when to switch rows.
- Adds title and description metatags.
- 8/22: Adds in data-e2e attribs in homepage Drupal template that were [added to non-Drupal template on 8/20](https://github.com/department-of-veterans-affairs/vets-website/commit/d36d1c27f62328143d188cee7dbcf26488eda603#diff-aed318b9f957a120f253572b64eef32a).

## Testing done
- Built FE with current `master` and Prod content.
- Navigated to home page.
- Observed that full hub list was in two columns instead of three.
- Observed that page <title> was missing text before the "|".
- Observed that the meta description fields were blank.
- Updated code.
- Rebuilt FE with new code.
- Observed that full hub list took up 3 columns and was properly ordered.
- Observed that the page <title> was accurate.
- Observed that the meta descriptions were accurate.

## Screenshots
<img width="1216" alt="Screen Shot 2019-08-21 at 2 59 42 PM" src="https://user-images.githubusercontent.com/1181665/63460407-74442300-c424-11e9-9248-6980a0d69a43.png">
<img width="1743" alt="Screen Shot 2019-08-21 at 2 59 53 PM" src="https://user-images.githubusercontent.com/1181665/63460417-78704080-c424-11e9-93b5-4ef63bf5c42d.png">


## Acceptance criteria
- [ ] Home page appears and behaves as it does on current va.gov.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
