### PR TITLE
fix background color on headings

### DIFF
--- a/src/applications/proxy-rewrite/sass/consolidated-patches.scss
+++ b/src/applications/proxy-rewrite/sass/consolidated-patches.scss
@@ -184,6 +184,6 @@ footer.footer {
 
 .vetnav-panel--submenu {
   h3 { 
-    background-color: $color-gray-light-alt;
+    background-color: transparent;
   }
 }


### PR DESCRIPTION
## Description
- fixes background header color on submenu

## Testing done


## Screenshots
<img width="793" alt="Screen Shot 2019-08-29 at 7 42 15 AM" src="https://user-images.githubusercontent.com/4998130/63945499-a828d500-ca30-11e9-8baf-375699811a50.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
