### PR TITLE
Add new profile-beta app

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -36,7 +36,8 @@
     ["module-resolver", {
       "root": "./src",
       "alias": {
-        "vet360": "./src/platform/user/profile/vet360"
+        "vet360": "./src/platform/user/profile/vet360",
+        "@profile360": "./src/applications/personalization/profile360"
       }
     }]
   ],

--- a/src/applications/personalization/profile360-beta/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360-beta/components/ProfileView.jsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import DowntimeNotification, {
+  externalServices,
+  externalServiceStatus,
+} from 'platform/monitoring/DowntimeNotification';
+import DowntimeApproaching from 'platform/monitoring/DowntimeNotification/components/DowntimeApproaching';
+import recordEvent from 'platform/monitoring/record-event';
+
+import Vet360TransactionReporter from 'vet360/containers/TransactionReporter';
+
+import Hero from '@profile360/components/Hero';
+import ContactInformation from '@profile360/components/ContactInformation';
+import PersonalInformation from '@profile360/components/PersonalInformation';
+import MilitaryInformation from '@profile360/components/MilitaryInformation';
+import PaymentInformation from '@profile360/containers/PaymentInformation';
+import PaymentInformationTOCItem from '@profile360/containers/PaymentInformationTOCItem';
+
+import IdentityVerification from '@profile360/components/IdentityVerification';
+import MVIError from '@profile360/components/MVIError';
+
+const ProfileTOC = ({ militaryInformation }) => (
+  <>
+    <h2 className="vads-u-font-size--h3">On this page</h2>
+    <ul>
+      <li>
+        <a href="#contact-information">Contact information</a>
+      </li>
+      <PaymentInformationTOCItem />
+      <li>
+        <a href="#personal-information">Personal information</a>
+      </li>
+      {militaryInformation && (
+        <li>
+          <a href="#military-information">Military service information</a>
+        </li>
+      )}
+    </ul>
+  </>
+);
+
+class ProfileView extends React.Component {
+  static propTypes = {
+    downtimeData: PropTypes.object,
+    fetchMilitaryInformation: PropTypes.func.isRequired,
+    fetchHero: PropTypes.func.isRequired,
+    fetchPersonalInformation: PropTypes.func.isRequired,
+    profile: PropTypes.shape({
+      hero: PropTypes.object,
+      personalInformation: PropTypes.object,
+      militaryInformation: PropTypes.object,
+    }),
+    user: PropTypes.object,
+  };
+
+  handleDowntimeApproaching = (downtime, children) => {
+    if (downtime.status === externalServiceStatus.downtimeApproaching) {
+      return (
+        <DowntimeApproaching
+          {...downtime}
+          {...this.props.downtimeData}
+          messaging={{
+            title: (
+              <h3>
+                Some parts of the profile will be down for maintenance soon
+              </h3>
+            ),
+          }}
+          content={children}
+        />
+      );
+    }
+    return children;
+  };
+
+  render() {
+    const {
+      user,
+      fetchMilitaryInformation,
+      fetchHero,
+      fetchPersonalInformation,
+      profile: { hero, personalInformation, militaryInformation },
+      downtimeData: { appTitle },
+    } = this.props;
+
+    let content;
+
+    if (user.profile.verified) {
+      if (user.profile.status === 'OK') {
+        content = (
+          <DowntimeNotification
+            appTitle={appTitle}
+            render={this.handleDowntimeApproaching}
+            dependencies={[
+              externalServices.emis,
+              externalServices.evss,
+              externalServices.mvi,
+              externalServices.vet360,
+            ]}
+          >
+            <div>
+              <Vet360TransactionReporter />
+              <Hero
+                fetchHero={fetchHero}
+                hero={hero}
+                militaryInformation={militaryInformation}
+              />
+              <ProfileTOC militaryInformation={militaryInformation} />
+              <div id="contact-information" />
+              <ContactInformation />
+              <div id="direct-deposit" />
+              <PaymentInformation />
+              <div id="personal-information" />
+              <PersonalInformation
+                fetchPersonalInformation={fetchPersonalInformation}
+                personalInformation={personalInformation}
+              />
+              {militaryInformation && <div id="military-information" />}
+              <MilitaryInformation
+                veteranStatus={user.profile.veteranStatus}
+                fetchMilitaryInformation={fetchMilitaryInformation}
+                militaryInformation={militaryInformation}
+              />
+            </div>
+          </DowntimeNotification>
+        );
+      } else {
+        content = (
+          <MVIError
+            facilitiesClick={() => {
+              recordEvent({
+                event: 'profile-navigation',
+                'profile-action': 'view-link',
+                'profile-section': 'find-center',
+              });
+            }}
+          />
+        );
+      }
+    } else {
+      content = (
+        <IdentityVerification
+          learnMoreClick={() => {
+            recordEvent({
+              event: 'profile-navigation',
+              'profile-action': 'view-link',
+              'additional-info': 'learn-more-identity',
+            });
+          }}
+          faqClick={() => {
+            recordEvent({
+              event: 'profile-navigation',
+              'profile-action': 'view-link',
+              'profile-section': 'vets-faqs',
+            });
+          }}
+          verifyClick={() => {
+            recordEvent({ event: 'verify-link-clicked' });
+          }}
+        />
+      );
+    }
+
+    return (
+      <div className="va-profile-wrapper row" style={{ marginBottom: 35 }}>
+        <div className="usa-width-two-thirds medium-8 small-12 columns">
+          {content}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ProfileView;

--- a/src/applications/personalization/profile360-beta/containers/VAProfileApp.jsx
+++ b/src/applications/personalization/profile360-beta/containers/VAProfileApp.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import backendServices from 'platform/user/profile/constants/backendServices';
+import {
+  initializeDowntimeWarnings,
+  dismissDowntimeWarning,
+} from 'platform/monitoring/DowntimeNotification/actions';
+
+import {
+  fetchHero,
+  fetchMilitaryInformation,
+  fetchPersonalInformation,
+} from '@profile360/actions';
+
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
+import ProfileView from '../components/ProfileView';
+
+class VAProfileApp extends React.Component {
+  render() {
+    return (
+      <div>
+        <RequiredLoginView
+          authRequired={1}
+          serviceRequired={backendServices.USER_PROFILE}
+          user={this.props.user}
+          loginUrl={this.props.loginUrl}
+          verifyUrl={this.props.verifyUrl}
+        >
+          <ProfileView
+            profile={this.props.profile}
+            user={this.props.user}
+            fetchHero={this.props.fetchHero}
+            fetchMilitaryInformation={this.props.fetchMilitaryInformation}
+            fetchPersonalInformation={this.props.fetchPersonalInformation}
+            downtimeData={{
+              appTitle: 'profile',
+              isDowntimeWarningDismissed: this.props.isDowntimeWarningDismissed,
+              initializeDowntimeWarnings: this.props.initializeDowntimeWarnings,
+              dismissDowntimeWarning: this.props.dismissDowntimeWarning,
+            }}
+          />
+        </RequiredLoginView>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  user: state.user,
+  profile: state.vaProfile,
+  isDowntimeWarningDismissed: state.scheduledDowntime.dismissedDowntimeWarnings.includes(
+    'profile',
+  ),
+});
+
+const mapDispatchToProps = {
+  fetchHero,
+  fetchMilitaryInformation,
+  fetchPersonalInformation,
+  initializeDowntimeWarnings,
+  dismissDowntimeWarning,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(VAProfileApp);
+export { VAProfileApp };

--- a/src/applications/personalization/profile360-beta/manifest.json
+++ b/src/applications/personalization/profile360-beta/manifest.json
@@ -1,0 +1,6 @@
+{
+  "appName": "VA Profile",
+  "entryFile": "./profile-360-beta-entry.jsx",
+  "entryName": "profile-360-beta",
+  "rootUrl": "/profile-beta"
+}

--- a/src/applications/personalization/profile360-beta/profile-360-beta-entry.jsx
+++ b/src/applications/personalization/profile360-beta/profile-360-beta-entry.jsx
@@ -1,0 +1,15 @@
+import '@profile360/sass/profile-360.scss';
+import 'platform/polyfills';
+
+import startApp from 'platform/startup';
+
+import routes from './routes';
+import reducer from '@profile360/reducers';
+import manifest from './manifest.json';
+
+startApp({
+  url: manifest.rootUrl,
+  reducer,
+  routes,
+  entryName: manifest.entryName,
+});

--- a/src/applications/personalization/profile360-beta/routes.jsx
+++ b/src/applications/personalization/profile360-beta/routes.jsx
@@ -1,0 +1,8 @@
+import VAProfileApp from './containers/VAProfileApp';
+
+const routes = {
+  path: '/',
+  component: VAProfileApp,
+};
+
+export default routes;

--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -110,8 +110,12 @@ class ProfileView extends React.Component {
               <ProfileTOC militaryInformation={militaryInformation} />
               <div id="contact-information" />
               <ContactInformation />
-              <div id="direct-deposit" />
-              <PaymentInformation />
+              {featureFlags.directDeposit && (
+                <>
+                  <div id="direct-deposit" />
+                  <PaymentInformation />
+                </>
+              )}
               <div id="personal-information" />
               <PersonalInformation
                 fetchPersonalInformation={fetchPersonalInformation}

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -30,8 +30,6 @@ import {
   editModalFieldChanged,
 } from '../actions/paymentInformation';
 
-import featureFlags from '../featureFlags';
-
 const AdditionalInfos = props => (
   <>
     <div className="vads-u-margin-bottom--2">
@@ -283,10 +281,6 @@ const PaymentInformationContainer = connect(
   mapDispatchToProps,
 )(PaymentInformation);
 
-const noop = () => null;
-
-export default (featureFlags.directDeposit
-  ? PaymentInformationContainer
-  : noop);
+export default PaymentInformationContainer;
 
 export { PaymentInformation };


### PR DESCRIPTION
This new app uses a ton of resources (components, containers, etc) from the existing profile360 application

## Description
We are launching a version of the profile 360 app that ungates the new direct deposit/payment information feature. Other than ungating that component on the ProfileView, this app is identical in every way to the existing profile 360 app. Thus the new profile360-beta ProfileView component uses containers and components from the sibling profile360 app.

## Testing done
local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs