### PR TITLE
VAGOV-2281: Home Page Rollout

### DIFF
--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -111,6 +111,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_FIELD_LINKS,
     featureFlags.FEATURE_REGION_DETAIL_PAGE_FEATURED_CONTENT,
     featureFlags.FEATURE_REGION_PAGE_LINKS,
+    featureFlags.FEATURE_HOME_PAGE,
   ],
 };
 

--- a/src/site/utilities/featureFlags.js
+++ b/src/site/utilities/featureFlags.js
@@ -99,6 +99,7 @@ const flagsByBuildtype = {
     featureFlags.FEATURE_HEALTH_SERVICE_API_ID,
     featureFlags.FEATURE_DOWNLOADABLE_FILE,
     featureFlags.FEATURE_FIELD_ALERT_DISMISSABLE,
+    featureFlags.FEATURE_HOME_PAGE,
   ],
   vagovprod: [
     featureFlags.FEATURE_FIELD_ADDITIONAL_INFO,


### PR DESCRIPTION
## Note: Please do not merge until after Monday 8/26 daily Prod deploy.

## Description
Moves the `FEATURE_HOME_PAGE` feature flag to the Prod and Staging arrays in `/src/site/utilities/featureFlags.js`.

This is the final step to roll out the Drupal-powered home page to the site front-end.

Note, if https://github.com/department-of-veterans-affairs/vets-website/pull/10586 is merged first, this PR is not necessary and can be closed.

cc @kevwalsh 

## Testing done


## Screenshots


## Acceptance criteria
- [ ] Home page is Drupal-powered in Prod.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
