### PR TITLE
make ppiu error handling more flexible

### DIFF
--- a/src/applications/personalization/profile360/actions/paymentInformation.js
+++ b/src/applications/personalization/profile360/actions/paymentInformation.js
@@ -68,7 +68,7 @@ export function savePaymentInformation(fields) {
       apiRequestOptions,
     );
 
-    if (response.error) {
+    if (response.error || response.errors) {
       recordEvent({
         event: 'profile-edit-failure',
         'profile-action': 'save-failure',

--- a/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
@@ -47,13 +47,16 @@ function hasError(errors, errorKey) {
 }
 
 export default function PaymentInformationEditModalError({ responseError }) {
-  const { errors = [] } = responseError.error;
   let content = <GenericError />;
 
-  if (hasError(errors, ACCOUNT_FLAGGED_FOR_FRAUD)) {
-    content = <FlaggedAccount />;
-  } else if (hasError(errors, INVALID_ROUTING_NUMBER)) {
-    content = <InvalidRoutingNumber />;
+  if (responseError.error) {
+    const { errors = [] } = responseError.error;
+
+    if (hasError(errors, ACCOUNT_FLAGGED_FOR_FRAUD)) {
+      content = <FlaggedAccount />;
+    } else if (hasError(errors, INVALID_ROUTING_NUMBER)) {
+      content = <InvalidRoutingNumber />;
+    }
   }
 
   return (

--- a/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
@@ -67,6 +67,20 @@ describe('<PaymentInformationEditModalError />', () => {
     ],
   };
 
+  // When vet360 was not working in the staging env, we saw this error when
+  // saving direct deposit info (hitting PUT ppiu/payment_information)
+  const upstreamError = {
+    errors: [
+      {
+        title: 'Bad Gateway',
+        detail: 'Received an an invalid response from the upstream server',
+        code: 'VET360_502',
+        source: 'Vet360::ContactInformation::Service',
+        status: '502',
+      },
+    ],
+  };
+
   it('renders', () => {
     const wrapper = shallow(
       <PaymentInformationEditModalError
@@ -109,6 +123,16 @@ describe('<PaymentInformationEditModalError />', () => {
     );
     expect(wrapper.html()).to.contain(
       'We’re sorry. You can’t change your direct deposit information right now because we’ve locked your account. We do this to protect your bank account information and prevent fraud when we think there may be a security issue.',
+    );
+    wrapper.unmount();
+  });
+
+  it('renders the default error when an upstream error occurs', () => {
+    const wrapper = shallow(
+      <PaymentInformationEditModalError responseError={upstreamError} />,
+    );
+    expect(wrapper.html()).to.contain(
+      'We’re sorry. We couldn’t update your payment information. Please try again later.',
     );
     wrapper.unmount();
   });


### PR DESCRIPTION
## Description
Yesterday on staging we were getting a different error from the ppiu endpoint that the FE was not able to handle. This PR fixes that.

This is the exact response body we were seeing (note the top-level `errors` prop and _no_ top-level `error` prop):

```
{
  errors: [
    {
      title: 'Bad Gateway',
      detail: 'Received an an invalid response from the upstream server',
      code: 'VET360_502',
      source: 'Vet360::ContactInformation::Service',
      status: '502',
    },
  ],
};
```

## Testing done
Manual + new unit test

## Screenshots


## Acceptance criteria
- [x] existing error responses are still handled
- [x] this new error response format is also handled (ie shows an error message and does not render an empty page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs