### PR TITLE
Add VAOS contact info page

### DIFF
--- a/src/applications/vaos/components/NewAppointmentLayout.jsx
+++ b/src/applications/vaos/components/NewAppointmentLayout.jsx
@@ -2,9 +2,12 @@ import React from 'react';
 
 export default function NewAppointmentLayout({ children }) {
   return (
-    <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0">
+    <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
       <div className="vads-l-row">
         <div className="vads-l-col--12 medium-screen:vads-l-col--8">
+          <h1 className="vaos-form__title vaos-u-margin-bottom--1 vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">
+            New appointment
+          </h1>
           {children}
         </div>
       </div>

--- a/src/applications/vaos/containers/ContactInfoPage.jsx
+++ b/src/applications/vaos/containers/ContactInfoPage.jsx
@@ -3,44 +3,74 @@ import { connect } from 'react-redux';
 import { openFormPage, updateFormData } from '../actions/newAppointment.js';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import ProgressButton from 'platform/forms-system/src/js/components/ProgressButton';
+import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 
 const initialSchema = {
   type: 'object',
-  required: ['typeOfAppointment'],
+  required: ['phoneNumber'],
   properties: {
-    typeOfAppointment: {
+    phoneNumber: {
       type: 'string',
-      enum: ['provider', 'typeOfCare'],
+      minLength: 10,
     },
-  },
-};
-
-const uiSchema = {
-  typeOfAppointment: {
-    'ui:title': 'How would you like to make an appointment?',
-    'ui:widget': 'radio',
-    'ui:options': {
-      labels: {
-        provider: 'Provider',
-        typeOfCare: 'Type of care',
+    bestTimeToCall: {
+      type: 'object',
+      properties: {
+        morning: {
+          type: 'boolean',
+        },
+        afternoon: {
+          type: 'boolean',
+        },
+        evening: {
+          type: 'boolean',
+        },
       },
     },
   },
 };
 
-const pageKey = 'type-appointment';
+const uiSchema = {
+  'ui:title': 'Where can we call to confirm your appointment?',
+  'ui:description':
+    'A scheduling clerk will contact you to coordinate an appointment date',
+  phoneNumber: phoneUI('Phone number'),
+  bestTimeToCall: {
+    'ui:title': 'Best times for VA to call',
+    morning: {
+      'ui:title': 'Morning (8 a.m. to noon EST)',
+      'ui:options': {
+        widgetClassNames: 'vaos-form__checkbox',
+      },
+    },
+    afternoon: {
+      'ui:title': 'Afternoon (noon - 4 p.m. EST)',
+      'ui:options': {
+        widgetClassNames: 'vaos-form__checkbox',
+      },
+    },
+    evening: {
+      'ui:title': 'Evening (4 p.m. to 8 p.m. EST)',
+      'ui:options': {
+        widgetClassNames: 'vaos-form__checkbox',
+      },
+    },
+  },
+};
 
-export class TypeOfAppointmentPage extends React.Component {
+const pageKey = 'contact-info';
+
+export class ContactInfoPage extends React.Component {
   componentDidMount() {
     this.props.openFormPage(pageKey, uiSchema, initialSchema);
   }
 
   goBack = () => {
-    this.props.router.push('/');
+    this.props.router.push('/new-appointment');
   };
 
   goForward = () => {
-    this.props.router.push('/new-appointment/contact-info');
+    this.props.router.push('/');
   };
 
   render() {
@@ -48,9 +78,9 @@ export class TypeOfAppointmentPage extends React.Component {
 
     return (
       <SchemaForm
-        name="Type of appointment"
-        title="Type of appointment"
-        schema={schema}
+        name="Contact info"
+        title="Contact info"
+        schema={schema || initialSchema}
         uiSchema={uiSchema}
         onSubmit={this.goForward}
         onChange={newData =>
@@ -83,7 +113,7 @@ export class TypeOfAppointmentPage extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    schema: state.newAppointment.pages[pageKey] || initialSchema,
+    schema: state.newAppointment.pages[pageKey],
     data: state.newAppointment.data,
   };
 }
@@ -96,4 +126,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(TypeOfAppointmentPage);
+)(ContactInfoPage);

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -3,12 +3,14 @@ import { Route, IndexRoute } from 'react-router';
 import LandingPage from './components/LandingPage';
 import NewAppointmentLayout from './components/NewAppointmentLayout';
 import TypeOfAppointmentPage from './containers/TypeOfAppointmentPage';
+import ContactInfoPage from './containers/ContactInfoPage';
 
 const routes = (
   <Route path="/">
     <IndexRoute component={LandingPage} />
     <Route path="new-appointment" component={NewAppointmentLayout}>
       <IndexRoute component={TypeOfAppointmentPage} />
+      <Route path="contact-info" component={ContactInfoPage} />
     </Route>
   </Route>
 );

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -11,3 +11,11 @@
   background-color: $color-primary;
   padding: 14px 0 0 17px;
 }
+
+.vaos-form__title {
+  text-transform: uppercase;
+}
+
+.vaos-form__checkbox > .schemaform-label {
+  margin-top: 0;
+}

--- a/src/applications/vaos/tests/containers/ContactInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ContactInfoPage.unit.spec.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+
+import { fillData } from 'platform/testing/unit/schemaform-utils.jsx';
+import { ContactInfoPage } from '../../containers/ContactInfoPage';
+
+describe('VAOS <ContactInfoPage>', () => {
+  it('should render', () => {
+    const openFormPage = sinon.spy();
+    const updateFormData = sinon.spy();
+
+    const form = mount(
+      <ContactInfoPage
+        openFormPage={openFormPage}
+        updateFormData={updateFormData}
+        data={{}}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(4);
+    form.unmount();
+  });
+
+  it('should not submit empty form', () => {
+    const openFormPage = sinon.spy();
+    const router = {
+      push: sinon.spy(),
+    };
+
+    const form = mount(
+      <ContactInfoPage openFormPage={openFormPage} router={router} data={{}} />,
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(router.push.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should call updateFormData after change', () => {
+    const openFormPage = sinon.spy();
+    const updateFormData = sinon.spy();
+    const router = {
+      push: sinon.spy(),
+    };
+
+    const form = mount(
+      <ContactInfoPage
+        openFormPage={openFormPage}
+        updateFormData={updateFormData}
+        router={router}
+        data={{}}
+      />,
+    );
+
+    fillData(form, 'input#root_phoneNumber', '5555555555');
+
+    expect(updateFormData.firstCall.args[2].phoneNumber).to.equal('5555555555');
+    form.unmount();
+  });
+
+  it('should submit with valid data', () => {
+    const openFormPage = sinon.spy();
+    const router = {
+      push: sinon.spy(),
+    };
+
+    const form = mount(
+      <ContactInfoPage
+        openFormPage={openFormPage}
+        router={router}
+        data={{ phoneNumber: '5555555555' }}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(router.push.called).to.be.true;
+    form.unmount();
+  });
+});

--- a/src/platform/forms-system/src/js/components/SchemaForm.jsx
+++ b/src/platform/forms-system/src/js/components/SchemaForm.jsx
@@ -223,4 +223,10 @@ SchemaForm.propTypes = {
   hideTitle: PropTypes.bool,
 };
 
+SchemaForm.defaultProps = {
+  // This is required when running tests, but we'd prefer not to force
+  // everyone to be aware of it when writing tests that use SchemaForm
+  safeRenderCompletion: navigator.userAgent === 'node.js',
+};
+
 export default SchemaForm;

--- a/src/platform/testing/unit/schemaform-utils.jsx
+++ b/src/platform/testing/unit/schemaform-utils.jsx
@@ -103,7 +103,6 @@ export class DefinitionTester extends React.Component {
     return (
       <SchemaForm
         onBlur={this.debouncedAutoSave}
-        safeRenderCompletion
         reviewMode={this.props.reviewMode}
         name="test"
         title={this.props.title || 'test'}


### PR DESCRIPTION
## Description
This adds the WIP contact info page to VAOS. As with all the other pages, they're subject to change, but this at least gets a page in place. I did not try to match the design exactly and let some things to how they look by default with `SchemaForm`. Once the designs are final, we can change things if necessary.

I also made one platform-wide change, to avoid some awkward prop threading for unit tests. 

## Testing done
Tested locally, wrote unit tests

## Screenshots
![Screen Shot 2019-08-28 at 1 23 37 PM](https://user-images.githubusercontent.com/634932/63889132-66574a80-c9ae-11e9-9f95-b55131d2fe97.png)


## Acceptance criteria
- [x] Page works
- [x] Other form tests still pass

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
