### PR TITLE
VAGOV-5716: Fix broken links in Pittsburgh Health Care sections

### DIFF
--- a/src/site/facilities/facilities_health_services_buttons.drupal.liquid
+++ b/src/site/facilities/facilities_health_services_buttons.drupal.liquid
@@ -6,7 +6,7 @@
         <a class="usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-width--full vads-u-font-size--md" href="/{{ path }}/make-an-appointment">Make an appointment</a>
     </div>
     <div class="medium-screen:vads-l-col--4 vads-l-col--12">
-        <a class="usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-width--full vads-u-font-size--md" href="/{{ path }}/become-a-patient">Register for care</a>
+        <a class="usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-width--full vads-u-font-size--md" href="/{{ path }}/register-for-care">Register for care</a>
     </div>
     <div class="medium-screen:vads-l-col--3 vads-l-col--12 vads-u-text-align--right">
         <a class="usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-margin-x--0 vads-u-width--full vads-u-font-size--md" href="/{{ path }}/pharmacy">Pharmacy</a>

--- a/src/site/facilities/main_buttons.drupal.liquid
+++ b/src/site/facilities/main_buttons.drupal.liquid
@@ -9,6 +9,6 @@
         <a class="usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-width--full vads-u-font-size--md" href="/{{ path }}/health-services">View all health services</a>
     </div>
     <div class="medium-screen:vads-l-col--3 vads-l-col--12 vads-u-text-align--right">
-        <a class="usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-margin-x--0 vads-u-width--full vads-u-font-size--md" href="/{{ path }}/become-a-patient">Register for care</a>
+        <a class="usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-margin-x--0 vads-u-width--full vads-u-font-size--md" href="/{{ path }}/register-for-care">Register for care</a>
     </div>
 </div>

--- a/src/site/layouts/person_profile.drupal.liquid
+++ b/src/site/layouts/person_profile.drupal.liquid
@@ -95,7 +95,7 @@
                             vads-u-margin--0
                             vads-u-margin-bottom--0p5">
                                 <span class="vads-u-font-weight--bold">Email:</span> <a target="blank"
-                                    href="{{ fieldEmailAddress }}">{{ fieldEmailAddress }}</a>
+                                    href="mailto:{{ fieldEmailAddress }}">{{ fieldEmailAddress }}</a>
                             </p>
                             {% endif %}
                             {% if fieldPhoneNumber %}

--- a/src/site/layouts/person_profile.drupal.liquid
+++ b/src/site/layouts/person_profile.drupal.liquid
@@ -55,10 +55,12 @@
 
                     <div class="usa-grid usa-grid-full vads-u-margin-bottom--2 small-screen:vads-u-display--flex small-screen:vads-u-flex-direction--row">
 
-                        <div class="usa-width-one-third small-screen:vads-u-margin-right--3">
-                            {% assign image = fieldMedia.entity.image %}
-                            <img src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="{{ image.derivative.width }}" height="{{ image.derivative.height }}">
-                        </div>
+                        {% if fieldMedia.entity.image != empty %}
+                            <div class="usa-width-one-third small-screen:vads-u-margin-right--3">
+                                {% assign image = fieldMedia.entity.image %}
+                                <img src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="{{ image.derivative.width }}" height="{{ image.derivative.height }}">
+                            </div>
+                        {% endif %}
 
                         <div class="usa-width-two-thirds vads-u-display--flex vads-u-flex-direction--column">
                             <h1 class="

--- a/src/site/teasers/event.drupal.liquid
+++ b/src/site/teasers/event.drupal.liquid
@@ -79,7 +79,7 @@ Example data:
         <div class="usa-width-five-sixths">
             {% if node.fieldFacilityLocation != empty %}
               <p class="vads-u-margin-top--0 vads-u-margin-bottom--1">
-                  <a href="{{ node.fieldFacilityLocation.entity.entityUrl.page }}">{{ node.fieldFacilityLocation.entity.title }}</a>
+                  <a href="{{ node.fieldFacilityLocation.entity.entityUrl.path }}">{{ node.fieldFacilityLocation.entity.title }}</a>
               </p>
             {% endif %}
             {% if node.fieldLocationHumanreadable != empty %}


### PR DESCRIPTION
## Description
Fixes register for care links throughout pittsburgh region pages, fixes event teasers location links, only shows image link on staff profiles is image exists, makes all emails on staff profiles mailto: links

## Testing done
Locally with staging data

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
