### PR TITLE
VAGOV-5341: update "Available at" wording for health service accordions

### DIFF
--- a/src/site/facilities/facility_social_links.drupal.liquid
+++ b/src/site/facilities/facility_social_links.drupal.liquid
@@ -1,5 +1,5 @@
 <section class="feature vads-u-background-color--gray-lightest vads-u-margin-top--4 small-screen:vads-u-margin-top--6 vads-u-padding-x--3 vads-u-padding-y--2p5">
-    <h3 class="vads-u-margin-bottom--2">Get updates from VA Pittsburgh</h3>
+    <h3 class="vads-u-margin-bottom--2">Get updates from {{ regionNickname }}</h3>
     <div class="va-c-list-link-teasers usa-grid usa-grid-full">
         {% if fieldLinks != empty and fieldLinks.length %}
             <div class="usa-width-one-half social-links">

--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -19,7 +19,7 @@
                 {% endif %}
 
                 {% if healthService.fieldLocalHealthCareService.length > 0 %}
-                    <p class="vads-u-font-weight--bold vads-u-font-family--serif">Available at</p>
+                    <h3>Available at these {{ regionNickname }} locations</h3>
                     <ul class="usa-unstyled-list">
                         {% for location in healthService.fieldLocalHealthCareService %}
                             {% assign facility = location.entity.fieldFacilityLocation.entity %}

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -192,7 +192,7 @@
 
             <!-- Social Links -->
             {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty || (fieldLinks != empty and fieldLinks.length)%}
-                {% include "src/site/facilities/facility_social_links.drupal.liquid" %}
+                {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldRegionPage.entity.fieldNicknameForThisFacility %}
             {% endif %}
 
         </article>

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -89,7 +89,7 @@
           <!-- Social Links -->
           {% if isContactPage %}
             {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty || (fieldLinks != empty and fieldLinks.length)%}
-              {% include "src/site/facilities/facility_social_links.drupal.liquid" %}
+              {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldOffice.entity.fieldNicknameForThisFacility %}
             {% endif %}
           {% endif %}
         </article>

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -246,7 +246,7 @@ Example data:
 
         <!-- Social Links -->
         {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty %}
-          {% include "src/site/facilities/facility_social_links.drupal.liquid" %}
+          {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldNicknameForThisFacility %}
         {% endif %}
 
     </article>

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -49,6 +49,17 @@ module.exports = `
         }
       }
     }
+    fieldRegionPage {
+      entity {
+        ... on NodeHealthCareRegionPage {
+          entityBundle
+          entityId
+          entityPublished
+          title
+          fieldNicknameForThisFacility
+        }
+      }
+    }
     ${socialMediaFields}
     fieldLocalHealthCareService {
       entity {

--- a/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
@@ -120,5 +120,13 @@ module.exports = `
         }
       }
     }
+    fieldOffice {
+      entity {
+        ...on NodeHealthCareRegionPage {
+          title
+          fieldNicknameForThisFacility
+        }
+      }
+    }
   }
 `;

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -19,6 +19,7 @@ const {
 module.exports = `
   fragment healthCareRegionPage on NodeHealthCareRegionPage {
     ${entityElementsFromPages}
+    fieldNicknameForThisFacility
     fieldMedia {
       entity {
         ... on MediaImage {

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -76,6 +76,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     entityUrl: hsEntityUrl,
     alert: page.alert,
     title: page.title,
+    regionNickname: page.fieldNicknameForThisFacility,
     clinicalHealthServices,
   };
   const hsPage = updateEntityUrlObj(


### PR DESCRIPTION
## Description
- update "Available at" wording for health service accordions
- use region nickname for  social links heading

## Testing done
locally with staging data

## Screenshots
![image](https://user-images.githubusercontent.com/19178435/63477864-220efc00-c43c-11e9-872e-42ddeb96ba8a.png)

## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-5341
- [ ] Update style to H3 
- [ ] Update Copy to "Available at these VA Pittsburgh locations" - this needs to be updated in prod in the content for the "VA Pittsburgh" part, but this code makes it dynamic to do so

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
