### PR TITLE
Bah addhiddenaria 1256+

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecSearchResult.jsx
@@ -62,8 +62,8 @@ export class SearchResult extends React.Component {
                   <div className="columns">
                     <h4>
                       <i
-                        className="fa fa-graduation-cap fa-search-result"
                         aria-hidden="true"
+                        className="fa fa-graduation-cap fa-search-result"
                       />
                       Tuition:
                       <div>{tuition}</div>
@@ -74,8 +74,8 @@ export class SearchResult extends React.Component {
                   <div className="columns">
                     <h4>
                       <i
-                        className="fa fa-home fa-search-result"
                         aria-hidden="true"
+                        className="fa fa-home fa-search-result"
                       />
                       Housing <span>(monthly):</span>
                       <div>{housing}</div>

--- a/src/applications/gi/components/vet-tec/VetTecSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecSearchResult.jsx
@@ -61,7 +61,10 @@ export class SearchResult extends React.Component {
                 <div className="row">
                   <div className="columns">
                     <h4>
-                      <i className="fa fa-graduation-cap fa-search-result" />
+                      <i
+                        className="fa fa-graduation-cap fa-search-result"
+                        aria-hidden="true"
+                      />
                       Tuition:
                       <div>{tuition}</div>
                     </h4>
@@ -70,7 +73,10 @@ export class SearchResult extends React.Component {
                 <div className="row">
                   <div className="columns">
                     <h4>
-                      <i className="fa fa-home fa-search-result" />
+                      <i
+                        className="fa fa-home fa-search-result"
+                        aria-hidden="true"
+                      />
                       Housing <span>(monthly):</span>
                       <div>{housing}</div>
                     </h4>


### PR DESCRIPTION
## Description
The Font Awesome icons are announcing themselves to screen readers. This can be improved by adding an aria-hidden="true" attribute to the icons per screenshot and link below.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/1256

## Testing done
local

## Screenshots


## Acceptance criteria
- [x] add aria-hidden="true" to icons

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
