### PR TITLE
fixed cautionary table on ipad

### DIFF
--- a/src/applications/gi/components/profile/CautionaryInformation.jsx
+++ b/src/applications/gi/components/profile/CautionaryInformation.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import environment from 'platform/utilities/environment';
 
 const TableRow = ({ description, thisCampus, allCampuses }) => {
   if (!thisCampus && !allCampuses) return null;
@@ -121,8 +122,12 @@ export class CautionaryInformation extends React.Component {
 
     const allComplaints = complaints.pop();
 
+    const cautionTableFix = environment.isProduction()
+      ? 'cautionary-information'
+      : 'cautionary-information-new';
+
     return (
-      <div className="cautionary-information">
+      <div className={cautionTableFix}>
         <div className="caution-flag">
           <AlertBox
             content={flagContent}

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -157,7 +157,7 @@
       }
     }
 
-    @include media-maxwidth($medium-screen) {
+    @include media-maxwidth($small-screen) {
       .table {
         display: none;
       }
@@ -221,7 +221,7 @@
       white-space: nowrap;
     }
 
-    padding-bottom:1rem;
+    padding-bottom: 1rem;
   }
 
   .vettec-logo-container {

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -157,6 +157,45 @@
       }
     }
 
+    @include media-maxwidth($medium-screen) {
+      .table {
+        display: none;
+      }
+    }
+  }
+  .cautionary-information-new {
+    .table {
+      table {
+        margin: 1em 0;
+      }
+
+      th:first-child {
+        width: 60%;
+      }
+    }
+
+    .complaints-by-type {
+      th:first-child span {
+        font-weight: normal;
+      }
+    }
+
+    .list {
+      h4 {
+        padding: 0.5em 0 !important;
+      }
+      .number {
+        text-align: right;
+      }
+      margin-bottom: 1em;
+    }
+
+    @media screen and (min-width: $medium-screen) {
+      .list {
+        display: none;
+      }
+    }
+
     @include media-maxwidth($small-screen) {
       .table {
         display: none;


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19580

On the profile page for a school with cautionary information, there is a table that breaks down the different types of complaints. This table does not show when viewing the page with an iPad.

The following screenshots are from the Trident Technical College profile page in production
https://www.va.gov/gi-bill-comparison-tool/profile/14915440

## Testing done
Local Testing

## Screenshots
![Simulator Screen Shot - iPad (6th generation) - 2019-09-04 at 11 55 56](https://user-images.githubusercontent.com/50601724/64275483-3eff0100-cf0b-11e9-8497-ee6f9b7e63d4.png)


## Acceptance criteria
- [x] Table is displayed on iPad

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
