### PR TITLE
add back codeclimate coverage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends gconf-service l
     --no-install-recommends \
   && npm install -g yarn@$YARN_VERSION \
   && npm install -g s3-cli \
-  && npm install -g codeclimate-test-reporter \
   && chmod +x /usr/local/lib/node_modules/yarn/bin/yarn.js
+
+RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /cc-test-reporter
+RUN chmod +x /cc-test-reporter
 
 RUN mkdir -p /application
 
 WORKDIR /application
 
 USER jenkins
+ENV CC_TEST_REPORTER_ID=fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,3 @@ RUN mkdir -p /application
 WORKDIR /application
 
 USER jenkins
-ENV CC_TEST_REPORTER_ID=fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ node('vetsgov-general-purpose') {
           dockerContainer.inside(commonStages.DOCKER_ARGS) {
             sh "/cc-test-reporter before-build"
             sh "cd /application && npm --no-color run test:coverage"
-            sh "CODECLIMATE_REPO_TOKEN=fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24 /cc-test-reporter < ./coverage/lcov.info"
+            sh "cd /application && CODECLIMATE_REPO_TOKEN=fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24 /cc-test-reporter  after-build"
           }
         }
       )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,9 @@ node('vetsgov-general-purpose') {
 
         unit: {
           dockerContainer.inside(commonStages.DOCKER_ARGS) {
+            sh "/cc-test-reporter before-build"
             sh "cd /application && npm --no-color run test:coverage"
+            sh "CODECLIMATE_REPO_TOKEN=fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24 /cc-test-reporter < ./coverage/lcov.info"
           }
         }
       )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ node('vetsgov-general-purpose') {
           dockerContainer.inside(commonStages.DOCKER_ARGS) {
             sh "/cc-test-reporter before-build"
             sh "cd /application && npm --no-color run test:coverage"
-            sh "cd /application && CODECLIMATE_REPO_TOKEN=fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24 /cc-test-reporter  after-build"
+            sh "cd /application && /cc-test-reporter after-build -r fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24"
           }
         }
       )


### PR DESCRIPTION
## Description
Send test coverage results to codeclimate as part of an initiative to have better test coverage.  Additional features with the [Codeclimate browser extension](https://codeclimate.com/browser-extension/)

![Screen Shot 2019-09-03 at 5 39 12 PM](https://user-images.githubusercontent.com/19188/64210804-373f4e00-ce72-11e9-99db-ae4885c70a0a.png)

## Testing done
Jenkins

## Screenshots
verified that CC received the coverage stats. 
<img width="819" alt="Screen Shot 2019-09-03 at 4 21 59 PM" src="https://user-images.githubusercontent.com/19188/64206083-7caa4e00-ce67-11e9-91ce-f69b8becf9bf.png">

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
