### PR TITLE
[Comparison Tool] Institutions profile school locations update

### DIFF
--- a/src/applications/gi/components/profile/SchoolLocations.jsx
+++ b/src/applications/gi/components/profile/SchoolLocations.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { getCalculatedBenefits } from '../../selectors/calculator';
 
+const TOTAL_ROWS_DISPLAYED_WITHOUT_VIEW_MORE = 15;
 const DEFAULT_ROWS_VIEWABLE = 10;
 const DEFAULT_ROWS_ADJUSTED = DEFAULT_ROWS_VIEWABLE - 1;
 
@@ -26,7 +27,9 @@ export class SchoolLocations extends React.Component {
     branches.forEach(branch => {
       totalRows += branch.extensions.length;
     });
-    return totalRows > DEFAULT_ROWS_VIEWABLE && !this.state.viewMore;
+    return (
+      totalRows > TOTAL_ROWS_DISPLAYED_WITHOUT_VIEW_MORE && !this.state.viewMore
+    );
   };
 
   createLinkTo = (facilityCode, name) => {
@@ -36,11 +39,7 @@ export class SchoolLocations extends React.Component {
     const { version } = this.props;
     const query = version ? `?version=${version}` : '';
 
-    return (
-      <a href={`${facilityCode}${query}`}>
-        <h6>{name}</h6>
-      </a>
-    );
+    return <a href={`${facilityCode}${query}`}>{name}</a>;
   };
 
   handleViewMoreClicked = () => {

--- a/src/applications/gi/components/profile/SchoolLocations.jsx
+++ b/src/applications/gi/components/profile/SchoolLocations.jsx
@@ -24,10 +24,9 @@ export class SchoolLocations extends React.Component {
   shouldHideViewMore = (facilityMap, maxRows) =>
     this.totalRows(facilityMap) > maxRows && !this.state.viewMore;
 
-  totalRows = facilityMap => {
-    let totalRows =
-      1 + facilityMap.branches.length + facilityMap.extensions.length; // always has a main row
-    facilityMap.branches.forEach(branch => {
+  totalRows = ({ branches, extensions }) => {
+    let totalRows = 1 + branches.length + extensions.length; // always has a main row
+    branches.forEach(branch => {
       totalRows += branch.extensions.length;
     });
     return totalRows;

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -220,6 +220,8 @@
     .location-cell {
       white-space: nowrap;
     }
+
+    padding-bottom:1rem;
   }
 
   .vettec-logo-container {

--- a/src/applications/gi/tests/components/SchoolLocations.unit.spec.jsx
+++ b/src/applications/gi/tests/components/SchoolLocations.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
-import createCommonStore from '../../../../platform/startup/store';
+import createCommonStore from 'platform/startup/store';
 import reducer from '../../reducers';
 import { calculatorConstants } from '../gibct-helpers';
 import SchoolLocations from '../../components/profile/SchoolLocations';

--- a/src/applications/gi/tests/components/SchoolLocations.unit.spec.jsx
+++ b/src/applications/gi/tests/components/SchoolLocations.unit.spec.jsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+import createCommonStore from '../../../../platform/startup/store';
+import reducer from '../../reducers';
+import { calculatorConstants } from '../gibct-helpers';
+import SchoolLocations from '../../components/profile/SchoolLocations';
+
+const defaultState = createCommonStore(reducer).getState();
+
+defaultState.constants = {
+  constants: {},
+  version: calculatorConstants.meta.version,
+  inProgress: false,
+};
+
+calculatorConstants.data.forEach(c => {
+  defaultState.constants.constants[c.attributes.name] = c.attributes.value;
+});
+
+describe('<SchoolLocations>', () => {
+  it('should render main row', () => {
+    const testState = {
+      ...defaultState,
+      profile: {
+        ...defaultState.profile,
+        attributes: {
+          facilityMap: {
+            main: {
+              institution: {
+                type: 'FOR PROFIT',
+                facilityCode: '100',
+                institution: 'MAIN FACILITY',
+                physicalCity: 'Test',
+                physicalState: 'TN',
+                physicalZip: '12345',
+                country: 'USA',
+                dodBah: '100',
+              },
+              extensions: [],
+              branches: [],
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <SchoolLocations
+        institution={testState.profile.attributes}
+        facilityMap={testState.profile.attributes.facilityMap}
+        calculator={testState.calculator}
+        eligibility={testState.eligibility}
+        constants={testState.constants}
+      />,
+    );
+
+    expect(wrapper.find('.main-row')).to.have.lengthOf(1);
+    expect(wrapper.find('.extension-row')).to.have.lengthOf(0);
+    expect(wrapper.find('.branch-row')).to.have.lengthOf(0);
+    wrapper.unmount();
+  });
+
+  it('should render main branch with extensions', () => {
+    const testState = {
+      ...defaultState,
+      profile: {
+        ...defaultState.profile,
+        attributes: {
+          facilityMap: {
+            main: {
+              institution: {
+                type: 'FOR PROFIT',
+                facilityCode: '100',
+                institution: 'MAIN FACILITY',
+                physicalCity: 'Test',
+                physicalState: 'TN',
+                physicalZip: '12345',
+                country: 'USA',
+                dodBah: '100',
+              },
+              extensions: [],
+              branches: [
+                {
+                  institution: {
+                    type: 'FOR PROFIT',
+                    facilityCode: '101',
+                    institution: 'MAIN BRANCH FACILITY',
+                    physicalCity: 'Test',
+                    physicalState: 'TN',
+                    physicalZip: '12345',
+                    country: 'USA',
+                    dodBah: '100',
+                  },
+                  extensions: [
+                    {
+                      type: 'FOR PROFIT',
+                      facilityCode: '102',
+                      institution: 'BRANCH EXTENSION FACILITY',
+                      physicalCity: 'Test',
+                      physicalState: 'TN',
+                      physicalZip: '12345',
+                      country: 'USA',
+                      dodBah: '100',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <SchoolLocations
+        institution={testState.profile.attributes}
+        facilityMap={testState.profile.attributes.facilityMap}
+        calculator={testState.calculator}
+        eligibility={testState.eligibility}
+        constants={testState.constants}
+      />,
+    );
+
+    expect(wrapper.find('.main-row')).to.have.lengthOf(1);
+    expect(wrapper.find('.extension-row')).to.have.lengthOf(1);
+    expect(wrapper.find('.branch-row')).to.have.lengthOf(1);
+    wrapper.unmount();
+  });
+
+  it('should render extension', () => {
+    const testState = {
+      ...defaultState,
+      profile: {
+        ...defaultState.profile,
+        attributes: {
+          facilityMap: {
+            main: {
+              institution: {
+                institution: 'MAIN FACILITY',
+                type: 'FOR PROFIT',
+                facilityCode: '100',
+                physicalCity: 'Test',
+                physicalState: 'TN',
+                physicalZip: '12345',
+                country: 'USA',
+                dodBah: '100',
+              },
+              extensions: [
+                {
+                  type: 'FOR PROFIT',
+                  facilityCode: '100',
+                  institution: 'MAIN EXTENSION FACILITY',
+                  physicalCity: 'Test',
+                  physicalState: 'TN',
+                  physicalZip: '12345',
+                  country: 'USA',
+                  dodBah: '100',
+                },
+              ],
+              branches: [],
+            },
+          },
+        },
+      },
+    };
+
+    const wrapper = mount(
+      <SchoolLocations
+        institution={testState.profile.attributes}
+        facilityMap={testState.profile.attributes.facilityMap}
+        calculator={testState.calculator}
+        eligibility={testState.eligibility}
+        constants={testState.constants}
+      />,
+    );
+
+    expect(wrapper.find('.main-row')).to.have.lengthOf(1);
+    expect(wrapper.find('.extension-row')).to.have.lengthOf(1);
+    expect(wrapper.find('.branch-row')).to.have.lengthOf(0);
+    wrapper.unmount();
+  });
+});

--- a/src/applications/gi/tests/components/SchoolLocations.unit.spec.jsx
+++ b/src/applications/gi/tests/components/SchoolLocations.unit.spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import sinon from 'sinon';
 import { mount } from 'enzyme';
 import createCommonStore from '../../../../platform/startup/store';
 import reducer from '../../reducers';


### PR DESCRIPTION
## Description

Update "view more" logic to display up to 15 locations without hiding additional locations behind "view more".  If there are more than 15 locations, only display the first 10 along with the "view more" ui.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19539

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19560

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/63716246-84d50e80-c813-11e9-8b98-c4a9d62314c4.png)

## Acceptance criteria
- [x] If the number of related school locations (main, branch, extensions) is less than or equal to 15, all locations are displayed.
- [x] If the number of related school locations is greater than 15 then only 10 locations are displayed with a "View More" link that displays the remaining locations.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
