### PR TITLE
1257: [SCREENREADER]: GIBCT® VET TEC - Heading levels should only inc…

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecAdditionalResources.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecAdditionalResources.jsx
@@ -69,9 +69,9 @@ const VetTecAdditionalResources = () => (
     <div className="vettec-logo-container">
       {renderVetTecLogo(classNames('vettec-logo'))}
     </div>
-    <h4 className="highlight vettec-additional-resources-header">
+    <h2 className="highlight vettec-additional-resources-header vads-u-font-size--h4">
       Additional Resources
-    </h4>
+    </h2>
     <VetTecAdditionalResourcesLinks />
   </div>
 );

--- a/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
@@ -6,7 +6,9 @@ const VetTecApplicationProcess = () => (
       'columns vads-u-margin-top--neg1p5 vads-u-margin-x--neg1p5 medium-screen:vads-l-col--10'
     }
   >
-    <h4>Enrolling in VET TEC is a two-step process:</h4>
+    <h3 className="vads-u-font-size--h4">
+      Enrolling in VET TEC is a two-step process:
+    </h3>
     <p>
       First, you’ll need to apply for Veteran Employment Through Technology
       Education Courses (VET TEC). You’ll get a Certificate of Eligibility (COE)
@@ -38,7 +40,9 @@ const VetTecApplicationProcess = () => (
         Learn more about VET TEC programs
       </a>
     </p>
-    <h4>Have questions about the VET TEC program or how to apply?</h4>
+    <h3 className="vads-u-font-size--h4">
+      Have questions about the VET TEC program or how to apply?
+    </h3>
     <div>
       <ul className="vet-tec-application-process-list">
         <li>

--- a/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
@@ -60,7 +60,7 @@ export class VetTecCalculator extends React.Component {
     <div className="tuition-section">
       <div className="row vads-u-margin-top--0p5">
         <div className="small-6 columns">
-          <h5>Tuition & fees:</h5>
+          <h4 className="vads-u-font-size--h5">Tuition & fees:</h4>
         </div>
         <div className="small-6 columns vads-u-text-align--right">
           <h5>{outputs.vetTecTuitionFees}</h5>
@@ -112,7 +112,9 @@ export class VetTecCalculator extends React.Component {
 
       <div className="row vads-u-margin-top--0p5">
         <div className="small-6 columns">
-          <h5 className="vads-u-font-family--sans">Out of pocket tuition:</h5>
+          <h4 className="vads-u-font-family--sans vads-u-font-size--h5">
+            Out of pocket tuition:
+          </h4>
         </div>
         <div className="small-6 columns vads-u-text-align--right">
           <h5 className="vads-u-font-family--sans">
@@ -126,7 +128,7 @@ export class VetTecCalculator extends React.Component {
   renderHousingSection = (outputs, showModal) => (
     <div className="housing-section">
       <div className="link-header">
-        <h5>Housing allowance</h5>{' '}
+        <h4 className="vads-u-font-size--h5">Housing allowance</h4>{' '}
         <button
           aria-label="housing allowance learn more"
           type="button"

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -10,6 +10,7 @@
 
   .link-header {
     h3,
+    h4,
     h5 {
       display: inline-block;
       padding: 0;
@@ -190,7 +191,6 @@
   }
 
   .school-locations {
-
     table {
       border: hidden;
       margin-top: 0em;


### PR DESCRIPTION
## Description
Heading levels are being skipped in the content areas on VET TEC provider detail views. This can be confusing for screen reader users who rely on headings to navigate content by importance. Screenshots attached below.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/1257

## Testing done
Unit and e2e tests pass locally

## Screenshots
N/A

## Acceptance criteria
- [x] As a screen reader user, I want to hear headings properly nested in the content.
- [x] As this user, I want to hear one heading level one, then heading level twos, with additional headings nested as appropriate.
- [x] As a visual user, I do not want the layout to change, only the semantic heading levels.


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
