### PR TITLE
VAGOV-5722: Fixing linkchecker error for add to calendar links

### DIFF
--- a/src/site/facilities/facility_health_service.drupal.liquid
+++ b/src/site/facilities/facility_health_service.drupal.liquid
@@ -13,7 +13,7 @@
                 {% endif %}
             </button>
             <div id="{{ serviceTaxonomy.entityBundle }}-{{ serviceTaxonomy.entityId }}" class="usa-accordion-content" aria-hidden="true">
-                {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}<div><span class="vads-u-font-style--italic">Common Conditions: </span>{{ serviceTaxonomy.fieldCommonlyTreatedCondition }}</div>{% endif %}
+                {% if serviceTaxonomy.fieldCommonlyTreatedCondition %}<div><span class="vads-u-font-style--italic">Common conditions: </span>{{ serviceTaxonomy.fieldCommonlyTreatedCondition }}</div>{% endif %}
 
                 {% if serviceTaxonomy.description.processed  %}<div>{{ serviceTaxonomy.description.processed }}</div>{% endif %}
 

--- a/src/site/includes/social-share.drupal.liquid
+++ b/src/site/includes/social-share.drupal.liquid
@@ -6,7 +6,7 @@
 <div id="va-c-social-share">
   <ul class="usa-unstyled-list">
     <li class="vads-u-margin-bottom--2p5">
-      <a id="add-to-calendar-link" data-start="{{fieldDate.value }}" data-end="{{fieldDate.endValue}}" data-location="{{fieldAddress.addressLine1}} {{fieldAddress.locality}}, {{fieldAddress.administrativeArea}}" data-subject="{{ title }}" data-description="{{fieldDescription}}" href="{{ addToCalendarLink }}">
+      <a id="add-to-calendar-link" data-start="{{fieldDate.value }}" data-end="{{fieldDate.endValue}}" data-location="{{fieldAddress.addressLine1}} {{fieldAddress.locality}}, {{fieldAddress.administrativeArea}}" data-subject="{{ title }}" data-description="{{fieldDescription}}" href="#">
         <i class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5"></i>Add to Calendar</a>
     </li>
 


### PR DESCRIPTION
## Description
Just adds an href attribute so the add to calendar link target isn't empty before it gets updated by javascript.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
