### PR TITLE
Update extension options label to include city and state

### DIFF
--- a/src/applications/gi/components/profile/CalculatorForm.jsx
+++ b/src/applications/gi/components/profile/CalculatorForm.jsx
@@ -45,6 +45,20 @@ class CalculatorForm extends React.Component {
     return extensions;
   }
 
+  createExtensionOptionLabel = extension => {
+    let extensionOptionLabel = extension.institution;
+    if (extension.city && extension.state) {
+      extensionOptionLabel = `${extensionOptionLabel} (${extension.city}, ${
+        extension.state
+      })`;
+    } else if (extension.city) {
+      extensionOptionLabel = `${extensionOptionLabel} (${extension.city})`;
+    } else if (extension.state) {
+      extensionOptionLabel = `${extensionOptionLabel} (${extension.state})`;
+    }
+    return extensionOptionLabel;
+  };
+
   handleBeneficiaryZIPCodeChanged = event => {
     if (!event.dirty) {
       this.props.onBeneficiaryZIPCodeChanged(event.value);
@@ -567,12 +581,9 @@ class CalculatorForm extends React.Component {
     if (extensions && extensions.length) {
       extensionOptions = [{ value: '', label: 'Please choose a location' }];
       extensions.forEach(extension => {
-        const extensionOptionLabel = `${extension.institution} (${
-          extension.city ? extension.city : ''
-        }, ${extension.state ? extension.state : ''})`;
         extensionOptions.push({
           value: extension.zip,
-          label: extensionOptionLabel,
+          label: this.createExtensionOptionLabel(extension),
         });
       });
       extensionOptions.push({ value: 'other', label: 'Other...' });

--- a/src/applications/gi/components/profile/CalculatorForm.jsx
+++ b/src/applications/gi/components/profile/CalculatorForm.jsx
@@ -45,18 +45,23 @@ class CalculatorForm extends React.Component {
     return extensions;
   }
 
-  createExtensionOptionLabel = extension => {
-    let extensionOptionLabel = extension.institution;
+  createExtensionOption = extension => {
+    const extensionOption = {
+      value: extension.zip,
+      label: '',
+    };
+
+    extensionOption.label = extension.institution;
     if (extension.city && extension.state) {
-      extensionOptionLabel = `${extensionOptionLabel} (${extension.city}, ${
+      extensionOption.label = `${extensionOption.label} (${extension.city}, ${
         extension.state
       })`;
     } else if (extension.city) {
-      extensionOptionLabel = `${extensionOptionLabel} (${extension.city})`;
+      extensionOption.label = `${extensionOption.label} (${extension.city})`;
     } else if (extension.state) {
-      extensionOptionLabel = `${extensionOptionLabel} (${extension.state})`;
+      extensionOption.label = `${extensionOption.label} (${extension.state})`;
     }
-    return extensionOptionLabel;
+    return extensionOption;
   };
 
   handleBeneficiaryZIPCodeChanged = event => {
@@ -581,10 +586,7 @@ class CalculatorForm extends React.Component {
     if (extensions && extensions.length) {
       extensionOptions = [{ value: '', label: 'Please choose a location' }];
       extensions.forEach(extension => {
-        extensionOptions.push({
-          value: extension.zip,
-          label: this.createExtensionOptionLabel(extension),
-        });
+        extensionOptions.push(this.createExtensionOption(extension));
       });
       extensionOptions.push({ value: 'other', label: 'Other...' });
 

--- a/src/applications/gi/components/profile/CalculatorForm.jsx
+++ b/src/applications/gi/components/profile/CalculatorForm.jsx
@@ -46,20 +46,18 @@ class CalculatorForm extends React.Component {
   }
 
   createExtensionOption = extension => {
+    const { city, institution, state, zip } = extension;
     const extensionOption = {
-      value: extension.zip,
-      label: '',
+      value: zip,
+      label: institution,
     };
 
-    extensionOption.label = extension.institution;
-    if (extension.city && extension.state) {
-      extensionOption.label = `${extensionOption.label} (${extension.city}, ${
-        extension.state
-      })`;
-    } else if (extension.city) {
-      extensionOption.label = `${extensionOption.label} (${extension.city})`;
-    } else if (extension.state) {
-      extensionOption.label = `${extensionOption.label} (${extension.state})`;
+    if (city && state) {
+      extensionOption.label = `${extensionOption.label} (${city}, ${state})`;
+    } else if (city) {
+      extensionOption.label = `${extensionOption.label} (${city})`;
+    } else if (state) {
+      extensionOption.label = `${extensionOption.label} (${state})`;
     }
     return extensionOption;
   };

--- a/src/applications/gi/components/profile/CalculatorForm.jsx
+++ b/src/applications/gi/components/profile/CalculatorForm.jsx
@@ -567,9 +567,12 @@ class CalculatorForm extends React.Component {
     if (extensions && extensions.length) {
       extensionOptions = [{ value: '', label: 'Please choose a location' }];
       extensions.forEach(extension => {
+        const extensionOptionLabel = `${extension.institution} (${
+          extension.city ? extension.city : ''
+        }, ${extension.state ? extension.state : ''})`;
         extensionOptions.push({
           value: extension.zip,
-          label: extension.institution,
+          label: extensionOptionLabel,
         });
       });
       extensionOptions.push({ value: 'other', label: 'Other...' });


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19536

## Testing done


## Screenshots
<img width="674" alt="Screen Shot 2019-08-23 at 10 45 37 AM" src="https://user-images.githubusercontent.com/48804654/63601311-2e599d00-c593-11e9-9af2-f6513cfbea56.png">


## Acceptance criteria
- [ ] "(city, state)" is appended to each answer in the answer dropdown for the question: "Choose the location where you'll take your classes?".

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
