### PR TITLE
VAGOV-5722: Remove empty href for ics links.

### DIFF
--- a/src/site/includes/social-share.drupal.liquid
+++ b/src/site/includes/social-share.drupal.liquid
@@ -6,7 +6,7 @@
 <div id="va-c-social-share">
   <ul class="usa-unstyled-list">
     <li class="vads-u-margin-bottom--2p5">
-      <a id="add-to-calendar-link" data-start="{{fieldDate.value }}" data-end="{{fieldDate.endValue}}" data-location="{{fieldAddress.addressLine1}} {{fieldAddress.locality}}, {{fieldAddress.administrativeArea}}" data-subject="{{ title }}" data-description="{{fieldDescription}}" href="{{ addToCalendarLink }}">
+      <a id="add-to-calendar-link" data-start="{{fieldDate.value }}" data-end="{{fieldDate.endValue}}" data-location="{{fieldAddress.addressLine1}} {{fieldAddress.locality}}, {{fieldAddress.administrativeArea}}" data-subject="{{ title }}" data-description="{{fieldDescription}}">
         <i class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5"></i>Add to Calendar</a>
     </li>
 


### PR DESCRIPTION
## Description
Link checker fails the ics links on event pages due to empty `href` attribute, eg https://staging.va.gov/pittsburgh-health-care/events/veterans-town-hall-0/

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
