### PR TITLE
[Footer] Add critical links

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -248,7 +248,7 @@
     "href": "https://www.usa.gov/",
     "order": 8,
     "target": null,
-    "title": "USAGov"
+    "title": "USA.gov"
   },
   {
     "column": "bottom_rail",

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -238,15 +238,29 @@
   },
   {
     "column": "bottom_rail",
-    "href": "https://www.va.gov/scorecard/",
+    "href": "https://www.oprm.va.gov/foia/",
     "order": 7,
+    "target": null,
+    "title": "Freedom of Information Act (FOIA)"
+  },
+  {
+    "column": "bottom_rail",
+    "href": "https://www.usa.gov/",
+    "order": 8,
+    "target": null,
+    "title": "USAGov"
+  },
+  {
+    "column": "bottom_rail",
+    "href": "https://www.va.gov/scorecard/",
+    "order": 9,
     "target": null,
     "title": "VA.gov scorecard"
   },
   {
     "column": "bottom_rail",
     "href": "https://www.va.gov/veterans-portrait-project/",
-    "order": 8,
+    "order": 10,
     "target": null,
     "title": "Veterans Portrait Project"
   }

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -240,14 +240,14 @@
     "column": "bottom_rail",
     "href": "https://www.oprm.va.gov/foia/",
     "order": 7,
-    "target": null,
+    "target": "_blank",
     "title": "Freedom of Information Act (FOIA)"
   },
   {
     "column": "bottom_rail",
     "href": "https://www.usa.gov/",
     "order": 8,
-    "target": null,
+    "target": "_blank",
     "title": "USA.gov"
   },
   {

--- a/src/site/stages/build/plugins/update-external-links.js
+++ b/src/site/stages/build/plugins/update-external-links.js
@@ -11,6 +11,7 @@ const newTabDomains = [
   'mobile.va.gov',
   'www.accesstocare.va.gov',
   'www.oit.va.gov',
+  'www.oprm.va.gov',
 ];
 
 function isVADomainThatOpensInNewTab(href) {


### PR DESCRIPTION
## Description
Adds two critical links into the footer.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/1417

## Testing done
Looked at the site locally

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/63950671-6e64c800-ca4a-11e9-8259-db03d99054c5.png)


## Acceptance criteria
- [ ] Links are in footer

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
