### PR TITLE
changed column size to fix text smushing

### DIFF
--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -202,7 +202,7 @@ export class Calculator extends React.Component {
     const { outputs } = this.props.calculated;
     return (
       <div className="row calculate-your-benefits">
-        <div className="usa-width-five-twelfths medium-5 columns">
+        <div className="usa-width-one-eigth medium-5 columns">
           {this.renderEligibilityForm()}
           {this.renderCalculatorForm()}
         </div>

--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -200,9 +200,12 @@ export class Calculator extends React.Component {
 
     // const it = this.props.profile.attributes;
     const { outputs } = this.props.calculated;
+    const fraction = environment.isProduction()
+      ? 'usa-width-five-twelfths'
+      : 'usa-width-one-eigth';
     return (
       <div className="row calculate-your-benefits">
-        <div className="usa-width-one-eigth medium-5 columns">
+        <div className={fraction + ' medium-5 columns'}>
           {this.renderEligibilityForm()}
           {this.renderCalculatorForm()}
         </div>

--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -201,11 +201,11 @@ export class Calculator extends React.Component {
     // const it = this.props.profile.attributes;
     const { outputs } = this.props.calculated;
     const fraction = environment.isProduction()
-      ? 'usa-width-five-twelfths'
-      : 'usa-width-one-eigth';
+      ? 'usa-width-five-twelfths medium-5 columns'
+      : 'usa-width-one-eigth medium-5 columns';
     return (
       <div className="row calculate-your-benefits">
-        <div className={fraction + ' medium-5 columns'}>
+        <div className={fraction}>
           {this.renderEligibilityForm()}
           {this.renderCalculatorForm()}
         </div>


### PR DESCRIPTION
## Description
On the school profile page in the GI Bill Comparison tool, The symbols indicating that a section can be expanded or collapsed are overlapping the header text for that section. This applies to the "Edit/Hide eligibility details" and "Edit/Hide calculator fields" sections

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19544
## Testing done


## Screenshots
![Simulator Screen Shot - iPad (5th generation) - 2019-08-26 at 12 07 03](https://user-images.githubusercontent.com/50601724/63705354-e9d03a80-c7fa-11e9-8951-921db3bc3046.png)


## Acceptance criteria
- [x] Fix edit eligibility and edit calculator text 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
