### PR TITLE
remove break tag to fix alignment for extensions label and 'learn more' button

### DIFF
--- a/src/applications/gi/components/profile/CalculatorForm.jsx
+++ b/src/applications/gi/components/profile/CalculatorForm.jsx
@@ -635,7 +635,7 @@ class CalculatorForm extends React.Component {
         <RadioButtons
           label={
             <span>
-              {'Where will you take the majority of your classes?'} <br />(
+              {'Where will you take the majority of your classes? '}
               <button
                 type="button"
                 className="va-button-link learn-more-button"
@@ -644,9 +644,8 @@ class CalculatorForm extends React.Component {
                   'calcBeneficiaryLocationQuestion',
                 )}
               >
-                Learn more
+                (Learn more)
               </button>
-              )
             </span>
           }
           name="beneficiaryLocationQuestion"


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19568

## Testing done


## Screenshots
<img width="1184" alt="Screen Shot 2019-08-29 at 10 03 01 AM" src="https://user-images.githubusercontent.com/48804654/63947040-365a8680-ca44-11e9-9c93-dbee523b37c8.png">

## Acceptance criteria
- [ ] 'learn more' button should be aligned with label text


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
