### PR TITLE
VAGOV-5753: spruce up bio paragraph styles

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -241,4 +241,5 @@ $duo-tone-lighten: #000000;
 .bio-image {
   height: 178px;
   width: 144px;
+  object-fit: cover;
 }

--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -231,3 +231,14 @@ $duo-tone-lighten: #000000;
 .featured-content-hr {
   width: 40px;
 }
+
+
+.bio-paragraph-image {
+  height: 110px;
+  width: 110px;
+}
+
+.bio-image {
+  height: 178px;
+  width: 144px;
+}

--- a/src/site/includes/bioParagraph.drupal.liquid
+++ b/src/site/includes/bioParagraph.drupal.liquid
@@ -1,52 +1,56 @@
-<div class="usa-grid usa-grid-full vads-u-margin-bottom--4">
+<div class="vads-u-display--flex vads-u-margin-bottom--4 vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
   {% if bio.fieldMedia != emtpy %}
-    <div class="usa-width-one-fourth">
+    <div class="vads-u-flex--auto medium-screen:vads-u-margin-right--3 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">
       {% assign image = bio.fieldMedia.entity.image %}
-      <img class="circular-profile-image" src="{{ image.derivative.url }}" alt="{{ image.alt }}"
-        title="{{ image.title }}" width="{{ image.derivative.width }}"
-        height="{{ image.derivative.height }}">
+      <img class="circular-profile-image bio-paragraph-image" src="{{ image.derivative.url }}" alt="{{ image.alt }}"
+        title="{{ image.title }}">
     </div>
   {% endif %}
-  <div class="usa-width-two-thirds">
-    <h2 class="
-        vads-u-margin-bottom--1
-        vads-u-font-size--md
-        medium-screen:vads-u-font-size--lg">
-      <a href="{{ bio.entityUrl.path }}">{{ bio.fieldNameFirst }}
-        {{ bio.fieldLastName }} {{ bio.fieldSuffix }}</a>
-    </h2>
+  <div class="vads-u-flex--1">
+
+    <p class="
+            vads-u-margin-top--0
+            vads-u-font-family--serif
+            vads-u-font-weight--bold
+            vads-u-display--block
+            vads-u-margin-bottom--0
+            vads-u-font-size--md"
+              href="{{ bio.entityUrl.path }}">{{ bio.fieldNameFirst }}
+        {{ bio.fieldLastName }} {{ bio.fieldSuffix }}</p>
     {% if bio.fieldDescription %}
     <p class="
         vads-u-font-weight--normal
+        vads-u-font-size--base
         vads-u-margin--0
-        vads-u-margin-bottom--0p5">
+        vads-u-margin-bottom--0">
       {{ bio.fieldDescription }}</p>
     {% endif %}
     {% if bio.fieldOffice.entity.entityLabel %}
     <p class="
         vads-u-font-weight--normal
+        vads-u-font-size--base
         vads-u-margin--0
-        vads-u-margin-bottom--0p5">
+        vads-u-margin-bottom--1">
       {{ bio.fieldOffice.entity.entityLabel }}
-    </p>
-    {% endif %}
-    {% if bio.fieldEmailAddress %}
-    <p class="
-        vads-u-font-weight--normal
-        vads-u-margin--0
-        vads-u-margin-bottom--0p5">
-      <b>Email:</b> <a target="blank"
-        href="mailto:{{ bio.fieldEmailAddress }}">{{ bio.fieldEmailAddress }}</a>
     </p>
     {% endif %}
     {% if bio.fieldPhoneNumber %}
     <p class="
         vads-u-font-weight--normal
         vads-u-margin--0
-        vads-u-margin-bottom--0p5">
+        vads-u-margin-bottom--1">
       <b>Phone:</b> <a
         href="tel:{{ bio.fieldPhoneNumber }}">{{ bio.fieldPhoneNumber }}</a>
     </p>
+    {% endif %}
+    {% if bio.fieldEmailAddress %}
+      <p class="
+        vads-u-font-weight--normal
+        vads-u-margin--0
+        vads-u-margin-bottom--1">
+        <b>Email:</b> <a target="blank"
+                         href="mailto:{{ bio.fieldEmailAddress }}">{{ bio.fieldEmailAddress }}</a>
+      </p>
     {% endif %}
   </div>
 </div>

--- a/src/site/layouts/bios_page.drupal.liquid
+++ b/src/site/layouts/bios_page.drupal.liquid
@@ -46,7 +46,7 @@
             <div class="usa-width-three-fourths">
                 {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 <article class="usa-content">
-                    <h1>Our Leadership Team</h1>
+                    <h1 class="vads-u-margin-bottom--3">Our Leadership Team</h1>
                     {% for bio in pagedItems %}
                         {% include "src/site/teasers/bio.drupal.liquid" with node = bio.entity %}
                     {% endfor %}

--- a/src/site/teasers/bio.drupal.liquid
+++ b/src/site/teasers/bio.drupal.liquid
@@ -40,63 +40,64 @@ Example data:
 {% if header == empty %}
 {% assign header = "h4" %}
 {% endif %}
-<div class="usa-grid usa-grid-full vads-u-margin-bottom--4">
+<div class="vads-u-display--flex vads-u-margin-bottom--4">
     {% if node.fieldMedia != empty %}
-        <div class="usa-width-one-third">
+        <div class="vads-u-margin-right--2 vads-u-flex--auto">
             {% assign image = node.fieldMedia.entity.image %}
-            <img src="{{ image.derivative.url }}" alt="{{ image.alt }}"
-                title="{{ image.title }}" width="{{ image.derivative.width }}"
-                height="{{ image.derivative.height }}">
+            <img class="bio-image" src="{{ image.derivative.url }}" alt="{{ image.alt }}"
+                title="{{ image.title }}">
         </div>
     {% endif %}
-    <div class="usa-width-two-thirds">
-        <h2 class="
-        vads-u-margin-bottom--1
-        vads-u-font-size--md
-        medium-screen:vads-u-font-size--lg">
-            <a href="{{ node.entityUrl.path }}">{{ node.fieldNameFirst }}
+    <div class="">
+
+        <a class="
+            vads-u-font-family--serif
+            vads-u-font-weight--bold
+            vads-u-display--block
+            vads-u-margin-bottom--1
+            vads-u-font-size--lg"
+           href="{{ node.entityUrl.path }}">{{ node.fieldNameFirst }}
                 {{ node.fieldLastName }} {{ node.fieldSuffix }}</a>
-        </h2>
+
         {% if node.fieldDescription %}
         <p class="
         vads-u-font-weight--normal
         vads-u-margin--0
-        vads-u-margin-bottom--0p5
+        vads-u-margin-bottom--0
         vads-u-font-family--serif
-        vads-u-font-size--lg">
+        vads-u-font-size--base
+        medium-screen:vads-u-font-size--lg">
             {{ node.fieldDescription }}</p>
         {% endif %}
         {% if node.fieldOffice.entity.entityLabel %}
         <p class="
         vads-u-font-weight--normal
         vads-u-margin--0
-        vads-u-margin-bottom--0p5
+        vads-u-margin-bottom--1
         vads-u-font-family--serif
-        vads-u-font-size--lg">
+        vads-u-font-size--base
+        medium-screen:vads-u-font-size--lg">
             {{ node.fieldOffice.entity.entityLabel }}
-        </p>
-        {% endif %}
-        {% if node.fieldEmailAddress %}
-        <p class="
-        vads-u-font-weight--normal
-        vads-u-margin--0
-        vads-u-margin-bottom--0p5
-        vads-u-font-family--serif
-        vads-u-font-size--lg">
-            Email: <a target="blank"
-                href="{{ node.fieldEmailAddress }}">{{ node.fieldEmailAddress }}</a>
         </p>
         {% endif %}
         {% if node.fieldPhoneNumber %}
         <p class="
-        vads-u-font-weight--normal
         vads-u-margin--0
-        vads-u-margin-bottom--0p5
-        vads-u-font-family--serif
-        vads-u-font-size--lg">
-            Phone: <a
+        vads-u-margin-bottom--1
+        vads-u-font-size--base">
+            <b>Phone:</b> <a
                 href="tel:{{ node.fieldPhoneNumber }}">{{ node.fieldPhoneNumber }}</a>
         </p>
+        {% endif %}
+        {% if node.fieldEmailAddress %}
+            <p class="
+        vads-u-margin--0
+        vads-u-margin-bottom--0
+        vads-u-font-size--base
+        medium-screen:vads-u-font-size--lg">
+               <b>Email:</b> <a target="blank"
+                          href="{{ node.fieldEmailAddress }}">{{ node.fieldEmailAddress }}</a>
+            </p>
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
## Description
makes the bio paragraph styles/pages look more like the mock-ups

## Testing done
locally with staging data

mock ups: 
- leadership page: https://app.zeplin.io/project/5d014fd159c9931608872c98/screen/5d24c5f195f75e9913820f25
- patient advocates page: https://app.zeplin.io/project/5d014fd159c9931608872c98/screen/5d24c5e1a601b59925b64975

1. rebuild
2. browse to here: http://localhost:3001/pittsburgh-health-care/leadership/
3. browse to here: http://localhost:3001/pittsburgh-health-care/patient-advocates/

not bad, eh?

## Screenshots
leadership 
![image](https://user-images.githubusercontent.com/19178435/63741975-182a3600-c84c-11e9-8d32-4f3639e302fa.png)

patient advocates
![image](https://user-images.githubusercontent.com/19178435/63741994-31cb7d80-c84c-11e9-81d0-e493522d779f.png)


## Acceptance criteria
- [ ] make it look pretty

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
