### PR TITLE
add oprm to the whitelist for testing

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -16,6 +16,11 @@
         "cookieOnly": false
     },
     {
+        "hostname": "www.oprm.va.gov",
+        "pathnameBeginning": "/",
+        "cookieOnly": true 
+    },
+    {
         "hostname": "www.telehealth.va.gov",
         "pathnameBeginning": "/",
         "cookieOnly": true


### PR DESCRIPTION
## Description
- adds oprm to the teamsite header whitelist for testing purposes 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
