### PR TITLE
Cms flag caching

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -251,7 +251,7 @@ def archiveAll(dockerContainer, String ref) {
 
 def cacheDrupalContent(dockerContainer, envUsedCache) {
   stage("Cache Drupal Content") {
-    if (!isDeployable()) { return }
+    // if (!isDeployable()) { return }
 
     try {
       def archives = [:]

--- a/script/drupal-aws-cache.js
+++ b/script/drupal-aws-cache.js
@@ -19,9 +19,6 @@ const fs = require('fs-extra');
 const decompress = require('decompress');
 
 const ENVIRONMENTS = require('../src/site/constants/environments');
-const {
-  getDrupalCacheKey,
-} = require('../src/site/stages/build/drupal/utilities-drupal');
 
 const defaultBuildtype = ENVIRONMENTS.LOCALHOST;
 const COMMAND_LINE_OPTIONS_DEFINITIONS = [
@@ -30,6 +27,17 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'unexpected', type: String, multile: true, defaultOption: true },
 ];
 const cacheUrl = `https://s3-us-gov-west-1.amazonaws.com/vetsgov-website-builds-s3-upload/content`;
+const options = commandLineArgs(COMMAND_LINE_OPTIONS_DEFINITIONS);
+const cacheDirectory = path.join('.cache', options.buildtype, 'drupal');
+
+// Load up the flags into `global` before requiring getDrupalCacheKey,
+// which uses the flags from `global`.
+require('../src/site/stages/build/drupal/load-saved-flags').useFlags(
+  cacheDirectory,
+);
+const {
+  getDrupalCacheKey,
+} = require('../src/site/stages/build/drupal/utilities-drupal');
 
 function downloadFile(url, dest) {
   return new Promise((resolve, reject) => {
@@ -54,9 +62,8 @@ function downloadFile(url, dest) {
   });
 }
 
-async function fetchCache(options) {
+async function fetchCache() {
   global.buildtype = options.buildtype;
-  const cacheDirectory = path.join('.cache', options.buildtype, 'drupal');
   const cacheEnv =
     options.buildtype === ENVIRONMENTS.LOCALHOST
       ? ENVIRONMENTS.VAGOVDEV
@@ -84,9 +91,8 @@ async function fetchCache(options) {
  * Compresses everything in .cache/{buildtype}/drupal/ and puts it in
  *  .cache/content/{buildtype}_{query-hash}.tar.bz2
  */
-async function createCacheFile(options) {
+async function createCacheFile() {
   global.buildtype = options.buildtype;
-  const cacheDirectory = path.join('.cache', options.buildtype, 'drupal');
   const cacheOutput = path.join('.cache', 'content');
   const cacheEnv =
     options.buildtype === ENVIRONMENTS.LOCALHOST
@@ -108,10 +114,8 @@ async function createCacheFile(options) {
   }
 }
 
-const options = commandLineArgs(COMMAND_LINE_OPTIONS_DEFINITIONS);
-
 if (options.fetch) {
-  fetchCache(options);
+  fetchCache();
 } else {
-  createCacheFile(options);
+  createCacheFile();
 }

--- a/script/drupal-aws-cache.js
+++ b/script/drupal-aws-cache.js
@@ -32,7 +32,7 @@ const cacheDirectory = path.join('.cache', options.buildtype, 'drupal');
 
 // Load up the flags into `global` before requiring getDrupalCacheKey,
 // which uses the flags from `global`.
-require('../src/site/stages/build/drupal/load-saved-flags').useFlags(
+require('../src/site/stages/build/drupal/load-saved-flags').loadFeatureFlags(
   cacheDirectory,
 );
 const {

--- a/src/site/stages/build/drupal/load-saved-flags.js
+++ b/src/site/stages/build/drupal/load-saved-flags.js
@@ -48,15 +48,11 @@ function useFlags(rawFlags) {
  * Attempt to load the feature flags from the file and put them in
  * global.cmsFeatureFlags.
  *
- * This is for use with the cache and preview scripts. The normal
- * build script does this in setUpFeatureFlags().
+ * This is for use with the drupal-aws-cache script. The normal build
+ * and preview build scripts do this in setUpFeatureFlags().
  */
 async function loadFeatureFlags(cacheDirectory) {
-  const featureFlagFile = path.join(
-    cacheDirectory,
-    'drupal',
-    'feature-flags.json',
-  );
+  const featureFlagFile = path.join(cacheDirectory, 'feature-flags.json');
   const rawFlags = fs.readJsonSync(featureFlagFile);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/src/site/stages/build/drupal/load-saved-flags.js
+++ b/src/site/stages/build/drupal/load-saved-flags.js
@@ -1,0 +1,66 @@
+const path = require('path');
+const fs = require('fs-extra');
+
+/**
+ * Takes an object of CMS feature flags, puts them in a Proxy which
+ * throws an error if one is used without being defined, and assigns
+ * that to global.cmsFeatureFlags.
+ *
+ * Returns the Proxy.
+ * @param {Object} rawFlags - The CMS feature flags to use
+ * @return {Proxy} - A Proxy containing all the feature flags; throws
+ *                   an error if a flag is called without existing
+ */
+function useFlags(rawFlags) {
+  const p = new Proxy(rawFlags, {
+    get(obj, prop) {
+      if (prop in obj) {
+        return obj[prop];
+      }
+      // Not sure where this was getting called, but V8 does some
+      // complicated things under the hood.
+      // https://www.mattzeunert.com/2016/07/20/proxy-symbol-tostring.html
+      // TL;DR: V8 calls some things we don't want to throw up on.
+      const ignoreList = [
+        'Symbol(Symbol.toStringTag)',
+        'Symbol(nodejs.util.inspect.custom)',
+        'inspect',
+        'Symbol(Symbol.iterator)',
+      ];
+      if (!ignoreList.includes(prop.toString())) {
+        throw new ReferenceError(
+          `Could not find feature flag ${prop.toString()}. This could be a typo or the feature flag wasn't returned from Drupal.`,
+        );
+      }
+
+      // If we get this far, I guess we make sure we don't mess up
+      // the expected behavior
+      return obj[prop];
+    },
+  });
+
+  global.cmsFeatureFlags = p;
+
+  return p;
+}
+
+/**
+ * Attempt to load the feature flags from the file and put them in
+ * global.cmsFeatureFlags.
+ *
+ * This is for use with the cache and preview scripts. The normal
+ * build script does this in setUpFeatureFlags().
+ */
+async function loadFeatureFlags(cacheDirectory) {
+  const featureFlagFile = path.join(
+    cacheDirectory,
+    'drupal',
+    'feature-flags.json',
+  );
+  const rawFlags = fs.readJsonSync(featureFlagFile);
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return useFlags(rawFlags);
+}
+
+module.exports = { loadFeatureFlags, useFlags };

--- a/src/site/stages/build/drupal/load-saved-flags.js
+++ b/src/site/stages/build/drupal/load-saved-flags.js
@@ -51,7 +51,7 @@ function useFlags(rawFlags) {
  * This is for use with the drupal-aws-cache script. The normal build
  * and preview build scripts do this in setUpFeatureFlags().
  */
-async function loadFeatureFlags(cacheDirectory) {
+function loadFeatureFlags(cacheDirectory) {
   const featureFlagFile = path.join(cacheDirectory, 'feature-flags.json');
   const rawFlags = fs.readJsonSync(featureFlagFile);
 


### PR DESCRIPTION
## Background
The build step in Jenkins for caching the Drupal content calls `script/drupal-aws-cache.js`, which `require`s the `utilities-drupal` file. This in turn `require`s the query files, which will break when the feature flags are not loaded up. 

```
Cannot read property 'FEATURE_FIELD_ALERT_DISMISSABLE' of undefined
```

## Description
By the time Jenkins gets to the caching step, there will be a `feature-flags.json`. This PR loads the file and puts the contents into `global` for use in the query files.

## Testing done
:see_no_evil: 

Unfortunately, I can neither run Jenkins locally nor test the AWS connection, but running the script locally seems to work. I don't get any errors, anyhow.

## Screenshots
N/A

## Acceptance criteria
- [ ] The build passes
- [ ] The cache step successfully caches the Drupal data

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
