### PR TITLE
[Homepage] Fix for tel protocol not allowed in HREFs of banner

### DIFF
--- a/src/applications/static-pages/renderHomepageBanner.js
+++ b/src/applications/static-pages/renderHomepageBanner.js
@@ -55,6 +55,8 @@ function renderToDocument(banner) {
 
   const content = sanitizeHtml(banner.content, {
     allowedTags: ACCEPTABLE_CONTENT_TAGS,
+    allowedSchemes: ['http', 'https', 'mailto', 'tel'],
+    allowedSchemesAppliedToAttributes: ['href'],
   });
 
   const root = document.getElementById('homepage-banner');


### PR DESCRIPTION
## Description
Currently, telephone links in the homepage banner aren't linking correctly. The HREF values are being stripped, because our sanitizer isn't allowing it. This PR configured the sanitizer to allow it to pass.

## Testing done
Confirmed HREFs beginning with tel work okay locally

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/64283238-09671180-cf25-11e9-999a-b401bcd7792c.png)


## Acceptance criteria
- [x] `tel:` links work

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
