### PR TITLE
[Homepage] Load the banner config at runtime off of GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,6 +271,7 @@
     "redux": "^4.0.0",
     "redux-thunk": "^2.1.0",
     "reselect": "^2.5.4",
+    "sanitize-html": "^1.20.1",
     "syswide-cas": "^5.3.0",
     "tinyliquid": "^0.2.33",
     "url-search-params": "^0.10.0",

--- a/src/applications/static-pages/renderHomepageBanner.js
+++ b/src/applications/static-pages/renderHomepageBanner.js
@@ -1,38 +1,51 @@
-const yaml = require('js-yaml');
+import yaml from 'js-yaml';
+import * as Sentry from '@sentry/browser';
 
 const HOMEPAGE_BANNER_YML_LOCATION =
   'https://raw.githubusercontent.com/department-of-veterans-affairs/vagov-content/master/fragments/home/banner.yml';
 
-async function renderHomepageBanner() {
+async function loadConfigFromGitHub() {
   const response = await fetch(HOMEPAGE_BANNER_YML_LOCATION, {
     mode: 'cors',
   });
 
   const homepageBannerYml = await response.text();
-  const homepageBanner = yaml.safeLoad(homepageBannerYml);
+  return yaml.safeLoad(homepageBannerYml);
+}
 
-  if (!homepageBanner.visible) {
+function renderToDocument(banner) {
+  if (!banner.visible) {
     return;
   }
 
   const root = document.getElementById('homepage-banner');
 
   root.innerHTML = `
-    <div class="usa-alert-full-width usa-alert-full-width-${
-      homepageBanner.type
-    }">
+    <div class="usa-alert-full-width usa-alert-full-width-${banner.type}">
       <div aria-live="polite" role="alert" class="usa-alert usa-alert-${
-        homepageBanner.type
+        banner.type
       }">
         <div class="usa-alert-body">
-          <h3 class="usa-alert-heading">${homepageBanner.title}</h3>
+          <h3 class="usa-alert-heading">${banner.title}</h3>
           <div class="usa-alert-text">
-            ${homepageBanner.content}
+            ${banner.content}
           </div>
         </div>
       </div>
     </div>
   `;
+}
+
+async function renderHomepageBanner() {
+  try {
+    const banner = await loadConfigFromGitHub();
+    renderToDocument(banner);
+  } catch (error) {
+    Sentry.withScope(scope => {
+      scope.setExtra('error', error);
+      Sentry.captureMessage(`Homepage Banner Error: ${error.message}`);
+    });
+  }
 }
 
 export default renderHomepageBanner;

--- a/src/applications/static-pages/renderHomepageBanner.js
+++ b/src/applications/static-pages/renderHomepageBanner.js
@@ -2,8 +2,10 @@ import yaml from 'js-yaml';
 import * as Sentry from '@sentry/browser';
 import sanitizeHtml from 'sanitize-html';
 
+// https://github.com/department-of-veterans-affairs/vagov-content/blob/master/fragments/home/banner.yml
+
 const HOMEPAGE_BANNER_YML_LOCATION =
-  'https://raw.githubusercontent.com/department-of-veterans-affairs/vagov-content/nick-test/fragments/home/banner.yml';
+  'https://github.com/department-of-veterans-affairs/vagov-content/blob/master/fragments/home/banner.yml';
 
 const ACCEPTABLE_CONTENT_TAGS = [
   'h4',

--- a/src/applications/static-pages/renderHomepageBanner.js
+++ b/src/applications/static-pages/renderHomepageBanner.js
@@ -2,8 +2,10 @@ import yaml from 'js-yaml';
 import * as Sentry from '@sentry/browser';
 import sanitizeHtml from 'sanitize-html';
 
-const HOMEPAGE_BANNER_YML_LOCATION =
-  'https://raw.githubusercontent.com/department-of-veterans-affairs/vagov-content/master/fragments/home/banner.yml';
+const VAGOV_CONTENT =
+  'https://raw.githubusercontent.com/department-of-veterans-affairs/vagov-content/master';
+
+const HOMEPAGE_BANNER_YML_LOCATION = `${VAGOV_CONTENT}/fragments/home/banner.yml?cache-break=${new Date().getTime()}`;
 
 const ACCEPTABLE_CONTENT_TAGS = [
   'h4',

--- a/src/applications/static-pages/renderHomepageBanner.js
+++ b/src/applications/static-pages/renderHomepageBanner.js
@@ -1,8 +1,28 @@
 import yaml from 'js-yaml';
 import * as Sentry from '@sentry/browser';
+import sanitizeHtml from 'sanitize-html';
 
 const HOMEPAGE_BANNER_YML_LOCATION =
-  'https://raw.githubusercontent.com/department-of-veterans-affairs/vagov-content/master/fragments/home/banner.yml';
+  'https://raw.githubusercontent.com/department-of-veterans-affairs/vagov-content/nick-test/fragments/home/banner.yml';
+
+const ACCEPTABLE_CONTENT_TAGS = [
+  'h4',
+  'h5',
+  'h6',
+  'blockquote',
+  'p',
+  'a',
+  'ul',
+  'ol',
+  'li',
+  'b',
+  'i',
+  'strong',
+  'em',
+  'hr',
+  'br',
+  'div',
+];
 
 async function loadConfigFromGitHub() {
   const response = await fetch(HOMEPAGE_BANNER_YML_LOCATION, {
@@ -18,17 +38,27 @@ function renderToDocument(banner) {
     return;
   }
 
+  const type = sanitizeHtml(banner.type, {
+    allowedTags: [],
+  });
+
+  const title = sanitizeHtml(banner.title, {
+    allowedTags: ['b', 'i', 'strong', 'em'],
+  });
+
+  const content = sanitizeHtml(banner.content, {
+    allowedTags: ACCEPTABLE_CONTENT_TAGS,
+  });
+
   const root = document.getElementById('homepage-banner');
 
   root.innerHTML = `
-    <div class="usa-alert-full-width usa-alert-full-width-${banner.type}">
-      <div aria-live="polite" role="alert" class="usa-alert usa-alert-${
-        banner.type
-      }">
+    <div class="usa-alert-full-width usa-alert-full-width-${type}">
+      <div aria-live="polite" role="alert" class="usa-alert usa-alert-${type}">
         <div class="usa-alert-body">
-          <h3 class="usa-alert-heading">${banner.title}</h3>
+          <h3 class="usa-alert-heading">${title}</h3>
           <div class="usa-alert-text">
-            ${banner.content}
+            ${content}
           </div>
         </div>
       </div>

--- a/src/applications/static-pages/renderHomepageBanner.js
+++ b/src/applications/static-pages/renderHomepageBanner.js
@@ -25,6 +25,11 @@ const ACCEPTABLE_CONTENT_TAGS = [
 ];
 
 async function loadConfigFromGitHub() {
+  // This is not an approach we should follow across any other area of the site.
+  // This is a solution for a specific edge case that we will not run into again.
+  // This edge case is that we need real-time updates to the homepage banner as
+  // the statuses of VA facilities change over the course of Hurricane Dorian.
+
   const response = await fetch(HOMEPAGE_BANNER_YML_LOCATION, {
     mode: 'cors',
   });

--- a/src/applications/static-pages/renderHomepageBanner.js
+++ b/src/applications/static-pages/renderHomepageBanner.js
@@ -2,10 +2,8 @@ import yaml from 'js-yaml';
 import * as Sentry from '@sentry/browser';
 import sanitizeHtml from 'sanitize-html';
 
-// https://github.com/department-of-veterans-affairs/vagov-content/blob/master/fragments/home/banner.yml
-
 const HOMEPAGE_BANNER_YML_LOCATION =
-  'https://github.com/department-of-veterans-affairs/vagov-content/blob/master/fragments/home/banner.yml';
+  'https://raw.githubusercontent.com/department-of-veterans-affairs/vagov-content/nick-test/fragments/home/banner.yml';
 
 const ACCEPTABLE_CONTENT_TAGS = [
   'h4',

--- a/src/applications/static-pages/renderHomepageBanner.js
+++ b/src/applications/static-pages/renderHomepageBanner.js
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/browser';
 import sanitizeHtml from 'sanitize-html';
 
 const HOMEPAGE_BANNER_YML_LOCATION =
-  'https://raw.githubusercontent.com/department-of-veterans-affairs/vagov-content/nick-test/fragments/home/banner.yml';
+  'https://raw.githubusercontent.com/department-of-veterans-affairs/vagov-content/master/fragments/home/banner.yml';
 
 const ACCEPTABLE_CONTENT_TAGS = [
   'h4',

--- a/src/applications/static-pages/renderHomepageBanner.js
+++ b/src/applications/static-pages/renderHomepageBanner.js
@@ -1,0 +1,38 @@
+const yaml = require('js-yaml');
+
+const HOMEPAGE_BANNER_YML_LOCATION =
+  'https://raw.githubusercontent.com/department-of-veterans-affairs/vagov-content/master/fragments/home/banner.yml';
+
+async function renderHomepageBanner() {
+  const response = await fetch(HOMEPAGE_BANNER_YML_LOCATION, {
+    mode: 'cors',
+  });
+
+  const homepageBannerYml = await response.text();
+  const homepageBanner = yaml.safeLoad(homepageBannerYml);
+
+  if (!homepageBanner.visible) {
+    return;
+  }
+
+  const root = document.getElementById('homepage-banner');
+
+  root.innerHTML = `
+    <div class="usa-alert-full-width usa-alert-full-width-${
+      homepageBanner.type
+    }">
+      <div aria-live="polite" role="alert" class="usa-alert usa-alert-${
+        homepageBanner.type
+      }">
+        <div class="usa-alert-body">
+          <h3 class="usa-alert-heading">${homepageBanner.title}</h3>
+          <div class="usa-alert-text">
+            ${homepageBanner.content}
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+export default renderHomepageBanner;

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -14,6 +14,7 @@ import subscribeAdditionalInfoEvents from './subscribeAdditionalInfoEvents';
 import createApplicationStatus from './createApplicationStatus';
 import createCallToActionWidget from './createCallToActionWidget';
 import createMyVALoginWidget from './createMyVALoginWidget';
+import renderHomepageBanner from './renderHomepageBanner';
 import createDisabilityFormWizard from '../disability-benefits/wizard/createWizard';
 import createDisabilityRatingCalculator from '../disability-benefits/disability-rating-calculator/createCalculator';
 import createEducationApplicationStatus from '../edu-benefits/components/createEducationApplicationStatus';
@@ -87,6 +88,7 @@ createBasicFacilityListWidget();
 
 // homepage widgets
 if (location.pathname === '/') {
+  renderHomepageBanner();
   createMyVALoginWidget(store);
 }
 

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -78,16 +78,12 @@
 
 {% include "src/site/blocks/pittsburgh-beta-banner.liquid" %}
 
-{% if path == '' and banner and banner.visible %}
-  <div class="usa-alert-full-width usa-alert-full-width-{{ banner.type }}">
-    <div aria-live="polite" role="alert" class="usa-alert usa-alert-{{ banner.type }}">
-      <div class="usa-alert-body">
-        <h3 class="usa-alert-heading">{{ banner.title }}</h3>
-        <div class="usa-alert-text">
-          {{ banner.content }}
-        </div>
-      </div>
-    </div>
+{% if path == '' or path == '/' %}
+  <div id="homepage-banner">
+    <!--
+      Rendered from vets-website/src/applications/static-pages/renderHomepageBanner.js
+    -->
   </div>
 {% endif %}
+
 <script async src="/js/incompatible-browser.js"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,7 +1408,7 @@ array-union@^1.0.1:
   dependencies:
     array-uniq "^1.0.1"
 
-array-uniq@^1.0.0, array-uniq@^1.0.1:
+array-uniq@^1.0.0, array-uniq@^1.0.1, array-uniq@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
 
@@ -4024,6 +4024,11 @@ domelementtype@1, domelementtype@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
 
+domelementtype@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
+  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+
 domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
@@ -6350,6 +6355,18 @@ htmlescape@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/htmlescape/-/htmlescape-1.1.1.tgz#3a03edc2214bca3b66424a3e7959349509cb0351"
 
+htmlparser2@^3.10.0:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
+  integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
+  dependencies:
+    domelementtype "^1.3.1"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^3.1.1"
+
 htmlparser2@^3.9.1:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
@@ -8341,6 +8358,11 @@ lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
 
+lodash.escaperegexp@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
+  integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -8372,9 +8394,14 @@ lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
-lodash.isplainobject@^4.0.0:
+lodash.isplainobject@^4.0.0, lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
 lodash.istypedarray@^3.0.0:
   version "3.0.6"
@@ -8414,6 +8441,11 @@ lodash.memoize@~3.0.3:
 lodash.mergewith@^4.0.0, lodash.mergewith@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
+
+lodash.mergewith@^4.6.1:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.omit@^4.0.2:
   version "4.5.0"
@@ -10731,6 +10763,15 @@ postcss@^7.0.0, postcss@^7.0.14:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+postcss@^7.0.5:
+  version "7.0.17"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.17.tgz#4da1bdff5322d4a0acaab4d87f3e782436bad31f"
+  integrity sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -11357,7 +11398,7 @@ readable-stream@^2.3.0, readable-stream@^2.3.5, readable-stream@^2.3.6:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6:
+readable-stream@^3.0.6, readable-stream@^3.1.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
   integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
@@ -12015,6 +12056,22 @@ sane@^2.0.0:
     watch "~0.18.0"
   optionalDependencies:
     fsevents "^1.2.3"
+
+sanitize-html@^1.20.1:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.20.1.tgz#f6effdf55dd398807171215a62bfc21811bacf85"
+  integrity sha512-txnH8TQjaQvg2Q0HY06G6CDJLVYCpbnxrdO0WN8gjCKaU5J0KbyGYhZxx5QJg3WLZ1lB7XU9kDkfrCXUozqptA==
+  dependencies:
+    chalk "^2.4.1"
+    htmlparser2 "^3.10.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.escaperegexp "^4.1.2"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.mergewith "^4.6.1"
+    postcss "^7.0.5"
+    srcset "^1.0.0"
+    xtend "^4.0.1"
 
 sass-graph@^2.2.4:
   version "2.2.4"
@@ -12739,6 +12796,14 @@ sprintf-js@^1.1.2:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+srcset@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/srcset/-/srcset-1.0.0.tgz#a5669de12b42f3b1d5e83ed03c71046fc48f41ef"
+  integrity sha1-pWad4StC87HV6D7QPHEEb8SPQe8=
+  dependencies:
+    array-uniq "^1.0.2"
+    number-is-nan "^1.0.0"
 
 sshpk@^1.7.0:
   version "1.13.0"


### PR DESCRIPTION
## Description
Currently, the homepage banner is written to the homepage HTML during each build and made visible to the site only during a deployment. The banner lives [here](https://github.com/department-of-veterans-affairs/vagov-content/blob/master/fragments/home/banner.yml), in YML.

However, over this weekend, the banner will need to be updated often, possibly several times an hour as facility statuses change. This would be impossible to do if a full deployment is required for each change, and this homepage banner is looked at closely by leadership. 

As a solution for this, this PR loads the YML file right off of GitHub on page load and renders it then. Although this results in the homepage banner flickering as it's rendered after page load, this keeps us from having to do a full deployment for just a banner update.

### Tickets
https://github.com/department-of-veterans-affairs/va.gov-team/issues/1448
https://github.com/department-of-veterans-affairs/va.gov-team/issues/1453

## Testing done
All local

## Screenshots
Note the console output indicating that the file was pulled from GitHub.

![image](https://user-images.githubusercontent.com/1915775/64044948-1905e500-cb36-11e9-8892-7ff053a97862.png)


## Acceptance criteria
- [x] Homepage banner can be updated without a deployment

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
