### PR TITLE
WIP: VAGOV-5722: Remove empty href for active pagination <a>.

### DIFF
--- a/src/site/includes/pagination.drupal.liquid
+++ b/src/site/includes/pagination.drupal.liquid
@@ -22,7 +22,7 @@
     {% endif %}
     <div class="va-pagination-inner">
       {% for page in paginator.inner %}
-        <a href="{{ page.href }}" class="{{ page.class }}" aria-label="Load page {{ page.label }}{{ paginator.ariaLabel }}">
+        <a {% if page.class != "va-pagination-active" %} href="{{ page.href }}" {% endif %} class="{{ page.class }}" aria-label="Load page {{ page.label }}{{ paginator.ariaLabel }}">
           {{ page.label }}
         </a>
       {% endfor %}


### PR DESCRIPTION
## Description
Broken link checker doesn't like empty href on drupal paginators. 

## Testing done


## Screenshots


## Acceptance criteria
- Broken link checker does not fail on 
`pittsburgh-health-care/press-releases` with `<a href="" class="va-pagination-active" aria-label="Load page 1 of press releases">`


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
