### PR TITLE
[Footer] Open link to FOIA in same tab

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -240,7 +240,7 @@
     "column": "bottom_rail",
     "href": "https://www.oprm.va.gov/foia/",
     "order": 7,
-    "target": "_blank",
+    "target": null,
     "title": "Freedom of Information Act (FOIA)"
   },
   {

--- a/src/site/stages/build/plugins/update-external-links.js
+++ b/src/site/stages/build/plugins/update-external-links.js
@@ -11,7 +11,6 @@ const newTabDomains = [
   'mobile.va.gov',
   'www.accesstocare.va.gov',
   'www.oit.va.gov',
-  'www.oprm.va.gov',
 ];
 
 function isVADomainThatOpensInNewTab(href) {


### PR DESCRIPTION
## Description
Follow-up to https://github.com/department-of-veterans-affairs/vets-website/pull/10656

This link should open in the same tab as www.va.gov.
## Testing done
local

## Screenshots
n/a

## Acceptance criteria
- [ ] link opens in same tab

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
