### PR TITLE
Remove the log line

### DIFF
--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -97,6 +97,3 @@ if (cmsFeatureFlags.GRAPHQL_MODULE_UPDATE) {
   const regex = new RegExp(`${regString}`, 'g');
   module.exports = query.replace(regex, updateQueryString);
 }
-
-// eslint-disable-next-line no-console
-console.log(module.exports);


### PR DESCRIPTION
## Description
There was a stray log line. I committed it to get the output from within Jenkins, but forgot to remove it later. :grimacing: 

## Acceptance criteria
- [ ] The query doesn't get logged anymore

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
