### PR TITLE
oprm.va.gov css overrride for teamsite header 

### DIFF
--- a/src/applications/proxy-rewrite/sass/consolidated-patches.scss
+++ b/src/applications/proxy-rewrite/sass/consolidated-patches.scss
@@ -183,5 +183,7 @@ footer.footer {
 }
 
 .vetnav-panel--submenu {
-  background-color: $color-white;
+  h3 { 
+    background-color: $color-gray-light-alt;
+  }
 }

--- a/src/applications/proxy-rewrite/sass/consolidated-patches.scss
+++ b/src/applications/proxy-rewrite/sass/consolidated-patches.scss
@@ -181,3 +181,7 @@ footer.footer {
   padding-left: 0 !important;
   padding-right: 0 !important;
 }
+
+.vetnav-panel--submenu {
+  background-color: $color-white;
+}

--- a/src/applications/proxy-rewrite/sass/style-consolidated.scss
+++ b/src/applications/proxy-rewrite/sass/style-consolidated.scss
@@ -136,7 +136,7 @@ $font-stack: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial"
 }
 
 .slider .prev, .slider .next, #slider-controls {
-  z-index: $low-layer;
+  z-index: $low-layer !important;
 }
 // ----- Patches to elements outside of .consolidated ----- //
 


### PR DESCRIPTION
## Description
- oprm.va.gov is getting the va.gov header. there were a few css issues that necessitated CSS overrides 

## Testing done
- verified locally on chrome
- verified changes do not impact benefits.va.gov and cem.va.gov 
- will verify on IE once changes are in staging (it's hard to do this locally) 

## Screenshots
<img width="1035" alt="Screen Shot 2019-08-26 at 12 28 24 PM" src="https://user-images.githubusercontent.com/4998130/63714182-792b1d00-c7fe-11e9-98d6-6923241ec015.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
