### PR TITLE
VAGOV-5334: add region page's related links to facility landing pages

### DIFF
--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -162,8 +162,8 @@
           {% endunless %}
 
             <!-- List of links section -->
-            {% if fieldRelatedLinks != empty %}
-                {% include "src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRelatedLinks.entity %}
+            {% if fieldRegionPage.entity.fieldRelatedLinks != empty %}
+                {% include "src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRegionPage.entity.fieldRelatedLinks.entity %}
             {% endif %}
 
             <!-- Local Health Services -->

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -57,6 +57,11 @@ module.exports = `
           entityPublished
           title
           fieldNicknameForThisFacility
+          fieldRelatedLinks {
+            entity {
+              ... listOfLinkTeasers
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Description
add region page's related links to facility landing pages

## Testing done
locally with staging data

1. rebuild site
2. browse to http://localhost:3001/pittsburgh-health-care/locations/pittsburgh-va-medical-center-university-drive/
3. scroll down past "Prepare for your visit"
4. "In the spotlight..." section should be there and be the same as the region page (http://localhost:3001/pittsburgh-health-care/)
5. check the other facility pages

## Screenshots
![image](https://user-images.githubusercontent.com/19178435/63643975-a4442e00-c691-11e9-8542-6f2b80976e57.png)

## Acceptance criteria
https://va-gov.atlassian.net/browse/VAGOV-5334
- [ ] Add "In the spotlight at VA Pittsburgh" component to Facility Landing Pages

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
