### PR TITLE
Don't cache except on the master branch

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -251,7 +251,7 @@ def archiveAll(dockerContainer, String ref) {
 
 def cacheDrupalContent(dockerContainer, envUsedCache) {
   stage("Cache Drupal Content") {
-    // if (!isDeployable()) { return }
+    if (!isDeployable()) { return }
 
     try {
       def archives = [:]


### PR DESCRIPTION
## Description
I commented out a line for testing a previous branch, and then merged it before reverting the change. :man_facepalming: 

The commit can be found [here](https://github.com/department-of-veterans-affairs/vets-website/pull/10672/commits/860d8f2d1695f6241524dc6b721a76a0f5b2c3ec).

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] The caching only happens on master, not on feature branches

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
